### PR TITLE
Metrics-RC-blog: add linkTitle

### DIFF
--- a/content/en/blog/2022/metrics-announcement.md
+++ b/content/en/blog/2022/metrics-announcement.md
@@ -1,5 +1,6 @@
 ---
 title: OpenTelemetry Metrics Release Candidates
+linkTitle: Metrics RCs
 date: 2022-05-18
 author: Morgan McLean
 ---


### PR DESCRIPTION
- Adds a shorter `linkTitle`, which will appear in the left-side blog post list. Shorter TOC titles are better (sorry that I missed this addition when reviewing the blog post).
- Followup to #1361

Preview: https://deploy-preview-1363--opentelemetry.netlify.app/blog/

/cc @austinlparker 