### PR TITLE
add link to 'instrumenting' concept and to k8s operator injection to …

### DIFF
--- a/content/en/docs/instrumentation/_index.md
+++ b/content/en/docs/instrumentation/_index.md
@@ -3,7 +3,7 @@ title: Instrumentation
 weight: 2
 ---
 
-OpenTelemetry code instrumentation is supported for the languages listed below.
+OpenTelemetry code [instrumentation](/docs/concepts/instrumenting/) is supported for the languages listed below.
 Depending on the language, topics covered will include some or all of the
 following:
 
@@ -11,3 +11,4 @@ following:
 - Manual instrumentation
 - Exporting data
 
+If you are using Kubernetes, you can use the [OpenTelemetry Operator for Kubernetes](https://github.com/open-telemetry/opentelemetry-operator) to [inject auto-instrumentation libraries](https://github.com/open-telemetry/opentelemetry-operator#opentelemetry-auto-instrumentation-injection) for Java, NodeJS and Python into your application.


### PR DESCRIPTION
Two changes for https://opentelemetry.io/docs/instrumentation/:
* I linked back from that page to the concept of [instrumenting](https://opentelemetry.io/docs/concepts/instrumenting/). Idea is that someone landing on that page might not know about the concept and can go back from there
* I added a short paragraph that highlights that auto instrumentation libraries for java, node.js & python can be injected via the kubernetes operator. For someone running apps on k8s, who "just" wants to get services instrumented, this is a live saver. Let me know what you think, maybe this could also have it's own section within the docs and not pointing out?

Preview: https://deploy-preview-1147--opentelemetry.netlify.app/docs/instrumentation/