### PR TITLE
Add basic .NET Automatic Instrumentation doc page

### DIFF
--- a/content/en/docs/concepts/glossary.md
+++ b/content/en/docs/concepts/glossary.md
@@ -38,6 +38,12 @@ A key-value pair. Used across telemetry signals - e.g. in [`Traces`](#trace) to
 attach data to a [`Span`](#span), or in [`Metrics`](#metric). See [attribute
 spec][attribute].
 
+### **Automatic Instrumentation**
+
+Refers to telemetry collection methods that do not require the end-user to
+modify application's source code. Methods vary by programming language, and
+examples include bytecode injection or monkey patching.
+
 ### **Baggage**
 
 A mechanism for propagating name/value pairs to help establish a causal

--- a/content/en/docs/instrumentation/net/automatic.md
+++ b/content/en/docs/instrumentation/net/automatic.md
@@ -5,7 +5,7 @@ weight: 3
 ---
 
 You can use [automatic instrumentation](/docs/reference/specification/glossary/#automatic-instrumentation)
-to initalize [signal](/docs/reference/specification/glossary/#signal) providers
+to initalize [signal](/docs/reference/specification/glossary/#signals) providers
 and generate telemetry data for supported [instrumented libraries](/docs/reference/specification/glossary/#instrumented-library)
 without modifying the application's source code.
 

--- a/content/en/docs/instrumentation/net/automatic.md
+++ b/content/en/docs/instrumentation/net/automatic.md
@@ -1,0 +1,28 @@
+---
+title: Automatic Instrumentation
+linkTitle: Automatic
+weight: 3
+---
+
+You can use [automatic instrumentation](/docs/reference/specification/glossary/#automatic-instrumentation)
+to initalize [signal](/docs/reference/specification/glossary/#signal) providers
+and generate telemetry data for supported [instrumented libraries](/docs/reference/specification/glossary/#instrumented-library)
+without modifying the application's source code.
+
+[Here][release] you can find the latest release of
+OpenTelemetry .NET Automatic Instrumentation.
+
+You can find the documentation in the [project's repository][repo].
+
+## Next steps
+
+After you have set up instrumentation libraries, you may want to add [manual
+instrumentation](/docs/instrumentation/net/manual) to collect custom telemetry
+data.
+
+If you do not want to rely on automatic instrumentation,
+which is currently in beta, you may want to use [instrumentation libraries]
+(/docs/instrumentation/net/libraries) explicitly instead.
+
+[release]: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest
+[repo]: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation

--- a/content/en/docs/instrumentation/net/exporters.md
+++ b/content/en/docs/instrumentation/net/exporters.md
@@ -295,5 +295,5 @@ Additionally, enriching your codebase with
 gives you customized observability data.
 
 You can also check the
-[automatic instrumentation for .NET](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation),
+[automatic instrumentation for .NET](/docs/instrumentation/net/automatic),
 which is currently in beta.

--- a/content/en/docs/instrumentation/net/libraries.md
+++ b/content/en/docs/instrumentation/net/libraries.md
@@ -1,7 +1,6 @@
 ---
 title: Using instrumentation libraries
 linkTitle: Libraries
-aliases: [/docs/instrumentation/net/automatic]
 weight: 3
 ---
 
@@ -121,7 +120,7 @@ You'll also want to configure an appropriate exporter to [export your telemetry
 data](/docs/instrumentation/net/exporters) to one or more telemetry backends.
 
 You can also check the
-[automatic instrumentation for .NET](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation),
+[automatic instrumentation for .NET](/docs/instrumentation/net/automatic),
 which is currently in beta.
 
 [opentelemetry-dotnet]: https://github.com/open-telemetry/opentelemetry-dotnet

--- a/content/en/docs/instrumentation/net/manual.md
+++ b/content/en/docs/instrumentation/net/manual.md
@@ -333,5 +333,5 @@ You'll also want to configure an appropriate exporter to [export your telemetry
 data](/docs/instrumentation/net/exporters) to one or more telemetry backends.
 
 You can also check the
-[automatic instrumentation for .NET](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation),
+[automatic instrumentation for .NET](/docs/instrumentation/net/automatic),
 which is currently in beta.

--- a/content/en/docs/instrumentation/net/netframework.md
+++ b/content/en/docs/instrumentation/net/netframework.md
@@ -152,5 +152,5 @@ You'll also want to configure an appropriate exporter to [export your telemetry
 data](/docs/instrumentation/net/exporters) to one or more telemetry backends.
 
 You can also check the
-[automatic instrumentation for .NET](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation),
+[automatic instrumentation for .NET](/docs/instrumentation/net/automatic),
 which is currently in beta.


### PR DESCRIPTION
Related https://github.com/open-telemetry/opentelemetry.io/issues/972

Follow-up after:
- https://github.com/open-telemetry/opentelemetry.io/pull/1565
- https://github.com/open-telemetry/opentelemetry-specification/pull/2700

Solves https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/999

This PR creates a very simple page. However, it can be further enhanced in the next PRs.

Preview: https://deploy-preview-1740--opentelemetry.netlify.app/docs/instrumentation/net/automatic/

PTAL @open-telemetry/dotnet-maintainers @open-telemetry/dotnet-instrumentation-maintainers @theletterf