### PR TITLE
Add troubleshooting to node.js

### DIFF
--- a/content/en/docs/instrumentation/js/getting-started/nodejs.md
+++ b/content/en/docs/instrumentation/js/getting-started/nodejs.md
@@ -90,6 +90,10 @@ Create a file with a name like `tracing.js` which will contain your tracing setu
 // Require dependencies
 const opentelemetry = require("@opentelemetry/sdk-node");
 const { getNodeAutoInstrumentations } = require("@opentelemetry/auto-instrumentations-node");
+const { diag, DiagConsoleLogger, DiagLogLevel } = require('@opentelemetry/api');
+
+// For troubleshooting, set the log level to DiagLogLevel.DEBUG
+diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
 
 const sdk = new opentelemetry.NodeSDK({
   traceExporter: new opentelemetry.tracing.ConsoleSpanExporter(),


### PR DESCRIPTION
Small change for the examples with node.js: it took me longer than I am happy to admit to find out how I can add debug output, so I thought it would be good to let people know during the getting started (inspired by @blumamir's [blog post](https://opentelemetry.io/blog/2022/troubleshooting-nodejs/), which has a bunch of great tips that should become part of the official docs:) )  