### PR TITLE
Add a frame border to an image

### DIFF
--- a/content/en/blog/2022/otel-demo-app-nomad/index.md
+++ b/content/en/blog/2022/otel-demo-app-nomad/index.md
@@ -291,7 +291,7 @@ emitted with OpenTelemetry.
 **Load Generator UI:**
 [http://otel-demo.localhost/loadgen/](http://otel-demo.localhost/loadgen/)
 
-![Screen capture of loadgenerator UI](loadgen.png "Screen capture of loadgenerator UI")
+<img style="border:2px solid black;" src="loadgen.png" width="700" alt="Screen capture of loadgenerator UI" />
 
 ## Gotchas
 


### PR DESCRIPTION
When I saw [this image](https://opentelemetry.io/blog/2022/otel-demo-app-nomad/#gotchas) for the first time, I thought it was some issues caused by a bad page rendering.

So have a try to add a frame border in the image to clearly indicate it is a picture.

![image](https://user-images.githubusercontent.com/79828097/216819913-8fe5a79e-b981-4f2e-8af7-0fa254ba3edb.png)
