### PR TITLE
Update Java Examples to external link

### DIFF
--- a/content/en/docs/instrumentation/java/examples.md
+++ b/content/en/docs/instrumentation/java/examples.md
@@ -1,36 +1,9 @@
 ---
 title: Examples
-description: Java instrumentation examples
-aliases:
-  - /docs/java/instrumentation_examples
-  - /docs/instrumentation/java/instrumentation_examples
-weight: 6
+# Note: this is a placeholder page. Attempting to visit this page will
+# redirect to the following URL:
+manualLink: https://github.com/open-telemetry/opentelemetry-java-docs#java-opentelemetry-examples
+manualLinkTarget: _blank
+_build: { render: link }
+weight: 60
 ---
-
-## Manual instrumentation
-
-For fully-functional examples of manual instrumentation, see [Java OpenTelemetry
-Examples][].
-
-## Community Resources
-
-### boot-opentelemetry-tempo
-
-Project demonstrating Complete Observability Stack utilizing
-[Prometheus](https://prometheus.io/), [Loki](https://grafana.com/oss/loki/)
-(_For distributed logging_), [Tempo](https://grafana.com/oss/tempo/) (_For
-Distributed tracing, this basically uses Jaeger Internally_),
-[Grafana](https://grafana.com/grafana/) for **Java/spring** based applications
-(_With OpenTelemetry auto / manual Instrumentation_) involving multiple
-microservices with DB interactions
-
-Checkout
-[boot-opentelemetry-tempo](https://github.com/mnadeem/boot-opentelemetry-tempo)
-and get started
-
-```console
-$ mvn clean package docker:build
-$ docker-compose up
-```
-
-[Java OpenTelemetry Examples]: https://github.com/open-telemetry/opentelemetry-java-docs#java-opentelemetry-examples

--- a/content/en/docs/instrumentation/java/getting-started.md
+++ b/content/en/docs/instrumentation/java/getting-started.md
@@ -139,7 +139,7 @@ For more:
 - Run this example with another [exporter][] for telemetry data.
 - Try [automatic instrumentation](../automatic/) on one of your own apps.
 - For light-weight customized telemetry, try [annotations][].
-- Learn about [manual instrumentation][] and try out more [examples](../examples).
+- Learn about [manual instrumentation][] and try out more [examples](https://github.com/open-telemetry/opentelemetry-java-docs#java-opentelemetry-examples).
 
 [annotations]: ../automatic/annotations
 [configure the Java agent]: ../automatic/#configuring-the-agent


### PR DESCRIPTION
Following the example from [Go](https://opentelemetry.io/docs/instrumentation/go/)
This will remove the "Community Resources", which has exactly 1 entry for a really long time, which I find looks a little bit odd. 
