### PR TITLE
Update docs after Java release

### DIFF
--- a/content/en/docs/instrumentation/java/_index.md
+++ b/content/en/docs/instrumentation/java/_index.md
@@ -56,7 +56,7 @@ using our BOM to keep the versions of the various components in sync.
       <dependency>
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-bom</artifactId>
-        <version>1.12.0</version>
+        <version>1.13.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -75,7 +75,7 @@ using our BOM to keep the versions of the various components in sync.
 
 ```kotlin
 dependencies {
-  implementation(platform("io.opentelemetry:opentelemetry-bom:1.12.0"))
+  implementation(platform("io.opentelemetry:opentelemetry-bom:1.13.0"))
   implementation("io.opentelemetry:opentelemetry-api")
 }
 ```

--- a/content/en/docs/instrumentation/java/automatic/agent-config.md
+++ b/content/en/docs/instrumentation/java/automatic/agent-config.md
@@ -60,7 +60,7 @@ You can provide a path to agent configuration file by setting the following prop
 You can enable [extensions][] by setting the following property:
 
 {{% config_option name="otel.javaagent.extensions" %}}
-  Path to a an extension jar file or folder, containing jar files. If pointing
+  Path to an extension jar file or folder, containing jar files. If pointing
   to a folder, every jar file in that folder will be treated as separate,
   independent extension.
 {{% /config_option %}}
@@ -304,11 +304,17 @@ instrumentation which would also disable the instrumentation's capturing of `htt
 [SpanKind.Server](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#spankind)
 span.
 
-{{% config_option name="otel.instrumentation.common.experimental.suppress-controller-spans" %}}
-  Suppress controller spans from being captured.
+{{% config_option
+  name="otel.instrumentation.common.experimental.controller-telemetry.enabled"
+  default=true
+%}}
+  Enables the controller telemetry.
 {{% /config_option %}}
-{{% config_option name="otel.instrumentation.common.experimental.suppress-view-spans" %}}
-  Suppress view spans from being captured.
+{{% config_option
+  name="otel.instrumentation.common.experimental.view-telemetry.enabled"
+  default=true
+%}}
+  Enables the view telemetry.
 {{% /config_option %}}
 
 ### Enable manual instrumentation only

--- a/content/en/docs/instrumentation/java/automatic/annotations.md
+++ b/content/en/docs/instrumentation/java/automatic/annotations.md
@@ -21,7 +21,7 @@ library to use the `@WithSpan` annotation.
   <dependency>
     <groupId>io.opentelemetry</groupId>
     <artifactId>opentelemetry-extension-annotations</artifactId>
-    <version>1.12.0</version>
+    <version>1.13.0</version>
   </dependency>
 </dependencies>
 ```
@@ -30,7 +30,7 @@ library to use the `@WithSpan` annotation.
 
 ```groovy
 dependencies {
-    implementation('io.opentelemetry:opentelemetry-extension-annotations:1.11.0')
+    implementation('io.opentelemetry:opentelemetry-extension-annotations:1.13.0')
 }
 ```
 


### PR DESCRIPTION
I've updated the versions to 1.13; and changed a few properties that we renamed in the last javaagent release.