### PR TITLE
fix(swift): add missing comma in Setup code example

### DIFF
--- a/content/en/docs/instrumentation/swift/manual.md
+++ b/content/en/docs/instrumentation/swift/manual.md
@@ -32,7 +32,7 @@ let otlpConfiguration = OtlpConfiguration(timeout: OtlpConfiguration.DefaultTime
 let grpcChannel = ClientConnection.usingPlatformAppropriateTLS(for: MultiThreadedEventLoopGroup(numberOfThreads:1))
                                                   .connect(host: <collector host>, port: <collector port>)
 
-let traceExporter = OtlpTraceExporter(channel: grpcChannel
+let traceExporter = OtlpTraceExporter(channel: grpcChannel,
                                       config: otlpConfiguration)
 
 // build & register the Tracer Provider using the built otlp trace exporter


### PR DESCRIPTION
I followed the swift instructions from the OpenTelemetry website and there is a comma missing in the Setup example:

![image](https://user-images.githubusercontent.com/22870745/213118068-c3d0e663-dcdd-446b-bd6b-446d837acfaf.png)

From [the swift docs](https://docs.swift.org/swift-book/LanguageGuide/Functions.html):
> You call the greet(person:alreadyGreeted:) function by passing it both a String argument value labeled person and a Bool argument value labeled alreadyGreeted in parentheses, separated by commas

According to the swift website, when calling a function, there should be a comma