### PR TITLE
Move Mastodon verification link to homepage (only)

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -4,7 +4,10 @@ show_banner: true
 developer_note:
   The blocks/cover shortcode (used below) will use as a background image any
   image file containing "background" in its name.
+spelling: cSpell:ignore shortcode
 ---
+
+<div class="d-none"><a rel="me" href="https://fosstodon.org/@opentelemetry"></a></div>
 
 {{< blocks/cover image_anchor="top" height="max" color="primary" >}}
 <img src="/img/logos/opentelemetry-horizontal-color.svg" class="otel-logo" alt="OpenTelemetry"/>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,7 +6,6 @@
     {{ partial "head.html" . }}
   </head>
   <body class="td-{{ .Kind }}{{ with .Page.Params.body_class }} {{ . }}{{ end }}">
-    <a rel="me" href="https://fosstodon.org/@opentelemetry" aria-hidden="true" tabindex="-1"></a>
     <header>
       {{ partial "navbar.html" . }}
     </header>


### PR DESCRIPTION
- Relocates the Mastondon `rel="me"` link from the layout (which applied to several site pages), into the homepage (which is the only page that needs to have the verification link).
- Closes #2104
- Followup to #2206 
  - According to https://www.boia.org/blog/is-it-okay-to-hide-content-from-screen-readers#:~:text=If%20you%20use%20HTML%20hidden,so%20aria%2Dhidden%20is%20redundant:
    > If you use HTML hidden or the CSS display:none, you don’t need aria-hidden

Preview: https://deploy-preview-2216--opentelemetry.netlify.app

/cc @Arhell 