### PR TITLE
Added F5 to vendor page

### DIFF
--- a/content/en/vendors/_index.md
+++ b/content/en/vendors/_index.md
@@ -19,6 +19,7 @@ This page exists to collect distributions and vendors who natively support OpenT
 | Lightstep | Yes        | Yes         | https://github.com/lightstep?q=launcher |
 | New Relic | Yes        | No          | https://newrelic.com/solutions/opentelemetry |
 | Splunk | Yes           | Yes         | https://www.splunk.com/en_us/blog/conf-splunklive/announcing-native-opentelemetry-support-in-splunk-apm.html |
+| F5      | No           | Yes         | https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/f5cloudexporter |
 
 _Vendors are listed alphabetically_
 


### PR DESCRIPTION
Signed-off-by: Granville Schmidt <1246157+gramidt@users.noreply.github.com>

F5 has been investing in OpenTelemetry. We have created the F5 Cloud exporter which utilizes OTLP (found in the the Otel Collector Contrib repository), contributing community projects such as the Loki Exporter, and participating in multiple SIGs. We plan to increase our contributions and further evangelize OpenTelemetry via articles, presentations, and other mediums.