### PR TITLE
Adds Java API-reference link to side nav

### DIFF
--- a/assets/scss/_external_link.scss
+++ b/assets/scss/_external_link.scss
@@ -1,24 +1,24 @@
 // External-link icon after an external link
 //
-// (+) To ensure that the external-link icon word-wraps along with the preceding
+// To ensure that the external-link icon word-wraps along with the preceding
 // word, rather than by itself, we (1) start content with $nbsp, and (2) ensure
-// display is not 'inline-block'.
+// that `display` is 'inline'.
 //
 // For a discussion concerning this topic, see
 // https://stackoverflow.com/questions/16100956/prevent-after-element-from-wrapping-to-next-line.
-
 
 $nbsp: \00A0;
 
 @mixin external-link-icon() {
   @extend .fas;
-  display: inherit; // (+) override .fas's setting of 'inline-block'
+  display: inline;
   @include font-size(60%);
   opacity: 0.8;
   vertical-align: text-top;
   content: fa-content($nbsp + $fa-var-external-link-alt);
 }
 
+.td-sidebar-nav a[target="_blank"]:after,
 a.external-link:after {
   @include external-link-icon();
 }

--- a/content/en/docs/instrumentation/java/_index.md
+++ b/content/en/docs/instrumentation/java/_index.md
@@ -71,10 +71,6 @@ dependencies {
 }
 ```
 
-### API reference
-
-- [Javadoc](https://www.javadoc.io/doc/io.opentelemetry)
-
 [maven central]: https://mvnrepository.com/artifact/io.opentelemetry
 [opentelemetry-java-docs]: https://github.com/open-telemetry/opentelemetry-java-docs#java-opentelemetry-examples
 [releases]: https://github.com/open-telemetry/opentelemetry-java/releases

--- a/content/en/docs/instrumentation/java/api.md
+++ b/content/en/docs/instrumentation/java/api.md
@@ -1,0 +1,10 @@
+---
+title: API reference
+linkTitle: API
+# Note: this is a placeholder page. Attempting to visit this page will
+# redirect to the following URL:
+manualLink: https://javadoc.io/doc/io.opentelemetry
+manualLinkTarget: _blank
+_build: { render: link }
+weight: 50
+---

--- a/content/en/docs/instrumentation/java/extensions.md
+++ b/content/en/docs/instrumentation/java/extensions.md
@@ -1,6 +1,9 @@
 ---
 title: Extensions
-description: Extensions add capabilities to the agent without having to create a separate distribution.
+description: >-
+  Extensions add capabilities to the agent without having to create a separate
+  distribution.
+weight: 10
 ---
 
 ## Introduction


### PR DESCRIPTION
- A first contribution to #1808
- Adds Java API-reference link to the side nav, as last entry in the section's subnav

Preview:

- https://deploy-preview-1859--opentelemetry.netlify.app/docs/instrumentation/java/

### Screenshots

> <img width="1036" alt="Screen Shot 2022-10-12 at 14 08 46" src="https://user-images.githubusercontent.com/4140793/195416822-185ac7b4-f4cc-4868-935c-4628ce586c57.png">

> <img width="1036" alt="Screen Shot 2022-10-12 at 14 10 08" src="https://user-images.githubusercontent.com/4140793/195416952-7a3283d2-20b1-4ef8-b75a-13f37545178e.png">
