### PR TITLE
Add some links to c++ docs

### DIFF
--- a/content/en/docs/instrumentation/cpp/_index.md
+++ b/content/en/docs/instrumentation/cpp/_index.md
@@ -28,3 +28,7 @@ as follows:
 - [OpenTelemetry for C++ on GitHub](https://github.com/open-telemetry/opentelemetry-cpp)
 - [Examples](https://github.com/open-telemetry/opentelemetry-cpp/tree/main/examples)
 - [Documentation](https://opentelemetry-cpp.readthedocs.io/en/latest/)
+  - [Overview](https://opentelemetry-cpp.readthedocs.io/en/latest/api/Overview.html)
+  - [Instrumenting code](https://opentelemetry-cpp.readthedocs.io/en/latest/api/GettingStarted.html)
+  - [Configuring the SDK](https://opentelemetry-cpp.readthedocs.io/en/latest/sdk/GettingStarted.html#tracerprovider)
+  - [Exporters](https://opentelemetry-cpp.readthedocs.io/en/latest/sdk/GettingStarted.html#exporter)


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-cpp/issues/1589#issuecomment-1234647520: a light touch update for the C++ page until the SIG finalised the discussion on how to proceed with the docs. cc: @lalitb 