### PR TITLE
Update metrics spec status

### DIFF
--- a/content/en/status/_index.md
+++ b/content/en/status/_index.md
@@ -62,7 +62,7 @@ Checking the current status for each client in the README of its [github repo](h
 
 #### Metrics
 
-**API:** draft  
+**API:** feature-freaze  
 **SDK:** draft  
 **Protocol:** stable  
 **Collector:** experimental  


### PR DESCRIPTION
Update the metrics API spec status once https://github.com/open-telemetry/opentelemetry-specification/pull/1833 is merged.