### PR TITLE
Add API and Examples to C++ sidenav

### DIFF
--- a/content/en/docs/instrumentation/cpp/_index.md
+++ b/content/en/docs/instrumentation/cpp/_index.md
@@ -7,22 +7,9 @@ description: >
   alt="C++"></img> A language-specific implementation of OpenTelemetry in C++.
 ---
 
-<!--
-You can see & update the `lang_instrumentation_index_head` shortcode in
-/layouts/shortcodes/lang_instrumentation_index_head.md
-
-The data (name, status) is located at
-/data/instrumentation.yaml
--->
-
 {{% lang_instrumentation_index_head "cpp" /%}}
 
-## Further Reading
+## Repositories
 
-- [OpenTelemetry for C++ on GitHub](https://github.com/open-telemetry/opentelemetry-cpp)
-- [Examples](https://github.com/open-telemetry/opentelemetry-cpp/tree/main/examples)
-- [Documentation](https://opentelemetry-cpp.readthedocs.io/en/latest/)
-  - [Overview](https://opentelemetry-cpp.readthedocs.io/en/latest/api/Overview.html)
-  - [Instrumenting code](https://opentelemetry-cpp.readthedocs.io/en/latest/api/GettingStarted.html)
-  - [Configuring the SDK](https://opentelemetry-cpp.readthedocs.io/en/latest/sdk/GettingStarted.html#tracerprovider)
-  - [Exporters](https://opentelemetry-cpp.readthedocs.io/en/latest/sdk/GettingStarted.html#exporter)
+- Main: [opentelemetry-cpp](https://github.com/open-telemetry/opentelemetry-cpp)
+- Contrib: [opentelemetry-cpp-contrib](https://github.com/open-telemetry/opentelemetry-cpp-contrib)

--- a/content/en/docs/instrumentation/cpp/api.md
+++ b/content/en/docs/instrumentation/cpp/api.md
@@ -1,0 +1,8 @@
+---
+title: API reference
+linkTitle: API
+redirect: https://opentelemetry-cpp.readthedocs.io/en/latest/
+manualLinkTarget: _blank
+_build: { render: link }
+weight: 50
+---

--- a/content/en/docs/instrumentation/cpp/examples.md
+++ b/content/en/docs/instrumentation/cpp/examples.md
@@ -1,0 +1,7 @@
+---
+title: Examples
+redirect: https://github.com/open-telemetry/opentelemetry-cpp/tree/main/examples
+manualLinkTarget: _blank
+_build: { render: link }
+weight: 60
+---

--- a/content/en/docs/instrumentation/cpp/getting-started.md
+++ b/content/en/docs/instrumentation/cpp/getting-started.md
@@ -1,5 +1,5 @@
 ---
-title: "Getting Started"
+title: Getting Started
 weight: 2
 ---
 


### PR DESCRIPTION
- Adds API and Examples to C++ sidenav and as main-page sections.
- Contributes to #1808
- Replaces previous "further reading" section (since it mainly linked to the API reference and Examples, and these are now separate links in the sidnav and subsections at the bottom of the page) by **Repositories** section
  - Also adds a link to contrib repo

Preview:

- https://deploy-preview-1928--opentelemetry.netlify.app/docs/instrumentation/cpp/

Redirect tests:

- https://deploy-preview-1928--opentelemetry.netlify.app/docs/instrumentation/cpp/api
- https://deploy-preview-1928--opentelemetry.netlify.app/docs/instrumentation/cpp/examples

Screenshot:

> <img width="800" alt="Screen Shot 2022-10-26 at 19 58 10" src="https://user-images.githubusercontent.com/4140793/198160657-4fe9ac1b-6777-4e7c-9023-5129d07b9124.png">
