### PR TITLE
Add depth 1 to git clone for collector demo

### DIFF
--- a/content/en/docs/collector/getting-started.md
+++ b/content/en/docs/collector/getting-started.md
@@ -14,7 +14,7 @@ Deploys a load generator, agent and gateway as well as Jaeger, Zipkin and
 Prometheus back-ends. More information can be found on the demo [README.md][]
 
 ```sh
-git clone git@github.com:open-telemetry/opentelemetry-collector-contrib.git; \
+git clone git@github.com:open-telemetry/opentelemetry-collector-contrib.git --depth 1; \
   cd opentelemetry-collector-contrib/examples/demo; \
   docker-compose up -d
 ```


### PR DESCRIPTION
Add depth 1 to git clone in demo section for faster clone and smaller repo size.