### PR TITLE
Update honeycomb .NET exporter

### DIFF
--- a/content/en/registry/exporter-dotnet-honeycomb.md
+++ b/content/en/registry/exporter-dotnet-honeycomb.md
@@ -8,9 +8,9 @@ tags:
   - c#
   - .net
   - exporter
-repo: https://github.com/martinjt/Honeycomb.OpenTelemetry
+repo: https://github.com/honeycombio/opentelemetry-dotnet
 license: Apache 2.0
 description: The OpenTelemetry Honeycomb Exporter for .NET.
-authors: Martin Thwaites
-otVersion: 0.2.0
+authors: Hound Technology Inc
+otVersion: latest
 ---


### PR DESCRIPTION
Honeycomb has now adopted the community project. This changes updates the github repo, authors and OpenTelemtry version.