### PR TITLE
CODEOWNERS: add entry for collector section

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,7 @@
 * @open-telemetry/docs-approvers
 
 # content owners
+content/en/docs/collector                @open-telemetry/docs-approvers @open-telemetry/collector-approvers
 content/en/docs/instrumentation/js/      @open-telemetry/docs-approvers @open-telemetry/javascript-approvers
 content/en/docs/instrumentation/cpp/     @open-telemetry/docs-approvers @open-telemetry/cpp-maintainers
 content/en/docs/instrumentation/java/    @open-telemetry/docs-approvers @open-telemetry/java-maintainers @open-telemetry/java-instrumentation-maintainers


### PR DESCRIPTION
@austinlparker - FYI, I granted [collector-approvers](https://github.com/orgs/open-telemetry/teams/collector-approvers) write access to the repo, which is required for the file to be valid.

/cc @open-telemetry/collector-approvers @open-telemetry/collector-contrib-approvers @cartermp 