### PR TITLE
Spec: link to supplementary guidelines in repo, update refcache and more

### DIFF
--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -112,8 +112,9 @@ while(<>) {
 
   s|\bREADME.md\b|_index.md|g;
 
-  # Rewrite paths into experimental directory as external links
-  s|(\.\.\/)+(experimental\/[^)]+)|https://github.com/open-telemetry/opentelemetry-specification/tree/main/$1|g;
+  # Rewrite paths that are outside of the main spec folder as external links
+  s|(\.\.\/)+(experimental\/[^)]+)|$otelSpecRepoUrl/tree/$otelSpecVers/$2|g;
+  s|(\.\.\/)+(supplementary-guidelines\/compatibility\/[^)]+)|$otelSpecRepoUrl/tree/$otelSpecVers/$2|g;
 
   # Rewrite inline links
   s|\]\(([^:\)]*?\.md(#.*?)?)\)|]({{% relref "$1" %}})|g;

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -23,6 +23,10 @@
     "StatusCode": 206,
     "LastSeen": "2023-02-15T21:09:05.748522-05:00"
   },
+  "http://github.com/open-telemetry/semantic-conventions": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:55:17.780686-04:00"
+  },
   "http://mypy-lang.org/": {
     "StatusCode": 206,
     "LastSeen": "2023-02-16T17:15:20.756374-05:00"
@@ -315,6 +319,14 @@
     "StatusCode": 200,
     "LastSeen": "2023-02-15T20:39:04.971548-05:00"
   },
+  "https://cloud.google.com/run/docs/container-contract#jobs-env-vars": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:58:51.977416-04:00"
+  },
+  "https://cloud.google.com/run/docs/managing/job-executions": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:58:46.213279-04:00"
+  },
   "https://cloud.google.com/run/docs/managing/revisions": {
     "StatusCode": 200,
     "LastSeen": "2023-02-15T20:39:40.667513-05:00"
@@ -443,6 +455,10 @@
     "StatusCode": 206,
     "LastSeen": "2023-02-15T21:13:29.941423-05:00"
   },
+  "https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.1": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:58:32.732504-04:00"
+  },
   "https://datatracker.ietf.org/doc/html/rfc7230#section-2.7.1": {
     "StatusCode": 200,
     "LastSeen": "2023-02-15T21:09:50.310882-05:00"
@@ -498,6 +514,10 @@
   "https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/": {
     "StatusCode": 206,
     "LastSeen": "2023-02-15T21:04:42.891544-05:00"
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded": {
+    "StatusCode": 206,
+    "LastSeen": "2023-05-15T13:58:02.84789-04:00"
   },
   "https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For": {
     "StatusCode": 206,
@@ -943,6 +963,18 @@
     "StatusCode": 200,
     "LastSeen": "2023-02-15T21:06:02.416793-05:00"
   },
+  "https://docs.oracle.com/en/java/javase/17/docs/api/jdk.management/com/sun/management/OperatingSystemMXBean.html#getCpuLoad%28%29": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:56:47.596682-04:00"
+  },
+  "https://docs.oracle.com/en/java/javase/17/docs/api/jdk.management/com/sun/management/OperatingSystemMXBean.html#getProcessCpuLoad%28%29": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:56:30.762393-04:00"
+  },
+  "https://docs.oracle.com/en/java/javase/17/docs/api/jdk.management/com/sun/management/OperatingSystemMXBean.html#getSystemCpuLoad%28%29": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:56:42.21615-04:00"
+  },
   "https://docs.oracle.com/javase/7/docs/api/java/lang/Throwable.html#printStackTrace%28%29": {
     "StatusCode": 200,
     "LastSeen": "2023-02-15T21:08:06.175077-05:00"
@@ -955,6 +987,54 @@
     "StatusCode": 200,
     "LastSeen": "2023-02-15T21:05:27.201201-05:00"
   },
