### PR TITLE
Fix JaegerExporter Import

### DIFF
--- a/content/en/docs/instrumentation/python/exporters.md
+++ b/content/en/docs/instrumentation/python/exporters.md
@@ -160,7 +160,7 @@ Then you can configure the exporter when initializing tracing:
 
 ```python
 from opentelemetry import trace
-from opentelemetry.exporter.jaeger import JaegerExporter
+from opentelemetry.exporter.jaeger.thrift import JaegerExporter
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor


### PR DESCRIPTION
Missing import despite running `pip install opentelemetry-exporter-jaeger`? `pip install opentelemetry-exportert-jaeger` installs `opentelemetry-exporter-jaeger-thrift-1.11.1` by default?