### PR TITLE
Erlang/Elixir: fix config key for traces exporter in examples

### DIFF
--- a/content/en/docs/instrumentation/erlang/getting-started.md
+++ b/content/en/docs/instrumentation/erlang/getting-started.md
@@ -125,16 +125,15 @@ of span processor that batches up multiple spans over a period of time:
 [
  {opentelemetry,
   [{span_processor, batch},
-   {exporter, {otel_exporter_stdout, []}}]}
+   {traces_exporter, {otel_exporter_stdout, []}}]}
 ].
 {{< /tab >}}
 
 {{< tab >}}
 # config/runtime.exs
-config :opentelemetry, :processors,
-  otel_batch_processor: %{
-    exporter: {:otel_exporter_stdout, []}
-  }
+config :opentelemetry, 
+  span_processor: :batch,
+  traces_exporter: {:otel_exporter_stdout, []}
 {{< /tab >}}
 
 {{< /tabs >}}
@@ -356,7 +355,7 @@ for the `otlp_protocol` the endpoint should be changed to `http://localhost:4317
 [
  {opentelemetry,
   [{span_processor, batch},
-   {exporter, otlp}]},
+   {traces_exporter, otlp}]},
 
  {opentelemetry_exporter,
   [{otlp_protocol, http_protobuf},
@@ -368,7 +367,7 @@ for the `otlp_protocol` the endpoint should be changed to `http://localhost:4317
 # config/runtime.exs
 config :opentelemetry,
   span_processor: :batch,
-  exporter: :otlp
+  traces_exporter: :otlp
 
 config :opentelemetry_exporter,
   otlp_protocol: :http_protobuf


### PR DESCRIPTION
The earlier patch that was sent by @ukutaht works but is a more complex form of the configuration. This change fixes both the Erlang and Elixir examples and switches the Elixir one back to the flat configuration, the issue was that the correct config key is `traces_exporter`, not `exporter`.