### PR TITLE
Make span kind description softer and closer the the spec

### DIFF
--- a/content/en/docs/concepts/signals/traces.md
+++ b/content/en/docs/concepts/signals/traces.md
@@ -326,7 +326,7 @@ back-end that processes spans can now assign a final status.
 
 ### Span Kind
 
-When a span is created, it is one of `Client`, `Server`, `Internal`, `Producer`, or `Consumer`. This span kind provides a hint to the tracing backend as to how the trace should be assembled. According to the OpenTelemetry specification, the parent of a server span is always a client span, and the child of a client span is always a server span. Similarly, the parent of a consumer span is always a producer and the child of a producer span is always a consumer. If not provided, the span kind is assumed to be internal.
+When a span is created, it is one of `Client`, `Server`, `Internal`, `Producer`, or `Consumer`. This span kind provides a hint to the tracing backend as to how the trace should be assembled. According to the OpenTelemetry specification, the parent of a server span is often a remote client span, and the child of a client span is usually a server span. Similarly, the parent of a consumer span is always a producer and the child of a producer span is always a consumer. If not provided, the span kind is assumed to be internal.
 
 For more information regarding SpanKind, see [SpanKind]({{< relref "/docs/reference/specification/trace/api#spankind" >}}).
 


### PR DESCRIPTION
Spec language is soft in regards to clients/server span relationships:

https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#spankind

Server span does not need to have a parent, it could also be that multiple server instrumentations that are not aware of each other create server->server spans. While not ideal, this is a reality.

Client spans can be nested under other client spans.  E.g.  DB ORM creates a client span and the underlying DB driver creates a client span. They are unaware of each other and have no knowledge if they are both enabled in the same application.