### PR TITLE
docs: ConsoleSpanExporter import path fix in PHP getting started guide

### DIFF
--- a/content/en/docs/instrumentation/php/getting-started.md
+++ b/content/en/docs/instrumentation/php/getting-started.md
@@ -21,7 +21,7 @@ Span typically represents a single unit of work. A Trace is a grouping of Spans.
 declare(strict_types=1);
 require __DIR__ . '/../vendor/autoload.php';
 
-use OpenTelemetry\SDK\Trace\SpanProcessor\ConsoleSpanExporter;
+use OpenTelemetry\SDK\Trace\SpanExporter\ConsoleSpanExporter;
 use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
 use OpenTelemetry\SDK\Trace\TracerProvider;
 


### PR DESCRIPTION
### Description

Getting the following 👇 error while running the example provided in the getting started guide over here 👉 https://opentelemetry.io/docs/instrumentation/php/getting-started/

<img width="1437" alt="Screenshot 2022-05-09 at 13 44 47" src="https://user-images.githubusercontent.com/32242596/167381951-45064eb7-0445-4f13-8ce3-72c9740da3b0.png">

### Why this fix
Console Span Exporter is part of the SpanExporter not SpanProcessor
https://github.com/open-telemetry/opentelemetry-php/blob/main/src/SDK/Trace/SpanExporter/ConsoleSpanExporter.php