### PR TITLE
OT migration: add C++ to version support table

### DIFF
--- a/content/en/docs/migration/opentracing.md
+++ b/content/en/docs/migration/opentracing.md
@@ -27,6 +27,7 @@ of the OpenTracing and OpenTelemetry APIs are listed in the table below.
 | [Python][]     | 2.7              | 3.6               |
 | [Javascript][] | 6                | 8.5               |
 | [.NET][]       | 1.3              | 1.4               |
+| [C++][]        | 11               | 11                |
 
 Note that the OpenTelemetry API and SDKs generally have higher language version
 requirements than their OpenTracing counterparts.
@@ -185,5 +186,6 @@ shim, see [OpenTracing Compatibility][OT_spec].
 [Java]: https://github.com/open-telemetry/opentelemetry-java/tree/main/opentracing-shim
 [Javascript]: https://www.npmjs.com/package/@opentelemetry/shim-opentracing
 [OpenTracing]: https://opentracing.io
-[OT_spec]: {{< relref "/docs/reference/specification/compatibility/opentracing" >}}
+[OT_spec]: /docs/reference/specification/compatibility/opentracing/
 [Python]: https://opentelemetry-python.readthedocs.io/en/stable/shim/opentracing_shim/opentracing_shim.html
+[C++]: https://github.com/open-telemetry/opentelemetry-cpp/issues/78


### PR DESCRIPTION
- For context, see #1132
- This PR adds the C++ entry that is missing, relative to the version of the table in the spec.
- **NOTE**: C++ doesn't appear to have an OT shim yet, so I chose to link to the issue used to track it's creation.

Preview: https://deploy-preview-1227--opentelemetry.netlify.app/docs/migration/opentracing/#language-version-support

/cc @tedsuo @carlosalberto @austinlparker 