### PR TITLE
Bring ruby manual instrumentation docs up to par with rest of languages

### DIFF
--- a/content/en/docs/instrumentation/ruby/getting-started.md
+++ b/content/en/docs/instrumentation/ruby/getting-started.md
@@ -101,4 +101,4 @@ provides a few more features that will allow you gain even deeper insights!
 [manual]: ../manual
 [repository]: https://github.com/open-telemetry/opentelemetry-ruby
 [sdk-env]: {{< relref "/docs/reference/specification/protocol/exporter#configuration-options" >}}
-[Span events]: ../manual#span-events
+[Span events]: ../manual#add-span-events

--- a/content/en/docs/instrumentation/ruby/manual.md
+++ b/content/en/docs/instrumentation/ruby/manual.md
@@ -46,7 +46,7 @@ rescue OpenTelemetry::SDK::ConfigurationError => e
 end
 
 # 'Tracer' can be used throughout your code now
-Tracer = OpenTelemetry.tracer_provider.tracer('<YOUR_TRACER_NAME>')
+MyAppTracer = OpenTelemetry.tracer_provider.tracer('<YOUR_TRACER_NAME>')
 ```
 
 With a `Tracer` acquired, you can manually trace code.
@@ -82,7 +82,7 @@ Typically when you create a new span, you'll want it to be the active/current sp
 require "opentelemetry/sdk"
 
 def do_work()
-  Tracer.in_span("do_work") do |span|
+  MyAppTracer.in_span("do_work") do |span|
     # do some work that the 'do_work' span tracks!
   end
 end
@@ -96,7 +96,7 @@ If you have a distinct sub-operation you’d like to track as a part of another 
 require "opentelemetry/sdk"
 
 def parent_work()
-  Tracer.in_span("parent") do |span|
+  MyAppTracer.in_span("parent") do |span|
     # do some work that the 'parent' span tracks!
 
     child_work()
@@ -106,7 +106,7 @@ def parent_work()
 end
 
 def child_work()
-  Tracer.in_span("child") do |span|
+  MyAppTracer.in_span("child") do |span|
     # do some work that the 'child' span tracks!
 end
 ```
