### PR TITLE
Updated release trace versions for .NET 

### DIFF
--- a/content/en/docs/net/_index.md
+++ b/content/en/docs/net/_index.md
@@ -21,7 +21,7 @@ This is the current release status for OpenTelemetry components in this language
 
 | Tracing | Metrics | Logging |
 | ------- | ------- | ------- |
-| Beta    | Alpha   | Beta    |
+| 1.0    | Alpha   | Beta    |
 
 You can find release information [here](https://github.com/open-telemetry/opentelemetry-dotnet/releases)
 

--- a/content/en/docs/python/_index.md
+++ b/content/en/docs/python/_index.md
@@ -19,7 +19,7 @@ is as follows:
 
 | Tracing | Metrics | Logging |
 | ------- | ------- | ------- |
-| Beta    | Alpha   | Not Yet Implemented |
+| 1.0    | Alpha   | Not Yet Implemented |
 
 The current release can be found [here](https://github.com/open-telemetry/opentelemetry-python/releases)
 

--- a/content/en/docs/python/_index.md
+++ b/content/en/docs/python/_index.md
@@ -19,7 +19,7 @@ is as follows:
 
 | Tracing | Metrics | Logging |
 | ------- | ------- | ------- |
-| 1.0    | Alpha   | Not Yet Implemented |
+| Beta    | Alpha   | Not Yet Implemented |
 
 The current release can be found [here](https://github.com/open-telemetry/opentelemetry-python/releases)
 


### PR DESCRIPTION
The above PR resolves #520 and updates the status of tracing for .NET and Python