### PR TITLE
Remove outdated statement on metrics status

### DIFF
--- a/content/en/status.md
+++ b/content/en/status.md
@@ -82,8 +82,6 @@ same as the **Protocol** status.
   - Experimental support for metric pipelines are available in the Collector.
   - Collector support for Prometheus is under development, in collaboration with
     the Prometheus community.
-  - The metric API and SDK specification is currently being prototyped in Java,
-    .NET, and Python.
 
 #### [Baggage][]
 


### PR DESCRIPTION
The metrics API and SDK are GA in Java and .NET, and in Python there is an RC out already.