### PR TITLE
Fix file name in otelcol config example

### DIFF
--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -126,7 +126,7 @@ receivers:
     protocols:
       grpc:
 
-exporters: ${file:otlp-exporter.yaml}
+exporters: ${file:receivers.yaml}
 
 service:
   extensions: [ ]


### PR DESCRIPTION
When copying the snippet I had for the config loading an external YAML content, I changed the file name in one place but not on the other. This PR fixes that.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

## Docs PR Checklist
<!--- Just making sure... -->
- [x] This PR is for a documentation page whose authoritative copy is in the opentelemetry.io repository.
