### PR TITLE
docs: make events an array in example span

### DIFF
--- a/content/en/docs/concepts/signals/traces.md
+++ b/content/en/docs/concepts/signals/traces.md
@@ -222,11 +222,13 @@ Sample Span:
     "http.host": "10.177.2.152:26040",
     "http.flavor": "1.1"
   },
-  "events": {
-    "name": "",
-    "message": "OK",
-    "timestamp": "2021-10-22 16:04:01.209512872 +0000 UTC"
-  }
+  "events": [
+    {
+      "name": "",
+      "message": "OK",
+      "timestamp": "2021-10-22 16:04:01.209512872 +0000 UTC"
+    }
+  ]
 }
 ```
 


### PR DESCRIPTION
Based on the example trace above it looks like the events property of a span is supposed to be an array an objects rather than an object.