### PR TITLE
Use AutoConfiguredOpenTelemetrySdk from latest Java packages

### DIFF
--- a/content/en/docs/instrumentation/java/manual.md
+++ b/content/en/docs/instrumentation/java/manual.md
@@ -616,7 +616,8 @@ variables and system properties, you can use the
 `opentelemetry-sdk-extension-autoconfigure` module.
 
 ```java
-OpenTelemetrySdk sdk = OpenTelemetrySdkAutoConfiguration.initialize();
+OpenTelemetrySdk sdk = AutoConfiguredOpenTelemetrySdk.initialize()
+    .getOpenTelemetrySdk();
 ```
 
 See the supported configuration options in the module's


### PR DESCRIPTION
fixes https://github.com/open-telemetry/opentelemetry.io/issues/1536 -- the old stuff is now deprecated as per the 1.15 packages.