### PR TITLE
Add nodejs Honeycomb exporter

### DIFF
--- a/content/registry/exporter-js-honeycomb.md
+++ b/content/registry/exporter-js-honeycomb.md
@@ -2,7 +2,7 @@
 title: Honeycomb.io JavaScript Exporter
 registryType: exporter
 isThirdParty: true
-language: dotnet
+language: js
 tags:
   - Node.js
   - exporter

--- a/content/registry/exporter-js-honeycomb.md
+++ b/content/registry/exporter-js-honeycomb.md
@@ -1,0 +1,14 @@
+---
+title: Honeycomb.io JavaScript Exporter
+registryType: exporter
+isThirdParty: true
+language: dotnet
+tags:
+  - Node.js
+  - exporter
+repo: https://github.com/honeycombio/opentelemetry-exporter-js
+license: Apache 2.0
+description: The OpenTelemetry Honeycomb Exporter for .NET.
+authors: Hound Technology Inc
+otVersion: 0.6.0
+---

--- a/content/registry/exporter-js-honeycomb.md
+++ b/content/registry/exporter-js-honeycomb.md
@@ -8,7 +8,7 @@ tags:
   - exporter
 repo: https://github.com/honeycombio/opentelemetry-exporter-js
 license: Apache 2.0
-description: The OpenTelemetry Honeycomb Exporter for .NET.
+description: The OpenTelemetry Honeycomb Exporter for Node.js.
 authors: Hound Technology Inc
 otVersion: 0.6.0
 ---


### PR DESCRIPTION
Adds a NodeJS Honeycomb exporter.

The exporter currently uses an older version of the OTel SDK but is planned to be updated.