### PR TITLE
Update repo url for python system metrics

### DIFF
--- a/content/en/registry/instrumentation-python-system-metrics.md
+++ b/content/en/registry/instrumentation-python-system-metrics.md
@@ -6,7 +6,7 @@ language: python
 tags:
   - python
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-system-metrics
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/metrics/instrumentation/opentelemetry-instrumentation-system-metrics
 license: Apache 2.0
 description: Instrumentation to collect system performance metrics.
 authors: OpenTelemetry Authors


### PR DESCRIPTION
System metrics were moved to a separate branch in https://github.com/open-telemetry/opentelemetry-python-contrib/pull/312, this PR just updates the URL to point to that branch.

Skimmed through the discussions in the PR and related issues, change seems to have been made because the system metrics instrumentation is experimental and will be added back to the main branch once it is ready for release, so should the references to system metrics be removed entirely instead?