### PR TITLE
Final move of registry into ecosystem section, and fix keyword search

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -9,3 +9,4 @@ IgnoreInternalURLs:
 IgnoreURLs:
   - ^/docs/instrumentation/\w+/(api|examples)/$
   - ^/docs/instrumentation/net/(metrics-api|traces-api)/
+  - ^/registry # [temporary] safe to ignore since we have a corresponding global rewrite rule

--- a/assets/js/registrySearch.js
+++ b/assets/js/registrySearch.js
@@ -50,7 +50,7 @@ if (pathName.includes("registry")) {
 
 // Runs search through Fuse for fuzzy search
 function executeSearch(searchQuery) {
-  fetch("/registry/index.json")
+  fetch("/ecosystem/registry/index.json")
     .then((res) => res.json())
     .then((json) => {
       let fuse = new Fuse(json, fuseOptions);

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -122,7 +122,8 @@
   }
 }
 
-.td-box--dark a {
+.td-box--dark a,
+.td-box--primary a {
   color: lighten($primary, 25%) !important;
 
   &:hover {

--- a/content/en/ecosystem/registry.md
+++ b/content/en/ecosystem/registry.md
@@ -1,8 +1,0 @@
----
-title: Registry
-manualLink: /registry/
-description:
-  Find libraries, plugins, integrations, and other useful tools for extending OpenTelemetry.
-_build: { render: link }
-weight: 20
----

--- a/content/en/ecosystem/registry/_index.md
+++ b/content/en/ecosystem/registry/_index.md
@@ -1,17 +1,20 @@
 ---
 title: Registry
+description: >-
+  Find libraries, plugins, integrations, and other useful tools for extending
+  OpenTelemetry.
+aliases: [/registry/*]
+type: default
+layout: registry
 outputs: [html, json]
-_build: { render: always }
-cascade:
-  _build: { render: link }
+weight: 20
 ---
 
-{{% blocks/lead color="primary" %}}
+{{% blocks/lead color="white" %}}
 
 # {{% param title %}}
 
-Find libraries, plugins, integrations, and other useful tools for extending
-OpenTelemetry.
+{{% param description %}}
 
 {{% /blocks/lead %}}
 
@@ -24,8 +27,8 @@ tracer implementations, utilities, and other useful projects in the
 OpenTelemetry ecosystem.
 
 - Not able to find an exporter for your language? Remember, the
-  [OpenTelemetry Collector](../docs/collector) supports exporting to a variety
-  of systems and works with all OpenTelemetry Core Components!
+  [OpenTelemetry Collector](/docs/collector) supports exporting to a variety of
+  systems and works with all OpenTelemetry Core Components!
 - Are you a project maintainer? See, [Adding a project to the OpenTelemetry
   Registry][add].
 - Check back regularly, the community and registry are growing!
@@ -34,3 +37,8 @@ OpenTelemetry ecosystem.
   https://github.com/open-telemetry/opentelemetry.io#adding-a-project-to-the-opentelemetry-registry
 
 {{% /blocks/section %}}
+
+{{<registry-search-form>}}
+
+[add]:
+  https://github.com/open-telemetry/opentelemetry.io#adding-a-project-to-the-opentelemetry-registry

--- a/layouts/ecosystem/registry.json.json
+++ b/layouts/ecosystem/registry.json.json
@@ -1,0 +1,5 @@
+{{ $entries := slice -}}
+{{ range $entry_name_ignored, $entry := .Site.Data.registry -}}
+  {{ $entries = $entries | append $entry -}}
+{{ end -}}
+{{ jsonify (dict "indent" "  ") $entries -}}

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -22,13 +22,6 @@
 {{ end -}}
 {{ end -}}
 
-
-{{ $registry_entry_prefixes := slice "collector" "exporter" "instrumentation" "otel" "resource" "sdk" "span" "tools" -}}
-{{ range $registry_entry_prefixes -}}
-/registry/{{ . }}*  /registry
-{{ end -}}
-
-
 {{/*
   Social-media image redirects. As mentioned in
   https://developers.facebook.com/docs/sharing/webmasters/images, we need to

--- a/layouts/registry/list.json.json
+++ b/layouts/registry/list.json.json
@@ -1,9 +1,0 @@
-{{- $.Scratch.Add "index" slice -}}
-{{- with .Site.GetPage "registry" -}}
-    {{- if .Pages -}}
-        {{- range .Pages.ByWeight -}}
-        {{- $.Scratch.Add "index" (dict "title" .Params.title "tags" .Params.tags "permalink" .Permalink "description" .Params.description "repo" .Params.repo "registryType" .Params.registryType "otVersion" .Params.otVersion "language" .Params.language) -}}
-        {{- end -}}
-    {{- end -}}
-{{- end -}}
-{{- $.Scratch.Get "index" | jsonify -}}

--- a/layouts/shortcodes/registry-search-form.html
+++ b/layouts/shortcodes/registry-search-form.html
@@ -1,5 +1,3 @@
-{{ define "main" -}}
-
 {{ $registry := .Site.Data.registry -}}
 
 {{ $languageNames := newScratch -}}
@@ -28,12 +26,10 @@
 {{ end -}}
 {{ $types = $types | uniq | sort -}}
 
-{{ .Content -}}
-
 <div class="td-content td-box">
   <section class="row section pb-5">
     <div class="col align-self-center">
-      <form action="{{ "/registry" | absURL }}" id="searchForm">
+      <form action="{{ "/ecosystem/registry" }}" id="searchForm">
         <div class="input-group">
           <div class="input-group-prepend">
             <span class="input-group-text" id="basic-addon1" title="{{ len $registry }} entries">Search</span>
@@ -99,4 +95,3 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/fuse.js/3.2.0/fuse.min.js"></script>
   {{ partial "script.html" (dict "src" "js/registrySearch.js") -}}
 </div>
-{{ end -}}


### PR DESCRIPTION
- Contributes to #2202
- Fully migrates the registry to be under `/ecosystem`
  - There are no more site pages or resources under `/registry`
- Redirects `/registry/*` to `/ecosystem/registry`
  - Query parameter are preserved in the redirect
- Tweaks the page design a bit:
  - New page section colors (see screenshot below)
- Ensures that the JSON data file is generated
- Ensure that the JS search uses updated paths, in particular to be able to access the JSON entries data
- Ran Prettifier on the main `.md` file

Preview:

- https://deploy-preview-2252--opentelemetry.netlify.app/ecosystem/registry
- https://deploy-preview-2252--opentelemetry.netlify.app/ecosystem/registry/?s=emf - shows that fuzzy search works
- https://deploy-preview-2252--opentelemetry.netlify.app/ecosystem/registry/?component=resource-detector
- https://deploy-preview-2252--opentelemetry.netlify.app/ecosystem/registry/index.json - the entries data file

Redirect tests:

- https://deploy-preview-2252--opentelemetry.netlify.app/registry
- https://deploy-preview-2252--opentelemetry.netlify.app/registry/?component=resource-detector

Screenshot:

> <img width="918" alt="image" src="https://user-images.githubusercontent.com/4140793/216393015-571d4d8b-ebb2-4958-b7f2-e2a6052f7ca3.png">
