### PR TITLE
Adding new and relocated instrumentation plugins for Go contrib repo

### DIFF
--- a/content/registry/instrumentation-go-gomemcache.md
+++ b/content/registry/instrumentation-go-gomemcache.md
@@ -1,0 +1,15 @@
+---
+title: Memcache instrumentation
+registryType: instrumentation
+isThirdParty: false
+language: go
+tags:
+  - go
+  - instrumentation
+  - memcache
+repo: https://github.com/open-telemetry/opentelemetry-go-contrib/tree/master/instrumentation/github.com/bradfitz/gomemcache
+license: Apache 2.0
+description: Go contrib plugin for the bradfitz/gomemcache package.
+authors: OpenTelemetry Authors
+otVersion: latest
+---

--- a/content/registry/instrumentation-go-grpc.md
+++ b/content/registry/instrumentation-go-grpc.md
@@ -1,0 +1,15 @@
+---
+title: gRPC instrumentation
+registryType: instrumentation
+isThirdParty: false
+language: go
+tags:
+  - go
+  - instrumentation
+  - grpc
+repo: https://github.com/open-telemetry/opentelemetry-go-contrib/tree/master/instrumentation/google.golang.org/grpc
+license: Apache 2.0
+description: Go contrib plugin for Google's grpc package.
+authors: OpenTelemetry Authors
+otVersion: latest
+---

--- a/content/registry/instrumentation-go-net-http.md
+++ b/content/registry/instrumentation-go-net-http.md
@@ -1,0 +1,16 @@
+---
+title: Go package net/http instrumentation
+registryType: instrumentation
+isThirdParty: false
+language: go
+tags:
+  - go
+  - instrumentation
+  - http
+  - trace
+repo: https://github.com/open-telemetry/opentelemetry-go-contrib/tree/master/instrumentation/net/http
+license: Apache 2.0
+description: Go contrib plugin for trace instrumentation of net/http handlers, http transports and http trace events
+authors: OpenTelemetry Authors
+otVersion: latest
+---

--- a/content/registry/instrumentation-go-runtime.md
+++ b/content/registry/instrumentation-go-runtime.md
@@ -1,0 +1,16 @@
+---
+title: Go runtime metrics instrumentation
+registryType: instrumentation
+isThirdParty: false
+language: go
+tags:
+  - go
+  - instrumentation
+  - runtime
+  - metrics
+repo: https://github.com/open-telemetry/opentelemetry-go-contrib/tree/master/instrumentation/runtime
+license: Apache 2.0
+description: Go contrib plugin for collecting metrics from Go runtime package
+authors: OpenTelemetry Authors
+otVersion: latest
+---


### PR DESCRIPTION
The memcache instrumentation is new.

The others were relocated from the opentelemetry-go repo to the opentelemetry-go-contrib repo.