### PR TITLE
replace oauth2clientcredentials with oauth2client

### DIFF
--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -509,7 +509,7 @@ them to every RPC made to a remote collector:
 
 ```yaml
 extensions:
-  oauth2clientcredentials:
+  oauth2client:
     client_id: agent
     client_secret: some-secret
     token_url: http://localhost:8080/auth/realms/opentelemetry/protocol/openid-connect/token
@@ -526,11 +526,11 @@ exporters:
   otlp/auth:
     endpoint: remote-collector:4317
     auth:
-      authenticator: oauth2clientcredentials
+      authenticator: oauth2client
 
 service:
   extensions:
-    - oauth2clientcredentials
+    - oauth2client
   pipelines:
     traces:
       receivers:


### PR DESCRIPTION
According to the [Readme of the Authenticator - OAuth2 Client Credentials in the opentelemetry-collector-contrib repo](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.46.0/extension/oauth2clientauthextension) the extension is named `oauth2client` and not `oauth2clientcredentials`.