### PR TITLE
Improve fibonacci code in Getting Started page

### DIFF
--- a/content/en/docs/instrumentation/go/getting-started.md
+++ b/content/en/docs/instrumentation/go/getting-started.md
@@ -23,20 +23,29 @@ Fibonacci project. Next, add the following to a new file named `fib.go` in that
 directory.
 
 ```go
-package main
-
-// Fibonacci returns the n-th fibonacci number.
-func Fibonacci(n uint) (uint64, error) {
-	if n <= 1 {
-		return uint64(n), nil
-	}
-
-	var n2, n1 uint64 = 0, 1
-	for i := uint(2); i < n; i++ {
-		n2, n1 = n1, n1+n2
-	}
-
-	return n2 + n1, nil
+package main 
+ 
+import ( 
+        "errors" 
+) 
+ 
+var ErrOverflow = errors.New("unsigned integer overflow") 
+ 
+// Fibonacci returns the n-th fibonacci number. 
+func Fibonacci(n uint) (uint64, error) { 
+        if n <= 1 { 
+                return uint64(n), nil 
+        } 
+ 
+        var n2, n1 uint64 = 0, 1 
+        for i := uint(2); i < n; i++ { 
+                if (n1 + n2) + n1 < n1 { 
+                        return 0, ErrOverflow 
+                } 
+                n2, n1 = n1, n1+n2 
+        } 
+ 
+        return n2 + n1, nil 
 }
 ```
 

--- a/content/en/docs/instrumentation/go/getting-started.md
+++ b/content/en/docs/instrumentation/go/getting-started.md
@@ -23,29 +23,29 @@ Fibonacci project. Next, add the following to a new file named `fib.go` in that
 directory.
 
 ```go
-package main 
- 
-import ( 
-        "errors" 
-) 
- 
-var ErrOverflow = errors.New("unsigned integer overflow") 
- 
-// Fibonacci returns the n-th fibonacci number. 
-func Fibonacci(n uint) (uint64, error) { 
-        if n <= 1 { 
-                return uint64(n), nil 
-        } 
- 
-        var n2, n1 uint64 = 0, 1 
-        for i := uint(2); i < n; i++ { 
-                if (n1 + n2) + n1 < n1 { 
-                        return 0, ErrOverflow 
-                } 
-                n2, n1 = n1, n1+n2 
-        } 
- 
-        return n2 + n1, nil 
+package main
+
+import (
+        "errors"
+)
+
+var ErrOverflow = errors.New("unsigned integer overflow")
+
+// Fibonacci returns the n-th fibonacci number.
+func Fibonacci(n uint) (uint64, error) {
+        if n <= 1 {
+                return uint64(n), nil
+        }
+
+        var n2, n1 uint64 = 0, 1
+        for i := uint(2); i < n; i++ {
+                if (n1 + n2) + n1 < n1 {
+                        return 0, ErrOverflow
+                }
+                n2, n1 = n1, n1+n2
+        }
+
+        return n2 + n1, nil
 }
 ```
 

--- a/content/en/docs/instrumentation/go/getting-started.md
+++ b/content/en/docs/instrumentation/go/getting-started.md
@@ -25,27 +25,26 @@ directory.
 ```go
 package main
 
-import (
-        "errors"
-)
+import "errors"
 
+// ErrOverflow is returned when Fibonacci returned value is too big to be represented as uint.
 var ErrOverflow = errors.New("unsigned integer overflow")
 
 // Fibonacci returns the n-th fibonacci number.
 func Fibonacci(n uint) (uint64, error) {
-        if n <= 1 {
-                return uint64(n), nil
-        }
+	if n <= 1 {
+		return uint64(n), nil
+	}
 
-        var n2, n1 uint64 = 0, 1
-        for i := uint(2); i < n; i++ {
-                if (n1 + n2) + n1 < n1 {
-                        return 0, ErrOverflow
-                }
-                n2, n1 = n1, n1+n2
-        }
+	var n2, n1 uint64 = 0, 1
+	for i := uint(2); i < n; i++ {
+		if (n1+n2)+n1 < n1 {
+			return 0, ErrOverflow
+		}
+		n2, n1 = n1, n1+n2
+	}
 
-        return n2 + n1, nil
+	return n2 + n1, nil
 }
 ```
 


### PR DESCRIPTION
The Fibonacci demo on the getting started page does not account for overflows. This fix improves it by throwing an error upon overflow (fib 94 or above for uint64). 


**Old:**
```
What Fibonacci number would you like to know: 
1
Fibonacci(1) = 1
What Fibonacci number would you like to know: 
93
Fibonacci(93) = 12200160415121876738
What Fibonacci number would you like to know: 
94
Fibonacci(94) = 1293530146158671551
What Fibonacci number would you like to know: 
95
Fibonacci(95) = 13493690561280548289
What Fibonacci number would you like to know: 
100
Fibonacci(100) = 3736710778780434371
```
**New:**
```
What Fibonacci number would you like to know: 
1
Fibonacci(1) = 1
What Fibonacci number would you like to know: 
93
Fibonacci(93) = 12200160415121876738
What Fibonacci number would you like to know: 
94
Fibonacci(94): unsigned integer overflow
What Fibonacci number would you like to know: 
95
Fibonacci(95): unsigned integer overflow
What Fibonacci number would you like to know: 
100
Fibonacci(100): unsigned integer overflow
```

