### PR TITLE
Fix NodeJS metrics example

### DIFF
--- a/content/en/docs/instrumentation/js/getting-started/nodejs.md
+++ b/content/en/docs/instrumentation/js/getting-started/nodejs.md
@@ -246,18 +246,15 @@ const meter = new MeterProvider({
   interval: 1000,
 }).getMeter('your-meter-name');
 
-const requestCount = meter.createCounter("requests", {
-  description: "Count all incoming requests"
-});
-
 const boundInstruments = new Map();
 
 module.exports.countAllRequests = () => {
   return (req, res, next) => {
     if (!boundInstruments.has(req.path)) {
-      const labels = { route: req.path };
-      const boundCounter = requestCount.bind(labels);
-      boundInstruments.set(req.path, boundCounter);
+      const requestCount = meter.createCounter(`requests${req.path.replace('/', '_')}`, {
+        description: `Count ${req.path} incoming requests`
+      });
+      boundInstruments.set(req.path, requestCount);
     }
 
     boundInstruments.get(req.path).add(1);


### PR DESCRIPTION
The new api.Counter doesn't support bind method anymore. Thus, using the new metrics package sdk-metrics-base, the NodeJS metrics example is also needed to update.