### PR TITLE
Banner: link to candidate-list and election posts

### DIFF
--- a/content/en/blog/2022/gc-candidates.md
+++ b/content/en/blog/2022/gc-candidates.md
@@ -3,6 +3,7 @@ title: Final list of candidates for the 2022 OpenTelemetry Governance Committee
 linkTitle: 2022 GC Candidates
 date: 2022-10-13
 author: OpenTelemetry Governance Committee
+aliases: [/blog/2022/gc-elections-2022-list-of-candidates]
 ---
 
 The OpenTelemetry election committee is pleased to announce the final list of

--- a/content/en/blog/2022/gc-elections.md
+++ b/content/en/blog/2022/gc-elections.md
@@ -3,7 +3,7 @@ title: Announcing the 2022 OpenTelemetry Governance Committee Election
 linkTitle: 2022 GC Election
 date: 2022-09-15
 author: OpenTelemetry Governance Committee
-aliases: [/blog/2022/gc-elections]
+aliases: [/blog/2022/gc-elections-2022]
 ---
 
 The OpenTelemetry project is excited to announce the 2022 OpenTelemetry

--- a/content/en/blog/2022/gc-elections.md
+++ b/content/en/blog/2022/gc-elections.md
@@ -1,8 +1,9 @@
 ---
 title: Announcing the 2022 OpenTelemetry Governance Committee Election
-linkTitle: Governance Committee Election 2022
+linkTitle: 2022 GC Election
 date: 2022-09-15
 author: OpenTelemetry Governance Committee
+aliases: [/blog/2022/gc-elections]
 ---
 
 The OpenTelemetry project is excited to announce the 2022 OpenTelemetry

--- a/layouts/partials/banner.md
+++ b/layouts/partials/banner.md
@@ -2,12 +2,10 @@
 
 <div class="o-banner">
 
-<i class="fas fa-bullhorn"></i> 
-The OpenTelemetry Governance elections are opening soon! [Learn about how to
-vote, how to run, and other important details][]
-
-[learn about how to vote, how to run, and other important details]:
-  /blog/2022/gc-elections-2022/
+<i class="fas fa-bullhorn"></i> [Vote](/blog/2022/gc-elections-2022/) for
+OpenTelemetry Governance Committee
+[candidates](/blog/2022/gc-elections-2022-list-of-candidates/) starting October
+18!
 
 </div>
 {{ end -}}

--- a/layouts/partials/banner.md
+++ b/layouts/partials/banner.md
@@ -2,10 +2,9 @@
 
 <div class="o-banner">
 
-<i class="fas fa-bullhorn"></i> [Vote](/blog/2022/gc-elections-2022/) for
-OpenTelemetry Governance Committee
-[candidates](/blog/2022/gc-elections-2022-list-of-candidates/) starting October
-18!
+<i class="fas fa-bullhorn"></i> [Vote](/blog/2022/gc-elections/) for
+OpenTelemetry Governance Committee [candidates](/blog/2022/gc-candidates/)
+starting October 18!
 
 </div>
 {{ end -}}


### PR DESCRIPTION
- Following through from #1863
- Also, "normalized" titles and paths of earlier 2022 GC posts, to match what we did in 2021; and, we don't need the year in the file name since each post is in a folder for a given year.

Preview:

- Homepage for the banner: https://deploy-preview-1864--opentelemetry.netlify.app
- Posts redirect tests (for the two that were renamed):
  - https://deploy-preview-1864--opentelemetry.netlify.app/blog/2022/gc-elections-2022
  - https://deploy-preview-1864--opentelemetry.netlify.app/blog/2022/gc-elections-2022-list-of-candidates

/cc @jpkrohling 

---

### Screenshot

> <img width="300" alt="image" src="https://user-images.githubusercontent.com/4140793/195631341-0db5fe10-7934-48cf-8a9b-e63eae9b4b10.png">
