### PR TITLE
Java docs: add link to fully functional example

### DIFF
--- a/content/en/docs/instrumentation/java/examples.md
+++ b/content/en/docs/instrumentation/java/examples.md
@@ -8,6 +8,7 @@ weight: 6
 ---
 
 Here are some of the resources for Opentelemetry instrumentation examples.
+Fully-functional examples of manual instrumentation are available in [Opentelemetry Java Docs].
 
 ## Community Resources
 

--- a/content/en/docs/instrumentation/java/examples.md
+++ b/content/en/docs/instrumentation/java/examples.md
@@ -33,3 +33,5 @@ $ mvn clean package docker:build
 ```console
 $ docker-compose up
 ```
+
+[Opentelemetry Java Docs]: https://github.com/open-telemetry/opentelemetry-java-docs

--- a/content/en/docs/instrumentation/java/manual.md
+++ b/content/en/docs/instrumentation/java/manual.md
@@ -16,8 +16,6 @@ any other implementation of the OpenTelemetry API. This way, libraries will
 obtain a real implementation only if the user application is configured for it.
 For more details, check out the [Library Guidelines].
 
-Fully-functional examples of manual instrumentation are available in [Opentelemetry Java Docs].
-
 ## Set up
 
 The first step is to get a handle to an instance of the `OpenTelemetry`

--- a/content/en/docs/instrumentation/java/manual.md
+++ b/content/en/docs/instrumentation/java/manual.md
@@ -565,7 +565,6 @@ io.opentelemetry.sdk.trace.export.BatchSpanProcessor = io.opentelemetry.extensio
 [HttpExchange]: https://docs.oracle.com/javase/8/docs/jre/api/net/httpserver/spec/com/sun/net/httpserver/HttpExchange.html
 [Instrumentation Library]: {{< relref "/docs/reference/specification/glossary#instrumentation-library" >}}
 [instrumented library]: {{< relref "/docs/reference/specification/glossary#instrumented-library" >}}
-[Opentelemetry Java Docs]: https://github.com/open-telemetry/opentelemetry-java-docs
 [Library Guidelines]: {{< relref "/docs/reference/specification/library-guidelines" >}}
 [Obtaining a Tracer]: {{< relref "/docs/reference/specification/trace/api#get-a-tracer" >}}
 [OpenTelemetry Collector]: https://github.com/open-telemetry/opentelemetry-collector

--- a/content/en/docs/instrumentation/java/manual.md
+++ b/content/en/docs/instrumentation/java/manual.md
@@ -16,6 +16,8 @@ any other implementation of the OpenTelemetry API. This way, libraries will
 obtain a real implementation only if the user application is configured for it.
 For more details, check out the [Library Guidelines].
 
+Fully-functional examples of manual instrumentation are available in [Opentelemetry Java Docs].
+
 ## Set up
 
 The first step is to get a handle to an instance of the `OpenTelemetry`
@@ -565,6 +567,7 @@ io.opentelemetry.sdk.trace.export.BatchSpanProcessor = io.opentelemetry.extensio
 [HttpExchange]: https://docs.oracle.com/javase/8/docs/jre/api/net/httpserver/spec/com/sun/net/httpserver/HttpExchange.html
 [Instrumentation Library]: {{< relref "/docs/reference/specification/glossary#instrumentation-library" >}}
 [instrumented library]: {{< relref "/docs/reference/specification/glossary#instrumented-library" >}}
+[Opentelemetry Java Docs]: https://github.com/open-telemetry/opentelemetry-java-docs
 [Library Guidelines]: {{< relref "/docs/reference/specification/library-guidelines" >}}
 [Obtaining a Tracer]: {{< relref "/docs/reference/specification/trace/api#get-a-tracer" >}}
 [OpenTelemetry Collector]: https://github.com/open-telemetry/opentelemetry-collector


### PR DESCRIPTION
The fully-functional example link is only referred in the [opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java#getting-started) repository, feel it might be good to show the example link here as well. 

---

Preview: https://deploy-preview-1203--opentelemetry.netlify.app/docs/instrumentation/java/manual/