### PR TITLE
Fix broken external links to demo docs

### DIFF
--- a/content/en/blog/2022/announcing-opentelemetry-demo-release.md
+++ b/content/en/blog/2022/announcing-opentelemetry-demo-release.md
@@ -8,7 +8,8 @@ author: Austin Parker
 Earlier this year, we announced a project to build an
 [OpenTelemetry Demo](/blog/2022/demo-announcement/), representing the breadth of
 OpenTelemetry features and languages. Today, the
-[Demo SIG](https://cloud-native.slack.com/archives/C03B4CWV4DA) is proud to announce
+[Demo SIG](https://cloud-native.slack.com/archives/C03B4CWV4DA) is proud to
+announce
 [OpenTelemetry Demo v1.0](https://github.com/open-telemetry/opentelemetry-demo/tree/v1.0.0)!
 With this demo, you’ll be able to quickly run a complete end-to-end distributed
 system instrumented with 100% OpenTelemetry Traces and Metrics.
@@ -17,12 +18,10 @@ system instrumented with 100% OpenTelemetry Traces and Metrics.
 
 One of our primary goals of this project has been to create a robust sample
 application for developers to use in learning OpenTelemetry, and we’re proud to
-say that we’ve done just that.
-Every OpenTelemetry language SDK except Swift is
-[represented](https://github.com/open-telemetry/opentelemetry-demo/blob/main/docs/service_table.md)
-in this release -- yes, even PHP!
-We’ve built complete [tracing flows](https://github.com/open-telemetry/opentelemetry-demo/blob/main/docs/trace_service_features.md)
-that demonstrate a breadth of common instrumentation tasks such as:
+say that we’ve done just that. Every OpenTelemetry language SDK except Swift is
+[represented](/docs/demo/service-table/) in this release -- yes, even PHP! We’ve
+built complete [tracing flows](/docs/demo/trace-features/) that demonstrate a
+breadth of common instrumentation tasks such as:
 
 - Enriching spans from automatic instrumentation.
 - Creating custom spans for richer, more useful traces.
@@ -31,23 +30,22 @@ that demonstrate a breadth of common instrumentation tasks such as:
 - Creating attributes, events, and other telemetry metadata.
 
 We’ve also integrated OpenTelemetry Metrics across
-[several services](https://github.com/open-telemetry/opentelemetry-demo/blob/main/docs/metric_service_features.md)
-to capture runtime and business metric use cases.
+[several services](/docs/demo/metric-features/) to capture runtime and business
+metric use cases.
 
-Now, it’d be enough to just provide a great demonstration of OpenTelemetry, but one
-thing we wanted to focus on for our 1.0 release was showing not just the ‘how’, but
-the ‘why’, of OpenTelemetry. To that end, we’ve built a framework for implementing
-[failure scenarios](https://github.com/open-telemetry/opentelemetry-demo/blob/main/docs/README.md#scenarios)
-gated by feature flags. In addition, we include pre-configured dashboards and walk-thrus
-in our docs on how to read and interpret the telemetry data each service emits to
-discover the underlying cause of performance regressions in the application.
+Now, it’d be enough to just provide a great demonstration of OpenTelemetry, but
+one thing we wanted to focus on for our 1.0 release was showing not just the
+‘how’, but the ‘why’, of OpenTelemetry. To that end, we’ve built a framework for
+implementing [failure scenarios](/docs/demo/#scenarios) gated by feature flags.
+In addition, we include pre-configured dashboards and walk-thrus in our docs on
+how to read and interpret the telemetry data each service emits to discover the
+underlying cause of performance regressions in the application.
 
 Another goal of this demo is to streamline the ability of vendors and commercial
 implementers of OpenTelemetry to have a standardized target for building demos
-around.
-We’ve already seen quite a bit of adoption, with five companies including
-Datadog, Dynatrace, Honeycomb, Lightstep, and New Relic integrating the
-community demo application into their product demos (you can find a list
+around. We’ve already seen quite a bit of adoption, with five companies
+including Datadog, Dynatrace, Honeycomb, Lightstep, and New Relic integrating
+the community demo application into their product demos (you can find a list
 [here](https://github.com/open-telemetry/opentelemetry-demo#demos-featuring-the-astronomy-shop)).
 We hope to encourage further contributions and collaboration along these lines.
 
@@ -63,12 +61,10 @@ for Swift, and more.
 
 We’d love for you to take the demo for a spin and let us know what you think!
 Check out the
-[docs](https://github.com/open-telemetry/opentelemetry-demo/tree/main/docs#opentelemetry-demo-documentation), or
-run the demo using
-[Docker](https://github.com/open-telemetry/opentelemetry-demo/blob/main/docs/docker_deployment.md)
-or
-[Kubernetes](https://github.com/open-telemetry/opentelemetry-demo/blob/main/docs/kubernetes_deployment.md),
-and let us know your thoughts. If you’d like to contribute, please file an
+[docs](https://github.com/open-telemetry/opentelemetry-demo/tree/main/docs#opentelemetry-demo-documentation),
+or run the demo using [Docker](/docs/demo/docker-deployment/) or
+[Kubernetes](/docs/demo/kubernetes-deployment/), and let us know your thoughts.
+If you’d like to contribute, please file an
 [issue on GitHub](https://github.com/open-telemetry/opentelemetry-demo/issues)
 or join us on the CNCF Slack in
 [#otel-community-demo](https://cloud-native.slack.com/archives/C03B4CWV4DA).

--- a/content/en/blog/2022/demo-announcement/index.md
+++ b/content/en/blog/2022/demo-announcement/index.md
@@ -156,5 +156,5 @@ from there.
 
 ### Interesting Links
 
-- [Demo Requirements](https://github.com/open-telemetry/opentelemetry-demo/tree/main/docs/requirements)
+- [Demo Requirements](/docs/demo/requirements/)
 - [Get Involved](https://github.com/open-telemetry/opentelemetry-demo#contributing)

--- a/content/en/blog/2022/frontend-overhaul/index.md
+++ b/content/en/blog/2022/frontend-overhaul/index.md
@@ -18,7 +18,7 @@ web app also shows different instrumentation techniques: automatic and manual,
 metrics, and baggage. All while following the standards and conventions
 prescribed in the official OTel documentation. More about the specific
 requirements can be
-[found here](https://github.com/open-telemetry/opentelemetry-demo/tree/main/docs/requirements).
+[found here](/docs/demo/requirements/).
 
 My company was focused on becoming part of and embracing the OpenTelemetry
 community. One of our goals this summer was to get more involved with a core

--- a/content/en/blog/2022/otel-demo-app-nomad/index.md
+++ b/content/en/blog/2022/otel-demo-app-nomad/index.md
@@ -333,7 +333,7 @@ jobspecs, please [hit me up](https://www.linkedin.com/in/adrianavillela/)!
 ## Final Thoughts
 
 Well, there you have it, folks! You now have an example of how to deploy
-[OpenTelemetry Demo App](https://github.com/open-telemetry/opentelemetry-demo/blob/main/docs/kubernetes_deployment.md)
+[OpenTelemetry Demo App](/docs/demo/kubernetes-deployment/)
 (a multi-micro-service app running OpenTelemetry) to HashiCorp Nomad. Main
 highlights:
 

--- a/content/en/blog/2023/jmx-metric-insight/index.md
+++ b/content/en/blog/2023/jmx-metric-insight/index.md
@@ -181,7 +181,7 @@ The
 which connects the checkout service with the accounting and fraud detection
 services is based on Kafka and utilises the JMX Metric Insight module to export
 Kafka broker metrics out of the box. You can head to the
-[documentation](https://github.com/open-telemetry/opentelemetry-demo/blob/main/docs/services/kafka.md).
+[documentation](/docs/demo/services/kafka/).
 
 ![Prometheus dashboard showing kafka_request_count metric](kafka-request-count-dashboard.png)
 

--- a/content/en/blog/2023/php-beta-release.md
+++ b/content/en/blog/2023/php-beta-release.md
@@ -22,9 +22,8 @@ There are many ways you can get started with our project:
   you started.
 - The [getting started guide](/docs/instrumentation/php/getting-started/) can
   help you to instrument a sample php file.
-- The
-  [quote service](https://github.com/open-telemetry/opentelemetry-demo/blob/main/docs/services/quoteservice.md),
-  is a demo application built in PHP to showcase the library.
+- The [quote service](/docs/demo/services/quote/), is a demo application built
+  in PHP to showcase the library.
 
 Questions? Feel free to reach out to us in the CNCF
 [#otel-php](https://cloud-native.slack.com/archives/C01NFPCV44V) Slack channel,

--- a/content/en/docs/demo/architecture.md
+++ b/content/en/docs/demo/architecture.md
@@ -114,9 +114,9 @@ classDef typescript fill:#e98516,color:black;
 ```
 
 Follow these links for the current state of
- [metric](https://github.com/open-telemetry/opentelemetry-demo/blob/main/docs/metric_service_features.md)
+ [metric](/docs/demo/metric-features/)
  and
- [trace](https://github.com/open-telemetry/opentelemetry-demo/blob/main/docs/trace_service_features.md)
+ [trace](/docs/demo/trace-features/)
  instrumentation of the demo applications.
 
 The collector is configured in


### PR DESCRIPTION
- Contributes to #2289
- Replaces all (now invalid) external links to the former demo docs folder by local paths.
- Runs the formatter

Note that there's one change left, but it's in the scope of the earlier PR, #2342.