### PR TITLE
[operator/java] Add instrumentation doc for java

### DIFF
--- a/content/en/docs/k8s-operator/automatic.md
+++ b/content/en/docs/k8s-operator/automatic.md
@@ -112,7 +112,68 @@ Coming Soon
 
 ### Java
 
-Coming Soon
+The following command will create a basic Instrumentation resource that is
+configured for instrumenting Java services.
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: demo-instrumentation
+spec:
+  exporter:
+    endpoint: http://demo-collector:4317
+  propagators:
+    - tracecontext
+    - baggage
+  sampler:
+    type: parentbased_traceidratio
+    argument: "1"
+EOF
+```
+
+By default, the Instrumentation resource that auto-instruments Java services
+uses `otlp` with the `grpc` protocol. This means that the configured endpoint
+must be able to receive OTLP over `grpc`. Therefore, the example uses
+`http://demo-collector:4317`, which will connect to the `grpc` port of the
+otlpreceiver of the Collector created in the previous step.
+
+By default the Java auto-instrumentation ships with
+[many many instrumentation libraries](/docs/instrumentation/java/automatic/#supported-libraries-frameworks-application-services-and-jvms).
+This makes instrumentation easy, but can result in too much or unwanted data. If
+there are any libraries you do not want to use you can set the
+`OTEL_INSTRUMENTATION_[NAME]_ENABLED=false` where `[NAME]` is the name of the
+libary. If you know exactly which libraries you want to use you can disbale the
+default libraries by setting `OTEL_INSTRUMENTATION_COMMON_DEFAULT_ENABLED=false`
+and then use `OTEL_INSTRUMENTATION_[NAME]_ENABLED=true` where `[NAME]` is the
+name of the library. See
+[Suppressing specific auto-instrumentation](/docs/instrumentation/java/automatic/agent-config/#suppressing-specific-auto-instrumentation)
+in the Java docs for more details
+
+```yaml
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: demo-instrumentation
+spec:
+  exporter:
+    endpoint: http://demo-collector:4317
+  propagators:
+    - tracecontext
+    - baggage
+  sampler:
+    type: parentbased_traceidratio
+    argument: "1"
+  java:
+    env:
+      - name: OTEL_INSTRUMENTATION_KAFKA_ENABLED
+        value: false
+      - name: OTEL_INSTRUMENTATION_REDISCALA_ENABLED
+        value: false
+```
+
+[See the Java Agent Configuration docs for more details.](/docs/instrumentation/java/automatic/agent-config/)
 
 ### Node.js
 

--- a/content/en/docs/k8s-operator/automatic.md
+++ b/content/en/docs/k8s-operator/automatic.md
@@ -112,7 +112,7 @@ Coming Soon
 
 ### Java
 
-The following command will create a basic Instrumentation resource that is
+The following command creates a basic Instrumentation resource that is
 configured for instrumenting Java services.
 
 ```bash
@@ -136,15 +136,15 @@ EOF
 By default, the Instrumentation resource that auto-instruments Java services
 uses `otlp` with the `grpc` protocol. This means that the configured endpoint
 must be able to receive OTLP over `grpc`. Therefore, the example uses
-`http://demo-collector:4317`, which will connect to the `grpc` port of the
+`http://demo-collector:4317`, which connects to the `grpc` port of the
 otlpreceiver of the Collector created in the previous step.
 
 By default, the Java auto-instrumentation ships with
-[many many instrumentation libraries](/docs/instrumentation/java/automatic/#supported-libraries-frameworks-application-services-and-jvms).
-This makes instrumentation easy, but can result in too much or unwanted data. If
+[many instrumentation libraries](/docs/instrumentation/java/automatic/#supported-libraries-frameworks-application-services-and-jvms).
+This makes instrumentation easy, but could result in too much or unwanted data. If
 there are any libraries you do not want to use you can set the
 `OTEL_INSTRUMENTATION_[NAME]_ENABLED=false` where `[NAME]` is the name of the
-libary. If you know exactly which libraries you want to use you can disbale the
+library. If you know exactly which libraries you want to use, you can disable the
 default libraries by setting `OTEL_INSTRUMENTATION_COMMON_DEFAULT_ENABLED=false`
 and then use `OTEL_INSTRUMENTATION_[NAME]_ENABLED=true` where `[NAME]` is the
 name of the library. For more details, see

--- a/content/en/docs/k8s-operator/automatic.md
+++ b/content/en/docs/k8s-operator/automatic.md
@@ -172,7 +172,7 @@ spec:
         value: false
 ```
 
-For more details, see [Agent Configuration](/docs/instrumentation/java/automatic/agent-config/).
+For more details, see [Java Agent Configuration](/docs/instrumentation/java/automatic/agent-config/).
 
 ### Node.js
 

--- a/content/en/docs/k8s-operator/automatic.md
+++ b/content/en/docs/k8s-operator/automatic.md
@@ -139,7 +139,7 @@ must be able to receive OTLP over `grpc`. Therefore, the example uses
 `http://demo-collector:4317`, which will connect to the `grpc` port of the
 otlpreceiver of the Collector created in the previous step.
 
-By default the Java auto-instrumentation ships with
+By default, the Java auto-instrumentation ships with
 [many many instrumentation libraries](/docs/instrumentation/java/automatic/#supported-libraries-frameworks-application-services-and-jvms).
 This makes instrumentation easy, but can result in too much or unwanted data. If
 there are any libraries you do not want to use you can set the
@@ -147,9 +147,8 @@ there are any libraries you do not want to use you can set the
 libary. If you know exactly which libraries you want to use you can disbale the
 default libraries by setting `OTEL_INSTRUMENTATION_COMMON_DEFAULT_ENABLED=false`
 and then use `OTEL_INSTRUMENTATION_[NAME]_ENABLED=true` where `[NAME]` is the
-name of the library. See
-[Suppressing specific auto-instrumentation](/docs/instrumentation/java/automatic/agent-config/#suppressing-specific-auto-instrumentation)
-in the Java docs for more details
+name of the library. For more details, see
+[Suppressing specific auto-instrumentation](/docs/instrumentation/java/automatic/agent-config/#suppressing-specific-auto-instrumentation).
 
 ```yaml
 apiVersion: opentelemetry.io/v1alpha1
@@ -173,7 +172,7 @@ spec:
         value: false
 ```
 
-[See the Java Agent Configuration docs for more details.](/docs/instrumentation/java/automatic/agent-config/)
+For more details, see [Agent Configuration](/docs/instrumentation/java/automatic/agent-config/).
 
 ### Node.js
 


### PR DESCRIPTION
Adds a section in the k8s operator instrumentation docs for Java.

Preview: https://deploy-preview-2253--opentelemetry.netlify.app/docs/k8s-operator/automatic/#java