### PR TITLE
Fix repo links for registry components moved from core to contrib

### DIFF
--- a/content/en/registry/collector-exporter-file.md
+++ b/content/en/registry/collector-exporter-file.md
@@ -7,7 +7,7 @@ tags:
   - go
   - exporter
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/fileexporter
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/fileexporter
 license: Apache 2.0
 description: The File Exporter for the OpenTelemetry Collector.
 authors: OpenTelemetry Authors

--- a/content/en/registry/collector-exporter-jaeger.md
+++ b/content/en/registry/collector-exporter-jaeger.md
@@ -7,7 +7,7 @@ tags:
   - go
   - exporter
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/jaegerexporter
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/jaegerexporter
 license: Apache 2.0
 description: The Jaeger Exporter for the OpenTelemetry Collector.
 authors: OpenTelemetry Authors

--- a/content/en/registry/collector-exporter-kafka.md
+++ b/content/en/registry/collector-exporter-kafka.md
@@ -7,7 +7,7 @@ tags:
   - go
   - exporter
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/kafkaexporter
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/kafkaexporter
 license: Apache 2.0
 description: The Kafka Exporter for the OpenTelemetry Collector.
 authors: OpenTelemetry Authors

--- a/content/en/registry/collector-exporter-opencensus.md
+++ b/content/en/registry/collector-exporter-opencensus.md
@@ -7,7 +7,7 @@ tags:
   - go
   - exporter
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/opencensusexporter
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/opencensusexporter
 license: Apache 2.0
 description: The OpenCensus Exporter for the OpenTelemetry Collector.
 authors: OpenTelemetry Authors

--- a/content/en/registry/collector-exporter-prometheus-remote-write.md
+++ b/content/en/registry/collector-exporter-prometheus-remote-write.md
@@ -7,7 +7,7 @@ tags:
   - go
   - exporter
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/prometheusremotewriteexporter
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusremotewriteexporter
 license: Apache 2.0
 description: The Prometheus Remote Write Exporter for the OpenTelemetry Collector.
 authors: OpenTelemetry Authors

--- a/content/en/registry/collector-exporter-prometheus.md
+++ b/content/en/registry/collector-exporter-prometheus.md
@@ -7,7 +7,7 @@ tags:
   - go
   - exporter
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/prometheusexporter
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusexporter
 license: Apache 2.0
 description: The Prometheus Exporter for the OpenTelemetry Collector.
 authors: OpenTelemetry Authors

--- a/content/en/registry/collector-exporter-zipkin.md
+++ b/content/en/registry/collector-exporter-zipkin.md
@@ -7,7 +7,7 @@ tags:
   - go
   - exporter
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/zipkinexporter
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/zipkinexporter
 license: Apache 2.0
 description: The Zipkin Exporter for the OpenTelemetry Collector.
 authors: OpenTelemetry Authors

--- a/content/en/registry/collector-extension-auth-bearertokenauthextension.md
+++ b/content/en/registry/collector-extension-auth-bearertokenauthextension.md
@@ -7,7 +7,7 @@ tags:
   - go
   - extension
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/bearertokenauthextension
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/bearertokenauthextension
 license: Apache 2.0
 description: The Bearer token authenticator extension allows gRPC and HTTP-based exporters to add authentication data to outgoing calls based on a static token.
 authors: OpenTelemetry Authors

--- a/content/en/registry/collector-extension-auth-oauth2clientcredentials.md
+++ b/content/en/registry/collector-extension-auth-oauth2clientcredentials.md
@@ -1,5 +1,5 @@
 ---
-title: OAuth2 client credentials authenticator extension
+title: OAuth2 Client Credentials authenticator extension
 registryType: extension
 isThirdParty: false
 language: collector
@@ -7,9 +7,9 @@ tags:
   - go
   - extension
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/oauth2clientcredentials
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/oauth2clientauthextension
 license: Apache 2.0
-description: The OAuth2 client credentials authenticator extension allows gRPC and HTTP-based exporters to add authentication data to outgoing calls.
+description: The OAuth2 Client Credentials authenticator extension allows gRPC and HTTP-based exporters to add authentication data to outgoing calls.
 authors: OpenTelemetry Authors
 otVersion: latest
 ---

--- a/content/en/registry/collector-extension-auth-oidc.md
+++ b/content/en/registry/collector-extension-auth-oidc.md
@@ -7,7 +7,7 @@ tags:
   - go
   - extension
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/oidcauthextension
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/oidcauthextension
 license: Apache 2.0
 description: The OIDC authenticator extension allows gRPC and HTTP-based receivers to require authentication from remote clients.
 authors: OpenTelemetry Authors

--- a/content/en/registry/collector-extension-fluentbit-subprocess.md
+++ b/content/en/registry/collector-extension-fluentbit-subprocess.md
@@ -7,7 +7,7 @@ tags:
   - go
   - extension
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/fluentbitextension
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/fluentbitextension
 license: Apache 2.0
 description: The FluentBit Subprocess Extension for the OpenTelemetry Collector facilitates running a FluentBit subprocess of the collector.
 authors: OpenTelemetry Authors

--- a/content/en/registry/collector-extension-healthcheck.md
+++ b/content/en/registry/collector-extension-healthcheck.md
@@ -7,7 +7,7 @@ tags:
   - go
   - extension
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/healthcheckextension
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckextension
 license: Apache 2.0
 description: The Health Check Extension for the OpenTelemetry Collector enables an HTTP url that can be probed to check the status of the the OpenTelemetry Collector.
 authors: OpenTelemetry Authors

