### PR TITLE
Add registry entry for github.com/MrAlias/redact

### DIFF
--- a/content/en/registry/tools-go-mralias-redact.md
+++ b/content/en/registry/tools-go-mralias-redact.md
@@ -1,0 +1,14 @@
+---
+title: redact
+registryType: utilities
+isThirdParty: true
+language: go
+tags:
+  - go
+  - utilities
+repo: https://github.com/MrAlias/redact
+license: Apache 2.0
+description: Collection of utilities to redact sensitive information from OpenTelemetry tracing data.
+authors: MrAlias
+otVersion: latest
+---


### PR DESCRIPTION
[redact](https://github.com/MrAlias/redact) is a 3rd-party open-source Go package under the Apache 2 license. It provides a set of utilities for OpenTelemetry-Go that help remove sensitive information from tracing data.