### PR TITLE
Initialize npm for the node.js example

### DIFF
--- a/content/en/docs/instrumentation/js/getting-started/nodejs.md
+++ b/content/en/docs/instrumentation/js/getting-started/nodejs.md
@@ -11,6 +11,12 @@ This is a small example application we will monitor in this guide.
 
 ### Dependencies
 
+Create an empty package.json:
+
+```sh
+npm init -f
+```
+
 Install dependencies used by the example.
 
 ```sh


### PR DESCRIPTION
This PR adds an `npm init -f` to the node.js example, while not strictly needed, I ran into the bug that npm installed packages into a parent folder which had a node_modules folder already, which is confusing. This makes sure that everything is contained in the same folder. It will also help in another addition I plan to do (resource detection)