### PR TITLE
Use CTA buttons in Getting started page

### DIFF
--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -2,15 +2,31 @@
 title: Getting Started
 description: Get started with OpenTelemetry based on your role.
 spelling: cSpell:ignore otel
+no_list: true
 weight: 1
 ---
 
-Before you deep dive into your role-specific _Getting Started_, you can try out
-the official [OpenTelemetry Demo][] to **see** what observability with
-OpenTelemetry looks like.
+Select a role[^1] to get started:
 
-If none of the roles below are applicable to you, [let us know][]!
+<div class="l-get-started-buttons justify-content-start mt-3 ml-3">
 
-[opentelemetry demo]: /ecosystem/demo/
-[let us know]:
+- [Dev](dev/)
+- [Ops](ops/)
+
+</div>
+
+
+You can also try out the official [OpenTelemetry Demo][demo] to _see_ what
+observability with OpenTelemetry looks like!
+
+<div class="l-primary-buttons justify-content-start mt-3 mb-5 ml-3">
+
+- [Try the demo][demo]
+
+</div>
+
+[^1]: If none of these roles apply to you, [let us know!][].
+
+[demo]: /ecosystem/demo/
+[let us know!]:
   https://github.com/open-telemetry/opentelemetry.io/issues/new?title=Add%20a%20new%20persona:%20My%20Persona&body=Provide%20a%20description%20of%20your%20role%20and%20responsibilities%20and%20what%20your%20observability%20goals%20are

--- a/content/en/docs/getting-started/demo.md
+++ b/content/en/docs/getting-started/demo.md
@@ -1,6 +1,0 @@
----
-title: Demo
-manualLink: /ecosystem/demo/
-_build: { render: link }
-weight: 5
----


### PR DESCRIPTION
- Final contribution to #2158
- Adds Call-To-Action buttons to the **Getting Started** page
- Drops the demo alias / placeholder page
- Drops the **Getting Started** subpage list

Preview: https://deploy-preview-2257--opentelemetry.netlify.app/docs/getting-started/

### Screenshots

Before:

> <img width="860" alt="image" src="https://user-images.githubusercontent.com/4140793/216477731-30b5f733-cfd2-46d7-87e9-4b351d519f96.png">


After:

> <img width="858" alt="image" src="https://user-images.githubusercontent.com/4140793/216477653-9a89684d-c998-445a-8d47-39eeba6c7900.png">



/cc @svrnm @cartermp 