### PR TITLE
Remove the OTLP receiver legacy gRPC port(55680) references

### DIFF
--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -43,7 +43,7 @@ processors:
 
 exporters:
   otlp:
-    endpoint: otelcol:55680
+    endpoint: otelcol:4317
 
 extensions:
   health_check:
@@ -87,9 +87,9 @@ processors:
 
 exporters:
   otlp:
-    endpoint: otelcol:55680
+    endpoint: otelcol:4317
   otlp/2:
-    endpoint: otelcol2:55680
+    endpoint: otelcol2:4317
 
 extensions:
   health_check:
@@ -322,7 +322,7 @@ exporters:
 
   # Data sources: traces, metrics, logs
   otlp:
-    endpoint: otelcol2:55680
+    endpoint: otelcol2:4317
     insecure: true
 
   # Data sources: traces, metrics

--- a/content/en/docs/collector/getting-started.md
+++ b/content/en/docs/collector/getting-started.md
@@ -73,10 +73,10 @@ own Prometheus metrics.
 ```bash
 $ git clone git@github.com:open-telemetry/opentelemetry-collector.git; \
     cd opentelemetry-collector/examples; \
-    go build main.go; ./main & pid1="$!";
+    go build main.go; ./main & pid1=$!; \
     docker run --rm -p 13133:13133 -p 14250:14250 -p 14268:14268 \
-      -p 55678-55680:55678-55680 -p 8888:8888 -p 9411:9411 \
-      -v "${PWD}/otel-local-config.yaml":/otel-local-config.yaml \
+      -p 55678-55679:55678-55679 -p 4317:4317 -p 8888:8888 -p 9411:9411 \
+      -v "${PWD}/local/otel-config.yaml":/otel-local-config.yaml \
       --name otelcol otel/opentelemetry-collector \
       --config otel-local-config.yaml; \
     kill $pid1; docker stop otelcol


### PR DESCRIPTION
**Description:**
The legacy gRPC port(55680) in OTLP Receiver will be disabled in OTel Collector before the collector GA.

This CR replaced all gRPC port occurrences from `55680` to `4317` in this repo.

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector/issues/2565

**Test**
```bash
$ git clone git@github.com:open-telemetry/opentelemetry-collector.git; \
    cd opentelemetry-collector/examples; \
    go build main.go; ./main & pid1=$!; \
    docker run --rm -p 13133:13133 -p 14250:14250 -p 14268:14268 \
      -p 55678-55679:55678-55679 -p 4317:4317 -p 8888:8888 -p 9411:9411 \
      -v "${PWD}/local/otel-config.yaml":/otel-local-config.yaml \
      --name otelcol otel/opentelemetry-collector \
      --config otel-local-config.yaml; \
    kill $pid1; docker stop otelcol
```