### PR TITLE
Prettier: switch to single-quotes by default

### DIFF
--- a/assets/scss/_external_link.scss
+++ b/assets/scss/_external_link.scss
@@ -18,7 +18,7 @@ $nbsp: \00A0;
   content: fa-content($nbsp + $fa-var-external-link-alt);
 }
 
-.td-sidebar-nav a[target="_blank"]:after,
+.td-sidebar-nav a[target='_blank']:after,
 a.external-link:after {
   @include external-link-icon();
 }

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1,9 +1,9 @@
 /* docsy-delta full file override: we're not tracking changes to the docsy file of the same name. */
 // cSpell:ignore cncf docsy
 
-@import "registry";
-@import "tabs";
-@import "external_link";
+@import 'registry';
+@import 'tabs';
+@import 'external_link';
 
 .td-home {
   .otel-logo {

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -12,8 +12,8 @@ $light-green: #c0f587;
 $primary: $opentelemetry-blue;
 $secondary: $opentelemetry-orange;
 $td-enable-google-fonts: false;
-$google_font_name: "Noto Sans";
-$google_font_family: "Noto+Sans:300,400,600,700";
+$google_font_name: 'Noto Sans';
+$google_font_family: 'Noto+Sans:300,400,600,700';
 
 $enable-gradients: false;
 $enable-rounded: true;

--- a/content/en/blog/2023/http-conventions-stability.md
+++ b/content/en/blog/2023/http-conventions-stability.md
@@ -2,7 +2,7 @@
 title: Final push to HTTP semantic convention stability
 linkTitle: HTTP semantic conventions
 date: 2023-01-30
-author: "[Trask Stalnaker](https://github.com/trask) (Microsoft)"
+author: '[Trask Stalnaker](https://github.com/trask) (Microsoft)'
 ---
 
 The OpenTelemetry community is beginning the final push to declare HTTP

--- a/content/en/blog/2023/jmx-metric-insight/index.md
+++ b/content/en/blog/2023/jmx-metric-insight/index.md
@@ -2,7 +2,7 @@
 title: Gaining JMX Metric Insights with the OpenTelemetry Java Agent
 linkTitle: JMX Metric Insight
 date: 2023-01-17
-author: "[Samudraneel Dasgupta](https://github.com/Samudraneel24) (Cisco)"
+author: '[Samudraneel Dasgupta](https://github.com/Samudraneel24) (Cisco)'
 ---
 
 [JMX](https://www.oracle.com/technical-resources/articles/javase/jmx.html) (Java
@@ -128,10 +128,10 @@ global:
   evaluation_interval: 10s
 
 scrape_configs:
-  - job_name: "my-kafka-broker"
+  - job_name: my-kafka-broker
     scrape_interval: 5s
     static_configs:
-      - targets: ["host.docker.internal:9464"]
+      - targets: [host.docker.internal:9464]
 ```
 
 Then run the command below to deploy Prometheus on Docker:
@@ -207,7 +207,7 @@ rules:
         metric: kafka.message.count
         type: counter
         desc: The number of messages received by the broker
-        unit: "{messages}"
+        unit: '{messages}'
 ```
 
 Each file can consist of multiple rules. Each rule can identify a set of one or

--- a/content/en/blog/2023/php-beta-release.md
+++ b/content/en/blog/2023/php-beta-release.md
@@ -2,7 +2,7 @@
 title: Opentelemetry PHP Beta Release
 linkTitle: PHP Beta Release
 date: 2023-01-30
-author: "[Bob Strecansky](https://github.com/bobstrecansky/) (Intuit)"
+author: '[Bob Strecansky](https://github.com/bobstrecansky/) (Intuit)'
 ---
 
 The OpenTelemetry PHP SIG is very excited to announce the release of

--- a/content/en/blog/2023/submitting-your-first-conference-talk.md
+++ b/content/en/blog/2023/submitting-your-first-conference-talk.md
@@ -2,7 +2,7 @@
 title: Submitting Your First Conference Talk
 linkTitle: Submitting a CFP
 date: 2023-02-10
-author: "[Josh Lee](https://github.com/joshleecreates/) (IBM)"
+author: '[Josh Lee](https://github.com/joshleecreates/) (IBM)'
 canonical_url: https://joshuamlee.com/submitting-your-first-conference-talk/
 ---
 

--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -234,10 +234,10 @@ receivers:
   prometheus:
     config:
       scrape_configs:
-        - job_name: "otel-collector"
+        - job_name: otel-collector
           scrape_interval: 5s
           static_configs:
-            - targets: ["localhost:8888"]
+            - targets: [localhost:8888]
 
   # Data sources: traces
   zipkin:
@@ -301,7 +301,7 @@ processors:
   resource:
     attributes:
       - key: cloud.zone
-        value: "zone-1"
+        value: zone-1
         action: upsert
       - key: k8s.cluster.name
         from_attribute: k8s-cluster
@@ -320,8 +320,8 @@ processors:
       to_attributes:
         rules:
           - ^\/api\/v1\/document\/(?P<documentId>.*)\/update$
-      from_attributes: ["db.svc", "operation"]
-      separator: "::"
+      from_attributes: [db.svc, operation]
+      separator: '::'
 ```
 
 ## Exporters
@@ -358,7 +358,7 @@ exporters:
 
   # Data sources: traces
   jaeger:
-    endpoint: "jaeger-all-in-one:14250"
+    endpoint: jaeger-all-in-one:14250
     tls:
       cert_file: cert.pem
       key_file: cert-key.pem
@@ -373,7 +373,7 @@ exporters:
 
   # Data sources: traces, metrics
   opencensus:
-    endpoint: "otelcol2:55678"
+    endpoint: otelcol2:55678
 
   # Data sources: traces, metrics, logs
   otlp:
@@ -388,12 +388,12 @@ exporters:
 
   # Data sources: metrics
   prometheus:
-    endpoint: "prometheus:8889"
-    namespace: "default"
+    endpoint: prometheus:8889
+    namespace: default
 
   # Data sources: metrics
   prometheusremotewrite:
-    endpoint: "http://some.url:9411/api/prom/push"
+    endpoint: http://some.url:9411/api/prom/push
     # For official Prometheus (e.g. running via Docker)
     # endpoint: 'http://prometheus:9090/api/v1/write'
     # tls:
@@ -401,7 +401,7 @@ exporters:
 
   # Data sources: traces
   zipkin:
-    endpoint: "http://localhost:9411/api/v2/spans"
+    endpoint: http://localhost:9411/api/v2/spans
 ```
 
 ## Extensions
@@ -525,8 +525,8 @@ configuration. For example to use the values stored on the `DB_KEY` and
 processors:
   attributes/example:
     actions:
-      - key: "${env:DB_KEY}"
-        action: "${env:OPERATION}"
+      - key: ${env:DB_KEY}
+        action: ${env:OPERATION}
 ```
 
 Use `$$` to indicate a literal `$`. For example, representing
@@ -535,8 +535,8 @@ Use `$$` to indicate a literal `$`. For example, representing
 ```yaml
 exporters:
   prometheus:
-    endpoint: "prometheus:8889"
-    namespace: "$$DataVisualization"
+    endpoint: prometheus:8889
+    namespace: $$DataVisualization
 ```
 
 ### Proxy Support

--- a/content/en/docs/collector/custom-collector.md
+++ b/content/en/docs/collector/custom-collector.md
@@ -84,7 +84,7 @@ following content:
 ```yaml
 dist:
   name: otelcol-dev
-  description: "Basic OTel Collector distribution for Developers"
+  description: Basic OTel Collector distribution for Developers
   output_path: ./otelcol-dev
 ```
 

--- a/content/en/docs/collector/getting-started.md
+++ b/content/en/docs/collector/getting-started.md
@@ -60,17 +60,17 @@ the following:
 # Collector
 otel-collector:
   image: otel/opentelemetry-collector
-  command: ["--config=/etc/otel-collector-config.yaml"]
+  command: [--config=/etc/otel-collector-config.yaml]
   volumes:
     - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
   ports:
-    - "1888:1888" # pprof extension
-    - "8888:8888" # Prometheus metrics exposed by the collector
-    - "8889:8889" # Prometheus exporter metrics
-    - "13133:13133" # health_check extension
-    - "4317:4317" # OTLP gRPC receiver
-    - "4318:4318" # OTLP http receiver
-    - "55679:55679" # zpages extension
+    - 1888:1888 # pprof extension
+    - 8888:8888 # Prometheus metrics exposed by the collector
+    - 8889:8889 # Prometheus exporter metrics
+    - 13133:13133 # health_check extension
+    - 4317:4317 # OTLP gRPC receiver
+    - 4318:4318 # OTLP http receiver
+    - 55679:55679 # zpages extension
 ```
 
 ## Kubernetes

--- a/content/en/docs/collector/management.md
+++ b/content/en/docs/collector/management.md
@@ -133,10 +133,10 @@ receivers:
   prometheus/own_metrics:
     config:
       scrape_configs:
-        - job_name: "otel-collector"
+        - job_name: otel-collector
           scrape_interval: 10s
           static_configs:
-            - targets: ["0.0.0.0:8888"]
+            - targets: [0.0.0.0:8888]
   hostmetrics:
     collection_interval: 10s
     scrapers:

--- a/content/en/docs/collector/scaling.md
+++ b/content/en/docs/collector/scaling.md
@@ -171,7 +171,7 @@ kind: Pod
 metadata:
   name: my-microservice
   annotations:
-    sidecar.opentelemetry.io/inject: "true"
+    sidecar.opentelemetry.io/inject: 'true'
 spec:
   containers:
     - name: my-microservice

--- a/content/en/docs/collector/transforming-telemetry.md
+++ b/content/en/docs/collector/transforming-telemetry.md
@@ -123,7 +123,7 @@ cluster-name for all metrics:
 processors:
   metricstransform/clustername:
     transforms:
-      - include: "^.*$"
+      - include: ^.*$
         match_type: regexp
         action: update
         operations:

--- a/content/en/docs/instrumentation/net/exporters.md
+++ b/content/en/docs/instrumentation/net/exporters.md
@@ -188,9 +188,9 @@ global:
   evaluation_interval: 1s
 
 scrape_configs:
-  - job_name: "prometheus"
+  - job_name: prometheus
     static_configs:
-      - targets: ["localhost:9090"]
+      - targets: [localhost:9090]
 ```
 
 Next, run the following docker command to set up Prometheus:

--- a/content/en/docs/k8s-operator/automatic.md
+++ b/content/en/docs/k8s-operator/automatic.md
@@ -164,7 +164,7 @@ spec:
     - baggage
   sampler:
     type: parentbased_traceidratio
-    argument: "1"
+    argument: '1'
   java:
     env:
       - name: OTEL_INSTRUMENTATION_KAFKA_ENABLED
@@ -234,7 +234,7 @@ spec:
     - baggage
   sampler:
     type: parentbased_traceidratio
-    argument: "1"
+    argument: '1'
   python:
     env:
       - name: OTEL_PYTHON_DISABLED_INSTRUMENTATIONS

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -110,7 +110,7 @@ params:
         url: https://github.com/open-telemetry
         icon: fab fa-github
         desc: Find us on GitHub.
-      - name: "Slack #opentelemetry"
+      - name: 'Slack #opentelemetry'
         url: https://cloud-native.slack.com/archives/CJFCJHG4Q
         icon: fab fa-slack
         desc: >-

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
   },
   "private": true,
   "prettier": {
-    "proseWrap": "always"
+    "proseWrap": "always",
+    "singleQuote": true
   },
   "textlint": {
     "rules": {


### PR DESCRIPTION
My original inclination (supported by @svrnm and @cartermp) was to opt for single quotes (https://github.com/open-telemetry/opentelemetry.io/pull/2290#discussion_r1098882987), but I reverted after seeing that YAML code blocks were being changed. Well, in retrospect (and given the situation we're facing in https://github.com/open-telemetry/opentelemetry.io/pull/2372#pullrequestreview-1306451171), I'd rather opt for single quotes for all (including JS code blocks, given that it's part of the OTel-JS standard).

WDYT @svrnm @cartermp?

This PR:

- Contributes to #1063
- Enables Prettier's single-quotes option
- Drops quotes from YAML code blocks in those situations where quotes are unnecessary

Two situations where I wasn't sure if the YAML key value type was important, so I didn't drop the quotes (cc @TylerHelmuth):

- https://github.com/open-telemetry/opentelemetry.io/commit/208befc5131ab827bd1c0da41dcca5e063c9bba4#r101481607
- https://github.com/open-telemetry/opentelemetry.io/commit/01c2c7fb0ef7089bf3ea511c7eb0c8bd52d9333b#r101482142

**Edit**: I added comments to this PR matching the two listed above. Sorry for the duplication!

Preview: https://deploy-preview-2377--opentelemetry.netlify.app