### PR TITLE
Update Python auto-instrumentation command

### DIFF
--- a/content/en/docs/instrumentation/python/automatic.md
+++ b/content/en/docs/instrumentation/python/automatic.md
@@ -263,7 +263,7 @@ of HTTP header names via the environment variables
 ```console
 $ export OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST="Accept-Encoding,User-Agent,Referer"
 $ export OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE="Last-Modified,Content-Type"
-$ opentelemetry-instrument --traces_exporter console python app.py
+$ opentelemetry-instrument --traces_exporter console --metrics_exporter console python app.py
 ```
 
 These configuration options are supported by the following HTTP instrumentations:

--- a/content/en/docs/instrumentation/python/automatic.md
+++ b/content/en/docs/instrumentation/python/automatic.md
@@ -172,7 +172,7 @@ Stop the execution of `server_instrumented.py` by pressing <kbd>Control+C</kbd>
 and run the following command instead:
 
 ```console
-$ opentelemetry-instrument --traces_exporter console --metrics_exporter console python server_uninstrumented.py
+$ opentelemetry-instrument --traces_exporter console --metrics_exporter none python server_uninstrumented.py
 ```
 
 In the console where you previously executed `client.py`, run the following
@@ -263,7 +263,7 @@ of HTTP header names via the environment variables
 ```console
 $ export OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST="Accept-Encoding,User-Agent,Referer"
 $ export OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE="Last-Modified,Content-Type"
-$ opentelemetry-instrument --traces_exporter console --metrics_exporter console python app.py
+$ opentelemetry-instrument --traces_exporter console --metrics_exporter none python app.py
 ```
 
 These configuration options are supported by the following HTTP instrumentations:

--- a/content/en/docs/instrumentation/python/automatic.md
+++ b/content/en/docs/instrumentation/python/automatic.md
@@ -172,7 +172,7 @@ Stop the execution of `server_instrumented.py` by pressing <kbd>Control+C</kbd>
 and run the following command instead:
 
 ```console
-$ opentelemetry-instrument --traces_exporter console python server_uninstrumented.py
+$ opentelemetry-instrument --traces_exporter console --metrics_exporter console python server_uninstrumented.py
 ```
 
 In the console where you previously executed `client.py`, run the following


### PR DESCRIPTION
I was running through the python automatic instrumentation doc and found this command out of date.  Before adding `metrics_exporter` I got this error

```
Configuration of configurator failed
Traceback (most recent call last):
  File "/Users/tylerhelmuth/projects/honeycomb/python_auto_instrumentation/lib/python3.10/site-packages/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py", line 105, in _load_configurators
    entry_point.load()().configure(auto_instrumentation_version=__version__)  # type: ignore
  File "/Users/tylerhelmuth/projects/honeycomb/python_auto_instrumentation/lib/python3.10/site-packages/opentelemetry/sdk/_configuration/__init__.py", line 321, in configure
    self._configure(**kwargs)
  File "/Users/tylerhelmuth/projects/honeycomb/python_auto_instrumentation/lib/python3.10/site-packages/opentelemetry/sdk/_configuration/__init__.py", line 337, in _configure
    _initialize_components(kwargs.get("auto_instrumentation_version"))
  File "/Users/tylerhelmuth/projects/honeycomb/python_auto_instrumentation/lib/python3.10/site-packages/opentelemetry/sdk/_configuration/__init__.py", line 281, in _initialize_components
    trace_exporters, metric_exporters, log_exporters = _import_exporters(
  File "/Users/tylerhelmuth/projects/honeycomb/python_auto_instrumentation/lib/python3.10/site-packages/opentelemetry/sdk/_configuration/__init__.py", line 250, in _import_exporters
    for (exporter_name, exporter_impl,) in _import_config_components(
  File "/Users/tylerhelmuth/projects/honeycomb/python_auto_instrumentation/lib/python3.10/site-packages/opentelemetry/sdk/util/__init__.py", line 54, in _import_config_components
    raise RuntimeError(
RuntimeError: Requested component 'otlp_proto_grpc' not found in entry points for 'opentelemetry_metrics_exporter'
Failed to auto initialize opentelemetry
Traceback (most recent call last):
  File "/Users/tylerhelmuth/projects/honeycomb/python_auto_instrumentation/lib/python3.10/site-packages/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py", line 121, in initialize
    _load_configurators()
  File "/Users/tylerhelmuth/projects/honeycomb/python_auto_instrumentation/lib/python3.10/site-packages/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py", line 109, in _load_configurators
    raise exc
  File "/Users/tylerhelmuth/projects/honeycomb/python_auto_instrumentation/lib/python3.10/site-packages/opentelemetry/instrumentation/auto_instrumentation/sitecustomize.py", line 105, in _load_configurators
    entry_point.load()().configure(auto_instrumentation_version=__version__)  # type: ignore
  File "/Users/tylerhelmuth/projects/honeycomb/python_auto_instrumentation/lib/python3.10/site-packages/opentelemetry/sdk/_configuration/__init__.py", line 321, in configure
    self._configure(**kwargs)
  File "/Users/tylerhelmuth/projects/honeycomb/python_auto_instrumentation/lib/python3.10/site-packages/opentelemetry/sdk/_configuration/__init__.py", line 337, in _configure
    _initialize_components(kwargs.get("auto_instrumentation_version"))
  File "/Users/tylerhelmuth/projects/honeycomb/python_auto_instrumentation/lib/python3.10/site-packages/opentelemetry/sdk/_configuration/__init__.py", line 281, in _initialize_components
    trace_exporters, metric_exporters, log_exporters = _import_exporters(
  File "/Users/tylerhelmuth/projects/honeycomb/python_auto_instrumentation/lib/python3.10/site-packages/opentelemetry/sdk/_configuration/__init__.py", line 250, in _import_exporters
    for (exporter_name, exporter_impl,) in _import_config_components(
  File "/Users/tylerhelmuth/projects/honeycomb/python_auto_instrumentation/lib/python3.10/site-packages/opentelemetry/sdk/util/__init__.py", line 54, in _import_config_components
    raise RuntimeError(
RuntimeError: Requested component 'otlp_proto_grpc' not found in entry points for 'opentelemetry_metrics_exporter'
```

but everything worked as expected when I added `--metrics_exporter console`. 