### PR TITLE
Update and move http conventions stability blog post

### DIFF
--- a/content/en/blog/2023/http-conventions-stability.md
+++ b/content/en/blog/2023/http-conventions-stability.md
@@ -1,7 +1,7 @@
 ---
 title: Final push to HTTP semantic convention stability
 linkTitle: HTTP semantic conventions
-date: 2023-01-26
+date: 2023-01-30
 author: "[Trask Stalnaker](https://github.com/trask) (Microsoft)"
 ---
 
@@ -12,27 +12,27 @@ and
 semantic conventions stable!
 
 Following the recently proposed
-[Semantic Convention Process](https://docs.google.com/document/d/1ghvajKaipiNZso3fDtyNxU7x1zx0_Eyd02OGpMGEpLE), 
-the HTTP semantic convention stability working group will meet three times
-a week for the next six weeks (starting January 30) to work through the
-remaining
+[Semantic Convention Process](https://docs.google.com/document/d/1ghvajKaipiNZso3fDtyNxU7x1zx0_Eyd02OGpMGEpLE),
+the HTTP semantic convention stability working group will meet three times a
+week for the next six weeks (starting January 30) to work through the remaining
 [list of issues](https://github.com/orgs/open-telemetry/projects/41/views/1).
-This group will submit spec PRs for any changes that need to be made
-prior to declaring the HTTP semantic conventions stable.
+This group will submit spec PRs for any changes that need to be made prior to
+declaring the HTTP semantic conventions stable.
 
 Once this is done, the community will have four weeks to review and provide
 feedback on the final set of PRs submitted by the working group.
 
 And finally, the working group and spec approvers will have two weeks to clean
-up and merge the final spec PRs, and mark the HTTP semantic conventions as stable. 
+up and merge the final spec PRs, and mark the HTTP semantic conventions as
+stable.
 
 If you are interested in participating in the working group, please join the
-meetings starting Monday, January 30 at 3pm Pacific Time, and continuing for
-six weeks on Mondays, Wednesdays and Fridays: 
+meetings starting Monday, January 30 at 3pm Pacific Time, and continuing for six
+weeks on Mondays, Wednesdays and Fridays:
 
-* Mon 3-3:30pm Pacific Time
-* Wed 3-3:30pm Pacific Time
-* Fri 9:30-10am Pacific Time
+- Mon 3-3:30pm Pacific Time
+- Wed 3-3:30pm Pacific Time
+- Fri 9:30-10am Pacific Time
 
 See the
 [OpenTelemetry calendar](https://github.com/open-telemetry/community#calendar)


### PR DESCRIPTION
follow up to the blog post, set's it to the proper date & moves it out from the directory.