### PR TITLE
registry update plugins to instrumentation

### DIFF
--- a/content/en/registry/instrumentation-js-aws-sdk.md
+++ b/content/en/registry/instrumentation-js-aws-sdk.md
@@ -1,15 +1,15 @@
 ---
-title: OpenTelemetry aws-sdk Plugin
+title: OpenTelemetry aws-sdk Instrumentation
 registryType: instrumentation
 isThirdParty: false
 language: js
 tags:
   - Node.js
-  - plugin
+  - instrumentation
   - aws-sdk
   - aws
 repo: https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/instrumentation-aws-sdk
 license: Apache 2.0
-description: aws-sdk plugin for Node.js.
+description: aws-sdk instrumentation for Node.js.
 authors: Aspecto Authors (amir@aspecto.io)
 ---

--- a/content/en/registry/instrumentation-js-kafkajs.md
+++ b/content/en/registry/instrumentation-js-kafkajs.md
@@ -1,15 +1,15 @@
 ---
-title: OpenTelemetry kafkajs Plugin
+title: OpenTelemetry kafkajs Instrumentation
 registryType: instrumentation
 isThirdParty: false
 language: js
 tags:
   - Node.js
-  - plugin
+  - instrumentation
   - kafkajs
   - kafka
 repo: https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/instrumentation-kafkajs
 license: Apache 2.0
-description: kafkajs plugin for Node.js.
+description: kafkajs instrumentation for Node.js.
 authors: Amir Blum (amir@aspecto.io)
 ---

--- a/content/en/registry/instrumentation-js-mongoose-instrumentation.md
+++ b/content/en/registry/instrumentation-js-mongoose-instrumentation.md
@@ -1,0 +1,15 @@
+---
+title: OpenTelemetry Mongoose Instrumentation
+registryType: instrumentation
+isThirdParty: false
+language: js
+tags:
+  - Node.js
+  - plugin
+  - Mongoose
+  - MongoDB
+repo: https://github.com/wdalmut/opentelemetry-plugin-mongoose
+license: MIT
+description: Mongoose instrumentation for Node.js.
+authors: Aspecto Authors
+---

--- a/content/en/registry/instrumentation-js-mongoose-instrumentation.md
+++ b/content/en/registry/instrumentation-js-mongoose-instrumentation.md
@@ -5,10 +5,10 @@ isThirdParty: false
 language: js
 tags:
   - Node.js
-  - plugin
+  - instrumentation
   - Mongoose
   - MongoDB
-repo: https://github.com/wdalmut/opentelemetry-plugin-mongoose
+repo: https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/instrumentation-mongoose
 license: MIT
 description: Mongoose instrumentation for Node.js.
 authors: Aspecto Authors

--- a/content/en/registry/instrumentation-js-sequelize.md
+++ b/content/en/registry/instrumentation-js-sequelize.md
@@ -1,14 +1,14 @@
 ---
-title: OpenTelemetry Sequelize Plugin
+title: OpenTelemetry Sequelize Instrumentation
 registryType: instrumentation
 isThirdParty: true
 language: js
 tags:
   - Node.js
-  - plugin
+  - instrumentation
   - sequelize
-repo: https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/instrumentation-sequelize
+repo: https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/instrumentation-mongoose
 license: Apache 2.0
-description: Sequelize plugin for Node.js.
+description: Sequelize instrumentation for Node.js.
 authors: Aspecto Authors (nir@aspecto.io)
 ---

--- a/content/en/registry/instrumentation-js-typeorm.md
+++ b/content/en/registry/instrumentation-js-typeorm.md
@@ -1,14 +1,14 @@
 ---
-title: OpenTelemetry TypeORM Plugin
+title: OpenTelemetry TypeORM Instrumentation
 registryType: instrumentation
 isThirdParty: false
 language: js
 tags:
   - Node.js
-  - plugin
+  - instrumentation
   - typeorm
 repo: https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/instrumentation-typeorm
 license: Apache 2.0
-description: TypeORM plugin for Node.js.
+description: TypeORM instrumentation for Node.js.
 authors: Aspecto Authors (nir@aspecto.io)
 ---


### PR DESCRIPTION
In our (Aspecto) extensions [repo](https://github.com/aspecto-io/opentelemetry-ext-js) we updated our plugins to the new [instrumentation API](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-instrumentation).  
As part of this change, the term "plugin" changes, this PR is updating the term where needed.  

We also created a new mongoose instrumentation, that contains bug fixes to the original plugin, as well follows the semantic conventions (as opposed to the previous plugin) and uses the new API, so that's added in this PR as well.