### PR TITLE
Add crates.io links for Rust crates

### DIFF
--- a/content/en/docs/instrumentation/rust/_index.md
+++ b/content/en/docs/instrumentation/rust/_index.md
@@ -29,7 +29,7 @@ Opentelemetry for Rust contains the following crates:
 - [opentelemetry-contrib](https://crates.io/crates/opentelemetry-contrib)
 - [opentelemetry-datadog](https://crates.io/crates/opentelemetry-datadog)
 - [opentelemetry-dynatrace](https://crates.io/crates/opentelemetry-dynatrace)
-- [opentelemetry-http](https://crates.io/crates/opentelemetry-dynatrace)
+- [opentelemetry-http](https://crates.io/crates/opentelemetry-http)
 - [opentelemetry-jaeger](https://crates.io/crates/opentelemetry-jaeger)
 - [opentelemetry-otlp](https://crates.io/crates/opentelemetry-otlp)
 - [opentelemetry-prometheus](https://crates.io/crates/opentelemetry-prometheus)

--- a/content/en/docs/instrumentation/rust/_index.md
+++ b/content/en/docs/instrumentation/rust/_index.md
@@ -23,7 +23,7 @@ as follows:
 
 ## Crates
 
-Opentelemetry for Rust published the following crates:
+Opentelemetry for Rust publishes the following crates:
 - [opentelemetry](https://crates.io/crates/opentelemetry)
 - [opentelemetry-aws](https://crates.io/crates/opentelemetry-aws)
 - [opentelemetry-contrib](https://crates.io/crates/opentelemetry-contrib)

--- a/content/en/docs/instrumentation/rust/_index.md
+++ b/content/en/docs/instrumentation/rust/_index.md
@@ -21,8 +21,24 @@ as follows:
 
 {{% latest_release "rust" /%}}
 
+## Crates
+
+Opentelemetry for Rust contains the following crates:
+- [opentelemetry](https://crates.io/crates/opentelemetry)
+- [opentelemetry-aws](https://crates.io/crates/opentelemetry-aws)
+- [opentelemetry-contrib](https://crates.io/crates/opentelemetry-contrib)
+- [opentelemetry-datadog](https://crates.io/crates/opentelemetry-datadog)
+- [opentelemetry-dynatrace](https://crates.io/crates/opentelemetry-dynatrace)
+- [opentelemetry-http](https://crates.io/crates/opentelemetry-dynatrace)
+- [opentelemetry-jaeger](https://crates.io/crates/opentelemetry-jaeger)
+- [opentelemetry-otlp](https://crates.io/crates/opentelemetry-otlp)
+- [opentelemetry-prometheus](https://crates.io/crates/opentelemetry-prometheus)
+- [opentelemetry-semantic-conventions](https://crates.io/crates/opentelemetry-semantic-conventions)
+- [opentelemetry-stackdriver](https://crates.io/crates/opentelemetry-stackdriver)
+- [opentelemetry-zipkin](https://crates.io/crates/opentelemetry-zipkin)
+
 ## Further Reading
 
-- [docs.rs](https://docs.rs/opentelemetry)
+- [Docs for Rust API & SDK](https://docs.rs/opentelemetry)
 - [Examples](https://github.com/open-telemetry/opentelemetry-rust/tree/main/examples)
-- [Contrib](https://github.com/open-telemetry/opentelemetry-rust#ecosystem)
+- [Ecosystem](https://github.com/open-telemetry/opentelemetry-rust#ecosystem)

--- a/content/en/docs/instrumentation/rust/_index.md
+++ b/content/en/docs/instrumentation/rust/_index.md
@@ -23,7 +23,7 @@ as follows:
 
 ## Crates
 
-Opentelemetry for Rust contains the following crates:
+Opentelemetry for Rust published the following crates:
 - [opentelemetry](https://crates.io/crates/opentelemetry)
 - [opentelemetry-aws](https://crates.io/crates/opentelemetry-aws)
 - [opentelemetry-contrib](https://crates.io/crates/opentelemetry-contrib)


### PR DESCRIPTION
Follow up on [opentelemetry-rust#776](https://github.com/open-telemetry/opentelemetry-rust/issues/766), add links to all published creates on crates.io

cc @open-telemetry/rust-approvers 