### PR TITLE
Status page: drop release details

### DIFF
--- a/content/en/status/_index.md
+++ b/content/en/status/_index.md
@@ -1,22 +1,20 @@
 ---
 title: Status
 menu:
-  main:
-    weight: 30
+  main: {weight: 30}
 aliases: [/project-status, /releases]
 ---
 
-<a class="td-offset-anchor"></a>
 <section class="row td-box td-box--1 position-relative td-box--gradient td-box--height-auto">
   <div class="container text-center td-arrow-down">
     <h1>OpenTelemetry Tracing Specification now 1.0!</h1>
-    <span class="h4 mb-0">
-      <p>Our goal is to provide a generally available, production quality
+    <p class="h4 mb-0">
+      Our goal is to provide a generally available, production quality
       release for the tracing data source across most OpenTelemetry components
       in the first half of 2021. Several components have already reached this
       milestone! We expect metrics to reach the same status in the second half
-      of 2021 and are targeting logs in 2022.</p>
-    </span>
+      of 2021 and are targeting logs in 2022.
+    </p>
   </div>
 </section>
 
@@ -107,11 +105,13 @@ An effort to expand the availability and quality of OpenTelemetry instrumentatio
 
 {{% /blocks/section %}}
 
-<section class="row td-box">
-  <div class="col">
-    <div class="row section">
-      <h2>Latest Releases</h2>
-      {{< release_notes >}}
-    </div>
-  </div>
+<section class="row td-box pt-0">
+<div class="col">
+<div class="row section">
+
+## Latest Releases
+{{% release_notes %}}
+
+</div>
+</div>
 </section>

--- a/layouts/shortcodes/release_notes.html
+++ b/layouts/shortcodes/release_notes.html
@@ -1,18 +1,17 @@
-{{ $data := "" }}
-{{ if site.Data.progress_generated }}
-  {{ $data = site.Data.progress_generated }}
-{{ else }}
-  {{ $data = site.Data.progress_source }}
-{{ end }}
-{{ $progressData := $data.data }}
+{{ $data := "" -}}
+{{ if site.Data.progress_generated -}}
+  {{ $data = site.Data.progress_generated -}}
+{{ else -}}
+  {{ $data = site.Data.progress_source -}}
+{{ end -}}
+{{ $progressData := $data.data -}}
 
-<br/>
-{{- range $progressData }}
-  <h3 class="title is-3">{{ .label }}</h3>
-  {{ if ne .releaseName "n/a" }}
-    <h4 class="subtitle is-5"><a href="{{ .releaseUrl }}">{{ .releaseName }}</a></h4>
-    <pre style="white-space: pre-wrap; max-width: 100%">{{ .releaseDescription }}</pre>
-  {{ else }}
-    <p>No release information available from GitHub.</p>
-  {{ end }}
-{{ end }}
+{{ range $progressData -}}
+
+- **{{ .label }}**:
+  {{ if ne .releaseName "n/a" -}}
+    <a href="{{ .releaseUrl }}" target="_blank" rel="noopener">{{ .releaseName }}</a>
+  {{- else -}}
+    No release information available from GitHub.
+  {{- end }}
+{{ end -}}


### PR DESCRIPTION
- As illustrated in #545, release details are misformatted (they're shown in code-font). While it is possible to process the release details as markdown, I don't think that it is worth it (and it doesn't look good) because to access the details, all the reader has to do is click on the release tag link.
- Closes #545 by dropping the release details. Instead we just list the components and link to their latest releases

Preview: https://deploy-preview-902--opentelemetry.netlify.app/status/#latest-releases


### Screenshots

Before:

> ![image](https://user-images.githubusercontent.com/4140793/141288765-834c754f-dadb-44ec-b1d6-02085c70562f.png)

After:

> <img width="400" alt="LR" src="https://user-images.githubusercontent.com/4140793/141289187-7cff0643-b3bf-47cb-9d04-aa4cf501e580.png">