### PR TITLE
Only show link to contrib page from Community

### DIFF
--- a/content/en/docs/contribution-guidelines.md
+++ b/content/en/docs/contribution-guidelines.md
@@ -1,9 +1,7 @@
 ---
-title: "Contribution Guidelines"
-linkTitle: "Contribution Guidelines"
-weight: 10000
-description: >
-  How to contribute to the OpenTelemetry documentation
+title: Contribution guidelines
+description: How to contribute to the OpenTelemetry
+_build: {list: never}
 ---
 
 OpenTelemetry is an open source project, and we gladly accept new contributions and contributors. Please see the CONTRIBUTING.md file in each SIG repository for information on getting started.

--- a/content/en/docs/contribution-guidelines.md
+++ b/content/en/docs/contribution-guidelines.md
@@ -1,7 +1,7 @@
 ---
 title: Contribution guidelines
 description: How to contribute to the OpenTelemetry
-_build: {list: never}
+toc_hide: true
 ---
 
 OpenTelemetry is an open source project, and we gladly accept new contributions and contributors. Please see the CONTRIBUTING.md file in each SIG repository for information on getting started.


### PR DESCRIPTION
- Contributes to
  - #895
  - #770
- Delists the [Contribution page](https://opentelemetry.io/docs/contribution-guidelines/) from the sidenav as part of the sidenav cleanup (pre-IA rework)
- The Contribution page remains accessible, as it was before, from the [community page](https://opentelemetry.io/community/)

Previews:

- https://deploy-preview-894--opentelemetry.netlify.app/docs/
- https://deploy-preview-894--opentelemetry.netlify.app/docs/contribution-guidelines/

Note that the Contribution page itself needs rework, but that will be handled separately.
