### PR TITLE
Homepage top nav: always use std bg color

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -4,8 +4,8 @@
 @import "registry";
 @import "tabs";
 
-.navbar-position-absolute {
-  position: absolute !important;
+.td-navbar {
+  background: $primary !important;
 }
 
 // Icons
@@ -83,7 +83,6 @@ a:hover {
   }
 }
 
-// Object
 .o-banner {
   @include media-breakpoint-up(md) {
     width: 100%;

--- a/src/js/base.js
+++ b/src/js/base.js
@@ -23,30 +23,24 @@ const tracer = require('./tracing');
     if (!promo.length) {
       return
     }
+    var promoOffset = bottomPos(promo);
+    var navbarOffset = $('.js-navbar-scroll').offset().top;
+    var threshold = Math.ceil($('.js-navbar-scroll').outerHeight());
+    if ((promoOffset - navbarOffset) < threshold) {
+      $('.js-navbar-scroll').addClass('navbar-bg-onscroll');
+    }
 
-    const announcementThreshold = Math.ceil($('section#announcement').outerHeight()) || -1;
-    // announcement_size + td-cover-block-0.padding-top/128px + img.padding-top/16 - nav.height/64px
-    const threshold = announcementThreshold + 128 + 16 - 64;
-    const onScroll = () => {
+
+    $(window).on('scroll', function () {
+      var navtop = $('.js-navbar-scroll').offset().top - $(window).scrollTop();
+      var promoOffset = bottomPos($('.js-td-cover'));
       var navbarOffset = $('.js-navbar-scroll').offset().top;
-      if (navbarOffset > threshold) {
+      if ((promoOffset - navbarOffset) < threshold) {
         $('.js-navbar-scroll').addClass('navbar-bg-onscroll');
       } else {
         $('.js-navbar-scroll').removeClass('navbar-bg-onscroll');
         $('.js-navbar-scroll').addClass('navbar-bg-onscroll--fade');
       }
-
-      var pageOffset = window.pageYOffset || document.documentElement.scrollTop;
-      if (pageOffset < announcementThreshold) {
-        $('.js-navbar-scroll').addClass('navbar-position-absolute').css("top", `${announcementThreshold}px`);
-      } else {
-        $('.js-navbar-scroll').removeClass('navbar-position-absolute').css("top", "0");
-      }
-    }
-
-    onScroll()
-    $(window).on('scroll', function () {
-      onScroll()
     });
   });
 


### PR DESCRIPTION
- Followup to #758, and so also contributes to #757
- This PR effectively undoes the changes introduced by:
  - #377
  - #413
- The "Bootstrap Fixed Header" code in `base.js` has been reverted to match Docsy

With the CSS changes in this PR, the homepage top nav has the same appearance and behaves the same as for any other site pages:

> ![image](https://user-images.githubusercontent.com/4140793/134333671-495e9447-4117-4015-9d4a-56c9406ed9ad.png)
