### PR TITLE
Adds cookie- / privacy-policy consent support

### DIFF
--- a/assets/js/privacy-notice.js
+++ b/assets/js/privacy-notice.js
@@ -1,0 +1,12 @@
+$(function () {
+  const key = 'linux-foundation-org-cookie-consent';
+  const consentValue = 'true'
+
+  if (Cookies.get(key) === consentValue) { return; }
+
+  $('#privacyNotice')
+    .on('hide.bs.modal', function () {
+      Cookies.set(key, consentValue, { sameSite: 'strict', expires: 90 });
+    })
+    .modal('show');
+});

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,1 +1,6 @@
 {{ partial "script.html" (dict "src" "js/tracing.js") -}}
+
+<script src="https://cdn.jsdelivr.net/npm/js-cookie@3.0.1/dist/js.cookie.min.js" integrity="sha256-0H3Nuz3aug3afVbUlsu12Puxva3CP4EhJtPExqs54Vg=" crossorigin="anonymous"></script>
+{{ partial "script.html" (dict "src" "js/privacy-notice.js") -}}
+
+{{ partialCached "privacy-notice.html" . -}}

--- a/layouts/partials/privacy-notice.html
+++ b/layouts/partials/privacy-notice.html
@@ -1,0 +1,22 @@
+<div class="modal fade" id="privacyNotice" data-backdrop="static" data-keyboard="false" tabindex="-1" aria-labelledby="privacyNoticeLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="privacyNoticeLabel">
+          Privacy policy
+        </h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Accept" title="Accept">
+          <span aria-hidden="true"><i style="color: green" class="fas fa-check-circle"></i></span>
+        </button>
+      </div>
+        <div class="modal-body">
+        <p>
+          This website uses cookies to deliver a better browsing experience.
+          To learn more about how we use cookies, and how to
+          view cookies and adjust your cookie settings, see our
+          <a href="https://www.linuxfoundation.org/cookies/" class="external-link" target="_blank" rel="noopener">Cookie policy</a>.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
- Contributes to #1636
- Features:
  - Displays a modal dialog that is centered in the page (works well on desktop and mobile).
  - The only way to dismiss the dialog is by clicking the "accept" button (the green check mark). So, the site cannot be used without a consent.
  - Tab-focus goes to the accept button.
- A first attempt at addressing GDPR requirements. If there is general agreement on moving forward with this I'll make some followup changes such as (most items, other than the first, are mainly a note-to-self):
  - **Only enabling this for production builds. WDYT?**
  - Moving the currently hard-coded styling into our SCSS files, and 
  - Switch to using FA 6 icon names.
  - I might also propose this as an upstream change to Docsy.

Preview:

- Any page from the preview server, such as:
  - Homepage: https://deploy-preview-1653--opentelemetry.netlify.app
  - Docs page, e.g.: https://deploy-preview-1653--opentelemetry.netlify.app/docs/instrumentation/go/
  - Blog page, e.g.: https://deploy-preview-1653--opentelemetry.netlify.app/blog/2022/demo-announcement/
- You can reset the cookie through you browser settings, but also through the JS console using the following commands:
  ```
  Cookies.get('linux-foundation-org-cookie-consent')
  Cookies.set('linux-foundation-org-cookie-consent', '')
  ```
  Or from, say, Chrome DevTools >> Application >> Storage >> Cookies.


/cc @caniszczyk @austinlparker @cartermp 