### PR TITLE
improve link css 

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -69,3 +69,14 @@ section#announcement {
     justify-content: center;
     padding: 6px;
 }
+
+
+.td-box--dark p > a {
+    color: #3176d9;
+}
+
+.td-box--dark p > a:hover,
+a:hover {
+    color: #3176d9;
+    text-decoration: underline;
+}


### PR DESCRIPTION
resolved #384 
1. all a/link use the same color
2. remove hover color change, used underline

before

![image](https://user-images.githubusercontent.com/2732352/108178671-acbedd00-713f-11eb-8fb4-76ccc8c70a26.png)



now
![image](https://user-images.githubusercontent.com/2732352/108178582-8e58e180-713f-11eb-82e9-58bb29a83a09.png)
