### PR TITLE
Add page for other languages

### DIFF
--- a/content/en/docs/instrumentation/other/_index.md
+++ b/content/en/docs/instrumentation/other/_index.md
@@ -10,7 +10,7 @@ Implementing the OpenTelemetry specification is not limited to the languages you
 will find in our documentation. OpenTelemetry is designed in a way that it is
 possible to implement it in every language you like.
 
-For some languages inofficial implementations exist, you can find them in the
+For some languages unofficial implementations exist, you can find them in the
 [registry](/registry). If you know about an implementation not listed there,
 please [add it to the registry][].
 

--- a/content/en/docs/instrumentation/other/_index.md
+++ b/content/en/docs/instrumentation/other/_index.md
@@ -1,0 +1,29 @@
+---
+linkTitle: Other
+title: Other languages
+weight: 99
+description: >-
+  Language-specific implementation of OpenTelemetry for other languages.
+---
+
+Implementing the OpenTelemetry specification is not limited to the languages you
+will find in our documentation. OpenTelemetry is designed in a way that it is
+possible to implement it in every language you like.
+
+For some languages inofficial implementations exist, you can find them in the
+[registry](/registry). If you know about an implementation not listed there,
+please [add it to the registry][].
+
+The OpenTelemetry community is open to maintain implementations for additional
+languages and with that make them "official" parts of the OpenTelemetry
+projects. For that you can raise an issue and gauge interest in the formation of
+a special interest group for your language.
+
+For the following languages a request to create a SIG exists:
+
+- [Lua](https://github.com/open-telemetry/community/issues/1276)
+- [Perl](https://github.com/open-telemetry/community/issues/828)
+- [Julia](https://github.com/open-telemetry/community/issues/898)
+
+[add it to the registry]:
+  https://github.com/open-telemetry/opentelemetry.io#adding-a-project-to-the-opentelemetry-registry

--- a/content/en/registry/otel-crystal.md
+++ b/content/en/registry/otel-crystal.md
@@ -1,0 +1,14 @@
+---
+title: opentelemetry-api.cr
+registryType: instrumentation
+isThirdParty: true
+language: Crystal
+tags:
+  - Crystal
+  - instrumentation
+repo: https://github.com/wyhaines/opentelemetry-api.cr
+license: Apache-2.0
+description: An unofficial implementation of OpenTelemetry in Crystal.
+authors: wyhaines
+otVersion: latest
+---

--- a/content/en/registry/otel-crystal.md
+++ b/content/en/registry/otel-crystal.md
@@ -2,9 +2,9 @@
 title: opentelemetry-api.cr
 registryType: instrumentation
 isThirdParty: true
-language: Crystal
+language: crystal
 tags:
-  - Crystal
+  - crystal
   - instrumentation
 repo: https://github.com/wyhaines/opentelemetry-api.cr
 license: Apache-2.0

--- a/content/en/registry/otel-dart.md
+++ b/content/en/registry/otel-dart.md
@@ -1,0 +1,14 @@
+---
+title: OpenTelemetry for Dart
+registryType: instrumentation
+isThirdParty: true
+language: Dart
+tags:
+  - Dart
+  - instrumentation
+repo: https://github.com/Workiva/opentelemetry-dart
+license: Apache-2.0
+description: An unofficial implementation of OpenTelemetry in Dart.
+authors: Workiva
+otVersion: latest
+---

--- a/content/en/registry/otel-dart.md
+++ b/content/en/registry/otel-dart.md
@@ -2,9 +2,9 @@
 title: OpenTelemetry for Dart
 registryType: instrumentation
 isThirdParty: true
-language: Dart
+language: dart
 tags:
-  - Dart
+  - dart
   - instrumentation
 repo: https://github.com/Workiva/opentelemetry-dart
 license: Apache-2.0

--- a/content/en/registry/otel-haskell.md
+++ b/content/en/registry/otel-haskell.md
@@ -1,0 +1,14 @@
+---
+title: OpenTelemetry for haskell
+registryType: instrumentation
+isThirdParty: true
+language: haskell
+tags:
+  - haskell
+  - instrumentation
+repo: https://github.com/ethercrow/opentelemetry-haskell
+license: Apache-2.0
+description: An unofficial implementation of OpenTelemetry in haskell.
+authors: ethercrow
+otVersion: latest
+---

--- a/content/en/registry/otel-julia.md
+++ b/content/en/registry/otel-julia.md
@@ -2,9 +2,9 @@
 title: OpenTelemetry.jl
 registryType: instrumentation
 isThirdParty: true
-language: Julia
+language: julia
 tags:
-  - Julia
+  - julia
   - instrumentation
 repo: https://github.com/oolong-dev/OpenTelemetry.jl
 license: Apache-2.0

--- a/content/en/registry/otel-julia.md
+++ b/content/en/registry/otel-julia.md
@@ -1,0 +1,14 @@
+---
+title: OpenTelemetry.jl
+registryType: instrumentation
+isThirdParty: true
+language: Julia
+tags:
+  - Julia
+  - instrumentation
+repo: https://github.com/oolong-dev/OpenTelemetry.jl
+license: Apache-2.0
+description: An unofficial implementation of OpenTelemetry in Julia.
+authors: oolong.dev (https://github.com/oolong-dev)
+otVersion: latest
+---

--- a/content/en/registry/otel-lua.md
+++ b/content/en/registry/otel-lua.md
@@ -1,0 +1,14 @@
+---
+title: opentelemetry-lua
+registryType: instrumentation
+isThirdParty: true
+language: lua
+tags:
+  - lua
+  - instrumentation
+repo: https://github.com/yangxikun/opentelemetry-lua
+license: Apache-2.0
+description: An unofficial implementation of OpenTelemetry in lua.
+authors: yangxikun
+otVersion: latest
+---

--- a/content/en/registry/otel-perl.md
+++ b/content/en/registry/otel-perl.md
@@ -2,9 +2,9 @@
 title: OpenTelemetry for Perl
 registryType: instrumentation
 isThirdParty: true
-language: Perl
+language: perl
 tags:
-  - Perl
+  - perl
   - instrumentation
 repo: https://github.com/jjatria/perl-opentelemetry
 license: Apache-2.0

--- a/content/en/registry/otel-perl.md
+++ b/content/en/registry/otel-perl.md
@@ -1,0 +1,14 @@
+---
+title: OpenTelemetry for Perl
+registryType: instrumentation
+isThirdParty: true
+language: Perl
+tags:
+  - Perl
+  - instrumentation
+repo: https://github.com/jjatria/perl-opentelemetry
+license: Apache-2.0
+description: An unofficial implementation of OpenTelemetry in Perl.
+authors: jjatria
+otVersion: latest
+---


### PR DESCRIPTION
Addresses #1807

Preview: 
* https://deploy-preview-2062--opentelemetry.netlify.app/docs/instrumentation/other/
* Registry examples: [Perl](https://deploy-preview-2062--opentelemetry.netlify.app/registry/?s=perl&component=&language=), [Julia](https://deploy-preview-2062--opentelemetry.netlify.app/registry/?s=julia&component=&language=)

copying your comments from there @chalin:

> For unofficial implementations that are sufficiently well developed, we could grant them their own page.

This sounds like a potential step 2, but we need to see if those sufficiently well developed projects move to become an "official" implementation eventually.

> For all others, I'd mention them on the [Instrumentation](https://opentelemetry.io/docs/instrumentation/) page.

Putting it there prominently enough without taking space for other important concerns was not possible, so I created a standalone page

> We can always start by listing all of the unofficial implementations on the [Instrumentation](https://opentelemetry.io/docs/instrumentation/) page and then promote them progressively to their own language-landing page.

I thought about having them in the registry first. This is already a place where we list inofficial things.

> We might need some (at least minimal) guidelines for deciding which languages get promoted.
The GC might need to be involved? WDYT @austinlparker?

I solved that by pointing out that there are already 3 issues for languages that want to have a SIG and saying that if you have interest, please raise another one. 

