### PR TITLE
Update spec to v1.12.0

### DIFF
--- a/content/en/docs/instrumentation/js/api/context.md
+++ b/content/en/docs/instrumentation/js/api/context.md
@@ -11,7 +11,7 @@ This document describes the OpenTelemetry context API for JavaScript and how it 
 
 More information:
 
-- [Context specification]({{< relref "/docs/reference/specification/context/context" >}})
+- [Context specification](/docs/reference/specification/context/)
 - [Context API reference](https://open-telemetry.github.io/opentelemetry-js-api/classes/contextapi.html)
 
 ## Context Manager
@@ -131,7 +131,7 @@ import * as api from "@opentelemetry/api";
 
 // Returns the active context
 // If no context is active, the ROOT_CONTEXT is returned
-const ctx =  api.context.active(); 
+const ctx =  api.context.active();
 ```
 
 ### Set Active Context

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -13,4 +13,4 @@
 {{ end -}}
 
 /docs/reference/specification/common/common  /docs/reference/specification/common
-/docs/reference/specification/common/common/* /docs/reference/specification/common/:splat
+/docs/reference/specification/context/context  /docs/reference/specification/context


### PR DESCRIPTION
Updates the spec to v1.12.0:

```console
$ pwd
.../opentelemetry.io/content-modules/opentelemetry-specification
$ git branch -v
* (HEAD detached at v1.12.0)     ae87c81 Release v1.12.0 (#2612)
```

Preview: 

- https://deploy-preview-1464--opentelemetry.netlify.app/docs/reference/specification/
- https://deploy-preview-1464--opentelemetry.netlify.app/docs/reference/specification/context/
- https://deploy-preview-1464--opentelemetry.netlify.app/docs/reference/specification/context/api-propagators/

Redirect tests (including a #1371 regression):

- https://deploy-preview-1464--opentelemetry.netlify.app/docs/reference/specification/context/context/ --> 301
- https://deploy-preview-1464--opentelemetry.netlify.app/docs/reference/specification/common/common/ --> 301

**Note**: While https://deploy-preview-1464--opentelemetry.netlify.app/docs/reference/specification/common/common/attribute-naming/ was tested in #1371, it was never a valid URL to begin with, so I've removed the unnecessary splat rule via this PR.

Previous update:

- #1371

/cc @carlosalberto @tigrannajaryan 