### PR TITLE
Manual setup example in Java is incomplete

### DIFF
--- a/content/en/docs/instrumentation/java/manual.md
+++ b/content/en/docs/instrumentation/java/manual.md
@@ -7,7 +7,6 @@ aliases:
   - /docs/instrumentation/java/manual_instrumentation
 weight: 5
 javaVersion: 1.20.1
-javaVersionSemConv: 1.20.1-alpha
 ---
 
 **Libraries** that want to export telemetry data using OpenTelemetry MUST only
@@ -73,7 +72,7 @@ the most important piece of telemetry source-identifying info.
 ```
 
 ### Gradle
-```
+```kotlin
 dependencies {
     implementation 'io.opentelemetry:opentelemetry-api:{{% param javaVersion %}}'
     implementation 'io.opentelemetry:opentelemetry-sdk:{{% param javaVersion %}}'

--- a/content/en/docs/instrumentation/java/manual.md
+++ b/content/en/docs/instrumentation/java/manual.md
@@ -35,6 +35,87 @@ the most important piece of telemetry source-identifying info.
 
 For example:
 
+<details>
+  <summary>Maven top level dependencies. Click me.</summary>
+  Note that opentelemetry-semconv does not exist (yet) as 1.20.1 but only as 1.20.1-alpha.
+  
+  ```
+  
+  <project>
+      <dependencyManagement>
+          <dependencies>
+              <dependency>
+                  <groupId>io.opentelemetry</groupId>
+                  <artifactId>opentelemetry-bom</artifactId>
+                  <version>1.20.1</version>
+                  <type>pom</type>
+                  <scope>import</scope>
+              </dependency>
+          </dependencies>
+      </dependencyManagement>
+      
+      <dependencies>
+          <dependency>
+              <groupId>io.opentelemetry</groupId>
+              <artifactId>opentelemetry-api</artifactId>
+          </dependency>
+          <dependency>
+              <groupId>io.opentelemetry</groupId>
+              <artifactId>opentelemetry-sdk</artifactId>
+          </dependency>
+          <dependency>
+              <groupId>io.opentelemetry</groupId>
+              <artifactId>opentelemetry-sdk-trace</artifactId>
+          </dependency>
+          <dependency>
+              <groupId>io.opentelemetry</groupId>
+              <artifactId>opentelemetry-sdk-metrics</artifactId>
+          </dependency>
+          <dependency>
+              <groupId>io.opentelemetry</groupId>
+              <artifactId>opentelemetry-sdk-common</artifactId>
+          </dependency>
+          <dependency>
+              <groupId>io.opentelemetry</groupId>
+              <artifactId>opentelemetry-exporter-otlp</artifactId>
+          </dependency>
+          <dependency>
+              <groupId>io.opentelemetry</groupId>
+              <artifactId>opentelemetry-context</artifactId>
+          </dependency>
+          <dependency>
+              <groupId>io.opentelemetry</groupId>
+              <artifactId>opentelemetry-semconv</artifactId>
+              <version>1.20.1-alpha</version>
+          </dependency>
+      </dependencies>
+  </project>
+  
+  ```
+</details>
+
+<details>
+  <summary>Java imports. Click me.</summary>
+  
+  ```java
+  
+  import io.opentelemetry.api.OpenTelemetry;
+  import io.opentelemetry.api.common.Attributes;
+  import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+  import io.opentelemetry.context.propagation.ContextPropagators;
+  import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
+  import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+  import io.opentelemetry.sdk.OpenTelemetrySdk;
+  import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+  import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
+  import io.opentelemetry.sdk.resources.Resource;
+  import io.opentelemetry.sdk.trace.SdkTracerProvider;
+  import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+  import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+  
+  ```
+</details>
+
 ```java
 Resource resource = Resource.getDefault()
   .merge(Resource.create(Attributes.of(ResourceAttributes.SERVICE_NAME, "logical-service-name")));

--- a/content/en/docs/instrumentation/java/manual.md
+++ b/content/en/docs/instrumentation/java/manual.md
@@ -6,6 +6,8 @@ aliases:
   - /docs/java/manual_instrumentation
   - /docs/instrumentation/java/manual_instrumentation
 weight: 5
+javaVersion: 1.20.1
+javaVersionSemConv: 1.20.1-alpha
 ---
 
 **Libraries** that want to export telemetry data using OpenTelemetry MUST only
@@ -37,7 +39,6 @@ For example:
 
 <details>
   <summary>Maven top level dependencies. Click me.</summary>
-  Note that opentelemetry-semconv does not exist (yet) as 1.20.1 but only as 1.20.1-alpha.
   
   ```
   
@@ -47,7 +48,7 @@ For example:
               <dependency>
                   <groupId>io.opentelemetry</groupId>
                   <artifactId>opentelemetry-bom</artifactId>
-                  <version>1.20.1</version>
+                  <version>{{% param javaVersion %}}</version>
                   <type>pom</type>
                   <scope>import</scope>
               </dependency>
@@ -86,7 +87,7 @@ For example:
           <dependency>
               <groupId>io.opentelemetry</groupId>
               <artifactId>opentelemetry-semconv</artifactId>
-              <version>1.20.1-alpha</version>
+              <version>{{% param javaVersionSemConv %}}</version>
           </dependency>
       </dependencies>
   </project>

--- a/content/en/docs/instrumentation/java/manual.md
+++ b/content/en/docs/instrumentation/java/manual.md
@@ -38,7 +38,7 @@ the most important piece of telemetry source-identifying info.
 For example:
 
 <details>
-  <summary>Maven top level dependencies. Click me.</summary>
+  <summary>Maven dependencies. Click me.</summary>
   
   ```
   
