### PR TITLE
Add collector and language support to sampling concept page

### DIFF
--- a/content/en/docs/concepts/sampling/index.md
+++ b/content/en/docs/concepts/sampling/index.md
@@ -121,3 +121,19 @@ of trace data may first use head sampling to only sample a small percentage of
 traces, and then later in the telemetry pipeline use tail sampling to make more
 sophisticated sampling decisions before exporting to a backend. This is often
 done in the interest of protecting the telemetry pipeline from being overloaded.
+
+## Support
+
+### Collector
+
+The OpenTelemetry Collector includes the following sampling processors:
+
+- [Probabilistic Sampling Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/probabilisticsamplerprocessor)
+- [Tail Sampling Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor)
+
+### Language SDKs
+
+For the individual language specific implementations of the OpenTelemetry API &
+SDK you will find support for sampling at the respective documentation pages:
+
+{{% sampling-support-list " " %}}

--- a/data/instrumentation.yaml
+++ b/data/instrumentation.yaml
@@ -1,66 +1,77 @@
 languages:
   cpp:
     name: C++
+    urlName: cpp
     status:
       traces: stable
       metrics: stable
       logs: experimental
   dotnet:
     name: .NET
+    urlName: dotnet
     status:
       traces: stable
       metrics: stable
       logs: mixed*
   erlang:
     name: Erlang/Elixir
+    urlName: erlang
     status:
       traces: stable
       metrics: experimental
       logs: experimental
   go:
     name: Go
+    urlName: go
     status:
       traces: stable
       metrics: beta
       logs: not yet implemented
   java:
     name: Java
+    urlName: java
     status:
       traces: stable
       metrics: stable
       logs: stable
   php:
     name: PHP
+    urlName: php
     status:
       traces: beta
       metrics: beta
       logs: alpha
   python:
     name: Python
+    urlName: python
     status:
       traces: stable
       metrics: stable
       logs: experimental
   ruby:
     name: Ruby
+    urlName: ruby
     status:
       traces: stable
       metrics: not yet implemented
       logs: not yet implemented
   js:
     name: JavaScript
+    urlName: js
     status:
       traces: stable
       metrics: stable
       logs: Development
   rust:
     name: Rust
+    urlName: rust
     status:
       traces: beta
       metrics: alpha
       logs: not yet implemented
   swift:
     name: Swift
+    urlName: swift
     status:
       traces: stable
       metrics: experimental

--- a/layouts/shortcodes/sampling-support-list.md
+++ b/layouts/shortcodes/sampling-support-list.md
@@ -1,9 +1,6 @@
 {{ $data := $.Site.Data.instrumentation.languages }}
 
 {{ range $data }}
-{{ end }}
-
-{{ range $data }}
   {{ $path := printf "docs/instrumentation/%s/sampling.md" .urlName }}
   {{ $name := .name }}
   {{ with site.GetPage $path }}- [{{ $name }}]({{ .RelPermalink }}){{ end }}

--- a/layouts/shortcodes/sampling-support-list.md
+++ b/layouts/shortcodes/sampling-support-list.md
@@ -1,0 +1,10 @@
+{{ $data := $.Site.Data.instrumentation.languages }}
+
+{{ range $data }}
+{{ end }}
+
+{{ range $data }}
+  {{ $path := printf "docs/instrumentation/%s/sampling.md" .urlName }}
+  {{ $name := .name }}
+  {{ with site.GetPage $path }}- [{{ $name }}]({{ .RelPermalink }}){{ end }}
+{{ end }}

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
           "Kubernetes",
           "MySQL",
           "NGINX",
+          "OpenTelemetry Collector",
           "OTel",
           "OTEP",
           "PHP",


### PR DESCRIPTION
This PR adds a section to the footer of the sampling concept page to point to relevant collector processors and to languages that have documentation on sampling (well-aware that for some languages just the docs are missing). This way readers can read on after going through the concepts, if this proves valuable we can use it as a pattern on other pages as well.