### PR TITLE
adjust-spec-pages: be more precise in selecting front matter

### DIFF
--- a/scripts/adjust-spec-pages.pl
+++ b/scripts/adjust-spec-pages.pl
@@ -54,7 +54,7 @@ while(<>) {
     $file = $ARGV;
     $frontMatterFromFile = '';
     $title = '';
-    if (/^<!---?/) {
+    if (/^<!---? Hugo/) {
         while(<>) {
           last if /^-?-->/;
           $frontMatterFromFile .= $_;


### PR DESCRIPTION
- Closes #2079
- Preview: https://deploy-preview-2109--opentelemetry.netlify.app/docs/reference/specification/metrics/semantic_conventions/hardware-metrics/
- Note that I'll be submitting a followup change to the spec since front matter (linkTitle) is missing for the new Hardware page.

The following diff of the generated site files confirms that the only change resulting from this PR (other than fixes to the docs side-nav), is the added content for the hardware page:

```console
$ (cd public && git diff -bw -I 'm-docsreferencespecification|^\s+' --ignore-blank-lines) | grep ^diff | grep -v \.xml
diff --git a/docs/reference/specification/metrics/semantic_conventions/hardware-metrics/index.html b/docs/reference/specification/metrics/semantic_conventions/hardware-metrics/index.html
$
```
