### PR TITLE
Upgrade packages including hugo-extended

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Hugo-generated assets
+.hugo_build.lock
 /public
 resources/
 

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -7,7 +7,7 @@
 .td-home {
   .otel-logo {
     margin-top: 2rem;
-    margin-bottom: 2rem;
+    margin-bottom: 3rem;
     max-height: 12rem;
     // max-width: 85%;
   }

--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
   },
   "private": true,
   "devDependencies": {
-    "autoprefixer": "^10.3.1",
+    "autoprefixer": "^10.4.0",
     "esm": "^3.2.25",
-    "hugo-extended": "0.88.1-patch1",
-    "netlify-cli": "^6.13.2",
+    "hugo-extended": "^0.89.2",
+    "netlify-cli": "^6.14.19",
     "node-fetch": "^2.6.1",
-    "postcss": "^8.3.6",
-    "postcss-cli": "^9.0.0",
+    "postcss": "^8.3.11",
+    "postcss-cli": "^9.0.2",
     "yaml": "^1.10.2"
   },
   "dependencies": {


### PR DESCRIPTION
Hugo 0.89.x has updates to Goldmark and Chroma, which cleans up issues like https://github.com/gohugoio/hugo/issues/8532.

This upgrade introduces only two generated-site-file diffs (aside from the Hugo version update):

```console
$ (cd public && git diff -bw --ignore-blank-lines -I "Hugo 0.8" -- . ':(exclude)*.xml') | grep -e ^diff
diff --git a/docs/js/instrumentation/index.html b/docs/js/instrumentation/index.html
diff --git a/index.html b/index.html
```

Here's the diff:

```diff
diff --git a/docs/js/instrumentation/index.html b/docs/js/instrumentation/index.html
index 7c13015c..51082441 100644
--- a/docs/js/instrumentation/index.html
+++ b/docs/js/instrumentation/index.html
@@ -642,7 +642,7 @@ If you do not register a global tracer provider, instrumentation which calls the
   <span style="color:#204a87;font-weight:bold">for</span> <span style="color:#000;font-weight:bold">(</span><span style="color:#204a87;font-weight:bold">let</span> <span style="color:#000">i</span> <span style="color:#ce5c00;font-weight:bold">=</span> <span style="color:#0000cf;font-weight:bold">0</span><span style="color:#000;font-weight:bold">;</span> <span style="color:#000">i</span> <span style="color:#ce5c00;font-weight:bold">&lt;=</span> <span style="color:#204a87">Math</span><span style="color:#000;font-weight:bold">.</span><span style="color:#000">floor</span><span style="color:#000;font-weight:bold">(</span><span style="color:#204a87">Math</span><span style="color:#000;font-weight:bold">.</span><span style="color:#000">random</span><span style="color:#000;font-weight:bold">()</span> <span style="color:#ce5c00;font-weight:bold">*</span> <span style="color:#0000cf;font-weight:bold">40000000</span><span style="color:#000;font-weight:bold">);</span> <span style="color:#000">i</span> <span style="color:#ce5c00;font-weight:bold">+=</span> <span style="color:#0000cf;font-weight:bold">1</span><span style="color:#000;font-weight:bold">)</span> <span style="color:#000;font-weight:bold">{</span>
     <span style="color:#8f5902;font-style:italic">// empty
 </span><span style="color:#8f5902;font-style:italic"></span>  <span style="color:#000;font-weight:bold">}</span>
-  <span style="color:#000">span</span><span style="color:#000;font-weight:bold">.</span><span style="color:#000">setAttribute</span><span style="color:#000;font-weight:bold">(</span><span style="color:#000">SemanticAttributes</span><span style="color:#000;font-weight:bold">.</span><span style="color:#000">CODE_FILEPATH</span><span style="color:#000;font-weight:bold">,</span> <span style="color:#0000cf;font-weight:bold">__</span><span style="color:#000">filename</span><span style="color:#000;font-weight:bold">);</span>
+  <span style="color:#000">span</span><span style="color:#000;font-weight:bold">.</span><span style="color:#000">setAttribute</span><span style="color:#000;font-weight:bold">(</span><span style="color:#000">SemanticAttributes</span><span style="color:#000;font-weight:bold">.</span><span style="color:#000">CODE_FILEPATH</span><span style="color:#000;font-weight:bold">,</span> <span style="color:#000">__filename</span><span style="color:#000;font-weight:bold">);</span>
   <span style="color:#000">span</span><span style="color:#000;font-weight:bold">.</span><span style="color:#000">end</span><span style="color:#000;font-weight:bold">();</span>
 <span style="color:#000;font-weight:bold">}</span>
 </code></pre></div><h2 id="span-status">Span Status</h2>
diff --git a/index.html b/index.html
index 506a9a48..8f8c0e40 100644
--- a/index.html
+++ b/index.html
@@ -190,7 +190,7 @@
           
           <div class="pt-3 lead">
             
-                <p><img src="/img/logos/opentelemetry-horizontal-color.svg" class="otel-logo" /></p>
+                <img src="/img/logos/opentelemetry-horizontal-color.svg" class="otel-logo" />
 <h1>High-quality, ubiquitous, and portable telemetry to enable effective observability</h1>
 <div class="l-primary-buttons mt-5">
 <ul>
```

The first file diff is a result of the fix of https://github.com/gohugoio/hugo/issues/8532. The second seems to be a fix in the markdown processor, which avoids wrapping an `<img>` in a paragraph when it shouldn't be.