### PR TITLE
registry: add erlang/elixir exporters and instrumentation libraries

### DIFF
--- a/content/en/registry/exporter-erlang-otlp.md
+++ b/content/en/registry/exporter-erlang-otlp.md
@@ -1,0 +1,16 @@
+---
+title: OTLP Exporter
+registryType: exporter
+isThirdParty: false
+language: erlang
+tags:
+  - erlang
+  - elixir
+  - otlp
+  - exporter
+repo: https://github.com/open-telemetry/opentelemetry-erlang/tree/main/apps/opentelemetry_exporter
+license: Apache 2.0
+description: This library provides a data exporter to the OpenTelemetry Collector using the OpenTelemetry Protocol.
+authors: OpenTelemetry Authors
+otVersion: latest
+---

--- a/content/en/registry/exporter-erlang-zipkin.md
+++ b/content/en/registry/exporter-erlang-zipkin.md
@@ -1,0 +1,16 @@
+---
+title: Zipkin Exporter
+registryType: exporter
+isThirdParty: false
+language: erlang
+tags:
+  - erlang
+  - elixir
+  - zipkin
+  - exporter
+repo: https://github.com/open-telemetry/opentelemetry-erlang/tree/main/apps/opentelemetry_zipkin
+license: Apache 2.0
+description: This library provides a span exporter using the Zipkin protocol.
+authors: OpenTelemetry Authors
+otVersion: latest
+---

--- a/content/en/registry/instrumentation-elixir-ecto.md
+++ b/content/en/registry/instrumentation-elixir-ecto.md
@@ -1,0 +1,16 @@
+---
+title: Ecto Instrumentation
+registryType: instrumentation
+isThirdParty: false
+language: elixir
+tags:
+  - elixir
+  - database
+  - sql
+  - instrumentation
+repo: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_ecto
+license: Apache 2.0
+description: Instrumentation for Elixir database library Ecto.
+authors: OpenTelemetry Authors
+otVersion: latest
+---

--- a/content/en/registry/instrumentation-elixir-oban.md
+++ b/content/en/registry/instrumentation-elixir-oban.md
@@ -1,0 +1,15 @@
+---
+title: Oban Instrumentation
+registryType: instrumentation
+isThirdParty: false
+language: elixir
+tags:
+  - elixir
+  - jobs
+  - instrumentation
+repo: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_oban
+license: Apache 2.0
+description: Instrumentation for Oban job processing framework.
+authors: OpenTelemetry Authors
+otVersion: latest
+---

--- a/content/en/registry/instrumentation-elixir-phoenix.md
+++ b/content/en/registry/instrumentation-elixir-phoenix.md
@@ -1,0 +1,16 @@
+---
+title: Phoenix Instrumentation
+registryType: instrumentation
+isThirdParty: false
+language: elixir
+tags:
+  - erlang
+  - elixir
+  - http
+  - instrumentation
+repo: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_phoenix
+license: Apache 2.0
+description: Instrumentation for Elixir web framework Phoenix.
+authors: OpenTelemetry Authors
+otVersion: latest
+---

--- a/content/en/registry/instrumentation-elixir-redix.md
+++ b/content/en/registry/instrumentation-elixir-redix.md
@@ -1,0 +1,15 @@
+---
+title: Redix Instrumentation
+registryType: instrumentation
+isThirdParty: false
+language: elixir
+tags:
+  - elixir
+  - redis
+  - instrumentation
+repo: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_redix
+license: Apache 2.0
+description: Instrumentation for redix Redis client.
+authors: OpenTelemetry Authors
+otVersion: latest
+---

--- a/content/en/registry/instrumentation-erlang-cowboy.md
+++ b/content/en/registry/instrumentation-erlang-cowboy.md
@@ -1,0 +1,16 @@
+---
+title: Cowboy Instrumentation
+registryType: instrumentation
+isThirdParty: false
+language: erlang
+tags:
+  - erlang
+  - elixir
+  - http
+  - instrumentation
+repo: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_cowboy
+license: Apache 2.0
+description: Instrumentation for Erlang HTTP server Cowboy.
+authors: OpenTelemetry Authors
+otVersion: latest
+---


### PR DESCRIPTION
Finally adding the exporters and instrumentation libraries from the `-contrib` repo for Erlang and Elixir.