### PR TITLE
Report issue if an external link is used to a local spec page

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,8 +1,14 @@
 {{ $isExternal := hasPrefix .Destination "http" -}}
-{{ if and $isExternal (findRE "^https://opentelemetry.io/\\w" .Destination) -}}
-  {{ errorf "%s: use a local path, not an external URL, for the following reference to a local page: %s"
-      .Page.File.Path .Destination -}}
+{{ if $isExternal -}}
+  {{ if findRE "^https://opentelemetry.io/\\w" .Destination -}}
+    {{ errorf "%s: use a local path, not an external URL, for the following reference to a site local page: %s"
+        .Page.File.Path .Destination -}}
+  {{ else if findRE "^https://github.com/open-telemetry/opentelemetry-specification/(blob|tree)/main/specification/\\w" .Destination -}}
+    {{ errorf "%s: use a local path, not an external URL, for the following reference to a local specification page: %s"
+    .Page.File.Path .Destination -}}
+  {{ end -}}
 {{ end -}}
+
 {{/* Until Hugo supports hook params (https://github.com/gohugoio/hugo/issues/6670), we'll inspect .Text. */ -}}
 {{ $noExternalIcon := in .Text "hk-no-external-icon" -}}
 <a href="{{ .Destination | safeURL }}"

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -79,8 +79,14 @@ while(<>) {
   s|(\]\()/specification/|$1$spec_base_path/)|;
   s|\.\./semantic_conventions/README.md|$semConvRef| if $ARGV =~ /overview/;
 
+  if (/\((https:\/\/github.com\/open-telemetry\/opentelemetry-specification\/\w+\/\w+\/specification([^\)]*))\)/) {
+    printf STDOUT "WARNING: link to spec page encoded as an external URL, but should be a local path, fix this upstream;\n  File: $ARGV \n  Link: $1\n";
+  }
+  s|\(https://github.com/open-telemetry/opentelemetry-specification/\w+/\w+/specification([^\)]*)\)|($spec_base_path$1)|;
+
   # Bug fix from original source
-  s/#(#(instrument|set-status))/$1/;
+  # TODO drop on fix lands for https://github.com/open-telemetry/opentelemetry-specification/pull/3310
+  s|/docs/reference/specification/metrics/data-model.md#metric-metadata-1|prometheus_and_openmetrics.md#metric-metadata-1|;
 
   # Images
   s|(\.\./)?internal(/img/[-\w]+\.png)|$2|g;


### PR DESCRIPTION
- Contributes to #2429
- Warns if a spec page contains an external URL to a local spec page, and then translates the external URL into a local path reference.
- Hugo reports an error if a website page contains an external URL to a local spec page