### PR TITLE
Add meter provider to java setup steps

### DIFF
--- a/content/en/docs/instrumentation/java/manual.md
+++ b/content/en/docs/instrumentation/java/manual.md
@@ -29,13 +29,18 @@ For example:
 
 ```java
 SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder()
-    .addSpanProcessor(BatchSpanProcessor.builder(OtlpGrpcSpanExporter.builder().build()).build())
-    .build();
+  .addSpanProcessor(BatchSpanProcessor.builder(OtlpGrpcSpanExporter.builder().build()).build())
+  .build();
+
+SdkMeterProvider meterProvider = SdkMeterProvider.builder()
+  .registerMetricReader(PeriodicMetricReader.builder(OtlpGrpcMetricExporter.builder().build()).build())
+  .build();
 
 OpenTelemetry openTelemetry = OpenTelemetrySdk.builder()
-    .setTracerProvider(sdkTracerProvider)
-    .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
-    .buildAndRegisterGlobal();
+  .setTracerProvider(sdkTracerProvider)
+  .setMeterProvider(sdkMeterProvider)
+  .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+  .buildAndRegisterGlobal();
 ```
 
 As an aside, if you are writing library instrumentation, it is strongly


### PR DESCRIPTION
Forgot to add this in #1341. This adds metrics to the [setup steps](https://opentelemetry.io/docs/instrumentation/java/manual/#set-up).