### PR TITLE
[Java] Add docs to enable only specific instrumentation

### DIFF
--- a/content/en/docs/instrumentation/java/automatic/_index.md
+++ b/content/en/docs/instrumentation/java/automatic/_index.md
@@ -18,12 +18,19 @@ service or app code, see [Manual instrumentation](../manual).
 ## Setup
 
  1. Download [opentelemetry-javaagent.jar][] from [Releases][] of the
-    `opentelemetry-java-instrumentation` repo. The JAR file contains the agent
-    and instrumentation libraries.
- 2. Place the JAR in your preferred directory and launch it with your app:
-
+    `opentelemetry-java-instrumentation` repo and place the JAR in your preferred directory.
+    The JAR file contains the agent and instrumentation libraries.
+ 2. Add `-javaagent:path/to/opentelemetry-javaagent.jar` and other config
+    to your JVM's startup arguments and launch your app:
+    - Directly on the startup command:
     ```console
-    $ java -javaagent:path/to/opentelemetry-javaagent.jar -jar myapp.jar
+    $ java -javaagent:path/to/opentelemetry-javaagent.jar -Dotel.service.name=your-service-name -jar myapp.jar
+    ```
+    - Via the `JAVA_TOOL_OPTIONS` and other environment variables:
+    ```console
+    $ export JAVA_TOOL_OPTIONS="-javaagent:path/to/opentelemetry-javaagent.jar"
+    $ export OTEL_SERVICE_NAME="your-service-name"
+    $ java -jar myapp.jar
     ```
 
 ## Configuring the agent

--- a/content/en/docs/instrumentation/java/automatic/agent-config.md
+++ b/content/en/docs/instrumentation/java/automatic/agent-config.md
@@ -194,8 +194,8 @@ This may be desireable to reduce startup overhead or to have more control of whi
 - Disable all instrumentation in the agent using `-Dotel.instrumentation.common.default-enabled=false`
 (or using the equivalent environment variable `OTEL_INSTRUMENTATION_COMMON_DEFAULT_ENABLED=false`).
 - Enable each desired instrumentation individually using `-Dotel.instrumentation.[name].enabled=true`
-(or using the equivalent environment variable `OTEL_INSTRUMENTATION_[NAME]_ENABLED`) where `name`
-(`NAME`) is the corresponding instrumentation `name` below.
+(or using the equivalent environment variable `OTEL_INSTRUMENTATION_[NAME]_ENABLED`) where `[name]`
+(`[NAME]`) is the corresponding instrumentation `name` below.
 
 ### Enable manual instrumentation only
 

--- a/content/en/docs/instrumentation/java/automatic/agent-config.md
+++ b/content/en/docs/instrumentation/java/automatic/agent-config.md
@@ -197,6 +197,10 @@ This may be desireable to reduce startup overhead or to have more control of whi
 (or using the equivalent environment variable `OTEL_INSTRUMENTATION_[NAME]_ENABLED`) where `[name]`
 (`[NAME]`) is the corresponding instrumentation `name` below.
 
+> **Note**: Some instrumentation relies on other instrumentation to function properly. When selectively
+enabling instrumentation, be sure to enable the transitive dependencies too. Determining this dependency
+relationship is left as an exercise to the user.
+
 ### Enable manual instrumentation only
 
 You can suppress all auto instrumentations but have support for manual

--- a/content/en/docs/instrumentation/java/automatic/agent-config.md
+++ b/content/en/docs/instrumentation/java/automatic/agent-config.md
@@ -42,6 +42,19 @@ The agent can consume configuration from one or more of the following sources
   [`ConfigPropertySource`](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/javaagent-extension-api/src/main/java/io/opentelemetry/javaagent/extension/config/ConfigPropertySource.java)
   SPI
 
+## Configuring with Environment Variables
+
+In some environments, configuring via Environment Variables is more preferred.
+Any setting configurable with a System Property can also be configured with an Environment Variable.
+Many settings below include both options, but where they don't apply the following steps
+to determine the correct name mapping of the desired System Property:
+
+- Convert the System Property to uppercase.
+- Replace all `.` and `-` characters with `_`.
+
+For example `otel.instrumentation.common.default-enabled`
+would convert to `OTEL_INSTRUMENTATION_COMMON_DEFAULT_ENABLED`.
+
 ### Configuration file
 
 You can provide a path to agent configuration file by setting the following
@@ -172,6 +185,23 @@ span link connecting it to the producer trace.
 
 You can disable the agent using `-Dotel.javaagent.enabled=false` (or using the
 equivalent environment variable `OTEL_JAVAAGENT_ENABLED=false`).
+
+### Enable only specific instrumentation
+
+You can disable all default auto instrumentation and selectively re-enable individual instrumentation.
+This may be desireable to reduce startup overhead or to have more control of which instrumentation is applied.
+
+- Disable all instrumentation in the agent using `-Dotel.instrumentation.common.default-enabled=false`
+(or using the equivalent environment variable `OTEL_INSTRUMENTATION_COMMON_DEFAULT_ENABLED=false`).
+- Enable each desired instrumentation individually using `-Dotel.instrumentation.[name].enabled=true`
+(or using the equivalent environment variable `OTEL_INSTRUMENTATION_[NAME]_ENABLED`) where `name`
+(`NAME`) is the corresponding instrumentation `name` below.
+
+### Enable manual instrumentation only
+
+You can suppress all auto instrumentations but have support for manual
+instrumentation with `@WithSpan` and normal API interactions by using
+`-Dotel.instrumentation.common.default-enabled=false -Dotel.instrumentation.opentelemetry-api.enabled=true -Dotel.instrumentation.opentelemetry-instrumentation-annotations.enabled=true`
 
 ### Suppressing specific agent instrumentation
 
@@ -321,12 +351,6 @@ instrumentation which would also disable the instrumentation's capturing of
   name="otel.instrumentation.common.experimental.view-telemetry.enabled"
   default=true
 %}} Enables the view telemetry. {{% /config_option %}}
-
-### Enable manual instrumentation only
-
-You can suppress all auto instrumentations but have support for manual
-instrumentation with `@WithSpan` and normal API interactions by using
-`-Dotel.instrumentation.common.default-enabled=false -Dotel.instrumentation.opentelemetry-api.enabled=true -Dotel.instrumentation.opentelemetry-instrumentation-annotations.enabled=true`
 
 ### Instrumentation span suppression behavior
 


### PR DESCRIPTION
Also:
- Added docs explaining the mapping of system properties to environment variables. 
- Moved the section for "Enable manual instrumentation only" to be grouped better.
- Added `JAVA_TOOL_OPTIONS` setup instructions.