@@ -146,7 +146,7 @@ You can also add attributes to a span as [it's being created](#creating-new-span
 ```ruby
 require "opentelemetry/sdk"
 
-tracer.in_span('foo', attributes: { "hello" => "world", "some.number" => 1024 }) do |span|
+MyAppTracer.in_span('foo', attributes: { "hello" => "world", "some.number" => 1024 }) do |span|
   #  do stuff with the span
 end
 ```
@@ -223,7 +223,7 @@ span_to_link_from = OpenTelemetry::Trace.current_span
 
 link = OpenTelemetry::Trace::Link.new(span_to_link_from.context)
 
-Tracer.in_span("new-span", links: [link])
+MyAppTracer.in_span("new-span", links: [link])
   # do something that 'new_span' tracks
 
   # The link in 'new_span' casually associated it with the previous one,

--- a/content/en/docs/instrumentation/ruby/manual.md
+++ b/content/en/docs/instrumentation/ruby/manual.md
@@ -33,8 +33,8 @@ TracerProvider. If you are using [instrumentation libraries](/docs/instrumentati
 then one will be registered for you.
 
 ```ruby
-# config/initializers/opentelemetry.rb
-require 'opentelemetry/sdk'
+# If in a rails app, this lives in config/initializers/opentelemetry.rb
+require "opentelemetry/sdk"
 
 begin
   OpenTelemetry::SDK.configure do |c|
@@ -58,6 +58,8 @@ With a `Tracer` acquired, you can manually trace code.
 It's very common to add information to the current [span](/docs/concepts/signals/traces#spans-in-opentelemetry) somewhere within your program. To do so, you can get the current span and add [attributes](/docs/concepts/signals/traces#attributes) to it.
 
 ```ruby
+require "opentelemetry/sdk"
+
 def track_extended_warranty(extended_warranty)
   # Get the current span
   current_span = OpenTelemetry::Trace.current_span
@@ -77,6 +79,8 @@ To create a [span](/docs/concepts/signals/traces#spans-in-opentelemetry), you’
 Typically when you create a new span, you'll want it to be the active/current span. To do that, use `in_span`:
 
 ```ruby
+require "opentelemetry/sdk"
+
 def do_work()
   Tracer.in_span("do_work") do |span|
     # do some work that the 'do_work' span tracks!
@@ -89,6 +93,8 @@ end
 If you have a distinct sub-operation you’d like to track as a part of another one, you can create nested [spans](/docs/concepts/signals/traces#spans-in-opentelemetry) to represent the relationship:
 
 ```ruby
+require "opentelemetry/sdk"
+
 def parent_work()
   Tracer.in_span("parent") do |span|
     # do some work that the 'parent' span tracks!
@@ -114,6 +120,8 @@ In the preceding example, two spans are created - named `parent` and `child` - w
 You can use `set_attribute` to add a single attribute to a span:
 
 ```ruby
+require "opentelemetry/sdk"
+
 current_span = OpenTelemetry::Trace.current_span
 
 current_span.set_attribute("animals", ["elephant", "tiger"])
@@ -122,6 +130,8 @@ current_span.set_attribute("animals", ["elephant", "tiger"])
 You can use `add_attributes` to add a map of attributes:
 
 ```ruby
+require "opentelemetry/sdk"
+
 current_span = OpenTelemetry::Trace.current_span
 
 current_span.add_attributes(
@@ -134,6 +144,8 @@ current_span.add_attributes(
 You can also add attributes to a span as [it's being created](#creating-new-spans):
 
 ```ruby
+require "opentelemetry/sdk"
+
 tracer.in_span('foo', attributes: { "hello" => "world", "some.number" => 1024 }) do |span|
   #  do stuff with the span
 end
@@ -175,6 +187,8 @@ current_span.add_attributes(
 A [span event](/docs/concepts/signals/traces#span-events) is a human-readable message on a span that represents "something happening" during it's lifetime. For example, imagine a function that requires exclusive access to a resource that is under a mutex. An event could be created at two points - once, when we try to gain access to the resource, and another when we acquire the mutex.
 
 ```ruby
+require "opentelemetry/sdk"
+
 span = OpenTelemetry::Trace.current_span
 
 span.add_event("Acquiring lock")
@@ -192,7 +206,7 @@ A useful characteristic of events is that their timestamps are displayed as offs
 Events can also have attributes of their own e.g.
 
 ```ruby
-require 'opentelemetry/sdk'
+require "opentelemetry/sdk"
 
 span.add_event("Cancelled wait due to external signal",
   attributes: { "pid" => 4328, "signal" => "SIGHUP" })
@@ -203,6 +217,8 @@ span.add_event("Cancelled wait due to external signal",
 A [span](/docs/concepts/signals/traces#spans-in-opentelemetry) can be created with zero or more [span links](/docs/concepts/signals/traces#span-links) that causally link it to another span. A link needs a [span context](/docs/concepts/signals/traces#span-context) to be created.
 
 ```ruby
+require "opentelemetry/sdk"
+
 span_to_link_from = OpenTelemetry::Trace.current_span
 
 link = OpenTelemetry::Trace::Link.new(span_to_link_from.context)
@@ -231,6 +247,8 @@ A [status](/docs/concepts/signals/traces#span-status) can be set on a [span](/do
 The status can be set at any time before the span is finished:
 
 ```ruby
+require "opentelemetry/sdk"
+
 current_span = OpenTelemetry::Trace.current_span
 
 begin
@@ -245,6 +263,8 @@ end
 It can be a good idea to record exceptions when they happen. It’s recommended to do this in conjunction with [setting span status](#set-span-status).
 
 ```ruby
+require "opentelemetry/sdk"
+
 current_span = OpenTelemetry::Trace.current_span
 
 begin

--- a/content/en/docs/instrumentation/ruby/manual.md
+++ b/content/en/docs/instrumentation/ruby/manual.md
@@ -205,7 +205,7 @@ A [span](/docs/concepts/signals/traces#spans-in-opentelemetry) can be created wi
 ```ruby
 span_to_link_from = OpenTelemetry::Trace.current_span
 
-link = Link.new(span_to_link_from.context)
+link = OpenTelemetry::Trace::Link.new(span_to_link_from.context)
 
 Tracer.in_span("new-span", links: [link])
   # do something that 'new_span' tracks

--- a/content/en/docs/instrumentation/ruby/manual.md
+++ b/content/en/docs/instrumentation/ruby/manual.md
@@ -256,8 +256,8 @@ link = OpenTelemetry::Trace::Link.new(span_to_link_from.context)
 MyAppTracer.in_span("new-span", links: [link])
   # do something that 'new_span' tracks
 
-  # The link in 'new_span' casually associated it with the previous one,
-  # but it is not a child span.
+  # The link in 'new_span' casually associated it with the span it's linked from,
+  # but it is not necessarily a child span.
 end
 ```
 

--- a/content/en/docs/instrumentation/ruby/manual.md
+++ b/content/en/docs/instrumentation/ruby/manual.md
@@ -172,7 +172,7 @@ current_span.add_attributes(
 
 ### Add Span Events
 
-An event is a human-readable message on a span that represents "something happening" during it's lifetime. For example, imagine a function that requires exclusive access to a resource that is under a mutex. An event could be created at two points - once, when we try to gain access to the resource, and another when we acquire the mutex.
+A [span event](docs/concepts/signals/traces#span-events) is a human-readable message on a span that represents "something happening" during it's lifetime. For example, imagine a function that requires exclusive access to a resource that is under a mutex. An event could be created at two points - once, when we try to gain access to the resource, and another when we acquire the mutex.
 
 ```ruby
 span = OpenTelemetry::Trace.current_span
@@ -255,7 +255,7 @@ rescue Exception => ex
 end
 ```
 
-Recording an exception creates a [Span Event](/docs/concepts/signals/traces#span-event) on the current span with a stack trace as an attribute on the span event.
+Recording an exception creates a [Span Event](/docs/concepts/signals/traces#span-events) on the current span with a stack trace as an attribute on the span event.
 
 Exceptions can also be recorded with additional attributes:
 

--- a/content/en/docs/instrumentation/ruby/manual.md
+++ b/content/en/docs/instrumentation/ruby/manual.md
@@ -172,7 +172,7 @@ current_span.add_attributes(
 
 ### Add Span Events
 
-A [span event](docs/concepts/signals/traces#span-events) is a human-readable message on a span that represents "something happening" during it's lifetime. For example, imagine a function that requires exclusive access to a resource that is under a mutex. An event could be created at two points - once, when we try to gain access to the resource, and another when we acquire the mutex.
+A [span event](/docs/concepts/signals/traces#span-events) is a human-readable message on a span that represents "something happening" during it's lifetime. For example, imagine a function that requires exclusive access to a resource that is under a mutex. An event could be created at two points - once, when we try to gain access to the resource, and another when we acquire the mutex.
 
 ```ruby
 span = OpenTelemetry::Trace.current_span

--- a/content/en/docs/instrumentation/ruby/manual.md
+++ b/content/en/docs/instrumentation/ruby/manual.md
@@ -25,8 +25,8 @@ Make sure that `service.name` is set by configuring a service name.
 ### Acquiring a Tracer
 
 To being [tracing](/docs/concepts/signals/traces), you will need to
-ensure you have an initialized [`Tracer`](docs/concepts/signals/traces#tracer) that comes from a
-[`TracerProvider`](docs/concepts/signals/traces#tracer-provider).
+ensure you have an initialized [`Tracer`](/docs/concepts/signals/traces#tracer) that comes from a
+[`TracerProvider`](/docs/concepts/signals/traces#tracer-provider).
 
 The easiest and most common way to do this is to use the globally-registered
 TracerProvider. If you are using [instrumentation libraries](/docs/instrumentation/ruby/automatic),
@@ -200,7 +200,7 @@ span.add_event("Cancelled wait due to external signal",
 
 ### Add Span Links
 
-A [span](/docs/concepts/signals/traces#spans-in-opentelemetry) can be created with zero or more [span links](/docs/concepts/signals/traces#spans-links) that causally link it to another span. A link needs a [span context](/docs/concepts/signals/traces#span-context) to be created.
+A [span](/docs/concepts/signals/traces#spans-in-opentelemetry) can be created with zero or more [span links](/docs/concepts/signals/traces#span-links) that causally link it to another span. A link needs a [span context](/docs/concepts/signals/traces#span-context) to be created.
 
 ```ruby
 span_to_link_from = OpenTelemetry::Trace.current_span
@@ -220,7 +220,7 @@ a long-running task that calls into sub-tasks asynchronously.
 
 ### Set span status
 
-A [status](/docs/concepts/signals/traces#spans-status) can be set on a [span](/docs/concepts/signals/traces#spans-in-opentelemetry), typically used to specify that a span has not completed successfully - StatusCode.ERROR. In rare scenarios, you could override the Error status with StatusCode.OK, but don’t set StatusCode.OK on successfully-completed spans.
+A [status](/docs/concepts/signals/traces#span-status) can be set on a [span](/docs/concepts/signals/traces#spans-in-opentelemetry), typically used to specify that a span has not completed successfully - StatusCode.ERROR. In rare scenarios, you could override the Error status with StatusCode.OK, but don’t set StatusCode.OK on successfully-completed spans.
 
 The status can be set at any time before the span is finished:
 

--- a/content/en/docs/instrumentation/ruby/manual.md
+++ b/content/en/docs/instrumentation/ruby/manual.md
@@ -8,8 +8,11 @@ aliases:
 weight: 4
 ---
 
-Auto-instrumentation is the easiest way to get started with instrumenting your code, but in order to get the most insight into your system, you should add manual instrumentation where appropriate.
-To do this, use the OpenTelemetry SDK to access the currently executing span and add attributes to it, and/or to create new spans.
+Auto-instrumentation is the easiest way to get started with instrumenting your
+code, but in order to get the most insight into your system, you should add
+manual instrumentation where appropriate. To do this, use the OpenTelemetry SDK
+to access the currently executing span and add attributes to it, and/or to
+create new spans.
 
 ## Initializing the SDK
 
@@ -19,18 +22,19 @@ First, ensure you have the SDK package installed:
 gem install opentelemetry-sdk
 ```
 
-Then include configuration code that runs when your program initializes.
-Make sure that `service.name` is set by configuring a service name.
+Then include configuration code that runs when your program initializes. Make
+sure that `service.name` is set by configuring a service name.
 
 ### Acquiring a Tracer
 
-To being [tracing](/docs/concepts/signals/traces), you will need to
-ensure you have an initialized [`Tracer`](/docs/concepts/signals/traces#tracer) that comes from a
-[`TracerProvider`](/docs/concepts/signals/traces#tracer-provider).
+To being [tracing](/docs/concepts/signals/traces), you will need to ensure you
+have an initialized [`Tracer`](/docs/concepts/signals/traces#tracer) that comes
+from a [`TracerProvider`](/docs/concepts/signals/traces#tracer-provider).
 
 The easiest and most common way to do this is to use the globally-registered
-TracerProvider. If you are using [instrumentation libraries](/docs/instrumentation/ruby/automatic),
-then one will be registered for you.
+TracerProvider. If you are using [instrumentation
+libraries](/docs/instrumentation/ruby/automatic), such as in a Rails app, then
+one will be registered for you.
 
 ```ruby
 # If in a rails app, this lives in config/initializers/opentelemetry.rb
@@ -55,7 +59,10 @@ With a `Tracer` acquired, you can manually trace code.
 
 ### Get the current span
 
-It's very common to add information to the current [span](/docs/concepts/signals/traces#spans-in-opentelemetry) somewhere within your program. To do so, you can get the current span and add [attributes](/docs/concepts/signals/traces#attributes) to it.
+It's very common to add information to the current
+[span](/docs/concepts/signals/traces#spans-in-opentelemetry) somewhere within
+your program. To do so, you can get the current span and add
+[attributes](/docs/concepts/signals/traces#attributes) to it.
 
 ```ruby
 require "opentelemetry/sdk"
@@ -74,9 +81,11 @@ end
 
 ### Creating New Spans
 
-To create a [span](/docs/concepts/signals/traces#spans-in-opentelemetry), you’ll need a [configured `Tracer`](#acquiring-a-tracer).
+To create a [span](/docs/concepts/signals/traces#spans-in-opentelemetry), you’ll
+need a [configured `Tracer`](#acquiring-a-tracer).
 
-Typically when you create a new span, you'll want it to be the active/current span. To do that, use `in_span`:
+Typically when you create a new span, you'll want it to be the active/current
+span. To do that, use `in_span`:
 
 ```ruby
 require "opentelemetry/sdk"
@@ -90,7 +99,10 @@ end
 
 ### Creating nested spans
 
-If you have a distinct sub-operation you’d like to track as a part of another one, you can create nested [spans](/docs/concepts/signals/traces#spans-in-opentelemetry) to represent the relationship:
+If you have a distinct sub-operation you’d like to track as a part of another
+one, you can create nested
+[spans](/docs/concepts/signals/traces#spans-in-opentelemetry) to represent the
+relationship:
 
 ```ruby
 require "opentelemetry/sdk"
@@ -111,11 +123,15 @@ def child_work()
 end
 ```
 
-In the preceding example, two spans are created - named `parent` and `child` - with `child` nested under `parent`. If you view a trace with these spans in a trace visualization tool, `child` will be nested under `parent`.
+In the preceding example, two spans are created - named `parent` and `child` -
+with `child` nested under `parent`. If you view a trace with these spans in a
+trace visualization tool, `child` will be nested under `parent`.
 
 ### Add attributes to a span
 
-[Attributes](/docs/concepts/signals/traces#attributes) let you attach key/value pairs to a [span](/docs/concepts/signals/traces#spans-in-opentelemetry) so it carries more information about the current operation that it’s tracking.
+[Attributes](/docs/concepts/signals/traces#attributes) let you attach key/value
+pairs to a [span](/docs/concepts/signals/traces#spans-in-opentelemetry) so it
+carries more information about the current operation that it’s tracking.
 
 You can use `set_attribute` to add a single attribute to a span:
 
@@ -141,7 +157,8 @@ current_span.add_attributes(
   })
 ```
 
-You can also add attributes to a span as [it's being created](#creating-new-spans):
+You can also add attributes to a span as [it's being
+created](#creating-new-spans):
 
 ```ruby
 require "opentelemetry/sdk"
@@ -151,15 +168,23 @@ MyAppTracer.in_span('foo', attributes: { "hello" => "world", "some.number" => 10
 end
 ```
 
-> &#9888; Spans are thread safe data structures that require locks when they are mutated.
-> You should therefore avoid calling `set_attribute` multiple times and instead assign attributes in bulk with a Hash, either during span creation or with `add_attributes` on an existing span.
+> &#9888; Spans are thread safe data structures that require locks when they are
+> mutated. You should therefore avoid calling `set_attribute` multiple times and
+> instead assign attributes in bulk with a Hash, either during span creation or
+> with `add_attributes` on an existing span.
 
-> &#9888; Sampling decisions happen at the moment of span creation.
-> If your sampler considers span attributes when deciding to sample a span, then you _must_ pass those attributes as part of span creation. Any attributes added after creation will not be seen by the sampler, because the sampling decision has already been made.
+> &#9888; Sampling decisions happen at the moment of span creation. If your
+> sampler considers span attributes when deciding to sample a span, then you
+> _must_ pass those attributes as part of span creation. Any attributes added
+> after creation will not be seen by the sampler, because the sampling decision
+> has already been made.
 
 ### Add semantic attributes
 
-[Semantic Attributes][semconv-spec] are pre-defined [Attributes](/docs/concepts/signals/traces#attributes) that are well-known naming conventions for common kinds of data. Using Semantic Attributes lets you normalize this kind of information across your systems.
+[Semantic Attributes][semconv-spec] are pre-defined
+[Attributes](/docs/concepts/signals/traces#attributes) that are well-known
+naming conventions for common kinds of data. Using Semantic Attributes lets you
+normalize this kind of information across your systems.
 
 To use Semantic Attributes in Ruby, add the appropriate gem:
 
@@ -184,7 +209,11 @@ current_span.add_attributes(
 
 ### Add Span Events
 
-A [span event](/docs/concepts/signals/traces#span-events) is a human-readable message on a span that represents "something happening" during it's lifetime. For example, imagine a function that requires exclusive access to a resource that is under a mutex. An event could be created at two points - once, when we try to gain access to the resource, and another when we acquire the mutex.
+A [span event](/docs/concepts/signals/traces#span-events) is a human-readable
+message on a span that represents "something happening" during it's lifetime.
+For example, imagine a function that requires exclusive access to a resource
+that is under a mutex. An event could be created at two points - once, when we
+try to gain access to the resource, and another when we acquire the mutex.
 
 ```ruby
 require "opentelemetry/sdk"
@@ -201,7 +230,9 @@ else
 end
 ```
 
-A useful characteristic of events is that their timestamps are displayed as offsets from the beginning of the span, allowing you to easily see how much time elapsed between them.
+A useful characteristic of events is that their timestamps are displayed as
+offsets from the beginning of the span, allowing you to easily see how much time
+elapsed between them.
 
 Events can also have attributes of their own e.g.
 
@@ -214,7 +245,10 @@ span.add_event("Cancelled wait due to external signal",
 
 ### Add Span Links
 
-A [span](/docs/concepts/signals/traces#spans-in-opentelemetry) can be created with zero or more [span links](/docs/concepts/signals/traces#span-links) that causally link it to another span. A link needs a [span context](/docs/concepts/signals/traces#span-context) to be created.
+A [span](/docs/concepts/signals/traces#spans-in-opentelemetry) can be created
+with zero or more [span links](/docs/concepts/signals/traces#span-links) that
+causally link it to another span. A link needs a [span
+context](/docs/concepts/signals/traces#span-context) to be created.
 
 ```ruby
 require "opentelemetry/sdk"
@@ -231,8 +265,8 @@ MyAppTracer.in_span("new-span", links: [link])
 end
 ```
 
-Span Links are often used to link together different traces that are related in some way, such as
-a long-running task that calls into sub-tasks asynchronously.
+Span Links are often used to link together different traces that are related in
+some way, such as a long-running task that calls into sub-tasks asynchronously.
 
 Links can also be created with additional attributes:
 
@@ -242,7 +276,11 @@ link = OpenTelemetry::Trace::Link.new(span_to_link_from.context, attributes: { "
 
 ### Set span status
 
-A [status](/docs/concepts/signals/traces#span-status) can be set on a [span](/docs/concepts/signals/traces#spans-in-opentelemetry), typically used to specify that a span has not completed successfully - StatusCode.ERROR. In rare scenarios, you could override the Error status with StatusCode.OK, but don’t set StatusCode.OK on successfully-completed spans.
+A [status](/docs/concepts/signals/traces#span-status) can be set on a
+[span](/docs/concepts/signals/traces#spans-in-opentelemetry), typically used to
+specify that a span has not completed successfully - StatusCode.ERROR. In rare
+scenarios, you could override the Error status with StatusCode.OK, but don’t set
+StatusCode.OK on successfully-completed spans.
 
 The status can be set at any time before the span is finished:
 
@@ -260,7 +298,8 @@ end
 
 ### Record exceptions in spans
 
-It can be a good idea to record exceptions when they happen. It’s recommended to do this in conjunction with [setting span status](#set-span-status).
+It can be a good idea to record exceptions when they happen. It’s recommended to
+do this in conjunction with [setting span status](#set-span-status).
 
 ```ruby
 require "opentelemetry/sdk"
@@ -275,7 +314,9 @@ rescue Exception => ex
 end
 ```
 
-Recording an exception creates a [Span Event](/docs/concepts/signals/traces#span-events) on the current span with a stack trace as an attribute on the span event.
+Recording an exception creates a [Span
+Event](/docs/concepts/signals/traces#span-events) on the current span with a
+stack trace as an attribute on the span event.
 
 Exceptions can also be recorded with additional attributes:
 
@@ -285,30 +326,43 @@ current_span.record_exception(ex, attributes: { "some.attribute" => 12 })
 
 ## Context Propagation
 
-> Distributed Tracing tracks the progression of a single Request, called a Trace, as it is handled by Services that make up an Application. A Distributed Trace transverses process, network and security boundaries. [Glossary][]
+> Distributed Tracing tracks the progression of a single Request, called a
+> Trace, as it is handled by Services that make up an Application. A Distributed
+> Trace transverses process, network and security boundaries. [Glossary][]
 
-This requires _context propagation_, a mechanism where identifiers for a trace are sent to remote processes.
+This requires _context propagation_, a mechanism where identifiers for a trace
+are sent to remote processes.
 
-> &#8505; The OpenTelemetry Ruby SDK will take care of context propagation as long as your service is leveraging auto-instrumented libraries. Please refer to the [README][auto-instrumentation] for more details.
+> &#8505; The OpenTelemetry Ruby SDK will take care of context propagation as
+> long as your service is leveraging auto-instrumented libraries. Please refer
+> to the [README][auto-instrumentation] for more details.
 
-In order to propagate trace context over the wire, a propagator must be registered with the OpenTelemetry SDK.
-The W3 TraceContext and Baggage propagators are configured by default.
-Operators may override this value by setting `OTEL_PROPAGATORS` environment variable to a comma separated list of [propagators][propagators].
-For example, to add B3 propagation, set `OTEL_PROPAGATORS` to the complete list of propagation formats you wish to support:
+In order to propagate trace context over the wire, a propagator must be
+registered with the OpenTelemetry SDK. The W3 TraceContext and Baggage
+propagators are configured by default. Operators may override this value by
+setting `OTEL_PROPAGATORS` environment variable to a comma separated list of
+[propagators][propagators]. For example, to add B3 propagation, set
+`OTEL_PROPAGATORS` to the complete list of propagation formats you wish to
+support:
 
 ```sh
 export OTEL_PROPAGATORS=tracecontext,baggage,b3
 ```
 
-Propagators other than `tracecontext` and `baggage` must be added as gem dependencies to your Gemfile, e.g.:
+Propagators other than `tracecontext` and `baggage` must be added as gem
+dependencies to your Gemfile, e.g.:
 
 ```ruby
 gem 'opentelemetry-propagator-b3'
 ```
 
 [glossary]: /docs/concepts/glossary/
-[propagators]: https://github.com/open-telemetry/opentelemetry-ruby/tree/main/propagator
-[auto-instrumentation]: https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation
-[semconv-gem]: https://github.com/open-telemetry/opentelemetry-ruby/tree/main/semantic_conventions
-[semconv-spec]: {{< relref "/docs/reference/specification/trace/semantic_conventions" >}}
+[propagators]:
+    https://github.com/open-telemetry/opentelemetry-ruby/tree/main/propagator
+[auto-instrumentation]:
+    https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation
+[semconv-gem]:
+    https://github.com/open-telemetry/opentelemetry-ruby/tree/main/semantic_conventions
+[semconv-spec]: {{< relref
+    "/docs/reference/specification/trace/semantic_conventions" >}}
 [OpenTelemetry Specification]: {{< relref "/docs/reference/specification" >}}

--- a/content/en/docs/instrumentation/ruby/manual.md
+++ b/content/en/docs/instrumentation/ruby/manual.md
@@ -90,7 +90,7 @@ span. To do that, use `in_span`:
 ```ruby
 require "opentelemetry/sdk"
 
-def do_work()
+def do_work
   MyAppTracer.in_span("do_work") do |span|
     # do some work that the 'do_work' span tracks!
   end
@@ -107,19 +107,20 @@ relationship:
 ```ruby
 require "opentelemetry/sdk"
 
-def parent_work()
+def parent_work
   MyAppTracer.in_span("parent") do |span|
     # do some work that the 'parent' span tracks!
 
-    child_work()
+    child_work
 
     # do some more work afterwards
   end
 end
 
-def child_work()
+def child_work
   MyAppTracer.in_span("child") do |span|
     # do some work that the 'child' span tracks!
+  end
 end
 ```
 
@@ -150,11 +151,10 @@ require "opentelemetry/sdk"
 
 current_span = OpenTelemetry::Trace.current_span
 
-current_span.add_attributes(
-  {
-    "my.cool.attribute" => "a value",
-    "my.first.name" => "Oscar"
-  })
+current_span.add_attributes({
+  "my.cool.attribute" => "a value",
+  "my.first.name" => "Oscar"
+})
 ```
 
 You can also add attributes to a span as [it's being
@@ -200,11 +200,10 @@ require 'opentelemetry/semantic_conventions'
 
 current_span = OpenTelemetry::Trace.current_span
 
-current_span.add_attributes(
-  {
-    OpenTelemetry::SemanticConventions::Trace::HTTP_METHOD => "GET",
-    OpenTelemetry::SemanticConventions::Trace::HTTP_URL => "https://opentelemetry.io/",
-  })
+current_span.add_attributes({
+  OpenTelemetry::SemanticConventions::Trace::HTTP_METHOD => "GET",
+  OpenTelemetry::SemanticConventions::Trace::HTTP_URL => "https://opentelemetry.io/",
+})
 ```
 
 ### Add Span Events
@@ -239,8 +238,10 @@ Events can also have attributes of their own e.g.
 ```ruby
 require "opentelemetry/sdk"
 
-span.add_event("Cancelled wait due to external signal",
-  attributes: { "pid" => 4328, "signal" => "SIGHUP" })
+span.add_event("Cancelled wait due to external signal", attributes: {
+  "pid" => 4328,
+  "signal" => "SIGHUP"
+})
 ```
 
 ### Add Span Links
@@ -290,9 +291,9 @@ require "opentelemetry/sdk"
 current_span = OpenTelemetry::Trace.current_span
 
 begin
-   1/0 # something that obviously fails
+  1/0 # something that obviously fails
 rescue
-    current_span.status = OpenTelemetry::Trace::Status.error("error message here!")
+  current_span.status = OpenTelemetry::Trace::Status.error("error message here!")
 end
 ```
 
@@ -307,10 +308,10 @@ require "opentelemetry/sdk"
 current_span = OpenTelemetry::Trace.current_span
 
 begin
-   1/0 # something that obviously fails
-rescue Exception => ex
-    current_span.status = OpenTelemetry::Trace::Status.error("error message here!")
-    current_span.record_exception(ex)
+  1/0 # something that obviously fails
+rescue Exception => e
+  current_span.status = OpenTelemetry::Trace::Status.error("error message here!")
+  current_span.record_exception(e)
 end
 ```
 

--- a/content/en/docs/instrumentation/ruby/manual.md
+++ b/content/en/docs/instrumentation/ruby/manual.md
@@ -40,13 +40,8 @@ one will be registered for you.
 # If in a rails app, this lives in config/initializers/opentelemetry.rb
 require "opentelemetry/sdk"
 
-begin
-  OpenTelemetry::SDK.configure do |c|
-    c.service_name = '<YOUR_SERVICE_NAME>'
-  end
-rescue OpenTelemetry::SDK::ConfigurationError => e
-  puts "Error configuring Ruby OpenTelemetry SDK"
-  puts e.inspect
+OpenTelemetry::SDK.configure do |c|
+  c.service_name = '<YOUR_SERVICE_NAME>'
 end
 
 # 'Tracer' can be used throughout your code now


### PR DESCRIPTION
Ready for review!

Preview link: https://deploy-preview-1994--opentelemetry.netlify.app/docs/instrumentation/ruby/manual/

App I used to validate things: https://github.com/cartermp/otel-lang-samples/blob/main/ruby/app/app/controllers/app_controller.rb (sent traces to honeycomb)

Remaining:

- [x] Span status
- [x] Record exception
- [x] Check all code samples because there's sure as shit some stuff that's wrong