### PR TITLE
Blog: use new canonical_url convention and change date of Welcome post

### DIFF
--- a/content/en/blog/2022/v1.0-trio.md
+++ b/content/en/blog/2022/v1.0-trio.md
@@ -1,7 +1,8 @@
 ---
-title: OpenTelemetry Erlang/Elixir, Javascript, and Ruby v1.0
+title: OpenTelemetry Erlang/Elixir, Javascript, and Ruby v1.0 (Medium)
 linkTitle: Erlang/Elixir, JS, and Ruby v1.0
 date: 2022-02-01
+canonical_url: https://medium.com/opentelemetry/opentelemetry-erlang-elixir-javascript-and-ruby-v1-0-3a0c32e0add4
 ---
 
 We are kicking off the new year with a bang! In the last couple months, three
@@ -9,4 +10,4 @@ new languages (Ruby, Javascript, and Erlang/Elixir) have had their first 1.0
 releases, joining the existing GA releases from C++, Go, Java, .Net, Python and
 Swift. Read all the details from the [announcement][].
 
-[announcement]: https://medium.com/opentelemetry/opentelemetry-erlang-elixir-javascript-and-ruby-v1-0-3a0c32e0add4
+[announcement]: {{% param canonical_url %}}

--- a/content/en/blog/2022/welcome.md
+++ b/content/en/blog/2022/welcome.md
@@ -1,7 +1,7 @@
 ---
 title: Welcome to the OpenTelemetry blog
 linkTitle: Welcome
-date: 2022-01-19
+date: 2022-02-02
 author: OpenTelemetry Communications team
 ---
 


### PR DESCRIPTION
- Contributes to #845
- [Blog v1.0-trio: use new canonical_url convention](https://github.com/open-telemetry/opentelemetry.io/commit/13d51c95eb540a65e72b386eb7faba70cadbde68)
- [Make Welcome post the older than all old Medium posts](https://github.com/open-telemetry/opentelemetry.io/commit/75a42dfd87bae97295da76b637d41135db815647)

Preview: https://deploy-preview-1137--opentelemetry.netlify.app/blog/2022/

/cc @austinlparker 