### PR TITLE
[bikeshedding] adjusted status page layout

### DIFF
--- a/content/en/status.md
+++ b/content/en/status.md
@@ -9,18 +9,13 @@ description: Maturity-level of the main OpenTelemetry components
 
 ## {{% param title %}}
 
-The development status, or maturity level, of the [main OpenTelemetry
-components][main-comp] are as follows:
+OpenTelemetry is made up of several components, each having different meanings
+for "status". For example, the status of a signal in the specification may not
+be the same as its status in a particular language SDK.
 
+The development status, or maturity level, of the [per-language
+SDKs](/docs/instrumentation/) is as follows:
 
-<div class="l-get-started-buttons">
-
-- [Specification status](/docs/reference/specification/status/)
-- [Collector status](/docs/collector/#status-and-releases)
-
-</div>
-
-The development status, or maturity level, of the [per-language SDKs](/docs/instrumentation/) is as follows:
 <div class="l-primary-buttons mt-5">
 
 - [C++](/docs/instrumentation/cpp/#status-and-releases) 
@@ -34,6 +29,17 @@ The development status, or maturity level, of the [per-language SDKs](/docs/inst
 - [Ruby](/docs/instrumentation/ruby/#status-and-releases) 
 - [Rust](/docs/instrumentation/rust/#status-and-releases) 
 - [Swift](/docs/instrumentation/swift/#status-and-releases) 
+
+</div>
+
+The development status, or maturity level, of the [language-agnostic
+components][main-comp] are as follows:
+
+
+<div class="l-primary-buttons mt-5">
+
+- [Specification status](/docs/reference/specification/status/)
+- [Collector status](/docs/collector/#status-and-releases)
 
 </div>
 

--- a/content/en/status.md
+++ b/content/en/status.md
@@ -16,7 +16,7 @@ be the same as its status in a particular language SDK.
 The development status, or maturity level, of the [per-language
 SDKs](/docs/instrumentation/) is as follows:
 
-<div class="l-primary-buttons mt-5">
+<div class="l-primary-buttons mt-0">
 
 - [C++](/docs/instrumentation/cpp/#status-and-releases) 
 - [.NET](/docs/instrumentation/net/#status-and-releases) 
@@ -35,14 +35,12 @@ SDKs](/docs/instrumentation/) is as follows:
 The development status, or maturity level, of the [language-agnostic
 components][main-comp] are as follows:
 
-
-<div class="l-primary-buttons mt-5">
+<div class="l-primary-buttons mt-0">
 
 - [Specification status](/docs/reference/specification/status/)
 - [Collector status](/docs/collector/#status-and-releases)
 
 </div>
-
 
 [main-comp]: /docs/concepts/components/
 

--- a/content/en/status.md
+++ b/content/en/status.md
@@ -9,12 +9,14 @@ description: Maturity-level of the main OpenTelemetry components
 
 ## {{% param title %}}
 
-OpenTelemetry is made up of several components, each having different meanings
-for "status". For example, the status of a signal in the specification may not
-be the same as its status in a particular language SDK.
+OpenTelemetry is made up of [several components][main-comp], some
+language-specific and others language-agnostic. When looking for a status, make
+sure to look for the status from the right component page. For example, the
+status of a signal in the specification may not be the same as the signal status
+in a particular language SDK.
 
-The development status, or maturity level, of the [per-language
-SDKs](/docs/instrumentation/) is as follows:
+For the development status, or maturity level, of a [language
+SDK](/docs/instrumentation/), see the status section of that language:
 
 <div class="l-primary-buttons mt-0">
 
@@ -32,8 +34,7 @@ SDKs](/docs/instrumentation/) is as follows:
 
 </div>
 
-The development status, or maturity level, of the [language-agnostic
-components][main-comp] are as follows:
+The development status, or maturity level, of the [collector](/docs/collector/) and [specification](/docs/reference/specification/) are as follows:
 
 <div class="l-primary-buttons mt-0">
 

--- a/content/en/status.md
+++ b/content/en/status.md
@@ -34,7 +34,8 @@ SDK](/docs/instrumentation/), see the status section of that language:
 
 </div>
 
-The development status, or maturity level, of the [collector](/docs/collector/) and [specification](/docs/reference/specification/) are as follows:
+For the development status, or maturity level, of the [collector](/docs/collector/)
+and [specification](/docs/reference/specification/), see the following:
 
 <div class="l-primary-buttons mt-0">
 


### PR DESCRIPTION
We chatted about this a little bit in the comms SIG, where it was pondered if it was better to have language SDK stuff first. So I did that! And did some color and words changing stuff too. It's a bikeshed that I'm painting.

Preview: https://deploy-preview-1655--opentelemetry.netlify.app/status/