### PR TITLE
Auto-update script: only match whole words, and other improvements

### DIFF
--- a/.github/workflows/auto-update-versions.yml
+++ b/.github/workflows/auto-update-versions.yml
@@ -21,12 +21,9 @@ jobs:
 
       - name: Auto-update
         run: |
-          .github/workflows/scripts/auto-update-version.sh "opentelemetry-collector-releases" "collectorVersion" "content/en/docs/collector/_index.md"
-          git reset --hard origin/main
-          .github/workflows/scripts/auto-update-version.sh "opentelemetry-java" "javaVersion" "content/en/docs/instrumentation/java/_index.md"
-          git reset --hard origin/main
-          .github/workflows/scripts/auto-update-version.sh "opentelemetry-java-instrumentation" "javaInstrumentationVersion" "content/en/docs/instrumentation/java/automatic/annotations.md"
-          git reset --hard origin/main
+          .github/workflows/scripts/auto-update-version.sh opentelemetry-collector-releases collectorVersion content/en/docs/collector/_index.md
+          .github/workflows/scripts/auto-update-version.sh opentelemetry-java javaVersion content/en/docs/instrumentation/java/_index.md
+          .github/workflows/scripts/auto-update-version.sh opentelemetry-java-instrumentation javaInstrumentationVersion content/en/docs/instrumentation/java/automatic/annotations.md
         env:
           # change this to secrets.GITHUB_TOKEN when testing against a fork
           GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}

--- a/.github/workflows/scripts/auto-update-version.sh
+++ b/.github/workflows/scripts/auto-update-version.sh
@@ -1,26 +1,59 @@
 #!/bin/bash -e
 
+GH=gh
+GIT=git
+
+if [[ -n "$GITHUB_ACTIONS" ]]; then
+  # Ensure that we're starting from a clean state
+  git reset --hard origin/main
+elif [[ "$1" != "-f" ]]; then
+  # Do a dry-run when script it executed locally, unless the
+  # force flag is specified (-f).
+  echo "Doing a dry-run when run locally. Use -f as the first argument to force execution."
+  GH="echo > DRY RUN: gh "
+  GIT="echo > DRY RUN: git "
+else
+  # Local execution with -f flag (force real vs. dry run)
+  shift
+fi
+
 repo=$1
 variable_name=$2
 file_names=("${@:3}") # remaining args
 
 latest_version=$(gh api -q .tag_name "repos/open-telemetry/$repo/releases/latest" | sed 's/^v//')
 
-echo "Repo: $repo"
-echo "Latest version: $latest_version"
+echo "REPO:            $repo"
+echo "LATEST VERSION:  $latest_version"
+
+# Version line regex, to match entire line -- works under Linux and macOS:
+vers_match_regex="^ *$variable_name:"
 
 for file_name in "${file_names[@]}"
 do
-  if ! grep -q "$variable_name" "$file_name"; then
-    echo "Could not find \"$variable_name\" in $file_name, failing job."
+  echo "SEARCHING for:   '$vers_match_regex' in $file_name"
+  if ! grep -q "$vers_match_regex" "$file_name"; then
+    echo "Could not find regex \"$vers_match_regex\" in $file_name. Aborting."
     exit 1
   fi
-  sed -i -e "s/$variable_name: .*/$variable_name: $latest_version/" "$file_name"
+  current_version=$(grep "$vers_match_regex" "$file_name")
+  echo "CURRENT VERSION: $current_version"
+
+  (set -x; sed -i.bak -e "s/\($vers_match_regex\) .*/\1 $latest_version/" "$file_name")
+
+  if [[ -e "$file_name".bak ]]; then
+    rm "$file_name".bak
+  fi
 done
 
-if git diff --quiet; then
-  echo "Already at the latest version."
+if git diff --quiet $file_names; then
+  echo "Already at the latest version. Exiting"
   exit 0
+else
+  echo
+  echo "Version update necessary:"
+  git diff $file_names
+  echo
 fi
 
 message="Update $repo version to $latest_version"
@@ -38,11 +71,11 @@ fi
 
 branch="opentelemetrybot/auto-update-$repo-$latest_version"
 
-git checkout -b "$branch"
-git commit -a -m "$message"
-git push --set-upstream origin "$branch"
+$GIT checkout -b "$branch"
+$GIT commit -a -m "$message"
+$GIT push --set-upstream origin "$branch"
 
 echo "Submitting auto-update PR '$message'."
-gh pr create --label auto-update \
+$GH pr create --label auto-update \
              --title "$message" \
              --body "$body"


### PR DESCRIPTION
- Prep for #2387
- When searching for version fields, the script now only matches:
  - At word boundaries (for the "variable" name)
  - An entire line
- Executes `git reset --hard origin/main` at the start of the script when run GH
- Adds support for running the script locally (macOS and Linux)
- When run locally, the script defaults to a dry run. Use `-f` to force a regular run.

/cc @trask 