### PR TITLE
Demo service feature tables: recover icons

### DIFF
--- a/content/en/docs/demo/metric-features.md
+++ b/content/en/docs/demo/metric-features.md
@@ -4,25 +4,25 @@ linkTitle: Metric Feature Coverage
 aliases: [/docs/demo/metric_service_features]
 ---
 
-Emoji Legend
+| Service         | Language        | Auto-instrumentation | Manual Instrumentation | Multiple Instruments | Views | Custom Attributes | Resource Detection | Trace Exemplars |
+| --------------- | --------------- | -------------------- | ---------------------- | -------------------- | ----- | ----------------- | ------------------ | --------------- |
+| Accounting      | Go              | 🚧                   | 🚧                     | 🚧                   | 🚧    | 🚧                | 🚧                 | 🚧              |
+| Ad              | Java            | ✅                   | ✅                     | 🚧                   | 🚧    | ✅                | ✅                 | ✅              |
+| Cart            | .NET            | ✅                   | 🚧                     | 🚧                   | 🚧    | 🚧                | 🚧                 | 🚧              |
+| Checkout        | Go              | ✅                   | 🚧                     | 🚧                   | 🚧    | 🚧                | 🚧                 | 🚧              |
+| Currency        | C++             | 🔕                   | 🚧                     | 🚧                   | 🚧    | 🚧                | 🚧                 | 🚧              |
+| Email           | Ruby            | 🚧                   | 🚧                     | 🚧                   | 🚧    | 🚧                | 🚧                 | 🚧              |
+| Feature Flag    | Erlang / Elixir | 🚧                   | 🚧                     | 🚧                   | 🚧    | 🚧                | 🚧                 | 🚧              |
+| Fraud Detection | Kotlin          | ✅                   | 🚧                     | 🚧                   | 🚧    | 🚧                | ✅                 | 🚧              |
+| Frontend        | TypeScript      | 🚧                   | 🚧                     | 🚧                   | 🚧    | 🚧                | 🚧                 | 🚧              |
+| Payment         | JavaScript      | 🚧                   | ✅                     | 🚧                   | 🚧    | 🚧                | ✅                 | 🚧              |
+| Product Catalog | Go              | 🚧                   | 🚧                     | 🚧                   | 🚧    | 🚧                | 🚧                 | 🚧              |
+| Quote           | PHP             | 🚧                   | 🚧                     | 🚧                   | 🚧    | 🚧                | 🚧                 | 🚧              |
+| Recommendation  | Python          | ✅                   | ✅                     | 🚧                   | 🚧    | 🚧                | 🚧                 | 🚧              |
+| Shipping        | Rust            | 🚧                   | 🚧                     | 🚧                   | 🚧    | 🚧                | 🚧                 | 🚧              |
 
-- Completed: :100:
-- Not Applicable: :no_bell:
-- Not Present (Yet): :construction:
+Emoji Legend:
 
-| Service         | Language        | Auto-instrumentation | Manual Instrumentation | Multiple Instruments | Views          | Custom Attributes | Resource Detection | Trace Exemplars |
-| --------------- | --------------- | -------------------- | ---------------------- | -------------------- | -------------- | ----------------- | ------------------ | --------------- |
-| Accounting      | Go              | :construction:       | :construction:         | :construction:       | :construction: | :construction:    | :construction:     | :construction:  |
-| Ad              | Java            | :100:                | :100:                  | :construction:       | :construction: | :100:             | :100:              | :100:           |
-| Cart            | .NET            | :100:                | :construction:         | :construction:       | :construction: | :construction:    | :construction:     | :construction:  |
-| Checkout        | Go              | :100:                | :construction:         | :construction:       | :construction: | :construction:    | :construction:     | :construction:  |
-| Currency        | C++             | :no_bell:            | :construction:         | :construction:       | :construction: | :construction:    | :construction:     | :construction:  |
-| Email           | Ruby            | :construction:       | :construction:         | :construction:       | :construction: | :construction:    | :construction:     | :construction:  |
-| Feature Flag    | Erlang / Elixir | :construction:       | :construction:         | :construction:       | :construction: | :construction:    | :construction:     | :construction:  |
-| Fraud Detection | Kotlin          | :100:                | :construction:         | :construction:       | :construction: | :construction:    | :100:              | :construction:  |
-| Frontend        | TypeScript      | :construction:       | :construction:         | :construction:       | :construction: | :construction:    | :construction:     | :construction:  |
-| Payment         | JavaScript      | :construction:       | :100:                  | :construction:       | :construction: | :construction:    | :100:              | :construction:  |
-| Product Catalog | Go              | :construction:       | :construction:         | :construction:       | :construction: | :construction:    | :construction:     | :construction:  |
-| Quote           | PHP             | :construction:       | :construction:         | :construction:       | :construction: | :construction:    | :construction:     | :construction:  |
-| Recommendation  | Python          | :100:                | :100:                  | :construction:       | :construction: | :construction:    | :construction:     | :construction:  |
-| Shipping        | Rust            | :construction:       | :construction:         | :construction:       | :construction: | :construction:    | :construction:     | :construction:  |
+- Completed: ✅
+- Not Applicable: 🔕
+- Not Present (Yet): 🚧

--- a/content/en/docs/demo/trace-features.md
+++ b/content/en/docs/demo/trace-features.md
@@ -4,25 +4,25 @@ linkTitle: Trace Feature Coverage
 aliases: [/docs/demo/trace_service_features]
 ---
 
