### PR TITLE
Update python jaeger export to mention both thrift and proto

### DIFF
--- a/content/en/docs/instrumentation/python/exporters.md
+++ b/content/en/docs/instrumentation/python/exporters.md
@@ -158,8 +158,8 @@ $ pip install opentelemetry-exporter-jaeger
 
 This will install packages for both:
 
-* `opentelemetry.exporter.jaeger.thrift`
-* `opentelemetry.exporter.jaeger.proto`
+* `opentelemetry-exporter-jaeger-thrift`
+* `opentelemetry-exporter-jaeger-proto-grpc`
 
 You can use either to export your traces to Jaeger.
 

--- a/content/en/docs/instrumentation/python/exporters.md
+++ b/content/en/docs/instrumentation/python/exporters.md
@@ -192,7 +192,7 @@ trace.set_tracer_provider(provider)
 The previous example uses thrift. To use protobuf, change the import declaration to:
 
 ```python
-from opentelemetry.exporter.jaeger.proto import JaegerExporter
+from opentelemetry.exporter.jaeger.proto.grpc import JaegerExporter
 ```
 
 ## Zipkin

--- a/content/en/docs/instrumentation/python/exporters.md
+++ b/content/en/docs/instrumentation/python/exporters.md
@@ -156,7 +156,14 @@ Next, install the Jaeger exporter package:
 $ pip install opentelemetry-exporter-jaeger
 ```
 
-Then you can configure the exporter when initializing tracing:
+This will install packages for both:
+
+* `opentelemetry.exporter.jaeger.thrift`
+* `opentelemetry.exporter.jaeger.proto`
+
+You can use either to export your traces to Jaeger.
+
+Once the package is installed, you can configure the exporter when initializing tracing:
 
 ```python
 from opentelemetry import trace
@@ -182,18 +189,10 @@ trace.set_tracer_provider(provider)
 # Merrily go about tracing!
 ```
 
-### Using Thrift
-
-If you'd prefer to use Thrift as the protocol, you can install the package:
-
-```console
-$ pip install opentelemetry-exporter-jaeger-thrift
-```
-
-And replace the `JaegerExporter` import declaration with the following:
+The previous example uses thrift. To use protobuf, change the import declaration to:
 
 ```python
-from opentelemetry.exporter.jaeger.thrift import JaegerExporter
+from opentelemetry.exporter.jaeger.proto import JaegerExporter
 ```
 
 ## Zipkin


### PR DESCRIPTION
Follow up to https://github.com/open-telemetry/opentelemetry.io/pull/1563#issuecomment-1196120715

Preview: https://deploy-preview-1566--opentelemetry.netlify.app/docs/instrumentation/python/exporters/#jaeger