### PR TITLE
Add @open-telemetry/end-user-wg to codeowners.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,3 +31,4 @@ content/en/docs/instrumentation/swift/  @open-telemetry/docs-approvers @open-tel
 content/en/docs/k8s-operator		@open-telemetry/operator-approvers @open-telemetry/operator-maintainers
 content/en/blog/                         @open-telemetry/docs-approvers @open-telemetry/blog-approvers
 content/en/community/demo/		@open-telemetry/demo-approvers @open-telemetry/demo-maintainers
+content/en/community/end-user/		@open-telemetry/end-user-wg


### PR DESCRIPTION
This will make sure that the end-user-wg will be asked for approval on changes within the end-user folder and they can approve changes.

cc @chalin , @cartermp , @open-telemetry/end-user-wg