### PR TITLE
Fixed specification milestones link

### DIFF
--- a/content/project-status.md
+++ b/content/project-status.md
@@ -2,7 +2,7 @@
 Title: "Project Status"
 ---
 
-OpenTelemetry implementations are currently in **beta** status. This page tracks the overall release milestones as we move towards full releases for each language SIG. You can find more details about the milestones at [this link](https://github.com/open-telemetry/opentelemetry-specification/blob/master/milestones.md).
+OpenTelemetry implementations are currently in **beta** status. This page tracks the overall release milestones as we move towards full releases for each language SIG. You can find more details about the milestones at [this link](https://github.com/open-telemetry/opentelemetry-specification/milestones).
 
 ## Summary
 Our current goal is to provide a generally available, production quality release by the second half of 2020. Currently, we are in the _alpha_ stage. What follows is a brief explanation of what we expect to be available, when.


### PR DESCRIPTION
Fixed broken specification milestones link on the https://opentelemetry.io/project-status/