### PR TITLE
.gitignore: add `.DS_Store`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ package-lock.json
 # Link checker
 tmp/
 
+# macOS
+.DS_Store
+
 # Misc
 scripts/collector.yaml
 assets/jsconfig.json


### PR DESCRIPTION
(This should be part of a dev's global .gitignore under macOS, but I suppose that it doesn't hurt to add it here.)