### PR TITLE
Ensure local page refs are local

### DIFF
--- a/content/en/blog/2022/apisix.md
+++ b/content/en/blog/2022/apisix.md
@@ -189,8 +189,8 @@ interface, resulting in a call chain consisting of two spans.
 
 ### Step 1: Deploy OpenTelemetry
 
-The following uses docker-compose as an example. For other deployments,
-see [Getting Started](https://opentelemetry.io/docs/collector/getting-started/).
+The following uses docker-compose as an example. For other deployments, see
+[Getting Started](/docs/collector/getting-started/).
 
 You can see the following command to deploy:
 
@@ -229,7 +229,7 @@ Apache APISIX.
 
 You can see the following example to create a route and enable
 the`opentelemetry` plugin for sampling:
-  
+
 ```shell
 curl http://127.0.0.1:9080/apisix/admin/routes/1 \
 -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' \
@@ -253,7 +253,7 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1 \
 ```
 
 Modify the `./examples/demo/otel-collector-config.yaml` file to add the OTLP
-HTTP Receiver.  
+HTTP Receiver.
 
 ```yaml
 receivers:
@@ -386,7 +386,7 @@ Trace systems on the market. Apache APISIX is also actively cooperating with
 communities to create a more powerful ecosystem.
 
 Apache APISIX is also currently working on additional plugins to support
-integration with more services, if you're interested, feel free to 
+integration with more services, if you're interested, feel free to
 [start a discussion](https://github.com/apache/apisix/discussions)
 on GitHub, or communicate via the [mailing list](https://apisix.apache.org/docs/general/subscribe-guide).
 

--- a/content/en/docs/instrumentation/java/getting-started.md
+++ b/content/en/docs/instrumentation/java/getting-started.md
@@ -99,7 +99,7 @@ For more:
 - Learn about [manual instrumentation][] and try out more [examples](../examples).
 
 [annotations]: ../automatic/annotations
-[configure the Java agent]: https://opentelemetry.io/docs/instrumentation/java/automatic/#configuring-the-agent
+[configure the Java agent]: ../automatic/#configuring-the-agent
 [console trace exporter,]: https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#logging-exporter
 [exporter]: https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#exporters
 [Get the example code.]: https://grpc.io/docs/languages/java/quickstart/#get-the-example-code

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,4 +1,8 @@
 {{ $isExternal := hasPrefix .Destination "http" -}}
+{{ if and $isExternal (findRE "^https://opentelemetry.io/\\w" .Destination) -}}
+  {{ errorf "%s: use a local path, not an external URL, for the following reference to a local page: %s"
+      .Page.File.Path .Destination -}}
+{{ end -}}
 {{/* Until Hugo supports hook params (https://github.com/gohugoio/hugo/issues/6670), we'll inspect .Text. */ -}}
 {{ $noExternalIcon := in .Text "hk-no-external-icon" -}}
 <a href="{{ .Destination | safeURL }}"

--- a/scripts/adjust-spec-pages.pl
+++ b/scripts/adjust-spec-pages.pl
@@ -91,5 +91,8 @@ while(<>) {
   # Rewrite link defs
   s|^(\[[^\]]+\]:\s*)([^:\s]*)(\s*(\(.*\))?)$|$1\{{% relref "$2" %}}$3|g;
 
+  # Make website-local page references local:
+  s|https://opentelemetry.io/|/|g;
+
   print;
 }


### PR DESCRIPTION
- Adds a build-time check to enforce #922 

Preview:

- https://deploy-preview-1282--opentelemetry.netlify.app/blog/2022/apisix
- https://deploy-preview-1282--opentelemetry.netlify.app/docs/instrumentation/java/getting-started
- https://deploy-preview-1282--opentelemetry.netlify.app/docs/reference/specification/compatibility/opentracing

/cc @austinlparker @cartermp 