### PR TITLE
Add a script to scan registry repo urls.

### DIFF
--- a/scripts/check-registry-urls
+++ b/scripts/check-registry-urls
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+REPO_DIR=$(dirname $0)/..
+
+REGISTRY_FILES=$REPO_DIR/content/en/registry/*
+
+for FILE in ${REGISTRY_FILES} ; do
+    REPO_URL=$(grep "repo: " ${FILE})
+    REPO_URL=${REPO_URL#repo: }
+    if [ -n "${REPO_URL}" ] ; then
+        RESULT=$(curl -I -s "{$REPO_URL}" -o /dev/null -w "%{http_code}")
+        if [ "${RESULT}" != "200" ] ; then
+            echo -e "- [ ] $(basename ${FILE}): ${REPO_URL}, error ${RESULT}"
+        fi
+    fi
+done


### PR DESCRIPTION
Nothing to fancy, just a small script that outputs a list of URLs in the registry that are not working which can be copied into a github issue (https://github.com/open-telemetry/opentelemetry.io/issues/1895)
 