### PR TITLE
Add concepts section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Whenever you submit a pull request to this repo, Netlify creates a [deploy previ
 * Fork and clone the repository
 * Install [Hugo](https://gohugo.io/getting-started/installing/#quick-install) and [npm](https://npmjs.com)
 * Run `make serve`
-* Open `http://localhost:1313` to check the site
+* Open `http://localhost:30000` to check the site
 
 > Please note that you need to install the "extended" version of Hugo (with built-in support) to run the site locally.
 

--- a/content/en/docs/collector/_index.md
+++ b/content/en/docs/collector/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Collector"
-weight: 1
+weight: 10
 ---
 
 This page contains documentation for the OpenTelemetry Collector.

--- a/content/en/docs/collector/about.md
+++ b/content/en/docs/collector/about.md
@@ -6,7 +6,7 @@ weight: 1
 ## Introduction
 
 The OpenTelemetry Collector offers a vendor-agnostic implementation on how to
-receive, process, and export telemetry data. In removes the need to run,
+receive, process, and export telemetry data. It removes the need to run,
 operate, and maintain multiple agents/collectors in order to support
 open-source observability data formats (e.g. Jaeger, Prometheus, etc.) sending
 to one or more open-source or commercial back-ends.
@@ -34,7 +34,7 @@ Projects:
 The OpenTelemetry Collector consists of a single binary and two deployment methods:
 
 1. An agent running with the application or on the same host as the application
-(e.g. binary, sidecar, or daemonset)
+(e.g. binary, sidecar, or daemonset).
 2. A gateway running as a standalone service (e.g. container or deployment)
 typically per cluster, datacenter or region.
 

--- a/content/en/docs/concepts/_index.md
+++ b/content/en/docs/concepts/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Concepts"
+weight: 1
+---
+
+The Concepts section help you learn more about the data sources and components
+of the OpenTelemetry project in order to obtain a deeper understand of how
+OpenTelemetry works.

--- a/content/en/docs/concepts/glossary.md
+++ b/content/en/docs/concepts/glossary.md
@@ -1,0 +1,172 @@
+---
+title: "Glossary"
+weight: 10
+---
+
+The OpenTelemetry project uses terminology you may or may not be familiar with.
+In addition, the project may define the terminology in a different way than
+others. This page captures terminology used in the project and what it means.
+
+## Generic Terminology
+
+- **Aggregation:** The process of combining multiple measurements into exact or
+  estimated statistics about the measurements that took place during an
+  interval of time, during program execution. Used by the `Metric` `Data Source`.
+- **API:** Application Programming Interface. In the OpenTelemetry project,
+  used to define how telemetry data is generated per `Data Source`.
+- **Application:** One or more `Services` designed for end users or other applications.
+- **APM:** Application Performance Monitoring. Typically a back-end of the
+  `Tracing` `Data Source`.
+- **[Attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/common/common.md#attributes):**
+  Used by the `Tracing` `Data Source` to attach name/value pairs to a `Span`.
+- **[Baggage](https://opentelemetry.io/docs/concepts/overview/#baggage):** A
+  mechanism for propagating name/value pairs to help establish a causal
+  relationship between events and services.
+- **Client Library:** See `Instrumented Library`.
+- **[Collector](https://opentelemetry.io/docs/concepts/overview/#collector):**
+  A vendor-agnostic implementation on how to receive, process, and export
+  telemetry data. A single binary that can be deployed as an agent or gateway.
+- **Contrib:** Several `Instrumentation Libraries` and the `Collector` offer a set
+  of core capabilities as well as a dedicated contrib repository for non-core
+  capabilities including vendor `Exporters`.
+- **[Context
+  Propagation](https://opentelemetry.io/docs/concepts/overview/#context-propagation):**
+  Allows all `Data Sources` to share an underlying context mechanism for storing
+  state and accessing data across the lifespan of a `Transaction`.
+- **[DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph):** Directed Acyclic Graph.
+- **[Data
+  Source](https://opentelemetry.io/docs/concepts/overview/#data-sources):** One
+  of `Traces`, `Metrics` or `Logs`.
+- **Dimension:** See `Label`.
+- **[Distributed
+  Tracing](https://opentelemetry.io/docs/concepts/overview/#distributed-tracing):**
+  Tracks the progression of a single `Request`, called a `Trace`, as it is handled
+  by `Services` that make up an `Application`. A `Distributed Trace` transverses
+  process, network and security boundaries.
+- **Event:** Something that happened where representation depends on the `Data
+  Source`. For example,
+  [`Spans`](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#add-events).
+- **Exporter:** Provides functionality to emit telemetry to consumers. Used by
+  [Instrumentation
+  Libraries](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/glossary.md#exporter-library)
+  and the
+  [Collector](https://opentelemetry.io/docs/collector/configuration/#exporters).
+  Exporters can be push or pull based.
+- **[Field](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/logs/data-model.md#field-kinds):**
+  name/value pairs added to `Log Records` (similar to `Attributes` for `Spans` and
+  `Labels` for `Metrics`).
+- **[gRPC](https://grpc.io):** A high-performance, open source universal `RPC` framework.
+- **[HTTP](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol):** Hypertext Transfer Protocol.
+- **[Instrumented
+  Library](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/glossary.md#instrumented-library):**
+  Denotes the `Library` for which the telemetry signals (`Traces`, `Metrics`, `Logs`)
+  are gathered.
+- **[Instrumentation
+  Library](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/glossary.md#instrumentation-library):**
+  Denotes the `Library` that provides the instrumentation for a given
+  `Instrumented Library`. `Instrumented Library` and `Instrumentation Library` may be
+  the same `Library` if it has built-in OpenTelemetry instrumentation.
+- **[JSON](https://en.wikipedia.org/wiki/JSON):** JavaScript Object Notation.
+- **[Label](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/metrics/api.md#labels):**
+  name/value pairs added to `Metric` data oints (similar to `Attributes` for `Spans`
+  and `Fields` for `Log Records`).
+- **Language:** Programming Language.
+- **Library:** A language-specific collection of behavior invoked by an interface.
+- **[Log](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/glossary.md#log):**
+  Sometimes used to refer to a collection of `Log Records`. May be ambiguous,
+  since people also sometimes use `Log` to refer to a single `Log Record`, thus
+  this term should be used carefully and in the context where ambiguity is
+  possible additional qualifiers should be used (e.g. `Log Record`).
+- **[Log
+  Record](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/glossary.md#log-record):**
+  A recording of an `Event`. Typically the record includes a timestamp indicating
+  when the `Event` happened as well as other data that describes what happened,
+  where it happened, etc.
+- **Metadata:** name/value pair added to telemetry data. OpenTelemetry calls
+  this `Attributes` on `Spans`, `Labels` on `Metrics` and `Fields` on `Logs`.
+- **[Metric](https://opentelemetry.io/docs/concepts/overview/#metrics):**
+  Records a data point, either raw measurements or predefined aggregation, as
+  timeseries with `Metadata`.
+- **OC:** `OpenCensus`.
+- **[OpenCensus](https://opencensus.io):** a set of libraries for various languages that allow you to
+  collect application metrics and distributed traces, then transfer the data to
+  a backend of your choice in real time. Precursor to OpenTelemetry.
+- **[OpenTracing](https://opentracing.io):** Vendor-neutral APIs and instrumentation for distributed tracing. Precursor to OpenTelemetry.
+- **OT:** `OpenTracing`.
+- **OTel:** OpenTelemetry.
+- **OtelCol:** OpenTelemetry Collector.
+- **OTLP:** OpenTelemetry Protocol.
+- **Processor:** Operation performed on data between being received and being
+  exported. For example, batching. Used by [Instrumentation
+  Libraries](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#span-processor)
+  and the
+  [Collector](https://opentelemetry.io/docs/collector/configuration/#processors).
+- **[Propagators](https://opentelemetry.io/docs/concepts/overview/):** Used to
+  serialize and deserialize specific parts of telemetry data such as span
+  context and `Baggage` in `Spans`.
+- **[Proto](https://opentelemetry.io/docs/concepts/overview/#proto):** Language independent interface types.
+- **[Receiver](https://opentelemetry.io/docs/collector/configuration/#receivers):**
+  Term used by the `Collector` to define how telemetry data is received.
+  Receivers can be push or pull based.
+- **Request:** See `Distributed Tracing`.
+- **[Resource](https://opentelemetry.io/docs/concepts/overview/#resource):**
+  Captures information about the entity for which telemetry is recorded. For
+  example, a process producing telemetry that is running in a container on
+  Kubernetes has a pod name, it is in a namespace and possibly is part of a
+  deployment which also has a name. All three of these attributes can be
+  included in the `Resource` and applied to any data source.
+- **[REST](https://en.wikipedia.org/wiki/Representational_state_transfer):** Representation State Transfer.
+- **[RPC](https://en.wikipedia.org/wiki/Remote_procedure_call):** Remote Procedure Call.
+- **[Sampling](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#sampling):**
+  A mechanism to control the amount of data exported. Most commonly used with
+  the `Tracing` `Data Source`.
+- **SDK:** Software Development Kit. Refers to a telemetry SDK that denotes a
+  `Library` that implement the OpenTelemetry `API`.
+- **Semantic Conventions:** Defines standard names and values of `Metadata` in
+  order to provide vendor-agnostic telemetry data.
+- **Service:** A component of an `Application`. Multiple instances of a
+  `Service` are typically deployed for high availability and scalability. A
+  `Service` may be deployed in multiple locations.
+- **[Span](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#span):**
+  Represents a single operation within a `Trace`.
+- **[Specification](https://opentelemetry.io/docs/concepts/overview/#specification):**
+  Describes the cross-language requirements and expectations for all
+  implementations.
+- **[Status](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#set-status):**
+  The result of the operation. Typically used to indicate whether an error
+  occurred.
+- **Tag:** See `Metadata`.
+- **[Trace](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/overview.md#trace):**
+  A `DAG` of `Spans`, where the edges between `Spans` are defined as
+  parent/child relationship.
+- **[Tracer](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#tracer):**
+  Responsible for creating `Spans`.
+- **Transaction:** See `Distributed Tracing`.
+- **[zPages](https://github.com/open-telemetry/opentelemetry-specification/blob/master/experimental/trace/zpages.md):**
+  An in-process alternative to external exporters. When included, they collect
+  and aggregate tracing and metrics information in the background; this data is
+  served on web pages when requested.
+
+## Additional Terminology
+
+### Traces
+
+- **[Trace API Terminology](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md)**
+- **[Trace SDK Terminology](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md)**
+
+### Metrics
+
+- **[Metric API Terminology](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/metrics/api.md#overview)**
+- **[Metric SDK Terminology](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/metrics/sdk.md#sdk-terminology)**
+
+### Logs
+
+- **[Trace Context Fields](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/logs/data-model.md#trace-context-fields)**
+- **[Severity Fields](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/logs/data-model.md#severity-fields)**
+- **[Log Record Fields](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/logs/data-model.md#log-and-event-record-definition)**
+
+### Semantic Conventions
+
+- **[Resource Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/semantic_conventions/README.md)**
+- **[Span Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/README.md)**
+- **[Metric Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/metrics/semantic_conventions/README.md)**

--- a/content/en/docs/concepts/overview.md
+++ b/content/en/docs/concepts/overview.md
@@ -1,0 +1,160 @@
+---
+title: "Overview"
+weight: 1
+---
+
+The OpenTelemetry project supports multiple data sources and consists of
+various components to generate, emit and collect telemetry data. All of these
+concepts are documented in the [specification
+repository](https://github.com/open-telemetry/opentelemetry-specification).
+This page provides quick links to learn more about these concepts and how they
+are defined in OpenTelemetry.
+
+## Data Sources
+
+OpenTelemetry supports multiple data sources as defined below. More data
+sources may be added in the future.
+
+### Traces
+
+Traces tracks the progression of a single request, called a trace, as it is
+handled by services that make up an application. The request may be initiated
+by a user or an application. Distributed tracing transverses process, network
+and security boundaries. Each unit of work is called a span; a trace is a tree
+of spans. Spans include metadata about the work including the time spent
+(latency), status and name/value tags called attributes. Distributed tracing
+provides Request, Error and Duration (RED) metrics and can be used to debug
+availability as well as performance issues.
+
+For more information, see the [distributed tracing
+specification](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/overview.md#distributed-tracing),
+which covers concepts including: trace, span, parent/child relationship, span
+context, attributes, events and links.
+
+### Metrics
+
+Metrics record data points, either raw measurements or predefined aggregation,
+as timeseries with metadata. The data contained within the metric consists of a
+single type, for example gauge or histogram, as well as points and labels. A
+metric also contains a name, description and unit. Application and request
+metrics are important indicators of availability and performance. Custom
+metrics can provide insights into how availability indicators impact user
+experience or the business. Collected data can be used to alert of an outage or
+trigger scheduling decisions to scale up a deployment automatically upon high
+demand.
+
+For more information, see the [metrics
+specification](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/overview.md#metrics),
+which covers topics including: measure, measurement, metric, data, data point
+and labels.
+
+### Logs
+
+Logs record timestamped text, either structured (recommended) or unstructured,
+with metadata. While logs are an independent data source, they may also be
+attached to spans. Any data that is not part of a distributed trace or a metric
+is a log. For example, events are a specific type of log. Logs are often used
+to determine the root cause of an issue and typically contain information about
+who changed what as well as the result of the change.
+
+For more information, see the [logs
+specification](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/overview.md#logs),
+which covers topics including: log, defined fields, trace context fields and
+severity fields.
+
+## Components
+
+The OpenTelemetry project consists of multiple components. These components are
+made available as a single implementation to ease adoption and ensure a
+vendor-agnostic solution. More components may be added in the future.
+
+### Proto
+
+Language independent interface types. Defined per data source for
+instrumentation libraries and the collector as well as for common aspects and
+resources. Proto files are extensively commented. For more information, see the
+[proto repository](https://github.com/open-telemetry/opentelemetry-proto).
+
+### Specification
+
+Describes the cross-language requirements and expectations for all
+implementations. Beyond definition of terms, the specification defines the
+following:
+
+- **API:** Used to generate telemetry data. Defined per data source as well as for
+  other aspects including baggage and propagators.
+- **SDK:** Implementation of the API with processing and exporting capabilities.
+  Defined per data source as well as for other aspects including resources and
+  configuration.
+- **Data:** Defines semantic conventions to provide vendor-agnostic
+  implementations as well as the OpenTelemetry protocol (OTLP).
+
+For more information, see the [specification
+repository](https://github.com/open-telemetry/opentelemetry-specification).
+
+### Collector
+
+The OpenTelemetry Collector offers a vendor-agnostic implementation on how to
+receive, process, and export telemetry data. It removes the need to run,
+operate, and maintain multiple agents/collectors in order to support
+open-source observability data formats (e.g. Jaeger, Prometheus, etc.) sending
+to one or more open-source or commercial back-ends. The Collector is the
+default location instrumentation libraries export telemetry data.
+
+The Collector provides a single binary and two deployment methods:
+
+- An agent running with the application or on the same host as the application
+  (e.g. binary, sidecar, or daemonset).
+- A gateway running as a standalone service (e.g. container or deployment)
+  typically per cluster, datacenter or region.
+
+For more information, see the [collector documentation](https://opentelemetry.io/docs/collector/).
+
+### Instrumentation Libraries
+
+The inspiration of the OpenTelemetry project is to make every library and
+application observable out of the box by having them call the OpenTelemetry API
+directly. Until that happens, there is a need for a separate library which can
+inject this information. A library that enables observability for another
+library is called an instrumentation library. The OpenTelemetry project
+provides an instrumentation library for multiple languages. All instrumentation
+libraries support manual (code modified) instrumentation and several support
+automatic (byte-code) instrumentation.
+
+For more information, see [instrumentation
+libraries](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/overview.md#instrumentation-libraries).
+
+## Other Concepts
+
+### Baggage
+
+Baggage is a mechanism for propagating name/value pairs to help establish a
+causal relationship between events and services. For more information, see
+the [baggage
+API](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/baggage/api.md).
+
+### Context Propagation
+
+Context propagation allows all data sources to share an underlying context
+mechanism for storing state and accessing data across the lifespan of a
+transaction. For more information, see the [context
+specification](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/context/context.md).
+
+### Propagators
+
+Propagators are used to serialize and deserialize specific parts of telemetry
+data such as span context and baggage in spans. For more information, see the
+[propagators
+API](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/context/api-propagators.md).
+
+### Resources
+
+Resources capture information about the entity for which telemetry is recorded.
+For example, a process producing telemetry that is running in a container on
+Kubernetes has a pod name, it is in a namespace and possibly is part of a
+deployment which also has a name. All three of these attributes can be included
+in the Resource and applied to any data source. Decoupling the discovery of
+resource information from exporters allow for independent development and easy
+customization or integration with other systems. For more information, see the
+[resource
+SDK](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/sdk.md).

--- a/content/en/docs/contribution-guidelines.md
+++ b/content/en/docs/contribution-guidelines.md
@@ -1,7 +1,7 @@
 ---
 title: "Contribution Guidelines"
 linkTitle: "Contribution Guidelines"
-weight: 9
+weight: 10000
 description: >
   How to contribute to the OpenTelemetry documentation
 ---

--- a/content/en/docs/workshop/_index.md
+++ b/content/en/docs/workshop/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Workshop"
-weight: 1
+weight: 10
 ---
 
-This section contains resources for the OpenTelemetry Workshop
+This section contains resources for the OpenTelemetry Workshop.


### PR DESCRIPTION
In an attempt to make it easier for people to understand what data
sources OpenTelemetry supports as well as the various components, I
added a concepts section (addresses #154). In addition, created a glossary within this
new section (addresses #193). The idea was to provide basic information
and link to authoritative resources as much as possible.

CREDIT: The information included pulls from the prior work of other
including:
- OpenTelemetry READMEs
- OpenCensus documentation
- Kubernetes documentation structure