### PR TITLE
Document setting span status and recording exceptions for .NET

### DIFF
--- a/content/en/docs/instrumentation/net/manual.md
+++ b/content/en/docs/instrumentation/net/manual.md
@@ -292,6 +292,28 @@ using var anotherActivity =
 // do some work
 ```
 
+## Set Activity status
+
+A status can be set on an activity, typically used to specify that an activity
+has not completed successfully - `ActivityStatusCode.Error`. In rare scenarios,
+you could override the `Error` status with `Ok`, but don't set `Ok` on
+successfully-completed spans.
+
+The status can be set at any time before the span is finished:
+
+```csharp
+using var myActivity = MyActivitySource.StartActivity("SayHello");
+
+try
+{
+	// do something
+}
+catch (Exception ex)
+{
+    myActivity.SetStatus(ActivityStatusCode.Error, "Something bad happened!");
+}
+```
+
 ## Next steps
 
 If you're not using [instrumentation libraries]({{< relref "automatic" >}}), we

--- a/content/en/docs/instrumentation/net/shim.md
+++ b/content/en/docs/instrumentation/net/shim.md
@@ -323,6 +323,49 @@ using var span = tracer.StartActiveSpan("another-span", links: links);
 // do some work
 ```
 
+## Set span status
+
+A status can be set on a span, typically used to specify that a span has not
+completed successfully - `Status.Error`. In rare scenarios, you could override
+the `Error` status with `Ok`, but don't set `Ok` on successfully-completed
+spans.
+
+The status can be set at any time before the span is finished:
+
+```csharp
+using var span = tracer.StartActiveSpan("SayHello");
+
+try
+{
+	// do something
+}
+catch (Exception ex)
+{
+    span.SetStatus(Status.Error, "Something bad happened!");
+}
+```
+
+### Record exceptions in spans
+
+It can be a good idea to record exceptions when they happen. It's recommended to
+do this in conjunction with setting [span status](#set-span-status).
+
+```java
+using var span = tracer.StartActiveSpan("SayHello");
+
+try
+{
+	// do something
+}
+catch (Exception ex)
+{
+    span.SetStatus(Status.Error, "Something bad happened!");
+    span.RecordException(ex)
+}
+```
+
+This will capture things like the current stack trace as attributes in the span.
+
 ## Next steps
 
 If you're not utilizing [instrumentation libraries]({{< relref "automatic" >}}),


### PR DESCRIPTION
This brings the .NET docs up to par with JS and Java.

Note that `RecordException` does not have an equivalent method on `Activity` in .NET, at it at least doesn't appear to be available based on API usage and docs I read. You could technically do it yourself in a helper extension method I guess?