### PR TITLE
Fix typos in logs language support

### DIFF
--- a/content/en/docs/concepts/signals/logs.md
+++ b/content/en/docs/concepts/signals/logs.md
@@ -91,9 +91,9 @@ the
 
 ## Language Support
 
-Metrics are a [stable](/docs/specs/otel/versioning-and-stability/#stable) signal
+Logs are a [stable](/docs/specs/otel/versioning-and-stability/#stable) signal
 in the OpenTelemetry specification. For the individual language specific
-implementations of the Metrics API & SDK, the status is as follows:
+implementations of the Logs API & SDK, the status is as follows:
 
 {{% logs-support-table %}}
 

--- a/content/en/docs/concepts/signals/logs.md
+++ b/content/en/docs/concepts/signals/logs.md
@@ -91,8 +91,8 @@ the
 
 ## Language Support
 
-Logs are a [stable](/docs/specs/otel/versioning-and-stability/#stable) signal
-in the OpenTelemetry specification. For the individual language specific
+Logs are a [stable](/docs/specs/otel/versioning-and-stability/#stable) signal in
+the OpenTelemetry specification. For the individual language specific
 implementations of the Logs API & SDK, the status is as follows:
 
 {{% logs-support-table %}}


### PR DESCRIPTION
Mention logs, not metrics.

Fixes https://github.com/open-telemetry/opentelemetry.io/issues/2898