### PR TITLE
Add Node version constraint to package.json & update contrib notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,11 +92,9 @@ $ npm run serve:netlify
 The website is built from the following content:
 
 - Files under `content/`, `static/`, etc. per [Hugo][] defaults.
-- Mount points, defined in [hugo.yaml][] under `mounts`.
-- Content from git submodules under [content-modules][].
-
-Note that nonstandard mount points and symlinked sections under `content/` refer
-to directories under [content-modules][], and no where else.
+- Mount points, defined in [hugo.yaml][] under `mounts`. Mounts are either
+  directly from git submodules under [content-modules][], or preprocessed
+  content from `content-modules` (placed under `tmp/`), and no where else.
 
 [hugo.yaml]:
   https://github.com/open-telemetry/opentelemetry.io/blob/main/hugo.yaml

--- a/package.json
+++ b/package.json
@@ -64,6 +64,35 @@
     "update:submodule:lang": "run-s update:submodule _get:submodule:non-lang",
     "update:submodule": "set -x && git submodule update --remote ${DEPTH:- --depth 1}"
   },
+  "devDependencies": {
+    "autoprefixer": "^10.4.14",
+    "cspell": "^6.31.1",
+    "hugo-extended": "0.113.0",
+    "netlify-cli": "^15.0.1",
+    "npm-run-all": "^4.1.5",
+    "postcss-cli": "^10.1.0",
+    "prettier": "^2.8.4",
+    "textlint": "^13.1.4",
+    "textlint-filter-rule-allowlist": "^4.0.0",
+    "textlint-filter-rule-comments": "^1.2.2",
+    "textlint-rule-terminology": "^3.0.4"
+  },
+  "dependencies": {
+    "@opentelemetry/api": "^1.3.0",
+    "@opentelemetry/auto-instrumentations-web": "^0.32.0",
+    "@opentelemetry/context-zone": "^1.8.0",
+    "@opentelemetry/core": "^1.8.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.40.0",
+    "@opentelemetry/instrumentation": "^0.40.0",
+    "@opentelemetry/resources": "^1.8.0",
+    "@opentelemetry/sdk-trace-base": "^1.8.0",
+    "@opentelemetry/sdk-trace-web": "^1.8.0",
+    "@opentelemetry/semantic-conventions": "^1.8.0"
+  },
+  "engines-comment": "Ensure that engines.node value stays consistent with the project's .nvmrc",
+  "engines": {
+    "node": "18.x"
+  },
   "private": true,
   "prettier": {
     "proseWrap": "always",
@@ -135,30 +164,5 @@
         ]
       }
     }
-  },
-  "devDependencies": {
-    "autoprefixer": "^10.4.14",
-    "cspell": "^6.31.1",
-    "hugo-extended": "0.113.0",
-    "netlify-cli": "^15.0.1",
-    "npm-run-all": "^4.1.5",
-    "postcss-cli": "^10.1.0",
-    "prettier": "^2.8.4",
-    "textlint": "^13.1.4",
-    "textlint-filter-rule-allowlist": "^4.0.0",
-    "textlint-filter-rule-comments": "^1.2.2",
-    "textlint-rule-terminology": "^3.0.4"
-  },
-  "dependencies": {
-    "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/auto-instrumentations-web": "^0.32.0",
-    "@opentelemetry/context-zone": "^1.8.0",
-    "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/exporter-trace-otlp-http": "^0.40.0",
-    "@opentelemetry/instrumentation": "^0.40.0",
-    "@opentelemetry/resources": "^1.8.0",
-    "@opentelemetry/sdk-trace-base": "^1.8.0",
-    "@opentelemetry/sdk-trace-web": "^1.8.0",
-    "@opentelemetry/semantic-conventions": "^1.8.0"
   }
 }


### PR DESCRIPTION
- Updates `CONTRIBUTING.md`: we don't use symlinks anymore; clarifies where content comes from.
- `package.json`:
  - Adds `engines.node` entry to require active LTS version (currently 18.x)
  - Moves dependencies entries to be before `textlint` config etc.