### PR TITLE
Bump collector version to 

### DIFF
--- a/content/en/docs/collector/getting-started.md
+++ b/content/en/docs/collector/getting-started.md
@@ -2,7 +2,7 @@
 title: Getting Started
 spelling: cSpell:ignore dpkg GOARCH journalctl kubectl
 weight: 1
-collectorVersion: 0.60.0
+collectorVersion: 0.61.0
 ---
 
 If you aren't familiar with the deployment models, components, and repositories


### PR DESCRIPTION
Use OpenTelemetry collector v in the collector getting started. PLEASE IGNORE