### PR TITLE
docs: Update legacy configs in configuration.md

### DIFF
--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -374,7 +374,7 @@ exporters:
 
   # Data sources: traces, metrics, logs
   logging:
-    loglevel: debug
+    verbosity: detailed
 
   # Data sources: traces, metrics
   opencensus:


### PR DESCRIPTION
Replace the deprecated
```yaml
exporters:
  logging:
    loglevel: debug
```

with

```yaml
exporters:
  logging:
    verbosity: detailed
```
