### PR TITLE
Update Python exporter docs with console, OTLP, and Prometheus metric exporters

### DIFF
--- a/content/en/docs/instrumentation/python/_index.md
+++ b/content/en/docs/instrumentation/python/_index.md
@@ -55,7 +55,7 @@ $ pip install opentelemetry-instrumentation-{instrumentation}
 ```
 
 These are for exporter and instrumentation packages respectively. The Jaeger,
-Zipkin, OTLP and OpenCensus Exporters can be found in the
+Zipkin, OTLP, OpenCensus, and Prometheus Exporters can be found in the
 [exporter](https://github.com/open-telemetry/opentelemetry-python/blob/main/exporter/)
 directory of the repository. Instrumentations and additional exporters can be
 found in the [Contrib repo


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-python/issues/2732

I tested out the example code to make sure everything is working as well. I also changed around the OTLP sections to present gRPC as the first option to push folks that way and because there isn't an OTLP/HTTP metric exporter yet.