### PR TITLE
Registry search results: fix Fuse template

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -142,7 +142,7 @@
 .td-default, // E.g.: Homepage, Status, Search, 404; excludes navbar
 .td-section main, .td-page main, // Doc and blog main content without left/right navs
 .td-page-meta {
-  a:hover {
+  a:hover:not(.dropdown-item) {
     text-decoration: underline;
   }
 }

--- a/layouts/shortcodes/registry-search-form.html
+++ b/layouts/shortcodes/registry-search-form.html
@@ -90,10 +90,11 @@
 </div>
 
 {{- define "registry-entry" -}}
+{{ $href := printf "href=%q" .repo | safeHTMLAttr -}}
 <li class="registry-entry" data-registrytype="{{ .registryType }}" data-registrylanguage="{{ .language }}">
   <div class="registry-entry-body">
     <div class="h5">
-      <a href="{{ .repo }}" target="_blank" rel="noopener">
+      <a {{ $href }} target="_blank" rel="noopener">
         {{- .title -}}
       </a>
     </div>


### PR DESCRIPTION
- Closes #2509
- Why did this happen? Because Go templates escape content based on context. For details see:
  - https://gohugo.io/functions/safehtmlattr/
  - https://discourse.gohugo.io/t/avoid-string-variable-escaping/13244/11

To test this fix:

- Visit https://deploy-preview-2511--opentelemetry.netlify.app/ecosystem/registry/?s=kotlin
- Click on any of the links in the search results