### PR TITLE
Minor markdown & typo fixes for collector

### DIFF
--- a/content/en/docs/collector/_index.md
+++ b/content/en/docs/collector/_index.md
@@ -28,7 +28,7 @@ is the default location to which instrumentation libraries export their telemetr
 
 ## When to use a collector
 
-For most language specific instrumentation libraries you have exporters for popular backends and OTLP. You might wonder, 
+For most language specific instrumentation libraries you have exporters for popular backends and OTLP. You might wonder,
 
 > under what circumstances does one use a collector to send data, as opposed to having each service send directly to the backend?
 

--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -4,6 +4,7 @@ weight: 20
 ---
 
 Please be sure to review the following documentation:
+
 - [Data Collection concepts](../../concepts/data-collection) in order to
   understand the repositories applicable to the OpenTelemetry Collector.
 - [Security
@@ -566,7 +567,6 @@ service:
         - otlp/auth
 ```
 
-
 ### Setting up certificates
 
 For a production setup, we strongly recommend using TLS certificates, either for
@@ -595,7 +595,6 @@ Install [cfssl](https://github.com/cloudflare/cfssl), and create the following
     ]
 }
 ```
-> csr.json
 
 Now, run the following commands:
 

--- a/content/en/docs/collector/trace-receiver.md
+++ b/content/en/docs/collector/trace-receiver.md
@@ -299,7 +299,7 @@ configuration aspects of a receiver component, take a look at the
 [config/receiver.go](https://github.com/open-telemetry/opentelemetry-collector/blob/v0.53.0/config/receiver.go)
 file inside the Collector's GitHub project.
 
-## Enabling the Collector to instantiate your receiver.
+## Enabling the Collector to instantiate your receiver
 
 At the beginning of this tutorial, you created your `dev-otelcol` instance,
 which is bootstrapped with the following components:
@@ -1254,7 +1254,7 @@ touch model.go
 ```
 
 Now, within the `model.go` file, add the definition for the `Atm` and the
-`BackendSytem` types as follow:
+`BackendSystem` types as follow:
 
 > model.go
 


### PR DESCRIPTION
Ran some markdown lint & language checks over the docs, here's a few minor fixes for the collector pages.