### PR TITLE
Tweak lines and fix a typo in workshop/resources.md

### DIFF
--- a/content/en/docs/reference/specification/status.md
+++ b/content/en/docs/reference/specification/status.md
@@ -41,9 +41,8 @@ Deprecated, Removed.
   support.
 - **Deprecated** components are stable but may eventually be removed.
 
-For complete definitions of lifecycles and long term support, see [Versioning
-and
-stability]({{< relref "/docs/reference/specification/versioning-and-stability" >}}).
+For complete definitions of lifecycles and long term support, see
+[Versioning and stability]({{< relref "/docs/reference/specification/versioning-and-stability" >}}).
 
 ## Current Status
 
@@ -105,7 +104,7 @@ same as the **Protocol** status.
   - The [logs data model][] is released as part of the OpenTelemetry Protocol.
   - Log processing for many data formats has been added to the Collector, thanks
     to the donation of Stanza to the OpenTelemetry project.
-  - Log appenders are currently under develop in many languages. Log appenders
+  - Log appenders are currently under development in many languages. Log appenders
     allow OpenTelemetry tracing data, such as trace and span IDs, to be appended
     to existing logging systems.
   - An OpenTelemetry logging SDK is currently under development. This allows

--- a/content/en/docs/workshop/resources.md
+++ b/content/en/docs/workshop/resources.md
@@ -2,12 +2,19 @@
 title: Workshop resources
 ---
 
-OpenTelemetry provides the following resources free of charge and available under the Apache 2.0 license. These resources are intended to aid you in running an OpenTelemetry workshop for your local user group, online community, corporation, or other association. You are free to make a copy of this material for your personal use as long as you attribute it to the OpenTelemetry authors and include a link to this page.
+OpenTelemetry provides the following resources free of charge and available
+under the Apache 2.0 license. These resources are intended to aid you in running
+an OpenTelemetry workshop for your local user group, online community,
+corporation, or other association. You are free to make a copy of this material
+for your personal use as long as you attribute it to the OpenTelemetry authors
+and include a link to this page.
 
 ## Slides
 
-The OpenTelemetry workshop slides can be found [here](https://docs.google.com/presentation/d/1nVhLIyqn_SiDo78jFHxnMdxYlnT0b7tYOHz3Pu4gzVQ/edit#slide=id.p).
+The OpenTelemetry workshop slides can be found
+[here](https://docs.google.com/presentation/d/1nVhLIyqn_SiDo78jFHxnMdxYlnT0b7tYOHz3Pu4gzVQ/edit#slide=id.p).
 
-## Sample Code
+## Sample code
 
-Sample code used in the slides can be found [here](https://glitch.com/@opentelemetry).
+Sample code used in the slides can be found
+[here](https://glitch.com/@opentelemetry).


### PR DESCRIPTION
Updated two files:

```
content/en/docs/reference/specification/status.md
content/en/docs/workshop/resources.md
```