### PR TITLE
Publish OpenTelemetry Schema File 1.4.0

### DIFF
--- a/static/schemas/1.4.0
+++ b/static/schemas/1.4.0
@@ -1,0 +1,4 @@
+file_format: 1.0.0
+schema_url: https://opentelemetry.io/schemas/1.4.0
+versions:
+  1.4.0:


### PR DESCRIPTION
As described in https://github.com/open-telemetry/opentelemetry.io/issues/577
this adds the first schema file. This should publish the file at
https://opentelemetry.io/schemas/1.4.0

Merge this PR after specification 1.4.0 is released.

We will automate the addition of future schemas later.