### PR TITLE
Fix URL anchor to #metric-signal

### DIFF
--- a/content/en/docs/concepts/data-sources.md
+++ b/content/en/docs/concepts/data-sources.md
@@ -109,7 +109,7 @@ metrics include:
 - Reporting current active requests being handled.
 
 For more information, see the [metrics
-specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#metrics),
+specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#metric-signal),
 which covers topics including: measure, measurement, metric, data, data point
 and labels.
 


### PR DESCRIPTION
Seems that the #metric anchor in the URL is an outdated one and the new one should be #metric-signal