### PR TITLE
Fixed path to config.yaml

### DIFF
--- a/content/en/docs/collector/getting-started.md
+++ b/content/en/docs/collector/getting-started.md
@@ -44,7 +44,7 @@ To load your custom configuration `config.yaml` from your current working direct
 
 {{< ot-tabs DockerHub ghcr.io >}}
 {{< ot-tab lang="sh" >}}
-docker run -v $(pwd)/config.yaml:/etc/otelcol/config.yaml otel/opentelemetry-collector:{{% param collectorVersion %}}
+docker run -v $(pwd)/config.yaml:/etc/otelcol-contrib/config.yaml otel/opentelemetry-collector:{{% param collectorVersion %}}
 {{< /ot-tab >}}
 
 {{< ot-tab lang="sh" >}}


### PR DESCRIPTION
The path is now correct for the opentelemetry-collector-contrib image.