### PR TITLE
Upgrade to Hugo 0.91.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "private": true,
   "devDependencies": {
     "autoprefixer": "^10.4.0",
-    "hugo-extended": "^0.89.4",
+    "hugo-extended": "0.91.0",
     "netlify-cli": "^8.0.6",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.3.11",


### PR DESCRIPTION
Closes #982

```console 
$ npm i -D --save-exact hugo-extended@latest
```

No significant changes to the generated site files other than updates to `js/tracing.js`:

```console
$ npm run check-links
...
> hugo --cleanDestinationDir -e dev -DFE
Start building sites … 
hugo v0.91.0-D1DC0E9A+extended darwin/amd64 BuildDate=2021-12-17T09:50:20Z VendorInfo=gohugoio
WARN 2021/12/17 10:14:32 The google_news internal template will be removed in a future release. Please remove calls to this template. See https://github.com/gohugoio/hugo/issues/9172 for additional information.
...
========================================================================
✔✔✔ passed in 499.064305ms
tested 491 documents
$ (cd public && git diff -bw --ignore-blank-lines -I "Hugo 0.") | grep ^diff
diff --git a/js/tracing.js b/js/tracing.js
```
