### PR TITLE
Remove "automatic" in distributions page

### DIFF
--- a/content/en/docs/concepts/distributions.md
+++ b/content/en/docs/concepts/distributions.md
@@ -36,10 +36,10 @@ Distributions would broadly fall into the following categories:
 - **"Plus":** These distributions provide the same functionality as upstream
   plus more. Customizations beyond those found in pure distributions would be
   the inclusion of additional components. Examples of this would include
-  automatic instrumentation libraries or vendor exporters not upstreamed to the
+  instrumentation libraries or vendor exporters not upstreamed to the
   OpenTelemetry project.
 - **"Minus":** These distributions provide a reduced set of functionality from
-  upstream. Examples of this would include the removal of automatic
+  upstream. Examples of this would include the removal of 
   instrumentation libraries or receivers/processors/exporters/extensions found
   in the OpenTelemetry Collector project. These distributions may be provided to
   increase supportability and security considerations.


### PR DESCRIPTION
The term "automatic instrumentation libraries" is misleading, so I removed the "automatic"