### PR TITLE
Update linux and windows packaging in collector get started page

### DIFF
--- a/content/en/docs/collector/getting-started.md
+++ b/content/en/docs/collector/getting-started.md
@@ -121,10 +121,10 @@ architecture.
 $ sudo apt-get update
 $ sudo apt-get -y install wget systemctl
 $ wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.39.0/otelcol_0.39.0_linux_amd64.deb
-$ dpkg -i otelcol_0.38.0_linux_amd64.deb
+$ dpkg -i otelcol_0.39.0_linux_amd64.deb
 ```
 
-To get started on Red Hat systems run the following replacing `v0.38.0` with the
+To get started on Red Hat systems run the following replacing `v0.39.0` with the
 version of the Collector you wish to run and `x86_64` with the appropriate
 architecture.
 
@@ -132,7 +132,7 @@ architecture.
 $ sudo yum update
 $ sudo yum -y install wget systemctl
 $ wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.39.0/otelcol_0.39.0_linux_amd64.rpm
-$ rpm -ivh otelcol_0.38.0_linux_amd64.rpm
+$ rpm -ivh otelcol_0.39.0_linux_amd64.rpm
 ```
 
 By default, the `otel-collector` systemd service will be started with the
@@ -159,7 +159,7 @@ $ sudo journalctl -u otel-collector
 
 ### Windows Packaging
 
-Windows releases are packaged as gzipped tarballs (`.tar.gz`) and will need to be unpacked with a tool that supports this compression format.
+Windows [releases](https://github.com/open-telemetry/opentelemetry-collector-releases/releases) are packaged as gzipped tarballs (`.tar.gz`) and will need to be unpacked with a tool that supports this compression format.
 
 Every Collector release includes an `otelcol.exe` executable that you can run after unpacking.
 

--- a/content/en/docs/collector/getting-started.md
+++ b/content/en/docs/collector/getting-started.md
@@ -113,14 +113,14 @@ systems. The packaging includes a default configuration that can be found at
 
 > Please note that systemd is require for automatic service configuration
 
-To get started on Debian systems run the following replacing `v0.38.0` with the
+To get started on Debian systems run the following replacing `v0.39.0` with the
 version of the Collector you wish to run and `amd64` with the appropriate
 architecture.
 
 ```console
 $ sudo apt-get update
 $ sudo apt-get -y install wget systemctl
-$ wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.38.0/otelcol_0.38.0_linux_amd64.deb
+$ wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.39.0/otelcol_0.39.0_linux_amd64.deb
 $ dpkg -i otelcol_0.38.0_linux_amd64.deb
 ```
 
@@ -131,7 +131,7 @@ architecture.
 ```console
 $ sudo yum update
 $ sudo yum -y install wget systemctl
-$ wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.38.0/otelcol_0.38.0_linux_amd64.rpm
+$ wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.39.0/otelcol_0.39.0_linux_amd64.rpm
 $ rpm -ivh otelcol_0.38.0_linux_amd64.rpm
 ```
 
@@ -159,14 +159,9 @@ $ sudo journalctl -u otel-collector
 
 ### Windows Packaging
 
-Every Collector release includes EXE and MSI packaging for Windows amd64 systems.
-The MSI packaging includes a default configuration that can be found at
-`\Program Files\OpenTelemetry Collector\config.yaml`.
+Windows releases are packaged as gzipped tarballs (`.tar.gz`) and will need to be unpacked with a tool that supports this compression format.
 
-> Please note the Collector service is automatically started
-
-The easiest way to get started is to double-click the MSI package and follow
-the wizard. Silent installation is also available.
+Every Collector release includes an `otelcol.exe` executable that you can run after unpacking.
 
 ### Local
 


### PR DESCRIPTION
fixes https://github.com/open-telemetry/opentelemetry.io/issues/741 (perhaps Collector releases can change back to including MSI packaging and/or archive with `.zip` but I think it's better to just be accurate for now)and gets an up to date version number.

Preview: https://deploy-preview-954--opentelemetry.netlify.app/docs/collector/getting-started/#linux-packaging