### PR TITLE
Initial content for demo page

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,3 +30,4 @@ content/en/docs/instrumentation/rust/  @open-telemetry/docs-approvers @open-tele
 content/en/docs/instrumentation/swift/  @open-telemetry/docs-approvers @open-telemetry/swift-mainteiners @open-telemetry/swift-approvers
 content/en/docs/k8s-operator		@open-telemetry/operator-approvers @open-telemetry/operator-maintainers
 content/en/blog/                         @open-telemetry/docs-approvers @open-telemetry/blog-approvers
+content/en/community/demo/		@open-telemetry/demo-approvers @open-telemetry/demo-maintainers

--- a/content/en/community/demo.md
+++ b/content/en/community/demo.md
@@ -1,5 +1,0 @@
----
-title: Demo
----
-
-Coming soon!

--- a/content/en/community/demo/_index.md
+++ b/content/en/community/demo/_index.md
@@ -1,0 +1,11 @@
+---
+title: OpenTelemetry Demo
+---
+
+{{% alert title="Note" color="warning" %}} The demo is a work in progress. If
+you'd like to help, check out our
+[contributing guidance](https://github.com/open-telemetry/opentelemetry-demo#contributing).
+{{% /alert %}}
+
+Get a first impression how observability with OpenTelemetry looks like with the
+[official OpenTelemetry Demo](https://github.com/open-telemetry/opentelemetry-demo).

--- a/content/en/community/demo/_index.md
+++ b/content/en/community/demo/_index.md
@@ -1,5 +1,6 @@
 ---
 title: OpenTelemetry Demo
+linkTitle: Demo
 ---
 
 {{% alert title="Note" color="warning" %}} The demo is a work in progress. If

--- a/content/en/community/demo/_index.md
+++ b/content/en/community/demo/_index.md
@@ -3,7 +3,7 @@ title: OpenTelemetry Demo
 linkTitle: Demo
 ---
 
-{{% alert title="Note" color="warning" %}} The demo is a work in progress. If
+{{% alert title="Important" color="warning" %}} The demo is a work in progress. If
 you'd like to help, check out our
 [contributing guidance](https://github.com/open-telemetry/opentelemetry-demo#contributing).
 {{% /alert %}}


### PR DESCRIPTION
This is giving the demo project a home within the website. Documentation can grow from here.

cc @open-telemetry/demo-maintainers , @open-telemetry/demo-approvers 

---

Preview: https://deploy-preview-1826--opentelemetry.netlify.app/community/demo/