### PR TITLE
Add demo docs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,6 @@
 [submodule "content-modules/opentelemetry-specification"]
 	path = content-modules/opentelemetry-specification
 	url = https://github.com/open-telemetry/opentelemetry-specification.git
+[submodule "content-modules/opentelemetry-demo"]
+	path = content-modules/opentelemetry-demo
+	url = https://github.com/open-telemetry/opentelemetry-demo

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -54,6 +54,8 @@ params:
   github_repo: https://github.com/open-telemetry/opentelemetry.io
   github_branch: main
   gcs_engine_id: bde3d634eca9cd335
+  # The following mermaid config can be dropped after we update Docsy to v0.6.0 or later
+  mermaid: { enable: true }
 
   ## Social media image path, such as Open Graph's og:image
   #

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -169,6 +169,8 @@ services:
 
 module:
   mounts:
+    - source: tmp/demo/docs
+      target: content/docs/demo
     - source: tmp/specification
       target: content/docs/reference/specification
     - source: content/en

--- a/scripts/adjust-spec-pages.pl
+++ b/scripts/adjust-spec-pages.pl
@@ -72,6 +72,8 @@ while(<>) {
     next;
   }
 
+  # SPECIFICATION custom processing
+
   s|\(https://github.com/open-telemetry/opentelemetry-specification\)|(/docs/reference/specification/)|;
   s|\.\./semantic_conventions/README.md|$semConvRef| if $ARGV =~ /overview/;
 
@@ -104,6 +106,13 @@ while(<>) {
 
   # Make website-local page references local:
   s|https://opentelemetry.io/|/|g;
+
+  # DEMO DOCS custom processing
+
+  s|\./(services/\w+)\.md|$1/|g if $ARGV =~ /demo.docs._index/;
+  s/#demo-screenshots/./;
+  s|(/vendors/)|/ecosystem$1|g;
+  s|(\.\.\/)+(src/)|https://github.com/open-telemetry/opentelemetry-demo/blob/main/$2|g if $ARGV =~ /demo.docs/;
 
   print;
 }

--- a/scripts/cp-spec-pages.sh
+++ b/scripts/cp-spec-pages.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
 BASE_DIR=$(dirname $0)
+DEST_BASE=tmp
+
 SPEC=content-modules/opentelemetry-specification/specification
-DEST=tmp/specification
+DEST=$DEST_BASE/specification
 
 rm -Rf $DEST
 mkdir -p $DEST
@@ -16,3 +18,21 @@ FILES=$(find $DEST -name "*.md")
 $BASE_DIR/adjust-spec-pages.pl $FILES
 
 echo "Specification pages copied and processed."
+
+# Demo docs
+
+SRC=content-modules/opentelemetry-demo/docs
+DEST=$DEST_BASE/demo/docs
+
+rm -Rf $DEST
+mkdir -p $DEST
+cp -R $SRC/* $DEST/
+
+find $DEST/ -name "README.md" -exec sh -c 'f="{}"; mv -- "$f" "${f%README.md}_index.md"' \;
+
+# To exclude a file use, e.g.: -not -path '*/some-path/_index.md'
+FILES=$(find $DEST -name "*.md")
+
+$BASE_DIR/adjust-spec-pages.pl $FILES
+
+echo "Demo doc pages copied and processed."


### PR DESCRIPTION
- Closes #2173 by bringing in the demo docs _as is_, via a git submodule.
- I propose this as a first cut, until the demo docs are frozen, after which we'll be able to migrate them from the demo repo to here. In the meantime, I'll submit some front-matter parameters to the demo repo to change the section weight, add linkTitles, etc.

WDYT @svrnm @cartermp @austinlparker @open-telemetry/demo-approvers ?

**Preview**: https://deploy-preview-2246--opentelemetry.netlify.app/docs/demo

p.s. I know that the scripts are misnamed, but I wanted to keep changes to a minimum in this PR.