### PR TITLE
Enable Prettier check over some /docs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -19,7 +19,10 @@ package-lock.json
 /content/en/blog/2021
 /content/en/blog/2022
 /content/en/community
-/content/en/docs
+/content/en/docs/collector
+/content/en/docs/concepts
+/content/en/docs/demo
+/content/en/docs/instrumentation
 /content/en/ecosystem
 /data
 /resources

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -15,5 +15,5 @@ for instrumenting, generating, collecting, and exporting telemetry data such as
 ![OpenTelemetry Reference Architecture](/img/otel_diagram.png)
 
 > For an in-depth guide on OpenTelemetry, including documentation and guides on
-> language-specific instrumentation or the Collector, please follow the links
-> in the navigation bar.
+> language-specific instrumentation or the Collector, please follow the links in
+> the navigation bar.

--- a/content/en/docs/acknowledgements/_index.md
+++ b/content/en/docs/acknowledgements/_index.md
@@ -6,10 +6,13 @@ aliases: [/acknowledgements]
 weight: 200
 ---
 
-We would like to acknowledge the following sources for some of the content on this site:
+We would like to acknowledge the following sources for some of the content on
+this site:
 
 1. [APM is Dying and That's Okay - Lightstep](https://lightstep.com/blog/apm-is-dying-and-thats-okay)
-2. [Alexandria Pigram](https://github.com/alexandriastech) via [Honeycomb](https://www.honeycomb.io/) for tracing content in [Traces](/docs/concepts/signals/traces/#tracing-in-opentelemetry)
+2. [Alexandria Pigram](https://github.com/alexandriastech) via
+   [Honeycomb](https://www.honeycomb.io/) for tracing content in
+   [Traces](/docs/concepts/signals/traces/#tracing-in-opentelemetry)
 3. [What is OpenTelemetry - Dynatrace](https://www.dynatrace.com/news/blog/what-is-opentelemetry-2/)
 4. [Understanding OpenTracing, OpenCensus, and OpenMetrics - BMC](https://www.bmc.com/blogs/opentracing-opencensus-openmetrics/)
 5. [Ask Miss O11y: Baggage in OTel - Honeycomb](https://www.honeycomb.io/blog/ask-miss-o11y-opentelemetry-baggage/)

--- a/content/en/docs/contribution-guidelines.md
+++ b/content/en/docs/contribution-guidelines.md
@@ -5,13 +5,14 @@ toc_hide: true
 ---
 
 OpenTelemetry is an open source project, and we gladly accept new contributions
-and contributors. Please see the CONTRIBUTING.md file in each SIG repository
-for information on getting started.
+and contributors. Please see the CONTRIBUTING.md file in each SIG repository for
+information on getting started.
 
 ## Contributing to the OpenTelemetry Documentation
 
-Individual SIGs may maintain documentation above and beyond what is offered here,
-but we strive for accurate general guidance on using the project from our main website.
+Individual SIGs may maintain documentation above and beyond what is offered
+here, but we strive for accurate general guidance on using the project from our
+main website.
 
 The per-language API, SDK, and "Getting Started" documentation is hosted in each
 language's GitHub repository. For more information,
@@ -20,8 +21,8 @@ of the website repository's CONTRIBUTING.md file.
 
 ### Contributor License Agreement (CLA)
 
-Contributors to this and other OpenTelemetry projects require acceptance of our CLA,
-managed by [EasyCLA](https://lfcla.com/).
+Contributors to this and other OpenTelemetry projects require acceptance of our
+CLA, managed by [EasyCLA](https://lfcla.com/).
 
 ### Code reviews
 
@@ -32,7 +33,8 @@ information on using pull requests.
 
 ### Getting started
 
-See [README.md](https://github.com/open-telemetry/opentelemetry.io#readme) for current information.
+See [README.md](https://github.com/open-telemetry/opentelemetry.io#readme) for
+current information.
 
 ## Code of conduct
 

--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -15,7 +15,6 @@ Select a role[^1] to get started:
 
 </div>
 
-
 You can also try out the official [OpenTelemetry Demo][demo] to _see_ what
 observability with OpenTelemetry looks like!
 

--- a/content/en/docs/getting-started/dev.md
+++ b/content/en/docs/getting-started/dev.md
@@ -1,16 +1,15 @@
 ---
 title: Dev
 description: >-
-  You develop software.
-  Your goal is to get observability by writing code.
-  You want to have your dependencies emit telemetry for you automatically.
+  You develop software. Your goal is to get observability by writing code. You
+  want to have your dependencies emit telemetry for you automatically.
 spelling: cSpell:ignore otel
 weight: 2
 ---
 
-OpenTelemetry can help you! To accomplish your goals of having your
-dependencies instrumented automatically and instrumenting your own code with our
-API manually, we recommend that you learn the following concepts first:
+OpenTelemetry can help you! To accomplish your goals of having your dependencies
+instrumented automatically and instrumenting your own code with our API
+manually, we recommend that you learn the following concepts first:
 
 - [What is OpenTelemetry?](/docs/concepts/what-is-opentelemetry/)
 - [How can I instrument dependencies without touching their code?](/docs/concepts/instrumenting/#automatic-instrumentation)

--- a/content/en/docs/getting-started/ops.md
+++ b/content/en/docs/getting-started/ops.md
@@ -8,9 +8,9 @@ spelling: cSpell:ignore otel
 weight: 4
 ---
 
-OpenTelemetry can help you! To accomplish your goal of getting
-telemetry out of applications without touching their code, we recommend that you
-learn the following:
+OpenTelemetry can help you! To accomplish your goal of getting telemetry out of
+applications without touching their code, we recommend that you learn the
+following:
 
 - [What is OpenTelemetry?](/docs/concepts/what-is-opentelemetry/)
 - [How can I instrument applications without touching their code?](/docs/concepts/instrumenting/#automatic-instrumentation)
@@ -18,6 +18,4 @@ learn the following:
 - [How can I get automation for Kubernetes with the OpenTelemetry Operator?](/docs/k8s-operator)
 
 If you are looking for a set of applications to try things out, you will find
-our official
-[OpenTelemetry Demo](/ecosystem/demo/)
-useful!
+our official [OpenTelemetry Demo](/ecosystem/demo/) useful!

--- a/content/en/docs/k8s-operator/_index.md
+++ b/content/en/docs/k8s-operator/_index.md
@@ -3,16 +3,17 @@ title: OpenTelemetry Operator for Kubernetes
 linkTitle: K8s Operator
 weight: 11
 description:
-  An implementation of a Kubernetes Operator, that
-  manages collectors and auto-instrumentation of the workload using OpenTelemetry
-  instrumentation libraries.
+  An implementation of a Kubernetes Operator, that manages collectors and
+  auto-instrumentation of the workload using OpenTelemetry instrumentation
+  libraries.
 spelling: cSpell:ignore Otel
 aliases: [/docs/operator]
 ---
 
 ## Introduction
 
-The OpenTelemetry Operator is an implementation of a [Kubernetes Operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/).
+The OpenTelemetry Operator is an implementation of a
+[Kubernetes Operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/).
 
 The operator manages:
 
@@ -21,7 +22,7 @@ The operator manages:
 
 ## Getting started
 
-To install the operator in an existing cluster, make sure you have cert-manager 
+To install the operator in an existing cluster, make sure you have cert-manager
 installed and run:
 
 ```bash
@@ -29,7 +30,7 @@ $ kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/rele
 ```
 
 Once the `opentelemetry-operator` deployment is ready, create an OpenTelemetry
- Collector (otelcol) instance, like:
+Collector (otelcol) instance, like:
 
 ```bash
 $ kubectl apply -f - <<EOF
@@ -60,4 +61,5 @@ EOF
 
 For more configuration options and for setting up the injection of
 auto-instrumentation of the workloads using OpenTelemetry instrumentation
-libraries, continue reading [here](https://github.com/open-telemetry/opentelemetry-operator/blob/main/README.md).
+libraries, continue reading
+[here](https://github.com/open-telemetry/opentelemetry-operator/blob/main/README.md).

--- a/content/en/docs/migration/opentracing.md
+++ b/content/en/docs/migration/opentracing.md
@@ -19,14 +19,14 @@ Before using an OpenTracing shim, check your project's language and runtime
 component versions, and update if necessary. The minimum **language** versions
 of the OpenTracing and OpenTelemetry APIs are listed in the table below.
 
-| Language       | OpenTracing API  | OpenTelemetry API |
-| -------------- | ---------------- | ----------------- |
-| [Go][]         | 1.13             | 1.16              |
-| [Java][]       | 7                | 8                 |
-| [Python][]     | 2.7              | 3.6               |
-| [Javascript][] | 6                | 8.5               |
-| [.NET][]       | 1.3              | 1.4               |
-| [C++][]        | 11               | 11                |
+| Language       | OpenTracing API | OpenTelemetry API |
+| -------------- | --------------- | ----------------- |
+| [Go][]         | 1.13            | 1.16              |
+| [Java][]       | 7               | 8                 |
+| [Python][]     | 2.7             | 3.6               |
+| [Javascript][] | 6               | 8.5               |
+| [.NET][]       | 1.3             | 1.4               |
+| [C++][]        | 11              | 11                |
 
 Note that the OpenTelemetry API and SDKs generally have higher language version
 requirements than their OpenTracing counterparts.
@@ -63,8 +63,8 @@ OpenTelemetry.
 Before changing any instrumentation, ensure that you can switch to the
 OpenTelemetry SDK without causing any break in the telemetry the application
 currently emits. Doing this step on its own – without simultaneously introducing
-any new instrumentation – is recommended, as it makes it easier to determine whether
-there is any kind of break in instrumentation.
+any new instrumentation – is recommended, as it makes it easier to determine
+whether there is any kind of break in instrumentation.
 
 1. Replace the OpenTracing Tracer implementation you are currently using with
    the OpenTelemetry SDK. For example, if you are using the Jaeger, remove the
@@ -72,9 +72,9 @@ there is any kind of break in instrumentation.
 2. Install the OpenTracing Shim. This shim allows the OpenTelemetry SDK to
    consume OpenTracing instrumentation.
 3. Configure the OpenTelemetry SDK to export data using the same protocol and
-   format that the OpenTracing client was using. For example, if you were using an
-   OpenTracing client that exported tracing data in Zipkin format, configure the
-   OpenTelemetry client to do the same.
+   format that the OpenTracing client was using. For example, if you were using
+   an OpenTracing client that exported tracing data in Zipkin format, configure
+   the OpenTelemetry client to do the same.
 4. Alternatively, configure the OpenTelemetry SDK to emit OTLP, and send the
    data to a Collector, where you can manage exporting data in multiple formats.
 
@@ -87,8 +87,8 @@ tools are still working.
 
 Once the OpenTelemetry SDK is installed, all new instrumentation can now be
 written using the OpenTelemetry API. With few exceptions, OpenTelemetry and
-OpenTracing instrumentation will work together seamlessly
-(see [limits on compatibility](#limits-on-compatibility) below).
+OpenTracing instrumentation will work together seamlessly (see
+[limits on compatibility](#limits-on-compatibility) below).
 
 What about existing instrumentation? There is no hard requirement to migrate
 existing application code to OpenTelemetry. However, we do recommend migrating
@@ -111,12 +111,13 @@ For existing instrumentation, it is recommended to:
    equivalent.
 2. Observe how this changes the telemetry which your application produces.
 3. Create new dashboards, alerts, etc which consume this new telemetry. Set up
-   these dashboards before deploying the new OpenTelemetry library to production.
+   these dashboards before deploying the new OpenTelemetry library to
+   production.
 4. Optionally, add processing rules to the Collector which converts the new
-   telemetry back into the old telemetry. The Collector can then be configured to
-   emit both versions of the same telemetry, creating a data overlap. This allows
-   new dashboards to populate themselves while you continue to use the old
-   dashboards.
+   telemetry back into the old telemetry. The Collector can then be configured
+   to emit both versions of the same telemetry, creating a data overlap. This
+   allows new dashboards to populate themselves while you continue to use the
+   old dashboards.
 
 ## Limits on compatibility
 
@@ -147,8 +148,8 @@ OpenTelemetry and OpenTracing APIs is not recommended when using baggage.
 
 Specifically, when baggage is set using the OpenTracing API:
 
-* It is not accessible via the OpenTelemetry API.
-* It is not injected by the OpenTelemetry propagators.
+- It is not accessible via the OpenTelemetry API.
+- It is not injected by the OpenTelemetry propagators.
 
 If you are using baggage, it is recommended that all baggage-related API calls
 be switched to OpenTelemetry at the same time. Be sure to check that any
@@ -158,10 +159,10 @@ into production.
 ### Context management in Javascript
 
 In Javascript, the OpenTelemetry API makes use of commonly available context
-managers, such as `async_hooks` for Node.js and `Zones.js` for the browser. These
-context managers make tracing instrumentation a much less invasive and onerous
-task, compared to adding a span as a parameter to every method which needs to
-be traced.
+managers, such as `async_hooks` for Node.js and `Zones.js` for the browser.
+These context managers make tracing instrumentation a much less invasive and
+onerous task, compared to adding a span as a parameter to every method which
+needs to be traced.
 
 However, the OpenTracing API predates the common use of these context managers.
 OpenTracing code which passes the current active span as a parameter may create
@@ -177,13 +178,15 @@ only one API is used at a time.
 
 For details on how each OpenTracing shim works, see the appropriate
 language-specific documentation. For details on the design of the OpenTracing
-shim, see [OpenTracing Compatibility][OT_spec].
+shim, see [OpenTracing Compatibility][ot_spec].
 
-[.NET]: /docs/instrumentation/net/shim/
-[Go]: https://pkg.go.dev/go.opentelemetry.io/otel/bridge/opentracing
-[Java]: https://github.com/open-telemetry/opentelemetry-java/tree/main/opentracing-shim
-[Javascript]: https://www.npmjs.com/package/@opentelemetry/shim-opentracing
-[OpenTracing]: https://opentracing.io
-[OT_spec]: /docs/reference/specification/compatibility/opentracing/
-[Python]: https://opentelemetry-python.readthedocs.io/en/stable/shim/opentracing_shim/opentracing_shim.html
-[C++]: https://github.com/open-telemetry/opentelemetry-cpp/issues/78
+[.net]: /docs/instrumentation/net/shim/
+[go]: https://pkg.go.dev/go.opentelemetry.io/otel/bridge/opentracing
+[java]:
+  https://github.com/open-telemetry/opentelemetry-java/tree/main/opentracing-shim
+[javascript]: https://www.npmjs.com/package/@opentelemetry/shim-opentracing
+[opentracing]: https://opentracing.io
+[ot_spec]: /docs/reference/specification/compatibility/opentracing/
+[python]:
+  https://opentelemetry-python.readthedocs.io/en/stable/shim/opentracing_shim/opentracing_shim.html
+[c++]: https://github.com/open-telemetry/opentelemetry-cpp/issues/78

--- a/content/en/docs/reference/specification/status.md
+++ b/content/en/docs/reference/specification/status.md
@@ -41,8 +41,9 @@ Deprecated, Removed.
   support.
 - **Deprecated** components are stable but may eventually be removed.
 
-For complete definitions of lifecycles and long term support, see
-[Versioning and stability]({{< relref "/docs/reference/specification/versioning-and-stability" >}}).
+For complete definitions of lifecycles and long term support, see [Versioning
+and
+stability]({{< relref "/docs/reference/specification/versioning-and-stability" >}}).
 
 ## Current Status
 
@@ -104,9 +105,9 @@ same as the **Protocol** status.
   - The [logs data model][] is released as part of the OpenTelemetry Protocol.
   - Log processing for many data formats has been added to the Collector, thanks
     to the donation of Stanza to the OpenTelemetry project.
-  - Log appenders are currently under development in many languages. Log appenders
-    allow OpenTelemetry tracing data, such as trace and span IDs, to be appended
-    to existing logging systems.
+  - Log appenders are currently under development in many languages. Log
+    appenders allow OpenTelemetry tracing data, such as trace and span IDs, to
+    be appended to existing logging systems.
   - An OpenTelemetry logging SDK is currently under development. This allows
     OpenTelemetry clients to ingest logging data from existing logging systems,
     outputting logs as part of OTLP along with tracing and metrics.

--- a/content/en/docs/workshop/resources.md
+++ b/content/en/docs/workshop/resources.md
@@ -5,8 +5,9 @@ title: Legacy Workshop resources
 > The following workshop contents are considered legacy and have outdated code.
 > Many of the slides are still relevant and you should feel free to use them.
 >
-> For a reference application, refer to the [OpenTelemetry Demo](https://github.com/open-telemetry/opentelemetry-demo)
-> to teach people how to best use automatic and manual instrumentation.
+> For a reference application, refer to the
+> [OpenTelemetry Demo](https://github.com/open-telemetry/opentelemetry-demo) to
+> teach people how to best use automatic and manual instrumentation.
 
 OpenTelemetry provides the following resources free of charge and available
 under the Apache 2.0 license. These resources are intended to aid you in running


### PR DESCRIPTION
- Contributes to #1063
- Enables format checking over the following under `/content/en/docs`:
  - `_index.md`
  - `acknowledgements`
  - `contribution-guidelines.md`
  - `getting-started`
  - `k8s-operator`
  - `migration`
  - `reference`
  - `workshop`

Preview: https://deploy-preview-2309--opentelemetry.netlify.app/docs
