### PR TITLE
Vendor page: AppDynamics link update

### DIFF
--- a/content/en/vendors.md
+++ b/content/en/vendors.md
@@ -14,7 +14,7 @@ products.
 
 | Company         | Distri&shy;bution | Native OTLP | Learn more
 | --------------- | ------------ | ----------- | --------------------------------------------------------------------------------------------------------------------------------
-| AppDynamics     | Yes          | Yes         | https://docs.appdynamics.com/22.3/en/application-monitoring/appdynamics-for-opentelemetry
+| AppDynamics     | Yes          | Yes         | https://docs.appdynamics.com/latest/en/application-monitoring/appdynamics-for-opentelemetry
 | Aspecto         | Yes          | Yes         | https://www.aspecto.io
 | AWS             | Yes          | No          | https://aws-otel.github.io
 | Azure           | Yes          | No          | https://docs.microsoft.com/azure/azure-monitor/app/opentelemetry-overview


### PR DESCRIPTION
Hi,

I have updated the URL to https://docs.appdynamics.com/latest/en/application-monitoring/appdynamics-for-opentelemetry on the vendors page