### PR TITLE
Drop OTel Python git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,6 +8,3 @@
 [submodule "content-modules/opentelemetry-specification"]
 	path = content-modules/opentelemetry-specification
 	url = https://github.com/open-telemetry/opentelemetry-specification.git
-[submodule "content-modules/opentelemetry-python"]
-	path = content-modules/opentelemetry-python
-	url = https://github.com/open-telemetry/opentelemetry-python


### PR DESCRIPTION
Followup to:

- #1111

The Python git submodule should have been dropped back then. Apparently I forgot to do so.

No changes to generated site pages:

```console
$ (cd public && git diff -bw --ignore-blank-lines) 
$
```