### PR TITLE
Added `clj-otel`, a Clojure API for OpenTelemetry

### DIFF
--- a/content/en/registry/otel-clojure.md
+++ b/content/en/registry/otel-clojure.md
@@ -1,0 +1,14 @@
+---
+title: clj-otel - Idiomatic Clojure API for OpenTelemetry
+registryType: extension
+isThirdParty: true
+language: java
+tags:
+  - clojure
+  - instrumentation
+repo: https://github.com/steffan-westcott/clj-otel
+license: Apache 2.0
+description: An idiomatic Clojure API for adding telemetry to your libraries and applications using OpenTelemetry.
+authors: Steffan Westcott
+otVersion: latest
+---


### PR DESCRIPTION
[`clj-otel`](https://github.com/steffan-westcott/clj-otel) provides an idiomatic Clojure API by wrapping the OpenTelemetry implementation for Java.