### PR TITLE
JS: make GH page links refer to this repo

### DIFF
--- a/content/en/docs/js/_index.md
+++ b/content/en/docs/js/_index.md
@@ -2,13 +2,8 @@
 title: Javascript
 weight: 20
 description: >-
-  <img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/JS_SDK.svg"></img>
+  <img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/JS_SDK.svg" alt="JS logo"></img>
   A language-specific implementation of OpenTelemetry in JavaScript (for Node.JS & the browser).
-cascade:
-  github_repo: &repo https://github.com/open-telemetry/opentelemetry-js
-  github_subdir: website_docs
-  path_base_for_github_subdir: content/en/docs/js/
-  github_project_repo: *repo
 ---
 
 This page contains an introduction to OpenTelemetry in JavaScript. This guide


### PR DESCRIPTION
- Closes #720
- Effectively reverts the `cascade` added by https://github.com/open-telemetry/opentelemetry-js/pull/2421

Preview: https://deploy-preview-733--opentelemetry.netlify.app/docs/js/