### PR TITLE
docs: Remove link from Elastic exporter

### DIFF
--- a/content/registry/collector-exporter-elastic.md
+++ b/content/registry/collector-exporter-elastic.md
@@ -9,7 +9,7 @@ tags:
   - collector
 repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter/elasticexporter
 license: Apache 2.0
-description: The OpenTelemetry Collector Exporter for the Elastic Stack. [Learn more](https://www.elastic.co/guide/en/apm/get-started/current/open-telemetry-elastic.html).
+description: The OpenTelemetry Collector Exporter for the Elastic Stack.
 authors: Elastic
 otVersion: latest
 ---


### PR DESCRIPTION
I made some changes to the Elastic exporter registry card in https://github.com/open-telemetry/opentelemetry.io/pull/224. I had assumed that markdown links would render in the [body content](https://opentelemetry.io/registry/collector-exporter-elastic/), but it turns out that they do not. This PR removes the link. Sorry for the mistake!

<img width="1434" alt="Screen Shot 2020-08-20 at 1 47 36 PM" src="https://user-images.githubusercontent.com/5618806/90824099-b92ac000-e2eb-11ea-8c12-af0bd370b5e7.png">

