### PR TITLE
code_block_from: add support for C# and "to" argument

### DIFF
--- a/layouts/shortcodes/code_block_from.md
+++ b/layouts/shortcodes/code_block_from.md
@@ -1,11 +1,16 @@
 {{ $file := .Get "file" -}}
 {{ $lang := .Get "lang" | default "" -}}
 {{ $from := .Get "from" | default 0 -}}
-{{ $to := .Get "to" -}}
+{{ $to := .Get "to" | default 99999 -}}
+{{ $showFileName := .Get "show-file" | default "true" -}}
+{{ $commentStart := "//" -}}
 
 {{ if not $lang -}}
   {{ if strings.HasSuffix $file ".py" -}}
     {{ $lang = "python" -}}
+    {{ $commentStart = "#" -}}
+  {{ else if strings.HasSuffix $file ".cs" -}}
+    {{ $lang = "csharp" -}}
   {{ end -}}
 {{ end -}}
 
@@ -13,13 +18,19 @@
 
 {{ $path := $file -}}
 {{ if $pathBase -}}
-{{ $path = printf "%s/%s" $pathBase $path -}}
+  {{ $path = printf "%s/%s" $pathBase $path -}}
 {{ end -}}
 {{ $fileContent := readFile $path -}}
 {{ $fileLines := split $fileContent "\n" -}}
-{{ $excerpt := after $from $fileLines -}}
+{{ $n := sub (int $to) (int $from) -}}
+{{ if le $n 0 }}
+  {{ errorf "Invalid line range (from=%s, to=%s) for file %s" $from $to $file -}}
+{{ end -}}
+{{ $excerpt := first $n (after $from $fileLines) -}}
 
 ```{{ $lang }}
-# {{ $file }}
+{{ if $showFileName -}}
+  {{ $commentStart }} {{ $file }}
+{{ end -}}
 {{ delimit $excerpt "\n" "" }}
 ```


### PR DESCRIPTION
- From #1120, incorporating @mic-max's changes. Thanks!
- Adding support for:
  - `to` argument
  - `show-file` boolean argument
  - language-specific comment marker
- No change to generated site files.

Still keeping this as simple as possible, making incremental improvements as needed until I can port a more complete solution (from another project).