### PR TITLE
Homepage: add direct link to Getting started

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -20,7 +20,7 @@ Learn more
 - [Collector]({{< relref "/docs/collector/getting-started" >}})
 - [Go]({{< relref "/docs/go/getting-started" >}})
 - [.NET]({{< relref "/docs/net/getting-started" >}})
-- [JavaScript]({{< relref "/docs/js" >}})
+- [JavaScript]({{< relref "/docs/js/getting_started" >}})
 - [<i class="fas fa-ellipsis-h"></i>]({{< relref "docs" >}})
 </div>
 {{< /blocks/cover >}}


### PR DESCRIPTION
- Closes #796. Followup to #794.
- I was originally going to wait for #781 and #780, but I think that it's better to have the direct link as of now.