### PR TITLE
Spec: add version to title

### DIFF
--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -15,6 +15,10 @@ my $specRepoUrl = 'https://github.com/open-telemetry/opentelemetry-specification
 my $semConvRef = "$specRepoUrl/blob/main/semantic_conventions/README.md";
 my $spec_base_path = '/docs/reference/specification';
 my $path_base_for_github_subdir = "content/en$spec_base_path";
+my %versions = qw(
+  spec: 1.20.0
+);
+my $spec_vers = $versions{'spec:'};
 
 my $rootFrontMatterExtra = <<"EOS";
 no_list: true
@@ -28,6 +32,11 @@ EOS
 
 sub printTitleAndFrontMatter() {
   print "---\n";
+  if ($title eq 'OpenTelemetry Specification') {
+    $title .= " $spec_vers";
+    # Temporary adjustment to front matter until spec is updated:
+    $frontMatterFromFile =~ s/linkTitle: .*/$& $spec_vers/;
+  }
   my $titleMaybeQuoted = ($title =~ ':') ? "\"$title\"" : $title;
   print "title: $titleMaybeQuoted\n";
   ($linkTitle) = $title =~ /^OpenTelemetry (.*)/;


### PR DESCRIPTION
Hi @open-telemetry/specs-approvers: before setting up a script to automatically fetch the latest version of the spec (#2387), I wanted to ensure that we agreed on how the version will be displayed. This PR is such a proposal, it:

- Adds the spec version to:
  - The Spec landing page title -- see the preview
  - The `linkTitle` so that the version appears in the:
    - Left sidenav
    - Breadcrumbs, and hence in every spec page
- Contributes to #2387

**Preview**: https://deploy-preview-2666--opentelemetry.netlify.app/docs/reference/specification/

### Screenshots

> <img width="1562" alt="Screen Shot 2023-05-07 at 15 05 08" src="https://user-images.githubusercontent.com/4140793/236697603-8fd4fec3-77b4-40c9-bbf7-053e121f0234.png">

/cc @open-telemetry/specs-approvers @tigrannajaryan 
