### PR TITLE
Vendors: Elastic provides native support for OTLP

### DIFF
--- a/content/en/vendors/_index.md
+++ b/content/en/vendors/_index.md
@@ -19,7 +19,7 @@ weight: 50
 | ------- | ------------ | ----------- | --------- |
 | AWS     | Yes          | No          | https://aws-otel.github.io/ |
 | Dynatrace | Yes        | Yes         | https://www.dynatrace.com/support/help/how-to-use-dynatrace/transactions-and-services/service-monitoring-settings/opentelemetry/ |
-| Elastic | Yes          | No          | https://www.elastic.co/guide/en/apm/get-started/current/open-telemetry-elastic.html |
+| Elastic | Yes          | Yes         | https://www.elastic.co/guide/en/apm/get-started/current/open-telemetry-elastic.html |
 | F5      | No           | Yes         | https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/f5cloudexporter |
 | Honeycomb | Yes        | Yes         | https://docs.honeycomb.io/getting-data-in/ |
 | Lightstep | Yes        | Yes         | https://github.com/lightstep?q=launcher |


### PR DESCRIPTION
Update the [vendors](https://opentelemetry.io/vendors/) page to indicate that Elastic provides native support for OTLP.