### PR TITLE
Add note about using the --prerelease flag in Manual section

### DIFF
--- a/content/en/docs/instrumentation/net/manual.md
+++ b/content/en/docs/instrumentation/net/manual.md
@@ -83,7 +83,11 @@ dotnet add package OpenTelemetry.Extensions.Hosting --prerelease
 dotnet add package OpenTelemetry.Exporter.Console --prerelease
 ```
 
-And then configure it in your ASP.NET Core startup routine where you have access
+Note that the `--prerelease` flag is required for all instrumentation packages 
+as they are all are pre-release, and using the flag is the only way to get the 
+latest version via the CLI. 
+
+Next, configure it in your ASP.NET Core startup routine where you have access
 to an `IServiceCollection`.
 
 ```csharp

--- a/content/en/docs/instrumentation/net/manual.md
+++ b/content/en/docs/instrumentation/net/manual.md
@@ -84,8 +84,7 @@ dotnet add package OpenTelemetry.Exporter.Console --prerelease
 ```
 
 Note that the `--prerelease` flag is required for all instrumentation packages 
-as they are all are pre-release, and using the flag is the only way to get the 
-latest version via the CLI. 
+because they are all are pre-release.
 
 Next, configure it in your ASP.NET Core startup routine where you have access
 to an `IServiceCollection`.


### PR DESCRIPTION
Opened a separate PR to add a note about using the `--prerelease` flag here in case it's considered redundant due to https://github.com/open-telemetry/opentelemetry.io/pull/2038/files, which adds the same note to the [Getting Started page](https://opentelemetry.io/docs/instrumentation/net/getting-started/#aspnet-core). Alternatively, could link back to the Getting Started section if verbosity/repetition is a concern. 