### PR TITLE
`exporter` ENDPOINT default schema

### DIFF
--- a/content/en/docs/concepts/sdk-configuration/otlp-exporter-configuration.md
+++ b/content/en/docs/concepts/sdk-configuration/otlp-exporter-configuration.md
@@ -24,15 +24,15 @@ endpoint and want one environment variable to control the endpoint.
 **Example:**
 
 * gRPC: `export OTEL_EXPORTER_OTLP_ENDPOINT="my-api-endpoint:443"`
-* HTTP: `export OTEL_EXPORTER_OTLP_ENDPOINT="https://my-api-endpoint/"`
+* HTTP: `export OTEL_EXPORTER_OTLP_ENDPOINT="http://my-api-endpoint/"`
 
 For OTLP/HTTP, exporters in the SDK construct signal-specific URLs when this
 environment variable is set. This means that if you're sending traces, metrics,
 and logs, the following URLS are constructed from the example above:
 
-* Traces: `"https://my-api-endpoint/v1/traces"`
-* Metrics: `"https://my-api-endpoint/v1/metrics"`
-* Logs: `"https://my-api-endpoint/v1/logs"`
+* Traces: `"http://my-api-endpoint/v1/traces"`
+* Metrics: `"http://my-api-endpoint/v1/metrics"`
+* Logs: `"http://my-api-endpoint/v1/logs"`
 
 ### `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
 
@@ -47,7 +47,7 @@ end with `v1/traces` if using OTLP/HTTP.
 **Example:**
 
 * gRPC: `export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="my-api-endpoint:443"`
-* HTTP:`export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="https://my-api-endpoint/v1/traces"`
+* HTTP:`export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://my-api-endpoint/v1/traces"`
 
 ### `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`
 
@@ -62,7 +62,7 @@ end with `v1/metrics` if using OTLP/HTTP.
 **Example:**
 
 * gRPC: `export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT="my-api-endpoint:443"`
-* HTTP:`export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT="https://my-api-endpoint/v1/metrics"`
+* HTTP:`export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT="http://my-api-endpoint/v1/metrics"`
 
 ### `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`
 
@@ -77,7 +77,7 @@ end with `v1/logs` if using OTLP/HTTP.
 **Example:**
 
 * gRPC: `export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT="my-api-endpoint:443"`
-* HTTP:`export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT="https://my-api-endpoint/v1/logs"`
+* HTTP:`export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT="http://my-api-endpoint/v1/logs"`
 
 ## Header configuration
 


### PR DESCRIPTION
In [specification/protocol/exporter](https://opentelemetry.io/docs/reference/specification/protocol/exporter/#configuration-options). 
> SDKs SHOULD default endpoint variables to use http scheme unless they have good reasons to choose https scheme for the default (e.g., for backward compatibility reasons in a stable SDK release).

So I think, the example of `ENDPOINT` should use `http`. If not, newcomer maybe confuse with should I use `https` by default.