### PR TITLE
Enable Prettier check over instrumentation/go & update go

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,13 +2,21 @@
 
 /.netlify
 /.vscode
-/content-modules
 /iconography
 /layouts
 package-lock.json
 /public
 /themes
 /tmp
+
+# Ignore content-modules except for Go docs
+
+/content-modules/*
+!/content-modules/opentelemetry-go
+/content-modules/opentelemetry-go/*
+!/content-modules/opentelemetry-go/website_docs
+/content-modules/opentelemetry-go/website_docs/**/*
+!/content-modules/opentelemetry-go/website_docs/**/*.md
 
 # Temporary while we ramp up use of Prettier
 


### PR DESCRIPTION
- Contributes to #1063
- Enables format checking over `instrumentation/go` section, which is a mount of otel-go content-module's `website_docs` folder
- Updates Go submodule to latest, in particular, bring in:
  - https://github.com/open-telemetry/opentelemetry-go/pull/3762
- [x] Waiting on https://github.com/open-telemetry/opentelemetry-go/pull/3762

Preview: https://deploy-preview-2380--opentelemetry.netlify.app/docs/instrumentation/go