### PR TITLE
Adding logz.io as vendor

### DIFF
--- a/content/en/vendors.md
+++ b/content/en/vendors.md
@@ -25,6 +25,7 @@ products.
 | Grafana Labs    | No           | Yes         | https://grafana.com/oss/opentelemetry/
 | Honeycomb       | Yes          | Yes         | https://docs.honeycomb.io/getting-data-in/
 | Lightstep       | Yes          | Yes         | https://github.com/lightstep?q=launcher
+| Logz.io         | Yes          | No          | https://docs.logz.io/shipping/tracing-sources/opentelemetry.html#overview
 | New Relic       | Yes          | Yes         | https://newrelic.com/solutions/opentelemetry
 | Sentry Software | Yes          | Yes         | https://www.sentrysoftware.com/products/hardware-sentry-opentelemetry-collector.html
 | Splunk          | Yes          | Yes         | https://www.splunk.com/en_us/blog/conf-splunklive/announcing-native-opentelemetry-support-in-splunk-apm.html


### PR DESCRIPTION
Adding vendor, we have limited support for OTLP now for metrics, so I kept this "no" for now.