### PR TITLE
Add DaoCloud to the vendor list of OTel

### DIFF
--- a/content/en/vendors.md
+++ b/content/en/vendors.md
@@ -19,11 +19,12 @@ OpenTelemetry in their commercial products.
 
 | Company                    | Distri&shy;bution | Native OTLP | Learn more                                                                                                                                            |
 | -------------------------- | ----------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| AppDynamics (Cisco)                | Yes               | Yes         | [docs.appdynamics.com/...](https://docs.appdynamics.com/latest/en/application-monitoring/appdynamics-for-opentelemetry)                               |
+| AppDynamics (Cisco)        | Yes               | Yes         | [docs.appdynamics.com/...](https://docs.appdynamics.com/latest/en/application-monitoring/appdynamics-for-opentelemetry)                               |
 | Aria by VMware (Wavefront) | No                | Yes         | [docs.wavefront.com/...](https://docs.wavefront.com/opentelemetry_tracing.html)                                                                       |
 | Aspecto                    | Yes               | Yes         | [aspecto.io](https://www.aspecto.io)                                                                                                                  |
 | AWS                        | Yes               | No          | [aws-otel.github.io](https://aws-otel.github.io)                                                                                                      |
 | Azure                      | Yes               | No          | [docs.microsoft.com/...](https://docs.microsoft.com/azure/azure-monitor/app/opentelemetry-overview)                                                   |
+| DaoCloud                   | Yes               | Yes         | [docs.daocloud.io/...](https://docs.daocloud.io/en/insight/06UserGuide/01quickstart/otel/otel/)                                                            |
 | Datadog                    | Yes               | Yes         | [docs.datadoghq.com/...](https://docs.datadoghq.com/tracing/setup_overview/open_standards)                                                            |
 | Dynatrace                  | Yes               | Yes         | [dynatrace.com/...](https://www.dynatrace.com/support/help/how-to-use-dynatrace/transactions-and-services/service-monitoring-settings/opentelemetry/) |
 | Elastic                    | Yes               | Yes         | [elastic.co/...](https://www.elastic.co/guide/en/apm/get-started/current/open-telemetry-elastic.html)                                                 |


### PR DESCRIPTION
DaoCloud provides a k8s-based platform, named DCE, in China past and recently exploring international market.

DCE well supports for observability with OTel.