### PR TITLE
Add link to community feedback survey

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -7,6 +7,7 @@ IgnoreInternalURLs: # list of paths
 IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - ^/docs/instrumentation/\w+/(api|examples)/$
   - ^/docs/instrumentation/net/(metrics-api|traces-api)/
+  - ^/community/end-user/feedback-survey/$
 
   - ^https://deploy-preview-\d+--opentelemetry.netlify.app/
   - ^https://www\.googletagmanager\.com

--- a/content/en/community/end-user/community-feedback-survey.md
+++ b/content/en/community/end-user/community-feedback-survey.md
@@ -1,0 +1,8 @@
+---
+title: Community Feedback Survey
+redirect: https://docs.google.com/forms/d/e/1FAIpQLSdKm6oLYRXlZOhEZMVmjoIn4eBToVYNmF6fwpm5GAIipQmPxA/viewform?pli=1
+manualLinkTarget: _blank
+_build: { render: link }
+weight: 60
+aliases: [/community-feedback]
+---

--- a/content/en/community/end-user/discussion-group.md
+++ b/content/en/community/end-user/discussion-group.md
@@ -2,6 +2,7 @@
 title: Monthly Discussion Group
 linkTitle: Monthly Discussions
 description: Monthly OpenTelemetry usage discussions, all are welcome!
+weight: 20
 ---
 
 Interested in learning how other end users are implementing OpenTelemetry in

--- a/content/en/community/end-user/feedback-survey.md
+++ b/content/en/community/end-user/feedback-survey.md
@@ -1,5 +1,5 @@
 ---
-title: Community Feedback Survey
+title: Feedback Survey
 redirect: https://docs.google.com/forms/d/e/1FAIpQLSdKm6oLYRXlZOhEZMVmjoIn4eBToVYNmF6fwpm5GAIipQmPxA/viewform?pli=1
 manualLinkTarget: _blank
 _build: { render: link }

--- a/content/en/community/end-user/interviews-feedback.md
+++ b/content/en/community/end-user/interviews-feedback.md
@@ -1,6 +1,7 @@
 ---
 title: Interviews or Feedback Sessions
 description: Help improve OpenTelemetry - share your feedback directly with us!
+weight: 10
 ---
 
 One of the core functions of the OpenTelemetry End User Working Group is to

--- a/content/en/community/end-user/otel-in-practice.md
+++ b/content/en/community/end-user/otel-in-practice.md
@@ -4,6 +4,7 @@ linkTitle: OTel in Practice
 description: >-
   _OpenTelemetry in Practice_ is a _series_ of talks initiated by some members
   of the End User Working Group.
+weight: 30
 ---
 
 We’re aiming to:

--- a/content/en/community/end-user/slack-channel.md
+++ b/content/en/community/end-user/slack-channel.md
@@ -3,6 +3,7 @@ title: Slack Channel
 linkTitle: Slack
 description: >-
   Join a private slack channel to discuss OpenTelemetry with other end users.
+weight: 40
 ---
 
 - Confirm your agreement with channel [Code of Conduct][] and reach out to Reese


### PR DESCRIPTION
@tedsuo what we discussed today at the booth

@open-telemetry/end-user-wg please take a look. The idea is to have an alias for the End-User Feedback Survey, easier to memorize than the long google docs URL. 

Previews:
https://deploy-preview-2615--opentelemetry.netlify.app/community/
&
https://deploy-preview-2615--opentelemetry.netlify.app/community/end-user/feedback-survey/
&
https://deploy-preview-2615--opentelemetry.netlify.app/community-feedback/

Final URLs will replace with "opentelemetry.io" so we will have `opentelemetry.io/community-feedback`. 

We could go even shorter, `opentelemetry.io/feedback` ?