### PR TITLE
Order node.js over browser for TOC

### DIFF
--- a/content/en/docs/instrumentation/js/getting-started/browser.md
+++ b/content/en/docs/instrumentation/js/getting-started/browser.md
@@ -1,6 +1,7 @@
 ---
 title: Browser
 aliases: [/docs/js/getting_started/browser]
+weight: 3
 ---
 
 While this guide uses the example application presented below, the steps to

--- a/content/en/docs/instrumentation/js/getting-started/nodejs.md
+++ b/content/en/docs/instrumentation/js/getting-started/nodejs.md
@@ -1,6 +1,7 @@
 ---
 title: Node.js
 aliases: [/docs/js/getting_started/nodejs]
+weight: 2
 ---
 
 This guide will show you how to get started with tracing in Node.js.


### PR DESCRIPTION
[Node is hit a lot more in our docs](https://play.honeycomb.io/opentelemetry-web/datasets/opentelemetry.io/result/ENZskzNonnB?useStackedGraphs). From my own work, I can also say that teams using node are ~4.5x more numerous than teams sending instrumentation from the browser. So let's have the TOC reflect that.

<img width="182" alt="image" src="https://user-images.githubusercontent.com/6309070/223848935-b62b5930-0dbc-40d1-b465-349076c6e353.png">
