### PR TITLE
Fix Collector endpoint URL

### DIFF
--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -384,7 +384,7 @@ exporters:
 
   # Data sources: traces, metrics
   otlphttp:
-    endpoint: https://example.com:4318/v1/traces
+    endpoint: https://example.com:4318
 
   # Data sources: metrics
   prometheus:


### PR DESCRIPTION
Remove suffix  `/v1/traces` from endpoint url, as the collector is automatically adding `/v1/traces` and cannot send the trace otherwise, as the url would be `http://localhost:4318/v1/traces/v1/traces` and fails.

Change from:
```yaml
otlphttp:
  endpoint: http://localhost:4318/v1/traces
```

To:
```yaml
otlphttp:
  endpoint: http://localhost:4318
```

<details>
<summary>Error</summary>

2023-02-27T07:39:22.117Z	error	exporterhelper/queued_retry.go:401	Exporting failed. The error is not retryable. Dropping data.	{"kind": "exporter", "data_type": "traces", "name": "otlphttp/1", "error": "Permanent error: error exporting items, request to http://localhost:4318/v1/traces/v1/traces responded with HTTP Status Code 404", "dropped_items": 30}
2023-02-27T07:39:22.118798298Z go.opentelemetry.io/collector/exporter/exporterhelper.(*retrySender).send
2023-02-27T07:39:22.118804048Z 	go.opentelemetry.io/collector@v0.72.0/exporter/exporterhelper/queued_retry.go:401
2023-02-27T07:39:22.118808589Z go.opentelemetry.io/collector/exporter/exporterhelper.(*tracesExporterWithObservability).send
2023-02-27T07:39:22.118813131Z 	go.opentelemetry.io/collector@v0.72.0/exporter/exporterhelper/traces.go:137
2023-02-27T07:39:22.118817464Z go.opentelemetry.io/collector/exporter/exporterhelper.(*queuedRetrySender).start.func1
2023-02-27T07:39:22.118821673Z 	go.opentelemetry.io/collector@v0.72.0/exporter/exporterhelper/queued_retry.go:205
2023-02-27T07:39:22.118825881Z go.opentelemetry.io/collector/exporter/exporterhelper/internal.(*boundedMemoryQueue).StartConsumers.func1
2023-02-27T07:39:22.118830214Z 	go.opentelemetry.io/collector@v0.72.0/exporter/exporterhelper/internal/bounded_memory_queue.go:61
2023-02-27T07:39:32.126262344Z 

</details>

