### PR TITLE
Fix dead links

### DIFF
--- a/content/en/registry/instrumentation-python-aio-httpclient.md
+++ b/content/en/registry/instrumentation-python-aio-httpclient.md
@@ -6,7 +6,7 @@ language: python
 tags:
   - python
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-aiohttp-client
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/instrumentation/opentelemetry-instrumentation-aiohttp-client
 license: Apache 2.0
 description: This library allows tracing HTTP requests made by the aiohttp client library.
 authors: OpenTelemetry Authors

--- a/content/en/registry/instrumentation-python-asgi.md
+++ b/content/en/registry/instrumentation-python-asgi.md
@@ -6,7 +6,7 @@ language: python
 tags:
   - python
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-asgi
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/instrumentation/opentelemetry-instrumentation-asgi
 license: Apache 2.0
 description: This library provides a WSGI middleware that can be used on any ASGI framework (such as Django / Flask) to track requests timing through OpenTelemetry.
 authors: OpenTelemetry Authors

--- a/content/en/registry/instrumentation-python-asyncpg.md
+++ b/content/en/registry/instrumentation-python-asyncpg.md
@@ -6,7 +6,7 @@ language: python
 tags:
   - python
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-asyncpg
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/instrumentation/opentelemetry-instrumentation-asyncpg
 license: Apache 2.0
 description: This library allows tracing PostgreSQL queries made by the asyncpg library.
 authors: OpenTelemetry Authors

--- a/content/en/registry/instrumentation-python-boto.md
+++ b/content/en/registry/instrumentation-python-boto.md
@@ -6,7 +6,7 @@ language: python
 tags:
   - python
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-boto
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/instrumentation/opentelemetry-instrumentation-boto
 license: Apache 2.0
 description: This library allows tracing requests made by the Boto library.
 authors: OpenTelemetry Authors

--- a/content/en/registry/instrumentation-python-botocore.md
+++ b/content/en/registry/instrumentation-python-botocore.md
@@ -6,7 +6,7 @@ language: python
 tags:
   - python
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-botocore
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/instrumentation/opentelemetry-instrumentation-botocore
 license: Apache 2.0
 description: This library allows tracing requests made by the Botocore library.
 authors: OpenTelemetry Authors

--- a/content/en/registry/instrumentation-python-celery.md
+++ b/content/en/registry/instrumentation-python-celery.md
@@ -6,7 +6,7 @@ language: python
 tags:
   - python
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-celery
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/instrumentation/opentelemetry-instrumentation-celery
 license: Apache 2.0
 description: Instrumentation for Celery.
 authors: OpenTelemetry Authors

--- a/content/en/registry/instrumentation-python-dbapi.md
+++ b/content/en/registry/instrumentation-python-dbapi.md
@@ -6,7 +6,7 @@ language: python
 tags:
   - python
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-dbapi
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/instrumentation/opentelemetry-instrumentation-dbapi
 license: Apache 2.0
 description: The trace integration with Database API for OpenTelemetry.
 authors: OpenTelemetry Authors

--- a/content/en/registry/instrumentation-python-django.md
+++ b/content/en/registry/instrumentation-python-django.md
@@ -6,7 +6,7 @@ language: python
 tags:
   - python
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-django
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/instrumentation/opentelemetry-instrumentation-django
 license: Apache 2.0
 description: This library allows tracing requests for Django applications.
 authors: OpenTelemetry Authors

--- a/content/en/registry/instrumentation-python-elasticsearch.md
+++ b/content/en/registry/instrumentation-python-elasticsearch.md
@@ -6,7 +6,7 @@ language: python
 tags:
   - python
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-elasticsearch
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/instrumentation/opentelemetry-instrumentation-elasticsearch
 license: Apache 2.0
 description: This library allows tracing elasticsearch made by the elasticsearch library.
 authors: OpenTelemetry Authors

--- a/content/en/registry/instrumentation-python-flask.md
+++ b/content/en/registry/instrumentation-python-flask.md
@@ -6,7 +6,7 @@ language: python
 tags:
   - python
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-flask
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/instrumentation/opentelemetry-instrumentation-flask
 license: Apache 2.0
 description: This library builds on the OpenTelemetry WSGI middleware to track web requests in Flask applications.
 authors: OpenTelemetry Authors

--- a/content/en/registry/instrumentation-python-grpc.md
+++ b/content/en/registry/instrumentation-python-grpc.md
@@ -6,7 +6,7 @@ language: python
 tags:
   - python
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-grpc
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/instrumentation/opentelemetry-instrumentation-grpc
 license: Apache 2.0
 description: Client and server interceptors for gRPC Python.
 authors: OpenTelemetry Authors

--- a/content/en/registry/instrumentation-python-jinja2.md
+++ b/content/en/registry/instrumentation-python-jinja2.md
@@ -6,7 +6,7 @@ language: python
 tags:
   - python
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-jinja2
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/instrumentation/opentelemetry-instrumentation-jinja2
 license: Apache 2.0
 description: Instrumentation for Jinja2.
 authors: OpenTelemetry Authors

--- a/content/en/registry/instrumentation-python-mysql.md
+++ b/content/en/registry/instrumentation-python-mysql.md
@@ -6,7 +6,7 @@ language: python
 tags:
   - python
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-mysql
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/instrumentation/opentelemetry-instrumentation-mysql
 license: Apache 2.0
 description: Instrumentation with MySQL that supports the mysql-connector library.
 authors: OpenTelemetry Authors

