### PR TITLE
Add .NET Honeycomb exporter

### DIFF
--- a/content/registry/exporter-dotnet-honeycomb.md
+++ b/content/registry/exporter-dotnet-honeycomb.md
@@ -1,0 +1,16 @@
+---
+title: Honeycomb.io .NET Exporter
+registryType: exporter
+isThirdParty: true
+language: dotnet
+tags:
+  - dotnet
+  - c#
+  - .net
+  - exporter
+repo: https://github.com/martinjt/Honeycomb.OpenTelemetry
+license: Apache 2.0
+description: The OpenTelemetry Honeycomb Exporter for .NET.
+authors: Martin Thwaites
+otVersion: 0.2.0
+---


### PR DESCRIPTION
Adds a .NET Honeycomb exporter created by community member @martinjt.

The exporter currently uses an older version of the .NET OTel SDK but is planned to be updated.