### PR TITLE
Add configprovider doc to otelcol doc

### DIFF
--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -118,6 +118,53 @@ service:
       exporters: [otlp]
 ```
 
+The configuration can also include other files, causing the Collector to merge the two files in a single in-memory representation of the YAML configuration:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+exporters: ${file:otlp-exporter.yaml}
+
+service:
+  extensions: [ ]
+  pipelines:
+    traces:
+      receivers:  [ otlp ]
+      processors: [  ]
+      exporters:  [ otlp ]
+```
+
+With the `receivers.yaml` file being:
+
+```yaml
+otlp:
+  endpoint: otelcol.observability.svc.cluster.local:443
+```
+
+The final result in memory will be:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+exporters:
+  otlp:
+    endpoint: otelcol.observability.svc.cluster.local:443
+
+service:
+  extensions: [ ]
+  pipelines:
+    traces:
+      receivers:  [ otlp ]
+      processors: [  ]
+      exporters:  [ otlp ]
+```
+
 ## Receivers
 
 <img width="35" src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Receivers.svg"></img>


### PR DESCRIPTION
This PR adds reference to otelcol's file config provider, which allows the config to make reference to other YAML files.

## Docs PR Checklist
<!--- Just making sure... -->
- [x] This PR is for a documentation page whose authoritative copy is in the opentelemetry.io repository.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

