### PR TITLE
Update metrics to stable for otel-cpp

### DIFF
--- a/data/instrumentation.yaml
+++ b/data/instrumentation.yaml
@@ -3,7 +3,7 @@ languages:
     name: C++
     status:
       traces: stable
-      metrics: alpha
+      metrics: stable
       logs: experimental
   dotnet:
     name: .NET


### PR DESCRIPTION
The latest otel-cpp release (https://github.com/open-telemetry/opentelemetry-cpp/releases/tag/v1.7.0) is also the stable release for Metrics. The status is also updated in the otel-cpp repo - https://github.com/open-telemetry/opentelemetry-cpp#project-status