### PR TITLE
Set correct stability for Rust

### DIFF
--- a/data/instrumentation.yaml
+++ b/data/instrumentation.yaml
@@ -56,7 +56,7 @@ languages:
   rust:
     name: Rust
     status:
-      traces: stable
+      traces: beta
       metrics: alpha
       logs: not yet implemented
   swift:


### PR DESCRIPTION
* From what I can tell Rust's status was incorrectly marked as stable. 
** Introduced in #1732 as what might be a typo.

Opened ticket on open-telemetry/opentelemetry-rust#977 to verify.