### PR TITLE
Add BullMQ instrumentation to the registry

### DIFF
--- a/content/en/registry/instrumentation-js-bullmq.md
+++ b/content/en/registry/instrumentation-js-bullmq.md
@@ -1,0 +1,15 @@
+---
+title: opentelemetry-instrumentation-bullmq
+registryType: instrumentation
+isThirdParty: true
+language: js
+tags:
+  - js
+  - instrumentation
+  - bullmq
+repo: https://github.com/jenniferplusplus/opentelemetry-instrumentation-bullmq
+license: Apache 2.0
+description: Auto instrumentation for the BullMQ message system
+authors: Jennifer Moore (contact@jenniferplusplus.com)
+otVersion: 1.0+
+---

--- a/content/en/registry/instrumentation-js-bullmq.md
+++ b/content/en/registry/instrumentation-js-bullmq.md
@@ -1,5 +1,5 @@
 ---
-title: opentelemetry-instrumentation-bullmq
+title: BullMQ Instrumentation
 registryType: instrumentation
 isThirdParty: true
 language: js


### PR DESCRIPTION
A few months ago I wrote an auto-instrumentation for the BullMQ javascript package. It's been in regular use by several projects since then, and I'd like to add it to the registry to hopefully make it easier for others to find.