### PR TITLE
Add Google Cloud Trace and Google Cloud Monitoring exporter for Go

### DIFF
--- a/content/registry/exporter-go-google-cloud-monitoring.md
+++ b/content/registry/exporter-go-google-cloud-monitoring.md
@@ -1,0 +1,13 @@
+---
+title: Google Cloud Monitoring Exporter
+registryType: exporter
+isThirdParty: true
+tags:
+  - go
+  - exporter
+repo: https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/tree/master/exporter/metric
+license: Apache 2.0
+description: The OpenTelemetry Google Cloud Monitoring Exporter for Go.
+authors: Google Authors
+otVersion: latest
+---

--- a/content/registry/exporter-go-google-cloud-monitoring.md
+++ b/content/registry/exporter-go-google-cloud-monitoring.md
@@ -2,6 +2,7 @@
 title: Google Cloud Monitoring Exporter
 registryType: exporter
 isThirdParty: true
+language: go
 tags:
   - go
   - exporter

--- a/content/registry/exporter-go-google-cloud-trace.md
+++ b/content/registry/exporter-go-google-cloud-trace.md
@@ -2,6 +2,7 @@
 title: Google Cloud Trace Exporter
 registryType: exporter
 isThirdParty: true
+language: go
 tags:
   - go
   - exporter

--- a/content/registry/exporter-go-google-cloud-trace.md
+++ b/content/registry/exporter-go-google-cloud-trace.md
@@ -1,0 +1,13 @@
+---
+title: Google Cloud Trace Exporter
+registryType: exporter
+isThirdParty: true
+tags:
+  - go
+  - exporter
+repo: https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/tree/master/exporter/trace
+license: Apache 2.0
+description: The OpenTelemetry Google Cloud Trace Exporter for Go.
+authors: Google Authors
+otVersion: latest
+---


### PR DESCRIPTION
Add 2 exporters to OTel registry
* Google Cloud Trace exporter for Go
* Google Cloud Monitoring exporter for Go