### PR TITLE
Updated release trace versions for .NET and Python

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -58,6 +58,14 @@ weight = 1
 
 [params]
 copyright = "The OpenTelemetry Authors | Documentation Distributed under CC BY 4.0 | "
+<<<<<<< HEAD
+=======
+
+[params.footer]
+text ="Privacy Policy"
+url ="https://www.linuxfoundation.org/en/privacy/#:~:text=The%20Linux%20Foundation%27s%20core%20purpose,%2C%20a%20%E2%80%9CProject%E2%80%9D).&text=The%20Privacy%20Policy%20does%20not,employees%20or%20other%20TLF%20personnel."
+
+>>>>>>> fbec367... added privacy policy in footer
 
 tagline = "Effective observability requires high-quality telemetry"
 sub_tagline = "**OpenTelemetry** makes robust, portable telemetry a built-in feature of cloud-native software."

--- a/config.toml
+++ b/config.toml
@@ -58,14 +58,13 @@ weight = 1
 
 [params]
 copyright = "The OpenTelemetry Authors | Documentation Distributed under CC BY 4.0 | "
-<<<<<<< HEAD
-=======
+
 
 [params.footer]
 text ="Privacy Policy"
 url ="https://www.linuxfoundation.org/en/privacy/#:~:text=The%20Linux%20Foundation%27s%20core%20purpose,%2C%20a%20%E2%80%9CProject%E2%80%9D).&text=The%20Privacy%20Policy%20does%20not,employees%20or%20other%20TLF%20personnel."
 
->>>>>>> fbec367... added privacy policy in footer
+
 
 tagline = "Effective observability requires high-quality telemetry"
 sub_tagline = "**OpenTelemetry** makes robust, portable telemetry a built-in feature of cloud-native software."

--- a/config.toml
+++ b/config.toml
@@ -58,12 +58,13 @@ weight = 1
 
 [params]
 copyright = "The OpenTelemetry Authors | Documentation Distributed under CC BY 4.0 | "
-
+<<<<<<< HEAD
+=======
 
 [params.footer]
 text ="Privacy Policy"
 url ="https://www.linuxfoundation.org/en/privacy/#:~:text=The%20Linux%20Foundation%27s%20core%20purpose,%2C%20a%20%E2%80%9CProject%E2%80%9D).&text=The%20Privacy%20Policy%20does%20not,employees%20or%20other%20TLF%20personnel."
-
+>>>>>>> fbec367... added privacy policy in footer
 
 
 tagline = "Effective observability requires high-quality telemetry"

--- a/content/en/community/_index.md
+++ b/content/en/community/_index.md
@@ -19,7 +19,7 @@ OpenTelemetry collaborates and integrates with other open-source projects includ
 
 {{% blocks/feature icon="far fa-building" title="Vendor Supported" url="/vendors"%}}
 Several cloud providers and observability vendors distribute or natively support OpenTelemetry.
-
+{{% /blocks/feature %}}
 
 {{% /blocks/section %}}
 

--- a/content/en/community/_index.md
+++ b/content/en/community/_index.md
@@ -19,7 +19,7 @@ OpenTelemetry collaborates and integrates with other open-source projects includ
 
 {{% blocks/feature icon="far fa-building" title="Vendor Supported" url="/vendors"%}}
 Several cloud providers and observability vendors distribute or natively support OpenTelemetry.
-{{% /blocks/feature %}}
+
 
 {{% /blocks/section %}}
 

--- a/content/en/docs/net/_index.md
+++ b/content/en/docs/net/_index.md
@@ -21,7 +21,7 @@ This is the current release status for OpenTelemetry components in this language
 
 | Tracing | Metrics | Logging |
 | ------- | ------- | ------- |
-| Beta    | Alpha   | Beta    |
+| 1.0    | Alpha   | Beta    |
 
 You can find release information [here](https://github.com/open-telemetry/opentelemetry-dotnet/releases)
 

--- a/content/en/docs/python/_index.md
+++ b/content/en/docs/python/_index.md
@@ -19,7 +19,7 @@ is as follows:
 
 | Tracing | Metrics | Logging |
 | ------- | ------- | ------- |
-| Beta    | Alpha   | Not Yet Implemented |
+| 1.0    | Alpha   | Not Yet Implemented |
 
 The current release can be found [here](https://github.com/open-telemetry/opentelemetry-python/releases)
 


### PR DESCRIPTION
The above PR resolves https://github.com/open-telemetry/opentelemetry.io/issues/520 and updates the status of tracing for .NET and Python 