### PR TITLE
Fix #2717: Replace docker-compose with docker compose

### DIFF
--- a/content/en/blog/2022/apisix/index.md
+++ b/content/en/blog/2022/apisix/index.md
@@ -192,7 +192,7 @@ resulting in a call chain consisting of two spans.
 
 ### Step 1: Deploy OpenTelemetry
 
-The following uses docker-compose as an example. For other deployments, see
+The following uses `docker compose` as an example. For other deployments, see
 [Getting Started](/docs/collector/getting-started/).
 
 You can see the following command to deploy:
@@ -200,7 +200,7 @@ You can see the following command to deploy:
 ```shell
 git clone https://github.com/open-telemetry/opentelemetry-collector-contrib.git
 cd opentelemetry-collector-contrib/examples/demo
-docker-compose up -d
+docker compose up -d
 ```
 
 Visit <http://127.0.0.1:16886> (Jaeger UI) or <http://127.0.0.1:9411/zipkin>

--- a/content/en/blog/2022/apisix/index.md
+++ b/content/en/blog/2022/apisix/index.md
@@ -195,7 +195,7 @@ resulting in a call chain consisting of two spans.
 The following uses `docker compose` as an example. For other deployments, see
 [Getting Started](/docs/collector/getting-started/).
 
-You can see the following command to deploy:
+You can see the following command to deploy[^1]:
 
 ```shell
 git clone https://github.com/open-telemetry/opentelemetry-collector-contrib.git
@@ -393,5 +393,9 @@ communicate via the
 [mailing list](https://apisix.apache.org/docs/general/join/#subscribe-to-the-mailing-list).
 
 _A version of this article was [originally posted][] on the Apache APISIX blog._
+
+[^1]:
+    Please note that `docker-compose` is deprecated and you should
+    [migrate to Compose V2](https://docs.docker.com/compose/migrate/)
 
 [originally posted]: {{% param canonical_url %}}

--- a/content/en/blog/2022/debug-otel-with-otel/index.md
+++ b/content/en/blog/2022/debug-otel-with-otel/index.md
@@ -139,8 +139,8 @@ services:
       - OTEL_SERVICE_NAME=frontend
 ```
 
-Spin up that environment by running `docker compose up` and send some requests
-to the frontend with `curl localhost:8000`
+Spin up that environment by running `docker compose up`[^1] and send some
+requests to the frontend with `curl localhost:8000`
 
 ### What did you expect to see?
 
@@ -201,7 +201,7 @@ backend:
     - OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST=tracestate,traceparent,baggage,X-B3-TraceId
 ```
 
-Once again we ran `docker compose up` to bring up our sample app and we send
+Once again we ran `docker compose up`[^1] to bring up our sample app and we send
 some request with `curl localhost:8080` to the frontend application.
 
 In Jaeger we still see that the traces are disconnected. However, when we look
@@ -246,6 +246,10 @@ RUN echo "load_module /opt/opentelemetry-webserver-sdk/WebServerModule/Nginx/ngx
 COPY default.conf /etc/nginx/conf.d
 COPY opentelemetry_module.conf /etc/nginx/conf.d
 ```
