### PR TITLE
Enable Prettier check over concepts section

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -18,7 +18,6 @@ package-lock.json
 /content/en/blog/2019
 /content/en/blog/2021
 /content/en/blog/2022
-/content/en/docs/concepts
 /content/en/docs/demo
 /data
 /resources

--- a/content/en/docs/concepts/data-collection.md
+++ b/content/en/docs/concepts/data-collection.md
@@ -1,7 +1,8 @@
 ---
-title: "Data Collection"
+title: Data Collection
 description: >-
-  The OpenTelemetry project facilitates the collection of telemetry data via the OpenTelemetry Collector
+  The OpenTelemetry project facilitates the collection of telemetry data via the
+  OpenTelemetry Collector.
 weight: 50
 ---
 

--- a/content/en/docs/concepts/distributions.md
+++ b/content/en/docs/concepts/distributions.md
@@ -1,13 +1,14 @@
 ---
-title: "Distributions"
+title: Distributions
 description: >-
- A distribution, not to be confused with a fork, is customized version of an OpenTelemetry component.
+  A distribution, not to be confused with a fork, is customized version of an
+  OpenTelemetry component.
 weight: 90
 ---
 
 The OpenTelemetry projects consists of multiple [components](../components) that
-support multiple [signals](../signals). The reference implementation
-of OpenTelemetry is available as:
+support multiple [signals](../signals). The reference implementation of
+OpenTelemetry is available as:
 
 - [Language-specific instrumentation libraries](../instrumenting)
 - [A Collector binary](../data-collection)
@@ -39,17 +40,18 @@ Distributions would broadly fall into the following categories:
   instrumentation libraries or vendor exporters not upstreamed to the
   OpenTelemetry project.
 - **"Minus":** These distributions provide a reduced set of functionality from
-  upstream. Examples of this would include the removal of
-  instrumentation libraries or receivers/processors/exporters/extensions found
-  in the OpenTelemetry Collector project. These distributions may be provided to
+  upstream. Examples of this would include the removal of instrumentation
+  libraries or receivers/processors/exporters/extensions found in the
+  OpenTelemetry Collector project. These distributions may be provided to
   increase supportability and security considerations.
 
 ## Who would create a distribution?
 
-Anyone could create a distribution. Today, several [vendors](/ecosystem/vendors/)
-offer distributions. In addition, end-users may consider creating a distribution
-if they wish to use components in the [Registry](/ecosystem/registry/) that are not
-upstreamed to the OpenTelemetry project.
+Anyone could create a distribution. Today, several
+[vendors](/ecosystem/vendors/) offer distributions. In addition, end-users may
+consider creating a distribution if they wish to use components in the
+[Registry](/ecosystem/registry/) that are not upstreamed to the OpenTelemetry
+project.
 
 ## Contribution or distribution?
 

--- a/content/en/docs/concepts/glossary.md
+++ b/content/en/docs/concepts/glossary.md
@@ -1,7 +1,8 @@
 ---
 title: Glossary
 description: >-
- Terminology you may or may not be familiar with used by the OpenTelemetry project
+  Terminology you may or may not be familiar with used by the OpenTelemetry
+  project.
 weight: 100
 ---
 
