### PR TITLE
More style tweaks for links over dark bg

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -110,28 +110,31 @@
     font-size: 18px;
     margin-bottom: 0;
   }
+
   img {
     margin-top: 1rem;
     width: 20rem;
     max-width: 80%;
   }
+
+  a.external-link:after {
+    display: none;
+  }
 }
 
-.td-box--dark p > a {
-  color: #92b5e7;
+.td-box--dark a {
+  color: lighten($primary, 25%) !important;
 
   &:hover {
-    color: #92b5e7;
     text-decoration: underline;
   }
 }
 
-.td-box--secondary p > strong > a {
-  color: #18478b;
+.td-box--secondary a {
+  color: darken($primary, 25%) !important;
 
   &:hover {
-    color: #18478b;
-    text-decoration: underline;  
+    text-decoration: underline;
   }
 }
 


### PR DESCRIPTION
- Closes #1866
- Followup to #1916 
- Fixes link-color contrast for Registry page -- see screenshots below
- Makes styling a little les brittle by dropping the `p >` constraint and using `lighten/darken` functions over the `$primary` color
- Also removes external-link icons from the CNCF section of the homepage.

Preview:

- https://deploy-preview-1937--opentelemetry.netlify.app
- Preview: https://deploy-preview-1937--opentelemetry.netlify.app/registry/

### Screenshots

Before

> <img width="1052" alt="image" src="https://user-images.githubusercontent.com/4140793/198310033-3a5aa010-38cb-4d4f-8b03-9f08ec4249d0.png">

After

> <img width="1050" alt="image" src="https://user-images.githubusercontent.com/4140793/198310126-9e6007c1-1640-4724-bb83-ca22418c72cb.png">
