### PR TITLE
[registry] streamline Honeycomb distro language

### DIFF
--- a/data/registry/instrumentation-dotnet-honeycomb.yml
+++ b/data/registry/instrumentation-dotnet-honeycomb.yml
@@ -1,4 +1,4 @@
-title: Honeycomb.io OpenTelemetry Distro for .NET
+title: Honeycomb OpenTelemetry Distro for .NET
 registryType: instrumentation
 isThirdParty: true
 language: dotnet
@@ -10,4 +10,4 @@ tags:
 repo: https://github.com/honeycombio/honeycomb-opentelemetry-dotnet
 license: Apache 2.0
 description: Honeycomb's distribution of OpenTelemetry for .NET
-authors: Hound Technology Inc
+authors: Honeycomb, Hound Technology, Inc

--- a/data/registry/instrumentation-go-honeycomb.yml
+++ b/data/registry/instrumentation-go-honeycomb.yml
@@ -1,4 +1,4 @@
-title: Honeycomb.io OpenTelemetry Distro for Go
+title: Honeycomb OpenTelemetry Distro for Go
 registryType: instrumentation
 isThirdParty: true
 language: go

--- a/data/registry/instrumentation-java-honeycomb.yml
+++ b/data/registry/instrumentation-java-honeycomb.yml
@@ -1,4 +1,4 @@
-title: Honeycomb.io OpenTelemetry Distro for Java
+title: Honeycomb OpenTelemetry Distro for Java
 registryType: instrumentation
 isThirdParty: true
 language: java
@@ -8,4 +8,4 @@ tags:
 repo: https://github.com/honeycombio/honeycomb-opentelemetry-java
 license: Apache 2.0
 description: Honeycomb's distribution of OpenTelemetry for Java
-authors: Hound Technology Inc
+authors: Honeycomb, Hound Technology, Inc

--- a/data/registry/instrumentation-js-node-honeycomb.yml
+++ b/data/registry/instrumentation-js-node-honeycomb.yml
@@ -1,4 +1,4 @@
-title: Honeycomb.io OpenTelemetry Distro for Node.js
+title: Honeycomb OpenTelemetry Distro for Node.js
 registryType: instrumentation
 isThirdParty: true
 language: js


### PR DESCRIPTION
Follow-up from #2254

Streamline title and authors language across Honeycomb distros in the Registry.