### PR TITLE
Blog post: list of candidates for 2022 GC elections

### DIFF
--- a/content/en/blog/2022/gc-elections-2022-list-of-candidates.md
+++ b/content/en/blog/2022/gc-elections-2022-list-of-candidates.md
@@ -1,6 +1,6 @@
 ---
 title: Final list of candidates for the 2022 OpenTelemetry Governance Committee
-linkTitle: Candidates for the Governance Committee Election 2022
+linkTitle: 2022 GC Candidates
 date: 2022-10-13
 author: OpenTelemetry Governance Committee
 ---

--- a/content/en/blog/2022/gc-elections-2022-list-of-candidates.md
+++ b/content/en/blog/2022/gc-elections-2022-list-of-candidates.md
@@ -1,5 +1,5 @@
 ---
-title: Final list of candidates for the 2022 OpenTelemetry Governance Committee Election
+title: Final list of candidates for the 2022 OpenTelemetry Governance Committee
 linkTitle: Candidates for the Governance Committee Election 2022
 date: 2022-10-13
 author: OpenTelemetry Governance Committee

--- a/content/en/blog/2022/gc-elections-2022-list-of-candidates.md
+++ b/content/en/blog/2022/gc-elections-2022-list-of-candidates.md
@@ -1,0 +1,25 @@
+---
+title: Final list of candidates for the 2022 OpenTelemetry Governance Committee Election
+linkTitle: Candidates for the Governance Committee Election 2022
+date: 2022-10-13
+author: OpenTelemetry Governance Committee
+---
+
+The OpenTelemetry election committee is pleased to announce the final list of candidates running for one of the four available seats. We encourage all voters to take a moment and review all candidates, picking the one that best represents your interest. You can find their pictures, profile link, and descriptions on the [candidates page](https://github.com/open-telemetry/community/blob/main/elections/2022/governance-committee-candidates.md), but here are their names:
+
+* Alolita Sharma
+* Daniel Dyla
+* Ken Finnigan
+* Michael Hausenblas
+* Morgan McLean
+* Pavol Loffay
+* Phillip Carter
+* Reese Lee
+* Reiley Yang
+* Sean Marciniak
+* Severin Neumann
+* Trask Stalnaker
+* Tyler Yahn
+* Vijay Samuel
+
+You can check your eligibility by reviewing [this GitHub issue](https://github.com/open-telemetry/community/issues/1173). If you are not listed there but believe you have the right to vote, please [fill out this registration form](https://forms.gle/mEDWyn6G7iCe4bvJ7).

--- a/content/en/blog/2022/gc-elections-2022-list-of-candidates.md
+++ b/content/en/blog/2022/gc-elections-2022-list-of-candidates.md
@@ -5,7 +5,13 @@ date: 2022-10-13
 author: OpenTelemetry Governance Committee
 ---
 
-The OpenTelemetry election committee is pleased to announce the final list of candidates running for one of the four available seats. We encourage all voters to take a moment and review all candidates, picking the one that best represents your interest. You can find their pictures, profile link, and descriptions on the [candidates page](https://github.com/open-telemetry/community/blob/main/elections/2022/governance-committee-candidates.md), but here are their names:
+The OpenTelemetry election committee is pleased to announce the final list of
+candidates running for one of the four available seats. We encourage all voters
+to take a moment and review all candidates, picking the one that best represents
+your interest. You can find their pictures, profile link, and descriptions on
+the [candidates
+page](https://github.com/open-telemetry/community/blob/main/elections/2022/governance-committee-candidates.md),
+but here are their names:
 
 * Alolita Sharma
 * Daniel Dyla


### PR DESCRIPTION
Blog post announcing the list of candidates for the 2022 GC elections.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
