### PR TITLE
Linkify .NET concepts, clarify concepts, fix some minor docs bugs

### DIFF
--- a/content/en/docs/concepts/otel-concepts.md
+++ b/content/en/docs/concepts/otel-concepts.md
@@ -206,24 +206,37 @@ components that will play a part in instrumenting our code:
 - Trace Exporter
 - Trace Context
 
-The primary responsibility of a **Tracer** is to create spans containing more
-information about what is happening during a request. The **Tracer** is also
-responsible for knowing the instrumentation library and data related to that
-specific library.
+### Tracer Provider
 
-Finally, the **Trace Provider** is responsible for providing access to and
-interaction with the **Tracer**.
+A Tracer Provider (sometimes called `TracerProvider`) is a factory for
+`Tracer`s. In most applications, a Tracer Provider is initialized once and its
+lifecycle is congruent with the application's lifecycle. Tracer Provider
+initialization also includes Resource and Exporter initialization. It is
+typically the first step in tracing with OpenTelemetry. In some language SDKs, a
+global Tracer Provider is already initialized for you.
 
-**Trace Exporters** send data to the open-source or vendor backend of your
-choice.
+### Tracer
 
-**Trace Context** is metadata about trace spans that provides correlation
-between spans across service and process boundaries. For example, if Service A
-calls Service B and you want to track the call in a trace. In that case, we will
-use Trace Context to capture and propagate metadata about spans in Service A so
-that spans created in Service B can connect to them.
+A Tracer creates spans containing more information about what is happening for a
+given operation, such as a request in a service. Tracers are created from Tracer
+Providers. In some languages, a global Tracer is already initialized for you.
 
-Trace Context is how distributed tracing ultimately works.
+### Trace Exporters
+
+Trace Exporters send traces to a consumer. This consumer can be standard output
+for debugging and development-time, the OpenTelemetry Collector, or any
+open-source or vendor backend of your choice.
+
+### Trace Context
+
+Trace Context is metadata about trace spans that provides correlation between
+spans across service and process boundaries. For example, let's say that Service
+A calls Service B and you want to track the call in a trace. In that case,
+OpenTelemetry will use Trace Context to capture the ID of the trace and current
+span from Service A, so that spans created in Service B can connect and add to
+the trace.
+
+This is known as Context Propagation.
 
 ### Context Propagation
 
@@ -258,9 +271,9 @@ associated with
 sampled
 
 **Trace State** - Provides more vendor-specific information for tracing across
