### PR TITLE
Add Datadog JS Exporter to registry

### DIFF
--- a/content/registry/exporter-js-datadog.md
+++ b/content/registry/exporter-js-datadog.md
@@ -2,7 +2,7 @@
 title: Datadog Exporter JS
 registryType: exporter
 isThirdParty: true
-language: ruby
+language: js
 tags:
   - Node.js
   - exporter

--- a/content/registry/exporter-js-datadog.md
+++ b/content/registry/exporter-js-datadog.md
@@ -1,0 +1,15 @@
+---
+title: Datadog Exporter JS
+registryType: exporter
+isThirdParty: true
+language: ruby
+tags:
+  - Node.js
+  - exporter
+  - datadog
+repo: https://github.com/DataDog/dd-opentelemetry-exporter-js
+license: Apache 2.0
+description: The OpenTelemetry Datadog Exporter for Node.js.
+authors: Datadog, Inc.
+otVersion: latest
+---


### PR DESCRIPTION
### Summary

Adds [dd-opentelemetry-exporter-js](https://github.com/DataDog/dd-opentelemetry-exporter-js) to the registry.

followup from the conversation and work here: https://github.com/open-telemetry/opentelemetry-js/pull/1316