### PR TITLE
Provide JS instructions to send traces to a collector

### DIFF
--- a/content/en/docs/instrumentation/js/exporters.md
+++ b/content/en/docs/instrumentation/js/exporters.md
@@ -107,5 +107,20 @@ const meter = new MeterProvider({
 
 ## OpenTelemetry Collector
 
-If you are looking for a vendor-agnostic way to receive, process and export your
-telemetry data follow the instructions to setup a [collector](/docs/collector/)
+To send trace data to a Collector you'll want to use the `exporter-collector` package:
+
+```shell
+npm install --save @opentelemetry/exporter-collector
+```
+
+And configure the exporter to point at your Collector endpoint:
+
+```javascript
+import { CollectorTraceExporter } from '@opentelemetry/exporter-collector';
+
+const exporter = new CollectorTraceExporter({
+  url: 'https://<your collector endpoint>:443/v1/traces'
+});
+```
+
+To set up a Collector, see [Getting Started with the Collector](/docs/collector/getting-started/).

--- a/content/en/docs/instrumentation/js/exporters.md
+++ b/content/en/docs/instrumentation/js/exporters.md
@@ -116,10 +116,12 @@ npm install --save @opentelemetry/exporter-collector
 And configure the exporter to point at your Collector endpoint:
 
 ```javascript
-import { CollectorTraceExporter } from '@opentelemetry/exporter-collector';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 
-const exporter = new CollectorTraceExporter({
-  url: 'https://<your collector endpoint>:443/v1/traces'
+const exporter = new OTLPTraceExporter({
+  url: '<your-collector-endpoint>/v1/traces', // url is optional and can be omitted - default is http://localhost:55681/v1/traces
+  headers: {}, // an optional object containing custom headers to be sent with each request
+  concurrencyLimit: 10, // an optional limit on pending requests
 });
 ```
 


### PR DESCRIPTION
fixes https://github.com/open-telemetry/opentelemetry.io/issues/703

I suppose this doesn't tell you how to send metrics data to a collector, so I'm happy to figure that out and do it too if it's needed, but since metrics are still in development I wonder if it's better to just hold off until they stabilize in the SDK.