### PR TITLE
Move spec status into spec section

### DIFF
--- a/content/en/docs/reference/specification/status.md
+++ b/content/en/docs/reference/specification/status.md
@@ -1,0 +1,126 @@
+---
+title: Specification status summary
+linkTitle: Status
+weight: 10
+---
+
+OpenTelemetry is developed on a signal by signal basis. Tracing, metrics,
+baggage, and logging are examples of signals. Signals are built on top of
+context propagation, a shared mechanism for correlating data across distributed
+systems.
+
+Each signal consists of four [core components](/docs/concepts/components/):
+
+- APIs
+- SDKs
+- [OpenTelemetry Protocol](/docs/reference/specification/protocol/) (OTLP)
+- [Collector](/docs/collector/)
+
+Signals also have contrib components, an ecosystem of plugins and
+instrumentation. All instrumentation shares the same semantic conventions, to
+ensure that they produce the same data when observing common operations, such as
+HTTP requests.
+
+To learn more about signals and components, see the specification
+[Overview]({{< relref "/docs/reference/specification/overview" >}}).
+
+## Component Lifecycle
+
+Components follow a development lifecycle: Draft, Experimental, Stable,
+Deprecated, Removed.
+
+- **Draft** components are under design, and have not been added to the
+  specification.
+- **Experimental** components are released and available for beta testing.
+- **Stable** components are backwards compatible and covered under long term
+  support.
+- **Deprecated** components are stable, but may eventually be removed.
+
+For complete definitions of lifecycles and long term support, see [Versioning
+and
+stability]({{< relref "/docs/reference/specification/versioning-and-stability" >}}).
+
+## Current Status
+
+The following is a high level status report for currently available signals.
+Note that while the OpenTelemetry clients conform to a shared specification,
+they are developed independently.
+
+Checking the current status for each client in the README of its
+[github repo](https://github.com/open-telemetry) is recommended. Client support
+for specific features can be found in the
+[specification compliance tables](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md).
+
+Note that, for each of the following sections, the **Collector** status is the
+same as the **Protocol** status.
+
+### [Tracing][]
+
+- {{% spec_status "API" "trace/api" "Status" %}}
+- {{% spec_status "SDK" "trace/sdk" "Status" %}}
+- {{% spec_status "Protocol" "protocol/otlp" "Tracing" %}}
+- Notes:
+  - The tracing specification is now completely stable, and covered by long term
+    support.
+  - The tracing specification is still extensible, but only in a backwards
+    compatible manner.
+  - OpenTelemetry clients are versioned to v1.0 once their tracing
+    implementation is complete.
+
+### [Metrics][]
+
+- {{% spec_status "API" "metrics/api" "Status" %}}
+- {{% spec_status "SDK" "metrics/sdk" "Status" %}}
+- {{% spec_status "Protocol" "protocol/otlp" "Metrics" %}}
+- Notes:
+  - OpenTelemetry Metrics is currently under active development.
+  - The data model is stable and released as part of the OTLP protocol.
+  - Experimental support for metric pipelines are available in the Collector.
+  - Collector support for Prometheus is under development, in collaboration with
+    the Prometheus community.
+
+### [Baggage][]
+
+- {{% spec_status "API" "baggage/api" "Status" %}}
+- **SDK:** stable
+- **Protocol:** N/A
+- Notes:
+  - OpenTelemetry Baggage is now completely stable.
+  - Baggage is not an observability tool, it is a system for attaching arbitrary
+    keys and values to a transaction, so that downstream services may access
+    them. As such, there is no OTLP or Collector component to baggage.
+
+### Logging
+
+- **API:** draft
+- **SDK:** draft
+- {{% spec_status "Protocol" "protocol/otlp" "Logs" %}}
+- Notes:
+  - OpenTelemetry Logging is currently under active development.
+  - The [logs data model][] is released as part of the OpenTelemetry Protocol.
+  - Log processing for many data formats has been added to the Collector, thanks
+    to the donation of Stanza to the the OpenTelemetry project.
+  - Log appenders are currently under develop in many languages. Log appenders
+    allow OpenTelemetry tracing data, such as trace and span IDs, to be appended
+    to existing logging systems.
+  - An OpenTelemetry logging SDK is currently under development. This allows
+    OpenTelemetry clients to ingest logging data from existing logging systems,
+    outputting logs as part of OTLP along with tracing and metrics.
+  - An OpenTelemetry logging API is not currently under development. We are
+    focusing first on integration with existing logging systems. When metrics is
+    complete, focus will shift to development of an OpenTelemetry logging API.
+
+### Instrumentation
+
+An effort to expand the availability and quality of OpenTelemetry
+instrumentation is scheduled for this summer.
+
+- Stabilize and define long term support for instrumentation
+- Provide instrumentation for a wider variety of important libraries
+- Provide testing and CI/CD tools for writing and verifying instrumentation
+  quality.
+
+[baggage]: /docs/reference/specification/baggage/
+[logs data model]: /docs/reference/specification/logs/data-model/
+[metrics]: /docs/reference/specification/metrics/
+[tracing]: /docs/reference/specification/trace/

--- a/content/en/status.md
+++ b/content/en/status.md
@@ -2,129 +2,20 @@
 title: Status
 menu: { main: { weight: 30 } }
 aliases: [/project-status, /releases]
+description: Maturity-level of the main OpenTelemetry components
 ---
 
 {{% blocks/section type="section" color="white" %}}
 
 ## {{% param title %}}
 
-OpenTelemetry is developed on a signal by signal basis. Tracing, metrics,
-baggage, and logging are examples of signals. Signals are built on top of
-context propagation, a shared mechanism for correlating data across distributed
-systems.
+The development status, or maturity level, of the [main OpenTelemetry
+components][main-comp] are as follows:
 
-Each signal consists of four [core components](/docs/concepts/components/):
+- [**Specification** status](/docs/reference/specification/status/)
+- [**Collector** status](/docs/collector/#status-and-releases)
+- **Language SDKs**: For the status of a supported language, consult the
+  **Status and releases** section in the language landing under
+  [Instrumentation](/docs/instrumentation/)
 
-- APIs
-- SDKs
-- [OpenTelemetry Protocol](/docs/reference/specification/protocol/) (OTLP)
-- [Collector](/docs/collector/)
-
-Signals also have contrib components, an ecosystem of plugins and
-instrumentation. All instrumentation shares the same semantic conventions, to
-ensure that they produce the same data when observing common operations, such as
-HTTP requests.
-
-To learn more about signals and components, see the specification
-[Overview]({{< relref "/docs/reference/specification/overview" >}}).
-
-### Component Lifecycle
-
-Components follow a development lifecycle: Draft, Experimental, Stable,
-Deprecated, Removed.
-
-- **Draft** components are under design, and have not been added to the
-  specification.
-- **Experimental** components are released and available for beta testing.
-- **Stable** components are backwards compatible and covered under long term
-  support.
-- **Deprecated** components are stable, but may eventually be removed.
-
-For complete definitions of lifecycles and long term support, see [Versioning
-and
-stability]({{< relref "/docs/reference/specification/versioning-and-stability" >}}).
-
-### Current Status
-
-The following is a high level status report for currently available signals.
-Note that while the OpenTelemetry clients conform to a shared specification,
-they are developed independently.
-
-Checking the current status for each client in the README of its
-[github repo](https://github.com/open-telemetry) is recommended. Client support
-for specific features can be found in the
-[specification compliance tables](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md).
-
-Note that, for each of the following sections, the **Collector** status is the
-same as the **Protocol** status.
-
-#### [Tracing][]
-
-- {{% spec_status "API" "trace/api" "Status" %}}
-- {{% spec_status "SDK" "trace/sdk" "Status" %}}
-- {{% spec_status "Protocol" "protocol/otlp" "Tracing" %}}
-- Notes:
-  - The tracing specification is now completely stable, and covered by long term
-    support.
-  - The tracing specification is still extensible, but only in a backwards
-    compatible manner.
-  - OpenTelemetry clients are versioned to v1.0 once their tracing
-    implementation is complete.
-
-#### [Metrics][]
-
-- {{% spec_status "API" "metrics/api" "Status" %}}
-- {{% spec_status "SDK" "metrics/sdk" "Status" %}}
-- {{% spec_status "Protocol" "protocol/otlp" "Metrics" %}}
-- Notes:
-  - OpenTelemetry Metrics is currently under active development.
-  - The data model is stable and released as part of the OTLP protocol.
-  - Experimental support for metric pipelines are available in the Collector.
-  - Collector support for Prometheus is under development, in collaboration with
-    the Prometheus community.
-
-#### [Baggage][]
-
-- {{% spec_status "API" "baggage/api" "Status" %}}
-- **SDK:** stable
-- **Protocol:** N/A
-- Notes:
-  - OpenTelemetry Baggage is now completely stable.
-  - Baggage is not an observability tool, it is a system for attaching arbitrary
-    keys and values to a transaction, so that downstream services may access
-    them. As such, there is no OTLP or Collector component to baggage.
-
-#### Logging
-
-- **API:** draft
-- **SDK:** draft
-- {{% spec_status "Protocol" "protocol/otlp" "Logs" %}}
-- Notes:
-  - OpenTelemetry Logging is currently under active development.
-  - The [logs data model][] is released as part of the OpenTelemetry Protocol.
-  - Log processing for many data formats has been added to the Collector, thanks
-    to the donation of Stanza to the the OpenTelemetry project.
-  - Log appenders are currently under develop in many languages. Log appenders
-    allow OpenTelemetry tracing data, such as trace and span IDs, to be appended
-    to existing logging systems.
-  - An OpenTelemetry logging SDK is currently under development. This allows
-    OpenTelemetry clients to ingest logging data from existing logging systems,
-    outputting logs as part of OTLP along with tracing and metrics.
-  - An OpenTelemetry logging API is not currently under development. We are
-    focusing first on integration with existing logging systems. When metrics is
-    complete, focus will shift to development of an OpenTelemetry logging API.
-
-#### Instrumentation
-
-An effort to expand the availability and quality of OpenTelemetry
-instrumentation is scheduled for this summer.
-
-- Stabilize and define long term support for instrumentation
-- Provide instrumentation for a wider variety of important libraries
-- Provide testing and CI/CD tools for writing and verifying instrumentation
-  quality.
-
-[baggage]: /docs/reference/specification/baggage/
-[logs data model]: /docs/reference/specification/logs/data-model/
-[metrics]: /docs/reference/specification/metrics/
-[tracing]: /docs/reference/specification/trace/
+[main-comp]: /docs/concepts/components/


### PR DESCRIPTION
- Contributes to #1574
- Moves the Status page content, which was only about the spec's status, (verbatim) into a new Spec status page
  - **TODO**: I'll address the page-meta links (like Edit this page) later.
- Adds basic structure and links to the /status page, until this page gets beautified


Preview:

- https://deploy-preview-1606--opentelemetry.netlify.app/status
- https://deploy-preview-1606--opentelemetry.netlify.app/docs/reference/specification/status

/cc @tedsuo @melbgirl 