### PR TITLE
Correcting CNCF blog url.

### DIFF
--- a/data/learn.yaml
+++ b/data/learn.yaml
@@ -17,7 +17,7 @@
   url: https://www.cncf.io/blog/2019/05/21/a-brief-history-of-opentelemetry-so-far/
   source:
     title: The CNCF blog
-    url: https://blog.cncf.io
+    url: https://www.cncf.io/newsroom/blog/
 - title: Jaeger and OpenTelemetry
   url: https://medium.com/jaegertracing/jaeger-and-opentelemetry-1846f701d9f2
   source:


### PR DESCRIPTION
Noticed that the CNCF blog link was a dead link.  Found the correct link.

Does not exist: https://blog.cncf.io
Corrected URL: https://www.cncf.io/newsroom/blog/