### PR TITLE
Update exporters.md - Adding missing library to example instrumentation.js

### DIFF
--- a/content/en/docs/instrumentation/js/exporters.md
+++ b/content/en/docs/instrumentation/js/exporters.md
@@ -77,6 +77,9 @@ const {
 const {
   OTLPMetricExporter
 } = require("@opentelemetry/exporter-metrics-otlp-proto");
+const {
+  PeriodicExportingMetricReader
+} = require('@opentelemetry/sdk-metrics');
 
 const sdk = new opentelemetry.NodeSDK({
   traceExporter: new OTLPTraceExporter({


### PR DESCRIPTION
The example instrumentation.js had a missing library: PeriodicExportingMetricReader

When running the example as-is with: node --require ./instrumentation.js app.js

The user would get an error:
ReferenceError: PeriodicExportingMetricReader is not defined