### PR TITLE
Add registry entry for otlpr

### DIFF
--- a/data/registry/exporter-go-otlpr.yml
+++ b/data/registry/exporter-go-otlpr.yml
@@ -1,0 +1,15 @@
+title: otlpr - A logr implementation backed by OTLP
+registryType: exporter
+isThirdParty: true
+language: go
+tags:
+  - go
+  - exporter
+  - log
+  - logging
+  - logr
+repo: https://github.com/MrAlias/otlpr
+license: Apache 2.0
+description: Provides a `logr.Logger` that exports messages as OTLP logs.
+authors: MrAlias
+otVersion: latest

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -1387,6 +1387,10 @@
     "StatusCode": 200,
     "LastSeen": "2023-02-20T07:47:31.703432-05:00"
   },
+  "https://github.com/MrAlias/otlpr": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-05T09:49:48.182190079-07:00"
+  },
   "https://github.com/MrAlias/redact": {
     "StatusCode": 200,
     "LastSeen": "2023-02-20T07:47:37.047773-05:00"


### PR DESCRIPTION
[`otlpr`](https://github.com/MrAlias/otlpr) is a 3rd-party, open source, Go project that provides a [logr.Logger](https://pkg.go.dev/github.com/go-logr/logr#Logger) that exports messages as OTLP logs.