### PR TITLE
Add python exporters doc

### DIFF
--- a/content/en/docs/instrumentation/net/exporters.md
+++ b/content/en/docs/instrumentation/net/exporters.md
@@ -166,9 +166,8 @@ using var tracerProvider = Sdk.CreateTracerProviderBuilder()
 
 ## Zipkin
 
-If you are using [Zipkin](https://zipkin.io/) to visualize traces to visualize
-trace data, you'll need to set it up first. This is how to run it in a docker
-container:
+If you are using [Zipkin](https://zipkin.io/) to visualize trace data, you'll
+need to set it up first. This is how to run it in a docker container:
 
 ```shell
 docker run --rm -d -p 9411:9411 --name zipkin openzipkin/zipkin

--- a/content/en/docs/instrumentation/python/exporters.md
+++ b/content/en/docs/instrumentation/python/exporters.md
@@ -1,5 +1,5 @@
 ---
-title: "Exporters"
+title: Exporters
 weight: 4
 ---
 
@@ -32,13 +32,14 @@ trace.set_tracer_provider(provider)
 
 ## OTLP endpoint or Collector
 
-To send data to an OTLP endpoint or the OpenTelemetry Collector, you'll want to
-configure an OTLP exporter that sends to your endpoint.
+To send data to an OTLP endpoint or the [OpenTelemetry
+Collector](/docs/collector/getting-started/), you'll want to configure an OTLP
+exporter that sends to your endpoint.
 
 First, install an OTLP exporter:
 
-```
-pip install opentelemetry-exporter-otlp-proto-http
+```shell
+$ pip install opentelemetry-exporter-otlp-proto-http
 ```
 
 Then you can use it when you initialize tracing:
@@ -60,7 +61,6 @@ processor = BatchSpanProcessor(OTLPSpanExporter(endpoint="your-endpoint-here"))
 provider.add_span_processor(processor)
 trace.set_tracer_provider(provider)
 
-
 # Merrily go about tracing!
 ```
 
@@ -68,8 +68,8 @@ trace.set_tracer_provider(provider)
 
 If you'd prefer to use gRPC, you can install the package:
 
-```
-pip install opentelemetry-exporter-otlp-proto-grpc
+```shell
+$ pip install opentelemetry-exporter-otlp-proto-grpc
 ```
 
 And replace the `OTLPSpanExporter` import declaration with the following:
@@ -100,8 +100,8 @@ $ docker run -d --name jaeger \
 
 Next, install the Jaeger exporter package:
 
-```
-pip install opentelemetry-exporter-jaeger
+```shell
+$ pip install opentelemetry-exporter-jaeger
 ```
 
 Then you can configure the exporter when initializing tracing:
@@ -134,8 +134,8 @@ trace.set_tracer_provider(provider)
 
 If you'd prefer to use Thrift as the protocol, you can install the package:
 
-```
-pip install opentelemetry-exporter-jaeger-thrift
+```shell
+$ pip install opentelemetry-exporter-jaeger-thrift
 ```
 
 And replace the `JaegerExporter` import declaration with the following:
@@ -150,13 +150,13 @@ If you are using [Zipkin](https://zipkin.io/) to visualize trace data, you'll
 need to set it up first. This is how to run it in a docker container:
 
 ```shell
-docker run --rm -d -p 9411:9411 --name zipkin openzipkin/zipkin
+$ docker run --rm -d -p 9411:9411 --name zipkin openzipkin/zipkin
 ```
 
 Next, install the Zipkin exporter package:
 
 ```shell
-pip install opentelemetry-exporter-zipkin-proto-http
+$ pip install opentelemetry-exporter-zipkin-proto-http
 ```
 
 Then you can configure the exporter when initializing tracing:
@@ -186,8 +186,8 @@ trace.set_tracer_provider(provider)
 
 If you'd prefer to use Thrift as the protocol, you can install the package:
 
-```
-pip install opentelemetry-exporter-zipkin-json
+```shell
+$ pip install opentelemetry-exporter-zipkin-json
 ```
 
 And replace the `ZipkinExporter` import declaration with the following:

--- a/content/en/docs/instrumentation/python/exporters.md
+++ b/content/en/docs/instrumentation/python/exporters.md
@@ -1,0 +1,197 @@
+---
+title: "Exporters"
+weight: 4
+---
+
+In order to visualize and analyze your traces and metrics, you will need to
+export them to a backend.
+
+## Console exporter
+
+The console exporter is useful for development and debugging tasks, and is the
+simplest to set up.
+
+```python
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+
+# Service name is required for most backends
+resource = Resource(attributes={
+    "service.name": "your-service-name"
+})
+
+provider = TracerProvider(resource=resource)
+processor = BatchSpanProcessor(ConsoleSpanExporter())
+provider.add_span_processor(processor)
+trace.set_tracer_provider(provider)
+
+# Merrily go about tracing!
+```
+
+## OTLP endpoint or Collector
+
+To send data to an OTLP endpoint or the OpenTelemetry Collector, you'll want to
+configure an OTLP exporter that sends to your endpoint.
+
+First, install an OTLP exporter:
+
+```
+pip install opentelemetry-exporter-otlp-proto-http
+```
+
+Then you can use it when you initialize tracing:
+
+```python
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+# Service name is required for most backends
+resource = Resource(attributes={
+    SERVICE_NAME: "your-service-name"
+})
+
+provider = TracerProvider(resource=resource)
+processor = BatchSpanProcessor(OTLPSpanExporter(endpoint="your-endpoint-here"))
+provider.add_span_processor(processor)
+trace.set_tracer_provider(provider)
+
+
+# Merrily go about tracing!
+```
+
+### Using gRPC
+
+If you'd prefer to use gRPC, you can install the package:
+
+```
+pip install opentelemetry-exporter-otlp-proto-grpc
+```
+
+And replace the `OTLPSpanExporter` import declaration with the following:
+
+```python
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+```
+
+## Jaeger
+
+If you are using [Jaeger](https://www.jaegertracing.io/) to visualize trace
+data, you'll need to set it up first. This is how to run it in a docker
+container:
+
+```shell
+$ docker run -d --name jaeger \
+  -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
+  -p 5775:5775/udp \
+  -p 6831:6831/udp \
+  -p 6832:6832/udp \
+  -p 5778:5778 \
+  -p 16686:16686 \
+  -p 14268:14268 \
+  -p 14250:14250 \
+  -p 9411:9411 \
+  jaegertracing/all-in-one:latest
+```
+
+Next, install the Jaeger exporter package:
+
+```
+pip install opentelemetry-exporter-jaeger
+```
+
+Then you can configure the exporter when initializing tracing:
+
+```python
+from opentelemetry import trace
+from opentelemetry.exporter.jaeger import JaegerExporter
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+resource = Resource(attributes={
+    SERVICE_NAME: "your-service-name"
+})
+
+jaeger_exporter = JaegerExporter(
+    agent_host_name="localhost",
+    agent_port=6831,
+)
+
+provider = TracerProvider(resource=resource)
+processor = BatchSpanProcessor(jaeger_exporter)
+provider.add_span_processor(processor)
+trace.set_tracer_provider(provider)
+
+# Merrily go about tracing!
+```
+
+### Using Thrift
+
+If you'd prefer to use Thrift as the protocol, you can install the package:
+
+```
+pip install opentelemetry-exporter-jaeger-thrift
+```
+
+And replace the `JaegerExporter` import declaration with the following:
+
+```python
+from opentelemetry.exporter.jaeger.thrift import JaegerExporter
+```
+
+## Zipkin
+
+If you are using [Zipkin](https://zipkin.io/) to visualize trace data, you'll
+need to set it up first. This is how to run it in a docker container:
+
+```shell
+docker run --rm -d -p 9411:9411 --name zipkin openzipkin/zipkin
+```
+
+Next, install the Zipkin exporter package:
+
+```shell
+pip install opentelemetry-exporter-zipkin-proto-http
+```
+
+Then you can configure the exporter when initializing tracing:
+
+```python
+from opentelemetry import trace
+from opentelemetry.exporter.zipkin.proto.http import ZipkinExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+
+resource = Resource(attributes={
+    SERVICE_NAME: "your-service-name"
+})
+
+zipkin_exporter = ZipkinExporter(endpoint="http://localhost:9411/api/v2/spans")
+
+provider = TracerProvider(resource=resource)
+processor = BatchSpanProcessor(zipkin_exporter)
+provider.add_span_processor(processor)
+trace.set_tracer_provider(provider)
+
+# merrily go about tracing!
+```
+
+### Using JSON
+
+If you'd prefer to use Thrift as the protocol, you can install the package:
+
+```
+pip install opentelemetry-exporter-zipkin-json
+```
+
+And replace the `ZipkinExporter` import declaration with the following:
+
+```python
+from opentelemetry.exporter.zipkin.json import ZipkinExporter
+```

--- a/content/en/docs/instrumentation/python/exporters.md
+++ b/content/en/docs/instrumentation/python/exporters.md
@@ -3,7 +3,7 @@ title: Exporters
 weight: 4
 ---
 
-In order to visualize and analyze your traces and metrics, you will need to
+In order to visualize and analyze your telemetry you will need to
 export them to a backend.
 
 ## Console exporter

--- a/content/en/docs/instrumentation/python/exporters.md
+++ b/content/en/docs/instrumentation/python/exporters.md
@@ -3,8 +3,7 @@ title: Exporters
 weight: 4
 ---
 
-In order to visualize and analyze your telemetry you will need to
-export them to a backend.
+In order to visualize and analyze your telemetry you will need to use an exporter.
 
 ## Console exporter
 
@@ -17,9 +16,11 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 
-# Service name is required for most backends
+# Service name is required for most backends,
+# and although it's not necessary for console export,
+# it's good to set service name anyways.
 resource = Resource(attributes={
-    "service.name": "your-service-name"
+    SERVICE_NAME: "your-service-name"
 })
 
 provider = TracerProvider(resource=resource)
@@ -38,7 +39,7 @@ exporter that sends to your endpoint.
 
 First, install an OTLP exporter:
 
-```shell
+```console
 $ pip install opentelemetry-exporter-otlp-proto-http
 ```
 
@@ -68,7 +69,7 @@ trace.set_tracer_provider(provider)
 
 If you'd prefer to use gRPC, you can install the package:
 
-```shell
+```console
 $ pip install opentelemetry-exporter-otlp-proto-grpc
 ```
 
@@ -84,7 +85,7 @@ If you are using [Jaeger](https://www.jaegertracing.io/) to visualize trace
 data, you'll need to set it up first. This is how to run it in a docker
 container:
 
-```shell
+```console
 $ docker run -d --name jaeger \
   -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
   -p 5775:5775/udp \
@@ -100,7 +101,7 @@ $ docker run -d --name jaeger \
 
 Next, install the Jaeger exporter package:
 
-```shell
+```console
 $ pip install opentelemetry-exporter-jaeger
 ```
 
@@ -134,7 +135,7 @@ trace.set_tracer_provider(provider)
 
 If you'd prefer to use Thrift as the protocol, you can install the package:
 
-```shell
+```console
 $ pip install opentelemetry-exporter-jaeger-thrift
 ```
 
@@ -149,13 +150,13 @@ from opentelemetry.exporter.jaeger.thrift import JaegerExporter
 If you are using [Zipkin](https://zipkin.io/) to visualize trace data, you'll
 need to set it up first. This is how to run it in a docker container:
 
-```shell
+```console
 $ docker run --rm -d -p 9411:9411 --name zipkin openzipkin/zipkin
 ```
 
 Next, install the Zipkin exporter package:
 
-```shell
+```console
 $ pip install opentelemetry-exporter-zipkin-proto-http
 ```
 
@@ -186,7 +187,7 @@ trace.set_tracer_provider(provider)
 
 If you'd prefer to use Thrift as the protocol, you can install the package:
 
-```shell
+```console
 $ pip install opentelemetry-exporter-zipkin-json
 ```
 


### PR DESCRIPTION
Preview: https://deploy-preview-1261--opentelemetry.netlify.app/docs/instrumentation/python/exporters/

Also includes a tiny one-line change for the .NET exporter equivalent where some words got slightly jumbled.

There is also a Prometheus exporter that could be documented, but I wasn't sure of the best way to use it yet (I've never done metrics + prometheus with python). There is a code sample in the Python repo that hints at a way to do it, but I'm not sure if it represents a good "getting started" best practice or not, so I decided to leave it out for now. Metrics is still under development in SDKs, anways 🙂 