### PR TITLE
Fix swift-maintainers team name in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,7 +27,7 @@ content/en/docs/instrumentation/php/     @open-telemetry/docs-approvers @open-te
 content/en/docs/instrumentation/python/  @open-telemetry/docs-approvers @open-telemetry/python-maintainers @open-telemetry/python-approvers
 content/en/docs/instrumentation/ruby/    @open-telemetry/docs-approvers @open-telemetry/ruby-approvers @open-telemetry/ruby-contrib-approvers
 content/en/docs/instrumentation/rust/  @open-telemetry/docs-approvers @open-telemetry/rust-maintainers @open-telemetry/rust-approvers
-content/en/docs/instrumentation/swift/  @open-telemetry/docs-approvers @open-telemetry/swift-mainteiners @open-telemetry/swift-approvers
+content/en/docs/instrumentation/swift/  @open-telemetry/docs-approvers @open-telemetry/swift-maintainers @open-telemetry/swift-approvers
 content/en/docs/k8s-operator		@open-telemetry/operator-approvers @open-telemetry/operator-maintainers
 content/en/blog/                         @open-telemetry/docs-approvers @open-telemetry/blog-approvers
 content/en/community/demo/		@open-telemetry/demo-approvers @open-telemetry/demo-maintainers


### PR DESCRIPTION
see https://github.com/open-telemetry/community/issues/1291