### PR TITLE
add Gorilla Mux plugin for Golang

### DIFF
--- a/content/registry/plugin-go-gorilla-mux.md
+++ b/content/registry/plugin-go-gorilla-mux.md
@@ -1,0 +1,13 @@
+---
+title: Gorilla Mux plugin for Golang
+registryType: plugin
+isThirdParty: false
+tags:
+  - go
+  - plugin
+repo: https://github.com/open-telemetry/opentelemetry-go-contrib/tree/master/plugins/gorilla/mux
+license: Apache 2.0
+description: Golang contrib plugin for the gorilla/mux package.
+authors: OpenTelemetry Authors
+otVersion: latest
+---


### PR DESCRIPTION
Gorilla Mux support is now part of the opentelemetry-go-contrib repo: https://github.com/open-telemetry/opentelemetry-go-contrib/pull/19