### PR TITLE
Sidenav: add visual cue for active entry

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -17,6 +17,16 @@
   }
 }
 
+.td-sidebar-nav-active-item {
+  color: $opentelemetry-purple;
+  &::before {
+    content: "\2022";
+    margin-left: -0.75rem;
+    padding-right: 0.25rem;
+    width: 0.5rem;
+  }
+}
+
 .l-buttons {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Followup to #859

Preview: https://deploy-preview-860--opentelemetry.netlify.app/docs/js/instrumentation/

### Screenshots

| Before | After |
|--|--|
| <img src="https://user-images.githubusercontent.com/4140793/138558034-f031b192-16e8-4fd6-9b02-66bcffb75b19.png" height=600> | <img src="https://user-images.githubusercontent.com/4140793/138559037-86b1c02f-cef6-4463-979e-ef78cea0633e.png" height=600>
