### PR TITLE
Hugo 0.89.4 upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
   "private": true,
   "devDependencies": {
     "autoprefixer": "^10.4.0",
-    "hugo-extended": "^0.89.2",
-    "netlify-cli": "^6.14.25",
+    "hugo-extended": "^0.89.4",
+    "netlify-cli": "^7.0.0",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.3.11",
     "postcss-cli": "^9.0.2"


### PR DESCRIPTION
No change in generated site files:

```console
$ (cd public && git diff -bw --ignore-blank-lines -I "Hugo 0.8")
$
```