### PR TITLE
Use canonical path to registry throughout the website

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -9,4 +9,5 @@ IgnoreInternalURLs:
 IgnoreURLs:
   - ^/docs/instrumentation/\w+/(api|examples)/$
   - ^/docs/instrumentation/net/(metrics-api|traces-api)/
+  # Next rule is waiting on update to Go docs
   - ^/registry # [temporary] safe to ignore since we have a corresponding global rewrite rule

--- a/content/en/blog/2022/apisix/index.md
+++ b/content/en/blog/2022/apisix/index.md
@@ -3,7 +3,7 @@ title: Apache APISIX Integrates with OpenTelemetry to Collect Tracing Data
 linkTitle: Apache APISIX-Opentelemetry Integration
 date: 2022-03-26
 author: >-
-  [Haochao Zhuang](https://github.com/dmsolr), 
+  [Haochao Zhuang](https://github.com/dmsolr),
   [Fei Han](https://github.com/hf400159)
 canonical_url: https://apisix.apache.org/blog/2022/02/28/apisix-integration-opentelemetry-plugin/
 ---
@@ -19,7 +19,7 @@ collection and reporting, but also provides data collection side for data
 receiving, processing, and exporting. Export to any or more OpenTelemetry
 backends, such as Jaeger, Zipkin, and OpenCensus. You can view the list of
 plugins that have adapted the OpenTelemetry Collector in the
-[registry](/registry/?s=collector).
+[registry](/ecosystem/registry/?s=collector).
 
 ![Architecture-Present](architecture-present.png)
 

--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -514,7 +514,7 @@ service:
 
 ### Configuration Environment Variables
 
-The use and expansion of environment variables is supported in the Collector configuration. 
+The use and expansion of environment variables is supported in the Collector configuration.
 For example to use the values stored on the `DB_KEY` and `OPERATION` environment variables you can write the following:
 
 ```yaml
@@ -564,7 +564,7 @@ authenticator for receivers, authenticating incoming connections. Refer to the
 authentication extension for a list of its capabilities, but in general, an
 authentication extension would only implement one of those traits. For a list of
 known authenticators, use the
-[Registry](/registry/?s=authenticator&component=extension&language=) available
+[Registry](/ecosystem/registry/?s=authenticator&component=extension) available
 in this website.
 
 To add a server authenticator to a receiver in your collector, make sure to:

--- a/content/en/docs/concepts/distributions.md
+++ b/content/en/docs/concepts/distributions.md
@@ -48,7 +48,7 @@ Distributions would broadly fall into the following categories:
 
 Anyone could create a distribution. Today, several [vendors](/ecosystem/vendors/)
 offer distributions. In addition, end-users may consider creating a distribution
-if they wish to use components in the [Registry](/registry) that are not
+if they wish to use components in the [Registry](/ecosystem/registry/) that are not
 upstreamed to the OpenTelemetry project.
 
 ## Contribution or distribution?

--- a/content/en/docs/concepts/instrumenting-library.md
+++ b/content/en/docs/concepts/instrumenting-library.md
@@ -49,7 +49,7 @@ are a good places to start!
 
 Some libraries are thin clients wrapping network calls. Chances are that
 OpenTelemetry has an instrumentation library for the underlying RPC client (check out
-the [registry](/registry/)). In this case, instrumenting the wrapper library
+the [registry](/ecosystem/registry/)). In this case, instrumenting the wrapper library
 may not be necessary.
 
 Don't instrument if:
@@ -213,7 +213,7 @@ should have a verbosity, logs are a better choice than traces.
 
 Chances are that your app uses logging or some similar module already. Your
 module might already have OpenTelemetry integration -- to find out, see the
-[registry](/registry/). Integrations usually stamp active trace context on all
+[registry](/ecosystem/registry/). Integrations usually stamp active trace context on all
 logs, so users can correlate them.
 
 If your language and ecosystem don't have common logging support, use [span
@@ -342,7 +342,7 @@ stable yet and we don't yet define metrics conventions.
 ### Instrumentation registry
 
 Please add your instrumentation library to the
-[OpenTelemetry registry](/registry/), so users can find it.
+[OpenTelemetry registry](/ecosystem/registry/), so users can find it.
 
 ### Performance
 

--- a/content/en/docs/concepts/instrumenting.md
+++ b/content/en/docs/concepts/instrumenting.md
@@ -93,7 +93,7 @@ options you may wish to take advantage of.
 Once you've configured the API and SDK, you'll then be free to create traces and
 metric events through the tracer and meter objects you obtained from the
 provider. Make use of Instrumentation Libraries for your dependencies -- check
-out the [registry](/registry) or your language's repository for more information
+out the [registry](/ecosystem/registry/) or your language's repository for more information
 on these.
 
 ### Export Data

--- a/content/en/docs/instrumentation/erlang/getting-started.md
+++ b/content/en/docs/instrumentation/erlang/getting-started.md
@@ -272,7 +272,7 @@ process and export telemetry data. The package
 provides support for both exporting over both HTTP (the default) and gRPC to the
 collector, which can then export Spans to a self-hosted service like Zipkin or
 Jaeger, as well as commercial services. For a full list of available exporters,
-see the [registry](/registry/?component=exporter).
+see the [registry](/ecosystem/registry/?component=exporter).
 
 For testing purposes the `opentelemetry-erlang` repo has a Collector
 configuration,

--- a/content/en/docs/instrumentation/erlang/instrumentation.md
+++ b/content/en/docs/instrumentation/erlang/instrumentation.md
@@ -346,7 +346,7 @@ many popular frameworks and libraries. You can find in the
 [opentelemetry-erlang-contrib
 repo](https://github.com/open-telemetry/opentelemetry-erlang-contrib/),
 published to [hex.pm](https://hex.pm) under the [OpenTelemetry
-Organization](https://hex.pm/orgs/opentelemetry) and the [registry](/registry).
+Organization](https://hex.pm/orgs/opentelemetry) and the [registry](/ecosystem/registry/).
 
 ## Creating Metrics
 

--- a/content/en/docs/instrumentation/java/manual.md
+++ b/content/en/docs/instrumentation/java/manual.md
@@ -48,7 +48,7 @@ the most important piece of telemetry source-identifying info.
             </dependency>
         </dependencies>
     </dependencyManagement>
-      
+
     <dependencies>
         <dependency>
             <groupId>io.opentelemetry</groupId>
@@ -79,7 +79,7 @@ dependencies {
     implementation 'io.opentelemetry:opentelemetry-exporter-otlp:{{% param javaVersion %}}'
     implementation 'io.opentelemetry:opentelemetry-semconv:{{% param javaVersion %}}-alpha'
 }
-```  
+```
 
 ### Imports
 ```java
@@ -918,7 +918,7 @@ io.opentelemetry.sdk.trace.export.BatchSpanProcessor = io.opentelemetry.extensio
 [Library Guidelines]: /docs/reference/specification/library-guidelines
 [Obtaining a Tracer]: /docs/reference/specification/trace/api/#get-a-tracer
 [OpenTelemetry Collector]: https://github.com/open-telemetry/opentelemetry-collector
-[OpenTelemetry Registry]: /registry/?component=exporter&language=java
+[OpenTelemetry Registry]: /ecosystem/registry/?component=exporter&language=java
 [ParentBased]: https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/ParentBasedSampler.java
 [Semantic Conventions]: /docs/reference/specification/trace/semantic_conventions
 [TraceIdRatioBased]: https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/TraceIdRatioBasedSampler.java

--- a/content/en/docs/instrumentation/js/getting-started/nodejs.md
+++ b/content/en/docs/instrumentation/js/getting-started/nodejs.md
@@ -29,7 +29,7 @@ Install dependencies used by the example.
 {{< tabpane lang=shell >}}
 
 {{< tab TypeScript >}}
-npm install express typescript ts-node @types/express @types/node 
+npm install express typescript ts-node @types/express @types/node
 {{< /tab >}}
 
 {{< tab JavaScript >}}
@@ -129,7 +129,7 @@ You may also want to use the `BatchSpanProcessor` to export spans in batches in 
 Many common modules such as the `http` standard library module, `express`, and
 others can be automatically instrumented using autoinstrumentation modules.
 To find autoinstrumenatation modules, you can look at the
-[registry](/registry/?language=js&component=instrumentation).
+[registry](/ecosystem/registry/?language=js&component=instrumentation).
 
 You can also install all instrumentations maintained by the OpenTelemetry authors
 by using the `@opentelemetry/auto-instrumentations-node` module.

--- a/content/en/docs/instrumentation/js/libraries.md
+++ b/content/en/docs/instrumentation/js/libraries.md
@@ -243,7 +243,7 @@ from the
 repository.
 
 You can also find more instrumentations available in the
-[registry](/registry/?language=js&component=instrumentation).
+[registry](/ecosystem/registry/?language=js&component=instrumentation).
 
 ## Next steps
 

--- a/content/en/docs/instrumentation/net/libraries.md
+++ b/content/en/docs/instrumentation/net/libraries.md
@@ -104,7 +104,7 @@ A full list of instrumentation libraries produced by OpenTelemetry is available
 from the [opentelemetry-dotnet][] repository.
 
 You can also find more instrumentations available in the
-[registry](/registry/?language=dotnet&component=instrumentation).
+[registry](/ecosystem/registry/?language=dotnet&component=instrumentation).
 
 ## Next steps
 

--- a/content/en/docs/instrumentation/other/_index.md
+++ b/content/en/docs/instrumentation/other/_index.md
@@ -11,7 +11,7 @@ will find in our documentation. OpenTelemetry is designed in a way that it is
 possible to implement it in every language you like.
 
 For some languages, unofficial implementations exist -- you can find them in the
-[registry](/registry). If you know about an implementation not listed there,
+[registry](/ecosystem/registry/). If you know about an implementation not listed there,
 please [add it to the registry][].
 
 The OpenTelemetry community is open to maintain implementations for additional

--- a/content/en/docs/instrumentation/python/_index.md
+++ b/content/en/docs/instrumentation/python/_index.md
@@ -43,7 +43,7 @@ directories.
 ## Extensions
 
 To find related projects like exporters, instrumentation libraries, tracer
-implementations, etc., visit the [Registry](/registry/?s=python).
+implementations, etc., visit the [Registry](/ecosystem/registry/?s=python).
 
 ### Installing Cutting-edge Packages
 

--- a/content/en/docs/instrumentation/python/automatic/_index.md
+++ b/content/en/docs/instrumentation/python/automatic/_index.md
@@ -69,7 +69,7 @@ A number of popular Python libraries are auto-instrumented, including
 [Flask](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-flask)
 and
 [Django](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-django).
-You can find the full list [here](/registry/?language=python&component=instrumentation).
+You can find the full list [here](/ecosystem/registry/?language=python&component=instrumentation).
 
 ## Troubleshooting
 

--- a/content/en/ecosystem/registry/_index.md
+++ b/content/en/ecosystem/registry/_index.md
@@ -39,6 +39,3 @@ OpenTelemetry ecosystem.
 {{% /blocks/section %}}
 
 {{<registry-search-form>}}
-
-[add]:
-  https://github.com/open-telemetry/opentelemetry.io#adding-a-project-to-the-opentelemetry-registry


### PR DESCRIPTION
- Contributes to #2202
- We can't drop the link-checker ignore rule yet because we're waiting on Go docs update:
  https://github.com/open-telemetry/opentelemetry-go/pull/3638

/cc @svrnm 