### PR TITLE
Add Datadog Ruby Exporter to registry

### DIFF
--- a/content/registry/exporter-ruby-datadog.md
+++ b/content/registry/exporter-ruby-datadog.md
@@ -1,0 +1,15 @@
+---
+title: Datadog Exporter Ruby
+registryType: exporter
+isThirdParty: true
+language: ruby
+tags:
+  - ruby
+  - exporter
+  - datadog
+repo: https://github.com/DataDog/dd-opentelemetry-exporter-ruby
+license: Apache 2.0
+description: The OpenTelemetry Datadog Exporter for Ruby.
+authors: Eric Mustin (eric.mustin@datadoghq.com)
+otVersion: latest
+---

--- a/content/registry/exporter-ruby-datadog.md
+++ b/content/registry/exporter-ruby-datadog.md
@@ -10,6 +10,6 @@ tags:
 repo: https://github.com/DataDog/dd-opentelemetry-exporter-ruby
 license: Apache 2.0
 description: The OpenTelemetry Datadog Exporter for Ruby.
-authors: Eric Mustin (eric.mustin@datadoghq.com)
+authors: Datadog, Inc.
 otVersion: latest
 ---


### PR DESCRIPTION
### Summary

Adds [dd-opentelemetry-exporter-ruby](https://github.com/DataDog/dd-opentelemetry-exporter-ruby) to the registry.

closes: https://github.com/DataDog/dd-opentelemetry-exporter-ruby/issues/7