### PR TITLE
Add some more instructions for blog posts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ file in `/content/en/registry` for your project. You can find a template in
 
 You can submit a blog post either by forking this repository and writting it
 locally or by using the GitHub UI. In both cases we ask you to follow the
-instructions provided by the [blog post template](archetypes/blog.md)
+instructions provided by the [blog post template](archetypes/blog.md).
 
 ### Fork & Write locally
 
@@ -34,12 +34,16 @@ Follow the [setup instructions][contributing.md] then, to create a skeletal blog
 post, run the following command from the repo root:
 
 ```console
-$ npx hugo new content/en/blog/2022/file-name-for-your-blog-post.md
+$ npx hugo new content/en/blog/2022/short-name-for-your-blog-post/index.md
 ```
 
 Start editing the markdown file at the path you provided in the previous
 command. The file is initialized from the blog-post starter under
-[archetypes](archetypes). Once your post is ready, submit it through a [pull
+[archetypes](archetypes).
+
+Put assets like images into the folder created.
+
+Once your post is ready, submit it through a [pull
 request][pr].
 
 ### Using the Github UI
@@ -48,6 +52,7 @@ request][pr].
   `Copy raw content` at the top right of the menu
 - [Create a new file](https://github.com/open-telemetry/opentelemetry.io/new/main)
 - Paste the content from the template
+- Name your file, e.g. `content/en/blog/2022/short-name-for-your-blog-post/index.md`
 - Start editing the markdown file
 - Once your post is ready click on `Propose changes` at the bottom.
 
@@ -107,5 +112,3 @@ already contributed][contributors]!
 [google doc]:
   https://docs.google.com/document/d/1wW0jLldwXN8Nptq2xmgETGbGn9eWP8fitvD5njM-xZY/edit?usp=sharing
 [slack]: https://cloud-native.slack.com/archives/C02UN96HZH6
-[blog post template for editing]:
-  https://github.com/open-telemetry/opentelemetry.io/edit/main/archetypes/blog.md

--- a/archetypes/blog.md
+++ b/archetypes/blog.md
@@ -3,9 +3,9 @@ title: {{ replaceRE "[-_]" " " .Name | title }}
 linkTitle: ADD A SHORT TITLE HERE # Mandatory, make sure that your short title. 
 date: {{ dateFormat "2006-01-02" .Date }} # Put the current date, we will keep the date updated until your PR is merged
 author: >- # If you have only one author, then add the single name on this line in quotes.
-  [Author1 Name](https://github.com/author1_GH_ID) (Organisation Name 1),
+  [Author1 Name](https://github.com/author1_GH_ID) (Organization Name 1),
   ...
-  [AuthorX Name](https://github.com/authorX_GH_ID) (Organisation Name X)
+  [AuthorX Name](https://github.com/authorX_GH_ID) (Organization Name X)
 draft: true # TODO: remove this line once your post is ready to be published
 # canonical_url: http://somewhere.else/ # TODO: if this blog post has been posted somewhere else already, uncomment & provide the conancial URL here.
 ---

--- a/archetypes/blog.md
+++ b/archetypes/blog.md
@@ -1,12 +1,13 @@
 ---
 title: {{ replaceRE "[-_]" " " .Name | title }}
-linkTitle: ADD A SHORT TITLE HERE # TODO: add short title or remove this line
-date: {{ dateFormat "2006-01-02" .Date }}
+linkTitle: ADD A SHORT TITLE HERE # Mandatory, make sure that your short title. 
+date: {{ dateFormat "2006-01-02" .Date }} # Put the current date, we will keep the date updated until your PR is merged
 author: >- # If you have only one author, then add the single name on this line in quotes.
-  [Author1 Name](https://github.com/author1_GH_ID),
+  [Author1 Name](https://github.com/author1_GH_ID) (Organisation Name 1),
   ...
-  [AuthorX Name](https://github.com/authorX_GH_ID)
+  [AuthorX Name](https://github.com/authorX_GH_ID) (Organisation Name X)
 draft: true # TODO: remove this line once your post is ready to be published
+# canonical_url: http://somewhere.else/ # TODO: if this blog post has been posted somewhere else already, uncomment & provide the conancial URL here.
 ---
 
 ## Top-level heading
@@ -18,6 +19,17 @@ Top-level headings start at **level 2**, as shown above.
 Wrap paragraph text at 80 characters, this helps make git diffs (which is line
 based) more useful. If you don't want to bother with that, then just run the
 markdown formatter (see below).
+
+## Images
+
+If you use images, make sure that your blog post is located in it's own
+directory. Put the images into the same directory.
+
+If you have an image stored at
+`content/en/{{ .File.Dir }}imagename.png`,
+you can reference them like the following:
+
+![Provide a good image description for improved accessibility](imagename.png)
 
 ## Markdown formatter
 


### PR DESCRIPTION
Related: #1632

Changes:
* Make blog posts in a folder the default
* Make short title mandatory
* Provide instructions for date
* Add instructions on how to add an organisation to an authors name
* Provide instructions for canonical url
* Provide instructions for images