+
+[^1]:
+    Please note that `docker-compose` is deprecated and you should
+    [migrate to Compose V2](https://docs.docker.com/compose/migrate/)
 
 [learn how to instrument nginx with opentelemetry]: /blog/2022/instrument-nginx/
 [put nginx between two services]:

--- a/content/en/blog/2022/debug-otel-with-otel/index.md
+++ b/content/en/blog/2022/debug-otel-with-otel/index.md
@@ -139,7 +139,7 @@ services:
       - OTEL_SERVICE_NAME=frontend
 ```
 
-Spin up that environment by running `docker-compose up` and send some requests
+Spin up that environment by running `docker compose up` and send some requests
 to the frontend with `curl localhost:8000`
 
 ### What did you expect to see?
@@ -201,7 +201,7 @@ backend:
     - OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST=tracestate,traceparent,baggage,X-B3-TraceId
 ```
 
-Once again we ran `docker-compose up` to bring up our sample app and we send
+Once again we ran `docker compose up` to bring up our sample app and we send
 some request with `curl localhost:8080` to the frontend application.
 
 In Jaeger we still see that the traces are disconnected. However, when we look

--- a/content/en/blog/2022/demo-announcement/index.md
+++ b/content/en/blog/2022/demo-announcement/index.md
@@ -15,7 +15,7 @@ scenarios will be documented for each signal, with fault injection, and more!
 
 If you want to skip the details then clone our
 [repo](https://github.com/open-telemetry/opentelemetry-demo) then run
-`docker compose up` from the command line. There are a couple
+`docker compose up`[^1] from the command line. There are a couple
 [technology requirements](https://github.com/open-telemetry/opentelemetry-demo-webstore#local-quickstart)
 so be sure to check those out too.
 
@@ -156,3 +156,7 @@ from there.
 
 - [Demo Requirements](/docs/demo/requirements/)
 - [Get Involved](https://github.com/open-telemetry/opentelemetry-demo#contributing)
+
+[^1]:
+    Please note that `docker-compose` is deprecated and you should
+    [migrate to Compose V2](https://docs.docker.com/compose/migrate/)

--- a/content/en/blog/2022/instrument-apache-httpd-server/index.md
+++ b/content/en/blog/2022/instrument-apache-httpd-server/index.md
@@ -22,7 +22,7 @@ the module.
 
 Getting started with the OpenTelemetry module for apache httpd is pretty simple,
 all you need is a docker engine and git. Download the source code from github
-and then build the docker image on CentOS7:
+and then build the docker image on CentOS7[^1]:
 
 ```sh
 git clone https://github.com/open-telemetry/opentelemetry-cpp-contrib
@@ -36,7 +36,7 @@ module for Apache and installs the same on the docker image.
 **Note**: The above commands might take around 1 hour to complete.
 
 When the build is finished, run the docker image, by typing the following
-command:
+command[^1]:
 
 ```sh
 docker compose --profile centos7 up -d
@@ -152,7 +152,7 @@ the package and install on the target system where apache is installed.
   cd  opentelemetry-cpp-contrib/instrumentation/otel-webserver-module
   ```
 
-- Trigger the build command to generate the package inside the docker image
+- Trigger the build command to generate the package inside the docker image[^1]
 
   ```sh
   docker compose --profile centos7 build
@@ -251,6 +251,10 @@ writing this blog, support for other architectures is not provided.
 
 - Now, restart the apache module and OpenTelemetry module should be
   instrumented.
+
+[^1]:
+    Please note that `docker-compose` is deprecated and you should
+    [migrate to Compose V2](https://docs.docker.com/compose/migrate/)
 
 [docker-compose.yml]:
   https://github.com/open-telemetry/opentelemetry-cpp-contrib/blob/main/instrumentation/otel-webserver-module/docker-compose.yml

--- a/content/en/blog/2022/instrument-apache-httpd-server/index.md
+++ b/content/en/blog/2022/instrument-apache-httpd-server/index.md
@@ -27,7 +27,7 @@ and then build the docker image on CentOS7:
 ```sh
 git clone https://github.com/open-telemetry/opentelemetry-cpp-contrib
 cd  instrumentation/otel-webserver-module
-docker-compose --profile centos7 build
+docker compose --profile centos7 build
 ```
 
 These commands download all required dependencies, builds the OpenTelemetry
@@ -39,7 +39,7 @@ When the build is finished, run the docker image, by typing the following
 command:
 
 ```sh
-docker-compose --profile centos7 up -d
+docker compose --profile centos7 up -d
 ```
 
 The above command starts up the centos7 image in a docker container named
@@ -155,7 +155,7 @@ the package and install on the target system where apache is installed.
 - Trigger the build command to generate the package inside the docker image
 
   ```sh
-  docker-compose --profile centos7 build
+  docker compose --profile centos7 build
   ```
 
 The above might take around an hour to build. This would build on Centos 7 image

--- a/content/en/blog/2022/instrument-nginx/index.md
+++ b/content/en/blog/2022/instrument-nginx/index.md
@@ -165,7 +165,7 @@ You don't need to rebuild your docker image, because the `docker-compose.yaml`
 above loads the `opentelemetry_module.conf` as a file volume on container
 startup.
 
-Get everything up and running:
+Get everything up and running[^1]:
 
 ```console
 $ docker compose up
@@ -329,7 +329,7 @@ You should now have the following files in your top level directory:
 - ./frontend/Dockerfile
 - ./frontend/app.js
 
-With everything in place, you can now start the demo environment:
+With everything in place, you can now start the demo environment[^1]:
 
 ```console
 $ docker compose up
@@ -357,6 +357,10 @@ The frontend trace should indicate an error, since nginx is forwarding the
 You should now be able to apply what you have learned from this blog post to
 your own installation of nginx. We would love to hear about your experience! If
 you run into any problems, [create an issue][].
+
+[^1]:
+    Please note that `docker-compose` is deprecated and you should
+    [migrate to Compose V2](https://docs.docker.com/compose/migrate/)
 
 [create an issue]:
   https://github.com/open-telemetry/opentelemetry-cpp-contrib/issues

--- a/content/en/blog/2022/instrument-nginx/index.md
+++ b/content/en/blog/2022/instrument-nginx/index.md
@@ -168,7 +168,7 @@ startup.
 Get everything up and running:
 
 ```console
-$ docker-compose up
+$ docker compose up
 ```
 
 In another shell, create some traffic:
@@ -332,7 +332,7 @@ You should now have the following files in your top level directory:
 With everything in place, you can now start the demo environment:
 
 ```console
-$ docker-compose up
+$ docker compose up
 ```
 
 Within a few moments you should have five docker containers up and running:

--- a/content/en/blog/2023/end-user-q-and-a-02.md
+++ b/content/en/blog/2023/end-user-q-and-a-02.md
@@ -245,7 +245,7 @@ World” program to send data to the Collector, and nothing is showing up, and
 need some guidance around this. How do we help folks who aren’t super familiar
 with Docker and aren’t super familiar with OpenTelemetry? Can we have some super
 simple reference implementations to hold folks’ hands as they get started? For
-example, for a Ruby developer, clone X repo, run `docker compose up`, and
+example, for a Ruby developer, clone X repo, run `docker compose up`[^1], and
 everything should be up and running. That way, they can focus on learning
 OpenTelemetry, rather than mess around with Docker networking and other
 distracting things.
@@ -285,6 +285,10 @@ that we can continue to improve OpenTelemetry. ❣️
 
 If you have a story to share about how you use OpenTelemetry at your
 organization, we’d love to hear from you! Ways to share:
+
+[^1]:
+    Please note that `docker-compose` is deprecated and you should
+    [migrate to Compose V2](https://docs.docker.com/compose/migrate/)
 
 - Join the [#otel-endusers channel](/community/end-user/slack-channel/) on the
   [CNCF Community Slack](https://communityinviter.com/apps/cloud-native/cncf)

--- a/content/en/blog/2023/end-user-q-and-a-02.md
+++ b/content/en/blog/2023/end-user-q-and-a-02.md
@@ -245,7 +245,7 @@ World” program to send data to the Collector, and nothing is showing up, and
 need some guidance around this. How do we help folks who aren’t super familiar
 with Docker and aren’t super familiar with OpenTelemetry? Can we have some super
 simple reference implementations to hold folks’ hands as they get started? For
-example, for a Ruby developer, clone X repo, run `docker-compose up`, and
+example, for a Ruby developer, clone X repo, run `docker compose up`, and
 everything should be up and running. That way, they can focus on learning
 OpenTelemetry, rather than mess around with Docker networking and other
 distracting things.

--- a/content/en/docs/collector/getting-started.md
+++ b/content/en/docs/collector/getting-started.md
@@ -18,7 +18,7 @@ Prometheus back-ends. More information can be found on the demo [README.md][].
 ```sh
 git clone git@github.com:open-telemetry/opentelemetry-collector-contrib.git --depth 1; \
   cd opentelemetry-collector-contrib/examples/demo; \
-  docker-compose up -d
+  docker compose up -d
 ```
 
 ## Docker

--- a/content/en/docs/collector/getting-started.md
+++ b/content/en/docs/collector/getting-started.md
@@ -21,6 +21,9 @@ git clone git@github.com:open-telemetry/opentelemetry-collector-contrib.git --de
   docker compose up -d
 ```
 
+**Note**: `docker-compose` is deprecated and you should
+[migrate to Compose V2](https://docs.docker.com/compose/migrate/)
+
 ## Docker
 
 Pull a docker image and run the collector in a container. Replace

--- a/content/en/docs/demo/docker-deployment.md
+++ b/content/en/docs/demo/docker-deployment.md
@@ -25,7 +25,7 @@ aliases: [/docs/demo/docker_deployment]
     cd opentelemetry-demo/
     ```
 
-3.  Run docker compose to start the demo:
+3.  Run docker compose[^1] to start the demo:
 
     ```shell
     docker compose up --no-build
@@ -38,8 +38,8 @@ aliases: [/docs/demo/docker_deployment]
     >   source. Removing the `--no-build` command line option will rebuild all
     >   images from source. It may take more than 20 minutes to build if the
     >   flag is omitted.
-    > - If you're running on Apple Silicon, run `docker compose build` in order
-    >   to create local images vs. pulling them from the repository.
+    > - If you're running on Apple Silicon, run `docker compose build`[^1] in
+    >   order to create local images vs. pulling them from the repository.
 
 ## Verify the Webstore and Telemetry
 
@@ -94,5 +94,9 @@ different exporters, you may find them and their documentation available at
 [opentelemetry-collector-contrib/exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter).
 
 After updating the `otelcol-config-extras.yml`, start the demo by running
-`docker compose up`. After a while, you should see the traces flowing into your
-backend as well.
+`docker compose up`[^1]. After a while, you should see the traces flowing into
+your backend as well.
+
+[^1]:
+    Please note that `docker-compose` is deprecated and you should
+    [migrate to Compose V2](https://docs.docker.com/compose/migrate/)

--- a/content/en/docs/demo/tests.md
+++ b/content/en/docs/demo/tests.md
@@ -10,5 +10,9 @@ execute the different flows in the webstore. While the backend services use
 To run the test you can simply run `make run-tests` at the root directory.
 
 In case you need to run a specific suite of tests you can execute
-`docker compose run frontendTests` for the frontend tests or
-`docker compose run integrationTests` for the backend tests.
+`docker compose run frontendTests`[^1] for the frontend tests or
+`docker compose run integrationTests`[^1] for the backend tests.
+
+[^1]:
+    Please note that `docker-compose` is deprecated and you should
+    [migrate to Compose V2](https://docs.docker.com/compose/migrate/)

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -719,6 +719,10 @@
     "StatusCode": 206,
     "LastSeen": "2023-02-15T21:03:17.781026-05:00"
   },
+  "https://docs.docker.com/compose/migrate/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-05-23T09:47:50.912587+02:00"
+  },
   "https://docs.docker.com/desktop": {
     "StatusCode": 206,
     "LastSeen": "2023-02-15T21:03:12.654004-05:00"


### PR DESCRIPTION
This PR addresses #2717 and replaces every instance of `docker-compose` with `docker compose`. There is also a commit included that adds a footnote to all pages that mention `docker compose` pointing out the migration to Compose V2