### PR TITLE
Add `baggage` to the import line of sample code in python cookbook page

### DIFF
--- a/content/en/docs/instrumentation/python/cookbook.md
+++ b/content/en/docs/instrumentation/python/cookbook.md
@@ -51,7 +51,7 @@ with tracer.start_as_current_span("parent"):
 ## Capturing baggage at different contexts
 
 ```python
-from opentelemetry import trace
+from opentelemetry import trace, baggage
 
 tracer = trace.get_tracer(__name__)
 with tracer.start_as_current_span(name="root span") as root_span:


### PR DESCRIPTION
Importing `opentelemetry.baggage` is missing in the sample code in "Capturing baggage at different contexts" section in python cookbook page, so I added it.