### PR TITLE
Update JS docs for examples and typos

### DIFF
--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -1036,8 +1036,8 @@ In JavaScript, each configuration type means the following:
 
 - `description` - a human-readable description for the instrument
 - `unit` - The description of the unit of measure that the value is intended to
-  represent. For example, `milliseconds` to measure duration, or `bytes` to count
-  number of bytes.
+  represent. For example, `milliseconds` to measure duration, or `bytes` to
+  count number of bytes.
 - `valueType` - The kind of numeric value used in measurements.
 
 It's generally recommended to describe each instrument you create.

--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -1009,7 +1009,7 @@ let temperature = 32;
 
 const gauge = myMeter.createObservableGauge('temperature.gauge');
 
-counter.addCallback((result) => {
+gauge.addCallback((result) => {
   result.observe(temperature);
 });
 
@@ -1049,7 +1049,7 @@ You can add Attributes to metrics when they are generated.
 ```js
 const counter = myMeter.createCounter('my.counter');
 
-cntr.add(1, { 'some.optional.attribute': 'some value' });
+counter.add(1, { 'some.optional.attribute': 'some value' });
 ```
 
 ### Configure Metric Views

--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -920,7 +920,7 @@ import express from "express";
 const app = express();
 
 app.get('/', (_req, _res) => {
-  const histogram = myMeter.createHistogram("taks.duration");
+  const histogram = myMeter.createHistogram("task.duration");
   const startTime = new Date().getTime()
 
   // do some work in an API call
@@ -939,7 +939,7 @@ const express = require('express');
 const app = express();
 
 app.get('/', (_req, _res) => {
-  const histogram = myMeter.createHistogram("taks.duration");
+  const histogram = myMeter.createHistogram("task.duration");
   const startTime = new Date().getTime()
 
   // do some work in an API call
@@ -1036,7 +1036,7 @@ In JavaScript, each configuration type means the following:
 
 - `description` - a human-readable description for the instrument
 - `unit` - The description of the unit of measure that the value is intended to
-  represent. For example, `milliseconds` to meaure duration, or `bytes` to count
+  represent. For example, `milliseconds` to measure duration, or `bytes` to count
   number of bytes.
 - `valueType` - The kind of numeric value used in measurements.
 

--- a/content/en/docs/instrumentation/js/propagation.md
+++ b/content/en/docs/instrumentation/js/propagation.md
@@ -22,7 +22,7 @@ and [http](https://www.npmjs.com/package/@opentelemetry/instrumentation-http)
 instrumentation libraries to automatically propagate trace context across
 services for you.
 
-**It is highly recommend that you use instrumentation libraries to progagate
+**It is highly recommend that you use instrumentation libraries to propagate
 context.** Although it is possible to propagate context manually, if your system
 uses libraries to communicate between services, use a matching instrumentation
 library to propagate context.

--- a/content/en/docs/instrumentation/js/serverless.md
+++ b/content/en/docs/instrumentation/js/serverless.md
@@ -280,7 +280,7 @@ Add the following content to your package.json:
 
 ### Add HTTP call to function
 
-The following code makes a call to the OpenTemetry web site to demonstrate an
+The following code makes a call to the OpenTelemetry web site to demonstrate an
 outbound call.
 
 ```javascript

--- a/content/en/docs/instrumentation/js/serverless.md
+++ b/content/en/docs/instrumentation/js/serverless.md
@@ -280,8 +280,8 @@ Add the following content to your package.json:
 
 ### Add HTTP call to function
 
-The following code makes a call to the OpenTelemetry web site to demonstrate an
-outbound call.
+The following code makes a call to the OpenTelemetry web site to demonstrate
+an outbound call.
 
 ```javascript
 /* index.js */

--- a/content/en/docs/instrumentation/js/serverless.md
+++ b/content/en/docs/instrumentation/js/serverless.md
@@ -280,8 +280,8 @@ Add the following content to your package.json:
 
 ### Add HTTP call to function
 
-The following code makes a call to the OpenTelemetry web site to demonstrate
-an outbound call.
+The following code makes a call to the OpenTelemetry web site to demonstrate an
+outbound call.
 
 ```javascript
 /* index.js */


### PR DESCRIPTION
I was working on adding a gauge to an example app and realized these docs had a mis-typed variable name. In my drive-by I updated a few other typos as well. Changes made:

- Update two variable names used in the JS metrics docs
- Fix a few typos I came across in the process
