### PR TITLE
Update java docs to point to 1.10.1 release

### DIFF
--- a/content/en/docs/instrumentation/java/_index.md
+++ b/content/en/docs/instrumentation/java/_index.md
@@ -55,7 +55,7 @@ using our BOM to keep the versions of the various components in sync.
       <dependency>
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-bom</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -74,7 +74,7 @@ using our BOM to keep the versions of the various components in sync.
 
 ```kotlin
 dependencies {
-  implementation(platform("io.opentelemetry:opentelemetry-bom:1.10.0"))
+  implementation(platform("io.opentelemetry:opentelemetry-bom:1.10.1"))
   implementation("io.opentelemetry:opentelemetry-api")
 }
 ```


### PR DESCRIPTION
Reflects latest java [release](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.10.1).