### PR TITLE
Add Roadmap to Community side-nav as redirect

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -5,6 +5,7 @@ IgnoreInternalURLs:
   # TODO: fix the source of these inlined TOC links
   # https://github.com/open-telemetry/opentelemetry.io/issues/1357
   - /docs/reference/specification/versioning-and-stability/#not-defined-semantic-conventions-stability
+  - /community/roadmap/
 IgnoreURLs:
   - ^/docs/instrumentation/\w+/(api|examples)/$
   - ^/docs/instrumentation/net/(metrics-api|traces-api)/

--- a/content/en/community/roadmap.md
+++ b/content/en/community/roadmap.md
@@ -1,0 +1,8 @@
+---
+title: OpenTelemetry Project Roadmap
+linkTitle: Roadmap
+redirect: https://github.com/open-telemetry/community/blob/main/roadmap.md
+manualLinkTarget: _blank
+_build: { render: link }
+weight: 20
+---


### PR DESCRIPTION
A quick addition so that the site path is reserved for the roadmap (and so it can potentially be used in the 2023/10 OTel in Focus).

**Preview**: https://deploy-preview-2239--opentelemetry.netlify.app/community/

### Screenshot

> <img width="994" alt="Screen Shot 2023-01-31 at 18 26 57" src="https://user-images.githubusercontent.com/4140793/215907107-0b937875-72ab-47ac-abb9-db2049dd04cb.png">
