### PR TITLE
Added OpenTelemetry Collector builder to the registry

### DIFF
--- a/content/registry/collector-builder.md
+++ b/content/registry/collector-builder.md
@@ -1,0 +1,13 @@
+---
+title: OpenTelemetry Collector Builder
+registryType: core
+isThirdParty: true
+language: collector
+tags:
+  - collector
+repo: https://github.com/observatorium/opentelemetry-collector-builder
+license: Apache 2.0
+description: A CLI tool that generates OpenTelemetry Collector binaries based on a manifest.
+authors: Red Hat
+otVersion: latest
+---

--- a/content/registry/instrumentation-python-opentracing-shim.md
+++ b/content/registry/instrumentation-python-opentracing-shim.md
@@ -1,6 +1,6 @@
 ---
 title: OpenTracing Shim Instrumentation
-registryType: Instrumentation
+registryType: instrumentation
 isThirdParty: true
 language: python
 tags:


### PR DESCRIPTION
This PR adds the OpenTelemetry Collector builder to the registry. 
It also fixes a minor issue, where the "instrumentation" option in the filter was duplicate due to a capitalization inconsistency.

﻿Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