-Emoji Legend
+| Service            | Language        | Instrumentation Libraries | Manual Span Creation | Span Data Enrichment | RPC Context Propagation | Span Links | Baggage | Resource Detection |
+| ------------------ | --------------- | ------------------------- | -------------------- | -------------------- | ----------------------- | ---------- | ------- | ------------------ |
+| Accounting Service | Go              | 🚧                        | 🚧                   | 🚧                   | 🚧                      | 🚧         | 🚧      | ✅                 |
+| Ad                 | Java            | ✅                        | ✅                   | ✅                   | 🔕                      | 🔕         | 🔕      | 🚧                 |
+| Cart               | .NET            | ✅                        | ✅                   | ✅                   | 🔕                      | 🔕         | 🔕      | ✅                 |
+| Checkout           | Go              | ✅                        | ✅                   | ✅                   | 🔕                      | 🔕         | 🔕      | ✅                 |
+| Currency           | C++             | 🔕                        | ✅                   | ✅                   | ✅                      | 🔕         | 🔕      | 🚧                 |
+| Email              | Ruby            | ✅                        | ✅                   | ✅                   | 🔕                      | 🔕         | 🔕      | 🚧                 |
+| Feature Flag       | Erlang / Elixir | ✅                        | ✅                   | ✅                   | 🔕                      | 🔕         | 🔕      | 🚧                 |
+| Fraud Detection    | Kotlin          | ✅                        | 🚧                   | 🚧                   | 🚧                      | 🚧         | 🚧      | 🚧                 |
+| Frontend           | JavaScript      | ✅                        | ✅                   | ✅                   | 🔕                      | ✅         | ✅      | ✅                 |
+| Payment            | JavaScript      | ✅                        | ✅                   | ✅                   | 🔕                      | 🔕         | ✅      | ✅                 |
+| Product Catalog    | Go              | ✅                        | 🔕                   | ✅                   | 🔕                      | 🔕         | 🔕      | 🚧                 |
+| Quote Service      | PHP             | ✅                        | ✅                   | ✅                   | 🔕                      | 🔕         | 🔕      | 🚧                 |
+| Recommendation     | Python          | ✅                        | ✅                   | ✅                   | 🔕                      | 🔕         | 🔕      | 🚧                 |
+| Shipping           | Rust            | 🔕                        | ✅                   | ✅                   | ✅                      | 🔕         | 🔕      | 🚧                 |
 
-- Completed: :100:
-- Not Applicable: :no_bell:
-- Not Present (Yet): :construction:
+Emoji Legend:
 
-| Service            | Language        | Instrumentation Libraries | Manual Span Creation | Span Data Enrichment | RPC Context Propagation | Span Links     | Baggage        | Resource Detection |
-| ------------------ | --------------- | ------------------------- | -------------------- | -------------------- | ----------------------- | -------------- | -------------- | ------------------ |
-| Accounting Service | Go              | :construction:            | :construction:       | :construction:       | :construction:          | :construction: | :construction: | :100:              |
-| Ad                 | Java            | :100:                     | :100:                | :100:                | :no_bell:               | :no_bell:      | :no_bell:      | :construction:     |
-| Cart               | .NET            | :100:                     | :100:                | :100:                | :no_bell:               | :no_bell:      | :no_bell:      | :100:              |
-| Checkout           | Go              | :100:                     | :100:                | :100:                | :no_bell:               | :no_bell:      | :no_bell:      | :100:              |
-| Currency           | C++             | :no_bell:                 | :100:                | :100:                | :100:                   | :no_bell:      | :no_bell:      | :construction:     |
-| Email              | Ruby            | :100:                     | :100:                | :100:                | :no_bell:               | :no_bell:      | :no_bell:      | :construction:     |
-| Feature Flag       | Erlang / Elixir | :100:                     | :100:                | :100:                | :no_bell:               | :no_bell:      | :no_bell:      | :construction:     |
-| Fraud Detection    | Kotlin          | :100:                     | :construction:       | :construction:       | :construction:          | :construction: | :construction: | :construction:     |
-| Frontend           | JavaScript      | :100:                     | :100:                | :100:                | :no_bell:               | :100:          | :100:          | :100:              |
-| Payment            | JavaScript      | :100:                     | :100:                | :100:                | :no_bell:               | :no_bell:      | :100:          | :100:              |
-| Product Catalog    | Go              | :100:                     | :no_bell:            | :100:                | :no_bell:               | :no_bell:      | :no_bell:      | :construction:     |
-| Quote Service      | PHP             | :100:                     | :100:                | :100:                | :no_bell:               | :no_bell:      | :no_bell:      | :construction:     |
-| Recommendation     | Python          | :100:                     | :100:                | :100:                | :no_bell:               | :no_bell:      | :no_bell:      | :construction:     |
-| Shipping           | Rust            | :no_bell:                 | :100:                | :100:                | :100:                   | :no_bell:      | :no_bell:      | :construction:     |
+- Completed: ✅
+- Not Applicable: 🔕
+- Not Present (Yet): 🚧


### PR DESCRIPTION
- Closes #2280
- Switches to using ✅ rather than 💯 -- in particular because the shape and color (green) of the check mark seems more visually imposing as a means of reflecting the "done" status
- Runs Prettier
- Moves the legend to after the tables

**Preview**:

- https://deploy-preview-2288--opentelemetry.netlify.app/docs/demo/trace-features/
- https://deploy-preview-2288--opentelemetry.netlify.app/docs/demo/metric-features/