### PR TITLE
Add registry entry for the official .NET OTLP exporter

### DIFF
--- a/content/en/registry/exporter-dotnet-otlp.md
+++ b/content/en/registry/exporter-dotnet-otlp.md
@@ -1,0 +1,16 @@
+---
+title: OTLP Exporter
+registryType: exporter
+isThirdParty: false
+language: dotnet
+tags:
+  - .NET
+  - C#
+  - dotnet
+  - exporter
+repo: https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Exporter.OpenTelemetryProtocol
+license: Apache 2.0
+description: This library allows to export data to the OpenTelemetry Collector using the OpenTelemetry Protocol.
+authors: OpenTelemetry Authors
+otVersion: latest
+---

--- a/templates/registry-entry.md
+++ b/templates/registry-entry.md
@@ -1,7 +1,7 @@
 ---
 title: My OpenTelemetry Integration // the name of your project
 registryType: <exporter/core/instrumentation> // the type of integration; is this an exporter, plugin, API package, or something else?
-isThirdParty: <false/true> // this is only false if the project is maintained by the OpenTelemetry project
+isThirdParty: <false/true> // this is only true if the project is not maintained by the OpenTelemetry project
 language: <js/go/dotnet/etc. or collector for collector plugins>
 tags:
   - <other useful search terms>

--- a/templates/registry-entry.md
+++ b/templates/registry-entry.md
@@ -1,7 +1,7 @@
 ---
 title: My OpenTelemetry Integration // the name of your project
 registryType: <exporter/core/instrumentation> // the type of integration; is this an exporter, plugin, API package, or something else?
-isThirdParty: <false/true> // this is only true if the project is maintained by the OpenTelemetry project
+isThirdParty: <false/true> // this is only false if the project is maintained by the OpenTelemetry project
 language: <js/go/dotnet/etc. or collector for collector plugins>
 tags:
   - <other useful search terms>


### PR DESCRIPTION
I noticed we didn't have a registry entry for the OTLP exporter in .NET. 

Also: I _think_ the `isThirdParty` field had a misleading comment so I modified that as well. I hope it's ok to bundle this together with this change. 