### PR TITLE
fix: Remove `LogLevel` import from Node.JS Getting Started guide

### DIFF
--- a/content/en/docs/js/getting_started/nodejs.md
+++ b/content/en/docs/js/getting_started/nodejs.md
@@ -58,12 +58,9 @@ Create a file named `tracing.js` and add the following code to create a tracer p
 ```javascript
 'use strict';
 
-const { LogLevel } = require("@opentelemetry/core");
 const { NodeTracerProvider } = require("@opentelemetry/node");
 
-const provider = new NodeTracerProvider({
-  logLevel: LogLevel.ERROR
-});
+const provider = new NodeTracerProvider();
 
 provider.register();
 ```
@@ -134,13 +131,10 @@ To export traces, modify `tracing.js` so that it matches the following code snip
 ```javascript
 'use strict';
 
-const { LogLevel } = require("@opentelemetry/core");
 const { NodeTracerProvider } = require("@opentelemetry/node");
 const { SimpleSpanProcessor, ConsoleSpanExporter } = require("@opentelemetry/tracing");
 
-const provider = new NodeTracerProvider({
-  logLevel: LogLevel.ERROR
-});
+const provider = new NodeTracerProvider();
 
 provider.register();
 
@@ -248,10 +242,9 @@ app.listen(parseInt(PORT, 10), () => { console.log(`Listening for requests on ht
 - tracing.js
 ```javascript
 'use strict';
-const { LogLevel } = require("@opentelemetry/core");
 const { NodeTracerProvider } = require("@opentelemetry/node");
 const { SimpleSpanProcessor, ConsoleSpanExporter } = require("@opentelemetry/tracing");
-const provider = new NodeTracerProvider({ logLevel: LogLevel.ERROR });
+const provider = new NodeTracerProvider();
 provider.register();
 provider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
 console.log("tracing initialized");


### PR DESCRIPTION
`LogLevel` doesn't seem to be exported from @opentelemetry/node (anymore) and causes the example to crash

```
/Users/nvenegas/Code/otel-nodejs/tracing.js:8
  logLevel: LogLevel.ERROR
            ^

ReferenceError: LogLevel is not defined
    at Object.<anonymous> (/Users/nvenegas/Code/otel-nodejs/tracing.js:8:13)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at Module._preloadModules (internal/modules/cjs/loader.js:1217:12)
    at loadPreloadModules (internal/bootstrap/pre_execution.js:449:5)
    at prepareMainThreadExecution (internal/bootstrap/pre_execution.js:76:3)
    at internal/main/run_main_module.js:7:1
```