### PR TITLE
Update getting-started.md

### DIFF
--- a/content/en/docs/instrumentation/python/getting-started.md
+++ b/content/en/docs/instrumentation/python/getting-started.md
@@ -74,7 +74,7 @@ You can now run your instrumented app with `opentelemetry-instrument` and have
 it print to the console for now:
 
 ```shell
-opentelemetry-instrument --traces_exporter console flask run
+opentelemetry-instrument --metrics_exporter none --traces_exporter console flask run
 ```
 
 When you send a request to the server, you'll get a result in a trace with a


### PR DESCRIPTION
opentelemetry-instrument --metrics_exporter none --traces_exporter console flask run to avoid error Requested component 'otlp_proto_grpc' not found in entry points for 'opentelemetry metrics exporter'