### PR TITLE
Add documentation landing page for k8s operator

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,4 +28,5 @@ content/en/docs/instrumentation/python/  @open-telemetry/docs-approvers @open-te
 # ruby is a content module
 content/en/docs/instrumentation/rust/  @open-telemetry/docs-approvers @open-telemetry/rust-maintainers @open-telemetry/rust-approvers
 content/en/docs/instrumentation/swift/  @open-telemetry/docs-approvers @open-telemetry/swift-mainteiners @open-telemetry/swift-approvers
+content/en/docs/k8s-operator		@open-telemetry/operator-approvers @open-telemetry/operator-maintainers
 content/en/blog/                         @open-telemetry/docs-approvers @open-telemetry/blog-approvers

--- a/content/en/docs/k8s-operator/_index.md
+++ b/content/en/docs/k8s-operator/_index.md
@@ -61,8 +61,3 @@ EOF
 For more configuration options and for setting up the injetion of
 auto-instrumentation of the workloads using OpenTelemetry instrumentation
 libraries, continue reading [here](https://github.com/open-telemetry/opentelemetry-operator/blob/main/README.md).
-
-## Helm Chart
-
-You can install the OpenTelemetry Operator into a Kubernetes cluster with
-the [OpenTelemetry Operator Helm Chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-operator)

--- a/content/en/docs/k8s-operator/_index.md
+++ b/content/en/docs/k8s-operator/_index.md
@@ -17,7 +17,7 @@ The OpenTelemetry Operator is an implementation of a [Kubernetes Operator](https
 The operator manages:
 
 - OpenTelemetry Collector
-- auto-instrumentation of the workloads using OpenTelemetry instrumentation libraries
+- [auto-instrumentation of the workloads using OpenTelemetry instrumentation libraries](https://github.com/open-telemetry/opentelemetry-operator#opentelemetry-auto-instrumentation-injection)
 
 ## Getting started
 

--- a/content/en/docs/k8s-operator/_index.md
+++ b/content/en/docs/k8s-operator/_index.md
@@ -1,0 +1,68 @@
+---
+title: OpenTelemetry Operator for Kubernetes
+linkTitle: K8s Operator
+weight: 11
+description:
+  An implementation of a Kubernetes Operator, that
+  manages collectors and auto-instrumentation of the workload using OpenTelemetry
+  instrumentation libraries.
+spelling: cSpell:ignore Otel
+aliases: [/docs/operator]
+---
+
+## Introduction
+
+The OpenTelemetry Operator is an implementation of a [Kubernetes Operator](https://coreos.com/operators/).
+
+The operator manages:
+
+- OpenTelemetry Collector
+- auto-instrumentation of the workloads using OpenTelemetry instrumentation libraries
+
+## Getting started
+
+To install the operator in an existing cluster, make sure you have cert-manager 
+installed and run:
+
+```bash
+$ kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml
+```
+
+Once the `opentelemetry-operator` deployment is ready, create an OpenTelemetry
+ Collector (otelcol) instance, like:
+
+```bash
+$ kubectl apply -f - <<EOF
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: simplest
+spec:
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    processors:
+
+    exporters:
+      logging:
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: []
+          exporters: [logging]
+EOF
+```
+
+For more configuration options and for setting up the injetion of
+auto-instrumentation of the workloads using OpenTelemetry instrumentation
+libraries, continue reading [here](https://github.com/open-telemetry/opentelemetry-operator/blob/main/README.md).
+
+## Helm Chart
+
+You can install the OpenTelemetry Operator into a Kubernetes cluster with
+the [OpenTelemetry Operator Helm Chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-operator)


### PR DESCRIPTION
@open-telemetry/operator-approvers , @open-telemetry/operator-maintainers: we thought it would be great to have the operator also represented within the documentation (see #1701)

This is a first draft which mainly is copied over from the README.md. So for now the main purpose is, that it allows people to find the operator more easily.

We can grow this into a user-facing documentation from there.

Please note that I also added you as CODEOWNER for the folder containing the documentation, so you will get notified and asked for approval when contributors add to it.