### PR TITLE
Clarify Wavefront in vendor list

### DIFF
--- a/content/en/vendors.md
+++ b/content/en/vendors.md
@@ -3,7 +3,7 @@ title: Vendor support
 spelling:
   cSpell:ignore appdynamics aria aspecto bution datadoghq distri dynatrace grafana
   cSpell:ignore Instana lightstep logz logicmonitor lumigo promscale
-  cSpell:ignore sentrysoftware signoz splunk sumologic uptrace vmware
+  cSpell:ignore sentrysoftware signoz splunk sumologic uptrace vmware wavefront
 ---
 
 {{% blocks/lead color="primary" %}}
@@ -17,31 +17,32 @@ OpenTelemetry in their commercial products.
 
 {{% blocks/section type="section" color="white" %}}
 
-| Company         | Distri&shy;bution | Native OTLP | Learn more                                                                                                                                            |
-| --------------- | ----------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| AppDynamics     | Yes               | Yes         | [docs.appdynamics.com/...](https://docs.appdynamics.com/latest/en/application-monitoring/appdynamics-for-opentelemetry)                               |
-| Aria by VMware  | No                | Yes         | [docs.wavefront.com/...](https://docs.wavefront.com/opentelemetry_tracing.html)
-| Aspecto         | Yes               | Yes         | [aspecto.io](https://www.aspecto.io)                                                                                                                  |
-| AWS             | Yes               | No          | [aws-otel.github.io](https://aws-otel.github.io)                                                                                                      |
-| Azure           | Yes               | No          | [docs.microsoft.com/...](https://docs.microsoft.com/azure/azure-monitor/app/opentelemetry-overview)                                                   |
-| Datadog         | Yes               | Yes         | [docs.datadoghq.com/...](https://docs.datadoghq.com/tracing/setup_overview/open_standards)                                                            |
-| Dynatrace       | Yes               | Yes         | [dynatrace.com/...](https://www.dynatrace.com/support/help/how-to-use-dynatrace/transactions-and-services/service-monitoring-settings/opentelemetry/) |
-| Elastic         | Yes               | Yes         | [elastic.co/...](https://www.elastic.co/guide/en/apm/get-started/current/open-telemetry-elastic.html)                                                 |
-| F5              | No                | Yes         | [opentelemetry-collector-contrib/...](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/f5cloudexporter)           |
-| Grafana Labs    | No                | Yes         | [grafana.com/...](https://grafana.com/oss/opentelemetry/)                                                                                             |
-| Honeycomb       | Yes               | Yes         | [docs.honeycomb.io/...](https://docs.honeycomb.io/getting-data-in/)                                                                                   |
-| Instana         | No                | Yes         | [ibm.com/docs/...](https://www.ibm.com/docs/en/obi/current?topic=apis-opentelemetry)                                                                  |
-| Lightstep       | Yes               | Yes         | [github.com/lightstep](https://github.com/lightstep?q=launcher)                                                                                       |
-| LogicMonitor    | Yes               | Yes         | [logicmonitor.com/...](https://www.logicmonitor.com/support/tracing/getting-started-with-tracing)                                                     |
-| Logz.io         | Yes               | No          | [docs.logz.io/...](https://docs.logz.io/shipping/tracing-sources/opentelemetry.html#overview)                                                         |
-| Lumigo          | Yes               | Yes         | [lumigo.io](https://docs.lumigo.io/docs/opentelemetry)                                                                                                                    |
-| New Relic       | No                | Yes         | [newrelic.com/...](https://newrelic.com/solutions/opentelemetry)                                                                                      |
-| Promscale       | No                | Yes         | [timescale.com/promscale](https://www.timescale.com/promscale)                                                                                        |
-| Sentry Software | Yes               | Yes         | [sentrysoftware.com/...](https://www.sentrysoftware.com/products/hardware-sentry-opentelemetry-collector.html)                                        |
-| SigNoz          | Yes               | Yes         | [signoz.io](https://signoz.io)                                                                                                                        |
-| Splunk          | Yes               | Yes         | [splunk.com/blog/...](https://www.splunk.com/en_us/blog/conf-splunklive/announcing-native-opentelemetry-support-in-splunk-apm.html)                   |
-| Sumo Logic      | Yes               | Yes         | [help.sumologic.com/](https://help.sumologic.com/Traces/Getting_Started_with_Transaction_Tracing)                                                     |
-| Uptrace         | Yes               | Yes         | [uptrace.dev](https://uptrace.dev)                                                                                                                    |
+| Company                    | Distri&shy;bution | Native OTLP | Learn more                                                                                                                                            |
+|----------------------------| ----------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AppDynamics                | Yes               | Yes         | [docs.appdynamics.com/...](https://docs.appdynamics.com/latest/en/application-monitoring/appdynamics-for-opentelemetry)                               |
+| Aria by VMware (Wavefront) | No                | Yes         | [docs.wavefront.com/...](https://docs.wavefront.com/opentelemetry_tracing.html)                                                                       |
+| Aspecto                    | Yes               | Yes         | [aspecto.io](https://www.aspecto.io)                                                                                                                  |
+| AWS                        | Yes               | No          | [aws-otel.github.io](https://aws-otel.github.io)                                                                                                      |
+| Azure                      | Yes               | No          | [docs.microsoft.com/...](https://docs.microsoft.com/azure/azure-monitor/app/opentelemetry-overview)                                                   |
+| Datadog                    | Yes               | Yes         | [docs.datadoghq.com/...](https://docs.datadoghq.com/tracing/setup_overview/open_standards)                                                            |
+| Dynatrace                  | Yes               | Yes         | [dynatrace.com/...](https://www.dynatrace.com/support/help/how-to-use-dynatrace/transactions-and-services/service-monitoring-settings/opentelemetry/) |
+| Elastic                    | Yes               | Yes         | [elastic.co/...](https://www.elastic.co/guide/en/apm/get-started/current/open-telemetry-elastic.html)                                                 |
+| F5                         | No                | Yes         | [opentelemetry-collector-contrib/...](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/f5cloudexporter)           |
+| Grafana Labs               | No                | Yes         | [grafana.com/...](https://grafana.com/oss/opentelemetry/)                                                                                             |
+| Honeycomb                  | Yes               | Yes         | [docs.honeycomb.io/...](https://docs.honeycomb.io/getting-data-in/)                                                                                   |
+| Instana                    | No                | Yes         | [ibm.com/docs/...](https://www.ibm.com/docs/en/obi/current?topic=apis-opentelemetry)                                                                  |
+| Lightstep                  | Yes               | Yes         | [github.com/lightstep](https://github.com/lightstep?q=launcher)                                                                                       |
+| LogicMonitor               | Yes               | Yes         | [logicmonitor.com/...](https://www.logicmonitor.com/support/tracing/getting-started-with-tracing)                                                     |
+| Logz.io                    | Yes               | No          | [docs.logz.io/...](https://docs.logz.io/shipping/tracing-sources/opentelemetry.html#overview)                                                         |
+| Lumigo                     | Yes               | Yes         | [lumigo.io](https://docs.lumigo.io/docs/opentelemetry)                                                                                                |
+| New Relic                  | No                | Yes         | [newrelic.com/...](https://newrelic.com/solutions/opentelemetry)                                                                                      |
+| Promscale                  | No                | Yes         | [timescale.com/promscale](https://www.timescale.com/promscale)                                                                                        |
+| Sentry Software            | Yes               | Yes         | [sentrysoftware.com/...](https://www.sentrysoftware.com/products/hardware-sentry-opentelemetry-collector.html)                                        |
+| SigNoz                     | Yes               | Yes         | [signoz.io](https://signoz.io)                                                                                                                        |
+| Splunk                     | Yes               | Yes         | [splunk.com/blog/...](https://www.splunk.com/en_us/blog/conf-splunklive/announcing-native-opentelemetry-support-in-splunk-apm.html)                   |
+| Sumo Logic                 | Yes               | Yes         | [help.sumologic.com/](https://help.sumologic.com/Traces/Getting_Started_with_Transaction_Tracing)                                                     |
+| Uptrace                    | Yes               | Yes         | [uptrace.dev](https://uptrace.dev)                                                                                                                    |
+
 
 _Vendors are listed alphabetically_
 


### PR DESCRIPTION
#1786 was merged before I could make an additional change, so that "Aria by VMware" is instead "Aria by VMware (Wavefront)". We intend this to be a stop-gap until a rebranding at VMware is finished.