### PR TITLE
Fixing CLI command for docker-compose in docker deployment Docs

### DIFF
--- a/content/en/docs/demo/docker-deployment.md
+++ b/content/en/docs/demo/docker-deployment.md
@@ -28,7 +28,7 @@ aliases: [/docs/demo/docker_deployment]
 3.  Run docker compose to start the demo:
 
     ```shell
-    docker compose up --no-build
+    docker-compose up --no-build
     ```
 
     > **Notes:**
@@ -94,5 +94,5 @@ different exporters, you may find them and their documentation available at
 [opentelemetry-collector-contrib/exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter).
 
 After updating the `otelcol-config-extras.yml`, start the demo by running
-`docker compose up`. After a while, you should see the traces flowing into your
+`docker-compose up`. After a while, you should see the traces flowing into your
 backend as well.


### PR DESCRIPTION
The shell command for docker-compose on linux / windows is one word with a hyphen tweaking the example to work without modifications

Not sure if there is a particular branch or tag to give for documentation updates but it is a 2 character fix so I don't want to overthink it.