### PR TITLE
Change file-ref to tracing.js|ts

### DIFF
--- a/content/en/docs/instrumentation/js/exporters.md
+++ b/content/en/docs/instrumentation/js/exporters.md
@@ -22,7 +22,7 @@ $ npm install --save @opentelemetry/exporter-trace-otlp-http
 ```
 
 Next, configure the exporter to point at an OTLP endpoint. For example you can
-update `app.js` from the
+update `tracing.ts|js` from the
 [Getting Started](/docs/instrumentation/js/getting-started/nodejs/) like the
 following:
 


### PR DESCRIPTION
In the Getting Started, we created two files `app.js|ts` and `tracing.js|ts` and the configuration is made in the `tracing.js|ts` file, so the ref is wrong.