### PR TITLE
Blog: redirect old posts to its Medium page directly

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -8,3 +8,5 @@ IgnoreInternalURLs:
   - HAHAHUGOSHORTCODE-s2-HBHB
   - HAHAHUGOSHORTCODE-s5-HBHB
   - HAHAHUGOSHORTCODE-s7-HBHB
+  # Blog entry redirects
+  - /blog/2022/v1.0-trio-redirect/

--- a/content/en/blog/2022/v1.0-trio-redirect.md
+++ b/content/en/blog/2022/v1.0-trio-redirect.md
@@ -1,0 +1,15 @@
+---
+title: OpenTelemetry Erlang/Elixir, Javascript, and Ruby v1.0
+linkTitle: Erlang/Elixir, JS, and Ruby v1.0
+date: 2022-02-01
+redirect: https://medium.com/opentelemetry/opentelemetry-erlang-elixir-javascript-and-ruby-v1-0-3a0c32e0add4
+manualLinkTarget: _blank
+_build: { render: link }
+---
+
+We are kicking off the new year with a bang! In the last couple months, three
+new languages (Ruby, Javascript, and Erlang/Elixir) have had their first 1.0
+releases, joining the existing GA releases from C++, Go, Java, .Net, Python and
+Swift. Read all the details from the [announcement][].
+
+[announcement]: {{< param "redirect" >}}

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -1,8 +1,15 @@
 # Netlify redirects. See https://www.netlify.com/docs/redirects/
 {{ range $p := .Site.Pages -}}
+
 {{ range .Aliases -}}
 {{ . | printf "%-35s" }} {{ $p.RelPermalink }}
 {{ end -}}
+
+
+{{ with .Param "redirect" -}}
+{{ $p.RelPermalink | printf "%-35s" }} {{ . }}
+{{ end -}}
+
 {{ end -}}
 
 {{ $languages := (.Site.GetPage "/docs/instrumentation").Pages -}}


### PR DESCRIPTION
- This is an alternative to #1091 
- Contributes to #845

Preview:

- Blog: https://deploy-preview-1092--opentelemetry.netlify.app/blog
  Notice that you see the v1.0-trio entry, but if you click on any link to that page, it'll send you directly to the Medium page.
- You can test the link here too: https://deploy-preview-1092--opentelemetry.netlify.app/blog/2022/v1.0-trio-redirect