### PR TITLE
Styling fix for OTel in focus

### DIFF
--- a/content/en/blog/2023/otel-in-focus-01.md
+++ b/content/en/blog/2023/otel-in-focus-01.md
@@ -1,9 +1,8 @@
 ---
-title: OpenTelemetry in Focus - January 2023
-linkTitle: OTel in Focus - 2023/01
+title: OpenTelemetry in Focus, January 2023
+linkTitle: OTel in Focus 2023/01
 date: 2023-01-31
-author: >-
-  [Austin Parker](https://github.com/austinlparker)
+author: '[Austin Parker](https://github.com/austinlparker)'
 ---
 
 Welcome to the first edition of _OpenTelemetry In Focus_! This blog is intended

--- a/content/en/blog/2023/otel-in-focus-02.md
+++ b/content/en/blog/2023/otel-in-focus-02.md
@@ -1,14 +1,9 @@
 ---
-title: OpenTelemetry in Focus - February 2023
-linkTitle: OTel in Focus - 2023/02
+title: OpenTelemetry in Focus, February 2023
+linkTitle: OTel in Focus 2023/02
 date: 2023-02-28
-author: >-
-  [Austin Parker](https://github.com/austinlparker)
+author: '[Austin Parker](https://github.com/austinlparker)'
 ---
-
-<style>
-  dt { padding-bottom: 0.5em; }
-</style>
 
 Welcome to this month’s edition of OpenTelemetry in Focus! It might be cold and
 snowy in much of the Northern Hemisphere, but that hasn’t frozen our progress.
@@ -22,71 +17,69 @@ channel.
 
 ## Releases and Updates
 
-Here's the latest updates from our core repositories.
+Here are the latest updates from our core repositories.
 
-<!-- prettier-ignore-start -->
-[Specification](/docs/reference/specification/)
+##### [Specification](/docs/reference/specification/)
 
-: [v1.18](https://github.com/open-telemetry/opentelemetry-specification/releases/tag/v1.18.0)
-  has been released, with a batch of semantic convention updates and
-  clarifications on mapping and converting between Prometheus and OpenTelemetry
-  Metrics.
+[v1.18](https://github.com/open-telemetry/opentelemetry-specification/releases/tag/v1.18.0)
+has been released, with a batch of semantic convention updates and
+clarifications on mapping and converting between Prometheus and OpenTelemetry
+Metrics.
 
-[Collector](/docs/collector/) and contrib
+##### [Collector](/docs/collector/) and contrib
 
-: [v0.72](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases)
-  have been released with several major changes to be aware of:
+[v0.72](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases)
+have been released with several major changes to be aware of:
 
-  - The minimum supported Golang version is now 1.19
-  - The host metrics receiver has removed deprecated metrics for process memory.
-  - The promtail receiver has been removed from collector-contrib.
-  - The Jaeger exporters are now deprecated, to be removed in a future release.
-  - [Connectors](https://github.com/open-telemetry/opentelemetry-collector/blob/main/connector/README.md)
-    have been added! These are components that act as exporters and receivers,
-    allowing you to route data through pipelines. Please see the component docs
-    for more information.
-  - Many bug fixes and enhancements.
+- The minimum supported Golang version is now 1.19
+- The host metrics receiver has removed deprecated metrics for process memory.
+- The promtail receiver has been removed from collector-contrib.
+- The Jaeger exporters are now deprecated, to be removed in a future release.
+- [Connectors](https://github.com/open-telemetry/opentelemetry-collector/blob/main/connector/README.md)
+  have been added! These are components that act as exporters and receivers,
+  allowing you to route data through pipelines. Please see the component docs
+  for more information.
+- Many bug fixes and enhancements.
 
-[Go](/docs/instrumentation/go/)
+##### [Go](/docs/instrumentation/go/)
 
-: [v1.14](https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.14.0)
-  has been released. This is the last release to support Go 1.18; 1.19 will be
-  required in the future. Semantic conventions have been updated, resulting in
-  changes to constant and function names. Finally, there’s a variety of bug
-  fixes and other small changes.
+[v1.14](https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.14.0)
+has been released. This is the last release to support Go 1.18; 1.19 will be
+required in the future. Semantic conventions have been updated, resulting in
+changes to constant and function names. Finally, there’s a variety of bug fixes
+and other small changes.
 
-[Java](/docs/instrumentation/java/)
+##### [Java](/docs/instrumentation/java/)
 
-: [v1.23](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.23.0)
-  has been released, bringing with it stable base2 exponential histogram
-  aggregations and significant metrics refactoring. Semantic convention updates,
-  improvements to SDK shutdown, and several enhancements to the SDK extensions
-  are also in this release. [Java
-  Instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.23.0)
-  has been updated as well, most notably changing HTTP span names to reflect
-  updated semantic conventions.
+[v1.23](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.23.0)
+has been released, bringing with it stable base2 exponential histogram
+aggregations and significant metrics refactoring. Semantic convention updates,
+improvements to SDK shutdown, and several enhancements to the SDK extensions are
+also in this release.
+[Java Instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.23.0)
+has been updated as well, most notably changing HTTP span names to reflect
+updated semantic conventions.
 
-[OpenTelemetry PHP](/docs/instrumentation/php/)
+##### [PHP](/docs/instrumentation/php/)
 
-: [v1 beta](https://github.com/open-telemetry/opentelemetry-php/releases/tag/1.0.0beta1)
-  was [announced](/blog/2023/php-beta-release/) at the end of January. The PHP
-  SIG is looking forward to your feedback. In addition, the Communications SIG
-  is planning a release of new documentation for PHP soon.
+[v1 beta](https://github.com/open-telemetry/opentelemetry-php/releases/tag/1.0.0beta1)
+was [announced](/blog/2023/php-beta-release/) at the end of January. The PHP SIG
+is looking forward to your feedback. In addition, the Communications SIG is
+planning a release of new documentation for PHP soon.
 
-[Python](/docs/instrumentation/python/)
+##### [Python](/docs/instrumentation/python/)
 
-: [v1.16](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.16.0)
-  has been released with deprecations to Jaeger exporters, several performance
-  improvements and bug fixes, and changes to Prometheus export.
+[v1.16](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.16.0)
+has been released with deprecations to Jaeger exporters, several performance
+improvements and bug fixes, and changes to Prometheus export.
 
-[.NET](/docs/instrumentation/net/)
+##### [.NET](/docs/instrumentation/net/)
 
-: [v1.4](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.4.0)
-  removes several deprecated extension methods.
-<!-- prettier-ignore-end -->
+[v1.4](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.4.0)
+removes several deprecated extension methods.
 
 As always, this is just a snapshot of important changes and improvements across
-the core projects. Please make sure you thoroughly read the release notes when
+the core projects. Make sure you thoroughly read the release notes when
 upgrading your OpenTelemetry dependencies.
 
 ## Project Updates


### PR DESCRIPTION
- Addresses https://github.com/open-telemetry/opentelemetry.io/pull/2444#issuecomment-1454728160
- Drops the in-page `<style>`s
- Reformats the latest OTel-in-focus post, replacing the definition list by plain level-5 headings (which don't appear in the ToC) and section text. (Btw, we don't want the headings to appear in the ToC because the headings contain links and the ToC element doesn't handle links gracefully.)
- Makes a few copyedits

Preview: https://deploy-preview-2465--opentelemetry.netlify.app/blog/2023/otel-in-focus-02/