### PR TITLE
Fix a typo in Python getting started guide

### DIFF
--- a/content/en/docs/instrumentation/python/getting-started.md
+++ b/content/en/docs/instrumentation/python/getting-started.md
@@ -129,7 +129,7 @@ single span printed to the console, such as the following:
 
 </details>
 
-The span generated for you tracks the lifetime of a request to the `/doroll`
+The span generated for you tracks the lifetime of a request to the `/rolldice`
 route.
 
 ## Add manual instrumentation to automatic instrumentation


### PR DESCRIPTION
Route listens on /rolldice, not /doroll.