### PR TITLE
Status page: use shortcode to automatically get statuses from spec

### DIFF
--- a/content/en/status/_index.md
+++ b/content/en/status/_index.md
@@ -49,9 +49,9 @@ Checking the current status for each client in the README of its [github repo](h
 
 #### Tracing
 
-- **API:** {{% spec_status "trace/api" "Status" %}}
-- **SDK:** {{% spec_status "trace/sdk" "Status" %}}
-- **Protocol:** {{% spec_status "protocol/otlp" "Tracing" %}}
+- {{% spec_status "API" "trace/api" "Status" %}}
+- {{% spec_status "SDK" "trace/sdk" "Status" %}}
+- {{% spec_status "Protocol" "protocol/otlp" "Tracing" %}}
 - **Collector:** experimental
 - Notes:
   - The tracing specification is now completely stable, and covered by long term support.
@@ -60,9 +60,9 @@ Checking the current status for each client in the README of its [github repo](h
 
 #### [Metrics][]
 
-- **API:** {{% spec_status "metrics/api" "Status" %}}
-- **SDK:** {{% spec_status "metrics/sdk" "Status" %}}
-- **Protocol:** {{% spec_status "protocol/otlp" "Metrics" %}}
+- {{% spec_status "API" "metrics/api" "Status" %}}
+- {{% spec_status "SDK" "metrics/sdk" "Status" %}}
+- {{% spec_status "Protocol" "protocol/otlp" "Metrics" %}}
 - **Collector:** experimental
 - Notes:
   - OpenTelemetry Metrics is currently under active development.
@@ -75,7 +75,7 @@ Checking the current status for each client in the README of its [github repo](h
 
 #### Baggage
 
-- **API:** {{% spec_status "baggage/api" "Status" %}}
+- {{% spec_status "API" "baggage/api" "Status" %}}
 - **SDK:** stable
 - **Protocol:** N/A
 - **Collector:** N/A
@@ -87,7 +87,7 @@ Checking the current status for each client in the README of its [github repo](h
 
 - **API:** draft
 - **SDK:** draft
-- **Protocol:** {{% spec_status "protocol/otlp" "Logs" %}}
+- {{% spec_status "Protocol" "protocol/otlp" "Logs" %}}
 - **Collector:** experimental
 - Notes:
   - OpenTelemetry Logging is currently under active development.

--- a/content/en/status/_index.md
+++ b/content/en/status/_index.md
@@ -49,9 +49,9 @@ Checking the current status for each client in the README of its [github repo](h
 
 #### Tracing
 
-- **API:** {{< spec_status "/docs/reference/specification/trace/api" "Status" >}} 
-- **SDK:** {{< spec_status "/docs/reference/specification/trace/sdk" "Status" >}}
-- **Protocol:** {{< spec_status "/docs/reference/specification/protocol/otlp" "Tracing" >}}
+- **API:** {{% spec_status "trace/api" "Status" %}}
+- **SDK:** {{% spec_status "trace/sdk" "Status" %}}
+- **Protocol:** {{% spec_status "protocol/otlp" "Tracing" %}}
 - **Collector:** experimental
 - Notes:
   - The tracing specification is now completely stable, and covered by long term support.
@@ -60,9 +60,9 @@ Checking the current status for each client in the README of its [github repo](h
 
 #### [Metrics][]
 
-- **API:** {{< spec_status "/docs/reference/specification/metrics/api" "Status" >}}
-- **SDK:** {{< spec_status "/docs/reference/specification/metrics/sdk" "Status" >}}
-- **Protocol:** {{< spec_status "/docs/reference/specification/protocol/otlp" "Metrics" >}}
+- **API:** {{% spec_status "metrics/api" "Status" %}}
+- **SDK:** {{% spec_status "metrics/sdk" "Status" %}}
+- **Protocol:** {{% spec_status "protocol/otlp" "Metrics" %}}
 - **Collector:** experimental
 - Notes:
   - OpenTelemetry Metrics is currently under active development.
@@ -75,7 +75,7 @@ Checking the current status for each client in the README of its [github repo](h
 
 #### Baggage
 
-- **API:** {{< spec_status "/docs/reference/specification/baggage/api" "Status" >}}
+- **API:** {{% spec_status "baggage/api" "Status" %}}
 - **SDK:** stable
 - **Protocol:** N/A
 - **Collector:** N/A
@@ -87,7 +87,7 @@ Checking the current status for each client in the README of its [github repo](h
 
 - **API:** draft
 - **SDK:** draft
-- **Protocol:** {{< spec_status "/docs/reference/specification/protocol/otlp" "Logs" >}}
+- **Protocol:** {{% spec_status "protocol/otlp" "Logs" %}}
 - **Collector:** experimental
 - Notes:
   - OpenTelemetry Logging is currently under active development.

--- a/content/en/status/_index.md
+++ b/content/en/status/_index.md
@@ -49,9 +49,9 @@ Checking the current status for each client in the README of its [github repo](h
 
 #### Tracing
 
-- **API:** stable
-- **SDK:** stable
-- **Protocol:** stable
+- **API:** {{< spec_status "/docs/reference/specification/trace/api" "Status" >}} 
+- **SDK:** {{< spec_status "/docs/reference/specification/trace/sdk" "Status" >}}
+- **Protocol:** {{< spec_status "/docs/reference/specification/protocol/otlp" "Tracing" >}}
 - **Collector:** experimental
 - Notes:
   - The tracing specification is now completely stable, and covered by long term support.
@@ -60,9 +60,9 @@ Checking the current status for each client in the README of its [github repo](h
 
 #### [Metrics][]
 
-- **API:** feature-freeze
-- **SDK:** experimental
-- **Protocol:** stable
+- **API:** {{< spec_status "/docs/reference/specification/metrics/api" "Status" >}}
+- **SDK:** {{< spec_status "/docs/reference/specification/metrics/sdk" "Status" >}}
+- **Protocol:** {{< spec_status "/docs/reference/specification/protocol/otlp" "Metrics" >}}
 - **Collector:** experimental
 - Notes:
   - OpenTelemetry Metrics is currently under active development.
@@ -75,7 +75,7 @@ Checking the current status for each client in the README of its [github repo](h
 
 #### Baggage
 
-- **API:** stable
+- **API:** {{< spec_status "/docs/reference/specification/baggage/api" "Status" >}}
 - **SDK:** stable
 - **Protocol:** N/A
 - **Collector:** N/A
@@ -87,7 +87,7 @@ Checking the current status for each client in the README of its [github repo](h
 
 - **API:** draft
 - **SDK:** draft
-- **Protocol:** experimental
+- **Protocol:** {{< spec_status "/docs/reference/specification/protocol/otlp" "Logs" >}}
 - **Collector:** experimental
 - Notes:
   - OpenTelemetry Logging is currently under active development.

--- a/layouts/shortcodes/spec_status.html
+++ b/layouts/shortcodes/spec_status.html
@@ -1,0 +1,31 @@
+{{ $err := "spec_status shortcode error" -}}
+{{ $pageRef := .Get 0 -}}
+{{ $page := .Site.GetPage $pageRef -}}
+{{ if not $page -}}
+  {{ errorf "spec_status: Can't find page at '%s'." $pageRef -}}
+{{ end -}}
+
+{{ $_match := .Get 1 | default "Status" -}}
+{{ $matchThis := printf ".*%s.*" $_match -}}
+
+{{ $statusLine := "" -}}
+{{ with findRE $matchThis $page.Content -}}
+  {{ $statusLine = index . 0 -}}
+{{ else -}}
+  {{ errorf "%s: page '%s' does not contain a line matching '%s'." $err $pageRef $_match -}}
+{{ end -}}
+
+{{ $status := "" -}}
+{{/* Valid statuses, as taken from:
+  - https://opentelemetry.io/docs/reference/specification/document-status/
+  - https://github.com/open-telemetry/opentelemetry-proto#maturity-level
+*/ -}}
+{{ $statusValueRE := "(?i:experimental|stable|deprecated|removed|mixed|feature.freeze|alpha|beta)" -}}
+{{ $statusRE := printf "%s(,\\s*%s)*" $statusValueRE $statusValueRE -}}
+{{ with findRE $statusRE $statusLine -}}
+  {{ $status = index . 0 -}}
+{{ else -}}
+  {{ errorf "%s: '%s' value did not match one of '%s' in file '%s': matched line is '%s'" $err $_match $statusValueRE $pageRef $statusLine -}}
+{{ end -}}
+
+{{ lower $status -}}

--- a/layouts/shortcodes/spec_status.html
+++ b/layouts/shortcodes/spec_status.html
@@ -1,5 +1,8 @@
 {{ $err := "spec_status shortcode error" -}}
 {{ $pageRef := .Get 0 -}}
+{{ if not (hasPrefix $pageRef "/") -}}
+  {{ $pageRef = printf "/docs/reference/specification/%s" $pageRef -}}
+{{ end -}}
 {{ $page := .Site.GetPage $pageRef -}}
 {{ if not $page -}}
   {{ errorf "spec_status: Can't find page at '%s'." $pageRef -}}

--- a/layouts/shortcodes/spec_status.html
+++ b/layouts/shortcodes/spec_status.html
@@ -1,5 +1,6 @@
 {{ $err := "spec_status shortcode error" -}}
-{{ $pageRef := .Get 0 -}}
+{{ $label := .Get 0 -}}
+{{ $pageRef := .Get 1 -}}
 {{ if not (hasPrefix $pageRef "/") -}}
   {{ $pageRef = printf "/docs/reference/specification/%s" $pageRef -}}
 {{ end -}}
@@ -8,11 +9,12 @@
   {{ errorf "spec_status: Can't find page at '%s'." $pageRef -}}
 {{ end -}}
 
-{{ $_match := .Get 1 | default "Status" -}}
+{{ $_match := .Get 2 | default "Status" -}}
 {{ $matchThis := printf ".*%s.*" $_match -}}
 
 {{ $statusLine := "" -}}
 {{ with findRE $matchThis $page.Content -}}
+  {{/* Note that content is in HTML. */ -}}
   {{ $statusLine = index . 0 -}}
 {{ else -}}
   {{ errorf "%s: page '%s' does not contain a line matching '%s'." $err $pageRef $_match -}}
@@ -31,4 +33,4 @@
   {{ errorf "%s: '%s' value did not match one of '%s' in file '%s': matched line is '%s'" $err $_match $statusValueRE $pageRef $statusLine -}}
 {{ end -}}
 
-{{ lower $status -}}
+**[{{ $label }}]({{ $page.RelPermalink }}):** {{ lower $status -}}


### PR DESCRIPTION
- Contributes to #952
- Closes #916
- Closes #874
- Note that #873 remains open because I don't know where to read the status from in the spec.

**Preview**: https://deploy-preview-959--opentelemetry.netlify.app/status

---

Here's the diff of the generated HTML (without the label links to the spec pages):

```diff
diff --git a/status/index.html b/status/index.html
index 2423f5d6..2d3db555 100644
--- a/status/index.html
+++ b/status/index.html
@@ -180,7 +180,7 @@ All instrumentation shares the same semantic conventions, to ensure that they pr
 <p>Checking the current status for each client in the README of its <a href="https://github.com/open-telemetry">github repo</a> is recommended. Client support for specific features can be found in the <a href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md">specification compliance tables</a>.</p>
 <h4 id="tracing">Tracing</h4>
 <ul>
-<li><strong>API:</strong> stable</li>
+<li><strong>API:</strong> stable, feature-freeze</li>
 <li><strong>SDK:</strong> stable</li>
 <li><strong>Protocol:</strong> stable</li>
 <li><strong>Collector:</strong> experimental</li>
@@ -194,8 +194,8 @@ All instrumentation shares the same semantic conventions, to ensure that they pr
 </ul>
 <h4 id="metrics"><a href="/docs/reference/specification/metrics/">Metrics</a></h4>
 <ul>
-<li><strong>API:</strong> feature-freeze</li>
-<li><strong>SDK:</strong> experimental</li>
+<li><strong>API:</strong> stable</li>
+<li><strong>SDK:</strong> feature-freeze</li>
 <li><strong>Protocol:</strong> stable</li>
 <li><strong>Collector:</strong> experimental</li>
 <li>Notes:
@@ -210,7 +210,7 @@ All instrumentation shares the same semantic conventions, to ensure that they pr
 </ul>
 <h4 id="baggage">Baggage</h4>
 <ul>
-<li><strong>API:</strong> stable</li>
+<li><strong>API:</strong> stable, feature-freeze</li>
 <li><strong>SDK:</strong> stable</li>
 <li><strong>Protocol:</strong> N/A</li>
 <li><strong>Collector:</strong> N/A</li>
@@ -225,7 +225,7 @@ All instrumentation shares the same semantic conventions, to ensure that they pr
 <ul>
 <li><strong>API:</strong> draft</li>
 <li><strong>SDK:</strong> draft</li>
-<li><strong>Protocol:</strong> experimental</li>
+<li><strong>Protocol:</strong> beta</li>
 <li><strong>Collector:</strong> experimental</li>
 <li>Notes:
 <ul>
```