### PR TITLE
adjust-spec: process img paths of schemas index page

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -28,6 +28,7 @@
     "relref",
     "subdir",
     "tabpane",
+    "tocstop",
     "Zipkin"
   ]
 }

--- a/scripts/adjust-spec-pages.pl
+++ b/scripts/adjust-spec-pages.pl
@@ -85,7 +85,7 @@ while(<>) {
 
   # Images
   s|(\.\./)?internal(/img/[-\w]+\.png)|$2|g;
-  s|(\]\()(img/.*?\))|$1../$2|g if $ARGV !~ /logs._index/;
+  s|(\]\()(img/.*?\))|$1../$2|g if $ARGV !~ /(logs|schemas)._index/;
 
   # Fix links that are to the title of the .md page
   # TODO: fix these in the spec


### PR DESCRIPTION
- Contributes to:
  - #906
  - https://github.com/open-telemetry/opentelemetry-specification/issues/2558
- Ensure img paths get processed properly for the schemas section once the following lands and the spec is updated in this repo: https://github.com/open-telemetry/opentelemetry-specification/pull/3046
- This PR **has no effect on the currently generated site files** (but it will, once the spec PR 3046 is integrated), so it is safe to merge before (or whether) PR 3046 is merged.

/cc @yurishkuro @bogdandrutu 

---

### Screenshot

Here's a screenshot of one of the file format pages once PR 3046 is integrated, along with this PR:

> <img width="1194" alt="Screen Shot 2022-12-16 at 15 27 29" src="https://user-images.githubusercontent.com/4140793/208183929-25534368-aaa4-4928-b161-4421044c2111.png">
