### PR TITLE
Add initial version of C++ Getting Started, Manual & Exporters

### DIFF
--- a/content/en/docs/instrumentation/cpp/_index.md
+++ b/content/en/docs/instrumentation/cpp/_index.md
@@ -14,6 +14,7 @@ You can see & update the `lang_instrumentation_index_head` shortcode in
 The data (name, status) is located at
 /data/instrumentation.yaml
 -->
+
 {{% lang_instrumentation_index_head "cpp" /%}}
 
 ## Further Reading

--- a/content/en/docs/instrumentation/cpp/_index.md
+++ b/content/en/docs/instrumentation/cpp/_index.md
@@ -4,8 +4,7 @@ weight: 11
 description: >
   <img width="35"
   src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/C++_SDK.svg"
-  alt="C++"></img>
-  A language-specific implementation of OpenTelemetry in C++.
+  alt="C++"></img> A language-specific implementation of OpenTelemetry in C++.
 ---
 
 <!--

--- a/content/en/docs/instrumentation/cpp/exporters.md
+++ b/content/en/docs/instrumentation/cpp/exporters.md
@@ -55,5 +55,5 @@ docker run -d --name jaeger \
 ## Next steps
 
 Enriching your codebase with
-[manual instrumentation](/docs/instrumentation/cüü/manual) gives you customized
+[manual instrumentation](/docs/instrumentation/cpp/manual) gives you customized
 observability data.

