### PR TITLE
Add apk instructions to C++ & fix cmake issue

### DIFF
--- a/content/en/docs/instrumentation/cpp/getting-started.md
+++ b/content/en/docs/instrumentation/cpp/getting-started.md
@@ -18,6 +18,7 @@ application (a http server & http client). For more details read
 You can build OpenTelemetry C++ on Windows, macOS or Linux. First you need to
 install some dependencies:
 
+<!-- prettier-ignore-start -->
 {{< ot-tabs "Linux (apt)" "Linux (yum)" "Linux (alpine)" "MacOS (homebrew)">}}
 {{< ot-tab lang="shell">}}
 $ sudo apt-get install git cmake g++ libcurl4-openssl-dev
@@ -34,6 +35,7 @@ $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/
 $ brew install git cmake
 {{< /ot-tab >}}
 {{< /ot-tabs >}}
+<!-- prettier-ignore-end -->
 
 ## Building
 

--- a/content/en/docs/instrumentation/cpp/getting-started.md
+++ b/content/en/docs/instrumentation/cpp/getting-started.md
@@ -18,12 +18,15 @@ application (a http server & http client). For more details read
 You can build OpenTelemetry C++ on Windows, macOS or Linux. First you need to
 install some dependencies:
 
-{{< ot-tabs "Linux (apt)" "Linux (yum)" "MacOS (homebrew)">}}
+{{< ot-tabs "Linux (apt)" "Linux (yum)" "Linux (alpine)" "MacOS (homebrew)">}}
 {{< ot-tab lang="shell">}}
 $ sudo apt-get install git cmake g++ libcurl4-openssl-dev
 {{< /ot-tab >}}
 {{< ot-tab lang="shell">}}
 $ sudo yum install git cmake g++ libcurl-devel
+{{< /ot-tab >}}
+{{< ot-tab lang="shell">}}
+$ sudo apk add git cmake g++ make curl-dev
 {{< /ot-tab >}}
 {{< ot-tab lang="shell">}}
 $ xcode-select —install
@@ -46,7 +49,7 @@ configuration:
 ```shell
 $ cd opentelemetry-cpp
 $ mkdir build && cd build
-$ cmake -DBUILD_TESTING=OFF ..
+$ cmake -DBUILD_TESTING=OFF -DWITH_EXAMPLES_HTTP=ON ..
 ```
 
 Once build configuration is created, build the CMake targets `http_client` and

--- a/content/en/registry/instrumentation-js-mongoose-instrumentation.md
+++ b/content/en/registry/instrumentation-js-mongoose-instrumentation.md
@@ -8,8 +8,8 @@ tags:
   - instrumentation
   - Mongoose
   - MongoDB
-repo: https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/instrumentation-mongoose
+repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-mongoose
 license: MIT
 description: Mongoose instrumentation for Node.js.
-authors: Aspecto Authors
+authors: The OpenTelemetry Authors
 ---

--- a/content/en/registry/instrumentation-js-mongoose-instrumentation.md
+++ b/content/en/registry/instrumentation-js-mongoose-instrumentation.md
@@ -8,8 +8,8 @@ tags:
   - instrumentation
   - Mongoose
   - MongoDB
-repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-mongoose
+repo: https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/instrumentation-mongoose
 license: MIT
 description: Mongoose instrumentation for Node.js.
-authors: The OpenTelemetry Authors
+authors: Aspecto Authors
 ---


### PR DESCRIPTION
I added instructions for building C++ with alpine/apk, I also found that the http examples can not be build anymore without adding a flag to cmake

