### PR TITLE
Add a space for the end user wg.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -97,6 +97,10 @@ params:
         url: https://www.youtube.com/channel/UCHZDBZTIfdy94xMjMKz-_MA
         icon: fab fa-youtube
         desc: Watch our meeting recordings on Youtube
+      - name: End User Resources
+        url: /enduser
+        icon: fas fa-user-group
+        desc: Connect with other end-users, share & learn from each other.
     developer:
       - name: GitHub
         url: https://github.com/open-telemetry

--- a/content/en/enduser/_index.md
+++ b/content/en/enduser/_index.md
@@ -96,3 +96,4 @@ You can find members of the End User Working Group in
 
 [code of conduct]:
   https://github.com/open-telemetry/community/blob/main/working-groups/end-user/discussion-group-code-of-conduct.md
+  

--- a/content/en/enduser/_index.md
+++ b/content/en/enduser/_index.md
@@ -1,0 +1,98 @@
+---
+title: End User
+menu: { main: { weight: 40 } }
+---
+
+{{% blocks/lead color="primary" %}}
+
+# End User
+
+Vendor-agnostic ways to connect with other users of OpenTelemetry, where you can
+share and learn best practices, have discussions synchronously and asynchronously
+and meet others who are on a journey to implement observability powered by
+OpenTelemetry.
+
+{{% /blocks/lead %}}
+
+{{% blocks/section type="section" color="white" %}}
+
+## OpenTelemetry In Practice
+
+**OpenTelemetry in Practice** is an experimental **series** of talks initiated
+by some members of the End User Working Group.
+
+We’re aiming to:
+
+- Address practical problems that commonly stop development teams from
+  succeeding with OpenTelemetry
+- Build stronger connections with developers focused on specific languages
+- Improve the experience of implementing OpenTelemetry in production
+
+Each OpenTelemetry in Practice session will include a half hour of lightning
+talks and a half hour of open conversation about the topic. We are looking for
+people to join the OpenTelemetry in Practice team and people to give talks at
+future events. So if you’re interested in shaping these conversations, reach out
+in the
+[#otel-user-research channel](https://cloud-native.slack.com/archives/C01RT3MSWGZ)
+of the [CNCF Slack](https://slack.cncf.io/).
+
+Our first conversation will be on August 23rd, at 10 AM PDT,
+[on Zoom](https://zoom.us/j/5227112777?pwd=TXBqZ3RMWVYxenVGdlk0SFlwMkwwQT09),
+and the topic is Kubernetes & The Collector.
+
+## Monthly Discussion Group
+
+- Monthly hour long sessions via google meet -- all are welcome!
+- We use a [Lean Coffee](http://leancoffee.org/) format where discussion topics
+  are generated and democratically selected by the group at the start of the
+  meeting. Topics are rigorously time-boxed by a facilitator.
+- [Chatham House Rule](https://www.chathamhouse.org/about-us/chatham-house-rule)
+  applies. Meetings will not be recorded.
+- The first AMER friendly meeting is on the [OpenTelemetry calendar](https://github.com/open-telemetry/community#calendar), scheduled for July 14th
+  2022 at 9AM PST. This meeting series is scheduled to repeat every 8 weeks.
+- The first EMEA friendly meeting is on the [OpenTelemetry calendar](https://github.com/open-telemetry/community#calendar), scheduled for August 16th 2022 at 11AM CET. This meeting series is scheduled to repeat every 8 weeks.
+- We intend to alternate months between APAC- and AMER-friendly
+  timezones. We will re-evaluate this plan based on attendance and
+  feedback.
+
+## Slack Channel (#otel-endusers)
+
+- Confirm your agreement with channel [Code of Conduct][] and reach out to Reese
+  Lee or Rynn Mancuso on CNCF slack for an invite to `#otel-endusers`.
+- [Chatham House Rule](https://www.chathamhouse.org/about-us/chatham-house-rule)
+  applies.
+- Troubleshooting or tactical SDK specific questions are still best directed to
+  individual SIG channels or the
+  [#opentelemetry](https://cloud-native.slack.com/archives/CJFCJHG4Q) channel.
+- Vendor specific questions are still best directed to vendor channels, or if it
+  doesn’t exist
+  [#otel-vendor](https://cloud-native.slack.com/archives/C031SAMGV2A)
+
+## Topics
+
+This group is what its members make it--whatever is of interest to the group is
+fair game! But here are some of the kinds of things we expect will be on the
+table:
+
+- Refactoring with telemetry
+- What is company X doing with OpenTelemetry?
+- Correlating multiple observability signals
+- Maintaining and scaling OpenTelemetry deployments
+- Writing custom instrumentation
+
+## Questions
+
+**Is this group only for OpenTelemetry end users?**
+
+No! Anyone is welcome to join and discuss their journey to observability. This
+group is hosted by the OpenTelemetry Community End-User Working Group, so we
+expect most participants will be from organizations that are evaluating or using
+OpenTelemetry.
+
+**I have questions about this, who can I reach out to?**
+
+You can find members of the End User Working Group in
+[#otel-user-research](https://cloud-native.slack.com/archives/C01RT3MSWGZ).
+
+[code of conduct]:
+  https://github.com/open-telemetry/community/blob/main/working-groups/end-user/discussion-group-code-of-conduct.md


### PR DESCRIPTION
Related: #1729 

Preview: https://deploy-preview-1730--opentelemetry.netlify.app/enduser/

A first draft for a dedicated space for the end users resources.

@cartermp, @chalin, @austinlparker: what do you think? I was not sure if I should put this within "Community" or give it it's own space (and link in the top level menu), maybe a better word to describe it like "Connect" or "End User Forum", etc.

@reese-lee, @musingvirtual: please let me know what you think.    