### PR TITLE
Java docs: fix redirects and rename files to use site convention

### DIFF
--- a/content/en/docs/concepts/instrumenting-library.md
+++ b/content/en/docs/concepts/instrumenting-library.md
@@ -171,9 +171,9 @@ try (Scope unused = span.makeCurrent()) {
 }
 ```
 
-Here're the full [examples of context extraction in Java](/docs/instrumentation/java/manual_instrumentation/#context-propagation), check out OpenTelemetry documentation in your language.
+Here're the full [examples of context extraction in Java](/docs/instrumentation/java/manual/#context-propagation), check out OpenTelemetry documentation in your language.
 
-In the case of a messaging system, you may receive more than one message at once. Received messages become [*links*](/docs/instrumentation/java/manual_instrumentation/#create-spans-with-links) on the span you create.
+In the case of a messaging system, you may receive more than one message at once. Received messages become [*links*](/docs/instrumentation/java/manual/#create-spans-with-links) on the span you create.
 Refer to [messaging conventions]({{< relref "/docs/reference/specification/trace/semantic_conventions/messaging" >}}) for details (WARNING: messaging conventions are [under constructions](https://github.com/open-telemetry/oteps/pull/173) 🚧).
 
 ### Injecting context
@@ -200,7 +200,7 @@ try (Scope unused = span.makeCurrent()) {
 }
 ```
 
-Here's the full [example of context injection in Java](/docs/instrumentation/java/manual_instrumentation/#context-propagation).
+Here's the full [example of context injection in Java](/docs/instrumentation/java/manual/#context-propagation).
 
 There might be some exceptions:
 

--- a/content/en/docs/instrumentation/java/automatic.md
+++ b/content/en/docs/instrumentation/java/automatic.md
@@ -1,6 +1,9 @@
 ---
 title: Automatic Instrumentation
 linkTitle: Automatic
+aliases:
+  - docs/java/automatic_instrumentation
+  - docs/instrumentation/java/automatic_instrumentation
 weight: 3
 ---
 
@@ -9,7 +12,7 @@ to any Java 8+ application. It dynamically injects bytecode to capture telemetry
 from many popular libraries and frameworks. It can be used to capture telemetry
 data at the "edges" of an app or service, such as inbound requests, outbound
 HTTP calls, database calls, and so on. To instrument application code in your
-app or service, use [Manual Instrumentation](../manual_instrumentation)
+app or service, use [Manual Instrumentation](../manual)
 
 ## Setup
 
@@ -83,5 +86,5 @@ debug logs. Note that these are quite verbose.
 ## Next steps
 
 After you have automatic instrumentation configured for your app or service, you
-may want to add [Manual Instrumentation](../manual_instrumentation) to collect
+may want to add [Manual Instrumentation](../manual) to collect
 custom telemetry data.

--- a/content/en/docs/instrumentation/java/examples.md
+++ b/content/en/docs/instrumentation/java/examples.md
@@ -1,6 +1,8 @@
 ---
 title: Instrumentation Examples
 linkTitle: Examples
+# instrumentation_examples
+aliases: [docs/java/instrumentation_examples]
 weight: 4
 ---
 

--- a/content/en/docs/instrumentation/java/examples.md
+++ b/content/en/docs/instrumentation/java/examples.md
@@ -1,7 +1,6 @@
 ---
 title: Instrumentation Examples
 linkTitle: Examples
-# instrumentation_examples
 aliases: [docs/java/instrumentation_examples]
 weight: 4
 ---

--- a/content/en/docs/instrumentation/java/manual.md
+++ b/content/en/docs/instrumentation/java/manual.md
@@ -1,6 +1,10 @@
 ---
 title: Manual Instrumentation
 linkTitle: Manual
+aliases:
+  - docs/java/getting_started
+  - docs/java/manual_instrumentation
+  - docs/instrumentation/java/manual_instrumentation
 weight: 3
 ---
 

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -5,10 +5,6 @@
 {{ end -}}
 {{ end -}}
 
-# https://github.com/open-telemetry/opentelemetry.io/issues/635#issuecomment-953920483
-/docs/java/automatic_instrumentation  https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/README.md
-/docs/java/getting_started  https://opentelemetry.io/docs/java/manual_instrumentation/
-
 {{ $languages := (.Site.GetPage "/docs/instrumentation").Pages -}}
 {{ range $languages -}}
 {{ $lang := .File.ContentBaseName -}}


### PR DESCRIPTION
I think that when we merged in the Java docs (#1002), we forgot to adjust these (non-alias) redirects: https://github.com/open-telemetry/opentelemetry.io/blob/09822ce98ca88fc8b24b9254c9e4811a0ba7b95b/layouts/index.redirects#L8-L10

This PR:

- Fixes the redirects
- Contributes to #997

Preview:

- https://deploy-preview-1068--opentelemetry.netlify.app/docs/instrumentation/java/

Redirect tests:

- https://deploy-preview-1068--opentelemetry.netlify.app/docs/java/automatic_instrumentation
- https://deploy-preview-1068--opentelemetry.netlify.app/docs/instrumentation/java/automatic_instrumentation
- https://deploy-preview-1068--opentelemetry.netlify.app/docs/java/getting_started
- https://deploy-preview-1068--opentelemetry.netlify.app/docs/java/manual_instrumentation
- https://deploy-preview-1068--opentelemetry.netlify.app/docs/instrumentation/java/manual_instrumentation
- https://deploy-preview-1068--opentelemetry.netlify.app/docs/java/instrumentation_examples