### PR TITLE
Settle on Node.js name, and use it consistently

### DIFF
--- a/content/en/blog/2022/troubleshooting-nodejs.md
+++ b/content/en/blog/2022/troubleshooting-nodejs.md
@@ -1,12 +1,12 @@
 ---
-title: Checklist for TroublesShooting OpenTelemetry Node.JS Tracing Issues
-linkTitle: TroublesShooting Node.JS Tracing Issues
+title: Checklist for TroublesShooting OpenTelemetry Node.js Tracing Issues
+linkTitle: TroublesShooting Node.js Tracing Issues
 date: 2022-02-22
 canonical_url: https://www.aspecto.io/blog/checklist-for-troubleshooting-opentelemetry-nodejs-tracing-issues
 ---
 
 I’ll try to make this one short and to the point. You are probably here because
-you installed OpenTelemetry in your NodeJS application and did not see any
+you installed OpenTelemetry in your Node.js application and did not see any
 traces or some expected spans were missing.
 
 There can be many reasons for that, but some are more common than others. In
@@ -16,7 +16,7 @@ methods and tips.
 ## Requirements
 
 I assume that you already have basic knowledge of what OpenTelemetry is and how
-it works and that you tried to set it up in your NodeJS application.
+it works and that you tried to set it up in your Node.js application.
 
 ### Enable Logging
 

--- a/content/en/docs/instrumentation/_index.md
+++ b/content/en/docs/instrumentation/_index.md
@@ -3,12 +3,18 @@ title: Instrumentation
 weight: 2
 ---
 
-OpenTelemetry code [instrumentation](/docs/concepts/instrumenting/) is supported for the languages listed below.
-Depending on the language, topics covered will include some or all of the
+OpenTelemetry code [instrumentation][] is supported for the languages listed
+below. Depending on the language, topics covered will include some or all of the
 following:
 
 - Automatic instrumentation
 - Manual instrumentation
 - Exporting data
 
-If you are using Kubernetes, you can use the [OpenTelemetry Operator for Kubernetes](https://github.com/open-telemetry/opentelemetry-operator) to [inject auto-instrumentation libraries](https://github.com/open-telemetry/opentelemetry-operator#opentelemetry-auto-instrumentation-injection) for Java, NodeJS and Python into your application.
+If you are using Kubernetes, you can use the [OpenTelemetry Operator for
+Kubernetes][otel-op] to [inject auto-instrumentation libraries][auto] for Java,
+Node.js and Python into your application.
+
+[auto]: https://github.com/open-telemetry/opentelemetry-operator#opentelemetry-auto-instrumentation-injection
+[instrumentation]: /docs/concepts/instrumenting/
+[otel-op]: https://github.com/open-telemetry/opentelemetry-operator

--- a/content/en/docs/instrumentation/js/_index.md
+++ b/content/en/docs/instrumentation/js/_index.md
@@ -2,7 +2,7 @@
 title: JavaScript
 description: >-
   <img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/JS_SDK.svg" alt="JS logo"></img>
-  A language-specific implementation of OpenTelemetry in JavaScript (for Node.JS & the browser).
+  A language-specific implementation of OpenTelemetry in JavaScript (for Node.js & the browser).
 aliases: [/js, /js/metrics, /js/tracing]
 spelling: cSpell:ignore Roadmap
 weight: 20

--- a/content/en/docs/instrumentation/js/getting-started/_index.md
+++ b/content/en/docs/instrumentation/js/getting-started/_index.md
@@ -4,7 +4,7 @@ aliases: [/docs/js/getting_started]
 weight: 1
 ---
 
-These two guides for Node.JS and the browser use simple examples in javascript
+These two guides for Node.js and the browser use simple examples in javascript
 to get you started with OpenTelemetry. Both will show you the following steps:
 
 - Install the required OpenTelemetry libraries

--- a/content/en/docs/instrumentation/js/getting-started/nodejs.md
+++ b/content/en/docs/instrumentation/js/getting-started/nodejs.md
@@ -1,5 +1,5 @@
 ---
-title: Node.JS
+title: Node.js
 aliases: [/docs/js/getting_started/nodejs]
 ---
 

--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -3,7 +3,7 @@ title: Instrumentation
 weight: 3
 ---
 
-This guide will cover creating and annotating spans, creating and annotating metrics, how to pass context, and a guide to automatic instrumentation for JavaScript. This simple example works in the browser as well as with Node.JS
+This guide will cover creating and annotating spans, creating and annotating metrics, how to pass context, and a guide to automatic instrumentation for JavaScript. This simple example works in the browser as well as with Node.js
 
 ## Example Application
 
@@ -148,7 +148,7 @@ function doWork(parent) {
   // Add an attribute to the same span later on
   span.setAttribute('attribute2', 'value2');
 
-  
+
   // Be sure to end the span!
   span.end();
 }

--- a/content/en/docs/migration/opentracing.md
+++ b/content/en/docs/migration/opentracing.md
@@ -158,7 +158,7 @@ into production.
 ### Context management in Javascript
 
 In Javascript, the OpenTelemetry API makes use of commonly available context
-managers, such as `async_hooks` for NodeJS and `Zones.js` for the browser. These
+managers, such as `async_hooks` for Node.js and `Zones.js` for the browser. These
 context managers make tracing instrumentation a much less invasive and onerous
 task, compared to adding a span as a parameter to every method which needs to
 be traced.


### PR DESCRIPTION
Let's settle on the official name used on https://nodejs.org, which is **Node.js**.

Preview, e.g.: https://deploy-preview-1220--opentelemetry.netlify.app/docs/instrumentation/