### PR TITLE
Demo docs: left-nav fixes, adjusted linkTitles and more

### DIFF
--- a/content/en/docs/demo/_index.md
+++ b/content/en/docs/demo/_index.md
@@ -1,28 +1,22 @@
 ---
 title: OpenTelemetry Demo Documentation
-linkTitle: Demo Documentation
+linkTitle: Demo
+cascade:
+  repo: https://github.com/open-telemetry/opentelemetry-demo
 ---
 
 Welcome to the OpenTelemetry Demo! This folder contains overall documentation
 for the project, how to install and run it, and some scenarios you can use to
 view OpenTelemetry in action.
 
-## Table of Contents
-
-- [Guided Scenarios](#scenarios)
-- [Language Instrumentation Examples](#language-feature-reference)
-- [Quick Start](#running-the-demo)
-- [References](#reference)
-- [Service Documentation](#service-documentation)
-
-### Running the Demo
+## Running the Demo
 
 Want to deploy the demo and see it in action? Start here.
 
 - [Docker]({{% relref "./docker_deployment.md" %}})
 - [Kubernetes]({{% relref "./kubernetes_deployment.md" %}})
 
-### Language Feature Reference
+## Language Feature Reference
 
 Want to understand how a particular language's instrumentation works? Start
 here.
@@ -41,7 +35,7 @@ here.
 | Ruby          | [Email Service]({{% relref "services/emailservice/" %}})                                                                                                                                | [Email Service]({{% relref "services/emailservice/" %}})                                                                         |
 | Rust          | [Shipping Service]({{% relref "services/shippingservice/" %}})                                                                                                                          | [Shipping Service]({{% relref "services/shippingservice/" %}})                                                                   |
 
-### Service Documentation
+## Service Documentation
 
 Specific information about how OpenTelemetry is deployed in each service can be
 found here:
@@ -59,7 +53,7 @@ found here:
 - [Recommendation Service]({{% relref "services/recommendationservice/" %}})
 - [Shipping Service]({{% relref "services/shippingservice/" %}})
 
-### Scenarios
+## Scenarios
 
 How can you solve problems with OpenTelemetry? These scenarios walk you through
 some pre-configured problems and show you how to interpret OpenTelemetry data to
@@ -71,7 +65,7 @@ We'll be adding more scenarios over time.
   with product id: `OLJCESPC7Z` using the Feature Flag service
 - Discover a memory leak and diagnose it using metrics and traces. [Read more]({{% relref "./scenarios/recommendation_cache.md" %}})
 
-### Reference
+## Reference
 
 Project reference documentation, like requirements and feature matrices.
 

--- a/content/en/docs/demo/current_architecture.md
+++ b/content/en/docs/demo/current_architecture.md
@@ -1,5 +1,6 @@
 ---
 title: Demo Architecture
+linkTitle: Architecture
 ---
 
 **OpenTelemetry Demo** is composed of microservices written in different programming

--- a/content/en/docs/demo/demo_features.md
+++ b/content/en/docs/demo/demo_features.md
@@ -1,5 +1,6 @@
 ---
-title: Features
+title: Demo Features
+linkTitle: Features
 ---
 
 - **[Kubernetes](https://kubernetes.io)**: the app is designed to run on

--- a/content/en/docs/demo/demo_screenshots.md
+++ b/content/en/docs/demo/demo_screenshots.md
@@ -1,14 +1,7 @@
 ---
 title: Demo Screenshots
+linkTitle: Screenshots
 ---
-
-- [Demo Screenshots](.)
-  - [Webstore](#webstore)
-  - [Jaeger](#jaeger)
-  - [Prometheus](#prometheus)
-  - [Grafana](#grafana)
-  - [Feature Flag UI](#feature-flag-ui)
-  - [Load Generator UI](#load-generator-ui)
 
 ## Webstore
 

--- a/content/en/docs/demo/docker_deployment.md
+++ b/content/en/docs/demo/docker_deployment.md
@@ -1,5 +1,6 @@
 ---
-title: Docker
+title: Docker deployment
+linkTitle: Docker
 ---
 
 ## Prerequisites

--- a/content/en/docs/demo/forking.md
+++ b/content/en/docs/demo/forking.md
@@ -1,15 +1,16 @@
 ---
-title: Forking this Repository
+title: Forking the demo repository
+linkTitle: Forking
 ---
 
-This repository is designed to be forked and used as a tool to show off what you
-are doing with OpenTelemetry.
+The [demo repository][] is designed to be forked and used as a tool to show off
+what you are doing with OpenTelemetry.
 
 Setting up a fork or a demo usually only requires overriding some environment
 variables and possibly replacing some container images.
 
-Live demos can be added to the
-[README](https://github.com/open-telemetry/opentelemetry-demo/blob/main/_index.md?plain=1#L186).
+Live demos can be added to the demo
+[README](https://github.com/open-telemetry/opentelemetry-demo/blob/main/README.md?plain=1).
 
 ## Suggestions for Fork Maintainers
 
@@ -28,3 +29,5 @@ Live demos can be added to the
 
 If you have any questions or would like to suggest ways that we can make your
 life easier as a fork maintainer, please open an issue.
+
+[demo repository]: {{% param repo %}}

--- a/content/en/docs/demo/kubernetes_deployment.md
+++ b/content/en/docs/demo/kubernetes_deployment.md
@@ -1,5 +1,6 @@
 ---
-title: Kubernetes
+title: Kubernetes deployment
+linkTitle: Kubernetes
 ---
 
 We provide a [OpenTelemetry Demo Helm

--- a/content/en/docs/demo/metric_service_features.md
+++ b/content/en/docs/demo/metric_service_features.md
@@ -1,5 +1,6 @@
 ---
 title: Metric Feature Coverage by Service
+linkTitle: Metric Feature Coverage
 ---
 
 Emoji Legend

--- a/content/en/docs/demo/requirements/_index.md
+++ b/content/en/docs/demo/requirements/_index.md
@@ -1,6 +1,6 @@
 ---
-title: OpenTelemetry Community Demo Requirements
-linkTitle: Community Demo Requirements
+title: Demo Requirements
+linkTitle: Requirements
 ---
 
 The following documents capture the Application, OpenTelemetry (OTel), and System
@@ -8,9 +8,7 @@ requirements for our shared demo application. These were decided upon in the
 ongoing SIG meeting.
 
 1. [Application Requirements]({{% relref "./application_requirements.md" %}})
-
 2. [OpenTelemetry Requirements]({{% relref "./opentelemetry_requirements.md" %}})
-
 3. [System Requirements]({{% relref "./system_requirements.md" %}})
 
 ## Target Personas
@@ -19,12 +17,9 @@ We're building the demo application with several different target personas in mi
 
 1. **Enthusiasts** at a company that can use the demo app as an individual to
    advocate for OTel within their organization.
-
 2. **Developers** with specific language skills who want to see a larger picture
    view.
-
 3. **APM Vendors** who can evaluate OTel in general or need to produce a demo of
    their OTel capabilities for customers.
-
 4. **Enterprises** considering adopting OTel and interested in understanding
    what a production-lite experience would be.

--- a/content/en/docs/demo/requirements/application_requirements.md
+++ b/content/en/docs/demo/requirements/application_requirements.md
@@ -1,5 +1,6 @@
 ---
 title: Application Requirements
+title: Application
 ---
 
 The following requirements were decided upon to define what OpenTelemetry (OTel)

--- a/content/en/docs/demo/requirements/architecture_requirements.md
+++ b/content/en/docs/demo/requirements/architecture_requirements.md
@@ -1,5 +1,6 @@
 ---
-title: Demo Architecture
+title: Architecture Requirements
+linkTitle: Architecture
 ---
 
 ## Summary

--- a/content/en/docs/demo/requirements/opentelemetry_requirements.md
+++ b/content/en/docs/demo/requirements/opentelemetry_requirements.md
@@ -1,6 +1,6 @@
 ---
 title: OpenTelemetry Requirements
-linkTitle: Requirements
+linkTitle: OTel Requirements
 ---
 
 The following requirements were decided upon to define what OpenTelemetry (OTel)
@@ -9,19 +9,13 @@ added:
 
 1. The demo must produce OTel logs, traces, & metrics out of the box for
    languages that have a GA SDK.
-
 2. Languages that have a Beta SDK available may be included but are not required
    like GA SDKs.
-
 3. Native OTel metrics should be produced where possible.
-
 4. Both manual instrumentation and instrumentation libraries
    (auto-instrumentation) should be demonstrated in each language.
-
 5. All data should be exported to the Collector first.
-
 6. The Collector must be configurable to allow for a variety of consumption
    experiences but default tools must be selected for each signal.
-
 7. The demo application architecture using the Collector should be designed to
    be a best practices reference architecture.

--- a/content/en/docs/demo/requirements/system_requirements.md
+++ b/content/en/docs/demo/requirements/system_requirements.md
@@ -1,5 +1,6 @@
 ---
 title: System Requirements
+linkTitle: System
 ---
 
 To ensure the demo runs correctly please ensure your environment meets the
@@ -7,6 +8,5 @@ following system requirements:
 
 1. Your system must meet [Docker Desktop](https://docs.docker.com/desktop)
    system requirements or you should use your preferred Cloud Service.
-
 2. The demo must be able to work on the following Operating Systems (OS):
    Linux, macOS and Windows with documentation provided for each OS.

--- a/content/en/docs/demo/scenarios/_index.md
+++ b/content/en/docs/demo/scenarios/_index.md
@@ -1,0 +1,3 @@
+---
+title: Scenarios
+---

--- a/content/en/docs/demo/scenarios/recommendation_cache.md
+++ b/content/en/docs/demo/scenarios/recommendation_cache.md
@@ -1,5 +1,6 @@
 ---
 title: Using Metrics and Traces to diagnose a memory leak
+linkTitle: Diagnosing memory leaks
 ---
 
 Application telemetry, such as the kind that OpenTelemetry can provide, is very

--- a/content/en/docs/demo/services/_index.md
+++ b/content/en/docs/demo/services/_index.md
@@ -1,0 +1,3 @@
+---
+title: Services
+---

--- a/content/en/docs/demo/services/accountingservice.md
+++ b/content/en/docs/demo/services/accountingservice.md
@@ -1,5 +1,6 @@
 ---
 title: Accounting Service
+linkTitle: Accounting
 ---
 
 This service calculates the total amount of sold products.

--- a/content/en/docs/demo/services/adservice.md
+++ b/content/en/docs/demo/services/adservice.md
@@ -1,5 +1,6 @@
 ---
 title: Ad Service
+linkTitle: Ad
 ---
 
 This service determines appropriate ads to serve to users based on context

--- a/content/en/docs/demo/services/cartservice.md
+++ b/content/en/docs/demo/services/cartservice.md
@@ -1,5 +1,6 @@
 ---
 title: Cart Service
+linkTitle: Cart
 ---
 
 This service maintains items placed in the shopping cart by users. It interacts

--- a/content/en/docs/demo/services/checkoutservice.md
+++ b/content/en/docs/demo/services/checkoutservice.md
@@ -1,5 +1,6 @@
 ---
 title: Checkout Service
+linkTitle: Checkout
 ---
 
 This service is responsible to process a checkout order from the user. The

--- a/content/en/docs/demo/services/currencyservice.md
+++ b/content/en/docs/demo/services/currencyservice.md
@@ -1,5 +1,6 @@
 ---
 title: Currency Service
+linkTitle: Currency
 ---
 
 This service provides functionality to convert amounts between different

--- a/content/en/docs/demo/services/emailservice.md
+++ b/content/en/docs/demo/services/emailservice.md
@@ -1,5 +1,6 @@
 ---
 title: Email Service
+linkTitle: Email
 ---
 
 This service will send a confirmation email to the user when an order is placed.

--- a/content/en/docs/demo/services/featureflagservice.md
+++ b/content/en/docs/demo/services/featureflagservice.md
@@ -1,5 +1,6 @@
 ---
 title: Feature Flag Service
+linkTitle: Feature Flag
 ---
 
 This service is written in Erlang/Elixir and it is responsible for creating,

--- a/content/en/docs/demo/services/frauddetectionservice.md
+++ b/content/en/docs/demo/services/frauddetectionservice.md
@@ -1,5 +1,6 @@
 ---
 title: Fraud Detection Service
+linkTitle: Fraud Detection
 ---
 
 This service analyses incoming orders and detects malicious customers.

--- a/content/en/docs/demo/services/frontendproxy.md
+++ b/content/en/docs/demo/services/frontendproxy.md
@@ -1,5 +1,6 @@
 ---
-title: Frontend Proxy(Envoy)
+title: Frontend Proxy (Envoy)
+linkTitle: Frontend Proxy
 ---
 
 The frontend proxy is used as a reverse proxy for user-facing web

--- a/content/en/docs/demo/services/paymentservice.md
+++ b/content/en/docs/demo/services/paymentservice.md
@@ -1,5 +1,6 @@
 ---
 title: Payment Service
+linkTitle: Payment
 ---
 
 This service is responsible to process credit card payments for orders. It will

--- a/content/en/docs/demo/services/productcatalogservice.md
+++ b/content/en/docs/demo/services/productcatalogservice.md
@@ -1,5 +1,6 @@
 ---
 title: Product Catalog Service
+linkTitle: Product Catalog
 ---
 
 This service is responsible to return information about products. The service

--- a/content/en/docs/demo/services/quoteservice.md
+++ b/content/en/docs/demo/services/quoteservice.md
@@ -1,5 +1,6 @@
 ---
 title: Quote Service
+linkTitle: Quote
 ---
 
 This service is responsible for calculating shipping costs, based on

--- a/content/en/docs/demo/services/recommendationservice.md
+++ b/content/en/docs/demo/services/recommendationservice.md
@@ -1,5 +1,6 @@
 ---
 title: Recommendation Service
+linkTitle: Recommendation
 ---
 
 This service is responsible to get a list of recommended products for the user

--- a/content/en/docs/demo/services/shippingservice.md
+++ b/content/en/docs/demo/services/shippingservice.md
@@ -1,5 +1,6 @@
 ---
 title: Shipping Service
+linkTitle: Shipping
 ---
 
 This service is responsible for providing shipping information including pricing

--- a/content/en/docs/demo/trace_service_features.md
+++ b/content/en/docs/demo/trace_service_features.md
@@ -1,5 +1,6 @@
 ---
 title: Trace Feature Coverage by Service
+linkTitle: Trace Feature Coverage
 ---
 
 Emoji Legend


### PR DESCRIPTION
- Closes #2274
  - Adds missing `_index.md` files under each doc folder
- Adds `linkTitle`s
- Drops manually-added in-page ToCs because the ToC are now autogenerated.
- Fixes the **Forking** page to refer to demo repo

Preview: https://deploy-preview-2275--opentelemetry.netlify.app/docs/demo/

/cc @open-telemetry/demo-approvers 

## Screenshots

**Before**:

> <img width="200" alt="image" src="https://user-images.githubusercontent.com/4140793/217050895-8322af77-26c2-4bed-848a-058be6a79686.png">

---

**After**:

> <img width="299" alt="image" src="https://user-images.githubusercontent.com/4140793/217050969-fe1d4daf-b870-4ab7-a8d3-febf7ea3ebb9.png">

With all sections open:

> <img width="200" alt="image" src="https://user-images.githubusercontent.com/4140793/217051099-1cae9614-9eac-44be-861e-61d05e2f6359.png">

