### PR TITLE
Move insecure option under `tis`

### DIFF
--- a/content/en/docs/collector/deployment/agent.md
+++ b/content/en/docs/collector/deployment/agent.md
@@ -49,7 +49,8 @@ processors:
 exporters:
   jaeger: # the Jaeger exporter, to ingest traces to backend
     endpoint: "https://jaeger.example.com:14250"
-    insecure: true
+    tls:
+      insecure: true
 
 service:
   pipelines:


### PR DESCRIPTION
Moves `insecure` option on Agent Deploy docs under `tls`

re: https://github.com/open-telemetry/opentelemetry-collector/pull/4063/files