### PR TITLE
Java agent config page: drop hard-coded TOC and opening sentence

### DIFF
--- a/content/en/docs/instrumentation/java/automatic/agent-config.md
+++ b/content/en/docs/instrumentation/java/automatic/agent-config.md
@@ -5,15 +5,6 @@ weight: 2
 spelling: cSpell:ignore autoconfiguration Autoconfiguration Dotel HSET javaagent serverlessapis Servlet servlet
 ---
 
-Please report any bugs or unexpected behavior you find.
-
-## Contents
-
-* [SDK Autoconfiguration](#sdk-autoconfiguration)
-* [Configuring the agent](#configuring-the-agent)
-* [Common instrumentation configuration](#common-instrumentation-configuration)
-* [Suppressing specific auto-instrumentation](#suppressing-specific-auto-instrumentation)
-
 ## SDK Autoconfiguration
 
 The SDK's autoconfiguration module is used for basic configuration of the agent. Read the


### PR DESCRIPTION
Followup to:

- #1482

The "Please report" is being dropped because, IMHO, it should have been dropped at the same time as the Note (#1482). The "Contents" isn't needed since Hugo generates a TOC automatically.