### PR TITLE
Replace ruby with rust in repo structure example

### DIFF
--- a/content/en/docs/concepts/instrumenting.md
+++ b/content/en/docs/concepts/instrumenting.md
@@ -20,8 +20,8 @@ repositories:
 - **[Contrib](https://github.com/open-telemetry/opentelemetry-java-contrib):**
   Optional components such as JMX metric gathers.
 
-Some instrumentation libraries, for example Ruby, offer a
-[single repository](https://github.com/open-telemetry/opentelemetry-ruby) that
+Some instrumentation libraries, for example Rust, offer a
+[single repository](https://github.com/open-telemetry/opentelemetry-rust) that
 supports both manual and automatic instrumentation. Other languages, for example
 JS, support both manual and automatic instrumentation, but separate
 [core](https://github.com/open-telemetry/opentelemetry-js) components from


### PR DESCRIPTION
Let's be honest, the `content/en/docs/concepts/instrumenting.md` needs a major rework, but before that I fixed that minor issue: ruby has a contrib repo now, so the statement is not true. I replaced it with rust for the time being.