### PR TITLE
Update spec to v1.11.0

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,3 +1,7 @@
 DirectoryPath: public
 IgnoreDirectoryMissingTrailingSlash: true
 IgnoreAltMissing: true
+IgnoreInternalURLs:
+  # TODO: fix the source of these inlined TOC links
+  # https://github.com/open-telemetry/opentelemetry.io/issues/1357
+  - /docs/reference/specification/versioning-and-stability/#not-defined-semantic-conventions-stability

--- a/content/en/docs/concepts/glossary.md
+++ b/content/en/docs/concepts/glossary.md
@@ -187,7 +187,7 @@ others. This page captures terminology used in the project and what it means.
 - **[Metric
   Conventions]({{< relref "/docs/reference/specification/metrics/semantic_conventions" >}})**
 
-[attribute]: /docs/reference/specification/common/common/#attributes
+[attribute]: /docs/reference/specification/common/#attributes
 [spec-exporter-lib]: /docs/reference/specification/glossary/#exporter-library
 [spec-instrumentation-lib]:
   /docs/reference/specification/glossary/#instrumentation-library


### PR DESCRIPTION
Updates the spec to v1.11.0:
```console
$ pwd
.../opentelemetry.io/content-modules/opentelemetry-specification
$ git branch -v
* (HEAD detached at ef5dc5f) ef5dc5f Release v1.11.0 (#2519)
```

Preview: 

/cc @carlosalberto 