### PR TITLE
Update vendors to include New Relic

### DIFF
--- a/content/en/vendors/_index.md
+++ b/content/en/vendors/_index.md
@@ -15,6 +15,7 @@ This page exists to collect distributions and vendors who natively support OpenT
 | ------- | ------------ | ----------- | --------- |
 | AWS     | Yes          | No          | https://aws-otel.github.io/ |
 | Lightstep | Yes        | Yes         | https://github.com/lightstep?q=launcher |
+| New Relic | Yes        | No          | https://newrelic.com/solutions/opentelemetry |
 | Splunk | Yes           | Yes         | https://www.splunk.com/en_us/blog/conf-splunklive/announcing-native-opentelemetry-support-in-splunk-apm.html |
 
 _Vendors are listed alphabetically_


### PR DESCRIPTION
Update the vendors supporting OpenTelemetry page to include New Relic.
You can learn more about our OpenTelemetry offering [here](https://newrelic.com/solutions/opentelemetry).