### PR TITLE
Rename .NET Automatic to Libraries

### DIFF
--- a/content/en/docs/instrumentation/net/exporters.md
+++ b/content/en/docs/instrumentation/net/exporters.md
@@ -286,10 +286,10 @@ using var tracerProvider = Sdk.CreateMeterProviderBuilder()
 
 ## Next steps
 
-To ensure you're getting the most data as easily as possible, install [automatic
-instrumentation libraries](/docs/instrumentation/net/automatic) to automatically
+To ensure you're getting the most data as easily as possible, install
+[instrumentation libraries](/docs/instrumentation/net/libraries) to
 generate observability data.
 
-Additionally, enriching your instrumentation generated automatically with
-[manual instrumentation](/docs/instrumentation/net/manual) of your own codebase
+Additionally, enriching your codebase with
+[manual instrumentation](/docs/instrumentation/net/manual)
 gets you customized observability data.

--- a/content/en/docs/instrumentation/net/exporters.md
+++ b/content/en/docs/instrumentation/net/exporters.md
@@ -293,3 +293,7 @@ generate observability data.
 Additionally, enriching your codebase with
 [manual instrumentation](/docs/instrumentation/net/manual)
 gives you customized observability data.
+
+You can also check the
+[automatic instrumentation for .NET](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation),
+which is currently in beta.

--- a/content/en/docs/instrumentation/net/exporters.md
+++ b/content/en/docs/instrumentation/net/exporters.md
@@ -292,4 +292,4 @@ generate observability data.
 
 Additionally, enriching your codebase with
 [manual instrumentation](/docs/instrumentation/net/manual)
-gets you customized observability data.
+gives you customized observability data.

