### PR TITLE
registry page: persistent value from filter language/component filter

### DIFF
--- a/layouts/registry/list.html
+++ b/layouts/registry/list.html
@@ -41,15 +41,18 @@
             <span class="input-group-text" id="basic-addon1">Search</span>
           </div>
           <input type="text" name="s" class="form-control" id="search-query" aria-label="Registry Search Input Field">
+          <input type="hidden" name="component" id="input-component" value="" />
+          <input type="hidden" name="language" id="input-language" value="" />
+
           <div class="input-group-append">
             <button type="button" class="btn btn-outline-success" onclick="document.getElementById('searchForm').submit();">Submit</button>
-            <button type="button" class="btn btn-outline-danger"  onclick="document.getElementById('search-query').value = ''; document.getElementById('searchForm').submit();">Reset</button>
+            <button type="button" class="btn btn-outline-danger"  onclick="document.getElementById('search-query').value = ''; document.getElementById('input-language').value = 'all';document.getElementById('input-component').value = 'all';document.getElementById('searchForm').submit();">Reset</button>
             <div>
               <button class="btn btn-outline-secondary dropdown-toggle" id="languageDropdown" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Language</button>
               <div class="dropdown-menu" id="languageFilter">
                 <a value="all" class="dropdown-item" href="#">Any Language</a>
                 {{ range $registryItems.GroupByParam "language" }}
-                <a value={{.Key}} class="dropdown-item" href="#">{{ $languages.Get .Key }}</a>
+                <a value={{.Key}} id="language-item-{{.Key}}" class="dropdown-item" href="#">{{ $languages.Get .Key }}</a>
                 {{ end }}
               </div>
             </div>
@@ -58,7 +61,7 @@
               <div class="dropdown-menu" id="componentFilter">
                 <a value="all" class="dropdown-item" href="#">Any Component</a>
                 {{ range $registryItems.GroupByParam "registryType" }}
-                <a value={{.Key}} class="dropdown-item" href="#">{{ $types.Get (lower .Key) }}</a>
+                <a value={{.Key}} id="component-item-{{.Key}}" class="dropdown-item" href="#">{{ $types.Get (lower .Key) }}</a>
                 {{ end }}
               </div>
             </div>

--- a/src/js/registrySearch.js
+++ b/src/js/registrySearch.js
@@ -18,8 +18,12 @@ let fuseOptions = {
 
 // Get searchQuery for queryParams
 let pathName = window.location.pathname;
-let urlParams = new URLSearchParams(window.location.search);
-let searchQuery = urlParams.get("s");
+let searchQuery = "";
+let selectedLanguage = "all";
+let selectedComponent = "all";
+
+parseUrlParams();
+
 if (pathName.includes("registry")) {
   // Run search or display default body
   if (searchQuery) {
@@ -31,6 +35,16 @@ if (pathName.includes("registry")) {
     if (defaultBody.style.display === "none") {
       defaultBody.style.display = "block";
     }
+  }
+
+  if (selectedLanguage!=="all" || selectedComponent!== "all"){
+    if (selectedLanguage!=="all"){
+      document.getElementById('languageDropdown').textContent = document.getElementById(`language-item-${selectedLanguage}`).textContent;
+    }
+    if (selectedComponent!=="all"){
+      document.getElementById('componentDropdown').textContent = document.getElementById(`component-item-${selectedComponent}`).textContent;
+    }
+    updateFilters();
   }
 }
 
@@ -139,8 +153,6 @@ function render(templateString, data) {
   return templateString;
 }
 
-let selectedLanguage = "all";
-let selectedComponent = "all";
 if (pathName.includes("registry")) {
   document.addEventListener('DOMContentLoaded', (event) => {
     let languageList = document.getElementById('languageFilter').querySelectorAll('.dropdown-item')
@@ -149,16 +161,27 @@ if (pathName.includes("registry")) {
       let val = evt.target.getAttribute('value')
       selectedLanguage = val;
       document.getElementById('languageDropdown').textContent = evt.target.textContent;
+      setInput("language", val);
       updateFilters();
     }))
     typeList.forEach((element) => element.addEventListener('click', function(evt) {
       let val = evt.target.getAttribute('value')
       selectedComponent = val;
       document.getElementById('componentDropdown').textContent = evt.target.textContent;
+      setInput("component", val);
       updateFilters();
     }))
   })
 }
+
+
+function setInput(key, value){
+  document.getElementById(`input-${key}`).value = value;
+  var queryParams = new URLSearchParams(window.location.search);
+  queryParams.set(key, value);
+  history.replaceState(null, null, "?"+queryParams.toString());
+}
+
 // Filters items based on language and component filters
 function updateFilters() {
   let allItems = [...document.getElementsByClassName("media")];
@@ -182,4 +205,11 @@ function updateFilters() {
       }
     });
   }
+}
+
+function parseUrlParams(){
+  let urlParams = new URLSearchParams(window.location.search);
+  searchQuery = urlParams.get("s");
+  selectedLanguage = urlParams.get("language") || "all";
+  selectedComponent = urlParams.get("component") || "all";
 }


### PR DESCRIPTION
## why need it?
for example, a freshman needs to search a JAVA AWS OTel SDK, maybe follow this step:
1. select language to `java`.
2. input search query: `aws` 
3. bomb. return a list with `aws`, not include `java` (because we don't persistent selected language/component)

## how this PR to fix it.
add two hide input, when form submit. will take language/component value.
when language/component value changed, update input value and urlParams
