### PR TITLE
Fix incorrect variable name (meterProvider -> sdkMeterProvider)

### DIFF
--- a/content/en/docs/instrumentation/java/manual.md
+++ b/content/en/docs/instrumentation/java/manual.md
@@ -32,7 +32,7 @@ SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder()
   .addSpanProcessor(BatchSpanProcessor.builder(OtlpGrpcSpanExporter.builder().build()).build())
   .build();
 
-SdkMeterProvider meterProvider = SdkMeterProvider.builder()
+SdkMeterProvider sdkMeterProvider = SdkMeterProvider.builder()
   .registerMetricReader(PeriodicMetricReader.builder(OtlpGrpcMetricExporter.builder().build()).build())
   .build();
 


### PR DESCRIPTION
The variable `meterProvider` is used as `sdkMeterProvider` later in the code.
This PR changes the name of the variable to be `sdkMeterProvider`.