### PR TITLE
Compact the left sidenav

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -66,10 +66,11 @@ params:
   gcs_engine_id: bde3d634eca9cd335
 
   ui:
+    footer_about_disable: true
     navbar_logo: true
     navbar_translucent_over_cover_disable: true
+    sidebar_menu_compact: true
     sidebar_search_disable: true
-    footer_about_disable: true
 
   links:
     user:


### PR DESCRIPTION
A compact left sidenav gives a much better user experience IMHO. When "uncompacted", the sidenav is just too unwieldy -- particularly on mobile -- and one looses the context of the page that we're in:

> <img src="https://user-images.githubusercontent.com/4140793/138557940-0f7f0f5c-c23d-442c-aa46-161753ff1bb4.png" width=150>

This is what it looks like when compacted:

> <img src="https://user-images.githubusercontent.com/4140793/138558034-f031b192-16e8-4fd6-9b02-66bcffb75b19.png" width=150>

