### PR TITLE
PHP instrumentation improvements

### DIFF
--- a/content/en/docs/instrumentation/php/getting-started.md
+++ b/content/en/docs/instrumentation/php/getting-started.md
@@ -36,9 +36,10 @@ to find a `php-http/async-client` implementation.
 
 #### ext-ffi
 
-Fibers support can be enabled by setting the `OTEL_PHP_FIBERS_ENABLED` environment
-variable to a truthy value (`1`, `true`, `on`). Using fibers with non-`CLI`
-SAPIs may require preloading of bindings. One way to achieve this is setting
+Fibers support can be enabled by setting the `OTEL_PHP_FIBERS_ENABLED`
+environment variable to a truthy value (`1`, `true`, `on`). Using fibers with
+non-`CLI` SAPIs may require preloading of bindings. One way to achieve this is
+setting
 [`ffi.preload`](https://www.php.net/manual/en/ffi.configuration.php#ini.ffi.preload)
 to `src/Context/fiber/zend_observer_fiber.h` and setting
 [`opcache.preload`](https://www.php.net/manual/en/opcache.preloading.php) to

--- a/content/en/docs/instrumentation/php/getting-started.md
+++ b/content/en/docs/instrumentation/php/getting-started.md
@@ -30,7 +30,7 @@ to find a `php-http/async-client` implementation.
 | ------------------------------------------------------------------------- | ----------------------------------------------------------------- |
 | [ext-grpc](https://github.com/grpc/grpc/tree/master/src/php)              | Required to use gRPC as a transport for the OTLP exporter         |
 | [ext-mbstring](https://www.php.net/manual/en/book.mbstring.php)           | More performant than the fallback, `symfony/polyfill-mbstring`    |
-| [ext-zlib](https://www.php.net/manual/en/book.zlib.php)                   | If you want to compress exported data                        |
+| [ext-zlib](https://www.php.net/manual/en/book.zlib.php)                   | If you want to compress exported data                             |
 | [ext-ffi](https://www.php.net/manual/en/book.ffi.php)                     | Fiber-based context storage                                       |
 | [ext-protobuf](https://github.com/protocolbuffers/protobuf/tree/main/php) | _Significant_ performance improvement for otlp+protobuf exporting |
 

--- a/content/en/docs/instrumentation/php/getting-started.md
+++ b/content/en/docs/instrumentation/php/getting-started.md
@@ -26,13 +26,13 @@ to find a `php-http/async-client` implementation.
 
 ### Optional PHP extensions
 
-| Extension                                                       | Why                                                               |
-| --------------------------------------------------------------- | ----------------------------------------------------------------- |
-| [ext-grpc](https://pecl.php.net/package/gRPC)                   | Required to use gRPC as a transport for the OTLP exporter         |
-| [ext-mbstring](https://www.php.net/manual/en/book.mbstring.php) | More performant than the fallback, `symfony/polyfill-mbstring`    |
-| [ext-zlib](https://www.php.net/manual/en/book.zlib.php)         | If you want to compress data for exporting                        |
-| [ext-ffi](https://www.php.net/manual/en/book.ffi.php)           | Fiber-based context storage                                       |
-| [ext-protobuf](https://pecl.php.net/package/protobuf)           | _Significant_ performance improvement for otlp+protobuf exporting |
+| Extension                                                                 | Why                                                               |
+| ------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| [ext-grpc](https://github.com/grpc/grpc/tree/master/src/php)              | Required to use gRPC as a transport for the OTLP exporter         |
+| [ext-mbstring](https://www.php.net/manual/en/book.mbstring.php)           | More performant than the fallback, `symfony/polyfill-mbstring`    |
+| [ext-zlib](https://www.php.net/manual/en/book.zlib.php)                   | If you want to compress data for exporting                        |
+| [ext-ffi](https://www.php.net/manual/en/book.ffi.php)                     | Fiber-based context storage                                       |
+| [ext-protobuf](https://github.com/protocolbuffers/protobuf/tree/main/php) | _Significant_ performance improvement for otlp+protobuf exporting |
 
 #### ext-ffi
 

--- a/content/en/docs/instrumentation/php/getting-started.md
+++ b/content/en/docs/instrumentation/php/getting-started.md
@@ -7,21 +7,27 @@ weight: 1
 
 ## Requirements
 
-OpenTelemetry for PHP requires a minimum PHP version of 7.4, and auto-instrumentation requires version 8.0+
+OpenTelemetry for PHP requires a minimum PHP version of 7.4, and
+auto-instrumentation requires version 8.0+
 
 ### Dependencies
 
-Some of the `SDK` and `Contrib` packages have a dependency on both a [HTTP Factories (PSR17)](https://www.php-fig.org/psr/psr-17/)
-and a [php-http/async-client](https://docs.php-http.org/en/latest/clients.html) implementation.
-You can find appropriate composer packages implementing given standards on [packagist.org](https://packagist.org/).
+Some of the `SDK` and `Contrib` packages have a dependency on both a
+[HTTP Factories (PSR17)](https://www.php-fig.org/psr/psr-17/) and a
+[php-http/async-client](https://docs.php-http.org/en/latest/clients.html)
+implementation. You can find appropriate composer packages implementing given
+standards on [packagist.org](https://packagist.org/).
 
-Please see [http-factory-implementations](https://packagist.org/providers/psr/http-factory-implementation) to find a `PSR17 (HTTP factories)` implementation,
-and [this async-client-implementations](https://packagist.org/providers/php-http/async-client-implementation) to find a `php-http/async-client` implementation.
+Please see
+[http-factory-implementations](https://packagist.org/providers/psr/http-factory-implementation)
+to find a `PSR17 (HTTP factories)` implementation, and
+[async-client-implementations](https://packagist.org/providers/php-http/async-client-implementation)
+to find a `php-http/async-client` implementation.
 
 ### Optional PHP extensions
 
 | Extension                                                       | Why                                                               |
-|-----------------------------------------------------------------|-------------------------------------------------------------------|
+| --------------------------------------------------------------- | ----------------------------------------------------------------- |
 | [ext-grpc](https://pecl.php.net/package/gRPC)                   | Required to use gRPC as a transport for the OTLP exporter         |
 | [ext-mbstring](https://www.php.net/manual/en/book.mbstring.php) | More performant than the fallback, `symfony/polyfill-mbstring`    |
 | [ext-zlib](https://www.php.net/manual/en/book.zlib.php)         | If you want to compress data for exporting                        |
@@ -29,22 +35,30 @@ and [this async-client-implementations](https://packagist.org/providers/php-http
 | [ext-protobuf](https://pecl.php.net/package/protobuf)           | _Significant_ performance improvement for otlp+protobuf exporting |
 
 #### ext-ffi
-`ext-ffi` can be enabled by setting the `OTEL_PHP_FIBERS_ENABLED` environment variable to a truthy value
-(`1`, `true`, `on`).
-Using fibers with non-`CLI` SAPIs may require preloading of bindings. One way to achieve this is setting
-[`ffi.preload`](https://www.php.net/manual/en/ffi.configuration.php#ini.ffi.preload) to `src/Context/fiber/zend_observer_fiber.h` and setting [`opcache.preload`](https://www.php.net/manual/en/opcache.preloading.php) to `vendor/autoload.php`.
+
+Fibers support can be enabled by setting the `OTEL_PHP_FIBERS_ENABLED` environment
+variable to a truthy value (`1`, `true`, `on`). Using fibers with non-`CLI`
+SAPIs may require preloading of bindings. One way to achieve this is setting
+[`ffi.preload`](https://www.php.net/manual/en/ffi.configuration.php#ini.ffi.preload)
+to `src/Context/fiber/zend_observer_fiber.h` and setting
+[`opcache.preload`](https://www.php.net/manual/en/opcache.preloading.php) to
+`vendor/autoload.php`.
 
 #### ext-protobuf
-The [native protobuf library](https://packagist.org/packages/google/protobuf) is significantly slower
-than the extension. We strongly encourage the use of the extension.
+
+The [native protobuf library](https://packagist.org/packages/google/protobuf) is
+significantly slower than the extension. We strongly encourage the use of the
+extension.
 
 ## Introduction
 
-OpenTelemetry for PHP is distributed via [packagist](https://packagist.org/packages/open-telemetry/),
-in a number of packages. We recommend that you install only the packages that you need, which as a
-minimum is usually `API`, `Context`, `SDK` and an exporter.
+OpenTelemetry for PHP is distributed via
+[packagist](https://packagist.org/packages/open-telemetry/), in a number of
+packages. We recommend that you install only the packages that you need, which
+as a minimum is usually `API`, `Context`, `SDK` and an exporter.
 
-We strongly encourage that your code only depend on classes and interfaces in the `API` package.
+We strongly encourage that your code only depend on classes and interfaces in
+the `API` package.
 
 ## Setup
 
@@ -202,6 +216,7 @@ The next step is to modify the code to send spans to the collector via OTLP
 instead of the console.
 
 This will require the installation of the otlp exporter:
+
 ```shell
 composer require opentelemetry/exporter-otlp
 ```

--- a/content/en/docs/instrumentation/php/getting-started.md
+++ b/content/en/docs/instrumentation/php/getting-started.md
@@ -8,7 +8,7 @@ weight: 1
 ## Requirements
 
 OpenTelemetry for PHP requires a minimum PHP version of 7.4, and
-auto-instrumentation requires version 8.0+
+auto-instrumentation requires version 8.0+.
 
 ### Dependencies
 
@@ -18,7 +18,7 @@ Some of the `SDK` and `Contrib` packages have a dependency on both a
 implementation. You can find appropriate composer packages implementing given
 standards on [packagist.org](https://packagist.org/).
 
-Please see
+See
 [http-factory-implementations](https://packagist.org/providers/psr/http-factory-implementation)
 to find a `PSR17 (HTTP factories)` implementation, and
 [async-client-implementations](https://packagist.org/providers/php-http/async-client-implementation)
@@ -26,11 +26,11 @@ to find a `php-http/async-client` implementation.
 
 ### Optional PHP extensions
 
-| Extension                                                                 | Why                                                               |
+| Extension                                                                 | Purpose                                                           |
 | ------------------------------------------------------------------------- | ----------------------------------------------------------------- |
 | [ext-grpc](https://github.com/grpc/grpc/tree/master/src/php)              | Required to use gRPC as a transport for the OTLP exporter         |
 | [ext-mbstring](https://www.php.net/manual/en/book.mbstring.php)           | More performant than the fallback, `symfony/polyfill-mbstring`    |
-| [ext-zlib](https://www.php.net/manual/en/book.zlib.php)                   | If you want to compress data for exporting                        |
+| [ext-zlib](https://www.php.net/manual/en/book.zlib.php)                   | If you want to compress exported data                        |
 | [ext-ffi](https://www.php.net/manual/en/book.ffi.php)                     | Fiber-based context storage                                       |
 | [ext-protobuf](https://github.com/protocolbuffers/protobuf/tree/main/php) | _Significant_ performance improvement for otlp+protobuf exporting |
 

--- a/content/en/docs/instrumentation/php/getting-started.md
+++ b/content/en/docs/instrumentation/php/getting-started.md
@@ -5,6 +5,47 @@ aliases: [/docs/instrumentation/php/getting_started]
 weight: 1
 ---
 
+## Requirements
+
+OpenTelemetry for PHP requires a minimum PHP version of 7.4, and auto-instrumentation requires version 8.0+
+
+### Dependencies
+
+Some of the `SDK` and `Contrib` packages have a dependency on both a [HTTP Factories (PSR17)](https://www.php-fig.org/psr/psr-17/)
+and a [php-http/async-client](https://docs.php-http.org/en/latest/clients.html) implementation.
+You can find appropriate composer packages implementing given standards on [packagist.org](https://packagist.org/).
+
+Please see [http-factory-implementations](https://packagist.org/providers/psr/http-factory-implementation) to find a `PSR17 (HTTP factories)` implementation,
+and [this async-client-implementations](https://packagist.org/providers/php-http/async-client-implementation) to find a `php-http/async-client` implementation.
+
+### Optional PHP extensions
+
+| Extension                                                       | Why                                                               |
+|-----------------------------------------------------------------|-------------------------------------------------------------------|
+| [ext-grpc](https://pecl.php.net/package/gRPC)                   | Required to use gRPC as a transport for the OTLP exporter         |
+| [ext-mbstring](https://www.php.net/manual/en/book.mbstring.php) | More performant than the fallback, `symfony/polyfill-mbstring`    |
+| [ext-zlib](https://www.php.net/manual/en/book.zlib.php)         | If you want to compress data for exporting                        |
+| [ext-ffi](https://www.php.net/manual/en/book.ffi.php)           | Fiber-based context storage                                       |
+| [ext-protobuf](https://pecl.php.net/package/protobuf)           | _Significant_ performance improvement for otlp+protobuf exporting |
+
+#### ext-ffi
+`ext-ffi` can be enabled by setting the `OTEL_PHP_FIBERS_ENABLED` environment variable to a truthy value
+(`1`, `true`, `on`).
+Using fibers with non-`CLI` SAPIs may require preloading of bindings. One way to achieve this is setting
+[`ffi.preload`](https://www.php.net/manual/en/ffi.configuration.php#ini.ffi.preload) to `src/Context/fiber/zend_observer_fiber.h` and setting [`opcache.preload`](https://www.php.net/manual/en/opcache.preloading.php) to `vendor/autoload.php`.
+
+#### ext-protobuf
+The [native protobuf library](https://packagist.org/packages/google/protobuf) is significantly slower
+than the extension. We strongly encourage the use of the extension.
+
+## Introduction
+
+OpenTelemetry for PHP is distributed via [packagist](https://packagist.org/packages/open-telemetry/),
+in a number of packages. We recommend that you install only the packages that you need, which as a
+minimum is usually `API`, `Context`, `SDK` and an exporter.
+
+We strongly encourage that your code only depend on classes and interfaces in the `API` package.
+
 ## Setup
 
 Before you get started make sure that you have php and
@@ -160,6 +201,11 @@ trace:
 The next step is to modify the code to send spans to the collector via OTLP
 instead of the console.
 
+This will require the installation of the otlp exporter:
+```shell
+composer require opentelemetry/exporter-otlp
+```
+
 Next, using the `GettingStarted.php` from earlier, replace the console exporter
 with an OTLP exporter:
 
@@ -218,4 +264,4 @@ Starting OtlpHttpExporter
 OpenTelemetry welcomes PHP
 ```
 
-Now, telemetry will be exported to the collector process.
+Now, telemetry will be exported to the collector.

--- a/content/en/docs/instrumentation/php/logging.md
+++ b/content/en/docs/instrumentation/php/logging.md
@@ -6,17 +6,19 @@ weight: 10
 ## Introduction
 
 As logging is a mature and well-established function, the
-[OpenTelemetry approach](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/README.md#introduction)
-is a little different for this signal than traces or metrics.
+[OpenTelemetry approach](/docs/concepts/signals/logs/)
+is a little different for this signal.
 
 The OpenTelemetry logger is not designed to be used directly, but rather to be
 integrated into existing logging libraries as a handler. In this way you can
-choose to have some or all of your application logs sent to an OpenTelemetry-compatible
-service such as the [collector](/docs/collector/).
+choose to have some or all of your application logs sent to an
+OpenTelemetry-compatible service such as the [collector](/docs/collector/).
 
 ## Setup
 
-Loggers must be obtained from a `LoggerProvider`, and log records must be emitted via an `EventLogger`:
+Loggers must be obtained from a `LoggerProvider`, and log records must be
+emitted via an `EventLogger`:
+
 ```php
 <?php
 $loggerProvider = new LoggerProvider(
@@ -28,7 +30,9 @@ $logger = $loggerProvider->getLogger('demo', '1.0', 'http://schema.url', true, [
 $eventLogger = new EventLogger($logger, 'my-domain');
 ```
 
-Once configured, a `LogRecord` can be created and sent via the event logger's `logEvent`method:
+Once configured, a `LogRecord` can be created and sent via the event logger's
+`logEvent`method:
+
 ```php
 $record = (new LogRecord('hello world'))
     ->setSeverityText('INFO')
@@ -39,7 +43,7 @@ $eventLogger->logEvent('foo', $record);
 
 ## Examples
 
-The [monolog-otel-integration example](https://github.com/open-telemetry/opentelemetry-php/blob/main/examples/logs/features/monolog-otel-integration.php)
-demonstrates using the popular Monolog logger to send some logs to a stream
-(in their usual format), as well as sending some logs to an OpenTelemetry
-collector.
+The
+[monolog-otel-integration example](https://github.com/open-telemetry/opentelemetry-php/blob/main/examples/logs/features/monolog-otel-integration.php)
+demonstrates using the popular Monolog logger to send some logs to a stream (in
+their usual format), as well as sending some logs to an OpenTelemetry collector.

--- a/content/en/docs/instrumentation/php/logging.md
+++ b/content/en/docs/instrumentation/php/logging.md
@@ -6,8 +6,8 @@ weight: 10
 ## Introduction
 
 As logging is a mature and well-established function, the
-[OpenTelemetry approach](/docs/concepts/signals/logs/)
-is a little different for this signal.
+[OpenTelemetry approach](/docs/concepts/signals/logs/) is a little different for
+this signal.
 
 The OpenTelemetry logger is not designed to be used directly, but rather to be
 integrated into existing logging libraries as a handler. In this way you can

--- a/content/en/docs/instrumentation/php/logging.md
+++ b/content/en/docs/instrumentation/php/logging.md
@@ -3,21 +3,18 @@ title: Logging
 weight: 10
 ---
 
-## Introduction
-
 As logging is a mature and well-established function, the
 [OpenTelemetry approach](/docs/concepts/signals/logs/) is a little different for
 this signal.
 
 The OpenTelemetry logger is not designed to be used directly, but rather to be
-integrated into existing logging libraries as a handler. In this way you can
+integrated into existing logging libraries as a handler. In this way, you can
 choose to have some or all of your application logs sent to an
 OpenTelemetry-compatible service such as the [collector](/docs/collector/).
 
 ## Setup
 
-Loggers must be obtained from a `LoggerProvider`, and log records must be
-emitted via an `EventLogger`:
+You get a logger from a `LoggerProvider`. Log records get emitted via an `EventLogger`:
 
 ```php
 <?php

--- a/content/en/docs/instrumentation/php/logging.md
+++ b/content/en/docs/instrumentation/php/logging.md
@@ -14,7 +14,8 @@ OpenTelemetry-compatible service such as the [collector](/docs/collector/).
 
 ## Setup
 
-You get a logger from a `LoggerProvider`. Log records get emitted via an `EventLogger`:
+You get a logger from a `LoggerProvider`. Log records get emitted via an
+`EventLogger`:
 
 ```php
 <?php

--- a/content/en/docs/instrumentation/php/logging.md
+++ b/content/en/docs/instrumentation/php/logging.md
@@ -1,0 +1,45 @@
+---
+title: Logging
+weight: 10
+---
+
+## Introduction
+
+As logging is a mature and well-established function, the
+[OpenTelemetry approach](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/README.md#introduction)
+is a little different for this signal than traces or metrics.
+
+The OpenTelemetry logger is not designed to be used directly, but rather to be
+integrated into existing logging libraries as a handler. In this way you can
+choose to have some or all of your application logs sent to an OpenTelemetry-compatible
+service such as the [collector](/docs/collector/).
+
+## Setup
+
+Loggers must be obtained from a `LoggerProvider`, and log records must be emitted via an `EventLogger`:
+```php
+<?php
+$loggerProvider = new LoggerProvider(
+    new SimpleLogsProcessor(
+        new ConsoleExporter()
+    )
+);
+$logger = $loggerProvider->getLogger('demo', '1.0', 'http://schema.url', true, [/*attributes*/]);
+$eventLogger = new EventLogger($logger, 'my-domain');
+```
+
+Once configured, a `LogRecord` can be created and sent via the event logger's `logEvent`method:
+```php
+$record = (new LogRecord('hello world'))
+    ->setSeverityText('INFO')
+    ->setAttributes([/*attributes*/]);
+
+$eventLogger->logEvent('foo', $record);
+```
+
+## Examples
+
+The [monolog-otel-integration example](https://github.com/open-telemetry/opentelemetry-php/blob/main/examples/logs/features/monolog-otel-integration.php)
+demonstrates using the popular Monolog logger to send some logs to a stream
+(in their usual format), as well as sending some logs to an OpenTelemetry
+collector.

--- a/content/en/docs/instrumentation/php/manual.md
+++ b/content/en/docs/instrumentation/php/manual.md
@@ -70,6 +70,18 @@ $instrumentation = new CachedInstrumentation('example');
 $tracer = $instrumentation->tracer();
 ```
 
+It's important to run the tracer provider's `shutdown()` method when the PHP
+process ends, to enable flushing of any enqueued telemetry.
+The shutdown process is blocking, so consider running it in an async process.
+Otherwise, you can use the `ShutdownHandler` to register the shutdown function
+as part of PHP's shutdown process:
+
+```php
+\OpenTelemetry\SDK\Common\Util\ShutdownHandler::register([$tracerProvider, 'shutdown']);
+\OpenTelemetry\SDK\Common\Util\ShutdownHandler::register([$meterProvider, 'shutdown']);
+```
+
+
 ## Acquiring a Tracer
 
 To do [Tracing](/docs/concepts/signals/traces/) you'll need to acquire a

--- a/content/en/docs/instrumentation/php/manual.md
+++ b/content/en/docs/instrumentation/php/manual.md
@@ -71,16 +71,15 @@ $tracer = $instrumentation->tracer();
 ```
 
 It's important to run the tracer provider's `shutdown()` method when the PHP
-process ends, to enable flushing of any enqueued telemetry.
-The shutdown process is blocking, so consider running it in an async process.
-Otherwise, you can use the `ShutdownHandler` to register the shutdown function
-as part of PHP's shutdown process:
+process ends, to enable flushing of any enqueued telemetry. The shutdown process
+is blocking, so consider running it in an async process. Otherwise, you can use
+the `ShutdownHandler` to register the shutdown function as part of PHP's
+shutdown process:
 
 ```php
 \OpenTelemetry\SDK\Common\Util\ShutdownHandler::register([$tracerProvider, 'shutdown']);
 \OpenTelemetry\SDK\Common\Util\ShutdownHandler::register([$meterProvider, 'shutdown']);
 ```
-
 
 ## Acquiring a Tracer
 

--- a/content/en/docs/instrumentation/php/sdk.md
+++ b/content/en/docs/instrumentation/php/sdk.md
@@ -8,7 +8,8 @@ set up and configured in a number of ways.
 
 ## Manual setup
 
-When manually setting up an SDK, you have full control.
+Setting up an SDK manually gives you the most control over the SDK's
+configuration:
 
 ```php
 <?php
@@ -29,7 +30,7 @@ $tracerProvider =  new TracerProvider(
 
 ## SDK Builder
 
-The SDK builder provides a fluent interface to configure parts of the SDK.
+The SDK builder provides a convenient interface to configure parts of the SDK.
 However, it doesn't support all of the features that manual setup does.
 
 ```php

--- a/content/en/docs/instrumentation/php/sdk.md
+++ b/content/en/docs/instrumentation/php/sdk.md
@@ -3,8 +3,8 @@ title: SDK
 weight: 8
 ---
 
-The OpenTelemetry SDK provides a working implementation of the API, and can be set up and configured
-in a number of ways.
+The OpenTelemetry SDK provides a working implementation of the API, and can be
+set up and configured in a number of ways.
 
 ## Manual setup
 
@@ -29,8 +29,8 @@ $tracerProvider =  new TracerProvider(
 
 ## SDK Builder
 
-The SDK builder provides a fluent interface to configure parts of the SDK. However, it doesn't support
-all of the features that manual setup does.
+The SDK builder provides a fluent interface to configure parts of the SDK.
+However, it doesn't support all of the features that manual setup does.
 
 ```php
 <?php
@@ -83,8 +83,9 @@ SDK autoloading happens as part of the composer autoloader.
 ## Configuration
 
 The PHP SDK supports most of the
-[available configurations](/docs/concepts/sdk-configuration/). Our conformance to the
-specification is listed in the [spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md).
+[available configurations](/docs/concepts/sdk-configuration/). Our conformance
+to the specification is listed in the
+[spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md).
 
 There are also a number of PHP-specific configurations:
 

--- a/content/en/docs/instrumentation/php/sdk.md
+++ b/content/en/docs/instrumentation/php/sdk.md
@@ -1,0 +1,79 @@
+---
+title: SDK
+weight: 8
+---
+
+The OpenTelemetry SDK provides a working implementation of the API.
+
+## Builder
+
+You can use the SDK builder as a convenience over the methods introduced in [getting started](getting-started):
+
+```php
+<?php
+
+use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;
+use OpenTelemetry\SDK\Sdk;
+use OpenTelemetry\SDK\Trace\Sampler\AlwaysOnSampler;
+use OpenTelemetry\SDK\Trace\Sampler\ParentBased;
+use OpenTelemetry\SDK\Trace\TracerProvider;
+
+$spanExporter = new InMemoryExporter(); //mock exporter for demonstration purposes
+$resource = ResourceInfoFactory::defaultResource();
+
+$tracerProvider = TracerProvider::builder()
+    ->addSpanProcessor(
+        (new BatchSpanProcessorBuilder($spanExporter))
+            ->setMeterProvider($meterProvider)
+            ->build()
+    )
+    ->setResource($resource)
+    ->setSampler(new ParentBased(new AlwaysOnSampler()))
+    ->build();
+
+Sdk::builder()
+    ->setTracerProvider($tracerProvider)
+    ->setMeterProvider($meterProvider)
+    ->setPropagator(TraceContextPropagator::getInstance())
+    ->setAutoShutdown(true)
+    ->buildAndRegisterGlobal();
+```
+
+## Autoloading
+
+If all configuration comes from environment variables (or `php.ini`), you can use SDK
+autoloading to automatically configure and globally register an SDK.
+The only requirement for this is that you set `OTEL_PHP_AUTOLOAD_ENABLED=true`, and
+any required configuration as set out in [sdk-configuration](/docs/concepts/sdk-configuration/).
+
+For example:
+
+```shell
+export OTEL_PHP_AUTOLOAD_ENABLED=true \
+       OTEL_EXPORTER_OTLP_PROTOCOL=grpc \
+       OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4317
+php example.php
+```
+
+```php
+<?php
+require 'vendor/autoload.php'; //sdk autoloading happens as part of composer initialization
+
+$tracer = OpenTelemetry\API\Common\Instrumentation\Globals::tracerProvider()->getTracer('name', 'version', 'schema.url', [/*attributes*/]);
+$meter = OpenTelemetry\API\Common\Instrumentation\Globals::meterProvider()->getTracer('name', 'version', 'schema.url', [/*attributes*/]);
+```
+
+## Configuration
+
+The PHP SDK supports most of the [available configurations](/docs/concepts/sdk-configuration/).
+
+There are also a number of PHP-specific configurations:
+
+| Name                                | Default value | Values                                                                | Example        | Description                                         |
+|-------------------------------------|---------------|-----------------------------------------------------------------------|----------------|-----------------------------------------------------|
+| OTEL_PHP_TRACES_PROCESSOR           | batch         | batch, simple                                                         | simple         | Span processor selection                            |
+| OTEL_PHP_DETECTORS                  | all           | env, host, os, process, process_runtime, sdk, sdk_provided, container | env,os,process | Resource detector selection                         |
+| OTEL_PHP_AUTOLOAD_ENABLED           | false         | true, false                                                           | true           | Enable/disable SDK autoloading                      |
+| OTEL_PHP_DISABLED_INSTRUMENTATIONS  | []            | Instrumentation name(s)                                               | psr15,psr18    | Disable one or more installed auto-instrumentations |
+
+Configurations can be provided as environment variables, or via `php.ini` (or a file included by `php.ini`)

--- a/content/en/docs/instrumentation/php/sdk.md
+++ b/content/en/docs/instrumentation/php/sdk.md
@@ -3,23 +3,39 @@ title: SDK
 weight: 8
 ---
 
-The OpenTelemetry SDK provides a working implementation of the API.
+The OpenTelemetry SDK provides a working implementation of the API, and can be set up and configured
+in a number of ways.
 
-## Builder
+## Manual setup
 
-You can use the SDK builder as a convenience over the methods introduced in [getting started](getting-started):
+When manually setting up an SDK, you have full control.
+
+```php
+<?php
+$exporter = new InMemoryExporter();
+$meterProvider = new NoopMeterProvider();
+$tracerProvider =  new TracerProvider(
+    new BatchSpanProcessor(
+        $exporter,
+        ClockFactory::getDefault(),
+        2048, //max queue size
+        5000, //export timeout
+        1024, //max batch size
+        true, //autoflush
+        $meterProvider
+    )
+);
+```
+
+## SDK Builder
+
+The SDK builder provides a fluent interface to configure parts of the SDK. However, it doesn't support
+all of the features that manual setup does.
 
 ```php
 <?php
 
-use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;
-use OpenTelemetry\SDK\Sdk;
-use OpenTelemetry\SDK\Trace\Sampler\AlwaysOnSampler;
-use OpenTelemetry\SDK\Trace\Sampler\ParentBased;
-use OpenTelemetry\SDK\Trace\TracerProvider;
-
 $spanExporter = new InMemoryExporter(); //mock exporter for demonstration purposes
-$resource = ResourceInfoFactory::defaultResource();
 
 $tracerProvider = TracerProvider::builder()
     ->addSpanProcessor(
@@ -27,8 +43,6 @@ $tracerProvider = TracerProvider::builder()
             ->setMeterProvider($meterProvider)
             ->build()
     )
-    ->setResource($resource)
-    ->setSampler(new ParentBased(new AlwaysOnSampler()))
     ->build();
 
 Sdk::builder()
@@ -41,17 +55,18 @@ Sdk::builder()
 
 ## Autoloading
 
-If all configuration comes from environment variables (or `php.ini`), you can use SDK
-autoloading to automatically configure and globally register an SDK.
-The only requirement for this is that you set `OTEL_PHP_AUTOLOAD_ENABLED=true`, and
-any required configuration as set out in [sdk-configuration](/docs/concepts/sdk-configuration/).
+If all configuration comes from environment variables (or `php.ini`), you can
+use SDK autoloading to automatically configure and globally register an SDK. The
+only requirement for this is that you set `OTEL_PHP_AUTOLOAD_ENABLED=true`, and
+provide any required/non-standard configuration as set out in
+[sdk-configuration](/docs/concepts/sdk-configuration/).
 
 For example:
 
 ```shell
-export OTEL_PHP_AUTOLOAD_ENABLED=true \
-       OTEL_EXPORTER_OTLP_PROTOCOL=grpc \
-       OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4317
+OTEL_PHP_AUTOLOAD_ENABLED=true \
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4317 \
 php example.php
 ```
 
@@ -63,17 +78,22 @@ $tracer = OpenTelemetry\API\Common\Instrumentation\Globals::tracerProvider()->ge
 $meter = OpenTelemetry\API\Common\Instrumentation\Globals::meterProvider()->getTracer('name', 'version', 'schema.url', [/*attributes*/]);
 ```
 
+SDK autoloading happens as part of the composer autoloader.
+
 ## Configuration
 
-The PHP SDK supports most of the [available configurations](/docs/concepts/sdk-configuration/).
+The PHP SDK supports most of the
+[available configurations](/docs/concepts/sdk-configuration/). Our conformance to the
+specification is listed in the [spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md).
 
 There are also a number of PHP-specific configurations:
 
-| Name                                | Default value | Values                                                                | Example        | Description                                         |
-|-------------------------------------|---------------|-----------------------------------------------------------------------|----------------|-----------------------------------------------------|
-| OTEL_PHP_TRACES_PROCESSOR           | batch         | batch, simple                                                         | simple         | Span processor selection                            |
-| OTEL_PHP_DETECTORS                  | all           | env, host, os, process, process_runtime, sdk, sdk_provided, container | env,os,process | Resource detector selection                         |
-| OTEL_PHP_AUTOLOAD_ENABLED           | false         | true, false                                                           | true           | Enable/disable SDK autoloading                      |
-| OTEL_PHP_DISABLED_INSTRUMENTATIONS  | []            | Instrumentation name(s)                                               | psr15,psr18    | Disable one or more installed auto-instrumentations |
+| Name                               | Default value | Values                                                                | Example        | Description                                         |
+| ---------------------------------- | ------------- | --------------------------------------------------------------------- | -------------- | --------------------------------------------------- |
+| OTEL_PHP_TRACES_PROCESSOR          | batch         | batch, simple                                                         | simple         | Span processor selection                            |
+| OTEL_PHP_DETECTORS                 | all           | env, host, os, process, process_runtime, sdk, sdk_provided, container | env,os,process | Resource detector selection                         |
+| OTEL_PHP_AUTOLOAD_ENABLED          | false         | true, false                                                           | true           | Enable/disable SDK autoloading                      |
+| OTEL_PHP_DISABLED_INSTRUMENTATIONS | []            | Instrumentation name(s)                                               | psr15,psr18    | Disable one or more installed auto-instrumentations |
 
-Configurations can be provided as environment variables, or via `php.ini` (or a file included by `php.ini`)
+Configurations can be provided as environment variables, or via `php.ini` (or a
+file included by `php.ini`)

--- a/data/instrumentation.yaml
+++ b/data/instrumentation.yaml
@@ -34,7 +34,7 @@ languages:
     status:
       traces: beta
       metrics: beta
-      logs: not yet implemented
+      logs: alpha
   python:
     name: Python
     status:

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -891,6 +891,10 @@
     "StatusCode": 200,
     "LastSeen": "2023-02-15T21:14:26.223031-05:00"
   },
+  "https://docs.php-http.org/en/latest/clients.html": {
+    "StatusCode": 200,
+    "LastSeen": "2023-03-29T03:57:45.844229122Z"
+  },
   "https://docs.python.org/3/library/sys.html#sys.implementation": {
     "StatusCode": 206,
     "LastSeen": "2023-02-15T21:12:08.314891-05:00"
@@ -3103,9 +3107,29 @@
     "StatusCode": 206,
     "LastSeen": "2023-02-16T17:45:10.013699-05:00"
   },
+  "https://packagist.org/": {
+    "StatusCode": 200,
+    "LastSeen": "2023-03-29T03:57:46.228775307Z"
+  },
+  "https://packagist.org/packages/google/protobuf": {
+    "StatusCode": 200,
+    "LastSeen": "2023-03-29T03:57:52.438347267Z"
+  },
+  "https://packagist.org/packages/open-telemetry/": {
+    "StatusCode": 200,
+    "LastSeen": "2023-03-29T03:57:52.875982797Z"
+  },
   "https://packagist.org/packages/open-telemetry/opentelemetry-instrumentation-installer": {
     "StatusCode": 200,
     "LastSeen": "2023-03-14T18:07:43.947011+01:00"
+  },
+  "https://packagist.org/providers/php-http/async-client-implementation": {
+    "StatusCode": 200,
+    "LastSeen": "2023-03-29T03:57:47.546094076Z"
+  },
+  "https://packagist.org/providers/psr/http-factory-implementation": {
+    "StatusCode": 200,
+    "LastSeen": "2023-03-29T03:57:46.915444079Z"
   },
   "https://packagist.org/search/": {
     "StatusCode": 200,
@@ -3959,9 +3983,33 @@
     "StatusCode": 206,
     "LastSeen": "2023-02-28T03:33:34.741771102Z"
   },
+  "https://www.php-fig.org/psr/psr-17/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-03-29T03:57:45.198897206Z"
+  },
   "https://www.php-fig.org/psr/psr-18/": {
     "StatusCode": 206,
     "LastSeen": "2023-02-28T03:33:35.061283512Z"
+  },
+  "https://www.php.net/manual/en/book.ffi.php": {
+    "StatusCode": 200,
+    "LastSeen": "2023-03-29T03:57:50.206342903Z"
+  },
+  "https://www.php.net/manual/en/book.mbstring.php": {
+    "StatusCode": 200,
+    "LastSeen": "2023-03-29T03:57:48.558076531Z"
+  },
+  "https://www.php.net/manual/en/book.zlib.php": {
+    "StatusCode": 200,
+    "LastSeen": "2023-03-29T03:57:49.468930417Z"
+  },
+  "https://www.php.net/manual/en/ffi.configuration.php#ini.ffi.preload": {
+    "StatusCode": 200,
+    "LastSeen": "2023-03-29T03:57:51.220192806Z"
+  },
+  "https://www.php.net/manual/en/opcache.preloading.php": {
+    "StatusCode": 200,
+    "LastSeen": "2023-03-29T03:57:51.962566491Z"
   },
   "https://www.python.org/dev/peps/pep-3333/": {
     "StatusCode": 206,


### PR DESCRIPTION
as PHP moves closer to GA, it's time to migrate a bunch of
existing documentation from our main readme over to opentelemetry.io

https://github.com/open-telemetry/opentelemetry-php/pull/946 is the related PR where content is being removed from opentelemetry-php's readme and linked back to opentelemetry.io or removed completely. Trying to promote opentelemetry.io as the official source of doco.

---

Preview: https://deploy-preview-2552--opentelemetry.netlify.app/docs/instrumentation/php/