### PR TITLE
add redirect from docs.opentelemetry.io -> /docs route

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,8 @@ command = "npm run build:preview"
 
 [context.production]
 command = "npm run build:production"
+
+[[redirects]]
+from = "https://docs.opentelemetry.io/*"
+to = "https://opentelemetry.io/docs/:splat"
+status = 200


### PR DESCRIPTION
Fixes #976 

cc @chalin, please check my work on the redirect syntax here. I've added `docs.opentelemetry.io` to the netlify DNS.