### PR TITLE
Build scripts: serve using netlify dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@
 * Run `npm install`
 * Run `npm run serve`
   * If you are on OS X and see an error like `too many open files` or `pipe failed`, you may need to increase the file descriptor limit. See [this Hugo GitHub issue](https://github.com/gohugoio/hugo/issues/6109).
-* To view the locally generated site, visit [localhost:30000][localhost].
+* To view the locally generated site, visit [localhost:8888][localhost].
 
 A few notes to be aware of:
 
@@ -52,4 +52,4 @@ changes.
 > Site administrators can access the admin interface
 > [here](https://app.netlify.com/sites/opentelemetry/overview).
 
-[localhost]: http://localhost:30000
+[localhost]: http://localhost:8888

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "scripts": {
     "_build": "hugo --cleanDestinationDir -e dev -DFE",
     "_check-links": "make check-links",
-    "_serve": "hugo serve -p 30000 -DFE",
+    "_serve": "netlify dev -c \"hugo serve -DFE --minify\"",
+    "_serve:hugo": "hugo serve -DFE --minify",
     "build:preview": "hugo --cleanDestinationDir -DFE --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",
     "build:production": "hugo --cleanDestinationDir --minify",
     "build": "npm run _build",
@@ -17,8 +18,10 @@
     "precheck-links": "npm run build",
     "preinstall": "npm run submodule:get",
     "preserve": "npm run submodule:get",
+    "preserve:hugo": "npm run submodule:get",
     "schemas:update": "npm run submodule:update content-modules/opentelemetry-specification",
     "serve": "npm run _serve",
+    "serve:hugo": "npm run _serve:hugo",
     "submodule:get": "git submodule update --init --recursive --depth 1",
     "submodule:update": "git submodule update --remote --recursive --depth 1",
     "test": "npm run check-links"
@@ -28,6 +31,7 @@
     "autoprefixer": "^10.3.1",
     "esm": "^3.2.25",
     "hugo-extended": "0.88.1-patch1",
+    "netlify-cli": "^6.13.2",
     "node-fetch": "^2.6.1",
     "postcss": "^8.3.6",
     "postcss-cli": "^9.0.0",


### PR DESCRIPTION
- Closes #791
- Prep work for #665
- `npm run serve` will now use [Netlify dev](https://www.netlify.com/products/dev/). Advantanges include:
  - You can locally test Netlify redirects
  - Live reload is supported