### PR TITLE
Remove metrics section in instrumenting library

### DIFF
--- a/content/en/docs/concepts/instrumenting-library/index.md
+++ b/content/en/docs/concepts/instrumenting-library/index.md
@@ -329,11 +329,6 @@ There might be some exceptions:
     or other things that can break due to async context flow limitations in your
     language
 
-## Metrics
-
-[Metrics API](/docs/reference/specification/metrics/api/) is not stable yet and
-we don't yet define metrics conventions.
-
 ## Misc
 
 ### Instrumentation registry


### PR DESCRIPTION
@chalin stated that
> the status being referred to in "Metrics API is not
> stable" is the implementation across supported languages: which is about
> 50% at the moment -- that is 50% of languages have "stable" metrics in
> contrast to some other status (beta, alpha, experimental or not
> implemented). So, in a sense, the statement is 50% correct 😅.

and @cartermp suggested that we remove the problematic paragraph and section altogether.

See: https://github.com/open-telemetry/opentelemetry.io/issues/2575

cc: @alolita 