### PR TITLE
Fix description for SNMP receiver

### DIFF
--- a/content/en/registry/collector-receiver-snmp.md
+++ b/content/en/registry/collector-receiver-snmp.md
@@ -9,7 +9,7 @@ tags:
     - collector
 repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/snmpreceiver
 license: Apache 2.0
-description: This receiver fetches stats from a SNMP enabled host using a [golang
+description: This receiver fetches stats from a SNMP enabled host using a [golang snmp client](https://github.com/gosnmp/gosnmp). Metrics are collected based upon different configurations in the config file.
 authors: OpenTelemetry Authors
 otVersion: latest
 ---


### PR DESCRIPTION
It looks like the SNMP receiver description was mangled. I copied the text here from the collector-contrib description in the README.