### PR TITLE
[python] Add doc for disabling instrumentation for python

### DIFF
--- a/content/en/docs/instrumentation/python/automatic/agent-config.md
+++ b/content/en/docs/instrumentation/python/automatic/agent-config.md
@@ -9,8 +9,9 @@ spelling: cSpell:ignore distro mkdir uninstrumented virtualenv
 
 The agent is highly configurable, either by:
 
-* Passing it configuration properties from the CLI
-* Setting [environment variables](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md)
+- Passing it configuration properties from the CLI
+- Setting
+  [environment variables](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md)
 
 ### Configuration properties
 
@@ -27,33 +28,74 @@ opentelemetry-instrument \
 
 Here's an explanation of what each configuration does:
 
-* `traces_exporter` specifies which trace exporter to use. In this case, traces are being exported to `console` (stdout) and to `otlp`. The `otlp` option tells `opentelemetry-instrument` to send it to an endpoint that accepts OTLP via gRPC. The full list of available options for traces_exporter can be found [here](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-instrumentation).
-* `otlp` used above for `traces_exporter` is the equivalent of using `otlp_proto_grpc`. To send traces via HTTP instead of gRPC, replace `otlp_proto_grpc` (or `otlp`) with `otlp_proto_http`.
-* `metrics_exporter` specifies which metrics exporter to use. In this case, metrics are being exported to `console` (stdout). It is currently required for your to specify a metrics exporter. If you aren't exporting metrics, specify `none` as the value instead.
-* `service_name` sets the name of the service associated to the trace, and is sent to your [Observability back-end](/vendors).
-* `exporter_otlp_endpoint` tells `opentelemetry-instrument` to send the traces to the given [Observability back-end's](/vendors) endpiont via gRPC, or directly to the [OpenTelemetry Collector](/docs/collector/).
-* `exporter_otlp_headers` is required depending on your chosen Observability back-end. More info exporter OTLP headers be found [here](/docs/concepts/sdk-configuration/otlp-exporter-configuration/#otel_exporter_otlp_headers).
-* If `exporter_otlp_endpoint` is omitted, the agent assumes that you are using the default Collector gRPC endpoint, `0.0.0.0:4317`. The above command is the equivalent of saying:
+- `traces_exporter` specifies which trace exporter to use. In this case, traces
+  are being exported to `console` (stdout) and to `otlp`. The `otlp` option
+  tells `opentelemetry-instrument` to send it to an endpoint that accepts OTLP
+  via gRPC. The full list of available options for traces_exporter can be found
+  [here](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-instrumentation).
+- `otlp` used above for `traces_exporter` is the equivalent of using
+  `otlp_proto_grpc`. To send traces via HTTP instead of gRPC, replace
+  `otlp_proto_grpc` (or `otlp`) with `otlp_proto_http`.
+- `metrics_exporter` specifies which metrics exporter to use. In this case,
+  metrics are being exported to `console` (stdout). It is currently required for
+  your to specify a metrics exporter. If you aren't exporting metrics, specify
+  `none` as the value instead.
+- `service_name` sets the name of the service associated to the trace, and is
+  sent to your [Observability back-end](/vendors).
+- `exporter_otlp_endpoint` tells `opentelemetry-instrument` to send the traces
+  to the given [Observability back-end's](/vendors) endpiont via gRPC, or
+  directly to the [OpenTelemetry Collector](/docs/collector/).
+- `exporter_otlp_headers` is required depending on your chosen Observability
+  back-end. More info exporter OTLP headers be found
+  [here](/docs/concepts/sdk-configuration/otlp-exporter-configuration/#otel_exporter_otlp_headers).
+- If `exporter_otlp_endpoint` is omitted, the agent assumes that you are using
+  the default Collector gRPC endpoint, `0.0.0.0:4317`. The above command is the
+  equivalent of saying:
 
-	```console
-	opentelemetry-instrument \
-	--traces_exporter console,otlp_proto_grpc \
-	--metrics_exporter console\
-	--service_name your-service-name \
-	--exporter_otlp_endpoint 0.0.0.0:4317 \
-	--exporter_otlp_insecure true \
-	python myapp.py
-	```
+  ```console
+  opentelemetry-instrument \
+  --traces_exporter console,otlp_proto_grpc \
+  --metrics_exporter console\
+  --service_name your-service-name \
+  --exporter_otlp_endpoint 0.0.0.0:4317 \
+  --exporter_otlp_insecure true \
+  python myapp.py
+  ```
 
-	For HTTP, replace `otlp_proto_grpc` with `otlp_proto_http`. If left unspecified, the endpoint is now assumed to be `0.0.0.0:4318` (default Collector HTTP endpoint).
+  For HTTP, replace `otlp_proto_grpc` with `otlp_proto_http`. If left
+  unspecified, the endpoint is now assumed to be `0.0.0.0:4318` (default
+  Collector HTTP endpoint).
 
 ### Environment Variables
 
-In some cases, configuring via [Environment Variables](/docs/concepts/sdk-configuration/) is more preferred. Any setting configurable with a configuration property can also be configured with an Environment Variable. 
+In some cases, configuring via
+[Environment Variables](/docs/concepts/sdk-configuration/) is more preferred.
+Any setting configurable with a configuration property can also be configured
+with an Environment Variable.
 
-You can apply the following steps to determine the correct name mapping of the desired configuration property:
+You can apply the following steps to determine the correct name mapping of the
+desired configuration property:
 
-* Convert the configuration property to uppercase.
-* Prefix environment variable with `OTEL_`
+- Convert the configuration property to uppercase.
+- Prefix environment variable with `OTEL_`
 
-For example, `exporter_otlp_endpoint` would convert to `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`.
+For example, `exporter_otlp_endpoint` would convert to
+`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`.
+
+### Disabling Specific Instrumentations
+
+The Python agent by default will detect a python program's packages and
+instrument any packages it can.  
+This makes instrumentation easy, but can result in too much or unwanted data.
+
+You can omit specific packages from instrumentation by using the
+`OTEL_PYTHON_DISABLED_INSTRUMENTATIONS` environment variable. The environment
+variable can be set to a comma-separated list of package names to exclude from
+instrumentation.
+
+For example, if your Python program uses the `redis` and `kafka-python`
+packages, by default the agent will use the
+`opentelemetry-instrumentation-redis` and
+`opentelemetry-instrumentation-kafka-python` packages to instrument them. To
+disable this, you can set
+`OTEL_PYTHON_DISABLED_INSTRUMENTATIONS=redis,kafka-python`.

--- a/content/en/docs/k8s-operator/automatic.md
+++ b/content/en/docs/k8s-operator/automatic.md
@@ -8,8 +8,7 @@ spelling: cSpell:ignore Otel
 ---
 
 The OpenTelemetry Operator supports injecting and configuring
-auto-instrumentation libraries for .NET, Java, NodeJS and Python
-services.
+auto-instrumentation libraries for .NET, Java, NodeJS and Python services.
 
 ## Installation
 
@@ -33,8 +32,10 @@ It is a best practice to send telemetry from containers to an
 [OpenTelemetry Collector](../../collector/) instead of directly to a backend.
 The Collector helps simplify secret management, decouples data export problems
 (such as a need to do retries) from your apps, and lets you add additional data
-to your telemetry, such as with the [k8sattributesprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor) component. If you
-chose not to use a Collector, you can skip to the next section.
+to your telemetry, such as with the
+[k8sattributesprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor)
+component. If you chose not to use a Collector, you can skip to the next
+section.
 
 The Operator provides a
 [Custom Resource Definition (CRD) for the OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md#opentelemetrycollector)
@@ -115,7 +116,8 @@ Coming Soon
 
 ### Python
 
-The following command will create a basic Instrumentation resource that is configured specifically for instrumenting Python services.
+The following command will create a basic Instrumentation resource that is
+configured specifically for instrumenting Python services.
 
 ```bash
 kubectl apply -f - <<EOF
@@ -146,6 +148,36 @@ otlpreceiver of the Collector created in the previous step.
 > to `http/proto` for Python services. If you use an older version of the
 > Operator you **MUST** set these env variables to `http/proto`, or python
 > auto-instrumentation will not work.
+
+By default the Python auto-instrumentation will detect the packages in your
+Python service and instrument anything it can. This makes instrumentation easy,
+but can result in too much or unwanted data. If there are any packages you do
+not want to instrument, you can set the `OTEL_PYTHON_DISABLED_INSTRUMENTATIONS`
+environment variable
+
+```yaml
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: demo-instrumentation
+spec:
+  exporter:
+    endpoint: http://demo-collector:4318
+  propagators:
+    - tracecontext
+    - baggage
+  sampler:
+    type: parentbased_traceidratio
+    argument: "1"
+  python:
+    env:
+      - name: OTEL_PYTHON_DISABLED_INSTRUMENTATIONS
+        value:
+          <comma-separated list of package names to exclude from
+          instrumentation>
+```
+
+[See the Python Agent Configuration docs for more details.](/docs/instrumentation/python/automatic/agent-config/#disabling-specific-instrumentations)
 
 ---
 


### PR DESCRIPTION
Adds docs to Python's auto-instrumentation config and the k8s operator auto-instrumentaiton config for python explaining how to omit specific packages from instrumentation.  This is an important feature in auto-instrumentation as instrumenting everything can lead to too much data or noise. 