### PR TITLE
Announcement blog for new EUDG

### DIFF
--- a/content/en/blog/2022/end-user-discussion-group-apac/index.md
+++ b/content/en/blog/2022/end-user-discussion-group-apac/index.md
@@ -17,17 +17,9 @@ starting in January 2023**!
 
 ## The what
 As mentioned above, these Discussion Groups are monthly meetings for end users 
-to discuss the challenges they're facing and to learn from each other. The End 
-User Working Group is also improving the process to share any collected user 
-feedback* with the appropriate project maintainers to help improve the user 
-experience and increase adoption. 
-
-If this is your first time hearing about these meetings, you are invited to 
-participate in any of the upcoming sessions that fit your schedule. Look for 
-the meetings by filtering them in one of the community's publicly available 
-[calendars](https://github.com/open-telemetry/community#calendar), and duplicate 
-the event to your own. There will also be periodic reminders in the general CNCF 
-Slack `#opentelemetry` channel. 
+to discuss the challenges they're facing in their OTel implementations and to 
+learn from each other, as well as to talk about the project itself and what is 
+working, what isn't, and what they'd like to see. 
 
 We encourage you to attend and ask questions to learn how other users have 
 implemented OpenTelemetry in their organizations, resolved common issues, and 
@@ -35,10 +27,26 @@ more. Example topics that have been discussed include tail sampling, collector
 scaling, and OpAMP; there really is no limit to the topics! We simply ask that 
 you be respectful and abide by the [Chatham House Rule](https://www.chathamhouse.org/about-us/chatham-house-rule#:~:text=The%20Rule%20reads%20as%20follows,other%20participant%2C%20may%20be%20revealed.).
 
+## The why
+This group started as a result of direct feedback from end users in the community! 
+Past participants have shared with us that these have been helpful and valuable 
+for them as they migrate their observability instrumentation to OpenTelemetry. 
+
+Additionally, the End User Working Group is also improving the process to share 
+any collected user feedback* with the appropriate project maintainers to help 
+improve the user experience and increase adoption. 
+
 *Information shared in the groups can be discussed publicly, but **not** the 
 identity of the person who said it or their affiliation. 
 
 ## The when
+If this is your first time hearing about these meetings, you are invited to 
+participate in any of the upcoming sessions that fit your schedule. Look for 
+the meetings by filtering them in one of the community's publicly available 
+[calendars](https://github.com/open-telemetry/community#calendar), and duplicate 
+the event to your own. There will also be periodic reminders in the general CNCF 
+Slack `#opentelemetry` channel. 
+
 Upcoming sessions:
 
 * **EMEA** (every third Tuesday of the month) - join [here](https://us06web.zoom.us/j/85691064809?pwd=c0VCejh)

--- a/content/en/blog/2022/end-user-discussion-group-apac/index.md
+++ b/content/en/blog/2022/end-user-discussion-group-apac/index.md
@@ -53,8 +53,8 @@ Upcoming sessions:
   * December 20, 2022 11AM CET
   * January 17, 2023 11AM CET
 * **APAC** (every third Wednesday of the month) - join [here](https://us06web.zoom.us/j/82702918447?pwd=WllKc0hmdTNuelhFdlhMM1Q3TktSQT09)
-  * January 18, 2023 11AM IST 
-  * February 15, 2023 11AM IST
+  * January 18, 2023 11AM IST (GMT +5.5)
+  * February 15, 2023 11AM IST (GMT +5.5)
 * **AMER** (every third Thursday of the month) - join [here](https://us06web.zoom.us/j/87037874951?pwd=WGo3eUZpeWFZTlhJQXhJeXZhQmwvUT09)
   * December 15, 2022 9AM PST
   * January 19, 2023 9AM PST

--- a/content/en/blog/2022/end-user-discussion-group-apac/index.md
+++ b/content/en/blog/2022/end-user-discussion-group-apac/index.md
@@ -49,14 +49,14 @@ Slack `#opentelemetry` channel.
 
 Upcoming sessions:
 
-* **EMEA** (every third Tuesday of the month) - join [here](https://us06web.zoom.us/j/85691064809?pwd=c0VCejh)
-  * December 20, 2022 11AM CET
-  * January 17, 2023 11AM CET
-* **APAC** (every third Wednesday of the month) - join [here](https://us06web.zoom.us/j/82702918447?pwd=WllKc0hmdTNuelhFdlhMM1Q3TktSQT09)
-  * January 18, 2023 11AM IST (GMT +5.5)
-  * February 15, 2023 11AM IST (GMT +5.5)
-* **AMER** (every third Thursday of the month) - join [here](https://us06web.zoom.us/j/87037874951?pwd=WGo3eUZpeWFZTlhJQXhJeXZhQmwvUT09)
-  * December 15, 2022 9AM PST
-  * January 19, 2023 9AM PST
+* **EMEA**: every third Tuesday of the month at 11AM CET (GMT +1), join [here](https://us06web.zoom.us/j/85691064809?pwd=c0VCejh) 
+  * December 20, 2022
+  * January 17, 2023
+* **APAC**: every third Wednesday of the month at 11AM IST (GMT +5.5), join [here](https://us06web.zoom.us/j/82702918447?pwd=WllKc0hmdTNuelhFdlhMM1Q3TktSQT09)
+  * January 18, 2023
+  * February 15, 2023
+* **AMER**: every third Thursday of the month at 9AM PST (GMT -8), join [here](https://us06web.zoom.us/j/87037874951?pwd=WGo3eUZpeWFZTlhJQXhJeXZhQmwvUT09)
+  * December 15, 2022
+  * January 19, 2023
 
 See y'all soon! 

--- a/content/en/blog/2022/end-user-discussion-group-apac/index.md
+++ b/content/en/blog/2022/end-user-discussion-group-apac/index.md
@@ -8,7 +8,7 @@ draft: true
 
 Since July, end users have been getting together to discuss their OpenTelemetry 
 adoption and implementation practices in a vendor-netural space known as the 
-[Monthly Discussion Groups](https://opentelemetry.io/community/end-user/discussion-group/) 
+[Monthly Discussion Groups](/community/end-user/discussion-group/) 
 (also referenced as the End User Discussion Groups). 
 
 Previously, they were only available in the EMEA and AMER regions; the End User 

--- a/content/en/blog/2022/end-user-discussion-group-apac/index.md
+++ b/content/en/blog/2022/end-user-discussion-group-apac/index.md
@@ -1,0 +1,54 @@
+---
+title: "End User Discussion Group: New APAC Sessions Announcement!"
+linkTitle: APAC End User Discussion Group
+date: 2022-12-01
+author: "[Reese Lee](https://github.com/reese-lee)"
+draft: true 
+---
+
+Since July, end users have been getting together to discuss their OpenTelemetry 
+adoption and implementation practices in a vendor-netural space known as the 
+[Monthly Discussion Groups](https://opentelemetry.io/community/end-user/discussion-group/) 
+(also referenced as the End User Discussion Groups). 
+
+Previously, they were only available in the EMEA and AMER regions; the End User 
+Working Group is pleased to announce that **APAC sessions will now be available, 
+starting in January 2023**! 
+
+## The what
+As mentioned above, these Discussion Groups are monthly meetings for end users 
+to discuss the challenges they're facing and to learn from each other. The End 
+User Working Group is also improving the process to share any collected user 
+feedback* with the appropriate project maintainers to help improve the user 
+experience and increase adoption. 
+
+If this is your first time hearing about these meetings, you are invited to 
+participate in any of the upcoming sessions that fit your schedule. Look for 
+the meetings by filtering them in one of the community's publicly available 
+[calendars](https://github.com/open-telemetry/community#calendar), and duplicate 
+the event to your own. There will also be periodic reminders in the general CNCF 
+Slack `#opentelemetry` channel. 
+
+We encourage you to attend and ask questions to learn how other users have 
+implemented OpenTelemetry in their organizations, resolved common issues, and 
+more. Example topics that have been discussed include tail sampling, collector 
+scaling, and OpAMP; there really is no limit to the topics! We simply ask that 
+you be respectful and abide by the [Chatham House Rule](https://www.chathamhouse.org/about-us/chatham-house-rule#:~:text=The%20Rule%20reads%20as%20follows,other%20participant%2C%20may%20be%20revealed.).
+
+*Information shared in the groups can be discussed publicly, but **not** the 
+identity of the person who said it or their affiliation. 
+
+## The when
+Upcoming sessions:
+
+* **EMEA** (every third Tuesday of the month) - join [here](https://us06web.zoom.us/j/85691064809?pwd=c0VCejh)
+  * December 20, 2022 11AM CET
+  * January 17, 2023 11AM CET
+* **APAC** (every third Wednesday of the month) - join [here](https://us06web.zoom.us/j/82702918447?pwd=WllKc0hmdTNuelhFdlhMM1Q3TktSQT09)
+  * January 18, 2023 11AM IST 
+  * February 15, 2023 11AM IST
+* **AMER** (every third Thursday of the month) - join [here](https://us06web.zoom.us/j/87037874951?pwd=WGo3eUZpeWFZTlhJQXhJeXZhQmwvUT09)
+  * December 15, 2022 9AM PST
+  * January 19, 2023 9AM PST
+
+See y'all soon! 

--- a/content/en/blog/2022/end-user-discussion-group-apac/index.md
+++ b/content/en/blog/2022/end-user-discussion-group-apac/index.md
@@ -33,10 +33,10 @@ Past participants have shared with us that these have been helpful and valuable
 for them as they migrate their observability instrumentation to OpenTelemetry. 
 
 Additionally, the End User Working Group is also improving the process to share 
-any collected user feedback* with the appropriate project maintainers to help 
+any collected user feedback\* with the appropriate project maintainers to help 
 improve the user experience and increase adoption. 
 
-*Information shared in the groups can be discussed publicly, but **not** the 
+\*Information shared in the groups can be discussed publicly, but **not** the 
 identity of the person who said it or their affiliation. 
 
 ## The when


### PR DESCRIPTION
This blog post has the following goals:

1. To announce the **new** End User Discussion Groups for the APAC region, starting January 2023
2. To promote the upcoming EMEA and AMER sessions
3. To raise awareness and increase attendance of these sessions, particularly to newer members of the community 