### PR TITLE
Add Sentry integrations to registry

### DIFF
--- a/content/en/registry/tools-java-sentry.md
+++ b/content/en/registry/tools-java-sentry.md
@@ -1,0 +1,18 @@
+---
+title: OpenTelemetry Java Integration for Sentry (sentry.io)
+registryType: utilities
+isThirdParty: true
+language: java
+tags:
+  - java
+  - processor
+  - propagator
+  - utilities
+  - sentry
+  - error monitoring
+repo: https://github.com/getsentry/sentry-java/tree/main/sentry-opentelemetry
+license: MIT
+description: The Sentry OpenTelemetry Java integration provides a processor and propagator to send data to Sentry and to associate traces/spans to Sentry errors. [See the Sentry docs to see how to configure](https://docs.sentry.io/platforms/java/performance/instrumentation/opentelemetry/).
+authors: Sentry (sentry.io) <otel@sentry.io>
+otVersion: latest
+---

--- a/content/en/registry/tools-js-sentry.md
+++ b/content/en/registry/tools-js-sentry.md
@@ -1,0 +1,19 @@
+---
+title: OpenTelemetry Node Integration for Sentry (sentry.io)
+registryType: utilities
+isThirdParty: true
+language: js
+tags:
+  - javascript
+  - node
+  - processor
+  - propagator
+  - utilities
+  - sentry
+  - error monitoring
+repo: https://github.com/getsentry/sentry-javascript/tree/master/packages/opentelemetry-node
+license: MIT
+description: The Sentry OpenTelemetry Node integration provides a processor and propagator to send data to Sentry and to associate traces/spans to Sentry errors. [See the Sentry docs to see how to configure](https://docs.sentry.io/platforms/node/performance/instrumentation/opentelemetry/).
+authors: Sentry (sentry.io) <otel@sentry.io>
+otVersion: latest
+---

--- a/content/en/registry/tools-python-sentry.md
+++ b/content/en/registry/tools-python-sentry.md
@@ -1,0 +1,18 @@
+---
+title: OpenTelemetry Python Integration for Sentry (sentry.io)
+registryType: utilities
+isThirdParty: true
+language: python
+tags:
+  - python
+  - processor
+  - propagator
+  - utilities
+  - sentry
+  - error monitoring
+repo: https://github.com/getsentry/sentry-python/tree/master/sentry_sdk/integrations/opentelemetry
+license: MIT
+description: The Sentry OpenTelemetry Python integration provides a processor and propagator to send data to Sentry and to associate traces/spans to Sentry errors. [See the Sentry docs to see how to configure](https://docs.sentry.io/platforms/python/performance/instrumentation/opentelemetry/).
+authors: Sentry (sentry.io) <otel@sentry.io>
+otVersion: latest
+---

--- a/content/en/registry/tools-ruby-sentry.md
+++ b/content/en/registry/tools-ruby-sentry.md
@@ -1,0 +1,18 @@
+---
+title: OpenTelemetry Ruby Integration for Sentry (sentry.io)
+registryType: utilities
+isThirdParty: true
+language: ruby
+tags:
+  - ruby
+  - processor
+  - propagator
+  - utilities
+  - sentry
+  - error monitoring
+repo: https://github.com/getsentry/sentry-ruby/tree/master/sentry-opentelemetry
+license: MIT
+description: The Sentry OpenTelemetry Ruby integration provides a processor and propagator to send data to Sentry and to associate traces/spans to Sentry errors. [See the Sentry docs to see how to configure](https://docs.sentry.io/platforms/ruby/performance/instrumentation/opentelemetry/).
+authors: Sentry (sentry.io) <otel@sentry.io>
+otVersion: latest
+---


### PR DESCRIPTION
[Sentry now has support for OpenTelemetry](https://github.com/getsentry/sentry/discussions/40712), so adding Sentry related items to the registry.