### PR TITLE
use css `scroll-margin-top` to offsetting an html anchor to adjust for fixed header 

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -50,13 +50,10 @@ footer {
         visibility: hidden;
     }
 
-    h2[id]:before, h3[id]:before, h4[id]:before, h5[id]:before {
-        display: block;
-        content: " ";
-        margin-top: -5rem;
-        height: 5rem;
-        visibility: hidden;
+    h2[id], h3[id], h4[id], h5[id] {
+        scroll-margin-top: 5rem;
     }
+
 }
 
 @import "styles_project";


### PR DESCRIPTION
1. found the problem.
![image](https://user-images.githubusercontent.com/2732352/103166161-511c5580-485a-11eb-9da0-314e470ec2d1.png)

reproduce this problem by the following URL:
- https://opentelemetry.io/about/#what-is-an-observability-framework
- https://opentelemetry.io/community/#opentelemetryio

2. found CSS code has handled this problem, btw not working.
3. fount the `h2` parent `section` used `display: flex`, make old logic not working.
4. use CSS `scroll-margin-top: {header-heigh}` to fix it :)