### PR TITLE
Add "collector troubleshooting" doc

### DIFF
--- a/content/en/docs/collector/troubleshooting.md
+++ b/content/en/docs/collector/troubleshooting.md
@@ -4,8 +4,8 @@ description: Recommendations for troubleshooting the collector
 weight: 25
 ---
 
-This document describes some options when troubleshooting the health or
-performance of The OpenTelemetry Collector. The Collector provides a variety of
+This page describes some options when troubleshooting the health or
+performance of the OpenTelemetry Collector. The Collector provides a variety of
 metrics, logs, and extensions for debugging issues.
 
 ## Sending test data

--- a/content/en/docs/collector/troubleshooting.md
+++ b/content/en/docs/collector/troubleshooting.md
@@ -12,8 +12,8 @@ metrics, logs, and extensions for debugging issues.
 
 For certain types of issues, particularly verifing configuration and debugging
 network issues, it can be helpful to send a small amount of data to a collector
-configured to output to local logs. This is detailed in
-["Local exporters" in the collector configuration documentation](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/troubleshooting.md#local-exporters).
+configured to output to local logs. For details, see
+[Local exporters](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/troubleshooting.md#local-exporters).
 
 ## Checklist for debugging complex pipelines
 

--- a/content/en/docs/collector/troubleshooting.md
+++ b/content/en/docs/collector/troubleshooting.md
@@ -1,0 +1,38 @@
+---
+title: Troubleshooting
+weight: 32
+---
+
+The OpenTelemetry Collector supports a variety of metrics, logs, and extensions
+for troubleshooting collector health and performance.
+
+Detailed recommendations, including common problems, are detailed in the
+OpenTelemetry Collector GitHub repo's
+[troubleshooting document](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/troubleshooting.md).
+
+## Sending test data
+
+For certain types of issues, particularly verifing configuration and debugging
+network issues, it can be helpful to send a small amount of data to a collector
+configured to output to local logs. This is detailed in
+["Local exporters" in the collector configuration documentation](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/troubleshooting.md#local-exporters).
+
+Other open source tools, like the
+[otel-cli](https://github.com/equinix-labs/otel-cli), are useful for generating
+trace data from the command line.
+
+## Checklist for debugging complex pipelines
+
+It can be difficult to isolate problems when telemetry flows through multiple
+collectors and networks. For each "hop" of telemetry data through a collector or
+other component in your telemetry pipeline, it’s important to verify the
+following:
+
+- Are there error messages in the logs of the collector?
+- How is the telemetry being ingested into this component?
+- How is the telemetry being modified (i.e. sampling, redacting) by this
+  component?
+- How is the telemetry being exported from this component?
+- What format is the telemetry in?
+- How is the next hop configured?
+- Are there any network policies that prevent data from getting in or out?

--- a/content/en/docs/collector/troubleshooting.md
+++ b/content/en/docs/collector/troubleshooting.md
@@ -1,6 +1,6 @@
 ---
 title: Troubleshooting
-weight: 32
+weight: 25
 ---
 
 The OpenTelemetry Collector supports a variety of metrics, logs, and extensions

--- a/content/en/docs/collector/troubleshooting.md
+++ b/content/en/docs/collector/troubleshooting.md
@@ -1,14 +1,12 @@
 ---
 title: Troubleshooting
+description: Recommendations for troubleshooting the collector
 weight: 25
 ---
 
-The OpenTelemetry Collector supports a variety of metrics, logs, and extensions
-for troubleshooting collector health and performance.
-
-Detailed recommendations, including common problems, are detailed in the
-OpenTelemetry Collector GitHub repo's
-[troubleshooting document](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/troubleshooting.md).
+This document describes some options when troubleshooting the health or
+performance of The OpenTelemetry Collector. The Collector provides a variety of
+metrics, logs, and extensions for debugging issues.
 
 ## Sending test data
 
@@ -32,3 +30,9 @@ following:
 - What format is the telemetry in?
 - How is the next hop configured?
 - Are there any network policies that prevent data from getting in or out?
+
+### More
+
+Detailed recommendations, including common problems, are in the OpenTelemetry
+Collector GitHub repo's
+[troubleshooting document](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/troubleshooting.md).

--- a/content/en/docs/collector/troubleshooting.md
+++ b/content/en/docs/collector/troubleshooting.md
@@ -17,10 +17,6 @@ network issues, it can be helpful to send a small amount of data to a collector
 configured to output to local logs. This is detailed in
 ["Local exporters" in the collector configuration documentation](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/troubleshooting.md#local-exporters).
 
-Other open source tools, like the
-[otel-cli](https://github.com/equinix-labs/otel-cli), are useful for generating
-trace data from the command line.
-
 ## Checklist for debugging complex pipelines
 
 It can be difficult to isolate problems when telemetry flows through multiple

--- a/content/en/docs/collector/troubleshooting.md
+++ b/content/en/docs/collector/troubleshooting.md
@@ -4,9 +4,9 @@ description: Recommendations for troubleshooting the collector
 weight: 25
 ---
 
-This page describes some options when troubleshooting the health or
-performance of the OpenTelemetry Collector. The Collector provides a variety of
-metrics, logs, and extensions for debugging issues.
+This page describes some options when troubleshooting the health or performance
+of the OpenTelemetry Collector. The Collector provides a variety of metrics,
+logs, and extensions for debugging issues.
 
 ## Sending test data
 
@@ -33,5 +33,6 @@ following:
 
 ### More
 
-For detailed recommendations, including common problems, see 
-[Troubleshooting](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/troubleshooting.md) from the Collector repo.
+For detailed recommendations, including common problems, see
+[Troubleshooting](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/troubleshooting.md)
+from the Collector repo.

--- a/content/en/docs/collector/troubleshooting.md
+++ b/content/en/docs/collector/troubleshooting.md
@@ -33,6 +33,5 @@ following:
 
 ### More
 
-Detailed recommendations, including common problems, are in the OpenTelemetry
-Collector GitHub repo's
-[troubleshooting document](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/troubleshooting.md).
+For detailed recommendations, including common problems, see 
+[Troubleshooting](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/troubleshooting.md) from the Collector repo.


### PR DESCRIPTION
This adds a short page that generally points users to the existing collector [troubleshooting docs](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/troubleshooting.md).

Two minor additions not covered in the main doc:
- Specifically calls out the "sending test data"/local exporter guidance (anecdotally a useful troubleshooting step for users doing first-time collector setup and not seeing data)
- Adds a high-level checklist of things to verify for complex setups (collectors to collectors, etc)

Think a future section that goes deeper into collector observability would be a great future addition.

---

Preview: https://deploy-preview-2382--opentelemetry.netlify.app/docs/collector/troubleshooting/