### PR TITLE
Semconv pages: don't warn about external links to spec

### DIFF
--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -83,7 +83,10 @@ while(<>) {
   s|\.\./semantic_conventions/README.md|$semConvRef| if $ARGV =~ /overview/;
   s|\.\./specification/(.*?\))|../otel/$1)|g if $ARGV =~ /otel\/specification/;
 
-  if (/\((https:\/\/github.com\/open-telemetry\/opentelemetry-specification\/\w+\/\w+\/specification([^\)]*))\)/) {
+  if (
+    /\((https:\/\/github.com\/open-telemetry\/opentelemetry-specification\/\w+\/\w+\/specification([^\)]*))\)/ &&
+    $ARGV !~ /semantic_conventions/
+    ) {
     printf STDOUT "WARNING: link to spec page encoded as an external URL, but should be a local path, fix this upstream;\n  File: $ARGV \n  Link: $1\n";
   }
   s|\(https://github.com/open-telemetry/opentelemetry-specification/\w+/\w+/specification([^\)]*)\)|($specBasePath/otel$1)|;


### PR DESCRIPTION
- Contributes to #2721

Concretely, this eliminates the following warnings (which are no longer relevant because the pages have moved):

```
WARNING: link to spec page encoded as an external URL, but should be a local path, fix this upstream;
  File: /Users/chalin/git/lf/open-telemetry/opentelemetry.io/tmp/otel/specification/metrics/semantic_conventions/http-metrics.md 
  Link: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument-advice
WARNING: link to spec page encoded as an external URL, but should be a local path, fix this upstream;
  File: /Users/chalin/git/lf/open-telemetry/opentelemetry.io/tmp/otel/specification/metrics/semantic_conventions/http-metrics.md 
  Link: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument-advice
```