### PR TITLE
Fix a small typo in the description of Winston package (JS) in the registry

### DIFF
--- a/content/en/registry/instrumentation-js-winston.md
+++ b/content/en/registry/instrumentation-js-winston.md
@@ -9,7 +9,7 @@ tags:
   - logging
 repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-winston
 license: Apache 2.0
-description: Instrumentation library for Bunyan.
+description: Instrumentation library for Winston.
 authors: OpenTelemetry Authors
 otVersion: latest
 ---


### PR DESCRIPTION
Noticed a small typo in one of the registry entries.

## Docs PR Checklist
<!--- Just making sure... -->
- [x] This PR is for a documentation page whose authoritative copy is in the opentelemetry.io repository.
