### PR TITLE
Update specification to 1.14.0, and fix broken links

### DIFF
--- a/content/en/blog/2022/exponential-histograms/index.md
+++ b/content/en/blog/2022/exponential-histograms/index.md
@@ -290,13 +290,13 @@ _A version of this article was [originally posted][] on the New Relic blog._
 [aggregation]: /docs/reference/specification/metrics/sdk/#aggregation
 [type of instrument]: /docs/reference/specification/metrics/api/#histogram
 [histogram-aggregation]:
-  /docs/reference/specification/metrics/sdk/#histogram-aggregation-common-behavior
+  /docs/reference/specification/metrics/sdk/#histogram-aggregations
 [explicit bucket histogram]:
   /docs/reference/specification/metrics/sdk/#explicit-bucket-histogram-aggregation
 [explicit bucket histogram proto]:
   https://github.com/open-telemetry/opentelemetry-proto/blob/724e427879e3d2bae2edc0218fff06e37b9eb46e/opentelemetry/proto/metrics/v1/metrics.proto#L382
 [exponential bucket histogram]:
-  /docs/reference/specification/metrics/sdk/#exponential-histogram-aggregation
+  /docs/reference/specification/metrics/sdk/#exponential-bucket-histogram-aggregation
 [exponential bucket histogram proto]:
   https://github.com/open-telemetry/opentelemetry-proto/blob/724e427879e3d2bae2edc0218fff06e37b9eb46e/opentelemetry/proto/metrics/v1/metrics.proto#L463
 [example code]:

--- a/content/en/docs/instrumentation/python/exporters.md
+++ b/content/en/docs/instrumentation/python/exporters.md
@@ -37,7 +37,7 @@ trace.set_tracer_provider(provider)
 
 Use a [`PeriodicExportingMetricReader`][pemr] to periodically print metrics to the console.
 `PeriodicExportingMetricReader` can be configured to export at a different interval, change the
-[temporality](/docs/reference/specification/metrics/datamodel/#temporality) for each instrument
+[temporality](/docs/reference/specification/metrics/data-model/#temporality) for each instrument
 kind, or change the default aggregation for each instrument kind.
 
 ```python

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -23,3 +23,6 @@
 {{ $og_image_current := `/img/social/logo-wordmark-001.png` -}}
 
 /featured-background.jpg  {{ $og_image_current }} {{/* homepage og:image used prior to 2022/08 */}}
+
+{{/* Temporary until alias is added to spec - https://github.com/open-telemetry/opentelemetry.io/issues/1850 */ -}}
+/docs/reference/specification/metrics/datamodel  /docs/reference/specification/metrics/data-model

--- a/scripts/adjust-spec-pages.pl
+++ b/scripts/adjust-spec-pages.pl
@@ -88,8 +88,10 @@ while(<>) {
   s|(\]\()(img/.*?\))|$1../$2|g if $ARGV !~ /logs._index/;
 
   # Fix links that are to the title of the .md page
+  # TODO: fix these in the spec
   s|(/context/api-propagators.md)#propagators-api|$1|g;
   s|(/semantic_conventions/faas.md)#function-as-a-service|$1|g;
+  s|(/resource/sdk.md)#resource-sdk|$1|g;
   s/#log-data-model/./;
 
   s|\.\.\/README.md\b|$specRepoUrl/|g if $ARGV =~ /specification._index/;


### PR DESCRIPTION
Updates the spec to v1.14.0 from v1.12.0 (compare spec changes via https://github.com/open-telemetry/opentelemetry-specification/compare/v1.12.0...v1.14.0):

- Closes #1846
- Fixes broken links into the updated spec pages.

Preview:

- https://deploy-preview-1851--opentelemetry.netlify.app/docs/reference/specification
- New schema files:
  -  https://deploy-preview-1851--opentelemetry.netlify.app/schemas/1.13.0
  -  https://deploy-preview-1851--opentelemetry.netlify.app/schemas/1.14.0
- Redirect test:
  - https://deploy-preview-1851--opentelemetry.netlify.app/docs/reference/specification/metrics/datamodel/#temporality

/cc @tigrannajaryan 

---

```console
$ (cd content-modules/opentelemetry-specification && git branch -v | grep \*)
* (HEAD detached at v1.14.0) 8c73c16 Release 1.14.0 (#2851)
```