### PR TITLE
Registry: add missing CSS class definitions for lang badges

### DIFF
--- a/assets/scss/_registry.scss
+++ b/assets/scss/_registry.scss
@@ -5,15 +5,20 @@
     min-width: 100%;
     margin: $registry-vertical-margin 0;
   }
-    
+
   &__search {
     min-width: 100%;
     margin: $registry-vertical-margin 0;
   }
-    
+
   &__header {
     background-color: $green;
   }
+}
+
+.badge.badge-collector {
+  color: white;
+  background-color: $collector;
 }
 
 .badge.badge-core {
@@ -49,7 +54,7 @@
 .badge.badge-utilities {
   color: white;
   background-color: $utilities;
-} 
+}
 
 .badge-tracer {
   color: white;
@@ -71,6 +76,11 @@
   background-color: $cpp;
 }
 
+.badge.badge-elixir {
+  color: $erlang;
+  background-color: inherit;
+  border: solid 1px;
+}
 .badge.badge-erlang {
   color: white;
   background-color: $erlang;
@@ -87,8 +97,19 @@
 }
 
 .badge.badge-js {
-  color: white;
+  color: inherit;
   background-color: $javascript;
+}
+
+.badge.badge-kotlin {
+  color: $java;
+  background-color: inherit;
+  border: solid 1px;
+}
+
+.badge.badge-lua {
+  color: white;
+  background-color: $lua;
 }
 
 .badge.badge-php {
@@ -111,7 +132,7 @@
   background-color: $rust;
 }
 
-.badge.badge-collector {
+.badge.badge-swift {
   color: white;
-  background-color: $collector;
+  background-color: $swift;
 }

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -31,14 +31,16 @@ $utilities: #2CD3B4;
 $receiver: #742cd3;
 $processor: #d32c42;
 
+$collector: #070002;
 $dotnet: #178600;
 $cpp: #f34b7d;
 $erlang: #B83998;
 $go: #00ADD8;
 $java: #b07219;
 $javascript: #f1e05a;
+$lua: #03037B;
 $php: #4F5D95;
 $python: #3572A5;
 $ruby: #701516;
 $rust: #dea584;
-$collector: #070002;
+$swift: #DE5D43;


### PR DESCRIPTION
- Followup to #1351
- Adds CSS classes for missing language badges
- Fixes contrast of JS language badge

Feedback @austinlparker @cartermp?

Preview: e.g.: https://deploy-preview-1352--opentelemetry.netlify.app/registry/?language=swift

---

Before: notices how the "swift" badge (in the entries) looks like a plain word 

> <img width="752" alt="image" src="https://user-images.githubusercontent.com/4140793/168690161-959881b6-798b-4686-8495-b245977eddb8.png">

After:

> <img width="751" alt="image" src="https://user-images.githubusercontent.com/4140793/168690538-48af549d-c440-4710-99c2-d4de96e06f81.png">
