### PR TITLE
Ruby landing page cleanup of links to API ref and examples

### DIFF
--- a/content/en/docs/instrumentation/ruby/_index.md
+++ b/content/en/docs/instrumentation/ruby/_index.md
@@ -23,13 +23,8 @@ OpenTelemetry Ruby is in use by a number of companies, including:
 
 If you would like to add your name to this list, submit a pull request.
 
-## Further Reading
+## Repository
 
-- [OpenTelemetry for Ruby on GitHub][repository]
-- [Ruby API Documentation][ruby-docs]
-- [Examples][]
+- [OpenTelemetry for Ruby repository][repo]
 
-[repository]: https://github.com/open-telemetry/opentelemetry-ruby
-[ruby-docs]: https://open-telemetry.github.io/opentelemetry-ruby/
-[examples]:
-  https://github.com/open-telemetry/opentelemetry-ruby/tree/main/examples
+[repo]: https://github.com/open-telemetry/opentelemetry-ruby


### PR DESCRIPTION
- Contributes to #2512, maybe closes it
- Drops links to API and Examples in Ruby landing page text, since they appear in the left-nav and the page listing at the bottom of the page (see the screenshot below)

**Preview**: https://deploy-preview-2515--opentelemetry.netlify.app/docs/instrumentation/ruby/

### Screenshot

> <img width="1179" alt="Screen Shot 2023-03-15 at 13 37 55" src="https://user-images.githubusercontent.com/4140793/225395955-ec297769-2f3e-413d-8ddb-d0d8bae6373e.png">


/cc @cartermp 