### PR TITLE
Add API&Examples link to erlang docs

### DIFF
--- a/content/en/docs/instrumentation/erlang/api.md
+++ b/content/en/docs/instrumentation/erlang/api.md
@@ -1,7 +1,7 @@
 ---
 title: API reference
 linkTitle: API
-redirect: https://hexdocs.pm/opentelemetry_api/1.0.0-rc.2/OpenTelemetry.html
+redirect: https://hexdocs.pm/opentelemetry_api/1.1.1/OpenTelemetry.html
 manualLinkTarget: _blank
 _build: { render: link }
 weight: 50

--- a/content/en/docs/instrumentation/erlang/api.md
+++ b/content/en/docs/instrumentation/erlang/api.md
@@ -1,7 +1,7 @@
 ---
 title: API reference
 linkTitle: API
-redirect: https://hexdocs.pm/opentelemetry_api/1.1.1/OpenTelemetry.html
+redirect: https://hexdocs.pm/opentelemetry_api/OpenTelemetry.html
 manualLinkTarget: _blank
 _build: { render: link }
 weight: 50

--- a/content/en/docs/instrumentation/erlang/api.md
+++ b/content/en/docs/instrumentation/erlang/api.md
@@ -1,0 +1,8 @@
+---
+title: API reference
+linkTitle: API
+redirect: https://hexdocs.pm/opentelemetry_api/1.0.0-rc.2/OpenTelemetry.html
+manualLinkTarget: _blank
+_build: { render: link }
+weight: 50
+---

--- a/content/en/docs/instrumentation/erlang/examples.md
+++ b/content/en/docs/instrumentation/erlang/examples.md
@@ -1,0 +1,7 @@
+---
+title: Examples
+redirect: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/examples
+manualLinkTarget: _blank
+_build: { render: link }
+weight: 60
+---


### PR DESCRIPTION
Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/1808

https://deploy-preview-1943--opentelemetry.netlify.app/docs/instrumentation/erlang/api/
https://deploy-preview-1943--opentelemetry.netlify.app/docs/instrumentation/erlang/examples/

![Screenshot 2022-10-28 at 10 40 50](https://user-images.githubusercontent.com/1519757/198544267-39202902-573f-478b-b497-aaf8d5518ae6.png)
