### PR TITLE
Don't create a docs alias for the "other" instrumentation page

### DIFF
--- a/content/en/docs/instrumentation/other/_index.md
+++ b/content/en/docs/instrumentation/other/_index.md
@@ -1,6 +1,6 @@
 ---
-linkTitle: Other
 title: Other languages
+linkTitle: Other
 weight: 99
 description: >-
   Language-specific implementation of OpenTelemetry for other languages.
@@ -10,7 +10,7 @@ Implementing the OpenTelemetry specification is not limited to the languages you
 will find in our documentation. OpenTelemetry is designed in a way that it is
 possible to implement it in every language you like.
 
-For some languages unofficial implementations exist, you can find them in the
+For some languages, unofficial implementations exist -- you can find them in the
 [registry](/registry). If you know about an implementation not listed there,
 please [add it to the registry][].
 

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -16,8 +16,10 @@
 {{ $languages := (.Site.GetPage "/docs/instrumentation").Pages -}}
 {{ range $languages -}}
 {{ $lang := .File.ContentBaseName -}}
+{{ if ne $lang "other" -}}
 /docs/{{ $lang }}   /docs/instrumentation/{{ $lang }}
 /docs/{{ $lang }}/*  /docs/instrumentation/{{ $lang }}/:splat
+{{ end -}}
 {{ end -}}
 
 {{/*


### PR DESCRIPTION
- Followup to #2062
- Copyedits to new "Other languages" page
- Skips the creation of a redirect rule of the form `/docs/<lang>` (to `/docs/instrumentation/<lang>`) for "other", since it isn't a language.

/cc @svrnm 