### PR TITLE
Add AWS SDK Extension package to registry

### DIFF
--- a/content/en/registry/sdk-extension-python-aws.md
+++ b/content/en/registry/sdk-extension-python-aws.md
@@ -1,0 +1,14 @@
+---
+title: AWS SDK Extension
+registryType: utilities
+isThirdParty: true
+language: python
+tags:
+  - python
+  - sdk-extension
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/master/sdk-extension/opentelemetry-sdk-extension-aws
+license: Apache 2.0
+description: This library provides components to configure OpenTelemetry Python to generate traces which are compatible with AWS X-Ray.
+authors: OpenTelemetry Authors
+otVersion: latest
+---


### PR DESCRIPTION
Adds a reference to the python package which allows OpenTelemetry Python users to configure the generation of traces to be compatible for the AWS X-Ray service.