### PR TITLE
Support use of local link checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ node_modules/
 data/progress_generated.yaml
 
 # Link checker
-bin/
 tmp/
 
 scripts/collector.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,11 @@
+HTMLTEST_DIR=tmp
+HTMLTEST?=htmltest # Specify as make arg if different
+# Use $(HTMLTEST) in PATH, if available; otherwise, we'll get a copy
+ifeq (, $(shell command -v $(HTMLTEST)))
+PRE_CHECK_LINKS=get-link-checker
+override HTMLTEST=$(HTMLTEST_DIR)/bin/htmltest
+endif
+
 build:
 	hugo --minify
 
@@ -6,14 +14,13 @@ ci-build-preview:
 		--baseURL $(DEPLOY_PRIME_URL) \
 		--minify
 
-ci-link-check:
-	curl https://raw.githubusercontent.com/wjdp/htmltest/master/godownloader.sh | bash
-	bin/htmltest
+ci-link-check: $(PRE_CHECK_LINKS)
+	$(HTMLTEST)
 
 clean:
-	rm -rf public
+	rm -rf $(HTMLTEST_DIR) public/* resources
 
-setup:
+setup: clean
 	npm install
 	npm run-script build
 	git submodule update --init --recursive --depth 1
@@ -26,6 +33,9 @@ test: build ci-link-check
 preview-build: get-milestones ci-build-preview ci-link-check
 
 production-build: get-milestones build ci-link-check
+
+get-link-checker:
+	curl https://htmltest.wjdp.uk | bash -s -- -b $(HTMLTEST_DIR)/bin
 
 get-milestones: setup
 	node -r esm ./scripts/fetchMilestones.js


### PR DESCRIPTION
When testing locally, if you have `htmltest` in your path, that command will be used. Otherwise, a copy will be fetched.

Closes #546