### PR TITLE
adjust-spec-pages.pl: fix sem. conv. rule

### DIFF
--- a/scripts/adjust-spec-pages.pl
+++ b/scripts/adjust-spec-pages.pl
@@ -52,7 +52,8 @@ while(<>) {
     next;
   }
 
-  s|../semantic_conventions/README.md|$semConvRef| if $ARGV =~ /overview/;
+  s|\(https://github.com/open-telemetry/opentelemetry-specification\)|(/docs/reference/specification/)|;
+  s|\.\./semantic_conventions/README.md|$semConvRef| if $ARGV =~ /overview/;
 
   # Bug fix from original source
   s/#(#(instrument|set-status))/$1/;


### PR DESCRIPTION
This PR fixes:

- The 3 links to semantic conventions in https://deploy-preview-909--opentelemetry.netlify.app/docs/reference/specification/overview/#semantic-conventions
- In https://deploy-preview-909--opentelemetry.netlify.app/docs/reference/specification/vendors/, we now link to the local spec