### PR TITLE
Update vendors page

### DIFF
--- a/content/en/vendors/_index.md
+++ b/content/en/vendors/_index.md
@@ -18,7 +18,7 @@ weight: 50
 | Company | Distribution | Native OTLP | Reference |
 | ------- | ------------ | ----------- | --------- |
 | AWS     | Yes          | No          | https://aws-otel.github.io/ |
-| Dynatrace | No         | Yes          | https://www.dynatrace.com/support/help/how-to-use-dynatrace/transactions-and-services/service-monitoring-settings/opentelemetry/ |
+| Dynatrace | Yes        | Yes         | https://www.dynatrace.com/support/help/how-to-use-dynatrace/transactions-and-services/service-monitoring-settings/opentelemetry/ |
 | Elastic | Yes          | No          | https://www.elastic.co/guide/en/apm/get-started/current/open-telemetry-elastic.html |
 | F5      | No           | Yes         | https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/f5cloudexporter |
 | Honeycomb | No         | Yes         | https://docs.honeycomb.io/getting-data-in/otel-collector/ |


### PR DESCRIPTION
The Dynatrace OneAgent serves as distro by picking up OpenTelemetry traces without the need for explicit configuration.