### PR TITLE
Update trace receiver documentation to align with the most recent updates to open telemetry collector.

### DIFF
--- a/content/en/docs/collector/trace-receiver.md
+++ b/content/en/docs/collector/trace-receiver.md
@@ -950,10 +950,10 @@ func (tailtracerRcvr *tailtracerReceiver) Start(ctx context.Context, host compon
 
 		for {
 			select {
-			case <-ticker.C:
-				tailtracerRcvr.logger.Info("I should start processing traces now!")
-			case <-ctx.Done():
-				return
+				case <-ticker.C:
+					tailtracerRcvr.logger.Info("I should start processing traces now!")
+				case <-ctx.Done():
+					return
 			}
 		}
 	}()
@@ -1607,25 +1607,25 @@ func generateAtm() Atm {
 	var newAtm Atm
 
 	switch i {
-	case 1:
-		newAtm = Atm{
-			ID:           111,
-			Name:         "ATM-111-IL",
-			SerialNumber: "atmxph-2022-111",
-			Version:      "v1.0",
-			ISPNetwork:   "comcast-chicago",
-			StateID:      "IL",
-		}
+		case 1:
+			newAtm = Atm{
+				ID:           111,
+				Name:         "ATM-111-IL",
+				SerialNumber: "atmxph-2022-111",
+				Version:      "v1.0",
+				ISPNetwork:   "comcast-chicago",
+				StateID:      "IL",
+			}
 
-	case 2:
-		newAtm = Atm{
-			ID:           222,
-			Name:         "ATM-222-CA",
-			SerialNumber: "atmxph-2022-222",
-			Version:      "v1.0",
-			ISPNetwork:   "comcast-sanfrancisco",
-			StateID:      "CA",
-		}
+		case 2:
+			newAtm = Atm{
+				ID:           222,
+				Name:         "ATM-222-CA",
+				SerialNumber: "atmxph-2022-222",
+				Version:      "v1.0",
+				ISPNetwork:   "comcast-sanfrancisco",
+				StateID:      "CA",
+			}
 	}
 
 	return newAtm
@@ -1644,13 +1644,12 @@ func generateBackendSystem() BackendSystem {
 	}
 
 	switch i {
-	case 1:
-		newBackend.Endpoint = "api/v2.5/balance"
-	case 2:
-		newBackend.Endpoint = "api/v2.5/deposit"
-	case 3:
-		newBackend.Endpoint = "api/v2.5/withdrawn"
-
+		case 1:
+			newBackend.Endpoint = "api/v2.5/balance"
+		case 2:
+			newBackend.Endpoint = "api/v2.5/deposit"
+		case 3:
+			newBackend.Endpoint = "api/v2.5/withdrawn"
 	}
 
 	return newBackend
@@ -1697,24 +1696,24 @@ func fillResourceWithBackendSystem(resource *pcommon.Resource, backend BackendSy
 	var osType, cloudProvider string
 
 	switch {
-	case backend.CloudProvider == "amzn":
-		cloudProvider = conventions.AttributeCloudProviderAWS
-	case backend.OSType == "mcrsft":
-		cloudProvider = conventions.AttributeCloudProviderAzure
-	case backend.OSType == "gogl":
-		cloudProvider = conventions.AttributeCloudProviderGCP
+		case backend.CloudProvider == "amzn":
+			cloudProvider = conventions.AttributeCloudProviderAWS
+		case backend.OSType == "mcrsft":
+			cloudProvider = conventions.AttributeCloudProviderAzure
+		case backend.OSType == "gogl":
+			cloudProvider = conventions.AttributeCloudProviderGCP
 	}
 
 	backendAttrs.PutStr(conventions.AttributeCloudProvider, cloudProvider)
 	backendAttrs.PutStr(conventions.AttributeCloudRegion, backend.CloudRegion)
 
 	switch {
-	case backend.OSType == "lnx":
-		osType = conventions.AttributeOSTypeLinux
-	case backend.OSType == "wndws":
-		osType = conventions.AttributeOSTypeWindows
-	case backend.OSType == "slrs":
-		osType = conventions.AttributeOSTypeSolaris
+		case backend.OSType == "lnx":
+			osType = conventions.AttributeOSTypeLinux
+		case backend.OSType == "wndws":
+			osType = conventions.AttributeOSTypeWindows
+		case backend.OSType == "slrs":
+			osType = conventions.AttributeOSTypeSolaris
 	}
 
 	backendAttrs.PutStr(conventions.AttributeOSType, osType)
@@ -2028,11 +2027,11 @@ func (tailtracerRcvr *tailtracerReceiver) Start(ctx context.Context, host compon
 		defer ticker.Stop()
 		for {
 			select {
-			case <-ticker.C:
-				tailtracerRcvr.logger.Info("I should start processing traces now!")
-				tailtracerRcvr.nextConsumer.ConsumeTraces(ctx, generateTraces(tailtracerRcvr.config.NumberOfTraces))
-			case <-ctx.Done():
-				return
+				case <-ticker.C:
+					tailtracerRcvr.logger.Info("I should start processing traces now!")
+					tailtracerRcvr.nextConsumer.ConsumeTraces(ctx, generateTraces(tailtracerRcvr.config.NumberOfTraces))
+				case <-ctx.Done():
+					return
 			}
 		}
 	}()
@@ -2183,13 +2182,13 @@ func appendTraceSpans(backend *BackendSystem, backendScopeSpans *ptrace.ScopeSpa
 	var atmOperationName string
 
 	switch {
-	case strings.Contains(backend.Endpoint, "balance"):
-        atmOperationName = "Check Balance"
-	case strings.Contains(backend.Endpoint, "deposit"):
-		atmOperationName = "Make Deposit"
-	case strings.Contains(backend.Endpoint, "withdraw"):
-		atmOperationName = "Fast Cash"
-	}
+		case strings.Contains(backend.Endpoint, "balance"):
+			atmOperationName = "Check Balance"
+		case strings.Contains(backend.Endpoint, "deposit"):
+			atmOperationName = "Make Deposit"
+		case strings.Contains(backend.Endpoint, "withdraw"):
+			atmOperationName = "Fast Cash"
+		}
 
 	atmSpanId := NewSpanID()
     atmSpanStartTime := time.Now()

--- a/content/en/docs/collector/trace-receiver.md
+++ b/content/en/docs/collector/trace-receiver.md
@@ -1372,7 +1372,7 @@ have data to represent the telemetry sources involved in your trace.
 Open the `tailtracer/model.go` file and add the following function to it:
 
 ```go
-func generateTraces() ptrace.Traces{
+func generateTraces(numberOfTraces int) ptrace.Traces{
 	traces := ptraces.NewTraces()
 
 	for i := 0; i <= numberOfTraces; i++{
@@ -1418,7 +1418,7 @@ Update the `generateTrace()` function with the following changes:
 Here is what the function should look like after you implemented these changes:
 
 ```go
-func generateTraces() ptrace.Traces{
+func generateTraces(numberOfTraces int) ptrace.Traces{
 	traces := ptrace.NewTraces()
 
 	for i := 0; i <= numberOfTraces; i++{
@@ -1659,7 +1659,7 @@ func getRandomNumber(min int, max int) int {
 	return i
 }
 
-func generateTraces() ptrace.Traces {
+func generateTraces(numberOfTraces int) ptrace.Traces {
 	traces := ptrace.NewTraces()
 
 	for i := 0; i <= numberOfTraces; i++ {
@@ -1733,7 +1733,7 @@ func fillResourceWithBackendSystem(resource *pcommon.Resource, backend BackendSy
 > - Updated the `fillResourceWithBackendSystem()` function by adding lines to
 >   properly assign the "service.name" and "service.version" attributes to the
 >   `pcommon.Resource` representing the `BackendSystem` entity
-> - Updated the `generateTraces()` function by adding lines to properly
+> - Updated the `generateTraces(numberOfTraces int)` function by adding lines to properly
 >   instantiate a `pcommon.Resource` and fill in the attribute information for
 >   both `Atm` and `BackendSystem` entities using the `fillResourceWithAtm()`
 >   and `fillResourceWithBackendSystem()` functions
@@ -1805,13 +1805,13 @@ Here is what `appendAtmSystemInstrScopeSpans` looks like after the update:
 }
 ```
 
-You can now update the `generateTraces()` function and add variables to
+You can now update the `generateTraces(numberOfTraces int)` function and add variables to
 represent the instrumentation scope used by both `Atm` and `BackendSystem`
 entities by initializing them with the `appendAtmSystemInstrScopeSpans()`. Here
 is what `generateTraces()` looks like after the update:
 
 ```go
-func generateTraces() ptrace.Traces{
+func generateTraces(numberOfTraces int) ptrace.Traces{
 	traces := ptraces.NewTraces()
 
 	for i := 0; i <= numberOfTraces; i++{
@@ -1974,7 +1974,7 @@ the trace by calling the `appendTraceSpans()` function. Here is what the updated
 `generateTraces()` function looks like:
 
 ```go
-func generateTraces() ptrace.Traces {
+func generateTraces(numberOfTraces int) ptrace.Traces {
 	traces := ptrace.NewTraces()
 
 	for i := 0; i <= numberOfTraces; i++ {
@@ -2027,7 +2027,7 @@ func (tailtracerRcvr *tailtracerReceiver) Start(ctx context.Context, host compon
 			select {
 			case <-ticker.C:
 				tailtracerRcvr.logger.Info("I should start processing traces now!")
-				tailtracerRcvr.nextConsumer.ConsumeTraces(ctx, generateTraces())
+				tailtracerRcvr.nextConsumer.ConsumeTraces(ctx, generateTraces(tailtracerRcvr.config.NumberOfTraces))
 			case <-ctx.Done():
 				return
 			}
@@ -2043,7 +2043,7 @@ func (tailtracerRcvr *tailtracerReceiver) Start(ctx context.Context, host compon
 > - Added a line under the `case <=ticker.C` condition calling the
 >   `tailtracerRcvr.nextConsumer.ConsumeTraces()` method passing the new context
 >   created within the `Start()` method (`ctx`) and a call to the
->   `generateTraces()` function so the generated traces can be pushed to the
+>   `generateTraces(numberOfTraces int)` function so the generated traces can be pushed to the
 >   next consumer in the pipeline
 
 If you run your `dev-otelcol` here is what the output should look like after 2

--- a/content/en/docs/collector/trace-receiver.md
+++ b/content/en/docs/collector/trace-receiver.md
@@ -94,7 +94,7 @@ processors:
 
 exporters:
   logging:
-    logLevel: debug
+    verbosity: Detailed
   jaeger:
     endpoint: localhost:14250
     tls:


### PR DESCRIPTION
This PR is to address outdated trace receiver documentation. Recently I followed this document, and a lot of interfaces and implementations were outdated. Thanks to some knowledge I have about the collector, I was able to find the issues in the document and implement a receiver. As a result I thought I would update the document to reflect these latest changes.

- dev-otelcol changed to otelcol-dev to align with [custom-collector document](https://opentelemetry.io/docs/collector/custom-collector/)'s update.
- updated implementation details, aligning them with the most recent refactoring in the code base of open telemetry collector.
- tested the updated document on myself by following the steps from scratch.