### PR TITLE
fix the ref for the GitHub badge while on the root page

### DIFF
--- a/layouts/partials/ghbadge.html
+++ b/layouts/partials/ghbadge.html
@@ -1,6 +1,7 @@
-{{ $urlTrimmed := strings.TrimRight "/" .RelPermalink }}
+{{ $filename := strings.TrimRight "/" .RelPermalink }}
+{{ $url := (cond (eq (len $filename) 0) "https://github.com/open-telemetry/" (printf "https://github.com/open-telemetry/opentelemetry.io/tree/master/content%s.md" $filename)) }}
 <a
-  href="https://github.com/open-telemetry/opentelemetry.io/tree/master/content{{ $urlTrimmed }}.md"
+  href="{{ $url }}"
   class="github-corner"
   aria-label="View source on GitHub"
   target="blank"


### PR DESCRIPTION
The Hugo script for the GitHub badge was returning an empty page
when on the root of the site, which then got concatenated into
a URL that didn't exist on GitHub. This commit checks to see if
that page portion is empty, and if so sets the URL for the badge
to the OpenTelemetry organization page