### PR TITLE
improv: modernize browser example

### DIFF
--- a/content/en/docs/js/getting_started/browser.md
+++ b/content/en/docs/js/getting_started/browser.md
@@ -9,7 +9,7 @@ This guide uses the example application in HTML & javascript provided below, but
 - Initialize a global [tracer](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#tracer)
 - Initialize and register a [span exporter](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#span-exporter)
 
-This is a very simple guide, if you'd like to see more complex examples go to [examples/tracer-web](https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/tracer-web)
+This is a very simple guide, if you'd like to see more complex examples go to [examples/tracer-web](https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/tracer-web).
 
 Copy the following file into an empty directory and call it `index.html`.
 
@@ -18,7 +18,7 @@ Copy the following file into an empty directory and call it `index.html`.
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Document Load Plugin Example</title>
+  <title>Document Load Instrumentation Example</title>
   <base href="/">
   <!--
     https://www.w3.org/TR/trace-context/
@@ -40,10 +40,10 @@ Copy the following file into an empty directory and call it `index.html`.
 
 # Installation
 
-To create traces in the browser, you will need `@opentelemetry/web`, and the plugin `@opentelemetry/plugin-document-load`:
+To create traces in the browser, you will need `@opentelemetry/web`, and the instrumentation `@opentelemetry/instrumentation-document-load`:
 
 ```shell
-npm install @opentelemetry/web @opentelemetry/plugin-document-load
+npm install @opentelemetry/web @opentelemetry/instrumentation-document-load
 ```
 
 In the following we will use parcel as web application bundler, but you can of course also use any other build tool:
@@ -68,122 +68,53 @@ We will add some code that will trace the document load timings and output those
 Add the following code to the `document-load.js` to create a tracer provider, which brings the plugin to trace document load:
 
 ```javascript
- // This is necessary for "parcel" to work OOTB. It is not needed for other build tools.
-import 'regenerator-runtime/runtime'
-import { LogLevel } from "@opentelemetry/core";
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { DocumentLoadInstrumentation } from '@opentelemetry/instrumentation-document-load';
 import { WebTracerProvider } from '@opentelemetry/web';
-import { DocumentLoad } from '@opentelemetry/plugin-document-load';
 
 // Minimum required setup - supports only synchronous operations
-const provider = new WebTracerProvider({
-  plugins: [
-    new DocumentLoad()
-  ]
-});
+const provider = new WebTracerProvider();
 provider.register();
+
+registerInstrumentations({
+  instrumentations: [
+    new DocumentLoadInstrumentation(),
+  ],
+  tracerProvider: provider,
+});
 ```
 
 Run `parcel index.html` and open the development webserver (e.g. at http://localhost:1234) to see if your code works.
 
-There will be no output of traces yet, for this we need to add an exporter
+There will be no output of traces yet, for this we need to add an exporter.
 
 ## Creating a Console Exporter
 
 To export traces, modify `document-load.js` so that it matches the following code snippet:
 
 ```javascript
- // This is necessary for "parcel" to work OOTB. It is not needed for other build tools.
-import 'regenerator-runtime/runtime'
-import { LogLevel } from "@opentelemetry/core";
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { DocumentLoadInstrumentation } from '@opentelemetry/instrumentation-document-load';
 import { WebTracerProvider } from '@opentelemetry/web';
-import { DocumentLoad } from '@opentelemetry/plugin-document-load';
 import { ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/tracing';
 
 // Minimum required setup - supports only synchronous operations
-const provider = new WebTracerProvider({
-  plugins: [
-    new DocumentLoad()
-  ]
-});
-provider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()))
+const provider = new WebTracerProvider();
+provider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
 provider.register();
+
+registerInstrumentations({
+  instrumentations: [
+    new DocumentLoadInstrumentation(),
+  ],
+  tracerProvider: provider,
+});
 ```
 
-Now, rebuild your application and open the browser again. In the console of the developer toolbar you should see some traces being exporterd:
+After saving the file, head back to the browser. By default Parcel should automatically rebuild the application and refresh the page. In the console of the developer toolbar you should start seeing traces being exported:
 
-```json
-{
-  "traceId": "ab42124a3c573678d4d8b21ba52df3bf",
-  "parentId": "cfb565047957cb0d",
-  "name": "documentFetch",
-  "id": "5123fc802ffb5255",
-  "kind": 0,
-  "timestamp": 1606814247811266,
-  "duration": 9390,
-  "attributes": {
-    "component": "document-load",
-    "http.response_content_length": 905
-  },
-  "status": {
-    "code": 0
-  },
-  "events": [
-    {
-      "name": "fetchStart",
-      "time": [
-        1606814247,
-        811266158
-      ]
-    },
-    {
-      "name": "domainLookupStart",
-      "time": [
-        1606814247,
-        811266158
-      ]
-    },
-    {
-      "name": "domainLookupEnd",
-      "time": [
-        1606814247,
-        811266158
-      ]
-    },
-    {
-      "name": "connectStart",
-      "time": [
-        1606814247,
-        811266158
-      ]
-    },
-    {
-      "name": "connectEnd",
-      "time": [
-        1606814247,
-        811266158
-      ]
-    },
-    {
-      "name": "requestStart",
-      "time": [
-        1606814247,
-        819101158
-      ]
-    },
-    {
-      "name": "responseStart",
-      "time": [
-        1606814247,
-        819791158
-      ]
-    },
-    {
-      "name": "responseEnd",
-      "time": [
-        1606814247,
-        820656158
-      ]
-    }
-  ]
-}
+```js
+{traceId: "ab42124a3c573678d4d8b21ba52df3bf", parentId: "af0261e69b996866", name: "documentFetch", id: "a1fbbd7ba725be4f", kind: 0, ...}
+{traceId: "ab42124a3c573678d4d8b21ba52df3bf", parentId: "af0261e69b996866", name: "resourceFetch", id: "530cb89307cf4972", kind: 0, ...}
+{traceId: "ab42124a3c573678d4d8b21ba52df3bf", parentId: "d21f7bc17caa5aba", name: "documentLoad", id: "af0261e69b996866", kind: 0, ...}
 ```


### PR DESCRIPTION
- changed `plugin` to `instrumentation`
- modernized API (basically simplified https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/examples/)
- some typos
- simplified console output reference