### PR TITLE
Closes (#1700) in docs

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/opentelemetry.io.iml" filepath="$PROJECT_DIR$/.idea/opentelemetry.io.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ perfect position to help us get better: the website and documentation is the
 entry point for newcomers like you, so if something is unclear or something is
 missing [let us know][]!
 
-Read on to learn about other ways on how you can help.
+Read on to learn about other ways you can help.
 
 ## Adding a project to the OpenTelemetry Registry
 

--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -9,7 +9,7 @@ the OpenTelemetry Collector and security standards respectively:
 - [Data Collection concepts](../../concepts/data-collection)
 - [Security standards](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security.md)
 
-## Components of the OpenTelemetry Collector
+## Components
 The OpenTelemetry Collector consists of three components for accessing telemetry data:
 
 - <img width="32" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Receivers.svg"></img>
@@ -116,7 +116,7 @@ service:
       exporters: [otlp]
 ```
 
-## Configuring Receivers
+## Receivers
 <img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Receivers.svg"></img>
 
 Many receivers come with their own default settings. When configuring these kinds of receivers, 
@@ -189,7 +189,7 @@ receivers:
 > For detailed receiver configuration, please see the [receiver
 README.md](https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/README.md).
 
-## Configuring Processors
+## Processors
 
 <img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Processors.svg"></img>
 
@@ -273,11 +273,10 @@ An exporter, which can be push or pull based, is how you send data to one or
 more backends/destinations. Exporters may support one or more [data
 sources](../../concepts/signals).
 
-The `exporters:` section is how exporters are configured. Exporters may come
-with default settings, but many require configuration to specify at least the
+Exporters are configured in the `exporters:` section of the YAML configuration file. Exporters may come
+with their own default settings, but many require configuration to specify at least the
 destination and security settings. Any configuration for an exporter must be
-done in this section. Configuration parameters specified for which the exporter
-provides a default configuration are overridden.
+done in this section. The default configuration parameters specified in the exporter are consequently overridden.
 
 > Configuring an exporter does not enable it. Exporters are enabled via
 > pipelines within the [service](#service) section.
@@ -346,18 +345,15 @@ exporters:
 ```
 
 ## Extensions
-
 Extensions are available primarily for tasks that do not involve processing telemetry
-data. Examples of extensions include health monitoring, service discovery, and
-data forwarding. Extensions are optional.
+data.
 
-The `extensions:` section is how extensions are configured. Many extensions
-come with default settings so simply specifying the name of the extension is
-enough to configure it (for example, `health_check:`). If configuration is
-required or a user wants to change the default configuration then such
-configuration must be defined in this section. Configuration parameters
-specified for which the extension provides a default configuration are
-overridden.
+Extensions are configured in the `extensions:` section of the YAML configuration file. Many extensions
+come with their own default settings so simply specifying the name of the extension is
+enough to configure it. An example of such extensions is provided in the YAML script below (see `health_check:`).
+If configuration is required or a user wants to change the default configuration then such
+configuration must be defined under the `extensions` section. The
+default configuration parameters specified in the extensions are consequently overridden.
 
 > Configuring an extension does not enable it. Extensions are enabled within
 > the [service](#service) section.
@@ -383,7 +379,7 @@ The service section is used to configure what components are enabled in the
 Collector based on the configuration found in the receivers, processors,
 exporters, and extensions sections. If a component is configured, but not
 defined within the service section then it is not enabled. The service section
-consists of three sub-sections:
+consists of three subsections:
 
 - extensions
 - pipelines
@@ -398,15 +394,15 @@ Extensions consist of a list of all extensions to enable. For example:
 
 Pipelines can be of the following types:
 
-- traces: collects and processes trace data.
-- metrics: collects and processes metric data.
-- logs: collects and processes log data.
+- _traces_: collects and processes trace data.
+- _metrics_: collects and processes metric data.
+- _logs_: collects and processes log data.
 
 A pipeline consists of a set of receivers, processors and exporters. Each
 receiver/processor/exporter must be defined in the configuration outside of the
 service section to be included in a pipeline.
 
-*Note:* Each receiver/processor/exporter can be used in more than one pipeline.
+***Note**:* Each receiver/processor/exporter can be used in more than one pipeline.
 For processor(s) referenced in multiple pipelines, each pipeline will get a
 separate instance of that processor(s). This is in contrast to
 receiver(s)/exporter(s) referenced in multiple pipelines, where only one
@@ -474,7 +470,7 @@ exporters:
 
 ### Proxy Support
 
-Exporters that leverage the net/http package (all do today) respect the
+Exporters that leverage the net/http package (apparently all today) respect the
 following proxy environment variables:
 
 - HTTP_PROXY

--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -193,14 +193,9 @@ README.md](https://github.com/open-telemetry/opentelemetry-collector/blob/main/r
 
 <img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Processors.svg"></img>
 
-Processors are run on data between being received and being exported.
-Processors are optional though [some are
-recommended](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor#recommended-processors).
-
-The `processors:` section is how processors are configured. Processors may come
-with default settings, but many require configuration. Any configuration for a
-processor must be done in this section. Configuration parameters specified for
-which the processor provides a default configuration are overridden. The order of the components
+Processors may come with their own default settings, but many of them require configuration. Any configuration for a
+processor must be done in the `processors` section and the default configuration parameters specified 
+in the processor are consequently overridden. The order of the components
 in the configuration script matters for processors because the data is transported 
 serially from one processor to the other.
 
@@ -209,8 +204,6 @@ serially from one processor to the other.
 
 A basic example of the default processors is provided below. A full list of 
 processors can be found [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor).
-
-
 
 > For detailed processor configuration, please see the [processor
 README.md](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/README.md).

--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -3,16 +3,14 @@ title: "Configuration"
 weight: 20
 ---
 
-
-Please be sure to review the following documentation in order to
-gain the required knowledge to use the OpenTelemetry Collector:
+Review the following documentation to gain understanding of the repositories applicable to 
+the OpenTelemetry Collector and security standards respectively:
 
 - [Data Collection concepts](../../concepts/data-collection)
-- [Security guidance](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security.md)
+- [Security standards](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security.md)
 
 ## Components of the OpenTelemetry Collector
-
-The Collector consists of three components that access telemetry data:
+The OpenTelemetry Collector consists of three components for accessing telemetry data:
 
 - <img width="32" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Receivers.svg"></img>
 [Receivers](#receivers)
@@ -21,13 +19,13 @@ The Collector consists of three components that access telemetry data:
 - <img width="32" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Exporters.svg"></img>
 [Exporters](#exporters)
 
-These components once configured must be enabled via pipelines within the
+After configuring these components, they must be enabled via pipelines within the
 [service](#service) section.
 
-Secondarily, there are [extensions](#extensions), which provide capabilities
-that can be added to the Collector, but which do not require direct access to
-telemetry data and are not part of pipelines. They are also enabled within the
-[service](#service) section.
+Furthermore, there are [extensions](#extensions) which provide capabilities
+that can be added to the Collector, but do not require direct access to
+telemetry data. They are also enabled within the
+[service](#service) section but are not part of pipelines.
 
 An example configuration would look like:
 
@@ -67,7 +65,9 @@ service:
       exporters: [otlp]
 ```
 
-Note that receivers, processors, exporters and/or pipelines are defined via component identifiers in `type[/name]` format (e.g. `otlp` or `otlp/2`).  Components of a given type can be defined more than once as long as the identifiers are unique. For example:
+Note that _receivers_, _processors_, _exporters_ and/or _pipelines_ are defined via component identifiers in
+`type[/name]` format (e.g. `otlp` or `otlp/2`).  Components of a given type can be defined more than 
+once as long as the identifiers are unique. For example:
 
 ```yaml
 receivers:
@@ -116,28 +116,22 @@ service:
       exporters: [otlp]
 ```
 
-## Receivers
-
+## Configuring Receivers
 <img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Receivers.svg"></img>
 
-A receiver, which can be push or pull based, is how data gets into the
-Collector. Receivers may support one or more [data sources](../../concepts/signals).
+Many receivers come with their own default settings. When configuring these kinds of receivers, 
+specifying the name of the receiver is enough. An example of such receivers is provided in the YAML
+configuration script below (see `zipkin:`). 
 
-The `receivers:` section is how receivers are configured. Many receivers come
-with default settings so simply specifying the name of the receiver is enough
-to configure it (for example, `zipkin:`). If configuration is required or a
-user wants to change the default configuration then such configuration must be
-defined in this section. Configuration parameters specified for which the
-receiver provides a default configuration are overridden.
+If further configuration is required or the user wants to change the default configuration, 
+then the modifications must be defined under the `receivers` section in the script. The 
+default configuration parameters specified in the receiver are consequently overridden.
 
 > Configuring a receiver does not enable it. Receivers are enabled via
 > pipelines within the [service](#service) section.
 
-One or more receivers must be configured. By default, no receivers
-are configured. A basic example of all available receivers is provided below.
-
-> For detailed receiver configuration, please see the [receiver
-README.md](https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/README.md).
+At least one or more receivers must be configured. By default, no receivers
+are configured. A basic example of all available receivers is provided below:
 
 ```yaml
 receivers:
@@ -192,7 +186,10 @@ receivers:
   zipkin:
 ```
 
-## Processors
+> For detailed receiver configuration, please see the [receiver
+README.md](https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/README.md).
+
+## Configuring Processors
 
 <img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Processors.svg"></img>
 
@@ -203,12 +200,17 @@ recommended](https://github.com/open-telemetry/opentelemetry-collector/tree/main
 The `processors:` section is how processors are configured. Processors may come
 with default settings, but many require configuration. Any configuration for a
 processor must be done in this section. Configuration parameters specified for
-which the processor provides a default configuration are overridden.
+which the processor provides a default configuration are overridden. The order of the components
+in the configuration script matters for processors because the data is transported 
+serially from one processor to the other.
 
 > Configuring a processor does not enable it. Processors are enabled via
 > pipelines within the [service](#service) section.
 
-A basic example of the default processors is provided below. A full list of processors can be found [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor)
+A basic example of the default processors is provided below. A full list of 
+processors can be found [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor).
+
+
 
 > For detailed processor configuration, please see the [processor
 README.md](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/README.md).

--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -3,14 +3,14 @@ title: "Configuration"
 weight: 20
 ---
 
-Please be sure to review the following documentation:
 
-- [Data Collection concepts](../../concepts/data-collection) in order to
-  understand the repositories applicable to the OpenTelemetry Collector.
-- [Security
-  guidance](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security.md)
+Please be sure to review the following documentation in order to
+gain the required knowledge to use the OpenTelemetry Collector:
 
-## Basics
+- [Data Collection concepts](../../concepts/data-collection)
+- [Security guidance](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security.md)
+
+## Components of the OpenTelemetry Collector
 
 The Collector consists of three components that access telemetry data:
 

--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -7,7 +7,7 @@ Review the following documentation to gain understanding of the repositories app
 the OpenTelemetry Collector and security standards respectively:
 
 - [Data Collection concepts](../../concepts/data-collection)
-- [Security standards](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security.md)
+- [Security guidance](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security.md)
 
 ## Components
 The OpenTelemetry Collector consists of three components for accessing telemetry data:
@@ -25,7 +25,7 @@ After configuring these components, they must be enabled via pipelines within th
 Furthermore, there are [extensions](#extensions) which provide capabilities
 that can be added to the Collector, but do not require direct access to
 telemetry data. They are also enabled within the
-[service](#service) section but are not part of pipelines.
+[service](#service) section, although they are not part of pipelines.
 
 An example configuration would look like:
 
@@ -65,7 +65,7 @@ service:
       exporters: [otlp]
 ```
 
-Note that _receivers_, _processors_, _exporters_ and/or _pipelines_ are defined via component identifiers in
+Note that _receivers_, _processors_, _exporters_ and _pipelines_ are defined via component identifiers in
 `type[/name]` format (e.g. `otlp` or `otlp/2`).  Components of a given type can be defined more than 
 once as long as the identifiers are unique. For example:
 
@@ -124,14 +124,14 @@ specifying the name of the receiver is enough. An example of such receivers is p
 configuration script below (see `zipkin:`). 
 
 If further configuration is required or the user wants to change the default configuration, 
-then the modifications must be defined under the `receivers` section in the script. The 
-default configuration parameters specified in the receiver are consequently overridden.
+then the modifications must be defined under the receiver-specific section (e.g. under `hostmetrics` or `fluentforward`) in the script. 
+The default configuration parameters specified in the receiver are consequently overridden.
 
 > Configuring a receiver does not enable it. Receivers are enabled via
 > pipelines within the [service](#service) section.
 
 At least one or more receivers must be configured. By default, no receivers
-are configured. A basic example of all available receivers is provided below:
+are configured. A basic example of some available receivers is provided below:
 
 ```yaml
 receivers:

--- a/content/en/docs/concepts/_index.md
+++ b/content/en/docs/concepts/_index.md
@@ -7,6 +7,6 @@ aliases: [/about, /docs/concepts/overview, /otel]
 weight: 1
 ---
 
-The concepts section helps you learn more about the data sources and components
+The **Concepts** section helps you learn more about the data sources and components
 of the OpenTelemetry project in order to obtain a deeper understanding of how
 OpenTelemetry works.

--- a/content/en/docs/concepts/data-collection.md
+++ b/content/en/docs/concepts/data-collection.md
@@ -5,33 +5,37 @@ description: >-
 weight: 50
 ---
 
+
+## The OpenTelemetry Collector
 The OpenTelemetry project facilitates the collection of telemetry data via the
-OpenTelemetry Collector. The OpenTelemetry Collector offers a vendor-agnostic
-implementation on how to receive, process, and export telemetry data. It removes
+OpenTelemetry Collector. The collector is a vendor-agnostic tool that receives telemetry data in
+various formats, processes it, and exports it to one or more specified destinations. It removes
 the need to run, operate, and maintain multiple agents/collectors in order to
 support open-source observability data formats (e.g. Jaeger, Prometheus, etc.)
 sending to one or more open-source or commercial back-ends. In addition, the
-Collector gives end-users control of their data. The Collector is the default
-location instrumentation libraries export their telemetry data.
+Collector gives end-users control over their data. The Collector is the default
+destination where instrumentation libraries export their telemetry data.
 
 > The Collector may be offered as a distribution, see [here](../distributions)
 > for more information.
 
-## Deployment
+## Deployments
 
 The OpenTelemetry Collector provides a single binary and two deployment methods:
-
 - **Agent:** A Collector instance running with the application or on the same
   host as the application (e.g. binary, sidecar, or daemonset).
 - **Gateway:** One or more Collector instances running as a standalone service
-  (e.g. container or deployment) typically per cluster, data center or region.
+  (e.g. container or deployment) typically per cluster, data center, or region.
 
 For information on how to use the Collector see the
 [getting started documentation](/docs/collector/getting-started).
 
-## Components
+## Components of the OpenTelemetry Collector
+The collector makes it possible for users to configure *pipelines* for signals by
+combining any necessary number of *receivers*, *processors*, and *exporters*.
+Multiple instances of components as well as pipelines can be defined via YAML configuration.
 
-The Collector is made up of the following components:
+Let's look at these components in more details:
 
 - <img width="32" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Receivers.svg"></img>
   `receivers`: How to get data into the Collector; these can be push or pull
@@ -41,11 +45,16 @@ The Collector is made up of the following components:
 - <img width="32" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Exporters.svg"></img>
   `exporters`: Where to send received data; these can be push or pull based
 
-These components are enabled through `pipelines`. Multiple instances of
-components as well as pipelines can be defined via YAML configuration.
+These components are enabled through `pipelines` as mentioned earlier. 
+
+### Receivers
+The receiver is the first component in a pipeline. It receives data in several supported
+[data formats](https://opentelemetry.io/docs/concepts/signals), and converts this data into 
+an internal data format recognized by the collector.
+
 
 For more information about these components see the
-[configuration documentation](/docs/collector/configuration).
+[configuration documentation](/docs/collector/configuration/#receivers).
 
 ## Repositories
 

--- a/content/en/docs/concepts/data-collection.md
+++ b/content/en/docs/concepts/data-collection.md
@@ -75,7 +75,7 @@ from one processor to the other. Processors are run on data between being receiv
 While processors are optional, [some are
 recommended](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor#recommended-processors).
 
-The table below shows the currently supported processors, and the signals they
+The table below shows some currently supported processors, and the signals they
 possess:
 
 | Signal                 |       Traces        |      Metrics       |               Logs |
@@ -91,9 +91,9 @@ possess:
 Processors are optional, although [some are 
 recommended](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor#recommended-processors). 
 
-Processors can be configured to transport values or consolidate data coming in from 
+Processors can be configured to transport values into or consolidate data coming in from 
 multiple systems, where different names are used to represent the same data. It is important to learn
-about the types of processors in detail to maximize their usage. 
+about the types of processors in detail to maximize their usage.
 
 **Attribute processors**
 

--- a/content/en/docs/concepts/data-collection.md
+++ b/content/en/docs/concepts/data-collection.md
@@ -66,7 +66,7 @@ The table below shows supported receiver formats for each signal type:
 | Prometheus           | :heavy_check_mark: | :heavy_check_mark: |                    |
 | Zipkin               | :heavy_check_mark: |                    |                    |
 
-For information about configuring receivers, see the [configuration documentation](/docs/collector/configuration/#receivers).
+Learn how to configure receivers in the [configuration documentation](/docs/collector/configuration/#receivers).
 
 ### Processors
 The job of the processor is to filter unwanted telemetry data and inject additional attributes to the data 
@@ -170,7 +170,7 @@ The job of the span processor is to manipulate the names or attributes of spans.
 and update its name based on those attributes. It supports   include` and `exclude` configuration parameters for filtering
 spans. Some span processors are used to change the collector's behavior.
 
-For information about configuring processors, see the
+Learn how to configure processors in the
 [configuration documentation](/docs/collector/configuration/#processors).
 
 ### Exporters
@@ -208,9 +208,17 @@ service:
       exporters: [otlp]
 ```
 
-For information about configuring processors, see the
-[configuration documentation](/docs/collector/configuration/#processors).
+Learn how to configure exporters in the [configuration documentation](/docs/collector/configuration/#exporters).
 
+### Extensions
+
+The job of extensions is to provide additional functionalities to the collector.
+Examples of extensions include health monitoring, service discovery, and
+data forwarding. Extensions are optional. The following extensions are currently available:
+- `ballast`: for configuring memory ballast for the collector, in order to improve the performance and stability of the collector.
+- `health_check`: used to make an endpoint available for checking the health of the collector.
+- `pprof`: enables the Go performance profiler used to identify performance issues in the collector.
+- `zpages`: enables an endpoint that provides debugging information about the components in the collector.
 
 ## Repositories
 

--- a/content/en/docs/concepts/data-collection.md
+++ b/content/en/docs/concepts/data-collection.md
@@ -33,7 +33,7 @@ For information on how to use the Collector see the
 ## Components of the OpenTelemetry Collector
 The collector makes it possible for users to configure *pipelines* for signals by
 combining any necessary number of *receivers*, *processors*, and *exporters*.
-Multiple instances of components as well as pipelines can be defined via YAML configuration.
+Multiple instances of these components as well as pipelines can be defined via YAML configuration.
 
 Let's look at these components in more details:
 
@@ -45,16 +45,53 @@ Let's look at these components in more details:
 - <img width="32" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Exporters.svg"></img>
   `exporters`: Where to send received data; these can be push or pull based
 
-These components are enabled through `pipelines` as mentioned earlier. 
+These components are enabled through `pipelines` as mentioned earlier. Read further to learn
+more about the components.
 
 ### Receivers
 The receiver is the first component in a pipeline. It receives data in several supported
 [data formats](https://opentelemetry.io/docs/concepts/signals), and converts this data into 
-an internal data format recognized by the collector.
+an internal data format recognized by the collector. Receivers can be push or pull based.
 
+You can set multiple protocols for a single receiver and make them listen to different ports by default. 
+The table below shows supported receiver formats for each signal type:
+
+| Signal Source        | Traces             | Metrics            | Logs               |
+| :---                 |    :----:          |  :---:             |               ---: |
+| Host Metrics         |                    | :heavy_check_mark: |                    |
+| Jaeger               | :heavy_check_mark: |                    |                    |
+| Kafka                | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| OpenCensus           | :heavy_check_mark: | :heavy_check_mark: |                    |
+| OpenTelemetry (OTLP) | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| Prometheus           | :heavy_check_mark: | :heavy_check_mark: |                    |
+| Zipkin               | :heavy_check_mark: |                    |                    |
+
+For information about configuring receivers, see the [configuration documentation](/docs/collector/configuration/#receivers).
+
+### Processors
+The job of the processor is to filter unwanted telemetry data and inject additional attributes to the data 
+before it is sent to the exporter. While receivers and exporters, the capabilities of processors differ immensely
+from one processor to the other.  The table below shows the currently supported processors, and the signals they
+possess:
+
+| Signal                 |       Traces        |      Metrics       |               Logs |
+|:-----------------------|:-------------------:|:------------------:|-------------------:|
+| Attributes             | :heavy_check_mark:  |                    | :heavy_check_mark: |
+| Batch                  | :heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: |
+| Filter                 |                     | :heavy_check_mark: |                    |
+| Memory Linter          | :heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: |
+| Probabilistic Sampling | :heavy_check_mark:  |                    |                    |
+| Resource               | :heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: |
+| Span                   | :heavy_check_mark:  |                    |                    |
+
+Processors are optional, although [some are 
+recommended](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor#recommended-processors). 
+
+Some kinds of configurations can be used to transport values or consolidate data coming in from 
+multiple systems, where different names are used to represent the same data.
 
 For more information about these components see the
-[configuration documentation](/docs/collector/configuration/#receivers).
+[configuration documentation](/docs/collector/configuration/#processors).
 
 ## Repositories
 

--- a/content/en/docs/concepts/data-collection.md
+++ b/content/en/docs/concepts/data-collection.md
@@ -71,7 +71,11 @@ For information about configuring receivers, see the [configuration documentatio
 ### Processors
 The job of the processor is to filter unwanted telemetry data and inject additional attributes to the data 
 before it is sent to the exporter. While receivers and exporters, the capabilities of processors differ immensely
-from one processor to the other. The table below shows the currently supported processors, and the signals they
+from one processor to the other. Processors are run on data between being received and being exported.
+While processors are optional, [some are
+recommended](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor#recommended-processors).
+
+The table below shows the currently supported processors, and the signals they
 possess:
 
 | Signal                 |       Traces        |      Metrics       |               Logs |
@@ -137,7 +141,7 @@ processors:
     limit_mib: 300
     spike_limit_mib: 50
   extensions:
-    meory_ballast:
+    memory_ballast:
       size_mib: 150
 ```
 
@@ -168,6 +172,45 @@ spans. Some span processors are used to change the collector's behavior.
 
 For information about configuring processors, see the
 [configuration documentation](/docs/collector/configuration/#processors).
+
+### Exporters
+The job of the exporter is to receive data in the internal collector format, convert it into the output format, and 
+transport it to one or more specified destinations. Multiple exporters of the same type can be configured to transport
+data to different destinations as required. Similarly, multiple exporters can be configured in the same pipeline to 
+transport data to multiple destinations.
+
+The table below shows the available exporters and the signals they support:
+
+| Exporters            |       Traces       |      Metrics       |               Logs |
+|:---------------------|:------------------:|:------------------:|-------------------:|
+| File                 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| Jaeger               | :heavy_check_mark: |                    |                    |
+| Kafka                | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| Logging              | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| OpenCensus           | :heavy_check_mark: | :heavy_check_mark: |                    |
+| OpenTelemetry (OTLP) |                    | :heavy_check_mark: | :heavy_check_mark: |
+| Prometheus           | :heavy_check_mark: | :heavy_check_mark: |                    |
+| Zipkin               | :heavy_check_mark: |                    |                    |
+
+
+The script below is an example of a Jaeger exporter for traces, and an otlp exporter for traces and metrics:
+```yaml
+exporters:
+  jaeger:
+    endpoint: jaeger:14250
+  otlp:
+    endpoint: otelcol:4317
+service:
+  pipelines:
+    traces:
+      exporters: [jaeger, otlp]
+    metrics:
+      exporters: [otlp]
+```
+
+For information about configuring processors, see the
+[configuration documentation](/docs/collector/configuration/#processors).
+
 
 ## Repositories
 

--- a/content/en/docs/concepts/data-collection.md
+++ b/content/en/docs/concepts/data-collection.md
@@ -91,7 +91,7 @@ possess:
 Processors are optional, although [some are 
 recommended](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor#recommended-processors). 
 
-Processors can be configured to transport values into or consolidate data coming in from 
+Processors can be configured to export data into or consolidate data coming in from 
 multiple systems, where different names are used to represent the same data. It is important to learn
 about the types of processors in detail to maximize their usage.
 

--- a/content/en/docs/concepts/observability-primer.md
+++ b/content/en/docs/concepts/observability-primer.md
@@ -16,7 +16,7 @@ questions about that system without knowing its inner workings. Furthermore,
 allows us to easily troubleshoot and handle novel problems (i.e. "unknown
 unknowns”), and helps us answer the question, "Why is this happening?"
 
-In order to be able to ask those questions of a system, the application must be
+In order to be able to ask those questions about a system, the application must be
 properly instrumented. That is, the application code must emit
 [signals](/docs/concepts/signals/) such as
 [traces](/docs/concepts/observability-primer/#distributed-traces),

--- a/content/en/docs/concepts/observability-primer.md
+++ b/content/en/docs/concepts/observability-primer.md
@@ -16,7 +16,7 @@ questions about that system without knowing its inner workings. Furthermore, it
 allows us to easily troubleshoot and handle novel problems (i.e. unknown
 unknowns), and helps us answer the question, "Why is this happening?"
 
-In order to be able to ask those questions about a system, the application must be
+In order to be able to ask those questions of a system, the application must be
 properly instrumented. That is, the application code must emit
 [signals](/docs/concepts/signals/) such as
 [traces](/docs/concepts/observability-primer/#distributed-traces),

--- a/content/en/docs/concepts/observability-primer.md
+++ b/content/en/docs/concepts/observability-primer.md
@@ -12,9 +12,9 @@ description: >-
 ## What is Observability?
 
 Observability lets us understand a system from the outside, by letting us ask
-questions about that system without knowing its inner workings. Furthermore,
-allows us to easily troubleshoot and handle novel problems (i.e. "unknown
-unknowns”), and helps us answer the question, "Why is this happening?"
+questions about that system without knowing its inner workings. Furthermore, it
+allows us to easily troubleshoot and handle novel problems (i.e. unknown
+unknowns), and helps us answer the question, "Why is this happening?"
 
 In order to be able to ask those questions about a system, the application must be
 properly instrumented. That is, the application code must emit

--- a/content/en/docs/concepts/what-is-opentelemetry.md
+++ b/content/en/docs/concepts/what-is-opentelemetry.md
@@ -6,7 +6,7 @@ weight: 10
 ---
 
 Microservices architectures have enabled developers to build and release
-software faster and with greater independence, as they were no longer beholden
+software faster and with greater independence. They are no longer bound
 to the elaborate release processes associated with monolithic architectures.
 
 As these now-distributed systems scaled, it became increasingly difficult for

--- a/content/en/docs/concepts/what-is-opentelemetry.md
+++ b/content/en/docs/concepts/what-is-opentelemetry.md
@@ -6,7 +6,7 @@ weight: 10
 ---
 
 Microservices architectures have enabled developers to build and release
-software faster and with greater independence. They are no longer bound
+software faster and with greater independence, as they are no longer beholden
 to the elaborate release processes associated with monolithic architectures.
 
 As these now-distributed systems scaled, it became increasingly difficult for


### PR DESCRIPTION
All I did:
1. I made the data-collection.md file contain the **theory/definitions** of the components of OpenTel Collector. 
2. I made the configuration.md file contain **only** the configurations examples for the components and stripped all definitions. I made grammatical changes to improve technical perception.
3. I made significant changes to both files, like tables (requires adding <meta charset=”utf8”> to the static site generator to show the ticks. Or replacing the :heavy_check_mark: with something else.), and more elaborate definitions with example scripts.