### PR TITLE
Fix OTel spec links to page source

### DIFF
--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -11,42 +11,39 @@ my $frontMatterFromFile = '';
 my $title = '';
 my $linkTitle = '';
 my $gD = 0;
-my $specRepoUrl = 'https://github.com/open-telemetry/opentelemetry-specification';
-my $semConvRef = "$specRepoUrl/blob/main/semantic_conventions/README.md";
-my $spec_base_path = '/docs/specification/otel';
-my $path_base_for_github_subdir = "content/en$spec_base_path";
+my $otelSpecRepoUrl = 'https://github.com/open-telemetry/opentelemetry-specification';
+my $otlpSpecRepoUrl = 'https://github.com/open-telemetry/opentelemetry-proto';
+my $semConvRef = "$otelSpecRepoUrl/blob/main/semantic_conventions/README.md";
+my $specBasePath = '/docs/specification';
+my $path_base_for_github_subdir = "content/en$specBasePath";
 my %versions = qw(
   spec: 1.20.0
+  otlp: main
 );
-my $spec_vers = $versions{'spec:'};
-
-my $rootFrontMatterExtra = <<"EOS";
-no_list: true
-cascade:
-  body_class: otel-docs-spec
-  github_repo: &repo $specRepoUrl
-  github_subdir: specification
-  path_base_for_github_subdir: $path_base_for_github_subdir/
-  github_project_repo: *repo
-EOS
+my $otelSpecVers = $versions{'spec:'};
+my $otlpSpecVers = $versions{'otlp:'};
 
 sub printTitleAndFrontMatter() {
   print "---\n";
   if ($title eq 'OpenTelemetry Specification') {
-    $title .= " $spec_vers";
+    $title .= " $otelSpecVers";
     # start:temporary adjustment to front matter until spec is updated:
     $frontMatterFromFile =~ s/linkTitle: .*/linkTitle: OTel spec/;
     # end:temporary adjustment
-    $frontMatterFromFile =~ s/linkTitle: .*/$& $spec_vers/;
+    $frontMatterFromFile =~ s/linkTitle: .*/$& $otelSpecVers/;
+  } elsif ( $title eq 'OpenTelemetry Protocol' ) {
+    # $frontMatterFromFile = "linkTitle: OTLP\n";
   }
   my $titleMaybeQuoted = ($title =~ ':') ? "\"$title\"" : $title;
   print "title: $titleMaybeQuoted\n";
   ($linkTitle) = $title =~ /^OpenTelemetry (.*)/;
   print "linkTitle: $linkTitle\n" if $linkTitle and $frontMatterFromFile !~ /linkTitle: /;
+  # Temporary adjustment until OTel spec is updated:
+  $frontMatterFromFile =~ s|(path_base_for_github_subdir: content/en/docs)/reference/specification/|$1/specification/otel/|;
   print "$frontMatterFromFile" if $frontMatterFromFile;
-  if ($ARGV =~ /specification.(.*?)_index.md$/) {
+  if ($ARGV =~ /otel\/specification\/(.*?)_index.md$/) {
     print "path_base_for_github_subdir:\n";
-    print "  from: $path_base_for_github_subdir/$1_index.md\n";
+    print "  from: $path_base_for_github_subdir/otel/$1_index.md\n";
     print "  to: $1README.md\n";
   }
   print "---\n";
@@ -86,15 +83,15 @@ while(<>) {
 
   # SPECIFICATION custom processing
 
-  s|\(https://github.com/open-telemetry/opentelemetry-specification\)|($spec_base_path/)|;
-  s|(\]\()/specification/|$1$spec_base_path/)|;
+  s|\(https://github.com/open-telemetry/opentelemetry-specification\)|($specBasePath/otel/)|;
+  s|(\]\()/specification/|$1$specBasePath/otel/)|;
   s|\.\./semantic_conventions/README.md|$semConvRef| if $ARGV =~ /overview/;
   s|\.\./specification/(.*?\))|../otel/$1)|g if $ARGV =~ /otel\/specification/;
 
   if (/\((https:\/\/github.com\/open-telemetry\/opentelemetry-specification\/\w+\/\w+\/specification([^\)]*))\)/) {
     printf STDOUT "WARNING: link to spec page encoded as an external URL, but should be a local path, fix this upstream;\n  File: $ARGV \n  Link: $1\n";
   }
