### PR TITLE
Remove incorrect sentence from deployment.md

### DIFF
--- a/content/en/docs/collector/deployment.md
+++ b/content/en/docs/collector/deployment.md
@@ -17,9 +17,7 @@ doing so, the Agent is capable of receiving telemetry data (push and pull
 based) as well as enhancing telemetry data with metadata such as custom tags or
 infrastructure information. In addition, the Agent can offload responsibilities
 that client instrumentation would otherwise need to handle including batching,
-retry, encryption, compression and more. OpenTelemetry instrumentation
-libraries by default export their data assuming a locally running Collector is
-available.
+retry, encryption, compression and more.
 
 ## Gateway
 


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-specification/issues/2520:

> [Instrumentation Libraries](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/glossary.md#instrumentation-library) provide instrumentation. It has no control on where the telemetry is exported. So I think the statement "OpenTelemetry instrumentation libraries by default export their data" is incorrect.

It could probably be updated with "SDKs by default export", but this still needs clarification [per my last comment on that matter](https://github.com/open-telemetry/opentelemetry-specification/issues/2520#issuecomment-1230073531)

cc: @cijothomas 