### PR TITLE
CI: link checking improvements & ext link checking

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,5 +1,4 @@
 DirectoryPath: public
 IgnoreDirectoryMissingTrailingSlash: true
-CheckExternal: false
 IgnoreAltMissing: true
 IgnoreInternalEmptyHash: true

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,23 @@
 HTMLTEST_DIR=tmp
 HTMLTEST?=htmltest # Specify as make arg if different
+HTMLTEST_ARGS?=--skip-external
+
 # Use $(HTMLTEST) in PATH, if available; otherwise, we'll get a copy
 ifeq (, $(shell which $(HTMLTEST)))
-PRE_CHECK_LINKS=get-link-checker
 override HTMLTEST=$(HTMLTEST_DIR)/bin/htmltest
+ifeq (, $(shell which $(HTMLTEST)))
+GET_LINK_CHECKER_IF_NEEDED=get-link-checker
+endif
 endif
 
-check-internal-links: $(PRE_CHECK_LINKS)
-	$(HTMLTEST)
+check-links: $(GET_LINK_CHECKER_IF_NEEDED)
+	$(HTMLTEST) $(HTMLTEST_ARGS)
 
 clean:
 	rm -rf $(HTMLTEST_DIR) public/* resources
 
 get-link-checker:
+	rm -Rf $(HTMLTEST_DIR)/bin
 	curl https://htmltest.wjdp.uk | bash -s -- -b $(HTMLTEST_DIR)/bin
 
 get-milestones:

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "scripts": {
     "_build": "hugo --cleanDestinationDir -e dev -DFE",
-    "_check-links": "make check-internal-links",
+    "_check-links": "make check-links",
     "_serve": "hugo serve -p 30000 -DFE",
     "build:preview": "hugo --cleanDestinationDir -DFE --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",
     "build:production": "hugo --cleanDestinationDir --minify",
     "build": "npm run _build",
+    "check-links:all": "HTMLTEST_ARGS= npm run _check-links",
     "check-links": "npm run _check-links",
     "clean": "make clean",
     "postbuild:preview": "npm run _check-links",


### PR DESCRIPTION
- Support checking internal _and_ external links
- Don't fetch a copy of the link checker if we previously did and the copy is still available.

Note: we'll want to wait until the next release of htmltest (> 0.14.0) before checking external links. So we're waiting on https://github.com/wjdp/htmltest/discussions/174.