### PR TITLE
Adjust .NET and JS aliases

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -2,18 +2,12 @@
 title: Documentation
 linkTitle: Docs
 aliases:
-  - /csharp/
-  - /csharp/metrics/
-  - /csharp/tracing/
   - /golang/
   - /golang/metrics/
   - /golang/tracing/
   - /java/
   - /java/metrics/
   - /java/tracing/
-  - /js/
-  - /js/metrics/
-  - /js/tracing/
   - /python/
   - /python/metrics/
   - /python/tracing/

--- a/content/en/docs/js/_index.md
+++ b/content/en/docs/js/_index.md
@@ -1,9 +1,10 @@
 ---
 title: JavaScript
-weight: 20
 description: >-
   <img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/JS_SDK.svg" alt="JS logo"></img>
   A language-specific implementation of OpenTelemetry in JavaScript (for Node.JS & the browser).
+aliases: [/js/, /js/metrics/, /js/tracing/]
+weight: 20
 ---
 
 This page contains an introduction to OpenTelemetry in JavaScript. This guide

--- a/content/en/docs/net/_index.md
+++ b/content/en/docs/net/_index.md
@@ -1,9 +1,10 @@
 ---
-title: ".NET"
-weight: 12
+title: .NET
 description: >
   <img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/.NET.svg" alt="NET logo"></img>
   A language-specific implementation of OpenTelemetry in .NET.
+aliases: [/csharp/, /csharp/metrics/, /csharp/tracing/]
+weight: 12
 ---
 
 Welcome to the OpenTelemetry for .NET documentation! This is intended to be an


### PR DESCRIPTION
Contributes to #665, for the languages that aren't brought in via a submodule

Preview redirect tests (selected):

- https://deploy-preview-840--opentelemetry.netlify.app/csharp/ --> `/docs/net/`
- https://deploy-preview-840--opentelemetry.netlify.app/csharp/metrics/ --> `/docs/net/`
- https://deploy-preview-840--opentelemetry.netlify.app/js/tracing/ --> `/docs/js/`

