### PR TITLE
Sorta redo the components page

### DIFF
--- a/content/en/docs/concepts/components.md
+++ b/content/en/docs/concepts/components.md
@@ -3,53 +3,65 @@ title: Components
 weight: 20
 ---
 
-The OpenTelemetry project consists of multiple components. These components are
-made available as a single implementation to ease adoption and ensure a
-vendor-agnostic solution. More components may be added in the future.
+OpenTelemetry is currently made up of several main components:
 
-## Proto
+* Cross-language specification
+* OpenTelemetry Collector
+* Per-language SDKs
+* Automatic instrumentation and contrib packages
 
-Language independent interface types. Defined per data source for
-instrumentation libraries and the collector as well as for common aspects and
-resources. Proto files are extensively commented. For more information, see the
-[proto repository](https://github.com/open-telemetry/opentelemetry-proto).
+OpenTelemetry lets you replace the need for vendor-specific SDKs and tools for generating
+telemetry data.
 
 ## Specification
 
 Describes the cross-language requirements and expectations for all
-implementations. Beyond definition of terms, the specification defines the
+implementations. Beyond a definition of terms, the specification defines the
 following:
 
-- **API:** Used to generate telemetry data. Defined per data source as well as for
-  other aspects including baggage and propagators.
-- **SDK:** Implementation of the API with processing and exporting capabilities.
-  Defined per data source as well as for other aspects including resources and
-  configuration.
-- **Data:** Defines semantic conventions to provide vendor-agnostic
-  implementations as well as the OpenTelemetry protocol (OTLP).
+- **API:** Defines data types and operations for generating and correlating
+  tracing, metrics, and logging data.
+- **SDK:** Defines requirements for a language-specific implementation of the API.
+  Configuration, data processing, and exporting concepts are also defined here.
+- **Data:** Defines the OpenTelemetry Line Protocol (OTLP) and vendor-agnostic
+  semantic conventions that a telemetry backend can provide support for.
 
 For more information, see the [Specification](/docs/reference/specification/).
 
+Additionally, extensively-commented protobuf interface files for API concepts
+can be found in the [proto repository](https://github.com/open-telemetry/opentelemetry-proto).
+
 ## Collector
 
-The OpenTelemetry Collector offers a vendor-agnostic implementation on how to
-receive, process, and export telemetry data. It removes the need to run,
-operate, and maintain multiple agents/collectors in order to support
-open-source observability data formats (e.g. Jaeger, Prometheus, etc.) sending
-to one or more open-source or commercial back-ends. The Collector is the
-default location instrumentation libraries export their telemetry data.
+The OpenTelemetry Collector is a vendor-adgnostic proxy that can receive, process,
+and export telemetry data. It supports other receiving different observability data
+formats (e.g., Jaeger, Prometheus, etc.) and sending data to one or more backends. It
+also supports processing and filtering telemetry data before it gets exported.
+Collector contrib packages bring support for more data formats and vendor backends.
 
 For more information, see [Data Collection](/docs/concepts/data-collection/).
 
-## Instrumentation Libraries
+## Language SDKs
 
-The inspiration of the OpenTelemetry project is to make every library and
-application observable out of the box by having them call the OpenTelemetry API
-directly. Until that happens, there is a need for a separate library which can
-inject this information. A library that enables observability for another
-library is called an instrumentation library. The OpenTelemetry project
-provides an instrumentation library for multiple languages. All instrumentation
-libraries support manual (code modified) instrumentation and several support
-automatic (byte-code) instrumentation.
+OpenTelemetry also has language SDKs that let you use the OpenTelemetry API to generate
+telemetry data with your language of choice and export that data to a preferred backend.
+These SDKs also let you incorporate automatic instrumentation for common libraries and
+frameworks that you can use to connect to manual instrumentation in your application.
+Vendors often make distributions of language SDKs to make exporting to their backends
+simplier.
 
 For more information, see [Instrumenting](/docs/concepts/instrumenting).
+
+## Automatic Instrumentation
+
+OpenTelemetry supports a broad number of components that generate relevant telemetry data
+from popular libraries and frameworks for supported languages. For example, inbound and
+outbound HTTP requests from an HTTP library will generate data about those requests.
+Using automatic instrumentation may differ from language to language, where one might
+prefer or require the use of a component that you load alongside your application, and
+another might prefer that you pull in a package explicitly in your codebase.
+
+It is a long-term goal that popular libraries are authored to be observable out of the box,
+such that pulling in a separate component is not required.
+
+For more information, see [Instrumenting Libraries](/docs/concepts/instrumenting-library/).


### PR DESCRIPTION
**Disclaimer:** this is a significant change to the page, so I'm more than happy to close this if it's not in line with preferred contribution guidelines or the vision for the docs

I took a look at https://github.com/open-telemetry/opentelemetry.io/issues/628 and felt that it was a symptom of a larger issue, which is that this page felt much more geared towards contributors to the OpenTelemetry project rather than users of OpenTelemetry. While I still think it's helpful to have documentation for contributors, I think most people who come to the OpenTelemetry docs are going to be users of SDKs and the collector, not current or potential contributors to GitHub projects. So I reworked this page to be a little bit more user oriented in an attempt to fix https://github.com/open-telemetry/opentelemetry.io/issues/628