### PR TITLE
docs: fix typo in getting-started.md

### DIFF
--- a/content/en/docs/instrumentation/php/getting-started.md
+++ b/content/en/docs/instrumentation/php/getting-started.md
@@ -219,7 +219,7 @@ instead of the console.
 This will require the installation of the otlp exporter:
 
 ```shell
-composer require opentelemetry/exporter-otlp
+composer require open-telemetry/exporter-otlp
 ```
 
 Next, using the `GettingStarted.php` from earlier, replace the console exporter


### PR DESCRIPTION
Fixes a typo in the composer command / package name