### PR TITLE
Update cookbook for manually setting span context.

### DIFF
--- a/content/en/docs/instrumentation/python/cookbook.md
+++ b/content/en/docs/instrumentation/python/cookbook.md
@@ -114,9 +114,13 @@ with tracer.start_as_current_span('child', context=ctx) as span:
     span.set_attribute('primes', [2, 3, 5, 7])
 
 # Or you can make it the current context, and then the next span will pick it up.
-context.attach(ctx)
-with tracer.start_as_current_span('child') as span:
-    span.set_attribute('evens', [2, 4, 6, 8])
+# The returned token lets you restore the previous context.
+token = context.attach(ctx)
+try:
+    with tracer.start_as_current_span('child') as span:
+        span.set_attribute('evens', [2, 4, 6, 8])
+finally:
+    context.detach(token)
 ```
 
 ## Using multiple tracer providers with different Resource

--- a/content/en/docs/instrumentation/python/cookbook.md
+++ b/content/en/docs/instrumentation/python/cookbook.md
@@ -66,26 +66,39 @@ print(baggage.get_baggage("context", child_ctx))
 
 ## Manually setting span context
 
+Usually your application or serving framework will take care of propagating your trace context for you. But in some cases, you may need to save your trace context (with `.inject`) and restore it elsewhere (with `.extract`) yourself.
+
 ```python
-from opentelemetry import trace
+from opentelemetry import trace, context
 from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import ConsoleSpanExporter, BatchSpanProcessor
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
+# Set up a simple processor to write spans out to the console so we can see what's happening.
 trace.set_tracer_provider(TracerProvider())
 trace.get_tracer_provider().add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
 
 tracer = trace.get_tracer(__name__)
 
-# Extracting from carrier header
+# A TextMapPropagator can use a regular Python dict as its Carrier.
+carrier = {}
+with tracer.start_as_current_span('first-trace'):
+    # Write the current context into the carrier.
+    TraceContextTextMapPropagator().extract(carrier)
+
+# The below might be in a different thread, on a different machine, etc.
+# As a typical example, it would be on a different microservice and the carrier would
+# have been forwarded via HTTP headers.
+
+# Extract the trace context from the carrier.
+# Here's what a typical carrier might look like, as it would have been extracted above.
 carrier = {'traceparent': '00-a9c3b99a95cc045e573e163c3ac80a77-d99d251a8caecd06-01'}
+# Then we use a propagator to get a trace context from it.
 ctx = TraceContextTextMapPropagator().extract(carrier=carrier)
 
-with tracer.start_as_current_span('child', context=ctx) as span:
-    span.set_attribute('primes', [2, 3, 5, 7])
-
-# Or if you have a SpanContext object already.
+# Instead of extracting the trace context from the carrier, if you have a SpanContext
+# object already you can get a trace context from it like this.
 span_context = SpanContext(
     trace_id=2604504634922341076776623263868986797,
     span_id=5213367945872657620,
@@ -94,7 +107,15 @@ span_context = SpanContext(
 )
 ctx = trace.set_span_in_context(NonRecordingSpan(span_context))
 
-with tracer.start_as_current_span("child", context=ctx) as span:
+# Now there are a few ways to make use of the trace context.
+
+# You can pass the context object when starting a span.
+with tracer.start_as_current_span('child', context=ctx) as span:
+    span.set_attribute('primes', [2, 3, 5, 7])
+
+# Or you can make it the current context, and then the next span will pick it up.
+context.attach(ctx)
+with tracer.start_as_current_span('child') as span:
     span.set_attribute('evens', [2, 4, 6, 8])
 ```
 

--- a/content/en/docs/instrumentation/python/cookbook.md
+++ b/content/en/docs/instrumentation/python/cookbook.md
@@ -81,20 +81,20 @@ trace.get_tracer_provider().add_span_processor(BatchSpanProcessor(ConsoleSpanExp
 
 tracer = trace.get_tracer(__name__)
 
-# A TextMapPropagator can use a regular Python dict as its Carrier.
-carrier = {}
+# A TextMapPropagator works with any dict-like object as its Carrier by default. You can also implement custom getters and setters.
 with tracer.start_as_current_span('first-trace'):
+    carrier = {}
     # Write the current context into the carrier.
-    TraceContextTextMapPropagator().extract(carrier)
+    TraceContextTextMapPropagator().inject(carrier)
 
 # The below might be in a different thread, on a different machine, etc.
 # As a typical example, it would be on a different microservice and the carrier would
 # have been forwarded via HTTP headers.
 
 # Extract the trace context from the carrier.
-# Here's what a typical carrier might look like, as it would have been extracted above.
+# Here's what a typical carrier might look like, as it would have been injected above.
 carrier = {'traceparent': '00-a9c3b99a95cc045e573e163c3ac80a77-d99d251a8caecd06-01'}
-# Then we use a propagator to get a trace context from it.
+# Then we use a propagator to get a context from it.
 ctx = TraceContextTextMapPropagator().extract(carrier=carrier)
 
 # Instead of extracting the trace context from the carrier, if you have a SpanContext


### PR DESCRIPTION
* Include an example of injecting the trace context into a text carrier dict.
* Add more explanatory text about what the different steps do, and which examples are different ways of doing the same thing.
* Add an example of context.attach as well as the pre-existing context=ctx passed to spans.

Followup to discussion in https://cloud-native.slack.com/archives/C01PD4HUVBL/p1648217884184149 .