### PR TITLE
Copyedits of demo deployment pages

### DIFF
--- a/content/en/docs/demo/docker-deployment.md
+++ b/content/en/docs/demo/docker-deployment.md
@@ -34,12 +34,12 @@ aliases: [/docs/demo/docker_deployment]
     > **Notes:**
     >
     > - The `--no-build` flag is used to fetch released docker images from
-      [ghcr](https://ghcr.io/open-telemetry/demo) instead of building from
-      source. Removing the `--no-build` command line option will rebuild all
-      images from source. It may take more than 20 minutes to build if the flag is
-      omitted.
-    > - If you're running on Apple Silicon, run `docker compose build`
-      in order to create local images vs. pulling them from the repository.
+    >   [ghcr](https://ghcr.io/open-telemetry/demo) instead of building from
+    >   source. Removing the `--no-build` command line option will rebuild all
+    >   images from source. It may take more than 20 minutes to build if the
+    >   flag is omitted.
+    > - If you're running on Apple Silicon, run `docker compose build` in order
+    >   to create local images vs. pulling them from the repository.
 
 ## Verify the Webstore and Telemetry
 
@@ -54,8 +54,8 @@ Once the images are built and containers are started you can access:
 ## Bring your own backend
 
 Likely you want to use the Webstore as a demo application for an observability
-backend you already have (e.g., an existing instance of Jaeger, Zipkin, or one of
-the [vendor of your choice](/ecosystem/vendors/).
+backend you already have (e.g., an existing instance of Jaeger, Zipkin, or one
+of the [vendor of your choice](/ecosystem/vendors/).
 
 OpenTelemetry Collector can be used to export telemetry data to multiple
 backends. By default, the collector in the demo application will merge the

--- a/content/en/docs/demo/docker-deployment.md
+++ b/content/en/docs/demo/docker-deployment.md
@@ -11,40 +11,37 @@ aliases: [/docs/demo/docker_deployment]
   v2.0.0+
 - 4 GB of RAM for the application
 
-## Clone Repo
+## Get and run the demo
 
-- Clone the Webstore Demo repository:
+1.  Clone the Webstore Demo repository:
 
-```shell
-git clone https://github.com/open-telemetry/opentelemetry-demo.git
-```
+    ```shell
+    git clone https://github.com/open-telemetry/opentelemetry-demo.git
+    ```
 
-## Open Folder
+2.  Change to the demo folder:
 
-- Navigate to the cloned folder:
+    ```shell
+    cd opentelemetry-demo/
+    ```
 
-```shell
-cd opentelemetry-demo/
-```
+3.  Run docker compose to start the demo:
 
-## Run Docker Compose
+    ```shell
+    docker compose up --no-build
+    ```
 
-- Start the demo:
+    > **Notes:**
+    >
+    > - The `--no-build` flag is used to fetch released docker images from
+      [ghcr](https://ghcr.io/open-telemetry/demo) instead of building from
+      source. Removing the `--no-build` command line option will rebuild all
+      images from source. It may take more than 20 minutes to build if the flag is
+      omitted.
+    > - If you're running on Apple Silicon, run `docker compose build`
+      in order to create local images vs. pulling them from the repository.
 
-```shell
-docker compose up --no-build
-```
-
-> **Note:** If you're running on Apple Silicon, please run
-> `docker compose build` in order to create local images vs. pulling them from
-> the repository.
-
-**Note:** The `--no-build` flag is used to fetch released docker images from
-[ghcr](https://ghcr.io/open-telemetry/demo) instead of building from source.
-Removing the `--no-build` command line option will rebuild all images from
-source. It may take more than 20 minutes to build if the flag is omitted.
-
-## Verify the Webstore & the Telemetry
+## Verify the Webstore and Telemetry
 
 Once the images are built and containers are started you can access:
 
@@ -57,15 +54,15 @@ Once the images are built and containers are started you can access:
 ## Bring your own backend
 
 Likely you want to use the Webstore as a demo application for an observability
-backend you already have (e.g. an existing instance of Jaeger, Zipkin, or one of
+backend you already have (e.g., an existing instance of Jaeger, Zipkin, or one of
 the [vendor of your choice](/ecosystem/vendors/).
 
 OpenTelemetry Collector can be used to export telemetry data to multiple
 backends. By default, the collector in the demo application will merge the
 configuration from two files:
 
-- otelcol-config.yml
-- otelcol-config-extras.yml
+- `otelcol-config.yml`
+- `otelcol-config-extras.yml`
 
 To add your backend, open the file
 [src/otelcollector/otelcol-config-extras.yml](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/otelcollector/otelcol-config-extras.yml)
@@ -74,22 +71,22 @@ with an editor.
 - Start by adding a new exporter. For example, if your backend supports OTLP
   over HTTP, add the following:
 
-```yaml
-exporters:
-  otlphttp/example:
-    endpoint: <your-endpoint-url>
-```
+  ```yaml
+  exporters:
+    otlphttp/example:
+      endpoint: <your-endpoint-url>
+  ```
 
 - Then add a new pipeline with your new exporter:
 
-```yaml
-service:
-  pipelines:
-    traces:
-      receivers: [otlp]
-      processors: [batch]
-      exporters: [otlphttp/example]
-```
+  ```yaml
+  service:
+    pipelines:
+      traces:
+        receivers: [otlp]
+        processors: [batch]
+        exporters: [otlphttp/example]
+  ```
 
 Vendor backends might require you to add additional parameters for
 authentication, please check their documentation. Some backends require

--- a/content/en/docs/demo/kubernetes-deployment.md
+++ b/content/en/docs/demo/kubernetes-deployment.md
@@ -59,9 +59,9 @@ with your Helm chart release name accordingly):
 kubectl port-forward svc/my-otel-demo-otelcol 4318:4318
 ```
 
-> **Note** > `kubectl port-forward` will proxy the port until the process
+> **Note**: `kubectl port-forward` will proxy the port until the process
 > terminates. You may need to create separate terminal sessions for each use of
-> `kubectl port-forward`, and use CTRL-C to terminate the process when done.
+> `kubectl port-forward`, and use <kbd>Ctrl-C</kbd> to terminate the process when done.
 
 With the frontendproxy and Collector port-forward set up, you can access:
 

--- a/content/en/docs/demo/kubernetes-deployment.md
+++ b/content/en/docs/demo/kubernetes-deployment.md
@@ -61,7 +61,8 @@ kubectl port-forward svc/my-otel-demo-otelcol 4318:4318
 
 > **Note**: `kubectl port-forward` will proxy the port until the process
 > terminates. You may need to create separate terminal sessions for each use of
-> `kubectl port-forward`, and use <kbd>Ctrl-C</kbd> to terminate the process when done.
+> `kubectl port-forward`, and use <kbd>Ctrl-C</kbd> to terminate the process
+> when done.
 
 With the frontendproxy and Collector port-forward set up, you can access:
 


### PR DESCRIPTION
- Reworks layout of steps in docker page
- Fix indentation of code blocks
- Some minor copyedits

**Preview**:

- https://deploy-preview-2503--opentelemetry.netlify.app/docs/demo/docker-deployment/
- https://deploy-preview-2503--opentelemetry.netlify.app/docs/demo/kubernetes-deployment/

---

### Screenshots (docker page):

Before:

> <img width="957" alt="image" src="https://user-images.githubusercontent.com/4140793/224860700-efb147a8-f5b7-49e0-8e96-d1d85ab01071.png">

After:

> <img width="1159" alt="image" src="https://user-images.githubusercontent.com/4140793/224860765-f00af0f5-3b92-405a-a24e-c57f395f8590.png">
