### PR TITLE
Set MRI ruby limit to >= 3.0

### DIFF
--- a/content/en/docs/instrumentation/ruby/getting-started.md
+++ b/content/en/docs/instrumentation/ruby/getting-started.md
@@ -14,7 +14,7 @@ using the [OpenTelemetry API][manual].
 These instructions will explain how to set up automatic and manual
 instrumentation for a Ruby service. In order to follow along, you will need:
 
-- MRI Ruby >= `2.7`, jruby >= `9.3.2.0`, or truffleruby >= 22.1
+- MRI Ruby >= `3.0`, jruby >= `9.3.2.0`, or truffleruby >= 22.1
 - Docker Compose
 
 > jruby only targets compatibility with MRI Ruby 2.6.8; which is EOL. This


### PR DESCRIPTION
Ruby 2.7 support dropped by the maintainers as of March 31, 2023. The 2.7 support has been removed from the Ruby OTel libraries as part of https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/389