### PR TITLE
consistent image name

### DIFF
--- a/content/en/docs/collector/getting-started.md
+++ b/content/en/docs/collector/getting-started.md
@@ -33,8 +33,8 @@ run.
 <!-- prettier-ignore-start -->
 {{< tabpane lang=shell persistLang=false >}}
 {{< tab DockerHub >}}
-docker pull otel/opentelemetry-collector:{{% param collectorVersion %}}
-docker run otel/opentelemetry-collector:{{% param collectorVersion %}}
+docker pull otel/opentelemetry-collector-contrib:{{% param collectorVersion %}}
+docker run otel/opentelemetry-collector-contrib:{{% param collectorVersion %}}
 {{< /tab >}}
 
 {{< tab ghcr.io >}}
@@ -50,7 +50,7 @@ directory, mount that file as a volume:
 <!-- prettier-ignore-start -->
 {{< tabpane lang=shell persistLang=false >}}
 {{< tab DockerHub >}}
-docker run -v $(pwd)/config.yaml:/etc/otelcol-contrib/config.yaml otel/opentelemetry-collector:{{% param collectorVersion %}}
+docker run -v $(pwd)/config.yaml:/etc/otelcol-contrib/config.yaml otel/opentelemetry-collector-contrib:{{% param collectorVersion %}}
 {{< /tab >}}
 
 {{< tab ghcr.io >}}
@@ -66,7 +66,7 @@ the following:
 
 ```yaml
 otel-collector:
-  image: otel/opentelemetry-collector
+  image: otel/opentelemetry-collector-contrib
   command: [--config=/etc/otel-collector-config.yaml]
   volumes:
     - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml


### PR DESCRIPTION
The docker registry example used `opentelemetry-collector` while the ghcr example uses `opentelemetry-collector-contrib`

This was causing an issue as the location where the configuration file must be mounted differs from one image to the other.