### PR TITLE
Update to new java docs repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
 [submodule "content-modules/opentelemetry-specification"]
 	path = content-modules/opentelemetry-specification
 	url = https://github.com/open-telemetry/opentelemetry-specification.git
-[submodule "content-modules/opentelemetry-java"]
-	path = content-modules/opentelemetry-java
+[submodule "content-modules/opentelemetry-java-docs"]
+	path = content-modules/opentelemetry-java-docs
 	url = https://github.com/open-telemetry/opentelemetry-java-docs
 [submodule "content-modules/opentelemetry-ruby"]
 	path = content-modules/opentelemetry-ruby

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,7 +10,7 @@
 	url = https://github.com/open-telemetry/opentelemetry-specification.git
 [submodule "content-modules/opentelemetry-java"]
 	path = content-modules/opentelemetry-java
-	url = https://github.com/open-telemetry/opentelemetry-java
+	url = https://github.com/open-telemetry/opentelemetry-java-docs
 [submodule "content-modules/opentelemetry-ruby"]
 	path = content-modules/opentelemetry-ruby
 	url = https://github.com/open-telemetry/opentelemetry-ruby

--- a/content/en/docs/instrumentation/java
+++ b/content/en/docs/instrumentation/java
@@ -1,1 +1,1 @@
-../../../../content-modules/opentelemetry-java/website_docs
+../../../../content-modules/opentelemetry-java-docs/website_docs


### PR DESCRIPTION
I'm not sure if you prefer renaming the directory to match also `content-modules/opentelemetry-java` --> `content-modules/opentelemetry-java-docs?`