### PR TITLE
Upgrade to postcss-cli, add postcss package too

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "bulma": "^0.9.3",
     "esm": "^3.2.25",
     "node-fetch": "^2.6.1",
-    "postcss-cli": "^7.1.2",
+    "postcss": "^8.3.6",
+    "postcss-cli": "^8.3.1",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
     "yaml": "^1.10.2"


### PR DESCRIPTION
Closes #678

As noted in the docsy docs (https://www.docsy.dev/docs/getting-started/#install-postcss), we also need to add `postcss` as a dependency when upgrading to `postcss-cli` v8.