### PR TITLE
add Gin plugin for Golang

### DIFF
--- a/content/registry/plugin-go-gin.md
+++ b/content/registry/plugin-go-gin.md
@@ -1,0 +1,13 @@
+---
+title: Gin Web Framework plugin for Golang
+registryType: plugin
+isThirdParty: false
+tags:
+  - go
+  - plugin
+repo: https://github.com/open-telemetry/opentelemetry-go-contrib/tree/master/instrumentation/gin-gonic/gin
+license: Apache 2.0
+description: Golang contrib plugin for the gin-gonic/gin package.
+authors: OpenTelemetry Authors
+otVersion: latest
+---


### PR DESCRIPTION
Gin support is now part of the opentelemetry-go-contrib repo: https://github.com/open-telemetry/opentelemetry-go-contrib/pull/15