### PR TITLE
Replace swap scraper with the paging scrape

### DIFF
--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -158,7 +158,7 @@ receivers:
       network:
       process:
       processes:
-      swap:
+      paging:
 
   # Data sources: traces
   jaeger:


### PR DESCRIPTION
After playing around with the example configuration, the collector was complaining that the swap scraper for `hostmetrics` receiver does not exist, it might have been the initial naming for the paging scraper. Fixing this in the configuration doc.