### PR TITLE
Update broken links in 4 instrumentations MD files

### DIFF
--- a/content/en/registry/instrumentation-js-aws-sdk.md
+++ b/content/en/registry/instrumentation-js-aws-sdk.md
@@ -8,9 +8,8 @@ tags:
   - plugin
   - aws-sdk
   - aws
-repo: https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/plugin-aws-sdk
+repo: https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/instrumentation-aws-sdk
 license: Apache 2.0
 description: aws-sdk plugin for Node.js.
 authors: Aspecto Authors (amir@aspecto.io)
-otVersion: ^0.8.3
 ---

--- a/content/en/registry/instrumentation-js-kafkajs.md
+++ b/content/en/registry/instrumentation-js-kafkajs.md
@@ -8,9 +8,8 @@ tags:
   - plugin
   - kafkajs
   - kafka
-repo: https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/plugin-kafkajs
+repo: https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/instrumentation-kafkajs
 license: Apache 2.0
 description: kafkajs plugin for Node.js.
 authors: Amir Blum (amir@aspecto.io)
-otVersion: ^0.8.3
 ---

--- a/content/en/registry/instrumentation-js-sequelize.md
+++ b/content/en/registry/instrumentation-js-sequelize.md
@@ -7,9 +7,8 @@ tags:
   - Node.js
   - plugin
   - sequelize
-repo: https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/plugin-sequelize
+repo: https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/instrumentation-sequelize
 license: Apache 2.0
 description: Sequelize plugin for Node.js.
 authors: Aspecto Authors (nir@aspecto.io)
-otVersion: ^0.12.0
 ---

--- a/content/en/registry/instrumentation-js-typeorm.md
+++ b/content/en/registry/instrumentation-js-typeorm.md
@@ -7,9 +7,8 @@ tags:
   - Node.js
   - plugin
   - typeorm
-repo: https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/plugin-typeorm
+repo: https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/instrumentation-typeorm
 license: Apache 2.0
 description: TypeORM plugin for Node.js.
 authors: Aspecto Authors (nir@aspecto.io)
-otVersion: ^0.11.0
 ---


### PR DESCRIPTION
The following MD files have been updated:
js-kafkajs, js-aws-sdk, js-sequelize, js-typeorm

Also, removed otVersion as I saw it is not visible anywhere and that other instrumentations don't seem to do it anymore.