### PR TITLE
Add a note to 'Distributions' page to follow marketing and trademark guidelines

### DIFF
--- a/content/en/docs/concepts/distributions.md
+++ b/content/en/docs/concepts/distributions.md
@@ -64,6 +64,12 @@ might be a good starting point.
 
 ## What you should know about distributions
 
+When using OpenTelemetry project collateral such as logo and name for your
+distribution make sure that you are in line with the [OpenTelemetry Marketing
+Guidelines for Contributing Organizations](https://github.com/open-telemetry/community/blob/main/marketing-guidelines.md)
+and the [Linux Foundation's branding and trademark usage
+guidelines](https://www.linuxfoundation.org/trademark-usage/).
+
 The OpenTelemetry project does not certify distributions at this time. In the
 future, OpenTelemetry may certify distributions and partners similarly to the
 Kubernetes project. When evaluating a distribution, ensure using the

--- a/content/en/docs/concepts/distributions.md
+++ b/content/en/docs/concepts/distributions.md
@@ -65,10 +65,8 @@ might be a good starting point.
 ## What you should know about distributions
 
 When using OpenTelemetry project collateral such as logo and name for your
-distribution make sure that you are in line with the [OpenTelemetry Marketing
-Guidelines for Contributing Organizations](https://github.com/open-telemetry/community/blob/main/marketing-guidelines.md)
-and the [Linux Foundation's branding and trademark usage
-guidelines](https://www.linuxfoundation.org/trademark-usage/).
+distribution, make sure that you are in line with the [OpenTelemetry Marketing
+Guidelines for Contributing Organizations][guidelines].
 
 The OpenTelemetry project does not certify distributions at this time. In the
 future, OpenTelemetry may certify distributions and partners similarly to the
@@ -77,3 +75,5 @@ distribution does not result in vendor lock-in.
 
 > Any support for a distribution comes from the distribution authors and
 > not the OpenTelemetry authors.
+
+[guidelines]: https://github.com/open-telemetry/community/blob/main/marketing-guidelines.md


### PR DESCRIPTION
While doing some research for creating a distribution of OpenTelemetry I was looking for guidelines for using logo, name and other collaterals. I expected to find something on the page about [Distributions](https://opentelemetry.io/docs/concepts/distributions/), so after finding them [here](https://github.com/open-telemetry/community/blob/main/marketing-guidelines.md), I thought it would be good to have them where I was looking for them.

Preview: https://deploy-preview-1150--opentelemetry.netlify.app/docs/concepts/distributions/#what-you-should-know-about-distributions