### PR TITLE
Fix typo of causal spelling

### DIFF
--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -230,7 +230,7 @@ span.addEvent('some log', {
 
 ## Span links
 
-Spans can be created with casaul links to other spans.
+Spans can be created with causal links to other spans.
 
 ```js
 function someFunction(spanToLinkFrom) {


### PR DESCRIPTION
There was a typo in spelling for causal, fixed that.