### PR TITLE
Upgrade hugo-extended to 0.92.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "private": true,
   "devDependencies": {
     "autoprefixer": "^10.4.2",
-    "hugo-extended": "0.92.1",
+    "hugo-extended": "0.92.2",
     "netlify-cli": "^9.6.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.6",


### PR DESCRIPTION
- Closes #1124
- No change in generated site files except for the generator version:
  ```console
  $ (cd public && git diff -I "Hugo 0.") 
  $
  ```