### PR TITLE
Erlang: fix heading levels

### DIFF
--- a/content/en/docs/erlang/_index.md
+++ b/content/en/docs/erlang/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Erlang/Elixir"
+title: Erlang/Elixir
 weight: 14
 description: >
   <img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Elixir_SDK.svg"></img>

--- a/content/en/docs/erlang/getting-started.md
+++ b/content/en/docs/erlang/getting-started.md
@@ -1,5 +1,5 @@
 ---
-title: "Getting Started"
+title: Getting Started
 weight: 20
 ---
 
@@ -7,13 +7,13 @@ Welcome to the OpenTelemetry for Erlang/Elixir getting started guide! This guide
 will walk you through the basic steps in installing, configuring, and exporting data
 from OpenTelemetry.
 
-# Installation
+## Installation
 
 OpenTelemetry packages for Erlang/Elixir are available on
 [hex.pm](https://hex.pm). There are two packages you might want to install,
 depending on what you are trying to accomplish.
 
-## `opentelemetry_api`
+### `opentelemetry_api`
 
 If you are developing a library or OTP Application that someone else would include
 into their deployed code and you want to provide OpenTelemetry instrumentation
@@ -22,7 +22,7 @@ only the API of OpenTelemetry. It will not start any processes and all API calls
 (such as starting a span) will be a no-op that creates no data, unless the
 `opentelemetry` SDK package is also installed.
 
-## `opentelemetry`
+### `opentelemetry`
 
 If you are developing an Application that will actually be deployed and export
 OpenTelemetry data, whether from instrumented dependencies or your code itself,
@@ -95,7 +95,7 @@ releases: [
 
 {{< /tabs >}}
 
-# Initialization and Configuration
+## Initialization and Configuration
 
 Configuration is done through the [Application
 environment](https://erlang.org/doc/design_principles/applications.html#configuring-an-application)
@@ -106,7 +106,7 @@ Provider](https://hexdocs.pm/opentelemetry_api/otel_tracer_provider.html), its
 [Span Processors](https://hexdocs.pm/opentelemetry/otel_span_processor.html) and
 the [Exporter](https://hexdocs.pm/opentelemetry/otel_exporter.html).
 
-## Using the Console Exporter
+### Using the Console Exporter
 
 Exporters are packages that allow telemetry data to be emitted somewhere -
 either to the console (which is what we're doing here), or to a remote system or
@@ -133,7 +133,7 @@ of span processor that batches up multiple spans over a period of time:
 {{< /tab >}}
 
 {{< tab >}}
-# config/runtime.exs
+## config/runtime.exs
 config :opentelemetry, :processors,
   otel_batch_processor: %{
     exporter: {:otel_exporter_stdout, []}
@@ -142,7 +142,7 @@ config :opentelemetry, :processors,
 
 {{< /tabs >}}
 
-# Working with Spans
+## Working with Spans
 
 Now that the dependencies and configuration are set up, we can create a module with
 a function `hello/0` that starts some spans:
@@ -174,7 +174,7 @@ nice_operation(_SpanCtx) ->
 {{< /tab >}}
 
 {{< tab >}}
-# lib/otel_getting_started.ex
+## lib/otel_getting_started.ex
 defmodule OtelGettingStarted do
   require OpenTelemetry.Tracer, as: Tracer
 

--- a/content/en/docs/erlang/instrumentation.md
+++ b/content/en/docs/erlang/instrumentation.md
@@ -1,5 +1,5 @@
 ---
-title: "Instrumentation"
+title: Instrumentation
 weight: 30
 ---
 
@@ -8,7 +8,7 @@ application. This can be done with direct calls to the OpenTelemetry API within
 your code or including a dependency which calls the API and hooks into your
 project, like a middleware for an HTTP server.
 
-# TracerProvider and Tracers
+## TracerProvider and Tracers
 
 In OpenTelemetry each service being traced has at least one `TracerProvider`
 that is used to hold configuration about the name/version of the service, what
@@ -78,7 +78,7 @@ In most cases you will not need to manually register or look up a
 section, and the `Tracer` for the Application the macro is used in will be used
 automatically.
 
-# Starting Spans
+## Starting Spans
 
 A trace is a tree of spans, starting with a root span that has no parent. To
 represent this tree, each span after the root has a parent span associated with
@@ -135,7 +135,7 @@ end
 
 {{< /tabs >}}
 
-## Cross Process Propagation
+### Cross Process Propagation
 
 The examples in the previous section were spans with a child-parent relationship
 within the same process where the parent is available in the process dictionary
@@ -143,7 +143,7 @@ when creating a child span. Using the process dictionary this way isn't possible
 when crossing processes, either by spawning a new process or sending a message
 to an existing process. Instead, the context must be manually passed as a variable.
 
-### Creating Spans for New Processes
+#### Creating Spans for New Processes
 
 To pass spans across processes we need to start a span that isn't connected to
 particular process. This can be done with the macro `start_span`. Unlike
@@ -189,7 +189,7 @@ OpenTelemetry.Tracer.end_span(span_ctx)
 
 {{< /tabs >}}
 
-### Linking the New Span
+#### Linking the New Span
 
 If the work being done by the other process is better represented as a `link` --
 see [the `link` definition in the
@@ -225,7 +225,7 @@ task = Task.async(fn ->
 
 {{< /tabs >}}
 
-## Attributes
+### Attributes
 
 Attributes are key-value pairs that are applied as metadata to your spans and
 are useful for aggregating, filtering, and grouping traces. Attributes can be
@@ -260,7 +260,7 @@ end
 
 {{< /tabs >}}
 
-### Semantic Attributes
+#### Semantic Attributes
 
 Semantic Attributes are attributes that are defined by the OpenTelemetry
 Specification in order to provide a shared set of attribute keys across multiple
@@ -270,7 +270,7 @@ available in the header `opentelemetry_api/include/otel_resource.hrl`.
 
 Tracing semantic conventions can be found [in this document](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions)
 
-## Events
+### Events
 
 An event is a human-readable message on a span that represents "something
 happening" during it's lifetime. For example, imagine a function that requires
@@ -322,7 +322,7 @@ Span.add_event("Process exited with reason", pid: pid, reason: Reason)
 
 {{< /tabs >}}
 
-# Cross Service Propagators
+## Cross Service Propagators
 
 Distributed traces extend beyond a single service, meaning some context must be
 propagated across services to create the parent-child relationship between
@@ -345,7 +345,7 @@ registered with OpenTelemetry. This can be done through configuration of the
 {{< /tab >}}
 
 {{< tab >}}
-# runtime.exs
+## runtime.exs
 ...
 text_map_propagators: [:baggage, :tracer_context],
 ...
@@ -358,7 +358,7 @@ specification](https://github.com/openzipkin/b3-propagation), originally from
 the [Zipkin project](https://zipkin.io/), then replace `trace_context` and
 `:trace_context` with `b3` and `:b3` for Erlang or Elixir respectively.
 
-# Library Instrumentation
+## Library Instrumentation
 
 Library instrumentations, broadly speaking, refers to instrumentation code that
 you didn't write but instead include through another library. OpenTelemetry for
@@ -367,7 +367,7 @@ many popular frameworks and libraries. You can find in the
 [opentelemetry-erlang-contrib
 repo](https://github.com/open-telemetry/opentelemetry-erlang-contrib/) and the [registry](/registry).
 
-# Creating Metrics
+## Creating Metrics
 
 The metrics API, found in `apps/opentelemetry-experimental-api` of the
 `opentelemetry-erlang` repository, is currently unstable, documentation TBA.


### PR DESCRIPTION
Closes #802

Preview:

- https://deploy-preview-803--opentelemetry.netlify.app/docs/erlang/getting-started/
- https://deploy-preview-803--opentelemetry.netlify.app/docs/erlang/instrumentation/

---

This fixes the table of contents for each of these pages. For example, for the *Getting started** page, it now looks like this:

> <img src="https://user-images.githubusercontent.com/4140793/135680542-dc487c7c-9972-4e79-a17b-c73ad9f6593b.png" width=200>

This is what the TOC looked like before:

> <img src="https://user-images.githubusercontent.com/4140793/135680621-0cebad58-e035-47fd-9aba-7af9ede94420.png" width=200>
