### PR TITLE
Add observability section to main page

### DIFF
--- a/assets/sass/home.sass
+++ b/assets/sass/home.sass
@@ -37,3 +37,24 @@ hr.highlight
     width: 40%
   +mobile
     width: 17.5%
+
+.observability-section
+  background-color: $dark
+
+  .title
+    color: $light
+
+  .content
+    color: $light
+
+    strong
+      color: $light
+
+    a
+      color: $primary
+
+      &:hover
+        color: $secondary
+
+    ul
+      list-style-type: square

--- a/config.toml
+++ b/config.toml
@@ -11,13 +11,13 @@ The term [**observability**](https://en.wikipedia.org/wiki/Observability) stems 
 
 In software, observability typically refers to telemetry produced by **services** and is divided into three major verticals:
 
-* [**Tracing**](https://opentracing.io/docs/overview/what-is-tracing) 
-* [**Metrics**](https://opencensus.io/stats)
-* **Logging**
+* [**Tracing**](https://opentracing.io/docs/overview/what-is-tracing), aka **distrbuted tracing**, provides insight into the full lifecycles, aka *traces*, of requests to the system, allowing you to pinpoint failures and performance issues.  
+* [**Metrics**](https://opencensus.io/stats) provide quantitative information about processes running inside the system, including counters, gauges, and histograms. This domain also encompasses querying that data and configuring automated responses to quantitatively specified abormal states.
+* [**Logging**](https://en.wikipedia.org/wiki/Log_file) provides insight into application-specific messages emitted by processes.
 
-OpenTelemetry is an effort to combine all three verticals into a *single system*. It replaces the [OpenTracing](https://opentracing.io) project, which focused exclusively on tracing, and the [OpenCensus](https://opencensus.io) project, which focused on tracing and metrics.
+OpenTelemetry is an effort to combine all three verticals into a single set of system components and language-specific telemetry libraries. It is meant to replace both the [OpenTracing](https://opentracing.io) project, which focused exclusively on tracing, and the [OpenCensus](https://opencensus.io) project, which focused on tracing and metrics.
 
-Intially, OpenTelemetry will not support logging
+Intially, OpenTelemetry will not support logging. This vertical will be incorporated over time.
 """
 
 [params.logos]

--- a/config.toml
+++ b/config.toml
@@ -6,6 +6,19 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
 tagline = "Effective observability requires high-quality telemetry"
 sub_tagline = "**OpenTelemetry** makes robust, portable telemetry a built-in feature of cloud-native software."
 font_awesome_version = "5.8.1"
+observability = """
+The term [**observability**](https://en.wikipedia.org/wiki/Observability) stems from the discipline of [control theory](https://en.wikipedia.org/wiki/Control_theory) and refers to how well a system can be understood on the basis of the **telemetry** that it produces.
+
+In software, observability typically refers to telemetry produced by **services** and is divided into three major verticals:
+
+* [**Tracing**](https://opentracing.io/docs/overview/what-is-tracing) 
+* [**Metrics**](https://opencensus.io/stats)
+* **Logging**
+
+OpenTelemetry is an effort to combine all three verticals into a *single system*. It replaces the [OpenTracing](https://opentracing.io) project, which focused exclusively on tracing, and the [OpenCensus](https://opencensus.io) project, which focused on tracing and metrics.
+
+Intially, OpenTelemetry will not support logging
+"""
 
 [params.logos]
 hero = "opentelemetry-horizontal-color.png"

--- a/config.toml
+++ b/config.toml
@@ -12,12 +12,14 @@ The term [**observability**](https://en.wikipedia.org/wiki/Observability) stems 
 In software, observability typically refers to telemetry produced by **services** and is divided into three major verticals:
 
 * [**Tracing**](https://opentracing.io/docs/overview/what-is-tracing), aka **distrbuted tracing**, provides insight into the full lifecycles, aka *traces*, of requests to the system, allowing you to pinpoint failures and performance issues.  
-* [**Metrics**](https://opencensus.io/stats) provide quantitative information about processes running inside the system, including counters, gauges, and histograms. This domain also encompasses querying that data and configuring automated responses to quantitatively specified abormal states.
+* [**Metrics**](https://opencensus.io/stats) provide quantitative information about processes running inside the system, including counters, gauges, and histograms.
 * [**Logging**](https://en.wikipedia.org/wiki/Log_file) provides insight into application-specific messages emitted by processes.
+
+These verticals are tightly interconnected. **Metrics** can be used to pinpoint, for example, a subset of misbehaving **traces**. **Logs** associated with those traces could help to find the root cause of this behavior. And then new **metrics** can be configured, based on this discovery, to catch this issue earler next time.
 
 OpenTelemetry is an effort to combine all three verticals into a single set of system components and language-specific telemetry libraries. It is meant to replace both the [OpenTracing](https://opentracing.io) project, which focused exclusively on tracing, and the [OpenCensus](https://opencensus.io) project, which focused on tracing and metrics.
 
-Intially, OpenTelemetry will not support logging. This vertical will be incorporated over time.
+OpenTelemetry will not initially support logging, though we aim to incorporate this over time.
 """
 
 [params.logos]

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -2,6 +2,7 @@
 {{ partial "home/hero.html" . }}
 {{ partial "home/project.html" . }}
 {{ partial "home/faq.html" . }}
+{{ partial "home/observability.html" . }}
 {{ partial "home/timeline.html" . }}
 {{ partial "home/learn-more.html" . }}
 {{ partial "home/cncf.html" . }}

--- a/layouts/partials/home/observability.html
+++ b/layouts/partials/home/observability.html
@@ -1,0 +1,20 @@
+{{ $observability := site.Params.observability | markdownify }}
+<section class="section observability-section">
+  <div class="container">
+    <div class="columns is-variable is-8">
+      <div class="column is-3">
+        <p class="title is-size-3 is-size-4-mobile has-text-weight-bold">
+          Observability
+        </p>
+
+        <hr class="highlight is-secondary" />
+      </div>
+
+      <div class="column">
+        <div class="content is-medium">
+          {{ $observability }}
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/layouts/partials/home/timeline.html
+++ b/layouts/partials/home/timeline.html
@@ -10,7 +10,7 @@
         <hr class="highlight is-secondary" />
       </div>
 
-      <div class="column content">
+      <div class="column content is-medium">
         <table class="table is-fullwidth">
           <thead>
             <tr>
@@ -38,9 +38,9 @@
 
         <br />
 
-        <p>
+        <sup>
           <sup><strong>*</strong></sup> Dates are subject to change based on community participation and other factors
-        </p>
+        </sup>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Not sure if this is desired or the right way to go about it, but I think it might be nice to give a breakdown of the different domains of observability. If this content is better left for a later date or a separate doc, I'm cool with that.