### PR TITLE
Add demo link to homepage and drop docs placeholder

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -14,6 +14,7 @@ developer_note:
 <div class="l-primary-buttons mt-5">
 
 - [Learn more](/docs/concepts/)
+- [Try the demo](/community/demo/)
 
 </div>
 

--- a/content/en/docs/opentelemetry-demo.md
+++ b/content/en/docs/opentelemetry-demo.md
@@ -1,6 +1,0 @@
----
-title: OpenTelemetry Demo
-manualLink: /community/demo/
-_build: { render: link }
-weight: 12
----


### PR DESCRIPTION
- Contributes to #2158
- Proposes to drop the demo sidebar placeholder under `/docs` in favor of a homepage link to the demo. Part of the rational here is to try to keep the docs top-level as short and coherent as possible. This is just a proposal, feedback is welcome.

### Screenshot

<img width="1054" alt="Screen Shot 2023-01-17 at 08 54 05" src="https://user-images.githubusercontent.com/4140793/212917446-462e20db-3abc-49dc-81ba-66eacb2be42a.png">

/cc @cartermp 