### PR TITLE
Demo docs: fix architecture diagram layout

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -237,3 +237,10 @@
     }
   }
 }
+
+.td-content pre.mermaid {
+  max-width: fit-content;
+  svg {
+    height: auto;
+  }
+}


### PR DESCRIPTION
- Closes #2281?
  @mviitane WDYT?
- This doesn't provide a pop-up, but I'd suggest we create a separate issue for that.
- **Preview**: https://deploy-preview-2317--opentelemetry.netlify.app/docs/demo/architecture/

# Screenshots

## Before

> <img width="1000" alt="image" src="https://user-images.githubusercontent.com/4140793/217974980-294bc930-c295-4b47-b5e0-5e139067cb12.png">

## After

> <img width="1797" alt="image" src="https://user-images.githubusercontent.com/4140793/217975048-a73a284b-6d8f-4005-bcad-5a38de195c64.png">

## From original demo repo docs (GitHub preview)

> <img width="1458" alt="image" src="https://user-images.githubusercontent.com/4140793/217975252-098aa07f-0a7e-4e8f-85a4-75de023ed853.png">
