### PR TITLE
add traceloop to vendors table and registry

### DIFF
--- a/content/en/ecosystem/vendors.md
+++ b/content/en/ecosystem/vendors.md
@@ -43,7 +43,7 @@ OpenTelemetry in their commercial products.
 | Splunk                     | Yes               | Yes         | [splunk.com/blog/...](https://www.splunk.com/en_us/blog/conf-splunklive/announcing-native-opentelemetry-support-in-splunk-apm.html)                   |
 | Sumo Logic                 | Yes               | Yes         | [help.sumologic.com/](https://help.sumologic.com/docs/apm/traces/quickstart/)                                                                         |
 | TelemetryHub               | No                | Yes         | [telemetryhub.com](https://app.telemetryhub.com/docs)                                                                                                 |
-| Traceloop                  | Yes               | Yes         | [traceloop.dev](https://docs.traceloop.dev)                                                                                                 |
+| Traceloop                  | No                | Yes         | [traceloop.dev](https://docs.traceloop.dev)                                                                                                 |
 | Uptrace                    | Yes               | Yes         | [uptrace.dev](https://uptrace.dev)                                                                                                                    |
 
 \* _Vendors are listed alphabetically_.

--- a/content/en/ecosystem/vendors.md
+++ b/content/en/ecosystem/vendors.md
@@ -43,6 +43,7 @@ OpenTelemetry in their commercial products.
 | Splunk                     | Yes               | Yes         | [splunk.com/blog/...](https://www.splunk.com/en_us/blog/conf-splunklive/announcing-native-opentelemetry-support-in-splunk-apm.html)                   |
 | Sumo Logic                 | Yes               | Yes         | [help.sumologic.com/](https://help.sumologic.com/docs/apm/traces/quickstart/)                                                                         |
 | TelemetryHub               | No                | Yes         | [telemetryhub.com](https://app.telemetryhub.com/docs)                                                                                                 |
+| Traceloop                  | Yes               | Yes         | [traceloop.dev](https://docs.traceloop.dev)                                                                                                 |
 | Uptrace                    | Yes               | Yes         | [uptrace.dev](https://uptrace.dev)                                                                                                                    |
 
 \* _Vendors are listed alphabetically_.

--- a/content/en/ecosystem/vendors.md
+++ b/content/en/ecosystem/vendors.md
@@ -43,7 +43,7 @@ OpenTelemetry in their commercial products.
 | Splunk                     | Yes               | Yes         | [splunk.com/blog/...](https://www.splunk.com/en_us/blog/conf-splunklive/announcing-native-opentelemetry-support-in-splunk-apm.html)                   |
 | Sumo Logic                 | Yes               | Yes         | [help.sumologic.com/](https://help.sumologic.com/docs/apm/traces/quickstart/)                                                                         |
 | TelemetryHub               | No                | Yes         | [telemetryhub.com](https://app.telemetryhub.com/docs)                                                                                                 |
-| Traceloop                  | No                | Yes         | [traceloop.dev](https://docs.traceloop.dev)                                                                                                 |
+| Traceloop                  | No                | Yes         | [traceloop.dev](https://docs.traceloop.dev)                                                                                                           |
 | Uptrace                    | Yes               | Yes         | [uptrace.dev](https://uptrace.dev)                                                                                                                    |
 
 \* _Vendors are listed alphabetically_.

--- a/data/registry/tools-traceloop.yml
+++ b/data/registry/tools-traceloop.yml
@@ -1,0 +1,16 @@
+title: Traceloop Jest Test Engine
+registryType: utilities
+isThirdParty: true
+language: js
+tags:
+  - js
+  - ts
+  - testing
+  - test-automation
+  - e2e-testing
+  - api-testing
+repo: https://github.com/traceloop/jest-opentelemetry
+license: Apache 2.0
+description: Generate e2e tests from traces
+authors: Traceloop dev <dev@traceloop.dev>
+otVersion: latest

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -855,6 +855,10 @@
     "StatusCode": 206,
     "LastSeen": "2023-02-15T21:03:39.650397-05:00"
   },
+  "https://docs.traceloop.dev": {
+    "StatusCode": 206,
+    "LastSeen": "2023-02-26T11:00:42.522142-08:00"
+  },
   "https://docs.wavefront.com/opentelemetry_tracing.html": {
     "StatusCode": 206,
     "LastSeen": "2023-02-15T21:01:54.460528-05:00"
@@ -2266,6 +2270,10 @@
   "https://github.com/tonglil/opentelemetry-go-datadog-propagator": {
     "StatusCode": 200,
     "LastSeen": "2023-02-20T07:47:42.43243-05:00"
+  },
+  "https://github.com/traceloop/jest-opentelemetry": {
+    "StatusCode": 200,
+    "LastSeen": "2023-02-26T11:00:43.117314-08:00"
   },
   "https://github.com/trask": {
     "StatusCode": 200,


### PR DESCRIPTION
Adds Traceloop (www.traceloop.dev) to vendors list and registry.