### PR TITLE
Fix syntax for trace_id/span_id injection example

### DIFF
--- a/content/en/docs/java/automatic_instrumentation.md
+++ b/content/en/docs/java/automatic_instrumentation.md
@@ -123,7 +123,7 @@ by specifying them in the pattern/format.
 Example for Spring Boot configuration (which uses logback):
 
 ```properties
-logging.pattern.console = %d{yyyy-MM-dd HH:mm:ss} - %logger{36} - %msg t:%X{traceId} s:%X{spanId} %n
+logging.pattern.console = %d{yyyy-MM-dd HH:mm:ss} - %logger{36} - %msg trace_id=%X{trace_id} span_id=%X{span_id} trace_flags=%X{trace_flags} %n
 ```
 
 #### Supported logging libraries


### PR DESCRIPTION
Fix syntax for %X{trace_id} / %X{span_id} + add trace_flags to match https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/logger-mdc-instrumentation.md#logger-mdc-auto-instrumentation