### PR TITLE
Add .NET runtime metrics instrumentation to the registry

### DIFF
--- a/content/en/registry/instrumentation-dotnet-runtime.md
+++ b/content/en/registry/instrumentation-dotnet-runtime.md
@@ -1,0 +1,17 @@
+---
+title: .NET runtime metrics instrumentation
+registryType: instrumentation
+isThirdParty: false
+language: dotnet
+tags:
+  - .NET
+  - C#
+  - dotnet
+  - instrumentation
+  - runtime
+  - metrics
+repo: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.Runtime
+license: Apache 2.0
+description: OpenTelemetry .NET contrib plugin for collecting metrics from .NET Runtime
+authors: OpenTelemetry Authors
+---


### PR DESCRIPTION
FYI @open-telemetry/dotnet-contrib-approvers