--- a/content/en/docs/instrumentation/net/getting-started.md
+++ b/content/en/docs/instrumentation/net/getting-started.md
@@ -113,7 +113,7 @@ var serviceVersion = "1.0.0";
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Configure important OpenTelemetry settings, the console exporter, and library instrumentation
+// Configure important OpenTelemetry settings, the console exporter, and instrumentation library
 builder.Services.AddOpenTelemetryTracing(tracerProviderBuilder =>
 {
     tracerProviderBuilder

--- a/content/en/docs/instrumentation/net/getting-started.md
+++ b/content/en/docs/instrumentation/net/getting-started.md
@@ -87,9 +87,8 @@ This output matches the span created in the preceding code sample.
 
 ## ASP.NET Core
 
-The following sample demonstrates automatic and manual
-[tracing](/docs/concepts/signals/traces/#tracing-in-opentelemetry) with ASP.NET
-Core.
+The following sample demonstrates [tracing](/docs/concepts/signals/traces/#tracing-in-opentelemetry)
+with ASP.NET Core.
 
 First, install requried packages:
 
@@ -114,7 +113,7 @@ var serviceVersion = "1.0.0";
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Configure important OpenTelemetry settings, the console exporter, and automatic instrumentation
+// Configure important OpenTelemetry settings, the console exporter, and library instrumentation
 builder.Services.AddOpenTelemetryTracing(tracerProviderBuilder =>
 {
     tracerProviderBuilder
@@ -186,8 +185,8 @@ Resource associated with Activity:
     service.instance.id: 45aacfb0-e117-40cb-9d4d-9bcca661f6dd
 ```
 
-This output has both the span created to track work in the route, and an
-automatically-created span that tracks the inbound ASP.NET Core request itself.
+This output has both the span created to track work in the route,
+and a span that tracks the inbound ASP.NET Core request itself.
 
 ## Send traces to a collector
 
@@ -312,13 +311,13 @@ Now, telemetry will be output by the collector process.
 
 ## Next steps
 
-To ensure you're getting the most data as easily as possible, install some
-[instrumentation libraries](/docs/instrumentation/net/automatic) to automatically
+To ensure you're getting the most data as easily as possible, install
+[instrumentation libraries](/docs/instrumentation/net/libraries) to
 generate observability data.
 
-Additionally, enriching your instrumentation generated automatically with
-[manual instrumentation](/docs/instrumentation/net/manual) of your own codebase gets you
-customized observability data.
+Additionally, enriching your codebase with
+[manual instrumentation](/docs/instrumentation/net/manual)
+gets you customized observability data.
 
 You'll also want to configure an appropriate exporter to [export your telemetry
 data](/docs/instrumentation/net/exporters) to one or more telemetry backends.

--- a/content/en/docs/instrumentation/net/getting-started.md
+++ b/content/en/docs/instrumentation/net/getting-started.md
@@ -23,7 +23,7 @@ dotnet add package OpenTelemetry
 
 ## Console application
 
-The following sample demonstrates manual
+The following example demonstrates manual
 [tracing](/docs/concepts/signals/traces/#tracing-in-opentelemetry) via a console
 app.
 

--- a/content/en/docs/instrumentation/net/getting-started.md
+++ b/content/en/docs/instrumentation/net/getting-started.md
@@ -7,7 +7,7 @@ OpenTelemetry for .NET is unique among OpenTelemetry implementations, as it is
 integrated with the .NET `System.Diagnostics` library. At a high level, you can
 think of OpenTelemetry for .NET as a bridge between the telemetry available
 through `System.Diagnostics` and the greater OpenTelemetry ecosystem, such as
-OpenTelemetry Protocol (OTLP) and the OpenTelemetry Collector. 
+OpenTelemetry Protocol (OTLP) and the OpenTelemetry Collector.
 
 ## Installation
 
@@ -317,7 +317,7 @@ generate observability data.
 
 Additionally, enriching your codebase with
 [manual instrumentation](/docs/instrumentation/net/manual)
-gets you customized observability data.
+gives you customized observability data.
 
 You'll also want to configure an appropriate exporter to [export your telemetry
 data](/docs/instrumentation/net/exporters) to one or more telemetry backends.

--- a/content/en/docs/instrumentation/net/getting-started.md
+++ b/content/en/docs/instrumentation/net/getting-started.md
@@ -185,8 +185,9 @@ Resource associated with Activity:
     service.instance.id: 45aacfb0-e117-40cb-9d4d-9bcca661f6dd
 ```
 
-This output has both the span created to track work in the route,
-and a span that tracks the inbound ASP.NET Core request itself.
+This output has both the manually created span to track work in the route,
+and a span created by the `OpenTelemetry.Instrumentation.AspNetCore`
+instrumentation library that tracks the inbound ASP.NET Core request.
 
 ## Send traces to a collector
 
@@ -321,3 +322,7 @@ gives you customized observability data.
 
 You'll also want to configure an appropriate exporter to [export your telemetry
 data](/docs/instrumentation/net/exporters) to one or more telemetry backends.
+
+You can also check the
+[automatic instrumentation for .NET](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation),
+which is currently in beta.

--- a/content/en/docs/instrumentation/net/libraries.md
+++ b/content/en/docs/instrumentation/net/libraries.md
@@ -58,7 +58,7 @@ var serviceVersion = "1.0.0";
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Configure important OpenTelemetry settings, the console exporter, and library instrumentation
+// Configure important OpenTelemetry settings, the console exporter, and instrumentation library
 builder.Services.AddOpenTelemetryTracing(b =>
 {
     b

--- a/content/en/docs/instrumentation/net/libraries.md
+++ b/content/en/docs/instrumentation/net/libraries.md
@@ -32,7 +32,7 @@ creating a
 
 ## Example with ASP.NET Core and HttpClient
 
-As an example, here's how you can automatically instrument inbound and output
+As an example, here's how you can instrument inbound and output
 requests from an ASP.NET Core app.
 
 First, get the appropriate packages:
@@ -58,7 +58,7 @@ var serviceVersion = "1.0.0";
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Configure important OpenTelemetry settings, the console exporter, and automatic instrumentation
+// Configure important OpenTelemetry settings, the console exporter, and library instrumentation
 builder.Services.AddOpenTelemetryTracing(b =>
 {
     b
@@ -94,12 +94,12 @@ app.Run();
 When you run this code and access the `/hello` endpoint, it will:
 
 * Start a new trace
-* Automatically generate a span representing the request made to the endpoint
-* Automatically generate a child span representing the HTTP GET made to
+* Generate a span representing the request made to the endpoint
+* Generate a child span representing the HTTP GET made to
   `https://example.com/`
 
-If you add more instrumentation libraries, then you can generate more data
-automatically.
+If you add more instrumentation libraries,
+then you get more telemetry data.
 
 ## Available instrumentation libraries
 

--- a/content/en/docs/instrumentation/net/libraries.md
+++ b/content/en/docs/instrumentation/net/libraries.md
@@ -4,12 +4,8 @@ weight: 3
 linkTitle: Libraries
 ---
 
-The [automatic instrumentation](/docs/reference/specification/glossary/#automatic-instrumentation)
-for .NET, that can be found in the [opentelemetry-dotnet-instrumentation][] repository,
-is currently in beta.
-
-However, you can always use [instrumentation libraries](/docs/reference/specification/glossary/#instrumentation-library)
-that generate telemetry data for a particular instrumented library.
+You can use [instrumentation libraries](/docs/reference/specification/glossary/#instrumentation-library)
+in order to generate telemetry data for a particular instrumented library.
 
 For example, [the instrumentation library for ASP.NET Core](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNetCore)
 will automatically
@@ -91,7 +87,8 @@ app.MapGet("/hello", async () =>
 app.Run();
 ```
 
-When you run this code and access the `/hello` endpoint, it will:
+When you run this code and access the `/hello` endpoint,
+the instrumentation libraries will:
 
 * Start a new trace
 * Generate a span representing the request made to the endpoint
@@ -122,5 +119,8 @@ OpenTelemetry and instrumentation libraries on .NET Framework.
 You'll also want to configure an appropriate exporter to [export your telemetry
 data](/docs/instrumentation/net/exporters) to one or more telemetry backends.
 
+You can also check the
+[automatic instrumentation for .NET](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation),
+which is currently in beta.
+
 [opentelemetry-dotnet]: https://github.com/open-telemetry/opentelemetry-dotnet
-[opentelemetry-dotnet-instrumentation]: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation

--- a/content/en/docs/instrumentation/net/libraries.md
+++ b/content/en/docs/instrumentation/net/libraries.md
@@ -1,23 +1,28 @@
 ---
-title: Automatic Instrumentation
+title: Using instrumentation libraries
 weight: 3
-linkTitle: Automatic
+linkTitle: Libraries
 ---
 
-.NET supports automatic instrumentation with [instrumentation
-libraries](/docs/reference/specification/glossary/#instrumentation-library) that
-generate telemetry data for a particular instrumented library.
+The [automatic instrumentation](/docs/reference/specification/glossary/#automatic-instrumentation)
+for .NET, that can be found in the [opentelemetry-dotnet-instrumentation][] repository,
+is currently in beta.
 
-For example, the instrumentation library for ASP.NET Core will automatically
-create [spans](/docs/concepts/signals/traces/#spans-in-opentelemetry) that track
-inbound requests once you configure it in your app/service.
+However, you can always use [instrumentation libraries](/docs/reference/specification/glossary/#instrumentation-library)
+that generate telemetry data for a particular instrumented library.
+
+For example, [the instrumentation library for ASP.NET Core](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNetCore)
+will automatically
+create [spans](/docs/concepts/signals/traces/#spans-in-opentelemetry)
+and [metrics](/docs/concepts/signals/metrics)
+based on the inbound HTTP requests.
 
 ## Setup
 
 Each instrumentation library is a NuGet package, and installing them is
 typically done like so:
 
-```
+```console
 dotnet add package OpenTelemetry.Instrumentation.{library-name-or-type}
 ```
 
@@ -118,3 +123,4 @@ You'll also want to configure an appropriate exporter to [export your telemetry
 data](/docs/instrumentation/net/exporters) to one or more telemetry backends.
 
 [opentelemetry-dotnet]: https://github.com/open-telemetry/opentelemetry-dotnet
+[opentelemetry-dotnet-instrumentation]: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation

--- a/content/en/docs/instrumentation/net/libraries.md
+++ b/content/en/docs/instrumentation/net/libraries.md
@@ -1,7 +1,8 @@
 ---
 title: Using instrumentation libraries
-weight: 3
 linkTitle: Libraries
+aliases: [/docs/instrumentation/net/automatic]
+weight: 3
 ---
 
 You can use [instrumentation libraries](/docs/reference/specification/glossary/#instrumentation-library)

--- a/content/en/docs/instrumentation/net/manual.md
+++ b/content/en/docs/instrumentation/net/manual.md
@@ -98,7 +98,7 @@ var serviceVersion = "1.0.0";
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Configure important OpenTelemetry settings, the console exporter, and automatic instrumentation
+// Configure important OpenTelemetry settings, the console exporter
 builder.Services.AddOpenTelemetryTracing(b =>
 {
     b
@@ -324,9 +324,9 @@ catch (Exception ex)
 
 ## Next steps
 
-After you've setup automatic instrumentation, you may want to use
-[instrumentation libraries](/docs/instrumentation/net/automatic).Instrumentation
-libraries will automatically instrument relevant libraries you're using and
+After you've setup manual instrumentation, you may want to use
+[instrumentation libraries](/docs/instrumentation/net/libraries). Instrumentation
+libraries will instrument relevant libraries you're using and
 generate data for things like inbound and outbound HTTP requests and more.
 
 You'll also want to configure an appropriate exporter to [export your telemetry

--- a/content/en/docs/instrumentation/net/manual.md
+++ b/content/en/docs/instrumentation/net/manual.md
@@ -331,3 +331,7 @@ generate data for things like inbound and outbound HTTP requests and more.
 
 You'll also want to configure an appropriate exporter to [export your telemetry
 data](/docs/instrumentation/net/exporters) to one or more telemetry backends.
+
+You can also check the
+[automatic instrumentation for .NET](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation),
+which is currently in beta.

--- a/content/en/docs/instrumentation/net/netframework.md
+++ b/content/en/docs/instrumentation/net/netframework.md
@@ -150,3 +150,7 @@ data.
 
 You'll also want to configure an appropriate exporter to [export your telemetry
 data](/docs/instrumentation/net/exporters) to one or more telemetry backends.
+
+You can also check the
+[automatic instrumentation for .NET](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation),
+which is currently in beta.

--- a/content/en/docs/instrumentation/net/shim.md
+++ b/content/en/docs/instrumentation/net/shim.md
@@ -90,7 +90,7 @@ var serviceVersion = "1.0.0";
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Configure important OpenTelemetry settings, the console exporter, and automatic instrumentation
+// Configure important OpenTelemetry settings, the console exporter, and library instrumentation
 builder.Services.AddOpenTelemetryTracing(tcb =>
 {
     tcb
@@ -375,9 +375,9 @@ This will capture things like the current stack trace as attributes in the span.
 
 ## Next steps
 
-After you've setup automatic instrumentation, you may want to use
-[instrumentation libraries](/docs/instrumentation/net/automatic).Instrumentation
-libraries will automatically instrument relevant libraries you're using and
+After you've setup manual instrumentation, you may want to use
+[instrumentation libraries](/docs/instrumentation/net/libraries). Instrumentation
+libraries will instrument relevant libraries you're using and
 generate data for things like inbound and outbound HTTP requests and more.
 
 You'll also want to configure an appropriate exporter to [export your telemetry

--- a/content/en/docs/instrumentation/net/shim.md
+++ b/content/en/docs/instrumentation/net/shim.md
@@ -90,7 +90,7 @@ var serviceVersion = "1.0.0";
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Configure important OpenTelemetry settings, the console exporter, and library instrumentation
+// Configure important OpenTelemetry settings, the console exporter, and instrumentation library
 builder.Services.AddOpenTelemetryTracing(tcb =>
 {
     tcb


### PR DESCRIPTION
## Why

Fixes https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/958

Relates to https://github.com/open-telemetry/opentelemetry-specification/issues/2336

I agree with @tedsuo regarding the differentiation between "auto-instrumentation" and "instrumentation libraries". Especially that I see that both approaches could coexist. For instance, it looks like both Go and .NET would support both scenarios.

After this PR is merged we can create a page dedicated to https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation. Tracked under https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/999

## What

In .NET docs

- Rename the "Automatic Instrumentation" page to "Using instrumentation libraries"
- Reference the beta of Automatic Instrumentation for .NET
- Appy some changes to make it similar to https://opentelemetry.io/docs/instrumentation/go/libraries/
- Update existing docs referring to "automatic instrumentation"

Preview:

- https://deploy-preview-1565--opentelemetry.netlify.app/docs/instrumentation/net/libraries/
- https://deploy-preview-1565--opentelemetry.netlify.app/docs/instrumentation/net/automatic/ -- redirect test
