### PR TITLE
Normalize concepts/*.md and drop some relref

### DIFF
--- a/content/en/docs/concepts/_index.md
+++ b/content/en/docs/concepts/_index.md
@@ -1,6 +1,7 @@
 ---
 title: Concepts
-description: What is OpenTelemetry, what does it provide and what does it support?
+description: >-
+  What is OpenTelemetry, what does it provide and what does it support?
 spelling: cSpell:ignore otel
 aliases: [/about, /docs/concepts/overview, /otel]
 weight: 1

--- a/content/en/docs/concepts/components.md
+++ b/content/en/docs/concepts/components.md
@@ -5,13 +5,13 @@ weight: 20
 
 OpenTelemetry is currently made up of several main components:
 
-* Cross-language specification
-* Tools to collect, transform, and export telemetry data
-* Per-language SDKs
-* Automatic instrumentation and contrib packages
+- Cross-language specification
+- Tools to collect, transform, and export telemetry data
+- Per-language SDKs
+- Automatic instrumentation and contrib packages
 
-OpenTelemetry lets you replace the need for vendor-specific SDKs and tools for generating
-and exporting telemetry data.
+OpenTelemetry lets you replace the need for vendor-specific SDKs and tools for
+generating and exporting telemetry data.
 
 ## Specification
 
@@ -21,48 +21,53 @@ following:
 
 - **API:** Defines data types and operations for generating and correlating
   tracing, metrics, and logging data.
-- **SDK:** Defines requirements for a language-specific implementation of the API.
-  Configuration, data processing, and exporting concepts are also defined here.
+- **SDK:** Defines requirements for a language-specific implementation of the
+  API. Configuration, data processing, and exporting concepts are also defined
+  here.
 - **Data:** Defines the OpenTelemetry Protocol (OTLP) and vendor-agnostic
   semantic conventions that a telemetry backend can provide support for.
 
 For more information, see the [Specification](/docs/reference/specification/).
 
 Additionally, extensively-commented protobuf interface files for API concepts
-can be found in the [proto repository](https://github.com/open-telemetry/opentelemetry-proto).
+can be found in the
+[proto repository](https://github.com/open-telemetry/opentelemetry-proto).
 
 ## Collector
 
-The OpenTelemetry Collector is a vendor-agnostic proxy that can receive, process,
-and export telemetry data. It supports receiving telemetry data in multiple formats
-(e.g., OTLP, Jaeger, Prometheus, as well as many commercial/proprietary tools)
-and sending data to one or more backends. It also supports processing and filtering
-telemetry data before it gets exported. Collector contrib packages bring support for
-more data formats and vendor backends.
+The OpenTelemetry Collector is a vendor-agnostic proxy that can receive,
+process, and export telemetry data. It supports receiving telemetry data in
+multiple formats (e.g., OTLP, Jaeger, Prometheus, as well as many
+commercial/proprietary tools) and sending data to one or more backends. It also
+supports processing and filtering telemetry data before it gets exported.
+Collector contrib packages bring support for more data formats and vendor
+backends.
 
 For more information, see [Data Collection](/docs/concepts/data-collection/).
 
 ## Language SDKs
 
-OpenTelemetry also has language SDKs that let you use the OpenTelemetry API to generate
-telemetry data with your language of choice and export that data to a preferred backend.
-These SDKs also let you incorporate automatic instrumentation for common libraries and
-frameworks that you can use to connect to manual instrumentation in your application.
-Vendors often make distributions of language SDKs to make exporting to their backends
-simpler.
+OpenTelemetry also has language SDKs that let you use the OpenTelemetry API to
+generate telemetry data with your language of choice and export that data to a
+preferred backend. These SDKs also let you incorporate automatic instrumentation
+for common libraries and frameworks that you can use to connect to manual
+instrumentation in your application. Vendors often make distributions of
+language SDKs to make exporting to their backends simpler.
 
 For more information, see [Instrumenting](/docs/concepts/instrumenting).
 
 ## Automatic Instrumentation
 
-OpenTelemetry supports a broad number of components that generate relevant telemetry data
-from popular libraries and frameworks for supported languages. For example, inbound and
-outbound HTTP requests from an HTTP library will generate data about those requests.
-Using automatic instrumentation may differ from language to language, where one might
-prefer or require the use of a component that you load alongside your application, and
-another might prefer that you pull in a package explicitly in your codebase.
+OpenTelemetry supports a broad number of components that generate relevant
+telemetry data from popular libraries and frameworks for supported languages.
+For example, inbound and outbound HTTP requests from an HTTP library will
+generate data about those requests. Using automatic instrumentation may differ
+from language to language, where one might prefer or require the use of a
+component that you load alongside your application, and another might prefer
+that you pull in a package explicitly in your codebase.
 
-It is a long-term goal that popular libraries are authored to be observable out of the box,
-such that pulling in a separate component is not required.
+It is a long-term goal that popular libraries are authored to be observable out
+of the box, such that pulling in a separate component is not required.
 
-For more information, see [Instrumenting Libraries](/docs/concepts/instrumenting-library/).
+For more information, see
+[Instrumenting Libraries](/docs/concepts/instrumenting-library/).

--- a/content/en/docs/concepts/data-collection.md
+++ b/content/en/docs/concepts/data-collection.md
@@ -5,15 +5,15 @@ weight: 50
 
 The OpenTelemetry project facilitates the collection of telemetry data via the
 OpenTelemetry Collector. The OpenTelemetry Collector offers a vendor-agnostic
-implementation on how to receive, process, and export telemetry data. It
-removes the need to run, operate, and maintain multiple agents/collectors in
-order to support open-source observability data formats (e.g. Jaeger,
-Prometheus, etc.) sending to one or more open-source or commercial back-ends.
-In addition, the Collector gives end-users control of their data. The Collector
-is the default location instrumentation libraries export their telemetry
-data.
+implementation on how to receive, process, and export telemetry data. It removes
+the need to run, operate, and maintain multiple agents/collectors in order to
+support open-source observability data formats (e.g. Jaeger, Prometheus, etc.)
+sending to one or more open-source or commercial back-ends. In addition, the
+Collector gives end-users control of their data. The Collector is the default
+location instrumentation libraries export their telemetry data.
 
-> The Collector may be offered as a distribution, see [here](../distributions) for more information.
+> The Collector may be offered as a distribution, see [here](../distributions)
+> for more information.
 
 ## Deployment
 
@@ -24,25 +24,26 @@ The OpenTelemetry Collector provides a single binary and two deployment methods:
 - **Gateway:** One or more Collector instances running as a standalone service
   (e.g. container or deployment) typically per cluster, datacenter or region.
 
-For information on how to use the Collector see the [getting started
-documentation](/docs/collector/getting-started).
+For information on how to use the Collector see the
+[getting started documentation](/docs/collector/getting-started).
 
 ## Components
 
 The Collector is made up of the following components:
 
 - <img width="32" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Receivers.svg"></img>
-`receivers`: How to get data into the Collector; these can be push or pull based
+  `receivers`: How to get data into the Collector; these can be push or pull
+  based
 - <img width="32" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Processors.svg"></img>
-`processors`: What to do with received data
+  `processors`: What to do with received data
 - <img width="32" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Exporters.svg"></img>
-`exporters`: Where to send received data; these can be push or pull based
+  `exporters`: Where to send received data; these can be push or pull based
 
 These components are enabled through `pipelines`. Multiple instances of
 components as well as pipelines can be defined via YAML configuration.
 
-For more information about these components see the [configuration
-documentation](/docs/collector/configuration).
+For more information about these components see the
+[configuration documentation](/docs/collector/configuration).
 
 ## Repositories
 
@@ -52,7 +53,7 @@ The OpenTelemetry project provides two versions of the Collector:
   Foundational components such as configuration and generally applicable
   receivers, processors, exporters, and extensions.
 - **[Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases):**
-  All the components of core plus optional or possibly experimental components. Offers support for popular
-  open-source projects including Jaeger, Prometheus, and Fluent Bit.
-  Also contains more specialized or vendor-specific receivers, processors,
-  exporters, and extensions.
+  All the components of core plus optional or possibly experimental components.
+  Offers support for popular open-source projects including Jaeger, Prometheus,
+  and Fluent Bit. Also contains more specialized or vendor-specific receivers,
+  processors, exporters, and extensions.

--- a/content/en/docs/concepts/data-sources.md
+++ b/content/en/docs/concepts/data-sources.md
@@ -3,22 +3,21 @@ title: Data sources
 weight: 30
 ---
 
-OpenTelemetry supports multiple data sources as defined below. More data
-sources may be added in the future.
+OpenTelemetry supports multiple data sources as defined below. More data sources
+may be added in the future.
 
 ## Traces
 
 Traces track the progression of a single request, called a **trace**, as it is
-handled by services that make up an application. The request may be initiated
-by a user or an application. Distributed tracing is a form of tracing that
-traverses process, network and security boundaries. Each unit of work in a
-trace is called a **span**; a trace is a tree of spans. Spans are objects
-that represent the work being done by individual services or components
-involved in a request as it flows through a system. A span contains a _span
-context_, which is a set of globally unique identifiers that represent the
-unique request that each span is a part of. A span provides Request, Error
-and Duration (RED) metrics that can be used to debug availability as
-well as performance issues.
+handled by services that make up an application. The request may be initiated by
+a user or an application. Distributed tracing is a form of tracing that
+traverses process, network and security boundaries. Each unit of work in a trace
+is called a **span**; a trace is a tree of spans. Spans are objects that
+represent the work being done by individual services or components involved in a
+request as it flows through a system. A span contains a _span context_, which is
+a set of globally unique identifiers that represent the unique request that each
+span is a part of. A span provides Request, Error and Duration (RED) metrics
+that can be used to debug availability as well as performance issues.
 
 A trace contains a single _root span_ which encapsulates the end-to-end latency
 for the entire request. You can think of this as a single logical operation,
@@ -31,9 +30,9 @@ which represent operations taking place as part of the request. Each span
 contains metadata about the operation, such as its name, start and end
 timestamps, attributes, events, and status.
 
-To create and manage spans in OpenTelemetry, the OpenTelemetry API provides the `tracer`
-interface. This object is responsible for tracking the active span in your
-process, and allows you to access the current span in order to perform
+To create and manage spans in OpenTelemetry, the OpenTelemetry API provides the
+`tracer` interface. This object is responsible for tracking the active span in
+your process, and allows you to access the current span in order to perform
 operations on it such as adding attributes, events, and finishing it when the
 work it tracks is complete. One or more `tracer` objects can be created in a
 process through the _tracer provider_, a factory interface that allows for
@@ -45,21 +44,20 @@ Generally, the lifecycle of a span resembles the following:
   request headers, if it exists.
 - A new span is created as a child of the extracted span context; if none
   exists, a new root span is created.
-- The service handles the request. Additional attributes and events are added
-  to the span that are useful for understanding the context of the request,
-  such as the hostname of the machine handling the request, or customer
-  identifiers.
-- New spans may be created to represent work being done by sub-components of
-  the service.
+- The service handles the request. Additional attributes and events are added to
+  the span that are useful for understanding the context of the request, such as
+  the hostname of the machine handling the request, or customer identifiers.
+- New spans may be created to represent work being done by sub-components of the
+  service.
 - When the service makes a remote call to another service, the current span
   context is serialized and forwarded to the next service by _injecting_ the
   span context into the headers or message envelope.
 - The work being done by the service completes, successfully or not. The span
   status is appropriately set, and the span is marked finished.
 
-For more information, see the [traces specification][],
-which covers concepts including: trace, span, parent/child relationship, span
-context, attributes, events and links.
+For more information, see the [traces specification][], which covers concepts
+including: trace, span, parent/child relationship, span context, attributes,
+events and links.
 
 ## Metrics
 
@@ -70,27 +68,27 @@ captured and associated metadata.
 
 Application and request metrics are important indicators of availability and
 performance. Custom metrics can provide insights into how availability
-indicators impact user experience or the business. Collected data can be used
-to alert of an outage or trigger scheduling decisions to scale up a deployment
+indicators impact user experience or the business. Collected data can be used to
+alert of an outage or trigger scheduling decisions to scale up a deployment
 automatically upon high demand.
 
 OpenTelemetry defines three _metric instruments_ today:
 
-- **counter**: a value that is summed over time -- you can think of
-this like an odometer on a car; it only ever goes up.
+- **counter**: a value that is summed over time -- you can think of this like an
+  odometer on a car; it only ever goes up.
 - **measure**: a value that is aggregated over time. This is more akin to the
   trip odometer on a car, it represents a value over some defined range.
 - **observer**: captures a current set of values at a particular point in time,
   like a fuel gauge in a vehicle.
 
-In addition to the three metric instruments, the concept of _aggregations_ is
-an important one to understand. An aggregation is a technique whereby a large
+In addition to the three metric instruments, the concept of _aggregations_ is an
+important one to understand. An aggregation is a technique whereby a large
 number of measurements are combined into either exact or estimated statistics
 about metric events that took place during a time window. The OpenTelemetry API
 itself does not allow you to specify these aggregations, but provides some
-default ones. In general, the OpenTelemetry SDK provides for common
-aggregations (such as sum, count, last value, and histograms) that are
-supported by visualizers and telemetry backends.
+default ones. In general, the OpenTelemetry SDK provides for common aggregations
+(such as sum, count, last value, and histograms) that are supported by
+visualizers and telemetry backends.
 
 Unlike request tracing, which is intended to capture request lifecycles and
 provide context to the individual pieces of a request, metrics are intended to
@@ -105,45 +103,47 @@ metrics include:
 - Reporting average balance values from an account.
 - Reporting current active requests being handled.
 
-For more information, see the [metrics specification][],
-which covers topics including: measure, measurement, metric, data, data point
-and labels.
+For more information, see the [metrics specification][], which covers topics
+including: measure, measurement, metric, data, data point and labels.
 
 ## Logs
 
-A **log** is a timestamped text record, either structured (recommended) or unstructured,
-with metadata. While logs are an independent data source, they may also be
-attached to spans. In OpenTelemetry, any data that is not part of a distributed trace or a metric
-is a log. For example, _events_ are a specific type of log. Logs are often used
-to determine the root cause of an issue and typically contain information about
-who changed what as well as the result of the change.
+A **log** is a timestamped text record, either structured (recommended) or
+unstructured, with metadata. While logs are an independent data source, they may
+also be attached to spans. In OpenTelemetry, any data that is not part of a
+distributed trace or a metric is a log. For example, _events_ are a specific
+type of log. Logs are often used to determine the root cause of an issue and
+typically contain information about who changed what as well as the result of
+the change.
 
-For more information, see the [logs specification][],
-which covers topics including: log, defined fields, trace context fields and
-severity fields.
+For more information, see the [logs specification][], which covers topics
+including: log, defined fields, trace context fields and severity fields.
 
 ## Baggage
 
-In addition to trace propagation, OpenTelemetry provides a simple mechanism 
-for propagating name/value pairs, called **baggage**. Baggage is intended 
-for indexing observability events in one service with attributes provided 
-by a prior service in the same transaction. This helps to establish a 
-causal relationship between these events.
+In addition to trace propagation, OpenTelemetry provides a simple mechanism for
+propagating name/value pairs, called **baggage**. Baggage is intended for
+indexing observability events in one service with attributes provided by a prior
+service in the same transaction. This helps to establish a causal relationship
+between these events.
 
 While baggage can be used to prototype other cross-cutting concerns, this
-mechanism is primarily intended to convey values for the OpenTelemetry 
+mechanism is primarily intended to convey values for the OpenTelemetry
 observability systems.
 
-These values can be consumed from baggage and used as additional dimensions 
-for metrics, or additional context for logs and traces. Some examples:
+These values can be consumed from baggage and used as additional dimensions for
+metrics, or additional context for logs and traces. Some examples:
 
-- A web service can benefit from including context around what service has sent the request
-- A SaaS provider can include context about the API user or token that is responsible for that request
-- Determining that a particular browser version is associated with a failure in an image processing service
+- A web service can benefit from including context around what service has sent
+  the request
+- A SaaS provider can include context about the API user or token that is
+  responsible for that request
+- Determining that a particular browser version is associated with a failure in
+  an image processing service
 
 For more information, see the [baggage specification][].
 
-[baggage specification]: {{< relref "/docs/reference/specification/overview#baggage-signal" >}}
-[logs specification]: {{< relref "/docs/reference/specification/overview#log-signal" >}}
-[metrics specification]: {{< relref "/docs/reference/specification/overview#metric-signal" >}}
-[traces specification]: {{< relref "/docs/reference/specification/overview#tracing-signal" >}}
+[baggage specification]: /docs/reference/specification/overview/#baggage-signal
+[logs specification]: /docs/reference/specification/overview/#log-signal
+[metrics specification]: /docs/reference/specification/overview/#metric-signal
+[traces specification]: /docs/reference/specification/overview/#tracing-signal

--- a/content/en/docs/concepts/distributions.md
+++ b/content/en/docs/concepts/distributions.md
@@ -3,9 +3,9 @@ title: "Distributions"
 weight: 90
 ---
 
-The OpenTelemetry projects consists of multiple [components](../components)
-that support multiple [data sources](../data-sources). The reference
-implementation of OpenTelemetry is available as:
+The OpenTelemetry projects consists of multiple [components](../components) that
+support multiple [data sources](../data-sources). The reference implementation
+of OpenTelemetry is available as:
 
 - [Language-specific instrumentation libraries](../instrumenting)
 - [A Collector binary](../data-collection)
@@ -30,26 +30,24 @@ Distributions would broadly fall into the following categories:
 
 - **"Pure":** These distributions provide the same functionality as upstream and
   are 100% compatible. Customizations would typically be to ease of use or
-  packaging. These customizations may be back-end, vendor, or end-user
-  specific.
-- **"Plus":** These distributions provide the same functionality as upstream plus
-  more. Customizations beyond those found in pure distributions would be the
-  inclusion of additional components. Examples of this would include automatic
-  instrumentation libraries or vendor exporters not upstreamed to the
+  packaging. These customizations may be back-end, vendor, or end-user specific.
+- **"Plus":** These distributions provide the same functionality as upstream
+  plus more. Customizations beyond those found in pure distributions would be
+  the inclusion of additional components. Examples of this would include
+  automatic instrumentation libraries or vendor exporters not upstreamed to the
   OpenTelemetry project.
 - **"Minus":** These distributions provide a reduced set of functionality from
   upstream. Examples of this would include the removal of automatic
   instrumentation libraries or receivers/processors/exporters/extensions found
-  in the OpenTelemetry Collector project. These distributions may be provided
-  to increase supportability and security considerations.
+  in the OpenTelemetry Collector project. These distributions may be provided to
+  increase supportability and security considerations.
 
 ## Who would create a distribution?
 
 Anyone could create a distribution. Today, several [vendors](../../../vendors)
-offer distributions. In addition, end-users may consider creating a
-distribution if they wish to use components in the
-[Registry](../../../registry) that are not upstreamed to the OpenTelemetry
-project.
+offer distributions. In addition, end-users may consider creating a distribution
+if they wish to use components in the [Registry](../../../registry) that are not
+upstreamed to the OpenTelemetry project.
 
 ## Creating your own distribution
 
@@ -58,8 +56,8 @@ project.
 A guide on how to create your own distribution is available in this blog post:
 ["Building your own OpenTelemetry Collector distribution"](https://medium.com/p/42337e994b63)
 
-If you are building your own distribution, the [OpenTelemetry Collector
-Builder](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder)
+If you are building your own distribution, the
+[OpenTelemetry Collector Builder](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder)
 might be a good starting point.
 
 ## What you should know about distributions
@@ -73,7 +71,8 @@ future, OpenTelemetry may certify distributions and partners similarly to the
 Kubernetes project. When evaluating a distribution, ensure using the
 distribution does not result in vendor lock-in.
 
-> Any support for a distribution comes from the distribution authors and
-> not the OpenTelemetry authors.
+> Any support for a distribution comes from the distribution authors and not the
+> OpenTelemetry authors.
 
-[guidelines]: https://github.com/open-telemetry/community/blob/main/marketing-guidelines.md
+[guidelines]:
+  https://github.com/open-telemetry/community/blob/main/marketing-guidelines.md

--- a/content/en/docs/concepts/glossary.md
+++ b/content/en/docs/concepts/glossary.md
@@ -10,60 +10,68 @@ others. This page captures terminology used in the project and what it means.
 ## Generic Terminology
 
 - **Aggregation:** The process of combining multiple measurements into exact or
-  estimated statistics about the measurements that took place during an
-  interval of time, during program execution. Used by the `Metric` `Data Source`.
-- **API:** Application Programming Interface. In the OpenTelemetry project,
-  used to define how telemetry data is generated per `Data Source`.
-- **Application:** One or more `Services` designed for end users or other applications.
+  estimated statistics about the measurements that took place during an interval
+  of time, during program execution. Used by the `Metric` `Data Source`.
+- **API:** Application Programming Interface. In the OpenTelemetry project, used
+  to define how telemetry data is generated per `Data Source`.
+- **Application:** One or more `Services` designed for end users or other
+  applications.
 - **APM:** Application Performance Monitoring. Typically a back-end of the
   `Tracing` `Data Source`.
-- <a id="attribute"></a>
-  **[Attribute][]:** A key-value pair. Used by the `Tracing` `Data Source` to attach data to a `Span`.
-- **[Baggage]({{< relref "/docs/reference/specification/overview#baggage-signal" >}}):** A
-  mechanism for propagating name/value pairs to help establish a causal
+- <a id="attribute"></a> **[Attribute][]:** A key-value pair. Used by the
+  `Tracing` `Data Source` to attach data to a `Span`.
+- **[Baggage]({{< relref "/docs/reference/specification/overview#baggage-signal" >}}):**
+  A mechanism for propagating name/value pairs to help establish a causal
   relationship between events and services.
 - **Client Library:** See `Instrumented Library`.
-- **Client-side App:** A component of an `Application` that is not running inside a private infrastructure and is typically used directly by end-users. Examples of client-side apps are browser apps, mobile apps, and apps running on IoT devices.
-- **[Collector](/docs/collector/):**
-  A vendor-agnostic implementation on how to receive, process, and export
-  telemetry data. A single binary that can be deployed as an agent or gateway.
-- **Contrib:** Several `Instrumentation Libraries` and the `Collector` offer a set
-  of core capabilities as well as a dedicated contrib repository for non-core
-  capabilities including vendor `Exporters`.
+- **Client-side App:** A component of an `Application` that is not running
+  inside a private infrastructure and is typically used directly by end-users.
+  Examples of client-side apps are browser apps, mobile apps, and apps running
+  on IoT devices.
+- **[Collector](/docs/collector/):** A vendor-agnostic implementation on how to
+  receive, process, and export telemetry data. A single binary that can be
+  deployed as an agent or gateway.
+- **Contrib:** Several `Instrumentation Libraries` and the `Collector` offer a
+  set of core capabilities as well as a dedicated contrib repository for
+  non-core capabilities including vendor `Exporters`.
 - **[Context
   Propagation]({{< relref "/docs/reference/specification/overview#context-propagation" >}}):**
   Allows all `Data Sources` to share an underlying context mechanism for storing
   state and accessing data across the lifespan of a `Transaction`.
-- **[DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph):** Directed Acyclic Graph.
-- **[Data Source](/docs/concepts/data-sources):** One of `Traces`, `Metrics` or `Logs`.
+- **[DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph):** Directed
+  Acyclic Graph.
+- **[Data Source](/docs/concepts/data-sources):** One of `Traces`, `Metrics` or
+  `Logs`.
 - **Dimension:** See `Label`.
-- **[Distributed Tracing](/docs/concepts/data-sources/#traces):**
-  Tracks the progression of a single `Request`, called a `Trace`, as it is handled
-  by `Services` that make up an `Application`. A `Distributed Trace` transverses
+- **[Distributed Tracing](/docs/concepts/data-sources/#traces):** Tracks the
+  progression of a single `Request`, called a `Trace`, as it is handled by
+  `Services` that make up an `Application`. A `Distributed Trace` transverses
   process, network and security boundaries.
-- **Event:** Something that happened where representation depends on the `Data
-  Source`. For example,
+- **Event:** Something that happened where representation depends on the
+  `Data Source`. For example,
   [`Spans`]({{< relref "/docs/reference/specification/trace/api#add-events" >}}).
 - **Exporter:** Provides functionality to emit telemetry to consumers. Used by
   [Instrumentation Libraries][spec-exporter-lib] and the
-  [Collector](/docs/collector/configuration#basics).
-  Exporters can be push or pull based.
+  [Collector](/docs/collector/configuration#basics). Exporters can be push or
+  pull based.
 - **[Field]({{< relref "/docs/reference/specification/logs/data-model#field-kinds" >}}):**
-  name/value pairs added to `Log Records` (similar to `Attributes` for `Spans` and
-  `Labels` for `Metrics`).
-- **[gRPC](https://grpc.io):** A high-performance, open source universal `RPC` framework.
-- **[HTTP](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol):** Hypertext Transfer Protocol.
-- **[Instrumented Library][spec-instrumented-lib]:**
-  Denotes the `Library` for which the telemetry signals (`Traces`, `Metrics`, `Logs`)
-  are gathered.
-- **[Instrumentation Library][spec-instrumentation-lib]:**
-  Denotes the `Library` that provides the instrumentation for a given
-  `Instrumented Library`. `Instrumented Library` and `Instrumentation Library` may be
-  the same `Library` if it has built-in OpenTelemetry instrumentation.
+  name/value pairs added to `Log Records` (similar to `Attributes` for `Spans`
+  and `Labels` for `Metrics`).
+- **[gRPC](https://grpc.io):** A high-performance, open source universal `RPC`
+  framework.
+- **[HTTP](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol):**
+  Hypertext Transfer Protocol.
+- **[Instrumented Library][spec-instrumented-lib]:** Denotes the `Library` for
+  which the telemetry signals (`Traces`, `Metrics`, `Logs`) are gathered.
+- **[Instrumentation Library][spec-instrumentation-lib]:** Denotes the `Library`
+  that provides the instrumentation for a given `Instrumented Library`.
+  `Instrumented Library` and `Instrumentation Library` may be the same `Library`
+  if it has built-in OpenTelemetry instrumentation.
 - **[JSON](https://en.wikipedia.org/wiki/JSON):** JavaScript Object Notation.
 - **Label:** see [Attribute](#attribute).
 - **Language:** Programming Language.
-- **Library:** A language-specific collection of behavior invoked by an interface.
+- **Library:** A language-specific collection of behavior invoked by an
+  interface.
 - **[Log]({{< relref "/docs/reference/specification/glossary#log" >}}):**
   Sometimes used to refer to a collection of `Log Records`. May be ambiguous,
   since people also sometimes use `Log` to refer to a single `Log Record`, thus
@@ -71,19 +79,21 @@ others. This page captures terminology used in the project and what it means.
   possible additional qualifiers should be used (e.g. `Log Record`).
 - **[Log
   Record]({{< relref "/docs/reference/specification/glossary#log-record" >}}):**
-  A recording of an `Event`. Typically the record includes a timestamp indicating
-  when the `Event` happened as well as other data that describes what happened,
-  where it happened, etc.
+  A recording of an `Event`. Typically the record includes a timestamp
+  indicating when the `Event` happened as well as other data that describes what
+  happened, where it happened, etc.
 - **Metadata:** name/value pair added to telemetry data. OpenTelemetry calls
   this `Attributes` on `Spans`, `Labels` on `Metrics` and `Fields` on `Logs`.
-- **[Metric](/docs/concepts/data-sources/#metrics):**
-  Records a data point, either raw measurements or predefined aggregation, as
-  timeseries with `Metadata`.
+- **[Metric](/docs/concepts/data-sources/#metrics):** Records a data point,
+  either raw measurements or predefined aggregation, as timeseries with
+  `Metadata`.
 - **OC:** `OpenCensus`.
-- **[OpenCensus](https://opencensus.io):** a set of libraries for various languages that allow you to
-  collect application metrics and distributed traces, then transfer the data to
-  a backend of your choice in real time. Precursor to OpenTelemetry.
-- **[OpenTracing](https://opentracing.io):** Vendor-neutral APIs and instrumentation for distributed tracing. Precursor to OpenTelemetry.
+- **[OpenCensus](https://opencensus.io):** a set of libraries for various
+  languages that allow you to collect application metrics and distributed
+  traces, then transfer the data to a backend of your choice in real time.
+  Precursor to OpenTelemetry.
+- **[OpenTracing](https://opentracing.io):** Vendor-neutral APIs and
+  instrumentation for distributed tracing. Precursor to OpenTelemetry.
 - **OT:** `OpenTracing`.
 - **OTel:** OpenTelemetry.
 - **OtelCol:** OpenTelemetry Collector.
@@ -91,24 +101,25 @@ others. This page captures terminology used in the project and what it means.
 - **Processor:** Operation performed on data between being received and being
   exported. For example, batching. Used by [Instrumentation
   Libraries]({{< relref "/docs/reference/specification/trace/sdk#span-processor" >}})
-  and the
-  [Collector](/docs/collector/configuration/#processors).
-- **[Propagators](/docs/instrumentation/go/manual/#propagators-and-context):** Used to
-  serialize and deserialize specific parts of telemetry data such as span
-  context and `Baggage` in `Spans`.
-- **[Proto](https://github.com/open-telemetry/opentelemetry-proto):** Language independent interface types.
-- **[Receiver](/docs/collector/configuration/#receivers):**
-  Term used by the `Collector` to define how telemetry data is received.
-  Receivers can be push or pull based.
+  and the [Collector](/docs/collector/configuration/#processors).
+- **[Propagators](/docs/instrumentation/go/manual/#propagators-and-context):**
+  Used to serialize and deserialize specific parts of telemetry data such as
+  span context and `Baggage` in `Spans`.
+- **[Proto](https://github.com/open-telemetry/opentelemetry-proto):** Language
+  independent interface types.
+- **[Receiver](/docs/collector/configuration/#receivers):** Term used by the
+  `Collector` to define how telemetry data is received. Receivers can be push or
+  pull based.
 - **Request:** See `Distributed Tracing`.
-- **Resource:**
-  Captures information about the entity for which telemetry is recorded. For
-  example, a process producing telemetry that is running in a container on
-  Kubernetes has a pod name, it is in a namespace and possibly is part of a
-  deployment which also has a name. All three of these attributes can be
-  included in the `Resource` and applied to any data source.
-- **[REST](https://en.wikipedia.org/wiki/Representational_state_transfer):** Representation State Transfer.
-- **[RPC](https://en.wikipedia.org/wiki/Remote_procedure_call):** Remote Procedure Call.
+- **Resource:** Captures information about the entity for which telemetry is
+  recorded. For example, a process producing telemetry that is running in a
+  container on Kubernetes has a pod name, it is in a namespace and possibly is
+  part of a deployment which also has a name. All three of these attributes can
+  be included in the `Resource` and applied to any data source.
+- **[REST](https://en.wikipedia.org/wiki/Representational_state_transfer):**
+  Representation State Transfer.
+- **[RPC](https://en.wikipedia.org/wiki/Remote_procedure_call):** Remote
+  Procedure Call.
 - **[Sampling]({{< relref "/docs/reference/specification/trace/sdk#sampling" >}}):**
   A mechanism to control the amount of data exported. Most commonly used with
   the `Tracing` `Data Source`.
@@ -121,51 +132,66 @@ others. This page captures terminology used in the project and what it means.
   `Service` may be deployed in multiple locations.
 - **[Span]({{< relref "/docs/reference/specification/trace/api#span" >}}):**
   Represents a single operation within a `Trace`.
-- **Span Link:** A span link is a link between causally-related spans. For details see [Links between spans]({{< relref "/docs/reference/specification/overview#links-between-spans" >}}) and [Specifying Links]({{< relref "/docs/reference/specification/trace/api#specifying-links" >}}).
-- **[Specification](/docs/concepts/components/#specification):**
-  Describes the cross-language requirements and expectations for all
-  implementations.
+- **Span Link:** A span link is a link between causally-related spans. For
+  details see [Links between
+  spans]({{< relref "/docs/reference/specification/overview#links-between-spans" >}})
+  and [Specifying
+  Links]({{< relref "/docs/reference/specification/trace/api#specifying-links" >}}).
+- **[Specification](/docs/concepts/components/#specification):** Describes the
+  cross-language requirements and expectations for all implementations.
 - **[Status]({{< relref "/docs/reference/specification/trace/api#set-status" >}}):**
   The result of the operation. Typically used to indicate whether an error
   occurred.
 - **Tag:** see `Metadata`.
-- **[Trace]({{< relref "/docs/reference/specification/overview#traces" >}}):**
-  A `DAG` of `Spans`, where the edges between `Spans` are defined as
-  parent/child relationship.
+- **[Trace]({{< relref "/docs/reference/specification/overview#traces" >}}):** A
+  `DAG` of `Spans`, where the edges between `Spans` are defined as parent/child
+  relationship.
 - **[Tracer]({{< relref "/docs/reference/specification/trace/api#tracer" >}}):**
   Responsible for creating `Spans`.
 - **Transaction:** See `Distributed Tracing`.
-- **[zPages][]:**
-  An in-process alternative to external exporters. When included, they collect
-  and aggregate tracing and metrics information in the background; this data is
-  served on web pages when requested.
+- **[zPages][]:** An in-process alternative to external exporters. When
+  included, they collect and aggregate tracing and metrics information in the
+  background; this data is served on web pages when requested.
 
 ## Additional Terminology
 
 ### Traces
 
-- **[Trace API Terminology]({{< relref "/docs/reference/specification/trace/api" >}})**
-- **[Trace SDK Terminology]({{< relref "/docs/reference/specification/trace/sdk" >}})**
+- **[Trace API
+  Terminology]({{< relref "/docs/reference/specification/trace/api" >}})**
+- **[Trace SDK
+  Terminology]({{< relref "/docs/reference/specification/trace/sdk" >}})**
 
 ### Metrics
 
-- **[Metric API Terminology]({{< relref "/docs/reference/specification/metrics/api#overview" >}})**
-- **[Metric SDK Terminology]({{< relref "/docs/reference/specification/metrics#specifications" >}})**
+- **[Metric API
+  Terminology]({{< relref "/docs/reference/specification/metrics/api#overview" >}})**
+- **[Metric SDK
+  Terminology]({{< relref "/docs/reference/specification/metrics#specifications" >}})**
 
 ### Logs
 
-- **[Trace Context Fields]({{< relref "/docs/reference/specification/logs/data-model#trace-context-fields" >}})**
-- **[Severity Fields]({{< relref "/docs/reference/specification/logs/data-model#severity-fields" >}})**
-- **[Log Record Fields]({{< relref "/docs/reference/specification/logs/data-model#log-and-event-record-definition" >}})**
+- **[Trace Context
+  Fields]({{< relref "/docs/reference/specification/logs/data-model#trace-context-fields" >}})**
+- **[Severity
+  Fields]({{< relref "/docs/reference/specification/logs/data-model#severity-fields" >}})**
+- **[Log Record
+  Fields]({{< relref "/docs/reference/specification/logs/data-model#log-and-event-record-definition" >}})**
 
 ### Semantic Conventions
 
-- **[Resource Conventions]({{< relref "/docs/reference/specification/resource/semantic_conventions" >}})**
-- **[Span Conventions]({{< relref "/docs/reference/specification/trace/semantic_conventions" >}})**
-- **[Metric Conventions]({{< relref "/docs/reference/specification/metrics/semantic_conventions" >}})**
+- **[Resource
+  Conventions]({{< relref "/docs/reference/specification/resource/semantic_conventions" >}})**
+- **[Span
+  Conventions]({{< relref "/docs/reference/specification/trace/semantic_conventions" >}})**
+- **[Metric
+  Conventions]({{< relref "/docs/reference/specification/metrics/semantic_conventions" >}})**
 
-[Attribute]: {{< relref "/docs/reference/specification/common/common#attributes" >}}
-[spec-exporter-lib]: {{< relref "/docs/reference/specification/glossary#exporter-library" >}}
-[spec-instrumentation-lib]: {{< relref "/docs/reference/specification/glossary#instrumentation-library" >}}
-[spec-instrumented-lib]: {{< relref "/docs/reference/specification/glossary#instrumented-library" >}}
-[zPages]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/experimental/trace/zpages.md
+[attribute]: /docs/reference/specification/common/common/#attributes
+[spec-exporter-lib]: /docs/reference/specification/glossary/#exporter-library
+[spec-instrumentation-lib]:
+  /docs/reference/specification/glossary/#instrumentation-library
+[spec-instrumented-lib]:
+  /docs/reference/specification/glossary/#instrumented-library
+[zpages]:
+  https://github.com/open-telemetry/opentelemetry-specification/blob/main/experimental/trace/zpages.md

--- a/content/en/docs/concepts/instrumenting-library.md
+++ b/content/en/docs/concepts/instrumenting-library.md
@@ -3,68 +3,122 @@ title: "Instrumenting libraries"
 weight: 40
 ---
 
-OpenTelemetry provides [automatic instrumentation](/docs/concepts/instrumenting#automatic-instrumentation) for many libraries, which is typically done through library hooks or monkey-patching library code.
+OpenTelemetry provides
+[automatic instrumentation](/docs/concepts/instrumenting#automatic-instrumentation)
+for many libraries, which is typically done through library hooks or
+monkey-patching library code.
 
-Native library instrumentation with OpenTelemetry provides better observability and developer experience for users, removing the need for libraries to expose and document hooks:
+Native library instrumentation with OpenTelemetry provides better observability
+and developer experience for users, removing the need for libraries to expose
+and document hooks:
 
-- custom logging hooks can be replaced by common and easy to use OpenTelemetry APIs, users will only interact with OpenTelemetry
-- traces, logs, metrics from library and application code are correlated and coherent
-- common conventions allow users to get similar and consistent telemetry within same technology and across libraries and languages
-- telemetry signals can be fine tuned (filtered, processed, aggregated) for various consumption scenarios using a wide variety of well-documented OpenTelemetry extensibility points.
+- custom logging hooks can be replaced by common and easy to use OpenTelemetry
+  APIs, users will only interact with OpenTelemetry
+- traces, logs, metrics from library and application code are correlated and
+  coherent
+- common conventions allow users to get similar and consistent telemetry within
+  same technology and across libraries and languages
+- telemetry signals can be fine tuned (filtered, processed, aggregated) for
+  various consumption scenarios using a wide variety of well-documented
+  OpenTelemetry extensibility points.
 
 ## Semantic Conventions
 
-Check out available [semantic conventions]({{< relref "/docs/reference/specification/trace/semantic_conventions/" >}}) that cover web-frameworks, RPC clients, databases, messaging clients, infra pieces and more!
+Check out available [semantic
+conventions]({{< relref "/docs/reference/specification/trace/semantic_conventions/" >}})
+that cover web-frameworks, RPC clients, databases, messaging clients, infra
+pieces and more!
 
-If your library is one of those things - follow the conventions, they are the main source of truth and tell which information should be included on spans.
-Conventions make instrumentation consistent: users who work with telemetry don't have to learn library specifics and observability vendors can build experiences for a wide variety of technologies (e.g. databases or messaging systems).
-When libraries follow conventions, many scenarios may be enabled out of the box without the user's input or configuration.
+If your library is one of those things - follow the conventions, they are the
+main source of truth and tell which information should be included on spans.
+Conventions make instrumentation consistent: users who work with telemetry don't
+have to learn library specifics and observability vendors can build experiences
+for a wide variety of technologies (e.g. databases or messaging systems). When
+libraries follow conventions, many scenarios may be enabled out of the box
+without the user's input or configuration.
 
-If you have any feedback or want to add a new convention - please come and contribute! [Instrumentation Slack](https://cloud-native.slack.com/archives/C01QZFGMLQ7) or [Specification repo](https://github.com/open-telemetry/opentelemetry-specification) are a good places to start!
+If you have any feedback or want to add a new convention - please come and
+contribute!
+[Instrumentation Slack](https://cloud-native.slack.com/archives/C01QZFGMLQ7) or
+[Specification repo](https://github.com/open-telemetry/opentelemetry-specification)
+are a good places to start!
 
 ## When **not** to instrument
 
-Some libraries are thin clients wrapping network calls. Chances are that OpenTelemetry has auto-instrumentation for the underlying RPC client (check out the [registry](/registry/)). In this case, library instrumentation may not be necessary.
+Some libraries are thin clients wrapping network calls. Chances are that
+OpenTelemetry has auto-instrumentation for the underlying RPC client (check out
+the [registry](/registry/)). In this case, library instrumentation may not be
+necessary.
 
 Don't instrument if:
 
 - your library is a thin proxy on top of documented or self-explanatory APIs
-- *and* OpenTelemetry has instrumentation for underlying network calls
-- *and* there are no conventions your library should follow to enrich telemetry
+- _and_ OpenTelemetry has instrumentation for underlying network calls
+- _and_ there are no conventions your library should follow to enrich telemetry
 
-If you're in doubt - don't instrument - you can always do it later when you see a need.
+If you're in doubt - don't instrument - you can always do it later when you see
+a need.
 
-If you choose not to instrument, it may still be useful to provide a way to configure OpenTelemetry handlers for your internal RPC client instance. It's essential in languages that don't support fully automatic instrumentation and still useful in others.
+If you choose not to instrument, it may still be useful to provide a way to
+configure OpenTelemetry handlers for your internal RPC client instance. It's
+essential in languages that don't support fully automatic instrumentation and
+still useful in others.
 
-The rest of this document gives guidance on what and how to instrument if you decide to do it.
+The rest of this document gives guidance on what and how to instrument if you
+decide to do it.
 
 ## OpenTelemetry API
 
 The first step is to take dependency on the OpenTelemetry API package.
 
-OpenTelemetry has [two main modules]({{< relref "/docs/reference/specification/overview" >}}) - API and SDK.
-OpenTelemetry API is a set of abstractions and not-operational implementations. Unless your application imports the OpenTelemetry SDK, your instrumentation does nothing and does not impact application performance.
+OpenTelemetry has [two main
+modules]({{< relref "/docs/reference/specification/overview" >}}) - API and SDK.
+OpenTelemetry API is a set of abstractions and not-operational implementations.
+Unless your application imports the OpenTelemetry SDK, your instrumentation does
+nothing and does not impact application performance.
 
 **Libraries should only use the OpenTelemetry API.**
 
-You may be rightfully concerned about adding new dependencies, here are some considerations to help you decide how to minimize dependency hell:
+You may be rightfully concerned about adding new dependencies, here are some
+considerations to help you decide how to minimize dependency hell:
 
-- OpenTelemetry Trace API reached stability in early 2021, it follows [Semantic Versioning 2.0]({{< relref "/docs/reference/specification/versioning-and-stability" >}}) and we take API stability seriously.
-- When taking dependency, use the earliest stable OpenTelemetry API (1.0.*) and avoid updating it unless you have to use new features.
-- While your instrumentation stabilizes, consider shipping it as a separate package, so that will never cause issues for users who don't use it. You can keep it in your repo, or [add it to OpenTelemetry](https://github.com/open-telemetry/oteps/blob/main/text/0155-external-modules.md#contrib-components), so it will ship with other instrumentation packages.
-- Semantic Conventions are [not stable yet]({{< relref "/docs/reference/specification/versioning-and-stability#not-defined-semantic-conventions-stability" >}}): while this does not cause any functional issues, you may need to update your instrumentation every once in a while. Having it in a preview plugin or in OpenTelemetry contrib repo may help keeping conventions up-to-date without breaking changes for your users.
+- OpenTelemetry Trace API reached stability in early 2021, it follows [Semantic
+  Versioning
+  2.0]({{< relref "/docs/reference/specification/versioning-and-stability" >}})
+  and we take API stability seriously.
+- When taking dependency, use the earliest stable OpenTelemetry API (1.0.\*) and
+  avoid updating it unless you have to use new features.
+- While your instrumentation stabilizes, consider shipping it as a separate
+  package, so that will never cause issues for users who don't use it. You can
+  keep it in your repo, or
+  [add it to OpenTelemetry](https://github.com/open-telemetry/oteps/blob/main/text/0155-external-modules.md#contrib-components),
+  so it will ship with other instrumentation packages.
+- Semantic Conventions are [not stable
+  yet]({{< relref "/docs/reference/specification/versioning-and-stability#not-defined-semantic-conventions-stability" >}}):
+  while this does not cause any functional issues, you may need to update your
+  instrumentation every once in a while. Having it in a preview plugin or in
+  OpenTelemetry contrib repo may help keeping conventions up-to-date without
+  breaking changes for your users.
 
 ### Getting a tracer
 
-All application configuration is hidden from your library through the Tracer API. Libraries should obtain tracer from [global `TracerProvider`]({{< relref "/docs/reference/specification/trace/api#get-a-tracer" >}}) by default.
+All application configuration is hidden from your library through the Tracer
+API. Libraries should obtain tracer from [global
+`TracerProvider`]({{< relref "/docs/reference/specification/trace/api#get-a-tracer" >}})
+by default.
 
 ```java
 private static final Tracer tracer = GlobalOpenTelemetry.getTracer("demo-db-client", "0.1.0-beta1");
 ```
 
-It's useful for libraries to have an API that allows applications to pass instances of `TracerProvider` explicitly which enables better dependency injection and simplifies testing.
+It's useful for libraries to have an API that allows applications to pass
+instances of `TracerProvider` explicitly which enables better dependency
+injection and simplifies testing.
 
-When obtaining the tracer, provide your library (or tracing plugin) name and version - they show up on the telemetry and help users process and filter telemetry, understand where it came from, and debug/report any instrumentation issues.
+When obtaining the tracer, provide your library (or tracing plugin) name and
+version - they show up on the telemetry and help users process and filter
+telemetry, understand where it came from, and debug/report any instrumentation
+issues.
 
 ## What to instrument
 
@@ -72,9 +126,12 @@ When obtaining the tracer, provide your library (or tracing plugin) name and ver
 
 ### Public APIs
 
-Public APIs are a good candidates for tracing: spans created for public API calls allow users to map telemetry to application code, understand the duration and outcome of library calls. Which calls to trace:
+Public APIs are a good candidates for tracing: spans created for public API
+calls allow users to map telemetry to application code, understand the duration
+and outcome of library calls. Which calls to trace:
 
-- public methods that make network calls internally or local operations that take significant time and may fail (e.g. IO)
+- public methods that make network calls internally or local operations that
+  take significant time and may fail (e.g. IO)
 - handlers that process requests or messages
 
 **Instrumentation example:**
@@ -110,26 +167,39 @@ private Response selectWithTracing(Query query) {
 }
 ```
 
-Follow conventions to populate attributes! If there is no applicable one, check out [general conventions]({{< relref "/docs/reference/specification/trace/semantic_conventions/span-general" >}}).
+Follow conventions to populate attributes! If there is no applicable one, check
+out [general
+conventions]({{< relref "/docs/reference/specification/trace/semantic_conventions/span-general" >}}).
 
 ### Nested network and other spans
 
-Network calls are usually traced with OpenTelemetry auto-instrumentations through corresponding client implementation.
+Network calls are usually traced with OpenTelemetry auto-instrumentations
+through corresponding client implementation.
 
-If OpenTelemetry does not support tracing your network client, use your best judgement, here are some considerations to help:
+If OpenTelemetry does not support tracing your network client, use your best
+judgement, here are some considerations to help:
 
-- Would tracing network calls improve observability for users or your ability to support them?
-- Is your library a wrapper on top of public, documented RPC API? Would users need to get support from the underlying service in case of issues?
+- Would tracing network calls improve observability for users or your ability to
+  support them?
+- Is your library a wrapper on top of public, documented RPC API? Would users
+  need to get support from the underlying service in case of issues?
   - instrument the library and make sure to trace individual network tries
-- Would tracing those calls with spans be very verbose? or would it noticeably impact performance?
-  - use logs with verbosity or span events: logs can be correlated to parent (public API calls), while span events should be set on public API span.
-  - if they have to be spans (to carry and propagate unique trace context), put them behind a configuration option and disable them by default.
+- Would tracing those calls with spans be very verbose? or would it noticeably
+  impact performance?
+  - use logs with verbosity or span events: logs can be correlated to parent
+    (public API calls), while span events should be set on public API span.
+  - if they have to be spans (to carry and propagate unique trace context), put
+    them behind a configuration option and disable them by default.
 
-If OpenTelemetry already supports tracing your network calls, you probably don't want to duplicate it. There may be some exceptions:
+If OpenTelemetry already supports tracing your network calls, you probably don't
+want to duplicate it. There may be some exceptions:
 
-- to support users without auto-instrumentation (which may not work in certain environments or users may have concerns with monkey-patching)
-- to enable custom (legacy) correlation and context propagation protocols with underlying service
-- enrich RPC spans with absolutely essential library/service-specific information not covered by auto-instrumentation
+- to support users without auto-instrumentation (which may not work in certain
+  environments or users may have concerns with monkey-patching)
+- to enable custom (legacy) correlation and context propagation protocols with
+  underlying service
+- enrich RPC spans with absolutely essential library/service-specific
+  information not covered by auto-instrumentation
 
 WARNING: Generic solution to avoid duplication is under construction 🚧.
 
@@ -156,9 +226,16 @@ using the active span if you can, since you don't control what it refers to.
 
 ### Extracting context
 
-If you work on a library or a service that receives upstream calls, e.g. a web framework or a messaging consumer, you should extract context from the incoming request/message. OpenTelemetry provides the `Propagator` API, which hides specific propagation standards and reads the trace `Context` from the wire. In case of a single response, there is just one context on the wire, which becomes the parent of the new span the library creates.
+If you work on a library or a service that receives upstream calls, e.g. a web
+framework or a messaging consumer, you should extract context from the incoming
+request/message. OpenTelemetry provides the `Propagator` API, which hides
+specific propagation standards and reads the trace `Context` from the wire. In
+case of a single response, there is just one context on the wire, which becomes
+the parent of the new span the library creates.
 
-After you create a span, you should pass new trace context to the application code (callback or handler), by making the span active; if possible, you should do this explicitly.
+After you create a span, you should pass new trace context to the application
+code (callback or handler), by making the span active; if possible, you should
+do this explicitly.
 
 ```java
 // extract the context
@@ -180,14 +257,25 @@ try (Scope unused = span.makeCurrent()) {
 }
 ```
 
-Here're the full [examples of context extraction in Java](/docs/instrumentation/java/manual/#context-propagation), check out OpenTelemetry documentation in your language.
+Here're the full
+[examples of context extraction in Java](/docs/instrumentation/java/manual/#context-propagation),
+check out OpenTelemetry documentation in your language.
 
-In the case of a messaging system, you may receive more than one message at once. Received messages become [*links*](/docs/instrumentation/java/manual/#create-spans-with-links) on the span you create.
-Refer to [messaging conventions]({{< relref "/docs/reference/specification/trace/semantic_conventions/messaging" >}}) for details (WARNING: messaging conventions are [under constructions](https://github.com/open-telemetry/oteps/pull/173) 🚧).
+In the case of a messaging system, you may receive more than one message at
+once. Received messages become
+[_links_](/docs/instrumentation/java/manual/#create-spans-with-links) on the
+span you create. Refer to [messaging
+conventions]({{< relref "/docs/reference/specification/trace/semantic_conventions/messaging" >}})
+for details (WARNING: messaging conventions are
+[under constructions](https://github.com/open-telemetry/oteps/pull/173) 🚧).
 
 ### Injecting context
 
-When you make an outbound call, you will usually want to propagate context to the downstream service. In this case, you should create a new span to trace the outgoing call and use `Propagator` API to inject context into the message. There may be other cases where you might want to inject context, e.g. when creating messages for async processing.
+When you make an outbound call, you will usually want to propagate context to
+the downstream service. In this case, you should create a new span to trace the
+outgoing call and use `Propagator` API to inject context into the message. There
+may be other cases where you might want to inject context, e.g. when creating
+messages for async processing.
 
 ```java
 Span span = tracer.spanBuilder("send")
@@ -209,42 +297,61 @@ try (Scope unused = span.makeCurrent()) {
 }
 ```
 
-Here's the full [example of context injection in Java](/docs/instrumentation/java/manual/#context-propagation).
+Here's the full
+[example of context injection in Java](/docs/instrumentation/java/manual/#context-propagation).
 
 There might be some exceptions:
 
 - downstream service does not support metadata or prohibits unknown fields
-- downstream service does not define correlation protocols. Is it possible that some future service version will support compatible context propagation? Inject it!
+- downstream service does not define correlation protocols. Is it possible that
+  some future service version will support compatible context propagation?
+  Inject it!
 - downstream service supports custom correlation protocol.
-  - best effort with custom propagator: use OpenTelemetry trace context if compatible.
+  - best effort with custom propagator: use OpenTelemetry trace context if
+    compatible.
   - or generate and stamp custom correlation ids on the span.
 
 ### In-process
 
-- **Make your spans active** (aka current): it enables correlating spans with logs and any nested auto-instrumentations.
-- If the library has a notion of context, support **optional** explicit trace context propagation *in addition* to active spans
-  - put spans (trace context) created by library in the context explicitly, document how to access it
+- **Make your spans active** (aka current): it enables correlating spans with
+  logs and any nested auto-instrumentations.
+- If the library has a notion of context, support **optional** explicit trace
+  context propagation _in addition_ to active spans
+  - put spans (trace context) created by library in the context explicitly,
+    document how to access it
   - allow users to pass trace context in your context
-- Within the library, propagate trace context explicitly - active spans may change during callbacks!
-  - capture active context from users on the public API surface as soon as you can, use it as a parent context for your spans
-  - pass context around and stamp attributes, exceptions, events on explicitly propagated instances
-  - this is essential if you start threads explicitly, do background processing or other things that can break due to async context flow limitations in your language
+- Within the library, propagate trace context explicitly - active spans may
+  change during callbacks!
+  - capture active context from users on the public API surface as soon as you
+    can, use it as a parent context for your spans
+  - pass context around and stamp attributes, exceptions, events on explicitly
+    propagated instances
+  - this is essential if you start threads explicitly, do background processing
+    or other things that can break due to async context flow limitations in your
+    language
 
 ## Metrics
 
-[Metrics API]({{< relref "/docs/reference/specification/metrics/api" >}}) is not stable yet and we don't yet define metrics conventions.
+[Metrics API]({{< relref "/docs/reference/specification/metrics/api" >}}) is not
+stable yet and we don't yet define metrics conventions.
 
 ## Misc
 
 ### Instrumentation registry
 
-Please add your instrumentation library to the [OpenTelemetry registry](/registry/), so users can find it.
+Please add your instrumentation library to the
+[OpenTelemetry registry](/registry/), so users can find it.
 
 ### Performance
 
-OpenTelemetry API is no-op and very performant when there is no SDK in the application. When OpenTelemetry SDK is configured, it [consumes bound resources]({{< relref "/docs/reference/specification/performance" >}}).
+OpenTelemetry API is no-op and very performant when there is no SDK in the
+application. When OpenTelemetry SDK is configured, it [consumes bound
+resources]({{< relref "/docs/reference/specification/performance" >}}).
 
-Real-life applications, especially on the high scale, would frequently have head-based sampling configured. Sampled-out spans are cheap and you can check if the span is recording, to avoid extra allocations and potentially expensive calculations, while populating attributes.
+Real-life applications, especially on the high scale, would frequently have
+head-based sampling configured. Sampled-out spans are cheap and you can check if
+the span is recording, to avoid extra allocations and potentially expensive
+calculations, while populating attributes.
 
 ```java
 // some attributes are important for sampling, they should be provided at creation time
@@ -263,13 +370,22 @@ if (span.isRecording()) {
 
 ### Error handling
 
-OpenTelemetry API is [forgiving at runtime]({{< relref "/docs/reference/specification/error-handling#basic-error-handling-principles" >}}) - does not fail on invalid arguments, never throws, and swallows exceptions. This way instrumentation issues do not affect application logic. Test the instrumentation to notice issues OpenTelemetry hides at runtime.
+OpenTelemetry API is [forgiving at
+runtime]({{< relref "/docs/reference/specification/error-handling#basic-error-handling-principles" >}}) -
+does not fail on invalid arguments, never throws, and swallows exceptions. This
+way instrumentation issues do not affect application logic. Test the
+instrumentation to notice issues OpenTelemetry hides at runtime.
 
 ### Testing
 
-Since OpenTelemetry has variety of auto-instrumentations, it's useful to try how your instrumentation interacts with other telemetry: incoming requests, outgoing requests, logs, etc. Use a typical application, with popular frameworks and libraries and all tracing enabled when trying out your instrumentation. Check out how libraries similar to yours show up.
+Since OpenTelemetry has variety of auto-instrumentations, it's useful to try how
+your instrumentation interacts with other telemetry: incoming requests, outgoing
+requests, logs, etc. Use a typical application, with popular frameworks and
+libraries and all tracing enabled when trying out your instrumentation. Check
+out how libraries similar to yours show up.
 
-For unit testing, you can usually mock or fake `SpanProcessor` and `SpanExporter`.
+For unit testing, you can usually mock or fake `SpanProcessor` and
+`SpanExporter`.
 
 ```java
 @Test
@@ -297,4 +413,4 @@ class TestExporter implements SpanExporter {
 }
 ```
 
-[span events]: {{< relref "/docs/reference/specification/trace/api#add-events" >}}
+[span events]: /docs/reference/specification/trace/api/#add-events

--- a/content/en/docs/concepts/instrumenting.md
+++ b/content/en/docs/concepts/instrumenting.md
@@ -18,19 +18,20 @@ repositories:
 - **[Contrib](https://github.com/open-telemetry/opentelemetry-java-contrib):**
   Optional components such as JMX metric gathers.
 
-Some instrumentation libraries, for example Ruby, offer a [single
-repository](https://github.com/open-telemetry/opentelemetry-ruby) that supports
-both manual and automatic instrumentation. Other languages, for example JS,
-support both manual and automatic instrumentation, but separate
+Some instrumentation libraries, for example Ruby, offer a
+[single repository](https://github.com/open-telemetry/opentelemetry-ruby) that
+supports both manual and automatic instrumentation. Other languages, for example
+JS, support both manual and automatic instrumentation, but separate
 [core](https://github.com/open-telemetry/opentelemetry-js) components from
-[contrib](https://github.com/open-telemetry/opentelemetry-js-contrib)
-components in separate repositories.
+[contrib](https://github.com/open-telemetry/opentelemetry-js-contrib) components
+in separate repositories.
 
 The exact installation mechanism for OpenTelemetry varies based on the language
 you're developing in, but there are some similarities covered in the sections
 below.
 
-> Instrumentation libraries may be offered as a distribution, see [here](../distributions) for more information.
+> Instrumentation libraries may be offered as a distribution, see
+> [here](../distributions) for more information.
 
 ## Automatic Instrumentation
 
@@ -39,8 +40,8 @@ below.
 In order to enable automatic instrumentation, one or more dependencies need to
 be added. How dependencies are added are language specific. At a minimum, these
 dependencies will add OpenTelemetry API and SDK capabilities. Some languages
-also require per instrumentation dependencies. Exporter dependencies may also
-be required. For more information about the OpenTelemetry API and SDK, see the
+also require per instrumentation dependencies. Exporter dependencies may also be
+required. For more information about the OpenTelemetry API and SDK, see the
 [specification](/docs/reference/specification/).
 
 ### Configure OpenTelemetry Instrumentation
@@ -62,35 +63,35 @@ other configuration options are available and may include:
 You'll first need to import OpenTelemetry to your service code. If you're
 developing a library or some other component that is intended to be consumed by
 a runnable binary, then you would only take a dependency on the API. If your
-artifact is a standalone process or service, then you would take a dependency
-on the API and the SDK. For more information about the OpenTelemetry API and
-SDK, see the [specification](/docs/reference/specification/).
+artifact is a standalone process or service, then you would take a dependency on
+the API and the SDK. For more information about the OpenTelemetry API and SDK,
+see the [specification](/docs/reference/specification/).
 
 ### Configure the OpenTelemetry API
 
 In order to create traces or metrics, you'll need to first create a tracer
 and/or meter provider. In general, we recommend that the SDK should provide a
 single default provider for these objects. You'll then get a tracer or meter
-instance from that provider, and give it a name and version. The name you
-choose here should identify what exactly is being instrumented -- if you're
-writing a library, for example, then you should name it after your library
-(i.e., `com.legitimatebusiness.myLibrary` or some other unique identifier) as
-this name will namespace all spans or metric events produced. It is also
-recommended that you supply a version string (i.e., `semver:1.0.0`) that
-corresponds to the current version of your library or service.
+instance from that provider, and give it a name and version. The name you choose
+here should identify what exactly is being instrumented -- if you're writing a
+library, for example, then you should name it after your library (i.e.,
+`com.legitimatebusiness.myLibrary` or some other unique identifier) as this name
+will namespace all spans or metric events produced. It is also recommended that
+you supply a version string (i.e., `semver:1.0.0`) that corresponds to the
+current version of your library or service.
 
 ### Configure the OpenTelemetry SDK
 
-If you're building a service process, you'll also need to configure the SDK
-with appropriate options for exporting your telemetry data to some analysis
-backend. We recommend that this configuration be handled programmatically
-through a configuration file or some other mechanism. There are also
-per-language tuning options you may wish to take advantage of.
+If you're building a service process, you'll also need to configure the SDK with
+appropriate options for exporting your telemetry data to some analysis backend.
+We recommend that this configuration be handled programmatically through a
+configuration file or some other mechanism. There are also per-language tuning
+options you may wish to take advantage of.
 
 ### Create Telemetry Data
 
-Once you've configured the API and SDK, you'll then be free to create traces
-and metric events through the tracer and meter objects you obtained from the
+Once you've configured the API and SDK, you'll then be free to create traces and
+metric events through the tracer and meter objects you obtained from the
 provider. You can also utilize a plugin or integration to create traces and
 metric events for you -- check out the [registry](/registry) or your language's
 repository for more information on these.
@@ -99,19 +100,19 @@ repository for more information on these.
 
 Once you've created telemetry data, you'll want to send it somewhere.
 OpenTelemetry supports two primary methods of exporting data from your process
-to an analysis backend, either directly from a process or by proxying it
-through the [OpenTelemetry Collector](/docs/collector).
+to an analysis backend, either directly from a process or by proxying it through
+the [OpenTelemetry Collector](/docs/collector).
 
 In-process export requires you to import and take a dependency on one or more
 _exporters_, libraries that translate OpenTelemetry's in-memory span and metric
 objects into the appropriate format for telemetry analysis tools like Jaeger or
-Prometheus. In addition, OpenTelemetry supports a wire protocol known as
-`OTLP`, which is supported by all OpenTelemetry SDKs. This protocol can be used
-to send data to the OpenTelemetry Collector, a standalone binary process that
-can be run as a proxy or sidecar to your service instances or run on a separate
-host. The Collector can then be configured to forward and export this data to
-your choice of analysis tools.
+Prometheus. In addition, OpenTelemetry supports a wire protocol known as `OTLP`,
+which is supported by all OpenTelemetry SDKs. This protocol can be used to send
+data to the OpenTelemetry Collector, a standalone binary process that can be run
+as a proxy or sidecar to your service instances or run on a separate host. The
+Collector can then be configured to forward and export this data to your choice
+of analysis tools.
 
-In addition to open source tools such as Jaeger or Prometheus, a growing list
-of companies support ingesting telemetry data from OpenTelemetry. Please see
+In addition to open source tools such as Jaeger or Prometheus, a growing list of
+companies support ingesting telemetry data from OpenTelemetry. Please see
 [this page](/vendors) for more details.

--- a/content/en/docs/concepts/what-is-opentelemetry.md
+++ b/content/en/docs/concepts/what-is-opentelemetry.md
@@ -3,12 +3,11 @@ title: "What is OpenTelemetry?"
 weight: 10
 ---
 
-OpenTelemetry is a set of APIs, SDKs, tooling and integrations that are
-designed for the creation and management of _telemetry data_ such as traces,
-metrics, and logs. The project provides a vendor-agnostic implementation that
-can be configured to send telemetry data to the backend(s) of your choice.
-It supports a variety of popular open-source projects including Jaeger and
-Prometheus.
+OpenTelemetry is a set of APIs, SDKs, tooling and integrations that are designed
+for the creation and management of _telemetry data_ such as traces, metrics, and
+logs. The project provides a vendor-agnostic implementation that can be
+configured to send telemetry data to the backend(s) of your choice. It supports
+a variety of popular open-source projects including Jaeger and Prometheus.
 
 ## Why you need OpenTelemetry and what it can do
 

--- a/content/en/docs/instrumentation/erlang/instrumentation.md
+++ b/content/en/docs/instrumentation/erlang/instrumentation.md
@@ -82,17 +82,17 @@ completes:
 {{< tabs Erlang Elixir >}}
 
 {{< tab >}}
-parent_function() ->    
+parent_function() ->
     ?with_span(<<"parent">>, #{}, fun child_function/0).
-               
+
 child_function() ->
     %% this is the same process, so the span <<"parent">> set as the active
-    %% span in the with_span call above will be the active span in this function    
-    ?with_span(<<"child">>, #{}, 
+    %% span in the with_span call above will be the active span in this function
+    ?with_span(<<"child">>, #{},
                fun() ->
                    %% do work here. when this function returns, <<"child">> will complete.
                end).
-    
+
 {{< /tab >}}
 
 {{< tab >}}
@@ -106,7 +106,7 @@ end
 
 def child_function() do
     # this is the same process, so the span <<"parent">> set as the active
-    # span in the with_span call above will be the active span in this function    
+    # span in the with_span call above will be the active span in this function
     OpenTelemetry.Tracer.with_span "child" do
         ## do work here. when this function returns, <<"child">> will complete.
     end
@@ -144,9 +144,9 @@ Ctx = otel_ctx:get_current(),
 proc_lib:spawn_link(fun() ->
                         otel_ctx:attach(Ctx),
                         ?set_current_span(SpanCtx),
-                        
+
                         %% do work here
-                        
+
                         ?end_span(SpanCtx)
                     end),
 {{< /tab >}}
@@ -159,10 +159,10 @@ task = Task.async(fn ->
                       OpenTelemetry.Ctx.attach(ctx),
                       OpenTelemetry.Tracer.set_current_span(span_ctx)
                       # do work here
-                      
+
                       # end span here or after `await` returns
                   end)
-                  
+
 _ = Task.await(task)
 OpenTelemetry.Tracer.end_span(span_ctx)
 {{< /tab >}}
@@ -224,8 +224,8 @@ in the body of the span operation:
 {{< tabs Erlang Elixir >}}
 
 {{< tab >}}
-?with_span(<<"my-span">>, #{attributes => [{<<"start-opts-attr">>, <<"start-opts-value">>}]}, 
-           fun() -> 
+?with_span(<<"my-span">>, #{attributes => [{<<"start-opts-attr">>, <<"start-opts-value">>}]},
+           fun() ->
                ?set_attributes([{<<"my-attribute">>, <<"my-value">>},
                                 {another_attribute, <<"value-of-attribute">>}])
            end)
@@ -261,8 +261,8 @@ the pool, and another when it is checked in.
 {{< tabs Erlang Elixir >}}
 
 {{< tab >}}
-?with_span(<<"my-span">>, #{}, 
-           fun() -> 
+?with_span(<<"my-span">>, #{},
+           fun() ->
                ?add_event(<<"checking out connection">>),
                %% acquire connection from connection pool
                ?add_event(<<"got connection, doing work">>),
@@ -321,7 +321,7 @@ registered with OpenTelemetry. This can be done through configuration of the
 ...
 {text_map_propagators, [baggage,
                         trace_context]},
-...                        
+...
 {{< /tab >}}
 
 {{< tab >}}
@@ -354,5 +354,5 @@ Organization](https://hex.pm/orgs/opentelemetry) and the [registry](/registry).
 The metrics API, found in `apps/opentelemetry-experimental-api` of the
 `opentelemetry-erlang` repository, is currently unstable, documentation TBA.
 
-[OpenTelemetry Specification]: {{< relref "/docs/reference/specification" >}}
-[Trace semantic conventions]: {{< relref "/docs/reference/specification/trace/semantic_conventions" >}}
+[OpenTelemetry Specification]: /docs/reference/specification
+[Trace semantic conventions]: /docs/reference/specification/trace/semantic_conventions

--- a/content/en/docs/instrumentation/java/manual.md
+++ b/content/en/docs/instrumentation/java/manual.md
@@ -681,12 +681,12 @@ io.opentelemetry.sdk.trace.export.BatchSpanProcessor = io.opentelemetry.extensio
 [AlwaysOffSampler]: https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/AlwaysOffSampler.java
 [AlwaysOnSampler]: https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/AlwaysOnSampler.java
 [HttpExchange]: https://docs.oracle.com/javase/8/docs/jre/api/net/httpserver/spec/com/sun/net/httpserver/HttpExchange.html
-[Instrumentation Library]: {{< relref "/docs/reference/specification/glossary#instrumentation-library" >}}
-[instrumented library]: {{< relref "/docs/reference/specification/glossary#instrumented-library" >}}
-[Library Guidelines]: {{< relref "/docs/reference/specification/library-guidelines" >}}
-[Obtaining a Tracer]: {{< relref "/docs/reference/specification/trace/api#get-a-tracer" >}}
+[Instrumentation Library]: /docs/reference/specification/glossary/#instrumentation-library
+[instrumented library]: /docs/reference/specification/glossary/#instrumented-library
+[Library Guidelines]: /docs/reference/specification/library-guidelines
+[Obtaining a Tracer]: /docs/reference/specification/trace/api/#get-a-tracer
 [OpenTelemetry Collector]: https://github.com/open-telemetry/opentelemetry-collector
-[OpenTelemetry Registry]: {{< relref "/registry/" >}}?component=exporter&language=java
+[OpenTelemetry Registry]: /registry/?component=exporter&language=java
 [ParentBased]: https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/ParentBasedSampler.java
-[Semantic Conventions]: {{< relref "/docs/reference/specification/trace/semantic_conventions" >}}
+[Semantic Conventions]: /docs/reference/specification/trace/semantic_conventions
 [TraceIdRatioBased]: https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/TraceIdRatioBasedSampler.java

--- a/content/en/docs/instrumentation/js/api/tracing.md
+++ b/content/en/docs/instrumentation/js/api/tracing.md
@@ -94,18 +94,18 @@ async function onGet(request, response) {
 
   // Create a new context from the current context which has the span "active"
   const ctx = trace.setSpan(context.active(), span);
-  
+
   // Call getUser with the newly created context
-  // 
+  //
   // context.with calls a function with an associated "active" context. Within
   // the function, calling context.active() returns the currently active context.
   // If there is no active context, the ROOT_CONTEXT will be returned, which
   // has no key-value pairs.
-  // 
+  //
   // context.with requires at least 2 arguments: a context and a function to be called.
   // If a third argument is provided, it will be bound to `this` `this` inside the function.
   // Any additional parameters are used as arguments when calling the function.
-  // 
+  //
   //   Return value is the value returned from getUser
   //    |                         Context to be used as the "active" context
   //    |                         |    Function to be called
@@ -203,4 +203,4 @@ One problem with span names and attributes is recognizing, categorizing, and ana
 
 For details, see [Trace semantic conventions]({{< relref "/docs/reference/specification/trace/semantic_conventions" >}}).
 
-[Getting Started]: {{< relref "../getting-started" >}}
+[Getting Started]: ../../getting-started

--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -25,9 +25,9 @@ function doWork() {
 
 ## Initializing a Tracer
 
-As you have learned in the previous [Getting Started][] guide you need a
-TracerProvider and an Exporter. Install the dependencies and add them to the head of
-your application code to get started:
+As you have learned in the previous [Getting Started](../getting-started) guide you
+need a TracerProvider and an Exporter. Install the dependencies and add them to
+the head of your application code to get started:
 
 ```shell
 npm install @opentelemetry/api
@@ -292,5 +292,3 @@ try {
   span.setStatus({ code: otel.SpanStatusCode.ERROR });
 }
 ```
-
-[Getting Started]: {{< relref "getting-started" >}}

--- a/content/en/status.md
+++ b/content/en/status.md
@@ -67,7 +67,7 @@ Note that, for each of the following sections, the **Collector** status is the s
   - Collector support for Prometheus is under development, in collaboration with the Prometheus community.
   - The metric API and SDK specification is currently being prototyped in Java, .NET, and Python.
 
-[metrics]: {{< relref "/docs/reference/specification/metrics/" >}}
+[metrics]: /docs/reference/specification/metrics/
 
 #### Baggage
 


### PR DESCRIPTION
- No change in content (other than whitespace changes)
- Mainly ran Prettier over the concepts files.
- Global-replaced Markdown link definitions that were using `relref`s, replacing them with equivalent paths.

/cc @austinlparker @cartermp 