### PR TITLE
Replace obsolete Make target for building collector

### DIFF
--- a/content/en/docs/collector/getting-started.md
+++ b/content/en/docs/collector/getting-started.md
@@ -182,6 +182,6 @@ $ git clone git@github.com:open-telemetry/opentelemetry-collector-contrib.git; \
     go build server/main.go; ./server/main & pid2="$!"; \
 
 $ git clone git@github.com:open-telemetry/opentelemetry-collector.git; \
-    cd opentelemetry-collector; make install-tools; make otelcol; \
-    ./bin/otelcol_$(go env GOOS)_$(go env GOARCH) --config ./examples/local/otel-config.yaml; kill $pid1; kill $pid2
+    cd opentelemetry-collector; make install-tools; make build-binary-cmd-otelcol; \
+    ./bin/cmd-otelcol --config ./examples/local/otel-config.yaml; kill $pid1; kill $pid2
 ```


### PR DESCRIPTION
`otelcol` is not longer available as a Make target in the collector repo: https://github.com/open-telemetry/opentelemetry-collector/issues/3928