### PR TITLE
Fix example paths

### DIFF
--- a/content/en/docs/collector/about.md
+++ b/content/en/docs/collector/about.md
@@ -102,8 +102,8 @@ Prometheus metrics.
 ```bash
 $ git clone git@github.com:open-telemetry/opentelemetry-collector.git; \
     cd opentelemetry-collector; make otelcol; \
-    go build examples/main.go; ./main & pid1="$!"; \
-    ./bin/$($GOOS)/otelcol --config ./examples/otel-local-config.yaml; kill $pid1
+    go build examples/demo/app/main.go; ./main & pid1="$!"; \
+    ./bin/$($GOOS)/otelcol --config ./examples/local/otel-config.yaml; kill $pid1
 ```
 
 ## Other

--- a/content/en/docs/collector/about.md
+++ b/content/en/docs/collector/about.md
@@ -103,7 +103,7 @@ Prometheus metrics.
 $ git clone git@github.com:open-telemetry/opentelemetry-collector.git; \
     cd opentelemetry-collector; make otelcol; \
     go build examples/demo/app/main.go; ./main & pid1="$!"; \
-    ./bin/$($GOOS)/otelcol --config ./examples/local/otel-config.yaml; kill $pid1
+    ./bin/otelcol_$(go env GOOS)_$(go env GOARCH) --config ./examples/local/otel-config.yaml; kill $pid1
 ```
 
 ## Other


### PR DESCRIPTION
The paths to `main.go` and `otel-config.yaml` have changed. This PR fixes the paths in the documentation.