### PR TITLE
Blog post regarding ECS and OTel SemConv Convergence

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -34,3 +34,5 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - ^https://opentelemetry\.io/.
   # TODO: drop after fix to https://github.com/open-telemetry/opentelemetry.io/issues/2354
   - ^https://open-telemetry\.github\.io/opentelemetry-python/benchmarks/
+  # TODO: remove after merge of https://github.com/open-telemetry/opentelemetry.io/pull/2594
+  - ^https://elastic.co/blog/ecs-elastic-common-schema-otel-opentelemetry-announcement

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -24,6 +24,7 @@
     "opentelemetry",
     "otel",
     "otelcol",
+    "OTEP",
     "otlp",
     "OTLP",
     "pluggable",

--- a/content/en/blog/2023/ecs-otel-semconv-convergence.md
+++ b/content/en/blog/2023/ecs-otel-semconv-convergence.md
@@ -1,0 +1,52 @@
+---
+title: Announcing the Elastic Common Schema (ECS) and OpenTelemetry Semantic Convention Convergence
+linkTitle: ECS and OTel SemConv Convergence
+date: 2023-04-07
+spelling:
+  cSpell:ignore Reiley Yang
+  cSpell:ignore ECS
+author: '[Reiley Yang](https://github.com/reyang)'
+---
+
+Today, we're very excited to make a joint announcement with
+[Elastic](https://www.elastic.co/) about the future of
+[ECS](https://www.elastic.co/guide/en/ecs/master/ecs-reference.html) (Elastic
+Common Schema) and the OpenTelemetry Semantic Conventions.
+
+The goal is to achieve convergence of ECS and OTel Semantic Conventions into a
+single open schema that is maintained by OpenTelemetry, so that OpenTelemetry
+Semantic Conventions truly is a successor of the Elastic Common Schema.
+OpenTelemetry shares the same interest of improving the convergence of
+observability and security in this space. We believe this schema merge brings
+huge value to the open-source community because:
+
+* ECS has years of proven success in the logs, metrics, traces and security
+  events schema, providing great coverage of the common problem domains.
+* ECS provides schema for security domain fields, which is an important aspect
+  of telemetry.
+* Converging two separate standards into one single standard will help to boost
+  the ecosystem (e.g. instrumentation libraries, tools and consumption
+  experiences), which benefits both the telemetry producers and consumers.
+* This joint effort would benefit from domain experts across logging, -
+  distributed tracing, metrics and security. As a result, we expect to have more
+  consistent signals across different pillars of observability and security.
+
+Both Elastic and the OpenTelemetry community understand that converging two
+widely used standards into one singular common schema, and having a smooth
+transition is critical for users. A dedicated OpenTelemetry Semantic Convention
+working group will be created with domain experts from both Elastic and
+OpenTelemetry joining. We're also welcoming domain experts who are passionate
+about data schemas and semantic conventions to join us. If you're interested in
+contributing, join our [OTel Semantic Conventions working
+group](https://github.com/open-telemetry/community#specification-sigs), and join
+the discussion on our [Slack
+channel](https://cloud-native.slack.com/archives/C041APFBYQP).
+
+## References
+
+* [Announcement from
+  Elastic](https://elastic.co/blog/ecs-elastic-common-schema-otel-opentelemetry-announcement)
+* [OpenTelemetry Semantic
+  Conventions](https://opentelemetry.io/docs/concepts/semantic-conventions/)
+* [OTEP 199: Merge Elastic Common Schema with OpenTelemetry Semantic
+  Conventions](https://github.com/open-telemetry/oteps/blob/d02a3e2e75dc934fb38c5db88eb41fbe85730af4/text/0199-support-elastic-common-schema-in-opentelemetry.md)

--- a/content/en/blog/2023/ecs-otel-semconv-convergence.md
+++ b/content/en/blog/2023/ecs-otel-semconv-convergence.md
@@ -27,7 +27,7 @@ huge value to the open-source community because:
 * Converging two separate standards into one single standard will help to boost
   the ecosystem (e.g. instrumentation libraries, tools and consumption
   experiences), which benefits both the telemetry producers and consumers.
-* This joint effort would benefit from domain experts across logging, -
+* This joint effort would benefit from domain experts across logging,
   distributed tracing, metrics and security. As a result, we expect to have more
   consistent signals across different pillars of observability and security.
 

--- a/content/en/blog/2023/ecs-otel-semconv-convergence.md
+++ b/content/en/blog/2023/ecs-otel-semconv-convergence.md
@@ -45,13 +45,20 @@ and join the discussion on our
 
 ## References
 
-- [Announcement from Elastic](https://elastic.co/blog/ecs-elastic-common-schema-otel-opentelemetry-announcement)
-- [OpenTelemetry Semantic Conventions](https://opentelemetry.io/docs/concepts/semantic-conventions/)
+- [Announcement from Elastic][]
+- [OpenTelemetry Semantic Conventions][]
 - [OTEP 199: Merge Elastic Common Schema with OpenTelemetry Semantic
-  Conventions](https://github.com/open-telemetry/oteps/blob/d02a3e2e75dc934fb38c5db88eb41fbe85730af4/text/0199-support-elastic-common-schema-in-opentelemetry.md)
+  Conventions][]
 - [OTEP Issue 197: Proposal: Add support for Elastic Common Schema (ECS) in
-  OpenTelemetry](https://github.com/open-telemetry/oteps/issues/197)
+  OpenTelemetry][]
 - [OTEP Pull Request 199: Support Elastic Common Schema in
-  OpenTelemetry](https://github.com/open-telemetry/oteps/pull/199)
+  OpenTelemetry][]
 - [OTEP Pull Request 222: Support Elastic Common Schema (ECS) in
-  OpenTelemetry](https://github.com/open-telemetry/oteps/pull/222)
+  OpenTelemetry][]
+
+[Announcement from Elastic]: https://elastic.co/blog/ecs-elastic-common-schema-otel-opentelemetry-announcement
+[OpenTelemetry Semantic Conventions]: /docs/concepts/semantic-conventions/
+[OTEP 199: Merge Elastic Common Schema with OpenTelemetry Semantic Conventions]: https://github.com/open-telemetry/oteps/blob/d02a3e2e75dc934fb38c5db88eb41fbe85730af4/text/0199-support-elastic-common-schema-in-opentelemetry.md
+[OTEP Issue 197: Proposal: Add support for Elastic Common Schema (ECS) in  OpenTelemetry]: https://github.com/open-telemetry/oteps/issues/197
+[OTEP Pull Request 199: Support Elastic Common Schema in OpenTelemetry]: https://github.com/open-telemetry/oteps/pull/199
+[OTEP Pull Request 222: Support Elastic Common Schema (ECS) in OpenTelemetry]: https://github.com/open-telemetry/oteps/pull/222

--- a/content/en/blog/2023/ecs-otel-semconv-convergence.md
+++ b/content/en/blog/2023/ecs-otel-semconv-convergence.md
@@ -47,4 +47,9 @@ and join the discussion on our
 
 - [Announcement from Elastic](https://elastic.co/blog/ecs-elastic-common-schema-otel-opentelemetry-announcement)
 - [OpenTelemetry Semantic Conventions](https://opentelemetry.io/docs/concepts/semantic-conventions/)
-- [OTEP 199: Merge Elastic Common Schema with OpenTelemetry Semantic Conventions](https://github.com/open-telemetry/oteps/blob/d02a3e2e75dc934fb38c5db88eb41fbe85730af4/text/0199-support-elastic-common-schema-in-opentelemetry.md)
+- [OTEP 199: Merge Elastic Common Schema with OpenTelemetry Semantic
+  Conventions](https://github.com/open-telemetry/oteps/blob/d02a3e2e75dc934fb38c5db88eb41fbe85730af4/text/0199-support-elastic-common-schema-in-opentelemetry.md)
+- [OTEP Pull Request 199: Support Elastic Common Schema in
+  OpenTelemetry](https://github.com/open-telemetry/oteps/pull/199)
+- [OTEP Pull Request 222: Support Elastic Common Schema (ECS) in
+  OpenTelemetry](https://github.com/open-telemetry/oteps/pull/222)

--- a/content/en/blog/2023/ecs-otel-semconv-convergence.md
+++ b/content/en/blog/2023/ecs-otel-semconv-convergence.md
@@ -1,10 +1,10 @@
 ---
-title: Announcing the Elastic Common Schema (ECS) and OpenTelemetry Semantic Convention Convergence
+title:
+  Announcing the Elastic Common Schema (ECS) and OpenTelemetry Semantic
+  Convention Convergence
 linkTitle: ECS and OTel SemConv Convergence
 date: 2023-04-17
-spelling:
-  cSpell:ignore Reiley Yang
-  cSpell:ignore ECS
+spelling: cSpell:ignore ECS Reiley SemConv Yang
 author: '[Reiley Yang](https://github.com/reyang)'
 ---
 
@@ -20,14 +20,14 @@ OpenTelemetry shares the same interest of improving the convergence of
 observability and security in this space. We believe this schema merge brings
 huge value to the open-source community because:
 
-* ECS has years of proven success in the logs, metrics, traces and security
+- ECS has years of proven success in the logs, metrics, traces and security
   events schema, providing great coverage of the common problem domains.
-* ECS provides schema for security domain fields, which is an important aspect
+- ECS provides schema for security domain fields, which is an important aspect
   of telemetry.
-* Converging two separate standards into one single standard will help to boost
+- Converging two separate standards into one single standard will help to boost
   the ecosystem (e.g. instrumentation libraries, tools and consumption
   experiences), which benefits both the telemetry producers and consumers.
-* This joint effort would benefit from domain experts across logging,
+- This joint effort would benefit from domain experts across logging,
   distributed tracing, metrics and security events. As a result, we expect to
   have more consistent signals across different pillars of observability and
   security events.
@@ -38,16 +38,13 @@ transition is critical for users. A dedicated OpenTelemetry Semantic Convention
 working group will be created with domain experts from both Elastic and
 OpenTelemetry joining. We're also welcoming domain experts who are passionate
 about data schemas and semantic conventions to join us. If you're interested in
-contributing, join our [OTel Semantic Conventions working
-group](https://github.com/open-telemetry/community#specification-sigs), and join
-the discussion on our [Slack
-channel](https://cloud-native.slack.com/archives/C041APFBYQP).
+contributing, join our
+[OTel Semantic Conventions working group](https://github.com/open-telemetry/community#specification-sigs),
+and join the discussion on our
+[Slack channel](https://cloud-native.slack.com/archives/C041APFBYQP).
 
 ## References
 
-* [Announcement from
-  Elastic](https://elastic.co/blog/ecs-elastic-common-schema-otel-opentelemetry-announcement)
-* [OpenTelemetry Semantic
-  Conventions](https://opentelemetry.io/docs/concepts/semantic-conventions/)
-* [OTEP 199: Merge Elastic Common Schema with OpenTelemetry Semantic
-  Conventions](https://github.com/open-telemetry/oteps/blob/d02a3e2e75dc934fb38c5db88eb41fbe85730af4/text/0199-support-elastic-common-schema-in-opentelemetry.md)
+- [Announcement from Elastic](https://elastic.co/blog/ecs-elastic-common-schema-otel-opentelemetry-announcement)
+- [OpenTelemetry Semantic Conventions](https://opentelemetry.io/docs/concepts/semantic-conventions/)
+- [OTEP 199: Merge Elastic Common Schema with OpenTelemetry Semantic Conventions](https://github.com/open-telemetry/oteps/blob/d02a3e2e75dc934fb38c5db88eb41fbe85730af4/text/0199-support-elastic-common-schema-in-opentelemetry.md)

--- a/content/en/blog/2023/ecs-otel-semconv-convergence.md
+++ b/content/en/blog/2023/ecs-otel-semconv-convergence.md
@@ -9,9 +9,9 @@ author: '[Reiley Yang](https://github.com/reyang)'
 ---
 
 Today, we're very excited to make a joint announcement with
-[Elastic](https://www.elastic.co/) about the future of [Elastic Common
-Schema](https://www.elastic.co/guide/en/ecs/master/ecs-reference.html) (ECS) and
-the [OpenTelemetry Semantic Conventions][].
+[Elastic](https://www.elastic.co/) about the future of
+[Elastic Common Schema](https://www.elastic.co/guide/en/ecs/master/ecs-reference.html)
+(ECS) and the [OpenTelemetry Semantic Conventions][].
 
 The goal is to achieve convergence of ECS and OTel Semantic Conventions into a
 single open schema that is maintained by OpenTelemetry, so that OpenTelemetry
@@ -55,9 +55,14 @@ and join the discussion on our
 - [OTEP Pull Request 222: Support Elastic Common Schema (ECS) in
   OpenTelemetry][]
 
-[Announcement from Elastic]: https://elastic.co/blog/ecs-elastic-common-schema-otel-opentelemetry-announcement
+[Announcement from Elastic]:
+  https://elastic.co/blog/ecs-elastic-common-schema-otel-opentelemetry-announcement
 [OpenTelemetry Semantic Conventions]: /docs/concepts/semantic-conventions/
-[OTEP 199: Merge Elastic Common Schema with OpenTelemetry Semantic Conventions]: https://github.com/open-telemetry/oteps/blob/d02a3e2e75dc934fb38c5db88eb41fbe85730af4/text/0199-support-elastic-common-schema-in-opentelemetry.md
-[OTEP Issue 197: Proposal: Add support for Elastic Common Schema (ECS) in  OpenTelemetry]: https://github.com/open-telemetry/oteps/issues/197
-[OTEP Pull Request 199: Support Elastic Common Schema in OpenTelemetry]: https://github.com/open-telemetry/oteps/pull/199
-[OTEP Pull Request 222: Support Elastic Common Schema (ECS) in OpenTelemetry]: https://github.com/open-telemetry/oteps/pull/222
+[OTEP 199: Merge Elastic Common Schema with OpenTelemetry Semantic Conventions]:
+  https://github.com/open-telemetry/oteps/blob/d02a3e2e75dc934fb38c5db88eb41fbe85730af4/text/0199-support-elastic-common-schema-in-opentelemetry.md
+[OTEP Issue 197: Proposal: Add support for Elastic Common Schema (ECS) in OpenTelemetry]:
+  https://github.com/open-telemetry/oteps/issues/197
+[OTEP Pull Request 199: Support Elastic Common Schema in OpenTelemetry]:
+  https://github.com/open-telemetry/oteps/pull/199
+[OTEP Pull Request 222: Support Elastic Common Schema (ECS) in OpenTelemetry]:
+  https://github.com/open-telemetry/oteps/pull/222

--- a/content/en/blog/2023/ecs-otel-semconv-convergence.md
+++ b/content/en/blog/2023/ecs-otel-semconv-convergence.md
@@ -49,6 +49,8 @@ and join the discussion on our
 - [OpenTelemetry Semantic Conventions](https://opentelemetry.io/docs/concepts/semantic-conventions/)
 - [OTEP 199: Merge Elastic Common Schema with OpenTelemetry Semantic
   Conventions](https://github.com/open-telemetry/oteps/blob/d02a3e2e75dc934fb38c5db88eb41fbe85730af4/text/0199-support-elastic-common-schema-in-opentelemetry.md)
+- [OTEP Issue 197: Proposal: Add support for Elastic Common Schema (ECS) in
+  OpenTelemetry](https://github.com/open-telemetry/oteps/issues/197)
 - [OTEP Pull Request 199: Support Elastic Common Schema in
   OpenTelemetry](https://github.com/open-telemetry/oteps/pull/199)
 - [OTEP Pull Request 222: Support Elastic Common Schema (ECS) in

--- a/content/en/blog/2023/ecs-otel-semconv-convergence.md
+++ b/content/en/blog/2023/ecs-otel-semconv-convergence.md
@@ -1,7 +1,7 @@
 ---
 title: Announcing the Elastic Common Schema (ECS) and OpenTelemetry Semantic Convention Convergence
 linkTitle: ECS and OTel SemConv Convergence
-date: 2023-04-07
+date: 2023-04-17
 spelling:
   cSpell:ignore Reiley Yang
   cSpell:ignore ECS

--- a/content/en/blog/2023/ecs-otel-semconv-convergence.md
+++ b/content/en/blog/2023/ecs-otel-semconv-convergence.md
@@ -9,9 +9,9 @@ author: '[Reiley Yang](https://github.com/reyang)'
 ---
 
 Today, we're very excited to make a joint announcement with
-[Elastic](https://www.elastic.co/) about the future of
-[ECS](https://www.elastic.co/guide/en/ecs/master/ecs-reference.html) (Elastic
-Common Schema) and the OpenTelemetry Semantic Conventions.
+[Elastic](https://www.elastic.co/) about the future of [Elastic Common
+Schema](https://www.elastic.co/guide/en/ecs/master/ecs-reference.html) (ECS) and
+the [OpenTelemetry Semantic Conventions][].
 
 The goal is to achieve convergence of ECS and OTel Semantic Conventions into a
 single open schema that is maintained by OpenTelemetry, so that OpenTelemetry
@@ -51,8 +51,7 @@ and join the discussion on our
   Conventions][]
 - [OTEP Issue 197: Proposal: Add support for Elastic Common Schema (ECS) in
   OpenTelemetry][]
-- [OTEP Pull Request 199: Support Elastic Common Schema in
-  OpenTelemetry][]
+- [OTEP Pull Request 199: Support Elastic Common Schema in OpenTelemetry][]
 - [OTEP Pull Request 222: Support Elastic Common Schema (ECS) in
   OpenTelemetry][]
 

--- a/content/en/blog/2023/ecs-otel-semconv-convergence.md
+++ b/content/en/blog/2023/ecs-otel-semconv-convergence.md
@@ -28,8 +28,9 @@ huge value to the open-source community because:
   the ecosystem (e.g. instrumentation libraries, tools and consumption
   experiences), which benefits both the telemetry producers and consumers.
 * This joint effort would benefit from domain experts across logging,
-  distributed tracing, metrics and security. As a result, we expect to have more
-  consistent signals across different pillars of observability and security.
+  distributed tracing, metrics and security events. As a result, we expect to
+  have more consistent signals across different pillars of observability and
+  security events.
 
 Both Elastic and the OpenTelemetry community understand that converging two
 widely used standards into one singular common schema, and having a smooth

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -219,6 +219,10 @@
     "StatusCode": 200,
     "LastSeen": "2023-02-15T20:41:03.78002-05:00"
   },
+  "https://cloud-native.slack.com/archives/C041APFBYQP": {
+    "StatusCode": 200,
+    "LastSeen": "2023-04-12T11:20:32.403714-04:00"
+  },
   "https://cloud-native.slack.com/archives/C0422FSELH0": {
     "StatusCode": 200,
     "LastSeen": "2023-02-15T20:40:32.32299-05:00"
@@ -1755,6 +1759,10 @@
     "StatusCode": 200,
     "LastSeen": "2023-02-20T08:15:28.84376-05:00"
   },
+  "https://github.com/open-telemetry/community#specification-sigs": {
+    "StatusCode": 200,
+    "LastSeen": "2023-04-12T11:20:27.134426-04:00"
+  },
   "https://github.com/open-telemetry/community/discussions/1203": {
     "StatusCode": 200,
     "LastSeen": "2023-02-20T08:04:49.421838-05:00"
@@ -2534,6 +2542,10 @@
   "https://github.com/reese-lee": {
     "StatusCode": 200,
     "LastSeen": "2023-02-20T08:04:55.176981-05:00"
+  },
+  "https://github.com/reyang": {
+    "StatusCode": 200,
+    "LastSeen": "2023-04-12T11:20:10.566057-04:00"
   },
   "https://github.com/riandyrn/otelchi": {
     "StatusCode": 200,
@@ -3895,6 +3907,10 @@
     "StatusCode": 200,
     "LastSeen": "2023-02-18T13:33:53.628417-05:00"
   },
+  "https://www.elastic.co/": {
+    "StatusCode": 200,
+    "LastSeen": "2023-04-12T11:20:16.022774-04:00"
+  },
   "https://www.elastic.co/guide/en/apm/get-started/current/open-telemetry-elastic.html": {
     "StatusCode": 206,
     "LastSeen": "2023-02-18T13:33:59.582146-05:00"
@@ -3906,6 +3922,10 @@
   "https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html": {
     "StatusCode": 206,
     "LastSeen": "2023-02-18T13:41:59.100249-05:00"
+  },
+  "https://www.elastic.co/guide/en/ecs/master/ecs-reference.html": {
+    "StatusCode": 206,
+    "LastSeen": "2023-04-12T11:20:21.66934-04:00"
   },
   "https://www.envoyproxy.io": {
     "StatusCode": 206,

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -2439,6 +2439,10 @@
     "StatusCode": 200,
     "LastSeen": "2023-02-20T07:41:21.740221-05:00"
   },
+  "https://github.com/open-telemetry/oteps/issues/197": {
+    "StatusCode": 200,
+    "LastSeen": "2023-03-30T19:59:09.626563-04:00"
+  },
   "https://github.com/open-telemetry/oteps/pull/108/files": {
     "StatusCode": 200,
     "LastSeen": "2023-02-20T08:01:24.26414-05:00"
@@ -2458,6 +2462,10 @@
   "https://github.com/open-telemetry/oteps/pull/192": {
     "StatusCode": 200,
     "LastSeen": "2023-02-20T08:09:46.360301-05:00"
+  },
+  "https://github.com/open-telemetry/oteps/pull/199": {
+    "StatusCode": 200,
+    "LastSeen": "2023-03-30T19:59:09.626563-04:00"
   },
   "https://github.com/open-telemetry/oteps/pull/212": {
     "StatusCode": 200,


### PR DESCRIPTION
# Note: **we would like the OTel blog published 7am Amsterdam time on April 18th which is 10pm PT on April 17th**.

## Background context

The stakeholders of ECS (Elastic Common Schema) and OpenTelemetry have been making progress since the past 12 months with the outcome of [OTEP 199](https://github.com/open-telemetry/oteps/pull/222). Since the OTEP 199 got approved/merged, we've had multiple discussions among the ECS stakeholders from Elastic, OpenTelemetry GC (Governance Committee) and TC (Technical Committee) members, now we've reached to a point that we are ready to publicly announce this merge in the upcoming [EU KubeCon](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/) event ❤️🍾🥳!

## What's the communication plan

The plan is that Elastic and OpenTelemetry will each publish an official post/announcement at **7am Amsterdam time on April 18th which is 10pm PT on April 17th** (right before KubeCon). This PR covers the blog post from OpenTelemetry, while Elastic will publish their announcement to https://elastic.co/blog/ecs-elastic-common-schema-otel-opentelemetry-announcement (note that the link will return 404 at this moment, and will become available at the publishing time).

## Additional info

A draft Google Doc was prepared and went through several rounds of internal reviews in the past two weeks, which resulted in this PR after the alignment. The original doc can be found from https://docs.google.com/document/d/1ymr4sVG-Npdr1-hys-PKhF6pZXc_bNYmR1fee_n9GWM/edit?usp=sharing.

@AlexanderWert @open-telemetry/governance-committee @open-telemetry/technical-committee