### PR TITLE
Fix a typo in timeline section

### DIFF
--- a/data/timeline.yaml
+++ b/data/timeline.yaml
@@ -6,7 +6,7 @@
 - milestone: Language libraries released (Golang, Python, NodeJS, C#)
   date: September 2019
   asterisk: true
-- milestone: Sunsetting of the Opencensus and OpenTracing libraries
+- milestone: Sunsetting of the OpenCensus and OpenTracing libraries
   date: November 2019
   asterisk: true
 - milestone: OpenTelemetry at KubeCon San Diego


### PR DESCRIPTION
Makes it `OpenCensus` 