### PR TITLE
Add blog archetype for old medium posts

### DIFF
--- a/archetypes/blog.md
+++ b/archetypes/blog.md
@@ -1,11 +1,9 @@
 ---
 title: {{ replaceRE "[-_]" " " .Name | title }}
-# Uncomment the next line if you'd like your post to have a short title:
-# linkTitle: SHORT TITLE GOES HERE
+linkTitle: ADD A SHORT TITLE HERE # TODO: add short title or remove this line
 date: {{ dateFormat "2006-01-02" .Date }}
-author: AUTHOR NAME(S) GO HERE
-# Remove the following draft status (and this comment) once your post is ready to be published:
-draft: true
+author: ADD AUTHOR NAME(S) HERE # TODO
+draft: true # TODO: remove this line once your post is ready to be published
 ---
 
 ## Top-level heading

--- a/archetypes/medium.md
+++ b/archetypes/medium.md
@@ -1,0 +1,10 @@
+---
+title: {{ replaceRE "[-_]" " " .Name | title }}
+linkTitle: ADD A SHORT TITLE HERE # TODO
+date: 2021-01-01 # TODO ADJUST THE DATE
+canonical_url: https://medium.com/opentelemetry/ADD-REST-OF-PATH-HERE # TODO
+---
+
+TODO: INTRO SENTENCE GOES HERE. For all the details, see the [original post][].
+
+[original post]: {{% param canonical_url %}}


### PR DESCRIPTION
- Contributes to #845
- Also tweaks the default blog archetype

To use the Medium archetype run, e.g.:

```console
$ hugo new --kind medium content/en/blog/2021/otel-gc.md
```