### PR TITLE
registry: add Go automatic instrumentation

### DIFF
--- a/content/en/registry/otel-go-autoinstrumentation.md
+++ b/content/en/registry/otel-go-autoinstrumentation.md
@@ -1,0 +1,14 @@
+---
+title: Go Automatic Instrumentation
+registryType: instrumentation
+isThirdParty: true
+language: go
+tags:
+  - go
+  - instrumentation
+repo: https://github.com/keyval-dev/opentelemetry-go-instrumentation
+license: Apache 2.0
+description: OpenTelemetry automatic instrumentation for Go applications. 
+authors: keyval Authors
+otVersion: latest
+---


### PR DESCRIPTION
This change adds https://github.com/keyval-dev/opentelemetry-go-instrumentation to the registry