### PR TITLE
make concepts come first in the docs page sidebar

### DIFF
--- a/content/en/docs/collector/_index.md
+++ b/content/en/docs/collector/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Collector"
 linkTitle: "Collector"
-weight: 10
+weight: 20
 description: >
   Vendor-agnostic way to receive, process and export telemetry data
 ---

--- a/content/en/docs/go/_index.md
+++ b/content/en/docs/go/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Go"
-weight: 1
+weight: 10
 ---
 
 This is the OpenTelemetry for Go documentation. OpenTelemetry is an observability framework -- an API, SDK, and tools that are designed to aid in the generation and collection of application telemetry data such as metrics, logs, and traces. This documentation is designed to help you understand how to get started using OpenTelemetry for Go.

--- a/content/en/docs/java/_index.md
+++ b/content/en/docs/java/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Java"
-weight: 1
+weight: 10
 ---
 
 OpenTelemetry Java consists of the following repositories:

--- a/content/en/docs/net/_index.md
+++ b/content/en/docs/net/_index.md
@@ -1,6 +1,6 @@
 ---
 title: ".NET"
-weight: 1
+weight: 10
 ---
 
 Welcome to the OpenTelemetry for .NET documentation! This is intended to be an overview of OpenTelemetry in this language, and a brief guide to its options and features.

--- a/content/en/docs/python/_index.md
+++ b/content/en/docs/python/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Python"
-weight: 1
+weight: 10
 ---
 
 This is the OpenTelemetry for Python documentation. OpenTelemetry is an observability framework -- an API, SDK, and tools that are designed to aid in the generation and collection of application telemetry data such as metrics, logs, and traces. This documentation is designed to help you understand how to get started using OpenTelemetry for Python.

--- a/content/en/docs/workshop/_index.md
+++ b/content/en/docs/workshop/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Workshop"
 linkTitle: "Workshop"
-weight: 10
+weight: 30
 description: >
   Resources to aid in running an OpenTelemetry workshop
 ---


### PR DESCRIPTION
Each language entry has weight 10 so that they are sorted in
alphabetical order. Concepts is weight 1 so it comes first and
other entries to come after each language, like collector and
workshops get a multiple of 10 weight.

Before this change `.Net` was the first entry on the docs page sidebar, now it is `Concepts`.