### PR TITLE
Add semantic conventions to the concepts TOC in docs

### DIFF
--- a/content/en/docs/concepts/semantic-conventions.md
+++ b/content/en/docs/concepts/semantic-conventions.md
@@ -1,0 +1,14 @@
+---
+title: Semantic Conventions
+description: >-
+  Common names for different kinds of operations and data
+weight: 30
+---
+
+OpenTelemetry defines Semantic Conventions (sometimes called Semantic Attributes) that specify common names for different kinds of operations and data. The benefit to using Semantic Conventions is in following a common naming scheme that can be standardized across a codebase, libraries, and platforms.
+
+Currently, Semantic Conventions are split by signal:
+
+* [Trace Semantic Conventions](/docs/reference/specification/trace/semantic_conventions/)
+* [Metric Semantic Conventions](/docs/reference/specification/metrics/semantic_conventions/)
+* [Resource Semantic Conventions](/docs/reference/specification/resource/semantic_conventions/)

--- a/content/en/docs/concepts/semantic-conventions.md
+++ b/content/en/docs/concepts/semantic-conventions.md
@@ -7,7 +7,7 @@ weight: 30
 
 OpenTelemetry defines Semantic Conventions (sometimes called Semantic Attributes) that specify common names for different kinds of operations and data. The benefit to using Semantic Conventions is in following a common naming scheme that can be standardized across a codebase, libraries, and platforms.
 
-Currently, Semantic Conventions are split by signal:
+Currently, Semantic Conventions are available for traces, metrics and resources:
 
 * [Trace Semantic Conventions](/docs/reference/specification/trace/semantic_conventions/)
 * [Metric Semantic Conventions](/docs/reference/specification/metrics/semantic_conventions/)


### PR DESCRIPTION
Adds it so you can navigate to this very important concept easily.

It should have more commentary and all that, but for now let's surface it more.