### PR TITLE
Update otel-js.md

### DIFF
--- a/content/registry/otel-js.md
+++ b/content/registry/otel-js.md
@@ -4,7 +4,7 @@ registryType: api
 isThirdParty: false
 tags:
   - javascript
-  - node
+  - node.js
   - browser
 repo: https://github.com/open-telemetry/opentelemetry-js
 license: Apache 2.0


### PR DESCRIPTION
adding .js so API and SDKs are returned when "js" search term is used.  Currently everything (exporters and collector) is listed except the SDK & API.