### PR TITLE
Blog archetype and "Add blog" instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,63 @@
 # <img src="https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png" alt="OpenTelemetry Icon" width="45" height=""> OpenTelemetry.io
 
-This is the source repo for the [OpenTelemetry](https://opentelemetry.io)
-website and project documentation. The site is built using [Hugo][] and hosted
-on [Netlify][].
+This is the source repo for the [OpenTelemetry][] website and project
+documentation. The site is [built][CONTRIBUTING.md] using [Hugo][] and hosted on
+[Netlify][].
 
 ## Adding a project to the OpenTelemetry Registry
 
 Do you maintain or contribute to an integration for OpenTelemetry? We'd love to
-feature your project in the registry!
+feature your project in the [registry][]!
 
-To add your project, please make a pull request. You'll need to create a data
+To add your project, submit a [pull request][PR]. You'll need to create a data
 file in `/content/en/registry` for your project. You can find a template in
 `./templates/registry-entry.md`
 
+## Adding a blog post
+
+Follow the [setup instructions][CONTRIBUTING.md]. To create a skeletal blog
+post, run the following command from the repo root:
+
+```console
+$ hugo new content/en/blog/2022/file-name-for-your-blog-post.md
+```
+
+Start editing the file at the path your provided in the previous command. The
+file is initialized from the blog-post starter under [archetypes](archetypes).
+Once your post is ready, submit it through a [pull request][PR].
+
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md).
+See [CONTRIBUTING.md][].
 
 Roles:
-- Approvers: [@open-telemetry/docs-approvers](https://github.com/orgs/open-telemetry/teams/docs-approvers)
-- Maintainers: [@open-telemetry/docs-maintainers](https://github.com/orgs/open-telemetry/teams/docs-maintainers)
-- Learn more about roles in the [community
-  repository](https://github.com/open-telemetry/community/blob/main/community-membership.md).
+- Approvers: [@open-telemetry/docs-approvers][]
+- Maintainers: [@open-telemetry/docs-maintainers][]
 
-Thanks to [all who have already
-contributed](https://github.com/open-telemetry/opentelemetry.io/graphs/contributors)!
+Learn more about roles in the [community repository][]. Thanks to [all who have
+already contributed][contributors]!
 
-## Documentation License
+## Documentation license
 
-<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />
-This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+This work is licensed under a <a rel="license"
+href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution
+4.0 International License</a>.
 
 The Creative Commons Attribution 4.0 license applies to the creative work of
 this site (documentation, visual assets, etc.) and not to the underlying code
 and does not supersede any licenses of the source code, its dependencies, etc.
 
+<a rel="license" href="http://creativecommons.org/licenses/by/4.0/">
+  <img alt="Creative Commons License" src="https://i.creativecommons.org/l/by/4.0/88x31.png" />
+</a>
+
+[@open-telemetry/docs-approvers]: https://github.com/orgs/open-telemetry/teams/docs-approvers
+[@open-telemetry/docs-maintainers]: https://github.com/orgs/open-telemetry/teams/docs-maintainers
+[community repository]: https://github.com/open-telemetry/community/blob/main/community-membership.md
+[CONTRIBUTING.md]: CONTRIBUTING.md
+[contributors]: https://github.com/open-telemetry/opentelemetry.io/graphs/contributors
 [Hugo]: https://gohugo.io
 [Netlify]: https://netlify.com
+[OpenTelemetry]: https://opentelemetry.io
+[PR]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request
+[registry]: https://opentelemetry.io/registry/

--- a/README.md
+++ b/README.md
@@ -15,16 +15,17 @@ file in `/content/en/registry` for your project. You can find a template in
 
 ## Adding a blog post
 
-Follow the [setup instructions][CONTRIBUTING.md]. To create a skeletal blog
+Follow the [setup instructions][CONTRIBUTING.md] then, to create a skeletal blog
 post, run the following command from the repo root:
 
 ```console
 $ hugo new content/en/blog/2022/file-name-for-your-blog-post.md
 ```
 
-Start editing the file at the path your provided in the previous command. The
-file is initialized from the blog-post starter under [archetypes](archetypes).
-Once your post is ready, submit it through a [pull request][PR].
+Start editing the markdown file at the path you provided in the previous
+command. The file is initialized from the blog-post starter under
+[archetypes](archetypes). Once your post is ready, submit it through a [pull
+request][PR].
 
 ## Contributing
 

--- a/archetypes/blog.md
+++ b/archetypes/blog.md
@@ -1,0 +1,20 @@
+---
+title: {{ replaceRE "[-_]" " " .Name | title }}
+# Uncomment the next line if you'd like your post to have a short title:
+# linkTitle: SHORT TITLE GOES HERE
+date: {{ dateFormat "2006-01-02" .Date }}
+author: AUTHOR NAME(S) GO HERE
+# Remove the following draft status (and this comment) once your post is ready to be published:
+draft: true
+---
+
+## Top-level heading
+
+Top-level headings start at level 2, as shown above.
+
+## Paragraphs
+
+Wrap paragraph text at 80 characters, this helps make git diffs (which is line
+based) more useful.
+
+Happy writing!


### PR DESCRIPTION
- Contributes to #845
- README preview: https://github.com/chalin/opentelemetry.io/blob/chalin-blog-archetype-2022-01-20/README.md

Note that I'll revisit the Registry instructions in another PR, possibly creating a [Hugo archetype file] for that too.

[Hugo archetype file]: https://gohugo.io/content-management/archetypes