### PR TITLE
Add documentation about using environment variables in config files

### DIFF
--- a/content/docs/collector/configuration.md
+++ b/content/docs/collector/configuration.md
@@ -184,3 +184,15 @@ extensions:
   pprof: {}
   zpages: {}
 ```
+
+## Using Environment Variables
+
+The use of environment variables is supported in the collector configuration. The support for environment variables makes it more explicit of what is coming just by looking at the configuration file, instead of relying on the internal automatic services. This support also makes configurations more dyamic in the environment.
+
+```yaml
+processors:
+  attributes/example:
+    actions:
+      - key: "$DB_KEY"
+        action: "$OPERATION"
+```


### PR DESCRIPTION
As a response to an [issue](https://github.com/open-telemetry/opentelemetry-collector/issues/557#issue-567228160) in the opentelemetry/collector repository, I am adding this piece of documentation into the collector/configuration section. This documentation will expose to the users about the capability of the configuration file handling environment variables.