### PR TITLE
Update OTel spec submodule to include the 1.20.0 schema.

### DIFF
--- a/content/en/docs/reference/specification/status.md
+++ b/content/en/docs/reference/specification/status.md
@@ -63,7 +63,7 @@ same as the **Protocol** status.
 
 - {{% spec_status "API" "trace/api" "Status" %}}
 - {{% spec_status "SDK" "trace/sdk" "Status" %}}
-- {{% spec_status "Protocol" "protocol/otlp" "Tracing" %}}
+- {{% spec_status "Protocol" "protocol/otlp" "Status" %}}
 - Notes:
   - The tracing specification is now completely stable, and covered by long term
     support.
@@ -76,7 +76,7 @@ same as the **Protocol** status.
 
 - {{% spec_status "API" "metrics/api" "Status" %}}
 - {{% spec_status "SDK" "metrics/sdk" "Status" %}}
-- {{% spec_status "Protocol" "protocol/otlp" "Metrics" %}}
+- {{% spec_status "Protocol" "protocol/otlp" "Status" %}}
 - Notes:
   - OpenTelemetry Metrics is currently under active development.
   - The data model is stable and released as part of the OTLP protocol.
@@ -99,7 +99,7 @@ same as the **Protocol** status.
 
 - **API:** draft
 - **SDK:** draft
-- {{% spec_status "Protocol" "protocol/otlp" "Logs" %}}
+- {{% spec_status "Protocol" "protocol/otlp" "Status" %}}
 - Notes:
   - OpenTelemetry Logging is currently under active development.
   - The [logs data model][] is released as part of the OpenTelemetry Protocol.

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -551,6 +551,66 @@
     "StatusCode": 206,
     "LastSeen": "2023-02-15T21:08:21.991813-05:00"
   },
+  "https://docs.aws.amazon.com/cli/latest/reference/s3api/abort-multipart-upload.html": {
+    "StatusCode": 206,
+    "LastSeen": "2023-04-07T13:37:22.279271-04:00"
+  },
+  "https://docs.aws.amazon.com/cli/latest/reference/s3api/complete-multipart-upload.html": {
+    "StatusCode": 206,
+    "LastSeen": "2023-04-07T13:37:27.43471-04:00"
+  },
+  "https://docs.aws.amazon.com/cli/latest/reference/s3api/copy-object.html": {
+    "StatusCode": 206,
+    "LastSeen": "2023-04-07T13:36:46.162913-04:00"
+  },
+  "https://docs.aws.amazon.com/cli/latest/reference/s3api/create-multipart-upload.html": {
+    "StatusCode": 206,
+    "LastSeen": "2023-04-07T13:37:32.598569-04:00"
+  },
+  "https://docs.aws.amazon.com/cli/latest/reference/s3api/delete-object.html": {
+    "StatusCode": 206,
+    "LastSeen": "2023-04-07T13:36:51.309382-04:00"
+  },
+  "https://docs.aws.amazon.com/cli/latest/reference/s3api/delete-objects.html": {
+    "StatusCode": 206,
+    "LastSeen": "2023-04-07T13:37:53.336367-04:00"
+  },
+  "https://docs.aws.amazon.com/cli/latest/reference/s3api/get-object.html": {
+    "StatusCode": 206,
+    "LastSeen": "2023-04-07T13:36:56.466253-04:00"
+  },
+  "https://docs.aws.amazon.com/cli/latest/reference/s3api/head-object.html": {
+    "StatusCode": 206,
+    "LastSeen": "2023-04-07T13:37:01.631169-04:00"
+  },
+  "https://docs.aws.amazon.com/cli/latest/reference/s3api/index.html": {
+    "StatusCode": 206,
+    "LastSeen": "2023-04-07T13:36:41.007694-04:00"
+  },
+  "https://docs.aws.amazon.com/cli/latest/reference/s3api/list-parts.html": {
+    "StatusCode": 206,
+    "LastSeen": "2023-04-07T13:37:37.752369-04:00"
+  },
+  "https://docs.aws.amazon.com/cli/latest/reference/s3api/put-object.html": {
+    "StatusCode": 206,
+    "LastSeen": "2023-04-07T13:37:06.788757-04:00"
+  },
+  "https://docs.aws.amazon.com/cli/latest/reference/s3api/restore-object.html": {
+    "StatusCode": 206,
+    "LastSeen": "2023-04-07T13:37:11.95168-04:00"
+  },
+  "https://docs.aws.amazon.com/cli/latest/reference/s3api/select-object-content.html": {
+    "StatusCode": 206,
+    "LastSeen": "2023-04-07T13:37:17.119514-04:00"
+  },
+  "https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html": {
+    "StatusCode": 206,
+    "LastSeen": "2023-04-07T13:37:48.173234-04:00"
+  },
+  "https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part.html": {
+    "StatusCode": 206,
+    "LastSeen": "2023-04-07T13:37:43.016705-04:00"
+  },
   "https://docs.aws.amazon.com/eks/latest/userguide/clusters.html": {
     "StatusCode": 206,
     "LastSeen": "2023-02-15T21:14:08.832435-05:00"
@@ -2543,6 +2603,10 @@
     "StatusCode": 200,
     "LastSeen": "2023-02-20T07:47:15.636056-05:00"
   },
+  "https://github.com/ulid/spec": {
+    "StatusCode": 200,
+    "LastSeen": "2023-04-07T13:37:59.916582-04:00"
+  },
   "https://github.com/vivint-smarthome/opentelemetry-stackdriver": {
     "StatusCode": 200,
     "LastSeen": "2023-02-20T07:42:54.386172-05:00"
@@ -2718,6 +2782,10 @@
   "https://hexdocs.pm/ecto/Ecto.html": {
     "StatusCode": 206,
     "LastSeen": "2023-03-29T12:11:59.363133963-06:00"
+  },
+  "https://hexdocs.pm/elixir/1.14.3/Exception.html#format/3": {
+    "StatusCode": 206,
+    "LastSeen": "2023-04-07T13:36:27.817661-04:00"
   },
   "https://hexdocs.pm/mix/Mix.Tasks.Release.html": {
     "StatusCode": 206,
@@ -3846,6 +3914,10 @@
   "https://www.envoyproxy.io/": {
     "StatusCode": 206,
     "LastSeen": "2023-02-18T13:35:14.153679-05:00"
+  },
+  "https://www.erlang.org/doc/man/erl_error.html#format_exception-3": {
+    "StatusCode": 206,
+    "LastSeen": "2023-04-07T13:36:35.670878-04:00"
   },
   "https://www.eventbrite.com/e/otel-unplugged-kubeconcloudnativecon-detroit-2022-tickets-427595037267": {
     "StatusCode": 200,


### PR DESCRIPTION
See:

- https://github.com/open-telemetry/opentelemetry-specification/pull/3364

**Preview**:

- https://deploy-preview-2584--opentelemetry.netlify.app/docs/reference/specification/
- https://deploy-preview-2584--opentelemetry.netlify.app/docs/reference/specification/status/
