### PR TITLE
Registry template cleanup

### DIFF
--- a/content/en/registry/otel-kotlin.md
+++ b/content/en/registry/otel-kotlin.md
@@ -2,7 +2,7 @@
 title: Kotlin
 registryType: core
 isThirdParty: true
-language: Kotlin
+language: kotlin
 tags:
   - Kotlin
   - Js

--- a/layouts/registry/list.html
+++ b/layouts/registry/list.html
@@ -29,7 +29,10 @@
               <div class="dropdown-menu" id="languageFilter">
                 <a value="all" class="dropdown-item">Any Language</a>
                 {{ range $registryItems.GroupByParam "language" -}}
-                <a value={{lower .Key}} id="language-item-{{lower .Key}}" class="dropdown-item">{{ $languageNames.Get .Key | default (humanize .Key) }}</a>
+                {{ if ne .Key (lower .Key) -}}
+                  {{ errorf "Language keys must be in lowercase. Some registry entry has the following invalid key: %s" .Key -}}
+                {{ end -}}
+                <a value={{.Key}} id="language-item-{{.Key}}" class="dropdown-item">{{ $languageNames.Get .Key | default (humanize .Key) }}</a>
                 {{ end -}}
               </div>
             </div>
@@ -38,7 +41,10 @@
               <div class="dropdown-menu" id="componentFilter">
                 <a value="all" class="dropdown-item">Any Component</a>
                 {{ range $registryItems.GroupByParam "registryType" -}}
-                <a value={{lower .Key}} id="component-item-{{lower .Key}}" class="dropdown-item">{{ humanize .Key }}</a>
+                {{ if ne .Key (lower .Key) -}}
+                  {{ errorf "Component-type keys must be in lowercase. Some registry entry has the following invalid key: %s" .Key -}}
+                {{ end -}}
+                <a value={{.Key}} id="component-item-{{.Key}}" class="dropdown-item">{{ humanize .Key }}</a>
                 {{ end -}}
               </div>
             </div>

--- a/layouts/registry/list.html
+++ b/layouts/registry/list.html
@@ -29,10 +29,10 @@
               <div class="dropdown-menu" id="languageFilter">
                 <a value="all" class="dropdown-item">Any Language</a>
                 {{ range $registryItems.GroupByParam "language" -}}
-                {{ if ne .Key (lower .Key) -}}
-                  {{ errorf "Language keys must be in lowercase. Some registry entry has the following invalid key: %s" .Key -}}
-                {{ end -}}
-                <a value={{.Key}} id="language-item-{{.Key}}" class="dropdown-item">{{ $languageNames.Get .Key | default (humanize .Key) }}</a>
+                  <a value={{.Key}} id="language-item-{{.Key}}" class="dropdown-item">{{ $languageNames.Get .Key | default (humanize .Key) }}</a>
+                  {{ if ne .Key (lower .Key) -}}
+                    {{ errorf "Language keys must be in lowercase. Some registry entry has the following invalid key: %s" .Key -}}
+                  {{ end -}}
                 {{ end -}}
               </div>
             </div>
@@ -41,10 +41,10 @@
               <div class="dropdown-menu" id="componentFilter">
                 <a value="all" class="dropdown-item">Any Component</a>
                 {{ range $registryItems.GroupByParam "registryType" -}}
-                {{ if ne .Key (lower .Key) -}}
-                  {{ errorf "Component-type keys must be in lowercase. Some registry entry has the following invalid key: %s" .Key -}}
-                {{ end -}}
-                <a value={{.Key}} id="component-item-{{.Key}}" class="dropdown-item">{{ humanize .Key }}</a>
+                  <a value={{.Key}} id="component-item-{{.Key}}" class="dropdown-item">{{ humanize .Key }}</a>
+                  {{ if ne .Key (lower .Key) -}}
+                    {{ errorf "Component-type keys must be in lowercase. Some registry entry has the following invalid key: %s" .Key -}}
+                  {{ end -}}
                 {{ end -}}
               </div>
             </div>

--- a/layouts/registry/list.html
+++ b/layouts/registry/list.html
@@ -1,27 +1,11 @@
 {{ define "main" }}
 {{ $registryItems := where .Data.Pages "Params.layout" "!=" "search" -}}
 
-{{ $languages := newScratch -}}
-{{ $languages.Set "collector" "Collector" -}}
-{{ $languages.Set "cpp" "C++" -}}
-{{ $languages.Set "dotnet" ".NET" -}}
-{{ $languages.Set "erlang" "Erlang" -}}
-{{ $languages.Set "go" "Go" -}}
-{{ $languages.Set "java" "Java" -}}
-{{ $languages.Set "js" "JavaScript" -}}
-{{ $languages.Set "php" "PHP" -}}
-{{ $languages.Set "python" "Python" -}}
-{{ $languages.Set "ruby" "Ruby" -}}
-{{ $languages.Set "rust" "Rust" -}}
-
-{{ $types := newScratch -}}
-{{ $types.Set "core" "Core" -}}
-{{ $types.Set "instrumentation" "Instrumentation" -}}
-{{ $types.Set "exporter" "Exporter" -}}
-{{ $types.Set "extension" "Extension" -}}
-{{ $types.Set "processor" "Processor" -}}
-{{ $types.Set "receiver" "Receiver" -}}
-{{ $types.Set "utilities" "Utilities" -}}
+{{ $languageNames := newScratch -}}
+{{ $languageNames.Set "cpp" "C++" -}}
+{{ $languageNames.Set "dotnet" ".NET" -}}
+{{ $languageNames.Set "js" "JavaScript" -}}
+{{ $languageNames.Set "php" "PHP" -}}
 
 {{ .Content -}}
 
@@ -45,7 +29,7 @@
               <div class="dropdown-menu" id="languageFilter">
                 <a value="all" class="dropdown-item">Any Language</a>
                 {{ range $registryItems.GroupByParam "language" -}}
-                <a value={{.Key}} id="language-item-{{.Key}}" class="dropdown-item">{{ $languages.Get .Key | default (humanize .Key) }}</a>
+                <a value={{lower .Key}} id="language-item-{{lower .Key}}" class="dropdown-item">{{ $languageNames.Get .Key | default (humanize .Key) }}</a>
                 {{ end -}}
               </div>
             </div>
@@ -54,7 +38,7 @@
               <div class="dropdown-menu" id="componentFilter">
                 <a value="all" class="dropdown-item">Any Component</a>
                 {{ range $registryItems.GroupByParam "registryType" -}}
-                <a value={{.Key}} id="component-item-{{.Key}}" class="dropdown-item">{{ $types.Get (lower .Key) }}</a>
+                <a value={{lower .Key}} id="component-item-{{lower .Key}}" class="dropdown-item">{{ humanize .Key }}</a>
                 {{ end -}}
               </div>
             </div>


### PR DESCRIPTION
- Followup to #1350
- Normalizes menu IDs
- Simplifies scratch maps -- actually drops `$types`.

Preview:

- https://deploy-preview-1351--opentelemetry.netlify.app/registry/
- Language selection example:
  - https://deploy-preview-1351--opentelemetry.netlify.app/registry/?language=kotlin

/cc @austinlparker 