### PR TITLE
Add mypy doc

### DIFF
--- a/content/en/docs/instrumentation/python/mypy.md
+++ b/content/en/docs/instrumentation/python/mypy.md
@@ -3,7 +3,8 @@ title: Using mypy
 ---
 
 If you're using [mypy](http://mypy-lang.org/), you'll need to turn on [namespace
-packages](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-namespace-packages), otherwise `mypy` won't be able to run correctly.
+packages](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-namespace-packages),
+otherwise `mypy` won't be able to run correctly.
 
 To turn on namespace packages, do one of the following:
 
@@ -18,4 +19,15 @@ Or, use a command-line switch:
 
 ```shell
 mypy --namespace-packages
+```
+
+## Using the `strict` option
+
+If you're using the `strict` option with mypy, and you're using the
+OpenTelemetry Python SDK (instead of just the API), you'll need to also set the
+following in your project configuration file:
+
+```toml
+[mypy-opentelemetry.sdk.*]
+implicit_reexport = True
 ```

--- a/content/en/docs/instrumentation/python/mypy.md
+++ b/content/en/docs/instrumentation/python/mypy.md
@@ -1,0 +1,23 @@
+---
+title: Using mypy
+weight: 5
+---
+
+If you're using [mypy](http://mypy-lang.org/), you'll need to turn on [namespace
+packages](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-namespace-packages).
+
+In your project configuration file, add the following:
+
+```toml
+[tool.mypy]
+namespace_packages = true
+```
+
+Or if you'd prefer a command-line switch, use `--namespace-packages`:
+
+```console
+mypy --namespace-packages
+```
+
+If you don't turn on namespace packages, then mypy won't be able to correctly
+run.

--- a/content/en/docs/instrumentation/python/mypy.md
+++ b/content/en/docs/instrumentation/python/mypy.md
@@ -1,6 +1,5 @@
 ---
 title: Using mypy
-weight: 5
 ---
 
 If you're using [mypy](http://mypy-lang.org/), you'll need to turn on [namespace
@@ -8,7 +7,7 @@ packages](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy
 
 To turn on namespace packages, do one of the following:
 
-- Add the following to your project configuration file:
+Add the following to your project configuration file:
 
 ```toml
 [tool.mypy]
@@ -17,9 +16,6 @@ namespace_packages = true
 
 Or, use a command-line switch:
 
-```console
+```shell
 mypy --namespace-packages
 ```
-
-If you don't turn on namespace packages, then mypy won't be able to correctly
-run.

--- a/content/en/docs/instrumentation/python/mypy.md
+++ b/content/en/docs/instrumentation/python/mypy.md
@@ -4,16 +4,18 @@ weight: 5
 ---
 
 If you're using [mypy](http://mypy-lang.org/), you'll need to turn on [namespace
-packages](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-namespace-packages).
+packages](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-namespace-packages), otherwise `mypy` won't be able to run correctly.
 
-In your project configuration file, add the following:
+To turn on namespace packages, do one of the following:
+
+- Add the following to your project configuration file:
 
 ```toml
 [tool.mypy]
 namespace_packages = true
 ```
 
-Or if you'd prefer a command-line switch, use `--namespace-packages`:
+Or, use a command-line switch:
 
 ```console
 mypy --namespace-packages


### PR DESCRIPTION
This came up before, but there was some recent conversation here that made me feel like we could do a quick doc explaining how to configure a mypy project: https://github.com/open-telemetry/opentelemetry-python/issues/2591#issuecomment-1206440086

There's mention of potentially needing this in a project configuration file:

```
[mypy-opentelemetry.sdk.*]
implicit_reexport = True
```

I do not know if this is also necessary, but it should be easy to add if it is.