### PR TITLE
Add section on alternate context propagation in python docs

### DIFF
--- a/content/en/docs/instrumentation/python/manual.md
+++ b/content/en/docs/instrumentation/python/manual.md
@@ -197,3 +197,48 @@ except Exception as ex:
     current_span.set_status(StatusCode.ERROR)
     current_span.record_exception(ex)
 ```
+
+## Change the default propagation format
+
+By default, OpenTelemetry Python will use the following propagation formats:
+
+* W3C Trace Context
+* W3C Baggage
+
+If you have a need to change the defaults, you can do so either via environment variables or in code:
+
+### Using Environment Variables
+
+You can set the `OTEL_PROPAGATORS` environment variable with a comma-separated list. Accepted values are:
+
+* `"tracecontext"`: W3C Trace Context
+* `"baggage"`: W3C Baggage
+* `"b3"`: B3 Single
+* `"b3multi"`: B3 Multi
+* `"jaeger"`: Jaeger
+* `"xray"`: AWS X-Ray (third party)
+* `"ottrace"`: OT Trace (third party)
+* `"none"`: No automatically configured propagator.
+
+The default configuration is equivalent to `OTEL_PROPAGATORS="tracecontext,baggage"`.
+
+### Using SDK APIs
+
+Alternatively, you can change the format in code.
+
+For example, if you need to use Zipkin's B3 propagation format instead, you can install the B3 package:
+
+```shell
+pip install opentelemetry-propagator-b3
+```
+
+And then set the B3 propagator in your tracing initialization code:
+
+```python
+from opentelemetry.propagate import set_global_textmap
+from opentelemetry.propagators.b3 import B3Format
+
+set_global_textmap(B3Format())
+```
+
+Note that environment variables will override what's configured in code.

--- a/content/en/docs/instrumentation/python/manual.md
+++ b/content/en/docs/instrumentation/python/manual.md
@@ -205,11 +205,13 @@ By default, OpenTelemetry Python will use the following propagation formats:
 * W3C Trace Context
 * W3C Baggage
 
-If you have a need to change the defaults, you can do so either via environment variables or in code:
+If you have a need to change the defaults, you can do so either via environment
+variables or in code:
 
 ### Using Environment Variables
 
-You can set the `OTEL_PROPAGATORS` environment variable with a comma-separated list. Accepted values are:
+You can set the `OTEL_PROPAGATORS` environment variable with a comma-separated
+list. Accepted values are:
 
 * `"tracecontext"`: W3C Trace Context
 * `"baggage"`: W3C Baggage
@@ -220,13 +222,15 @@ You can set the `OTEL_PROPAGATORS` environment variable with a comma-separated l
 * `"ottrace"`: OT Trace (third party)
 * `"none"`: No automatically configured propagator.
 
-The default configuration is equivalent to `OTEL_PROPAGATORS="tracecontext,baggage"`.
+The default configuration is equivalent to
+`OTEL_PROPAGATORS="tracecontext,baggage"`.
 
 ### Using SDK APIs
 
 Alternatively, you can change the format in code.
 
-For example, if you need to use Zipkin's B3 propagation format instead, you can install the B3 package:
+For example, if you need to use Zipkin's B3 propagation format instead, you can
+install the B3 package:
 
 ```shell
 pip install opentelemetry-propagator-b3


### PR DESCRIPTION
This was in the readthedocs stuff, so I'm pulling it over (and adding the environment variables bit).

Preview: https://deploy-preview-1426--opentelemetry.netlify.app/docs/instrumentation/python/manual/#change-the-default-propagation-format