### PR TITLE
Python: fix API link, add examples to sidenav and repos section

### DIFF
--- a/content/en/docs/instrumentation/python/_index.md
+++ b/content/en/docs/instrumentation/python/_index.md
@@ -61,21 +61,13 @@ $ pip install -e ./opentelemetry-api
 $ pip install -e ./opentelemetry-sdk
 ```
 
-## Learn more
+## Repositories and benchmarks
 
-- [API reference](api)
-  - [Traces API][], [Traces SDK][]
-  - [Metrics API][], [Metrics SDK][]
-  - [Logs API][]
-- [Contrib repository][]
+- Main repo: [opentelemetry-python](https://github.com/open-telemetry/opentelemetry-python)
+- Contrib repo: [opentelemetry-python-contrib][]
 - [Performance benchmarks][]
 
-[Contrib repository]:
+[opentelemetry-python-contrib]:
     https://github.com/open-telemetry/opentelemetry-python-contrib
 [Performance benchmarks]:
     https://open-telemetry.github.io/opentelemetry-python/benchmarks/
-[Metrics API]: https://opentelemetry-python.readthedocs.io/en/stable/api/metrics.html
-[Traces API]: https://opentelemetry-python.readthedocs.io/en/stable/api/trace.html
-[Logs API]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/logs.html
-[Metrics SDK]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/metrics.html
-[Traces SDK]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/trace.html

--- a/content/en/docs/instrumentation/python/_index.md
+++ b/content/en/docs/instrumentation/python/_index.md
@@ -63,18 +63,15 @@ $ pip install -e ./opentelemetry-sdk
 
 ## Learn more
 
-- [API reference][]
+- [API reference](api)
   - [Traces API][], [Traces SDK][]
   - [Metrics API][], [Metrics SDK][]
   - [Logs API][]
-- [Examples][]
 - [Contrib repository][]
 - [Performance benchmarks][]
 
-[API & SDK reference]: https://opentelemetry-python.readthedocs.io/en/stable/
 [Contrib repository]:
     https://github.com/open-telemetry/opentelemetry-python-contrib
-[Examples]: https://opentelemetry-python.readthedocs.io/en/stable/examples/
 [Performance benchmarks]:
     https://open-telemetry.github.io/opentelemetry-python/benchmarks/
 [Metrics API]: https://opentelemetry-python.readthedocs.io/en/stable/api/metrics.html

--- a/content/en/docs/instrumentation/python/examples.md
+++ b/content/en/docs/instrumentation/python/examples.md
@@ -1,0 +1,7 @@
+---
+title: Examples
+redirect: https://opentelemetry-python.readthedocs.io/en/stable/examples/
+manualLinkTarget: _blank
+_build: { render: link }
+weight: 60
+---


### PR DESCRIPTION
- There's an undefined link in the Python landing page, see https://opentelemetry.io/docs/instrumentation/python/#learn-more:

  > <img width="150" alt="image" src="https://user-images.githubusercontent.com/4140793/198607561-b1a0049d-dac5-4431-8289-83e89744a8d0.png">
  
  This PR fixes that by replacing the final "Learn more" section by a "Repositories and benchmarks" section, since this is the pattern we've started to follow for other language SIGs. A link to the API reference is already in the sidenav and subsection TOC (added via #1934).
- Adds "Examples" to sidenav
- Contributes to #1808, which also adds Examples for those SIGs that have them
- Followup to #1934

Preview: https://deploy-preview-1946--opentelemetry.netlify.app/docs/instrumentation/python/

Redirect test: https://deploy-preview-1946--opentelemetry.netlify.app/docs/instrumentation/python/examples

### Screenshot

> <img width="1396" alt="Screen Shot 2022-10-28 at 09 29 55" src="https://user-images.githubusercontent.com/4140793/198611929-dad83116-4bbe-40c9-9379-84b974a44b59.png">

/cc @cartermp @svrnm 

