### PR TITLE
Add entry for Ruby AWS SDK Instrumentation

### DIFF
--- a/content/en/registry/instrumentation-ruby-aws-sdk.md
+++ b/content/en/registry/instrumentation-ruby-aws-sdk.md
@@ -1,0 +1,16 @@
+---
+title: OpenTelemetry aws-sdk Instrumentation
+registryType: instrumentation
+isThirdParty: false
+language: ruby
+tags:
+  - ruby
+  - instrumentation
+  - aws-sdk
+  - aws
+repo: https://github.com/open-telemetry/opentelemetry-ruby/tree/main/instrumentation/aws_sdk
+license: Apache 2.0
+description: aws-sdk instrumentation for Ruby.
+authors: OpenTelemetry Authors
+otVersion: latest
+---


### PR DESCRIPTION
# Description

Because https://github.com/open-telemetry/opentelemetry-ruby/pull/1014 was merged, we can update our registry!