### PR TITLE
fingerprinted registrySearch.js in production mode only

### DIFF
--- a/layouts/registry/list.html
+++ b/layouts/registry/list.html
@@ -1,6 +1,5 @@
 {{ define "main" }}
 {{ $registryItems := where .Data.Pages "Params.layout" "!=" "search" }}
-{{ $search := resources.Get "js/registrySearch.js" | fingerprint }}
 
 {{ $languages := newScratch }}
 {{ $languages.Set "collector" "Collector" }}
@@ -95,6 +94,12 @@
     </li>
   </script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/fuse.js/3.2.0/fuse.min.js"></script>
-  <script src="{{ $search.RelPermalink }}" integrity="{{ $search.Data.Integrity }}" type="application/javascript"></script>
+  {{ $js := resources.Get "js/registrySearch.js" -}}
+  {{ if hugo.IsProduction -}}
+    {{ $js = $js | minify | fingerprint -}}
+    <script src="{{ $js.RelPermalink }}" integrity="{{ $js.Data.Integrity }}" crossorigin="anonymous"></script>
+  {{ else -}}
+    <script src="{{ $js.RelPermalink }}"></script>
+  {{- end }}
 </div>
-{{ end }}
+{{ end -}}


### PR DESCRIPTION
- Closes #726 
- Prep work for #744
- No change to generated site files in production mode, except that `registrySearch.js` will now be minified

Preview: https://deploy-preview-774--opentelemetry.netlify.app/registry/