### PR TITLE
Url for CNCF main blog was incorrect.

### DIFF
--- a/data/learn.yaml
+++ b/data/learn.yaml
@@ -17,7 +17,7 @@
   url: https://www.cncf.io/blog/2019/05/21/a-brief-history-of-opentelemetry-so-far/
   source:
     title: The CNCF blog
-    url: https://blog.cncf.io
+    url: https://www.cncf.io/category/blog/
 - title: Jaeger and OpenTelemetry
   url: https://medium.com/jaegertracing/jaeger-and-opentelemetry-1846f701d9f2
   source:


### PR DESCRIPTION
Originally the URL was:
https://blog.cncf.io/

Changing to:
https://www.cncf.io/category/blog/

The original URL does not resolve/exist.  Looks like a straightforward mistype.