### PR TITLE
CI: ignore snippet-injected GA link

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -7,9 +7,13 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - ^/docs/instrumentation/\w+/(api|examples)/$
   - ^/docs/instrumentation/net/(metrics-api|traces-api)/
 
+  - ^https://deploy-preview-\d+--opentelemetry.netlify.app/
+  - ^https://www\.googletagmanager\.com
+
   - ^https?://localhost\b
   - ^https?://127\.0\.0\.1\b
   - ^https?://(otel-demo|traefik)\.localhost
+
   - ^https?://(www\.)?github\b # TODO: process GitHub links too
   - ^https?://(www\.)?linkedin\.com\b # Always yields 999 Request Denied
   - ^https://mvnrepository\.com # Always yields 403 Forbidden
@@ -28,5 +32,3 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - ^https://www\.jaegertracing\.io/docs/latest/opentelemetry
   # TODO: drop after fix to https://github.com/open-telemetry/opentelemetry-specification/pull/3230
   - ^https://wikipedia\.org/wiki/Double-precision_floating-point_format
-  # Ignore links into Netlify deploy-preview servers (because the preview might not be deployed when we check)
-  - ^https://deploy-preview-\d+--opentelemetry.netlify.app/


### PR DESCRIPTION
- Followup to #2364
- [Production deploy failed](https://app.netlify.com/sites/opentelemetry/deploys/63f2500dcc5bf2000865d6ed) after that because I forgot about Netlify injecting GA code. 
- Adds the GA tag manager URL to the link-checker ignore list