### PR TITLE
Java auto: reorg pages before adding content

### DIFF
--- a/content/en/docs/instrumentation/java/automatic/_index.md
+++ b/content/en/docs/instrumentation/java/automatic/_index.md
@@ -79,7 +79,7 @@ debug logs. Note that these are quite verbose.
 ## Next steps
 
 After you have automatic instrumentation configured for your app or service, you
-might want to [annotate](../annotations) selected methods or add [manual
+might want to [annotate](annotations) selected methods or add [manual
 instrumentation](../manual) to collect custom telemetry data.
 
 [Agent Configuration]: https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/agent-config.md

--- a/content/en/docs/instrumentation/java/automatic/annotations.md
+++ b/content/en/docs/instrumentation/java/automatic/annotations.md
@@ -1,6 +1,7 @@
 ---
 title: Annotations
 description: Using instrumentation annotations with a Java agent.
+aliases: [/docs/instrumentation/java/annotations]
 weight: 4
 ---
 
@@ -100,5 +101,5 @@ javaagent to capture spans around specific methods.
 ## Next steps
 
 Beyond the use of annotations, the OpenTelemetry API allows you to obtain
-a tracer that can be used for [Manual Instrumentation](../manual)
+a tracer that can be used for [Manual Instrumentation](../../manual)
 and execute code within the scope of that span.

--- a/content/en/docs/instrumentation/java/getting-started.md
+++ b/content/en/docs/instrumentation/java/getting-started.md
@@ -98,7 +98,7 @@ For more:
 - For light-weight customized telemetry, try [annotations][].
 - Learn about [manual instrumentation][] and try out more [examples](../examples).
 
-[annotations]: ../annotations
+[annotations]: ../automatic/annotations
 [configure the Java agent]: https://opentelemetry.io/docs/instrumentation/java/automatic/#configuring-the-agent
 [console trace exporter,]: https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#logging-exporter
 [exporter]: https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#exporters


### PR DESCRIPTION
- This PR creates an **Automatic** section, in preparation for
  - #1229

  It was originally proposed in #1178 -- though we now have a firmer case to do so with #1229 :).
- No change in content, other than adjusting page links (and adding an alias).

Preview: https://deploy-preview-1232--opentelemetry.netlify.app/docs/instrumentation/java/
Redirect test: https://deploy-preview-1232--opentelemetry.netlify.app/docs/instrumentation/java/annotations

/cc @Gaurang-Patel @svrnm 