### PR TITLE
Link homepage demo CTA button to demo docs

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -25,7 +25,7 @@ spelling: cSpell:ignore shortcode
 <div class="l-primary-buttons mt-5">
 
 - [Learn more](/docs/concepts/)
-- [Try the demo](/ecosystem/demo/)
+- [Try the demo](/docs/demo/)
 
 </div>
 

--- a/content/en/ecosystem/demo.md
+++ b/content/en/ecosystem/demo.md
@@ -7,14 +7,12 @@ description:
   environment.
 aliases:
   - /community/demo
-  - /docs/demo
   - /docs/getting-started/demo
   - /docs/opentelemetry-demo
 weight: 10
 ---
 
-The [OpenTelemetry Demo](https://github.com/open-telemetry/opentelemetry-demo)
-does the following:
+The [OpenTelemetry Demo](/docs/demo/) does the following:
 
 - Provides a realistic example of a distributed system that can be used to
   demonstrate OpenTelemetry instrumentation and observability.
@@ -32,4 +30,7 @@ If you find yourself asking questions like:
 - How do I consider the [architecture](/docs/demo/architecture/) of a system
   using OpenTelemetry?
 
-Then check out the [Demo](https://github.com/open-telemetry/opentelemetry-demo).
+For more information, see:
+
+- [Demo documentation](/docs/demo/)
+- [Demo repo](https://github.com/open-telemetry/opentelemetry-demo)


### PR DESCRIPTION
- Changes homepage demo button link to refer to the demo docs
- Crosslinks [/ecosystem/demo](https://deploy-preview-2502--opentelemetry.netlify.app/ecosystem/demo/) and [/docs/demo](https://deploy-preview-2502--opentelemetry.netlify.app/docs/demo/)
- Copyedits to `/ecosystem/demo` page: add links to "more info" through demo docs and demo repo

Preview:

- https://deploy-preview-2502--opentelemetry.netlify.app/
- https://deploy-preview-2502--opentelemetry.netlify.app/docs/demo/
- https://deploy-preview-2502--opentelemetry.netlify.app/ecosystem/demo/