### PR TITLE
Adds a redirect for otel-concepts.md

### DIFF
--- a/content/en/docs/concepts/signals/_index.md
+++ b/content/en/docs/concepts/signals/_index.md
@@ -1,7 +1,9 @@
 ---
 title: Signals
 description: Categories of telemetry supported by OpenTelemetry
-aliases: [/docs/concepts/data-sources]
+aliases:
+  - /docs/concepts/data-sources
+  - /docs/concepts/otel-concepts
 weight: 11
 ---
 


### PR DESCRIPTION
@svrnm & @cartermp: based on the content of `otel-concepts.md`, it seems that the **Signals** page is the most suitable redirect target. This PR adds such a redirect rule (via `aliases`).

- Closes #1458

Preview redirect tests

- https://deploy-preview-1460--opentelemetry.netlify.app/docs/concepts/otel-concepts
- https://deploy-preview-1460--opentelemetry.netlify.app/docs/concepts/data-sources/