### PR TITLE
check-collector-version.sh: fix for Linux sed

### DIFF
--- a/.github/workflows/scripts/check-collector-version.sh
+++ b/.github/workflows/scripts/check-collector-version.sh
@@ -35,7 +35,7 @@ echo "Latest version: $latest_version"
 
 fileWithVersInfo=${REPO_DIR}/content/en/docs/collector/_index.md
 
-sed -i $BACKUP_EXT "s/collectorVersion:.*/collectorVersion: $latest_version/" $fileWithVersInfo
+sed -i$BACKUP_EXT -e "s/collectorVersion:.*/collectorVersion: $latest_version/" $fileWithVersInfo
 
 if [[ -e $fileWithVersInfo$BACKUP_EXT ]]; then
   rm $fileWithVersInfo$BACKUP_EXT


### PR DESCRIPTION
Followup to:

- #2266

Which broke the script under Linux, despite my attempt at addressing the `sed` differences between Linux and macOS. The result was action failures:
  - https://github.com/open-telemetry/opentelemetry.io/actions/runs/4101553729/jobs/7073465659

Take 2. Tested script under macOS. Tested command change under Linux. 🤞 😄 