### PR TITLE
Sidenav: support open/closed sections

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -65,6 +65,8 @@
   }
 }
 
+.foldable-nav { padding-top: 0.5rem; } // TODO: propagate this fix to Docsy. Also class name should be prefixed with td
+
 // Adjust the spacing of page-meta and page-TOC (https://github.com/open-telemetry/opentelemetry.io/pull/354)
 .td-toc #TableOfContents {
   padding-top: 1rem;

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -17,16 +17,6 @@
   }
 }
 
-.td-sidebar-nav-active-item {
-  color: $opentelemetry-purple;
-  &::before {
-    content: "\2022";
-    margin-left: -0.75rem;
-    padding-right: 0.25rem;
-    width: 0.5rem;
-  }
-}
-
 .l-buttons {
   display: flex;
   flex-wrap: wrap;
@@ -145,7 +135,7 @@ a:hover {
 // Contribution section in community page
 .community-contribution {
   text-align: center;
-  
+
   & > p {
     font-size: $h3-font-size;
     font-weight: $headings-font-weight;

--- a/config.yaml
+++ b/config.yaml
@@ -71,6 +71,7 @@ params:
     navbar_logo: true
     navbar_translucent_over_cover_disable: true
     sidebar_menu_compact: true
+    sidebar_menu_foldable: true
     sidebar_search_disable: true
 
   links:


### PR DESCRIPTION
Now that #963 has landed, I think that it makes sense to start using foldable section entries in the sidenav.

Preview: https://deploy-preview-970--opentelemetry.netlify.app/docs

### Screenshots

Before:

> <img src="https://user-images.githubusercontent.com/4140793/144273079-4b23ab7e-2fe5-40a1-ba55-07aa61ae49c2.png" width=250>

> <img src="https://user-images.githubusercontent.com/4140793/144273118-46771693-5157-4563-903c-261c544a1728.png" width=250>

After:

