### PR TITLE
Update docs: meter.RecordBatch is missing a parameter

### DIFF
--- a/content/en/docs/go/getting-started.md
+++ b/content/en/docs/go/getting-started.md
@@ -193,8 +193,8 @@ Let's put the concepts we've just covered together, and create a trace and some 
 		span.SetAttributes(anotherKey.String("yes"))
 
 		meter.RecordBatch(
+			ctx,
 			commonAttributes,
-
 			valueRecorder.Measurement(2.0),
 		)
 


### PR DESCRIPTION
The function definition of RecordBatch is as below.
```
// RecordBatch atomically records a batch of measurements.
func (m Meter) RecordBatch(ctx context.Context, ls []attribute.KeyValue, ms ...Measurement) {
	if m.impl == nil {
		return
	}
	m.impl.RecordBatch(ctx, ls, ms...)
}
```
This first parameter is missing in the caller.