### PR TITLE
Markdown fixes for java docs, remove note on agent config

### DIFF
--- a/content/en/docs/instrumentation/java/automatic/_index.md
+++ b/content/en/docs/instrumentation/java/automatic/_index.md
@@ -20,9 +20,9 @@ service or app code, see [Manual instrumentation](../manual).
     `opentelemetry-java-instrumentation` repo. The JAR file contains the agent
     and all automatic instrumentation packages.
  2. Place the JAR in your preferred directory and launch it with your app:
-    ```sh
-    java -javaagent:path/to/opentelemetry-javaagent.jar \
-        -jar myapp.jar
+
+    ```console
+    $ java -javaagent:path/to/opentelemetry-javaagent.jar -jar myapp.jar
     ```
 
 ## Configuring the agent

--- a/content/en/docs/instrumentation/java/automatic/agent-config.md
+++ b/content/en/docs/instrumentation/java/automatic/agent-config.md
@@ -5,7 +5,7 @@ weight: 2
 spelling: cSpell:ignore autoconfiguration Autoconfiguration Dotel HSET javaagent serverlessapis Servlet servlet
 ---
 
-> <h3>NOTE: subject to change!</h3>
+> ### NOTE: subject to change!
 >
 > Note: The environment variables/system properties in this document are very likely to change over time.
 > Please check back here when trying out a new version!
@@ -28,11 +28,11 @@ to find settings such as configuring export or sampling.
 Here are some quick links into those docs for the configuration options for specific portions of the SDK & agent:
 
 * [Exporters](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#exporters)
-  + [OTLP exporter (both span and metric exporters)](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure/README.md#otlp-exporter-both-span-and-metric-exporters)
-  + [Jaeger exporter](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure/README.md#jaeger-exporter)
-  + [Zipkin exporter](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure/README.md#zipkin-exporter)
-  + [Prometheus exporter](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure/README.md#prometheus-exporter)
-  + [Logging exporter](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure/README.md#logging-exporter)
+  * [OTLP exporter (both span and metric exporters)](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure/README.md#otlp-exporter-both-span-and-metric-exporters)
+  * [Jaeger exporter](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure/README.md#jaeger-exporter)
+  * [Zipkin exporter](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure/README.md#zipkin-exporter)
+  * [Prometheus exporter](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure/README.md#prometheus-exporter)
+  * [Logging exporter](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure/README.md#logging-exporter)
 * [Trace context propagation](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure/README.md#propagator)
 * [OpenTelemetry Resource and service name](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure/README.md#opentelemetry-resource)
 * [Batch span processor](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure/README.md#batch-span-processor)
@@ -43,6 +43,7 @@ Here are some quick links into those docs for the configuration options for spec
 ## Configuring the agent
 
 The agent can consume configuration from one or more of the following sources (ordered from highest to lowest priority):
+
 * system properties
 * environment variables
 * the [configuration file](#configuration-file)
@@ -357,18 +358,18 @@ example, if we have a database client which uses Reactor Netty http client which
 uses Netty networking library, then without any suppression we would have 3
 nested spans:
 
-- `CLIENT` span with database semantic attributes from the database client instrumentation
-- `CLIENT` span with http semantic attributes from Reactor Netty instrumentation
-- `CLIENT` span with http semantic attributes from Netty instrumentation
+* `CLIENT` span with database semantic attributes from the database client instrumentation
+* `CLIENT` span with http semantic attributes from Reactor Netty instrumentation
+* `CLIENT` span with http semantic attributes from Netty instrumentation
 
 With default suppression, we would have 1 span:
 
-- `CLIENT` span with database semantic attributes from the database client
+* `CLIENT` span with database semantic attributes from the database client
   instrumentation
 
 With suppression by type, we would have 2 nested spans:
 
-- `CLIENT` span with database semantic attributes from the database client instrumentation
-- `CLIENT` span with http semantic attributes from Reactor Netty instrumentation
+* `CLIENT` span with database semantic attributes from the database client instrumentation
+* `CLIENT` span with http semantic attributes from Reactor Netty instrumentation
 
 [extensions]: https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/examples/extension#readme

--- a/content/en/docs/instrumentation/java/automatic/agent-config.md
+++ b/content/en/docs/instrumentation/java/automatic/agent-config.md
@@ -5,11 +5,6 @@ weight: 2
 spelling: cSpell:ignore autoconfiguration Autoconfiguration Dotel HSET javaagent serverlessapis Servlet servlet
 ---
 
-> ### NOTE: subject to change!
->
-> Note: The environment variables/system properties in this document are very likely to change over time.
-> Please check back here when trying out a new version!
-
 Please report any bugs or unexpected behavior you find.
 
 ## Contents

--- a/content/en/docs/instrumentation/java/extensions.md
+++ b/content/en/docs/instrumentation/java/extensions.md
@@ -12,7 +12,7 @@ Consider an instrumented database client that creates a span per database call a
 connection to provide span attributes. The following are sample use cases for that scenario that can be solved by using
 extensions:
 
-* _"I don't want this span at all"_: 
+* _"I don't want this span at all"_:
   Create an extension to disable selected instrumentation by providing new default settings.
 * _"I want to edit some attributes that don't depend on any db connection instance"_:
   Create an extension that provide a custom `SpanProcessor`.

--- a/content/en/docs/instrumentation/java/getting-started.md
+++ b/content/en/docs/instrumentation/java/getting-started.md
@@ -18,7 +18,7 @@ First, get and run the hello-world example without instrumentation:
 
  1. [Get the example code.][]
  2. [Run the example:][] you should see the client output "Hello world".
- 3.  Stop the server before proceeding, if it is still running.
+ 3. Stop the server before proceeding, if it is still running.
 
 ## Run the instrumented example
 
@@ -32,22 +32,27 @@ a number of ways, the steps below use environment variables.
  2. Set and export variables that specify the Java agent JAR and a [console
     trace exporter,][] using a notation suitable for your shell/terminal
     environment &mdash; we illustrate a notation for bash-like shells:
+
     ```console
     $ export JAVA_OPTS="-javaagent:PATH/TO/opentelemetry-javaagent.jar"
     $ export OTEL_TRACES_EXPORTER=logging
     ```
+
     {{% alert title="Important" color="warning" %}}Replace `PATH/TO` above, with
     your path to the JAR.{{% /alert %}}
  3. Run the **server** as a background process. For example, for bash-like
     shells run:
+
     ```console
     $ ./build/install/examples/bin/hello-world-server &
     [otel.javaagent 2022-03-19 13:38:16:712 +0000] [main] INFO io.opentelemetry.javaagent.tooling.VersionLogger - opentelemetry-javaagent - version: 1.12.0
     Mar 19, 2022 1:38:18 PM io.grpc.examples.helloworld.HelloWorldServer start
     ...
     ```
+
     Note the output from the `otel.javaagent`.
  4. From the _same_ terminal, run the **client**:
+
     ```console
     $ ./build/install/examples/bin/hello-world-client
     [otel.javaagent 2022-03-19 13:38:48:462 +0000] [main] INFO io.opentelemetry.javaagent.tooling.VersionLogger - opentelemetry-javaagent - version: 1.12.0
@@ -57,7 +62,9 @@ a number of ways, the steps below use environment variables.
     Mar 19, 2022 1:38:51 PM io.grpc.examples.helloworld.HelloWorldClient greet
     INFO: Greeting: Hello world
     ```
+
  5. Stop the server process. For example, for bash-like shells run:
+
     ```console
     $ jobs
     [1]+  Running                 ./build/install/examples/bin/hello-world-server &


### PR DESCRIPTION
Some fixes for the java docs from markdownlint 

---

Preview, e.g.:

- https://deploy-preview-1482--opentelemetry.netlify.app/docs/instrumentation/java/automatic/agent-config/
