### PR TITLE
Add .NET to the beta list

### DIFF
--- a/layouts/partials/home/beta.html
+++ b/layouts/partials/home/beta.html
@@ -6,6 +6,7 @@
       <h1 class="title has-text-centered has-text-white">OpenTelemetry Beta Now Available!</h1>
       <p class="has-text-centered">
         The OpenTelemetry API and SDK for the following languages are now in beta:
+        <a href="https://github.com/open-telemetry/opentelemetry-dotnet">.NET</a>,
         <a href="https://github.com/open-telemetry/opentelemetry-java">Java</a>,
         <a href="https://github.com/open-telemetry/opentelemetry-js">JavaScript</a>,
         <a href="https://github.com/open-telemetry/opentelemetry-python">Python</a>,


### PR DESCRIPTION
It seems we've missed this during OTel .NET beta, trying to fix it now.