### PR TITLE
Update Sumo Logic OTLP support status

### DIFF
--- a/content/en/vendors/_index.md
+++ b/content/en/vendors/_index.md
@@ -25,7 +25,7 @@ weight: 50
 | Lightstep | Yes        | Yes         | https://github.com/lightstep?q=launcher |
 | New Relic | Yes        | No          | https://newrelic.com/solutions/opentelemetry |
 | Splunk | Yes           | Yes         | https://www.splunk.com/en_us/blog/conf-splunklive/announcing-native-opentelemetry-support-in-splunk-apm.html |
-| Sumo Logic | Yes       | No          | https://help.sumologic.com/Traces/Getting_Started_with_Transaction_Tracing |
+| Sumo Logic | Yes       | Yes         | https://help.sumologic.com/Traces/Getting_Started_with_Transaction_Tracing |
 
 _Vendors are listed alphabetically_
 


### PR DESCRIPTION
Sumo Logic now accepts OTLP/HTTP traces and I believe the status for Native OTLP support can be now updated