### PR TITLE
Cross-link across .NET docs

### DIFF
--- a/content/en/docs/instrumentation/net/automatic.md
+++ b/content/en/docs/instrumentation/net/automatic.md
@@ -101,8 +101,8 @@ You can also find more instrumentations available in the [opentelemetry registry
 After you have observability generated automatically with instrumentation libraries, you may want to add
 [manual instrumentation]({{< relref "manual" >}}) to collect custom telemetry data.
 
-If you are using .NET Framework 4.x instead of modern .NET, refer to the [.NET Framework docs]({{< "netframework" >}})
+If you are using .NET Framework 4.x instead of modern .NET, refer to the [.NET Framework docs]({{< relref "netframework" >}})
 to configure OpenTelemetry and instrumentation libraries on .NET Framework.
 
-You'll also want to configure an appropriate exporter to [export your telemetry data]({{< "exporters" >}})
+You'll also want to configure an appropriate exporter to [export your telemetry data]({{< relref "exporters" >}})
 to one or more telemetry backends.

--- a/content/en/docs/instrumentation/net/automatic.md
+++ b/content/en/docs/instrumentation/net/automatic.md
@@ -98,7 +98,7 @@ You can also find more instrumentations available in the [opentelemetry registry
 
 ## Next steps
 
-After you have observability generated automatically with instrumentation libraries, you may want to add
+After you have set up instrumentation libraries, you may want to add
 [manual instrumentation]({{< relref "manual" >}}) to collect custom telemetry data.
 
 If you are using .NET Framework 4.x instead of modern .NET, refer to the [.NET Framework docs]({{< relref "netframework" >}})

--- a/content/en/docs/instrumentation/net/automatic.md
+++ b/content/en/docs/instrumentation/net/automatic.md
@@ -100,3 +100,9 @@ You can also find more instrumentations available in the [opentelemetry registry
 
 After you have observability generated automatically with instrumentation libraries, you may want to add
 [manual instrumentation]({{< relref "manual" >}}) to collect custom telemetry data.
+
+If you are using .NET Framework 4.x instead of modern .NET, refer to the [.NET Framework docs]({{< "netframework" >}})
+to configure OpenTelemetry and instrumentation libraries on .NET Framework.
+
+You'll also want to configure an appropriate exporter to [export your telemetry data]({{< "exporters" >}})
+to one or more telemetry backends.

--- a/content/en/docs/instrumentation/net/getting-started.md
+++ b/content/en/docs/instrumentation/net/getting-started.md
@@ -184,3 +184,6 @@ generate observability data.
 
 Additionally, enriching your instrumentation generated automatically with [manual instrumentation]({{< relref "manual" >}}) of your own codebase
 gets you customized observability data.
+
+You'll also want to configure an appropriate exporter to [export your telemetry data]({{< "exporters" >}})
+to one or more telemetry backends.

--- a/content/en/docs/instrumentation/net/getting-started.md
+++ b/content/en/docs/instrumentation/net/getting-started.md
@@ -185,5 +185,5 @@ generate observability data.
 Additionally, enriching your instrumentation generated automatically with [manual instrumentation]({{< relref "manual" >}}) of your own codebase
 gets you customized observability data.
 
-You'll also want to configure an appropriate exporter to [export your telemetry data]({{< "exporters" >}})
+You'll also want to configure an appropriate exporter to [export your telemetry data]({{< relref "exporters" >}})
 to one or more telemetry backends.

--- a/content/en/docs/instrumentation/net/manual.md
+++ b/content/en/docs/instrumentation/net/manual.md
@@ -285,7 +285,7 @@ using var anotherActivity =
 
 ## Next steps
 
-If you're not utilizing [instrumentation libraries]({{< relref "automatic" >}}), it's highly recommended that you do so.
+If you're not using [instrumentation libraries]({{< relref "automatic" >}}), we highly recommend that you do.
 Instrumentation libraries will automatically instrument relevant libraries you're using and generate
 data for things like inbound and outbound HTTP requests and more.
 

--- a/content/en/docs/instrumentation/net/manual.md
+++ b/content/en/docs/instrumentation/net/manual.md
@@ -18,7 +18,7 @@ developers must still know to be able to instrument their applications, wich
 are covered here as well as the `System.Diagnostics` API.
 
 If you prefer to use OpenTelemetry APIs instead of `System.Diagnostics` APIs,
-you can refer to the [OpenTelemetry API Shim docs for tracing]({{< "shim" >}}).
+you can refer to the [OpenTelemetry API Shim docs for tracing]({{< relref "shim" >}}).
 
 ## Initializing tracing
 
@@ -285,9 +285,9 @@ using var anotherActivity =
 
 ## Next steps
 
-If you're not utilizing [instrumentation libraries]({{< "automatic" >}}), it's highly recommended that you do so.
+If you're not utilizing [instrumentation libraries]({{< relref "automatic" >}}), it's highly recommended that you do so.
 Instrumentation libraries will automatically instrument relevant libraries you're using and generate
 data for things like inbound and outbound HTTP requests and more.
 
-You'll also want to configure an appropriate exporter to [export your telemetry data]({{< "exporters" >}})
+You'll also want to configure an appropriate exporter to [export your telemetry data]({{< relref "exporters" >}})
 to one or more telemetry backends.

--- a/content/en/docs/instrumentation/net/manual.md
+++ b/content/en/docs/instrumentation/net/manual.md
@@ -10,11 +10,15 @@ Manual instrumentation is the process of adding observability code to your appli
 
 .NET is different from other languages/runtimes that support OpenTelemetry.
 Tracing is implemented by the [System.Diagnostics](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics)
-API, repurposing older constructs like `ActivitySource` and `Activity` to
+API, repurposing existing constructs like `ActivitySource` and `Activity` to
 be OpenTelemetry-compliant under the covers.
 
 However, there are parts of the OpenTelemetry API and terminology that .NET
-developers must still know to be able to instrument their applications.
+developers must still know to be able to instrument their applications, wich
+are covered here as well as the `System.Diagnostics` API.
+
+If you prefer to use OpenTelemetry APIs instead of `System.Diagnostics` APIs,
+you can refer to the [OpenTelemetry API Shim docs for tracing]({{< "shim" >}}).
 
 ## Initializing tracing
 
@@ -278,3 +282,12 @@ using var anotherActivity =
 
 // do some work
 ```
+
+## Next steps
+
+If you're not utilizing [instrumentation libraries]({{< "automatic" >}}), it's highly recommended that you do so.
+Instrumentation libraries will automatically instrument relevant libraries you're using and generate
+data for things like inbound and outbound HTTP requests and more.
+
+You'll also want to configure an appropriate exporter to [export your telemetry data]({{< "exporters" >}})
+to one or more telemetry backends.

--- a/content/en/docs/instrumentation/net/netframework.md
+++ b/content/en/docs/instrumentation/net/netframework.md
@@ -137,3 +137,11 @@ exception is thrown.
 
 You can also set the `RecordException` property to `true`, which will store an exception on the
 `Activity` itself as an `ActivityEvent`.
+
+## Next steps
+
+After you have observability generated automatically with instrumentation libraries, you may want to add
+[manual instrumentation]({{< relref "manual" >}}) to collect custom telemetry data.
+
+You'll also want to configure an appropriate exporter to [export your telemetry data]({{< "exporters" >}})
+to one or more telemetry backends.

--- a/content/en/docs/instrumentation/net/netframework.md
+++ b/content/en/docs/instrumentation/net/netframework.md
@@ -143,5 +143,5 @@ You can also set the `RecordException` property to `true`, which will store an e
 After you have observability generated automatically with instrumentation libraries, you may want to add
 [manual instrumentation]({{< relref "manual" >}}) to collect custom telemetry data.
 
-You'll also want to configure an appropriate exporter to [export your telemetry data]({{< "exporters" >}})
+You'll also want to configure an appropriate exporter to [export your telemetry data]({{< relref "exporters" >}})
 to one or more telemetry backends.

--- a/content/en/docs/instrumentation/net/shim.md
+++ b/content/en/docs/instrumentation/net/shim.md
@@ -315,9 +315,9 @@ using var span = tracer.StartActiveSpan("another-span", links: links);
 
 ## Next steps
 
-If you're not utilizing [instrumentation libraries]({{< "automatic" >}}), it's highly recommended that you do so.
+If you're not utilizing [instrumentation libraries]({{< relref "automatic" >}}), it's highly recommended that you do so.
 Instrumentation libraries will automatically instrument relevant libraries you're using and generate
 data for things like inbound and outbound HTTP requests and more.
 
-You'll also want to configure an appropriate exporter to [export your telemetry data]({{< "exporters" >}})
+You'll also want to configure an appropriate exporter to [export your telemetry data]({{< relref "exporters" >}})
 to one or more telemetry backends.

--- a/content/en/docs/instrumentation/net/shim.md
+++ b/content/en/docs/instrumentation/net/shim.md
@@ -312,3 +312,12 @@ using var span = tracer.StartActiveSpan("another-span", links: links);
 
 // do some work
 ```
+
+## Next steps
+
+If you're not utilizing [instrumentation libraries]({{< "automatic" >}}), it's highly recommended that you do so.
+Instrumentation libraries will automatically instrument relevant libraries you're using and generate
+data for things like inbound and outbound HTTP requests and more.
+
+You'll also want to configure an appropriate exporter to [export your telemetry data]({{< "exporters" >}})
+to one or more telemetry backends.


### PR DESCRIPTION
.NET docs are now more or less complete, but need to be cross-linked across one another. This _can_ help with SEO (at least my understanding circa 2019 this is true, that's a moving target I guess), and in general promotes a coherency I'd expect from technical docs.

Example preview: https://deploy-preview-1041--opentelemetry.netlify.app/docs/instrumentation/net/getting-started/#next-steps