### PR TITLE
Note JS metrics are stable as of 1.8.0

### DIFF
--- a/data/instrumentation.yaml
+++ b/data/instrumentation.yaml
@@ -51,7 +51,7 @@ languages:
     name: JavaScript
     status:
       traces: stable
-      metrics: Release Candidate
+      metrics: stable
       logs: Development
   rust:
     name: Rust


### PR DESCRIPTION
Updates the stability data for the Javascript SDK and API which recently took its `metrics` implementation stable with the 1.8.0 release. 

Source: https://github.com/open-telemetry/opentelemetry-js/releases/tag/v1.8.0