### PR TITLE
Address accessibility issue of link to instrumentation

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -26,7 +26,7 @@ developer_note:
 - [Go](/docs/instrumentation/go/getting-started/)
 - [.NET](/docs/instrumentation/net/getting-started/)
 - [JavaScript](/docs/instrumentation/js/getting-started/)
-- [<i class="fas fa-ellipsis-h"></i>](/docs/instrumentation/)
+- [<i class="fas fa-ellipsis-h" aria-label="All languages"></i>](/docs/instrumentation/)
 
 </div>
 {{< /blocks/cover >}}


### PR DESCRIPTION
- I've tested this with a screen reader under Safari and it works as intended, when focus hits the button with the elipsis label, the reader reads "All languages"
- Closes #1612
- If @cartermp agrees, this also closes #1614

Preview: https://deploy-preview-1617--opentelemetry.netlify.app