### PR TITLE
Vendor page: use blocks shortcode and markdown instead of HTML

### DIFF
--- a/content/en/vendors/_index.md
+++ b/content/en/vendors/_index.md
@@ -2,16 +2,12 @@
 title: Vendor support
 ---
 
-<a class="td-offset-anchor"></a>
+{{% blocks/lead color="primary" %}}
+# {{% param title %}}
 
-<section class="row td-box td-box--1 position-relative td-box--gradient td-box--height-auto">
-  <div class="container text-center td-arrow-down">
-    <h1>Vendors Supporting OpenTelemetry</h1>
-    <span class="h4 mb-0">
-      <p>Distributions and vendors who natively support OpenTelemetry in their commercial products.</p>
-    </span>
-  </div>
-</section>
+Distributions and vendors who natively support OpenTelemetry in their commercial
+products.
+{{% /blocks/lead %}}
 
 {{% blocks/section type="section" color="white" %}}
 


### PR DESCRIPTION
- Contributes to #1170
- Contributes to #1172
- Note the change in title: the page now uses the title in the front matter:
  - New title: Vendor support
  - Old title: Vendors Supporting OpenTelemetry

Preview: https://deploy-preview-1171--opentelemetry.netlify.app/vendors/