### PR TITLE
Update Hugo and Docsy deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,9 @@
     "serve:hugo": "npm run _serve:hugo",
     "serve": "npm run _serve",
     "test": "npm run check-links",
+    "update:pkg:docsy-dep": "npm install --save-dev autoprefixer@latest postcss@latest postcss-cli@latest",
     "update:pkg:hugo": "npm install --save-dev --save-exact hugo-extended@latest",
-    "update:pkg:hugo+": "npm install --save-dev autoprefixer@latest postcss@latest postcss-cli@latest",
+    "update:pkg:hugo+": "npm run update:pkg:hugo && npm run update:pkg:docsy-dep",
     "update:pkg:netlify": "npm install --save-dev netlify-cli@latest",
     "update:pkg:other": "npm install --save-dev npm-run-all@latest",
     "update:submodule:lang": "run-s update:submodule _get:submodule:non-lang",
@@ -72,12 +73,12 @@
     }
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.12",
-    "hugo-extended": "0.108.0",
+    "autoprefixer": "^10.4.13",
+    "hugo-extended": "0.109.0",
     "netlify-cli": "^12.0.3",
     "npm-run-all": "^4.1.5",
-    "postcss": "^8.4.17",
-    "postcss-cli": "^10.0.0",
+    "postcss": "^8.4.21",
+    "postcss-cli": "^10.1.0",
     "prettier": "^2.6.2",
     "textlint": "^12.2.3",
     "textlint-rule-terminology": "^3.0.4"


### PR DESCRIPTION
- Closes #2133
- Updates NPM packages for Hugo and Docsy deps
- Tweaks NPM scripts

There is no change in the generated site files:

```console
$ npm run update:pkg:hugo+
...
$ npm run check-links               
...
Start building sites … 
hugo v0.109.0-47b12b83e636224e5e601813ff3e6790c191e371+extended darwin/amd64 BuildDate=2022-12-23T10:38:11Z VendorInfo=gohugoio
...
htmltest started at 03:45:46 on public
========================================================================
✔✔✔ passed in 2.344007504s
tested 901 documents
$ (cd public && git diff -bw --ignore-blank-lines -I "Hugo 0\.")
$ 
```