### PR TITLE
Rename reference/spec to specification/otel and add OTLP submodule 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,3 +11,6 @@
 [submodule "content-modules/community"]
 	path = content-modules/community
 	url = https://github.com/open-telemetry/community
+[submodule "content-modules/opentelemetry-proto"]
+	path = content-modules/opentelemetry-proto
+	url = https://github.com/open-telemetry/opentelemetry-proto

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -9,6 +9,8 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - ^/docs/instrumentation/net/(metrics-api|traces-api)/
   - ^/community/end-user/feedback-survey/$
   - ^(/docs/migration/)?opencensus/$
+  # TODO: drop after OTel spec rework is complete
+  - ^/docs/reference/specification
 
   - ^https://deploy-preview-\d+--opentelemetry.netlify.app/
   - ^https://www\.googletagmanager\.com

--- a/content/en/docs/instrumentation/erlang/getting-started.md
+++ b/content/en/docs/instrumentation/erlang/getting-started.md
@@ -100,11 +100,12 @@ and the [Zipkin protocol](https://hex.pm/packages/opentelemetry_zipkin).
 
 Configuration is done through the
 [Application environment](https://erlang.org/doc/design_principles/applications.html#configuring-an-application)
-or [OS Environment Variables]({{< relref
-"/docs/reference/specification/sdk-environment-variables" >}}). The SDK (`opentelemetry`
-Application) uses the configuration to initialize a [Tracer Provider](https://hexdocs.pm/opentelemetry/otel_tracer_server.html),
-its [Span Processors](https://hexdocs.pm/opentelemetry/otel_span_processor.html)
-and the [Exporter](https://hexdocs.pm/opentelemetry/otel_exporter.html).
+or
+[OS Environment Variables](/docs/specification/otel/sdk-environment-variables/).
+The SDK (`opentelemetry` Application) uses the configuration to initialize a
+[Tracer Provider](https://hexdocs.pm/opentelemetry/otel_tracer_server.html), its
+[Span Processors](https://hexdocs.pm/opentelemetry/otel_span_processor.html) and
+the [Exporter](https://hexdocs.pm/opentelemetry/otel_exporter.html).
 
 ### Using the Console Exporter
 

--- a/content/en/docs/instrumentation/erlang/propagation.md
+++ b/content/en/docs/instrumentation/erlang/propagation.md
@@ -7,8 +7,8 @@ weight: 35
 
 Distributed traces extend beyond a single service, meaning some context must be
 propagated across services to create the parent-child relationship between
-Spans. This requires cross service [_context
-propagation_]({{< relref "/docs/reference/specification/overview#context-propagation" >}}),
+Spans. This requires cross service
+[_context propagation_](/docs/specification/otel/overview/#context-propagation),
 a mechanism where identifiers for a Trace are sent to remote processes.
 
 Instrumentation Libraries for HTTP frameworks and servers like

--- a/content/en/docs/instrumentation/js/instrumentation.md
+++ b/content/en/docs/instrumentation/js/instrumentation.md
@@ -403,9 +403,9 @@ tracer.startActiveSpan(
 
 There are semantic conventions for spans representing operations in well-known
 protocols like HTTP or database calls. Semantic conventions for these spans are
-defined in the specification at [Trace Semantic Conventions]({{< relref
-"/docs/reference/specification/trace/semantic_conventions" >}}). In the simple example
-of this guide the source code attributes can be used.
+defined in the specification at
+[Trace Semantic Conventions](/docs/specification/otel/trace/semantic_conventions/).
+In the simple example of this guide the source code attributes can be used.
 
 First add the semantic conventions as a dependency to your application:
 

--- a/content/en/docs/reference/_index.md
+++ b/content/en/docs/reference/_index.md
@@ -1,5 +1,0 @@
----
-title: Reference
-weight: 100
-description: Reference material like the OpenTelemetry Specification
----

--- a/content/en/docs/specification/_index.md
+++ b/content/en/docs/specification/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Specifications
 linkTitle: Specs
+aliases: [/docs/reference]
 weight: 100
 ---

--- a/content/en/docs/specification/_index.md
+++ b/content/en/docs/specification/_index.md
@@ -1,0 +1,5 @@
+---
+title: Specifications
+linkTitle: Specs
+weight: 100
+---

--- a/content/en/docs/specification/otel/status.md
+++ b/content/en/docs/specification/otel/status.md
@@ -27,7 +27,7 @@ ensure that they produce the same data when observing common operations, such as
 HTTP requests.
 
 To learn more about signals and components, see the specification
-[Overview]({{< relref "/docs/reference/specification/overview" >}}).
+[Overview](/docs/reference/specification/overview/).
 
 ## Component Lifecycle
 
@@ -41,9 +41,8 @@ Deprecated, Removed.
   support.
 - **Deprecated** components are stable but may eventually be removed.
 
-For complete definitions of lifecycles and long term support, see [Versioning
-and
-stability]({{< relref "/docs/reference/specification/versioning-and-stability" >}}).
+For complete definitions of lifecycles and long term support, see
+[Versioning and stability](/docs/reference/specification/versioning-and-stability/).
 
 ## Current Status
 

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -175,8 +175,8 @@ module:
       target: content
     - source: content-modules/opentelemetry-go/website_docs
       target: content/docs/instrumentation/go
-    - source: tmp/specification
-      target: content/docs/reference/specification
+    - source: tmp/otel/specification
+      target: content/docs/specification/otel
     - source: tmp/community/mission-vision-values.md
       target: content/community/mission.md
     - source: tmp/community/roadmap.md

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -22,6 +22,9 @@
 {{ end -}}
 {{ end -}}
 
+/docs/reference/specification    /docs/specification/otel
+/docs/reference/specification/*  /docs/specification/otel/:splat
+
 {{/*
   Social-media image redirects. As mentioned in
   https://developers.facebook.com/docs/sharing/webmasters/images, we need to

--- a/layouts/shortcodes/spec_status.html
+++ b/layouts/shortcodes/spec_status.html
@@ -2,7 +2,7 @@
 {{ $label := .Get 0 -}}
 {{ $pageRef := .Get 1 -}}
 {{ if not (hasPrefix $pageRef "/") -}}
-  {{ $pageRef = printf "/docs/reference/specification/%s" $pageRef -}}
+  {{ $pageRef = printf "/docs/specification/otel/%s" $pageRef -}}
 {{ end -}}
 {{ $page := .Site.GetPage $pageRef -}}
 {{ if not $page -}}
@@ -22,7 +22,7 @@
 
 {{ $status := "" -}}
 {{/* Valid statuses, as taken from:
-  - https://opentelemetry.io/docs/reference/specification/document-status/
+  - https://opentelemetry.io/docs/specification/otel/document-status/
   - https://github.com/open-telemetry/opentelemetry-proto#maturity-level
 */ -}}
 {{ $statusValueRE := "(?i:experimental|stable|deprecated|removed|mixed|feature.freeze|alpha|beta)" -}}

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -13,7 +13,7 @@ my $linkTitle = '';
 my $gD = 0;
 my $specRepoUrl = 'https://github.com/open-telemetry/opentelemetry-specification';
 my $semConvRef = "$specRepoUrl/blob/main/semantic_conventions/README.md";
-my $spec_base_path = '/docs/reference/specification';
+my $spec_base_path = '/docs/specification/otel';
 my $path_base_for_github_subdir = "content/en$spec_base_path";
 my %versions = qw(
   spec: 1.20.0
@@ -34,7 +34,9 @@ sub printTitleAndFrontMatter() {
   print "---\n";
   if ($title eq 'OpenTelemetry Specification') {
     $title .= " $spec_vers";
-    # Temporary adjustment to front matter until spec is updated:
+    # start:temporary adjustment to front matter until spec is updated:
+    $frontMatterFromFile =~ s/linkTitle: .*/linkTitle: OTel spec/;
+    # end:temporary adjustment
     $frontMatterFromFile =~ s/linkTitle: .*/$& $spec_vers/;
   }
   my $titleMaybeQuoted = ($title =~ ':') ? "\"$title\"" : $title;
@@ -87,6 +89,7 @@ while(<>) {
   s|\(https://github.com/open-telemetry/opentelemetry-specification\)|($spec_base_path/)|;
   s|(\]\()/specification/|$1$spec_base_path/)|;
   s|\.\./semantic_conventions/README.md|$semConvRef| if $ARGV =~ /overview/;
+  s|\.\./specification/(.*?\))|../otel/$1)|g if $ARGV =~ /otel\/specification/;
 
   if (/\((https:\/\/github.com\/open-telemetry\/opentelemetry-specification\/\w+\/\w+\/specification([^\)]*))\)/) {
     printf STDOUT "WARNING: link to spec page encoded as an external URL, but should be a local path, fix this upstream;\n  File: $ARGV \n  Link: $1\n";

--- a/scripts/content-modules/cp-pages.sh
+++ b/scripts/content-modules/cp-pages.sh
@@ -3,10 +3,10 @@
 SCRIPT_DIR="$(cd `dirname $0`; pwd)"
 DEST_BASE="$(cd $SCRIPT_DIR; cd ../../; pwd)/tmp"
 
-## Specification pages
+## OTel specification pages
 
 SRC=content-modules/opentelemetry-specification/specification
-DEST=$DEST_BASE/specification
+DEST=$DEST_BASE/otel/specification
 
 rm -Rf $DEST
 mkdir -p $DEST


### PR DESCRIPTION
- Prep for #2642
- Adds OTLP repo as a submodule under `content-modules/opentelemetry-proto`
  Note: the content is not yet displayed, this PR only adds the submodule
- Moves `/docs/reference/specification` to `/docs/specification/otel`
- Accordingly adjusts some links to refer to the new OTel spec home, but not all (I've temporarily added an ignore rule to the link checker config)

**Preview**:

- https://deploy-preview-2677--opentelemetry.netlify.app/docs/specification
- https://deploy-preview-2677--opentelemetry.netlify.app/docs/specification/otel/

**Redirect rule tests**:

- https://deploy-preview-2677--opentelemetry.netlify.app/docs/reference
- https://deploy-preview-2677--opentelemetry.netlify.app/docs/reference/specification
- https://deploy-preview-2677--opentelemetry.netlify.app/docs/reference/specification/overview