### PR TITLE
Revert "Don't use __name__ for tracers in python docs (#2519)"

### DIFF
--- a/content/en/docs/demo/services/recommendation.md
+++ b/content/en/docs/demo/services/recommendation.md
@@ -30,7 +30,7 @@ endpoints, resource attributes, and service name are automatically set by the
 OpenTelemetry auto instrumentor based on environment variables.
 
 ```python
-    tracer = trace.get_tracer_provider().get_tracer("recommendationservice")
+    tracer = trace.get_tracer_provider().get_tracer("app.system.recommendation")
 ```
 
 ### Add attributes to auto-instrumented spans
@@ -70,7 +70,7 @@ name are automatically set by the OpenTelemetry auto instrumentor based on
 environment variables.
 
 ```python
-    meter = metrics.get_meter_provider().get_meter("recommendationservice")
+    meter = metrics.get_meter_provider().get_meter("app.system.recommendation")
 ```
 
 ### Custom metrics

--- a/content/en/docs/instrumentation/python/cookbook.md
+++ b/content/en/docs/instrumentation/python/cookbook.md
@@ -10,7 +10,7 @@ This page is a cookbook for common scenarios.
 ```python
 from opentelemetry import trace
 
-tracer = trace.get_tracer("my.tracer")
+tracer = trace.get_tracer(__name__)
 with tracer.start_as_current_span("print") as span:
     print("foo")
     span.set_attribute("printed_string", "foo")
@@ -31,7 +31,7 @@ current_span.set_attribute("hometown", "seattle")
 from opentelemetry import trace
 import time
 
-tracer = trace.get_tracer("my.tracer")
+tracer = trace.get_tracer(__name__)
 
 # Create a new span to track some work
 with tracer.start_as_current_span("parent"):
@@ -53,7 +53,7 @@ with tracer.start_as_current_span("parent"):
 ```python
 from opentelemetry import trace, baggage
 
-tracer = trace.get_tracer("my.tracer")
+tracer = trace.get_tracer(__name__)
 with tracer.start_as_current_span(name="root span") as root_span:
     parent_ctx = baggage.set_baggage("context", "parent")
     with tracer.start_as_current_span(
@@ -82,7 +82,7 @@ from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapProp
 trace.set_tracer_provider(TracerProvider())
 trace.get_tracer_provider().add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
 
-tracer = trace.get_tracer("my.tracer")
+tracer = trace.get_tracer(__name__)
 
 # A TextMapPropagator works with any dict-like object as its Carrier by default. You can also implement custom getters and setters.
 with tracer.start_as_current_span('first-trace'):
@@ -140,7 +140,7 @@ trace.set_tracer_provider(
 )
 trace.get_tracer_provider().add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
 
-tracer = trace.get_tracer("tracer.one")
+tracer = trace.get_tracer(__name__)
 with tracer.start_as_current_span("some-name") as span:
     span.set_attribute("key", "value")
 
@@ -151,7 +151,7 @@ another_tracer_provider = TracerProvider(
 )
 another_tracer_provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
 
-another_tracer = trace.get_tracer("tracer.two", tracer_provider=another_tracer_provider)
+another_tracer = trace.get_tracer(__name__, tracer_provider=another_tracer_provider)
 with another_tracer.start_as_current_span("name-here") as span:
     span.set_attribute("another-key", "another-value")
 ```

--- a/content/en/docs/instrumentation/python/distro.md
+++ b/content/en/docs/instrumentation/python/distro.md
@@ -67,8 +67,8 @@ The following code will create a span with no configuration.
 # no_configuration.py
 from opentelemetry import trace
 
-with trace.get_tracer("my.tracer").start_as_current_span("foo"):
-    with trace.get_tracer("my.tracer").start_as_current_span("bar"):
+with trace.get_tracer(__name__).start_as_current_span("foo"):
+    with trace.get_tracer(__name__).start_as_current_span("bar"):
         print("baz")
 ```
 

--- a/content/en/docs/instrumentation/python/getting-started.md
+++ b/content/en/docs/instrumentation/python/getting-started.md
@@ -277,7 +277,7 @@ from random import randint
 from flask import Flask, request
 
 # Acquire a tracer
-tracer = trace.get_tracer("diceroller.tracer")
+tracer = trace.get_tracer(__name__)
 
 app = Flask(__name__)
 
@@ -402,9 +402,9 @@ from opentelemetry import metrics
 from random import randint
 from flask import Flask, request
 
-tracer = trace.get_tracer("diceroller.tracer")
+tracer = trace.get_tracer(__name__)
 # Acquire a meter.
-meter = metrics.get_meter(diceroller.meter)
+meter = metrics.get_meter(__name__)
 
 # Now create a counter instrument to make measurements with
 roll_counter = meter.create_counter(

--- a/content/en/docs/instrumentation/python/manual.md
+++ b/content/en/docs/instrumentation/python/manual.md
@@ -36,7 +36,7 @@ provider.add_span_processor(processor)
 trace.set_tracer_provider(provider)
 
 # Creates a tracer from the global tracer provider
-tracer = trace.get_tracer("my.tracer.name")
+tracer = trace.get_tracer(__name__)
 ```
 
 To start collecting metrics, you'll need to initialize a
@@ -58,7 +58,7 @@ provider = MeterProvider(metric_readers=[metric_reader])
 metrics.set_meter_provider(provider)
 
 # Creates a meter from the global meter provider
-meter = metrics.get_meter("my.meter.name")
+meter = metrics.get_meter(__name__)
 ```
 
 ## Tracing


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry.io/issues/2517

- There is a dedicated `service.name` resource attribute semantic convention for the service name. The tracer/meter name is used for the scope. It could be seen as a system -> subsystem -> module, and the user decides which is appropriate for them.
- tracer and meter wouldn't have different names within the same scope.