### PR TITLE
PR-actions workflow with support for `/fix:format`

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -1,0 +1,46 @@
+name: PR actions
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  fix-format:
+    name: /fix:format
+    runs-on: ubuntu-latest
+
+    if: |
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/fix:format')
+    permissions:
+      contents: write
+
+    env:
+      PR_NUM: ${{ github.event.issue.number }}
+      COMMENT: ${{ github.event.comment.body }}
+
+    steps:
+      - name: Context info
+        run: |
+          echo $PR_NUM
+          echo $COMMENT
+
+      - uses: actions/checkout@v3
+
+      - run: gh pr checkout $PR_NUM
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - run: npm install --ignore-scripts
+      - run: |
+          npm run prettier:write
+          git status
+          git branch -v
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: 'Results from /fix:format'
+          commit_user_name: opentelemetrybot
+          commit_user_email: 107717825+opentelemetrybot@users.noreply.github.com
+        env:
+          GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
- A first attempt at a comment-triggerable bot action to reformat files in a PR.
- Contributes to #2448