### PR TITLE
Link to latest release for all SIGs (non-submodule)

### DIFF
--- a/content/en/docs/collector/_index.md
+++ b/content/en/docs/collector/_index.md
@@ -4,6 +4,7 @@ weight: 10
 description: >-
   <img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Collector.svg" alt="Collector logo"></img>
   Vendor-agnostic way to receive, process and export telemetry data.
+spelling: cSpell:ignore Otel
 aliases: [/docs/collector/about]
 ---
 
@@ -23,3 +24,5 @@ Objectives:
 - *Observability*: An exemplar of an observable service.
 - *Extensibility*: Customizable without touching the core code.
 - *Unification*: Single codebase, deployable as an agent or collector with support for traces, metrics, and logs (future).
+
+{{% latest_release "collector" /%}}

--- a/content/en/docs/cpp/_index.md
+++ b/content/en/docs/cpp/_index.md
@@ -1,8 +1,7 @@
 ---
-title: "C++"
+title: C++
 weight: 11
-description: >
-  A language-specific implementation of OpenTelemetry in C++.
+description: A language-specific implementation of OpenTelemetry in C++.
 ---
 
 This is the OpenTelemetry for C++ documentation. OpenTelemetry is an
@@ -20,7 +19,7 @@ as follows:
 | --------  | -------      | -------      |
 | Stable    | Experimental | Experimental |
 
-The current release can be found [here](https://github.com/open-telemetry/opentelemetry-cpp/releases)
+{{% latest_release "cpp" /%}}
 
 ## Further Reading
 

--- a/content/en/docs/erlang/_index.md
+++ b/content/en/docs/erlang/_index.md
@@ -20,7 +20,8 @@ The current status of the major functional components for OpenTelemetry Erlang/E
 | ------- | ------- | ------- |
 | Beta    | Alpha   | Not Yet Implemented |
 
-The current release can be found
-[here](https://github.com/open-telemetry/opentelemetry-erlang/releases) and in
-[hex.pm](https://hex.pm) packages [opentelemetry_api](https://hex.pm/packages/opentelemetry_api)
-and [opentelemetry](https://hex.pm/packages/opentelemetry), which is the SDK.
+{{% latest_release "erlang" %}}
+  For SDK packages from [hex.pm](https://hex.pm), see
+  [opentelemetry_api](https://hex.pm/packages/opentelemetry_api) and
+  [opentelemetry](https://hex.pm/packages/opentelemetry).
+{{% /latest_release %}}

--- a/content/en/docs/js/_index.md
+++ b/content/en/docs/js/_index.md
@@ -4,6 +4,7 @@ description: >-
   <img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/JS_SDK.svg" alt="JS logo"></img>
   A language-specific implementation of OpenTelemetry in JavaScript (for Node.JS & the browser).
 aliases: [/js, /js/metrics, /js/tracing]
+spelling: cSpell:ignore Roadmap
 weight: 20
 ---
 
@@ -19,7 +20,7 @@ export data.
 | Metrics | Development | Development       |
 | Logs    | Roadmap     | Roadmap           |
 
-You can find release information [here](https://github.com/open-telemetry/opentelemetry-js/releases)
+{{% latest_release "js" /%}}
 
 ## Further Reading
 

--- a/content/en/docs/net/_index.md
+++ b/content/en/docs/net/_index.md
@@ -24,7 +24,7 @@ This is the current release status for OpenTelemetry components in this language
 | ------- | ------- | ------- |
 | 1.0    | Alpha   | Beta    |
 
-You can find release information [here](https://github.com/open-telemetry/opentelemetry-dotnet/releases)
+{{% latest_release "dotnet" /%}}
 
 # Further Reading
 

--- a/content/en/docs/rust/_index.md
+++ b/content/en/docs/rust/_index.md
@@ -1,7 +1,6 @@
 ---
 title: Rust
-description: >
-  A language-specific implementation of OpenTelemetry in Rust.
+description: A language-specific implementation of OpenTelemetry in Rust.
 weight: 26
 ---
 
@@ -20,7 +19,7 @@ as follows:
 | ------- | ------- | ------- |
 | Beta    | Alpha   | Not Yet Implemented |
 
-The current release can be found [here](https://github.com/open-telemetry/opentelemetry-rust/releases)
+{{% latest_release "rust" /%}}
 
 ## Further Reading
 

--- a/content/en/docs/swift/_index.md
+++ b/content/en/docs/swift/_index.md
@@ -1,8 +1,7 @@
 ---
-title: "Swift"
+title: Swift
 weight: 28
-description: >
-  A language-specific implementation of OpenTelemetry in Swift.
+description: A language-specific implementation of OpenTelemetry in Swift.
 ---
 
 This is the OpenTelemetry for Swift documentation. OpenTelemetry is an
@@ -20,7 +19,7 @@ as follows:
 | ------- | ------- | -------             |
 | Beta    | Alpha   | Not Yet Implemented |
 
-The current release can be found [here](https://github.com/open-telemetry/opentelemetry-swift/releases)
+{{% latest_release "swift" /%}}
 
 ## Further Reading
 

--- a/layouts/shortcodes/latest_release.md
+++ b/layouts/shortcodes/latest_release.md
@@ -1,0 +1,9 @@
+{{ $relUrl := printf "https://github.com/open-telemetry/opentelemetry-%s" (.Get 0) -}}
+
+For releases, including the [latest release][], see [Releases][].
+{{- .Inner }}
+
+[latest release]: {{ $relUrl }}/releases/latest
+[Releases]: {{ $relUrl }}
+
+{{/* */ -}}

--- a/layouts/shortcodes/latest_release.md
+++ b/layouts/shortcodes/latest_release.md
@@ -5,5 +5,3 @@ For releases, including the [latest release][], see [Releases][].
 
 [latest release]: {{ $relUrl }}/releases/latest
 [Releases]: {{ $relUrl }}
-
-{{/* */ -}}


### PR DESCRIPTION
Contributes to #905

Preview:

- https://deploy-preview-930--opentelemetry.netlify.app/docs/cpp
- https://deploy-preview-930--opentelemetry.netlify.app/docs/erlang
- https://deploy-preview-930--opentelemetry.netlify.app/docs/js
- https://deploy-preview-930--opentelemetry.netlify.app/docs/net
- https://deploy-preview-930--opentelemetry.netlify.app/docs/rust
- https://deploy-preview-930--opentelemetry.netlify.app/docs/swift
