### PR TITLE
Add C++ packages to registry

### DIFF
--- a/data/registry/tools-cpp-alpine-apk.yml
+++ b/data/registry/tools-cpp-alpine-apk.yml
@@ -9,6 +9,6 @@ tags:
   - package
 repo: https://pkgs.alpinelinux.org/packages?name=opentelemetry-cpp-* 
 license: Apache 2.0
-description: If you are using alpine linux you can install opentelemetry-cpp with these packages.
+description: Alpine Linux packages in support of opentelemetry-cpp.
 authors: Severin Neumann
 otVersion: unknown

--- a/data/registry/tools-cpp-alpine-apk.yml
+++ b/data/registry/tools-cpp-alpine-apk.yml
@@ -1,5 +1,5 @@
 title: Alpine Linux Packages for OpenTelemetry C++
-registryType: core
+registryType: core exporter
 isThirdParty: true
 language: cpp
 tags:

--- a/data/registry/tools-cpp-alpine-apk.yml
+++ b/data/registry/tools-cpp-alpine-apk.yml
@@ -1,4 +1,4 @@
-title: Alpine Linux Package for OpenTelemetry C++
+title: Alpine Linux Packages for OpenTelemetry C++
 registryType: core
 isThirdParty: true
 language: cpp

--- a/data/registry/tools-cpp-alpine-apk.yml
+++ b/data/registry/tools-cpp-alpine-apk.yml
@@ -7,7 +7,7 @@ tags:
   - alpine linux
   - apk
   - package
-repo: https://pkgs.alpinelinux.org/packages?name=opentelemetry-cpp-* 
+repo: https://pkgs.alpinelinux.org/packages?name=opentelemetry-cpp-*
 license: Apache 2.0
 description: Alpine Linux packages in support of opentelemetry-cpp.
 authors: Severin Neumann

--- a/data/registry/tools-cpp-alpine-apk.yml
+++ b/data/registry/tools-cpp-alpine-apk.yml
@@ -1,0 +1,14 @@
+title: Alpine Linux Package for OpenTelemetry C++
+registryType: core
+isThirdParty: true
+language: cpp
+tags:
+  - cpp
+  - alpine
+  - apk
+  - package
+repo: https://pkgs.alpinelinux.org/packages?name=opentelemetry-cpp-* 
+license: Apache 2.0
+description: If you are using alpine linux you can install opentelemetry-cpp with these packages.
+authors: Severin Neumann
+otVersion: unknown

--- a/data/registry/tools-cpp-alpine-apk.yml
+++ b/data/registry/tools-cpp-alpine-apk.yml
@@ -4,7 +4,7 @@ isThirdParty: true
 language: cpp
 tags:
   - cpp
-  - alpine
+  - alpine linux
   - apk
   - package
 repo: https://pkgs.alpinelinux.org/packages?name=opentelemetry-cpp-* 

--- a/data/registry/tools-cpp-conan.yml
+++ b/data/registry/tools-cpp-conan.yml
@@ -9,5 +9,5 @@ tags:
 repo: https://conan.io/center/opentelemetry-cpp
 license: MIT
 description: Conan package for `opentelemetry-cpp`.
-authors: Others
+authors:
 otVersion: unknown

--- a/data/registry/tools-cpp-conan.yml
+++ b/data/registry/tools-cpp-conan.yml
@@ -8,6 +8,6 @@ tags:
   - package
 repo: https://conan.io/center/opentelemetry-cpp
 license: MIT
-description: If you are using Conan to manage your dependencies, add opentelemetry-cpp/x.y.z to your conanfile's requires.
+description: Conan package for `opentelemetry-cpp`.
 authors: Others
 otVersion: unknown

--- a/data/registry/tools-cpp-conan.yml
+++ b/data/registry/tools-cpp-conan.yml
@@ -1,0 +1,13 @@
+title: Conan Package for OpenTelemetry C++
+registryType: core
+isThirdParty: true
+language: cpp
+tags:
+  - cpp
+  - conan
+  - package
+repo: https://conan.io/center/opentelemetry-cpp
+license: MIT
+description: If you are using Conan to manage your dependencies, add opentelemetry-cpp/x.y.z to your conanfile's requires.
+authors: Others
+otVersion: unknown

--- a/data/registry/tools-cpp-vcpkg.yml
+++ b/data/registry/tools-cpp-vcpkg.yml
@@ -6,7 +6,7 @@ tags:
   - cpp
   - vcpkg
   - package
-repo: https://github.com/microsoft/vcpkg/tree/master/ports/opentelemetry-cpp 
+repo: https://github.com/microsoft/vcpkg/tree/master/ports/opentelemetry-cpp
 license: MIT 
 description: If you are using vcpkg, then you can install opentelemetry-cpp with this package. 
 authors: Others

--- a/data/registry/tools-cpp-vcpkg.yml
+++ b/data/registry/tools-cpp-vcpkg.yml
@@ -9,5 +9,5 @@ tags:
 repo: https://github.com/microsoft/vcpkg/tree/master/ports/opentelemetry-cpp
 license: MIT 
 description: A vcpkg package for opentelemetry-cpp. 
-authors: Others
+authors:
 otVersion: unknown

--- a/data/registry/tools-cpp-vcpkg.yml
+++ b/data/registry/tools-cpp-vcpkg.yml
@@ -8,6 +8,6 @@ tags:
   - package
 repo: https://github.com/microsoft/vcpkg/tree/master/ports/opentelemetry-cpp
 license: MIT 
-description: If you are using vcpkg, then you can install opentelemetry-cpp with this package. 
+description: A vcpkg package for opentelemetry-cpp. 
 authors: Others
 otVersion: unknown

--- a/data/registry/tools-cpp-vcpkg.yml
+++ b/data/registry/tools-cpp-vcpkg.yml
@@ -1,0 +1,13 @@
+title: vcpkg package for OpenTelemetry C++
+registryType: core
+isThirdParty: true
+language: cpp
+tags:
+  - cpp
+  - vcpkg
+  - package
+repo: https://github.com/microsoft/vcpkg/tree/master/ports/opentelemetry-cpp 
+license: MIT 
+description: If you are using vcpkg, then you can install opentelemetry-cpp with this package. 
+authors: Others
+otVersion: unknown


### PR DESCRIPTION
Since I created one of them, I thought it would be great to have these different options to install OpenTelemetry C++ via package managers listed in our registry.

Source: https://github.com/open-telemetry/opentelemetry-cpp/blob/main/INSTALL.md#using-package-managers