### PR TITLE
Add install collector script

### DIFF
--- a/content/en/install-collector.sh
+++ b/content/en/install-collector.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+echo -n "Installing the OpenTelemetry Collector into your current directory: $(pwd) in 3"
+#sleep 1
+#echo -n " 2"
+#sleep 1
+#echo -n " 1"
+#sleep 1
+echo ""
+
+LATEST_URL=$(curl -Ls -o /dev/null -w %{url_effective} https://github.com/open-telemetry/opentelemetry-collector-releases/releases/latest)
+
+VERSION=${LATEST_URL##*/v}
+
+case "$(uname -s)" in
+   Darwin)
+     SUFFIX="darwin_amd64.tar.gz"
+     # SUFFIX="darwin_arm64.tar.gz"
+     ;;
+   Linux)
+     SUFFIX="linux_amd64.tar.gz"
+     # SUFFIX="linux_arm64.tar.gz"
+     ;;
+   CYGWIN*|MINGW32*|MSYS*|MINGW*)
+     SUFFIX="linux_amd64.tar.gz"
+     ;;
+   # Add here more strings to compare
+   # See correspondence table at the bottom of this answer
+   *)
+     echo "Your operating system is not supported, please compile the collector following these instructions: http://localhost:8888/docs/collector/getting-started/#local"
+     exit -1
+     ;;
+esac
+
+URL="https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${VERSION}/otelcol-contrib_${VERSION}_${SUFFIX}"
+FILE="otelcol-contrib_${VERSION}_${SUFFIX}"
+
+echo " * Downloading ${URL}"
+
+curl -L -o "${FILE}" "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${VERSION}/otelcol-contrib_${VERSION}_${SUFFIX}"
+
+echo " * Unpacking ${FILE}"
+
+tar xvfz ${FILE}

--- a/content/en/install/otelcol-contrib.sh
+++ b/content/en/install/otelcol-contrib.sh
@@ -12,20 +12,31 @@ LATEST_URL=$(curl -Ls -o /dev/null -w %{url_effective} https://github.com/open-t
 
 VERSION=${LATEST_URL##*/v}
 
+ARCH=""
+
+case "$(uname -m)" in
+   x86_64)
+     ARCH="amd64"
+     ;;
+   arm64)
+     ARCH="arm64"
+     ;;
+   *)
+     echo "Your operating system is not supported, please compile the collector following these instructions: http://localhost:8888/docs/collector/getting-started/#local"
+     exit -1
+     ;;
+esac
+
 case "$(uname -s)" in
    Darwin)
-     SUFFIX="darwin_amd64.tar.gz"
-     # SUFFIX="darwin_arm64.tar.gz"
+     SUFFIX="darwin_${ARCH}.tar.gz"
      ;;
    Linux)
-     SUFFIX="linux_amd64.tar.gz"
-     # SUFFIX="linux_arm64.tar.gz"
+     SUFFIX="linux_${ARCH}.tar.gz"
      ;;
    CYGWIN*|MINGW32*|MSYS*|MINGW*)
-     SUFFIX="linux_amd64.tar.gz"
+     SUFFIX="linux_${ARCH}.tar.gz"
      ;;
-   # Add here more strings to compare
-   # See correspondence table at the bottom of this answer
    *)
      echo "Your operating system is not supported, please compile the collector following these instructions: http://localhost:8888/docs/collector/getting-started/#local"
      exit -1

--- a/content/en/install/otelcol.sh
+++ b/content/en/install/otelcol.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+echo -n "Installing the OpenTelemetry Collector into your current directory: $(pwd) in 3"
+#sleep 1
+#echo -n " 2"
+#sleep 1
+#echo -n " 1"
+#sleep 1
+echo ""
+
+LATEST_URL=$(curl -Ls -o /dev/null -w %{url_effective} https://github.com/open-telemetry/opentelemetry-collector-releases/releases/latest)
+
+VERSION=${LATEST_URL##*/v}
+
+ARCH=""
+
+case "$(uname -m)" in
+   x86_64)
+     ARCH="amd64"
+     ;;
+   arm64)
+     ARCH="arm64"
+     ;;
+   *)
+     echo "Your operating system is not supported, please compile the collector following these instructions: http://localhost:8888/docs/collector/getting-started/#local"
+     exit -1
+     ;;
+esac
+
+case "$(uname -s)" in
+   Darwin)
+     SUFFIX="darwin_${ARCH}.tar.gz"
+     ;;
+   Linux)
+     SUFFIX="linux_${ARCH}.tar.gz"
+     ;;
+   CYGWIN*|MINGW32*|MSYS*|MINGW*)
+     SUFFIX="linux_${ARCH}.tar.gz"
+     ;;
+   *)
+     echo "Your operating system is not supported, please compile the collector following these instructions: http://localhost:8888/docs/collector/getting-started/#local"
+     exit -1
+     ;;
+esac
+
+URL="https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${VERSION}/otelcol_${VERSION}_${SUFFIX}"
+FILE="otelcol_${VERSION}_${SUFFIX}"
+
+echo " * Downloading ${URL}"
+
+curl -L -o "${FILE}" "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${VERSION}/otelcol_${VERSION}_${SUFFIX}"
+
+echo " * Unpacking ${FILE}"
+
+tar xvfz ${FILE}


### PR DESCRIPTION
Creating this as a draft because I wanted to pitch the idea first. While updating the collector getting started, I played around with the different ways of getting a collector up and running. Pulling and running it through a docker container is definitely the most convenient way but it comes with plenty of overhead and sometimes I just want to have a collector running on my laptop. This requires a few clicks right now (and you need to read closely because arm64 and amd64 are hard to distinguish), so I thought, why not have a similar install experience as `brew` or `nvm`:

```console
/bin/bash -c "$(curl -s http://opentelemetry.io/install/otelcol.sh)" 
./otelcol --config config.yml
```

or in a video:


https://user-images.githubusercontent.com/1519757/166491524-e1b2d65b-ebbc-44ec-a62f-cef605c43eca.mp4

what do you think, something OTel needs? :-)
