### PR TITLE
Add Splunk OTel Go instrumentation in registry

### DIFF
--- a/content/en/registry/instrumentation-go-splunkbuntdb.md
+++ b/content/en/registry/instrumentation-go-splunkbuntdb.md
@@ -1,0 +1,15 @@
+---
+title: splunkbuntdb -- Instrumentation for github.com/tidwall/buntdb
+registryType: instrumentation
+isThirdParty: true
+language: go
+tags:
+  - go
+  - instrumentation
+  - sql
+repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/tidwall/buntdb/splunkbuntdb
+license: Apache 2.0
+description: Instrumentation for the `github.com/tidwall/buntdb` package.
+authors: Splunk Inc.
+otVersion: v1.3.0
+---

--- a/content/en/registry/instrumentation-go-splunkchi.md
+++ b/content/en/registry/instrumentation-go-splunkchi.md
@@ -1,0 +1,15 @@
+---
+title: splunkchi -- Instrumentation for github.com/go-chi/chi
+registryType: instrumentation
+isThirdParty: true
+language: go
+tags:
+  - go
+  - instrumentation
+  - http
+repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/go-chi/chi/splunkchi
+license: Apache 2.0
+description: Instrumentation for the `github.com/go-chi/chi` package.
+authors: Splunk Inc.
+otVersion: v1.3.0
+---

--- a/content/en/registry/instrumentation-go-splunkclient-go.md
+++ b/content/en/registry/instrumentation-go-splunkclient-go.md
@@ -1,0 +1,15 @@
+---
+title: splunkclient-go -- Instrumentation for k8s.io/client-go
+registryType: instrumentation
+isThirdParty: true
+language: go
+tags:
+  - go
+  - instrumentation
+  - kubernetes
+repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/k8s.io/client-go/splunkclient-go
+license: Apache 2.0
+description: Instrumentation for the `k8s.io/client-go` package.
+authors: Splunk Inc.
+otVersion: v1.3.0
+---

--- a/content/en/registry/instrumentation-go-splunkdns.md
+++ b/content/en/registry/instrumentation-go-splunkdns.md
@@ -1,0 +1,15 @@
+---
+title: splunkdns -- Instrumentation for github.com/miekg/dns
+registryType: instrumentation
+isThirdParty: true
+language: go
+tags:
+  - go
+  - instrumentation
+  - dns
+repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/miekg/dns/splunkdns
+license: Apache 2.0
+description: Instrumentation for the `github.com/miekg/dns` package.
+authors: Splunk Inc.
+otVersion: v1.3.0
+---

--- a/content/en/registry/instrumentation-go-splunkelastic.md
+++ b/content/en/registry/instrumentation-go-splunkelastic.md
@@ -1,0 +1,16 @@
+---
+title: splunkelastic -- Instrumentation for gopkg.in/olivere/elastic
+registryType: instrumentation
+isThirdParty: true
+language: go
+tags:
+  - go
+  - instrumentation
+  - database
+  - elasticsearch
+repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/gopkg.in/olivere/elastic/splunkelastic
+license: Apache 2.0
+description: Instrumentation for the `gopkg.in/olivere/elastic` package.
+authors: Splunk Inc.
+otVersion: v1.3.0
+---

--- a/content/en/registry/instrumentation-go-splunkgorm.md
+++ b/content/en/registry/instrumentation-go-splunkgorm.md
@@ -1,0 +1,15 @@
+---
+title: splunkgorm -- Instrumentation for github.com/jinzhu/gorm
+registryType: instrumentation
+isThirdParty: true
+language: go
+tags:
+  - go
+  - instrumentation
+  - database
+repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/jinzhu/gorm/splunkgorm
+license: Apache 2.0
+description: Instrumentation for the `github.com/jinzhu/gorm` package.
+authors: Splunk Inc.
+otVersion: v1.3.0
+---

--- a/content/en/registry/instrumentation-go-splunkgraphql.md
+++ b/content/en/registry/instrumentation-go-splunkgraphql.md
@@ -1,0 +1,15 @@
+---
+title: splunkgraphql -- Instrumentation for github.com/graph-gophers/graphql-go
+registryType: instrumentation
+isThirdParty: true
+language: go
+tags:
+  - go
+  - instrumentation
+  - graphql
+repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql
+license: Apache 2.0
+description: Instrumentation for the `github.com/graph-gophers/graphql-go` package.
+authors: Splunk Inc.
+otVersion: v1.3.0
+---

--- a/content/en/registry/instrumentation-go-splunkhttp.md
+++ b/content/en/registry/instrumentation-go-splunkhttp.md
@@ -1,0 +1,15 @@
+---
+title: splunkhttp -- Instrumentation for net/http
+registryType: instrumentation
+isThirdParty: true
+language: go
+tags:
+  - go
+  - instrumentation
+  - http
+repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/net/http/splunkhttp
+license: Apache 2.0
+description: Splunk specific instrumentation for the Golang `net/http` package.
+authors: Splunk Inc.
+otVersion: v1.3.0
+---

--- a/content/en/registry/instrumentation-go-splunkhttprouter.md
+++ b/content/en/registry/instrumentation-go-splunkhttprouter.md
@@ -1,0 +1,15 @@
+---
+title: splunkhttprouter -- Instrumentation for github.com/julienschmidt/httprouter
+registryType: instrumentation
+isThirdParty: true
+language: go
+tags:
+  - go
+  - instrumentation
+  - http
+repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter
+license: Apache 2.0
+description: Instrumentation for the `github.com/julienschmidt/httprouter` package.
+authors: Splunk Inc.
+otVersion: v1.3.0
+---

