### PR TITLE
Update OTLP spec page

### DIFF
--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -28,9 +28,6 @@ sub printTitleAndFrontMatter() {
   if ($title eq 'OpenTelemetry Specification') {
     $title .= " $otelSpecVers";
     $frontMatterFromFile =~ s/(linkTitle:) .*/$1 OTel $otelSpecVers/;
-  # TODO: remove once OTLP spec page is updated
-  } elsif ( $ARGV =~ /otlp\/docs\/specification.md$/ ) {
-    $frontMatterFromFile =~ s/(linkTitle:) .*/$1 OTLP/;
   }
   my $titleMaybeQuoted = ($title =~ ':') ? "\"$title\"" : $title;
   print "title: $titleMaybeQuoted\n";

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -2519,6 +2519,10 @@
     "StatusCode": 200,
     "LastSeen": "2023-02-20T08:02:30.815811-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-proto/issues/new": {
+    "StatusCode": 200,
+    "LastSeen": "2023-06-02T11:03:11.716374-04:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-python": {
     "StatusCode": 200,
     "LastSeen": "2023-02-20T07:46:59.434879-05:00"


### PR DESCRIPTION
- Contributes to #2642
- Updates OTLP spec to pick up https://github.com/open-telemetry/opentelemetry-proto/pull/479
- Drops temporary tweak to `adjust-pages.pl` script.

**Preview**: https://deploy-preview-2816--opentelemetry.netlify.app/docs/specs

/cc @open-telemetry/specs-approvers 