### PR TITLE
CI: warn about external links to local pages rather than abort with an error

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,10 +1,10 @@
 {{ $isExternal := hasPrefix .Destination "http" -}}
 {{ if $isExternal -}}
   {{ if findRE "^https://opentelemetry.io/\\w" .Destination -}}
-    {{ errorf "%s: use a local path, not an external URL, for the following reference to a site local page: %s"
+    {{ warnf "%s: use a local path, not an external URL, for the following reference to a site local page: %s"
         .Page.File.Path .Destination -}}
   {{ else if findRE "^https://github.com/open-telemetry/opentelemetry-specification/(blob|tree)/main/specification/\\w" .Destination -}}
-    {{ errorf "%s: use a local path, not an external URL, for the following reference to a local specification page: %s"
+    {{ warnf "%s: use a local path, not an external URL, for the following reference to a local specification page: %s"
     .Page.File.Path .Destination -}}
   {{ end -}}
 {{ end -}}


### PR DESCRIPTION
- The site build fails under Windows, apparently because of the difference in behavior of the [adjust-pages.pl](https://github.com/open-telemetry/opentelemetry.io/blob/main/scripts/content-modules/adjust-pages.pl) script.
- For now, turn those errors into warnings. I'll reintroduce the errors separately, via: #2448
- Contributes to #2448

/cc @svrnm @tsloughter 