### PR TITLE
Document the component type/name identifier syntax

### DIFF
--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -67,8 +67,7 @@ service:
       exporters: [otlp]
 ```
 
-Note that the same receiver, processor, exporter and/or pipeline can be defined
-more than once. For example:
+Note that receivers, processors, exporters and/or pipelines are defined via component identifiers in `type[/name]` format (e.g. `otlp` or `otlp/2`).  Components of a given type can be defined more than once as long as the identifiers are unique. For example:
 
 ```yaml
 receivers:


### PR DESCRIPTION
As a new user of the OpenTelemetry collector, it was quite confusing to see YAML field names/identifiers with forward slash characters (i.e. `/`) in the config file. While this is clearly allowed by the YAML spec, it was unclear what effect this naming convention would have in the context of the OpenTelemetry collector config file and process. As far as I know, the only place this naming convention is documented is [in code](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/identifiable.go). 

The [`componentID` struct](https://github.com/open-telemetry/opentelemetry-collector/blob/v0.56.0/config/identifiable.go#L34-L41) was particularly helpful in demystifying the component identifier syntax, with the rest of [`identifiable.go`](https://github.com/open-telemetry/opentelemetry-collector/blob/v0.56.0/config/identifiable.go) providing helpful context. 

```golang
// ComponentID represents the identity for a component. It combines two values:
// * type - the Type of the component.
// * name - the name of that component.
// The component ComponentID (combination type + name) is unique for a given component.Kind.
type ComponentID struct {
	typeVal Type   `mapstructure:"-"`
	nameVal string `mapstructure:"-"`
}
```

This PR proposes to explain what the items in the `receivers`, `processors`, `exporters` and/or `pipelines` sections are called (i.e. "components"), and that component identifiers have a naming convention (i.e. [`component[/name]`](https://github.com/open-telemetry/opentelemetry-collector/blob/v0.56.0/config/identifiable.go#L53)). 

I hope this helps! 😊 

> PS – I got here by clicking an "edit this page" link from [this page](https://opentelemetry.io/docs/collector/configuration/) on the OpenTelemetry documentation website. I have not yet reviewed any contributor guidelines since none were referenced in this workflow (from the "edit this page" link to submitting this PR from my browser on GitHub.com). Please let me know if I need to do a CLA dance and/or sign my commits and I'll be happy to do so. 🍻