### PR TITLE
Don't format the Vendors table

### DIFF
--- a/content/en/ecosystem/vendors.md
+++ b/content/en/ecosystem/vendors.md
@@ -10,43 +10,44 @@ spelling: cSpell:ignore appdynamics aria aspecto bution coralogix daocloud datad
 [Distributions](/docs/concepts/distributions/) and vendors who natively support
 OpenTelemetry in their commercial products.
 
-| Company\*                  | Distri&shy;bution | Native OTLP | Learn more                                                                                                                                                                            |
-| -------------------------- | ----------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| AppDynamics (Cisco)        | Yes               | Yes         | [docs.appdynamics.com/...](https://docs.appdynamics.com/latest/en/application-monitoring/appdynamics-for-opentelemetry)                                                               |
-| Aria by VMware (Wavefront) | No                | Yes         | [docs.wavefront.com/...](https://docs.wavefront.com/opentelemetry_tracing.html)                                                                                                       |
-| Aspecto                    | Yes               | Yes         | [aspecto.io](https://www.aspecto.io)                                                                                                                                                  |
-| AWS                        | Yes               | No          | [aws-otel.github.io](https://aws-otel.github.io)                                                                                                                                      |
-| Azure                      | Yes               | No          | [docs.microsoft.com/...](https://docs.microsoft.com/azure/azure-monitor/app/opentelemetry-overview)                                                                                   |
-| Coralogix                  | Yes               | Yes         | [coralogix.com/...](https://coralogix.com/docs/opentelemetry/)                                                                                                                        |
-| DaoCloud                   | Yes               | Yes         | [docs.daocloud.io/...](https://docs.daocloud.io/en/insight/06UserGuide/01quickstart/otel/otel/)                                                                                       |
-| Datadog                    | Yes               | Yes         | [docs.datadoghq.com/...](https://docs.datadoghq.com/tracing/setup_overview/open_standards)                                                                                            |
-| Dynatrace                  | Yes               | Yes         | [dynatrace.com/...](https://www.dynatrace.com/support/help/how-to-use-dynatrace/transactions-and-services/service-monitoring-settings/opentelemetry/)                                 |
-| Elastic                    | Yes               | Yes         | [elastic.co/...](https://www.elastic.co/guide/en/apm/get-started/current/open-telemetry-elastic.html)                                                                                 |
-| F5                         | No                | Yes         | [opentelemetry-collector-contrib/...](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/f5cloudexporter)                                           |
-| Google Cloud Platform      | No                | Yes         | [opentelemetry-collector-contrib/...](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudexporter)                                       |
-| Grafana Labs               | No                | Yes         | [grafana.com/...](https://grafana.com/oss/opentelemetry/)                                                                                                                             |
-| Helios                     | Yes               | Yes         | [gethelios.dev](https://gethelios.dev/)                                                                                                                                               |
-| Honeycomb                  | Yes               | Yes         | [docs.honeycomb.io/...](https://docs.honeycomb.io/getting-data-in/)                                                                                                                   |
-| Instana                    | No                | Yes         | [ibm.com/docs/...](https://www.ibm.com/docs/en/obi/current?topic=apis-opentelemetry)                                                                                                  |
-| ITRS                       | Yes               | Yes         | [https://docs.itrsgroup.com/docs/geneos/...](https://docs.itrsgroup.com/docs/geneos/data-collection/opentelemetry/current/opentelemetry.html)                                         |
-| KloudFuse                  | No                | Yes         | [kloudfuse.com](https://kloudfuse.atlassian.net/wiki/spaces/EX/pages/753860609/APM#Sending-traces-to-Kloudfuse-data-plane%3A)                                                         |
-| Lightstep                  | Yes               | Yes         | [github.com/lightstep](https://github.com/lightstep?q=launcher)                                                                                                                       |
-| LogicMonitor               | Yes               | Yes         | [logicmonitor.com/...](https://www.logicmonitor.com/support/tracing/getting-started-with-tracing)                                                                                     |
-| Logz.io                    | Yes               | No          | [docs.logz.io/...](https://docs.logz.io/shipping/tracing-sources/opentelemetry.html#overview)                                                                                         |
-| LogScale                   | No                | Yes         | [library.humio.com/...](https://library.humio.com/falcon-logscale/log-shippers-opentelemetry.html)                                                                                    |
-| Lumigo                     | Yes               | Yes         | [lumigo.io](https://docs.lumigo.io/docs/opentelemetry)                                                                                                                                |
-| New Relic                  | No                | Yes         | [newrelic.com/...](https://newrelic.com/solutions/opentelemetry)                                                                                                                      |
-| observIQ                   | Yes               | Yes         | [observiq.com/...](https://docs.bindplane.observiq.com)                                                                                                                               |
-| Oracle                     | No                | Yes         | [docs.oracle.com/...](https://docs.oracle.com/en-us/iaas/application-performance-monitoring/doc/configure-open-source-tracing-systems.html#GUID-4D941163-F357-4839-8B06-688876D4C61F) |
-| Promscale                  | No                | Yes         | [timescale.com/promscale](https://www.timescale.com/promscale)                                                                                                                        |
-| Sentry Software            | Yes               | Yes         | [sentrysoftware.com/...](https://www.sentrysoftware.com/products/hardware-sentry-opentelemetry-collector.html)                                                                        |
-| ServicePilot               | No                | Yes         | [servicepilot.com/...](https://www.servicepilot.com/en/doc/apm#opentelemetry)                                                                                                         |
-| SigNoz                     | Yes               | Yes         | [signoz.io](https://signoz.io)                                                                                                                                                        |
-| SolarWinds                 | Yes               | Yes         | [documentation.solarwinds.com/...](https://documentation.solarwinds.com/en/success_center/observability/default.htm#cshid=third-otel-integration)                                     |
-| Splunk                     | Yes               | Yes         | [splunk.com/blog/...](https://www.splunk.com/en_us/blog/conf-splunklive/announcing-native-opentelemetry-support-in-splunk-apm.html)                                                   |
-| Sumo Logic                 | Yes               | Yes         | [help.sumologic.com/](https://help.sumologic.com/docs/apm/traces/quickstart/)                                                                                                         |
-| TelemetryHub               | No                | Yes         | [telemetryhub.com](https://app.telemetryhub.com/docs)                                                                                                                                 |
-| Traceloop                  | No                | Yes         | [traceloop.dev](https://docs.traceloop.dev)                                                                                                                                           |
-| Uptrace                    | Yes               | Yes         | [uptrace.dev](https://uptrace.dev)                                                                                                                                                    |
+<!-- prettier-ignore -->
+| Company\*                  | Distri&shy;bution | Native OTLP | Learn more
+| -------------------------- | ----------------- | ----------- | -----------
+| AppDynamics (Cisco)        | Yes               | Yes         | [docs.appdynamics.com/...](https://docs.appdynamics.com/latest/en/application-monitoring/appdynamics-for-opentelemetry)
+| Aria by VMware (Wavefront) | No                | Yes         | [docs.wavefront.com/...](https://docs.wavefront.com/opentelemetry_tracing.html)
+| Aspecto                    | Yes               | Yes         | [aspecto.io](https://www.aspecto.io)
+| AWS                        | Yes               | No          | [aws-otel.github.io](https://aws-otel.github.io)
+| Azure                      | Yes               | No          | [docs.microsoft.com/...](https://docs.microsoft.com/azure/azure-monitor/app/opentelemetry-overview)
+| Coralogix                  | Yes               | Yes         | [coralogix.com/...](https://coralogix.com/docs/opentelemetry/)
+| DaoCloud                   | Yes               | Yes         | [docs.daocloud.io/...](https://docs.daocloud.io/en/insight/06UserGuide/01quickstart/otel/otel/)
+| Datadog                    | Yes               | Yes         | [docs.datadoghq.com/...](https://docs.datadoghq.com/tracing/setup_overview/open_standards)
+| Dynatrace                  | Yes               | Yes         | [dynatrace.com/...](https://www.dynatrace.com/support/help/how-to-use-dynatrace/transactions-and-services/service-monitoring-settings/opentelemetry/)
+| Elastic                    | Yes               | Yes         | [elastic.co/...](https://www.elastic.co/guide/en/apm/get-started/current/open-telemetry-elastic.html)
+| F5                         | No                | Yes         | [opentelemetry-collector-contrib/...](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/f5cloudexporter)
+| Google Cloud Platform      | No                | Yes         | [opentelemetry-collector-contrib/...](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudexporter)
+| Grafana Labs               | No                | Yes         | [grafana.com/...](https://grafana.com/oss/opentelemetry/)
+| Helios                     | Yes               | Yes         | [gethelios.dev](https://gethelios.dev/)
+| Honeycomb                  | Yes               | Yes         | [docs.honeycomb.io/...](https://docs.honeycomb.io/getting-data-in/)
+| Instana                    | No                | Yes         | [ibm.com/docs/...](https://www.ibm.com/docs/en/obi/current?topic=apis-opentelemetry)
+| ITRS                       | Yes               | Yes         | [docs.itrsgroup.com/docs/geneos/...](https://docs.itrsgroup.com/docs/geneos/data-collection/opentelemetry/current/opentelemetry.html)
+| KloudFuse                  | No                | Yes         | [kloudfuse.com](https://kloudfuse.atlassian.net/wiki/spaces/EX/pages/753860609/APM#Sending-traces-to-Kloudfuse-data-plane%3A)
+| Lightstep                  | Yes               | Yes         | [github.com/lightstep](https://github.com/lightstep?q=launcher)
+| LogicMonitor               | Yes               | Yes         | [logicmonitor.com/...](https://www.logicmonitor.com/support/tracing/getting-started-with-tracing)
+| Logz.io                    | Yes               | No          | [docs.logz.io/...](https://docs.logz.io/shipping/tracing-sources/opentelemetry.html#overview)
+| LogScale                   | No                | Yes         | [library.humio.com/...](https://library.humio.com/falcon-logscale/log-shippers-opentelemetry.html)
+| Lumigo                     | Yes               | Yes         | [lumigo.io](https://docs.lumigo.io/docs/opentelemetry)
+| New Relic                  | No                | Yes         | [newrelic.com/...](https://newrelic.com/solutions/opentelemetry)
+| observIQ                   | Yes               | Yes         | [observiq.com/...](https://docs.bindplane.observiq.com)
+| Oracle                     | No                | Yes         | [docs.oracle.com/...](https://docs.oracle.com/en-us/iaas/application-performance-monitoring/doc/configure-open-source-tracing-systems.html#GUID-4D941163-F357-4839-8B06-688876D4C61F)
+| Promscale                  | No                | Yes         | [timescale.com/promscale](https://www.timescale.com/promscale)
+| Sentry Software            | Yes               | Yes         | [sentrysoftware.com/...](https://www.sentrysoftware.com/products/hardware-sentry-opentelemetry-collector.html)
+| ServicePilot               | No                | Yes         | [servicepilot.com/...](https://www.servicepilot.com/en/doc/apm#opentelemetry)
+| SigNoz                     | Yes               | Yes         | [signoz.io](https://signoz.io)
+| SolarWinds                 | Yes               | Yes         | [documentation.solarwinds.com/...](https://documentation.solarwinds.com/en/success_center/observability/default.htm#cshid=third-otel-integration)
+| Splunk                     | Yes               | Yes         | [splunk.com/blog/...](https://www.splunk.com/en_us/blog/conf-splunklive/announcing-native-opentelemetry-support-in-splunk-apm.html)
+| Sumo Logic                 | Yes               | Yes         | [help.sumologic.com/](https://help.sumologic.com/docs/apm/traces/quickstart/)
+| TelemetryHub               | No                | Yes         | [telemetryhub.com](https://app.telemetryhub.com/docs)
+| Traceloop                  | No                | Yes         | [traceloop.dev](https://docs.traceloop.dev)
+| Uptrace                    | Yes               | Yes         | [uptrace.dev](https://uptrace.dev)
 
 \* _Vendors are listed alphabetically_.


### PR DESCRIPTION
- Temporary "fix" (until the Vendors table is data driven) to avoid rebase conflicts when entries are added to the vendor table via separate commits: don't run the formatter over the vendor table.
- Trimmed `https://` from the start of the link text (not the link URL) of the new ITRS entry.
- Dropped the trailing `|` from the end of the table markdown to make it easier to add entry (and not worry about padding the last row cell with spaces.
- Other than that the table entries are the same
- Kinda contributes to #2178
