### PR TITLE
Add Kotlin SDK to registry

### DIFF
--- a/content/en/registry/otel-kotlin.md
+++ b/content/en/registry/otel-kotlin.md
@@ -1,0 +1,16 @@
+---
+title: Kotlin
+registryType: core
+isThirdParty: true
+language: Kotlin
+tags:
+  - Kotlin
+  - Js
+  - Jvm
+  - Native
+repo: https://github.com/dcxp/opentelemetry-kotlin
+license: Apache 2.0
+description: The OpenTelemetry API and SDK for Kotlin.
+authors: SNK; OpenTelemetry Authors
+otVersion: latest
+---


### PR DESCRIPTION
Hello Team,

i am working on a Kotlin multi platform SDK for OpenTelemetry. As advised in this discussion (https://github.com/open-telemetry/community/discussions/958) i add the current repository of this library to the OpenTelemetry repository with this pullrequest.  