### PR TITLE
fix(swift): URLSession instrumentation missing argument label

### DIFF
--- a/content/en/docs/instrumentation/swift/libraries.md
+++ b/content/en/docs/instrumentation/swift/libraries.md
@@ -108,7 +108,7 @@ Below is an example of initialization.
 parameters defined above to suit the needs of the application.
 
 ```swift
-let sessionInstrumentation = URLSessionInstrumentation(URLSessionInstrumentationConfiguration())
+let sessionInstrumentation = URLSessionInstrumentation(configuration: URLSessionInstrumentationConfiguration())
 ```
 
 ### Details


### PR DESCRIPTION
The `NSURLSession Instrumentation` example for swift is showing this snippet:

```swift
let sessionInstrumentation = URLSessionInstrumentation(URLSessionInstrumentationConfiguration())
```

But the `URLSessionInstrumentation` init function is expecting it's argument with a `configuration` label.

Here is the error in XCode:
![image](https://user-images.githubusercontent.com/22870745/213173651-2d16b3dd-4e73-455b-a5ef-650e0199318e.png)

The example should include the `configuration:` label when calling the function