### PR TITLE
SDK.start doesn't seem to return a promise

### DIFF
--- a/content/en/docs/instrumentation/js/getting-started/nodejs.md
+++ b/content/en/docs/instrumentation/js/getting-started/nodejs.md
@@ -163,10 +163,7 @@ const sdk = new NodeSDK({
 
 sdk
   .start()
-  .then(() => {
-    console.log('Tracing initialized');
-  })
-  .catch((error) => console.log('Error initializing tracing', error));
+
 {{< /tab >}}
 
 {{< tab JavaScript >}}
@@ -182,10 +179,7 @@ const sdk = new opentelemetry.NodeSDK({
 
 sdk
   .start()
-  .then(() => {
-    console.log('Tracing initialized');
-  })
-  .catch((error) => console.log('Error initializing tracing', error));
+
 {{< /tab >}}
 
 {{< /tabpane >}}


### PR DESCRIPTION
I ran into this earlier while using vanilla JS (it crashed on the `then`)

And just now when using TS it says `start` returns void.