### PR TITLE
Remove manual TOCs in JS docs

### DIFF
--- a/content/en/docs/instrumentation/js/exporters.md
+++ b/content/en/docs/instrumentation/js/exporters.md
@@ -7,11 +7,6 @@ In order to visualize and analyze your traces and metrics, you will need to expo
 
 Below you will find some introductions on how to setup backends and the matching exporters.
 
-- [OTLP endpoint or Collector](#otlp-endpoint-or-collector)
-- [Jaeger](#jaeger)
-- [Zipkin](#zipkin)
-- [Prometheus](#prometheus)
-
 ## OTLP endpoint or Collector
 
 To send trace data to a Collector you'll want to use an exporter package, such as `@opentelemetry/exporter-trace-otlp-http`:

--- a/content/en/docs/instrumentation/js/getting-started/browser.md
+++ b/content/en/docs/instrumentation/js/getting-started/browser.md
@@ -5,15 +5,6 @@ aliases: [/docs/js/getting_started/browser]
 
 This guide uses the example application in HTML & javascript provided below, but the steps to instrument your own application should be broadly the same.
 
-- [Example Application](#example-application)
-  - [Installation](#installation)
-  - [Initialization and Configuration](#initialization-and-configuration)
-  - [Creating a Tracer Provider](#creating-a-tracer-provider)
-  - [Creating an Exporter](#creating-an-exporter)
-  - [Add Instrumentations](#add-instrumentations)
-- [Meta Packages for Web](#meta-packages-for-web)
-- [Instrumentation with Browser Extension](#instrumentation-with-browser-extension)
-
 ## Example Application
 
 This is a very simple guide, if you'd like to see more complex examples go to [examples/tracer-web](https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/tracer-web)

--- a/content/en/docs/instrumentation/js/getting-started/nodejs.md
+++ b/content/en/docs/instrumentation/js/getting-started/nodejs.md
@@ -5,23 +5,6 @@ aliases: [/docs/js/getting_started/nodejs]
 
 This guide will show you how to get started with tracing in Node.js.
 
-- [Example Application](#example-application)
-  - [Dependencies](#dependencies)
-  - [Code](#code)
-- [Tracing](#tracing)
-  - [Dependencies](#dependencies-1)
-    - [Core Dependencies](#core-dependencies)
-    - [Exporter](#exporter)
-    - [Instrumentation Modules](#instrumentation-modules)
-  - [Setup](#setup)
-  - [Run Application](#run-application)
-- [Metrics](#metrics)
-  - [Dependencies](#dependencies-2)
-    - [Core Dependencies](#core-dependencies-1)
-    - [Exporter](#exporter-1)
-  - [Setup](#setup-1)
-  - [Run Application](#run-application-1)
-
 ## Example Application
 
 This is a small example application we will monitor in this guide.

--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -5,14 +5,6 @@ weight: 3
 
 This guide will cover creating and annotating spans, creating and annotating metrics, how to pass context, and a guide to automatic instrumentation for JavaScript. This simple example works in the browser as well as with Node.JS
 
-- [Example Application](#example-application)
-- [Initializing a Tracer](#initializing-a-tracer)
-- [Create Spans](#create-spans)
-- [Create Nested Spans](#create-nested-spans)
-- [Attributes](#attributes)
-  - [Semantic Attributes](#semantic-attributes)
-- [Span Status](#span-status)
-
 ## Example Application
 
 In the following this guide will use the following sample app:


### PR DESCRIPTION
Closes https://github.com/open-telemetry/opentelemetry.io/issues/980 now that Java manual TOCs are also gone