@@ -29,7 +30,9 @@ One or more [`Services`](#service) designed for end users or other applications.
 
 ### **APM**
 
-Application Performance Monitoring is about monitoring software applications, their performance (speed, reliability, availability, etc.) to detect issues, alerting and tooling for finding the root cause.
+Application Performance Monitoring is about monitoring software applications,
+their performance (speed, reliability, availability, etc.) to detect issues,
+alerting and tooling for finding the root cause.
 
 ### **Attribute**
 
@@ -181,8 +184,8 @@ A name/value pair added to telemetry data. OpenTelemetry calls this
 
 ### **Metric**
 
-Records a data point, either raw measurements or predefined aggregation, as
-time series with [`Metadata`](#metadata). See [more][metric].
+Records a data point, either raw measurements or predefined aggregation, as time
+series with [`Metadata`](#metadata). See [more][metric].
 
 ### **OC**
 

--- a/content/en/docs/concepts/instrumenting-library/index.md
+++ b/content/en/docs/concepts/instrumenting-library/index.md
@@ -1,13 +1,11 @@
 ---
 title: Instrumenting libraries
-description: Learn how to add native instrumentation to your library
+description: Learn how to add native instrumentation to your library.
 weight: 40
 ---
 
-OpenTelemetry provides
-[instrumentation libraries][]
-for many libraries, which is typically done through library hooks or
-monkey-patching library code.
+OpenTelemetry provides [instrumentation libraries][] for many libraries, which
+is typically done through library hooks or monkey-patching library code.
 
 Native library instrumentation with OpenTelemetry provides better observability
 and developer experience for users, removing the need for libraries to expose
@@ -25,8 +23,8 @@ and document hooks:
 
 ## Semantic Conventions
 
-Check out available [semantic
-conventions]({{< relref "/docs/reference/specification/trace/semantic_conventions/" >}})
+Check out available
+[semantic conventions](/docs/reference/specification/trace/semantic_conventions/)
 that cover web-frameworks, RPC clients, databases, messaging clients, infra
 pieces and more!
 
@@ -47,9 +45,9 @@ are a good places to start!
 ## When **not** to instrument
 
 Some libraries are thin clients wrapping network calls. Chances are that
-OpenTelemetry has an instrumentation library for the underlying RPC client (check out
-the [registry](/ecosystem/registry/)). In this case, instrumenting the wrapper library
-may not be necessary.
+OpenTelemetry has an instrumentation library for the underlying RPC client
+(check out the [registry](/ecosystem/registry/)). In this case, instrumenting
+the wrapper library may not be necessary.
 
 Don't instrument if:
 
@@ -72,19 +70,18 @@ decide to do it.
 
 The first step is to take dependency on the OpenTelemetry API package.
 
-OpenTelemetry has [two main
-modules]({{< relref "/docs/reference/specification/overview" >}}) - API and SDK.
-OpenTelemetry API is a set of abstractions and not-operational implementations.
-Unless your application imports the OpenTelemetry SDK, your instrumentation does
-nothing and does not impact application performance.
+OpenTelemetry has [two main modules](/docs/reference/specification/overview/) -
+API and SDK. OpenTelemetry API is a set of abstractions and not-operational
+implementations. Unless your application imports the OpenTelemetry SDK, your
+instrumentation does nothing and does not impact application performance.
 
 **Libraries should only use the OpenTelemetry API.**
 
 You may be rightfully concerned about adding new dependencies, here are some
 considerations to help you decide how to minimize dependency hell:
 
-- OpenTelemetry Trace API reached stability in early 2021, it follows [Semantic
-  Versioning 2.0](/docs/reference/specification/versioning-and-stability)
+- OpenTelemetry Trace API reached stability in early 2021, it follows
+  [Semantic Versioning 2.0](/docs/reference/specification/versioning-and-stability)
   and we take API stability seriously.
 - When taking dependency, use the earliest stable OpenTelemetry API (1.0.\*) and
   avoid updating it unless you have to use new features.
@@ -100,13 +97,13 @@ considerations to help you decide how to minimize dependency hell:
   for your users.
 
   [stable, but subject to evolution]:
-      /docs/reference/specification/versioning-and-stability/#semantic-conventions-stability
+    /docs/reference/specification/versioning-and-stability/#semantic-conventions-stability
 
 ### Getting a tracer
 
 All application configuration is hidden from your library through the Tracer
-API. Libraries should obtain tracer from [global
-`TracerProvider`]({{< relref "/docs/reference/specification/trace/api#get-a-tracer" >}})
+API. Libraries should obtain tracer from
+[global `TracerProvider`](/docs/reference/specification/trace/api/#get-a-tracer)
 by default.
 
 ```java
@@ -168,8 +165,8 @@ private Response selectWithTracing(Query query) {
 ```
 
 Follow conventions to populate attributes! If there is no applicable one, check
-out [general
-conventions](/docs/reference/specification/trace/semantic_conventions/span-general/).
+out
+[general conventions](/docs/reference/specification/trace/semantic_conventions/span-general/).
 
 ### Nested network and other spans
 
@@ -213,8 +210,8 @@ should have a verbosity, logs are a better choice than traces.
 
 Chances are that your app uses logging or some similar module already. Your
 module might already have OpenTelemetry integration -- to find out, see the
-[registry](/ecosystem/registry/). Integrations usually stamp active trace context on all
-logs, so users can correlate them.
+[registry](/ecosystem/registry/). Integrations usually stamp active trace
+context on all logs, so users can correlate them.
 
 If your language and ecosystem don't have common logging support, use [span
 events][] to share additional app details. Events maybe more convenient if you
@@ -266,8 +263,8 @@ check out OpenTelemetry documentation in your language.
 In the case of a messaging system, you may receive more than one message at
 once. Received messages become
 [_links_](/docs/instrumentation/java/manual/#create-spans-with-links) on the
-span you create. Refer to [messaging
-conventions]({{< relref "/docs/reference/specification/trace/semantic_conventions/messaging" >}})
+span you create. Refer to
+[messaging conventions](/docs/reference/specification/trace/semantic_conventions/messaging/)
 for details (WARNING: messaging conventions are
 [under constructions](https://github.com/open-telemetry/oteps/pull/173) 🚧).
 
@@ -334,8 +331,8 @@ There might be some exceptions:
 
 ## Metrics
 
-[Metrics API]({{< relref "/docs/reference/specification/metrics/api" >}}) is not
-stable yet and we don't yet define metrics conventions.
+[Metrics API](/docs/reference/specification/metrics/api/) is not stable yet and
+we don't yet define metrics conventions.
 
 ## Misc
 
@@ -347,8 +344,8 @@ Please add your instrumentation library to the
 ### Performance
 
 OpenTelemetry API is no-op and very performant when there is no SDK in the
-application. When OpenTelemetry SDK is configured, it [consumes bound
-resources]({{< relref "/docs/reference/specification/performance" >}}).
+application. When OpenTelemetry SDK is configured, it
+[consumes bound resources](/docs/reference/specification/performance/).
 
 Real-life applications, especially on the high scale, would frequently have
 head-based sampling configured. Sampled-out spans are cheap and you can check if
@@ -372,8 +369,8 @@ if (span.isRecording()) {
 
 ### Error handling
 
-OpenTelemetry API is [forgiving at
-runtime]({{< relref "/docs/reference/specification/error-handling#basic-error-handling-principles" >}}) -
+OpenTelemetry API is
+[forgiving at runtime](/docs/reference/specification/error-handling/#basic-error-handling-principles) -
 does not fail on invalid arguments, never throws, and swallows exceptions. This
 way instrumentation issues do not affect application logic. Test the
 instrumentation to notice issues OpenTelemetry hides at runtime.
@@ -415,5 +412,6 @@ class TestExporter implements SpanExporter {
 }
 ```
 
-[instrumentation libraries]: /docs/reference/specification/overview/#instrumentation-libraries
+[instrumentation libraries]:
+  /docs/reference/specification/overview/#instrumentation-libraries
 [span events]: /docs/reference/specification/trace/api/#add-events

--- a/content/en/docs/concepts/instrumenting.md
+++ b/content/en/docs/concepts/instrumenting.md
@@ -1,13 +1,13 @@
 ---
-title: "Instrumenting"
+title: Instrumenting
 description: >-
   How OpenTelemetry facilitates automatic and manual instrumentation of
-  applications
+  applications.
 weight: 40
 ---
 
-In order to make a system observable, it must be **instrumented**: That is, code from the
-system's components must emit
+In order to make a system observable, it must be **instrumented**: That is, code
+from the system's components must emit
 [traces](/docs/concepts/observability-primer/#distributed-traces),
 [metrics](/docs/concepts/observability-primer/#reliability--metrics), and
 [logs](/docs/concepts/observability-primer/#logs).
@@ -93,8 +93,8 @@ options you may wish to take advantage of.
 Once you've configured the API and SDK, you'll then be free to create traces and
 metric events through the tracer and meter objects you obtained from the
 provider. Make use of Instrumentation Libraries for your dependencies -- check
-out the [registry](/ecosystem/registry/) or your language's repository for more information
-on these.
+out the [registry](/ecosystem/registry/) or your language's repository for more
+information on these.
 
 ### Export Data
 

--- a/content/en/docs/concepts/observability-primer.md
+++ b/content/en/docs/concepts/observability-primer.md
@@ -1,19 +1,14 @@
 ---
 title: Observability Primer
-description: >-
-  Learn some core concepts before you dig into OpenTelemetry
+description: Learn some core concepts before you dig into OpenTelemetry.
 weight: 9
-description: >-
- Before digging into OpenTelemetry, it is important to understand some core concepts first.
 ---
-
-
 
 ## What is Observability?
 
 Observability lets us understand a system from the outside, by letting us ask
-questions about that system without knowing its inner workings. Furthermore,
-it allows us to easily troubleshoot and handle novel problems (i.e. "unknown
+questions about that system without knowing its inner workings. Furthermore, it
+allows us to easily troubleshoot and handle novel problems (i.e. "unknown
 unknowns”), and helps us answer the question, "Why is this happening?"
 
 In order to be able to ask those questions of a system, the application must be
@@ -30,8 +25,8 @@ which application code is instrumented, to help make a system observable.
 
 ## Reliability & Metrics
 
-**Telemetry** refers to data emitted from a system, about its behavior. The
-data can come in the form of [Traces](#distributed-traces),
+**Telemetry** refers to data emitted from a system, about its behavior. The data
+can come in the form of [Traces](#distributed-traces),
 [Metrics](#reliability--metrics), and [Logs](#logs).
 
 **Reliability** answers the question: "Is the service doing what users expect it
@@ -89,21 +84,22 @@ provide information about the operation it tracks.
 Below is a sample of the type of information that would be present in a Span:
 
 #### Span Attributes
-| Key                           | Value                                           |
-| ----------------------------- | ------------------------------------------------|
-| net.transport                 | IP.TCP                                          |
-| net.peer.ip                   | 10.244.0.1                                      |
-| net.peer.port                 | 10243                                           |
-| net.host.name                 | localhost                                       |
-| http.method                   | GET                                             |
-| http.target                   | /cart                                           |
-| http.server_name              | frontend                                        |
-| http.route                    | /cart                                           |
-| http.scheme                   | http                                            |
-| http.host                     | localhost                                       |
-| http.flavor                   | 1.1                                             |
-| http.status_code              | 200                                             |
-| http.user_agent               | Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36             |
+
+| Key              | Value                                                                                                                 |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------- |
+| net.transport    | IP.TCP                                                                                                                |
+| net.peer.ip      | 10.244.0.1                                                                                                            |
+| net.peer.port    | 10243                                                                                                                 |
+| net.host.name    | localhost                                                                                                             |
+| http.method      | GET                                                                                                                   |
+| http.target      | /cart                                                                                                                 |
+| http.server_name | frontend                                                                                                              |
+| http.route       | /cart                                                                                                                 |
+| http.scheme      | http                                                                                                                  |
+| http.host        | localhost                                                                                                             |
+| http.flavor      | 1.1                                                                                                                   |
+| http.status_code | 200                                                                                                                   |
+| http.user_agent  | Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36 |
 
 > For more on Spans and how they pertain to OTel, visit
 > [Spans in OpenTelemetry](/docs/concepts/signals/traces/#spans-in-opentelemetry).
@@ -111,9 +107,8 @@ Below is a sample of the type of information that would be present in a Span:
 ### Distributed Traces
 
 A **Distributed Trace**, more commonly known as a **Trace**, records the paths
-taken by requests (made by an application or end-user) as they propagate
-through multi-service architectures, like microservice and serverless
-applications.
+taken by requests (made by an application or end-user) as they propagate through
+multi-service architectures, like microservice and serverless applications.
 
 Without tracing, it is challenging to pinpoint the cause of performance problems
 in a distributed system.
@@ -135,7 +130,7 @@ what steps make up a request).
 Many Observability back-ends visualize Traces as waterfall diagrams that may
 look something like this:
 
-![Sample Trace](/img/waterfall_trace.png "trace waterfall diagram")
+![Sample Trace](/img/waterfall_trace.png 'trace waterfall diagram')
 
 Waterfall diagrams show the parent-child relationship between a Root Span and
 its child Spans. When a Span encapsulates another Span, this also represents a

--- a/content/en/docs/concepts/sdk-configuration/_index.md
+++ b/content/en/docs/concepts/sdk-configuration/_index.md
@@ -3,4 +3,7 @@ title: SDK Configuration
 weight: 51
 ---
 
-OpenTelemetry SDKs support configuration in each language and with environment variables. The following pages describe the environment variables you can use to configure your SDK. Values set with environment variables override equivalent configuration done in code using SDK APIs.
+OpenTelemetry SDKs support configuration in each language and with environment
+variables. The following pages describe the environment variables you can use to
+configure your SDK. Values set with environment variables override equivalent
+configuration done in code using SDK APIs.

--- a/content/en/docs/concepts/sdk-configuration/general-sdk-configuration.md
+++ b/content/en/docs/concepts/sdk-configuration/general-sdk-configuration.md
@@ -1,15 +1,15 @@
 ---
-title: "General SDK Configuration"
+title: General SDK Configuration
 description: >-
- General-purpose environment variables for configuring an OpenTelemetry SDK.
+  General-purpose environment variables for configuring an OpenTelemetry SDK.
 weight: 1
 ---
 
 ## `OTEL_SERVICE_NAME`
 
 Sets the value of the
-[`service.name`](/docs/reference/specification/resource/semantic_conventions/#service) resource
-attribute.
+[`service.name`](/docs/reference/specification/resource/semantic_conventions/#service)
+resource attribute.
 
 **Default value:** `"unknown_service"`
 
@@ -22,14 +22,14 @@ If `service.name` is also provided in `OTEL_RESOURCE_ATTRIBUTES`, then
 
 ## `OTEL_RESOURCE_ATTRIBUTES`
 
-Key-value pairs to be used as resource attributes. See [Resource
-SDK](/docs/reference/specification/resource/sdk#specifying-resource-information-via-an-environment-variable)
+Key-value pairs to be used as resource attributes. See
+[Resource SDK](/docs/reference/specification/resource/sdk#specifying-resource-information-via-an-environment-variable)
 for more details.
 
 **Default value:** Empty.
 
-See [Resource semantic
-conventions](/docs/reference/specification/resource/semantic_conventions/#semantic-attributes-with-sdk-provided-default-value)
+See
+[Resource semantic conventions](/docs/reference/specification/resource/semantic_conventions/#semantic-attributes-with-sdk-provided-default-value)
 for semantic conventions to follow for common resource types.
 
 **Example:**
@@ -56,8 +56,8 @@ Accepted values for `OTEL_TRACES_SAMPLER` are:
 - `"parentbased_traceidratio"`: `ParentBased(root=TraceIdRatioBased)`
 - `"parentbased_jaeger_remote"`: `ParentBased(root=JaegerRemoteSampler)`
 - `"jaeger_remote"`: `JaegerRemoteSampler`
-- `"xray"`: [AWS X-Ray Centralized
-  Sampling](https://docs.aws.amazon.com/xray/latest/devguide/xray-console-sampling.html)
+- `"xray"`:
+  [AWS X-Ray Centralized Sampling](https://docs.aws.amazon.com/xray/latest/devguide/xray-console-sampling.html)
   (_third party_)
 
 ## `OTEL_TRACES_SAMPLER_ARG`
@@ -89,9 +89,9 @@ be set as follows:
   - `endpoint`: the endpoint in form of `scheme://host:port` of gRPC server that
     serves the sampling strategy for the service
     ([sampling.proto](https://github.com/jaegertracing/jaeger-idl/blob/master/proto/api_v2/sampling.proto)).
-  - `pollingIntervalMs`:  in milliseconds indicating how often the sampler will
+  - `pollingIntervalMs`: in milliseconds indicating how often the sampler will
     poll the backend for updates to sampling strategy.
-  - `initialSamplingRate`:  in the [0..1] range, which is used as the sampling
+  - `initialSamplingRate`: in the [0..1] range, which is used as the sampling
     probability when the backend cannot be reached to retrieve a sampling
     strategy. This value stops having an effect once a sampling strategy is
     retrieved successfully, as the remote strategy will be used until a new
@@ -111,15 +111,18 @@ Accepted values for `OTEL_PROPAGATORS` are:
 
 - `"tracecontext"`: [W3C Trace Context](https://www.w3.org/TR/trace-context/)
 - `"baggage"`: [W3C Baggage](https://www.w3.org/TR/baggage/)
-- `"b3"`: [B3 Single](/docs/reference/specification/context/api-propagators#configuration)
-- `"b3multi"`: [B3 Multi](/docs/reference/specification/context/api-propagators#configuration)
+- `"b3"`:
+  [B3 Single](/docs/reference/specification/context/api-propagators#configuration)
+- `"b3multi"`:
+  [B3 Multi](/docs/reference/specification/context/api-propagators#configuration)
 - `"jaeger"`:
   [Jaeger](https://www.jaegertracing.io/docs/1.21/client-libraries/#propagation-format)
-- `"xray"`: [AWS
-  X-Ray](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader)
+- `"xray"`:
+  [AWS X-Ray](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader)
   (_third party_)
-- `"ottrace"`: [OT
-  Trace](https://github.com/opentracing?q=basic&type=&language=) (_third party_)
+- `"ottrace"`:
+  [OT Trace](https://github.com/opentracing?q=basic&type=&language=) (_third
+  party_)
 - `"none"`: No automatically configured propagator.
 
 ## `OTEL_TRACES_EXPORTER`
@@ -152,7 +155,8 @@ Specifies which exporter is used for metrics.
 Accepted values for `OTEL_METRICS_EXPORTER` are:
 
 - `"otlp"`: [OTLP][spec-otlp]
-- `"prometheus"`: [Prometheus](https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md)
+- `"prometheus"`:
+  [Prometheus](https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md)
 - `"none"`: No automatically configured exporter for metrics.
 
 ## `OTEL_LOGS_EXPORTER`

--- a/content/en/docs/concepts/sdk-configuration/otlp-exporter-configuration.md
+++ b/content/en/docs/concepts/sdk-configuration/otlp-exporter-configuration.md
@@ -1,7 +1,6 @@
 ---
-title: "OTLP Exporter Configuration"
-description: >-
- Environment variables for configuring your OTLP Exporter.
+title: OTLP Exporter Configuration
+description: Environment variables for configuring your OTLP Exporter.
 weight: 2
 ---
 
@@ -18,21 +17,21 @@ endpoint and want one environment variable to control the endpoint.
 
 **Default value:**
 
-* gRPC: `"http://localhost:4317"`
-* HTTP: `"http://localhost:4318"`
+- gRPC: `"http://localhost:4317"`
+- HTTP: `"http://localhost:4318"`
 
 **Example:**
 
-* gRPC: `export OTEL_EXPORTER_OTLP_ENDPOINT="my-api-endpoint:443"`
-* HTTP: `export OTEL_EXPORTER_OTLP_ENDPOINT="http://my-api-endpoint/"`
+- gRPC: `export OTEL_EXPORTER_OTLP_ENDPOINT="my-api-endpoint:443"`
+- HTTP: `export OTEL_EXPORTER_OTLP_ENDPOINT="http://my-api-endpoint/"`
 
 For OTLP/HTTP, exporters in the SDK construct signal-specific URLs when this
 environment variable is set. This means that if you're sending traces, metrics,
 and logs, the following URLs are constructed from the example above:
 
-* Traces: `"http://my-api-endpoint/v1/traces"`
-* Metrics: `"http://my-api-endpoint/v1/metrics"`
-* Logs: `"http://my-api-endpoint/v1/logs"`
+- Traces: `"http://my-api-endpoint/v1/traces"`
+- Metrics: `"http://my-api-endpoint/v1/metrics"`
+- Logs: `"http://my-api-endpoint/v1/logs"`
 
 ### `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
 
@@ -41,28 +40,30 @@ end with `v1/traces` if using OTLP/HTTP.
 
 **Default value:**
 
-* gRPC: `"http://localhost:4317"`
-* HTTP: `"http://localhost:4318/v1/traces"`
+- gRPC: `"http://localhost:4317"`
+- HTTP: `"http://localhost:4318/v1/traces"`
 
 **Example:**
 
-* gRPC: `export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="my-api-endpoint:443"`
-* HTTP: `export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://my-api-endpoint/v1/traces"`
+- gRPC: `export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="my-api-endpoint:443"`
+- HTTP:
+  `export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://my-api-endpoint/v1/traces"`
 
 ### `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`
 
-Endpoint URL for metric data only, with an optionally-specified port number. Must
-end with `v1/metrics` if using OTLP/HTTP.
+Endpoint URL for metric data only, with an optionally-specified port number.
+Must end with `v1/metrics` if using OTLP/HTTP.
 
 **Default value:**
 
-* gRPC: `"http://localhost:4317"`
-* HTTP: `"http://localhost:4318/v1/metrics"`
+- gRPC: `"http://localhost:4317"`
+- HTTP: `"http://localhost:4318/v1/metrics"`
 
 **Example:**
 
-* gRPC: `export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT="my-api-endpoint:443"`
-* HTTP: `export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT="http://my-api-endpoint/v1/metrics"`
+- gRPC: `export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT="my-api-endpoint:443"`
+- HTTP:
+  `export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT="http://my-api-endpoint/v1/metrics"`
 
 ### `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`
 
@@ -71,13 +72,14 @@ end with `v1/logs` if using OTLP/HTTP.
 
 **Default value:**
 
-* gRPC: `"http://localhost:4317"`
-* HTTP: `"http://localhost:4318/v1/logs"`
+- gRPC: `"http://localhost:4317"`
+- HTTP: `"http://localhost:4318/v1/logs"`
 
 **Example:**
 
-* gRPC: `export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT="my-api-endpoint:443"`
-* HTTP: `export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT="http://my-api-endpoint/v1/logs"`
+- gRPC: `export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT="my-api-endpoint:443"`
+- HTTP:
+  `export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT="http://my-api-endpoint/v1/logs"`
 
 ## Header configuration
 
@@ -90,7 +92,8 @@ A list of headers to apply to all outgoing data (traces, metrics, and logs).
 
 **Default value:** N/A
 
-**Example:** `export OTEL_EXPORTER_OTLP_HEADERS="api-key=key,other-config-value=value"`
+**Example:**
+`export OTEL_EXPORTER_OTLP_HEADERS="api-key=key,other-config-value=value"`
 
 ### `OTEL_EXPORTER_OTLP_TRACES_HEADERS`
 
@@ -98,7 +101,8 @@ A list of headers to apply to all outgoing traces.
 
 **Default value:** N/A
 
-**Example:** `export OTEL_EXPORTER_OTLP_TRACES_HEADERS="api-key=key,other-config-value=value"`
+**Example:**
+`export OTEL_EXPORTER_OTLP_TRACES_HEADERS="api-key=key,other-config-value=value"`
 
 ### `OTEL_EXPORTER_OTLP_METRICS_HEADERS`
 
@@ -106,7 +110,8 @@ A list of headers to apply to all outgoing metrics.
 
 **Default value:** N/A
 
-**Example:** `export OTEL_EXPORTER_OTLP_METRICS_HEADERS="api-key=key,other-config-value=value"`
+**Example:**
+`export OTEL_EXPORTER_OTLP_METRICS_HEADERS="api-key=key,other-config-value=value"`
 
 ### `OTEL_EXPORTER_OTLP_LOGS_HEADERS`
 
@@ -114,7 +119,8 @@ A list of headers to apply to all outgoing logs.
 
 **Default value:** N/A
 
-**Example:** `export OTEL_EXPORTER_OTLP_LOGS_HEADERS="api-key=key,other-config-value=value"`
+**Example:**
+`export OTEL_EXPORTER_OTLP_LOGS_HEADERS="api-key=key,other-config-value=value"`
 
 ## Timeout Configuration
 
@@ -123,7 +129,8 @@ an OTLP Exporter will wait before transmitting the net batch of data.
 
 ### `OTEL_EXPORTER_OTLP_TIMEOUT`
 
-The timeout value for all outgoing data (traces, metrics, and logs) in milliseconds.
+The timeout value for all outgoing data (traces, metrics, and logs) in
+milliseconds.
 
 **Default value:** `10000` (10s)
 
@@ -157,40 +164,43 @@ The timeout value for all outgoing logs in milliseconds.
 
 Specifies the OTLP transport protocol to be used for all telemetry data.
 
-**Default value:** SDK-dependent, but will typically be either `http/protobuf` or `grpc`.
+**Default value:** SDK-dependent, but will typically be either `http/protobuf`
+or `grpc`.
 
 **Example:** `export OTEL_EXPORTER_OTLP_PROTOCOL=grpc`
 
 Valid values are:
 
-* `grpc` to use OTLP/gRPC
-* `http/protobuf` to use OTLP/HTTP + protobuf
-* `http/json` to use OTLP/HTTP + json
+- `grpc` to use OTLP/gRPC
+- `http/protobuf` to use OTLP/HTTP + protobuf
+- `http/json` to use OTLP/HTTP + json
 
 ### `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`
 
 Specifies the OTLP transport protocol to be used for trace data.
 
-**Default value:** SDK-dependent, but will typically be either `http/protobuf` or `grpc`.
+**Default value:** SDK-dependent, but will typically be either `http/protobuf`
+or `grpc`.
 
 **Example:** `export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc`
 
 Valid values are:
 
-* `grpc` to use OTLP/gRPC
-* `http/protobuf` to use OTLP/HTTP + protobuf
-* `http/json` to use OTLP/HTTP + json
+- `grpc` to use OTLP/gRPC
+- `http/protobuf` to use OTLP/HTTP + protobuf
+- `http/json` to use OTLP/HTTP + json
 
 ### `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL`
 
 Specifies the OTLP transport protocol to be used for metrics data.
 
-**Default value:** SDK-dependent, but will typically be either `http/protobuf` or `grpc`.
+**Default value:** SDK-dependent, but will typically be either `http/protobuf`
+or `grpc`.
 
 **Example:** `export OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=grpc`
 
 Valid values are:
 
-* `grpc` to use OTLP/gRPC
-* `http/protobuf` to use OTLP/HTTP + protobuf
-* `http/json` to use OTLP/HTTP + json
+- `grpc` to use OTLP/gRPC
+- `http/protobuf` to use OTLP/HTTP + protobuf
+- `http/json` to use OTLP/HTTP + json

--- a/content/en/docs/concepts/semantic-conventions.md
+++ b/content/en/docs/concepts/semantic-conventions.md
@@ -1,17 +1,16 @@
 ---
 title: Semantic Conventions
-description: >-
-  Common names for different kinds of operations and data
+description: Common names for different kinds of operations and data.
 weight: 30
 ---
 
-OpenTelemetry defines Semantic Conventions (sometimes called Semantic Attributes)
-that specify common names for different kinds of operations and data. The benefit
-to using Semantic Conventions is in following a common naming scheme that can be
-standardized across a codebase, libraries, and platforms.
+OpenTelemetry defines Semantic Conventions (sometimes called Semantic
+Attributes) that specify common names for different kinds of operations and
+data. The benefit to using Semantic Conventions is in following a common naming
+scheme that can be standardized across a codebase, libraries, and platforms.
 
 Currently, Semantic Conventions are available for traces, metrics and resources:
 
-* [Trace Semantic Conventions](/docs/reference/specification/trace/semantic_conventions/)
-* [Metric Semantic Conventions](/docs/reference/specification/metrics/semantic_conventions/)
-* [Resource Semantic Conventions](/docs/reference/specification/resource/semantic_conventions/)
+- [Trace Semantic Conventions](/docs/reference/specification/trace/semantic_conventions/)
+- [Metric Semantic Conventions](/docs/reference/specification/metrics/semantic_conventions/)
+- [Resource Semantic Conventions](/docs/reference/specification/resource/semantic_conventions/)

--- a/content/en/docs/concepts/signals/baggage.md
+++ b/content/en/docs/concepts/signals/baggage.md
@@ -1,7 +1,7 @@
 ---
-title: "Baggage"
+title: Baggage
 description: >-
- Baggage refers to contextual information that’s passed between spans
+  Baggage refers to contextual information that’s passed between spans.
 weight: 4
 ---
 
@@ -14,11 +14,11 @@ your trace, which involves multiple services; however, `CustomerId` is only
 available in one specific service. To accomplish your goal, you can use
 OpenTelemetry Baggage to propagate this value across your system.
 
-OpenTelemetry uses [Context
-Propagation](/docs/concepts/signals/traces/#context-propagation) to pass Baggage
-around, and each of the different library implementations has propagators that
-parse and make that Baggage available without you needing to explicitly
-implement it.
+OpenTelemetry uses
+[Context Propagation](/docs/concepts/signals/traces/#context-propagation) to
+pass Baggage around, and each of the different library implementations has
+propagators that parse and make that Baggage available without you needing to
+explicitly implement it.
 
 ![OTel Baggage](/img/otel_baggage.png)
 

--- a/content/en/docs/concepts/signals/logs.md
+++ b/content/en/docs/concepts/signals/logs.md
@@ -1,7 +1,8 @@
 ---
-title: "Logs"
+title: Logs
 description: >-
-  A log is a timestamped text record, either structured (recommended) or unstructured, with metadata. 
+  A log is a timestamped text record, either structured (recommended) or
+  unstructured, with metadata.
 weight: 3
 ---
 

--- a/content/en/docs/concepts/signals/metrics.md
+++ b/content/en/docs/concepts/signals/metrics.md
@@ -1,7 +1,6 @@
 ---
-title: "Metrics"
-description: >-
-  A metric is a measurement about a service, captured at runtime.
+title: Metrics
+description: A metric is a measurement about a service, captured at runtime.
 weight: 2
 ---
 

--- a/content/en/docs/concepts/signals/traces.md
+++ b/content/en/docs/concepts/signals/traces.md
@@ -1,8 +1,8 @@
 ---
 title: Traces
 description: >-
-  Traces give us the big picture of what happens when a request is made by a user
-  or an application.
+  Traces give us the big picture of what happens when a request is made by a
+  user or an application.
 weight: 1
 ---
 
@@ -217,18 +217,18 @@ work done in an application.
 
 Span Context is an immutable object on every span that contains the following:
 
-* The Trace ID representing the trace that the span is a part of
-* The Span's Span ID
-* Trace Flags, a binary encoding containing information about the trace
-* Trace State, a list of key-value pairs that can carry vendor-specific trace
+- The Trace ID representing the trace that the span is a part of
+- The Span's Span ID
+- Trace Flags, a binary encoding containing information about the trace
+- Trace State, a list of key-value pairs that can carry vendor-specific trace
   information
 
 Span Context is the part of a span that is serialized and propagated alongside
 [Distributed Context](#context-propagation) and
 [Baggage](/docs/concepts/signals/baggage).
 
-Because Span Context contains the Trace ID, it is used when creating [Span
-Links](#span-links).
+Because Span Context contains the Trace ID, it is used when creating
+[Span Links](#span-links).
 
 ### Attributes
 
@@ -241,15 +241,15 @@ the item to add to the cart, and the cart ID.
 
 Attributes have the following rules that each language SDK implements:
 
-* Keys must be non-null string values
-* Values must be a non-null string, boolean, floating point value, integer, or
+- Keys must be non-null string values
+- Values must be a non-null string, boolean, floating point value, integer, or
   an array of these values
 
-Additionally, there are [Semantic
-Attributes](/docs/reference/specification/trace/semantic_conventions/), which
-are known naming conventions for metadata that is typically present in common
-operations. It's helpful to use semantic attribute naming wherever possible so
-that common kinds of metadata are standardized across systems.
+Additionally, there are
+[Semantic Attributes](/docs/reference/specification/trace/semantic_conventions/),
+which are known naming conventions for metadata that is typically present in
+common operations. It's helpful to use semantic attribute naming wherever
+possible so that common kinds of metadata are standardized across systems.
 
 ### Span Events
 
@@ -312,8 +312,8 @@ span is usually a server span. Similarly, the parent of a consumer span is
 always a producer and the child of a producer span is always a consumer. If not
 provided, the span kind is assumed to be internal.
 
-For more information regarding SpanKind, see [SpanKind]({{< relref
-"/docs/reference/specification/trace/api#spankind" >}}).
+For more information regarding SpanKind, see
+[SpanKind](/docs/reference/specification/trace/api/#spankind).
 
 #### Client
 

--- a/content/en/docs/concepts/what-is-opentelemetry.md
+++ b/content/en/docs/concepts/what-is-opentelemetry.md
@@ -1,7 +1,6 @@
 ---
-title: "What is OpenTelemetry?"
-description: >-
-  Background information on OpenTelemetry
+title: What is OpenTelemetry?
+description: Background information on OpenTelemetry.
 weight: 10
 ---
 


### PR DESCRIPTION
- Contributes to #1063
- Enables format checking over concepts section
- Replaces `relref` link(s) by standard markdown link(s)
- Normalizes some front matter

Preview: https://deploy-preview-2399--opentelemetry.netlify.app/docs/concepts/