### PR TITLE
Call out that spans can be nested in the conceptual docs

### DIFF
--- a/content/en/docs/concepts/signals/traces.md
+++ b/content/en/docs/concepts/signals/traces.md
@@ -230,10 +230,9 @@ Sample Span:
 }
 ```
 
-As is implied by the present of a parent span ID, spans can be nested as
-child spans that represent sub-operations. This allows them to accurately
-model work done in an application.
-
+Spans can be nested, as is implied by the presence of a parent span ID:
+child spans represent sub-operations. This allows spans to more accurately
+capture the work done in an application.
 ### Span Context
 
 Span Context is an immutable object on every span that contains the following:

--- a/content/en/docs/concepts/signals/traces.md
+++ b/content/en/docs/concepts/signals/traces.md
@@ -187,6 +187,7 @@ work or operation. Spans are the building blocks of Traces. In OpenTelemetry,
 they include the following information:
 
 - Name
+- Parent span ID
 - Start and End Timestamps
 - [Span Context](#span-context)
 - [Attributes](#attributes)
@@ -228,6 +229,10 @@ Sample Span:
   }
 }
 ```
+
+As is implied by the present of a parent span ID, spans can be nested as
+child spans that represent sub-operations. This allows them to accurately
+model work done in an application.
 
 ### Span Context
 


### PR DESCRIPTION
It's kinda Spans 101 level stuff, but it's not explicitly called out and I figured that felt missing.