### PR TITLE
Move icon below heading to fix links and toc

### DIFF
--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -117,7 +117,9 @@ service:
       exporters: [otlp]
 ```
 
-## <a name="receivers"></a><img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Receivers.svg"></img> Receivers
+## Receivers
+
+<img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Receivers.svg"></img>
 
 A receiver, which can be push or pull based, is how data gets into the
 Collector. Receivers may support one or more [data
@@ -192,7 +194,9 @@ receivers:
   zipkin:
 ```
 
-## <a name="processors"></a><img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Processors.svg"></img> Processors
+## Processors
+
+<img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Processors.svg"></img>
 
 Processors are run on data between being received and being exported.
 Processors are optional though [some are
@@ -270,7 +274,9 @@ processors:
       separator: "::"
 ```
 
-## <a name="exporters"></a><img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Exporters.svg"></img> Exporters
+## Exporters
+
+<img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Exporters.svg"></img>
 
 An exporter, which can be push or pull based, is how you send data to one or
 more backends/destinations. Exporters may support one or more [data


### PR DESCRIPTION
I was pretty confused trying to navigate the documentation, especially when there was so much code snippets that looked alike, until I realized the links here were broken (didn't take me anywhere): 
![image](https://user-images.githubusercontent.com/3250776/111701403-062a3280-87f8-11eb-90c9-d0a9d68ce026.png)

Currently:
1. The links in the ToC to these sections are broken (unclickable)
	![image](https://user-images.githubusercontent.com/3250776/111701439-15a97b80-87f8-11eb-8809-fe8d995c93b0.png)
2. The permalink for these sections is actually: `https://opentelemetry.io/docs/collector/configuration/#a-namereceiversaimg-width35-srchttpsrawgithubcomopen-telemetryopentelemetryiomainiconography32x32receiverssvgimg-receivers`

I figured moving the icon down was the easiest way to fix them.