### PR TITLE
Adding Datadog as an opentelemetry provider in the documentation

### DIFF
--- a/content/en/vendors/_index.md
+++ b/content/en/vendors/_index.md
@@ -20,6 +20,7 @@ title: Vendor support
 | Aspecto         | Yes          | Yes         | https://www.aspecto.io/                                                                                                          |
 | AWS             | Yes          | No          | https://aws-otel.github.io/                                                                                                      |
 | Azure           | Yes          | No          | https://docs.microsoft.com/azure/azure-monitor/app/opentelemetry-overview                                                        |
+| Datadog         | Yes          | Yes         | https://docs.datadoghq.com/tracing/setup_overview/open_standards                                                                 |
 | Dynatrace       | Yes          | Yes         | https://www.dynatrace.com/support/help/how-to-use-dynatrace/transactions-and-services/service-monitoring-settings/opentelemetry/ |
 | Elastic         | Yes          | Yes         | https://www.elastic.co/guide/en/apm/get-started/current/open-telemetry-elastic.html                                              |
 | F5              | No           | Yes         | https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/f5cloudexporter                             |


### PR DESCRIPTION
Adding Datadog to the entry list https://opentelemetry.io/vendors/
The exporter being already available in the repository https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter.

Checked the file renders okay and ran the test according to the Contributing Guidelines:
```
✔✔✔ passed in 379.079277ms
tested 485 documents
```