### PR TITLE
Update dependencies for Prometheus exporter

### DIFF
--- a/content/en/docs/instrumentation/js/exporters.md
+++ b/content/en/docs/instrumentation/js/exporters.md
@@ -126,7 +126,7 @@ Update your opentelemetry configuration to use the exporter and to send data to 
 
 ```javascript
 const { PrometheusExporter } = require('@opentelemetry/exporter-prometheus');
-const { MeterProvider }  = require('@opentelemetry/metrics');
+const { MeterProvider }  = require('@opentelemetry/sdk-metrics-base');
 const meter = new MeterProvider({
   exporter: new PrometheusExporter({port: 9090}),
   interval: 1000,


### PR DESCRIPTION
I'm a little unsure, but all other examples show using `@opentelemetry/sdk-metrics-base` and everything works using it, so I think this is a valid change, but maybe there's a reason for using the other package I am not clear on…