### PR TITLE
Auto link in stability table

### DIFF
--- a/layouts/shortcodes/lang_instrumentation_index_head.md
+++ b/layouts/shortcodes/lang_instrumentation_index_head.md
@@ -1,7 +1,18 @@
 {{ $data := index $.Site.Data.instrumentation.languages (.Get 0) }}
 {{ $name := $data.name }}
 {{ $relUrl := printf "https://github.com/open-telemetry/opentelemetry-%s/releases" (.Get 0) -}}
-
+{{ $tracesStatus := $data.status.traces | humanize }}
+{{ $metricsStatus := $data.status.metrics | humanize }}
+{{ $logsStatus := $data.status.logs | humanize }}
+{{ if in "Stable Experimental" $tracesStatus }}
+    {{ $tracesStatus = printf "[%s](/docs/reference/specification/versioning-and-stability/#%s)" $tracesStatus $data.status.traces }}
+{{ end }}
+{{ if in "Stable Experimental" $metricsStatus }}
+    {{ $metricsStatus = printf "[%s](/docs/reference/specification/versioning-and-stability/#%s)" $metricsStatus $data.status.metrics }}
+{{ end }}
+{{ if in "Stable Experimental" $logsStatus }}
+    {{ $logsStatus = printf "[%s](/docs/reference/specification/versioning-and-stability/#%s)" $logsStatus $data.status.logs }}
+{{ end }}
 This is the OpenTelemetry {{ $name }} documentation. OpenTelemetry is an
 observability framework -- an API, SDK, and tools that are designed to aid in
 the generation and collection of application telemetry data such as metrics,
@@ -15,7 +26,7 @@ as follows:
 
 | Traces    | Metrics      | Logs         |
 | --------  | -------      | -------      |
-| {{ $data.status.traces | humanize }}    | {{ $data.status.metrics | humanize }} | {{ $data.status.logs | humanize }} |
+| {{ $tracesStatus }}    | {{ $metricsStatus }} | {{ $logsStatus }} |
 
 For releases, including the [latest release][], see [Releases][].
 {{- .Inner }}


### PR DESCRIPTION
Small improvement for the tables with the stability matrix: if the value is "Stable" or "Experimental" it will automatically link the definition in the spec like some of the pages are doing it already. 