### PR TITLE
Python: add installation instructions, refine status info, and more

### DIFF
--- a/content/en/docs/instrumentation/python/_index.md
+++ b/content/en/docs/instrumentation/python/_index.md
@@ -13,19 +13,79 @@ the generation and collection of application telemetry data such as metrics,
 logs, and traces. This documentation is designed to help you understand how to
 get started using OpenTelemetry for Python.
 
+## Version support
+
+OpenTelemetry-Python supports Python 3.6 and higher.
+
 ## Status and Releases
 
 The current status of the major functional components for OpenTelemetry Python
 is as follows:
 
-| Tracing   | Metrics | Logging      |
-| -------   | ------- | ------------ |
-| Stable    | Alpha   | Experimental |
+- **Tracing** ([API][api/t], [SDK][sdk/t]): [Stable][]
+- **Metrics** ([API][api/m], [SDK][sdk/m]): [Alpha][Experimental]
+- **[Logging][]**: [Experimental][]
+
+[api/m]: https://opentelemetry-python.readthedocs.io/en/stable/api/metrics.html
+[api/t]: https://opentelemetry-python.readthedocs.io/en/stable/api/trace.html
+[Experimental]: /docs/reference/specification/versioning-and-stability/#stable
+[Logging]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/logs.html
+[sdk/m]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/metrics.html
+[sdk/t]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/trace.html
+[Stable]: /docs/reference/specification/versioning-and-stability/#stable
 
 {{% latest_release "python" /%}}
 
-## Further Reading
+## Installation
 
-- [Read the Docs](https://opentelemetry-python.readthedocs.io/en/stable/)
-- [Examples](https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples)
-- [Contrib Repository](https://github.com/open-telemetry/opentelemetry-python-contrib)
+The API and SDK packages are available on PyPI, and can installed via pip:
+
+```console
+$ pip install opentelemetry-api
+$ pip install opentelemetry-sdk
+```
+
+In addition, there are several extension packages which can be installed separately as:
+
+```console
+$ pip install opentelemetry-exporter-{exporter}
+$ pip install opentelemetry-instrumentation-{instrumentation}
+```
+
+These are for exporter and instrumentation packages respectively.
+The Jaeger, Zipkin, OTLP and OpenCensus Exporters can be found in the [exporter](https://github.com/open-telemetry/opentelemetry-python/blob/main/exporter/)
+directory of the repository. Instrumentations and additional exporters can be found in the
+[Contrib repo instrumentation](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation)
+and [Contrib repo exporter](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/exporter) directories.
+
+## Extensions
+
+To find related projects like exporters, instrumentation libraries, tracer
+implementations, etc., visit the [Registry](/registry/?s=python).
+
+### Installing Cutting Edge Packages
+
+While the project is pre-1.0, there may be significant functionality that
+has not yet been released to PyPI. In that situation, you may want to
+install the packages directly from the repo. This can be done by cloning the
+repository and doing an [editable
+install](https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs):
+
+```console
+$ git clone https://github.com/open-telemetry/opentelemetry-python.git
+$ cd opentelemetry-python
+$ pip install -e ./opentelemetry-api
+$ pip install -e ./opentelemetry-sdk
+```
+
+## Learn more
+
+- [API reference][]
+- [Examples][]
+- [Contrib repository][]
+- [Performance benchmarks][]
+
+[API reference]: https://opentelemetry-python.readthedocs.io/en/stable/
+[Contrib repository]: https://github.com/open-telemetry/opentelemetry-python-contrib
+[Examples]: https://opentelemetry-python.readthedocs.io/en/stable/examples/
+[Performance benchmarks]: https://open-telemetry.github.io/opentelemetry-python/benchmarks/

--- a/content/en/docs/instrumentation/python/_index.md
+++ b/content/en/docs/instrumentation/python/_index.md
@@ -28,7 +28,7 @@ is as follows:
 
 [api/m]: https://opentelemetry-python.readthedocs.io/en/stable/api/metrics.html
 [api/t]: https://opentelemetry-python.readthedocs.io/en/stable/api/trace.html
-[Experimental]: /docs/reference/specification/versioning-and-stability/#stable
+[Experimental]: /docs/reference/specification/versioning-and-stability/#experimental
 [Logging]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/logs.html
 [sdk/m]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/metrics.html
 [sdk/t]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/trace.html

--- a/content/en/docs/instrumentation/python/_index.md
+++ b/content/en/docs/instrumentation/python/_index.md
@@ -22,14 +22,14 @@ OpenTelemetry-Python supports Python 3.6 and higher.
 The current status of the major functional components for OpenTelemetry Python
 is as follows:
 
-- **Tracing** ([API][api/t], [SDK][sdk/t]): [Stable][]
+- **Traces** ([API][api/t], [SDK][sdk/t]): [Stable][]
 - **Metrics** ([API][api/m], [SDK][sdk/m]): [Alpha][Experimental]
-- **[Logging][]**: [Experimental][]
+- **Logs** ([SDK][sdk/l]): [Experimental][]
 
 [api/m]: https://opentelemetry-python.readthedocs.io/en/stable/api/metrics.html
 [api/t]: https://opentelemetry-python.readthedocs.io/en/stable/api/trace.html
 [Experimental]: /docs/reference/specification/versioning-and-stability/#experimental
-[Logging]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/logs.html
+[sdk/l]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/logs.html
 [sdk/m]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/metrics.html
 [sdk/t]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/trace.html
 [Stable]: /docs/reference/specification/versioning-and-stability/#stable

--- a/content/en/docs/instrumentation/python/_index.md
+++ b/content/en/docs/instrumentation/python/_index.md
@@ -63,12 +63,11 @@ and [Contrib repo exporter](https://github.com/open-telemetry/opentelemetry-pyth
 To find related projects like exporters, instrumentation libraries, tracer
 implementations, etc., visit the [Registry](/registry/?s=python).
 
-### Installing Cutting Edge Packages
+### Installing Cutting-edge Packages
 
-While the project is pre-1.0, there may be significant functionality that
-has not yet been released to PyPI. In that situation, you may want to
-install the packages directly from the repo. This can be done by cloning the
-repository and doing an [editable
+There is some functionality that has not yet been released to PyPI. In that
+situation, you may want to install the packages directly from the repo. This can
+be done by cloning the repository and doing an [editable
 install](https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs):
 
 ```console


### PR DESCRIPTION
- Contributes to #1109
- Moves various sections of [opentelemetry-python/docs/index.rst](https://github.com/open-telemetry/opentelemetry-python/blob/main/docs/index.rst) into the Python instrumentation landing page.
- The corresponding Python repo PR to remove the sections/pages is:
  - https://github.com/open-telemetry/opentelemetry-python/pull/2453

Preview: https://deploy-preview-1116--opentelemetry.netlify.app/docs/instrumentation/python/

/cc @open-telemetry/python-approvers 