### PR TITLE
Fix typo

### DIFF
--- a/content/en/docs/concepts/signals/metrics.md
+++ b/content/en/docs/concepts/signals/metrics.md
@@ -20,7 +20,7 @@ through the OpenTelemetry API:
 - **Counter**: A value that accumulates over time -- you can think of this like
   an odometer on a car; it only ever goes up.
 - **Asynchronous Counter**: Same as the **Counter**, but is collected once for
-  each export. Could be used if you don't have access to the continous
+  each export. Could be used if you don't have access to the continuous
   increments, but only to the aggregated value.
 - **UpDownCounter**: A value that accumulates over time, but can also go down
   again. An example could be a queue length, it will increase and decrease with

--- a/content/en/docs/concepts/signals/metrics.md
+++ b/content/en/docs/concepts/signals/metrics.md
@@ -27,7 +27,7 @@ through the OpenTelemetry API:
   the number of work items in the queue.
 - **Asynchronous UpDownCounter**: Same as the **UpDownCounter**, but is
   collected once for each export. Could be used if you don't have access to the
-  continous changes, but only to the aggregated value (e.g., current queue
+  continuous changes, but only to the aggregated value (e.g., current queue
   size).
 - **(Asynchronous) Gauge**: Measures a current value at the time it is read. An
   example would be the fuel gauge in a vehicle. Gauges are _always_


### PR DESCRIPTION
According to e.g. https://word.tips/spelling/continuous-vs-continous/ and https://www.quora.com/Which-one-is-spelled-correctly-continous-or-continuous `continous` is incorrect spelling, the correct one is `continuous`.