### PR TITLE
Add Prisma tracing instrumentation to the registry

### DIFF
--- a/content/en/registry/instrumentation-js-prisma.md
+++ b/content/en/registry/instrumentation-js-prisma.md
@@ -1,0 +1,15 @@
+---
+title: Prisma Tracing Instrumentation
+registryType: instrumentation
+isThirdParty: true
+language: js
+tags:
+  - Node.js
+  - tracing
+  - instrumentation 
+repo: https://github.com/prisma/prisma/tree/main/packages/instrumentation
+license: Apache 2.0
+description:  OpenTelemetry compliant tracing instrumentation for the Prisma ORM. 
+authors: Prisma (hello@prisma.io) 
+otVersion: latest
+---


### PR DESCRIPTION
Adds [prisma tracing instrumentation](https://github.com/prisma/prisma/tree/main/packages/instrumentation) to the registry.

Please let me know if any modifications to this PR or anything else is needed to get this approved. 