### PR TITLE
Demo docs: fix mermaid diagram width on FF and Safari

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -239,7 +239,7 @@
 }
 
 .td-content pre.mermaid {
-  max-width: fit-content;
+  max-width: inherit;
   svg {
     height: auto;
   }


### PR DESCRIPTION
- Closes #2281?
- **Preview**: https://deploy-preview-2320--opentelemetry.netlify.app/docs/demo/architecture/
  - Tested under Chrome, FF and Safari.
- For screenshots, see #2318.