### PR TITLE
Added Dataset collector exporter to the registry

### DIFF
--- a/data/registry/collector-exporter-dataset.yml
+++ b/data/registry/collector-exporter-dataset.yml
@@ -1,0 +1,13 @@
+title: Dataset Collector Exporter
+registryType: exporter
+isThirdParty: true
+language: collector
+tags:
+  - go
+  - exporter
+  - collector
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datasetexporter
+license: Apache 2.0
+description: The Dataset Exporter for the OpenTelemetry Collector.
+authors: Dataset
+otVersion: latest


### PR DESCRIPTION
In this PR - https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/22154 - I have added the final PR.

Based on the instructions here - https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md - I would like to ask you for adding this component to the registry.
 