### PR TITLE
Add otel webserver module to registry.

### DIFF
--- a/content/en/registry/instrumentation-cpp-otel-webserver-module.md
+++ b/content/en/registry/instrumentation-cpp-otel-webserver-module.md
@@ -1,0 +1,17 @@
+---
+title: OpenTelemetry Webserver Module
+registryType: instrumentation
+isThirdParty: false
+language: cpp
+tags:
+  - c++
+  - instrumentation
+  - apache
+  - nginx
+  - webserver
+repo: https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/main/instrumentation/otel-webserver-module
+license: Apache 2.0
+description: The OTEL webserver module comprises only Apache webserver module currently. Further support for Nginx webserver would be added in future.
+authors: OpenTelemetry Authors
+otVersion: latest
+---


### PR DESCRIPTION
Adding the otel webserver module from https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/main/instrumentation/otel-webserver-module to the registry.