### PR TITLE
chore: add gocql to opentelemetry registry

### DIFF
--- a/content/registry/instrumentation-go-gocql.md
+++ b/content/registry/instrumentation-go-gocql.md
@@ -1,0 +1,17 @@
+---
+title: Cassandra Database Instrumentation
+registryType: instrumentation
+isThirdParty: false
+language: go
+tags:
+  - go
+  - instrumentation
+  - cassandra
+  - gocql
+  - database
+repo: https://github.com/open-telemetry/opentelemetry-go-contrib/tree/master/instrumentation/github.com/gocql/gocql
+license: Apache 2.0
+description: Go contrib plugin for the github.com/gocql/gocql package.
+authors: OpenTelemetry Authors
+otVersion: latest
+---


### PR DESCRIPTION
Addresses: [#91](https://github.com/open-telemetry/opentelemetry-go-contrib/issues/91)

This PR adds the [gocql integration](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/master/instrumentation/github.com/gocql/gocql) to the opentelemetry registry.