### PR TITLE
Drop obsolete navbar style customization

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -52,39 +52,6 @@
   background: $primary !important;
 }
 
-// Icons
-#main_navbar {
-  li i {
-  padding-right: 0.5em;
-
-      &:before {
-          display: inline-block;
-          text-align: center;
-          min-width: 1em;
-      }
-  }
-.alert {
-  background-color: inherit;
-  padding:0;
-  color: $secondary;
-  border: 0;
-  font-weight: inherit;
-
-      &:before {
-          display: inline-block;
-          font-style: normal;
-          font-variant: normal;
-          text-rendering: auto;
-          -webkit-font-smoothing: antialiased;
-          font-family: "Font Awesome 5 Free";
-          font-weight: 900; 
-          content: "\f0d9";
-          padding-left: 0.5em;
-          padding-right: 0.5em;
-      }
-  }  
-}
-
 // Adjust the spacing of page-meta and page-TOC (https://github.com/open-telemetry/opentelemetry.io/pull/354)
 .td-toc #TableOfContents {
   padding-top: 1rem;


### PR DESCRIPTION
- Final cleanup step following #810 and #763, completely reverting #550 (since, as I mentioned elsewhere, this is a standard feature in more recent versions of docsy.
- There is no change in generated site files and no resulting change in appearance (none that I can see when doing a side-by-side compare).
