### PR TITLE
Fix broken links in registry

### DIFF
--- a/content/en/registry/instrumentation-java-jms.md
+++ b/content/en/registry/instrumentation-java-jms.md
@@ -6,7 +6,7 @@ language: java
 tags:
   - java
   - instrumentation
-repo: https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/jms-1.1
+repo: https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/jms
 license: Apache 2.0
 description: This library provides a JMS instrumentation to track requests through OpenTelemetry.
 authors: OpenTelemetry Authors

--- a/content/en/registry/resource-detector-go-aws.md
+++ b/content/en/registry/resource-detector-go-aws.md
@@ -11,7 +11,7 @@ tags:
     - lambda
     - resource-detector
     - go
-repo: [https://github.com/open-telemetry/opentelemetry-go-contrib/blob/main/detectors/aws/](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/detectors/aws)
+repo: https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/detectors/aws
 license: Apache 2.0
 description: AWS resource detectors for go.
 authors: OpenTelemetry Authors

--- a/content/en/registry/resource-detector-go-aws.md
+++ b/content/en/registry/resource-detector-go-aws.md
@@ -11,7 +11,7 @@ tags:
     - lambda
     - resource-detector
     - go
-repo: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/main/detectors/aws/
+repo: [https://github.com/open-telemetry/opentelemetry-go-contrib/blob/main/detectors/aws/](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/detectors/aws)
 license: Apache 2.0
 description: AWS resource detectors for go.
 authors: OpenTelemetry Authors


### PR DESCRIPTION
- instrumentation-java-jms.md: https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/jms-1.1, error 404
- resource-detector-go-aws.md: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/main/detectors/aws/, error 301