### PR TITLE
Upgrade to Hugo 0.87.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "make production-build"
 
 [build.environment]
-HUGO_VERSION = "0.65.3"
+HUGO_VERSION = "0.87.0"
 
 [context.production.environment]
 HUGO_ENV = "production"


### PR DESCRIPTION
Closes #636 (note that I need the features of more recent versions of Hugo to implement other changes to the site).

In comparing normalized versions of the generated site files (ignoring modified dates/times and other similar meta data), the only non-whitespace differences are in the following files:

- `/docs/collector/configuration/index.html`
- `/docs/erlang/getting-started/index.html`
- `/docs/erlang/instrumentation/index.html`
- `/docs/js/instrumentation/index.html`

The changes to these files are due to differences in code-highlighter inlined styles. For example, https://opentelemetry.io/docs/erlang/getting-started/#opentelemetry, changes from

> <img src=https://user-images.githubusercontent.com/4140793/129446123-a30a9e13-553a-4fcb-8fe9-2e1d5d526a1e.png width=400>

to

> <img src=https://user-images.githubusercontent.com/4140793/129446131-c963e505-4aad-454f-82c2-85f32e6b2c8d.png width=400>

Note that the keywords are not bold.

---

Here's the diff command I used:

```console
# Build and then ...
$ cd ../opentelemetry.io.g
$ git diff -b -w --ignore-blank-lines -- . ':(exclude)*.xml' ':(exclude)*.css' ':(exclude)*.map'
...
```

---

Strangely the word count for `/docs/collector/configuration/index.html` differs by 6 words. I didn't investigate further, and assumed it wasn't significant.