### PR TITLE
Incremental improvements for migration docs

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -8,6 +8,7 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - ^/docs/instrumentation/\w+/(api|examples)/$
   - ^/docs/instrumentation/net/(metrics-api|traces-api)/
   - ^/community/end-user/feedback-survey/$
+  - ^/docs/migration/opencensus/$
 
   - ^https://deploy-preview-\d+--opentelemetry.netlify.app/
   - ^https://www\.googletagmanager\.com

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -8,7 +8,7 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - ^/docs/instrumentation/\w+/(api|examples)/$
   - ^/docs/instrumentation/net/(metrics-api|traces-api)/
   - ^/community/end-user/feedback-survey/$
-  - ^/docs/migration/opencensus/$
+  - ^(/docs/migration/)?opencensus/$
 
   - ^https://deploy-preview-\d+--opentelemetry.netlify.app/
   - ^https://www\.googletagmanager\.com

--- a/content/en/docs/migration/_index.md
+++ b/content/en/docs/migration/_index.md
@@ -7,7 +7,7 @@ weight: 50
 ## OpenTracing and OpenCensus
 
 OpenTelemetry was created as a merger of OpenTracing and OpenCensus. From the
-start OpenTelemetry was considered [to be the next major version of both
+start, OpenTelemetry was considered [to be the next major version of both
 OpenTracing and OpenCensus][]. Because of that, one of the [key goals][] of the
 OpenTelemetry project is to provide backward compatibility with OpenCensus and a
 migration story for existing users.

--- a/content/en/docs/migration/_index.md
+++ b/content/en/docs/migration/_index.md
@@ -13,7 +13,7 @@ OpenTelemetry project is to provide backward compatibility with OpenCensus and a
 migration story for existing users.
 
 If you come from one of these projects, you can follow the migration guides for
-both [OpenTracing](./opentracing/) and [OpenCensus](./opencensus/)
+both [OpenTracing](opentracing/) and [OpenCensus](opencensus/)
 
 ## Jaeger Client
 

--- a/content/en/docs/migration/_index.md
+++ b/content/en/docs/migration/_index.md
@@ -3,3 +3,29 @@ title: Migration
 description: How to migrate to OpenTelemetry
 weight: 50
 ---
+
+## OpenTracing and OpenCensus
+
+OpenTelemetry was created as a merger of OpenTracing and OpenCensus. From the
+start OpenTelemetry was considered [to be the next major version of both
+OpenTracing and OpenCensus][]. Because of that, one of the [key goals][] of the
+OpenTelemetry project is to provide backward compatibility with OpenCensus and a
+migration story for existing users.
+
+If you come from one of these projects, you can follow the migration guides for
+both [OpenTracing](./opentracing/) and [OpenCensus](./opencensus/)
+
+## Jaeger Client
+
+The [Jaeger community](https://www.jaegertracing.io/) deprecated their
+[Client Libraries](https://www.jaegertracing.io/docs/latest/client-libraries/)
+and recommends using the OpenTelemetry APIs, SDKs and instrumentations.
+
+The Jaeger backend can receive trace data via the OpenTelemetry Protocol (OTLP)
+since v1.35. Therefore you can migrate your OpenTelemetry SDKs and collectors
+from using the Jaeger exporter to the OTLP exporter.
+
+[to be the next major version of both OpenTracing and OpenCensus]:
+  https://www.cncf.io/blog/2019/05/21/a-brief-history-of-opentelemetry-so-far/
+[key goals]:
+  https://medium.com/opentracing/merging-opentracing-and-opencensus-f0fe9c7ca6f0

--- a/content/en/docs/migration/_index.md
+++ b/content/en/docs/migration/_index.md
@@ -9,8 +9,8 @@ weight: 50
 OpenTelemetry was created as a merger of OpenTracing and OpenCensus. From the
 start, OpenTelemetry was considered [to be the next major version of both
 OpenTracing and OpenCensus][]. Because of that, one of the [key goals][] of the
-OpenTelemetry project is to provide backward compatibility with OpenCensus and a
-migration story for existing users.
+OpenTelemetry project is to provide backward compatibility with both projects
+and a migration story for existing users.
 
 If you come from one of these projects, you can follow the migration guides for
 both [OpenTracing](opentracing/) and [OpenCensus](opencensus/)

--- a/content/en/docs/migration/opencensus.md
+++ b/content/en/docs/migration/opencensus.md
@@ -1,7 +1,7 @@
 ---
 title: Migrating from OpenCensus
 linkTitle: OpenCensus
-redirect: https://opentelemetry.io/docs/reference/specification/compatibility/opencensus/#migration-path
+redirect: /docs/reference/specification/compatibility/opencensus/#migration-path
 manualLinkTarget: _blank
 _build: { render: link }
 weight: 3

--- a/content/en/docs/migration/opencensus.md
+++ b/content/en/docs/migration/opencensus.md
@@ -1,0 +1,8 @@
+---
+title: Migrating from OpenCensus
+linkTitle: OpenCensus
+redirect: https://opentelemetry.io/docs/reference/specification/compatibility/opencensus/#migration-path
+manualLinkTarget: _blank
+_build: { render: link }
+weight: 3
+---

--- a/content/en/docs/migration/opentracing.md
+++ b/content/en/docs/migration/opentracing.md
@@ -2,6 +2,7 @@
 title: Migrating from OpenTracing
 linkTitle: OpenTracing
 spelling: cSpell:ignore codebases opentracing
+weight: 2
 ---
 
 Backward compatibility with [OpenTracing][] has been a priority for the

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -4131,6 +4131,10 @@
     "StatusCode": 206,
     "LastSeen": "2023-02-18T13:42:20.916021-05:00"
   },
+  "https://www.jaegertracing.io/docs/latest/client-libraries/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-05-05T15:20:49.484688+02:00"
+  },
   "https://www.jaegertracing.io/docs/latest/client-libraries/#propagation-format": {
     "StatusCode": 200,
     "LastSeen": "2023-02-18T13:39:37.864392-05:00"


### PR DESCRIPTION
Some incremental improvements for migration docs:

* Some introduction for where Otel comes from and why we provide oc & ot migration (copied some of your words @aabmass, hope that's OK :))
* Also some words about jaeger (copied from the jaeger docs (cc @pavolloffay) & @jpkrohling [blog post](https://medium.com/jaegertracing/migrating-from-jaeger-client-to-opentelemetry-sdk-bd337d796759))
* Linked to the spec for OpenCensus for now, not sure if this works in the long run and if we might need a separate migration guide like we have one for ot