### PR TITLE
Fix name of scraper in hostmetrics config

### DIFF
--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -156,9 +156,9 @@ receivers:
       load:
       memory:
       network:
+      paging:
       process:
       processes:
-      swap:
 
   # Data sources: traces
   jaeger:


### PR DESCRIPTION
Since https://github.com/open-telemetry/opentelemetry-collector/pull/2311, 'swap' is known as 'paging'.