### PR TITLE
Update OTel Go metrics status to beta

### DIFF
--- a/data/instrumentation.yaml
+++ b/data/instrumentation.yaml
@@ -21,7 +21,7 @@ languages:
     name: Go
     status:
       traces: stable
-      metrics: alpha
+      metrics: beta
       logs: not yet implemented
   java:
     name: Java


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-go/issues/3830

Preview: 
1. https://deploy-preview-2451--opentelemetry.netlify.app/docs/instrumentation/go/#status-and-releases
2. https://deploy-preview-2451--opentelemetry.netlify.app/docs/instrumentation/

PTAL @open-telemetry/go-approvers