### PR TITLE
Tweak line wrappings in /signals/traces.md

### DIFF
--- a/content/en/docs/concepts/signals/traces.md
+++ b/content/en/docs/concepts/signals/traces.md
@@ -249,8 +249,8 @@ Span Context is an immutable object on every span that contains the following:
 Span Context is the part of a span that is serialized and propagated alongside
 [Distributed Context](#context-propagation) and [Baggage](/docs/concepts/signals/baggage).
 
-Because Span Context contains the Trace ID, it is used when creating [Span
-Links](#span-links).
+Because Span Context contains the Trace ID, it is used when creating
+[Span Links](#span-links).
 
 ### Attributes
 
@@ -267,11 +267,11 @@ Attributes have the following rules that each language SDK implements:
 * Values must be a non-null string, boolean, floating point value, integer, or
   an array of these values
 
-Additionally, there are [Semantic
-Attributes](/docs/reference/specification/trace/semantic_conventions/), which
-are known naming conventions for metadata that is typically present in common
-operations. It's helpful to use semantic attribute naming wherever possible
-so that common kinds of metadata is standardized across systems.
+Additionally, there are
+[Semantic Attributes](/docs/reference/specification/trace/semantic_conventions/),
+which are known naming conventions for metadata that is typically present in
+common operations. It's helpful to use semantic attribute naming wherever
+possible so that common kinds of metadata are standardized across systems.
 
 ### Span Events
 
@@ -326,26 +326,41 @@ back-end that processes spans can now assign a final status.
 
 ### Span Kind
 
-When a span is created, it is one of `Client`, `Server`, `Internal`, `Producer`, or `Consumer`. This span kind provides a hint to the tracing backend as to how the trace should be assembled. According to the OpenTelemetry specification, the parent of a server span is often a remote client span, and the child of a client span is usually a server span. Similarly, the parent of a consumer span is always a producer and the child of a producer span is always a consumer. If not provided, the span kind is assumed to be internal.
+When a span is created, it is one of `Client`, `Server`, `Internal`, `Producer`,
+or `Consumer`. This span kind provides a hint to the tracing backend as to how
+the trace should be assembled. According to the OpenTelemetry specification, the
+parent of a server span is often a remote client span, and the child of a client
+span is usually a server span. Similarly, the parent of a consumer span is
+always a producer and the child of a producer span is always a consumer. If not
+provided, the span kind is assumed to be internal.
 
-For more information regarding SpanKind, see [SpanKind]({{< relref "/docs/reference/specification/trace/api#spankind" >}}).
+For more information regarding SpanKind, see
+[SpanKind]({{< relref "/docs/reference/specification/trace/api#spankind" >}}).
 
 #### Client
 
-Client spans represent a synchronous outgoing remote call such as an outgoing HTTP request or database call. Note that in this context, "synchronous" does not refer to `async/await`, but to the fact that it is not queued for later processing.
+A client span represents a synchronous outgoing remote call such as an outgoing
+HTTP request or database call. Note that in this context, "synchronous" does not
+refer to `async/await`, but to the fact that it is not queued for later processing.
 
 #### Server
 
-Server spans represent a synchronous incoming remote call such as an incoming HTTP request or remote procedure call.
+A server span represents a synchronous incoming remote call such as an incoming
+HTTP request or remote procedure call.
 
 #### Internal
 
-Internal spans represent operations which do not cross a process boundary. Things like instrumenting a function call or an express middleware may use internal spans.
+Internal spans represent operations which do not cross a process boundary.
+Things like instrumenting a function call or an express middleware may use
+internal spans.
 
 #### Producer
 
-Producer spans represent the creation of a job which may be asynchronously processed later. It may be a remote job such as one inserted into a job queue or a local job handled by an event listener.
+Producer spans represent the creation of a job which may be asynchronously
+processed later. It may be a remote job such as one inserted into a job queue or
+a local job handled by an event listener.
 
 #### Consumer
 
-Consumer spans represent the processing of a job created by a producer and may start long after the producer span has already ended.
+Consumer spans represent the processing of a job created by a producer and may
+start long after the producer span has already ended.


### PR DESCRIPTION
Tweak long lines in the file:
```
content/en/docs/concepts/signals/traces.md
```
also changed three singular and plural issues:
```
so that common kinds of metadata are
A client span represents
A server span represents
```
