### PR TITLE
consistency of signal names in status page

### DIFF
--- a/content/en/docs/instrumentation/cpp/_index.md
+++ b/content/en/docs/instrumentation/cpp/_index.md
@@ -17,7 +17,7 @@ get started using OpenTelemetry for C++.
 The current status of the major functional components for OpenTelemetry C++ is
 as follows:
 
-| Tracing   | Metrics      | Logging      |
+| Traces    | Metrics      | Logs         |
 | --------  | -------      | -------      |
 | Stable    | Experimental | Experimental |
 

--- a/content/en/docs/instrumentation/erlang/_index.md
+++ b/content/en/docs/instrumentation/erlang/_index.md
@@ -16,7 +16,7 @@ get started using OpenTelemetry for Erlang/Elixir or any other language for the 
 
 The current status of the major functional components for OpenTelemetry Erlang/Elixir is as follows:
 
-| Tracing | Metrics | Logging |
+| Traces  | Metrics | Logs    |
 | ------- | ------- | ------- |
 | Stable  | Alpha   | Not Yet Implemented |
 

--- a/content/en/docs/instrumentation/js/_index.md
+++ b/content/en/docs/instrumentation/js/_index.md
@@ -16,7 +16,7 @@ export data.
 
 | Signal  | API Status        | SDK Status        |
 | ------- | ----------------- | ----------------- |
-| Trace   | Stable            | Stable            |
+| Traces  | Stable            | Stable            |
 | Metrics | Release Candidate | Release Candidate |
 | Logs    | Development       | Development       |
 

--- a/content/en/docs/instrumentation/php/_index.md
+++ b/content/en/docs/instrumentation/php/_index.md
@@ -15,7 +15,7 @@ get started using OpenTelemetry for PHP.
 The current status of the major functional components for OpenTelemetry PHP is
 as follows:
 
-| Tracing   | Metrics   | Logging             |
+| Traces    | Metrics   | Logs                |
 | -------   | -------   | -------             |
 | Pre-Alpha | Pre-Alpha | Not Yet Implemented |
 

--- a/content/en/docs/instrumentation/rust/_index.md
+++ b/content/en/docs/instrumentation/rust/_index.md
@@ -15,7 +15,7 @@ get started using OpenTelemetry for Rust.
 The current status of the major functional components for OpenTelemetry Rust is
 as follows:
 
-| Tracing | Metrics | Logging |
+| Traces  | Metrics | Logs    |
 | ------- | ------- | ------- |
 | Beta    | Alpha   | Not Yet Implemented |
 

--- a/content/en/docs/instrumentation/swift/_index.md
+++ b/content/en/docs/instrumentation/swift/_index.md
@@ -15,7 +15,7 @@ get started using OpenTelemetry for Swift.
 The current status of the major functional components for OpenTelemetry Swift is
 as follows:
 
-| Tracing | Metrics | Logging             |
+| Traces  | Metrics | Logs                |
 | ------- | ------- | -------             |
 | Beta    | Alpha   | Not Yet Implemented |
 


### PR DESCRIPTION
This PR contains changes for signal name consistency on the status page.
Resolves #1121 for the status page of all languages.

Preview: https://deploy-preview-1706--opentelemetry.netlify.app/