### PR TITLE
Add calendar link to blog post

### DIFF
--- a/content/en/blog/2022/new-end-user-resources.md
+++ b/content/en/blog/2022/new-end-user-resources.md
@@ -25,7 +25,7 @@ observability powered by OpenTelemetry.
   meeting. Topics are rigorously time-boxed by a facilitator.
 - [Chatham House Rule](https://www.chathamhouse.org/about-us/chatham-house-rule)
   applies. Meetings will not be recorded.
-- The first meeting is on the OpenTelemetry calendar, scheduled for July 14th
+- The first meeting is on the [OpenTelemetry calendar](https://github.com/open-telemetry/community#calendar), scheduled for July 14th
   2022 at 9AM PST. We intend to alternate months between APAC friendly and AMER
   friendly timezones, we will re-evaluate this plan depending on attendance and
   feedback.


### PR DESCRIPTION
* Add a link to the calendar for the unaware folks (myself included 😄 )