### PR TITLE
Update getting-started.md

### DIFF
--- a/content/en/docs/instrumentation/python/getting-started.md
+++ b/content/en/docs/instrumentation/python/getting-started.md
@@ -574,7 +574,7 @@ configuration:
 
 ```shell
 docker run -p 4317:4317 \
-    -v /tmp/otel-collector-config.yaml:/etc/otel-collector-config.yaml \
+    -v $(pwd)/tmp/otel-collector-config.yaml:/etc/otel-collector-config.yaml \
     otel/opentelemetry-collector:latest \
     --config=/etc/otel-collector-config.yaml
 ```


### PR DESCRIPTION
The -v argument may not always work with relative directories and it might be a good idea to pass the pathname of the current working directory in the context of this getting started tutorial.