### PR TITLE
Call out workshop resources are legacy

### DIFF
--- a/content/en/docs/workshop/resources.md
+++ b/content/en/docs/workshop/resources.md
@@ -1,6 +1,12 @@
 ---
-title: Workshop resources
+title: Legacy Workshop resources
 ---
+
+> The following workshop contents are considered legacy and have outdated code.
+> Many of the slides are still relevant and you should feel free to use them.
+>
+> For a reference application, refer to the [OpenTelemetry Demo](https://github.com/open-telemetry/opentelemetry-demo)
+> to teach people how to best use automatic and manual instrumentation.
 
 OpenTelemetry provides the following resources free of charge and available
 under the Apache 2.0 license. These resources are intended to aid you in running


### PR DESCRIPTION
fixes https://github.com/open-telemetry/opentelemetry.io/issues/1596

Preview: https://deploy-preview-2127--opentelemetry.netlify.app/docs/workshop/resources/