### PR TITLE
Drop temporary spec redirect rule

### DIFF
--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -29,6 +29,3 @@
 {{ $og_image_current := `/img/social/logo-wordmark-001.png` -}}
 
 /featured-background.jpg  {{ $og_image_current }} {{/* homepage og:image used prior to 2022/08 */}}
-
-{{/* Temporary until alias is added to spec - https://github.com/open-telemetry/opentelemetry.io/issues/1850 */ -}}
-/docs/reference/specification/metrics/datamodel  /docs/reference/specification/metrics/data-model


### PR DESCRIPTION
- Closes #1850 since the rule is now being added via an alias in the appropriate spec page:

```console
$ (cd public; g diff )
diff --git a/_redirects b/_redirects
index aaabcc33..784ac0fa 100644
--- a/_redirects
+++ b/_redirects
@@ -97,5 +97,3 @@
 /docs/swift   /docs/instrumentation/swift
 /docs/swift/*  /docs/instrumentation/swift/:splat
 /featured-background.jpg  /img/social/logo-wordmark-001.png 
-
-/docs/reference/specification/metrics/datamodel  /docs/reference/specification/metrics/data-model
$ grep datamodel public/_redirects # This is the rule added via the spec aliases entry
/docs/reference/specification/metrics/datamodel /docs/reference/specification/metrics/data-model/
```

/cc @tigrannajaryan @carlosalberto @svrnm 