-  s|\(https://github.com/open-telemetry/opentelemetry-specification/\w+/\w+/specification([^\)]*)\)|($spec_base_path$1)|;
+  s|\(https://github.com/open-telemetry/opentelemetry-specification/\w+/\w+/specification([^\)]*)\)|($specBasePath/otel$1)|;
 
   # Images
   s|(\.\./)?internal(/img/[-\w]+\.png)|$2|g;
@@ -106,8 +103,12 @@ while(<>) {
   s|(/semantic_conventions/faas.md)#function-as-a-service|$1|g;
   s|(/resource/sdk.md)#resource-sdk|$1|g;
 
-  s|\.\.\/README.md\b|$specRepoUrl/|g if $ARGV =~ /specification._index/;
+  s|\.\.\/README.md\b|$otelSpecRepoUrl/|g if $ARGV =~ /specification._index/;
   s|\.\.\/README.md\b|..| if $ARGV =~ /specification.library-guidelines.md/;
+
+  s|\.\.\/(opentelemetry/proto/?.*)|$otlpSpecRepoUrl/tree/$otlpSpecVers/$1/|g if $ARGV =~ /\/tmp\/otlp/;
+  s|\.\.\/README.md\b|$otlpSpecRepoUrl/|g if $ARGV =~ /\/tmp\/otlp/;
+
   s|\bREADME.md\b|_index.md|g;
 
   # Rewrite paths into experimental directory as external links

--- a/scripts/content-modules/cp-pages.sh
+++ b/scripts/content-modules/cp-pages.sh
@@ -3,7 +3,7 @@
 SCRIPT_DIR="$(cd `dirname $0`; pwd)"
 DEST_BASE="$(cd $SCRIPT_DIR; cd ../../; pwd)/tmp"
 
-## OTel specification pages
+## OTel specification
 
 SRC=content-modules/opentelemetry-specification/specification
 DEST=$DEST_BASE/otel/specification
@@ -19,9 +19,36 @@ FILES=$(find $DEST -name "*.md")
 
 $SCRIPT_DIR/adjust-pages.pl $FILES
 
-echo "Specification pages copied and processed."
+echo "OTEL SPEC pages copied and processed."
 
-## Community pages
+## OTLP specification
+
+SRC=content-modules/opentelemetry-proto/specification
+DEST=$DEST_BASE/otlp/specification
+
+rm -Rf $DEST
+mkdir -p $DEST
+cp -R $SRC/* $DEST/
+
+find $DEST/ -name "README.md" -exec sh -c 'f="{}"; mv -- "$f" "${f%README.md}_index.md"' \;
+
+# To exclude a file use, e.g.: -not -path '*/specification/_index.md'
+FILES=$(find $DEST -name "*.md")
+
+$SCRIPT_DIR/adjust-pages.pl $FILES
+
+echo "OTLP SPEC pages copied and processed."
+
+# SRC=content-modules/opentelemetry-proto/opentelemetry
+# DEST=$DEST_BASE/otlp/opentelemetry
+
+# rm -Rf $DEST
+# mkdir -p $DEST
+# cp -R $SRC/* $DEST/
+
+# echo "OTLP SPEC protos copied and processed."
+
+## Community
 
 SRC=content-modules/community
 DEST=$DEST_BASE/community
@@ -37,4 +64,4 @@ FILES=$(find $DEST -name mission-vision-values.md -o -name roadmap.md)
 
 $SCRIPT_DIR/adjust-pages.pl $FILES
 
-echo "Community pages copied and processed."
+echo "COMMUNITY pages copied and processed."


### PR DESCRIPTION
Some spec page links to GitHub page source were broken by #2677. This fixes those links and brings in a bit more code in prep for hosting the OTLP spec pages.

This PR impacts only the OTel spec pages and only the GH link URLs.

```console
$ cd public
$ g diff | grep ^diff | grep -v 'docs/spec' # only spec pages are affected
$ g diff | grep ^diff | wc -l                                   
      96
$ g diff | grep ^diff | grep -E '^diff.*index.html$' | wc -l    # only index pages are affected
      96
$ g diff -I 'View page source|Edit this page| Create child page' # only the GH links are affected
$
```

Contributes to:

- #2642

/cc @tigrannajaryan 