### PR TITLE
(js) Update Collector HTTP Port to 4318

### DIFF
--- a/content/en/docs/instrumentation/js/exporters.md
+++ b/content/en/docs/instrumentation/js/exporters.md
@@ -24,7 +24,7 @@ const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-http')
 const { SimpleSpanProcessor } = require('@opentelemetry/sdk-trace-base');
 
 const exporter = new OTLPTraceExporter({
-  // optional - url default value is http://localhost:55681/v1/traces
+  // optional - url default value is http://localhost:4318/v1/traces
   url: '<your-collector-endpoint>/v1/traces',
 
   // optional - collection of custom headers to be sent with each request, empty by default


### PR DESCRIPTION
Update the default collector HTTP port to `4318` instead of `55681` since the newest versions of the exporter default to `4318`.