### PR TITLE
Update configuration.md

### DIFF
--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -301,7 +301,7 @@ exporters:
 
   # Data sources: traces
   jaeger:
-    endpoint: "http://jaeger-all-in-one:14250"
+    endpoint: "jaeger-all-in-one:14250"
     tls:
       insecure: true
 


### PR DESCRIPTION
Can't connect "Jaeger all-in-one" deployed as described here <https://www.jaegertracing.io/docs/1.29/deployment/#all-in-one> if we use the old url.

The port is using grpc rather than HTTP protocol. (<https://www.jaegertracing.io/docs/1.29/deployment/#collector>)