### PR TITLE
Add entry for OTel Python AWS Lambda Instrumentation

### DIFF
--- a/content/en/registry/instrumentation-python-aws-lambda.md
+++ b/content/en/registry/instrumentation-python-aws-lambda.md
@@ -1,0 +1,14 @@
+---
+title: AWS Lambda Instrumentation
+registryType: instrumentation
+isThirdParty: true
+language: python
+tags:
+  - python
+  - instrumentation
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-aws-lambda
+license: Apache 2.0
+description: This library allows tracing invocations of functions on AWS Lambda.
+authors: OpenTelemetry Authors
+otVersion: latest
+---


### PR DESCRIPTION
# Description

As of https://github.com/open-telemetry/opentelemetry-python-contrib/pull/777 we have instrumentation for AWS Lambda functions on OTel Python.