### PR TITLE
Add missing redirects for Java and JS example pages

### DIFF
--- a/content/en/docs/instrumentation/java/examples.md
+++ b/content/en/docs/instrumentation/java/examples.md
@@ -1,7 +1,9 @@
 ---
 title: Instrumentation Examples
 linkTitle: Examples
-aliases: [docs/java/instrumentation_examples]
+aliases:
+  - /docs/java/instrumentation_examples
+  - /docs/instrumentation/java/instrumentation_examples
 weight: 4
 ---
 

--- a/content/en/docs/instrumentation/js/examples.md
+++ b/content/en/docs/instrumentation/js/examples.md
@@ -1,6 +1,7 @@
 ---
 title: Instrumentation Examples
 title: Examples
+aliases: [/docs/instrumentation/js/instrumentation_examples]
 weight: 4
 ---
 


### PR DESCRIPTION
They were missing from #1068 and #1095.