### PR TITLE
Fix #1499 - add file name to the top of php example

### DIFF
--- a/content/en/docs/instrumentation/php/getting-started.md
+++ b/content/en/docs/instrumentation/php/getting-started.md
@@ -17,6 +17,7 @@ Span typically represents a single unit of work. A Trace is a grouping of Spans.
 
 ```php
 <?php
+// GettingStarted.php
 
 declare(strict_types=1);
 require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
fixes #1499 (not the wordpress part) 