### PR TITLE
Add Client-side apps to glossary

### DIFF
--- a/content/en/docs/concepts/glossary.md
+++ b/content/en/docs/concepts/glossary.md
@@ -23,6 +23,7 @@ others. This page captures terminology used in the project and what it means.
   mechanism for propagating name/value pairs to help establish a causal
   relationship between events and services.
 - **Client Library:** See `Instrumented Library`.
+- **Client-side App:** A component of an `Application` that is not running inside a private infrastructure and is typically used directly by end-users. Examples of client-side apps are browser apps, mobile apps, and apps running on IoT devices.
 - **[Collector](/docs/collector/):**
   A vendor-agnostic implementation on how to receive, process, and export
   telemetry data. A single binary that can be deployed as an agent or gateway.


### PR DESCRIPTION
The Client-Side SIG is working on updates to the spec to distinguish client-side telemetry. We would like to add the term `Client-side` to the glossary, so that it is clear what it refers to and how it is distinguished from services.