### PR TITLE
Enable Prettier check over instrumentation/cpp

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -20,7 +20,6 @@ package-lock.json
 /content/en/blog/2022
 /content/en/docs/concepts
 /content/en/docs/demo
-content/en/docs/instrumentation/cpp
 content/en/docs/instrumentation/erlang
 content/en/docs/instrumentation/go
 content/en/docs/instrumentation/other

--- a/content/en/docs/instrumentation/cpp/exporters.md
+++ b/content/en/docs/instrumentation/cpp/exporters.md
@@ -117,8 +117,8 @@ auto processor = trace_sdk::SimpleSpanProcessorFactory::Create(std::move(exporte
 
 ### Batch span processor
 
-A batch span processor will group several spans together, before sending
-them to an exporter.
+A batch span processor will group several spans together, before sending them to
+an exporter.
 
 ```cpp
 #include "opentelemetry/sdk/trace/batch_span_processor_factory.h"
@@ -194,7 +194,8 @@ std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> reader{
     new opentelemetry::sdk::metrics::PeriodicExportingMetricReader(std::move(exporter), options)};
 ```
 
-To learn more on how to use the Prometheus exporter, try out the [prometheus example](https://github.com/open-telemetry/opentelemetry-cpp/tree/main/examples/prometheus)
+To learn more on how to use the Prometheus exporter, try out the
+[prometheus example](https://github.com/open-telemetry/opentelemetry-cpp/tree/main/examples/prometheus)
 
 ## Next steps
 

--- a/content/en/docs/instrumentation/cpp/getting-started.md
+++ b/content/en/docs/instrumentation/cpp/getting-started.md
@@ -20,38 +20,43 @@ install some dependencies:
 
 <!-- prettier-ignore-start -->
 {{< ot-tabs "Linux (apt)" "Linux (yum)" "Linux (alpine)" "MacOS (homebrew)">}}
+
 {{< ot-tab lang="shell">}}
-$ sudo apt-get install git cmake g++ libcurl4-openssl-dev
+sudo apt-get install git cmake g++ libcurl4-openssl-dev
 {{< /ot-tab >}}
+
 {{< ot-tab lang="shell">}}
-$ sudo yum install git cmake g++ libcurl-devel
+sudo yum install git cmake g++ libcurl-devel
 {{< /ot-tab >}}
+
 {{< ot-tab lang="shell">}}
-$ sudo apk add git cmake g++ make curl-dev
+sudo apk add git cmake g++ make curl-dev
 {{< /ot-tab >}}
+
 {{< ot-tab lang="shell">}}
-$ xcode-select —install
-$ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-$ brew install git cmake
+xcode-select —install
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+brew install git cmake
 {{< /ot-tab >}}
+
 {{< /ot-tabs >}}
 <!-- prettier-ignore-end -->
 
 ## Building
 
-Get the opentelementry-cpp source:
+Get the `opentelementry-cpp` source:
 
 ```shell
-$ git clone --recursive https://github.com/open-telemetry/opentelemetry-cpp
+git clone --recursive https://github.com/open-telemetry/opentelemetry-cpp
 ```
 
 Navigate to the repository cloned above, and create the CMake build
 configuration:
 
 ```shell
-$ cd opentelemetry-cpp
-$ mkdir build && cd build
-$ cmake -DBUILD_TESTING=OFF -DWITH_EXAMPLES_HTTP=ON ..
+cd opentelemetry-cpp
+mkdir build && cd build
+cmake -DBUILD_TESTING=OFF -DWITH_EXAMPLES_HTTP=ON ..
 ```
 
 Once build configuration is created, build the CMake targets `http_client` and
@@ -64,7 +69,7 @@ cmake --build . --target http_client http_server
 If all goes well, you should find binaries `http_server` and `http_client` in
 `./examples/http`:
 
-```shell
+```console
 $ ls ./examples/http
 CMakeFiles  Makefile  cmake_install.cmake  http_client  http_server
 ```
@@ -73,14 +78,14 @@ CMakeFiles  Makefile  cmake_install.cmake  http_client  http_server
 
 Open two terminals, in the first terminal, start the http server:
 
-```shell
+```console
 $ ./examples/http/http_server
 Server is running..Press ctrl-c to exit..
 ```
 
 In the other terminal, run the http client:
 
-```shell
+```console
 $ ./examples/http/http_client
 {
   name          : /helloworld
@@ -116,7 +121,7 @@ $ ./examples/http/http_client
 
 Also the server should dump you a trace to the console:
 
-```shell
+```properties
 {
   name          : /helloworld
   trace_id      : 05eec7a55d3544434265dad89d7fe96f

--- a/content/en/docs/instrumentation/cpp/manual.md
+++ b/content/en/docs/instrumentation/cpp/manual.md
@@ -97,16 +97,17 @@ context to remote services using the W3C Trace Context HTTP headers.
 
 ### Further Reading
 
-* [Traces API](https://opentelemetry-cpp.readthedocs.io/en/latest/otel_docs/namespace_opentelemetry__trace.html)
-* [Traces SDK](https://opentelemetry-cpp.readthedocs.io/en/latest/otel_docs/namespace_opentelemetry__sdk__trace.html)
-* [Simple Metrics Example](https://github.com/open-telemetry/opentelemetry-cpp/tree/main/examples/metrics_simple)
-
+- [Traces API](https://opentelemetry-cpp.readthedocs.io/en/latest/otel_docs/namespace_opentelemetry__trace.html)
+- [Traces SDK](https://opentelemetry-cpp.readthedocs.io/en/latest/otel_docs/namespace_opentelemetry__sdk__trace.html)
+- [Simple Metrics Example](https://github.com/open-telemetry/opentelemetry-cpp/tree/main/examples/metrics_simple)
 
 ## Metrics
 
 ### Initialize Exporter and Reader
 
-Initialize an exporter and a reader. In this case, we initialize an OStream Exporter which will print to stdout by default. The reader periodically collects metrics from the Aggregation Store and exports them.
+Initialize an exporter and a reader. In this case, we initialize an OStream
+Exporter which will print to stdout by default. The reader periodically collects
+metrics from the Aggregation Store and exports them.
 
 ```cpp
 std::unique_ptr<opentelemetry::sdk::metrics::MetricExporter> exporter{new opentelemetry::exporters::OStreamMetricExporter};
@@ -116,7 +117,8 @@ std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> reader{
 
 ### Initialize Meter Provider
 
-Initialize a MeterProvider and add the reader. We will use this to obtain Meter objects in the future.
+Initialize a MeterProvider and add the reader. We will use this to obtain Meter
+objects in the future.
 
 ```cpp
 auto provider = std::shared_ptr<opentelemetry::metrics::MeterProvider>(new opentelemetry::sdk::metrics::MeterProvider());
@@ -126,7 +128,10 @@ p->AddMetricReader(std::move(reader));
 
 ### Create a Counter
 
-Create a Counter instrument from the Meter, and record the measurement. Every Meter pointer returned by the MeterProvider points to the same Meter. This means that the Meter will be able to combine metrics captured from different functions without having to constantly pass the Meter around the library.
+Create a Counter instrument from the Meter, and record the measurement. Every
+Meter pointer returned by the MeterProvider points to the same Meter. This means
+that the Meter will be able to combine metrics captured from different functions
+without having to constantly pass the Meter around the library.
 
 ```cpp
 auto meter = provider->GetMeter(name, "1.2.0");
@@ -149,7 +154,9 @@ histogram_counter->Record(val, labelkv);
 
 ### Create Observable Counter
 
-Create a Observable Counter Instrument from the Meter, and add a callback. The callback would be used to record the measurement during metrics collection. Ensure to keep the Instrument object active for the lifetime of collection.
+Create a Observable Counter Instrument from the Meter, and add a callback. The
+callback would be used to record the measurement during metrics collection.
+Ensure to keep the Instrument object active for the lifetime of collection.
 
 ```cpp
 auto meter = provider->GetMeter(name, "1.2.0");
@@ -161,7 +168,10 @@ counter->AddCallback(MeasurementFetcher::Fetcher, nullptr);
 
 #### Map the Counter Instrument to Sum Aggregation
 
-Create a view to map the Counter Instrument to Sum Aggregation. Add this view to provider. View creation is optional unless we want to add custom aggregation config, and attribute processor. Metrics SDK will implicitly create a missing view with default mapping between Instrument and Aggregation.
+Create a view to map the Counter Instrument to Sum Aggregation. Add this view to
+provider. View creation is optional unless we want to add custom aggregation
+config, and attribute processor. Metrics SDK will implicitly create a missing
+view with default mapping between Instrument and Aggregation.
 
 ```cpp
 std::unique_ptr<opentelemetry::sdk::metrics::InstrumentSelector> instrument_selector{
@@ -202,6 +212,6 @@ p->AddView(std::move(observable_instrument_selector), std::move(observable_meter
 
 ### Further Reading
 
-* [Metrics API](https://opentelemetry-cpp.readthedocs.io/en/latest/otel_docs/namespace_opentelemetry__metrics.html#)
-* [Metrics SDK](https://opentelemetry-cpp.readthedocs.io/en/latest/otel_docs/namespace_opentelemetry__sdk__metrics.html)
-* [Simple Metrics Example](https://github.com/open-telemetry/opentelemetry-cpp/tree/main/examples/metrics_simple)
+- [Metrics API](https://opentelemetry-cpp.readthedocs.io/en/latest/otel_docs/namespace_opentelemetry__metrics.html#)
+- [Metrics SDK](https://opentelemetry-cpp.readthedocs.io/en/latest/otel_docs/namespace_opentelemetry__sdk__metrics.html)
+- [Simple Metrics Example](https://github.com/open-telemetry/opentelemetry-cpp/tree/main/examples/metrics_simple)


### PR DESCRIPTION
- Contributes to #1063
- Enables format checking over `instrumentation/cpp` section
- Fixes code-block languages for commands

Preview: https://deploy-preview-2389--opentelemetry.netlify.app/docs/instrumentation/cpp/