### PR TITLE
Add Elastic APM exporter to registry

### DIFF
--- a/content/registry/collector-exporter-elastic.md
+++ b/content/registry/collector-exporter-elastic.md
@@ -1,0 +1,14 @@
+---
+title: Elastic APM Exporter
+registryType: exporter
+isThirdParty: true
+tags:
+  - go
+  - exporter
+  - collector
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/elasticexporter
+license: Apache 2.0
+description: The OpenTelemetry Collector Exporter for Elastic APM.
+authors: Elastic
+otVersion: latest
+---


### PR DESCRIPTION
The Elastic APM exporter for OpenTelemetry Collector was just merged (https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/240). I'd like to add it to the registry to hope folks find it.