### PR TITLE
Update code owners to contain all language sigs.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,10 +17,15 @@
 
 # content owners
 content/en/docs/collector                @open-telemetry/docs-approvers @open-telemetry/collector-approvers
-content/en/docs/instrumentation/js/      @open-telemetry/docs-approvers @open-telemetry/javascript-approvers
 content/en/docs/instrumentation/cpp/     @open-telemetry/docs-approvers @open-telemetry/cpp-maintainers
 content/en/docs/instrumentation/erlang/  @open-telemetry/docs-approvers @open-telemetry/erlang-approvers
+# go is a content module
 content/en/docs/instrumentation/java/    @open-telemetry/docs-approvers @open-telemetry/java-maintainers @open-telemetry/java-instrumentation-maintainers
+content/en/docs/instrumentation/js/      @open-telemetry/docs-approvers @open-telemetry/javascript-approvers
 content/en/docs/instrumentation/net/     @open-telemetry/docs-approvers @open-telemetry/dotnet-approvers @open-telemetry/dotnet-instrumentation-approvers
+content/en/docs/instrumentation/php/     @open-telemetry/docs-approvers @open-telemetry/php-maintainers @open-telemetry/php-approvers
 content/en/docs/instrumentation/python/  @open-telemetry/docs-approvers @open-telemetry/python-maintainers @open-telemetry/python-approvers
+# ruby is a content module
+content/en/docs/instrumentation/rust/  @open-telemetry/docs-approvers @open-telemetry/rust-maintainers @open-telemetry/rust-approvers
+content/en/docs/instrumentation/swift/  @open-telemetry/docs-approvers @open-telemetry/swift-maintainers @open-telemetry/swift-approvers
 content/en/blog/                         @open-telemetry/docs-approvers @open-telemetry/blog-approvers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,5 +27,5 @@ content/en/docs/instrumentation/php/     @open-telemetry/docs-approvers @open-te
 content/en/docs/instrumentation/python/  @open-telemetry/docs-approvers @open-telemetry/python-maintainers @open-telemetry/python-approvers
 # ruby is a content module
 content/en/docs/instrumentation/rust/  @open-telemetry/docs-approvers @open-telemetry/rust-maintainers @open-telemetry/rust-approvers
-content/en/docs/instrumentation/swift/  @open-telemetry/docs-approvers @open-telemetry/swift-maintainers @open-telemetry/swift-approvers
+content/en/docs/instrumentation/swift/  @open-telemetry/docs-approvers @open-telemetry/swift-mainteiners @open-telemetry/swift-approvers
 content/en/blog/                         @open-telemetry/docs-approvers @open-telemetry/blog-approvers


### PR DESCRIPTION
For the languages with a (content_module) I added a comment to clarify why they are missing