### PR TITLE
fix: typescript example application

### DIFF
--- a/content/en/docs/instrumentation/js/getting-started/nodejs.md
+++ b/content/en/docs/instrumentation/js/getting-started/nodejs.md
@@ -29,7 +29,7 @@ Install dependencies used by the example.
 {{< tabpane lang=shell >}}
 
 {{< tab TypeScript >}}
-npm install express typescript ts-node express @types/express @types/node 
+npm install express typescript ts-node @types/express @types/node 
 {{< /tab >}}
 
 {{< tab JavaScript >}}

--- a/content/en/docs/instrumentation/js/getting-started/nodejs.md
+++ b/content/en/docs/instrumentation/js/getting-started/nodejs.md
@@ -70,14 +70,14 @@ app.listen(PORT, () => {
 /*app.js*/
 const express = require("express");
 
-const PORT = process.env.PORT || "8080";
+const PORT = parseInt(process.env.PORT || "8080");
 const app = express();
 
 app.get("/", (req, res) => {
   res.send("Hello World");
 });
 
-app.listen(parseInt(PORT, 10), () => {
+app.listen(PORT, () => {
   console.log(`Listening for requests on http://localhost:${PORT}`);
 });
 {{< /tab >}}

--- a/content/en/docs/instrumentation/js/getting-started/nodejs.md
+++ b/content/en/docs/instrumentation/js/getting-started/nodejs.md
@@ -61,9 +61,9 @@ app.get("/", (req, res) => {
   res.send("Hello World");
 });
 
-app.listen(PORT), () => {
+app.listen(PORT, () => {
   console.log(`Listening for requests on http://localhost:${PORT}`);
-};
+});
 {{< /tab >}}
 
 {{< tab JavaScript >}}


### PR DESCRIPTION
fixing 2 minor issues I spotted in typescript [Example Application](https://opentelemetry.io/docs/instrumentation/js/getting-started/nodejs/#example-application):

1. `npm install` lists the `express` dependency twice, which is redundant. Removed one of these.
2. when calling `app.listen()` on the express `app`, the arrow function that prints a message to log should actually be a second parameter to the `listen` function. The parentheses are currently closed too early (after the `PORT` parameter), causing no message to be output to the console as intended.
3. `parseInt` function on the `PORT` is invoked in different patterns in js and ts examples (when extracting env variable in ts, and when invoking `app.listen` in js). I aligned them so the call is done in the same place for both examples