### PR TITLE
Serve OTel schemas from opentelemetry-specification submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "content-modules/opentelemetry-go"]
 	path = content-modules/opentelemetry-go
 	url = https://github.com/open-telemetry/opentelemetry-go
+[submodule "content-modules/opentelemetry-specification"]
+	path = content-modules/opentelemetry-specification
+	url = https://github.com/open-telemetry/opentelemetry-specification.git

--- a/config.toml
+++ b/config.toml
@@ -236,3 +236,10 @@ name = "Noto Sans"
 sizes = [300,400,600,700]
 type = "sans_serif"
 
+[module]
+[[module.mounts]]
+  source = 'static'
+  target = 'static'
+[[module.mounts]]
+  source = 'content-modules/opentelemetry-specification/schemas'
+  target = 'static/schemas'

--- a/static/schemas/1.4.0
+++ b/static/schemas/1.4.0
@@ -1,4 +1,0 @@
-file_format: 1.0.0
-schema_url: https://opentelemetry.io/schemas/1.4.0
-versions:
-  1.4.0:

--- a/static/schemas/1.5.0
+++ b/static/schemas/1.5.0
@@ -1,5 +1,0 @@
-file_format: 1.0.0
-schema_url: https://opentelemetry.io/schemas/1.5.0
-versions:
-  1.5.0:
-  1.4.0:

--- a/static/schemas/1.6.1
+++ b/static/schemas/1.6.1
@@ -1,6 +1,0 @@
-file_format: 1.0.0
-schema_url: https://opentelemetry.io/schemas/1.6.1
-versions:
-  1.6.1:
-  1.5.0:
-  1.4.0:


### PR DESCRIPTION
- Closes #709
- I've checked that this **generates the same site files**, plus `schemas/1.6.0`, because that schema hasn't been deleted yet from `opentelemetry-specification` -- pending the merge of this PR, https://github.com/open-telemetry/opentelemetry-specification/pull/1910.

Preview checks:

- https://deploy-preview-715--opentelemetry.netlify.app/schemas/1.4.0
- https://deploy-preview-715--opentelemetry.netlify.app/schemas/1.5.0
- https://deploy-preview-715--opentelemetry.netlify.app/schemas/1.6.1

/cc @carlosalberto @tigrannajaryan 