### PR TITLE
Fixes #2907 - Schema files are served from semantic-conventions.

### DIFF
--- a/.github/workflows/auto-update-versions.yml
+++ b/.github/workflows/auto-update-versions.yml
@@ -26,6 +26,7 @@ jobs:
           .github/workflows/scripts/auto-update-version.sh opentelemetry-java-instrumentation javaInstrumentationVersion content/en/docs/instrumentation/java/automatic/annotations.md
           .github/workflows/scripts/auto-update-version.sh opentelemetry-specification spec scripts/content-modules/adjust-pages.pl
           .github/workflows/scripts/auto-update-version.sh opentelemetry-proto otlp scripts/content-modules/adjust-pages.pl
+          .github/workflows/scripts/auto-update-version.sh semantic-conventions semconv
         env:
           # change this to secrets.GITHUB_TOKEN when testing against a fork
           GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}

--- a/.github/workflows/auto-update-versions.yml
+++ b/.github/workflows/auto-update-versions.yml
@@ -26,7 +26,7 @@ jobs:
           .github/workflows/scripts/auto-update-version.sh opentelemetry-java-instrumentation javaInstrumentationVersion content/en/docs/instrumentation/java/automatic/annotations.md
           .github/workflows/scripts/auto-update-version.sh opentelemetry-specification spec scripts/content-modules/adjust-pages.pl
           .github/workflows/scripts/auto-update-version.sh opentelemetry-proto otlp scripts/content-modules/adjust-pages.pl
-          .github/workflows/scripts/auto-update-version.sh semantic-conventions semconv
+          .github/workflows/scripts/auto-update-version.sh semantic-conventions semconv scripts/content-modules/adjust-pages.pl
         env:
           # change this to secrets.GITHUB_TOKEN when testing against a fork
           GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -189,6 +189,8 @@ module:
       target: content/community/mission.md
     - source: tmp/community/roadmap.md
       target: content/community/roadmap.md
+    - source: tmp/semconv/specification/
+      target: content/docs/specs/semconv
     - source: static
       target: static
     - source: content-modules/semantic-conventions/schemas

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -35,6 +35,7 @@ sub printTitleAndFrontMatter() {
   } elsif ($title eq 'OpenTelemetry Protocol Specification') {
     $frontMatterFromFile =~ s/(title|linkTitle): .*/$& $otlpSpecVers/g;
   } elsif ($title eq 'OpenTelemetry Semantic Conventions') {
+    $title .= " $semconvSpecVers";
     $frontMatterFromFile =~ s/(title|linkTitle): .*/$& $semconvSpecVers/g;
   }
   my $titleMaybeQuoted = ($title =~ ':') ? "\"$title\"" : $title;
@@ -82,6 +83,10 @@ while(<>) {
     while(<>) { last if/<!-- tocstop -->/; }
     next;
   }
+
+  # SEMANTIC CONVENTIONS custom processing
+
+  s|\(https://github.com/open-telemetry/semantic-conventions\)|($specBasePath/semconv)|;
 
   # SPECIFICATION custom processing
 

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -13,15 +13,18 @@ my $linkTitle = '';
 my $gD = 0;
 my $otelSpecRepoUrl = 'https://github.com/open-telemetry/opentelemetry-specification';
 my $otlpSpecRepoUrl = 'https://github.com/open-telemetry/opentelemetry-proto';
+my $semconvSpecRepoUrl = 'https://github.com/open-telemetry/semantic-conventions';
 my $semConvRef = "$otelSpecRepoUrl/blob/main/semantic_conventions/README.md";
 my $specBasePath = '/docs/specs';
 my $path_base_for_github_subdir = "content/en$specBasePath";
 my %versions = qw(
   spec: 1.22.0
   otlp: 0.20.0
+  semconv: 1.21.0
 );
 my $otelSpecVers = $versions{'spec:'};
 my $otlpSpecVers = $versions{'otlp:'};
+my $semconvSpecVers = $versions{'semconv:'};
 my $unused;
 
 sub printTitleAndFrontMatter() {
@@ -31,6 +34,8 @@ sub printTitleAndFrontMatter() {
     $frontMatterFromFile =~ s/(linkTitle:) .*/$1 OTel $otelSpecVers/;
   } elsif ($title eq 'OpenTelemetry Protocol Specification') {
     $frontMatterFromFile =~ s/(title|linkTitle): .*/$& $otlpSpecVers/g;
+  } elsif ($title eq 'OpenTelemetry Semantic Conventions') {
+    $frontMatterFromFile =~ s/(title|linkTitle): .*/$& $semconvSpecVers/g;
   }
   my $titleMaybeQuoted = ($title =~ ':') ? "\"$title\"" : $title;
   print "title: $titleMaybeQuoted\n" if $frontMatterFromFile !~ /title: /;

--- a/scripts/content-modules/cp-pages.sh
+++ b/scripts/content-modules/cp-pages.sh
@@ -15,7 +15,7 @@ cp -R $SRC/* $DEST/
 find $DEST/ -name "README.md" -exec sh -c 'f="{}"; mv -- "$f" "${f%README.md}_index.md"' \;
 
 # To exclude a file use, e.g.: -not -path '*/specification/_index.md'
-FILES=$(find $DEST -name "*.md")
+FILES=$(find $DEST -name "*.md" -not -path '*/specification/*/semantic_conventions/*')
 
 $SCRIPT_DIR/adjust-pages.pl $FILES
 

--- a/scripts/content-modules/cp-pages.sh
+++ b/scripts/content-modules/cp-pages.sh
@@ -65,3 +65,21 @@ FILES=$(find $DEST -name mission-vision-values.md -o -name roadmap.md)
 $SCRIPT_DIR/adjust-pages.pl $FILES
 
 echo "COMMUNITY pages: copied and processed"
+
+## Semantic Conventions
+
+SRC=content-modules/semantic-conventions/specification
+DEST=$DEST_BASE/semconv/specification
+
+rm -Rf $DEST
+mkdir -p $DEST
+cp -R $SRC/* $DEST/
+
+find $DEST/ -name "README.md" -exec sh -c 'f="{}"; mv -- "$f" "${f%README.md}_index.md"' \;
+
+# To exclude a file use, e.g.: -not -path '*/specification/_index.md'
+FILES=$(find $DEST -name "*.md")
+
+$SCRIPT_DIR/adjust-pages.pl $FILES
+
+echo "OTEL SEMCONV pages: copied and processed"


### PR DESCRIPTION
We'd like to move schema files to be served from the semantic-conventions repository.  This is the first step, next we'd like to add an OpenTelemetry-Bot action that will bump the content module every time semantic conventions cuts a release.

DO NOT MERGE:  This would make the `1.21.0` schema available immediately. 

This PR is for review, to make sure this is the right approach for publishing schema files into the website going forward.


## TODOS

- [X] Add semantic-conventions as subcontent module
- [X] Update auto-upgrade script to apply to semantic-conventions subcontent module
- [ ] Add semantic conventions to ToC / index
- [ ] Ensure semantic-conventions -> specification links are accurately internalized to the website
- [ ] Ensure specification -> semantic-conventions links are accurately internalized to the website.
- [ ] Remove `specification/semantic_conventions/*.md` from being pulled in OpenTelemetry specification.
- [ ] Figure out if supplementary guidelines belong on the website
