### PR TITLE
Remove prometheus exporter for JavaScript

### DIFF
--- a/content/en/docs/instrumentation/js/exporters.md
+++ b/content/en/docs/instrumentation/js/exporters.md
@@ -3,7 +3,7 @@ title: "Exporters"
 weight: 3
 ---
 
-In order to visualize and analyze your traces and metrics, you will need to
+In order to visualize and analyze your traces, you will need to
 export them to a backend such as [Jaeger](https://www.jaegertracing.io/) or
 [Zipkin](https://zipkin.io/). OpenTelemetry JS provides exporters for some
 common open source backends.
@@ -89,48 +89,4 @@ const { ZipkinExporter } = require("@opentelemetry/exporter-zipkin");
 const { BatchSpanProcessor } = require("@opentelemetry/sdk-trace-base");
 
 provider.addSpanProcessor(new BatchSpanProcessor(new ZipkinExporter()));
-```
-
-## Prometheus
-
-To set up Prometheus as quickly as possible, run it in a docker container. You
-will need a `prometheus.yml` to configure the backend, use the following example
-and modify it to your needs:
-
-```yml
-global:
-  scrape_interval: 15s
-  evaluation_interval: 15s
-
-scrape_configs:
-  - job_name: "prometheus"
-    static_configs:
-      - targets: ["localhost:9090"]
-```
-
-With this file you can now start the docker container:
-
-```shell
-docker run \
-    -p 9090:9090 \
-    -v ${PWD}/prometheus.yml:/etc/prometheus/prometheus.yml \
-    prom/prometheus
-```
-
-Install the exporter package as a dependency for your application:
-
-```shell
-npm install --save @opentelemetry/exporter-prometheus
-```
-
-Update your opentelemetry configuration to use the exporter and to send data to
-your prometheus backend:
-
-```javascript
-const { PrometheusExporter } = require("@opentelemetry/exporter-prometheus");
-const { MeterProvider } = require("@opentelemetry/sdk-metrics-base");
-const meter = new MeterProvider({
-  exporter: new PrometheusExporter({ port: 9090 }),
-  interval: 1000,
-}).getMeter("prometheus");
 ```


### PR DESCRIPTION
Removing the prometheus metric exporter from javascript docs until we can provide an updated & correct version

See https://github.com/open-telemetry/opentelemetry.io/pull/1621#discussion_r947656433 for details, cc: @pichlermarc , @cartermp 