### PR TITLE
Fix broken Metrics SDK terminology link

### DIFF
--- a/content/en/docs/concepts/glossary.md
+++ b/content/en/docs/concepts/glossary.md
@@ -157,7 +157,7 @@ others. This page captures terminology used in the project and what it means.
 ### Metrics
 
 - **[Metric API Terminology](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#overview)**
-- **[Metric SDK Terminology](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#sdk-terminology)**
+- **[Metric SDK Terminology](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics#specifications)**
 
 ### Logs
 


### PR DESCRIPTION
The Metrics SDK Terminology link points to a non-existent page (sdk.md). This proposed change would link to the Metrics specification list for now, which shows that the Metrics SDK is not available yet. As soon as the SDK page is available and the metrics specification list gets updated, this link will still get people to the right place, and it could be updated later to link directly to the metrics SDK page once it exists.