### PR TITLE
doc: update c# code samples

### DIFF
--- a/content/en/docs/instrumentation/net/exporters.md
+++ b/content/en/docs/instrumentation/net/exporters.md
@@ -22,12 +22,10 @@ services:
 
 ```csharp
 var builder = WebApplication.CreateBuilder(args);
-
-builder.Services.AddOpenTelemetryTracing(b =>
-{
+builder.Services.AddOpenTelemetry().WithTracing(b =>
     b.AddConsoleExporter()
     // The rest of your setup code goes here too
-});
+).StartWithHost();
 ```
 
 Otherwise, configure the exporter when creating a tracer provider:
@@ -57,8 +55,7 @@ services:
 ```csharp
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddOpenTelemetryTracing(b =>
-{
+builder.Services.AddOpenTelemetry().WithTracing(b =>
     b
     .AddOtlpExporter(opt =>
     {
@@ -66,7 +63,7 @@ builder.Services.AddOpenTelemetryTracing(b =>
         opt.Protocol = OtlpExportProtocol.HttpProtobuf;
     })
     // The rest of your setup code goes here too
-});
+).StartWithHost();
 ```
 
 Otherwise, configure the exporter when creating a tracer provider:
@@ -148,15 +145,14 @@ services:
 ```csharp
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddOpenTelemetryTracing(b =>
-{
+builder.Services.AddOpenTelemetry().WithTracing(b =>
     b
     .AddZipkinExporter(o =>
     {
         o.Endpoint = new Uri("your-zipkin-uri-here");
     })
     // The rest of your setup code goes here too
-});
+).StartWithHost();
 ```
 
 Otherwise, configure the exporter when creating a tracer provider:
@@ -214,8 +210,7 @@ services:
 ```csharp
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddOpenTelemetryMetrics(b =>
-{
+builder.Services.AddOpenTelemetry().WithMetrics(b =>
     b
     .AddPrometheusExporter(options =>
     {
@@ -225,7 +220,7 @@ builder.Services.AddOpenTelemetryMetrics(b =>
         options.ScrapeResponseCacheDurationMilliseconds = 0;
     })
     // The rest of your setup code goes here too
-});
+).StartWithHost();
 ```
 
 Otherwise, configure the exporter when creating a meter provider:

--- a/content/en/docs/instrumentation/net/libraries.md
+++ b/content/en/docs/instrumentation/net/libraries.md
@@ -45,6 +45,7 @@ Next, configure each instrumentation library at startup and use them!
 
 ```csharp
 using System.Diagnostics;
+using OpenTelemetry;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
@@ -55,8 +56,7 @@ var serviceVersion = "1.0.0";
 var builder = WebApplication.CreateBuilder(args);
 
 // Configure important OpenTelemetry settings, the console exporter, and instrumentation library
-builder.Services.AddOpenTelemetryTracing(b =>
-{
+builder.Services.AddOpenTelemetry().WithTracing(b =>
     b
     .AddConsoleExporter()
     .AddSource(serviceName)
@@ -64,8 +64,8 @@ builder.Services.AddOpenTelemetryTracing(b =>
         ResourceBuilder.CreateDefault()
             .AddService(serviceName: serviceName, serviceVersion: serviceVersion))
     .AddHttpClientInstrumentation()
-    .AddAspNetCoreInstrumentation();
-});
+    .AddAspNetCoreInstrumentation()
+).StartWithHost();
 
 var app = builder.Build();
 

--- a/content/en/docs/instrumentation/net/manual.md
+++ b/content/en/docs/instrumentation/net/manual.md
@@ -83,7 +83,7 @@ dotnet add package OpenTelemetry.Extensions.Hosting --prerelease
 dotnet add package OpenTelemetry.Exporter.Console --prerelease
 ```
 
-Note that the `--prerelease` flag is required for all instrumentation packages 
+Note that the `--prerelease` flag is required for all instrumentation packages
 because they are all are pre-release.
 
 Next, configure it in your ASP.NET Core startup routine where you have access
@@ -102,15 +102,14 @@ var serviceVersion = "1.0.0";
 var builder = WebApplication.CreateBuilder(args);
 
 // Configure important OpenTelemetry settings, the console exporter
-builder.Services.AddOpenTelemetryTracing(b =>
-{
+builder.Services.AddOpenTelemetry().WithTracing(b =>
     b
     .AddConsoleExporter()
     .AddSource(serviceName)
     .SetResourceBuilder(ResourceBuilder
         .CreateDefault()
-        .AddService(serviceName: serviceName, serviceVersion: serviceVersion));
-});
+        .AddService(serviceName: serviceName, serviceVersion: serviceVersion))
+).StartWithHost();
 ```
 
 This is also where you can configure instrumentation libraries.

--- a/content/en/docs/instrumentation/net/shim.md
+++ b/content/en/docs/instrumentation/net/shim.md
@@ -82,6 +82,7 @@ And then configure it in your ASP.NET Core startup routine where you have access
 to an `IServiceCollection`.
 
 ```csharp
+using OpenTelemetry;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
@@ -92,16 +93,15 @@ var serviceVersion = "1.0.0";
 var builder = WebApplication.CreateBuilder(args);
 
 // Configure important OpenTelemetry settings, the console exporter, and instrumentation library
-builder.Services.AddOpenTelemetryTracing(tcb =>
-{
+builder.Services.AddOpenTelemetry().WithTracing(tcb =>
     tcb
     .AddSource(serviceName)
     .SetResourceBuilder(
         ResourceBuilder.CreateDefault()
             .AddService(serviceName: serviceName, serviceVersion: serviceVersion))
     .AddAspNetCoreInstrumentation()
-    .AddConsoleExporter();
-});
+    .AddConsoleExporter()
+).StartWithHost();
 ```
 
 In the preceding example, a [`Tracer`](/docs/concepts/signals/traces/#tracer)


### PR DESCRIPTION
Fixes: `OpenTelemetryServicesExtensions.AddOpenTelemetryTracing(IServiceCollection, Action<TracerProviderBuilder>)' is obsolete: 'Use the AddOpenTelemetry().WithTracing(configure).StartWithHost() pattern instead. This method will be removed in a future version. `

Haven't tested them out thoroughly so please review. 