### PR TITLE
Update opentelemetry-go and drop registry link-check ignore rule

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -9,5 +9,3 @@ IgnoreInternalURLs:
 IgnoreURLs:
   - ^/docs/instrumentation/\w+/(api|examples)/$
   - ^/docs/instrumentation/net/(metrics-api|traces-api)/
-  # Next rule is waiting on update to Go docs
-  - ^/registry # [temporary] safe to ignore since we have a corresponding global rewrite rule


### PR DESCRIPTION
- Brings in #3638, and no other doc changes
- Contributes to #2202

/cc @open-telemetry/go-instrumentation-approvers @svrnm 