### PR TITLE
Upgrade Hugo to 0.113.0 and adjust lang params

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,4 +1,6 @@
 baseURL: https://opentelemetry.io
+title: &title OpenTelemetry
+description: &desc The OpenTelemetry Project Site
 disableKinds: [taxonomy, taxonomyTerm]
 theme: [docsy]
 disableAliases: true # We do redirects via Netlify's _redirects file
@@ -8,11 +10,10 @@ enableGitInfo: true
 enableMissingTranslationPlaceholders: true
 languages:
   en:
-    title: OpenTelemetry
-    description: The OpenTelemetry Project Site
     languageName: English
-    weight: 1
-
+    params:
+      title: *title
+      description: *desc
 imaging:
   resampleFilter: CatmullRom
   quality: 75

--- a/package.json
+++ b/package.json
@@ -137,10 +137,10 @@
   "devDependencies": {
     "autoprefixer": "^10.4.14",
     "cspell": "^6.31.1",
-    "hugo-extended": "0.111.3",
+    "hugo-extended": "0.113.0",
     "netlify-cli": "^15.0.1",
     "npm-run-all": "^4.1.5",
-    "postcss": "^8.4.21",
+    "postcss": "^8.4.24",
     "postcss-cli": "^10.1.0",
     "prettier": "^2.8.4",
     "textlint": "^13.1.4",


### PR DESCRIPTION
- Closes #2821
- Closes #2803
- Adjusts the `languages.en` config. Without these adjustments, we hit the following issues:
  - https://github.com/google/docsy/issues/1531
  - https://github.com/google/docsy/issues/1538
- There are no significant changes to the generated site files
  ```console
  $ npm run build
  ...
  $ (cd public && git diff -I "Hugo 0\." -- . ':(exclude)*.xml') # no output
  $ 
  ```

