### PR TITLE
Add blog-approvers to README and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,9 +6,9 @@
 #
 # Learn about membership in OpenTelemetry community:
 #  https://github.com/open-telemetry/community/blob/main/community-membership.md
-# 
 #
-# Learn about CODEOWNERS file format: 
+#
+# Learn about CODEOWNERS file format:
 #  https://help.github.com/en/articles/about-code-owners
 #
 
@@ -18,3 +18,4 @@
 # content owners
 content/en/docs/instrumentation/cpp/     @open-telemetry/cpp-maintainers
 content/en/docs/instrumentation/java/    @open-telemetry/java-maintainers @open-telemetry/java-instrumentation-maintainers
+content/en/blog/  @open-telemetry/blog-approvers

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ See [CONTRIBUTING.md][].
 Roles:
 - Approvers: [@open-telemetry/docs-approvers][]
 - Maintainers: [@open-telemetry/docs-maintainers][]
+- Blog approvers: [@open-telemetry/blog-approvers][]
 
 Learn more about roles in the [community repository][]. Thanks to [all who have
 already contributed][contributors]!
@@ -52,6 +53,7 @@ and does not supersede any licenses of the source code, its dependencies, etc.
   <img alt="Creative Commons License" src="https://i.creativecommons.org/l/by/4.0/88x31.png" />
 </a>
 
+[@open-telemetry/blog-approvers]: https://github.com/orgs/open-telemetry/teams/blog-approvers
 [@open-telemetry/docs-approvers]: https://github.com/orgs/open-telemetry/teams/docs-approvers
 [@open-telemetry/docs-maintainers]: https://github.com/orgs/open-telemetry/teams/docs-maintainers
 [community repository]: https://github.com/open-telemetry/community/blob/main/community-membership.md


### PR DESCRIPTION
- Contributes to #845, followup to #1062
- README preview: https://github.com/chalin/opentelemetry.io/blob/chalin-blog-approvers-2022-01-20/README.md