### PR TITLE
End span outside task process doesn't work

### DIFF
--- a/content/en/docs/erlang/instrumentation.md
+++ b/content/en/docs/erlang/instrumentation.md
@@ -173,15 +173,15 @@ span_ctx = OpenTelemetry.Tracer.start_span(<<"child">>)
 ctx = OpenTelemetry.Ctx.get_current()
 
 task = Task.async(fn ->
-                      OpenTelemetry.Ctx.attach(ctx),
+                      OpenTelemetry.Ctx.attach(ctx)
                       OpenTelemetry.Tracer.set_current_span(span_ctx)
                       # do work here
                       
-                      # end span here or after `await` returns
+                      # end span here
+                      OpenTelemetry.Tracer.end_span(span_ctx)
                   end)
                   
 _ = Task.await(task)
-OpenTelemetry.Tracer.end_span(span_ctx)
 {{< /tab >}}
 
 {{< /tabs >}}


### PR DESCRIPTION
I found the `end_span` is not working if called outside the task context. Probably it relies on `self()` to retrieve the ctx registry? 
The comma after `OpenTelemetry.Ctx.attach(ctx)` was a typo also. This example now works properly.