### PR TITLE
Add New Relic Python exporter to registry

### DIFF
--- a/content/en/registry/exporter-python-newrelic.md
+++ b/content/en/registry/exporter-python-newrelic.md
@@ -1,0 +1,14 @@
+---
+title: New Relic Python Exporter
+registryType: exporter
+isThirdParty: true
+language: python
+tags:
+  - python
+  - exporter
+repo: https://github.com/newrelic/opentelemetry-exporter-python
+license: Apache 2.0
+description: The OpenTelemetry New Relic Exporter for Python.
+authors: New Relic Authors
+otVersion: latest
+---


### PR DESCRIPTION
Adds [newrelic/opentelemetry-exporter-python](https://github.com/newrelic/opentelemetry-exporter-python) to registry. 