### PR TITLE
Add images to config for 'Twitter Cards'

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,6 +11,7 @@ languages:
     title: OpenTelemetry
     description: The OpenTelemetry Project Site
     languageName: English
+    images: ["/featured-background.jpg"]
     weight: 1
 
 imaging:

--- a/config.yaml
+++ b/config.yaml
@@ -11,6 +11,7 @@ languages:
     title: OpenTelemetry
     description: The OpenTelemetry Project Site
     languageName: English
+    # Social media image (e.g., Open Graph). Update the version tag when the image changes.
     images: ["/featured-background.jpg?v1"]
     weight: 1
 

--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,7 @@ languages:
     title: OpenTelemetry
     description: The OpenTelemetry Project Site
     languageName: English
-    images: ["/featured-background.jpg"]
+    images: [/featured-background.jpg?v1]
     weight: 1
 
 imaging:

--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,7 @@ languages:
     title: OpenTelemetry
     description: The OpenTelemetry Project Site
     languageName: English
-    images: [/featured-background.jpg?v1]
+    images: ["/featured-background.jpg?v1"]
     weight: 1
 
 imaging:


### PR DESCRIPTION
- Contributes to #1519

---

Just stumbled upon this, when putting a link to opentelemetry.io outside the main page I don't get an image for my "twitter card":

<img width="598" alt="Screen Shot 2022-07-05 at 18 58 08" src="https://user-images.githubusercontent.com/1519757/177378966-e3ea0061-3e9e-4285-a3a9-57356f0b0c83.png">

It looks like the required tags (especially meta og:image) are only added if there is a featured-background.jpg in the same path or an images attribute for that page. I set a default attribute in the config.yml -- I am still trying to validate if this not breaking anything else but it looks good so far. 

Note: We could use the images parameter for individual pages to show a different image!