### PR TITLE
Add semantic-conventions as a submodule and get schemas from there, with one exception

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,3 +11,6 @@
 [submodule "content-modules/opentelemetry-proto"]
 	path = content-modules/opentelemetry-proto
 	url = https://github.com/open-telemetry/opentelemetry-proto
+[submodule "content-modules/semantic-conventions"]
+	path = content-modules/semantic-conventions
+	url = https://github.com/open-telemetry/semantic-conventions

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -191,8 +191,17 @@ module:
       target: content/community/roadmap.md
     - source: static
       target: static
+    - source: content-modules/semantic-conventions/schemas
+      target: static/schemas
+      # TODO: drop the lines marked below once
+      # https://github.com/open-telemetry/opentelemetry.io/issues/2721
+      # is fully resolved.
+      # [DROP-FROM-HERE
+      excludeFiles: [1.21.0]
     - source: content-modules/opentelemetry-specification/schemas
       target: static/schemas
+      includeFiles: [1.21.0]
+      # DROP-TO-HERE]
     - source: static/img
       target: static/img
     - source: content-modules/opentelemetry-specification/internal/img


### PR DESCRIPTION
- Contributes to #2721
  - Brings in https://github.com/open-telemetry/semantic-conventions as a `content-modules`
- Closes #2907
  - Also ensure that we temporarily get the 1.21.0 schema from the OTel spec repo (will track removal of this special case via 2721)

There are no changes in the generated site files:

```console
$ npm run build
...
$ (cd public && git diff) # no change
$
```
