### PR TITLE
Add python manual instrumentation docs to include metrics

### DIFF
--- a/content/en/docs/instrumentation/python/manual.md
+++ b/content/en/docs/instrumentation/python/manual.md
@@ -341,3 +341,16 @@ meter.create_observable_gauge(
     description="The active config version for each configuration",
 )
 ```
+
+## Additional References
+
+- Trace
+    - [Trace Concepts](/docs/concepts/signals/traces/)
+    - [Trace Specification](/docs/reference/specification/overview/#tracing-signal)
+    - [Python Trace API Documentation](https://opentelemetry-python.readthedocs.io/en/latest/api/trace.html)
+    - [Python Trace SDK Documentation](https://opentelemetry-python.readthedocs.io/en/latest/sdk/trace.html)
+- Metrics
+    - [Metrics Concepts](/docs/concepts/signals/metrics/)
+    - [Metrics Specification](/docs/reference/specification/metrics/)
+    - [Python Metrics API Documentation](https://opentelemetry-python.readthedocs.io/en/latest/api/metrics.html)
+    - [Python Metrics SDK Documentation](https://opentelemetry-python.readthedocs.io/en/latest/sdk/metrics.html)

--- a/content/en/docs/instrumentation/python/manual.md
+++ b/content/en/docs/instrumentation/python/manual.md
@@ -305,8 +305,8 @@ def do_work(work_item):
 ### Creating and using asynchronous instruments
 
 [Asynchronous instruments](/docs/reference/specification/metrics/api/#synchronous-and-asynchronous-instruments)
-give the user a way to register callback functions, which are invoked on demand to generate
-take measurements. This is useful to periodically measure a value that cannot be instrumented
+give the user a way to register callback functions, which are invoked on demand to make
+measurements. This is useful to periodically measure a value that cannot be instrumented
 directly. Async instruments are created with zero or more callbacks which will be invoked
 during metric collection. Each callback accepts options from the SDK and returns its
 observations.


### PR DESCRIPTION
Tracking in https://github.com/open-telemetry/opentelemetry-python/issues/2732

This updates the manual instrumentation documentation for python with metrics instrumentation.