--- a/content/en/registry/instrumentation-go-splunkkafka.md
+++ b/content/en/registry/instrumentation-go-splunkkafka.md
@@ -1,0 +1,15 @@
+---
+title: splunkkafka -- Instrumentation for github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka
+registryType: instrumentation
+isThirdParty: true
+language: go
+tags:
+  - go
+  - instrumentation
+  - kafka
+repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka
+license: Apache 2.0
+description: Instrumentation for the `github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka` package.
+authors: Splunk Inc.
+otVersion: v1.3.0
+---

--- a/content/en/registry/instrumentation-go-splunkleveldb.md
+++ b/content/en/registry/instrumentation-go-splunkleveldb.md
@@ -1,0 +1,16 @@
+---
+title: splunkleveldb -- Instrumentation for github.com/syndtr/goleveldb/leveldb
+registryType: instrumentation
+isThirdParty: true
+language: go
+tags:
+  - go
+  - instrumentation
+  - database
+  - leveldb
+repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb
+license: Apache 2.0
+description: Instrumentation for the `github.com/syndtr/goleveldb/leveldb` package.
+authors: Splunk Inc.
+otVersion: v1.3.0
+---

--- a/content/en/registry/instrumentation-go-splunkmysql.md
+++ b/content/en/registry/instrumentation-go-splunkmysql.md
@@ -1,0 +1,16 @@
+---
+title: splunkmysql -- Instrumentation for github.com/go-sql-driver/mysql
+registryType: instrumentation
+isThirdParty: true
+language: go
+tags:
+  - go
+  - instrumentation
+  - database
+  - mysql
+repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/go-sql-driver/mysql/splunkmysql
+license: Apache 2.0
+description: Instrumentation for the `github.com/go-sql-driver/mysql` package.
+authors: Splunk Inc.
+otVersion: v1.3.0
+---

--- a/content/en/registry/instrumentation-go-splunkpgx.md
+++ b/content/en/registry/instrumentation-go-splunkpgx.md
@@ -1,0 +1,16 @@
+---
+title: splunkpgx -- Instrumentation for github.com/jackc/pgx
+registryType: instrumentation
+isThirdParty: true
+language: go
+tags:
+  - go
+  - instrumentation
+  - database
+  - postgres
+repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/jackc/pgx/splunkpgx
+license: Apache 2.0
+description: Instrumentation for the `github.com/jackc/pgx` package.
+authors: Splunk Inc.
+otVersion: v1.3.0
+---

--- a/content/en/registry/instrumentation-go-splunkpq.md
+++ b/content/en/registry/instrumentation-go-splunkpq.md
@@ -1,0 +1,16 @@
+---
+title: splunkpq -- Instrumentation for github.com/lib/pq
+registryType: instrumentation
+isThirdParty: true
+language: go
+tags:
+  - go
+  - instrumentation
+  - database
+  - postgres
+repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/lib/pq/splunkpq
+license: Apache 2.0
+description: Instrumentation for the `github.com/lib/pq` package.
+authors: Splunk Inc.
+otVersion: v1.3.0
+---

--- a/content/en/registry/instrumentation-go-splunkredigo.md
+++ b/content/en/registry/instrumentation-go-splunkredigo.md
@@ -1,0 +1,16 @@
+---
+title: splunkredigo -- Instrumentation for github.com/gomodule/redigo
+registryType: instrumentation
+isThirdParty: true
+language: go
+tags:
+  - go
+  - instrumentation
+  - database
+  - redis
+repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/gomodule/redigo/splunkredigo
+license: Apache 2.0
+description: Instrumentation for the `github.com/gomodule/redigo` package.
+authors: Splunk Inc.
+otVersion: v1.3.0
+---

--- a/content/en/registry/instrumentation-go-splunksql.md
+++ b/content/en/registry/instrumentation-go-splunksql.md
@@ -1,0 +1,16 @@
+---
+title: splunksql -- Instrumentation for database/sql
+registryType: instrumentation
+isThirdParty: true
+language: go
+tags:
+  - go
+  - instrumentation
+  - database
+  - sql
+repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/database/sql/splunksql
+license: Apache 2.0
+description: Instrumentation for the Golang `database/sql` package.
+authors: Splunk Inc.
+otVersion: v1.3.0
+---

--- a/content/en/registry/instrumentation-go-splunksqlx.md
+++ b/content/en/registry/instrumentation-go-splunksqlx.md
@@ -1,0 +1,15 @@
+---
+title: splunksqlx -- Instrumentation for github.com/jmoiron/sqlx
+registryType: instrumentation
+isThirdParty: true
+language: go
+tags:
+  - go
+  - instrumentation
+  - database
+repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/jmoiron/sqlx/splunksqlx
+license: Apache 2.0
+description: Instrumentation for the `github.com/jmoiron/sqlx` package.
+authors: Splunk Inc.
+otVersion: v1.3.0
+---


### PR DESCRIPTION
Add listing for the following OTel Go instrumentation libraries:

- splunkbuntdb
- splunkchi
- splunkclient-go
- splunkdns
- splunkelastic
- splunkgorm
- splunkgraphql
- splunkhttp
- splunkhttprouter
- splunkkafka
- splunkleveldb
- splunkmysql
- splunkpgx
- splunkpq
- splunkredigo
- splunksql
- splunksqlx