### PR TITLE
Enable Prettier check over instrumentation/js

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -23,7 +23,6 @@ package-lock.json
 content/en/docs/instrumentation/cpp
 content/en/docs/instrumentation/erlang
 content/en/docs/instrumentation/go
-content/en/docs/instrumentation/js
 content/en/docs/instrumentation/other
 content/en/docs/instrumentation/php
 content/en/docs/instrumentation/ruby

--- a/content/en/docs/instrumentation/js/_index.md
+++ b/content/en/docs/instrumentation/js/_index.md
@@ -1,10 +1,9 @@
 ---
 title: JavaScript
 description: >-
-  <img width="35" class="img-initial"
-  src="/img/logos/32x32/JS_SDK.svg"
-  alt="JavaScript"></img>
-  A language-specific implementation of OpenTelemetry in JavaScript (for Node.js & the browser).
+  <img width="35" class="img-initial" src="/img/logos/32x32/JS_SDK.svg"
+  alt="JavaScript"></img> A language-specific implementation of OpenTelemetry in
+  JavaScript (for Node.js & the browser).
 aliases: [/js, /js/metrics, /js/tracing]
 spelling: cSpell:ignore Roadmap
 weight: 20

--- a/content/en/docs/instrumentation/js/context.md
+++ b/content/en/docs/instrumentation/js/context.md
@@ -5,10 +5,11 @@ aliases: [/docs/instrumentation/js/api/context]
 weight: 8
 ---
 
-In order for OpenTelemetry to work, it must store and propagate important telemetry data.
-For example, when a request is received and a span is started it must be available to a component which creates its child span.
-To solve this problem, OpenTelemetry stores the span in the Context.
-This document describes the OpenTelemetry context API for JavaScript and how it is used.
+In order for OpenTelemetry to work, it must store and propagate important
+telemetry data. For example, when a request is received and a span is started it
+must be available to a component which creates its child span. To solve this
+problem, OpenTelemetry stores the span in the Context. This document describes
+the OpenTelemetry context API for JavaScript and how it is used.
 
 More information:
 
@@ -17,13 +18,14 @@ More information:
 
 ## Context Manager
 
-The context API depends on a context manager to work.
-The examples in this document will assume you have already configured a context manager.
-Typically the context manager is provided by your SDK, however it is possible to register one directly like this:
+The context API depends on a context manager to work. The examples in this
+document will assume you have already configured a context manager. Typically
+the context manager is provided by your SDK, however it is possible to register
+one directly like this:
 
 ```typescript
-import * as api from "@opentelemetry/api";
-import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
+import * as api from '@opentelemetry/api';
+import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 
 const contextManager = new AsyncHooksContextManager();
 contextManager.enable();
@@ -32,20 +34,20 @@ api.context.setGlobalContextManager(contextManager);
 
 ## Root Context
 
-The `ROOT_CONTEXT` is the empty context.
-If no context is active, the `ROOT_CONTEXT` is active.
-Active context is explained below [Active Context](#active-context).
+The `ROOT_CONTEXT` is the empty context. If no context is active, the
+`ROOT_CONTEXT` is active. Active context is explained below
+[Active Context](#active-context).
 
 ## Context Keys
 
-Context entries are key-value pairs.
-Keys can be created by calling `api.createContextKey(description)`.
+Context entries are key-value pairs. Keys can be created by calling
+`api.createContextKey(description)`.
 
 ```typescript
-import * as api from "@opentelemetry/api";
+import * as api from '@opentelemetry/api';
 
-const key1 = api.createContextKey("My first key");
-const key2 = api.createContextKey("My second key");
+const key1 = api.createContextKey('My first key');
+const key2 = api.createContextKey('My second key');
 ```
 
 ## Basic Operations
@@ -55,9 +57,9 @@ const key2 = api.createContextKey("My second key");
 Entries are accessed using the `context.getValue(key)` method.
 
 ```typescript
-import * as api from "@opentelemetry/api";
+import * as api from '@opentelemetry/api';
 
-const key = api.createContextKey("some key");
+const key = api.createContextKey('some key');
 // ROOT_CONTEXT is the empty context
 const ctx = api.ROOT_CONTEXT;
 
@@ -66,101 +68,111 @@ const value = ctx.getValue(key);
 
 ### Set Entry
 
-Entries are created by using the `context.setValue(key, value)` method.
-Setting a context entry creates a new context with all the entries of the previous context, but with the new entry.
-Setting a context entry does not modify the previous context.
+Entries are created by using the `context.setValue(key, value)` method. Setting
+a context entry creates a new context with all the entries of the previous
+context, but with the new entry. Setting a context entry does not modify the
+previous context.
 
 ```typescript
-import * as api from "@opentelemetry/api";
+import * as api from '@opentelemetry/api';
 
-const key = api.createContextKey("some key");
+const key = api.createContextKey('some key');
 const ctx = api.ROOT_CONTEXT;
 
 // add a new entry
-const ctx2 = ctx.setValue(key, "context 2");
+const ctx2 = ctx.setValue(key, 'context 2');
 
 // ctx2 contains the new entry
-console.log(ctx2.getValue(key)) // "context 2"
+console.log(ctx2.getValue(key)); // "context 2"
 
 // ctx is unchanged
-console.log(ctx.getValue(key)) // undefined
+console.log(ctx.getValue(key)); // undefined
 ```
 
 ### Delete Entry
 
-Entries are removed by calling `context.deleteValue(key)`.
-Deleting a context entry creates a new context with all the entries of the previous context, but without the entry identified by the key.
-Deleting a context entry does not modify the previous context.
+Entries are removed by calling `context.deleteValue(key)`. Deleting a context
+entry creates a new context with all the entries of the previous context, but
+without the entry identified by the key. Deleting a context entry does not
+modify the previous context.
 
 ```typescript
-import * as api from "@opentelemetry/api";
+import * as api from '@opentelemetry/api';
 
-const key = api.createContextKey("some key");
+const key = api.createContextKey('some key');
 const ctx = api.ROOT_CONTEXT;
-const ctx2 = ctx.setValue(key, "context 2");
+const ctx2 = ctx.setValue(key, 'context 2');
 
 // remove the entry
 const ctx3 = ctx.deleteValue(key);
 
 // ctx3 does not contain the entry
-console.log(ctx3.getValue(key)) // undefined
+console.log(ctx3.getValue(key)); // undefined
 
 // ctx2 is unchanged
-console.log(ctx2.getValue(key)) // "context 2"
+console.log(ctx2.getValue(key)); // "context 2"
 // ctx is unchanged
-console.log(ctx.getValue(key)) // undefined
+console.log(ctx.getValue(key)); // undefined
 ```
 
 ## Active Context
 
-**IMPORTANT**: This assumes you have configured a Context Manager.
-Without one, `api.context.active()` will _ALWAYS_ return the `ROOT_CONTEXT`.
+**IMPORTANT**: This assumes you have configured a Context Manager. Without one,
+`api.context.active()` will _ALWAYS_ return the `ROOT_CONTEXT`.
 
 The active context is the context which is returned by `api.context.active()`.
