### PR TITLE
Update to Hugo 0.92.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "private": true,
   "devDependencies": {
     "autoprefixer": "^10.4.0",
-    "hugo-extended": "0.91.2",
+    "hugo-extended": "0.92.0",
     "netlify-cli": "^8.0.6",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.3.11",


### PR DESCRIPTION
Ran:

```console
$ npm i -D --save-exact hugo-extended@latest
```

The only significant diff is the Hugo version and changes to `tracing.js`, which seems ok:

```console
$ (cd public && git diff -bw --ignore-blank-lines -I "Hugo 0.") | grep ^diff    
diff --git a/js/tracing.js b/js/tracing.js
$ (cd public && git diff -bw --ignore-blank-lines -I "Hugo 0.") | head      
diff --git a/js/tracing.js b/js/tracing.js
index ac44c908..cc769388 100644
--- a/js/tracing.js
+++ b/js/tracing.js
@@ -132,11 +132,11 @@
 
   // node_modules/@opentelemetry/api/build/esm/internal/global-utils.js
   function registerGlobal(type, instance, diag3, allowOverride) {
-    var _a5;
+    var _a3;
```

Closes #1044