### PR TITLE
Use status and releases shortcode for java

### DIFF
--- a/content/en/docs/instrumentation/java/_index.md
+++ b/content/en/docs/instrumentation/java/_index.md
@@ -10,6 +10,10 @@ weight: 18
 javaVersion: 1.18.0
 ---
 
+{{% lang_instrumentation_index_head "java" /%}}
+
+### Repositories
+
 OpenTelemetry Java consists of the following repositories:
 
 - [opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java):
@@ -24,12 +28,6 @@ OpenTelemetry Java consists of the following repositories:
   Provides helpful libraries and standalone OpenTelemetry-based utilities that
   don't fit the express scope of the OpenTelemetry Java or Java Instrumentation
   projects. For example, JMX metric gathering.
-
-## Status and Releases
-
-| Traces | Metrics | Logs         |
-|--------|---------|--------------|
-| Stable | Stable  | Experimental |
 
 ### Components
 

--- a/data/instrumentation.yaml
+++ b/data/instrumentation.yaml
@@ -16,7 +16,13 @@ languages:
     status:
       traces: stable
       metrics: alpha
-      logging: not yet implemented
+      logs: not yet implemented
+  java:
+    name: Java
+    status:
+      traces: stable
+      metrics: stable
+      logs: experimental
   php:
     name: PHP
     status:

--- a/layouts/shortcodes/lang_instrumentation_index_head.md
+++ b/layouts/shortcodes/lang_instrumentation_index_head.md
@@ -2,11 +2,11 @@
 {{ $name := $data.name }}
 {{ $relUrl := printf "https://github.com/open-telemetry/opentelemetry-%s/releases" (.Get 0) -}}
 
-This is the OpenTelemetry for {{ $name }} documentation. OpenTelemetry is an
+This is the OpenTelemetry {{ $name }} documentation. OpenTelemetry is an
 observability framework -- an API, SDK, and tools that are designed to aid in
 the generation and collection of application telemetry data such as metrics,
 logs, and traces. This documentation is designed to help you understand how to
-get started using OpenTelemetry for {{ $name }}.
+get started using OpenTelemetry {{ $name }}.
 
 ## Status and Releases
 


### PR DESCRIPTION
This updates the _index.md for java to make use of the shortcode that displays the table for stability and some standard text at the top of the page.