### PR TITLE
Add semantic attributes section to python manual instrumentation doc

### DIFF
--- a/content/en/docs/instrumentation/python/manual.md
+++ b/content/en/docs/instrumentation/python/manual.md
@@ -155,6 +155,29 @@ current_span.set_attribute("operation.name", "Saying hello!")
 current_span.set_attribute("operation.other-stuff", [1, 2, 3])
 ```
 
+### Add semantic attributes
+
+[Semantic Attributes](/docs/reference/specification/trace/semantic_conventions/) are pre-defined [Attributes](/docs/concepts/signals/traces/#attributes) that are well-known naming conventions for common kinds of data. Using Semantic Attributes lets you normalize this kind of information across your systems.
+
+To use Semantic Attributes in Python, ensure you have the semantic convetions package:
+
+```shell
+pip install opentelemetry-semantic-conventions
+```
+
+Then you can use it in code:
+
+```python
+from opentelemetry import trace
+from opentelemetry.semconv.trace import SpanAttributes
+
+// ...
+
+current_span = trace.get_current_span()
+rollspan.set_attribute(SpanAttributes.HTTP_METHOD, "GET")
+rollspan.set_attribute(SpanAttributes.HTTP_URL, "www.gooddeals.com")
+```
+
 ### Adding events
 
 An [event](/docs/concepts/signals/traces/#span-events) is a human-readable

--- a/content/en/docs/instrumentation/python/manual.md
+++ b/content/en/docs/instrumentation/python/manual.md
@@ -175,7 +175,7 @@ from opentelemetry.semconv.trace import SpanAttributes
 
 current_span = trace.get_current_span()
 rollspan.set_attribute(SpanAttributes.HTTP_METHOD, "GET")
-rollspan.set_attribute(SpanAttributes.HTTP_URL, "www.gooddeals.com")
+rollspan.set_attribute(SpanAttributes.HTTP_URL, "https://opentelemetry.io/")
 ```
 
 ### Adding events

--- a/content/en/docs/instrumentation/python/manual.md
+++ b/content/en/docs/instrumentation/python/manual.md
@@ -174,8 +174,8 @@ from opentelemetry.semconv.trace import SpanAttributes
 // ...
 
 current_span = trace.get_current_span()
-rollspan.set_attribute(SpanAttributes.HTTP_METHOD, "GET")
-rollspan.set_attribute(SpanAttributes.HTTP_URL, "https://opentelemetry.io/")
+current_span.set_attribute(SpanAttributes.HTTP_METHOD, "GET")
+current_span.set_attribute(SpanAttributes.HTTP_URL, "https://opentelemetry.io/")
 ```
 
 ### Adding events


### PR DESCRIPTION
Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/1539

Preview: https://deploy-preview-1703--opentelemetry.netlify.app/docs/instrumentation/python/manual/#add-semantic-attributes