### PR TITLE
Fixed F5 position to be listed alphabetically

### DIFF
--- a/content/en/vendors/_index.md
+++ b/content/en/vendors/_index.md
@@ -15,11 +15,11 @@ This page exists to collect distributions and vendors who natively support OpenT
 | ------- | ------------ | ----------- | --------- |
 | AWS     | Yes          | No          | https://aws-otel.github.io/ |
 | Elastic | Yes          | No          | https://www.elastic.co/guide/en/apm/get-started/current/open-telemetry-elastic.html |
+| F5      | No           | Yes         | https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/f5cloudexporter |
 | Honeycomb | No         | Yes         | https://docs.honeycomb.io/getting-data-in/otel-collector/ |
 | Lightstep | Yes        | Yes         | https://github.com/lightstep?q=launcher |
 | New Relic | Yes        | No          | https://newrelic.com/solutions/opentelemetry |
 | Splunk | Yes           | Yes         | https://www.splunk.com/en_us/blog/conf-splunklive/announcing-native-opentelemetry-support-in-splunk-apm.html |
-| F5      | No           | Yes         | https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/f5cloudexporter |
 
 _Vendors are listed alphabetically_
 


### PR DESCRIPTION
Signed-off-by: Granville Schmidt <1246157+gramidt@users.noreply.github.com>

Just fixing the position of F5 which was added in #368. Sorry for missing the "Vendors are listed alphabetically". 