### PR TITLE
Markdown fixes for erlang docs

### DIFF
--- a/content/en/docs/instrumentation/erlang/_index.md
+++ b/content/en/docs/instrumentation/erlang/_index.md
@@ -22,7 +22,7 @@ The current status of the major functional components for OpenTelemetry Erlang/E
 
 {{% latest_release "erlang" %}}
   Packages of the API, SDK and OTLP exporter are published to
-  [hex.pm](https://hex.pm) as 
+  [hex.pm](https://hex.pm) as
   [opentelemetry_api](https://hex.pm/packages/opentelemetry_api),
   [opentelemetry](https://hex.pm/packages/opentelemetry) and
   [opentelemetry_exporter](https://hex.pm/packages/opentelemetry_exporter).

--- a/content/en/docs/instrumentation/erlang/getting-started.md
+++ b/content/en/docs/instrumentation/erlang/getting-started.md
@@ -46,7 +46,6 @@ $ mix new --sup otel_getting_started
 
 {{< /tabs >}}
 
-
 Then, in the project you just created, add both `opentelemetry_api` and
 `opentelemetry` as dependencies. We add both because this is a project we will
 run as a Release and export spans from.
@@ -131,7 +130,7 @@ of span processor that batches up multiple spans over a period of time:
 
 {{< tab >}}
 # config/runtime.exs
-config :opentelemetry, 
+config :opentelemetry,
   span_processor: :batch,
   traces_exporter: {:otel_exporter_stdout, []}
 {{< /tab >}}
@@ -375,5 +374,3 @@ config :opentelemetry_exporter,
 {{< /tab >}}
 
 {{< /tabs >}}
-
-

--- a/content/en/docs/instrumentation/erlang/instrumentation.md
+++ b/content/en/docs/instrumentation/erlang/instrumentation.md
@@ -283,7 +283,6 @@ end
 
 {{< /tabs >}}
 
-
 A useful characteristic of events is that their timestamps are displayed as
 offsets from the beginning of the span, allowing you to easily see how much time
 elapsed between them.


### PR DESCRIPTION
Some fixes for the erlang docs from markdownlint