### PR TITLE
Remove link to browser extension

### DIFF
--- a/content/en/docs/instrumentation/js/getting-started/browser.md
+++ b/content/en/docs/instrumentation/js/getting-started/browser.md
@@ -223,7 +223,3 @@ registerInstrumentations({
 To leverage the most common instrumentations all in one you can simply use the
 [OpenTelemetry Meta Packages for Web](https://www.npmjs.com/package/@opentelemetry/auto-instrumentations-web)
 
-## Instrumentation with Browser Extension
-
-If you'd like to quickly preview what OpenTelemetry instrumentation would look like with your website (or any other site)
-installed, you can use the [OpenTelemetry Browser Extension](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/opentelemetry-browser-extension-autoinjection)


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1110, I need to fix & bring back the browser extension, until then the link is broken, so I removed it.