### PR TITLE
Updated broken architecture link

### DIFF
--- a/content/en/ecosystem/demo.md
+++ b/content/en/ecosystem/demo.md
@@ -29,8 +29,7 @@ If you find yourself asking questions like:
 - What's the best way to use OpenTelemetry APIs?
 - How should my services be configured?
 - How should my OpenTelemetry Collector be configured?
-- How do I consider the
-  [architecture](/docs/demo/architecture/)
-  of a system using OpenTelemetry?
+- How do I consider the [architecture](/docs/demo/architecture/) of a system
+  using OpenTelemetry?
 
 Then check out the [Demo](https://github.com/open-telemetry/opentelemetry-demo).

--- a/content/en/ecosystem/demo.md
+++ b/content/en/ecosystem/demo.md
@@ -30,7 +30,7 @@ If you find yourself asking questions like:
 - How should my services be configured?
 - How should my OpenTelemetry Collector be configured?
 - How do I consider the
-  [architecture](https://opentelemetry.io/docs/demo/architecture/)
+  [architecture](/docs/demo/architecture/)
   of a system using OpenTelemetry?
 
 Then check out the [Demo](https://github.com/open-telemetry/opentelemetry-demo).

--- a/content/en/ecosystem/demo.md
+++ b/content/en/ecosystem/demo.md
@@ -30,7 +30,7 @@ If you find yourself asking questions like:
 - How should my services be configured?
 - How should my OpenTelemetry Collector be configured?
 - How do I consider the
-  [architecture](https://github.com/open-telemetry/opentelemetry-demo/blob/main/docs/current_architecture.md)
+  [architecture](https://opentelemetry.io/docs/demo/architecture/)
   of a system using OpenTelemetry?
 
 Then check out the [Demo](https://github.com/open-telemetry/opentelemetry-demo).


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry.io/issues/2317#issue-1578836510

What happened?
https://github.com/open-telemetry/opentelemetry-demo/blob/main/docs/current_architecture.md

returned 404

The link is not accessible from - https://opentelemetry.io/ecosystem/demo/