### PR TITLE
Fix collector download URL for macOS

### DIFF
--- a/content/en/docs/collector/getting-started.md
+++ b/content/en/docs/collector/getting-started.md
@@ -232,13 +232,13 @@ tool that supports this compression format:
 <!-- prettier-ignore-start -->
 {{< tabpane lang=shell persistLang=false >}}
 {{< tab Intel >}}
-curl -O -L https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param collectorVersion %}}/otelcol*{{% param collectorVersion %}}\_darwin_amd64.tar.gz
-tar -xvf otelcol*{{% param collectorVersion %}}\_darwin_amd64.tar.gz
+curl -O -L https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param collectorVersion %}}/otelcol_{{% param collectorVersion %}}_darwin_amd64.tar.gz
+tar -xvf otelcol_{{% param collectorVersion %}}_darwin_amd64.tar.gz
 {{< /tab >}}
 
 {{< tab ARM >}}
-curl -O -L https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param collectorVersion %}}/otelcol*{{% param collectorVersion %}}\_darwin_arm64.tar.gz
-tar -xvf otelcol*{{% param collectorVersion %}}\_darwin_arm64.tar.gz
+curl -O -L https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param collectorVersion %}}/otelcol_{{% param collectorVersion %}}_darwin_arm64.tar.gz
+tar -xvf otelcol_{{% param collectorVersion %}}_darwin_arm64.tar.gz
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
The existing URL returns a not found. I have verified that the new URL is valid and correct in both bash and ZSH.