### PR TITLE
Announce first beta for .NET auto instrumentation

### DIFF
--- a/content/en/blog/2022/dotnet-instrumentation-first-beta.md
+++ b/content/en/blog/2022/dotnet-instrumentation-first-beta.md
@@ -4,17 +4,29 @@ date: 2022-05-12
 author: OpenTelemetry .NET Automatic Instrumentation Team
 ---
 
-The .NET community already has a stable OpenTelemetry SDK. Using the SDK requires engineers 
-to modify and rebuild their applications, which may be undesirable or not possible in some 
-scenarios. Furthermore, the OpenTelemetry SDK does not provide instrumentation for all libraries 
-or versions of libraries, and as a result, there is a desire to leverage 
-[byte-code instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v0.1.0-beta.1/docs/design.md#bytecode-instrumentations) 
-to support gathering telemetry from those libraries. The 
-[OpenTelemetry .NET Automatic Instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation) 
-project strives to solve both of those problems.
+We're excited to announce the first beta release](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.1.0-beta.1) 
+of the [OpenTelemetry .NET Automatic Instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation) 
+project!
 
-The [first beta release](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.1.0-beta.1) 
-of this project includes support for:
+Without this project, .NET developers need to use instrumentation packages to automatically generate
+telemetry data. For example, to instrument inbound ASP.NET Core requests, you need to use the
+ASP.NET Core instrumentation package and initialize it with the OpenTelemetry SDK.
+
+Now with the .NET Automatic Instrumentation project, developers can run the agent
+side-by-side with their application and get telemetry automatically.
+This approach has several benefits:
+
+* A technical path forward to support automatic instrumentation via 
+[byte-code instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v0.1.0-beta.1/docs/design.md#bytecode-instrumentations), 
+which can allow for more automatic instrumentation support than relying solely on published 
+instrumentation libraries
+* No need to install and initialize an instrumentation library
+* No need to modify and rebuild an application to add automatic instrumentation
+* Less code needed to get started
+
+This first beta release is an important milestone because it establishes the technical foundation
+on which a rich set of automatic instrumentation capabilities can be built on. This release 
+includes support for:
 
 * Gathering trace data from .NET applications without requiring code changes[^devopsnote]
 * Gathering trace data from .NET libraries that the SDK does not support[^librarysupport]
@@ -25,7 +37,7 @@ Automatic Instrumentation.
 
 Over the next few months we plan to:
 
-* Support additional instrumentation libraries
+* Support additional [instrumentation libraries](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v0.1.0-beta.1/docs/config.md#instrumented-libraries-and-frameworks)
 * Improve dependency management
 * Enable metrics support
 

--- a/content/en/blog/2022/dotnet-instrumentation-first-beta.md
+++ b/content/en/blog/2022/dotnet-instrumentation-first-beta.md
@@ -1,0 +1,42 @@
+---
+title: OpenTelemetry .NET Automatic Instrumentation Releases its first Beta
+date: 2022-05-12
+author: OpenTelemetry .NET Automatic Instrumentation Team
+---
+
+The .NET community already has a stable OpenTelemetry SDK. Using the SDK requires engineers 
+to modify and rebuild their applications, which may be undesirable or not possible in some 
+scenarios. Furthermore, the OpenTelemetry SDK does not provide instrumentation for all libraries 
+or versions of libraries, and as a result, there is a desire to leverage 
+[byte-code instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v0.1.0-beta.1/docs/design.md#bytecode-instrumentations) 
+to support gathering telemetry from those libraries. The 
+[OpenTelemetry .NET Automatic Instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation) 
+project strives to solve both of those problems.
+
+The [first beta release](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.1.0-beta.1) 
+of this project includes support for:
+
+* Gathering trace data from .NET applications without requiring code changes[^devopsnote]
+* Gathering trace data from .NET libraries that the SDK does not support[^librarysupport]
+
+See the [examples](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/tree/v0.1.0-beta.1/examples) 
+for demonstrations of different instrumentation scenarios covered by the OpenTelemetry .NET 
+Automatic Instrumentation.
+
+Over the next few months we plan to:
+
+* Support additional instrumentation libraries
+* Improve dependency management
+* Enable metrics support
+
+Please, give us your **feedback** (using your preferred method):
+
+* [Submit a GitHub issue](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/new).
+* Write to us on [Slack](https://cloud-native.slack.com/archives/C01NR1YLSE7). If you are new, you 
+can create a CNCF Slack account [here](http://slack.cncf.io/).
+
+[^devopsnote]: The [supported and unsupported scenarios documentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v0.1.0-beta.1/docs/design.md#supported-and-unsupported-scenarios) 
+describe the current limits.
+
+[^librarysupport]: The [instrumentation library documentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v0.1.0-beta.1/docs/config.md#instrumented-libraries-and-frameworks) 
+contains the list of libraries we can gather telemetry data from.


### PR DESCRIPTION
Adds a blog post to announce the first beta release of the .NET Automatic Instrumentation project.

Relates to open-telemetry/opentelemetry-dotnet-instrumentation#572.