### PR TITLE
Move spec-status page to be immediately under /docs/specs

### DIFF
--- a/content/en/docs/specs/status.md
+++ b/content/en/docs/specs/status.md
@@ -1,12 +1,8 @@
 ---
 title: Specification Status Summary
 linkTitle: Status
+aliases: [/docs/specs/otel/status]
 weight: 10
-# Undo specification-section-wide page-meta parameter settings:
-github_repo: &repo https://github.com/open-telemetry/opentelemetry.io
-github_subdir:
-path_base_for_github_subdir:
-github_project_repo: *repo
 ---
 
 OpenTelemetry is developed on a signal by signal basis. Tracing, metrics,
@@ -26,7 +22,7 @@ instrumentation. All instrumentation shares the same semantic conventions, to
 ensure that they produce the same data when observing common operations, such as
 HTTP requests.
 
-To learn more about signals and components, see the specification
+To learn more about signals and components, see the OTel specification
 [Overview](/docs/specs/otel/overview/).
 
 ## Component Lifecycle

--- a/content/en/status.md
+++ b/content/en/status.md
@@ -40,7 +40,7 @@ following:
 
 <div class="l-status-primary mt-0">
 
-- [Specification status](/docs/specs/otel/status/)
+- [Specification status](/docs/specs/status/)
 - [Collector status](/docs/collector/#status-and-releases)
 
 </div>

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -27,7 +27,7 @@ sub printTitleAndFrontMatter() {
   print "---\n";
   if ($title eq 'OpenTelemetry Specification') {
     $title .= " $otelSpecVers";
-    $frontMatterFromFile =~ s/linkTitle: .*/$& $otelSpecVers/;
+    $frontMatterFromFile =~ s/(linkTitle:) .*/$1 OTel $otelSpecVers/;
   # TODO: remove once OTLP spec page is updated
   } elsif ( $ARGV =~ /otlp\/docs\/specification.md$/ ) {
     $frontMatterFromFile =~ s/(linkTitle:) .*/$1 OTLP/;


### PR DESCRIPTION
- Moves `/docs/specs/otel/status` to `/docs/specs/status`, since the status page covers status from both the OTel and OTLP specs.
- Adjusts the `linkTitle` of the OTel spec to be "OTel <vers>"
- Contributes to:
  - #2642
  - #2793

---

**Preview**: https://deploy-preview-2796--opentelemetry.netlify.app/docs/specs/status

#### Screenshot

> <img width="1060" alt="Screen Shot 2023-05-25 at 18 50 14" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/854d4d56-a4e8-4e8b-81e1-8c8654961f72">

/cc @tigrannajaryan @open-telemetry/specs-approvers 