### PR TITLE
Upgrade to Hugo 0.88.1 via NPM

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,13 +3,11 @@
 ## Dev Setup
 
 * Fork and clone the repository
-* Install [Hugo](https://gohugo.io/getting-started/installing/#quick-install)
-  * Please note that you need to install the "extended" version of Hugo (with built-in support) to run the site locally.
 * Install [npm](https://npmjs.com)
 * Run `npm install`
 * Run `npm run serve`
   * If you are on OS X and see an error like `too many open files` or `pipe failed`, you may need to increase the file descriptor limit. See [this Hugo GitHub issue](https://github.com/gohugoio/hugo/issues/6109).
-* Open `http://localhost:30000` to check the site
+* To view the locally generated site, visit [localhost:30000][localhost].
 
 A few notes to be aware of:
 
@@ -53,3 +51,5 @@ changes.
 
 > Site administrators can access the admin interface
 > [here](https://app.netlify.com/sites/opentelemetry/overview).
+
+[localhost]: http://localhost:30000

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,9 +2,6 @@
 publish = "public"
 command = "npm run build:production"
 
-[build.environment]
-HUGO_VERSION = "0.87.0"
-
 [context.production.environment]
 HUGO_ENV = "production"
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "autoprefixer": "^10.3.1",
     "esm": "^3.2.25",
+    "hugo-extended": "0.88.1",
     "node-fetch": "^2.6.1",
     "postcss": "^8.3.6",
     "postcss-cli": "^9.0.0",


### PR DESCRIPTION
I'm having some strange site-generation issues with the current version of Hugo. The latest version seems to be fine.

This PR switches to using the very convenient [hugo-extended](https://www.npmjs.com/package/hugo-extended) NPM package to fetch the proper version of Hugo. This makes is easier for contributors -- who will no longer need to separately install Hugo.