### PR TITLE
Add Mastodon link to footer

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -81,6 +81,10 @@ params:
         url: https://fosstodon.org/@opentelemetry
         icon: fab fa-mastodon
         desc: Follow us on Mastodon to get the latest news!
+      - name: Twitter
+        url: https://twitter.com/opentelemetry
+        icon: fab fa-twitter
+        desc: Follow us on Twitter to get the latest news!
       - name: Stack Overflow
         url: https://stackoverflow.com/questions/tagged/open-telemetry
         icon: fab fa-stack-overflow

--- a/config.yaml
+++ b/config.yaml
@@ -77,10 +77,10 @@ params:
         url: https://github.com/open-telemetry/community#mailing-lists
         icon: fa fa-envelope
         desc: List of mailing lists that the project uses.
-      - name: Twitter
-        url: https://twitter.com/opentelemetry
-        icon: fab fa-twitter
-        desc: Follow us on Twitter to get the latest news!
+      - name: Mastodon
+        url: https://fosstodon.org/@opentelemetry
+        icon: fab fa-mastodon
+        desc: Follow us on Mastodon to get the latest news!
       - name: Stack Overflow
         url: https://stackoverflow.com/questions/tagged/open-telemetry
         icon: fab fa-stack-overflow

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,7 +6,6 @@
     {{ partial "head.html" . }}
   </head>
   <body class="td-{{ .Kind }}{{ with .Page.Params.body_class }} {{ . }}{{ end }}">
-    <a rel="me" href="https://fosstodon.org/@opentelemetry"></a>
     <header>
       {{ partial "navbar.html" . }}
     </header>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,6 +6,7 @@
     {{ partial "head.html" . }}
   </head>
   <body class="td-{{ .Kind }}{{ with .Page.Params.body_class }} {{ . }}{{ end }}">
+    <a rel="me" href="https://fosstodon.org/@opentelemetry"></a>
     <header>
       {{ partial "navbar.html" . }}
     </header>


### PR DESCRIPTION
Related: #2104

the best place for having the link to the mastodon account would be the footer where we have all those other links.

Only challenge: I can not set the `rel="me"` easily, this is something that probably needs to be fixed in docs, @chalin? 