@@ -66,23 +66,7 @@ For example:
           </dependency>
           <dependency>
               <groupId>io.opentelemetry</groupId>
-              <artifactId>opentelemetry-sdk-trace</artifactId>
-          </dependency>
-          <dependency>
-              <groupId>io.opentelemetry</groupId>
-              <artifactId>opentelemetry-sdk-metrics</artifactId>
-          </dependency>
-          <dependency>
-              <groupId>io.opentelemetry</groupId>
-              <artifactId>opentelemetry-sdk-common</artifactId>
-          </dependency>
-          <dependency>
-              <groupId>io.opentelemetry</groupId>
               <artifactId>opentelemetry-exporter-otlp</artifactId>
-          </dependency>
-          <dependency>
-              <groupId>io.opentelemetry</groupId>
-              <artifactId>opentelemetry-context</artifactId>
           </dependency>
           <dependency>
               <groupId>io.opentelemetry</groupId>
@@ -94,6 +78,22 @@ For example:
   
   ```
 </details>
+
+<details>
+  <summary>Gradle dependencies. Click me.</summary>
+  
+  ```
+
+dependencies {
+    implementation 'io.opentelemetry:opentelemetry-api:{{% param javaVersion %}}'
+    implementation 'io.opentelemetry:opentelemetry-sdk:{{% param javaVersion %}}'
+    implementation 'io.opentelemetry:opentelemetry-exporter-otlp:{{% param javaVersion %}}'
+    implementation 'io.opentelemetry:opentelemetry-semconv:{{% param javaVersionSemConv %}}'
+}
+  
+  ```
+</details>
+  
 
 <details>
   <summary>Java imports. Click me.</summary>

--- a/content/en/docs/instrumentation/java/manual.md
+++ b/content/en/docs/instrumentation/java/manual.md
@@ -35,88 +35,71 @@ It is also strongly recommended to define a `Resource` instance as a representat
 entity producing the telemetry; in particular the `service.name` attribute is
 the most important piece of telemetry source-identifying info.
 
-For example:
-
-<details>
-  <summary>Maven dependencies. Click me.</summary>
-  
-  ```
-  
-  <project>
-      <dependencyManagement>
-          <dependencies>
-              <dependency>
-                  <groupId>io.opentelemetry</groupId>
-                  <artifactId>opentelemetry-bom</artifactId>
-                  <version>{{% param javaVersion %}}</version>
-                  <type>pom</type>
-                  <scope>import</scope>
-              </dependency>
-          </dependencies>
-      </dependencyManagement>
+### Maven
+```xml
+<project>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>{{% param javaVersion %}}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
       
-      <dependencies>
-          <dependency>
-              <groupId>io.opentelemetry</groupId>
-              <artifactId>opentelemetry-api</artifactId>
-          </dependency>
-          <dependency>
-              <groupId>io.opentelemetry</groupId>
-              <artifactId>opentelemetry-sdk</artifactId>
-          </dependency>
-          <dependency>
-              <groupId>io.opentelemetry</groupId>
-              <artifactId>opentelemetry-exporter-otlp</artifactId>
-          </dependency>
-          <dependency>
-              <groupId>io.opentelemetry</groupId>
-              <artifactId>opentelemetry-semconv</artifactId>
-              <version>{{% param javaVersionSemConv %}}</version>
-          </dependency>
-      </dependencies>
-  </project>
-  
-  ```
-</details>
+    <dependencies>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+            <version>{{% param javaVersion %}}-alpha</version>
+        </dependency>
+    </dependencies>
+</project>
+```
 
-<details>
-  <summary>Gradle dependencies. Click me.</summary>
-  
-  ```
-
+### Gradle
+```
 dependencies {
     implementation 'io.opentelemetry:opentelemetry-api:{{% param javaVersion %}}'
     implementation 'io.opentelemetry:opentelemetry-sdk:{{% param javaVersion %}}'
     implementation 'io.opentelemetry:opentelemetry-exporter-otlp:{{% param javaVersion %}}'
-    implementation 'io.opentelemetry:opentelemetry-semconv:{{% param javaVersionSemConv %}}'
+    implementation 'io.opentelemetry:opentelemetry-semconv:{{% param javaVersion %}}-alpha'
 }
-  
-  ```
-</details>
-  
+```  
 
-<details>
-  <summary>Java imports. Click me.</summary>
-  
-  ```java
-  
-  import io.opentelemetry.api.OpenTelemetry;
-  import io.opentelemetry.api.common.Attributes;
-  import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
-  import io.opentelemetry.context.propagation.ContextPropagators;
-  import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
-  import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
-  import io.opentelemetry.sdk.OpenTelemetrySdk;
-  import io.opentelemetry.sdk.metrics.SdkMeterProvider;
-  import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
-  import io.opentelemetry.sdk.resources.Resource;
-  import io.opentelemetry.sdk.trace.SdkTracerProvider;
-  import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
-  import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
-  
-  ```
-</details>
+### Imports
+```java
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+```
 
+### Example
 ```java
 Resource resource = Resource.getDefault()
   .merge(Resource.create(Attributes.of(ResourceAttributes.SERVICE_NAME, "logical-service-name")));


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry.io/issues/2029 Manual Instrumentation example in Java is missing dependencies and imports and this makes it a time waster. Both are added as a collapsible section.