### PR TITLE
Fix link to Traces concepts page in Go docs

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -40,5 +40,3 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - ^https://www\.jaegertracing\.io/docs/latest/opentelemetry
   # TODO: drop after fix to https://github.com/open-telemetry/opentelemetry-specification/pull/3230
   - ^https://wikipedia\.org/wiki/Double-precision_floating-point_format
-  # TODO: drop after Go docs are fixed:
-  - ^/docs/concepts/signals/traces/#tracing-in-opentelemetry


### PR DESCRIPTION
- Closes #2203

**Preview**: https://deploy-preview-2411--opentelemetry.netlify.app/docs/instrumentation/go/exporters/