### PR TITLE
Update Erlang/Elixir documentation

### DIFF
--- a/content/en/docs/erlang/getting-started.md
+++ b/content/en/docs/erlang/getting-started.md
@@ -54,15 +54,15 @@ run as a Release and export spans from.
 {{< tabs Erlang Elixir >}}
 
 {{< tab >}}
-{deps, [{opentelemetry_api, "~> 1.0.0-rc.1"}, 
-        {opentelemetry, "~> 1.0.0-rc.1"}]}.
+{deps, [{opentelemetry_api, "~> 1.0.0-rc.3"}, 
+        {opentelemetry, "~> 1.0.0-rc.3"}]}.
 {{< /tab >}}
 
 {{< tab >}}
 def deps do
   [
-    {:opentelemetry_api, "~> 1.0.0-rc.1"},
-    {:opentelemetry, "~> 1.0.0-rc.1"}
+    {:opentelemetry_api, "~> 1.0.0-rc.3"},
+    {:opentelemetry, "~> 1.0.0-rc.3"}
   ]
 end
 {{< /tab >}}

--- a/content/en/docs/erlang/instrumentation.md
+++ b/content/en/docs/erlang/instrumentation.md
@@ -23,19 +23,16 @@ Each OTP Application has a `Tracer` registered for it when the `opentelemetry`
 Application boots. This can be disabled by setting the Application environment
 variable `register_loaded_applications` to `false`. If you want a more specific
 named `Tracer` or disable the automatic registration you can register a `Tracer`
-either with a name and version or with an Application name and
-`opentelemetry` will get the version from the loaded Application. Examples:
+with a name and version. Examples:
 
 {{< tabs Erlang Elixir >}}
 
 {{< tab >}}
 opentelemetry:register_tracer(test_tracer, <<"0.1.0">>),
-opentelemetry:register_application_tracer(myapp),
 {{< /tab >}}
 
 {{< tab >}}
 OpenTelemetry.register_tracer(:test_tracer, "0.1.0")
-OpenTelemetry.register_application_tracer(:myapp)
 {{< /tab >}}
 
 {{< /tabs >}}


### PR DESCRIPTION
- Bump example version to latest `1.0.0-rc.3`
- Remove outdated `register_application_tracer` example as of this PR https://github.com/open-telemetry/opentelemetry-erlang/pull/287

