### PR TITLE
OTel spec: link to local OTLP, and fix README link

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "_prebuild": "run-s get:submodule cp:spec",
     "_prepare:docsy": "cd themes/docsy && npm install",
     "_prettier:any": "npx prettier --ignore-path ''",
-    "_serve:hugo": "hugo serve -DFE --minify",
+    "_serve:hugo": "hugo server -DFE --minify",
     "_serve:netlify": "netlify dev -c \"npm run _serve:hugo\"",
     "all": "npm-run-all",
     "build:preview": "set -x && npm run _build -- --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -91,6 +91,8 @@ while(<>) {
   }
   s|\(https://github.com/open-telemetry/opentelemetry-specification/\w+/\w+/specification([^\)]*)\)|($specBasePath/otel$1)|;
 
+  s|(https://)?github.com/open-telemetry/opentelemetry-proto/(blob/main/)?docs/specification.md|$specBasePath/otlp/|g;
+
   # Images
   s|(\.\./)?internal(/img/[-\w]+\.png)|$2|g;
   s|(\]\()(img/.*?\))|$1../$2|g if $ARGV !~ /(logs|schemas)._index/ && $ARGV !~ /otlp\/docs/;
@@ -108,7 +110,7 @@ while(<>) {
   s|\.\./README.md\b|$otlpSpecRepoUrl/|g if $ARGV =~ /\/tmp\/otlp/;
   s|\.\./examples/README.md\b|$otlpSpecRepoUrl/tree/$otlpSpecVers/examples/|g if $ARGV =~ /\/tmp\/otlp/;
 
-  s|\bREADME.md\b|_index.md|g;
+  s|\bREADME.md\b|_index.md|g if $ARGV !~ /otel\/specification\/protocol\/_index.md/;
 
   # Rewrite paths that are outside of the main spec folder as external links
   s|(\.\.\/)+(experimental\/[^)]+)|$otelSpecRepoUrl/tree/$otelSpecVers/$2|g;

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -22,6 +22,7 @@ my %versions = qw(
 );
 my $otelSpecVers = $versions{'spec:'};
 my $otlpSpecVers = $versions{'otlp:'};
+my $unused;
 
 sub printTitleAndFrontMatter() {
   print "---\n";
@@ -33,7 +34,8 @@ sub printTitleAndFrontMatter() {
   }
   my $titleMaybeQuoted = ($title =~ ':') ? "\"$title\"" : $title;
   print "title: $titleMaybeQuoted\n" if $frontMatterFromFile !~ /title: /;
-  ($linkTitle) = $title =~ /^OpenTelemetry (.*)/;
+  ($unused, $linkTitle) = $title =~ /^OpenTelemetry (Protocol )?(.*)/;
+  $linkTitle = 'Design Goals' if $title eq 'Design Goals for OpenTelemetry Wire Protocol';
   print "linkTitle: $linkTitle\n" if $linkTitle and $frontMatterFromFile !~ /linkTitle: /;
   print "$frontMatterFromFile" if $frontMatterFromFile;
   if ($ARGV =~ /otel\/specification\/(.*?)_index.md$/) {


### PR DESCRIPTION
- Followup to #2856
- Closes #2642
- Ensures that external links to the OTLP spec become a local path inside OTel spec pages
- Also includes a workaround for the `_serve:hugo` script, avoiding the error message `Error: command error: unknown command "-DFE" for "hugo server"` when stopping the server

Here are the affected files:

```console
$ (cd public && git diff | grep ^diff)                                                               
diff --git a/docs/specs/otel/protocol/exporter/index.html b/docs/specs/otel/protocol/exporter/index.html
diff --git a/docs/specs/otel/protocol/file-exporter/index.html b/docs/specs/otel/protocol/file-exporter/index.html
diff --git a/docs/specs/otel/protocol/index.xml b/docs/specs/otel/protocol/index.xml
diff --git a/docs/specs/otel/protocol/otlp/index.html b/docs/specs/otel/protocol/otlp/index.html
```

And an example of the change:

```diff
$ (cd public && git diff -I '<meta' docs/specs/otel/protocol/otlp/index.html)
diff --git a/docs/specs/otel/protocol/otlp/index.html b/docs/specs/otel/protocol/otlp/index.html
index bed2713b3..9838d69a1 100644
--- a/docs/specs/otel/protocol/otlp/index.html
+++ b/docs/specs/otel/protocol/otlp/index.html
@@ -1536,7 +1536,7 @@
                
        </header>
        <p>This page has moved to
-<a href="https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md" target="_blank" rel="noopener" class="external-link">github.com/open-telemetry/opentelemetry-proto/docs/specification.md</a>.</p>
+<a href="/docs/specs/otlp/">/docs/specs/otlp/</a>.</p>
```