### PR TITLE
Update New Relic distribution status

### DIFF
--- a/content/en/vendors.md
+++ b/content/en/vendors.md
@@ -7,7 +7,7 @@ spelling: cSpell:ignore bution distri Uptrace
 
 # {{% param title %}}
 
-Distributions and vendors who natively support OpenTelemetry in their commercial
+[Distributions](/docs/concepts/distributions/) and vendors who natively support OpenTelemetry in their commercial
 products.
 {{% /blocks/lead %}}
 
@@ -30,7 +30,7 @@ products.
 | LogicMonitor    | Yes          | Yes         | <https://www.logicmonitor.com/support/tracing/getting-started-with-tracing>
 | Logz.io         | Yes          | No          | <https://docs.logz.io/shipping/tracing-sources/opentelemetry.html#overview>
 | Lumigo          | Yes          | Yes         | <https://www.lumigo.io>
-| New Relic       | Yes          | Yes         | <https://newrelic.com/solutions/opentelemetry>
+| New Relic       | No           | Yes         | <https://newrelic.com/solutions/opentelemetry>
 | Promscale       | No           | Yes         | <https://www.timescale.com/promscale>
 | Sentry Software | Yes          | Yes         | <https://www.sentrysoftware.com/products/hardware-sentry-opentelemetry-collector.html>
 | SigNoz          | Yes          | Yes         | <https://signoz.io>


### PR DESCRIPTION
This PR updates New Relic's distribution status on the vendor page.  With the removal of the newrelicexporter from Collector Contrib, New Relic no longer has any distributions or company-specific components.

I also added a link to the distributions page to help clarify what a distribution means if you are on the vendor page.