### PR TITLE
Improve linkTitles for .NET

### DIFF
--- a/content/en/docs/instrumentation/net/exporters.md
+++ b/content/en/docs/instrumentation/net/exporters.md
@@ -1,5 +1,5 @@
 ---
-title: "Exporters"
+title: Exporters
 weight: 4
 ---
 
@@ -106,7 +106,7 @@ If you are using .NET 5 or higher, the previous code sample is not required.
 
 ### Jaeger
 
-To try out the OTLP exporter, you can run [Jaeger](https://www.jaegertracing.io/) 
+To try out the OTLP exporter, you can run [Jaeger](https://www.jaegertracing.io/)
 as an OTLP endpoint and for trace visualization in a docker container:
 
 ```shell

--- a/content/en/docs/instrumentation/net/framework-config.md
+++ b/content/en/docs/instrumentation/net/framework-config.md
@@ -1,6 +1,7 @@
 ---
-title: ".NET Framework instrumentation configuration"
-linkTitle: ".NET Framework"
+title: .NET Framework instrumentation configuration
+linkTitle: Framework config
+aliases: [/docs/instrumentation/net/netframework]
 weight: 5
 ---
 
@@ -50,7 +51,7 @@ public class WebApiApplication : HttpApplication
     {
         _tracerProvider = Sdk.CreateTracerProviderBuilder()
             .AddAspNetInstrumentation()
-            
+
             // Other configuration, like adding an exporter and setting resources
             .AddConsoleExporter()
             .AddSource("my-service-name")

--- a/content/en/docs/instrumentation/net/netframework.md
+++ b/content/en/docs/instrumentation/net/netframework.md
@@ -1,7 +1,6 @@
 ---
 title: .NET Framework instrumentation configuration
-linkTitle: Framework config
-aliases: [/docs/instrumentation/net/netframework]
+linkTitle: .NET Framework
 weight: 5
 ---
 

--- a/content/en/docs/instrumentation/net/resources.md
+++ b/content/en/docs/instrumentation/net/resources.md
@@ -1,7 +1,6 @@
 ---
-title: "Resources"
+title: Resources
 weight: 6
-description:
 ---
 
 A [resource][] represents the entity producing telemetry as resource attributes.
@@ -12,7 +11,7 @@ three of these attributes can be included in the resource.
 In your observability backend, you can use resource information to better
 investigate interesting behavior. For example, if your trace or metrics data
 indicate latency in your system, you can narrow it down to a specific container,
-pod, or kubernetes deployment.
+pod, or Kubernetes deployment.
 
 ## Setup
 

--- a/content/en/docs/instrumentation/net/shim.md
+++ b/content/en/docs/instrumentation/net/shim.md
@@ -1,6 +1,6 @@
 ---
 title: OpenTelemetry Tracing Shim
-linkTitle: OpenTelemetry API Shim
+linkTitle: Tracing Shim
 weight: 5
 ---
 
@@ -167,7 +167,7 @@ If you're not using ASP.NET Core or would rather not inject an instance of a
 var tracer = tracerProvider.GetTracer(serviceName);
 
 // Assign it somewhere globally
- 
+
 //...
 ```
 


### PR DESCRIPTION
The original intent of this PR was to propose improved linkTitles (that show up in the sidenav) for two pages. Here are the linkTitle changes

- _.NET Framework instrumentation configuration_
  - Old linkTitle: .NET Framework
  - New linkTitle: Framework config
  - Rational: we're already under the .NET section so the prefix ".NET" isn't that helpful in a short linkTitle. Added config to the linkTitle (and renamed the page to match), since that's what the page seems to be about
- _OpenTelemetry Tracing Shim_
  - Old linkTitle: OpenTelemetry API Shim
  - New linkTitle: Tracing Shim
  - Rational: the entire site is about OTel so the prefix "OpenTelemetry" isn't that helpful. "Tracing Shim" seems like the most appropriate short title.

Also did other minor front-matter cleanup and fixed capitalization.