### PR TITLE
Java pages need only one version parameter

### DIFF
--- a/content/en/docs/instrumentation/java/_index.md
+++ b/content/en/docs/instrumentation/java/_index.md
@@ -7,7 +7,8 @@ description: >-
   A language-specific implementation of OpenTelemetry in Java.
 aliases: [/java, /java/metrics, /java/tracing]
 weight: 18
-javaVersion: 1.23.1
+cascade:
+  javaVersion: 1.23.1
 ---
 
 {{% lang_instrumentation_index_head "java" /%}}

--- a/content/en/docs/instrumentation/java/manual.md
+++ b/content/en/docs/instrumentation/java/manual.md
@@ -6,7 +6,6 @@ aliases:
   - /docs/java/manual_instrumentation
   - /docs/instrumentation/java/manual_instrumentation
 weight: 5
-javaVersion: 1.20.1
 ---
 
 **Libraries** that want to export telemetry data using OpenTelemetry MUST only


### PR DESCRIPTION
It is best to keep things DRY and have a single "version" variable.

**Preview**:

- https://deploy-preview-2352--opentelemetry.netlify.app/docs/instrumentation/java/
- https://deploy-preview-2352--opentelemetry.netlify.app/docs/instrumentation/java/manual/ 

/cc @trask @svrnm 