### PR TITLE
Add spec link to front page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,9 @@ title = "OpenTelemetry"
 baseURL = "https://opentelemetry.io"
 disableKinds = ["taxonomy", "taxonomyTerm"]
 
+[blackfriday]
+hrefTargetBlank = true
+
 [params]
 tagline = "Effective observability requires high-quality telemetry"
 sub_tagline = "**OpenTelemetry** makes robust, portable telemetry a built-in feature of cloud-native software."

--- a/data/faq.yaml
+++ b/data/faq.yaml
@@ -1,6 +1,8 @@
 - q: What is OpenTelemetry?
   a: |
     OpenTelemetry is made up of an integrated set of APIs and libraries as well as a collection mechanism via an agent and collector. These components are used to generate, collect, and describe telemetry about distributed systems. This data includes basic context propagation, distributed traces, metrics, and other signals in the future. OpenTelemetry is designed to make it easy to get critical telemetry data out of your services and into your backend(s) of choice. For each supported language it offers a single set of APIs, libraries, and data specifications, and developers can take advantage of whichever components they see fit.
+- q: Where can I read the OpenTelemetry specification?
+  a: The spec is available in the [open-telemetry/specification](https://github.com/open-telemetry/specification) repo on GitHub.
 - q: I want to start instrumenting production code today. What should I use?
   a: |
     We are still working on the first production-ready release of OpenTelemetry. For those who want to start instrumenting production code immediately, use either [OpenCensus](https://opencensus.io) or [OpenTracing](https://opentracing.io). OpenTelemetry will provide compatibility bridges and there is no need to wait for production-ready OpenTelemetry APIs in your language.


### PR DESCRIPTION
This PR provides a link to the OT spec in the FAQ on the landing page.