### PR TITLE
updated build command to fix multiple issues with build client and server on local

### DIFF
--- a/content/en/docs/collector/getting-started.md
+++ b/content/en/docs/collector/getting-started.md
@@ -168,20 +168,29 @@ Every Collector release includes an `otelcol.exe` executable that you can run af
 Builds the latest version of the collector based on the local operating system,
 runs the binary with all receivers enabled and exports all the data it receives
 locally to a file. Data is sent to the container and the container scrapes its own
-Prometheus metrics.
+Prometheus metrics. The following example uses two terminal windows to better illustrate
+the collector.   In the first terminal window run the following:
 
 ```console
-$ git clone https://github.com/open-telemetry/opentelemetry-collector-contrib.git; \
-    cd opentelemetry-collector-contrib/examples/demo/client; \
-    go build -o main main.go; ./main & pid1="$!"; \
-    cd ../server; \
-    go build -o main main.go; ./main & pid2="$!"; \
-    cd ../../../..
-
-$ git clone https://github.com/open-telemetry/opentelemetry-collector.git; \
-    cd opentelemetry-collector; make install-tools; make otelcorecol; \
-    ./bin/otelcorecol_* --config ./examples/local/otel-config.yaml; kill $pid1; kill $pid2
+$ git clone https://github.com/open-telemetry/opentelemetry-collector.git
+$ cd opentelemetry-collector
+$ make install-tools 
+$ make otelcorecol
+$ ./bin/otelcorecol_* --config ./examples/local/otel-config.yaml
 ```
+In a second terminal window, you can test the newly built collector
+by doing the following:
+
+```console
+$ git clone https://github.com/open-telemetry/opentelemetry-collector-contrib.git
+$ cd opentelemetry-collector-contrib/examples/demo/server 
+$ go build -o main main.go; ./main & pid1="$!"
+$ cd ../client
+$ go build -o main main.go; ./main
+```
+
+To stop the client, use the Ctrl-c command.  To stop the server, use the `kill $pid1` command.
+To stop the collector, you can use Ctrl-c command in its terminal window as well.
 
  **Note:**  The above commands demonstrate the process in a bash shell. These commands may vary slightly
  for other shells.

--- a/content/en/docs/collector/getting-started.md
+++ b/content/en/docs/collector/getting-started.md
@@ -172,9 +172,10 @@ Prometheus metrics.
 
 ```console
 $ git clone https://github.com/open-telemetry/opentelemetry-collector-contrib.git; \
-    cd opentelemetry-collector-contrib/examples/demo; \
-    go build -o client/main client/main.go; ./client/main & pid1="$!"; \
-    go build -o server/main server/main.go; ./server/main & pid2="$!"; \
+    cd opentelemetry-collector-contrib/examples/demo/client; \
+    go build -o main main.go; ./main & pid1="$!"; \
+    cd ../server; \
+    go build -o main main.go; ./main & pid2="$!"; \
 
 $ git clone https://github.com/open-telemetry/opentelemetry-collector.git \
     cd opentelemetry-collector; make install-tools; make otelcorecol; \

--- a/content/en/docs/collector/getting-started.md
+++ b/content/en/docs/collector/getting-started.md
@@ -173,8 +173,8 @@ Prometheus metrics.
 ```console
 $ git clone https://github.com/open-telemetry/opentelemetry-collector-contrib.git; \
     cd opentelemetry-collector-contrib/examples/demo; \
-    go build -o client/main client/main.go; ./client/main & pid1="$\!"; \
-    go build -o server/main server/main.go; ./server/main & pid2="$\!"; \
+    go build -o client/main client/main.go; ./client/main & pid1="$!"; \
+    go build -o server/main server/main.go; ./server/main & pid2="$!"; \
 
 $ git clone https://github.com/open-telemetry/opentelemetry-collector.git \
     cd opentelemetry-collector; make install-tools; make otelcorecol; \

--- a/content/en/docs/collector/getting-started.md
+++ b/content/en/docs/collector/getting-started.md
@@ -176,8 +176,9 @@ $ git clone https://github.com/open-telemetry/opentelemetry-collector-contrib.gi
     go build -o main main.go; ./main & pid1="$!"; \
     cd ../server; \
     go build -o main main.go; ./main & pid2="$!"; \
+    cd ../../../..
 
 $ git clone https://github.com/open-telemetry/opentelemetry-collector.git \
     cd opentelemetry-collector; make install-tools; make otelcorecol; \
-    ./bin/cmd-otelcol --config ./examples/local/otel-config.yaml; kill $pid1; kill $pid2
+    ./bin/otelcorecol_* --config ./examples/local/otel-config.yaml; kill $pid1; kill $pid2
 ```

--- a/content/en/docs/collector/getting-started.md
+++ b/content/en/docs/collector/getting-started.md
@@ -182,3 +182,6 @@ $ git clone https://github.com/open-telemetry/opentelemetry-collector.git; \
     cd opentelemetry-collector; make install-tools; make otelcorecol; \
     ./bin/otelcorecol_* --config ./examples/local/otel-config.yaml; kill $pid1; kill $pid2
 ```
+
+ **Note:**  The above commands demonstrate the process in a bash shell. These commands may vary slightly
+ for other shells.

--- a/content/en/docs/collector/getting-started.md
+++ b/content/en/docs/collector/getting-started.md
@@ -178,7 +178,7 @@ $ git clone https://github.com/open-telemetry/opentelemetry-collector-contrib.gi
     go build -o main main.go; ./main & pid2="$!"; \
     cd ../../../..
 
-$ git clone https://github.com/open-telemetry/opentelemetry-collector.git \
+$ git clone https://github.com/open-telemetry/opentelemetry-collector.git; \
     cd opentelemetry-collector; make install-tools; make otelcorecol; \
     ./bin/otelcorecol_* --config ./examples/local/otel-config.yaml; kill $pid1; kill $pid2
 ```

--- a/content/en/docs/collector/getting-started.md
+++ b/content/en/docs/collector/getting-started.md
@@ -171,12 +171,12 @@ locally to a file. Data is sent to the container and the container scrapes its o
 Prometheus metrics.
 
 ```console
-$ git clone git@github.com:open-telemetry/opentelemetry-collector-contrib.git; \
+$ git clone https://github.com/open-telemetry/opentelemetry-collector-contrib.git; \
     cd opentelemetry-collector-contrib/examples/demo; \
-    go build client/main.go; ./client/main & pid1="$!"; \
-    go build server/main.go; ./server/main & pid2="$!"; \
+    go build -o client/main client/main.go; ./client/main & pid1="$\!"; \
+    go build -o server/main server/main.go; ./server/main & pid2="$\!"; \
 
-$ git clone git@github.com:open-telemetry/opentelemetry-collector.git; \
+$ git clone https://github.com/open-telemetry/opentelemetry-collector.git \
     cd opentelemetry-collector; make install-tools; make otelcorecol; \
     ./bin/cmd-otelcol --config ./examples/local/otel-config.yaml; kill $pid1; kill $pid2
 ```


### PR DESCRIPTION
Signed-off-by: Brad Topol <btopol@us.ibm.com>

Updated build local commands in the getting started doc to fix a github permission denied issue, and make sure the
two main executables are placed in the correct directories, and added backslashes to enable the command to work
even when history expansion is enabled in the shell.
