### PR TITLE
Add docs-approvers on all CODEOWNERS paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,7 +16,7 @@
 * @open-telemetry/docs-approvers
 
 # content owners
-content/en/docs/instrumentation/cpp/     @open-telemetry/cpp-maintainers
-content/en/docs/instrumentation/java/    @open-telemetry/java-maintainers @open-telemetry/java-instrumentation-maintainers
-content/en/docs/instrumentation/python/    @open-telemetry/python-maintainers @open-telemetry/python-approvers
-content/en/blog/  @open-telemetry/blog-approvers
+content/en/docs/instrumentation/cpp/     @open-telemetry/docs-approvers @open-telemetry/cpp-maintainers
+content/en/docs/instrumentation/java/    @open-telemetry/docs-approvers @open-telemetry/java-maintainers @open-telemetry/java-instrumentation-maintainers
+content/en/docs/instrumentation/python/  @open-telemetry/docs-approvers @open-telemetry/python-maintainers @open-telemetry/python-approvers
+content/en/blog/                         @open-telemetry/docs-approvers @open-telemetry/blog-approvers


### PR DESCRIPTION
I noticed in #1307 that @open-telemetry/docs-approvers weren't assigned as reviewers, should they be?