### PR TITLE
Fixing spelling error

### DIFF
--- a/content/docs/collector/configuration.md
+++ b/content/docs/collector/configuration.md
@@ -187,7 +187,7 @@ extensions:
 
 ## Using Environment Variables
 
-The use of environment variables is supported in the collector configuration. The support for environment variables makes it more explicit of what is coming just by looking at the configuration file, instead of relying on the internal automatic services. This support also makes configurations more dyamic in the environment.
+The use of environment variables is supported in the collector configuration. The support for environment variables makes it more explicit of what is coming just by looking at the configuration file, instead of relying on the internal automatic services. This support also makes configurations more dynamic in the environment.
 
 ```yaml
 processors:


### PR DESCRIPTION
Fixing spelling error found on the Collector configuration page: https://opentelemetry.io/docs/collector/configuration/