### PR TITLE
Install @opentelemetry/api when instrumenting app

### DIFF
--- a/content/en/docs/instrumentation/js/getting-started/nodejs.md
+++ b/content/en/docs/instrumentation/js/getting-started/nodejs.md
@@ -132,6 +132,7 @@ automatically create spans for each incoming request.
 
 ```shell
 npm install @opentelemetry/sdk-node \
+  @opentelemetry/api \
   @opentelemetry/auto-instrumentations-node \
   @opentelemetry/sdk-metrics
 ```


### PR DESCRIPTION
The auto instrumentation docs are broken because at some point, the `@opentelemetry/api` dependency was changed to a peer dependency in the upstream packages.
This causes packages install to fail.

This PR adds the api package to the install command.