### PR TITLE
Specification: handle spec-local paths into experimental directory

### DIFF
--- a/scripts/adjust-spec-pages.pl
+++ b/scripts/adjust-spec-pages.pl
@@ -98,6 +98,9 @@ while(<>) {
   s|\.\.\/README.md\b|..| if $ARGV =~ /specification.library-guidelines.md/;
   s|\bREADME.md\b|_index.md|g;
 
+  # Rewrite paths into experimental directory as external links
+  s|(\.\.\/)+(experimental\/[^)]+)|https://github.com/open-telemetry/opentelemetry-specification/tree/main/$1|g;
+
   # Rewrite inline links
   s|\]\(([^:\)]*?\.md(#.*?)?)\)|]({{% relref "$1" %}})|g;
 


### PR DESCRIPTION
- https://github.com/open-telemetry/opentelemetry-specification/pull/2925 is ready, but attempting to build the spec in the context of the website is currently failing for #1977 as can be seen from this build log:
  - https://app.netlify.com/sites/opentelemetry/deploys/636ab38fc9bcfb000a4b90ab:
    ```nocode
    2:53:14 PM: ERROR 2022/11/08 19:53:14 [en] REF_NOT_FOUND: Ref "../../experimental/serialization/json.md": "/opt/build/repo/tmp/specification/logs/data-model.md:431:27": page not found
    2:53:16 PM: Error: Error building site: logged 1 error(s)
    ```
 
The problem is that the spec page has a link defined via a local path that points _outside_ of the specification. Hence, such links need to be encoded as a full URL to the corresponding page. This PR fixes such links for paths that refer to the `experimental` folder.

I've checked that this change has no impact on the generated site pages, built from the spec v1.14; and that it fixes the issue for v1.15.0 of the spec.

/cc @tigrannajaryan @carlosalberto @cartermp @svrnm 
