### PR TITLE
Remove Kubecon EU'23 banner

### DIFF
--- a/layouts/partials/banner.md
+++ b/layouts/partials/banner.md
@@ -2,7 +2,7 @@
 
 <div class="o-banner">
 
-Join us at [KubeCon + CloudNativeCon EU, April 18-21](/blog/2023/kubecon-eu/)!
+[The OpenTelemetry Demo Turns 1(.4)](/blog/2023/demo-birthday/)!
 
 </div>
 {{ end -}}


### PR DESCRIPTION
Removes the banner for KubeCon EU, replaces it with the demo birthday blog.