### PR TITLE
Add php to registry scanner

### DIFF
--- a/scripts/registry-scanner/index.mjs
+++ b/scripts/registry-scanner/index.mjs
@@ -59,6 +59,7 @@ if (process.argv.length < 3) {
         - java
         - js
         - dotnet
+	- php
     Use 'all' if you want to run all of them.
     
     Example: ${path.basename(process.argv[0])} ${path.basename(
@@ -131,6 +132,17 @@ const scanners = {
   },
   go: async () => {
     scanForGo();
+  },
+  php: async () => {
+    scanByLanguage(
+      'instrumentation',
+      'php',
+      'src/Instrumentation',
+      'md',
+      'opentelemetry-php-contrib',
+      () => true,
+      (name) => name.toLowerCase()
+    );
   },
   all: () => {
     scanners.collector();
@@ -266,10 +278,11 @@ async function createFilesFromScanResult(existing, found, settings) {
         parsedReadme.description
       );
       // collector entries are named reverse (collector-{registryTpe}) compared to languages ({registryTpe}-{language}), we fix this here.
-      const fileName =
+      const fileName = (
         language === 'collector'
           ? `${language}-${registryType}-${currentKey}.yml`
-          : `${registryType}-${language}-${currentKey}.yml`;
+          : `${registryType}-${language}-${currentKey}.yml`
+      ).toLowerCase();
       if (!ignoreList.includes(fileName)) {
         await fs.writeFile(fileName, yaml);
       }

--- a/scripts/registry-scanner/index.mjs
+++ b/scripts/registry-scanner/index.mjs
@@ -59,7 +59,7 @@ if (process.argv.length < 3) {
         - java
         - js
         - dotnet
-	      - php
+        - php
         - go
     Use 'all' if you want to run all of them (except go).
     

--- a/scripts/registry-scanner/index.mjs
+++ b/scripts/registry-scanner/index.mjs
@@ -59,8 +59,9 @@ if (process.argv.length < 3) {
         - java
         - js
         - dotnet
-	- php
-    Use 'all' if you want to run all of them.
+	      - php
+        - go
+    Use 'all' if you want to run all of them (except go).
     
     Example: ${path.basename(process.argv[0])} ${path.basename(
       process.argv[1]
@@ -152,6 +153,7 @@ const scanners = {
     scanners.erlang();
     scanners.python();
     scanners.dotnet();
+    scanners.php();
   },
 };
 


### PR DESCRIPTION
Add scanner capabilities for php contrib repo, cc @open-telemetry/php-approvers, see https://github.com/open-telemetry/opentelemetry.io/pull/2756 for results (+ some manual intervention) 