### PR TITLE
Fix rogue ` in opentracing migration guide

### DIFF
--- a/content/en/docs/migration/opentracing.md
+++ b/content/en/docs/migration/opentracing.md
@@ -140,7 +140,7 @@ In OpenTracing, baggage is carried with a SpanContext object associated with a
 Span. In OpenTelemetry, context and propagation are lower-level concepts –
 spans, baggage, metrics instruments, and other items are carried within a
 context object.
-`
+
 As a result of this change, baggage which is set using the OpenTracing API is
 not available to OpenTelemetry Propagators. As a result, mixing the
 OpenTelemetry and OpenTracing APIs is not recommended when using baggage.


### PR DESCRIPTION
A backtick is present in between paragraphs in the "Migrating from OpenTracing" page.

I believe this was mean to be a simple paragraph break.

This PR removes the backtick, leaving an empty new line to create the paragraph break.

### Preview
Before: https://opentelemetry.io/docs/migration/opentracing/#baggage
After: https://deploy-preview-1798--opentelemetry.netlify.app/docs/migration/opentracing/#baggage