### PR TITLE
Style inline images as blocks with a border

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -244,3 +244,10 @@
     height: auto;
   }
 }
+
+.td-content img:not(.img-initial) {
+  display: block;
+  border: $border-width solid $border-color;
+  margin-bottom: $paragraph-margin-bottom;
+  @extend .td-max-width-on-larger-screens;
+}

--- a/content/en/blog/2022/why-and-how-ebay-pivoted-to-opentelemetry/index.md
+++ b/content/en/blog/2022/why-and-how-ebay-pivoted-to-opentelemetry/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Why and How eBay Pivoted to OpenTelemetry"
+title: Why and How eBay Pivoted to OpenTelemetry
 linkTitle: eBay OpenTelemetry
 date: 2022-12-19
 author: "[Vijay Samuel](https://github.com/vjsamuel) (eBay)"
@@ -134,6 +134,7 @@ Filebeat and Auditbeat, would interface with the Sherlock.io platform when
 deployed as a DaemonSet:
 
 ![daemonset](daemonset.jpeg)
+{.border-0}
 
 ## Moving To Cluster Local Scrapes
 
@@ -177,6 +178,7 @@ that are monitored by that instance alone, the failure percentage is reduced to
 The new deployment pattern can be visualized as follows:
 
 ![clusterlocal](cluster-local.jpeg)
+{.border-0}
 
 ## Decoupling Autodiscover
 
@@ -250,6 +252,7 @@ filereloadreceiver in place, we were able to generate new configurations for the
 OpenTelemetry Collector as follows.
 
 ![config](config.jpeg)
+{.border-0}
 
 As shown above, we were able to keep the end user contract of Pod/Namespace
 annotations the same and simply swap the agent under the hood. This greatly

--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -13,11 +13,11 @@ Familiarity with the following pages is assumed:
 
 The Collector consists of three components that access telemetry data:
 
