### PR TITLE
fix go exporter config

### DIFF
--- a/content/en/registry/exporter-go-zipkin.md
+++ b/content/en/registry/exporter-go-zipkin.md
@@ -2,9 +2,9 @@
 title: Zipkin Exporter
 registryType: exporter
 isThirdParty: true
-language: java
+language: go
 tags:
-  - java
+  - go
   - exporter
 repo: https://github.com/open-telemetry/opentelemetry-go/tree/main/exporters/zipkin
 license: Apache 2.0


### PR DESCRIPTION
https://opentelemetry.io/registry/?language=java
There's two zipkin exporter option.