### PR TITLE
Enable Prettier check over instrumentation/net

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -24,7 +24,6 @@ content/en/docs/instrumentation/cpp
 content/en/docs/instrumentation/erlang
 content/en/docs/instrumentation/go
 content/en/docs/instrumentation/js
-content/en/docs/instrumentation/net
 content/en/docs/instrumentation/other
 content/en/docs/instrumentation/php
 content/en/docs/instrumentation/ruby

--- a/content/en/docs/instrumentation/net/_index.md
+++ b/content/en/docs/instrumentation/net/_index.md
@@ -1,10 +1,8 @@
 ---
 title: .NET
 description: >
-  <img width="35" class="img-initial"
-  src="/img/logos/32x32/.NET.svg"
-  alt=".NET"></img>
-  A language-specific implementation of OpenTelemetry in .NET.
+  <img width="35" class="img-initial" src="/img/logos/32x32/.NET.svg"
+  alt=".NET"></img> A language-specific implementation of OpenTelemetry in .NET.
 aliases: [/csharp, /csharp/metrics, /csharp/tracing]
 weight: 12
 ---
@@ -17,19 +15,20 @@ stable, the [OTLP Log Exporter][] is still non-stable.
 
 ## Version Support
 
-OpenTelemetry for .NET supports all officially supported versions of [.NET
-Core](https://dotnet.microsoft.com/download/dotnet-core) and [.NET
-Framework](https://dotnet.microsoft.com/download/dotnet-framework) except for
-.NET Framework 3.5 SP1.
+OpenTelemetry for .NET supports all officially supported versions of
+[.NET Core](https://dotnet.microsoft.com/download/dotnet-core) and
+[.NET Framework](https://dotnet.microsoft.com/download/dotnet-framework) except
+for .NET Framework 3.5 SP1.
 
 ## Repositories
 
 OpenTelemetry .NET consists of the following repositories:
 
 - [OpenTelemetry .NET](https://github.com/open-telemetry/opentelemetry-dotnet)
-- [OpenTelemetry .NET
-  Contrib](https://github.com/open-telemetry/opentelemetry-dotnet-contrib)
+- [OpenTelemetry .NET Contrib](https://github.com/open-telemetry/opentelemetry-dotnet-contrib)
 - [OpenTelemetry .NET Automatic Instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation)
 
-[ILogger]: https://docs.microsoft.com/dotnet/api/microsoft.extensions.logging.ilogger
-[OTLP Log Exporter]: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md#otlp-logs
+[ilogger]:
+  https://docs.microsoft.com/dotnet/api/microsoft.extensions.logging.ilogger
+[otlp log exporter]:
+  https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md#otlp-logs

--- a/content/en/docs/instrumentation/net/automatic.md
+++ b/content/en/docs/instrumentation/net/automatic.md
@@ -4,24 +4,29 @@ linkTitle: Automatic
 weight: 3
 ---
 
-You can use [automatic instrumentation](/docs/reference/specification/glossary/#automatic-instrumentation)
-to initialize [signal](/docs/reference/specification/glossary/#signals) providers
-and generate telemetry data for supported [instrumented libraries](/docs/reference/specification/glossary/#instrumented-library)
+You can use
+[automatic instrumentation](/docs/reference/specification/glossary/#automatic-instrumentation)
+to initialize [signal](/docs/reference/specification/glossary/#signals)
+providers and generate telemetry data for supported
+[instrumented libraries](/docs/reference/specification/glossary/#instrumented-library)
 without modifying the application's source code.
 
-[Here][release] you can find the latest release of
-OpenTelemetry .NET Automatic Instrumentation.
+[Here][release] you can find the latest release of OpenTelemetry .NET Automatic
+Instrumentation.
 
 You can find the documentation in the [project's repository][repo].
 
 ## Next steps
 
 After you have set up the automatic instrumentation, you may want to add
-[manual instrumentation](/docs/instrumentation/net/manual)
-to collect custom telemetry data.
+[manual instrumentation](/docs/instrumentation/net/manual) to collect custom
+telemetry data.
 
-If you do not want to rely on automatic instrumentation,
-which is currently in beta, you may want to use [instrumentation libraries](/docs/instrumentation/net/libraries) explicitly instead.
+If you do not want to rely on automatic instrumentation, which is currently in
+beta, you may want to use
+[instrumentation libraries](/docs/instrumentation/net/libraries) explicitly
+instead.
 
-[release]: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest
+[release]:
+  https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest
 [repo]: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation

--- a/content/en/docs/instrumentation/net/exporters.md
+++ b/content/en/docs/instrumentation/net/exporters.md
@@ -4,8 +4,8 @@ weight: 4
 ---
 
 In order to visualize and analyze your
-[traces](/docs/concepts/signals/traces/#tracing-in-opentelemetry) and metrics, you
-will need to export them to a backend.
+[traces](/docs/concepts/signals/traces/#tracing-in-opentelemetry) and metrics,
+you will need to export them to a backend.
 
 ## Console exporter
 
@@ -106,8 +106,9 @@ If you are using .NET 5 or higher, the previous code sample is not required.
 
 ### Jaeger
 
-To try out the OTLP exporter, you can run [Jaeger](https://www.jaegertracing.io/)
-as an OTLP endpoint and for trace visualization in a docker container:
+To try out the OTLP exporter, you can run
+[Jaeger](https://www.jaegertracing.io/) as an OTLP endpoint and for trace
+visualization in a docker container:
 
 ```shell
 docker run -d --name jaeger \
@@ -248,13 +249,13 @@ using var tracerProvider = Sdk.CreateMeterProviderBuilder()
 ## Next steps
 
 To ensure you're getting the most data as easily as possible, install
-[instrumentation libraries](/docs/instrumentation/net/libraries) to
-generate observability data.
+[instrumentation libraries](/docs/instrumentation/net/libraries) to generate
+observability data.
 
 Additionally, enriching your codebase with
-[manual instrumentation](/docs/instrumentation/net/manual)
-gives you customized observability data.
+[manual instrumentation](/docs/instrumentation/net/manual) gives you customized
+observability data.
 
 You can also check the
-[automatic instrumentation for .NET](/docs/instrumentation/net/automatic),
-which is currently in beta.
+[automatic instrumentation for .NET](/docs/instrumentation/net/automatic), which
+is currently in beta.

--- a/content/en/docs/instrumentation/net/getting-started.md
+++ b/content/en/docs/instrumentation/net/getting-started.md
@@ -23,7 +23,8 @@ dotnet add package OpenTelemetry.Instrumentation.AspNetCore --prerelease
 dotnet add package OpenTelemetry.Instrumentation.Http --prerelease
 dotnet add package OpenTelemetry.Instrumentation.SqlClient --prerelease
 ```
-Note that the `--prerelease` flag is required for all instrumentation packages 
+
+Note that the `--prerelease` flag is required for all instrumentation packages
 because they are all are pre-release.
 
 This will also install the `OpenTelemetry` package.
@@ -195,7 +196,8 @@ app.MapGet("/hello", () =>
 app.Run();
 ```
 
-The output will be similar as with tracing, but now includes the request counter and periodically exports a histogram of request times for each route.
+The output will be similar as with tracing, but now includes the request counter
+and periodically exports a histogram of request times for each route.
 
 <details>
 <summary>View example output</summary>
@@ -246,7 +248,7 @@ Export app.request-counter, Meter: MyCompany.MyProduct.MyService
 Value: 1
 
 (2022-11-16T06:09:04.2574360Z, 2022-11-16T06:09:44.2393730Z] http.flavor: 1.1 http.host: localhost:7026 http.method: GET http.scheme: https http.status_code: 200 http.target: /hello Histogram
-Value: Sum: 40.041 Count: 1 
+Value: Sum: 40.041 Count: 1
 (-Infinity,0]:0
 (0,5]:0
 (0,10]:0
@@ -273,10 +275,10 @@ The [OpenTelemetry Collector](/docs/collector/getting-started/) is a vital
 component of most production deployments. A collector is most beneficial in the
 following situations, among others:
 
-* A single telemetry sink shared by multiple services, to reduce overhead of
+- A single telemetry sink shared by multiple services, to reduce overhead of
   switching exporters
-* Aggregate traces across multiple services, running on multiple hosts
-* A central place to process traces prior to exporting them to a backend
+- Aggregate traces across multiple services, running on multiple hosts
+- A central place to process traces prior to exporting them to a backend
 
 ### Configure and run a local collector
 
@@ -421,13 +423,14 @@ To ensure you're getting the most data as easily as possible, install
 [instrumentation libraries](/docs/instrumentation/net/libraries) to generate
 observability data.
 
-Additionally, enriching your codebase with [manual
-instrumentation](/docs/instrumentation/net/manual) gives you customized
+Additionally, enriching your codebase with
+[manual instrumentation](/docs/instrumentation/net/manual) gives you customized
 observability data.
 
-You'll also want to configure an appropriate exporter to [export your telemetry
-data](/docs/instrumentation/net/exporters) to one or more telemetry backends.
+You'll also want to configure an appropriate exporter to
+[export your telemetry data](/docs/instrumentation/net/exporters) to one or more
+telemetry backends.
 
-You can also check the [automatic instrumentation for
-.NET](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation),
+You can also check the
+[automatic instrumentation for .NET](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation),
 which is currently in beta.

--- a/content/en/docs/instrumentation/net/libraries.md
+++ b/content/en/docs/instrumentation/net/libraries.md
@@ -4,36 +4,36 @@ linkTitle: Libraries
 weight: 3
 ---
 
-You can use [instrumentation libraries](/docs/reference/specification/glossary/#instrumentation-library)
+You can use
+[instrumentation libraries](/docs/reference/specification/glossary/#instrumentation-library)
 in order to generate telemetry data for a particular instrumented library.
 
-For example, [the instrumentation library for ASP.NET Core](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNetCore)
-will automatically
-create [spans](/docs/concepts/signals/traces/#spans-in-opentelemetry)
-and [metrics](/docs/concepts/signals/metrics)
-based on the inbound HTTP requests.
+For example,
+[the instrumentation library for ASP.NET Core](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNetCore)
+will automatically create
+[spans](/docs/concepts/signals/traces/#spans-in-opentelemetry) and
+[metrics](/docs/concepts/signals/metrics) based on the inbound HTTP requests.
 
 ## Setup
 
 Each instrumentation library is a NuGet package, and installing them is
 typically done like so:
 
-```console
+```
 dotnet add package OpenTelemetry.Instrumentation.{library-name-or-type}
 ```
 
 It is typically then registered at application startup time, such as when
-creating a
-[TracerProvider](/docs/concepts/signals/traces/#tracer-provider).
+creating a [TracerProvider](/docs/concepts/signals/traces/#tracer-provider).
 
 ## Example with ASP.NET Core and HttpClient
 
-As an example, here's how you can instrument inbound and output
-requests from an ASP.NET Core app.
+As an example, here's how you can instrument inbound and output requests from an
+ASP.NET Core app.
 
 First, get the appropriate packages:
 
-```console
+```
 dotnet add package OpenTelemetry --prerelease
 dotnet add package OpenTelemetry.Extensions.Hosting --prerelease
 dotnet add package OpenTelemetry.Exporter.Console --prerelease
@@ -87,16 +87,14 @@ app.MapGet("/hello", async () =>
 app.Run();
 ```
 
-When you run this code and access the `/hello` endpoint,
-the instrumentation libraries will:
+When you run this code and access the `/hello` endpoint, the instrumentation
+libraries will:
 
-* Start a new trace
-* Generate a span representing the request made to the endpoint
-* Generate a child span representing the HTTP GET made to
-  `https://example.com/`
+- Start a new trace
+- Generate a span representing the request made to the endpoint
+- Generate a child span representing the HTTP GET made to `https://example.com/`
 
-If you add more instrumentation libraries,
-then you get more telemetry data.
+If you add more instrumentation libraries, then you get more telemetry data.
 
 ## Available instrumentation libraries
 
@@ -108,19 +106,20 @@ You can also find more instrumentations available in the
 
 ## Next steps
 
-After you have set up instrumentation libraries, you may want to add [manual
-instrumentation](/docs/instrumentation/net/manual) to collect custom telemetry
-data.
+After you have set up instrumentation libraries, you may want to add
+[manual instrumentation](/docs/instrumentation/net/manual) to collect custom
+telemetry data.
 
-If you are using .NET Framework 4.x instead of modern .NET, refer to the [.NET
-Framework docs](/docs/instrumentation/net/netframework) to configure
+If you are using .NET Framework 4.x instead of modern .NET, refer to the
+[.NET Framework docs](/docs/instrumentation/net/netframework) to configure
 OpenTelemetry and instrumentation libraries on .NET Framework.
 
-You'll also want to configure an appropriate exporter to [export your telemetry
-data](/docs/instrumentation/net/exporters) to one or more telemetry backends.
+You'll also want to configure an appropriate exporter to
+[export your telemetry data](/docs/instrumentation/net/exporters) to one or more
+telemetry backends.
 
 You can also check the
-[automatic instrumentation for .NET](/docs/instrumentation/net/automatic),
-which is currently in beta.
+[automatic instrumentation for .NET](/docs/instrumentation/net/automatic), which
+is currently in beta.
 
 [opentelemetry-dotnet]: https://github.com/open-telemetry/opentelemetry-dotnet

--- a/content/en/docs/instrumentation/net/manual.md
+++ b/content/en/docs/instrumentation/net/manual.md
@@ -9,8 +9,8 @@ application.
 
 ## A note on terminology
 
-.NET is different from other languages/runtimes that support OpenTelemetry.
-The [Tracing API](/docs/concepts/signals/traces/#tracing-in-opentelemetry) is
+.NET is different from other languages/runtimes that support OpenTelemetry. The
+[Tracing API](/docs/concepts/signals/traces/#tracing-in-opentelemetry) is
 implemented by the
 [System.Diagnostics](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics)
 API, repurposing existing constructs like `ActivitySource` and `Activity` to be
@@ -21,8 +21,7 @@ developers must still know to be able to instrument their applications, which
 are covered here as well as the `System.Diagnostics` API.
 
 If you prefer to use OpenTelemetry APIs instead of `System.Diagnostics` APIs,
-you can refer to the [OpenTelemetry API Shim docs for tracing]({{< relref "shim"
->}}).
+you can refer to the [OpenTelemetry API Shim docs for tracing](../shim).
 
 ## Initializing tracing
 
@@ -83,11 +82,11 @@ dotnet add package OpenTelemetry.Extensions.Hosting --prerelease
 dotnet add package OpenTelemetry.Exporter.Console --prerelease
 ```
 
-Note that the `--prerelease` flag is required for all instrumentation packages 
+Note that the `--prerelease` flag is required for all instrumentation packages
 because they are all are pre-release.
 
-Next, configure it in your ASP.NET Core startup routine where you have access
-to an `IServiceCollection`.
+Next, configure it in your ASP.NET Core startup routine where you have access to
+an `IServiceCollection`.
 
 ```csharp
 using OpenTelemetry;
@@ -242,8 +241,8 @@ public static void DoWork()
 
 ## Creating new root Activities
 
-If you wish to create a new root Activity, you'll need to "de-parent" from
-the current activity.
+If you wish to create a new root Activity, you'll need to "de-parent" from the
+current activity.
 
 ```csharp
 public static void DoWork()
@@ -374,13 +373,13 @@ catch (Exception ex)
 
 ## Next steps
 
-After you've set up manual instrumentation, you may want to use [instrumentation
-libraries](../libraries/). As the name suggests, they will
-instrument relevant libraries you're using and generate spans (activities) for things like
-inbound and outbound HTTP requests and more.
+After you've set up manual instrumentation, you may want to use
+[instrumentation libraries](../libraries/). As the name suggests, they will
+instrument relevant libraries you're using and generate spans (activities) for
+things like inbound and outbound HTTP requests and more.
 
-You'll also want to configure an appropriate exporter to [export your telemetry
-data](../exporters/) to one or more telemetry backends.
+You'll also want to configure an appropriate exporter to
+[export your telemetry data](../exporters/) to one or more telemetry backends.
 
-You can also check the [automatic instrumentation for
-.NET](../automatic/), which is currently in beta.
+You can also check the [automatic instrumentation for .NET](../automatic/),
+which is currently in beta.

--- a/content/en/docs/instrumentation/net/netframework.md
+++ b/content/en/docs/instrumentation/net/netframework.md
@@ -5,8 +5,8 @@ weight: 5
 ---
 
 OpenTelemetry supports both
-[.NET](https://dotnet.microsoft.com/en-us/learn/dotnet/what-is-dotnet) and [.NET
-Framework](https://dotnet.microsoft.com/en-us/learn/dotnet/what-is-dotnet-framework)
+[.NET](https://dotnet.microsoft.com/en-us/learn/dotnet/what-is-dotnet) and
+[.NET Framework](https://dotnet.microsoft.com/en-us/learn/dotnet/what-is-dotnet-framework)
 (an older Windows-based .NET implementation).
 
 If you're already using the modern, cross-platform implementation of .NET, you
@@ -18,8 +18,8 @@ Initialization for ASP.NET is a little different than for ASP.NET Core.
 
 First, install the following NuGet packages:
 
-* [OpenTelemetry.Instrumentation.AspNet](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNet/)
-* [OpenTelemetry.Extensions.Hosting](https://www.nuget.org/packages/OpenTelemetry.Extensions.Hosting)
+- [OpenTelemetry.Instrumentation.AspNet](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNet/)
+- [OpenTelemetry.Extensions.Hosting](https://www.nuget.org/packages/OpenTelemetry.Extensions.Hosting)
 
 Next, modify your `Web.Config` file to add a required HttpModule:
 
@@ -93,9 +93,10 @@ this.tracerProvider = Sdk.CreateTracerProviderBuilder()
     .Build();
 ```
 
-Filtering happens at an early stage, and is different from [Sampling]({{< relref
-"/docs/reference/specification/trace/sdk#sampling" >}}), which occurs after data
-has been collected. Filtering will limit what gets collected in the first place.
+Filtering happens at an early stage, and is different from
+[Sampling](/docs/reference/specification/trace/sdk/#sampling), which occurs
+after data has been collected. Filtering will limit what gets collected in the
+first place.
 
 ### Enrich
 
@@ -130,8 +131,8 @@ this.tracerProvider = Sdk.CreateTracerProviderBuilder()
     .Build();
 ```
 
-See [Add tags to an Activity]({{< relref "manual#add-tags-to-an-activity" >}})
-for annotating trace data more generally.
+See [Add tags to an Activity](../manual/#add-tags-to-an-activity) for annotating
+trace data more generally.
 
 ### RecordException
 
@@ -144,13 +145,14 @@ exception on the `Activity` itself as an `ActivityEvent`.
 ## Next steps
 
 After you have observability generated automatically with instrumentation
-libraries, you may want to add [manual
-instrumentation](/docs/instrumentation/net/manual) to collect custom telemetry
-data.
+libraries, you may want to add
+[manual instrumentation](/docs/instrumentation/net/manual) to collect custom
+telemetry data.
 
-You'll also want to configure an appropriate exporter to [export your telemetry
-data](/docs/instrumentation/net/exporters) to one or more telemetry backends.
+You'll also want to configure an appropriate exporter to
+[export your telemetry data](/docs/instrumentation/net/exporters) to one or more
+telemetry backends.
 
 You can also check the
-[automatic instrumentation for .NET](/docs/instrumentation/net/automatic),
-which is currently in beta.
+[automatic instrumentation for .NET](/docs/instrumentation/net/automatic), which
+is currently in beta.

--- a/content/en/docs/instrumentation/net/resources.md
+++ b/content/en/docs/instrumentation/net/resources.md
@@ -29,7 +29,7 @@ via environment variables, running unix programs like `uname` to generate the
 resource data.
 
 ```console
-env OTEL_RESOURCE_ATTRIBUTES="service.name=resource-tutorial-dotnet,service.namespace=tutorial,service.version=1.0,service.instance.id=`uuidgen`,host.name=`HOSTNAME`,host.type=`uname -m`,os.name=`uname -s`,os.version=`uname -r`" dotnet run
+$ env OTEL_RESOURCE_ATTRIBUTES="service.name=resource-tutorial-dotnet,service.namespace=tutorial,service.version=1.0,service.instance.id=`uuidgen`,host.name=`HOSTNAME`,host.type=`uname -m`,os.name=`uname -s`,os.version=`uname -r`" dotnet run
 
 Activity.TraceId:          d1cbb7787440cc95b325835cb2ff8018
 Activity.SpanId:           2ca007300fcb3068
@@ -99,17 +99,17 @@ activity?.SetTag("bar", "Hello, World!");
 activity?.SetTag("baz", new int[] { 1, 2, 3 });
 ```
 
-In this example, the `service.name` and `service.version` values are
-set in code as well. Additionally, `service.instance.id` gets a
-default value.
+In this example, the `service.name` and `service.version` values are set in code
+as well. Additionally, `service.instance.id` gets a default value.
 
-If you run the same command as in [Adding resources with environment
-variables](#adding-resources-with-environment-variables), but this time
-without `service.name` `service.version`, and `service.instance.id`,
-you'll see the `environment.name` and `team.name` resources in the resource list:
+If you run the same command as in
+[Adding resources with environment variables](#adding-resources-with-environment-variables),
+but this time without `service.name` `service.version`, and
+`service.instance.id`, you'll see the `environment.name` and `team.name`
+resources in the resource list:
 
 ```console
-env OTEL_RESOURCE_ATTRIBUTES="service.namespace=tutorial,host.name=`HOSTNAME`,host.type=`uname -m`,os.name=`uname -s`,os.version=`uname -r`" dotnet run
+$ env OTEL_RESOURCE_ATTRIBUTES="service.namespace=tutorial,host.name=`HOSTNAME`,host.type=`uname -m`,os.name=`uname -s`,os.version=`uname -r`" dotnet run
 
 Activity.TraceId:          d1cbb7787440cc95b325835cb2ff8018
 Activity.SpanId:           2ca007300fcb3068

--- a/content/en/docs/instrumentation/net/shim.md
+++ b/content/en/docs/instrumentation/net/shim.md
@@ -415,10 +415,11 @@ This will capture things like the current stack trace as attributes in the span.
 
 ## Next steps
 
-After you've setup manual instrumentation, you may want to use [instrumentation
-libraries](/docs/instrumentation/net/libraries). Instrumentation libraries will
-instrument relevant libraries you're using and generate data for things like
-inbound and outbound HTTP requests and more.
+After you've setup manual instrumentation, you may want to use
+[instrumentation libraries](/docs/instrumentation/net/libraries).
+Instrumentation libraries will instrument relevant libraries you're using and
+generate data for things like inbound and outbound HTTP requests and more.
 
-You'll also want to configure an appropriate exporter to [export your telemetry
-data](/docs/instrumentation/net/exporters) to one or more telemetry backends.
+You'll also want to configure an appropriate exporter to
+[export your telemetry data](/docs/instrumentation/net/exporters) to one or more
+telemetry backends.


### PR DESCRIPTION
- Contributes to #1063
- Enables format checking over `instrumentation/net` section
- Replaces `relref` link(s) by standard markdown link(s)
- Adjusts some code-block languages

Preview: https://deploy-preview-2368--opentelemetry.netlify.app/docs/instrumentation/net/