### PR TITLE
Repo links: support file renames

### DIFF
--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -15,7 +15,18 @@
 {{ else if $gh_subdir }}
 {{ $gh_repo_path = printf "%s/%s/content/%s" $gh_branch $gh_subdir $pathFormatted }}
 {{ end }}
-{{ $gh_repo_path = replace $gh_repo_path ($.Param "path_base_for_github_subdir") "" -}}
+
+{{ $ghs_base := $.Param "path_base_for_github_subdir" -}}
+{{ $ghs_rename := "" -}}
+{{ if reflect.IsMap $ghs_base -}}
+  {{ $ghs_rename = $ghs_base.to -}}
+  {{ $ghs_base = $ghs_base.from -}}
+{{ end -}}
+
+{{ with $ghs_base -}}
+  {{ $gh_repo_path = replaceRE . $ghs_rename $gh_repo_path -}}
+{{ end -}}
+
 {{ $editURL := printf "%s/edit/%s" $gh_repo $gh_repo_path }}
 {{ $createURL := printf "%s/edit/%s" $gh_repo $gh_repo_path }}
 {{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (htmlEscape $.Title )}}


### PR DESCRIPTION
- In support of #852 and #866
- There is no change in the generated site files.
- Delta while awaiting for https://github.com/google/docsy/pull/737.