### PR TITLE
Docs flow fix for beginners, move "What is OpenTelemetry?" to top level

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -26,6 +26,7 @@
     "otelcol",
     "otlp",
     "OTLP",
+    "pluggable",
     "protobuf",
     "relref",
     "roadmap",

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -24,7 +24,7 @@ spelling: cSpell:ignore shortcode
 
 <div class="l-primary-buttons mt-5">
 
-- [Learn more](/docs/concepts/)
+- [Learn more](/docs/what-is-opentelemetry/)
 - [Try the demo](/docs/demo/)
 
 </div>

--- a/content/en/blog/2022/otel-demo-app-nomad/index.md
+++ b/content/en/blog/2022/otel-demo-app-nomad/index.md
@@ -29,8 +29,8 @@ Before we move on, I am assuming that you have a basic understanding of:
   [This blog post](https://danielabaron.me/blog/nomad-tips-and-tricks/) by
   [Daniela Baron](https://danielabaron.me) is also great.
 - **[Observability](/docs/concepts/observability-primer/#what-is-observability)**
-  (o11y) and **[OpenTelemetry](/docs/concepts/what-is-opentelemetry/)** (OTel).
-  If not, see [Observability primer](/docs/concepts/observability-primer/).
+  (o11y) and **[OpenTelemetry](/docs/what-is-opentelemetry/)** (OTel). If not,
+  see [Observability primer](/docs/concepts/observability-primer/).
 
 ### Pre-Requisites
 

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -10,11 +10,7 @@ OpenTelemetry, also known as OTel for short, is a vendor-neutral open-source
 for instrumenting, generating, collecting, and exporting telemetry data such as
 [traces](concepts/observability-primer/#distributed-traces),
 [metrics](concepts/observability-primer/#reliability--metrics),
-[logs](concepts/observability-primer/#logs). As an industry-standard it is
+[logs](concepts/observability-primer/#logs). As an industry-standard, it is
 [natively supported by a number of vendors](/ecosystem/vendors/).
 
 ![OpenTelemetry Reference Architecture](/img/otel_diagram.png)
-
-> For an in-depth guide on OpenTelemetry, including documentation and guides on
-> language-specific instrumentation or the Collector, please follow the links in
-> the navigation bar.

--- a/content/en/docs/concepts/_index.md
+++ b/content/en/docs/concepts/_index.md
@@ -1,12 +1,10 @@
 ---
-title: Concepts
-description: >-
-  What is OpenTelemetry, what does it provide and what does it support?
-spelling: cSpell:ignore otel
-aliases: [/about, /docs/concepts/overview, /otel]
+title: OpenTelemetry Concepts
+linkTitle: Concepts
+description: Key concepts in OpenTelemetry
+aliases: [/docs/concepts/overview]
 weight: 2
 ---
 
-The concepts section helps you learn more about the data sources and components
-of the OpenTelemetry project in order to obtain a deeper understanding of how
-OpenTelemetry works.
+In this section you'll learn about the data sources and key components of the
+OpenTelemetry project. This will help you understanding how OpenTelemetry works.

--- a/content/en/docs/concepts/glossary.md
+++ b/content/en/docs/concepts/glossary.md
@@ -196,13 +196,13 @@ Short form for [`OpenCensus`](#opencensus).
 A set of libraries for various languages that allow you to collect application
 metrics and distributed traces, then transfer the data to a backend of your
 choice in real time.
-[Precursor to OpenTelemetry](/docs/concepts/what-is-opentelemetry/#so-what). See
+[Precursor to OpenTelemetry](/docs/what-is-opentelemetry/#so-what). See
 [more][opencensus].
 
 ### **OpenTracing**
 
 Vendor-neutral APIs and instrumentation for distributed tracing.
-[Precursor to OpenTelemetry](/docs/concepts/what-is-opentelemetry/#so-what). See
+[Precursor to OpenTelemetry](/docs/what-is-opentelemetry/#so-what). See
 [more][opentracing].
 
 ### **OT**
@@ -211,7 +211,7 @@ Short form for [`OpenTracing`](#opentracing).
 
 ### **OTel**
 
-Short form for [OpenTelemetry](/docs/concepts/what-is-opentelemetry).
+Short form for [OpenTelemetry](/docs/what-is-opentelemetry/).
 
 ### **OTelCol**
 

--- a/content/en/docs/concepts/observability-primer.md
+++ b/content/en/docs/concepts/observability-primer.md
@@ -102,7 +102,7 @@ The following table contains examples of span attributes:
 | http.user_agent  | Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36 |
 
 For more on spans and how they pertain to OTel, see
-[Spans](/docs/concepts/signals/traces/#spans-in-opentelemetry).
+[Spans](/docs/concepts/signals/traces/#spans).
 
 ### Distributed Traces
 

--- a/content/en/docs/concepts/observability-primer.md
+++ b/content/en/docs/concepts/observability-primer.md
@@ -1,6 +1,6 @@
 ---
 title: Observability Primer
-description: Learn some core concepts before you dig into OpenTelemetry.
+description: Core observability concepts.
 weight: 9
 ---
 
@@ -20,14 +20,14 @@ properly instrumented. That is, the application code must emit
 instrumented when developers don't need to add more instrumentation to
 troubleshoot an issue, because they have all of the information they need.
 
-[**OpenTelemetry**](/docs/concepts/what-is-opentelemetry) is the mechanism by
-which application code is instrumented, to help make a system observable.
+[OpenTelemetry](/docs/what-is-opentelemetry/) is the mechanism by which
+application code is instrumented, to help make a system observable.
 
 ## Reliability & Metrics
 
 **Telemetry** refers to data emitted from a system, about its behavior. The data
-can come in the form of [Traces](#distributed-traces),
-[Metrics](#reliability--metrics), and [Logs](#logs).
+can come in the form of [traces](#distributed-traces),
+[metrics](#reliability--metrics), and [logs](#logs).
 
 **Reliability** answers the question: "Is the service doing what users expect it
 to be doing?” A system could be up 100% of the time, but if, when a user clicks
@@ -53,13 +53,13 @@ To understand Distributed Tracing, let's start with some basics.
 
 ### Logs
 
-A **Log** is a timestamped message emitted by services or other components.
-Unlike [Traces](#distributed-traces), however, they are not necessarily
+A **log** is a timestamped message emitted by services or other components.
+Unlike [traces](#distributed-traces), however, they are not necessarily
 associated with any particular user request or transaction. They are found
 almost everywhere in software, and have been heavily relied on in the past by
 both developers and operators alike to help them understand system behavior.
 
-Sample Log:
+Sample log:
 
 ```text
 I, [2021-02-23T13:26:23.505892 #22473]  INFO -- : [6459ffe1-ea53-4044-aaa3-bf902868f730] Started GET "/" for ::1 at 2021-02-23 13:26:23 -0800
@@ -68,22 +68,22 @@ I, [2021-02-23T13:26:23.505892 #22473]  INFO -- : [6459ffe1-ea53-4044-aaa3-bf902
 Unfortunately, logs aren't extremely useful for tracking code execution, as they
 typically lack contextual information, such as where they were called from.
 
-They become far more useful when they are included as part of a [Span](#spans).
+They become far more useful when they are included as part of a [span](#spans).
 
 ### Spans
 
-A **Span** represents a unit of work or operation. It tracks specific operations
+A **span** represents a unit of work or operation. It tracks specific operations
 that a request makes, painting a picture of what happened during the time in
 which that operation was executed.
 
-A Span contains name, time-related data,
+A span contains name, time-related data,
 [structured log messages](/docs/concepts/signals/traces/#span-events), and
-[other metadata (i.e. Attributes)](/docs/concepts/signals/traces/#attributes) to
-provide information about the operation it tracks.
+[other metadata (that is, Attributes)](/docs/concepts/signals/traces/#attributes)
+to provide information about the operation it tracks.
 
-Below is a sample of the type of information that would be present in a Span:
+#### Span attributes
 
-#### Span Attributes
+The following table contains examples of span attributes:
 
 | Key              | Value                                                                                                                 |
 | ---------------- | --------------------------------------------------------------------------------------------------------------------- |
@@ -101,12 +101,12 @@ Below is a sample of the type of information that would be present in a Span:
 | http.status_code | 200                                                                                                                   |
 | http.user_agent  | Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36 |
 
-> For more on Spans and how they pertain to OTel, visit
-> [Spans in OpenTelemetry](/docs/concepts/signals/traces/#spans-in-opentelemetry).
+For more on spans and how they pertain to OTel, see
+[Spans](/docs/concepts/signals/traces/#spans-in-opentelemetry).
 
 ### Distributed Traces
 
-A **Distributed Trace**, more commonly known as a **Trace**, records the paths
+A **distributed trace**, more commonly known as a **trace**, records the paths
 taken by requests (made by an application or end-user) as they propagate through
 multi-service architectures, like microservice and serverless applications.
 
@@ -122,19 +122,19 @@ Tracing makes debugging and understanding distributed systems less daunting by
 breaking down what happens within a request as it flows through a distributed
 system.
 
-A Trace is made of one or more Spans. The first Span represents the Root Span.
-Each Root Span represents a request from start to finish. The Spans underneath
+A trace is made of one or more spans. The first span represents the root span.
+Each root span represents a request from start to finish. The spans underneath
 the parent provide a more in-depth context of what occurs during a request (or
 what steps make up a request).
 
-Many Observability back-ends visualize Traces as waterfall diagrams that may
+Many Observability back-ends visualize traces as waterfall diagrams that may
 look something like this:
 
-![Sample Trace](/img/waterfall_trace.png 'trace waterfall diagram')
+![Sample Trace](/img/waterfall_trace.png 'Trace waterfall diagram')
 
-Waterfall diagrams show the parent-child relationship between a Root Span and
-its child Spans. When a Span encapsulates another Span, this also represents a
+Waterfall diagrams show the parent-child relationship between a root span and
+its child spans. When a span encapsulates another span, this also represents a
 nested relationship.
 
-> For more on Traces and how they pertain to OTel, visit
-> [Traces in OpenTelemetry](/docs/concepts/signals/traces/).
+For more on traces and how they pertain to OTel, see
+[Traces](/docs/concepts/signals/traces/).

--- a/content/en/docs/concepts/signals/traces.md
+++ b/content/en/docs/concepts/signals/traces.md
@@ -88,9 +88,9 @@ Consider the following example trace that tracks three units of work:
 ```
 
 This sample trace output has three distinct log-like items, called
-[Spans](#spans-in-opentelemetry), named `Hello-Greetings`, `Hello-Salutations`
-and `Hello`. Because each request's context has the same `trace_id`, they are
-considered to be a part of the same Trace.
+[Spans](#spans), named `Hello-Greetings`, `Hello-Salutations` and `Hello`.
+Because each request's context has the same `trace_id`, they are considered to
+be a part of the same Trace.
 
 Another thing you'll note is that each Span of this example Trace looks like a
 structured log. That's because it kind of is! One way to think of Traces is that

--- a/content/en/docs/concepts/signals/traces.md
+++ b/content/en/docs/concepts/signals/traces.md
@@ -107,7 +107,7 @@ components that will play a part in instrumenting our code:
 - Trace Exporter
 - Trace Context
 
-### Tracer Provider
+## Tracer Provider
 
 A Tracer Provider (sometimes called `TracerProvider`) is a factory for
 `Tracer`s. In most applications, a Tracer Provider is initialized once and its
@@ -116,19 +116,19 @@ also includes Resource and Exporter initialization. It is typically the first
 step in tracing with OpenTelemetry. In some language SDKs, a global Tracer
 Provider is already initialized for you.
 
-### Tracer
+## Tracer
 
 A Tracer creates spans containing more information about what is happening for a
 given operation, such as a request in a service. Tracers are created from Tracer
 Providers.
 
-### Trace Exporters
+## Trace Exporters
 
 Trace Exporters send traces to a consumer. This consumer can be standard output
 for debugging and development-time, the OpenTelemetry Collector, or any open
 source or vendor backend of your choice.
 
-### Context Propagation
+## Context Propagation
 
 Context Propagation is the core concept that enables Distributed Tracing. With
 Context Propagation, Spans can be correlated with each other and assembled into
@@ -159,9 +159,9 @@ By combining Context and Propagation, you now can assemble a Trace.
 
 [traces specification]: /docs/reference/specification/overview/#tracing-signal
 
-## Spans in OpenTelemetry
+## Spans
 
-A [**Span**](/docs/concepts/observability-primer/#spans) represents a unit of
+A [**span**](/docs/concepts/observability-primer/#spans) represents a unit of
 work or operation. Spans are the building blocks of Traces. In OpenTelemetry,
 they include the following information:
 
@@ -174,7 +174,7 @@ they include the following information:
 - [Span Links](#span-links)
 - [Span Status](#span-status)
 
-Sample Span:
+Sample span:
 
 ```json
 {
@@ -217,15 +217,15 @@ work done in an application.
 
 ### Span Context
 
-Span Context is an immutable object on every span that contains the following:
+Span context is an immutable object on every span that contains the following:
 
 - The Trace ID representing the trace that the span is a part of
-- The Span's Span ID
+- The span's Span ID
 - Trace Flags, a binary encoding containing information about the trace
 - Trace State, a list of key-value pairs that can carry vendor-specific trace
   information
 
-Span Context is the part of a span that is serialized and propagated alongside
+Span context is the part of a span that is serialized and propagated alongside
 [Distributed Context](#context-propagation) and
 [Baggage](/docs/concepts/signals/baggage).
 

--- a/content/en/docs/demo/_index.md
+++ b/content/en/docs/demo/_index.md
@@ -3,6 +3,7 @@ title: OpenTelemetry Demo Documentation
 linkTitle: Demo
 cascade:
   repo: https://github.com/open-telemetry/opentelemetry-demo
+weight: 2
 ---
 
 Welcome to the [OpenTelemetry Demo](/ecosystem/demo/) documentation, which

--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -1,7 +1,6 @@
 ---
 title: Getting Started
 description: Get started with OpenTelemetry based on your role.
-spelling: cSpell:ignore otel
 no_list: true
 weight: 1
 ---
@@ -15,7 +14,7 @@ Select a role[^1] to get started:
 
 </div>
 
-You can also try out the official [OpenTelemetry Demo][demo] to _see_ what
+You can also try out the official [OpenTelemetry demo][demo] to _see_ what
 observability with OpenTelemetry looks like!
 
 <div class="l-primary-buttons justify-content-start mt-3 mb-5 ms-3">

--- a/content/en/docs/getting-started/dev.md
+++ b/content/en/docs/getting-started/dev.md
@@ -1,17 +1,19 @@
 ---
-title: Dev
-description: >-
-  You develop software. Your goal is to get observability by writing code. You
-  want to have your dependencies emit telemetry for you automatically.
-spelling: cSpell:ignore otel
-weight: 2
+title: Getting started for Developers
+linkTitle: Dev
 ---
+
+This is the [getting-started](..) page for you if:
+
+- You develop software.
+- Your goal is to get observability by writing code.
+- You want to have your dependencies emit telemetry for you automatically.
 
 OpenTelemetry can help you! To accomplish your goals of having your dependencies
 instrumented automatically and instrumenting your own code with our API
 manually, we recommend that you learn the following concepts first:
 
-- [What is OpenTelemetry?](/docs/concepts/what-is-opentelemetry/)
+- [What is OpenTelemetry?](/docs/what-is-opentelemetry/)
 - [How can I instrument dependencies without touching their code?](/docs/concepts/instrumenting/#automatic-instrumentation)
 - [How can I instrument my application manually?](/docs/concepts/instrumenting/#manual-instrumentation)
 
@@ -21,7 +23,8 @@ natively:
 
 - [How can I add native instrumentation to my library?](/docs/concepts/instrumenting-library/)
 
-Next, you can deep dive into the documentations for the language you are using:
+Next, you can deep dive into the documentations for the
+[language](/docs/instrumentation/) you are using:
 
 - [C++](/docs/instrumentation/cpp/)
 - [.NET](/docs/instrumentation/net/)
@@ -34,3 +37,4 @@ Next, you can deep dive into the documentations for the language you are using:
 - [Ruby](/docs/instrumentation/ruby/)
 - [Rust](/docs/instrumentation/rust/)
 - [Swift](/docs/instrumentation/swift/)
+- [Other](/docs/instrumentation/other/)

--- a/content/en/docs/getting-started/ops.md
+++ b/content/en/docs/getting-started/ops.md
@@ -1,21 +1,23 @@
 ---
-title: Ops
-description: >-
-  You run a set of applications in production. Your goal is to get telemetry out
-  of them without touching their code. You want to collect traces, metrics, and
-  logs from several services and send them off to your observability backend.
-spelling: cSpell:ignore otel
-weight: 4
+title: Getting started for Ops
+linkTitle: Ops
 ---
+
+This is the [getting-started](..) page for you if:
+
+- You run a set of applications in production.
+- Your goal is to get telemetry out of them without touching their code.
+- You want to collect traces, metrics, and logs from several services and send
+  them off to your observability backend.
 
 OpenTelemetry can help you! To accomplish your goal of getting telemetry out of
 applications without touching their code, we recommend that you learn the
 following:
 
-- [What is OpenTelemetry?](/docs/concepts/what-is-opentelemetry/)
+- [What is OpenTelemetry?](/docs/what-is-opentelemetry/)
 - [How can I instrument applications without touching their code?](/docs/concepts/instrumenting/#automatic-instrumentation)
-- [How can I set up a collector?](/docs/collector)
-- [How can I get automation for Kubernetes with the OpenTelemetry Operator?](/docs/k8s-operator)
+- [How can I set up a collector?](/docs/collector/)
+- [How can I get automation for Kubernetes with the OpenTelemetry Operator?](/docs/k8s-operator/)
 
 If you are looking for a set of applications to try things out, you will find
-our official [OpenTelemetry Demo](/ecosystem/demo/) useful!
+our official [OpenTelemetry demo](/ecosystem/demo/) useful!

--- a/content/en/docs/instrumentation/erlang/instrumentation.md
+++ b/content/en/docs/instrumentation/erlang/instrumentation.md
@@ -54,7 +54,7 @@ This is how the Erlang and Elixir macros for starting and updating `Spans` get a
 ### Create Spans
 
 Now that you have [Tracer](/docs/concepts/signals/traces/#tracer)s initialized,
-you can create [Spans](/docs/concepts/signals/traces/#spans-in-opentelemetry).
+you can create [Spans](/docs/concepts/signals/traces/#spans).
 
 <!-- prettier-ignore-start -->
 {{< tabpane langEqualsHeader=true >}}
@@ -74,7 +74,7 @@ require OpenTelemetry.Tracer
 
 OpenTelemetry.Tracer.with_span :main do
   # do work here
-  # when the block ends the Span ends       
+  # when the block ends the Span ends
 end
 {{< /tab >}}
 
@@ -182,8 +182,8 @@ _ = Task.await(task)
 
 ### Linking the New Span
 
-A [Span](/docs/concepts/signals/traces/#spans-in-opentelemetry) can be created
-with zero or more Span Links that causally link it to another Span. A
+A [Span](/docs/concepts/signals/traces/#spans) can be created with zero or more
+Span Links that causally link it to another Span. A
 [Link](/docs/concepts/signals/traces/#span-links) needs a Span context to be
 created.
 
@@ -275,7 +275,7 @@ include semantic attributes like the scheme of the URL:
 alias OpenTelemetry.SemanticConventions.Trace, as: Trace
 
 Tracer.with_span :span_1, %{attributes: [{Trace.http_scheme(), <<"https">>}]} do
-  
+
 end
 {{< /tab >}}
 
@@ -286,7 +286,7 @@ end
 A [Span
 Event](/docs/concepts/signals/traces/#span-events) is a
 human-readable message on an
-[Span](/docs/concepts/signals/traces/#spans-in-opentelemetry)
+[Span](/docs/concepts/signals/traces/#spans)
 that represents a discrete event with no duration that can be tracked by a
 single time stamp. You can think of it like a primitive log.
 
@@ -331,10 +331,10 @@ Tracer.add_event("Process exited with reason", pid: pid, reason: Reason)
 ### Set Span Status
 
 A [Status](/docs/concepts/signals/traces/#span-status) can be set on a
-[Span](/docs/concepts/signals/traces/#spans-in-opentelemetry), typically used to
-specify that a Span has not completed successfully - `StatusCode.ERROR`. In rare
-scenarios, you could override the Error status with `StatusCode.OK`, but don’t
-set `StatusCode.OK` on successfully-completed spans.
+[Span](/docs/concepts/signals/traces/#spans), typically used to specify that a
+Span has not completed successfully - `StatusCode.ERROR`. In rare scenarios, you
+could override the Error status with `StatusCode.OK`, but don’t set
+`StatusCode.OK` on successfully-completed spans.
 
 The status can be set at any time before the span is finished:
 

--- a/content/en/docs/instrumentation/java/automatic/annotations.md
+++ b/content/en/docs/instrumentation/java/automatic/annotations.md
@@ -8,8 +8,8 @@ javaAnnotationsVersion: 1.24.0
 
 For most users, the out-of-the-box instrumentation is completely sufficient and
 nothing more has to be done. Sometimes, however, users wish to create
-[spans](/docs/concepts/signals/traces/#spans-in-opentelemetry) for their own
-custom code without doing too much code change.
+[spans](/docs/concepts/signals/traces/#spans) for their own custom code without
+doing too much code change.
 
 ## Dependencies
 
@@ -39,8 +39,8 @@ dependencies {
 
 ## Creating spans around methods with `@WithSpan`
 
-To create a [span](/docs/concepts/signals/traces/#spans-in-opentelemetry)
-corresponding to one of your method, annotate the method with `@WithSpan`.
+To create a [span](/docs/concepts/signals/traces/#spans) corresponding to one of
+your method, annotate the method with `@WithSpan`.
 
 ```java
 import io.opentelemetry.instrumentation.annotations.WithSpan;
@@ -77,11 +77,10 @@ types listed below, then the span will not be ended until the future completes.
 
 ## Adding attributes to the span with `@SpanAttribute`
 
-When a [span](/docs/concepts/signals/traces/#spans-in-opentelemetry) is created
-for an annotated method the values of the arguments to the method invocation can
-be automatically added as
-[attributes](/docs/concepts/signals/traces/#attributes) to the created span by
-annotating the method parameters with the `@SpanAttribute` annotation.
+When a [span](/docs/concepts/signals/traces/#spans) is created for an annotated
+method the values of the arguments to the method invocation can be automatically
+added as [attributes](/docs/concepts/signals/traces/#attributes) to the created
+span by annotating the method parameters with the `@SpanAttribute` annotation.
 
 ```java
 import io.opentelemetry.instrumentation.annotations.SpanAttribute;

--- a/content/en/docs/instrumentation/java/manual.md
+++ b/content/en/docs/instrumentation/java/manual.md
@@ -159,8 +159,8 @@ instance will interoperate, regardless of name.
 
 ### Create Spans
 
-To create [Spans](/docs/concepts/signals/traces/#spans-in-opentelemetry), you
-only need to specify the name of the span. The start and end time of the span is
+To create [Spans](/docs/concepts/signals/traces/#spans), you only need to
+specify the name of the span. The start and end time of the span is
 automatically set by the OpenTelemetry SDK.
 
 ```java
@@ -179,9 +179,9 @@ It's required to call `end()` to end the span when you want it to end.
 ### Create nested Spans
 
 Most of the time, we want to correlate
-[spans](/docs/concepts/signals/traces/#spans-in-opentelemetry) for nested
-operations. OpenTelemetry supports tracing within processes and across remote
-processes. For more details how to share context between remote processes, see
+[spans](/docs/concepts/signals/traces/#spans) for nested operations.
+OpenTelemetry supports tracing within processes and across remote processes. For
+more details how to share context between remote processes, see
 [Context Propagation](#context-propagation).
 
 For a method `a` calling a method `b`, the spans could be manually linked in the
@@ -244,8 +244,8 @@ Span childRemoteParent = tracer.spanBuilder("Child").setParent(remoteContext).st
 ### Get the current span
 
 Sometimes it's helpful to do something with the current/active
-[span](/docs/concepts/signals/traces/#spans-in-opentelemetry) at a particular
-point in program execution.
+[span](/docs/concepts/signals/traces/#spans) at a particular point in program
+execution.
 
 ```java
 Span span = Span.current()
@@ -259,9 +259,9 @@ Span span = Span.fromContext(context)
 
 ### Span Attributes
 
-In OpenTelemetry [spans](/docs/concepts/signals/traces/#spans-in-opentelemetry)
-can be created freely and it's up to the implementor to annotate them with
-attributes specific to the represented operation.
+In OpenTelemetry [spans](/docs/concepts/signals/traces/#spans) can be created
+freely and it's up to the implementor to annotate them with attributes specific
+to the represented operation.
 [Attributes](/docs/concepts/signals/traces/#attributes) provide additional
 context on a span about the specific operation it tracks, such as results or
 operation properties.
@@ -308,11 +308,10 @@ span.setAttribute(SemanticAttributes.HTTP_URL, url.toString());
 
 ### Create Spans with events
 
-[Spans](/docs/concepts/signals/traces/#spans-in-opentelemetry) can be annotated
-with named events (called
-[Span Events](/docs/concepts/signals/traces/#span-events)) that can carry zero
-or more [Span Attributes](#span-attributes), each of which itself is a key:value
-map paired automatically with a timestamp.
+[Spans](/docs/concepts/signals/traces/#spans) can be annotated with named events
+(called [Span Events](/docs/concepts/signals/traces/#span-events)) that can
+carry zero or more [Span Attributes](#span-attributes), each of which itself is
+a key:value map paired automatically with a timestamp.
 
 ```java
 span.addEvent("Init");
@@ -330,8 +329,8 @@ span.addEvent("End Computation", eventAttributes);
 
 ### Create Spans with links
 
-A [Span](/docs/concepts/signals/traces/#spans-in-opentelemetry) may be linked to
-zero or more other Spans that are causally related via a
+A [Span](/docs/concepts/signals/traces/#spans) may be linked to zero or more
+other Spans that are causally related via a
 [Span Link](/docs/concepts/signals/traces/#span-links). Links can be used to
 represent batched operations where a Span was initiated by multiple initiating
 Spans, each representing a single incoming item being processed in the batch.
@@ -351,10 +350,10 @@ For more details how to read context from remote processes, see
 ### Set span status
 
 A [status](/docs/concepts/signals/traces/#span-status) can be set on a
-[span](/docs/concepts/signals/traces/#spans-in-opentelemetry), typically used to
-specify that a span has not completed successfully - `SpanStatus.Error`. In rare
-scenarios, you could override the `Error` status with `OK`, but don't set `OK`
-on successfully-completed spans.
+[span](/docs/concepts/signals/traces/#spans), typically used to specify that a
+span has not completed successfully - `SpanStatus.Error`. In rare scenarios, you
+could override the `Error` status with `OK`, but don't set `OK` on
+successfully-completed spans.
 
 The status can be set at any time before the span is finished:
 
@@ -537,13 +536,13 @@ public void handle(<Library Specific Annotation> HttpHeaders headers){
 
 ## Metrics
 
-[Spans](/docs/concepts/signals/traces/#spans-in-opentelemetry) provide detailed
-information about your application, but produce data that is proportional to the
-load on the system. In contrast, [metrics](/docs/concepts/signals/metrics)
-combine individual measurements into aggregations, and produce data which is
-constant as a function of system load. The aggregations lack details required to
-diagnose low level issues, but complement spans by helping to identify trends
-and providing application runtime telemetry.
+[Spans](/docs/concepts/signals/traces/#spans) provide detailed information about
+your application, but produce data that is proportional to the load on the
+system. In contrast, [metrics](/docs/concepts/signals/metrics) combine
+individual measurements into aggregations, and produce data which is constant as
+a function of system load. The aggregations lack details required to diagnose
+low level issues, but complement spans by helping to identify trends and
+providing application runtime telemetry.
 
 The metrics API defines a variety of instruments. Instruments record
 measurements, which are aggregated by the metrics SDK and eventually exported

--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -264,8 +264,7 @@ involved.
 ### Create spans
 
 Now that you have a [`Tracer`](/docs/concepts/signals/traces/#tracer)
-initialized, you can create
-[`Span`s](/docs/concepts/signals/traces/#spans-in-opentelemetry).
+initialized, you can create [`Span`s](/docs/concepts/signals/traces/#spans).
 
 ```javascript
 // Create a span. A span must be closed.
@@ -284,10 +283,10 @@ common kind of span to create.
 
 ### Create nested spans
 
-Nested [spans](/docs/concepts/signals/traces/#spans-in-opentelemetry) let you
-track work that's nested in nature. For example, the `doWork` function below
-represents a nested operation. The following sample creates a nested span that
-tracks the `doWork` function:
+Nested [spans](/docs/concepts/signals/traces/#spans) let you track work that's
+nested in nature. For example, the `doWork` function below represents a nested
+operation. The following sample creates a nested span that tracks the `doWork`
+function:
 
 ```javascript
 const mainWork = () => {
@@ -348,8 +347,8 @@ together but are conceptually independent from one another.
 ### Get the current span
 
 Sometimes it's helpful to do something with the current/active
-[span](/docs/concepts/signals/traces/#spans-in-opentelemetry) at a particular
-point in program execution.
+[span](/docs/concepts/signals/traces/#spans) at a particular point in program
+execution.
 
 ```js
 const activeSpan = opentelemetry.trace.getActiveSpan();
@@ -359,9 +358,8 @@ const activeSpan = opentelemetry.trace.getActiveSpan();
 
 ### Get a span from context
 
-It can also be helpful to get the
-[span](/docs/concepts/signals/traces/#spans-in-opentelemetry) from a given
-context that isn't necessarily the active span.
+It can also be helpful to get the [span](/docs/concepts/signals/traces/#spans)
+from a given context that isn't necessarily the active span.
 
 ```js
 const ctx = getContextFromSomewhere();
@@ -373,8 +371,8 @@ const span = opentelemetry.trace.getSpan(ctx);
 ### Attributes
 
 [Attributes](/docs/concepts/signals/traces/#attributes) let you attach key/value
-pairs to a [`Span`](/docs/concepts/signals/traces/#spans-in-opentelemetry) so it
-carries more information about the current operation that it's tracking.
+pairs to a [`Span`](/docs/concepts/signals/traces/#spans) so it carries more
+information about the current operation that it's tracking.
 
 ```javascript
 tracer.startActiveSpan('app.new-span', (span) => {
@@ -446,9 +444,9 @@ const doWork = () => {
 ### Span events
 
 A [Span Event](/docs/concepts/signals/traces/#span-events) is a human-readable
-message on an [`Span`](/docs/concepts/signals/traces/#spans-in-opentelemetry)
-that represents a discrete event with no duration that can be tracked by a
-single time stamp. You can think of it like a primitive log.
+message on an [`Span`](/docs/concepts/signals/traces/#spans) that represents a
+discrete event with no duration that can be tracked by a single time stamp. You
+can think of it like a primitive log.
 
 ```js
 span.addEvent('Doing something');
@@ -469,10 +467,10 @@ span.addEvent('some log', {
 
 ### Span links
 
-[`Span`s](/docs/concepts/signals/traces/#spans-in-opentelemetry) can be created
-with zero or more [`Link`s](/docs/concepts/signals/traces/#span-links) to other
-Spans that are causally related. A common scenario is to correlate one or more
-traces with the current span.
+[`Span`s](/docs/concepts/signals/traces/#spans) can be created with zero or more
+[`Link`s](/docs/concepts/signals/traces/#span-links) to other Spans that are
+causally related. A common scenario is to correlate one or more traces with the
+current span.
 
 ```js
 const someFunction = (spanToLinkFrom) => {

--- a/content/en/docs/instrumentation/js/libraries.md
+++ b/content/en/docs/instrumentation/js/libraries.md
@@ -10,9 +10,8 @@ in order to generate telemetry data for a library or framework.
 
 For example,
 [the instrumentation library for Express](https://www.npmjs.com/package/@opentelemetry/instrumentation-express)
-will automatically create
-[spans](/docs/concepts/signals/traces/#spans-in-opentelemetry) based on the
-inbound HTTP requests.
+will automatically create [spans](/docs/concepts/signals/traces/#spans) based on
+the inbound HTTP requests.
 
 ## Setup
 

--- a/content/en/docs/instrumentation/net/getting-started.md
+++ b/content/en/docs/instrumentation/net/getting-started.md
@@ -127,8 +127,7 @@ public IActionResult Index()
 ```
 
 When you run the app and navigate to the `/` route, you'll see output about
-[spans](/docs/concepts/signals/traces/#spans-in-opentelemetry) similar to the
-following:
+[spans](/docs/concepts/signals/traces/#spans) similar to the following:
 
 <details>
 <summary>View example output</summary>

--- a/content/en/docs/instrumentation/net/libraries.md
+++ b/content/en/docs/instrumentation/net/libraries.md
@@ -10,8 +10,7 @@ in order to generate telemetry data for a particular instrumented library.
 
 For example,
 [the instrumentation library for ASP.NET Core](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNetCore)
-will automatically create
-[spans](/docs/concepts/signals/traces/#spans-in-opentelemetry) and
+will automatically create [spans](/docs/concepts/signals/traces/#spans) and
 [metrics](/docs/concepts/signals/metrics) based on the inbound HTTP requests.
 
 ## Setup

--- a/content/en/docs/instrumentation/net/manual.md
+++ b/content/en/docs/instrumentation/net/manual.md
@@ -130,8 +130,7 @@ endpoint, you'll have to use a different exporter.
 
 Once tracing is initialized, you can configure an
 [`ActivitySource`](/docs/concepts/signals/traces/#tracer), which will be how you
-trace operations with
-[`Activity`s](/docs/concepts/signals/traces/#spans-in-opentelemetry).
+trace operations with [`Activity`s](/docs/concepts/signals/traces/#spans).
 
 Typically, an `ActivitySource` is instantiated once per app/service that is
 being instrumented, so it's a good idea to instantiate it once in a shared
@@ -157,9 +156,8 @@ although it is generally sufficient to just have one defined per service.
 
 ## Creating Activities
 
-To create an
-[`Activity`](/docs/concepts/signals/traces/#spans-in-opentelemetry), give it a
-name and create it from your
+To create an [`Activity`](/docs/concepts/signals/traces/#spans), give it a name
+and create it from your
 [`ActivitySource`](/docs/concepts/signals/traces/#tracer).
 
 ```csharp

--- a/content/en/docs/instrumentation/net/shim.md
+++ b/content/en/docs/instrumentation/net/shim.md
@@ -121,8 +121,7 @@ endpoint, you'll have to use a different exporter.
 
 Once tracing is initialized, you can configure a
 [`Tracer`](/docs/concepts/signals/traces/#tracer), which will be how you trace
-operations with
-[`Span`s](/docs/concepts/signals/traces/#spans-in-opentelemetry).
+operations with [`Span`s](/docs/concepts/signals/traces/#spans).
 
 Typically, a `Tracer` is instantiated once per app/service that is being
 instrumented, so it's a good idea to instantiate it once in a shared location.
@@ -180,8 +179,8 @@ generally sufficient to just have one defined per service.
 
 ## Creating Spans
 
-To create a [span](/docs/concepts/signals/traces/#spans-in-opentelemetry), give
-it a name and create it from your `Tracer`.
+To create a [span](/docs/concepts/signals/traces/#spans), give it a name and
+create it from your `Tracer`.
 
 ```csharp
 using var span = MyTracer.StartActiveSpan("SayHello");
@@ -246,9 +245,9 @@ block is explicitly defined, rather than scoped to `DoWork` itself like
 ## Creating independent Spans
 
 The previous examples showed how to create
-[Spans](/docs/concepts/signals/traces/#spans-in-opentelemetry) that follow a
-nested heirarchy. In some cases, you'll want to create independent Spans that
-are siblings of the same root rather than being nested.
+[Spans](/docs/concepts/signals/traces/#spans) that follow a nested heirarchy. In
+some cases, you'll want to create independent Spans that are siblings of the
+same root rather than being nested.
 
 ```csharp
 public static void DoWork(Tracer tracer)
@@ -270,9 +269,8 @@ public static void DoWork(Tracer tracer)
 
 ## Creating new root Spans
 
-You can also create new root
-[spans](/docs/concepts/signals/traces/#spans-in-opentelemetry) that are
-completely detached from the current trace.
+You can also create new root [spans](/docs/concepts/signals/traces/#spans) that
+are completely detached from the current trace.
 
 ```csharp
 public static void DoWork(Tracer tracer)

--- a/content/en/docs/instrumentation/php/manual.md
+++ b/content/en/docs/instrumentation/php/manual.md
@@ -94,8 +94,8 @@ instance will interoperate, regardless of name.
 
 ### Create Spans
 
-To create [Spans](/docs/concepts/signals/traces/#spans-in-opentelemetry), you
-only need to specify the name of the span. The start and end time of the span is
+To create [Spans](/docs/concepts/signals/traces/#spans), you only need to
+specify the name of the span. The start and end time of the span is
 automatically set by the OpenTelemetry SDK.
 
 ```php
@@ -117,9 +117,9 @@ scope if you have activated it.
 ### Create nested Spans
 
 Most of the time, we want to correlate
-[spans](/docs/concepts/signals/traces/#spans-in-opentelemetry) for nested
-operations. OpenTelemetry supports tracing within processes and across remote
-processes. For more details how to share context between remote processes, see
+[spans](/docs/concepts/signals/traces/#spans) for nested operations.
+OpenTelemetry supports tracing within processes and across remote processes. For
+more details how to share context between remote processes, see
 [Context Propagation](../propagation/).
 
 For a method `a` calling a method `b`, the spans could be manually linked in the
@@ -142,8 +142,8 @@ following way:
 ### Get the current span
 
 Sometimes it's helpful to do something with the current/active
-[span](/docs/concepts/signals/traces/#spans-in-opentelemetry) at a particular
-point in program execution.
+[span](/docs/concepts/signals/traces/#spans) at a particular point in program
+execution.
 
 ```php
 $span = OpenTelemetry\API\Trace\Span::getCurrent();
@@ -157,9 +157,9 @@ $span = OpenTelemetry\API\Trace\Span::fromContext($context);
 
 ### Span Attributes
 
-In OpenTelemetry [spans](/docs/concepts/signals/traces/#spans-in-opentelemetry)
-can be created freely and it's up to the implementor to annotate them with
-attributes specific to the represented operation.
+In OpenTelemetry [spans](/docs/concepts/signals/traces/#spans) can be created
+freely and it's up to the implementor to annotate them with attributes specific
+to the represented operation.
 [Attributes](/docs/concepts/signals/traces/#attributes) provide additional
 context on a span about the specific operation it tracks, such as results or
 operation properties.
@@ -172,11 +172,10 @@ $span->setAttribute("http.url", (string) $url);
 
 ### Create Spans with events
 
-[Spans](/docs/concepts/signals/traces/#spans-in-opentelemetry) can be annotated
-with named events (called
-[Span Events](/docs/concepts/signals/traces/#span-events)) that can carry zero
-or more [Span Attributes](#span-attributes), each of which itself is a key:value
-map paired automatically with a timestamp.
+[Spans](/docs/concepts/signals/traces/#spans) can be annotated with named events
+(called [Span Events](/docs/concepts/signals/traces/#span-events)) that can
+carry zero or more [Span Attributes](#span-attributes), each of which itself is
+a key:value map paired automatically with a timestamp.
 
 ```php
 $span->addEvent("Init");
@@ -194,8 +193,8 @@ $span->addEvent("End Computation", $eventAttributes);
 
 ### Create Spans with links
 
-A [Span](/docs/concepts/signals/traces/#spans-in-opentelemetry) may be linked to
-zero or more other Spans that are causally related via a
+A [Span](/docs/concepts/signals/traces/#spans) may be linked to zero or more
+other Spans that are causally related via a
 [Span Link](/docs/concepts/signals/traces/#span-links). Links can be used to
 represent batched operations where a Span was initiated by multiple initiating
 Spans, each representing a single incoming item being processed in the batch.
@@ -215,10 +214,10 @@ For more details how to read context from remote processes, see
 ### Set span status and record exceptions
 
 A [status](/docs/concepts/signals/traces/#span-status) can be set on a
-[span](/docs/concepts/signals/traces/#spans-in-opentelemetry), typically used to
-specify that a span has not completed successfully - `SpanStatus::ERROR`. In
-rare scenarios, you could override the `Error` status with `Ok`, but don't set
-`Ok` on successfully-completed spans.
+[span](/docs/concepts/signals/traces/#spans), typically used to specify that a
+span has not completed successfully - `SpanStatus::ERROR`. In rare scenarios,
+you could override the `Error` status with `Ok`, but don't set `Ok` on
+successfully-completed spans.
 
 It can be a good idea to record exceptions when they happen. It's recommended to
 do this in conjunction with setting span status.

--- a/content/en/docs/instrumentation/python/manual.md
+++ b/content/en/docs/instrumentation/python/manual.md
@@ -65,8 +65,8 @@ meter = metrics.get_meter(__name__)
 
 ### Creating spans
 
-To create a [span](/docs/concepts/signals/traces/#spans-in-opentelemetry),
-you'll typically want it to be started as the current span.
+To create a [span](/docs/concepts/signals/traces/#spans), you'll typically want
+it to be started as the current span.
 
 ```python
 def do_work():
@@ -82,9 +82,8 @@ span. This is usually done to track concurrent or asynchronous operations.
 ### Creating nested spans
 
 If you have a distinct sub-operation you'd like to track as a part of another
-one, you can create
-[spans](/docs/concepts/signals/traces/#spans-in-opentelemetry) to represent the
-relationship:
+one, you can create [spans](/docs/concepts/signals/traces/#spans) to represent
+the relationship:
 
 ```python
 def do_work():
@@ -105,10 +104,9 @@ nested span under `parent`.
 
 ### Creating spans with decorators
 
-It's common to have a single
-[span](/docs/concepts/signals/traces/#spans-in-opentelemetry) track the
-execution of an entire function. In that scenario, there is a decorator you can
-use to reduce code:
+It's common to have a single [span](/docs/concepts/signals/traces/#spans) track
+the execution of an entire function. In that scenario, there is a decorator you
+can use to reduce code:
 
 ```python
 @tracer.start_as_current_span("do_work")
@@ -129,8 +127,8 @@ use a decorator.
 ### Get the current span
 
 Sometimes it's helpful to access whatever the current
-[span](/docs/concepts/signals/traces/#spans-in-opentelemetry) is at a point in
-time so that you can enrich it with more information.
+[span](/docs/concepts/signals/traces/#spans) is at a point in time so that you
+can enrich it with more information.
 
 ```python
 from opentelemetry import trace
@@ -142,8 +140,8 @@ current_span = trace.get_current_span()
 ### Add attributes to a span
 
 [Attributes](/docs/concepts/signals/traces/#attributes) let you attach key/value
-pairs to a [span](/docs/concepts/signals/traces/#spans-in-opentelemetry) so it
-carries more information about the current operation that it's tracking.
+pairs to a [span](/docs/concepts/signals/traces/#spans) so it carries more
+information about the current operation that it's tracking.
 
 ```python
 from opentelemetry import trace
@@ -185,9 +183,9 @@ current_span.set_attribute(SpanAttributes.HTTP_URL, "https://opentelemetry.io/")
 ### Adding events
 
 An [event](/docs/concepts/signals/traces/#span-events) is a human-readable
-message on a [span](/docs/concepts/signals/traces/#spans-in-opentelemetry) that
-represents "something happening" during its lifetime. You can think of it as a
-primitive log.
+message on a [span](/docs/concepts/signals/traces/#spans) that represents
+"something happening" during its lifetime. You can think of it as a primitive
+log.
 
 ```python
 from opentelemetry import trace
@@ -203,9 +201,9 @@ current_span.add_event("Did it!")
 
 ### Adding links
 
-A [span](/docs/concepts/signals/traces/#spans-in-opentelemetry) can be created
-with zero or more span [links](/docs/concepts/signals/traces/#span-links) that
-causally link it to another span. A link needs a span context to be created.
+A [span](/docs/concepts/signals/traces/#spans) can be created with zero or more
+span [links](/docs/concepts/signals/traces/#span-links) that causally link it to
+another span. A link needs a span context to be created.
 
 ```python
 from opentelemetry import trace
@@ -227,10 +225,10 @@ with tracer.start_as_current_span("span-2", links=[link_from_span_1]):
 ### Set span status
 
 A [status](/docs/concepts/signals/traces/#span-status) can be set on a
-[span](/docs/concepts/signals/traces/#spans-in-opentelemetry), typically used to
-specify that a span has not completed successfully - `StatusCode.ERROR`. In rare
-scenarios, you could override the Error status with `StatusCode.OK`, but don’t
-set `StatusCode.OK` on successfully-completed spans.
+[span](/docs/concepts/signals/traces/#spans), typically used to specify that a
+span has not completed successfully - `StatusCode.ERROR`. In rare scenarios, you
+could override the Error status with `StatusCode.OK`, but don’t set
+`StatusCode.OK` on successfully-completed spans.
 
 The status can be set at any time before the span is finished:
 

--- a/content/en/docs/instrumentation/ruby/manual.md
+++ b/content/en/docs/instrumentation/ruby/manual.md
@@ -55,8 +55,8 @@ With a `Tracer` acquired, you can manually trace code.
 ### Get the current span
 
 It's very common to add information to the current
-[span](/docs/concepts/signals/traces#spans-in-opentelemetry) somewhere within
-your program. To do so, you can get the current span and add
+[span](/docs/concepts/signals/traces#spans) somewhere within your program. To do
+so, you can get the current span and add
 [attributes](/docs/concepts/signals/traces#attributes) to it.
 
 ```ruby
@@ -76,8 +76,8 @@ end
 
 ### Creating New Spans
 
-To create a [span](/docs/concepts/signals/traces#spans-in-opentelemetry), you’ll
-need a [configured `Tracer`](#acquiring-a-tracer).
+To create a [span](/docs/concepts/signals/traces#spans), you’ll need a
+[configured `Tracer`](#acquiring-a-tracer).
 
 Typically when you create a new span, you'll want it to be the active/current
 span. To do that, use `in_span`:
@@ -95,9 +95,8 @@ end
 ### Creating nested spans
 
 If you have a distinct sub-operation you’d like to track as a part of another
-one, you can create nested
-[spans](/docs/concepts/signals/traces#spans-in-opentelemetry) to represent the
-relationship:
+one, you can create nested [spans](/docs/concepts/signals/traces#spans) to
+represent the relationship:
 
 ```ruby
 require "opentelemetry/sdk"
@@ -126,8 +125,8 @@ trace visualization tool, `child` will be nested under `parent`.
 ### Add attributes to a span
 
 [Attributes](/docs/concepts/signals/traces#attributes) let you attach key/value
-pairs to a [span](/docs/concepts/signals/traces#spans-in-opentelemetry) so it
-carries more information about the current operation that it’s tracking.
+pairs to a [span](/docs/concepts/signals/traces#spans) so it carries more
+information about the current operation that it’s tracking.
 
 You can use `set_attribute` to add a single attribute to a span:
 
@@ -241,9 +240,9 @@ span.add_event("Cancelled wait due to external signal", attributes: {
 
 ### Add Span Links
 
-A [span](/docs/concepts/signals/traces#spans-in-opentelemetry) can be created
-with zero or more [span links](/docs/concepts/signals/traces#span-links) that
-causally link it to another span. A link needs a
+A [span](/docs/concepts/signals/traces#spans) can be created with zero or more
+[span links](/docs/concepts/signals/traces#span-links) that causally link it to
+another span. A link needs a
 [span context](/docs/concepts/signals/traces#span-context) to be created.
 
 ```ruby
@@ -273,10 +272,10 @@ link = OpenTelemetry::Trace::Link.new(span_to_link_from.context, attributes: { "
 ### Set span status
 
 A [status](/docs/concepts/signals/traces#span-status) can be set on a
-[span](/docs/concepts/signals/traces#spans-in-opentelemetry), typically used to
-specify that a span has not completed successfully - StatusCode.ERROR. In rare
-scenarios, you could override the Error status with StatusCode.OK, but don’t set
-StatusCode.OK on successfully-completed spans.
+[span](/docs/concepts/signals/traces#spans), typically used to specify that a
+span has not completed successfully - StatusCode.ERROR. In rare scenarios, you
+could override the Error status with StatusCode.OK, but don’t set StatusCode.OK
+on successfully-completed spans.
 
 The status can be set at any time before the span is finished:
 

--- a/content/en/docs/instrumentation/swift/manual.md
+++ b/content/en/docs/instrumentation/swift/manual.md
@@ -70,9 +70,9 @@ let  tracer = OpenTelemetry.instance.tracerProvider.get(instrumentationName: "in
 
 ### Creating Spans
 
-A [span](/docs/concepts/signals/traces/#spans-in-opentelemetry) represents a
-unit of work or operation. Spans are the building blocks of Traces. To create a
-span use the span builder associated with the tracer:
+A [span](/docs/concepts/signals/traces/#spans) represents a unit of work or
+operation. Spans are the building blocks of Traces. To create a span use the
+span builder associated with the tracer:
 
 ```swift
 let span =  let builder = tracer.spanBuilder(spanName: "\(name)").startSpan()

--- a/content/en/docs/what-is-opentelemetry.md
+++ b/content/en/docs/what-is-opentelemetry.md
@@ -1,7 +1,8 @@
 ---
 title: What is OpenTelemetry?
-description: Background information on OpenTelemetry.
-weight: 10
+description: A short explanation of what OpenTelemetry is, and is not.
+aliases: [/about, /docs/concepts/what-is-opentelemetry, /otel]
+weight: -1
 ---
 
 Microservices architectures have enabled developers to build and release
@@ -97,6 +98,11 @@ OpenTelemetry is not an observability back-end like Jaeger or Prometheus.
 Instead, it supports exporting data to a variety of open source and commercial
 back-ends. It provides a pluggable architecture so additional technology
 protocols and formats can be easily added.
+
+## What next?
+
+- [Getting started](/docs/getting-started/) &mdash; jump right in!
+- Learn about [OpenTelemetry concepts](/docs/concepts/).
 
 [cncf-incubating-project]:
   https://www.cncf.io/blog/2021/08/26/opentelemetry-becomes-a-cncf-incubating-project/


### PR DESCRIPTION
- (**Main change**) **Moves "What is OpenTelemetry?" to the top level,** out of "Concenpts".
  - Adds a "What next?" section at the end of the "What is OpenTelemetry?" page
  - Changes homepage "Learn more" link to "What is OpenTelemetry?"
- **Getting-started pages for Dev and Ops** pages:
  - Moves each page description into main text, reformatted as a bulleted list, following the new introductory sentence "This is the getting-started page for you if:"
- In the docs left nav: relocates the demo docs to be just below "Concepts"
- Traces signal page:
  - Fixes #2558
  - Renames "Spans in OpenTelemetry" section to just "Spans" (to be consistent with other section headings)
- Tweaks "Concepts" page title, description, and introductory paragraph
- Makes other copyedits

**Preview**:

- https://deploy-preview-2559--opentelemetry.netlify.app/docs/what-is-opentelemetry/
- https://deploy-preview-2559--opentelemetry.netlify.app/docs/getting-started/dev/, also see Ops page
- https://deploy-preview-2559--opentelemetry.netlify.app/docs/concepts/
- https://deploy-preview-2559--opentelemetry.netlify.app/docs/concepts/observability-primer/
