### PR TITLE
Upgrade Hugo to 0.98.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,11 +53,11 @@
     "proseWrap": "always"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.4",
-    "hugo-extended": "0.96.0",
-    "netlify-cli": "^10.0.0",
+    "autoprefixer": "^10.4.7",
+    "hugo-extended": "0.98.0",
+    "netlify-cli": "^10.6.2",
     "npm-run-all": "^4.1.5",
-    "postcss": "^8.4.12",
+    "postcss": "^8.4.14",
     "postcss-cli": "^9.1.0",
     "prettier": "^2.6.2"
   },


### PR DESCRIPTION
- Steps towards #1456
- Changes in the generated site files are shown below. 

```console
$ npm run cd:public -- git diff -bw --ignore-blank-lines -I "Hugo 0." -- . ':(exclude)*.[^h]*' | grep ^diff 
diff --git a/blog/2022/dotnet-instrumentation-first-beta/index.html b/blog/2022/dotnet-instrumentation-first-beta/index.html
diff --git a/registry/index.html b/registry/index.html
```

Notes:

- For the blog entry with footnotes, then changes seem to be the result of https://github.com/gohugoio/hugo/pull/9822.
- I'm not sure why the gRPC entry is moved in the registry page, but this change is inconsequential (and I checked that the entries are identical).

```console
$ npm run cd:public -- git diff -bw --ignore-blank-lines -I "Hugo 0." -- . ':(exclude)*.[^h]*'
```
```diff
diff --git a/blog/2022/dotnet-instrumentation-first-beta/index.html b/blog/2022/dotnet-instrumentation-first-beta/index.html
index aea42c55..8eeac925 100644
--- a/blog/2022/dotnet-instrumentation-first-beta/index.html
+++ b/blog/2022/dotnet-instrumentation-first-beta/index.html
@@ -353,21 +353,21 @@ OpenTelemetry .NET Automatic Instrumentation.</p>
 If you are new, you can create a CNCF Slack account
 <a href="http://slack.cncf.io/" target="_blank" rel="noopener" class="external-link">here</a>.</li>
 </ul>
-<section class="footnotes" role="doc-endnotes">
+<div class="footnotes" role="doc-endnotes">
 <hr>
 <ol>
-<li id="fn:1" role="doc-endnote">
+<li id="fn:1">
 <p>The
 <a href="https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v0.1.0-beta.1/docs/design.md#supported-and-unsupported-scenarios" target="_blank" rel="noopener" class="external-link">supported and unsupported scenarios documentation</a>
 describe the current limits.&#160;<a href="#fnref:1" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
 </li>
-<li id="fn:2" role="doc-endnote">
+<li id="fn:2">
 <p>The
 <a href="https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v0.1.0-beta.1/docs/config.md#instrumented-libraries-and-frameworks" target="_blank" rel="noopener" class="external-link">instrumentation library documentation</a>
 contains the list of libraries we can gather telemetry data from.&#160;<a href="#fnref:2" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
 </li>
 </ol>
-</section>
+</div>
 
        
 
diff --git a/registry/index.html b/registry/index.html
index 356c576f..232e9538 100644
--- a/registry/index.html
+++ b/registry/index.html
@@ -1299,6 +1299,14 @@ Registry</a>.</li>
             <span class="badge badge-collector float-right mr-2">collector</span>
           </div>
         </li>
+      <li class="media" data-registrytype="instrumentation" data-registrylanguage="go">
+          <div class="media-body">
+            <a href="https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/google.golang.org/grpc" target="_blank" rel="noopener"><h5 class="mt-0 mb-1">gRPC instrumentation</h5></a>
+            Go contrib plugin for Google&#39;s grpc package.
+            <span class="badge badge-instrumentation float-right">instrumentation</span>
+            <span class="badge badge-go float-right mr-2">go</span>
+          </div>
+        </li>
       <li class="media" data-registrytype="instrumentation" data-registrylanguage="java">
           <div class="media-body">
             <a href="https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/grpc-1.6" target="_blank" rel="noopener"><h5 class="mt-0 mb-1">gRPC Instrumentation</h5></a>
@@ -1323,14 +1331,6 @@ Registry</a>.</li>
             <span class="badge badge-python float-right mr-2">python</span>
           </div>
         </li>
-      <li class="media" data-registrytype="instrumentation" data-registrylanguage="go">
-          <div class="media-body">
-            <a href="https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/google.golang.org/grpc" target="_blank" rel="noopener"><h5 class="mt-0 mb-1">gRPC instrumentation</h5></a>
-            Go contrib plugin for Google&#39;s grpc package.
-            <span class="badge badge-instrumentation float-right">instrumentation</span>
-            <span class="badge badge-go float-right mr-2">go</span>
-          </div>
-        </li>
       <li class="media" data-registrytype="instrumentation" data-registrylanguage="erlang">
           <div class="media-body">
             <a href="https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_grpcbox" target="_blank" rel="noopener"><h5 class="mt-0 mb-1">grpcbox Instrumentation</h5></a>
```
