### PR TITLE
Prettier base config and NPM scripts in preparation for CI integration

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,23 @@
+# Base
+
+/.netlify
+/.vscode
+/content-modules
+/iconography
+/layouts
+package-lock.json
+/public
+/themes
+/tmp
+
+# Temporary while we ramp up use of Prettier
+
+/.github
+/archetypes
+/assets
+/content
+/data
+/resources
+/scripts
+/static
+/templates

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ request an enhancement, [create an issue][new-issue].
 ## Submitting a change
 
 Enhancements and fixes to the website are most welcome! Before submitting a
-[pull request][PR] (PR) over the website, run `npm run test` and address any
+[pull request][pr] (PR) over the website, run `npm run test` and address any
 reported issues.
 
 ### Submodule changes
@@ -153,7 +153,8 @@ required.
 [hugo]: https://gohugo.io
 [localhost:8888]: http://localhost:8888
 [netlify]: https://netlify.com
-[new-issue]: https://github.com/open-telemetry/opentelemetry.io/issues/new/choose
+[new-issue]:
+  https://github.com/open-telemetry/opentelemetry.io/issues/new/choose
 [nodejs-rel]: https://nodejs.org/en/about/releases/
 [nodejs-win]:
   https://docs.microsoft.com/en-us/windows/dev-environment/javascript/nodejs-on-windows
@@ -161,4 +162,5 @@ required.
   https://github.com/nvm-sh/nvm/blob/master/README.md#installing-and-updating
 [nvm-windows]: https://github.com/coreybutler/nvm-windows
 [org]: https://github.com/open-telemetry
-[pr]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests
+[pr]:
+  https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests

--- a/README.md
+++ b/README.md
@@ -47,9 +47,8 @@ If your post will have images or other assets, instead run:
 npx hugo new content/en/blog/2023/short-name-for-post/index.md
 ```
 
-Edit the markdown file at the path you provided in the previous
-command. The file is initialized from the blog-post starter under
-[archetypes](archetypes).
+Edit the markdown file at the path you provided in the previous command. The
+file is initialized from the blog-post starter under [archetypes](archetypes).
 
 Put assets, if any, like images into the folder created.
 

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -40,7 +40,8 @@ outputs:
   home: [HTML, REDIRECTS, RSS]
 
 params:
-  copyright: 'The OpenTelemetry Authors | Documentation Distributed under CC BY 4.0 | '
+  copyright: >-
+    The OpenTelemetry Authors | Documentation Distributed under CC BY 4.0 |
   tagline: Effective observability requires high-quality telemetry
   sub_tagline: >-
     **OpenTelemetry** makes robust, portable telemetry a built-in feature of
@@ -108,7 +109,7 @@ params:
         url: https://github.com/open-telemetry
         icon: fab fa-github
         desc: Find us on GitHub.
-      - name: 'Slack #opentelemetry'
+      - name: "Slack #opentelemetry"
         url: https://cloud-native.slack.com/archives/CJFCJHG4Q
         icon: fab fa-slack
         desc: >-
@@ -159,7 +160,7 @@ params:
 
   fonts:
     - name: Noto Sans
-      sizes: [300,400,600,700]
+      sizes: [300, 400, 600, 700]
       type: sans_serif
 
 services:

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "precheck-links": "npm run build",
     "prepare": "run-s get:submodule _prepare:docsy",
     "preserve:hugo": "npm run _prebuild",
+    "prettier:check-all": "npx prettier --check .",
+    "prettier:no-ignore": "npx prettier --ignore-path ''",
     "preserve": "npm run _prebuild",
     "s": "run-s",
     "schemas:update": "npm run update:submodule content-modules/opentelemetry-specification",


### PR DESCRIPTION
- Preparation for use of Prettier as part of CI
  - Sets up a base config for use of Prettier, that makes it easy for contributors to use
  - Defines NPM scripts for checking all files
- Offers an alternative base to #2179
- Contributes to #1063
- Includes minor Prettier fixes for a few top-level files

---

The `check-all` script will then be useful for a GH action since it fails which a human friendly message when formatting needs to be applied. For example:

```console
$ npm run prettier:check-all ; echo $?        
...
Checking formatting...
[warn] README.md
[warn] Code style issues found in the above file. Forgot to run Prettier?
1
```

To fix the issues add the `-w` flag:

```console
$ npm run prettier:check-all -- -w    
...
Checking formatting...
[warn] README.md
[warn] Code style issues fixed in the above file.
```

Now check again, and all is good:

```console
$ npm run prettier:check-all ; echo $?
...
Checking formatting...
All matched files use Prettier code style!
0
```

To run Prettier on a file that is ignored by default, use either of the following commands:

```console
$ npm run prettier:no-ignore -- -w assets/scss/_tabs.scss
...
assets/scss/_tabs.scss 39ms
$ npx prettier --ignore-path '' -w assets/scss/_tabs.scss
assets/scss/_tabs.scss 37ms
```