### PR TITLE
Mount Go website_docs rather than symlink to it

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -20,7 +20,6 @@ package-lock.json
 /content/en/blog/2022
 /content/en/docs/concepts
 /content/en/docs/demo
-/content/en/docs/instrumentation/go
 /data
 /resources
 /scripts

--- a/content/en/docs/instrumentation/go
+++ b/content/en/docs/instrumentation/go
@@ -1,1 +1,0 @@
-../../../../content-modules/opentelemetry-go/website_docs

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -173,12 +173,14 @@ services:
 
 module:
   mounts:
+    - source: content/en
+      target: content
+    - source: content-modules/opentelemetry-go/website_docs
+      target: content/docs/instrumentation/go
     - source: tmp/specification
       target: content/docs/reference/specification
     - source: tmp/community/roadmap.md
       target: content/community/roadmap.md
-    - source: content/en
-      target: content
     - source: static
       target: static
     - source: content-modules/opentelemetry-specification/schemas


### PR DESCRIPTION
- Contributes to #1063
- In preparation for #2380
- Deletes the `/content/en/docs/instrumentation/go` symlink
- (Hugo) mounts the Go `website_docs` as `/content/en/docs/instrumentation/go`
- There is no net change in the generated site files (Other than reordering of redirect rules and changes in .xml files)