### PR TITLE
Make collectorVersion available to entire Collector section

### DIFF
--- a/content/en/docs/collector/_index.md
+++ b/content/en/docs/collector/_index.md
@@ -1,9 +1,11 @@
 ---
 title: Collector
-weight: 10
 description: Vendor-agnostic way to receive, process and export telemetry data.
 spelling: cSpell:ignore Otel
 aliases: [/docs/collector/about]
+cascade:
+  collectorVersion: 0.70.0
+weight: 10
 ---
 
 ![OpenTelemetry Collector diagram with Jaeger, OTLP and Prometheus integration](https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/Otel_Collector.svg)

--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -1,5 +1,5 @@
 ---
-title: "Configuration"
+title: Configuration
 weight: 20
 ---
 

--- a/content/en/docs/collector/custom-auth.md
+++ b/content/en/docs/collector/custom-auth.md
@@ -1,5 +1,5 @@
 ---
-title: "Building a custom authenticator"
+title: Building a custom authenticator
 weight: 30
 ---
 

--- a/content/en/docs/collector/distributions.md
+++ b/content/en/docs/collector/distributions.md
@@ -1,6 +1,5 @@
 ---
 title: Distributions
-spelling: cSpell:ignore
 weight: 25
 ---
 

--- a/content/en/docs/collector/getting-started.md
+++ b/content/en/docs/collector/getting-started.md
@@ -2,7 +2,6 @@
 title: Getting Started
 spelling: cSpell:ignore dpkg GOARCH journalctl kubectl
 weight: 1
-collectorVersion: 0.70.0
 ---
 
 If you aren't familiar with the deployment models, components, and repositories


### PR DESCRIPTION
- Make `collectorVersion` param available to entire **Collector** section
- Contributes to:
  - #1194
  - #2090
- Includes other minor front-matter cleanup
- There are no changes to the generated site files (except for Git info)

Preview, e.g.:

- https://deploy-preview-2259--opentelemetry.netlify.app/docs/collector/getting-started/#docker - see that the page still refers to `0.70.0`