### PR TITLE
Add and use _param shortcode to keep notes DRY

### DIFF
--- a/content/en/blog/2022/apisix/index.md
+++ b/content/en/blog/2022/apisix/index.md
@@ -394,8 +394,6 @@ communicate via the
 
 _A version of this article was [originally posted][] on the Apache APISIX blog._
 
-[^1]:
-    Please note that `docker-compose` is deprecated and you should
-    [migrate to Compose V2](https://docs.docker.com/compose/migrate/)
+[^1]: {{% _param notes.docker-compose-v2 %}}
 
 [originally posted]: {{% param canonical_url %}}

--- a/content/en/blog/2022/debug-otel-with-otel/index.md
+++ b/content/en/blog/2022/debug-otel-with-otel/index.md
@@ -247,9 +247,7 @@ COPY default.conf /etc/nginx/conf.d
 COPY opentelemetry_module.conf /etc/nginx/conf.d
 ```
 
-[^1]:
-    Please note that `docker-compose` is deprecated and you should
-    [migrate to Compose V2](https://docs.docker.com/compose/migrate/)
+[^1]: {{% _param notes.docker-compose-v2 %}}
 
 [learn how to instrument nginx with opentelemetry]: /blog/2022/instrument-nginx/
 [put nginx between two services]:

--- a/content/en/blog/2022/demo-announcement/index.md
+++ b/content/en/blog/2022/demo-announcement/index.md
@@ -157,6 +157,4 @@ from there.
 - [Demo Requirements](/docs/demo/requirements/)
 - [Get Involved](https://github.com/open-telemetry/opentelemetry-demo#contributing)
 
-[^1]:
-    Please note that `docker-compose` is deprecated and you should
-    [migrate to Compose V2](https://docs.docker.com/compose/migrate/)
+[^1]: {{% _param notes.docker-compose-v2 %}}

--- a/content/en/blog/2022/instrument-apache-httpd-server/index.md
+++ b/content/en/blog/2022/instrument-apache-httpd-server/index.md
@@ -252,9 +252,7 @@ writing this blog, support for other architectures is not provided.
 - Now, restart the apache module and OpenTelemetry module should be
   instrumented.
 
-[^1]:
-    Please note that `docker-compose` is deprecated and you should
-    [migrate to Compose V2](https://docs.docker.com/compose/migrate/)
+[^1]: {{% _param notes.docker-compose-v2 %}}
 
 [docker-compose.yml]:
   https://github.com/open-telemetry/opentelemetry-cpp-contrib/blob/main/instrumentation/otel-webserver-module/docker-compose.yml

--- a/content/en/blog/2022/instrument-nginx/index.md
+++ b/content/en/blog/2022/instrument-nginx/index.md
@@ -358,9 +358,7 @@ You should now be able to apply what you have learned from this blog post to
 your own installation of nginx. We would love to hear about your experience! If
 you run into any problems, [create an issue][].
 
-[^1]:
-    Please note that `docker-compose` is deprecated and you should
-    [migrate to Compose V2](https://docs.docker.com/compose/migrate/)
+[^1]: {{% _param notes.docker-compose-v2 %}}
 
 [create an issue]:
   https://github.com/open-telemetry/opentelemetry-cpp-contrib/issues

--- a/content/en/blog/2023/end-user-q-and-a-02.md
+++ b/content/en/blog/2023/end-user-q-and-a-02.md
@@ -286,10 +286,6 @@ that we can continue to improve OpenTelemetry. ❣️
 If you have a story to share about how you use OpenTelemetry at your
 organization, we’d love to hear from you! Ways to share:
 
-[^1]:
-    Please note that `docker-compose` is deprecated and you should
-    [migrate to Compose V2](https://docs.docker.com/compose/migrate/)
-
 - Join the [#otel-endusers channel](/community/end-user/slack-channel/) on the
   [CNCF Community Slack](https://communityinviter.com/apps/cloud-native/cncf)
 - Join our monthly
@@ -306,3 +302,5 @@ Be sure to follow OpenTelemetry on
 [Mastodon](https://fosstodon.org/@opentelemetry) and
 [Twitter](https://twitter.com/opentelemetry), and share your stories using the
 **#OpenTelemetry** hashtag!
+
+[^1]: {{% _param notes.docker-compose-v2 %}}

--- a/content/en/docs/collector/getting-started.md
+++ b/content/en/docs/collector/getting-started.md
@@ -21,8 +21,8 @@ git clone git@github.com:open-telemetry/opentelemetry-collector-contrib.git --de
   docker compose up -d
 ```
 
-**Note**: `docker-compose` is deprecated and you should
-[migrate to Compose V2](https://docs.docker.com/compose/migrate/)
+{{% alert title="Note" color="info" %}} {{% _param notes.docker-compose-v2 %}}
+{{% /alert %}}
 
 ## Docker
 

--- a/content/en/docs/demo/docker-deployment.md
+++ b/content/en/docs/demo/docker-deployment.md
@@ -97,6 +97,4 @@ After updating the `otelcol-config-extras.yml`, start the demo by running
 `docker compose up`[^1]. After a while, you should see the traces flowing into
 your backend as well.
 
-[^1]:
-    Please note that `docker-compose` is deprecated and you should
-    [migrate to Compose V2](https://docs.docker.com/compose/migrate/)
+[^1]: {{% _param notes.docker-compose-v2 %}}

--- a/content/en/docs/demo/tests.md
+++ b/content/en/docs/demo/tests.md
@@ -13,6 +13,4 @@ In case you need to run a specific suite of tests you can execute
 `docker compose run frontendTests`[^1] for the frontend tests or
 `docker compose run integrationTests`[^1] for the backend tests.
 
-[^1]:
-    Please note that `docker-compose` is deprecated and you should
-    [migrate to Compose V2](https://docs.docker.com/compose/migrate/)
+[^1]: {{% _param notes.docker-compose-v2 %}}

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -162,6 +162,11 @@ params:
       sizes: [300, 400, 600, 700]
       type: sans_serif
 
+  notes: # as markdown
+    docker-compose-v2: |
+      `docker-compose` is deprecated. For details, see
+      [Migrate to Compose V2](https://docs.docker.com/compose/migrate/).
+
 services:
   googleAnalytics:
     # The following is a placeholder (fake) ID useful for local test builds. The

--- a/layouts/shortcodes/_param.md
+++ b/layouts/shortcodes/_param.md
@@ -1,0 +1,21 @@
+{{/*
+
+Like Hugo's `param` shortcode
+(https://gohugo.io/content-management/shortcodes/#param) but better, because it
+can be used to render markdown simply by invoking it as {{% _param name %}}.
+
+An enhanced version of:
+https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/shortcodes/param.html
+
+*/ -}}
+
+{{ $name := (.Get 0) -}}
+{{ with $name -}}
+  {{ with ($.Page.Param .) -}}
+    {{ . }}
+  {{- else -}}
+    {{ errorf "Page or site param %q not found: %s" $name $.Position -}}
+  {{ end -}}
+{{- else -}}
+  {{ errorf "Missing param key: %s" $.Position -}}
+{{ end -}}


### PR DESCRIPTION
- Followup to #2775
- Introduces a new shortcode named `_param`, that is like the Hugo `param` shortcode, but can be used with Markdown content.
- Replaces all hard-coded notes and footnotes with the text "`docker-compose` is deprecated" with in invocation of `_param`
- Adds the shared note content to `hugo.yaml` under `param.notes`
- In `content/en/docs/collector/getting-started.md`, turns the `**Note**` into a Docsy `alert`

**Preview** (sampling of edited pages):

- https://deploy-preview-2781--opentelemetry.netlify.app/docs/collector/getting-started/#demo
- https://deploy-preview-2781--opentelemetry.netlify.app/blog/2023/end-user-q-and-a-02/#fn:1

/cc @svrnm @cartermp 