### PR TITLE
Registry language menu: add missing titles

### DIFF
--- a/layouts/registry/list.html
+++ b/layouts/registry/list.html
@@ -45,7 +45,7 @@
               <div class="dropdown-menu" id="languageFilter">
                 <a value="all" class="dropdown-item">Any Language</a>
                 {{ range $registryItems.GroupByParam "language" -}}
-                <a value={{.Key}} id="language-item-{{.Key}}" class="dropdown-item">{{ $languages.Get .Key }}</a>
+                <a value={{.Key}} id="language-item-{{.Key}}" class="dropdown-item">{{ $languages.Get .Key | default (humanize .Key) }}</a>
                 {{ end -}}
               </div>
             </div>


### PR DESCRIPTION
- Closes #1349 

Preview: https://deploy-preview-1350--opentelemetry.netlify.app/registry/?language=lua

Screenshot: note that all of the missing languages (see #1349) are now being shown.

> <img width="175" alt="image" src="https://user-images.githubusercontent.com/4140793/168668425-fd58c883-ef84-4ab9-a18f-713563633302.png">
