### PR TITLE
Homepage: add Java CTA

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -18,6 +18,7 @@ mission_url: https://github.com/open-telemetry/community/blob/main/mission-visio
 <div class="l-get-started-buttons">
 
 - [Collector]({{< relref "/docs/collector/getting-started" >}})
+- [Java]({{< relref "/docs/instrumentation/java/" >}})
 - [Go]({{< relref "/docs/instrumentation/go/getting-started" >}})
 - [.NET]({{< relref "/docs/instrumentation/net/getting-started" >}})
 - [JavaScript]({{< relref "/docs/instrumentation/js/getting-started" >}})


### PR DESCRIPTION
Given that Java instrumentation pages are not #1 according to recent analytics, this PR adds a Java CTA, which for now, links to the Java instrumentation landing page.

/cc @austinlparker @cartermp 

Preview: https://deploy-preview-1207--opentelemetry.netlify.app/

Screenshot (mobile):

> <img width="300" alt="image" src="https://user-images.githubusercontent.com/4140793/158393866-e6e6afc3-efe9-4fc6-9eef-eeae9836f77f.png">
