### PR TITLE
Update kubernetes-deployment.md

### DIFF
--- a/content/en/docs/demo/kubernetes-deployment.md
+++ b/content/en/docs/demo/kubernetes-deployment.md
@@ -88,7 +88,8 @@ would specify the following in your values file:
 ```yaml
 components:
   frontendProxy:
-    serviceType: LoadBalancer
+    service:
+      type: LoadBalancer
 ```
 
 > **Note**


### PR DESCRIPTION
Environment:
OS: Multipass on Mac running Ubuntu 22.04 LTS
K8s: K3s v1.25.6+k3s1

Using serviceType yields the following error:

Error: UPGRADE FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
opentelemetry-demo:
- components.frontendProxy: Additional property serviceType is not allowed
Using the following in values file works:

```
components:
  frontendProxy:
    service:
      type: LoadBalancer
```