### PR TITLE
Add apiclarity exporter & tortoiseORM instrumentation to registry

### DIFF
--- a/content/en/registry/collector-exporter-apiclarity.md
+++ b/content/en/registry/collector-exporter-apiclarity.md
@@ -1,0 +1,16 @@
+---
+title: APIClarity HTTP Exporter
+registryType: exporter
+isThirdParty: true
+language: collector
+tags:
+  - go
+  - exporter
+  - collector
+  - apiclarity
+repo: https://github.com/openclarity/apiclarity/tree/master/plugins/otel-collector
+license: Apache 2.0
+description: Exports traces and/or metrics via HTTP to an APIClarity endpoint for analysis.
+authors: Cisco Systems
+otVersion: latest
+---

--- a/content/en/registry/instrumentation-python-tortoiseorm.md
+++ b/content/en/registry/instrumentation-python-tortoiseorm.md
@@ -1,0 +1,15 @@
+---
+title: OpenTelemetry Tortoise ORM Instrumentation
+registryType: instrumentation
+isThirdParty: false
+language: python
+tags:
+    - tortoiseorm
+    - instrumentation
+    - python
+repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-tortoiseorm
+license: Apache 2.0
+description: This library allows tracing queries made by tortoise ORM backends, mysql, postgres and sqlite.
+authors: OpenTelemetry Authors
+otVersion: latest
+---


### PR DESCRIPTION
As the title suggests 2 additions to the registry:

* APIClarity Exporter: https://github.com/openclarity/apiclarity/tree/master/plugins/otel-collector
* TortoiseORM instrumentation https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-tortoiseorm

Preview: https://deploy-preview-2053--opentelemetry.netlify.app/registry/