### PR TITLE
Add brief note about using --prerelease flag

### DIFF
--- a/content/en/docs/instrumentation/net/getting-started.md
+++ b/content/en/docs/instrumentation/net/getting-started.md
@@ -101,8 +101,7 @@ dotnet add package OpenTelemetry.Instrumentation.SqlClient --prerelease
 ```
 
 Note that the `--prerelease` flag is required for all instrumentation packages 
-as they are all are pre-release, and using the flag is the only way to get the 
-latest version via the CLI. 
+because they are all are pre-release.
 
 Next, paste the following code into your `Program.cs` file:
 

--- a/content/en/docs/instrumentation/net/getting-started.md
+++ b/content/en/docs/instrumentation/net/getting-started.md
@@ -100,6 +100,10 @@ dotnet add package OpenTelemetry.Instrumentation.Http --prerelease
 dotnet add package OpenTelemetry.Instrumentation.SqlClient --prerelease
 ```
 
+Note that the `--prerelease` flag is required for all instrumentation packages 
+as they are all are pre-release, and using the flag is the only way to get the 
+latest version via the CLI. 
+
 Next, paste the following code into your `Program.cs` file:
 
 ```csharp


### PR DESCRIPTION
This PR adds a brief note about the use of the `--prerelease` flag when adding OTel instrumentation packages via the CLI. For additional context, see this [Slack thread](https://cloud-native.slack.com/archives/C02UN96HZH6/p1669067199829659). 