### PR TITLE
Add "transforming telemetry" section to collector docs 

### DIFF
--- a/content/en/docs/collector/transforming-telemetry.md
+++ b/content/en/docs/collector/transforming-telemetry.md
@@ -17,7 +17,7 @@ The filter processor allows users to filter telemetry based on `include` or `exc
 
 For example, to _only_ allow span data from services app1, app2, and app3 and drop data from all other services:
 
-```
+```yaml
 processors:
   filter/allowlist:
     spans:
@@ -87,7 +87,7 @@ processors:
       new_name: system.cpu.usage_time
 ```
 
-The [metrics transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor)` `also supports regexes to apply transform rules to multiple metric names or metric labels at the same time. This example renames cluster_name to cluster-name for all metrics:
+The [metrics transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor) also supports regexes to apply transform rules to multiple metric names or metric labels at the same time. This example renames cluster_name to cluster-name for all metrics:
 
 
 ```
@@ -107,7 +107,7 @@ processors:
 
 **Processor**: [resource detection processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor) and [k8sattributes processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor)
 
-Lightstep recommends that customers use processors to enrich their telemetry data with relevant infrastructure metadata to help teams quickly identify when underlying infrastructure is impacting service health or performance.
+It is recommended that end-users use processors to enrich their telemetry data with relevant infrastructure metadata to help teams quickly identify when underlying infrastructure is impacting service health or performance.
 
 The resource detection processor adds relevant cloud or host-level information to telemetry: 
 

--- a/content/en/docs/collector/transforming-telemetry.md
+++ b/content/en/docs/collector/transforming-telemetry.md
@@ -105,7 +105,7 @@ processors:
 
 ## Enriching Telemetry with Resource Attributes
 
-**Processor**: [resource detection processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor) and [k8sattributes processor](k8sattributesprocessor)
+**Processor**: [resource detection processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor) and [k8sattributes processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor)
 
 Lightstep recommends that customers use processors to enrich their telemetry data with relevant infrastructure metadata to help teams quickly identify when underlying infrastructure is impacting service health or performance.
 

--- a/content/en/docs/collector/transforming-telemetry.md
+++ b/content/en/docs/collector/transforming-telemetry.md
@@ -1,0 +1,128 @@
+---
+title: Transforming telemetry
+weight: 31
+---
+The OpenTelemetry Collector is a convenient place to transform data before sending it to a vendor or other systems. This is frequently done for data quality, goveranance, cost, and security reasons.
+
+Processors available from the the [Collector Contrib repository](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor) support dozens of different transformations on metric, span and log data. The following sections provide some basic examples on getting started with a few frequently-used processors.
+
+The configuration of processors, particularly advanced transformations, may have a signficant impact on collector performance.
+
+## Basic filtering
+
+**Processor**: [filter processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor)
+
+The filter processor allows users to filter telemetry based on `include` or `exclude` rules. Include rules are used for defining "allow lists" where anything that does _not_ match include rules is dropped from the collector. Exclude rules are used for defining 
+"deny lists" where telemetry that matches rules is dropped from the collector.
+
+For example, to _only_ allow span data from services app1, app2, and app3 and drop data from all other services:
+
+```
+processors:
+  filter/allowlist:
+    spans:
+      include:
+        match_type: strict
+        services:
+          - app1
+          - app2
+          - app3
+```
+
+To only block spans from a service called development while allowing all other spans, an exclude rule is used:
+
+```
+processors:
+  filter/denylist:
+    spans:
+      exclude:
+        match_type: strict
+        services:
+          - development
+```
+
+The [filter processor docs](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor) have more examples, including filtering on logs and metrics. More advanced filtering is also available in the [transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor).
+
+
+## Adding or Deleting Attributes
+
+**Processor**: [attributes processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/attributesprocessor) or [resource processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourceprocessor)
+
+The attributes processor can be used to update, insert, delete, or replace existing attributes on metrics or traces. For example, here’s a configuration that adds an attribute called account_id to all spans:
+
+```
+processors:
+  attributes/accountid:
+    actions:
+      - key: account_id
+        value: 2245
+        action: insert
+```
+
+The resource processor has an identical configuration, but applies only to [resource attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md). Use the resource processor to modify infrastructure metadata related to telemetry. For example, this inserts the Kubernetes cluster name:
+
+```
+processors:
+  resource/k8s:
+    attributes:
+    - key: k8s.cluster.name
+      from_attribute: k8s-cluster
+      action: insert
+```
+
+More advanced attribute transformations are also available in the [transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor).
+
+## Renaming Metrics or Metric Labels
+
+**Processor:** [metrics transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor)
+
+The [metrics transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor) shares some functionality with the [attributes processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/attributesprocessor), but also supports renaming and other metric-specific functionality.
+
+```
+processors:
+  metricstransform/rename:
+    transforms:
+      include: system.cpu.usage`
+      action: update
+      new_name: system.cpu.usage_time
+```
+
+The [metrics transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor)` `also supports regexes to apply transform rules to multiple metric names or metric labels at the same time. This example renames cluster_name to cluster-name for all metrics:
+
+
+```
+processors:
+  metricstransform/clustername:
+   transforms:
+     - include: "^.*$"
+       match_type: regexp
+       action: update
+       operations:
+       - action: update_label
+         label: cluster_name
+         new_label: cluster-name
+```
+
+## Enriching Telemetry with Resource Attributes
+
+**Processor**: [resource detection processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor) and [k8sattributes processor](k8sattributesprocessor)
+
+Lightstep recommends that customers use processors to enrich their telemetry data with relevant infrastructure metadata to help teams quickly identify when underlying infrastructure is impacting service health or performance.
+
+The resource detection processor adds relevant cloud or host-level information to telemetry: 
+
+```
+processors:
+  resourcedetection/system:
+    # Modify the list of detectors to match the cloud environment
+    detectors: [env, system, gcp, ec2, azure]
+    timeout: 2s
+    override: false
+```
+
+Similarly, the k8s processor enriches telemetry with relevant Kubernetes metadata like pod name, node name, or workload name. The collector pod must be configured to have read access to certain Kubernetes RBAC APIs, which is documented [here](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor#hdr-RBAC). To use the default options, it can be configured with an empty block:
+
+```
+processors:
+  k8sattributes/default:
+```

--- a/content/en/docs/collector/transforming-telemetry.md
+++ b/content/en/docs/collector/transforming-telemetry.md
@@ -2,20 +2,33 @@
 title: Transforming telemetry
 weight: 31
 ---
-The OpenTelemetry Collector is a convenient place to transform data before sending it to a vendor or other systems. This is frequently done for data quality, goveranance, cost, and security reasons.
 
-Processors available from the the [Collector Contrib repository](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor) support dozens of different transformations on metric, span and log data. The following sections provide some basic examples on getting started with a few frequently-used processors.
+The OpenTelemetry Collector is a convenient place to transform data before
+sending it to a vendor or other systems. This is frequently done for data
+quality, goveranance, cost, and security reasons.
 
-The configuration of processors, particularly advanced transformations, may have a signficant impact on collector performance.
+Processors available from the the
+[Collector Contrib repository](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor)
+support dozens of different transformations on metric, span and log data. The
+following sections provide some basic examples on getting started with a few
+frequently-used processors.
+
+The configuration of processors, particularly advanced transformations, may have
+a signficant impact on collector performance.
 
 ## Basic filtering
 
-**Processor**: [filter processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor)
+**Processor**:
+[filter processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor)
 
-The filter processor allows users to filter telemetry based on `include` or `exclude` rules. Include rules are used for defining "allow lists" where anything that does _not_ match include rules is dropped from the collector. Exclude rules are used for defining 
-"deny lists" where telemetry that matches rules is dropped from the collector.
+The filter processor allows users to filter telemetry based on `include` or
+`exclude` rules. Include rules are used for defining "allow lists" where
+anything that does _not_ match include rules is dropped from the collector.
+Exclude rules are used for defining "deny lists" where telemetry that matches
+rules is dropped from the collector.
 
-For example, to _only_ allow span data from services app1, app2, and app3 and drop data from all other services:
+For example, to _only_ allow span data from services app1, app2, and app3 and
+drop data from all other services:
 
 ```yaml
 processors:
@@ -29,7 +42,8 @@ processors:
           - app3
 ```
 
-To only block spans from a service called development while allowing all other spans, an exclude rule is used:
+To only block spans from a service called development while allowing all other
+spans, an exclude rule is used:
 
 ```yaml
 processors:
@@ -41,13 +55,20 @@ processors:
           - development
 ```
 
-The [filter processor docs](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor) have more examples, including filtering on logs and metrics.
+The
+[filter processor docs](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor)
+have more examples, including filtering on logs and metrics.
 
 ## Adding or Deleting Attributes
 
-**Processor**: [attributes processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/attributesprocessor) or [resource processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourceprocessor)
+**Processor**:
+[attributes processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/attributesprocessor)
+or
+[resource processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourceprocessor)
 
-The attributes processor can be used to update, insert, delete, or replace existing attributes on metrics or traces. For example, here’s a configuration that adds an attribute called account_id to all spans:
+The attributes processor can be used to update, insert, delete, or replace
+existing attributes on metrics or traces. For example, here’s a configuration
+that adds an attribute called account_id to all spans:
 
 ```yaml
 processors:
@@ -58,22 +79,30 @@ processors:
         action: insert
 ```
 
-The resource processor has an identical configuration, but applies only to [resource attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md). Use the resource processor to modify infrastructure metadata related to telemetry. For example, this inserts the Kubernetes cluster name:
+The resource processor has an identical configuration, but applies only to
+[resource attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md).
+Use the resource processor to modify infrastructure metadata related to
+telemetry. For example, this inserts the Kubernetes cluster name:
 
 ```yaml
 processors:
   resource/k8s:
     attributes:
-    - key: k8s.cluster.name
-      from_attribute: k8s-cluster
-      action: insert
+      - key: k8s.cluster.name
+        from_attribute: k8s-cluster
+        action: insert
 ```
 
 ## Renaming Metrics or Metric Labels
 
-**Processor:** [metrics transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor)
+**Processor:**
+[metrics transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor)
 
-The [metrics transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor) shares some functionality with the [attributes processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/attributesprocessor), but also supports renaming and other metric-specific functionality.
+The
+[metrics transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor)
+shares some functionality with the
+[attributes processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/attributesprocessor),
+but also supports renaming and other metric-specific functionality.
 
 ```yaml
 processors:
@@ -84,29 +113,38 @@ processors:
       new_name: system.cpu.usage_time
 ```
 
-The [metrics transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor) also supports regexes to apply transform rules to multiple metric names or metric labels at the same time. This example renames cluster_name to cluster-name for all metrics:
-
+The
+[metrics transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor)
+also supports regexes to apply transform rules to multiple metric names or
+metric labels at the same time. This example renames cluster_name to
+cluster-name for all metrics:
 
 ```yaml
 processors:
   metricstransform/clustername:
-   transforms:
-     - include: "^.*$"
-       match_type: regexp
-       action: update
-       operations:
-       - action: update_label
-         label: cluster_name
-         new_label: cluster-name
+    transforms:
+      - include: "^.*$"
+        match_type: regexp
+        action: update
+        operations:
+          - action: update_label
+            label: cluster_name
+            new_label: cluster-name
 ```
 
 ## Enriching Telemetry with Resource Attributes
 
-**Processor**: [resource detection processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor) and [k8sattributes processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor)
+**Processor**:
+[resource detection processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor)
+and
+[k8sattributes processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor)
 
-These processors can be used for enriching telemetry with relevant infrastructure metadata to help teams quickly identify when underlying infrastructure is impacting service health or performance.
+These processors can be used for enriching telemetry with relevant
+infrastructure metadata to help teams quickly identify when underlying
+infrastructure is impacting service health or performance.
 
-The resource detection processor adds relevant cloud or host-level information to telemetry: 
+The resource detection processor adds relevant cloud or host-level information
+to telemetry:
 
 ```yaml
 processors:
@@ -117,7 +155,12 @@ processors:
     override: false
 ```
 
-Similarly, the k8s processor enriches telemetry with relevant Kubernetes metadata like pod name, node name, or workload name. The collector pod must be configured to have read access to certain Kubernetes RBAC APIs, which is documented [here](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor#hdr-RBAC). To use the default options, it can be configured with an empty block:
+Similarly, the k8s processor enriches telemetry with relevant Kubernetes
+metadata like pod name, node name, or workload name. The collector pod must be
+configured to have read access to certain Kubernetes RBAC APIs, which is
+documented
+[here](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor#hdr-RBAC).
+To use the default options, it can be configured with an empty block:
 
 ```yaml
 processors:
@@ -126,4 +169,8 @@ processors:
 
 ## Advanced Transformations
 
-More advanced attribute transformations are also available in the [transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor). The transform processor allows end-users to specify transformations on metrics, logs, and traces using the [OpenTelemetry Transformation Language](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl).
+More advanced attribute transformations are also available in the
+[transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor).
+The transform processor allows end-users to specify transformations on metrics,
+logs, and traces using the
+[OpenTelemetry Transformation Language](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl).

--- a/content/en/docs/collector/transforming-telemetry.md
+++ b/content/en/docs/collector/transforming-telemetry.md
@@ -1,6 +1,6 @@
 ---
 title: Transforming telemetry
-weight: 31
+weight: 26
 ---
 
 The OpenTelemetry Collector is a convenient place to transform data before

--- a/content/en/docs/collector/transforming-telemetry.md
+++ b/content/en/docs/collector/transforming-telemetry.md
@@ -31,7 +31,7 @@ processors:
 
 To only block spans from a service called development while allowing all other spans, an exclude rule is used:
 
-```
+```yaml
 processors:
   filter/denylist:
     spans:
@@ -41,8 +41,7 @@ processors:
           - development
 ```
 
-The [filter processor docs](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor) have more examples, including filtering on logs and metrics. More advanced filtering is also available in the [transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor).
-
+The [filter processor docs](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor) have more examples, including filtering on logs and metrics.
 
 ## Adding or Deleting Attributes
 
@@ -50,7 +49,7 @@ The [filter processor docs](https://github.com/open-telemetry/opentelemetry-coll
 
 The attributes processor can be used to update, insert, delete, or replace existing attributes on metrics or traces. For example, here’s a configuration that adds an attribute called account_id to all spans:
 
-```
+```yaml
 processors:
   attributes/accountid:
     actions:
@@ -61,7 +60,7 @@ processors:
 
 The resource processor has an identical configuration, but applies only to [resource attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md). Use the resource processor to modify infrastructure metadata related to telemetry. For example, this inserts the Kubernetes cluster name:
 
-```
+```yaml
 processors:
   resource/k8s:
     attributes:
@@ -70,19 +69,17 @@ processors:
       action: insert
 ```
 
-More advanced attribute transformations are also available in the [transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor).
-
 ## Renaming Metrics or Metric Labels
 
 **Processor:** [metrics transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor)
 
 The [metrics transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor) shares some functionality with the [attributes processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/attributesprocessor), but also supports renaming and other metric-specific functionality.
 
-```
+```yaml
 processors:
   metricstransform/rename:
     transforms:
-      include: system.cpu.usage`
+      include: system.cpu.usage
       action: update
       new_name: system.cpu.usage_time
 ```
@@ -90,7 +87,7 @@ processors:
 The [metrics transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor) also supports regexes to apply transform rules to multiple metric names or metric labels at the same time. This example renames cluster_name to cluster-name for all metrics:
 
 
-```
+```yaml
 processors:
   metricstransform/clustername:
    transforms:
@@ -107,11 +104,11 @@ processors:
 
 **Processor**: [resource detection processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor) and [k8sattributes processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor)
 
-It is recommended that end-users use processors to enrich their telemetry data with relevant infrastructure metadata to help teams quickly identify when underlying infrastructure is impacting service health or performance.
+These processors can be used for enriching telemetry with relevant infrastructure metadata to help teams quickly identify when underlying infrastructure is impacting service health or performance.
 
 The resource detection processor adds relevant cloud or host-level information to telemetry: 
 
-```
+```yaml
 processors:
   resourcedetection/system:
     # Modify the list of detectors to match the cloud environment
@@ -122,7 +119,11 @@ processors:
 
 Similarly, the k8s processor enriches telemetry with relevant Kubernetes metadata like pod name, node name, or workload name. The collector pod must be configured to have read access to certain Kubernetes RBAC APIs, which is documented [here](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor#hdr-RBAC). To use the default options, it can be configured with an empty block:
 
-```
+```yaml
 processors:
   k8sattributes/default:
 ```
+
+## Advanced Transformations
+
+More advanced attribute transformations are also available in the [transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor). The transform processor allows end-users to specify transformations on metrics, logs, and traces using the [OpenTelemetry Transformation Language](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl).


### PR DESCRIPTION
Have recently received feedback from several new collector users around usability of docs in the [various processors in collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor). Specifically, it's difficult to know where to start for some very simple (and common) use cases like adding an attribute to a span or filtering based on service name.

This PR proposes a new section under the collector docs called "Transforming telemetry" that documents some simple examples/use-cases and links to processors for more information. 

Goal of the doc isn't to exhaustively document all configurations or duplicate what is already in the contrib repo, but to provide a friendly "new to collector processors" introduction to users with some simple examples before pointing to the contrib repo for more information.

---

**Preview**: https://deploy-preview-2304--opentelemetry.netlify.app/docs/collector/transforming-telemetry/
