### PR TITLE
Upgrade docsy to match upstream HEAD

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -145,3 +145,5 @@ a:hover {
     margin-bottom: $headings-margin-bottom;
   }
 }
+
+.td-breadcrumbs__single { display: none !important; }


### PR DESCRIPTION
Also, taking advantage of a recent update, we now hide breadcrumbs that have only a single crumb (i.e., /docs).