### PR TITLE
Standardizing name/formatting for go instrumentation plugins

### DIFF
--- a/content/registry/instrumentation-go-gin.md
+++ b/content/registry/instrumentation-go-gin.md
@@ -1,5 +1,5 @@
 ---
-title: Gin Web Framework plugin for Golang
+title: Gin-gonic Instrumentation
 registryType: instrumentation
 isThirdParty: false
 language: go
@@ -9,7 +9,7 @@ tags:
   - http
 repo: https://github.com/open-telemetry/opentelemetry-go-contrib/tree/master/instrumentation/github.com/gin-gonic/gin
 license: Apache 2.0
-description: Golang contrib plugin for the gin-gonic/gin package.
+description: Go contrib plugin for the gin-gonic/gin package.
 authors: OpenTelemetry Authors
 otVersion: latest
 ---

--- a/content/registry/instrumentation-go-gorilla-mux.md
+++ b/content/registry/instrumentation-go-gorilla-mux.md
@@ -1,5 +1,5 @@
 ---
-title: Gorilla Mux plugin for Golang
+title: Gorilla Mux instrumentation
 registryType: instrumentation
 isThirdParty: false
 language: go
@@ -9,7 +9,7 @@ tags:
   - http
 repo: https://github.com/open-telemetry/opentelemetry-go-contrib/tree/master/instrumentation/github.com/gorilla/mux
 license: Apache 2.0
-description: Golang contrib plugin for the gorilla/mux package.
+description: Go contrib plugin for the gorilla/mux package.
 authors: OpenTelemetry Authors
 otVersion: latest
 ---

--- a/content/registry/instrumentation-go-labstack.md
+++ b/content/registry/instrumentation-go-labstack.md
@@ -1,5 +1,5 @@
 ---
-title: Labstack Echo HTTP framework plugin for Go
+title: Labstack Echo instrumentation
 registryType: instrumentation
 isThirdParty: false
 language: go

--- a/content/registry/instrumentation-go-macaron.md
+++ b/content/registry/instrumentation-go-macaron.md
@@ -1,5 +1,5 @@
 ---
-title: Macaron HTTP framework plugin for Go
+title: Macaron Instrumentation
 registryType: instrumentation
 isThirdParty: false
 language: go

--- a/content/registry/instrumentation-go-mongodb.md
+++ b/content/registry/instrumentation-go-mongodb.md
@@ -1,5 +1,5 @@
 ---
-title: MongoDB database plugin for Go
+title: MongoDB database instrumentation
 registryType: instrumentation
 isThirdParty: false
 language: go


### PR DESCRIPTION
Refer to Go as Go, not Golang. 
Keep title shorter so it fits better in the opentelemetry.io registry display