### PR TITLE
Add SemConv spec under docs/specs (preview)

### DIFF
--- a/content/en/docs/specs/semconv/_index.md
+++ b/content/en/docs/specs/semconv/_index.md
@@ -1,0 +1,6 @@
+---
+title: OpenTelemetry Semantic Conventions
+linkTitle: SemConv
+cascade:
+  draft: true
+---

--- a/content/en/docs/specs/semconv/_index.md
+++ b/content/en/docs/specs/semconv/_index.md
@@ -1,6 +1,6 @@
 ---
 title: OpenTelemetry Semantic Conventions
-linkTitle: SemConv
+linkTitle: Semantic Conventions
 cascade:
   draft: true
 ---

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -185,6 +185,14 @@ module:
       target: content/docs/specs/otlp/_index.md
     - source: tmp/otlp/docs/img
       target: content/docs/specs/otlp/img
+    - source: tmp/semconv/specification/logs
+      target: content/docs/specs/semconv/logs
+    - source: tmp/semconv/specification/metrics
+      target: content/docs/specs/semconv/metrics
+    - source: tmp/semconv/specification/resource
+      target: content/docs/specs/semconv/resource
+    - source: tmp/semconv/specification/trace
+      target: content/docs/specs/semconv/trace
     - source: tmp/community/mission-vision-values.md
       target: content/community/mission.md
     - source: tmp/community/roadmap.md

--- a/scripts/content-modules/cp-pages.sh
+++ b/scripts/content-modules/cp-pages.sh
@@ -65,3 +65,21 @@ FILES=$(find $DEST -name mission-vision-values.md -o -name roadmap.md)
 $SCRIPT_DIR/adjust-pages.pl $FILES
 
 echo "COMMUNITY pages: copied and processed"
+
+## Semantic Conventions
+
+SRC=content-modules/semantic-conventions/specification
+DEST=$DEST_BASE/semconv/specification
+
+rm -Rf $DEST
+mkdir -p $DEST
+cp -R $SRC/* $DEST/
+
+find $DEST/ -name "README.md" -exec sh -c 'f="{}"; mv -- "$f" "${f%README.md}_index.md"' \;
+
+# To exclude a file use, e.g.: -not -path '*/specification/_index.md'
+FILES=$(find $DEST -name "*.md")
+
+$SCRIPT_DIR/adjust-pages.pl $FILES
+
+echo "OTEL SEMCONV pages: copied and processed"

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -311,6 +311,14 @@
     "StatusCode": 200,
     "LastSeen": "2023-02-15T20:40:15.875102-05:00"
   },
+  "https://cloud.google.com/compute/docs/instances/custom-hostname-vm": {
+    "StatusCode": 200,
+    "LastSeen": "2023-06-27T17:18:02.125065-04:00"
+  },
+  "https://cloud.google.com/compute/docs/internal-dns#instance-fully-qualified-domain-names": {
+    "StatusCode": 200,
+    "LastSeen": "2023-06-27T17:17:56.736764-04:00"
+  },
   "https://cloud.google.com/error-reporting/reference/rest/v1beta1/projects.events/report": {
     "StatusCode": 200,
     "LastSeen": "2023-02-15T20:39:17.120733-05:00"
@@ -1002,6 +1010,10 @@
   "https://docs.oracle.com/en/java/javase/17/docs/api/jdk.management/com/sun/management/OperatingSystemMXBean.html#getProcessCpuLoad%28%29": {
     "StatusCode": 200,
     "LastSeen": "2023-05-15T13:56:30.762393-04:00"
+  },
+  "https://docs.oracle.com/en/java/javase/17/docs/api/jdk.management/com/sun/management/OperatingSystemMXBean.html#getProcessCpuTime%28%29": {
+    "StatusCode": 200,
+    "LastSeen": "2023-06-27T17:17:39.237886-04:00"
   },
   "https://docs.oracle.com/en/java/javase/17/docs/api/jdk.management/com/sun/management/OperatingSystemMXBean.html#getSystemCpuLoad%28%29": {
     "StatusCode": 200,
@@ -4491,9 +4503,17 @@
     "StatusCode": 206,
     "LastSeen": "2023-05-15T13:56:52.995519-04:00"
   },
+  "https://www.ibm.com/docs/api/v1/content/SSYKE2_8.0.0/openj9/api/jdk8/jre/management/extension/com/ibm/lang/management/OperatingSystemMXBean.html": {
+    "StatusCode": 206,
+    "LastSeen": "2023-06-27T17:17:49.452299-04:00"
+  },
   "https://www.ibm.com/docs/api/v1/content/SSYKE2_8.0.0/openj9/api/jdk8/jre/management/extension/com/ibm/lang/management/OperatingSystemMXBean.html#getProcessCpuLoad--": {
     "StatusCode": 206,
     "LastSeen": "2023-06-09T09:34:45.428293-04:00"
+  },
+  "https://www.ibm.com/docs/api/v1/content/SSYKE2_8.0.0/openj9/api/jdk8/jre/management/extension/com/ibm/lang/management/OperatingSystemMXBean.html#getProcessCpuTime--": {
+    "StatusCode": 206,
+    "LastSeen": "2023-06-27T17:17:44.341257-04:00"
   },
   "https://www.ibm.com/docs/api/v1/content/SSYKE2_8.0.0/openj9/api/jdk8/jre/management/extension/com/ibm/lang/management/OperatingSystemMXBean.html#getSystemCpuLoad--": {
     "StatusCode": 206,
@@ -4827,6 +4847,10 @@
     "StatusCode": 200,
     "LastSeen": "2023-05-15T13:58:27.159768-04:00"
   },
+  "https://www.rfc-editor.org/rfc/rfc5789.html": {
+    "StatusCode": 200,
+    "LastSeen": "2023-06-27T17:17:33.646508-04:00"
+  },
   "https://www.rfc-editor.org/rfc/rfc9110.html": {
     "StatusCode": 200,
     "LastSeen": "2023-02-18T13:35:03.0461-05:00"
@@ -4838,6 +4862,10 @@
   "https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent": {
     "StatusCode": 200,
     "LastSeen": "2023-02-18T13:40:51.35642-05:00"
+  },
+  "https://www.rfc-editor.org/rfc/rfc9110.html#name-methods": {
+    "StatusCode": 200,
+    "LastSeen": "2023-06-27T17:17:27.904619-04:00"
   },
   "https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin": {
     "StatusCode": 200,


### PR DESCRIPTION
- Contributes to #2721
- Supersedes #2908
- Adds semconv spec to `docs/specs`
- Pages will only appear in deploy previews, not on the production server, since all spec pages are marked as `draft: true`
- We won't want to publish the semconv spec until the following restructuring is complete, IMHO:
  https://github.com/open-telemetry/semantic-conventions/issues/137

**Preview**: https://deploy-preview-2920--opentelemetry.netlify.app/docs/specs/semconv/

/cc @jsuereth @joaopgrassi 