### PR TITLE
Update Elastic exporter and get-involved.md

### DIFF
--- a/content/get-involved.md
+++ b/content/get-involved.md
@@ -54,6 +54,7 @@ To add your project, please make a pull request to the [opentelemetry.io reposit
 title: My OpenTelemetry Integration // the name of your project
 registryType: <exporter/api/collector/plugin> // the type of integration; is this an exporter, plugin, API package, or something else?
 isThirdParty: <false/true> // this is only true if the project is maintained by the OpenTelemetry project
+language: <collector/cpp/dotnet/erlang/go/java/js/php/python/etc> // language of your integration
 tags:
   - <language>
   - <other useful search terms>

--- a/content/registry/collector-exporter-elastic.md
+++ b/content/registry/collector-exporter-elastic.md
@@ -1,5 +1,5 @@
 ---
-title: Elastic APM Exporter
+title: Elastic Exporter
 registryType: exporter
 isThirdParty: true
 tags:
@@ -8,7 +8,7 @@ tags:
   - collector
 repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/elasticexporter
 license: Apache 2.0
-description: The OpenTelemetry Collector Exporter for Elastic APM.
+description: The OpenTelemetry Collector Exporter for the Elastic Stack. [Learn more](https://www.elastic.co/guide/en/apm/get-started/current/open-telemetry-elastic.html).
 authors: Elastic
 otVersion: latest
 ---

--- a/content/registry/collector-exporter-elastic.md
+++ b/content/registry/collector-exporter-elastic.md
@@ -2,6 +2,7 @@
 title: Elastic Exporter
 registryType: exporter
 isThirdParty: true
+language: collector
 tags:
   - go
   - exporter


### PR DESCRIPTION
## Summary

* https://github.com/open-telemetry/opentelemetry.io/pull/183 added a new `language` attribute to the registry cards. This PR updates the documentation in `get-involved.md` to include this new attribute.
* Elastic exporter: Renames the exporter, links to documentation, and adds a `language`. Similar changes have been proposed in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/483.