-- <img width="32" src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Receivers.svg"></img>
+- <img width="32" class="img-initial" src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Receivers.svg"></img>
   [Receivers](#receivers)
-- <img width="32" src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Processors.svg"></img>
+- <img width="32" class="img-initial" src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Processors.svg"></img>
   [Processors](#processors)
-- <img width="32" src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Exporters.svg"></img>
+- <img width="32" class="img-initial" src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Exporters.svg"></img>
   [Exporters](#exporters)
 
 These components once configured must be enabled via pipelines within the
@@ -168,7 +168,7 @@ service:
 
 ## Receivers
 
-<img width="35" src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Receivers.svg"></img>
+<img width="35" class="img-initial" src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Receivers.svg"></img>
 
 A receiver, which can be push or pull based, is how data gets into the
 Collector. Receivers may support one or more
@@ -245,7 +245,7 @@ receivers:
 
 ## Processors
 
-<img width="35" src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Processors.svg"></img>
+<img width="35" class="img-initial" src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Processors.svg"></img>
 
 Processors are run on data between being received and being exported. Processors
 are optional though
@@ -326,7 +326,7 @@ processors:
 
 ## Exporters
 
-<img width="35" src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Exporters.svg"></img>
+<img width="35" class="img-initial" src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Exporters.svg"></img>
 
 An exporter, which can be push or pull based, is how you send data to one or
 more backends/destinations. Exporters may support one or more

--- a/content/en/docs/concepts/data-collection.md
+++ b/content/en/docs/concepts/data-collection.md
@@ -33,12 +33,12 @@ For information on how to use the Collector see the
 
 The Collector is made up of the following components:
 
-- <img width="32" src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Receivers.svg"></img>
+- <img width="32" class="img-initial" src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Receivers.svg"></img>
   `receivers`: How to get data into the Collector; these can be push or pull
   based
-- <img width="32" src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Processors.svg"></img>
+- <img width="32" class="img-initial" src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Processors.svg"></img>
   `processors`: What to do with received data
-- <img width="32" src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Exporters.svg"></img>
+- <img width="32" class="img-initial" src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Exporters.svg"></img>
   `exporters`: Where to send received data; these can be push or pull based
 
 These components are enabled through `pipelines`. Multiple instances of

--- a/content/en/docs/instrumentation/cpp/_index.md
+++ b/content/en/docs/instrumentation/cpp/_index.md
@@ -2,7 +2,7 @@
 title: C++
 weight: 11
 description: >
-  <img width="35"
+  <img width="35" class="img-initial"
   src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/C++_SDK.svg"
   alt="C++"></img> A language-specific implementation of OpenTelemetry in C++.
 ---

--- a/content/en/docs/instrumentation/erlang/_index.md
+++ b/content/en/docs/instrumentation/erlang/_index.md
@@ -2,19 +2,12 @@
 title: Erlang/Elixir
 weight: 14
 description: >
-  <img width="35"
+  <img width="35" class="img-initial"
   src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Erlang_SDK.svg"
   alt="Erlang/Elixir"></img>
   A language-specific implementation of OpenTelemetry in Erlang/Elixir.
 ---
 
-<!--
-You can see & update the `lang_instrumentation_index_head` shortcode in
-/layouts/shortcodes/lang_instrumentation_index_head.md
-
-The data (name, status) is located at
-/data/instrumentation.yaml
--->
 {{% lang_instrumentation_index_head "erlang" %}}
   Packages of the API, SDK and OTLP exporter are published to
   [hex.pm](https://hex.pm) as

--- a/content/en/docs/instrumentation/java/_index.md
+++ b/content/en/docs/instrumentation/java/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Java
 description: >-
-  <img width="35"
+  <img width="35" class="img-initial"
   src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Java_SDK.svg"
   alt="Java"></img>
   A language-specific implementation of OpenTelemetry in Java.

--- a/content/en/docs/instrumentation/js/_index.md
+++ b/content/en/docs/instrumentation/js/_index.md
@@ -1,7 +1,7 @@
 ---
 title: JavaScript
 description: >-
-  <img width="35"
+  <img width="35" class="img-initial"
   src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/JS_SDK.svg"
   alt="JavaScript"></img>
   A language-specific implementation of OpenTelemetry in JavaScript (for Node.js & the browser).

--- a/content/en/docs/instrumentation/net/_index.md
+++ b/content/en/docs/instrumentation/net/_index.md
@@ -1,7 +1,7 @@
 ---
 title: .NET
 description: >
-  <img width="35"
+  <img width="35" class="img-initial"
   src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/.NET.svg"
   alt=".NET"></img>
   A language-specific implementation of OpenTelemetry in .NET.
@@ -9,13 +9,6 @@ aliases: [/csharp, /csharp/metrics, /csharp/tracing]
 weight: 12
 ---
 
-<!--
-You can see & update the `lang_instrumentation_index_head` shortcode in
-/layouts/shortcodes/lang_instrumentation_index_head.md
-
-The data (name, status) is located at
-/data/instrumentation.yaml
--->
 {{% lang_instrumentation_index_head "dotnet" %}}
 
 \* While the OpenTelemetryLoggerProvider (i.e integration with [ILogger][]) is

--- a/content/en/docs/instrumentation/php/_index.md
+++ b/content/en/docs/instrumentation/php/_index.md
@@ -1,20 +1,13 @@
 ---
 title: PHP
 description: >-
-  <img width="35"
+  <img width="35" class="img-initial"
   src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/PHP.svg"
   alt="PHP"></img>
   A language-specific implementation of OpenTelemetry in PHP.
 weight: 21
 ---
 
-<!--
-You can see & update the `lang_instrumentation_index_head` shortcode in
-/layouts/shortcodes/lang_instrumentation_index_head.md
-
-The data (name, status) is located at
-/data/instrumentation.yaml
--->
 {{% lang_instrumentation_index_head "php" /%}}
 
 ## Further Reading

--- a/content/en/docs/instrumentation/python/_index.md
+++ b/content/en/docs/instrumentation/python/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Python
 description: >-
-  <img width="35"
+  <img width="35" class="img-initial"
   src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Python_SDK.svg"
   alt="Python"></img> A language-specific implementation of OpenTelemetry in
   Python.

--- a/content/en/docs/instrumentation/ruby/_index.md
+++ b/content/en/docs/instrumentation/ruby/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Ruby
 description: >
-  <img width="35" src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Ruby_SDK.svg" alt="Ruby"></img>
+  <img width="35" class="img-initial" src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Ruby_SDK.svg" alt="Ruby"></img>
   A language-specific implementation of OpenTelemetry in Ruby.
 aliases: [/ruby, /ruby/metrics, /ruby/tracing]
 weight: 24

--- a/content/en/docs/instrumentation/rust/_index.md
+++ b/content/en/docs/instrumentation/rust/_index.md
@@ -1,20 +1,13 @@
 ---
 title: Rust
 description: >-
-  <img width="35"
+  <img width="35" class="img-initial"
   src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Rust.svg"
   alt="Rust"></img>
   A language-specific implementation of OpenTelemetry in Rust.
 weight: 26
 ---
 
-<!--
-You can see & update the `lang_instrumentation_index_head` shortcode in
-/layouts/shortcodes/lang_instrumentation_index_head.md
-
-The data (name, status) is located at
-/data/instrumentation.yaml
--->
 {{% lang_instrumentation_index_head "rust" /%}}
 
 ## Crates

--- a/content/en/docs/instrumentation/swift/_index.md
+++ b/content/en/docs/instrumentation/swift/_index.md
@@ -2,19 +2,12 @@
 title: Swift
 weight: 28
 description: >-
-  <img width="35"
+  <img width="35" class="img-initial"
   src="https://raw.githubusercontent.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Swift.svg"
   alt="Swift"></img>
   A language-specific implementation of OpenTelemetry in Swift.
 ---
 
-<!--
-You can see & update the `lang_instrumentation_index_head` shortcode in
-/layouts/shortcodes/lang_instrumentation_index_head.md
-
-The data (name, status) is located at
-/data/instrumentation.yaml
--->
 {{% lang_instrumentation_index_head "swift" /%}}
 
 ## Further Reading

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -20,6 +20,10 @@ imaging:
 
 markup:
   goldmark:
+    parser:
+      attribute:
+        block: true
+      wrapStandAloneImageWithinParagraph: false
     renderer:
       unsafe: true
   highlight:


### PR DESCRIPTION
- Closes #2358 using styles only. Maybe we can consider use of a render hook later.
- Ensures that image elements in markdown are treated as block-level elements
- Adds a light border around images, which is necessary (in most cases) when the image background is white. The border around barker images isn't a problem in general. 
- Supports an easy way to declare that an image:
  - Shouldn't have a border by adding `{.border-0}` after an image. There's an example of this in the PR.
  - Isn't a figure, by using the `img-initial ` class.
- Closes #2271

Preview:

- https://deploy-preview-2359--opentelemetry.netlify.app/blog/2022/otel-demo-app-nomad/#4--see-it-in-nomad - illustrates how most images benefit from a border. This was also the target of #2271
- https://deploy-preview-2359--opentelemetry.netlify.app/blog/2022/why-and-how-ebay-pivoted-to-opentelemetry/ - shows inline images without borders
- https://deploy-preview-2359--opentelemetry.netlify.app/docs/instrumentation/cpp/ - for the inline image in the description
- https://deploy-preview-2359--opentelemetry.netlify.app/docs/concepts/data-collection/#components - more inline images

### Screenshots

Before:

> <img width="1056" alt="image" src="https://user-images.githubusercontent.com/4140793/219678028-138611dd-706e-4c10-9b06-7e3f45114953.png">


After:

> <img width="1023" alt="image" src="https://user-images.githubusercontent.com/4140793/219679423-4cebfbd7-4876-4ae6-bb27-385b99d5b7c6.png">

