### PR TITLE
Java docs: config-option formatting proposal

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -160,6 +160,7 @@ a:hover {
 
     summary {
       display: block;
+      &::-webkit-details-marker { display: none; }
 
       &::after {
         color: $secondary;

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -164,13 +164,13 @@ a:hover {
       &::after {
         color: $secondary;
         @extend .fas;
-        content: fa-content($nbsp + $fa-var-chevron-circle-down);
+        content: fa-content($nbsp + $fa-var-plus-circle);
       }
     }
 
     &[open] summary::after {
       @extend .fas;
-      content: fa-content($nbsp + $fa-var-chevron-circle-up);
+      content: fa-content($nbsp + $fa-var-minus-circle);
     }
   }
 }

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -148,3 +148,29 @@ a:hover {
 }
 
 .td-breadcrumbs__single { display: none !important; }
+
+.config-option {
+  padding-inline-start: 2em;
+
+  .label { font-weight: bold; }
+
+  details {
+    background-color: $gray-100;
+    margin-bottom: .5em;
+
+    summary {
+      display: block;
+
+      &::after {
+        color: $secondary;
+        @extend .fas;
+        content: fa-content($nbsp + $fa-var-chevron-circle-down);
+      }
+    }
+
+    &[open] summary::after {
+      @extend .fas;
+      content: fa-content($nbsp + $fa-var-chevron-circle-up);
+    }
+  }
+}

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -150,7 +150,7 @@ a:hover {
 .td-breadcrumbs__single { display: none !important; }
 
 .config-option {
-  padding-inline-start: 2em;
+  padding-inline-start: 1.5em;
 
   .label { font-weight: bold; }
 

--- a/content/en/docs/instrumentation/java/automatic/agent-config.md
+++ b/content/en/docs/instrumentation/java/automatic/agent-config.md
@@ -49,19 +49,21 @@ The agent can consume configuration from one or more of the following sources (o
 
 ### Configuration file
 
-You can provide a path to agent configuration file by setting the corresponding property.
+You can provide a path to agent configuration file by setting the following property:
 
-| System property                      | Environment variable                 | Description                                                                      |
-|--------------------------------------|--------------------------------------|----------------------------------------------------------------------------------|
-| `otel.javaagent.configuration-file` | `OTEL_JAVAAGENT_CONFIGURATION_FILE` | Path to valid Java properties file which contains the javaagent configuration.|
+{{% config_option name="otel.javaagent.configuration-file" %}}
+  Path to valid Java properties file which contains the agent configuration.
+{{% /config_option %}}
 
 ### Extensions
 
-You can enable [extensions][] by setting the corresponding property.
+You can enable [extensions][] by setting the following property:
 
-| System property                      | Environment variable                 | Description                                                                      |
-|--------------------------------------|--------------------------------------|----------------------------------------------------------------------------------|
-| `otel.javaagent.extensions` | `OTEL_JAVAAGENT_EXTENSIONS` | Path to a an extension jar file or folder, containing jar files. If pointing to a folder, every jar file in that folder will be treated as separate, independent extension|
+{{% config_option name="otel.javaagent.extensions" %}}
+  Path to a an extension jar file or folder, containing jar files. If pointing
+  to a folder, every jar file in that folder will be treated as separate,
+  independent extension.
+{{% /config_option %}}
 
 ## Common instrumentation configuration
 
@@ -102,6 +104,15 @@ to disable it:
 You can configure the agent to capture predefined HTTP headers as span attributes, according to the
 [semantic convention](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-request-and-response-headers).
 Use the following properties to define which HTTP headers you want to capture:
+
+{{% config_option name="otel.instrumentation.http.capture-headers.client.request" %}}
+  A comma-separated list of HTTP header names. HTTP client instrumentations will
+  capture HTTP request header values for all configured header names.
+{{% /config_option %}}
+{{% config_option name="otel.instrumentation.http.capture-headers.client.response" %}}
+  A comma-separated list of HTTP header names. HTTP client instrumentations will
+  capture HTTP response header values for all configured header names.
+{{% /config_option %}}
 
 | System property / Environment variable | Description |
 | -------------------------------------- | ----------- |

--- a/layouts/shortcodes/config_option.html
+++ b/layouts/shortcodes/config_option.html
@@ -1,0 +1,17 @@
+{{ $name := .Get "name" -}}
+{{ $_envVar := $name | upper | replaceRE "[.-]" "_" -}}
+{{ $envVar := .Get "envVar" | default $_envVar -}}
+
+<div class="config-option">
+<details>
+  <summary style="">
+    <span class="label">System property</span>:
+      <code>{{ $name }}</code>
+  </summary>
+  <span class="label">Environment variable</span>:
+    <code>{{ $envVar }}</code>
+</details>
+
+<span class="label">Description</span>:
+{{- .Inner }}
+</div>

--- a/layouts/shortcodes/config_option.html
+++ b/layouts/shortcodes/config_option.html
@@ -4,7 +4,7 @@
 
 <div class="config-option">
 <details>
-  <summary style="">
+  <summary title="Expand to view environment variable">
     <span class="label">System property</span>:
       <code>{{ $name }}</code>
   </summary>


### PR DESCRIPTION
Currently, documented config options are formatted as **table entries**. This PR proposes an **alternative layout**, which, in particular, **works much better on mobile** and narrow displays (as shown below).

### Environment variable is hidden by default

The layout uses labeled paragraphs, and only shows the environment variable if the reader wants to see it (by **clicking** on the down-arrow chevron). The following screenshot shows the env-var in the Extensions section, but it is hidden in the Config-file section:

> <img width="615" alt="config-options-open-close" src="https://user-images.githubusercontent.com/4140793/161072766-742d1844-4883-4ba1-9737-65eb320d862b.png">


---

### Comparison of new vs old layout

**For comparison**, the following screen shot shows both the

- new formatting (green)
- old tabular layout (red)

for two of the "HTTP request and response headers" section:

> <img width="624" alt="config-optn-compare" src="https://user-images.githubusercontent.com/4140793/161073450-f30f120a-7916-4409-b489-3fe26caba110.png">

---

Previews:

- https://deploy-preview-1257--opentelemetry.netlify.app/docs/instrumentation/java/automatic/agent-config/#configuration-file
- https://deploy-preview-1257--opentelemetry.netlify.app/docs/instrumentation/java/automatic/agent-config/#capturing-http-request-and-response-headers

Contributes to #1247.

If you agree with this new formatting, I'll merge this PR and update all of the rest of the config-option documentation in the page.

/cc @austinlparker @cartermp @open-telemetry/java-instrumentation-approvers 