### PR TITLE
Update traces exporters in kubernetes-deployment.md

### DIFF
--- a/content/en/docs/demo/kubernetes-deployment.md
+++ b/content/en/docs/demo/kubernetes-deployment.md
@@ -167,7 +167,7 @@ opentelemetry-collector:
         traces:
           receivers: [otlp]
           processors: [batch]
-          exporters: [otlphttp/example]
+          exporters: [spanmetrics, otlphttp/example]
 ```
 
 > **Note** When merging YAML values with Helm, objects are merged and arrays are


### PR DESCRIPTION
Had to add spanmetrics to traces/exporters, otherwise the otel collector pod crashed with this error:

"collector server run finished with error: invalid configuration: connectors::spanmetrics: must be used as both receiver and exporter but is not used as exporter"