### PR TITLE
Add connect-rpc to registry

### DIFF
--- a/content/en/registry/instrumentation-go-connect-rpc.md
+++ b/content/en/registry/instrumentation-go-connect-rpc.md
@@ -1,0 +1,16 @@
+---
+title: Connect RPC instrumentation
+registryType: instrumentation
+isThirdParty: false
+language: go
+tags:
+  - go
+  - instrumentation
+  - connect
+  - grpc
+repo: https://github.com/bufbuild/connect-opentelemetry-go
+license: Apache 2.0
+description: Go contrib plugin for Connect RPC.
+authors: Buf
+otVersion: latest
+---


### PR DESCRIPTION
Adds https://github.com/bufbuild/connect-opentelemetry-go to registry. 

This instrumentation implements both [grpc trace/metrics](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/rpc.md#grpc) standard plus the [connect rpc](https://github.com/open-telemetry/opentelemetry-specification/pull/3116) conventions which is why it has both `grpc` and `connect` tags