### PR TITLE
Point to rubydoc for ruby API

### DIFF
--- a/content/en/docs/instrumentation/ruby/api.md
+++ b/content/en/docs/instrumentation/ruby/api.md
@@ -1,7 +1,7 @@
 ---
 title: API reference
 linkTitle: API
-redirect: https://open-telemetry.github.io/opentelemetry-ruby/
+redirect: https://www.rubydoc.info/gems/opentelemetry-sdk
 manualLinkTarget: _blank
 _build: { render: link }
 weight: 50


### PR DESCRIPTION
This appears to be the right place