### PR TITLE
Add manual instrumentation doc for .NET

### DIFF
--- a/content/en/docs/instrumentation/net/getting-started.md
+++ b/content/en/docs/instrumentation/net/getting-started.md
@@ -1,5 +1,5 @@
 ---
-title: "Getting Started"
+title: Getting Started
 weight: 2
 ---
 
@@ -38,7 +38,6 @@ using OpenTelemetry.Resources;
 // Define some important constants and the activity source
 var serviceName = "MyCompany.MyProduct.MyService";
 var serviceVersion = "1.0.0";
-var MyActivitySource = new ActivitySource(serviceName);
 
 // Configure important OpenTelemetry settings and the console exporter
 using var tracerProvider = Sdk.CreateTracerProviderBuilder()
@@ -48,6 +47,8 @@ using var tracerProvider = Sdk.CreateTracerProviderBuilder()
             .AddService(serviceName: serviceName, serviceVersion: serviceVersion))
     .AddConsoleExporter()
     .Build();
+
+var MyActivitySource = new ActivitySource(serviceName);
 
 using var activity = MyActivitySource.StartActivity("SayHello");
 activity?.SetTag("foo", 1);
@@ -101,7 +102,6 @@ using OpenTelemetry.Trace;
 // Define some important constants and the activity source
 var serviceName = "MyCompany.MyProduct.MyService";
 var serviceVersion = "1.0.0";
-var MyActivitySource = new ActivitySource(serviceName);
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -120,6 +120,8 @@ builder.Services.AddOpenTelemetryTracing(b =>
 });
 
 var app = builder.Build();
+
+var MyActivitySource = new ActivitySource(serviceName);
 
 app.MapGet("/hello", () =>
 {

--- a/content/en/docs/instrumentation/net/manual.md
+++ b/content/en/docs/instrumentation/net/manual.md
@@ -207,8 +207,8 @@ which is not likely to be desired.
 
 ## Add tags to an Activity
 
-Tags let you attach key/value pairs to an `Activity` so it carries more information about the current operation
-that it's tracking.
+Tags (the equivalent of Attributes in OpenTelemetry) let you attach key/value pairs to an `Activity`
+so it carries more information about the current operation that it's tracking.
 
 ```csharp
 using var myActivity = MyActivitySource.StartActivity("SayHello")

--- a/content/en/docs/instrumentation/net/manual.md
+++ b/content/en/docs/instrumentation/net/manual.md
@@ -1,0 +1,106 @@
+---
+title: Manual Instrumentation
+linkTitle: Manual
+weight: 3
+---
+
+Manual instrumentation is the process of adding observability code to your application.
+
+## A note on terminology
+
+.NET is different from other languages/runtimes that support OpenTelemetry.
+Tracing is implemented by the [System.Diagnostics](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics)
+API, repurposing older constructs like `ActivitySource` and `Activity` to
+be OpenTelemetry-compliant under the covers.
+
+However, there are parts of the OpenTelemetry API and terminology that .NET
+developers must still know to be able to instrument their applications.
+
+## Initializing tracing
+
+There are two main ways to initialize tracing, depending on if you're using
+a console app or something that's ASP.NET Core-based.
+
+### Console app
+
+To start tracing in a console app, you need to create a tracer provider.
+
+First, ensure that you have the right packages:
+
+```
+dotnet add package OpenTelemetry
+dotnet add package OpenTelemetry.Exporter.Console
+```
+
+And then use code like this at the beginning of your program, during any important
+startup operations.
+
+```csharp
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Resources;
+
+// ...
+
+var serviceName = "MyServiceName";
+var serviceVersion "1.0.0";
+
+using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+    .AddSource(serviceName)
+    .SetResourceBuilder(
+        ResourceBuilder.CreateDefault()
+            .AddService(serviceName: serviceName, serviceVersion: serviceVersion))
+    .AddConsoleExporter()
+    .Build();
+
+//...
+```
+
+This is also where you can configure instrumentation libraries.
+
+Note that this sample uses the Console Exporter. If you are exporting to another endpoint,
+you'll have to use a different exporter.
+
+### ASP.NET Core
+
+To start tracing in an ASP.NET Core-based app, use the OpenTelemetry extensions for ASP.NET Core setup.
+
+First, ensure that you have the right packages:
+
+```
+dotnet add package OpenTelemetry --prerelease
+dotnet add package OpenTelemetry.Extensions.Hosting --prerelease
+dotnet add package OpenTelemetry.Exporter.Console --prerelease
+```
+
+And then configure it in your ASP.NET Core startup routine where you have access to an `IServiceCollection`.
+
+```csharp
+using System.Diagnostics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+// Define some important constants and the activity source
+var serviceName = "MyCompany.MyProduct.MyService";
+var serviceVersion = "1.0.0";
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Configure important OpenTelemetry settings, the console exporter, and automatic instrumentation
+builder.Services.AddOpenTelemetryTracing(b =>
+{
+    b
+    .AddConsoleExporter()
+    .AddSource(serviceName)
+    .SetResourceBuilder(
+        ResourceBuilder.CreateDefault()
+            .AddService(serviceName: serviceName, serviceVersion: serviceVersion))
+});
+```
+
+This is also where you can configure instrumentation libraries.
+
+Note that this sample uses the Console Exporter. If you are exporting to another endpoint,
+you'll have to use a different exporter.
+
+## Seting up an ActivitySource


### PR DESCRIPTION
Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/1001 (but really contributes to the implicit ".NET has no docs" issue).

Also contributes to:

https://github.com/open-telemetry/opentelemetry.io/issues/974
https://github.com/open-telemetry/opentelemetry.io/issues/973