### PR TITLE
add examples for async counter, updown counter, gauge

### DIFF
--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -681,7 +681,7 @@ OpenTelemetry JavaScript currently supports the following `Instrument`s:
 * Asynchronous UpDownCounter, an asynchronous instrument which supports
   increments and decrements
 
-For more on synchronous vs. asynchronous instruments, or what metric is best suited for your use case, see these supplementary [guidelines](https://opentelemetry.io/docs/reference/specification/metrics/supplementary-guidelines/).
+For more on synchronous vs. asynchronous instruments, or what metric is best suited for your use case, see these supplementary [guidelines](/docs/reference/specification/metrics/supplementary-guidelines/).
 
 If a `MeterProvider` is not created either by an instrumentation library or
 manually, the OpenTelemetry Metrics API will use a no-op implementation and
@@ -1016,11 +1016,20 @@ cntr.add(1, { 'some.optional.attribute': 'some value' });
 
 ### Configure Metric Views
 
-A Metric View provides developers with the ability to customize metrics exposed by the Metrics SDK. 
+A Metric View provides developers with the ability to customize metrics exposed by the Metrics SDK.
 
-To instantiate a view, one must first select a target instrument. The following are valid selectors for metrics: `instrumentType`, `instrumentName`, `meterName`, `meterVersion`, and `meterSchemaUrl`. Selecting by instrument name has support for wildcards, so you can select all instruments using `*` or select all instruments starting with `http` by using `http*`.
+#### Selectors
 
-Here are some examples of configurations possible with views:
+To instantiate a view, one must first select a target instrument. The following are valid selectors for metrics:
+- `instrumentType`
+- `instrumentName`
+- `meterName`
+- `meterVersion`
+- `meterSchemaUrl`
+
+Selecting by `instrumentName` (of type string) has support for wildcards, so you can select all instruments using `*` or select all instruments whose name starts with `http` by using `http*`.
+
+#### Examples
 
 Filter attributes on all metric types:
 
@@ -1051,6 +1060,8 @@ const histogramView = new View({
   instrumentType: InstrumentType.HISTOGRAM,
 });
 ```
+
+#### Attach to meter provider
 
 Once a view has been configured, attach it to the corresponding meter provider:
 ```js

--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -963,7 +963,7 @@ counter.addCallback(
 //... calls to addEvent and removeEvent
 ```
 
-### Using Observable (aka Async) Gauges
+### Using Observable (Async) Gauges
 
 Observable Gauges should be used to measure non-additive values. 
 

--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -953,7 +953,7 @@ counter.addCallback(
 //... calls to addEvent and removeEvent
 ```
 
-### Using Observable (aka Async) Guages
+### Using Observable (aka Async) Gauges
 
 Observable Gauges should be used to measure non-additive values. 
 

--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -1063,10 +1063,12 @@ const histogramView = new View({
 
 #### Attach to meter provider
 
-Once a view has been configured, attach it to the corresponding meter provider:
+Once views have been configured, attach them to the corresponding meter provider:
 ```js
 const meterProvider = new MeterProvider({
   views: [
+    limitAttributesView,
+    dropView,
     histogramView
   ]
 });

--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -1034,7 +1034,7 @@ Selecting by `instrumentName` (of type string) has support for wildcards, so you
 Filter attributes on all metric types:
 
 ```js
-new View({
+const limitAttributesView = new View({
   // only export the attribute 'environment'
   attributeKeys: ['environment'],
   // apply the view to all instruments

--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -1041,7 +1041,8 @@ const dropView = new View({
 });
 ```
 
-- Define explicit bucket sizes for Histogram metrics
+Define explicit bucket sizes for the Histogram named `http.server.duration`:
+
 ```js
 const histogramView = new View({
   aggregation: new ExplicitBucketHistogramAggregation([0, 1, 5, 10, 15, 20, 25, 30]),

--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -824,11 +824,19 @@ involved.
 
 ### Synchronous and asynchronous instruments
 
-OpenTelemetry provides two major categories of instruments: synchronous and asynchronous (observable) instruments. Synchronous instruments can be used anywhere in the code. Using these, measurements can be pushed to the instrument at any time during the execution. This means that during an export cycle, multiple or no measurements can take place. 
+OpenTelemetry provides two major categories of instruments: synchronous and asynchronous (observable) instruments.
 
-Asynchronous instruments, on the other hand, provide a measurement at the request of the SDK. When the SDK exports, a callback that was provided to the instrument on creation is invoked. This callback provides the SDK with a measurement, which is then immediately exported. Therefore all measurements on asynchronous instruments are performed once per export cycle. 
+Synchronous instruments take a measurement when they are called. The measurement is done as another call during program execution, just like any other function call. Periodically, the aggregation of these measurements is exported by a configured exporter. Because measurements are decoupled from exporting values, an export cycle may contain zero or multiple aggregated measurements.
 
-Asynchronous instruments are useful when updating a counter is NOT computationally cheap, the increments happen at very high frequencies, or we simply derive no value from knowing the precise timestamp of increments. In these instances, we would rather observe a cumulative value directly, rather than aggregate a series of deltas in post-processing (the synchronous example). Take note of the use of `observe` rather than `add` in the appropriate code examples below.
+Asynchronous instruments, on the other hand, provide a measurement at the request of the SDK. When the SDK exports, a callback that was provided to the instrument on creation is invoked. This callback provides the SDK with a measurement that is immediately exported. All measurements on asynchronous instruments are performed once per export cycle. 
+
+Asynchronous instruments are useful in several circumstances, such as:
+
+* When updating a counter is not computationally cheap, and thus you don't want the currently executing thread to have to wait for that measurement
+* Observations need to happen at frequencies unrelated to program execution (i.e., they cannot be accurately measured when tied to a request lifecycle)
+* There is no value from knowing the precise timestamp of increments
+
+In cases like these, it's often better to observe a cumulative value directly, rather than aggregate a series of deltas in post-processing (the synchronous example). Take note of the use of `observe` rather than `add` in the appropriate code examples below.
 
 ### Using Counters
 

--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -955,7 +955,7 @@ counter.addCallback(
 
 ### Using Observable (aka Async) Guages
 
-Observable Guages should be used to measure non-additive values. 
+Observable Gauges should be used to measure non-additive values. 
 
 ```js
 let temperature = 32

--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -1006,6 +1006,50 @@ const counter = myMeter.createCounter('my.counter');
 cntr.add(1, { 'some.optional.attribute': 'some value' });
 ```
 
+### Configure Metric Views
+
+A Metric View provides developers with the ability to customize metrics exposed by the Metrics SDK. 
+
+To instantiate a view, one must first select a target instrument. The following are valid selectors for metrics: `instrumentType`, `instrumentName`, `meterName`, `meterVersion`, and `meterSchemaUrl`. Selecting by instrument name has support for wildcards, so you can select all instruments using `*` or select all instruments starting with `http` by using `http*`.
+
+Once you've selected a target instrument, here are some examples of configurations possible with views:
+
+- Filter attributes reported on metrics
+```js
+new View({
+  // only export the attribute 'environment'
+  attributeKeys: ['environment'],
+  // apply the view to all instruments
+  instrumentName: '*',
+})
+```
+
+- Select instruments to be processed or ignored
+```js
+const dropView = new View({
+  aggregation: new DropAggregation(),
+  meterName: 'pubsub',
+});
+```
+
+- Define explicit bucket sizes for Histogram metrics
+```js
+const histogramView = new View({
+  aggregation: new ExplicitBucketHistogramAggregation([0, 1, 5, 10, 15, 20, 25, 30]),
+  instrumentName: 'http.server.duration',
+  instrumentType: InstrumentType.HISTOGRAM,
+});
+```
+
+Lastly, once a view has been configured, simply attach it to the corresponding meter provider:
+```js
+const meterProvider = new MeterProvider({
+  views: [
+    histogramView
+  ]
+});
+```
+
 ## Next steps
 
 You'll also want to configure an appropriate exporter to [export your telemetry

--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -937,7 +937,7 @@ counter.addCallback(
 //... calls to addEvent
 ```
 
-### Using Observable (aka Async) UpDown Counters
+### Using Observable (Async) UpDown Counters
 
 Observable UpDown counters can increment and decrement, allowing you to measure an additive, non-negative, non-monotonically increasing cumulative value.
 

--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -1022,7 +1022,8 @@ To instantiate a view, one must first select a target instrument. The following 
 
 Once you've selected a target instrument, here are some examples of configurations possible with views:
 
-- Filter attributes reported on metrics
+Filter attributes on all metric types:
+
 ```js
 new View({
   // only export the attribute 'environment'

--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -1050,7 +1050,7 @@ const histogramView = new View({
 });
 ```
 
-Lastly, once a view has been configured, simply attach it to the corresponding meter provider:
+Once a view has been configured, attach it to the corresponding meter provider:
 ```js
 const meterProvider = new MeterProvider({
   views: [

--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -681,7 +681,7 @@ OpenTelemetry JavaScript currently supports the following `Instrument`s:
 * Asynchronous UpDownCounter, an asynchronous instrument which supports
   increments and decrements
 
-For more on synchronous vs. asynchronous instruments, or what metric is best suited for your use case, see these supplementary [guidelines](/docs/reference/specification/metrics/supplementary-guidelines/).
+For more on synchronous and asynchronous instruments, and which kind is best suited for your use case, see [Supplementary Guidelines](/docs/reference/specification/metrics/supplementary-guidelines/).
 
 If a `MeterProvider` is not created either by an instrumentation library or
 manually, the OpenTelemetry Metrics API will use a no-op implementation and

--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -1020,7 +1020,7 @@ A Metric View provides developers with the ability to customize metrics exposed 
 
 To instantiate a view, one must first select a target instrument. The following are valid selectors for metrics: `instrumentType`, `instrumentName`, `meterName`, `meterVersion`, and `meterSchemaUrl`. Selecting by instrument name has support for wildcards, so you can select all instruments using `*` or select all instruments starting with `http` by using `http*`.
 
-Once you've selected a target instrument, here are some examples of configurations possible with views:
+Here are some examples of configurations possible with views:
 
 Filter attributes on all metric types:
 

--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -1032,7 +1032,8 @@ new View({
 })
 ```
 
-- Select instruments to be processed or ignored
+Drop all instruments with the meter name `pubsub`:
+
 ```js
 const dropView = new View({
   aggregation: new DropAggregation(),

--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -902,6 +902,75 @@ app.get('/', (_req, _res) => {
 {{< /tab >}}
 {{< /tabpane>}}
 
+### Using Observable (aka Async) Counters
+
+Observable counters can be used to measure an additive, non-negative, monotonically increasing value. They are
+useful when increasing the counter is NOT computationally cheap, the increments happen at very high frequencies, or we simply derive no value from knowing the precise timestamp of increments.
+
+In these instances, we would rather observe the aggregate value directly, rather than aggregate a series of deltas in post-processing (the synchronous example). Take note of the use of `observe` rather than `add`.
+
+```js
+let events = []
+
+const addEvent = (name) => {
+  events = append(events, name)
+}
+
+const counter = myMeter.createObservableCounter('events.counter');
+
+counter.addCallback(
+  (result) => {
+    result.observe(len(events))
+  }
+)
+
+//... calls to addEvent
+```
+
+### Using Observable (aka Async) UpDown Counters
+
+Observable UpDown counters can increment and decrement, allowing you to measure an additive, non-negative, non-monotonically increasing cumulative value.
+
+```js
+let events = []
+
+const addEvent = (name) => {
+  events = append(events, name)
+}
+
+const removeEvent = () => {
+  events.pop()
+}
+
+const counter = myMeter.createObservableUpDownCounter('events.counter');
+
+counter.addCallback(
+  (result) => {
+    result.observe(len(events))
+  }
+)
+
+//... calls to addEvent and removeEvent
+```
+
+### Using Observable (aka Async) Guages
+
+Observable Guages should be used to measure non-additive values. 
+
+```js
+let temperature = 32
+
+const gauge = myMeter.createObservableGauge('temperature.gauge');
+
+counter.addCallback(
+  (result) => {
+    result.observe(temperature)
+  }
+)
+
+//... temperature variable is modified by a sensor
+```
+
 ### Describing instruments
 
 When you create instruments like counters, histograms, etc. you can give them a

--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -824,7 +824,7 @@ involved.
 
 ### Synchronous and asynchronous instruments
 
-OpenTelemetry provides two major categories of instruments: synchronous and asynchronous (observable) instruments.
+OpenTelemetry instruments are either synchronous or asynchronous (observable).
 
 Synchronous instruments take a measurement when they are called. The measurement is done as another call during program execution, just like any other function call. Periodically, the aggregation of these measurements is exported by a configured exporter. Because measurements are decoupled from exporting values, an export cycle may contain zero or multiple aggregated measurements.
 

--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -915,7 +915,7 @@ app.get('/', (_req, _res) => {
 {{< /tab >}}
 {{< /tabpane>}}
 
-### Using Observable (aka Async) Counters
+### Using Observable (Async) Counters
 
 Observable counters can be used to measure an additive, non-negative, monotonically increasing value.
 

--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -681,6 +681,8 @@ OpenTelemetry JavaScript currently supports the following `Instrument`s:
 * Asynchronous UpDownCounter, an asynchronous instrument which supports
   increments and decrements
 
+For more on synchronous vs. asynchronous instruments, or what metric is best suited for your use case, see these supplementary [guidelines](https://opentelemetry.io/docs/reference/specification/metrics/supplementary-guidelines/).
+
 If a `MeterProvider` is not created either by an instrumentation library or
 manually, the OpenTelemetry Metrics API will use a no-op implementation and
 fail to generate data.
@@ -822,12 +824,15 @@ involved.
 
 ### Synchronous and asynchronous instruments
 
-OpenTelemetry provides two major categories of instruments: synchronous and anynchronous (observable) instruments. Synchronous instruments can be used anywhere in the code. Using these, measurements can be pushed to the instrument at any time during the execution. This means that during an export cycle, multiple or no measurements can take place. Asynchronous instruments, on the other hand, provide a measurement at the request of the SDK. When the SDK exports, a callback that was provided to the instrument on creation is invoked. This callback provides the SDK with a measurement, which is then immediately exported. Therefore all measurement on asynchronous instruments are performed once per export cycle. 
+OpenTelemetry provides two major categories of instruments: synchronous and asynchronous (observable) instruments. Synchronous instruments can be used anywhere in the code. Using these, measurements can be pushed to the instrument at any time during the execution. This means that during an export cycle, multiple or no measurements can take place. 
+
+Asynchronous instruments, on the other hand, provide a measurement at the request of the SDK. When the SDK exports, a callback that was provided to the instrument on creation is invoked. This callback provides the SDK with a measurement, which is then immediately exported. Therefore all measurements on asynchronous instruments are performed once per export cycle. 
+
+Asynchronous instruments are useful when updating a counter is NOT computationally cheap, the increments happen at very high frequencies, or we simply derive no value from knowing the precise timestamp of increments. In these instances, we would rather observe a cumulative value directly, rather than aggregate a series of deltas in post-processing (the synchronous example). Take note of the use of `observe` rather than `add` in the appropriate code examples below.
 
 ### Using Counters
 
-Counters can by used to measure a non-negative, increasing value. They are
-useful when increasing the counter is computationally cheap.
+Counters can by used to measure a non-negative, increasing value.
 
 ```js
 const counter = myMeter.createCounter('events.counter');
@@ -904,10 +909,7 @@ app.get('/', (_req, _res) => {
 
 ### Using Observable (aka Async) Counters
 
-Observable counters can be used to measure an additive, non-negative, monotonically increasing value. They are
-useful when increasing the counter is NOT computationally cheap, the increments happen at very high frequencies, or we simply derive no value from knowing the precise timestamp of increments.
-
-In these instances, we would rather observe the aggregate value directly, rather than aggregate a series of deltas in post-processing (the synchronous example). Take note of the use of `observe` rather than `add`.
+Observable counters can be used to measure an additive, non-negative, monotonically increasing value.
 
 ```js
 let events = []


### PR DESCRIPTION
Notes:
- added descriptions and code examples for various async instruments
- i would like to point out that the descriptions earlier in the document for synchronous counters, etc. slightly deviate from my description. in particular, i reference the terms `additive` and `monotonic` which are not necessarily referenced in earlier descriptions. i think we should agree on making all of these consistent before merging.
- i relied on this page to inform my descriptions, and this is also how i interpreted the various metrics when implementing them in Golang: https://opentelemetry.io/docs/reference/specification/metrics/supplementary-guidelines/

---

Preview: https://deploy-preview-2144--opentelemetry.netlify.app/docs/instrumentation/js/instrumentation