### PR TITLE
Add DotNet instrumentations to registry (+ fix for otel webserver module)

### DIFF
--- a/content/en/registry/instrumentation-cpp-otel-webserver-module.md
+++ b/content/en/registry/instrumentation-cpp-otel-webserver-module.md
@@ -11,7 +11,7 @@ tags:
   - webserver
 repo: https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/main/instrumentation/otel-webserver-module
 license: Apache 2.0
-description: The OTEL webserver module comprises only Apache webserver module currently. Further support for Nginx webserver would be added in future.
+description: The OTEL webserver module comprises of both Apache and Nginx instrumentation.
 authors: OpenTelemetry Authors
 otVersion: latest
 ---

--- a/content/en/registry/instrumentation-dotnet-aspnet.md
+++ b/content/en/registry/instrumentation-dotnet-aspnet.md
@@ -1,0 +1,15 @@
+---
+title: ASP.NET Instrumentation
+registryType: instrumentation
+isThirdParty: false
+language: dotnet
+tags:
+    - aspnet
+    - instrumentation
+    - dotnet
+repo: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.AspNet
+license: Apache 2.0
+description: This is an Instrumentation Library, which instruments ASP.NET and collect metrics and traces about incoming web requests.
+authors: OpenTelemetry Authors
+otVersion: latest
+---

--- a/content/en/registry/instrumentation-dotnet-aws.md
+++ b/content/en/registry/instrumentation-dotnet-aws.md
@@ -1,0 +1,15 @@
+---
+title: AWS SDK client instrumentation
+registryType: instrumentation
+isThirdParty: false
+language: dotnet
+tags:
+    - instrumentation
+    - instrumentation
+    - dotnet
+repo: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Contrib.Instrumentation.AWS
+license: Apache 2.0
+description: This package provides AWS SDK client instrumentation
+authors: OpenTelemetry Authors
+otVersion: latest
+---

--- a/content/en/registry/instrumentation-dotnet-awslambda.md
+++ b/content/en/registry/instrumentation-dotnet-awslambda.md
@@ -1,0 +1,15 @@
+---
+title: AWS .NET SDK for Lambda
+registryType: instrumentation
+isThirdParty: false
+language: dotnet
+tags:
+    - awslambda
+    - instrumentation
+    - dotnet
+repo: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.AWSLambda
+license: Apache 2.0
+description: This repo contains SDK to instrument Lambda handler to create incoming span.
+authors: OpenTelemetry Authors
+otVersion: latest
+---

--- a/content/en/registry/instrumentation-dotnet-elasticsearchclient.md
+++ b/content/en/registry/instrumentation-dotnet-elasticsearchclient.md
@@ -1,0 +1,15 @@
+---
+title: Elasticsearch Client Instrumentation for OpenTelemetry .NET
+registryType: instrumentation
+isThirdParty: false
+language: dotnet
+tags:
+    - elasticsearchclient
+    - instrumentation
+    - dotnet
+repo: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.ElasticsearchClient
+license: Apache 2.0
+description: Automatically instruments events emitted by the NEST/Elasticsearch.Net client library.
+authors: OpenTelemetry Authors
+otVersion: latest
+---

--- a/content/en/registry/instrumentation-dotnet-entityframeworkcore.md
+++ b/content/en/registry/instrumentation-dotnet-entityframeworkcore.md
@@ -1,0 +1,15 @@
+---
+title: EntityFrameworkCore Instrumentation for OpenTelemetry .NET
+registryType: instrumentation
+isThirdParty: false
+language: dotnet
+tags:
+    - entityframeworkcore
+    - instrumentation
+    - dotnet
+repo: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.EntityFrameworkCore
+license: Apache 2.0
+description: Automatically instruments the outgoing database requests from Microsoft.EntityFrameworkCore.
+authors: OpenTelemetry Authors
+otVersion: latest
+---

--- a/content/en/registry/instrumentation-dotnet-eventcounters.md
+++ b/content/en/registry/instrumentation-dotnet-eventcounters.md
@@ -1,0 +1,15 @@
+---
+title: EventCounters Instrumentation for OpenTelemetry .NET
+registryType: instrumentation
+isThirdParty: false
+language: dotnet
+tags:
+    - eventcounters
+    - instrumentation
+    - dotnet
+repo: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.EventCounters
+license: Apache 2.0
+description: This is an Instrumentation Library , which republishes EventCounters using OpenTelemetry Metrics API.
+authors: OpenTelemetry Authors
+otVersion: latest
+---

--- a/content/en/registry/instrumentation-dotnet-grpccore.md
+++ b/content/en/registry/instrumentation-dotnet-grpccore.md
@@ -1,0 +1,15 @@
+---
+title: gRPC Core-based Client and Server Interceptors for OpenTelemetry .NET
+registryType: instrumentation
+isThirdParty: false
+language: dotnet
+tags:
+    - grpccore
+    - instrumentation
+    - dotnet
+repo: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.GrpcCore
+license: Apache 2.0
+description: Adds OpenTelemetry instrumentation for gRPC Core-based client and server calls.
+authors: OpenTelemetry Authors
+otVersion: latest
+---

