### PR TITLE
Adding a "HOW-TO: Building your own collector" tutorial to the collector

### DIFF
--- a/content/en/docs/collector/custom-collector.md
+++ b/content/en/docs/collector/custom-collector.md
@@ -1,5 +1,5 @@
 ---
-title: "Building your own Collector instance"
+title: Building your own Collector instance
 weight: 30
 ---
 
@@ -17,7 +17,7 @@ The `ocb` binary is available as a downloadable asset within the [OpenTelemetry 
 
 v0.53.0 is the latest and the assets are named based on OS and chipset, so download the one that fits your configuration.
 
-The binary has a pretty long name, so you can simply rename it to `ocb`; and if you are running Linux or macOS, you will also need to provide execution permissions for the binary. 
+The binary has a pretty long name, so you can simply rename it to `ocb`; and if you are running Linux or macOS, you will also need to provide execution permissions for the binary.
 
 Open your terminal and type the following commands to accomplish both operations:
 
@@ -29,7 +29,6 @@ chmod 777 ocb
 To make sure the `ocb` is ready to be used, go to your terminal and type `./ocb help`, and once you hit enter you should have the following output:
 
 ```
-
 OpenTelemetry Collector distribution builder (dev)
 
 Usage:
@@ -71,7 +70,7 @@ Here are the tags for the `dist` map:
 | module:          | The module name for the new distribution, following Go mod conventions. Optional, but recommended.| Yes | "go.opentelemetry.io/collector/cmd/builder" |
 | name:            | The binary name for your distribution | Yes | "otelcol-custom" |
 | description:     | A long name for the application. | Yes | "Custom OpenTelemetry Collector distribution" |
-| otelcol_version: | The OpenTelemetry Collector version to use as base for the distribution. | Yes | "0.53.0" | 
+| otelcol_version: | The OpenTelemetry Collector version to use as base for the distribution. | Yes | "0.53.0" |
 | output_path:     | The path to write the output (sources and binary). | Yes | "/var/folders/86/s7l1czb16g124tng0d7wyrtw0000gn/T/otelcol-distribution3618633831" |
 | version:         | The version for your custom OpenTelemetry Collector. | Yes | "1.0.0" |
 | go:              | Which Go binary to use to compile the generated sources. | Yes | go from the PATH |
@@ -86,9 +85,9 @@ Go ahead and create a manifest file named `builder-config.yaml` with the followi
 > builder-config.yaml
 ```yaml
 dist:
-    name: otelcol-dev 
+    name: otelcol-dev
     description: "Basic OTel Collector distribution for Developers"
-    output_path: ./otelcol-dev 
+    output_path: ./otelcol-dev
 ```
 
 Now you need to add the modules representing the components you want to be incorporated in this custom Collector distribution. Take a look at the [ocb configuration documentation](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder#configuration) to understand the different modules and how to add the components.
@@ -103,9 +102,9 @@ Here is what my `builder-config.yaml` manifest file looks after adding the modul
 
 ```yaml
 dist:
-    name: otelcol-dev 
+    name: otelcol-dev
     description: "Basic OTel Collector distribution for Developers"
-    output_path: ./otelcol-dev 
+    output_path: ./otelcol-dev
 
 exporters:
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter v0.53.0"

--- a/content/en/docs/collector/custom-collector.md
+++ b/content/en/docs/collector/custom-collector.md
@@ -44,7 +44,8 @@ chmod 777 ocb
 ```
 
 To make sure the `ocb` is ready to be used, go to your terminal and type
-`./ocb help`, and once you hit enter you should have the output of the `help` command showing up in your console.
+`./ocb help`, and once you hit enter you should have the output of the `help`
+command showing up in your console.
 
 ## Step 2 - Create a builder manifest file
 

--- a/content/en/docs/collector/custom-collector.md
+++ b/content/en/docs/collector/custom-collector.md
@@ -44,34 +44,7 @@ chmod 777 ocb
 ```
 
 To make sure the `ocb` is ready to be used, go to your terminal and type
-`./ocb help`, and once you hit enter you should have the following output:
-
-```
-OpenTelemetry Collector distribution builder (dev)
-
-Usage:
-  builder [flags]
-  builder [command]
-
-Available Commands:
-  completion  Generate the autocompletion script for the specified shell
-  help        Help about any command
-  version     Version of opentelemetry-collector-builder
-
-Flags:
-      --config string            config file (default is $HOME/.otelcol-builder.yaml)
-      --description string       A descriptive name for the OpenTelemetry Collector distribution (default "Custom OpenTelemetry Collector distribution")
-      --go string                The Go binary to use during the compilation phase. Default: go from the PATH
-  -h, --help                     help for builder
-      --module string            The Go module for the new distribution (default "go.opentelemetry.io/collector/cmd/builder")
-      --name string              The executable name for the OpenTelemetry Collector distribution (default "otelcol-custom")
-      --otelcol-version string   Which version of OpenTelemetry Collector to use as base (default "0.42.0")
-      --output-path string       Where to write the resulting files (default "/var/folders/86/s7l1czb16g124tng0d7wyrtw0000gn/T/otelcol-distribution3618633831")
-      --skip-compilation         Whether builder should only generate go code with no compile of the collector (default false)
-      --version string           The version for the OpenTelemetry Collector distribution (default "1.0.0")
-
-Use "builder [command] --help" for more information about a command.
-```
+`./ocb help`, and once you hit enter you should have the output of the `help` command showing up in your console. 
 
 ## Step 2 - Create a builder manifest file
 

--- a/content/en/docs/collector/custom-collector.md
+++ b/content/en/docs/collector/custom-collector.md
@@ -3,30 +3,49 @@ title: Building your own Collector instance
 weight: 30
 ---
 
-If you are planning to build and debug custom collector receivers, processors, extensions, or exporters, you are going to need your own Collector instance. That will allow you to launch and debug your OpenTelemetry Collector components directly within your favorite Golang IDE.
+If you are planning to build and debug custom collector receivers, processors,
+extensions, or exporters, you are going to need your own Collector instance.
+That will allow you to launch and debug your OpenTelemetry Collector components
+directly within your favorite Golang IDE.
 
-The other interesting aspect of approaching the component development this way is that you can use all the debugging features from your IDE (stack traces are great teachers!) to understand how the Collector itself interacts with your component code.
+The other interesting aspect of approaching the component development this way
+is that you can use all the debugging features from your IDE (stack traces are
+great teachers!) to understand how the Collector itself interacts with your
+component code.
 
-The OpenTelemetry Community developed a tool called [OpenTelemetry Collector builder](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder)(aka `ocb`) to assist people in assembling their own distribution, making it easy to build a distribution that includes their custom components along with components that are publicly available.
+The OpenTelemetry Community developed a tool called [OpenTelemetry Collector
+builder][ocb] (or `ocb` for short) to assist people in assembling their own
+distribution, making it easy to build a distribution that includes their custom
+components along with components that are publicly available.
 
-As part of the process the `builder` will generate the Collector's source code, which you can use to help build and debug your own custom components, so let's get started.
+As part of the process the `builder` will generate the Collector's source code,
+which you can use to help build and debug your own custom components, so let's
+get started.
 
 ## Step 1 - Install the builder
 
-The `ocb` binary is available as a downloadable asset within the [OpenTelemetry Collector Releases Page](https://github.com/open-telemetry/opentelemetry-collector/releases) within the Collector's GitHub project. You will find the list of assets at the bottom of the page.
+The `ocb` binary is available as a downloadable asset within the
+[OpenTelemetry Collector Releases Page](https://github.com/open-telemetry/opentelemetry-collector/releases)
+within the Collector's GitHub project. You will find the list of assets at the
+bottom of the page.
 
-v0.53.0 is the latest and the assets are named based on OS and chipset, so download the one that fits your configuration.
+v0.53.0 is the latest and the assets are named based on OS and chipset, so
+download the one that fits your configuration.
 
-The binary has a pretty long name, so you can simply rename it to `ocb`; and if you are running Linux or macOS, you will also need to provide execution permissions for the binary.
+The binary has a pretty long name, so you can simply rename it to `ocb`; and if
+you are running Linux or macOS, you will also need to provide execution
+permissions for the binary.
 
-Open your terminal and type the following commands to accomplish both operations:
+Open your terminal and type the following commands to accomplish both
+operations:
 
 ```cmd
 mv ocb_0.53.0_darwin_amd64 ocb
 chmod 777 ocb
 ```
 
-To make sure the `ocb` is ready to be used, go to your terminal and type `./ocb help`, and once you hit enter you should have the following output:
+To make sure the `ocb` is ready to be used, go to your terminal and type
+`./ocb help`, and once you hit enter you should have the following output:
 
 ```
 OpenTelemetry Collector distribution builder (dev)
@@ -55,59 +74,74 @@ Flags:
 Use "builder [command] --help" for more information about a command.
 ```
 
-
 ## Step 2 - Create a builder manifest file
 
+The builder's `manifest` file is a `yaml` where you pass information about the
+code generation and compile process combined with the components that you would
+like to add to your Collector's distribution.
 
-The builder's `manifest` file is a `yaml` where you pass information about the code generation and compile process combined with the components that you would like to add to your Collector's distribution.
-
-The `manifest` starts with a map named `dist` which contains tags to help you configure the code generation and compile process. In fact, all the tags for `dist` are the equivalent of the `ocb` command line `flags`.
+The `manifest` starts with a map named `dist` which contains tags to help you
+configure the code generation and compile process. In fact, all the tags for
+`dist` are the equivalent of the `ocb` command line `flags`.
 
 Here are the tags for the `dist` map:
 
-| Tag              | Description | Optional | Default Value|
-|------------------|-------------|----------|--------------|
-| module:          | The module name for the new distribution, following Go mod conventions. Optional, but recommended.| Yes | "go.opentelemetry.io/collector/cmd/builder" |
-| name:            | The binary name for your distribution | Yes | "otelcol-custom" |
-| description:     | A long name for the application. | Yes | "Custom OpenTelemetry Collector distribution" |
-| otelcol_version: | The OpenTelemetry Collector version to use as base for the distribution. | Yes | "0.53.0" |
-| output_path:     | The path to write the output (sources and binary). | Yes | "/var/folders/86/s7l1czb16g124tng0d7wyrtw0000gn/T/otelcol-distribution3618633831" |
-| version:         | The version for your custom OpenTelemetry Collector. | Yes | "1.0.0" |
-| go:              | Which Go binary to use to compile the generated sources. | Yes | go from the PATH |
+| Tag              | Description                                                                                        | Optional | Default Value                                                                     |
+| ---------------- | -------------------------------------------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------- |
+| module:          | The module name for the new distribution, following Go mod conventions. Optional, but recommended. | Yes      | "go.opentelemetry.io/collector/cmd/builder"                                       |
+| name:            | The binary name for your distribution                                                              | Yes      | "otelcol-custom"                                                                  |
+| description:     | A long name for the application.                                                                   | Yes      | "Custom OpenTelemetry Collector distribution"                                     |
+| otelcol_version: | The OpenTelemetry Collector version to use as base for the distribution.                           | Yes      | "0.53.0"                                                                          |
+| output_path:     | The path to write the output (sources and binary).                                                 | Yes      | "/var/folders/86/s7l1czb16g124tng0d7wyrtw0000gn/T/otelcol-distribution3618633831" |
+| version:         | The version for your custom OpenTelemetry Collector.                                               | Yes      | "1.0.0"                                                                           |
+| go:              | Which Go binary to use to compile the generated sources.                                           | Yes      | go from the PATH                                                                  |
 
+As you can see on the table above, all the `dist` tags are optional, so you will
+be adding custom values for them depending if your intentions to make your
+custom Collector distribution available for consumption by other users or if you
+are simply leveraging the `ocb` to bootstrap your component development and
+testing environment.
 
-As you can see on the table above, all the `dist` tags are optional, so you will be adding custom values for them depending if your intentions to make your custom Collector distribution available for consumption by other users or if you are simply leveraging the `ocb` to bootstrap your component development and testing environment.
+For this tutorial, you will be creating a Collector's distribution to support
+the development and testing of components.
 
-For this tutorial, you will be creating a Collector's distribution to support the development and testing of components.
-
-Go ahead and create a manifest file named `builder-config.yaml` with the following content:
+Go ahead and create a manifest file named `builder-config.yaml` with the
+following content:
 
 > builder-config.yaml
+
 ```yaml
 dist:
-    name: otelcol-dev
-    description: "Basic OTel Collector distribution for Developers"
-    output_path: ./otelcol-dev
+  name: otelcol-dev
+  description: "Basic OTel Collector distribution for Developers"
+  output_path: ./otelcol-dev
 ```
 
-Now you need to add the modules representing the components you want to be incorporated in this custom Collector distribution. Take a look at the [ocb configuration documentation](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder#configuration) to understand the different modules and how to add the components.
+Now you need to add the modules representing the components you want to be
+incorporated in this custom Collector distribution. Take a look at the
+[ocb configuration documentation](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder#configuration)
+to understand the different modules and how to add the components.
 
-We will be adding the following components to our development and testing collector distribution:
+We will be adding the following components to our development and testing
+collector distribution:
 
 - Exporters: Jaeger and Logging
 - Receivers: OTLP
 - Processors: Batch
 
-Here is what my `builder-config.yaml` manifest file looks after adding the modules for the components above:
+Here is what my `builder-config.yaml` manifest file looks after adding the
+modules for the components above:
 
 ```yaml
 dist:
-    name: otelcol-dev
-    description: "Basic OTel Collector distribution for Developers"
-    output_path: ./otelcol-dev
+  name: otelcol-dev
+  description: "Basic OTel Collector distribution for Developers"
+  output_path: ./otelcol-dev
 
 exporters:
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter v0.53.0"
+  - gomod:
+      "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter
+      v0.53.0"
   - import: go.opentelemetry.io/collector/exporter/loggingexporter
     gomod: go.opentelemetry.io/collector v0.53.0
 
@@ -120,16 +154,17 @@ processors:
     gomod: go.opentelemetry.io/collector v0.53.0
 ```
 
-
 ## Step 3 - Generating the Code and Building your Collector's distribution.
 
-All you need now is to let the `ocb` do it's job, so go to your terminal and type the following command:
+All you need now is to let the `ocb` do it's job, so go to your terminal and
+type the following command:
 
 ```
 ocb --config builder-config.yaml
 ```
 
-If everything went well, here is what the output of the command should look like:
+If everything went well, here is what the output of the command should look
+like:
 
 ```
 
@@ -143,6 +178,13 @@ If everything went well, here is what the output of the command should look like
 
 ```
 
-As defined in the `dist` section of your config file, you now have a folder named `otelcol-dev` containing all the source code and the binary for your Collector's distribution.
+As defined in the `dist` section of your config file, you now have a folder
+named `otelcol-dev` containing all the source code and the binary for your
+Collector's distribution.
 
-You can now use the generated code to bootstrap your component development projects and easily build and distribute your own Collector distribution with your components.
+You can now use the generated code to bootstrap your component development
+projects and easily build and distribute your own Collector distribution with
+your components.
+
+[ocb]:
+  https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder

--- a/content/en/docs/collector/custom-collector.md
+++ b/content/en/docs/collector/custom-collector.md
@@ -1,6 +1,6 @@
 ---
-title: Building your own Collector instance
-weight: 30
+title: Building a custom collector
+weight: 29
 ---
 
 If you are planning to build and debug custom collector receivers, processors,
@@ -44,7 +44,7 @@ chmod 777 ocb
 ```
 
 To make sure the `ocb` is ready to be used, go to your terminal and type
-`./ocb help`, and once you hit enter you should have the output of the `help` command showing up in your console. 
+`./ocb help`, and once you hit enter you should have the output of the `help` command showing up in your console.
 
 ## Step 2 - Create a builder manifest file
 

--- a/content/en/docs/collector/custom-collector.md
+++ b/content/en/docs/collector/custom-collector.md
@@ -24,9 +24,8 @@ get started.
 
 ## Step 1 - Install the builder
 
-The `ocb` binary is available as a downloadable asset within the
-[OpenTelemetry Collector Releases Page](https://github.com/open-telemetry/opentelemetry-collector/releases)
-within the Collector's GitHub project. You will find the list of assets at the
+The `ocb` binary is available as a downloadable asset from the [OpenTelemetry
+Collector releases page][releases]. You will find the list of assets at the
 bottom of the page.
 
 v0.53.0 is the latest and the assets are named based on OS and chipset, so
@@ -159,15 +158,14 @@ processors:
 All you need now is to let the `ocb` do it's job, so go to your terminal and
 type the following command:
 
-```
+```cmd
 ocb --config builder-config.yaml
 ```
 
 If everything went well, here is what the output of the command should look
 like:
 
-```
-
+```nocode
 2022-06-13T14:25:03.037-0500	INFO	internal/command.go:85	OpenTelemetry Collector distribution builder	{"version": "0.53.0", "date": "2022-06-08T15:05:37Z"}
 2022-06-13T14:25:03.039-0500	INFO	internal/command.go:108	Using config file	{"path": "builder-config.yaml"}
 2022-06-13T14:25:03.040-0500	INFO	builder/config.go:99	Using go	{"go-executable": "/usr/local/go/bin/go"}
@@ -175,7 +173,6 @@ like:
 2022-06-13T14:25:03.445-0500	INFO	builder/main.go:108	Getting go modules
 2022-06-13T14:25:04.675-0500	INFO	builder/main.go:87	Compiling
 2022-06-13T14:25:17.259-0500	INFO	builder/main.go:94	Compiled	{"binary": "./otelcol-dev/otelcol-dev"}
-
 ```
 
 As defined in the `dist` section of your config file, you now have a folder
@@ -183,8 +180,9 @@ named `otelcol-dev` containing all the source code and the binary for your
 Collector's distribution.
 
 You can now use the generated code to bootstrap your component development
-projects and easily build and distribute your own Collector distribution with
+projects and easily build and distribute your own collector distribution with
 your components.
 
 [ocb]:
   https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder
+[releases]: https://github.com/open-telemetry/opentelemetry-collector/releases

--- a/content/en/docs/collector/howto-custom-collector.md
+++ b/content/en/docs/collector/howto-custom-collector.md
@@ -13,16 +13,16 @@ As part of the process the `builder` will generate the Collector's source code, 
 
 ## Step 1 - Install the builder
 
-The `ocb` binary is available as a downloadable asset within the [OpenTelemetry Collector Releases Page](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.49.0) within the Collector's GitHub project. You will find the list of assets at the bottom of the page.
+The `ocb` binary is available as a downloadable asset within the [OpenTelemetry Collector Releases Page](https://github.com/open-telemetry/opentelemetry-collector/releases) within the Collector's GitHub project. You will find the list of assets at the bottom of the page.
 
-v0.49.0 is the latest and the assets are named based on OS and chipset, so download the one that fits your configuration.
+v0.53.0 is the latest and the assets are named based on OS and chipset, so download the one that fits your configuration.
 
 The binary has a pretty long name, so you can simply rename it to `ocb`; and if you are running Linux or macOS, you will also need to provide execution permissions for the binary. 
 
 Open your terminal and type the following commands to accomplish both operations:
 
 ```cmd
-mv ocb_0.49.0_darwin_amd64 ocb
+mv ocb_0.53.0_darwin_amd64 ocb
 chmod 777 ocb
 ```
 
@@ -108,17 +108,17 @@ dist:
     output_path: ./otelcol-dev 
 
 exporters:
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter v0.49.0"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter v0.53.0"
   - import: go.opentelemetry.io/collector/exporter/loggingexporter
-    gomod: go.opentelemetry.io/collector v0.49.0
+    gomod: go.opentelemetry.io/collector v0.53.0
 
 receivers:
   - import: go.opentelemetry.io/collector/receiver/otlpreceiver
-    gomod: go.opentelemetry.io/collector v0.49.0
+    gomod: go.opentelemetry.io/collector v0.53.0
 
 processors:
   - import: go.opentelemetry.io/collector/processor/batchprocessor
-    gomod: go.opentelemetry.io/collector v0.49.0
+    gomod: go.opentelemetry.io/collector v0.53.0
 ```
 
 
@@ -134,13 +134,13 @@ If everything went well, here is what the output of the command should look like
 
 ```
 
-2022-04-26T10:51:19.705-0500    INFO    internal/command.go:85  OpenTelemetry Collector distribution builder    {"version": "0.49.0", "date": "2022-04-13T22:49:20Z"}
-2022-04-26T10:51:19.706-0500    INFO    internal/command.go:108 Using config file       {"path": "builder-config.yaml"}
-2022-04-26T10:51:19.707-0500    INFO    builder/config.go:99    Using go        {"go-executable": "/usr/local/go/bin/go"}
-2022-04-26T10:51:19.709-0500    INFO    builder/main.go:76      Sources created {"path": "./otelcol-dev"}
-2022-04-26T10:51:20.345-0500    INFO    builder/main.go:108     Getting go modules
-2022-04-26T10:51:30.285-0500    INFO    builder/main.go:87      Compiling
-2022-04-26T10:51:40.217-0500    INFO    builder/main.go:94      Compiled        {"binary": "./otelcol-dev/otelcol-dev"}
+2022-06-13T14:25:03.037-0500	INFO	internal/command.go:85	OpenTelemetry Collector distribution builder	{"version": "0.53.0", "date": "2022-06-08T15:05:37Z"}
+2022-06-13T14:25:03.039-0500	INFO	internal/command.go:108	Using config file	{"path": "builder-config.yaml"}
+2022-06-13T14:25:03.040-0500	INFO	builder/config.go:99	Using go	{"go-executable": "/usr/local/go/bin/go"}
+2022-06-13T14:25:03.041-0500	INFO	builder/main.go:76	Sources created	{"path": "./otelcol-dev"}
+2022-06-13T14:25:03.445-0500	INFO	builder/main.go:108	Getting go modules
+2022-06-13T14:25:04.675-0500	INFO	builder/main.go:87	Compiling
+2022-06-13T14:25:17.259-0500	INFO	builder/main.go:94	Compiled	{"binary": "./otelcol-dev/otelcol-dev"}
 
 ```
 

--- a/content/en/docs/collector/howto-custom-collector.md
+++ b/content/en/docs/collector/howto-custom-collector.md
@@ -62,7 +62,7 @@ Use "builder [command] --help" for more information about a command.
 
 The builder's `manifest` file is a `yaml` where you basically pass information about the code generation and compile process combined with the components that you would like to add to your Collector's distribution.
 
-The `manifest` starts with a map named `dist` which basically contains tags to help you configure the code generation and compile process. In fact, all the tags for `dist` are the equivalent of the `ocb` command line `flags`.
+The `manifest` starts with a map named `dist` which contains tags to help you configure the code generation and compile process. In fact, all the tags for `dist` are the equivalent of the `ocb` command line `flags`.
 
 Here are the tags for the `dist` map:
 

--- a/content/en/docs/collector/howto-custom-collector.md
+++ b/content/en/docs/collector/howto-custom-collector.md
@@ -1,14 +1,17 @@
-# HOW-TO: Build your own Collector instance
+---
+title: "Building your own Collector instance"
+weight: 30
+---
 
-If you are planning to build and debug your components, you are going to need your own Collector instance. That will allow you to launch and debug your Collector components directly within your favorite Golang IDE.
+If you are planning to build and debug your components, you are going to need your own Collector instance. That will allow you to launch and debug your OpenTelemetry Collector components directly within your favorite Golang IDE.
 
-The other really cool aspect of approaching the component development this way is that you can use all the cool debugging features from your IDE (stack traces are great teachers!) to understand how the Collector itself interacts with your component code.
+The other interesting aspect of approaching the component development this way is that you can use all the debugging features from your IDE (stack traces are great teachers!) to understand how the Collector itself interacts with your component code.
 
-In order to me it easy for developers to create their own custom builds of the Collector, the OpenTelemetry Community has developed a tool called `OpenTelemetry Collector Builder`.
+In order to make it easy for developers to create their own custom builds of the Collector, the OpenTelemetry Community has developed a tool called [OpenTelemetry Collector builder](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder).
 
-The `builder` is meant to help developers to quickly assemble and build their own collector's distributions, based on a given configuration file.
+The `builder` is meant to help developers to quickly assemble and build their own Collector's distributions, based on a given configuration file.
 
-As part of the process the `builder` will generate the collector's source code, which you can borrow and steal as your own to help build and debug your own components, so let's get started.
+As part of the process the `builder` will generate the Collector's source code, which you can borrow and steal as your own to help build and debug your own components, so let's get started.
 
 ## Step 1 - Install the builder
 
@@ -54,7 +57,7 @@ Use "builder [command] --help" for more information about a command.
 
 ## Step 2 - Create a builder config file
 
-The builder config file is a `yaml` where you basically pass information about the code generation and compile process combined with the components that you would like to add to your collector's distribution.
+The builder config file is a `yaml` where you basically pass information about the code generation and compile process combined with the components that you would like to add to your Collector's distribution.
 
 Go ahead and create a `builder-config.yaml` with the following content:
 
@@ -107,6 +110,6 @@ If everything went well, here is what the output of the command should look like
 
 ```
 
-As defined in the `dist` section of your config file, you now have a folder named `otelcol-mybuild` containing all the source code and the binary for your collector's distribution.
+As defined in the `dist` section of your config file, you now have a folder named `otelcol-mybuild` containing all the source code and the binary for your Collector's distribution.
 
-You can now use the generated code to bootstrap your component development projects and easily build and distribute your own collector distribution with your components.
+You can now use the generated code to bootstrap your component development projects and easily build and distribute your own Collector distribution with your components.

--- a/content/en/docs/collector/howto-custom-collector.md
+++ b/content/en/docs/collector/howto-custom-collector.md
@@ -3,7 +3,7 @@ title: "Building your own Collector instance"
 weight: 30
 ---
 
-If you are planning to build and debug your components, you are going to need your own Collector instance. That will allow you to launch and debug your OpenTelemetry Collector components directly within your favorite Golang IDE.
+If you are planning to build and debug custom collector receivers, processors, extensions, or exporters, you are going to need your own Collector instance. That will allow you to launch and debug your OpenTelemetry Collector components directly within your favorite Golang IDE.
 
 The other interesting aspect of approaching the component development this way is that you can use all the debugging features from your IDE (stack traces are great teachers!) to understand how the Collector itself interacts with your component code.
 

--- a/content/en/docs/collector/howto-custom-collector.md
+++ b/content/en/docs/collector/howto-custom-collector.md
@@ -7,25 +7,26 @@ If you are planning to build and debug your components, you are going to need yo
 
 The other interesting aspect of approaching the component development this way is that you can use all the debugging features from your IDE (stack traces are great teachers!) to understand how the Collector itself interacts with your component code.
 
-In order to make it easy for developers to create their own custom builds of the Collector, the OpenTelemetry Community has developed a tool called [OpenTelemetry Collector builder](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder).
-
-The `builder` is meant to help developers to quickly assemble and build their own Collector's distributions, based on a given configuration file.
+The OpenTelemetry Community developed a tool called [OpenTelemetry Collector builder](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder)(aka `ocb`) to assist people in assembling their own distribution, making it easy to build a distribution that includes their custom components along with components that are publicly available.
 
 As part of the process the `builder` will generate the Collector's source code, which you can borrow and steal as your own to help build and debug your own components, so let's get started.
 
 ## Step 1 - Install the builder
 
-You can install the builder through the `go install` command. 
+The `ocb` binary is available as a downloadable asset within the [OpenTelemetry Collector Releases Page](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.49.0) within the Collector's GitHub project. You will find the list of assets at the bottom of the page.
 
-Open your terminal and type:
+v0.49.0 is the latest and the assets are named based on OS and chipset, so download the one that fits your configuration.
 
+The binary has a pretty long name, so you can simply rename it to `ocb`; and if you are running Linux or macOS, you will also need to provide execution permissions for the binary. 
+
+Open your terminal and type the following commands to accomplish both operations:
+
+```cmd
+mv ocb_0.49.0_darwin_amd64 ocb
+chmod 777 ocb
 ```
-go install go.opentelemetry.io/collector/cmd/builder@latest
-```
 
-The `builder` command will be installed on your `$GOPATH/bin`, which most likely is already added to your path.
-
-To make sure it's there, go to your terminal and type `builder help`, and once you hit enter you should have the following output:
+To make sure the `ocb` is ready to be used, go to your terminal and type `./ocb help`, and once you hit enter you should have the following output:
 
 ```
 
@@ -55,61 +56,94 @@ Flags:
 Use "builder [command] --help" for more information about a command.
 ```
 
-## Step 2 - Create a builder config file
 
-The builder config file is a `yaml` where you basically pass information about the code generation and compile process combined with the components that you would like to add to your Collector's distribution.
+## Step 2 - Create a builder manifest file
+
+
+The builder's `manifest` file is a `yaml` where you basically pass information about the code generation and compile process combined with the components that you would like to add to your Collector's distribution.
+
+The `manifest` starts with a map named `dist` which basically contains tags to help you configure the code generation and compile process. In fact, all the tags for `dist` are the equivalent of the `ocb` command line `flags`.
+
+Here are the tags for the `dist` map:
+
+| Tag              | Description | Optional | Default Value|
+|------------------|-------------|----------|--------------|
+| module:          | The module name for the new distribution, following Go mod conventions. Optional, but recommended.| Yes | "go.opentelemetry.io/collector/cmd/builder" |
+| name:            | The binary name for your distribution | Yes | "otelcol-custom" |
+| description:     | A long name for the application. | Yes | "Custom OpenTelemetry Collector distribution" |
+| otelcol_version: | The OpenTelemetry Collector version to use as base for the distribution. | Yes | "0.49.0" | 
+| output_path:     | The path to write the output (sources and binary). | Yes | "/var/folders/86/s7l1czb16g124tng0d7wyrtw0000gn/T/otelcol-distribution3618633831" |
+| version:         | The version for your custom OpenTelemetry Collector. | Yes | "1.0.0" |
+| go:              | Which Go binary to use to compile the generated sources. | Yes | go from the PATH |
+
+
+As you can see on the table above, all the `dist` tags are optional, so you will be adding custom values for them depending if your intentions to make your custom Collector distribution available for consumption by other users or if you are simply leveraging the `ocb` to bootstrap your component development and testing environment.
+
+For this tutorial, you will be creating a Collector's distribution to support the development and testing of components.
 
 Go ahead and create a `builder-config.yaml` with the following content:
 
 > builder-config.yaml
 ```yaml
 dist:
-    module: github.com/open-telemetry/opentelemetry-collector # the module name for the new distribution, following Go mod conventions. Optional, but recommended.
-    name: otelcol-mybuild # the binary name. Optional.
-    description: "Custom OpenTelemetry Collector distribution" # a long name for the application. Optional.
-    otelcol_version: "0.41.0" # the OpenTelemetry Collector version to use as base for the distribution. Optional.
-    output_path: ./otelcol-mybuild # the path to write the output (sources and binary). Optional.
-    version: "1.0.0" # the version for your custom OpenTelemetry Collector. Optional.
-    go: "/usr/local/go/bin/go" # which Go binary to use to compile the generated sources. Optional.
+    name: otelcol-dev 
+    description: "Basic OTel Collector distribution for Developers"
+    output_path: ./otelcol-dev 
+```
+
+Now you need to add the modules representing the components you want to be incorporated in this custom Collector distribution. Take a look at the [ocb configuration documentation](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder#configuration) to understand the different modules and how to add the components.
+
+We will be adding the following components to our development and testing collector distribution:
+
+- Exporters: Jaeger and Logging
+- Receivers: Otlp
+- Processors: Batch
+
+Here is what my `builder-config.yaml` manifest file looks after adding the modules for the components above:
+
+```yaml
+dist:
+    name: otelcol-dev 
+    description: "Basic OTel Collector distribution for Developers"
+    output_path: ./otelcol-dev 
+
 exporters:
-  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter v0.41.0"
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter v0.49.0"
   - import: go.opentelemetry.io/collector/exporter/loggingexporter
-    gomod: go.opentelemetry.io/collector v0.41.0
+    gomod: go.opentelemetry.io/collector v0.49.0
 
 receivers:
   - import: go.opentelemetry.io/collector/receiver/otlpreceiver
-    gomod: go.opentelemetry.io/collector v0.41.0
+    gomod: go.opentelemetry.io/collector v0.49.0
 
 processors:
   - import: go.opentelemetry.io/collector/processor/batchprocessor
-    gomod: go.opentelemetry.io/collector v0.41.0
+    gomod: go.opentelemetry.io/collector v0.49.0
 ```
 
-For more information on how to create your builder config file, check out the [OpenTelemetry Collector builder](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder) folder inside the Collector's project in GitHub.
 
 ## Step 3 - Generating the Code and Building your Collector's distribution.
 
-All you need now is to let the `builder` do it's job, so go to your terminal and type the following command:
+All you need now is to let the `ocb` do it's job, so go to your terminal and type the following command:
 
 ```
-builder --config builder-config.yaml
+ocb --config builder-config.yaml
 ```
 
 If everything went well, here is what the output of the command should look like:
 
 ```
 
-2022-01-13T10:21:01.777-0600	INFO	internal/command.go:82	OpenTelemetry Collector distribution builder	{"version": "dev", "date": "unknown"}
-2022-01-13T10:21:01.779-0600	INFO	internal/command.go:102	Using config file	{"path": "builder-config.yaml"}
-2022-01-13T10:21:02.239-0600	INFO	builder/config.go:103	Using go	{"go-executable": "/usr/local/go/bin/go"}
-2022-01-13T10:21:02.239-0600	INFO	builder/main.go:52	You're building a distribution with non-aligned version of the builder. Compilation may fail due to API changes. Please upgrade your builder or API	{"builder-version": "0.42.0"}
-2022-01-13T10:21:02.241-0600	INFO	builder/main.go:76	Sources created{"path": "./otelcol-mybuild"}
-2022-01-13T10:21:02.841-0600	INFO	builder/main.go:108	Getting go modules
-2022-01-13T10:21:03.131-0600	INFO	builder/main.go:87	Compiling
-2022-01-13T10:21:07.816-0600	INFO	builder/main.go:94	Compiled	{"binary": "./otelcol-mybuild/otelcol-mybuild"}
+2022-04-26T10:51:19.705-0500    INFO    internal/command.go:85  OpenTelemetry Collector distribution builder    {"version": "0.49.0", "date": "2022-04-13T22:49:20Z"}
+2022-04-26T10:51:19.706-0500    INFO    internal/command.go:108 Using config file       {"path": "builder-config.yaml"}
+2022-04-26T10:51:19.707-0500    INFO    builder/config.go:99    Using go        {"go-executable": "/usr/local/go/bin/go"}
+2022-04-26T10:51:19.709-0500    INFO    builder/main.go:76      Sources created {"path": "./otelcol-dev"}
+2022-04-26T10:51:20.345-0500    INFO    builder/main.go:108     Getting go modules
+2022-04-26T10:51:30.285-0500    INFO    builder/main.go:87      Compiling
+2022-04-26T10:51:40.217-0500    INFO    builder/main.go:94      Compiled        {"binary": "./otelcol-dev/otelcol-dev"}
 
 ```
 
-As defined in the `dist` section of your config file, you now have a folder named `otelcol-mybuild` containing all the source code and the binary for your Collector's distribution.
+As defined in the `dist` section of your config file, you now have a folder named `otelcol-dev` containing all the source code and the binary for your Collector's distribution.
 
 You can now use the generated code to bootstrap your component development projects and easily build and distribute your own Collector distribution with your components.

--- a/content/en/docs/collector/howto-custom-collector.md
+++ b/content/en/docs/collector/howto-custom-collector.md
@@ -9,7 +9,7 @@ The other interesting aspect of approaching the component development this way i
 
 The OpenTelemetry Community developed a tool called [OpenTelemetry Collector builder](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder)(aka `ocb`) to assist people in assembling their own distribution, making it easy to build a distribution that includes their custom components along with components that are publicly available.
 
-As part of the process the `builder` will generate the Collector's source code, which you can borrow and steal as your own to help build and debug your own components, so let's get started.
+As part of the process the `builder` will generate the Collector's source code, which you can use to help build and debug your own custom components, so let's get started.
 
 ## Step 1 - Install the builder
 

--- a/content/en/docs/collector/howto-custom-collector.md
+++ b/content/en/docs/collector/howto-custom-collector.md
@@ -96,7 +96,7 @@ Now you need to add the modules representing the components you want to be incor
 We will be adding the following components to our development and testing collector distribution:
 
 - Exporters: Jaeger and Logging
-- Receivers: Otlp
+- Receivers: OTLP
 - Processors: Batch
 
 Here is what my `builder-config.yaml` manifest file looks after adding the modules for the components above:

--- a/content/en/docs/collector/howto-custom-collector.md
+++ b/content/en/docs/collector/howto-custom-collector.md
@@ -71,7 +71,7 @@ Here are the tags for the `dist` map:
 | module:          | The module name for the new distribution, following Go mod conventions. Optional, but recommended.| Yes | "go.opentelemetry.io/collector/cmd/builder" |
 | name:            | The binary name for your distribution | Yes | "otelcol-custom" |
 | description:     | A long name for the application. | Yes | "Custom OpenTelemetry Collector distribution" |
-| otelcol_version: | The OpenTelemetry Collector version to use as base for the distribution. | Yes | "0.49.0" | 
+| otelcol_version: | The OpenTelemetry Collector version to use as base for the distribution. | Yes | "0.53.0" | 
 | output_path:     | The path to write the output (sources and binary). | Yes | "/var/folders/86/s7l1czb16g124tng0d7wyrtw0000gn/T/otelcol-distribution3618633831" |
 | version:         | The version for your custom OpenTelemetry Collector. | Yes | "1.0.0" |
 | go:              | Which Go binary to use to compile the generated sources. | Yes | go from the PATH |

--- a/content/en/docs/collector/howto-custom-collector.md
+++ b/content/en/docs/collector/howto-custom-collector.md
@@ -1,0 +1,112 @@
+# HOW-TO: Build your own Collector instance
+
+If you are planning to build and debug your components, you are going to need your own Collector instance. That will allow you to launch and debug your Collector components directly within your favorite Golang IDE.
+
+The other really cool aspect of approaching the component development this way is that you can use all the cool debugging features from your IDE (stack traces are great teachers!) to understand how the Collector itself interacts with your component code.
+
+In order to me it easy for developers to create their own custom builds of the Collector, the OpenTelemetry Community has developed a tool called `OpenTelemetry Collector Builder`.
+
+The `builder` is meant to help developers to quickly assemble and build their own collector's distributions, based on a given configuration file.
+
+As part of the process the `builder` will generate the collector's source code, which you can borrow and steal as your own to help build and debug your own components, so let's get started.
+
+## Step 1 - Install the builder
+
+You can easily install the builder through the go install command. 
+
+Open your terminal and type:
+
+```
+go install go.opentelemetry.io/collector/cmd/builder@latest
+```
+
+The `builder` command will be installed on your `$GOPATH/bin`, which most likely is already added to your path.
+
+To make sure it's there, go to your terminal and type `builder help`, and once you hit enter you should have the following output:
+
+```
+
+OpenTelemetry Collector distribution builder (dev)
+
+Usage:
+  builder [flags]
+  builder [command]
+
+Available Commands:
+  completion  Generate the autocompletion script for the specified shell
+  help        Help about any command
+  version     Version of opentelemetry-collector-builder
+
+Flags:
+      --config string            config file (default is $HOME/.otelcol-builder.yaml)
+      --description string       A descriptive name for the OpenTelemetry Collector distribution (default "Custom OpenTelemetry Collector distribution")
+      --go string                The Go binary to use during the compilation phase. Default: go from the PATH
+  -h, --help                     help for builder
+      --module string            The Go module for the new distribution (default "go.opentelemetry.io/collector/cmd/builder")
+      --name string              The executable name for the OpenTelemetry Collector distribution (default "otelcol-custom")
+      --otelcol-version string   Which version of OpenTelemetry Collector to use as base (default "0.42.0")
+      --output-path string       Where to write the resulting files (default "/var/folders/86/s7l1czb16g124tng0d7wyrtw0000gn/T/otelcol-distribution3618633831")
+      --skip-compilation         Whether builder should only generate go code with no compile of the collector (default false)
+      --version string           The version for the OpenTelemetry Collector distribution (default "1.0.0")
+
+Use "builder [command] --help" for more information about a command.
+```
+
+## Step 2 - Create a builder config file
+
+The builder config file is a `yaml` where you basically pass information about the code generation and compile process combined with the components that you would like to add to your collector's distribution.
+
+Go ahead and create a `builder-config.yaml` with the following content:
+
+> builder-config.yaml
+```yaml
+dist:
+    module: github.com/open-telemetry/opentelemetry-collector # the module name for the new distribution, following Go mod conventions. Optional, but recommended.
+    name: otelcol-mybuild # the binary name. Optional.
+    description: "Custom OpenTelemetry Collector distribution" # a long name for the application. Optional.
+    otelcol_version: "0.41.0" # the OpenTelemetry Collector version to use as base for the distribution. Optional.
+    output_path: ./otelcol-mybuild # the path to write the output (sources and binary). Optional.
+    version: "1.0.0" # the version for your custom OpenTelemetry Collector. Optional.
+    go: "/usr/local/go/bin/go" # which Go binary to use to compile the generated sources. Optional.
+exporters:
+  - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter v0.41.0"
+  - import: go.opentelemetry.io/collector/exporter/loggingexporter
+    gomod: go.opentelemetry.io/collector v0.41.0
+
+receivers:
+  - import: go.opentelemetry.io/collector/receiver/otlpreceiver
+    gomod: go.opentelemetry.io/collector v0.41.0
+
+processors:
+  - import: go.opentelemetry.io/collector/processor/batchprocessor
+    gomod: go.opentelemetry.io/collector v0.41.0
+```
+
+For more information on how to create your builder config file, checkout [OpenTelemetry Collector builder](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder) folder inside the Collector's project in GitHub.
+
+## Step 3 - Generating the Code and Building your Collector's distribution.
+
+All you need now is to let the `builder` do it's job, so go to your terminal and type the following command:
+
+```
+builder --config builder-config.yaml
+```
+
+If everything went well, here is what the output of the command should look like:
+
+```
+
+2022-01-13T10:21:01.777-0600	INFO	internal/command.go:82	OpenTelemetry Collector distribution builder	{"version": "dev", "date": "unknown"}
+2022-01-13T10:21:01.779-0600	INFO	internal/command.go:102	Using config file	{"path": "builder-config.yaml"}
+2022-01-13T10:21:02.239-0600	INFO	builder/config.go:103	Using go	{"go-executable": "/usr/local/go/bin/go"}
+2022-01-13T10:21:02.239-0600	INFO	builder/main.go:52	You're building a distribution with non-aligned version of the builder. Compilation may fail due to API changes. Please upgrade your builder or API	{"builder-version": "0.42.0"}
+2022-01-13T10:21:02.241-0600	INFO	builder/main.go:76	Sources created{"path": "./otelcol-mybuild"}
+2022-01-13T10:21:02.841-0600	INFO	builder/main.go:108	Getting go modules
+2022-01-13T10:21:03.131-0600	INFO	builder/main.go:87	Compiling
+2022-01-13T10:21:07.816-0600	INFO	builder/main.go:94	Compiled	{"binary": "./otelcol-mybuild/otelcol-mybuild"}
+
+```
+
+As defined in the `dist` section of your config file, you now have a folder named `otelcol-mybuild` containing all the source code and the binary for your collector's distribution.
+
+You can now use the generated code to bootstrap your component development projects and easily build and distribute your own collector distribution with your components.

--- a/content/en/docs/collector/howto-custom-collector.md
+++ b/content/en/docs/collector/howto-custom-collector.md
@@ -60,7 +60,7 @@ Use "builder [command] --help" for more information about a command.
 ## Step 2 - Create a builder manifest file
 
 
-The builder's `manifest` file is a `yaml` where you basically pass information about the code generation and compile process combined with the components that you would like to add to your Collector's distribution.
+The builder's `manifest` file is a `yaml` where you pass information about the code generation and compile process combined with the components that you would like to add to your Collector's distribution.
 
 The `manifest` starts with a map named `dist` which contains tags to help you configure the code generation and compile process. In fact, all the tags for `dist` are the equivalent of the `ocb` command line `flags`.
 


### PR DESCRIPTION
Hoping to start a series of "HOW-TO" docs in the collector to help developers learning how to build components like the one I am proposing here [Tutorial on how to build a trace receiver #1265](https://github.com/open-telemetry/opentelemetry.io/pull/1265)

This would be the step one in the journey for component developers.

---

Preview: https://deploy-preview-1277--opentelemetry.netlify.app/docs/collector/howto-custom-collector/