### PR TITLE
Add registry entry for OTel Browser Extension Autoinjection

### DIFF
--- a/content/en/registry/tools-browser-extension-autoinjection.md
+++ b/content/en/registry/tools-browser-extension-autoinjection.md
@@ -1,0 +1,20 @@
+---
+title: OpenTelemetry Browser Extension Autoinjection
+registryType: utilities
+isThirdParty: false
+language: js
+tags:
+  - js
+  - browser
+  - web-ext
+  - browser-extension
+  - chrome-extension
+  - firefox-extension
+  - autoinjection
+repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/opentelemetry-browser-extension-autoinjection
+license: Apache 2.0
+description: >
+    This browser extension allows you to inject OpenTelemetry instrumentation in any web page. It uses the Web SDK and can export data to Zipkin or an OpenTelemetry Collector.
+authors: OpenTelemetry Authors
+otVersion: latest
+---


### PR DESCRIPTION
A browser extension to inject OpenTelemetry into websites was recently added to the opentelemetry-contrib-js repo, would be great to have it also in the registry. (see https://github.com/open-telemetry/opentelemetry-js-contrib/pull/498)