--- a/content/en/docs/instrumentation/cpp/exporters.md
+++ b/content/en/docs/instrumentation/cpp/exporters.md
@@ -1,0 +1,59 @@
+---
+title: Exporters
+weight: 4
+---
+
+In order to visualize and analyze your
+[traces](/docs/concepts/signals/traces/#tracing-in-opentelemetry) and metrics,
+you will need to export them to a backend.
+
+## Logging exporter
+
+The logging exporter is useful for development and debugging tasks, and is the
+simplest to set up.
+
+```cpp
+auto ostream_exporter =
+    std::unique_ptr<opentelemetry::sdk::trace::SpanExporter>(new opentelemetry::exporter::trace::OStreamSpanExporter);
+```
+
+## OTLP endpoint
+
+To send trace data to an OTLP endpoint (like the [collector](/docs/collector) or
+Jaeger) you'll want to configure an OTLP exporter that sends to your endpoint.
+
+```cpp
+opentelemetry::exporter::otlp::OtlpHttpExporterOptions opts;
+opts.url = "http://localhost:4318/v1/traces";
+auto otlp_http_exporter =
+    std::unique_ptr<opentelemetry::sdk::trace::SpanExporter>(new opentelemetry::exporter::otlp::OtlpHttpExporter(opts));
+```
+
+### Jaeger
+
+To try out the OTLP exporter, you can run
+[Jaeger](https://www.jaegertracing.io/) as an OTLP endpoint and for trace
+visualization in a docker container:
+
+```shell
+docker run -d --name jaeger \
+  -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
+  -e COLLECTOR_OTLP_ENABLED=true \
+  -p 6831:6831/udp \
+  -p 6832:6832/udp \
+  -p 5778:5778 \
+  -p 16686:16686 \
+  -p 4317:4317 \
+  -p 4318:4318 \
+  -p 14250:14250 \
+  -p 14268:14268 \
+  -p 14269:14269 \
+  -p 9411:9411 \
+  jaegertracing/all-in-one:latest
+```
+
+## Next steps
+
+Enriching your codebase with
+[manual instrumentation](/docs/instrumentation/cüü/manual) gives you customized
+observability data.

--- a/content/en/docs/instrumentation/cpp/exporters.md
+++ b/content/en/docs/instrumentation/cpp/exporters.md
@@ -7,9 +7,9 @@ In order to visualize and analyze your
 [traces](/docs/concepts/signals/traces/#tracing-in-opentelemetry) and metrics,
 you will need to export them to a backend.
 
-## Logging exporter
+## OStream exporter
 
-The logging exporter is useful for development and debugging tasks, and is the
+The OStream exporter is useful for development and debugging tasks, and is the
 simplest to set up.
 
 ```cpp
@@ -22,12 +22,28 @@ auto ostream_exporter =
 To send trace data to an OTLP endpoint (like the [collector](/docs/collector) or
 Jaeger) you'll want to configure an OTLP exporter that sends to your endpoint.
 
+### OTLP HTTP Exporter
+
 ```cpp
 opentelemetry::exporter::otlp::OtlpHttpExporterOptions opts;
 opts.url = "http://localhost:4318/v1/traces";
 auto otlp_http_exporter =
     std::unique_ptr<opentelemetry::sdk::trace::SpanExporter>(new opentelemetry::exporter::otlp::OtlpHttpExporter(opts));
 ```
+
+### OTLP GRPC Exporter
+
+```cpp
+opentelemetry::exporter::otlp::OtlpGrpcExporterOptions opts;
+opts.endpoint = "localhost:4317";
+opts.use_ssl_credentials = true;
+opts.ssl_credentials_cacert_as_string = "ssl-certificate";
+auto otlp_grpc_exporter =
+    std::unique_ptr<opentelemetry::sdk::trace::SpanExporter>(new opentelemetry::exporter::otlp::OtlpGrpcExporter(opts));
+```
+
+You can find an example of how to use the OTLP exporter
+[here](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/examples/otlp/README.md).
 
 ### Jaeger
 
@@ -50,6 +66,20 @@ docker run -d --name jaeger \
   -p 14269:14269 \
   -p 9411:9411 \
   jaegertracing/all-in-one:latest
+```
+
+## Zipkin
+
+To send trace data to a zipkin endpoint you'll want to configure a zipkin
+exporter that sends to your endpoint.
+
+```cpp
+opentelemetry::exporter::zipkin::ZipkinExporterOptions opts;
+opts.endpoint = "http://localhost:9411/api/v2/spans" ; // or export OTEL_EXPORTER_ZIPKIN_ENDPOINT="..."
+opts.service_name = "default_service" ;
+auto zipkin_exporter =
+    std::unique_ptr<opentelemetry::sdk::trace::SpanExporter>(new opentelemetry::exporter::zipkin::ZipkinExporter(opts));
+
 ```
 
 ## Next steps

--- a/content/en/docs/instrumentation/cpp/getting-started.md
+++ b/content/en/docs/instrumentation/cpp/getting-started.md
@@ -1,0 +1,153 @@
+---
+title: "Getting Started"
+weight: 2
+---
+
+Welcome to the OpenTelemetry C++ getting started guide! This guide will walk you
+through the basic steps in installing, instrumenting with, configuring, and
+exporting data from OpenTelemetry.
+
+You can use Cmake or Bazel for building OpenTelemetry C++. The following getting
+started guide will make use of CMake and only provide you the most essential
+steps to have a working example application (a http server & http client). For
+more details read
+[these instructions](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/INSTALL.md).
+
+## Prerequisites
+
+You can build OpenTelemetry C++ on Windows, macOS or Linux. First you need to
+install some dependencies:
+
+{{< ot-tabs "Linux (apt)"  >}}
+
+{{< ot-tab >}} sudo apt-get install git cmake g++ libcurl4-openssl-dev
+{{< /ot-tab >}}
+
+{{< /ot-tabs >}}
+
+## Building
+
+Get the opentelementry-cpp source:
+
+```shell
+$ git clone --recursive https://github.com/open-telemetry/opentelemetry-cpp
+```
+
+Navigate to the repository cloned above, and create the CMake build
+configuration:
+
+```shell
+$ cd opentelemetry-cpp
+$ mkdir build && cd build
+$ cmake -DBUILD_TESTING=OFF ..
+```
+
+Once build configuration is created, build the CMake targets - this includes
+building SDKs, and building unittests for API and SDK.
+
+```shell
+cmake --build . --target http_client http_server
+```
+
+If all goes well, you should find binaries `http_server` and `http_client` in
+`./examples/http`:
+
+```shell
+$ ls ./examples/http
+CMakeFiles  Makefile  cmake_install.cmake  http_client  http_server
+```
+
+## Run Application
+
+Open two terminals, in the first terminal, start the http server:
+
+```shell
+$ ./examples/http/http_server
+Server is running..Press ctrl-c to exit..
+```
+
+In the other terminal, run the http client:
+
+```shell
+$ ./examples/http/http_client
+{
+  name          : /helloworld
+  trace_id      : 05eec7a55d3544434265dad89d7fe96f
+  span_id       : 45fb62c58c907f05
+  tracestate    :
+  parent_span_id: 0000000000000000
+  start         : 1665577080650384378
+  duration      : 1640298
+  description   :
+  span kind     : Client
+  status        : Unset
+  attributes    :
+    http.header.Date: Wed, 12 Oct 2022 12:18:00 GMT
+    http.header.Content-Length: 0
+    http.status_code: 200
+    http.method: GET
+    .header.Host: localhost
+    http.header.Content-Type: text/plain
+    http.header.Connection: keep-alive
+    .scheme: http
+    http.url: http://localhost:8800/helloworld
+  events        :
+  links         :
+  resources     :
+    service.name: unknown_service
+    telemetry.sdk.version: 1.6.1
+    telemetry.sdk.name: opentelemetry
+    telemetry.sdk.language: cpp
+  instr-lib     : http-client
+}
+```
+
+Also the server should dump you a trace to the console:
+
+```shell
+{
+  name          : /helloworld
+  trace_id      : 05eec7a55d3544434265dad89d7fe96f
+  span_id       : 8df967d8547813fe
+  tracestate    :
+  parent_span_id: 45fb62c58c907f05
+  start         : 1665577080651459495
+  duration      : 46331
+  description   :
+  span kind     : Server
+  status        : Unset
+  attributes    :
+    http.header.Traceparent: 00-05eec7a55d3544434265dad89d7fe96f-45fb62c58c907f05-01
+    http.header.Accept: */*
+    http.request_content_length: 0
+    http.header.Host: localhost:8800
+    http.scheme: http
+    http.client_ip: 127.0.0.1:49466
+    http.method: GET
+    net.host.port: 8800
+    net.host.name: localhost
+  events        :
+    {
+      name          : Processing request
+      timestamp     : 1665577080651472827
+      attributes    :
+    }
+  links         :
+  resources     :
+    service.name: unknown_service
+    telemetry.sdk.version: 1.6.1
+    telemetry.sdk.name: opentelemetry
+    telemetry.sdk.language: cpp
+  instr-lib     : http-server
+}
+```
+
+## What's next
+
+Enrich your instrumentation generated automatically with
+[manual](/docs/instrumentation/cpp/manual) of your own codebase. This gets you
+customized observability data.
+
+You'll also want to configure an appropriate exporter to
+[export your telemetry data](/docs/instrumentation/cpp/exporters) to one or more
+telemetry backends.

--- a/content/en/docs/instrumentation/cpp/getting-started.md
+++ b/content/en/docs/instrumentation/cpp/getting-started.md
@@ -7,10 +7,10 @@ Welcome to the OpenTelemetry C++ getting started guide! This guide will walk you
 through the basic steps in installing, instrumenting with, configuring, and
 exporting data from OpenTelemetry.
 
-You can use Cmake or Bazel for building OpenTelemetry C++. The following getting
-started guide will make use of CMake and only provide you the most essential
-steps to have a working example application (a http server & http client). For
-more details read
+You can use [CMake](https://cmake.org/) or [Bazel](https://bazel.build/) for
+building OpenTelemetry C++. The following getting started guide will make use of
+CMake and only provide you the most essential steps to have a working example
+application (a http server & http client). For more details read
 [these instructions](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/INSTALL.md).
 
 ## Prerequisites
@@ -49,8 +49,8 @@ $ mkdir build && cd build
 $ cmake -DBUILD_TESTING=OFF ..
 ```
 
-Once build configuration is created, build the CMake targets - this includes
-building SDKs, and building unittests for API and SDK.
+Once build configuration is created, build the CMake targets `http_client` and
+`http_server`:
 
 ```shell
 cmake --build . --target http_client http_server

--- a/content/en/docs/instrumentation/cpp/getting-started.md
+++ b/content/en/docs/instrumentation/cpp/getting-started.md
@@ -18,16 +18,18 @@ more details read
 You can build OpenTelemetry C++ on Windows, macOS or Linux. First you need to
 install some dependencies:
 
-{{< ot-tabs "Linux (apt)" "Linux (yum)" >}}
-
-{{< ot-tab >}} 
-sudo apt-get install git cmake g++ libcurl4-openssl-dev
+{{< ot-tabs "Linux (apt)" "Linux (yum)" "MacOS (homebrew)">}}
+{{< ot-tab lang="shell">}}
+$ sudo apt-get install git cmake g++ libcurl4-openssl-dev
 {{< /ot-tab >}}
-
-{{< ot-tab >}} 
-sudo yum install git cmake g++ libcurl-devel
+{{< ot-tab lang="shell">}}
+$ sudo yum install git cmake g++ libcurl-devel
 {{< /ot-tab >}}
-
+{{< ot-tab lang="shell">}}
+$ xcode-select —install
+$ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+$ brew install git cmake
+{{< /ot-tab >}}
 {{< /ot-tabs >}}
 
 ## Building

--- a/content/en/docs/instrumentation/cpp/getting-started.md
+++ b/content/en/docs/instrumentation/cpp/getting-started.md
@@ -18,9 +18,14 @@ more details read
 You can build OpenTelemetry C++ on Windows, macOS or Linux. First you need to
 install some dependencies:
 
-{{< ot-tabs "Linux (apt)"  >}}
+{{< ot-tabs "Linux (apt)" "Linux (yum)" >}}
 
-{{< ot-tab >}} sudo apt-get install git cmake g++ libcurl4-openssl-dev
+{{< ot-tab >}} 
+sudo apt-get install git cmake g++ libcurl4-openssl-dev
+{{< /ot-tab >}}
+
+{{< ot-tab >}} 
+sudo yum install git cmake g++ libcurl-devel
 {{< /ot-tab >}}
 
 {{< /ot-tabs >}}

--- a/content/en/docs/instrumentation/cpp/manual.md
+++ b/content/en/docs/instrumentation/cpp/manual.md
@@ -21,7 +21,7 @@ default no-op implementation of a `TracerProvider`.
 
 The `Tracer` acquired in the second step is needed to create and start Spans.
 
-## Start a span
+## Start a span
 
 ```cpp
 auto span = tracer->StartSpan("HandleRequest");
@@ -31,7 +31,7 @@ This creates a span, sets its name to `"HandleRequest"`, and sets its start time
 to the current time. Refer to the API documentation for other operations that
 are available to enrich spans with additional data.
 
-## Mark a span as active
+## Mark a span as active
 
 ```cpp
 auto scope = tracer->WithActiveSpan(span);
@@ -45,7 +45,7 @@ The concept of an active span is important, as any span that is created without
 explicitly specifying a parent is parented to the currently active span. A span
 without a parent is called root span.
 
-## Create nested Spans
+## Create nested Spans
 
 ```cpp
 auto outer_span = tracer->StartSpan("Outer operation");

--- a/content/en/docs/instrumentation/cpp/manual.md
+++ b/content/en/docs/instrumentation/cpp/manual.md
@@ -1,0 +1,94 @@
+---
+title: Manual Instrumentation
+linkTitle: Manual
+weight: 3
+---
+
+Manual instrumentation is the process of adding observability code to your
+application.
+
+## Initializing tracing
+
+```cpp
+auto provider = opentelemetry::trace::Provider::GetTracerProvider();
+auto tracer = provider->GetTracer("foo_library", "1.0.0");
+```
+
+The `TracerProvider` acquired in the first step is a singleton object that is
+usually provided by the OpenTelemetry C++ SDK. It is used to provide specific
+implementations for API interfaces. In case no SDK is used, the API provides a
+default no-op implementation of a `TracerProvider`.
+
+The `Tracer` acquired in the second step is needed to create and start Spans.
+
+## Start a span
+
+```cpp
+auto span = tracer->StartSpan("HandleRequest");
+```
+
+This creates a span, sets its name to `"HandleRequest"`, and sets its start time
+to the current time. Refer to the API documentation for other operations that
+are available to enrich spans with additional data.
+
+## Mark a span as active
+
+```cpp
+auto scope = tracer->WithActiveSpan(span);
+```
+
+This marks a span as active and returns a `Scope` object. The scope object
+controls how long a span is active. The span remains active for the lifetime of
+the scope object.
+
+The concept of an active span is important, as any span that is created without
+explicitly specifying a parent is parented to the currently active span. A span
+without a parent is called root span.
+
+## Create nested Spans
+
+```cpp
+auto outer_span = tracer->StartSpan("Outer operation");
+auto outer_scope = tracer->WithActiveSpan(outer_span);
+{
+    auto inner_span = tracer->StartSpan("Inner operation");
+    auto inner_scope = tracer->WithActiveSpan(inner_span);
+    // ... perform inner operation
+    inner_span->End();
+}
+// ... perform outer operation
+outer_span->End();
+```
+
+Spans can be nested, and have a parent-child relationship with other spans. When
+a given span is active, the newly created span inherits the active span’s trace
+ID, and other context attributes.
+
+## Context Propagation
+
+```cpp
+// set global propagator
+opentelemetry::context::propagation::GlobalTextMapPropagator::SetGlobalPropagator(
+    nostd::shared_ptr<opentelemetry::context::propagation::TextMapPropagator>(
+        new opentelemetry::trace::propagation::HttpTraceContext()));
+
+// get global propagator
+HttpTextMapCarrier<opentelemetry::ext::http::client::Headers> carrier;
+auto propagator =
+    opentelemetry::context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
+
+//inject context to headers
+auto current_ctx = opentelemetry::context::RuntimeContext::GetCurrent();
+propagator->Inject(carrier, current_ctx);
+
+//Extract headers to context
+auto current_ctx = opentelemetry::context::RuntimeContext::GetCurrent();
+auto new_context = propagator->Extract(carrier, current_ctx);
+auto remote_span = opentelemetry::trace::propagation::GetSpan(new_context);
+```
+
+`Context` contains the meta-data of the currently active Span including Span Id,
+Trace Id, and flags. Context Propagation is an important mechanism in
+distributed tracing to transfer this Context across service boundary often
+through HTTP headers. OpenTelemetry provides a text-based approach to propagate
+context to remote services using the W3C Trace Context HTTP headers.


### PR DESCRIPTION
Since I was playing around with c++ opentelemetry anyways I thought it might be a nice exercise to get the docs drafted for it. This first version is not ideal, but hopefully a good start:

* Getting Started leads people to have a http_server & http_client up and running
* Manual & Exporters are mostly text copys from https://opentelemetry-cpp.readthedocs.io/, they still lack some context with the getting started

Preview: https://deploy-preview-1857--opentelemetry.netlify.app/docs/instrumentation/cpp/getting-started/