### PR TITLE
add a release notes tracker

### DIFF
--- a/content/project-status.md
+++ b/content/project-status.md
@@ -7,6 +7,9 @@ OpenTelemetry implementations are currently in **pre-release** status. This page
 # Current SIG Progress
 {{< progress_chart >}}
 
+# Current SIG Release
+{{< release_notes >}}
+
 # Status Definitions
 
 When we refer to an alpha, beta, or release, what do we mean? This section defines these terms.

--- a/data/progress_source.yaml
+++ b/data/progress_source.yaml
@@ -17,45 +17,69 @@ data:
     openIssues: 0
     closedIssues: 0
     totalIssues: 0
+    releaseName: "n/a"
+    releaseDescription: "n/a"
+    releaseUrl: ""
   - label: Go
     sourceUrl: https://github.com/open-telemetry/opentelemetry-go
     msLabel: v0.1
     openIssues: 0
     closedIssues: 0
     totalIssues: 0
+    releaseName: "n/a"
+    releaseDescription: "n/a"
+    releaseUrl: ""
   - label: JavaScript
     sourceUrl: https://github.com/open-telemetry/opentelemetry-js
     msLabel: v0.1
     openIssues: 0
     closedIssues: 0
     totalIssues: 0
+    releaseName: "n/a"
+    releaseDescription: "n/a"
+    releaseUrl: ""
   - label: Java
     sourceUrl: https://github.com/open-telemetry/opentelemetry-java
     msLabel: v0.1
     openIssues: 0
     closedIssues: 0
     totalIssues: 0
+    releaseName: "n/a"
+    releaseDescription: "n/a"
+    releaseUrl: ""
   - label: Python
     sourceUrl: https://github.com/open-telemetry/opentelemetry-python
     msLabel: v0.1
     openIssues: 0
     closedIssues: 0
     totalIssues: 0
+    releaseName: "n/a"
+    releaseDescription: "n/a"
+    releaseUrl: ""
   - label: PHP
     sourceUrl: https://github.com/open-telemetry/opentelemetry-php
     msLabel: v0.1
     openIssues: 0
     closedIssues: 0
     totalIssues: 0
+    releaseName: "n/a"
+    releaseDescription: "n/a"
+    releaseUrl: ""
   - label: Ruby
     sourceUrl: https://github.com/open-telemetry/opentelemetry-ruby
     msLabel: v0.1
     openIssues: 0
     closedIssues: 0
     totalIssues: 0
+    releaseName: "n/a"
+    releaseDescription: "n/a"
+    releaseUrl: ""
   - label: Collector
     sourceUrl: https://github.com/open-telemetry/opentelemetry-service
     msLabel: v0.1
     openIssues: 0
     closedIssues: 0
     totalIssues: 0
+    releaseName: "n/a"
+    releaseDescription: "n/a"
+    releaseUrl: ""

--- a/layouts/shortcodes/release_notes.html
+++ b/layouts/shortcodes/release_notes.html
@@ -1,0 +1,19 @@
+{{ $data := "" }}
+{{ if site.Data.progress_generated }}
+  {{ $data = site.Data.progress_generated }}
+{{ else }}
+  {{ $data = site.Data.progress_source }}
+{{ end }}
+{{ $progressData := $data.data }}
+
+<section class="releaseNotes">
+  {{- range $progressData }}
+    <h1 class="title is-3">{{ .label }}</h1>
+    {{ if ne .releaseName "n/a" }}
+      <h2 class="subtitle is-5"><a href="{{ .releaseUrl }}">{{ .releaseName }}</a></h2>
+      <pre>{{ .releaseDescription }}</pre>
+    {{ else }}
+      <p>No release information available from GitHub.</p>
+    {{ end }}
+  {{ end }}
+</section>


### PR DESCRIPTION
Fixes #58 

This pulls in the latest release (pre release or normal release) from GitHub for each repo and adds a description + link to the release to the project status page.