### PR TITLE
Fix verb about setup and set up

### DIFF
--- a/content/en/docs/collector/_index.md
+++ b/content/en/docs/collector/_index.md
@@ -37,7 +37,7 @@ Also, in a development or small-scale environment you can get decent results wit
 However, in general we recommend using a collector alongside your service, since it allows your service to offload data quickly and the collector
 can take care of additional handling like retries, batching, encryption or even sensitive data filtering.
 
-It is also easier to [setup a collector](./getting-started) than you might think: the default OTLP exporters in each language assume a local collector endpoint, so you'd start up a collector and you'd just start getting telemetry.
+It is also easier to [set up a collector](./getting-started) than you might think: the default OTLP exporters in each language assume a local collector endpoint, so you'd start up a collector and you'd just start getting telemetry.
 
 ## Status and releases
 

--- a/content/en/docs/collector/trace-receiver.md
+++ b/content/en/docs/collector/trace-receiver.md
@@ -70,7 +70,7 @@ docker run -d --name jaeger \
   jaegertracing/all-in-one:1.29
 ```
 
-Now, create a `config.yaml` file so you can setup your Collector's components.
+Now, create a `config.yaml` file so you can set up your Collector's components.
 
 ```cmd
 cd dev-otelcol
@@ -111,7 +111,7 @@ Notice that I am only using the `insecure` flag in my `jaeger` receiver config
 to make my local development setup easier; you should not use this flag when
 running your collector in production.
 
-In order to verify that your initial pipeline is properly setup, you should have
+In order to verify that your initial pipeline is properly set up, you should have
 the following output after running your `dev-otelcol` command:
 
 ```cmd

--- a/content/en/docs/getting-started/ops.md
+++ b/content/en/docs/getting-started/ops.md
@@ -14,8 +14,8 @@ learn the following:
 
 - [What is OpenTelemetry?](/docs/concepts/what-is-opentelemetry/)
 - [How can I instrument applications without touching their code?](/docs/concepts/instrumenting/#automatic-instrumentation)
-- [How can I setup a collector?](/docs/collector)
-- [How you can get automation for Kubernetes with the OpenTelemetry Operator?](/docs/k8s-operator)
+- [How can I set up a collector?](/docs/collector)
+- [How can I get automation for Kubernetes with the OpenTelemetry Operator?](/docs/k8s-operator)
 
 If you are looking for a set of applications to try things out, you will find
 our official

--- a/content/en/docs/instrumentation/js/resources.md
+++ b/content/en/docs/instrumentation/js/resources.md
@@ -14,7 +14,7 @@ investigate interesting behavior. For example, if your trace or metrics data
 indicate latency in your system, you can narrow it down to a specific container,
 pod, or kubernetes deployment.
 
-Below you will find some introductions on how to setup resource detection with
+Below you will find some introductions on how to set up resource detection with
 the Node.JS SDK.
 
 ## Setup

--- a/content/en/docs/instrumentation/net/manual.md
+++ b/content/en/docs/instrumentation/net/manual.md
@@ -371,7 +371,7 @@ catch (Exception ex)
 
 ## Next steps
 
-After you've setup manual instrumentation, you may want to use [instrumentation
+After you've set up manual instrumentation, you may want to use [instrumentation
 libraries](../libraries/). As the name suggests, they will
 instrument relevant libraries you're using and generate spans (activities) for things like
 inbound and outbound HTTP requests and more.

--- a/content/en/docs/instrumentation/python/distro.md
+++ b/content/en/docs/instrumentation/python/distro.md
@@ -23,7 +23,7 @@ auto-instrumentation via the `opentelemetry_distro` and
 any other code is executed.
 
 In order to automatically export data from OpenTelemetry to the OpenTelemetry
-collector, installing the package will setup all the required entry points.
+collector, installing the package will set up all the required entry points.
 
 ```console
 $ pip install opentelemetry-distro[otlp] opentelemetry-instrumentation


### PR DESCRIPTION
Find some typos about setup and set up.

- `setup`: a noun (e.g., it was a setup!) or an adjective (e.g., follow the setup instructions). 
- `set up`: a verb, e.g., I will set up my computer.
