### PR TITLE
Link-checker ignore-path rule adjustment

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -6,4 +6,4 @@ IgnoreInternalURLs:
   # https://github.com/open-telemetry/opentelemetry.io/issues/1357
   - /docs/reference/specification/versioning-and-stability/#not-defined-semantic-conventions-stability
 IgnoreURLs:
-  - (/docs/instrumentation/java|..)/(api|examples)/
+  - ^/docs/instrumentation/\w+/(api|examples)/$

--- a/content/en/docs/instrumentation/java/getting-started.md
+++ b/content/en/docs/instrumentation/java/getting-started.md
@@ -139,7 +139,7 @@ For more:
 - Run this example with another [exporter][] for telemetry data.
 - Try [automatic instrumentation](../automatic/) on one of your own apps.
 - For light-weight customized telemetry, try [annotations][].
-- Learn about [manual instrumentation][] and try out more [examples](../examples/).
+- Learn about [manual instrumentation][] and try out more [examples]({{% relref examples %}}).
 
 [annotations]: ../automatic/annotations
 [configure the Java agent]: ../automatic/#configuring-the-agent


### PR DESCRIPTION
- Adjusts link-checker ignore-path rule so that it covers all language SIGs over the full path `/docs/instrumentation/<lang>`.
- Drops support for relative paths, opting for use of `relref` instead.