+  "https://docs.oracle.com/javase/8/docs/api/java/lang/management/BufferPoolMXBean.html#getCount--": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:57:14.880125-04:00"
+  },
+  "https://docs.oracle.com/javase/8/docs/api/java/lang/management/BufferPoolMXBean.html#getMemoryUsed--": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:57:03.887248-04:00"
+  },
+  "https://docs.oracle.com/javase/8/docs/api/java/lang/management/BufferPoolMXBean.html#getTotalCapacity--": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:57:09.298646-04:00"
+  },
+  "https://docs.oracle.com/javase/8/docs/api/java/lang/management/ClassLoadingMXBean.html#getLoadedClassCount--": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:56:25.355665-04:00"
+  },
+  "https://docs.oracle.com/javase/8/docs/api/java/lang/management/ClassLoadingMXBean.html#getTotalLoadedClassCount--": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:56:14.545008-04:00"
+  },
+  "https://docs.oracle.com/javase/8/docs/api/java/lang/management/ClassLoadingMXBean.html#getUnloadedClassCount--": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:56:19.961265-04:00"
+  },
+  "https://docs.oracle.com/javase/8/docs/api/java/lang/management/GarbageCollectorMXBean.html": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:55:51.648587-04:00"
+  },
+  "https://docs.oracle.com/javase/8/docs/api/java/lang/management/MemoryPoolMXBean.html#getCollectionUsage--": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:55:40.687863-04:00"
+  },
+  "https://docs.oracle.com/javase/8/docs/api/java/lang/management/MemoryPoolMXBean.html#getUsage--": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:55:35.246976-04:00"
+  },
+  "https://docs.oracle.com/javase/8/docs/api/java/lang/management/OperatingSystemMXBean.html#getSystemLoadAverage--": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:56:58.440619-04:00"
+  },
+  "https://docs.oracle.com/javase/8/docs/api/java/lang/management/ThreadMXBean.html#getDaemonThreadCount--": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:56:03.660423-04:00"
+  },
+  "https://docs.oracle.com/javase/8/docs/api/java/lang/management/ThreadMXBean.html#getThreadCount--": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:56:09.060511-04:00"
+  },
   "https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html": {
     "StatusCode": 200,
     "LastSeen": "2023-02-15T21:05:04.694703-05:00"
@@ -962,6 +1042,14 @@
   "https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html": {
     "StatusCode": 200,
     "LastSeen": "2023-02-15T21:05:10.377544-05:00"
+  },
+  "https://docs.oracle.com/javase/8/docs/jre/api/management/extension/com/sun/management/GarbageCollectionNotificationInfo.html": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:55:46.183553-04:00"
+  },
+  "https://docs.oracle.com/javase/8/docs/jre/api/management/extension/com/sun/management/GcInfo.html#getDuration--": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:55:57.139861-04:00"
   },
   "https://docs.oracle.com/javase/8/docs/jre/api/net/httpserver/spec/com/sun/net/httpserver/HttpExchange.html": {
     "StatusCode": 200,
@@ -1174,6 +1262,10 @@
   "https://en.wikipedia.org/wiki/In-band_signaling": {
     "StatusCode": 200,
     "LastSeen": "2023-02-15T21:20:05.938917-05:00"
+  },
+  "https://en.wikipedia.org/wiki/Inter-process_communication": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:57:25.897409-04:00"
   },
   "https://en.wikipedia.org/wiki/JSON": {
     "StatusCode": 200,
@@ -1959,6 +2051,10 @@
     "StatusCode": 200,
     "LastSeen": "2023-02-20T08:14:38.263463-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-configuration": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:57:37.029913-04:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-cpp": {
     "StatusCode": 200,
     "LastSeen": "2023-02-20T07:45:10.175573-05:00"
@@ -2547,6 +2643,14 @@
     "StatusCode": 200,
     "LastSeen": "2023-03-30T22:09:47.191499-04:00"
   },
