### PR TITLE
Move "how to add a registry entry" into website

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,7 @@ Read on to learn about other ways on how you can help.
 
 ## Adding a project to the OpenTelemetry Registry
 
-Do you maintain or contribute to an integration for OpenTelemetry? We'd love to
-feature your project in the [registry][]!
-
-To add your project, submit a [pull request][]. You'll need to create a data
-file in [data/registry][] for your project. You can find a template in
-[templates/registry-entry.yml][].
+For details, see [Adding to the registry][].
 
 ## Submitting a blog post
 
@@ -93,7 +88,7 @@ already contributed][contributors]!
 - Documentation: [CC-BY-4.0](LICENSE)
 - Code: [Apache-2.0](LICENSE-CODE)
 
-[data/registry]: data/registry
+[adding to the registry]: https://opentelemetry.io/ecosystem/registry/adding/
 [let us know]:
   https://github.com/open-telemetry/opentelemetry.io/issues/new/choose
 [@open-telemetry/blog-approvers]:
@@ -122,4 +117,3 @@ already contributed][contributors]!
 [google doc]:
   https://docs.google.com/document/d/1wW0jLldwXN8Nptq2xmgETGbGn9eWP8fitvD5njM-xZY/edit?usp=sharing
 [slack]: https://cloud-native.slack.com/archives/C02UN96HZH6
-[templates/registry-entry.yml]: templates/registry-entry.yml

--- a/content/en/ecosystem/registry/_index.md
+++ b/content/en/ecosystem/registry/_index.md
@@ -29,12 +29,9 @@ OpenTelemetry ecosystem.
 - Not able to find an exporter for your language? Remember, the
   [OpenTelemetry Collector](/docs/collector) supports exporting to a variety of
   systems and works with all OpenTelemetry Core Components!
-- Are you a project maintainer? See, [Adding a project to the OpenTelemetry
-  Registry][add].
+- Are you a project maintainer? See,
+  [Adding a project to the OpenTelemetry Registry](adding).
 - Check back regularly, the community and registry are growing!
-
-[add]:
-  https://github.com/open-telemetry/opentelemetry.io#adding-a-project-to-the-opentelemetry-registry
 
 {{% /blocks/section %}}
 

--- a/content/en/ecosystem/registry/adding.md
+++ b/content/en/ecosystem/registry/adding.md
@@ -1,0 +1,19 @@
+---
+title: Adding to the registry
+linkTitle: Adding
+description: How to add entries to the registry.
+---
+
+Do you maintain or contribute to an integration for OpenTelemetry? We'd love to
+feature your project in the [registry](../)!
+
+To add your project, submit a [pull request][]. You'll need to create a data
+file in [data/registry][] for your project, by using the following template:
+[registry-entry.yml][].
+
+[data/registry]:
+  https://github.com/open-telemetry/opentelemetry.io/tree/main/data/registry
+[pull request]:
+  https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request
+[registry-entry.yml]:
+  https://github.com/open-telemetry/opentelemetry.io/tree/main/templates/registry-entry.yml


### PR DESCRIPTION
- Moves the "how to add a registry entry" entry of the repo README into Ecosystem > Registry section under Adding
- Contributes to #2202

**Preview**:

- https://deploy-preview-2310--opentelemetry.netlify.app/ecosystem/registry/adding/
- https://deploy-preview-2310--opentelemetry.netlify.app/ecosystem/registry/