--- a/content/en/registry/instrumentation-python-psycopg2.md
+++ b/content/en/registry/instrumentation-python-psycopg2.md
@@ -6,7 +6,7 @@ language: python
 tags:
   - python
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-psycopg2
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/instrumentation/opentelemetry-instrumentation-psycopg2
 license: Apache 2.0
 description: This library provides tracing for PostgreSQL via psycopg2.
 authors: OpenTelemetry Authors

--- a/content/en/registry/instrumentation-python-pymemcache.md
+++ b/content/en/registry/instrumentation-python-pymemcache.md
@@ -6,7 +6,7 @@ language: python
 tags:
   - python
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-pymemcache
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/instrumentation/opentelemetry-instrumentation-pymemcache
 license: Apache 2.0
 description: Instrumentation for Pymemcache.
 authors: OpenTelemetry Authors

--- a/content/en/registry/instrumentation-python-pymongo.md
+++ b/content/en/registry/instrumentation-python-pymongo.md
@@ -6,7 +6,7 @@ language: python
 tags:
   - python
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-pymongo
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/instrumentation/opentelemetry-instrumentation-pymongo
 license: Apache 2.0
 description: Instrumentation for the pymongo library.
 authors: OpenTelemetry Authors

--- a/content/en/registry/instrumentation-python-pymysql.md
+++ b/content/en/registry/instrumentation-python-pymysql.md
@@ -6,7 +6,7 @@ language: python
 tags:
   - python
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-pymysql
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/instrumentation/opentelemetry-instrumentation-pymysql
 license: Apache 2.0
 description: This library provides tracing for PyMySQL.
 authors: OpenTelemetry Authors

--- a/content/en/registry/instrumentation-python-pyramid.md
+++ b/content/en/registry/instrumentation-python-pyramid.md
@@ -6,7 +6,7 @@ language: python
 tags:
   - python
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-pyramid
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/instrumentation/opentelemetry-instrumentation-pyramid
 license: Apache 2.0
 description: Instrumentation for Pyramid.
 authors: OpenTelemetry Authors

--- a/content/en/registry/instrumentation-python-redis.md
+++ b/content/en/registry/instrumentation-python-redis.md
@@ -6,7 +6,7 @@ language: python
 tags:
   - python
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-redis
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/instrumentation/opentelemetry-instrumentation-redis
 license: Apache 2.0
 description: This library allows tracing requests made by the Redis library.
 authors: OpenTelemetry Authors

--- a/content/en/registry/instrumentation-python-requests.md
+++ b/content/en/registry/instrumentation-python-requests.md
@@ -6,7 +6,7 @@ language: python
 tags:
   - python
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-requests
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/instrumentation/opentelemetry-instrumentation-requests
 license: Apache 2.0
 description: This library allows tracing HTTP requests made by the requests library.
 authors: OpenTelemetry Authors

--- a/content/en/registry/instrumentation-python-sqlalchemy.md
+++ b/content/en/registry/instrumentation-python-sqlalchemy.md
@@ -6,7 +6,7 @@ language: python
 tags:
   - python
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-sqlalchemy
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/instrumentation/opentelemetry-instrumentation-sqlalchemy
 license: Apache 2.0
 description: This library allows tracing requests made by the SQLAlchemy library.
 authors: OpenTelemetry Authors

--- a/content/en/registry/instrumentation-python-sqlite3.md
+++ b/content/en/registry/instrumentation-python-sqlite3.md
@@ -6,7 +6,7 @@ language: python
 tags:
   - python
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-sqlite3
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/instrumentation/opentelemetry-instrumentation-sqlite3
 license: Apache 2.0
 description: Instrumentation for Sqlite3.
 authors: OpenTelemetry Authors

--- a/content/en/registry/instrumentation-python-starlette.md
+++ b/content/en/registry/instrumentation-python-starlette.md
@@ -6,7 +6,7 @@ language: python
 tags:
   - python
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-starlette
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/instrumentation/opentelemetry-instrumentation-starlette
 license: Apache 2.0
 description: This library provides automatic and manual instrumentation of Starlette web frameworks, instrumenting http requests served by applications utilizing the framework.
 authors: OpenTelemetry Authors

--- a/content/en/registry/instrumentation-python-system-metrics.md
+++ b/content/en/registry/instrumentation-python-system-metrics.md
@@ -6,7 +6,7 @@ language: python
 tags:
   - python
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-system-metrics
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/instrumentation/opentelemetry-instrumentation-system-metrics
 license: Apache 2.0
 description: Instrumentation to collect system performance metrics.
 authors: OpenTelemetry Authors

--- a/content/en/registry/instrumentation-python-wsgi.md
+++ b/content/en/registry/instrumentation-python-wsgi.md
@@ -6,7 +6,7 @@ language: python
 tags:
   - python
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-python/tree/master/instrumentation/opentelemetry-instrumentation-wsgi
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/instrumentation/opentelemetry-instrumentation-wsgi
 license: Apache 2.0
 description: This library provides a WSGI middleware that can be used on any WSGI framework (such as Django / Flask) to track requests timing through OpenTelemetry.
 authors: OpenTelemetry Authors


### PR DESCRIPTION
Python instrumentation packages have been moved from core repo to contrib repo.