### PR TITLE
Make .../api and .../example valid paths (Java)

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -5,3 +5,5 @@ IgnoreInternalURLs:
   # TODO: fix the source of these inlined TOC links
   # https://github.com/open-telemetry/opentelemetry.io/issues/1357
   - /docs/reference/specification/versioning-and-stability/#not-defined-semantic-conventions-stability
+IgnoreURLs:
+  - (/docs/instrumentation/java|..)/(api|examples)/

--- a/content/en/docs/instrumentation/java/api.md
+++ b/content/en/docs/instrumentation/java/api.md
@@ -1,9 +1,7 @@
 ---
 title: API reference
 linkTitle: API
-# Note: this is a placeholder page. Attempting to visit this page will
-# redirect to the following URL:
-manualLink: https://javadoc.io/doc/io.opentelemetry
+redirect: https://javadoc.io/doc/io.opentelemetry
 manualLinkTarget: _blank
 _build: { render: link }
 weight: 50

--- a/content/en/docs/instrumentation/java/examples.md
+++ b/content/en/docs/instrumentation/java/examples.md
@@ -1,14 +1,10 @@
 ---
 title: Examples
-# This is a placeholder page that redirects to the following link
-manualLink: https://github.com/open-telemetry/opentelemetry-java-docs#java-opentelemetry-examples
+redirect: https://github.com/open-telemetry/opentelemetry-java-docs#java-opentelemetry-examples
 manualLinkTarget: _blank
 aliases:
   - /docs/java/instrumentation_examples
   - /docs/instrumentation/java/instrumentation_examples
-# TODO(@chalin): ideally, the `_build` config below should be uncommented so that
-# the placeholder page doesn't actually get generated, but that can cause our
-# simple non-redirect-rule-aware link checker to falsely report a 404.
-# _build: { render: link }
+_build: { render: link }
 weight: 60
 ---

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -2,17 +2,15 @@
 {{/* cSpell:ignore wordmark */ -}}
 
 {{ range $p := .Site.Pages -}}
-{{ with .Aliases -}}
 
-{{ range $alias := . -}}
-  {{ $alias | printf "%-35s" }} {{ $p.RelPermalink }}
+{{ range $p.Aliases -}}
+  {{ . | printf "%-35s" }} {{ $p.RelPermalink }}
 {{ end -}}
 
-{{ with $p.Params.manualLink -}}
-  {{ $p.RelPermalink }} {{ . }} 301!
+{{ with $p.Params.redirect -}}
+  {{ $p.RelPermalink | printf "%-35s" }} {{ . }}
 {{ end -}}
 
-{{ end }}{{/* with .Aliases */ -}}
 {{ end }}{{/* range $p */ -}}
 
 {{ $languages := (.Site.GetPage "/docs/instrumentation").Pages -}}


### PR DESCRIPTION
For a **detailed explanation of this feature, see** https://github.com/open-telemetry/opentelemetry.io/issues/1914#issuecomment-1291246238

- Contributes to #1914 for Java
- Followup to #1910

---

**Preview**: https://deploy-preview-1915--opentelemetry.netlify.app/docs/instrumentation/java/

**Redirect tests**:

- Placeholder pages:

  - https://deploy-preview-1915--opentelemetry.netlify.app/docs/java/api/
  - https://deploy-preview-1915--opentelemetry.netlify.app/docs/java/examples/

- Aliases, whose redirects should still work:

  - https://deploy-preview-1915--opentelemetry.netlify.app/docs/java/instrumentation_examples
  - https://deploy-preview-1915--opentelemetry.netlify.app/docs/instrumentation/java/instrumentation_examples