### PR TITLE
Fix OpenTelemetry .NET status

### DIFF
--- a/content/en/docs/instrumentation/net/_index.md
+++ b/content/en/docs/instrumentation/net/_index.md
@@ -23,7 +23,14 @@ language:
 
 | Tracing | Metrics | Logging |
 | ------- | ------- | ------- |
-| Stable  | Stable  | Stable  |
+| Stable  | Stable  | Stable* |
+
+\* Most components are providing Stable support for
+[ILogger](https://docs.microsoft.com/dotnet/api/microsoft.extensions.logging.ilogger)
+integration. OTLP Log Exporter is still Experimental. Please refer to the
+official [OpenTelemetry
+.NET](https://github.com/open-telemetry/opentelemetry-dotnet) project to get the
+latest status of individual components.
 
 {{% latest_release "dotnet" /%}}
 

--- a/content/en/docs/instrumentation/net/_index.md
+++ b/content/en/docs/instrumentation/net/_index.md
@@ -23,7 +23,7 @@ language:
 
 | Tracing | Metrics | Logging |
 | ------- | ------- | ------- |
-| 1.0    | Alpha   | Beta    |
+| Stable  | Stable  | Stable  |
 
 {{% latest_release "dotnet" /%}}
 


### PR DESCRIPTION
Metrics Stable version was shipped 7 days ago.
The integration with ILogger is also stable.

---

Preview: https://deploy-preview-1312--opentelemetry.netlify.app/docs/instrumentation/net/