### PR TITLE
fix: add beego instrumentation to registry

### DIFF
--- a/content/registry/instrumentation-go-beego.md
+++ b/content/registry/instrumentation-go-beego.md
@@ -1,0 +1,16 @@
+---
+title: Beego Instrumentation
+registryType: instrumentation
+isThirdParty: false
+language: go
+tags:
+  - go
+  - instrumentation
+  - http
+  - trace
+repo: https://github.com/open-telemetry/opentelemetry-go-contrib/tree/master/instrumentation/github.com/astaxie/beego
+license: Apache 2.0
+description: Go contrib plugin for the github.com/astaxie/beego package.
+authors: OpenTelemetry Authors
+otVersion: latest
+---


### PR DESCRIPTION
This PR adds the `github.com/astaxie/beego` instrumentation to the opentelemetry.io registry