### PR TITLE
Update integrations page

### DIFF
--- a/content/en/ecosystem/integrations.md
+++ b/content/en/ecosystem/integrations.md
@@ -4,21 +4,22 @@ description: OpenTelemetry integrations with other open-source projects
 aliases: [/integrations]
 ---
 
-OpenTelemetry integrates with or is integrated into various open source projects.
+OpenTelemetry integrates with or is integrated into various open source
+projects.
 
 ## Within OpenTelemetry
 
 OpenTelemetry provides integration with the following open source projects.
 
-| External Project*                                         | OpenTelemetry Supported Components                       |
-| ----------------                                          | ----------------------------------                       |
+| External Project\*                                        | OpenTelemetry Supported Components                       |
+| --------------------------------------------------------- | -------------------------------------------------------- |
 | [Apache Kafka](https://kafka.apache.org/)                 | Collector                                                |
 | [Elasticsearch](https://github.com/elastic/elasticsearch) | Collector, C++, Java, Python                             |
 | [Fluent Bit](https://fluentbit.io/)                       | Collector                                                |
 | [Graphite](https://graphiteapp.org/)                      | Collector                                                |
 | [Jaeger](https://www.jaegertracing.io/)                   | Collector, DotNet, Go, Java, JS, PHP, Python, Ruby, Rust |
 | [OpenCensus](https://opencensus.io/)                      | Collector, Python                                        |
-| [OpenTracing](https://opentracing.io/)                    | DotNet, Go, Java, JS, Python, Ruby
+| [OpenTracing](https://opentracing.io/)                    | DotNet, Go, Java, JS, Python, Ruby                       |
 | [OpenMetrics](https://openmetrics.io/) [^partial-support] | Collector                                                |
 | [Prometheus](https://prometheus.io/) [^partial-support]   | Collector, C++, Go, Java, JS, Rust                       |
 | [Zipkin](https://zipkin.io/)                              | Collector, DotNet, Go, Java, JS, PHP, Python, Rust       |
@@ -30,12 +31,12 @@ _Projects are listed alphabetically_
 
 The following open source projects use OpenTelemetry components.
 
-| External Project                                                                               | Applicable OpenTelemetry Components |
-| ----------------                                                                               | ----------------------------------- |
-| [Jaeger](https://www.jaegertracing.io/docs/1.21/opentelemetry/) [^not-ga]                      | Collector                           |
-| [Spring Sleuth](https://github.com/spring-cloud-incubator/spring-cloud-sleuth-otel/) [^not-ga] | Java                                |
+| External Project                                                                           | Applicable OpenTelemetry Components |
+| ------------------------------------------------------------------------------------------ | ----------------------------------- |
+| [Docker buildx](https://github.com/docker/buildx/blob/master/docs/guides/opentelemetry.md) | Go                                  |
+| [Jaeger](https://www.jaegertracing.io/docs/latest/opentelemetry/)                          | Collector                           |
+| [Micrometer](https://micrometer.io/docs/tracing#_micrometer_tracing_opentelemetry_setup)   | Java                                |
+| [Quarkus](https://quarkus.io/guides/opentelemetry)                                         | Java                                |
 
-
-\* _Projects are listed alphabetically_.
-[^partial-support]: Projects only partially supported at this time. Full support coming soon!
-[^not-ga]: Projects offering experimental or beta support. GA support coming soon!
+\* _Projects are listed alphabetically_. [^partial-support]: Projects only
+partially supported at this time. Full support coming soon!

--- a/content/en/ecosystem/registry.md
+++ b/content/en/ecosystem/registry.md
@@ -1,6 +1,8 @@
 ---
 title: Registry
 manualLink: /registry/
+description:
+  Find libraries, plugins, integrations, and other useful tools for extending OpenTelemetry.
 _build: { render: link }
 weight: 20
 ---


### PR DESCRIPTION
Sleuth/Spring states that they make use of MicroMeter

Docker Buildx has OpenTelemetry support

Jaeger is kind of stable