### PR TITLE
Config cleanup: drop contentDir, and params with default values

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,9 +5,6 @@ disableAliases: true # We do redirects via Netlify's _redirects file
 enableGitInfo: true
 
 # Language settings
-contentDir: content/en
-defaultContentLanguage: en
-defaultContentLanguageInSubdir: false
 enableMissingTranslationPlaceholders: true
 languages:
   en:
@@ -149,6 +146,8 @@ params:
 
 module:
   mounts:
+    - source: content/en
+      target: content
     - source: static
       target: static
     - source: content-modules/opentelemetry-specification/schemas


### PR DESCRIPTION
- Context: https://discourse.gohugo.io/t/content-mount-problem-for-single-language-multilingual-site/37215/8
  - Part of #906 work
- Also dropping params that are being unnecessarily set to their default values. For details concerning default values see https://gohugo.io/getting-started/configuration.
- No change in generated site files
  ```console
  $ npm run check-links && (cd public && git diff)
  ...
  ✔✔✔ passed in 589.25155ms
  tested 557 documents
  $
  ```