### PR TITLE
Docs: fix getting started with Python example

### DIFF
--- a/content/en/docs/instrumentation/python/getting-started.md
+++ b/content/en/docs/instrumentation/python/getting-started.md
@@ -404,7 +404,7 @@ from flask import Flask, request
 
 tracer = trace.get_tracer("diceroller.tracer")
 # Acquire a meter.
-meter = metrics.get_meter(diceroller.meter)
+meter = metrics.get_meter("diceroller.meter")
 
 # Now create a counter instrument to make measurements with
 roll_counter = meter.create_counter(


### PR DESCRIPTION
Issue number: #2687 

Changes:
Added double quotes to make sure that example will work.