### PR TITLE
Change type of `show-file` to boolean

### DIFF
--- a/layouts/shortcodes/code_block_from.md
+++ b/layouts/shortcodes/code_block_from.md
@@ -2,7 +2,7 @@
 {{ $lang := .Get "lang" | default "" -}}
 {{ $from := .Get "from" | default 0 -}}
 {{ $to := .Get "to" | default 99999 -}}
-{{ $showFileName := .Get "show-file" | default "true" -}}
+{{ $showFileName := .Get "show-file" | default true -}}
 {{ $commentStart := "//" -}}
 
 {{ if not $lang -}}


### PR DESCRIPTION
After rebasing and making use of the shortcode I realised that this should not be surrounded by quotations to be the actual Hugo templating boolean type. I assume that was the intention. 

If the intention was to make this a string for more flexibility of values, please close 👍