### PR TITLE
Add 3rd party instrumentation for Go: `go-chi/chi` from @riandyrn

### DIFF
--- a/content/en/registry/instrumentation-go-riandyrn-go-chi-chi.md
+++ b/content/en/registry/instrumentation-go-riandyrn-go-chi-chi.md
@@ -1,0 +1,16 @@
+---
+title: otelchi --- Instrumentation for go-chi/chi
+registryType: instrumentation
+isThirdParty: true
+language: go
+tags:
+  - go
+  - instrumentation
+  - go-chi
+  - chi
+repo: https://github.com/riandyrn/otelchi
+license: Apache 2.0
+description: Instrumentation for the Golang `go-chi/chi` package.
+authors: Riandy R.N (riandyrn@gmail.com)
+otVersion: v1.0.1
+---


### PR DESCRIPTION
Following recommendation given by @MrAlias in [this comment](https://github.com/open-telemetry/opentelemetry-go-contrib/pull/986#issuecomment-941280855).