### PR TITLE
Improve Python automatic-instrumentation docs

### DIFF
--- a/content/en/docs/instrumentation/python/automatic.md
+++ b/content/en/docs/instrumentation/python/automatic.md
@@ -29,7 +29,7 @@ the automatic instrumentation agent does exactly the same thing as manual
 instrumentation.
 
 To better understand auto-instrumentation it's useful to know how OpenTelemetry achieves 
-the automatic instrumentation. It happens through [monkey-patching](https://en.wikipedia.org/wiki/Monkey_patch) which is done the
+the automatic instrumentation. It happens through [monkey-patching](https://en.wikipedia.org/wiki/Monkey_patch) which is done through
 [instrumentation libraries][instrumentation]. `opentelemetry-instrumentation-flask` is
 one of these, which we will be using below. 
 

--- a/content/en/docs/instrumentation/python/automatic.md
+++ b/content/en/docs/instrumentation/python/automatic.md
@@ -28,8 +28,12 @@ with the agent. They should both produce the same results, demonstrating that
 the automatic instrumentation agent does exactly the same thing as manual
 instrumentation.
 
-To better understand auto-instrumentation, see the relevant part of both
-scripts:
+To better understand auto-instrumentation it's useful to know how OpenTelemetry achieves 
+the automatic instrumentation. It happens through monkey-patching which is done the
+[instrumentation libraries][instrumentation]. `opentelemetry-instrumentation-flask` is
+one of these, which we will be using below. 
+
+Now on to an example of manually instrumented code and code that is auto-instrumented
 
 ### Manually instrumented server
 
@@ -87,6 +91,15 @@ $ pip install requests
 The examples that follow send instrumentation results to the console. Learn more
 about installing and configuring the [OpenTelemetry Distro](../distro) to send
 telemetry to other destinations, like an OpenTelemetry Collector.
+
+**Note**: If you were to use auto-instrumentation and manually instrumenting your code the
+pacakage `opentelemetry-distro` won't let you set a `Resource` with attributes defined in your code, 
+you will need to set all your desired parameters through [environment variables][env]
+
+It is also possible to use the instrumentation libraries (such as `opentelemetry-instrumentation-flask`)
+by themselves which may have an advantage of customizing options. However, by choosing
+to do this it means you forego using auto-instrumentation by starting your application with
+`opentelemetry-instrument` as this is mutually exclusive. 
 
 ## Execute
 
@@ -228,9 +241,12 @@ reloader. To run instrumentation while the debug mode is enabled, set the
 if __name__ == "__main__":
     app.run(port=8082, debug=True, use_reloader=False)
 ```
-
+[env]:
+    https://opentelemetry-python.readthedocs.io/en/latest/sdk/environment_variables.html
+[instrumentation]:
+    https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-instrumentation
 [distro]:
-    https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples/distro
+    https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-distro
 [OpenTracing example]:
     https://github.com/yurishkuro/opentracing-tutorial/tree/master/python
 [source files]:

--- a/content/en/docs/instrumentation/python/automatic.md
+++ b/content/en/docs/instrumentation/python/automatic.md
@@ -29,7 +29,7 @@ the automatic instrumentation agent does exactly the same thing as manual
 instrumentation.
 
 To better understand auto-instrumentation it's useful to know how OpenTelemetry achieves 
-the automatic instrumentation. It happens through monkey-patching which is done the
+the automatic instrumentation. It happens through [monkey-patching](https://en.wikipedia.org/wiki/Monkey_patch) which is done the
 [instrumentation libraries][instrumentation]. `opentelemetry-instrumentation-flask` is
 one of these, which we will be using below. 
 

--- a/content/en/docs/instrumentation/python/automatic.md
+++ b/content/en/docs/instrumentation/python/automatic.md
@@ -27,15 +27,12 @@ with the agent. They should both produce the same results, demonstrating that
 the automatic instrumentation agent does exactly the same thing as manual
 instrumentation.
 
-To better understand auto-instrumentation it's useful to know how OpenTelemetry
-achieves the automatic instrumentation. It happens through
-[monkey-patching](https://en.wikipedia.org/wiki/Monkey_patch) which is done
-through [instrumentation libraries][instrumentation].
-`opentelemetry-instrumentation-flask` is one of these, which we will be using
-below.
-
-Now on to an example of manually instrumented code and code that is
-auto-instrumented
+Automatic instrumentation utilizes [monkey-patching][] to dynamically rewrite
+methods and classes at runtime through [instrumentation
+libraries][instrumentation]. This reduces the amount of work required to
+integrate OpenTelemetry into your application code. Below, you will see the
+difference between a Flask route instrumented manually versus one that utilizes
+automatic instrumentation.
 
 ### Manually instrumented server
 
@@ -94,10 +91,14 @@ The examples that follow send instrumentation results to the console. Learn more
 about installing and configuring the [OpenTelemetry Distro](../distro) to send
 telemetry to other destinations, like an OpenTelemetry Collector.
 
-**Note**: If you were to use auto-instrumentation and manually instrumenting
-your code the package `opentelemetry-distro` won't let you set a `Resource`
-with attributes defined in your code, you will need to set all your desired
-parameters through [environment variables][env]
+> **Note**: To use automatic instrumentation through `opentelemetry-instrument`,
+> you must configure it via environment variables or the command line. The agent
+> creates a telemetry pipeline that cannot be modified other than through these
+> means. If you need more customization for your telemetry pipelines, then you
+> need to forego the agent and import the OpenTelemetry SDK and instrumentation
+> libraries into your code and configure them there. You may also extend
+> automatic instrumentation by importing the OpenTelemetry API. For more
+> details, see the [API reference][].
 
 It is also possible to use the instrumentation libraries (such as
 `opentelemetry-instrumentation-flask`) by themselves which may have an advantage
@@ -246,13 +247,10 @@ if __name__ == "__main__":
     app.run(port=8082, debug=True, use_reloader=False)
 ```
 
-[env]:
-  https://opentelemetry-python.readthedocs.io/en/latest/sdk/environment_variables.html
-[instrumentation]:
-  https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-instrumentation
-[distro]:
-  https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-distro
-[opentracing example]:
-  https://github.com/yurishkuro/opentracing-tutorial/tree/master/python
-[source files]:
-  https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples/auto-instrumentation
+[API reference]: https://opentelemetry-python.readthedocs.io/en/latest/index.html
+[distro]: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-distro
+[env]: https://opentelemetry-python.readthedocs.io/en/latest/sdk/environment_variables.html
+[instrumentation]: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-instrumentation
+[monkey-patching]: https://stackoverflow.com/questions/5626193/what-is-monkey-patching
+[opentracing example]: https://github.com/yurishkuro/opentracing-tutorial/tree/master/python
+[source files]: https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples/auto-instrumentation

--- a/content/en/docs/instrumentation/python/automatic.md
+++ b/content/en/docs/instrumentation/python/automatic.md
@@ -19,7 +19,6 @@ example is based on an [OpenTracing example][]. You can download or view the
 This example uses two different scripts. The main difference between them is
 whether or not they’re instrumented manually:
 
-
 1. `server_instrumented.py` - instrumented manually
 2. `server_uninstrumented.py` - not instrumented manually
 
@@ -28,12 +27,15 @@ with the agent. They should both produce the same results, demonstrating that
 the automatic instrumentation agent does exactly the same thing as manual
 instrumentation.
 
-To better understand auto-instrumentation it's useful to know how OpenTelemetry achieves 
-the automatic instrumentation. It happens through [monkey-patching](https://en.wikipedia.org/wiki/Monkey_patch) which is done through
-[instrumentation libraries][instrumentation]. `opentelemetry-instrumentation-flask` is
-one of these, which we will be using below. 
+To better understand auto-instrumentation it's useful to know how OpenTelemetry
+achieves the automatic instrumentation. It happens through
+[monkey-patching](https://en.wikipedia.org/wiki/Monkey_patch) which is done
+through [instrumentation libraries][instrumentation].
+`opentelemetry-instrumentation-flask` is one of these, which we will be using
+below.
 
-Now on to an example of manually instrumented code and code that is auto-instrumented
+Now on to an example of manually instrumented code and code that is
+auto-instrumented
 
 ### Manually instrumented server
 
@@ -92,14 +94,16 @@ The examples that follow send instrumentation results to the console. Learn more
 about installing and configuring the [OpenTelemetry Distro](../distro) to send
 telemetry to other destinations, like an OpenTelemetry Collector.
 
-**Note**: If you were to use auto-instrumentation and manually instrumenting your code the
-pacakage `opentelemetry-distro` won't let you set a `Resource` with attributes defined in your code, 
-you will need to set all your desired parameters through [environment variables][env]
+**Note**: If you were to use auto-instrumentation and manually instrumenting
+your code the package `opentelemetry-distro` won't let you set a `Resource`
+with attributes defined in your code, you will need to set all your desired
+parameters through [environment variables][env]
 
-It is also possible to use the instrumentation libraries (such as `opentelemetry-instrumentation-flask`)
-by themselves which may have an advantage of customizing options. However, by choosing
-to do this it means you forego using auto-instrumentation by starting your application with
-`opentelemetry-instrument` as this is mutually exclusive. 
+It is also possible to use the instrumentation libraries (such as
+`opentelemetry-instrumentation-flask`) by themselves which may have an advantage
+of customizing options. However, by choosing to do this it means you forego
+using auto-instrumentation by starting your application with
+`opentelemetry-instrument` as this is mutually exclusive.
 
 ## Execute
 
@@ -127,37 +131,37 @@ example:
 
 ```json
 {
-    "name": "server_request",
-    "context": {
-        "trace_id": "0xfa002aad260b5f7110db674a9ddfcd23",
-        "span_id": "0x8b8bbaf3ca9c5131",
-        "trace_state": "{}"
-    },
-    "kind": "SpanKind.SERVER",
-    "parent_id": null,
-    "start_time": "2020-04-30T17:28:57.886397Z",
-    "end_time": "2020-04-30T17:28:57.886490Z",
-    "status": {
-        "status_code": "OK"
-    },
-    "attributes": {
-        "http.method": "GET",
-        "http.server_name": "127.0.0.1",
-        "http.scheme": "http",
-        "host.port": 8082,
-        "http.host": "localhost:8082",
-        "http.target": "/server_request?param=testing",
-        "net.peer.ip": "127.0.0.1",
-        "net.peer.port": 52872,
-        "http.flavor": "1.1"
-    },
-    "events": [],
-    "links": [],
-    "resource": {
-        "telemetry.sdk.language": "python",
-        "telemetry.sdk.name": "opentelemetry",
-        "telemetry.sdk.version": "0.16b1"
-    }
+  "name": "server_request",
+  "context": {
+    "trace_id": "0xfa002aad260b5f7110db674a9ddfcd23",
+    "span_id": "0x8b8bbaf3ca9c5131",
+    "trace_state": "{}"
+  },
+  "kind": "SpanKind.SERVER",
+  "parent_id": null,
+  "start_time": "2020-04-30T17:28:57.886397Z",
+  "end_time": "2020-04-30T17:28:57.886490Z",
+  "status": {
+    "status_code": "OK"
+  },
+  "attributes": {
+    "http.method": "GET",
+    "http.server_name": "127.0.0.1",
+    "http.scheme": "http",
+    "host.port": 8082,
+    "http.host": "localhost:8082",
+    "http.target": "/server_request?param=testing",
+    "net.peer.ip": "127.0.0.1",
+    "net.peer.port": 52872,
+    "http.flavor": "1.1"
+  },
+  "events": [],
+  "links": [],
+  "resource": {
+    "telemetry.sdk.language": "python",
+    "telemetry.sdk.name": "opentelemetry",
+    "telemetry.sdk.version": "0.16b1"
+  }
 }
 ```
 
@@ -183,41 +187,41 @@ example:
 
 ```json
 {
-    "name": "server_request",
-    "context": {
-        "trace_id": "0x9f528e0b76189f539d9c21b1a7a2fc24",
-        "span_id": "0xd79760685cd4c269",
-        "trace_state": "{}"
-    },
-    "kind": "SpanKind.SERVER",
-    "parent_id": "0xb4fb7eee22ef78e4",
-    "start_time": "2020-04-30T17:10:02.400604Z",
-    "end_time": "2020-04-30T17:10:02.401858Z",
-    "status": {
-        "status_code": "OK"
-    },
-    "attributes": {
-        "http.method": "GET",
-        "http.server_name": "127.0.0.1",
-        "http.scheme": "http",
-        "host.port": 8082,
-        "http.host": "localhost:8082",
-        "http.target": "/server_request?param=testing",
-        "net.peer.ip": "127.0.0.1",
-        "net.peer.port": 48240,
-        "http.flavor": "1.1",
-        "http.route": "/server_request",
-        "http.status_text": "OK",
-        "http.status_code": 200
-    },
-    "events": [],
-    "links": [],
-    "resource": {
+  "name": "server_request",
+  "context": {
+    "trace_id": "0x9f528e0b76189f539d9c21b1a7a2fc24",
+    "span_id": "0xd79760685cd4c269",
+    "trace_state": "{}"
+  },
+  "kind": "SpanKind.SERVER",
+  "parent_id": "0xb4fb7eee22ef78e4",
+  "start_time": "2020-04-30T17:10:02.400604Z",
+  "end_time": "2020-04-30T17:10:02.401858Z",
+  "status": {
+    "status_code": "OK"
+  },
+  "attributes": {
+    "http.method": "GET",
+    "http.server_name": "127.0.0.1",
+    "http.scheme": "http",
+    "host.port": 8082,
+    "http.host": "localhost:8082",
+    "http.target": "/server_request?param=testing",
+    "net.peer.ip": "127.0.0.1",
+    "net.peer.port": 48240,
+    "http.flavor": "1.1",
+    "http.route": "/server_request",
+    "http.status_text": "OK",
+    "http.status_code": 200
+  },
+  "events": [],
+  "links": [],
+  "resource": {
     "telemetry.sdk.language": "python",
     "telemetry.sdk.name": "opentelemetry",
     "telemetry.sdk.version": "0.16b1",
     "service.name": ""
-    }
+  }
 }
 ```
 
@@ -241,13 +245,14 @@ reloader. To run instrumentation while the debug mode is enabled, set the
 if __name__ == "__main__":
     app.run(port=8082, debug=True, use_reloader=False)
 ```
+
 [env]:
-    https://opentelemetry-python.readthedocs.io/en/latest/sdk/environment_variables.html
+  https://opentelemetry-python.readthedocs.io/en/latest/sdk/environment_variables.html
 [instrumentation]:
-    https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-instrumentation
+  https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-instrumentation
 [distro]:
-    https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-distro
-[OpenTracing example]:
-    https://github.com/yurishkuro/opentracing-tutorial/tree/master/python
+  https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-distro
+[opentracing example]:
+  https://github.com/yurishkuro/opentracing-tutorial/tree/master/python
 [source files]:
-    https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples/auto-instrumentation
+  https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples/auto-instrumentation


### PR DESCRIPTION
There was some ambiguity in what way auto-instrumentation is compatible
with manual instrumentation. This should reduce that ambiguity.

---

Preview: https://deploy-preview-1311--opentelemetry.netlify.app/docs/instrumentation/python/automatic/