### PR TITLE
Add OTLP to docs/specs

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -182,8 +182,10 @@ module:
       target: content/docs/instrumentation/go
     - source: tmp/otel/specification
       target: content/docs/specs/otel
-    # - source: tmp/otlp/docs
-    #   target: content/docs/specs/otlp
+    - source: tmp/otlp/docs
+      target: content/docs/specs/otlp
+    - source: tmp/otlp/opentelemetry/proto
+      target: static/docs/specs/otlp/proto
     - source: tmp/community/mission-vision-values.md
       target: content/community/mission.md
     - source: tmp/community/roadmap.md

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -182,10 +182,10 @@ module:
       target: content/docs/instrumentation/go
     - source: tmp/otel/specification
       target: content/docs/specs/otel
-    - source: tmp/otlp/docs
-      target: content/docs/specs/otlp
-    - source: tmp/otlp/opentelemetry/proto
-      target: static/docs/specs/otlp/proto
+    - source: tmp/otlp/docs/specification.md
+      target: content/docs/specs/otlp/index.md
+    - source: tmp/otlp/docs/img
+      target: content/docs/specs/otlp/img
     - source: tmp/community/mission-vision-values.md
       target: content/community/mission.md
     - source: tmp/community/roadmap.md

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -28,8 +28,9 @@ sub printTitleAndFrontMatter() {
   if ($title eq 'OpenTelemetry Specification') {
     $title .= " $otelSpecVers";
     $frontMatterFromFile =~ s/linkTitle: .*/$& $otelSpecVers/;
-  } elsif ( $title eq 'OpenTelemetry Protocol' ) {
-    # $frontMatterFromFile = "linkTitle: OTLP\n";
+  # TODO: remove once OTLP spec page is updated
+  } elsif ( $ARGV =~ /otlp\/docs\/specification.md$/ ) {
+    $frontMatterFromFile =~ s/(linkTitle:) .*/$1 OTLP/;
   }
   my $titleMaybeQuoted = ($title =~ ':') ? "\"$title\"" : $title;
   print "title: $titleMaybeQuoted\n";
@@ -85,7 +86,7 @@ while(<>) {
 
   if (
     /\((https:\/\/github.com\/open-telemetry\/opentelemetry-specification\/\w+\/\w+\/specification([^\)]*))\)/ &&
-    $ARGV !~ /semantic_conventions/
+    $ARGV !~ /semantic_conventions|otlp\/docs/
     ) {
     printf STDOUT "WARNING: link to spec page encoded as an external URL, but should be a local path, fix this upstream;\n  File: $ARGV \n  Link: $1\n";
   }
@@ -93,7 +94,7 @@ while(<>) {
 
   # Images
   s|(\.\./)?internal(/img/[-\w]+\.png)|$2|g;
-  s|(\]\()(img/.*?\))|$1../$2|g if $ARGV !~ /(logs|schemas)._index/;
+  s|(\]\()(img/.*?\))|$1../$2|g if $ARGV !~ /(logs|schemas)._index/ && $ARGV !~ /otlp\/docs/;
 
   # Fix links that are to the title of the .md page
   # TODO: fix these in the spec
@@ -104,7 +105,7 @@ while(<>) {
   s|\.\.\/README.md\b|$otelSpecRepoUrl/|g if $ARGV =~ /specification._index/;
   s|\.\.\/README.md\b|..| if $ARGV =~ /specification.library-guidelines.md/;
 
-  s|\.\./(opentelemetry/proto/?.*)|$otlpSpecRepoUrl/tree/$otlpSpecVers/$1/|g if $ARGV =~ /\/tmp\/otlp/;
+  s|\.\./(opentelemetry/proto/?.*)|$otlpSpecRepoUrl/tree/$otlpSpecVers/$1|g if $ARGV =~ /\/tmp\/otlp/;
   s|\.\./README.md\b|$otlpSpecRepoUrl/|g if $ARGV =~ /\/tmp\/otlp/;
   s|\.\./examples/README.md\b|$otlpSpecRepoUrl/tree/$otlpSpecVers/examples/|g if $ARGV =~ /\/tmp\/otlp/;
 

--- a/scripts/content-modules/cp-pages.sh
+++ b/scripts/content-modules/cp-pages.sh
@@ -26,8 +26,6 @@ echo "OTEL SPEC pages: copied and processed"
 SRC=content-modules/opentelemetry-proto/docs
 DEST=$DEST_BASE/otlp/docs
 
-if [[ -e $SRC ]]; then
-
 rm -Rf $DEST
 mkdir -p $DEST
 cp -R $SRC/* $DEST/
@@ -41,20 +39,14 @@ $SCRIPT_DIR/adjust-pages.pl $FILES
 
 echo "OTLP SPEC pages: copied and processed."
 
-# SRC=content-modules/opentelemetry-proto/opentelemetry
-# DEST=$DEST_BASE/otlp/opentelemetry
+SRC=content-modules/opentelemetry-proto/opentelemetry
+DEST=$DEST_BASE/otlp/opentelemetry
 
-# rm -Rf $DEST
-# mkdir -p $DEST
-# cp -R $SRC/* $DEST/
+rm -Rf $DEST
+mkdir -p $DEST
+cp -R $SRC/* $DEST/
 
-# echo "OTLP SPEC protos copied and processed."
-
-else
-
-echo "OTLP SPEC pages: skipped"
-
-fi
+echo "OTLP SPEC protos copied and processed."
 
 ## Community
 


### PR DESCRIPTION
- Contributes (possibly closes) #2642
- Adds the OTLP spec under `/docs/specs`

**Preview**: https://deploy-preview-2786--opentelemetry.netlify.app/docs/specs/otlp

/cc @tigrannajaryan 