### PR TITLE
Corrrected the OAuth2 Extension name in the collector docs.

### DIFF
--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -512,10 +512,11 @@ them to every RPC made to a remote collector:
 
 ```yaml
 extensions:
-  oauth2clientcredentials:
+  oauth2client:
     client_id: agent
     client_secret: some-secret
     token_url: http://localhost:8080/auth/realms/opentelemetry/protocol/openid-connect/token
+    scopes: ["api.metrics.write"]
 
 receivers:
   otlp:
@@ -533,7 +534,7 @@ exporters:
 
 service:
   extensions:
-    - oauth2clientcredentials
+    - oauth2client
   pipelines:
     traces:
       receivers:


### PR DESCRIPTION
The extension name for  OAuth2 authenticator  is `oauth2client`. Corrected it from `oauth2clientcredentials`.

Reference: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/oauth2clientauthextension