### PR TITLE
Add JS shortcode support for index page

### DIFF
--- a/content/en/docs/instrumentation/js/_index.md
+++ b/content/en/docs/instrumentation/js/_index.md
@@ -10,9 +10,16 @@ spelling: cSpell:ignore Roadmap
 weight: 20
 ---
 
-This page contains an introduction to OpenTelemetry in JavaScript. This guide
-will walk you through installation and instrumentation and show you how to
-export data.
+<!--
+You can see & update the `lang_instrumentation_index_head` shortcode in
+/layouts/shortcodes/lang_instrumentation_index_head.md
+
+The data (name, status) is located at
+/data/instrumentation.yaml
+-->
+{{% lang_instrumentation_index_head "js" %}}
+
+{{% /lang_instrumentation_index_head %}}
 
 ## Status and Releases
 

--- a/content/en/docs/instrumentation/js/_index.md
+++ b/content/en/docs/instrumentation/js/_index.md
@@ -12,16 +12,6 @@ weight: 20
 
 {{% lang_instrumentation_index_head "js" /%}}
 
-## Status and Releases
-
-| Signal  | API Status        | SDK Status        |
-| ------- | ----------------- | ----------------- |
-| Traces  | Stable            | Stable            |
-| Metrics | Release Candidate | Release Candidate |
-| Logs    | Development       | Development       |
-
-{{% latest_release "js" /%}}
-
 ## Further Reading
 
 - [OpenTelemetry for JavaScript on GitHub](https://github.com/open-telemetry/opentelemetry-js)

--- a/content/en/docs/instrumentation/js/_index.md
+++ b/content/en/docs/instrumentation/js/_index.md
@@ -10,16 +10,7 @@ spelling: cSpell:ignore Roadmap
 weight: 20
 ---
 
-<!--
-You can see & update the `lang_instrumentation_index_head` shortcode in
-/layouts/shortcodes/lang_instrumentation_index_head.md
-
-The data (name, status) is located at
-/data/instrumentation.yaml
--->
-{{% lang_instrumentation_index_head "js" %}}
-
-{{% /lang_instrumentation_index_head %}}
+{{% lang_instrumentation_index_head "js" /%}}
 
 ## Status and Releases
 

--- a/data/instrumentation.yaml
+++ b/data/instrumentation.yaml
@@ -47,11 +47,11 @@ languages:
       traces: stable
       metrics: not yet implemented
       logs: not yet implemented
-  ruby:
-    name: Ruby
+  js:
+    name: JavaScript
     status:
       traces: stable
-      metrics: not yet implemented
+      metrics: Release Candidate
       logs: not yet implemented
   rust:
     name: Rust

--- a/data/instrumentation.yaml
+++ b/data/instrumentation.yaml
@@ -52,7 +52,7 @@ languages:
     status:
       traces: stable
       metrics: Release Candidate
-      logs: not yet implemented
+      logs: Development
   rust:
     name: Rust
     status:


### PR DESCRIPTION
This brings the JS index page up to par with the others, also addressing https://github.com/open-telemetry/opentelemetry.io/issues/1777 in the process

Preview: https://deploy-preview-1884--opentelemetry.netlify.app/docs/instrumentation/js/