### PR TITLE
Update link to Jaeger

### DIFF
--- a/content/en/docs/collector/about.md
+++ b/content/en/docs/collector/about.md
@@ -95,7 +95,7 @@ configuration, automatic sidecar injection into deployments, among others.
 ### Local
 
 Builds the latest version of the collector based on the local operating system,
-runs the binary with all receivers enabled and exports all the data it receivers
+runs the binary with all receivers enabled and exports all the data it receives
 locally to a file. Data is sent to the container and the container scrapes its own
 Prometheus metrics.
 
@@ -113,7 +113,7 @@ The OpenTelemetry collector can be extended or embedded into other applications.
 The list of applications extending the collector:
 
 * [opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib)
-* [jaeger-opentelemetry-collector](https://github.com/jaegertracing/jaeger-opentelemetry-collector)
+* [jaeger](https://github.com/jaegertracing/jaeger/tree/master/cmd/opentelemetry)
 
 A guide on how to create your own distribution is available in this blog post: 
 ["Building your own OpenTelemetry Collector distribution"](https://medium.com/p/42337e994b63)


### PR DESCRIPTION
jaeger-opentelemetry-collector has been archived, and the link to jaeger within the archived repo is broken anyway.