### PR TITLE
Update Hugo to 0.93.2, and other modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,10 +46,10 @@
   "private": true,
   "devDependencies": {
     "autoprefixer": "^10.4.2",
-    "hugo-extended": "0.92.2",
-    "netlify-cli": "^9.6.1",
+    "hugo-extended": "0.93.2",
+    "netlify-cli": "^9.12.3",
     "npm-run-all": "^4.1.5",
-    "postcss": "^8.4.6",
+    "postcss": "^8.4.7",
     "postcss-cli": "^9.1.0"
   },
   "dependencies": {


### PR DESCRIPTION
Update Hugo to [0.93.2](https://github.com/gohugoio/hugo/releases/tag/v0.93.2), which introduces support for:
- [code-block hooks](https://github.com/gohugoio/hugo/releases/tag/v0.93.0)
- [GoAT](https://github.com/bep/goat)

Changes to the generated site files are due to updates to the Chroma lexer, which impacts how HTML for code blocks is generated (as introduced by this PR, in particular, https://github.com/alecthomas/chroma/pull/571).


I've checked several of the changed HTML files and they look the same visually. For example, compare the first code block of these pages:
  - https://opentelemetry.io/docs/reference/specification/metrics/api/
  - https://deploy-preview-1186--opentelemetry.netlify.app/docs/reference/specification/metrics/api/