--- a/content/en/registry/collector-extension-pprof.md
+++ b/content/en/registry/collector-extension-pprof.md
@@ -7,7 +7,7 @@ tags:
   - go
   - extension
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/pprofextension
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/pprofextension
 license: Apache 2.0
 description: The Performance Profiler Extension for the OpenTelemetry Collector can be used to collect performance profiles and investigate issues with the service.
 authors: OpenTelemetry Authors

--- a/content/en/registry/collector-processor-attributes.md
+++ b/content/en/registry/collector-processor-attributes.md
@@ -7,7 +7,7 @@ tags:
   - go
   - processor
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/attributesprocessor
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/attributesprocessor
 license: Apache 2.0
 description: The Attribute Processor for the OpenTelemetry Collector modifies attributes of a span.
 authors: OpenTelemetry Authors

--- a/content/en/registry/collector-processor-filter.md
+++ b/content/en/registry/collector-processor-filter.md
@@ -7,7 +7,7 @@ tags:
   - go
   - processor
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/filterprocessor
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor
 license: Apache 2.0
 description: The Filter Processor for the OpenTelemetry Collector can be configured to include or exclude metrics.
 authors: OpenTelemetry Authors

--- a/content/en/registry/collector-processor-probablisistic-sampling.md
+++ b/content/en/registry/collector-processor-probablisistic-sampling.md
@@ -7,7 +7,7 @@ tags:
   - go
   - processor
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/probabilisticsamplerprocessor
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/probabilisticsamplerprocessor
 license: Apache 2.0
 description: The Probabilistic Sampling Processor for the OpenTelemetry Collector provides probablistic sampling of traces.
 authors: OpenTelemetry Authors

--- a/content/en/registry/collector-processor-resource.md
+++ b/content/en/registry/collector-processor-resource.md
@@ -7,7 +7,7 @@ tags:
   - go
   - processor
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/resourceprocessor
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourceprocessor
 license: Apache 2.0
 description: The Resource Processor for the OpenTelemetry Collector can be used to apply changes on resource attributes.
 authors: OpenTelemetry Authors

--- a/content/en/registry/collector-processor-span.md
+++ b/content/en/registry/collector-processor-span.md
@@ -7,7 +7,7 @@ tags:
   - go
   - processor
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/resourceprocessor
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/spanprocessor
 license: Apache 2.0
 description: The Span Processor for the OpenTelemetry Collector modifies either the span name or attributes of a span based on the span name.
 authors: OpenTelemetry Authors

--- a/content/en/registry/collector-receiver-fluent-forward.md
+++ b/content/en/registry/collector-receiver-fluent-forward.md
@@ -7,7 +7,7 @@ tags:
   - go
   - receiver
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/fluentforwardreceiver
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/fluentforwardreceiver
 license: Apache 2.0
 description: The Fluent Forward Receiver for the OpenTelemetry Collector.
 authors: OpenTelemetry Authors

--- a/content/en/registry/collector-receiver-jaeger.md
+++ b/content/en/registry/collector-receiver-jaeger.md
@@ -7,7 +7,7 @@ tags:
   - go
   - receiver
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/jaegerreceiver
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/jaegerreceiver
 license: Apache 2.0
 description: The Jaeger Receiver for the OpenTelemetry Collector.
 authors: OpenTelemetry Authors

--- a/content/en/registry/collector-receiver-kafka.md
+++ b/content/en/registry/collector-receiver-kafka.md
@@ -7,7 +7,7 @@ tags:
   - go
   - receiver
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/kafkareceiver
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kafkareceiver
 license: Apache 2.0
 description: The Kafka Receiver for the OpenTelemetry Collector.
 authors: OpenTelemetry Authors

--- a/content/en/registry/collector-receiver-opencensus.md
+++ b/content/en/registry/collector-receiver-opencensus.md
@@ -7,7 +7,7 @@ tags:
   - go
   - receiver
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/opencensusreceiver
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/opencensusreceiver
 license: Apache 2.0
 description: The OpenCensus Receiver for the OpenTelemetry Collector.
 authors: OpenTelemetry Authors

--- a/content/en/registry/collector-receiver-prometheus.md
+++ b/content/en/registry/collector-receiver-prometheus.md
@@ -7,7 +7,7 @@ tags:
   - go
   - receiver
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/prometheusreceiver
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver
 license: Apache 2.0
 description: The Prometheus Receiver for the OpenTelemetry Collector.
 authors: OpenTelemetry Authors

--- a/content/en/registry/collector-receiver-zipkin.md
+++ b/content/en/registry/collector-receiver-zipkin.md
@@ -7,7 +7,7 @@ tags:
   - go
   - receiver
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/zipkinreceiver
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/zipkinreceiver
 license: Apache 2.0
 description: The Zipkin Receiver for the OpenTelemetry Collector.
 authors: OpenTelemetry Authors

--- a/content/en/registry/exporter-go-kafka.md
+++ b/content/en/registry/exporter-go-kafka.md
@@ -7,7 +7,7 @@ tags:
   - go
   - exporter
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/kafkaexporter
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/kafkaexporter
 license: Apache 2.0
 description: The OpenTelemetry Kafka Exporter for Go.
 authors: OpenTelemetry Authors

--- a/content/en/registry/exporter-go-prometheus.md
+++ b/content/en/registry/exporter-go-prometheus.md
@@ -7,7 +7,7 @@ tags:
   - go
   - exporter
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/prometheusexporter
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusexporter
 license: Apache 2.0
 description: The OpenTelemetry Prometheus Exporter for Go.
 authors: OpenTelemetry Authors


### PR DESCRIPTION
Resolve docs: broken links in registry #717