### PR TITLE
Contributing: setup instruction update, and more

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,54 +1,83 @@
 # Contributing to OpenTelemetry.io
 
-## Dev Setup
+## Dev setup
 
-* Fork and clone the repository
-* Install [npm](https://npmjs.com)
-* Run `npm install`
-* Run `npm run serve`
-  * If you are on OS X and see an error like `too many open files` or `pipe failed`, you may need to increase the file descriptor limit. See [this Hugo GitHub issue](https://github.com/gohugoio/hugo/issues/6109).
-* To view the locally generated site, visit [localhost:8888][localhost].
+Follow these steps for local or [cloud-IDE][] (via [Gitpod.io][]) development:
 
-A few notes to be aware of:
+- Fork and clone this repository (only for local development only).
+- Install the latest [LTS release][] of **Node**, for example, using
+  **[nvm][]**:
+  ```console
+  $ nvm install --lts
+  ```
+- Get npm packages and other prerequisites:
+  ```console
+  $ npm install
+  ```
+- Serve the site locally at [localhost:8888][]:
+  ```console
+  $ npm run serve
+  ```
+  > **Note**: See an error like `too many open files` or `pipe failed` under macOS? You may need to increase the file descriptor limit. See [Hugo issue #6109](https://github.com/gohugoio/hugo/issues/6109).
+- To build the site only, run:
+  ```console
+  $ npm run build
+  ```
+  You'll find the generated site files under `public`.
 
-* Before submitting a PR be sure to run `npm run test` and address any issues uncovered
+## Content and submodules
 
-## Mirrored Documentation
+The website is built from:
 
-### Language-specific documentation (under `/content/en/docs/<language>`)
+- Content under `content/`, `static/`, etc. per usual for [Hugo][] sites.
+- Mount points, defined in [config.yaml][] under `mounts`.
+- Content from git submodules under [content-modules][].
 
-The per-language API, SDK, and "Getting Started" documentation is hosted in each language's repository under the `website_docs` directory.
-The content of those docs is mirrored to each language's directory in this repository (open-telemetry/opentelemetry.io): [`/content/en/docs/<language>`](./content/en/docs/).
+Note that nonstandard mount points and symlinked sections under `content/` refer
+to directories under [content-modules][], and no where else.
 
-Content updates for those pages should take place in your language's repository.
-That includes changes to:
+[config.yaml]: https://github.com/open-telemetry/opentelemetry.io/blob/main/config.yaml
+[content-modules]: https://github.com/open-telemetry/opentelemetry.io/tree/main/content-modules
 
-* the "Status and Releases" section in `_index.md`
-* the "Getting Started" page, if it exists
-* any language-specific instrumentation pages
-* any other pages that live under that language's section on [the docs site](https://opentelemetry.io/docs/)
+## Submitting a change
 
-Once a release occurs for a SIG or any content gets updated in those docs, an issue or PR should be created in this repository to pull the latest into `/content/en/docs/<language>`.
+Before submitting a PR, run `npm run test` and address any issues uncovered.
 
-### Anything else under `content/`
+### Submodule changes
 
-All other content, including entries in the [Registry](https://opentelemetry.io/registry/), is hosted in this repository and can be updated here.
+If you change any content inside of a [content-modules][] submodule, then you'll
+need to **_first_** submit a PR (containing the submodule changes) to the
+submodule's repo. Only after the submodule PR has been accepted, can you update
+the submodule and have the changes appear in this website.
 
-## Deploy previews
+It is easiest to manage your `content-modules` changes by working with the repo
+that the corresponding submodule is linked to, rather than inside the submodule
+itself.
 
-Whenever you submit a pull request to this repo, Netlify creates a [deploy
-preview](https://www.netlify.com/blog/2016/07/20/introducing-deploy-previews-in-netlify/)
-for the changes in that specific PR. You can view the deploy preview in the
-Netlify panel that appears under the PR description.
+> **For expert contributors**, you can work directly in the submodule. You'll
+then be able to directly build and serve your (submodule) changes. By default,
+the CI scripts get submodules on every invocation. To prevent this behavior
+while you work within a submodule, set the environment variable `GET="no"`.
+You'll also need to `git fetch --unshallow` the submodule before you can submit
+a PR. Alternatively, set `DEPTH=" "` and re-fetch submodules.
 
-## Publishing the site
+## Site deploys and PR previews
 
-The OpenTelemetry website is published automatically by
-[Netlify](https://netlify.com). When changes are pushed to the `main` branch,
-Netlify re-builds and re-deploys the site and stages a deploy preview for those
-changes.
+If you submit a PR, Netlify will create a [deploy preview][] so that you can
+review your changes. Once your PR is merged, Netlify deploys the updated site to
+the production server.
 
-> Site administrators can access the admin interface
-> [here](https://app.netlify.com/sites/opentelemetry/overview).
+> **Note**: PR previews include _draft pages_, but production builds do not.
 
-[localhost]: http://localhost:8888
+To see deploy logs and more, visit project's [dashboard][] -- Netlify login
+required.
+
+[cloud-IDE]: https://gitpod.io/#https://github.com/open-telemetry/opentelemetry.io
+[dashboard]: https://app.netlify.com/sites/opentelemetry/overview
+[deploy preview]: https://www.netlify.com/blog/2016/07/20/introducing-deploy-previews-in-netlify/
+[Gitpod.io]: https://gitpod.io
+[Hugo]: https://gohugo.io
+[localhost:8888]: http://localhost:8888
+[LTS release]: https://nodejs.org/en/about/releases/
+[Netlify]: https://netlify.com
+[nvm]: https://github.com/nvm-sh/nvm/blob/master/README.md#installing-and-updating

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # <img src="https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png" alt="OpenTelemetry Icon" width="45" height=""> OpenTelemetry.io
 
-This repo houses the source code for the
-[OpenTelemetry](https://opentelemetry.io) website and project documentation.
+This is the source repo for the [OpenTelemetry](https://opentelemetry.io)
+website and project documentation. The site is built using [Hugo][] and hosted
+on [Netlify][].
 
 ## Adding a project to the OpenTelemetry Registry
 
@@ -14,26 +15,20 @@ To add your project, please make a pull request. You'll need to create a data fi
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
 
-Approvers ([@open-telemetry/docs-approvers](https://github.com/orgs/open-telemetry/teams/docs-approvers))
+Roles: 
+- Approvers: [@open-telemetry/docs-approvers](https://github.com/orgs/open-telemetry/teams/docs-approvers)
+- Maintainers: [@open-telemetry/docs-maintainers](https://github.com/orgs/open-telemetry/teams/docs-maintainers))
+- Learn more about roles in the [community
+  repository](https://github.com/open-telemetry/community/blob/main/community-membership.md).
 
-- [Shelby Spees](https://github.com/shelbyspees), Honeycomb
-
-Maintainers ([@open-telemetry/docs-maintainers](https://github.com/orgs/open-telemetry/teams/docs-maintainers))
-
-- [Steve Flanders](https://github.com/flands), Splunk
-- [Morgan McLean](https://github.com/mtwo), Google
-- [Austin Parker](https://github.com/austinlparker), LightStep
-
-Learn more about roles in the [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md).
-
-Thanks to all the people who already contributed!
-
-<a href="https://github.com/open-telemetry/opentelemetry.io/graphs/contributors">
-  <img src="https://contributors-img.web.app/image?repo=open-telemetry/opentelemetry.io" />
-</a>
+Thanks to [all who have already
+contributed](https://github.com/open-telemetry/opentelemetry.io/graphs/contributors)!
 
 ## Documentation License
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
 
 Please note the Creative Commons Attribution 4.0 license applies to the creative work of this site (documentation, visual assets, etc.) and not to the underlying code and does not supersede any licenses of the source code, its dependencies, etc.
+
+[Hugo]: https://gohugo.io
+[Netlify]: https://netlify.com


### PR DESCRIPTION
- Updated dev setup instructions. Also link to Gitpod.
- Replace "mirroring" section by current info.

Preview:

- https://github.com/chalin/opentelemetry.io/blob/chalin-dev-doc-updates-2021-11-17/CONTRIBUTING.md
- https://github.com/chalin/opentelemetry.io/blob/chalin-dev-doc-updates-2021-11-17/README.md