### PR TITLE
Add more details to metrics concept page

### DIFF
--- a/content/en/docs/concepts/signals/metrics.md
+++ b/content/en/docs/concepts/signals/metrics.md
@@ -105,7 +105,7 @@ Metrics are a [stable](/docs/specs/otel/versioning-and-stability/#stable) signal
 in the OpenTelemetry specification. For the individual language specific
 implementations of the Metrics API & SDK, the status is as follows:
 
-{{% metrics_support_table "metrics" %}}
+{{% metrics_support_table " " %}}
 
 ## Specification
 

--- a/content/en/docs/concepts/signals/metrics.md
+++ b/content/en/docs/concepts/signals/metrics.md
@@ -3,10 +3,10 @@ title: Metrics
 weight: 2
 ---
 
-A **metric** is a measurement about a service, captured at runtime. Logically,
-the moment of capturing one of these measurements is known as a _metric event_
-which consists not only of the measurement itself, but the time that it was
-captured and associated metadata.
+A **metric** is a **measurement** about a service, captured at runtime.
+Logically, the moment of capturing one of these measurements is known as a
+**metric event** which consists not only of the measurement itself, but the time
+that it was captured and associated metadata.
 
 Application and request metrics are important indicators of availability and
 performance. Custom metrics can provide insights into how availability
@@ -14,8 +14,39 @@ indicators impact user experience or the business. Collected data can be used to
 alert of an outage or trigger scheduling decisions to scale up a deployment
 automatically upon high demand.
 
-OpenTelemetry defines six _metric instruments_ today which can be created
-through the OpenTelemetry API:
+To understand how metrics in OpenTelemetry works, let's look at a list of
+components that will play a part in instrumenting our code.
+
+## Meter Provider
+
+A Meter Provider (sometimes called `MeterProvider`) is a factory for `Meter`s.
+In most applications, a Meter Provider is initialized once and its lifecycle
+matches the application's lifecycle. Meter Provider initialization also includes
+Resource and Exporter initialization. It is typically the first step in metering
+with OpenTelemetry. In some language SDKs, a global Meter Provider is already
+initialized for you.
+
+## Meter
+
+A Meter creates _metric instruments_, capturing measurements about a service at
+runtime. Meters are created from Meter Providers.
+
+## Metric Exporter
+
+Metric Exporters send metric data to a consumer. This consumer can be standard
+output for debugging and development-time, the OpenTelemetry Collector, or any
+open source or vendor backend of your choice.
+
+## Metric Instruments
+
+In OpenTelemetry measurements are captured by **metric instruments**. Such an
+metric instrument is defined by a name, a kind, an optional unit and an optional
+description. The name, unit and description of such an instrument is chosen by
+the developer or defined via
+[semantic conventions](/docs/specs/otel/metrics/semantic_conventions/) for
+common ones like request or process metrics.
+
+The instrument type is one of the following six:
 
 - **Counter**: A value that accumulates over time -- you can think of this like
   an odometer on a car; it only ever goes up.
@@ -37,19 +68,21 @@ through the OpenTelemetry API:
   values, and are not interested in every individual value, but a statistic
   about these values (e.g., How many requests take fewer than 1s?)
 
-In addition to the metric instruments, the concept of _aggregations_ is an
+## Aggregation
+
+In addition to the metric instruments, the concept of **aggregations** is an
 important one to understand. An aggregation is a technique whereby a large
 number of measurements are combined into either exact or estimated statistics
 about metric events that took place during a time window. The OTLP protocol
 transports such aggregated metrics. The OpenTelemetry API provides a default
-aggregation for each instrument which can be overridden using the Views API. The
+aggregation for each instrument which can be overridden using the Views. The
 OpenTelemetry project aims to provide default aggregations that are supported by
 visualizers and telemetry backends.
 
-Unlike request tracing, which is intended to capture request lifecycles and
-provide context to the individual pieces of a request, metrics are intended to
-provide statistical information in aggregate. Some examples of use cases for
-metrics include:
+Unlike [request tracing](/docs/concepts/signals/traces/), which is intended to
+capture request lifecycles and provide context to the individual pieces of a
+request, metrics are intended to provide statistical information in aggregate.
+Some examples of use cases for metrics include:
 
 - Reporting the total number of bytes read by a service, per protocol type.
 - Reporting the total number of bytes read and the bytes per request.
@@ -59,6 +92,22 @@ metrics include:
 - Reporting average balance values from an account.
 - Reporting current active requests being handled.
 
-> For more information, see the [metrics specification][].
+## Views
 
-[metrics specification]: /docs/specs/otel/overview/#metric-signal
+A View provides SDK users with the flexibility to customize the metrics that are
+output by the SDK. They can customize which metric instruments are to be
+processed or ignored. They can customize aggregation and what attributes are to
+be reported on metrics.
+
+## Language Support
+
+Metrics are a [stable](/docs/specs/otel/versioning-and-stability/#stable) signal
+in the OpenTelemetry specification. For the individual language specific
+implementations of the Metrics API & SDK, the status is as follows:
+
+{{% metrics_support_table "metrics" %}}
+
+## Specification
+
+To learn more about metrics in OpenTelemetry, see the
+[metrics specification](/docs/specs/otel/overview/#metric-signal).

--- a/layouts/shortcodes/metrics_support_table.md
+++ b/layouts/shortcodes/metrics_support_table.md
@@ -1,0 +1,15 @@
+{{ $data := $.Site.Data.instrumentation.languages }}
+
+Language | Metrics |
+| --- | --- |
+| [C++](/docs/instrumentation/cpp/) | {{ $data.cpp.status.metrics | humanize }} |
+| [C#/.NET](/docs/instrumentation/net/) | {{ $data.dotnet.status.metrics | humanize }} |
+| [Erlang/Elixir](/docs/instrumentation/erlang/) | {{ $data.erlang.status.metrics | humanize }} |
+| [Go](/docs/instrumentation/go/) | {{ $data.go.status.metrics | humanize }} |
+| [Java](/docs/instrumentation/java/) | {{ $data.java.status.metrics | humanize }} |
+| [JavaScript](/docs/instrumentation/js/) | {{ $data.js.status.metrics | humanize }} |
+| [PHP](/docs/instrumentation/php/) | {{ $data.php.status.metrics | humanize }} |
+| [Python](/docs/instrumentation/python/) | {{$data.python.status.metrics | humanize }} |
+| [Ruby](/docs/instrumentation/ruby/) | {{ $data.ruby.status.metrics | humanize }} |
+| [Rust](/docs/instrumentation/rust/) | {{ $data.rust.status.metrics | humanize }} |
+| [Swift](/docs/instrumentation/swift/) | {{ $data.swift.status.metrics | humanize }} |


### PR DESCRIPTION
Based on the feedback from https://github.com/open-telemetry/opentelemetry.io/issues/2877, I tried to improve some of the metrics concept page:

* I gave it a structure that is closer to the one we have for traces already (i.e. calling out components like MeterProvider, Meter, etc.)
* Added a metrics support table that (a) provides a link to the languages, and (b) calls out metric stability across them, such that an end user is not going to be surprised if for a specific language they can not find metric instructions

If the latter proves valuable for metrics I can create the same for traces (and later for logs)