### PR TITLE
Fix manual instrumentation examples in .NET

### DIFF
--- a/content/en/docs/instrumentation/net/manual.md
+++ b/content/en/docs/instrumentation/net/manual.md
@@ -56,9 +56,9 @@ var serviceVersion = "1.0.0";
 
 using var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .AddSource(serviceName)
-    .SetResourceBuilder(
-        ResourceBuilder.CreateDefault()
-            .AddService(serviceName: serviceName, serviceVersion: serviceVersion))
+    .SetResourceBuilder(ResourceBuilder
+        .CreateDefault()
+        .AddService(serviceName: serviceName, serviceVersion: serviceVersion))
     .AddConsoleExporter()
     .Build();
 
@@ -104,9 +104,9 @@ builder.Services.AddOpenTelemetryTracing(b =>
     b
     .AddConsoleExporter()
     .AddSource(serviceName)
-    .SetResourceBuilder(
-        ResourceBuilder.CreateDefault()
-            .AddService(serviceName: serviceName, serviceVersion: serviceVersion));
+    .SetResourceBuilder(ResourceBuilder
+        .CreateDefault()
+        .AddService(serviceName: serviceName, serviceVersion: serviceVersion));
 });
 ```
 

--- a/content/en/docs/instrumentation/net/manual.md
+++ b/content/en/docs/instrumentation/net/manual.md
@@ -46,8 +46,8 @@ important startup operations.
 
 ```csharp
 using OpenTelemetry;
-using OpenTelemetry.Trace;
 using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
 
 // ...
 

--- a/content/en/docs/instrumentation/net/manual.md
+++ b/content/en/docs/instrumentation/net/manual.md
@@ -52,7 +52,7 @@ using OpenTelemetry.Trace;
 // ...
 
 var serviceName = "MyServiceName";
-var serviceVersion "1.0.0";
+var serviceVersion = "1.0.0";
 
 using var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .AddSource(serviceName)
@@ -106,7 +106,7 @@ builder.Services.AddOpenTelemetryTracing(b =>
     .AddSource(serviceName)
     .SetResourceBuilder(
         ResourceBuilder.CreateDefault()
-            .AddService(serviceName: serviceName, serviceVersion: serviceVersion))
+            .AddService(serviceName: serviceName, serviceVersion: serviceVersion));
 });
 ```
 


### PR DESCRIPTION
- Reorder using directives
- Fix compiler errors for missing assignment operator and line ending
- Reformat line continuations