### PR TITLE
Add Teletrace to vendor list

### DIFF
--- a/content/en/ecosystem/vendors.md
+++ b/content/en/ecosystem/vendors.md
@@ -47,6 +47,7 @@ OpenTelemetry in their commercial products.
 | Splunk                     | Yes               | Yes         | [splunk.com/blog/...](https://www.splunk.com/en_us/blog/conf-splunklive/announcing-native-opentelemetry-support-in-splunk-apm.html)
 | Sumo Logic                 | Yes               | Yes         | [help.sumologic.com/](https://help.sumologic.com/docs/apm/traces/quickstart/)
 | TelemetryHub               | No                | Yes         | [telemetryhub.com](https://app.telemetryhub.com/docs)
+| Teletrace                  | Yes               | Yes         | [docs.teletrace.io](https://docs.teletrace.io/)
 | Traceloop                  | No                | Yes         | [traceloop.dev](https://docs.traceloop.dev)
 | Uptrace                    | Yes               | Yes         | [uptrace.dev](https://uptrace.dev)
 

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -1023,6 +1023,10 @@
     "StatusCode": 206,
     "LastSeen": "2023-03-11T14:17:28.309561-05:00"
   },
+  "https://docs.teletrace.io/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-04-15T22:50:33.371377+03:00"
+  },
   "https://docs.traceloop.dev": {
     "StatusCode": 206,
     "LastSeen": "2023-02-26T11:00:42.522142-08:00"


### PR DESCRIPTION
[Teletrace](https://github.com/teletrace/teletrace) is an open-source tracing platform. In short, the project architecture includes an [OTel distribution](https://github.com/teletrace/teletrace/tree/main/teletrace-otelcol), query backend, and a UI.