-The context object contains entries which allow tracing components which are tracing a single thread of execution to communicate with each other and ensure the trace is successfully created.
-For example, when a span is created it may be added to the context.
-Later, when another span is created it may use the span from the context as its parent span.
-This is accomplished through the use of mechanisms like [async_hooks](https://nodejs.org/api/async_hooks.html) or [AsyncLocalStorage](https://nodejs.org/api/async_context.html#async_context_class_asynclocalstorage) in node, or [zone.js](https://github.com/angular/angular/tree/main/packages/zone.js) on the web in order to propagate the context through a single execution.
-If no context is active, the `ROOT_CONTEXT` is returned, which is just the empty context object.
+The context object contains entries which allow tracing components which are
+tracing a single thread of execution to communicate with each other and ensure
+the trace is successfully created. For example, when a span is created it may be
+added to the context. Later, when another span is created it may use the span
+from the context as its parent span. This is accomplished through the use of
+mechanisms like [async_hooks](https://nodejs.org/api/async_hooks.html) or
+[AsyncLocalStorage](https://nodejs.org/api/async_context.html#async_context_class_asynclocalstorage)
+in node, or
+[zone.js](https://github.com/angular/angular/tree/main/packages/zone.js) on the
+web in order to propagate the context through a single execution. If no context
+is active, the `ROOT_CONTEXT` is returned, which is just the empty context
+object.
 
 ### Get Active Context
 
 The active context is the context which is returned by `api.context.active()`.
 
 ```typescript
-import * as api from "@opentelemetry/api";
+import * as api from '@opentelemetry/api';
 
 // Returns the active context
 // If no context is active, the ROOT_CONTEXT is returned
-const ctx =  api.context.active();
+const ctx = api.context.active();
 ```
 
 ### Set Active Context
 
-A context can be made active by use of `api.context.with(ctx, callback)`.
-During execution of the `callback`, the context passed to `with` will be returned by `context.active`.
+A context can be made active by use of `api.context.with(ctx, callback)`. During
+execution of the `callback`, the context passed to `with` will be returned by
+`context.active`.
 
 ```typescript
-import * as api from "@opentelemetry/api";
+import * as api from '@opentelemetry/api';
 
-const key = api.createContextKey("Key to store a value");
+const key = api.createContextKey('Key to store a value');
 const ctx = api.context.active();
 
-api.context.with(ctx.setValue(key, "context 2"), async () => {
+api.context.with(ctx.setValue(key, 'context 2'), async () => {
   // "context 2" is active
-  console.log(api.context.active().getValue(key)) // "context 2"
+  console.log(api.context.active().getValue(key)); // "context 2"
 });
 ```
 
-The return value of `api.context.with(context, callback)` is the return value of the callback.
-The callback is always called synchronously.
+The return value of `api.context.with(context, callback)` is the return value of
+the callback. The callback is always called synchronously.
 
 ```typescript
-import * as api from "@opentelemetry/api";
+import * as api from '@opentelemetry/api';
 
 const name = await api.context.with(api.context.active(), async () => {
   const row = await db.getSomeValue();
-  return row["name"];
+  return row['name'];
 });
 
 console.log(name); // name returned by the db
@@ -169,23 +181,23 @@ console.log(name); // name returned by the db
 Active context executions may be nested.
 
 ```typescript
-import * as api from "@opentelemetry/api";
+import * as api from '@opentelemetry/api';
 
-const key = api.createContextKey("Key to store a value");
+const key = api.createContextKey('Key to store a value');
 const ctx = api.context.active();
 
 // No context is active
 console.log(api.context.active().getValue(key)); // undefined
 
-api.context.with(ctx.setValue(key, "context 2"), () => {
+api.context.with(ctx.setValue(key, 'context 2'), () => {
   // "context 2" is active
-  console.log(api.context.active().getValue(key)) // "context 2"
-  api.context.with(ctx.setValue(key, "context 3"), () => {
+  console.log(api.context.active().getValue(key)); // "context 2"
+  api.context.with(ctx.setValue(key, 'context 3'), () => {
     // "context 3" is active
-    console.log(api.context.active().getValue(key)) // "context 3"
+    console.log(api.context.active().getValue(key)); // "context 3"
   });
   // "context 2" is active
-  console.log(api.context.active().getValue(key)) // "context 2"
+  console.log(api.context.active().getValue(key)); // "context 2"
 });
 
 // No context is active
@@ -194,33 +206,34 @@ console.log(api.context.active().getValue(key)); // undefined
 
 ### Example
 
-This more complex example illustrates how the context is not modified, but new context objects are created.
+This more complex example illustrates how the context is not modified, but new
+context objects are created.
 
 ```typescript
-import * as api from "@opentelemetry/api";
+import * as api from '@opentelemetry/api';
 
-const key = api.createContextKey("Key to store a value");
+const key = api.createContextKey('Key to store a value');
 
-const ctx =  api.context.active(); // Returns ROOT_CONTEXT when no context is active
-const ctx2 = ctx.setValue(key, "context 2"); // does not modify ctx
+const ctx = api.context.active(); // Returns ROOT_CONTEXT when no context is active
+const ctx2 = ctx.setValue(key, 'context 2'); // does not modify ctx
 
-console.log(ctx.getValue(key)) //? undefined
-console.log(ctx2.getValue(key)) //? "context 2"
+console.log(ctx.getValue(key)); //? undefined
+console.log(ctx2.getValue(key)); //? "context 2"
 
 const ret = api.context.with(ctx2, () => {
-    const ctx3 = api.context.active().setValue(key, "context 3");
+  const ctx3 = api.context.active().setValue(key, 'context 3');
 
-    console.log(api.context.active().getValue(key)); //? "context 2"
-    console.log(ctx.getValue(key)) //? undefined
-    console.log(ctx2.getValue(key)) //? "context 2"
-    console.log(ctx3.getValue(key)) //? "context 3"
+  console.log(api.context.active().getValue(key)); //? "context 2"
+  console.log(ctx.getValue(key)); //? undefined
+  console.log(ctx2.getValue(key)); //? "context 2"
+  console.log(ctx3.getValue(key)); //? "context 3"
 
-    api.context.with(ctx3, () => {
-        console.log(api.context.active().getValue(key)); //? "context 3"
-    });
-    console.log(api.context.active().getValue(key)); //? "context 2"
+  api.context.with(ctx3, () => {
+    console.log(api.context.active().getValue(key)); //? "context 3"
+  });
+  console.log(api.context.active().getValue(key)); //? "context 2"
 
-    return "return value"
+  return 'return value';
 });
 
 // The value returned by the callback is returned to the caller

--- a/content/en/docs/instrumentation/js/examples.md
+++ b/content/en/docs/instrumentation/js/examples.md
@@ -13,7 +13,8 @@ The repository of the [JavaScript version of OpenTelemetry][repo] holds some
 [examples][] of how to run real application with OpenTelemetry JavaScript.
 
 [repo]: https://github.com/open-telemetry/opentelemetry-js
-[examples]: https://github.com/open-telemetry/opentelemetry-js/tree/main/examples
+[examples]:
+  https://github.com/open-telemetry/opentelemetry-js/tree/main/examples
 
 ## Plugin & Package Examples
 
@@ -21,14 +22,16 @@ Many of the packages and plugins at the [contributions repository][] for
 OpenTelemetry JavaScript come with an usage example. You can find them in the
 [examples folder][].
 
-[contributions repository]: https://github.com/open-telemetry/opentelemetry-js-contrib
-[examples folder]: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/examples
+[contributions repository]:
+  https://github.com/open-telemetry/opentelemetry-js-contrib
+[examples folder]:
+  https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/examples
 
 ## Community Resources
 
-The [nodejs-opentelemetry-tempo][tempo] project illustrates the use of OpenTelemetry
-(through automatic and manual instrumentation) involving microservices with DB
-interactions. It uses the following:
+The [nodejs-opentelemetry-tempo][tempo] project illustrates the use of
+OpenTelemetry (through automatic and manual instrumentation) involving
+microservices with DB interactions. It uses the following:
 
 - [Prometheus](https://prometheus.io), for monitoring and alerting
 - [Loki](https://grafana.com/oss/loki/), for distributed logging

--- a/content/en/docs/instrumentation/js/exporters.md
+++ b/content/en/docs/instrumentation/js/exporters.md
@@ -1,5 +1,5 @@
 ---
-title: "Exporters"
+title: Exporters
 weight: 5
 ---
 
@@ -8,8 +8,8 @@ backend such as [Jaeger](https://www.jaegertracing.io/) or
 [Zipkin](https://zipkin.io/). OpenTelemetry JS provides exporters for some
 common open source backends.
 
-Below you will find some introductions on how to set up backends and the matching
-exporters.
+Below you will find some introductions on how to set up backends and the
+matching exporters.
 
 ## OTLP endpoint
 
@@ -17,8 +17,8 @@ To send trace data to a OTLP endpoint (like the [collector](/docs/collector) or
 Jaeger) you'll want to use an exporter package, such as
 `@opentelemetry/exporter-trace-otlp-http`:
 
-```console
-$ npm install --save @opentelemetry/exporter-trace-otlp-http
+```shell
+npm install --save @opentelemetry/exporter-trace-otlp-http
 ```
 
 Next, configure the exporter to point at an OTLP endpoint. For example you can
@@ -26,6 +26,7 @@ update `tracing.ts|js` from the
 [Getting Started](/docs/instrumentation/js/getting-started/nodejs/) like the
 following:
 
+<!-- prettier-ignore-start -->
 {{< tabpane langEqualsHeader=true >}}
 {{< tab Typescript >}}
 /*tracing.ts*/
@@ -72,12 +73,13 @@ sdk.start();
 {{< /tab >}}
 
 {{< /tabpane>}}
+<!-- prettier-ignore-end -->
 
 To try out the `OTLPTraceExporter` quickly, you can run Jaeger in a docker
 container:
 
 ```shell
-$ docker run -d --name jaeger \
+docker run -d --name jaeger \
   -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
   -e COLLECTOR_OTLP_ENABLED=true \
   -p 6831:6831/udp \
@@ -100,20 +102,19 @@ that:
 
 1. Using grpc & http/proto for exporting is not supported
 2. [Content Security Policies][] (CSPs) of your website might block your exports
-3. [Cross-Origin Resource Sharing][] (CORS) headers might not allow your exports to be sent
+3. [Cross-Origin Resource Sharing][] (CORS) headers might not allow your exports
+   to be sent
 4. You might need to expose your collector to the public internet
 
 Below you will find instructions to use the right exporter, to configure your
-CSPs and CORS headers and what precautions you have to take when exposing
-your collector.
+CSPs and CORS headers and what precautions you have to take when exposing your
+collector.
 
 #### Use OTLP exporter with HTTP/JSON
 
-[OpenTelemetry Collector Exporter with grpc][] and
-[OpenTelemetry Collector Exporter with protobuf][]
-do only work with Node.JS,
-therefore you are limited to use the
-[OpenTelemetry Collector Exporter with http][].
+[OpenTelemetry Collector Exporter with grpc][] and [OpenTelemetry Collector
+Exporter with protobuf][] do only work with Node.JS, therefore you are limited
+to use the [OpenTelemetry Collector Exporter with http][].
 
 Make sure that the receiving end of your exporter (collector or observability
 backend) does support `http/json`, and that you are exporting your data to the
@@ -122,8 +123,8 @@ right endpoint, i.e., make sure that your port is set to `4318`.
 #### Configure CSPs
 
 If your website is making use of Content Security Policies (CSPs), make sure
-that the domain of your OTLP endpoint is included. If your collector endpoint
-is `https://collector.example.com:4318/v1/traces`, add the following directive:
+that the domain of your OTLP endpoint is included. If your collector endpoint is
+`https://collector.example.com:4318/v1/traces`, add the following directive:
 
 ```text
 connect-src collector.example.com:4318/v1/traces
@@ -138,8 +139,9 @@ If your website and collector are hosted at a different origin, your browser
 might block the requests going out to your collector. You need to configure
 special headers for Cross-Origin Resource Sharing (CORS).
 
-The OpenTelemetry collector provides [a feature][] for http-based receivers to add
-the required headers to allow the receiver to accept traces from a web browser:
+The OpenTelemetry collector provides [a feature][] for http-based receivers to
+add the required headers to allow the receiver to accept traces from a web
+browser:
 
 ```yaml
 receivers:
@@ -168,8 +170,8 @@ put a reverse proxy (nginx, apache, ...) in front of it. The reverse proxy can
 take care of SSL-offloading, setting the right CORS headers, and many other
 features specific to web applications.
 
-Below you will find a configuration for the popular nginx webserver to get
-you started:
+Below you will find a configuration for the popular nginx webserver to get you
+started:
 
 ```nginx
 server {
@@ -216,6 +218,7 @@ npm install --save @opentelemetry/exporter-zipkin
 Update your opentelemetry configuration to use the exporter and to send data to
 your zipkin backend:
 
+<!-- prettier-ignore-start -->
 {{< tabpane langEqualsHeader=true >}}
 {{< tab Typescript >}}
 import { ZipkinExporter } from "@opentelemetry/exporter-zipkin";
@@ -230,18 +233,18 @@ const { BatchSpanProcessor } = require("@opentelemetry/sdk-trace-base");
 
 provider.addSpanProcessor(new BatchSpanProcessor(new ZipkinExporter()));
 {{< /tab >}}
-
 {{< /tabpane>}}
+<!-- prettier-ignore-end -->
 
-[Content Security Policies]:
+[content security policies]:
   https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/
 [cross-origin resource sharing]:
   https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
-[OpenTelemetry Collector Exporter with grpc]:
+[opentelemetry collector exporter with grpc]:
   https://www.npmjs.com/package/@opentelemetry/exporter-trace-otlp-grpc
-[OpenTelemetry Collector Exporter with protobuf]:
+[opentelemetry collector exporter with protobuf]:
   https://www.npmjs.com/package/@opentelemetry/exporter-trace-otlp-proto
-[OpenTelemetry Collector Exporter with http]:
+[opentelemetry collector exporter with http]:
   https://www.npmjs.com/package/@opentelemetry/exporter-trace-otlp-http
 [a feature]:
   https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/confighttp/README.md

--- a/content/en/docs/instrumentation/js/getting-started/_index.md
+++ b/content/en/docs/instrumentation/js/getting-started/_index.md
@@ -8,5 +8,6 @@ These two guides for Node.js and the browser use simple examples in javascript
 to get you started with OpenTelemetry. Both will show you the following steps:
 
 - Install the required OpenTelemetry libraries
-- Initialize a global [tracer]({{< relref "/docs/reference/specification/trace/api#tracer" >}})
-- Initialize and register a [span exporter]({{< relref "/docs/reference/specification/trace/sdk#span-exporter" >}})
+- Initialize a global [tracer](/docs/reference/specification/trace/api/#tracer)
+- Initialize and register a
+  [span exporter](/docs/reference/specification/trace/sdk/#span-exporter)

--- a/content/en/docs/instrumentation/js/getting-started/browser.md
+++ b/content/en/docs/instrumentation/js/getting-started/browser.md
@@ -11,7 +11,8 @@ instrument your own application should be similar.
 Ensure that you have the following installed locally:
 
 - [Node.js](https://nodejs.org/en/download/)
-- [TypeScript](https://www.typescriptlang.org/download), if you will be using TypeScript.
+- [TypeScript](https://www.typescriptlang.org/download), if you will be using
+  TypeScript.
 
 ## Example Application
 
@@ -23,25 +24,29 @@ Copy the following file into an empty directory and call it `index.html`.
 ```html
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>Document Load Instrumentation Example</title>
-  <base href="/">
-  <!--
-    https://www.w3.org/TR/trace-context/
-    Set the `traceparent` in the server's HTML template code. It should be
-    dynamically generated server side to have the server's request trace Id,
-    a parent span Id that was set on the server's request span, and the trace
-    flags to indicate the server's sampling decision
-    (01 = sampled, 00 = notsampled).
-    '{version}-{traceId}-{spanId}-{sampleDecision}'
-  -->
-  <meta name="traceparent" content="00-ab42124a3c573678d4d8b21ba52df3bf-d21f7bc17caa5aba-01">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-</head>
-<body>
-  Example of using Web Tracer with document load instrumentation with console exporter and collector exporter
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <title>Document Load Instrumentation Example</title>
+    <base href="/" />
+    <!--
+      https://www.w3.org/TR/trace-context/
+      Set the `traceparent` in the server's HTML template code. It should be
+      dynamically generated server side to have the server's request trace Id,
+      a parent span Id that was set on the server's request span, and the trace
+      flags to indicate the server's sampling decision
+      (01 = sampled, 00 = notsampled).
+      '{version}-{traceId}-{spanId}-{sampleDecision}'
+    -->
+    <meta
+      name="traceparent"
+      content="00-ab42124a3c573678d4d8b21ba52df3bf-d21f7bc17caa5aba-01"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    Example of using Web Tracer with document load instrumentation with console
+    exporter and collector exporter
+  </body>
 </html>
 ```
 
@@ -74,20 +79,19 @@ npm install --save-dev parcel
 ```
 
 Create an empty code file named `document-load` with a `.ts` or `.js` extension,
-as appropriate, based on the language you've chosen to write your app in. Add the
-following code to your HTML right before the `</body>` closing tag:
+as appropriate, based on the language you've chosen to write your app in. Add
+the following code to your HTML right before the `</body>` closing tag:
 
+<!-- prettier-ignore-start -->
 {{< tabpane lang=html >}}
-
 {{< tab TypeScript >}}
 <script type="module" src="document-load.ts"></script>
 {{< /tab >}}
-
 {{< tab JavaScript >}}
 <script type="module" src="document-load.js"></script>
 {{< /tab >}}
-
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 We will add some code that will trace the document load timings and output those
 as OpenTelemetry Spans.
@@ -113,9 +117,7 @@ provider.register({
 
 // Registering instrumentations
 registerInstrumentations({
-  instrumentations: [
-    new DocumentLoadInstrumentation(),
-  ],
+  instrumentations: [new DocumentLoadInstrumentation()],
 });
 ```
 
@@ -125,24 +127,32 @@ Now build the app with parcel:
 npx parcel index.html
 ```
 
-and open the development webserver (e.g. at `http://localhost:1234`) to see if your code works.
+and open the development webserver (e.g. at `http://localhost:1234`) to see if
+your code works.
 
 There will be no output of traces yet, for this we need to add an exporter.
 
 ### Creating an Exporter
 
-In the following example, we will use the `ConsoleSpanExporter` which prints all spans to the console.
+In the following example, we will use the `ConsoleSpanExporter` which prints all
+spans to the console.
 
-In order to visualize and analyze your traces, you will need to export them to a tracing backend.
-Follow [these instructions](../../exporters) for setting up a backend and exporter.
+In order to visualize and analyze your traces, you will need to export them to a
+tracing backend. Follow [these instructions](../../exporters) for setting up a
+backend and exporter.
 
-You may also want to use the `BatchSpanProcessor` to export spans in batches in order to more efficiently use resources.
+You may also want to use the `BatchSpanProcessor` to export spans in batches in
+order to more efficiently use resources.
 
-To export traces to the console, modify `document-load.ts|js` so that it matches the following code snippet:
+To export traces to the console, modify `document-load.ts|js` so that it matches
+the following code snippet:
 
 ```js
 /* document-load.ts|js file - the code is the same for both the languages */
-import { ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import {
+  ConsoleSpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
 import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
 import { DocumentLoadInstrumentation } from '@opentelemetry/instrumentation-document-load';
 import { ZoneContextManager } from '@opentelemetry/context-zone';
@@ -158,9 +168,7 @@ provider.register({
 
 // Registering instrumentations
 registerInstrumentations({
-  instrumentations: [
-    new DocumentLoadInstrumentation(),
-  ],
+  instrumentations: [new DocumentLoadInstrumentation()],
 });
 ```
 
@@ -186,59 +194,35 @@ developer toolbar you should see some traces being exported:
   "events": [
     {
       "name": "fetchStart",
-      "time": [
-        1606814247,
-        811266158
-      ]
+      "time": [1606814247, 811266158]
     },
     {
       "name": "domainLookupStart",
-      "time": [
-        1606814247,
-        811266158
-      ]
+      "time": [1606814247, 811266158]
     },
     {
       "name": "domainLookupEnd",
-      "time": [
-        1606814247,
-        811266158
-      ]
+      "time": [1606814247, 811266158]
     },
     {
       "name": "connectStart",
-      "time": [
-        1606814247,
-        811266158
-      ]
+      "time": [1606814247, 811266158]
     },
     {
       "name": "connectEnd",
-      "time": [
-        1606814247,
-        811266158
-      ]
+      "time": [1606814247, 811266158]
     },
     {
       "name": "requestStart",
-      "time": [
-        1606814247,
-        819101158
-      ]
+      "time": [1606814247, 819101158]
     },
     {
       "name": "responseStart",
-      "time": [
-        1606814247,
-        819791158
-      ]
+      "time": [1606814247, 819791158]
     },
     {
       "name": "responseEnd",
-      "time": [
-        1606814247,
-        820656158
-      ]
+      "time": [1606814247, 820656158]
     }
   ]
 }
@@ -253,7 +237,7 @@ register additional instrumentations for those:
 registerInstrumentations({
   instrumentations: [
     new UserInteractionInstrumentation(),
-    new XMLHttpRequestInstrumentation()
+    new XMLHttpRequestInstrumentation(),
   ],
 });
 ```
@@ -262,4 +246,3 @@ registerInstrumentations({
 
 To leverage the most common instrumentations all in one you can simply use the
 [OpenTelemetry Meta Packages for Web](https://www.npmjs.com/package/@opentelemetry/auto-instrumentations-web)
-

--- a/content/en/docs/instrumentation/js/getting-started/nodejs.md
+++ b/content/en/docs/instrumentation/js/getting-started/nodejs.md
@@ -10,7 +10,8 @@ This guide will show you how to get started with tracing in Node.js.
 Ensure that you have the following installed locally:
 
 - [Node.js](https://nodejs.org/en/download/)
-- [TypeScript](https://www.typescriptlang.org/download), if you will be using TypeScript.
+- [TypeScript](https://www.typescriptlang.org/download), if you will be using
+  TypeScript.
 
 ## Example Application
 
@@ -26,6 +27,7 @@ npm init -f
 
 Install dependencies used by the example.
 
+<!-- prettier-ignore-start -->
 {{< tabpane lang=shell >}}
 
 {{< tab TypeScript >}}
@@ -37,6 +39,7 @@ npm install express
 {{< /tab >}}
 
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 ### Code
 
@@ -48,6 +51,7 @@ tsc --init
 
 Create `app.ts|js` and add the following code to the file:
 
+<!-- prettier-ignore-start -->
 {{< tabpane langEqualsHeader=true >}}
 
 {{< tab TypeScript >}}
@@ -83,10 +87,12 @@ app.listen(PORT, () => {
 {{< /tab >}}
 
 {{< /tabpane>}}
+<!-- prettier-ignore-end -->
 
 Run the application with the following request and open <http://localhost:8080>
 in your web browser to ensure it is working.
 
+<!-- prettier-ignore-start -->
 {{< tabpane lang=console >}}
 
 {{< tab TypeScript >}}
@@ -100,6 +106,7 @@ Listening for requests on http://localhost:8080
 {{< /tab >}}
 
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 ## Tracing
 
@@ -117,22 +124,25 @@ npm install @opentelemetry/sdk-node @opentelemetry/api
 
 #### Exporter
 
-In the following example, we will use the `ConsoleSpanExporter` which prints all spans to the console.
+In the following example, we will use the `ConsoleSpanExporter` which prints all
+spans to the console.
 
-In order to visualize and analyze your traces, you will need to export them to a tracing backend.
-Follow [these instructions](../../exporters) for setting up a backend and exporter.
+In order to visualize and analyze your traces, you will need to export them to a
+tracing backend. Follow [these instructions](../../exporters) for setting up a
+backend and exporter.
 
-You may also want to use the `BatchSpanProcessor` to export spans in batches in order to more efficiently use resources.
+You may also want to use the `BatchSpanProcessor` to export spans in batches in
+order to more efficiently use resources.
 
 #### Instrumentation Modules
 
 Many common modules such as the `http` standard library module, `express`, and
-others can be automatically instrumented using autoinstrumentation modules.
-To find autoinstrumentation modules, you can look at the
+others can be automatically instrumented using autoinstrumentation modules. To
+find autoinstrumentation modules, you can look at the
 [registry](/ecosystem/registry/?language=js&component=instrumentation).
 
-You can also install all instrumentations maintained by the OpenTelemetry authors
-by using the `@opentelemetry/auto-instrumentations-node` module.
+You can also install all instrumentations maintained by the OpenTelemetry
+authors by using the `@opentelemetry/auto-instrumentations-node` module.
 
 ```shell
 npm install @opentelemetry/auto-instrumentations-node
@@ -142,10 +152,12 @@ npm install @opentelemetry/auto-instrumentations-node
 
 The tracing setup and configuration should be run before your application code.
 One tool commonly used for this task is the
-[`-r, --require module`](https://nodejs.org/api/cli.html#cli_r_require_module) flag.
+[`-r, --require module`](https://nodejs.org/api/cli.html#cli_r_require_module)
+flag.
 
 Create a file named `tracing.ts|js`, which will contain your tracing setup code.
 
+<!-- prettier-ignore-start -->
 {{< tabpane langEqualsHeader=true >}}
 
 {{< tab TypeScript >}}
@@ -185,12 +197,14 @@ sdk.start()
 {{< /tab >}}
 
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 ### Run Application
 
 Now you can run your application as you normally would, but you can use the
 `--require` flag to load the tracing code before the application code.
 
+<!-- prettier-ignore-start -->
 {{< tabpane lang=console >}}
 
 {{< tab TypeScript >}}
@@ -204,9 +218,11 @@ Listening for requests on http://localhost:8080
 {{< /tab >}}
 
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
-Open <http://localhost:8080> in your web browser and reload the page a few times,
-after a while you should see the spans printed in the console by the `ConsoleSpanExporter`.
+Open <http://localhost:8080> in your web browser and reload the page a few
+times, after a while you should see the spans printed in the console by the
+`ConsoleSpanExporter`.
 
 <details>
 <summary>View example output</summary>
@@ -295,16 +311,19 @@ after a while you should see the spans printed in the console by the `ConsoleSpa
 ## Next Steps
 
 Enrich your instrumentation generated automatically with
-[manual instrumentation](/docs/instrumentation/js/instrumentation) of your own codebase.
-This gets you customized observability data.
+[manual instrumentation](/docs/instrumentation/js/instrumentation) of your own
+codebase. This gets you customized observability data.
 
-You'll also want to configure an appropriate exporter to [export your telemetry
-data](/docs/instrumentation/js/exporters) to one or more telemetry backends.
+You'll also want to configure an appropriate exporter to
+[export your telemetry data](/docs/instrumentation/js/exporters) to one or more
+telemetry backends.
 
 ## Troubleshooting
 
-Did something go wrong? Remember that you need to explicitly enable logging in order to see logs from OpenTelemetry:
+Did something go wrong? Remember that you need to explicitly enable logging in
+order to see logs from OpenTelemetry:
 
+<!-- prettier-ignore-start -->
 {{< tabpane langEqualsHeader=true >}}
 
 {{< tab TypeScript >}}
@@ -329,3 +348,4 @@ diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
 {{< /tab >}}
 
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->

--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -36,6 +36,7 @@ npm install \
 Next, create a separate `tracing.js|ts` file that has all the SDK initialization
 code in it:
 
+<!-- prettier-ignore-start -->
 {{< tabpane langEqualsHeader=true >}}
 
 {{< tab TypeScript >}}
@@ -103,10 +104,12 @@ provider.register();
 {{< /tab >}}
 
 {{< /tabpane>}}
+<!-- prettier-ignore-end -->
 
-Next, ensure that `tracing.js|ts` is required in your node invocation. This is also
-required if you're registering instrumentation libraries. For example:
+Next, ensure that `tracing.js|ts` is required in your node invocation. This is
+also required if you're registering instrumentation libraries. For example:
 
+<!-- prettier-ignore-start -->
 {{< tabpane lang=shell >}}
 
 {{< tab TypeScript >}}
@@ -118,6 +121,7 @@ node --require './tracing.js' <app-file.js>
 {{< /tab >}}
 
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 #### Browser
 
@@ -135,6 +139,7 @@ npm install \
 Create a `tracing.js|ts` file that initialized the Web SDK, creates a
 `TracerProvider`, and exports a `Tracer`.
 
+<!-- prettier-ignore-start -->
 {{< tabpane langEqualsHeader=true >}}
 {{< tab TypeScript >}}
 import { Resource } from "@opentelemetry/resources";
@@ -199,6 +204,7 @@ provider.register();
 {{< /tab >}}
 
 {{< /tabpane>}}
+<!-- prettier-ignore-end -->
 
 You'll need to bundle this file with your web application to be able to use
 tracing throughout the rest of your web application.
@@ -226,6 +232,7 @@ In most cases, stick with `BatchSpanProcessor` over `SimpleSpanProcessor`.
 Anywhere in your application where you write manual tracing code should call
 `getTracer` to acquire a tracer. For example:
 
+<!-- prettier-ignore-start -->
 {{< tabpane langEqualsHeader=true >}}
 {{< tab TypeScript >}}
 import opentelemetry from "@opentelemetry/api";
@@ -248,6 +255,7 @@ const tracer = opentelemetry.trace.getTracer(
 // You can now use a 'tracer' to do tracing!
 {{< /tab >}}
 {{< /tabpane>}}
+<!-- prettier-ignore-end -->
 
 It's generally recommended to call `getTracer` in your app when you need it
 rather than exporting the `tracer` instance to the rest of your app. This helps
@@ -262,9 +270,9 @@ initialized, you can create
 
 ```javascript
 // Create a span. A span must be closed.
-tracer.startActiveSpan('main', span => {
+tracer.startActiveSpan('main', (span) => {
   for (let i = 0; i < 10; i += 1) {
-    console.log(i)
+    console.log(i);
   }
 
   // Be sure to end the span!
@@ -284,17 +292,17 @@ tracks the `doWork` function:
 
 ```javascript
 const mainWork = () => {
-  tracer.startActiveSpan('main', parentSpan => {
+  tracer.startActiveSpan('main', (parentSpan) => {
     for (let i = 0; i < 3; i += 1) {
       doWork(i);
     }
     // Be sure to end the parent span!
     parentSpan.end();
   });
-}
+};
 
 const doWork = (i) => {
-  tracer.startActiveSpan(`doWork:${i}`, span => {
+  tracer.startActiveSpan(`doWork:${i}`, (span) => {
     // simulate some random work.
     for (let i = 0; i <= Math.floor(Math.random() * 40000000); i += 1) {
       // empty
@@ -304,7 +312,7 @@ const doWork = (i) => {
     // it will continue to track work beyond 'doWork'!
     span.end();
   });
-}
+};
 ```
 
 This code will create 3 child spans that have `parentSpan`'s span ID as their
@@ -328,7 +336,7 @@ const doWork = () => {
   span1.end();
   span2.end();
   span3.end();
-}
+};
 ```
 
 In this example, `span1`, `span2`, and `span3` are sibling spans and none of
@@ -370,26 +378,28 @@ pairs to a [`Span`](/docs/concepts/signals/traces/#spans-in-opentelemetry) so it
 carries more information about the current operation that it's tracking.
 
 ```javascript
-tracer.startActiveSpan('app.new-span', span => {
+tracer.startActiveSpan('app.new-span', (span) => {
   // do some work...
 
   // Add an attribute to the span
   span.setAttribute('attribute1', 'value1');
-  
+
   span.end();
 });
 ```
+
 You can also add attributes to a span as it's created:
 
 ```javascript
 tracer.startActiveSpan(
   'app.new-span',
   { attributes: { attribute1: 'value1' } },
-  span => {
+  (span) => {
     // do some work...
-    
+
     span.end();
-  });
+  }
+);
 ```
 
 #### Semantic Attributes
@@ -397,8 +407,8 @@ tracer.startActiveSpan(
 There are semantic conventions for spans representing operations in well-known
 protocols like HTTP or database calls. Semantic conventions for these spans are
 defined in the specification at [Trace Semantic Conventions]({{< relref
-"/docs/reference/specification/trace/semantic_conventions" >}}). In the simple
-example of this guide the source code attributes can be used.
+"/docs/reference/specification/trace/semantic_conventions" >}}). In the simple example
+of this guide the source code attributes can be used.
 
 First add the semantic conventions as a dependency to your application:
 
@@ -408,6 +418,7 @@ npm install --save @opentelemetry/semantic-conventions
 
 Add the following to the top of your application file:
 
+<!-- prettier-ignore-start -->
 {{< tabpane langEqualsHeader=true >}}
 {{< tab TypeScript >}}
 import { SemanticAttributes } from "@opentelemetry/semantic-conventions";
@@ -416,20 +427,21 @@ import { SemanticAttributes } from "@opentelemetry/semantic-conventions";
 const { SemanticAttributes } = require('@opentelemetry/semantic-conventions');
 {{< /tab >}}
 {{< /tabpane>}}
+<!-- prettier-ignore-end -->
 
 Finally, you can update your file to include semantic attributes:
 
 ```javascript
 const doWork = () => {
-  tracer.startActiveSpan('app.doWork', span => {
+  tracer.startActiveSpan('app.doWork', (span) => {
     span.setAttribute(SemanticAttributes.CODE_FUNCTION, 'doWork');
     span.setAttribute(SemanticAttributes.CODE_FILEPATH, __filename);
-  
+
     // Do some work...
 
     span.end();
   });
-}
+};
 ```
 
 ### Span events
@@ -463,7 +475,6 @@ with zero or more [`Link`s](/docs/concepts/signals/traces/#span-links) to other
 Spans that are causally related. A common scenario is to correlate one or more
 traces with the current span.
 
-
 ```js
 const someFunction = (spanToLinkFrom) => {
   const options = {
@@ -490,6 +501,7 @@ typically used to specify that a span has not completed successfully -
 
 The status can be set at any time before the span is finished:
 
+<!-- prettier-ignore-start -->
 {{< tabpane langEqualsHeader=true >}}
 {{< tab TypeScript >}}
 import opentelemetry from "@opentelemetry/api";
@@ -523,11 +535,12 @@ tracer.startActiveSpan('app.doWork', span => {
       });
     }
   }
-  
+
   span.end();
 });
 {{< /tab >}}
 {{< /tabpane>}}
+<!-- prettier-ignore-end -->
 
 By default, the status for all spans is `Unset` rather than `Ok`. It is
 typically the job of another component in your telemetry pipeline to interpret
@@ -539,6 +552,7 @@ explicitly tracking an error.
 It can be a good idea to record exceptions when they happen. It's recommended to
 do this in conjunction with setting [span status](#span-status).
 
+<!-- prettier-ignore-start -->
 {{< tabpane langEqualsHeader=true >}}
 {{< tab TypeScript >}}
 import opentelemetry from "@opentelemetry/api";
@@ -565,6 +579,7 @@ try {
 }
 {{< /tab >}}
 {{< /tabpane>}}
+<!-- prettier-ignore-end -->
 
 ### Using `sdk-trace-base` and manually propagating span context
 
@@ -577,6 +592,7 @@ nested spans.
 
 Initializing tracing is similar to how you'd do it with Node.js or the Web SDK.
 
+<!-- prettier-ignore-start -->
 {{< tabpane langEqualsHeader=true >}}
 {{< tab TypeScript >}}
 import opentelemetry from "@opentelemetry/api";
@@ -617,6 +633,7 @@ const tracer = opentelemetry.trace.getTracer(
 );
 {{< /tab >}}
 {{< /tabpane>}}
+<!-- prettier-ignore-end -->
 
 Like the other examples in this document, this exports a tracer you can use
 throughout the app.
@@ -637,7 +654,7 @@ const mainWork = () => {
 
   // Be sure to end the parent span!
   parentSpan.end();
-}
+};
 
 const doWork = (parent, i) => {
   // To create a child span, we need to mark the current (parent) span as the active span
@@ -656,7 +673,7 @@ const doWork = (parent, i) => {
   // Make sure to end this child span! If you don't,
   // it will continue to track work beyond 'doWork'!
   span.end();
-}
+};
 ```
 
 All other APIs behave the same when you use `sdk-trace-base` compared with the
@@ -669,23 +686,25 @@ initialized `MeterProvider` that lets you create a `Meter`. `Meter`s let you
 create `Instrument`s that you can use to create different kinds of metrics.
 OpenTelemetry JavaScript currently supports the following `Instrument`s:
 
-* Counter, a synchronous instrument which supports non-negative increments
-* Asynchronous Counter, a asynchronous instrument which supports non-negative
+- Counter, a synchronous instrument which supports non-negative increments
+- Asynchronous Counter, a asynchronous instrument which supports non-negative
   increments
-* Histogram, a synchronous instrument which supports arbitrary values that are
+- Histogram, a synchronous instrument which supports arbitrary values that are
   statistically meaningful, such as histograms, summaries or percentile
-* Asynchronous Gauge, an asynchronous instrument which supports non-additive
+- Asynchronous Gauge, an asynchronous instrument which supports non-additive
   values, such as room temperature
-* UpDownCounter, a synchronous instrument which supports increments and
+- UpDownCounter, a synchronous instrument which supports increments and
   decrements, such as number of active requests
-* Asynchronous UpDownCounter, an asynchronous instrument which supports
+- Asynchronous UpDownCounter, an asynchronous instrument which supports
   increments and decrements
 
-For more on synchronous and asynchronous instruments, and which kind is best suited for your use case, see [Supplementary Guidelines](/docs/reference/specification/metrics/supplementary-guidelines/).
+For more on synchronous and asynchronous instruments, and which kind is best
+suited for your use case, see
+[Supplementary Guidelines](/docs/reference/specification/metrics/supplementary-guidelines/).
 
 If a `MeterProvider` is not created either by an instrumentation library or
-manually, the OpenTelemetry Metrics API will use a no-op implementation and
-fail to generate data.
+manually, the OpenTelemetry Metrics API will use a no-op implementation and fail
+to generate data.
 
 ### Initialize Metrics
 
@@ -702,6 +721,8 @@ npm install \
 
 Next, create a separate `instrumentation.js|ts` file that has all the SDK
 initialization code in it:
+
+<!-- prettier-ignore-start -->
 {{< tabpane langEqualsHeader=true >}}
 {{< tab TypeScript >}}
 import otel from "@opentelemetry/api";
@@ -773,9 +794,11 @@ myServiceMeterProvider.addMetricReader(metricReader);
 otel.metrics.setGlobalMeterProvider(myServiceMeterProvider)
 {{< /tab >}}
 {{< /tabpane>}}
+<!-- prettier-ignore-end -->
 
 You'll need to `--require` this file when you run your app, such as:
 
+<!-- prettier-ignore-start -->
 {{< tabpane lang=shell >}}
 
 {{< tab TypeScript >}}
@@ -787,14 +810,16 @@ node --require './instrumentation.js' <app-file.js>
 {{< /tab >}}
 
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 Now that a `MeterProvider` is configured, you can acquire a `Meter`.
 
 ### Acquiring a Meter
 
-Anywhere in your application where you have manually instrumented code you can call
-`getMeter` to acquire a meter. For example:
+Anywhere in your application where you have manually instrumented code you can
+call `getMeter` to acquire a meter. For example:
 
+<!-- prettier-ignore-start -->
 {{< tabpane langEqualsHeader=true >}}
 {{< tab TypeScript >}}
 import otel from "@opentelemetry/api";
@@ -816,6 +841,7 @@ const myMeter = otel.metrics.getMeter(
 // You can now use a 'meter' to create instruments!
 {{< /tab >}}
 {{< /tabpane>}}
+<!-- prettier-ignore-end -->
 
 It’s generally recommended to call `getMeter` in your app when you need it
 rather than exporting the meter instance to the rest of your app. This helps
@@ -826,17 +852,30 @@ involved.
 
 OpenTelemetry instruments are either synchronous or asynchronous (observable).
 
-Synchronous instruments take a measurement when they are called. The measurement is done as another call during program execution, just like any other function call. Periodically, the aggregation of these measurements is exported by a configured exporter. Because measurements are decoupled from exporting values, an export cycle may contain zero or multiple aggregated measurements.
+Synchronous instruments take a measurement when they are called. The measurement
+is done as another call during program execution, just like any other function
+call. Periodically, the aggregation of these measurements is exported by a
+configured exporter. Because measurements are decoupled from exporting values,
+an export cycle may contain zero or multiple aggregated measurements.
 
-Asynchronous instruments, on the other hand, provide a measurement at the request of the SDK. When the SDK exports, a callback that was provided to the instrument on creation is invoked. This callback provides the SDK with a measurement that is immediately exported. All measurements on asynchronous instruments are performed once per export cycle. 
+Asynchronous instruments, on the other hand, provide a measurement at the
+request of the SDK. When the SDK exports, a callback that was provided to the
+instrument on creation is invoked. This callback provides the SDK with a
+measurement that is immediately exported. All measurements on asynchronous
+instruments are performed once per export cycle.
 
 Asynchronous instruments are useful in several circumstances, such as:
 
-* When updating a counter is not computationally cheap, and thus you don't want the currently executing thread to have to wait for that measurement
-* Observations need to happen at frequencies unrelated to program execution (i.e., they cannot be accurately measured when tied to a request lifecycle)
-* There is no value from knowing the precise timestamp of increments
+- When updating a counter is not computationally cheap, and thus you don't want
+  the currently executing thread to have to wait for that measurement
+- Observations need to happen at frequencies unrelated to program execution
+  (i.e., they cannot be accurately measured when tied to a request lifecycle)
+- There is no value from knowing the precise timestamp of increments
 
-In cases like these, it's often better to observe a cumulative value directly, rather than aggregate a series of deltas in post-processing (the synchronous example). Take note of the use of `observe` rather than `add` in the appropriate code examples below.
+In cases like these, it's often better to observe a cumulative value directly,
+rather than aggregate a series of deltas in post-processing (the synchronous
+example). Take note of the use of `observe` rather than `add` in the appropriate
+code examples below.
 
 ### Using Counters
 
@@ -854,7 +893,6 @@ counter.add(1);
 
 UpDown counters can increment and decrement, allowing you to observe a
 cumulative value that goes up or down.
-
 
 ```js
 const counter = myMeter.createUpDownCounter('events.counter');
@@ -875,6 +913,7 @@ Histograms are used to measure a distribution of values over time.
 For example, here's how you might report a distribution of response times for an
 API route with Express:
 
+<!-- prettier-ignore-start -->
 {{< tabpane langEqualsHeader=true >}}
 {{< tab TypeScript >}}
 import express from "express";
@@ -914,69 +953,66 @@ app.get('/', (_req, _res) => {
 });
 {{< /tab >}}
 {{< /tabpane>}}
+<!-- prettier-ignore-end -->
 
 ### Using Observable (Async) Counters
 
-Observable counters can be used to measure an additive, non-negative, monotonically increasing value.
+Observable counters can be used to measure an additive, non-negative,
+monotonically increasing value.
 
 ```js
-let events = []
+let events = [];
 
 const addEvent = (name) => {
-  events = append(events, name)
-}
+  events = append(events, name);
+};
 
 const counter = myMeter.createObservableCounter('events.counter');
 
-counter.addCallback(
-  (result) => {
-    result.observe(len(events))
-  }
-)
+counter.addCallback((result) => {
+  result.observe(len(events));
+});
 
 //... calls to addEvent
 ```
 
 ### Using Observable (Async) UpDown Counters
 
-Observable UpDown counters can increment and decrement, allowing you to measure an additive, non-negative, non-monotonically increasing cumulative value.
+Observable UpDown counters can increment and decrement, allowing you to measure
+an additive, non-negative, non-monotonically increasing cumulative value.
 
 ```js
-let events = []
+let events = [];
 
 const addEvent = (name) => {
-  events = append(events, name)
-}
+  events = append(events, name);
+};
 
 const removeEvent = () => {
-  events.pop()
-}
+  events.pop();
+};
 
 const counter = myMeter.createObservableUpDownCounter('events.counter');
 
-counter.addCallback(
-  (result) => {
-    result.observe(len(events))
-  }
-)
+counter.addCallback((result) => {
+  result.observe(len(events));
+});
 
 //... calls to addEvent and removeEvent
 ```
 
 ### Using Observable (Async) Gauges
 
-Observable Gauges should be used to measure non-additive values. 
+Observable Gauges should be used to measure non-additive values.
 
 ```js
-let temperature = 32
+let temperature = 32;
 
 const gauge = myMeter.createObservableGauge('temperature.gauge');
 
-counter.addCallback(
-  (result) => {
-    result.observe(temperature)
-  }
-)
+counter.addCallback((result) => {
+  result.observe(temperature);
+});
 
 //... temperature variable is modified by a sensor
 ```
@@ -987,20 +1023,23 @@ When you create instruments like counters, histograms, etc. you can give them a
 description.
 
 ```js
-const httpServerResponseDuration = myMeter.createHistogram("http.server.duration", {
-  description: 'A distribution of the HTTP server response times',
-  unit: 'milliseconds',
-  valueType: ValueType.INT
-});
+const httpServerResponseDuration = myMeter.createHistogram(
+  'http.server.duration',
+  {
+    description: 'A distribution of the HTTP server response times',
+    unit: 'milliseconds',
+    valueType: ValueType.INT,
+  }
+);
 ```
 
 In JavaScript, each configuration type means the following:
 
-* `description` - a human-readable description for the instrument
-* `unit` - The description of the unit of measure that the value is intended to
+- `description` - a human-readable description for the instrument
+- `unit` - The description of the unit of measure that the value is intended to
   represent. For example, `milliseconds` to meaure duration, or `bytes` to count
   number of bytes.
-* `valueType` - The kind of numeric value used in measurements.
+- `valueType` - The kind of numeric value used in measurements.
 
 It's generally recommended to describe each instrument you create.
 
@@ -1016,18 +1055,23 @@ cntr.add(1, { 'some.optional.attribute': 'some value' });
 
 ### Configure Metric Views
 
-A Metric View provides developers with the ability to customize metrics exposed by the Metrics SDK.
+A Metric View provides developers with the ability to customize metrics exposed
+by the Metrics SDK.
 
 #### Selectors
 
-To instantiate a view, one must first select a target instrument. The following are valid selectors for metrics:
+To instantiate a view, one must first select a target instrument. The following
+are valid selectors for metrics:
+
 - `instrumentType`
 - `instrumentName`
 - `meterName`
 - `meterVersion`
 - `meterSchemaUrl`
 
-Selecting by `instrumentName` (of type string) has support for wildcards, so you can select all instruments using `*` or select all instruments whose name starts with `http` by using `http*`.
+Selecting by `instrumentName` (of type string) has support for wildcards, so you
+can select all instruments using `*` or select all instruments whose name starts
+with `http` by using `http*`.
 
 #### Examples
 
@@ -1039,7 +1083,7 @@ const limitAttributesView = new View({
   attributeKeys: ['environment'],
   // apply the view to all instruments
   instrumentName: '*',
-})
+});
 ```
 
 Drop all instruments with the meter name `pubsub`:
@@ -1055,7 +1099,9 @@ Define explicit bucket sizes for the Histogram named `http.server.duration`:
 
 ```js
 const histogramView = new View({
-  aggregation: new ExplicitBucketHistogramAggregation([0, 1, 5, 10, 15, 20, 25, 30]),
+  aggregation: new ExplicitBucketHistogramAggregation([
+    0, 1, 5, 10, 15, 20, 25, 30,
+  ]),
   instrumentName: 'http.server.duration',
   instrumentType: InstrumentType.HISTOGRAM,
 });
@@ -1063,18 +1109,17 @@ const histogramView = new View({
 
 #### Attach to meter provider
 
-Once views have been configured, attach them to the corresponding meter provider:
+Once views have been configured, attach them to the corresponding meter
+provider:
+
 ```js
 const meterProvider = new MeterProvider({
-  views: [
-    limitAttributesView,
-    dropView,
-    histogramView
-  ]
+  views: [limitAttributesView, dropView, histogramView],
 });
 ```
 
 ## Next steps
 
-You'll also want to configure an appropriate exporter to [export your telemetry
-data](/docs/instrumentation/js/exporters) to one or more telemetry backends.
+You'll also want to configure an appropriate exporter to
+[export your telemetry data](/docs/instrumentation/js/exporters) to one or more
+telemetry backends.

--- a/content/en/docs/instrumentation/js/libraries.md
+++ b/content/en/docs/instrumentation/js/libraries.md
@@ -4,12 +4,12 @@ linkTitle: Libraries
 weight: 3
 ---
 
-You can use [instrumentation
-libraries](/docs/reference/specification/glossary/#instrumentation-library) in
-order to generate telemetry data for a library or framework.
+You can use
+[instrumentation libraries](/docs/reference/specification/glossary/#instrumentation-library)
+in order to generate telemetry data for a library or framework.
 
-For example, [the instrumentation library for
-Express](https://www.npmjs.com/package/@opentelemetry/instrumentation-express)
+For example,
+[the instrumentation library for Express](https://www.npmjs.com/package/@opentelemetry/instrumentation-express)
 will automatically create
 [spans](/docs/concepts/signals/traces/#spans-in-opentelemetry) based on the
 inbound HTTP requests.
@@ -44,6 +44,7 @@ npm install @opentelemetry/auto-instrumentations-node
 
 Then in your tracing initialization code, use `registerInstrumentations`:
 
+<!-- prettier-ignore-start -->
 {{< tabpane langEqualsHeader=true >}}
 
 {{< tab TypeScript >}}
@@ -121,6 +122,7 @@ provider.register();
 {{< /tab >}}
 
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 ### Using individual instrumentation packages
 
@@ -139,6 +141,7 @@ npm install --save @opentelemetry/instrumentation-http @opentelemetry/instrument
 
 And then register each instrumentation library:
 
+<!-- prettier-ignore-start -->
 {{< tabpane langEqualsHeader=true >}}
 
 {{< tab TypeScript >}}
@@ -222,13 +225,14 @@ provider.register();
 {{< /tab >}}
 
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 ## Configuring instrumentation libraries
 
 Some instrumentation libraries offer additional configuration options.
 
-For example, [Express
-instrumentation](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-express#express-instrumentation-options)
+For example,
+[Express instrumentation](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-express#express-instrumentation-options)
 offers ways to ignore specified middleware or enrich spans created automatically
 with a request hook.
 
@@ -247,9 +251,10 @@ You can also find more instrumentations available in the
 
 ## Next steps
 
-After you have set up instrumentation libraries, you may want to add [manual
-instrumentation](/docs/instrumentation/js/instrumentation) to collect custom
-telemetry data.
+After you have set up instrumentation libraries, you may want to add
+[manual instrumentation](/docs/instrumentation/js/instrumentation) to collect
+custom telemetry data.
 
-You'll also want to configure an appropriate exporter to [export your telemetry
-data](/docs/instrumentation/js/exporters) to one or more telemetry backends.
+You'll also want to configure an appropriate exporter to
+[export your telemetry data](/docs/instrumentation/js/exporters) to one or more
+telemetry backends.

--- a/content/en/docs/instrumentation/js/propagation.md
+++ b/content/en/docs/instrumentation/js/propagation.md
@@ -4,6 +4,7 @@ description: Context propagation for the JS SDK
 aliases: [/docs/instrumentation/js/api/propagation]
 weight: 7
 ---
+
 Propagation is the mechanism that moves data between services and processes.
 Although not limited to tracing, it is what allows traces to build causal
 information about a system across services that are arbitrarily distributed
@@ -36,8 +37,8 @@ library. There may not be an instrumentation library that matches a library
 you're using to have services communicate with one another. Or you many have
 requirements that instrumentation libraries cannot fulfill, even if they exist.
 
-When you must propagate context manually, you can use the [context
-api](/docs/instrumentation/js/context).
+When you must propagate context manually, you can use the
+[context api](/docs/instrumentation/js/context).
 
 The following generic example demonstrates how you can propagate trace context
 manually.
@@ -46,17 +47,17 @@ First, on the sending service, you'll need to inject the current `context`:
 
 ```js
 // Sending service
-import { context, propagation, trace } from '@opentelemetry/api'
-const output = {}
+import { context, propagation, trace } from '@opentelemetry/api';
+const output = {};
 
 // Serialize the traceparent and tracestate from context into
 // an output object.
 //
 // This example uses the active trace context, but you can
 // use whatever context is appropriate to your scenario.
-propagation.inject(context.active(), output)
+propagation.inject(context.active(), output);
 
-const { traceparent, tracestate } = output
+const { traceparent, tracestate } = output;
 // You can then pass the traceparent and tracestate
 // data to whatever mechanism you use to propagate
 // across services.
@@ -67,26 +68,29 @@ parsed HTTP headers) and then set them as the current trace context.
 
 ```js
 // Receiving service
-import { context, propagation, trace } from '@opentelemetry/api'
+import { context, propagation, trace } from '@opentelemetry/api';
 
 // Assume "input" is an object with 'traceparent' & 'tracestate' keys
-const input = {}
+const input = {};
 
 // Extracts the 'traceparent' and 'tracestate' data into a context object.
 //
 // You can then treat this context as the active context for your
 // traces.
-let activeContext = propagation.extract(context.active(), input)
+let activeContext = propagation.extract(context.active(), input);
 
+let tracer = trace.getTracer('app-name');
 
-let tracer = trace.getTracer('app-name')
-
-let span = tracer.startSpan(spanName, {
-  attributes: {}
-}, activeContext)
+let span = tracer.startSpan(
+  spanName,
+  {
+    attributes: {},
+  },
+  activeContext
+);
 
 // Set the created span as active in the deserialized context.
-trace.setSpan(activeContext, span)
+trace.setSpan(activeContext, span);
 ```
 
 From there, when you have a deserialized active context, you can create spans

--- a/content/en/docs/instrumentation/js/resources.md
+++ b/content/en/docs/instrumentation/js/resources.md
@@ -1,7 +1,6 @@
 ---
-title: "Resources"
+title: Resources
 weight: 6
-description:
 ---
 
 A [resource][] represents the entity producing telemetry as resource attributes.
@@ -12,7 +11,7 @@ three of these attributes can be included in the resource.
 In your observability backend, you can use resource information to better
 investigate interesting behavior. For example, if your trace or metrics data
 indicate latency in your system, you can narrow it down to a specific container,
-pod, or kubernetes deployment.
+pod, or Kubernetes deployment.
 
 Below you will find some introductions on how to set up resource detection with
 the Node.JS SDK.
@@ -132,7 +131,7 @@ To make sure that you can stop your docker container with <kbd>Ctrl + C</kbd>
 (`SIGINT`) add the following to the bottom of `app.js`:
 
 ```javascript
-process.on("SIGINT", function () {
+process.on('SIGINT', function () {
   process.exit();
 });
 ```
@@ -147,14 +146,14 @@ npm install @opentelemetry/resource-detector-docker
 Next, update your `tracing.js` like the following:
 
 ```javascript
-const opentelemetry = require("@opentelemetry/sdk-node");
+const opentelemetry = require('@opentelemetry/sdk-node');
 const {
   getNodeAutoInstrumentations,
-} = require("@opentelemetry/auto-instrumentations-node");
-const { diag, DiagConsoleLogger, DiagLogLevel } = require("@opentelemetry/api");
+} = require('@opentelemetry/auto-instrumentations-node');
+const { diag, DiagConsoleLogger, DiagLogLevel } = require('@opentelemetry/api');
 const {
   dockerCGroupV1Detector,
-} = require("@opentelemetry/resource-detector-docker");
+} = require('@opentelemetry/resource-detector-docker');
 
 // For troubleshooting, set the log level to DiagLogLevel.DEBUG
 diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
@@ -195,15 +194,15 @@ via an environment variable are missing! To resolve this, when you set the
 `processDetector` detectors:
 
 ```javascript
-const opentelemetry = require("@opentelemetry/sdk-node");
+const opentelemetry = require('@opentelemetry/sdk-node');
 const {
   getNodeAutoInstrumentations,
-} = require("@opentelemetry/auto-instrumentations-node");
-const { diag, DiagConsoleLogger, DiagLogLevel } = require("@opentelemetry/api");
+} = require('@opentelemetry/auto-instrumentations-node');
+const { diag, DiagConsoleLogger, DiagLogLevel } = require('@opentelemetry/api');
 const {
   dockerCGroupV1Detector,
-} = require("@opentelemetry/resource-detector-docker");
-const { envDetector, processDetector } = require("@opentelemetry/resources");
+} = require('@opentelemetry/resource-detector-docker');
+const { envDetector, processDetector } = require('@opentelemetry/resources');
 
 // For troubleshooting, set the log level to DiagLogLevel.DEBUG
 diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);

--- a/content/en/docs/instrumentation/js/serverless.md
+++ b/content/en/docs/instrumentation/js/serverless.md
@@ -11,8 +11,8 @@ OpenTelemetry instrumentation libraries.
 The following show how to use Lambda wrappers with OpenTelemetry to instrument
 AWS Lambda functions and send traces to a configured backend.
 
-Check out [OpenTelemetry Lambda Layers](https://github.com/open-telemetry/opentelemetry-lambda),
-if you are interested in a plug and play user experience.
+If you are interested in a plug and play user experience, see
+[OpenTelemetry Lambda Layers](https://github.com/open-telemetry/opentelemetry-lambda).
 
 ### Dependencies
 
@@ -36,28 +36,28 @@ npm install \
 
 ### AWS Lambda wrapper code
 
-This file contains all the OpenTelemetry logic, which enables tracing.
-Please save the following code as `lambda-wrapper.js`.
+This file contains all the OpenTelemetry logic, which enables tracing. Save the
+following code as `lambda-wrapper.js`.
 
 ```javascript
 /* lambda-wrapper.js */
 
-const api = require("@opentelemetry/api");
-const { BatchSpanProcessor } = require("@opentelemetry/sdk-trace-base");
+const api = require('@opentelemetry/api');
+const { BatchSpanProcessor } = require('@opentelemetry/sdk-trace-base');
 const {
   OTLPTraceExporter,
-} = require("@opentelemetry/exporter-trace-otlp-http");
-const { NodeTracerProvider } = require("@opentelemetry/sdk-trace-node");
-const { registerInstrumentations } = require("@opentelemetry/instrumentation");
+} = require('@opentelemetry/exporter-trace-otlp-http');
+const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
+const { registerInstrumentations } = require('@opentelemetry/instrumentation');
 const {
   getNodeAutoInstrumentations,
-} = require("@opentelemetry/auto-instrumentations-node");
+} = require('@opentelemetry/auto-instrumentations-node');
 
 api.diag.setLogger(new api.DiagConsoleLogger(), api.DiagLogLevel.ALL);
 
 const provider = new NodeTracerProvider();
 const collectorOptions = {
-  url: "<backend_url>",
+  url: '<backend_url>',
 };
 
 const spanProcessor = new BatchSpanProcessor(
@@ -70,7 +70,7 @@ provider.register();
 registerInstrumentations({
   instrumentations: [
     getNodeAutoInstrumentations({
-      "@opentelemetry/instrumentation-aws-lambda": {
+      '@opentelemetry/instrumentation-aws-lambda': {
         disableAwsContextPropagation: true,
       },
     }),
@@ -92,13 +92,13 @@ More details can be found in the instrumentation
 
 ### AWS Lambda function handler
 
-Now that you have a Lambda wrapper, create a simple handler that servers
-as a Lambda function. Save the following code as `handler.js`.
+Now that you have a Lambda wrapper, create a simple handler that servers as a
+Lambda function. Save the following code as `handler.js`.
 
 ```javascript
 /* handler.js */
 
-"use strict";
+'use strict';
 
 const https = require('https');
 
@@ -106,11 +106,11 @@ function getRequest() {
   const url = 'https://opentelemetry.io/';
 
   return new Promise((resolve, reject) => {
-    const req = https.get(url, res => {
+    const req = https.get(url, (res) => {
       resolve(res.statusCode);
     });
 
-    req.on('error', err => {
+    req.on('error', (err) => {
       reject(new Error(err));
     });
   });
@@ -134,10 +134,11 @@ exports.handler = async (event) => {
 ### Deployment
 
 There are multiple ways of deploying your Lambda function:
-* [AWS Console](https://aws.amazon.com/console/)
-* [AWS CLI](https://aws.amazon.com/cli/)
-* [Serverless Framework](https://github.com/serverless/serverless)
-* [Terraform](https://github.com/hashicorp/terraform)
+
+- [AWS Console](https://aws.amazon.com/console/)
+- [AWS CLI](https://aws.amazon.com/cli/)
+- [Serverless Framework](https://github.com/serverless/serverless)
+- [Terraform](https://github.com/hashicorp/terraform)
 
 Here we will be using Serverless Framework, more details can be found in the
 [Setting Up Serverless Framework guide](https://www.serverless.com/framework/docs/getting-started).
@@ -146,11 +147,11 @@ Create a file called `serverless.yml`:
 
 ```yaml
 service: lambda-otel-native
-frameworkVersion: "3"
+frameworkVersion: '3'
 provider:
   name: aws
   runtime: nodejs14.x
-  region: "<your-region>"
+  region: '<your-region>'
   environment:
     NODE_OPTIONS: --require lambda-wrapper
 functions:
@@ -181,19 +182,23 @@ function in the backend!
 
 ## GCP function
 
-The following shows how to instrument [http triggered function](https://cloud.google.com/functions/docs/writing/write-http-functions) using the Google Cloud Platform (GCP) UI.
+The following shows how to instrument
+[http triggered function](https://cloud.google.com/functions/docs/writing/write-http-functions)
+using the Google Cloud Platform (GCP) UI.
 
 ### Creating function
 
-Login to GCP and create or select a project where your function should be placed.
-In the side menu go to _Serverless_ and select _Cloud Functions_. Next, click on _Create Function_,
-and select [2nd generation](https://cloud.google.com/blog/products/serverless/cloud-functions-2nd-generation-now-generally-available)
-for your environment, provide a function name and select your region.  
+Login to GCP and create or select a project where your function should be
+placed. In the side menu go to _Serverless_ and select _Cloud Functions_. Next,
+click on _Create Function_, and select
+[2nd generation](https://cloud.google.com/blog/products/serverless/cloud-functions-2nd-generation-now-generally-available)
+for your environment, provide a function name and select your region.
 
 ### Setup environment variable for otelwrapper
 
 If closed, open the _Runtime, build, connections and security settings_ menu and
-scroll down and add the environment variable `NODE_OPTIONS` with the following value:
+scroll down and add the environment variable `NODE_OPTIONS` with the following
+value:
 
 ```shell
 --require ./otelwrapper.js
@@ -205,28 +210,31 @@ On the next screen (_Code_), select Node.js version 16 for your runtime.
 
 ### Establish otel wrapper
 
-Create a new file called `otelwrapper.js`, that will be used to instrument your service.
-Please make sure that you provide a `SERVICE_NAME` and that you set the `<address for your backend>`.
+Create a new file called `otelwrapper.js`, that will be used to instrument your
+service. Please make sure that you provide a `SERVICE_NAME` and that you set the
+`<address for your backend>`.
 
 ```javascript
 /* otelwrapper.js */
 
 const { Resource } = require('@opentelemetry/resources');
-const { SemanticResourceAttributes } = require ('@opentelemetry/semantic-conventions');
-const api = require("@opentelemetry/api");
-const { BatchSpanProcessor } = require("@opentelemetry/sdk-trace-base");
+const {
+  SemanticResourceAttributes,
+} = require('@opentelemetry/semantic-conventions');
+const api = require('@opentelemetry/api');
+const { BatchSpanProcessor } = require('@opentelemetry/sdk-trace-base');
 const {
   OTLPTraceExporter,
-} = require("@opentelemetry/exporter-trace-otlp-http");
-const { NodeTracerProvider } = require("@opentelemetry/sdk-trace-node");
-const { registerInstrumentations } = require("@opentelemetry/instrumentation");
+} = require('@opentelemetry/exporter-trace-otlp-http');
+const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
+const { registerInstrumentations } = require('@opentelemetry/instrumentation');
 const {
   getNodeAutoInstrumentations,
-} = require("@opentelemetry/auto-instrumentations-node");
+} = require('@opentelemetry/auto-instrumentations-node');
 
 const providerConfig = {
   resource: new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: "<your function name>",
+    [SemanticResourceAttributes.SERVICE_NAME]: '<your function name>',
   }),
 };
 
@@ -234,7 +242,7 @@ api.diag.setLogger(new api.DiagConsoleLogger(), api.DiagLogLevel.ALL);
 
 const provider = new NodeTracerProvider(providerConfig);
 const collectorOptions = {
-  url: "<address for your backend>",
+  url: '<address for your backend>',
 };
 
 const spanProcessor = new BatchSpanProcessor(
@@ -245,9 +253,7 @@ provider.addSpanProcessor(spanProcessor);
 provider.register();
 
 registerInstrumentations({
-  instrumentations: [
-    getNodeAutoInstrumentations(),
-  ],
+  instrumentations: [getNodeAutoInstrumentations()],
 });
 ```
 
@@ -274,7 +280,8 @@ Add the following content to your package.json:
 
 ### Add HTTP call to function
 
-The following code makes a call to the OpenTemetry web site to demonstrate an outbound call.
+The following code makes a call to the OpenTemetry web site to demonstrate an
+outbound call.
 
 ```javascript
 /* index.js */
@@ -282,12 +289,14 @@ const functions = require('@google-cloud/functions-framework');
 const https = require('https');
 
 functions.http('helloHttp', (req, res) => {
-  let url = "https://opentelemetry.io/";
-  https.get(url, (response) => {
-    res.send(`Response ${response.body}!`);
-  }).on('error', (e) => {
-    res.send(`Error ${e}!`);
-  })
+  let url = 'https://opentelemetry.io/';
+  https
+    .get(url, (response) => {
+      res.send(`Response ${response.body}!`);
+    })
+    .on('error', (e) => {
+      res.send(`Error ${e}!`);
+    });
 });
 ```
 


### PR DESCRIPTION
- Contributes to #1063
- Enables format checking over `instrumentation/js` section
- Replaces `relref` link(s) by standard markdown link(s)
- Copyedits (minor)

⚠️ **Note**: code excerpts in code blocks also get reformatted per Prettier rules.

Preview: https://deploy-preview-2372--opentelemetry.netlify.app/docs/instrumentation/js/