### PR TITLE
Fix banner on mobile

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -46,13 +46,6 @@
   padding-top: 1rem;
 }
 
-// https://github.com/open-telemetry/opentelemetry.io/pull/377/files
-section#announcement {
-  display: flex;
-  justify-content: center;
-  padding: 6px;
-}
-
 // Homepage
 #cncf {
   width: 100%;
@@ -87,5 +80,24 @@ a:hover {
   h2[id]:before, h3[id]:before, h4[id]:before, h5[id]:before {
     margin-top: 0;
     height: 0;
+  }
+}
+
+// Object
+.o-banner {
+  @include media-breakpoint-up(md) {
+    width: 100%;
+    position: fixed;
+    margin-left: -15px;
+    z-index: 32;
+    top: 4rem;
+  }
+
+  background: $gray-100;
+  text-align: center;
+
+  & p {
+    padding: 0.5rem;
+    margin-bottom: initial;
   }
 }

--- a/config.toml
+++ b/config.toml
@@ -98,12 +98,6 @@ algolia_docsearch = false
 # Enable Lunr.js offline search
 offlineSearch = false
 
-# param for displaying an announcement block on homepage; see PR #377
-announcement = true
-# announcement_message is only displayed when announcement = true; update with your specific message
-announcement_message = "<span style='padding-right:12px'>🎉 </span> The OpenTelemetry tracing specification is now 1.0!&nbsp;&nbsp;<a href='https://medium.com/opentelemetry/opentelemetry-specification-v1-0-0-tracing-edition-72dd08936978'>Learn more today!</a>"
-
-
 # User interface configuration
 [params.ui]
 # Enable to show the side bar menu in its compact state.

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "OpenTelemetry"
+title: OpenTelemetry
+show_banner: true
 ---
 
 {{< blocks/cover title="" image_anchor="center" height="min" color="dark" >}}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -10,7 +10,11 @@
       {{ partial "navbar.html" . }}
     </header>
     <div class="container-fluid td-default td-outer">
-      {{ partial "banner.html" . }}
+      {{- /*
+        I'd like to use .RenderString so that render-* hooks work, but it results in a nil pointer error.
+        Track this via https://github.com/gohugoio/hugo/issues/7280.
+      */ -}}
+      {{ partial "banner.md" . | markdownify }}
       <main role="main" class="td-main">
         {{ block "main" . }}{{ end }}
       </main>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,18 +1,16 @@
+{{/* docsy-delta */ -}}
+
 <!doctype html>
 <html lang="{{ .Site.Language.Lang }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
   </head>
   <body class="td-{{ .Kind }}">
-    {{ block "announcement" . }}
-      {{ if .IsHome }}
-        {{ partial "announcement.html" . }}
-      {{ end }}
-    {{ end }}
     <header>
       {{ partial "navbar.html" . }}
     </header>
     <div class="container-fluid td-default td-outer">
+      {{ partial "banner.html" . }}
       <main role="main" class="td-main">
         {{ block "main" . }}{{ end }}
       </main>

--- a/layouts/partials/announcement.html
+++ b/layouts/partials/announcement.html
@@ -1,5 +1,0 @@
-{{ if .Param "announcement"}}
-<section id="announcement" >
-    {{ .Param "announcement_message" | markdownify }}
-</section>
-{{ end }}

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -1,0 +1,8 @@
+{{ if .Params.show_banner -}}
+<div class="o-banner">
+    <p>
+        The OpenTelemetry tracing specification is now 1.0!
+        <a href='https://medium.com/opentelemetry/opentelemetry-specification-v1-0-0-tracing-edition-72dd08936978'>Learn more</a>
+    </p>
+</div>
+{{ end -}}

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -1,8 +1,0 @@
-{{ if .Params.show_banner -}}
-<div class="o-banner">
-    <p>
-        The OpenTelemetry tracing specification is now 1.0!
-        <a href='https://medium.com/opentelemetry/opentelemetry-specification-v1-0-0-tracing-edition-72dd08936978'>Learn more</a>
-    </p>
-</div>
-{{ end -}}

--- a/layouts/partials/banner.md
+++ b/layouts/partials/banner.md
@@ -1,0 +1,10 @@
+{{ if .Params.show_banner -}}
+<div class="o-banner">
+
+The OpenTelemetry tracing specification is now 1.0!
+[Learn more][]
+
+[Learn more]: https://medium.com/opentelemetry/opentelemetry-specification-v1-0-0-tracing-edition-72dd08936978
+
+</div>
+{{ end -}}


### PR DESCRIPTION
- Closes #757 
- This moves the banner to be under the topnav, which IMHO makes it much more visibile.
- I still have to strip out the code mods from `src/js/base.js`, but I'll do that in a followup PR.

Preview: https://deploy-preview-758--opentelemetry.netlify.app/

---

### Screenshots (see #757 for the "before" screenshot):

Mobile:

<img width="319" alt="Screen Shot 2021-09-22 at 6 15 00 AM" src="https://user-images.githubusercontent.com/4140793/134326011-5c98d75f-228d-4012-b3d6-59b24ad0676d.png">

Desktop:

<img width="1282" alt="Screen Shot 2021-09-22 at 6 15 24 AM" src="https://user-images.githubusercontent.com/4140793/134326046-5a3008b6-91ee-497e-8cc6-f059c83d9bf1.png">

