### PR TITLE
[collector] Use ${env:ENV} style syntax for env variable expansion

### DIFF
--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -467,8 +467,8 @@ service:
 
 ### Configuration Environment Variables
 
-The use and expansion of environment variables is supported in the Collector
-configuration using PowerShell-style syntax. For example:
+The use and expansion of environment variables is supported in the Collector configuration. 
+For example to use the values stored on the `DB_KEY` and `OPERATION` environment variables you can write the following:
 
 ```yaml
 processors:

--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -468,14 +468,14 @@ service:
 ### Configuration Environment Variables
 
 The use and expansion of environment variables is supported in the Collector
-configuration using shell-style syntax. For example:
+configuration using PowerShell-style syntax. For example:
 
 ```yaml
 processors:
   attributes/example:
     actions:
-      - key: "${DB_KEY}"
-        action: "$OPERATION"
+      - key: "${env:DB_KEY}"
+        action: "${env:OPERATION}"
 ```
 
 Use `$$` to indicate a literal `$`. For example, representing


### PR DESCRIPTION
Uses new `${env:ENV}` style syntax for environment variable expansion. This is the recommended way as of recent Collector versions.

Relates to open-telemetry/opentelemetry-collector-contrib/issues/17299