### PR TITLE
Add link to interview/feedback sessions resource

### DIFF
--- a/content/en/community/end-user/_index.md
+++ b/content/en/community/end-user/_index.md
@@ -12,6 +12,7 @@ practices:
 - [A synchronous monthly discussion group](discussion-group/)
 - [A private slack channel](slack-channel/)
 - [Talks about OTel in practice](otel-in-practice/)
+- [Direct interview/feedback sessions](interviews-feedback/)
 
 These forums will bring together operations and development engineers from
 different organizations to discuss challenges and solutions to achieving


### PR DESCRIPTION
Adds a link to the newly added page about user interview/feedback sessions (https://github.com/open-telemetry/opentelemetry.io/pull/2297). 