### PR TITLE
Add Golang instrumentation for Kafka

### DIFF
--- a/content/registry/instrumentation-go-sarama.md
+++ b/content/registry/instrumentation-go-sarama.md
@@ -1,0 +1,16 @@
+---
+title: OpenTelemetry Kafka Instrumentation
+registryType: instrumentation
+isThirdParty: false
+language: go
+tags:
+  - go
+  - instrumentation
+  - kafka
+  - sarama
+repo: https://github.com/open-telemetry/opentelemetry-go-contrib/tree/master/instrumentation/github.com/Shopify/sarama
+license: Apache 2.0
+description: Go contrib plugin for the github.com/Shopify/sarama package.
+authors: OpenTelemetry Authors
+otVersion: latest
+---


### PR DESCRIPTION
Split from https://github.com/open-telemetry/opentelemetry-go-contrib/issues/87.


Add the Golang [instrumentation](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/master/instrumentation/github.com/Shopify/sarama) for Kafka to the opentelemetry registry.