### PR TITLE
Remove "READ THIS FIRST" from  DOCS_UPDATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/DOCS_UPDATE.md
+++ b/.github/ISSUE_TEMPLATE/DOCS_UPDATE.md
@@ -7,10 +7,6 @@ assignees: ''
 
 ---
 
-## IMPORTANT - READ THIS FIRST
-The authoritative copy of the documentation for each language is contained in the respective language repository at `/website_docs`.
-Please report any issues in the appropriate SIG repository.
-
 **What needs to be changed?**
 Describe the update that is required.
 


### PR DESCRIPTION
As discussed on slack: this is only true for ruby & go and is just a barrier for new comers to get started, let's remove this.