### PR TITLE
updated trace timestamps

### DIFF
--- a/content/en/docs/concepts/signals/traces.md
+++ b/content/en/docs/concepts/signals/traces.md
@@ -25,7 +25,7 @@ Sample Trace:
     },
     "parent_id": "0x051581bf3cb55c13",
     "start_time": "2022-04-29T18:52:58.114304Z",
-    "end_time": "2022-04-29T18:52:58.114435Z",
+    "end_time": "2022-04-29T22:52:58.114561Z",
     "attributes": {
         "http.route": "some_route1"
     },
@@ -39,7 +39,7 @@ Sample Trace:
         },
         {
             "name": "bye now!",
-            "timestamp": "2022-04-29T22:52:58.114561Z",
+            "timestamp": "2022-04-29T18:52:58.114585Z",
             "attributes": {
                 "event_attributes": 1
             }


### PR DESCRIPTION
### Target :
In docs under `Sample Trace` in [#tracing-in-opentelemetry](https://opentelemetry.io/docs/concepts/signals/traces/#tracing-in-opentelemetry) timestamp of the *second event* is greater than the *end_time* of the span itself. 

> Hence, it has been updated!

fixes : #2287 
cc : @svrnm @cartermp 

