### PR TITLE
.NET: normalize alias paths

### DIFF
--- a/content/en/docs/net/_index.md
+++ b/content/en/docs/net/_index.md
@@ -3,7 +3,7 @@ title: .NET
 description: >
   <img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/.NET.svg" alt="NET logo"></img>
   A language-specific implementation of OpenTelemetry in .NET.
-aliases: [/csharp/, /csharp/metrics/, /csharp/tracing/]
+aliases: [/csharp, /csharp/metrics, /csharp/tracing]
 weight: 12
 ---
 


### PR DESCRIPTION
Contributes to #665

Preview redirect tests (selected):

- https://deploy-preview-842--opentelemetry.netlify.app/csharp/ --> `/docs/net/`
- https://deploy-preview-842--opentelemetry.netlify.app/csharp/metrics/ --> `/docs/net/`