### PR TITLE
Upgrade Hugo to 0.111.1 and fix doc issues

### DIFF
--- a/content/en/blog/2022/k8s-otel-expose/index.md
+++ b/content/en/blog/2022/k8s-otel-expose/index.md
@@ -222,9 +222,9 @@ spec:
     privateKeySecretRef:
       name: letsencrypt
     solvers:
-    - http01:
-        ingress:
-          class: nginx
+      - http01:
+          ingress:
+            class: nginx
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -237,19 +237,19 @@ metadata:
 spec:
   tls:
     - hosts:
-      - your-host # REPLACE your domain endpoint, e.g., traces@example.com
+        - your-host # REPLACE your domain endpoint, e.g., traces@example.com
       secretName: letsencrypt
   rules:
-  - host: your-host # REPLACE your domain endpoint, e.g., traces@example.com
-    http:
-      paths:
-      - pathType: Prefix
-        path: "/"
-        backend:
-          service:
-            name: otel-collector-app-collector
-            port:
-              number: 4317
+    - host: your-host # REPLACE your domain endpoint, e.g., traces@example.com
+      http:
+        paths:
+          - pathType: Prefix
+            path: '/'
+            backend:
+              service:
+                name: otel-collector-app-collector
+                port:
+                  number: 4317
 ```
 
 ### Edge Cluster configuration

--- a/content/en/blog/2022/k8s-otel-expose/index.md
+++ b/content/en/blog/2022/k8s-otel-expose/index.md
@@ -218,7 +218,7 @@ metadata:
 spec:
   acme:
     server: https://acme-v02.api.letsencrypt.org/directory
-    email: <REPLACE: your e-mail address, e.g.: "someone@example.com">
+    email: your-email-address-here@example.com # REPLACE
     privateKeySecretRef:
       name: letsencrypt
     solvers:
@@ -231,16 +231,16 @@ kind: Ingress
 metadata:
   name: ingress-otel
   annotations:
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
-    cert-manager.io/cluster-issuer: "letsencrypt"
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/backend-protocol: GRPC
+    cert-manager.io/cluster-issuer: letsencrypt
 spec:
   tls:
     - hosts:
-      - <REPLACE: your domain endpoint, e.g.: "traces@example.com">
+      - your-host # REPLACE your domain endpoint, e.g., traces@example.com
       secretName: letsencrypt
   rules:
-  - host: <REPLACE: your domain endpoint, e.g.: "traces@example.com">
+  - host: your-host # REPLACE your domain endpoint, e.g., traces@example.com
     http:
       paths:
       - pathType: Prefix

--- a/content/en/docs/instrumentation/cpp/_index.md
+++ b/content/en/docs/instrumentation/cpp/_index.md
@@ -6,7 +6,7 @@ description: >
   alt="C++"></img> A language-specific implementation of OpenTelemetry in C++.
 ---
 
-{{% lang_instrumentation_index_head "cpp" /%}}
+{{% lang_instrumentation_index_head cpp /%}}
 
 ## Repositories
 

--- a/content/en/docs/instrumentation/erlang/_index.md
+++ b/content/en/docs/instrumentation/erlang/_index.md
@@ -7,7 +7,7 @@ description: >
   in Erlang/Elixir.
 ---
 
-{{% lang_instrumentation_index_head "erlang" %}}
+{{% lang_instrumentation_index_head erlang %}}
 
 Packages of the API, SDK and OTLP exporter are published to
 [hex.pm](https://hex.pm) as

--- a/content/en/docs/instrumentation/java/_index.md
+++ b/content/en/docs/instrumentation/java/_index.md
@@ -9,7 +9,7 @@ cascade:
   javaVersion: 1.23.1
 ---
 
-{{% lang_instrumentation_index_head "java" /%}}
+{{% lang_instrumentation_index_head java /%}}
 
 ### Repositories
 

--- a/content/en/docs/instrumentation/js/_index.md
+++ b/content/en/docs/instrumentation/js/_index.md
@@ -9,7 +9,7 @@ spelling: cSpell:ignore Roadmap
 weight: 20
 ---
 
-{{% lang_instrumentation_index_head "js" /%}}
+{{% lang_instrumentation_index_head js /%}}
 
 ## Further Reading
 

--- a/content/en/docs/instrumentation/net/_index.md
+++ b/content/en/docs/instrumentation/net/_index.md
@@ -7,10 +7,11 @@ aliases: [/csharp, /csharp/metrics, /csharp/tracing]
 weight: 12
 ---
 
-{{% lang_instrumentation_index_head "dotnet" %}}
+{{% lang_instrumentation_index_head dotnet %}}
 
 \* While the OpenTelemetryLoggerProvider (i.e integration with [ILogger][]) is
 stable, the [OTLP Log Exporter][] is still non-stable.
+
 {{% /lang_instrumentation_index_head %}}
 
 ## Version Support

--- a/content/en/docs/instrumentation/php/_index.md
+++ b/content/en/docs/instrumentation/php/_index.md
@@ -6,7 +6,7 @@ description: >-
 weight: 21
 ---
 
-{{% lang_instrumentation_index_head "php" /%}}
+{{% lang_instrumentation_index_head php /%}}
 
 ## Further Reading
 

--- a/content/en/docs/instrumentation/python/_index.md
+++ b/content/en/docs/instrumentation/python/_index.md
@@ -8,7 +8,7 @@ aliases: [/python, /python/metrics, /python/tracing]
 weight: 22
 ---
 
-{{% lang_instrumentation_index_head "python" %}}
+{{% lang_instrumentation_index_head python /%}}
 
 ## Version support
 

--- a/content/en/docs/instrumentation/ruby/_index.md
+++ b/content/en/docs/instrumentation/ruby/_index.md
@@ -7,7 +7,7 @@ aliases: [/ruby, /ruby/metrics, /ruby/tracing]
 weight: 24
 ---
 
-{{% lang_instrumentation_index_head "ruby" /%}}
+{{% lang_instrumentation_index_head ruby /%}}
 
 ## Who's using OpenTelemetry Ruby?
 

--- a/content/en/docs/instrumentation/rust/_index.md
+++ b/content/en/docs/instrumentation/rust/_index.md
@@ -6,7 +6,7 @@ description: >-
 weight: 26
 ---
 
-{{% lang_instrumentation_index_head "rust" /%}}
+{{% lang_instrumentation_index_head rust /%}}
 
 ## Crates
 

--- a/content/en/docs/instrumentation/swift/_index.md
+++ b/content/en/docs/instrumentation/swift/_index.md
@@ -7,7 +7,7 @@ description: >-
 weight: 28
 ---
 
-{{% lang_instrumentation_index_head "swift" /%}}
+{{% lang_instrumentation_index_head swift /%}}
 
 ## Further Reading
 

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   },
   "devDependencies": {
     "autoprefixer": "^10.4.13",
-    "hugo-extended": "0.110.0",
+    "hugo-extended": "0.111.1",
     "netlify-cli": "^13.0.0",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.21",


### PR DESCRIPTION
- Closes #2452
- Upgrades to [Hugo 0.111.1](https://github.com/gohugoio/hugo/releases/tag/v0.111.1)
- Fixes a bug in a page that was missing an end-tag marker for a shortcode
- Fixes YAML sample in 2022 blog since some of the content is meant to be in comments (and otherwise results in pretty-printed YAML).
- Drops unnecessary quotes around shortcode arguments

The only changes to the generated site files, other than the updated Hugo version, are due to pretty-printer changes and the YAML fragment update:

```console
$ (cd public && git diff -bw --ignore-blank-lines -I "Hugo 0\.") | grep ^diff | grep -v \.xml
diff --git a/blog/2022/k8s-otel-expose/index.html b/blog/2022/k8s-otel-expose/index.html
diff --git a/docs/demo/services/shipping/index.html b/docs/demo/services/shipping/index.html
```