### PR TITLE
Fixed typo in heading

### DIFF
--- a/content/en/docs/contribution-guidelines.md
+++ b/content/en/docs/contribution-guidelines.md
@@ -1,6 +1,6 @@
 ---
 title: Contribution guidelines
-description: How to contribute to the OpenTelemetry
+description: How to contribute to OpenTelemetry
 toc_hide: true
 ---
 


### PR DESCRIPTION
removed 'the' in "How to contribute to the OpenTelemetry"