### PR TITLE
Fix broken link

### DIFF
--- a/content/en/registry/collector-exporter-google-cloud-operations.md
+++ b/content/en/registry/collector-exporter-google-cloud-operations.md
@@ -7,7 +7,7 @@ tags:
   - go
   - exporter
   - collector
-repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/stackdriverexporter
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudexporter
 license: Apache 2.0
 description: The Google Cloud Operations Exporter for the OpenTelemetry Collector.
 authors: Google


### PR DESCRIPTION
The Google Cloud Ops exporter used to be called the
Stackdriver exporter, but that was moved some time ago.