### PR TITLE
Add head link to canonical_url if present

### DIFF
--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,4 +1,3 @@
-{{/* Include link to blog canonical URL, if "canonical_url" field exists in front matter. */}}
 {{ with .Params.canonical_url -}}
 <link rel="canonical" href="{{ . }}">
 {{ end -}}

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,0 +1,4 @@
+{{/* Include link to blog canonical URL, if "canonical_url" field exists in front matter. */}}
+{{ if .Params.canonical_url }}
+<link rel="canonical" href="{{ .Params.canonical_url }}">
+{{ end }}

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,4 +1,4 @@
 {{/* Include link to blog canonical URL, if "canonical_url" field exists in front matter. */}}
-{{ if .Params.canonical_url }}
-<link rel="canonical" href="{{ .Params.canonical_url }}">
-{{ end }}
+{{ with .Params.canonical_url -}}
+<link rel="canonical" href="{{ . }}">
+{{ end -}}


### PR DESCRIPTION
Originally included this in in #1648, but splitting it out upon [request](https://github.com/open-telemetry/opentelemetry.io/pull/1648#discussion_r951827203). 

This is the / a [recommended way](https://en.wikipedia.org/wiki/Canonical_link_element) to specify a canonical page, which is good for everyone. 

---

(**Edit**: @chalin)

Previews, e.g.:

- https://deploy-preview-1649--opentelemetry.netlify.app/blog/2021/womens-day/, which now includes the following in its `<head>`:
  > ```html
  > <link rel=canonical href=https://medium.com/opentelemetry/opentelemetry-observes-international-womens-day-2021-4493a157f119>
  > ```