+  "https://github.com/open-telemetry/oteps/pull/225": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:57:49.752268-04:00"
+  },
+  "https://github.com/open-telemetry/semantic-conventions": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:58:20.569641-04:00"
+  },
   "https://github.com/opentelemetry-php/contrib-auto-psr15": {
     "StatusCode": 200,
     "LastSeen": "2023-02-20T07:44:32.187118-05:00"
@@ -2958,6 +3062,10 @@
   "https://joshuamlee.com/submitting-your-first-conference-talk/": {
     "StatusCode": 206,
     "LastSeen": "2023-02-16T17:09:33.386443-05:00"
+  },
+  "https://json-schema.org/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-05-15T13:57:42.563111-04:00"
   },
   "https://kafka.apache.org/": {
     "StatusCode": 206,
@@ -3398,6 +3506,18 @@
   "https://operatorhub.io/operator/opentelemetry-operator": {
     "StatusCode": 206,
     "LastSeen": "2023-02-16T17:45:10.013699-05:00"
+  },
+  "https://osi-model.com/application-layer/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-05-15T13:55:23.216154-04:00"
+  },
+  "https://osi-model.com/network-layer/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-05-15T13:57:31.282166-04:00"
+  },
+  "https://osi-model.com/transport-layer/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-05-15T13:57:20.475585-04:00"
   },
   "https://packagist.org/": {
     "StatusCode": 200,
@@ -4119,6 +4239,14 @@
     "StatusCode": 206,
     "LastSeen": "2023-02-18T13:38:12.987934-05:00"
   },
+  "https://www.ibm.com/docs/api/v1/content/SSYKE2_8.0.0/com.ibm.java.api.80.doc/com.ibm.lang.management/com/ibm/lang/management/OperatingSystemMXBean.html#getProcessCpuLoad--": {
+    "StatusCode": 206,
+    "LastSeen": "2023-05-15T13:56:36.701476-04:00"
+  },
+  "https://www.ibm.com/docs/api/v1/content/SSYKE2_8.0.0/com.ibm.java.api.80.doc/com.ibm.lang.management/com/ibm/lang/management/OperatingSystemMXBean.html#getSystemCpuLoad--": {
+    "StatusCode": 206,
+    "LastSeen": "2023-05-15T13:56:52.995519-04:00"
+  },
   "https://www.ibm.com/docs/en/ibm-mq/9.1": {
     "StatusCode": 206,
     "LastSeen": "2023-02-18T13:43:07.738636-05:00"
@@ -4134,6 +4262,10 @@
   "https://www.iso.org/iso-8601-date-and-time-format.html": {
     "StatusCode": 200,
     "LastSeen": "2023-02-18T13:40:27.898905-05:00"
+  },
+  "https://www.itu.int/ITU-T/studygroups/com17/oid.html": {
+    "StatusCode": 206,
+    "LastSeen": "2023-05-15T13:58:40.102533-04:00"
   },
   "https://www.jaegertracing.io/": {
     "StatusCode": 206,
@@ -4411,9 +4543,29 @@
     "StatusCode": 200,
     "LastSeen": "2023-02-18T13:40:39.41697-05:00"
   },
+  "https://www.rfc-editor.org/rfc/rfc3986": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:57:57.369817-04:00"
+  },
+  "https://www.rfc-editor.org/rfc/rfc3986#section-3.1": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:55:29.45078-04:00"
+  },
   "https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2": {
     "StatusCode": 200,
     "LastSeen": "2023-02-18T13:40:45.246566-05:00"
+  },
+  "https://www.rfc-editor.org/rfc/rfc3986#section-3.3": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:58:08.899345-04:00"
+  },
+  "https://www.rfc-editor.org/rfc/rfc3986#section-3.4": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:58:14.968637-04:00"
+  },
+  "https://www.rfc-editor.org/rfc/rfc3986#section-3.5": {
+    "StatusCode": 200,
+    "LastSeen": "2023-05-15T13:58:27.159768-04:00"
   },
   "https://www.rfc-editor.org/rfc/rfc9110.html": {
     "StatusCode": 200,


### PR DESCRIPTION
- Contributes to #2698
- Fixes rewrite rule for links into the `experimental` folder
- Rewrites links to top-level supplementary-guidelines as version-specific URL into spec repo
- Updates refcache, with entries necessary for processing the spec `@HEAD` since there are a lot of new entries
- No change in generated site files, other than the refcache