### PR TITLE
Restructure end-user section in /community

### DIFF
--- a/content/en/community/end-user/_index.md
+++ b/content/en/community/end-user/_index.md
@@ -5,78 +5,33 @@ Description: Vendor-agnostic resources for users of OpenTelemetry
 ---
 
 The [OpenTelemetry End User Working Group][] has heard feedback from users who
-desire a vendor-agnostic space to discuss adopting OpenTelemetry, so we’re
-excited to announce two new ways for you to connect with other users of the
-project and share best practices, a synchronous monthly discussion group and a
-new private slack channel. These forums will bring together operations and
+desire a vendor-agnostic space to discuss adopting OpenTelemetry, so we provide
+multiple ways for you to connect with other users of the project and share best
+practices:
+
+* [A synchronous monthly discussion group](/community/end-user/discussion-group/)
+* [A private slack channel](/community/end-user/slack-channel/)
+* [Talks about OTel in practice](/community/end-user/otel-in-practice/)
+
+These forums will bring together operations and
 development engineers from different organizations to discuss challenges and
 solutions to achieving ubiquitous observability. Share successes and failures,
 discover best practices, and meet others who are also on a journey to implement
 observability powered by OpenTelemetry.
 
-### OpenTelemetry In Practice
-
-**OpenTelemetry in Practice** is an experimental **series** of talks initiated
-by some members of the End User Working Group.
-
-We’re aiming to:
-
-- Address practical problems that commonly stop development teams from
-  succeeding with OpenTelemetry
-- Build stronger connections with developers focused on specific languages
-- Improve the experience of implementing OpenTelemetry in production
-
-Each OpenTelemetry in Practice session will include a half hour of lightning
-talks and a half hour of open conversation about the topic. We are looking for
-people to join the OpenTelemetry in Practice team and people to give talks at
-future events. So if you’re interested in shaping these conversations, reach out
-in the
-[#otel-user-research channel](https://cloud-native.slack.com/archives/C01RT3MSWGZ)
-of the [CNCF Slack](https://slack.cncf.io/).
-
-Our first conversation will be on August 23rd, at 10 AM PDT,
-[on Zoom](https://zoom.us/j/5227112777?pwd=TXBqZ3RMWVYxenVGdlk0SFlwMkwwQT09),
-and the topic is Kubernetes & The Collector.
-
-### Monthly Discussion Group
-
-- Monthly hour long sessions via google meet -- all are welcome!
-- We use a [Lean Coffee](https://leancoffee.org/) format where discussion topics
-  are generated and democratically selected by the group at the start of the
-  meeting. Topics are rigorously time-boxed by a facilitator.
-- [Chatham House Rule](https://www.chathamhouse.org/about-us/chatham-house-rule)
-  applies. Meetings will not be recorded.
-- The first AMER friendly meeting is on the [OpenTelemetry calendar](https://github.com/open-telemetry/community#calendar), scheduled for July 14th
-  2022 at 9AM PST. This meeting series is scheduled to repeat every 8 weeks.
-- The first EMEA friendly meeting is on the [OpenTelemetry calendar](https://github.com/open-telemetry/community#calendar), scheduled for August 16th 2022 at 11AM CET. This meeting series is scheduled to repeat every 8 weeks.
-- We intend to alternate months between APAC- and AMER-friendly
-  timezones. We will re-evaluate this plan based on attendance and
-  feedback.
-
-### Slack Channel (#otel-endusers)
-
-- Confirm your agreement with channel [Code of Conduct][] and reach out to Reese
-  Lee or Rynn Mancuso on CNCF slack for an invite to `#otel-endusers`.
-- [Chatham House Rule](https://www.chathamhouse.org/about-us/chatham-house-rule)
-  applies.
-- Troubleshooting or tactical SDK specific questions are still best directed to
-  individual SIG channels or the
-  [#opentelemetry](https://cloud-native.slack.com/archives/CJFCJHG4Q) channel.
-- Vendor specific questions are still best directed to vendor channels, or if it
-  doesn’t exist
-  [#otel-vendor](https://cloud-native.slack.com/archives/C031SAMGV2A)
-
 ### Topics
 
-This group is what its members make it--whatever is of interest to the group is
-fair game! But here are some of the kinds of things we expect will be on the
+This group is what its members make it -- whatever is of interest to the group
+is fair game!
+
+But here are some of the kinds of things we expect will be on the
 table:
 
-- Refactoring with telemetry
-- What is company X doing with OpenTelemetry?
-- Correlating multiple observability signals
-- Maintaining and scaling OpenTelemetry deployments
-- Writing custom instrumentation
+* Refactoring with telemetry
+* What is company X doing with OpenTelemetry?
+* Correlating multiple observability signals
+* Maintaining and scaling OpenTelemetry deployments
+* Writing custom instrumentation
 
 ### Questions
 
@@ -92,7 +47,5 @@ OpenTelemetry.
 You can find members of the End User Working Group in
 [#otel-user-research](https://cloud-native.slack.com/archives/C01RT3MSWGZ).
 
-[code of conduct]:
-  https://github.com/open-telemetry/community/blob/main/working-groups/end-user/discussion-group-code-of-conduct.md
 [opentelemetry end user working group]:
   https://github.com/open-telemetry/community/tree/main/working-groups/end-user

--- a/content/en/community/end-user/_index.md
+++ b/content/en/community/end-user/_index.md
@@ -9,9 +9,9 @@ desire a vendor-agnostic space to discuss adopting OpenTelemetry, so we provide
 multiple ways for you to connect with other users of the project and share best
 practices:
 
-* [A synchronous monthly discussion group](/community/end-user/discussion-group/)
-* [A private slack channel](/community/end-user/slack-channel/)
-* [Talks about OTel in practice](/community/end-user/otel-in-practice/)
+* [A synchronous monthly discussion group](discussion-group/)
+* [A private slack channel](slack-channel/)
+* [Talks about OTel in practice](otel-in-practice/)
 
 These forums will bring together operations and
 development engineers from different organizations to discuss challenges and

--- a/content/en/community/end-user/discussion-group.md
+++ b/content/en/community/end-user/discussion-group.md
@@ -1,0 +1,21 @@
+---
+title: Monthly Discussion Group
+Description: >-
+ Monthly hour long sessions -- all are welcome!
+---
+
+ We use a [Lean Coffee](https://leancoffee.org/) format where discussion topics
+  are generated and democratically selected by the group at the start of the
+  meeting. Topics are rigorously time-boxed by a facilitator.
+
+[Chatham House Rule](https://www.chathamhouse.org/about-us/chatham-house-rule)
+  applies. Meetings will not be recorded.
+
+The first AMER friendly meeting is on the [OpenTelemetry calendar](https://github.com/open-telemetry/community#calendar), scheduled for July 14th
+  2022 at 9AM PST. This meeting series is scheduled to repeat every 8 weeks.
+
+The first EMEA friendly meeting is on the [OpenTelemetry calendar](https://github.com/open-telemetry/community#calendar), scheduled for August 16th 2022 at 11AM CET. This meeting series is scheduled to repeat every 8 weeks.
+
+We intend to alternate months between APAC- and AMER-friendly
+  timezones. We will re-evaluate this plan based on attendance and
+  feedback.

--- a/content/en/community/end-user/discussion-group.md
+++ b/content/en/community/end-user/discussion-group.md
@@ -1,5 +1,6 @@
 ---
 title: Monthly Discussion Group
+linkTitle: Monthly Discussions
 Description: >-
  Monthly hour long sessions -- all are welcome!
 ---

--- a/content/en/community/end-user/otel-in-practice.md
+++ b/content/en/community/end-user/otel-in-practice.md
@@ -1,0 +1,25 @@
+---
+title: OpenTelemetry In Practice
+linkTitle: OTel in Practice
+Description: >- 
+ **OpenTelemetry in Practice** is a **series** of talks initiated
+ by some members of the End User Working Group.
+---
+
+We’re aiming to:
+
+- Address practical problems that commonly stop development teams from
+  succeeding with OpenTelemetry
+- Build stronger connections with developers focused on specific languages
+- Improve the experience of implementing OpenTelemetry in production
+
+Each OpenTelemetry in Practice session will include a half hour of lightning
+talks and a half hour of open conversation about the topic. We are looking for
+people to join the OpenTelemetry in Practice team and people to give talks at
+future events. So if you’re interested in shaping these conversations, reach out
+in the
+[#otel-user-research channel](https://cloud-native.slack.com/archives/C01RT3MSWGZ)
+of the [CNCF Slack](https://slack.cncf.io/).
+
+Join the [OpenTelemetry in Practice Meetup Group](https://www.meetup.com/de-DE/opentelemetry-in-practice-meetup-group/)
+to get invited to our next talk!

--- a/content/en/community/end-user/slack-channel.md
+++ b/content/en/community/end-user/slack-channel.md
@@ -1,0 +1,20 @@
+---
+title: Slack Channel
+Description: >-
+ Join a private slack channel to discuss OpenTelemetry with other endusers.
+---
+
+- Confirm your agreement with channel [Code of Conduct][] and reach out to Reese
+  Lee or Rynn Mancuso on CNCF slack for an invite to `#otel-endusers`.
+- [Chatham House Rule](https://www.chathamhouse.org/about-us/chatham-house-rule)
+  applies.
+- Troubleshooting or tactical SDK specific questions are still best directed to
+  individual SIG channels or the
+  [#opentelemetry](https://cloud-native.slack.com/archives/CJFCJHG4Q) channel.
+- Vendor specific questions are still best directed to vendor channels, or if it
+  doesn’t exist
+  [#otel-vendor](https://cloud-native.slack.com/archives/C031SAMGV2A)
+
+
+[code of conduct]:
+  https://github.com/open-telemetry/community/blob/main/working-groups/end-user/discussion-group-code-of-conduct.md


### PR DESCRIPTION
I thought it would look better in the /community if the content for the end user forums is in sub-pages, let me know what you think

https://deploy-preview-1872--opentelemetry.netlify.app/community/end-user/