### PR TITLE
erlang/elixir: update getting started to use 1.0.0-rc1

### DIFF
--- a/content/en/docs/erlang/getting-started.md
+++ b/content/en/docs/erlang/getting-started.md
@@ -54,15 +54,15 @@ run as a Release and export spans from.
 {{< tabs Erlang Elixir >}}
 
 {{< tab >}}
-{deps, [{opentelemetry_api, "~> 0.6"}, 
-        {opentelemetry, "~> 0.6"}]}.
+{deps, [{opentelemetry_api, "~> 1.0.0-rc.1"}, 
+        {opentelemetry, "~> 1.0.0-rc.1"}]}.
 {{< /tab >}}
 
 {{< tab >}}
 def deps do
   [
-    {:opentelemetry_api, "~> 0.6"},
-    {:opentelemetry, "~> 0.6"}
+    {:opentelemetry_api, "~> 1.0.0-rc.1"},
+    {:opentelemetry, "~> 1.0.0-rc.1"}
   ]
 end
 {{< /tab >}}


### PR DESCRIPTION
Forgot to update this when the RC was released. Once 1.0 is released it can just be updated to use like `~> 1.0` so that it doesn't have to be continually updated when new releases come out.