### PR TITLE
Add New Relic Java Agent Distro to registry. Fix typo.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,5 +22,5 @@ The OpenTelemetry website is published automatically by
 Netlify re-builds and re-deploys the site and stages a deploy preview for those
 changes.
 
-> Site adminstrators can access the admin interface
+> Site administrators can access the admin interface
 > [here](https://app.netlify.com/sites/opentelemetry/overview).

--- a/content/en/registry/otel-java-instrumentation-newrelic.md
+++ b/content/en/registry/otel-java-instrumentation-newrelic.md
@@ -1,0 +1,14 @@
+---
+title: New Relic Java Agent Distro
+registryType: instrumentation
+isThirdParty: true
+language: java
+tags:
+  - java
+  - instrumentation
+repo: https://github.com/newrelic/newrelic-opentelemetry-integration-java
+license: Apache 2.0
+description: New Relic distribution of the OpenTelemetry Java agent.
+authors: New Relic opensource@newrelic.com
+otVersion: latest
+---


### PR DESCRIPTION
Adds the highlighted New Relic Java Agent Distro project to registry

<img width="601" alt="nr-distro" src="https://user-images.githubusercontent.com/3496648/101819369-02d92980-3ada-11eb-8901-eb4a044d6c76.png">

Which redirects to this project: https://github.com/newrelic/newrelic-opentelemetry-integration-java