-multiple distributed systems. Please refer to
-[W3C Trace Context](https://www.w3.org/TR/trace-context/#trace-flags) for
-further explanation.
+multiple distributed systems. Please refer to [W3C Trace
+Context](https://www.w3.org/TR/trace-context/#trace-flags) for further
+explanation.
 
 By combining Context and Propagation, you now can assemble a Trace.
 

--- a/content/en/docs/concepts/otel-concepts.md
+++ b/content/en/docs/concepts/otel-concepts.md
@@ -210,7 +210,7 @@ components that will play a part in instrumenting our code:
 
 A Tracer Provider (sometimes called `TracerProvider`) is a factory for
 `Tracer`s. In most applications, a Tracer Provider is initialized once and its
-lifecycle is congruent with the application's lifecycle. Tracer Provider
+lifecycle matches the application's lifecycle. Tracer Provider
 initialization also includes Resource and Exporter initialization. It is
 typically the first step in tracing with OpenTelemetry. In some language SDKs, a
 global Tracer Provider is already initialized for you.

--- a/content/en/docs/instrumentation/net/automatic.md
+++ b/content/en/docs/instrumentation/net/automatic.md
@@ -5,12 +5,12 @@ linkTitle: Automatic
 ---
 
 .NET supports automatic instrumentation with [instrumentation
-libraries](/docs/reference/specification/glossary/#instrumentation-library)
-that generate telemetry data for a particular instrumented library.
+libraries](/docs/reference/specification/glossary/#instrumentation-library) that
+generate telemetry data for a particular instrumented library.
 
 For example, the instrumentation library for ASP.NET Core will automatically
-create spans that track inbound requests once you configure it in your
-app/service.
+create [spans](/docs/concepts/otel-concepts#spans-in-opentelemetry) that track
+inbound requests once you configure it in your app/service.
 
 ## Setup
 
@@ -22,7 +22,8 @@ dotnet add package OpenTelemetry.Instrumentation.{library-name-or-type}
 ```
 
 It is typically then registered at application startup time, such as when
-creating a TracerProvider.
+creating a
+[TracerProvider](/docs/concepts/otel-concepts#tracing-in-opentelemetry).
 
 ## Example with ASP.NET Core and HttpClient
 
@@ -106,13 +107,14 @@ You can also find more instrumentations available in the
 ## Next steps
 
 After you have set up instrumentation libraries, you may want to add [manual
-instrumentation]({{< relref "manual" >}}) to collect custom telemetry data.
+instrumentation](/docs/instrumentation/net/manual) to collect custom telemetry
+data.
 
 If you are using .NET Framework 4.x instead of modern .NET, refer to the [.NET
-Framework docs]({{< relref "netframework" >}}) to configure OpenTelemetry and
-instrumentation libraries on .NET Framework.
+Framework docs](/docs/instrumentation/net/netframework) to configure
+OpenTelemetry and instrumentation libraries on .NET Framework.
 
 You'll also want to configure an appropriate exporter to [export your telemetry
-data]({{< relref "exporters" >}}) to one or more telemetry backends.
+data](/docs/instrumentation/net/exporters) to one or more telemetry backends.
 
 [opentelemetry-dotnet]: https://github.com/open-telemetry/opentelemetry-dotnet

--- a/content/en/docs/instrumentation/net/exporters.md
+++ b/content/en/docs/instrumentation/net/exporters.md
@@ -3,8 +3,9 @@ title: "Exporters"
 weight: 4
 ---
 
-In order to visualize and analyze your traces and metrics, you will need to
-export them to a backend.
+In order to visualize and analyze your
+[traces](/docs/concepts/otel-concepts#tracing-in-opentelemetry) and metrics, you
+will need to export them to a backend.
 
 ## Console exporter
 
@@ -286,9 +287,9 @@ using var tracerProvider = Sdk.CreateMeterProviderBuilder()
 ## Next steps
 
 To ensure you're getting the most data as easily as possible, install [automatic
-instrumentation libraries]({{< relref "automatic" >}}) to automatically generate
-observability data.
+instrumentation libraries](/docs/instrumentation/net/automatic) to automatically
+generate observability data.
 
 Additionally, enriching your instrumentation generated automatically with
-[manual instrumentation]({{< relref "manual" >}}) of your own codebase gets you
-customized observability data.
+[manual instrumentation](/docs/instrumentation/net/manual) of your own codebase
+gets you customized observability data.

--- a/content/en/docs/instrumentation/net/getting-started.md
+++ b/content/en/docs/instrumentation/net/getting-started.md
@@ -23,7 +23,9 @@ dotnet add package OpenTelemetry
 
 ## Console application
 
-The following sample demonstrates manual tracing via a console app.
+The following sample demonstrates manual
+[tracing](/docs/concepts/otel-concepts#tracing-in-opentelemetry) via a console
+app.
 
 First, install the required package:
 
@@ -61,7 +63,8 @@ activity?.SetTag("bar", "Hello, World!");
 activity?.SetTag("baz", new int[] { 1, 2, 3 });
 ```
 
-The code will generate a single span like this:
+The code will generate a single
+[span](/docs/concepts/otel-concepts#spans-in-opentelemetry) like this:
 
 ```
 Activity.Id:          00-cf0e89a41682d0cc7a132277da6a45d6-c714dd3b15e21378-01
@@ -84,7 +87,8 @@ This output matches the span created in the preceding code sample.
 
 ## ASP.NET Core
 
-The following sample demonstrates automatic and manual tracing with ASP.NET
+The following sample demonstrates automatic and manual
+[tracing](/docs/concepts/otel-concepts#tracing-in-opentelemetry) with ASP.NET
 Core.
 
 First, install requried packages:
@@ -142,8 +146,9 @@ app.MapGet("/hello", () =>
 app.Run();
 ```
 
-When you run the app and navigate to the `/hello` route, you'll see output
-similar to the following:
+When you run the app and navigate to the `/hello` route, you'll see output about
+[spans](/docs/concepts/otel-concepts#spans-in-opentelemetry) similar to the
+following:
 
 ```
 Activity.Id:          00-d72f7e51dd06b57211f415489df89b1c-c8a394817946316d-01
@@ -197,7 +202,8 @@ following situations, among others:
 
 ### Configure and run a local collector
 
-First, save the following collector configuration code to a file in the `/tmp/` directory:
+First, save the following collector configuration code to a file in the `/tmp/`
+directory:
 
 ```yaml
 # /tmp/otel-collector-config.yaml
@@ -307,12 +313,12 @@ Now, telemetry will be output by the collector process.
 ## Next steps
 
 To ensure you're getting the most data as easily as possible, install some
-[instrumentation libraries]({{< relref "automatic" >}}) to automatically
+[instrumentation libraries](/docs/instrumentation/net/automatic) to automatically
 generate observability data.
 
 Additionally, enriching your instrumentation generated automatically with
-[manual instrumentation]({{< relref "manual" >}}) of your own codebase gets you
+[manual instrumentation](/docs/instrumentation/net/manual) of your own codebase gets you
 customized observability data.
 
 You'll also want to configure an appropriate exporter to [export your telemetry
-data]({{< relref "exporters" >}}) to one or more telemetry backends.
+data](/docs/instrumentation/net/exporters) to one or more telemetry backends.

--- a/content/en/docs/instrumentation/net/manual.md
+++ b/content/en/docs/instrumentation/net/manual.md
@@ -28,7 +28,7 @@ you can refer to the [OpenTelemetry API Shim docs for tracing]({{< relref "shim"
 
 There are two main ways to initialize
 [tracing](/docs/concepts/otel-concepts#tracing-in-opentelemetry), depending on
-if you're using a console app or something that's ASP.NET Core-based.
+whether you're using a console app or something that's ASP.NET Core-based.
 
 ### Console app
 

--- a/content/en/docs/instrumentation/net/manual.md
+++ b/content/en/docs/instrumentation/net/manual.md
@@ -10,7 +10,8 @@ application.
 ## A note on terminology
 
 .NET is different from other languages/runtimes that support OpenTelemetry.
-Tracing is implemented by the
+[Tracing](/docs/concepts/otel-concepts#tracing-in-opentelemetry) is implemented
+by the
 [System.Diagnostics](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics)
 API, repurposing existing constructs like `ActivitySource` and `Activity` to be
 OpenTelemetry-compliant under the covers.
@@ -25,8 +26,9 @@ you can refer to the [OpenTelemetry API Shim docs for tracing]({{< relref "shim"
 
 ## Initializing tracing
 
-There are two main ways to initialize tracing, depending on if you're using a
-console app or something that's ASP.NET Core-based.
+There are two main ways to initialize
+[tracing](/docs/concepts/otel-concepts#tracing-in-opentelemetry), depending on
+if you're using a console app or something that's ASP.NET Core-based.
 
 ### Console app
 
@@ -115,8 +117,10 @@ endpoint, you'll have to use a different exporter.
 
 ## Setting up an ActivitySource
 
-Once tracing is initialized, you can configure an `ActivitySource`, which will
-be how you trace operations with `Activity`s.
+Once tracing is initialized, you can configure an
+[`ActivitySource`](/docs/concepts/otel-concepts#tracer), which will be how you
+trace operations with
+[`Activity`s](/docs/concepts/otel-concepts#spans-in-opentelemetry).
 
 Typically, an `ActivitySource` is instantiated once per app/service that is
 being instrumented, so it's a good idea to instantiate it once in a shared
@@ -142,7 +146,9 @@ although it is generally sufficient to just have one defined per service.
 
 ## Creating Activities
 
-To create an activity, give it a name and create it from your `ActivitySource`.
+To create an [activity](/docs/concepts/otel-concepts#spans-in-opentelemetry),
+give it a name and create it from your
+[`ActivitySource`](/docs/concepts/otel-concepts#tracer).
 
 ```csharp
 using var myActivity = MyActivitySource.StartActivity("SayHello");
@@ -219,9 +225,9 @@ Note that `using` is not used in the prior example. Doing so will end current
 
 ## Add tags to an Activity
 
-Tags (the equivalent of Attributes in OpenTelemetry) let you attach key/value
-pairs to an `Activity` so it carries more information about the current
-operation that it's tracking.
+Tags (the equivalent of [`Attributes`](/docs/concepts/otel-concepts#attributes)
+in OpenTelemetry) let you attach key/value pairs to an `Activity` so it carries
+more information about the current operation that it's tracking.
 
 ```csharp
 using var myActivity = MyActivitySource.StartActivity("SayHello");
@@ -233,8 +239,9 @@ activity?.SetTag("operation.other-stuff", new int[] { 1, 2, 3 });
 
 ## Adding events
 
-An event is a human-readable message on an `Activity` that represents "something
-happening" during its lifetime. You can think of it like a primitive log.
+An [event](/docs/concepts/otel-concepts#span-events) is a human-readable message
+on an `Activity` that represents "something happening" during its lifetime. You
+can think of it like a primitive log.
 
 ```csharp
 using var myActivity = MyActivitySource.StartActivity("SayHello");
@@ -271,7 +278,8 @@ myActivity?.AddEvent(new("Gonna try it!", DateTimeOffset.Now, new(eventTags)));
 
 ## Adding links
 
-An `Activity` can be created with zero or more `ActivityLink`s that are causally
+An `Activity` can be created with zero or more
+[`ActivityLink`s](/docs/concepts/otel-concepts#span-links) that are causally
 related.
 
 ```csharp
@@ -294,10 +302,10 @@ using var anotherActivity =
 
 ## Set Activity status
 
-A status can be set on an activity, typically used to specify that an activity
-has not completed successfully - `ActivityStatusCode.Error`. In rare scenarios,
-you could override the `Error` status with `Ok`, but don't set `Ok` on
-successfully-completed spans.
+A [status](/docs/concepts/otel-concepts#span-status) can be set on an activity,
+typically used to specify that an activity has not completed successfully -
+`ActivityStatusCode.Error`. In rare scenarios, you could override the `Error`
+status with `Ok`, but don't set `Ok` on successfully-completed spans.
 
 The status can be set at any time before the span is finished:
 
@@ -317,9 +325,9 @@ catch (Exception ex)
 ## Next steps
 
 After you've setup automatic instrumentation, you may want to use
-[instrumentation libraries]({{< relref "automatic" >}}).Instrumentation
+[instrumentation libraries](/docs/instrumentation/net/automatic).Instrumentation
 libraries will automatically instrument relevant libraries you're using and
 generate data for things like inbound and outbound HTTP requests and more.
 
 You'll also want to configure an appropriate exporter to [export your telemetry
-data]({{< relref "exporters" >}}) to one or more telemetry backends.
+data](/docs/instrumentation/net/exporters) to one or more telemetry backends.

--- a/content/en/docs/instrumentation/net/manual.md
+++ b/content/en/docs/instrumentation/net/manual.md
@@ -146,7 +146,7 @@ although it is generally sufficient to just have one defined per service.
 
 ## Creating Activities
 
-To create an [activity](/docs/concepts/otel-concepts#spans-in-opentelemetry),
+To create an [`Activity`](/docs/concepts/otel-concepts#spans-in-opentelemetry),
 give it a name and create it from your
 [`ActivitySource`](/docs/concepts/otel-concepts#tracer).
 

--- a/content/en/docs/instrumentation/net/netframework.md
+++ b/content/en/docs/instrumentation/net/netframework.md
@@ -144,8 +144,9 @@ exception on the `Activity` itself as an `ActivityEvent`.
 ## Next steps
 
 After you have observability generated automatically with instrumentation
-libraries, you may want to add [manual instrumentation]({{< relref "manual" >}})
-to collect custom telemetry data.
+libraries, you may want to add [manual
+instrumentation](/docs/instrumentation/net/manual) to collect custom telemetry
+data.
 
 You'll also want to configure an appropriate exporter to [export your telemetry
-data]({{< relref "exporters" >}}) to one or more telemetry backends.
+data](/docs/instrumentation/net/exporters) to one or more telemetry backends.

--- a/content/en/docs/instrumentation/net/shim.md
+++ b/content/en/docs/instrumentation/net/shim.md
@@ -4,7 +4,7 @@ linkTitle: OpenTelemetry API Shim
 weight: 5
 ---
 
-NET is different from other languages/runtimes that support OpenTelemetry.
+.NET is different from other languages/runtimes that support OpenTelemetry.
 Tracing is implemented by the
 [System.Diagnostics](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics)
 API, repurposing older constructs like `ActivitySource` and `Activity` to be
@@ -18,12 +18,14 @@ terminology consistent with the OpenTelemetry spec.
 
 ## Initializing tracing
 
-There are two main ways to initialize tracing, depending on if you're using a
-console app or something that's ASP.NET Core-based.
+There are two main ways to initialize
+[tracing](/docs/concepts/otel-concepts#tracing-in-opentelemetry), depending on
+if you're using a console app or something that's ASP.NET Core-based.
 
 ### Console app
 
-To start tracing in a console app, you need to create a tracer provider.
+To start [tracing](/docs/concepts/otel-concepts#tracing-in-opentelemetry) in a
+console app, you need to create a tracer provider.
 
 First, ensure that you have the right packages:
 
@@ -63,8 +65,8 @@ endpoint, you'll have to use a different exporter.
 
 ### ASP.NET Core
 
-To start tracing in an ASP.NET Core-based app, use the OpenTelemetry extensions
-for ASP.NET Core setup.
+To start [tracing](/docs/concepts/otel-concepts#tracing-in-opentelemetry) in an
+ASP.NET Core-based app, use the OpenTelemetry extensions for ASP.NET Core setup.
 
 First, ensure that you have the right packages:
 
@@ -103,9 +105,10 @@ builder.Services.AddOpenTelemetryTracing(b =>
 .AddSingleton(TracerProvider.Default.GetTracer(serviceName)));
 ```
 
-In the preceding example, a `Tracer` corresponding to the service is injected
-during setup. This lets you get access to an instance in your endpoint mapping
-(or controllers if you're using an older version of .NET).
+In the preceding example, a [`Tracer`](/docs/concepts/otel-concepts#tracer)
+corresponding to the service is injected during setup. This lets you get access
+to an instance in your endpoint mapping (or controllers if you're using an older
+version of .NET).
 
 It's not required to inject a service-level tracer, nor does it improve
 performance either. You will need to decide where you'll want your tracer
@@ -118,8 +121,9 @@ endpoint, you'll have to use a different exporter.
 
 ## Setting up a tracer
 
-Once tracing is initialized, you can configure a `Tracer`, which will be how you
-trace operations with `Span`s.
+Once tracing is initialized, you can configure a
+[`Tracer`](/docs/concepts/otel-concepts#tracer), which will be how you trace
+operations with [`Span`s](/docs/concepts/otel-concepts#spans-in-opentelemetry).
 
 Typically, a `Tracer` is instantiated once per app/service that is being
 instrumented, so it's a good idea to instantiate it once in a shared location.
@@ -154,7 +158,8 @@ app.MapGet("/hello", (Tracer tracer) =>
 ### Acquiring a tracer from a TracerProvider
 
 If you're not using ASP.NET Core or would rather not inject an instance of a
-`Tracer`, create one from your instantialized `TracerProvider`:
+`Tracer`, create one from your instantialized
+[`TracerProvider`](/docs/concepts/otel-concepts#tracer-provider):
 
 ```csharp
 // ...
@@ -174,7 +179,8 @@ generally sufficient to just have one defined per service.
 
 ## Creating Spans
 
-To create a span, give it a name and create it from your `Tracer`.
+To create a [span](/docs/concepts/otel-concepts#spans-in-opentelemetry), give it
+a name and create it from your `Tracer`.
 
 ```csharp
 using var span = MyTracer.StartActiveSpan("SayHello");
@@ -185,7 +191,7 @@ using var span = MyTracer.StartActiveSpan("SayHello");
 ## Creating nested Spans
 
 If you have a distinct sub-operation you'd like to track as a part of another
-one, you can create activities to represent the relationship.
+one, you can create spans to represent the relationship.
 
 ```csharp
 public static void ParentOperation(Tracer tracer)
@@ -238,8 +244,8 @@ block is explicitly defined, rather than scoped to `DoWork` itself like
 
 ## Get the current Span
 
-Sometimes it's helpful to access whatever the current `TelemetrySpan` is at a point
-in time so you can enrich it with more information.
+Sometimes it's helpful to access whatever the current `TelemetrySpan` is at a
+point in time so you can enrich it with more information.
 
 ```csharp
 var span = Tracer.CurrentSpan;
@@ -252,8 +258,9 @@ behavior.
 
 ## Add Attributes to a Span
 
-Attributes let you attach key/value pairs to a `TelemetrySpan` so it carries
-more information about the current operation that it's tracking.
+[Attributes](/docs/concepts/otel-concepts#attributes) let you attach key/value
+pairs to a `TelemetrySpan` so it carries more information about the current
+operation that it's tracking.
 
 ```csharp
 using var span = tracer.StartActiveSpan("SayHello");
@@ -265,9 +272,9 @@ span.SetAttribute("operation.other-stuff", new int[] { 1, 2, 3 });
 
 ## Adding events
 
-An event is a human-readable message on an `TelemetrySpan` that represents
-"something happening" during its lifetime. You can think of it like a primitive
-log.
+An [event](/docs/concepts/otel-concepts#span-events) is a human-readable message
+on an `TelemetrySpan` that represents "something happening" during its lifetime.
+You can think of it like a primitive log.
 
 ```csharp
 using var span = tracer.StartActiveSpan("SayHello");
@@ -281,7 +288,8 @@ span.AddEvent("Doing something...");
 span.AddEvent("Dit it!");
 ```
 
-Events can also be created with a timestamp and a collection of Tags.
+Events can also be created with a timestamp and a collection of
+[attributes](/docs/concepts/otel-concepts#attributes).
 
 ```csharp
 using var span = tracer.StartActiveSpan("SayHello");
@@ -305,8 +313,8 @@ span.AddEvent("asdf", DateTimeOffset.Now, new(attributeData));
 
 ## Adding links
 
-A `TelemetrySpan` can be created with zero or more `Link`s that are causally
-related.
+A `TelemetrySpan` can be created with zero or more
+[`Link`s](/docs/concepts/otel-concepts#span-links) that are causally related.
 
 ```csharp
 // Get a context from somewhere, perhaps it's passed in as a parameter
@@ -324,10 +332,10 @@ using var span = tracer.StartActiveSpan("another-span", links: links);
 
 ## Set span status
 
-A status can be set on a span, typically used to specify that a span has not
-completed successfully - `Status.Error`. In rare scenarios, you could override
-the `Error` status with `Ok`, but don't set `Ok` on successfully-completed
-spans.
+A [status](/docs/concepts/otel-concepts#span-status) can be set on a span,
+typically used to specify that a span has not completed successfully -
+`Status.Error`. In rare scenarios, you could override the `Error` status with
+`Ok`, but don't set `Ok` on successfully-completed spans.
 
 The status can be set at any time before the span is finished:
 
@@ -368,9 +376,9 @@ This will capture things like the current stack trace as attributes in the span.
 ## Next steps
 
 After you've setup automatic instrumentation, you may want to use
-[instrumentation libraries]({{< relref "automatic" >}}).Instrumentation
+[instrumentation libraries](/docs/instrumentation/net/automatic).Instrumentation
 libraries will automatically instrument relevant libraries you're using and
 generate data for things like inbound and outbound HTTP requests and more.
 
 You'll also want to configure an appropriate exporter to [export your telemetry
-data]({{< relref "exporters" >}}) to one or more telemetry backends.
+data](/docs/instrumentation/net/exporters) to one or more telemetry backends.

--- a/content/en/docs/instrumentation/net/shim.md
+++ b/content/en/docs/instrumentation/net/shim.md
@@ -6,7 +6,7 @@ weight: 5
 
 .NET is different from other languages/runtimes that support OpenTelemetry.
 Tracing is implemented by the
-[System.Diagnostics](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics)
+[System.Diagnostics](https://docs.microsoft.com/dotnet/api/system.diagnostics)
 API, repurposing older constructs like `ActivitySource` and `Activity` to be
 OpenTelemetry-compliant under the covers.
 

--- a/content/en/docs/instrumentation/net/shim.md
+++ b/content/en/docs/instrumentation/net/shim.md
@@ -20,7 +20,7 @@ terminology consistent with the OpenTelemetry spec.
 
 There are two main ways to initialize
 [tracing](/docs/concepts/otel-concepts#tracing-in-opentelemetry), depending on
-if you're using a console app or something that's ASP.NET Core-based.
+whether you're using a console app or something that's ASP.NET Core-based.
 
 ### Console app
 


### PR DESCRIPTION
Preview link: https://deploy-preview-1392--opentelemetry.netlify.app/docs/instrumentation/net/getting-started/

Now that https://github.com/open-telemetry/opentelemetry.io/pull/1387 is in, we can start linking to these concepts from docs!! It's a dream come true, we've been talking about this since at least October and it's now happening.

This does some linkification to language-agnostic concepts from .NET docs.

* Add them links
* Add some more stuff into the concepts -- these came about when I wanted to link to something, but there wasn't an appropriate sub-header even though the content was there. So I just header-ified stuff and tweaked the words a bit more (including clearing up a few things that are probably kinda inaccurate)
* Fixed a few minor docs bugs in the .NET docs as I came across them