### PR TITLE
Add link for Mastodon verification

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,6 +6,7 @@
     {{ partial "head.html" . }}
   </head>
   <body class="td-{{ .Kind }}{{ with .Page.Params.body_class }} {{ . }}{{ end }}">
+    <a rel="me" href="https://fosstodon.org/@opentelemetry"></a>
     <header>
       {{ partial "navbar.html" . }}
     </header>


### PR DESCRIPTION
This PR adds an empty link to the body in order to verify the OpenTelemetry Mastodon account.