### PR TITLE
update the otlp exporter configuration

### DIFF
--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -320,7 +320,8 @@ exporters:
   # Data sources: traces, metrics, logs
   otlp:
     endpoint: otelcol2:4317
-    insecure: true
+    tls:
+      insecure: true
 
   # Data sources: traces, metrics
   otlphttp:


### PR DESCRIPTION
As per the issue https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5377, the example configuration is out dated as `insecure` is now under the `tls` node. 