--- a/content/en/registry/instrumentation-dotnet-hangfire.md
+++ b/content/en/registry/instrumentation-dotnet-hangfire.md
@@ -1,0 +1,15 @@
+---
+title: Hangfire Instrumentation for OpenTelemetry .NET
+registryType: instrumentation
+isThirdParty: false
+language: dotnet
+tags:
+    - hangfire
+    - instrumentation
+    - dotnet
+repo: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.Hangfire
+license: Apache 2.0
+description: This is an Instrumentation Library, which instruments Hangfire and collects telemetry about BackgroundJob.
+authors: OpenTelemetry Authors
+otVersion: latest
+---

--- a/content/en/registry/instrumentation-dotnet-masstransit.md
+++ b/content/en/registry/instrumentation-dotnet-masstransit.md
@@ -1,0 +1,15 @@
+---
+title: MassTransit Instrumentation for OpenTelemetry .NET
+registryType: instrumentation
+isThirdParty: false
+language: dotnet
+tags:
+    - masstransit
+    - instrumentation
+    - dotnet
+repo: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.MassTransit
+license: Apache 2.0
+description: Automatically instruments DiagnosticSource events emitted by MassTransit library.
+authors: OpenTelemetry Authors
+otVersion: latest
+---

--- a/content/en/registry/instrumentation-dotnet-mysqldata.md
+++ b/content/en/registry/instrumentation-dotnet-mysqldata.md
@@ -1,0 +1,15 @@
+---
+title: MySqlData Instrumentation for OpenTelemetry
+registryType: instrumentation
+isThirdParty: false
+language: dotnet
+tags:
+    - mysqldata
+    - instrumentation
+    - dotnet
+repo: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.MySqlData
+license: Apache 2.0
+description: This is an Instrumentation Library, which instruments MySql.Data and collects telemetry about database operations.
+authors: OpenTelemetry Authors
+otVersion: latest
+---

--- a/content/en/registry/instrumentation-dotnet-owin.md
+++ b/content/en/registry/instrumentation-dotnet-owin.md
@@ -1,0 +1,15 @@
+---
+title: OWIN Instrumentation for OpenTelemetry .NET
+registryType: instrumentation
+isThirdParty: false
+language: dotnet
+tags:
+    - owin
+    - instrumentation
+    - dotnet
+repo: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.Owin
+license: Apache 2.0
+description: This is an Instrumentation Library, which instruments OWIN/Katana and collects telemetry about incoming requests.
+authors: OpenTelemetry Authors
+otVersion: latest
+---

--- a/content/en/registry/instrumentation-dotnet-process.md
+++ b/content/en/registry/instrumentation-dotnet-process.md
@@ -1,0 +1,15 @@
+---
+title: Process Instrumentation for OpenTelemetry .NET
+registryType: instrumentation
+isThirdParty: false
+language: dotnet
+tags:
+    - process
+    - instrumentation
+    - dotnet
+repo: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.Process
+license: Apache 2.0
+description: This is an Instrumentation Library, which instruments .NET and collect telemetry about process behavior.
+authors: OpenTelemetry Authors
+otVersion: latest
+---

--- a/content/en/registry/instrumentation-dotnet-quartz.md
+++ b/content/en/registry/instrumentation-dotnet-quartz.md
@@ -1,0 +1,15 @@
+---
+title: QuartzNET Instrumentation for OpenTelemetry .NET
+registryType: instrumentation
+isThirdParty: false
+language: dotnet
+tags:
+    - quartz
+    - instrumentation
+    - dotnet
+repo: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.Quartz
+license: Apache 2.0
+description: Automatically instruments the Quartz jobs from Quartz.
+authors: OpenTelemetry Authors
+otVersion: latest
+---

--- a/content/en/registry/instrumentation-dotnet-stackexchangeredis.md
+++ b/content/en/registry/instrumentation-dotnet-stackexchangeredis.md
@@ -1,0 +1,15 @@
+---
+title: StackExchange.Redis Instrumentation for OpenTelemetry
+registryType: instrumentation
+isThirdParty: false
+language: dotnet
+tags:
+    - stackexchangeredis
+    - instrumentation
+    - dotnet
+repo: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.StackExchangeRedis
+license: Apache 2.0
+description: This is an Instrumentation Library, which instruments StackExchange.Redis and collects traces about outgoing calls to Redis.
+authors: OpenTelemetry Authors
+otVersion: latest
+---

--- a/content/en/registry/instrumentation-dotnet-wcf.md
+++ b/content/en/registry/instrumentation-dotnet-wcf.md
@@ -1,0 +1,15 @@
+---
+title: WCF Instrumentation for OpenTelemetry .NET
+registryType: instrumentation
+isThirdParty: false
+language: dotnet
+tags:
+    - wcf
+    - instrumentation
+    - dotnet
+repo: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.Wcf
+license: Apache 2.0
+description: Instruments WCF clients and/or services using implementations of IClientMessageInspector and IDispatchMessageInspector respectively.
+authors: OpenTelemetry Authors
+otVersion: latest
+---


### PR DESCRIPTION
DotNet instrumentations to registry.

I also added a small update for the registry entry for otel-webserver-module since it now has nginx support as well, didn't want to have a standalone PR for that.