### PR TITLE
Add entry for missing OTel component color

### DIFF
--- a/assets/scss/_registry.scss
+++ b/assets/scss/_registry.scss
@@ -21,4 +21,10 @@
     background-color: inherit;
     border: solid 1px;
   }
+
+  // Default color attributes, in case we miss a component definition above;
+  // which has happened, see https://github.com/open-telemetry/opentelemetry.io/pull/2481.
+  $default-otel-badge-bg: $yellow;
+  color: color-contrast($default-otel-badge-bg);
+  background-color: $default-otel-badge-bg;
 }

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -26,6 +26,7 @@ $otel-component-colors: (
   'processor': #d32c42,
   'python': #3572a5,
   'receiver': #742cd3,
+  'resource-detector': green,
   'ruby': #701516,
   'rust': #dea584,
   'swift': #de5d43,


### PR DESCRIPTION
- Prep for #2419
- Adds a badge color class for `resource-detector`
- Adds default badge color attributes in case we miss a component again
- **Preview**: https://deploy-preview-2481--opentelemetry.netlify.app/ecosystem/registry/?component=resource-detector

---

### Screenshots

Before:

> <img width="918" alt="image" src="https://user-images.githubusercontent.com/4140793/224451004-d2be3c49-846b-4a39-91a7-f0ae8fe76dad.png">

After:

> <img width="908" alt="image" src="https://user-images.githubusercontent.com/4140793/224451039-60fd94ff-cfa5-4856-8f83-8fdabf4d9059.png">

