### PR TITLE
Consistency update for TOCs of manual instrumentation pages

### DIFF
--- a/content/en/docs/instrumentation/cpp/manual.md
+++ b/content/en/docs/instrumentation/cpp/manual.md
@@ -7,7 +7,13 @@ description: Manual instrumentation for OpenTelemetry C++
 
 {{% docs/instrumentation/manual-intro %}}
 
-## Tracing
+## Setup
+
+Follow the instructions in the
+[Getting Started Guide](/docs/instrumentation/cpp/getting-started/) to build
+OpenTelemetry C++.
+
+## Traces
 
 ### Initializing tracing
 
@@ -215,3 +221,13 @@ p->AddView(std::move(observable_instrument_selector), std::move(observable_meter
 - [Metrics API](https://opentelemetry-cpp.readthedocs.io/en/latest/otel_docs/namespace_opentelemetry__metrics.html#)
 - [Metrics SDK](https://opentelemetry-cpp.readthedocs.io/en/latest/otel_docs/namespace_opentelemetry__sdk__metrics.html)
 - [Simple Metrics Example](https://github.com/open-telemetry/opentelemetry-cpp/tree/main/examples/metrics_simple)
+
+## Logs
+
+The logs API & SDK are currently under development.
+
+## Next Steps
+
+You’ll also want to configure an appropriate exporter to
+[export your telemetry data](/docs/instrumentation/cpp/exporters) to one or more
+telemetry backends.

--- a/content/en/docs/instrumentation/erlang/exporters.md
+++ b/content/en/docs/instrumentation/erlang/exporters.md
@@ -1,0 +1,126 @@
+---
+title: Exporters
+weight: 50
+spelling: cSpell:ignore ostream jaegertracing millis chrono
+---
+
+In order to visualize and analyze your [traces](/docs/concepts/signals/traces/)
+and metrics, you will need to export them to a backend.
+
+## Exporting to the OpenTelemetry Collector
+
+The [Collector](/docs/collector/) provides a vendor agnostic way to receive,
+process and export telemetry data. The package
+[opentelemetry_exporter](https://hex.pm/packages/opentelemetry_exporter)
+provides support for both exporting over both HTTP (the default) and gRPC to the
+collector, which can then export Spans to a self-hosted service like Zipkin or
+Jaeger, as well as commercial services. For a full list of available exporters,
+see the [registry](/ecosystem/registry/?component=exporter).
+
+For testing purposes the `opentelemetry-erlang` repo has a Collector
+configuration,
+[config/otel-collector-config.yaml](https://github.com/open-telemetry/opentelemetry-erlang/blob/main/config/otel-collector-config.yaml)
+that can be used as a starting point. This configuration is used in
+[docker-compose.yml](https://github.com/open-telemetry/opentelemetry-erlang/blob/main/docker-compose.yml)
+to start the Collector with receivers for both HTTP and gRPC that then export to
+Zipkin also run by [docker-compose](https://docs.docker.com/compose/).
+
+To export to the running Collector the `opentelemetry_exporter` package must be
+added to the project's dependencies:
+
+<!-- prettier-ignore-start -->
+{{< tabpane langEqualsHeader=true >}}
+
+{{< tab Erlang >}}
+{deps, [{opentelemetry_api, "~> 1.3"},
+        {opentelemetry, "~> 1.3"},
+        {opentelemetry_exporter, "~> 1.4"}]}.
+{{< /tab >}}
+
+{{< tab Elixir >}}
+def deps do
+  [
+    {:opentelemetry_api, "~> 1.3"},
+    {:opentelemetry, "~> 1.3"},
+    {:opentelemetry_exporter, "~> 1.4"}
+  ]
+end
+{{< /tab >}}
+
+{{< /tabpane >}}
+<!-- prettier-ignore-end -->
+
+It should then be added to the configuration of the Release before the SDK
+Application to ensure the exporter's dependencies are started before the SDK
+attempts to initialize and use the exporter.
+
+Example of Release configuration in `rebar.config` and for
+[mix's Release task](https://hexdocs.pm/mix/Mix.Tasks.Release.html):
+
+<!-- prettier-ignore-start -->
+{{< tabpane langEqualsHeader=true >}}
+
+{{< tab Erlang >}}
+%% rebar.config
+{relx, [{release, {my_instrumented_release, "0.1.0"},
+         [opentelemetry_exporter,
+	      {opentelemetry, temporary},
+          my_instrumented_app]},
+
+       ...]}.
+{{< /tab >}}
+
+{{< tab Elixir >}}
+# mix.exs
+def project do
+  [
+    releases: [
+      my_instrumented_release: [
+        applications: [opentelemetry_exporter: :permanent, opentelemetry: :temporary]
+      ],
+
+      ...
+    ]
+  ]
+end
+{{< /tab >}}
+
+{{< /tabpane >}}
+<!-- prettier-ignore-end -->
+
+Finally, the runtime configuration of the `opentelemetry` and
+`opentelemetry_exporter` Applications are set to export to the Collector. The
+configurations below show the defaults that are used if none are set, which are
+the HTTP protocol with endpoint of `localhost` on port `4318`. If using `grpc`
+for the `otlp_protocol` the endpoint should be changed to
+`http://localhost:4317`.
+
+<!-- prettier-ignore-start -->
+{{< tabpane langEqualsHeader=true >}}
+
+{{< tab Erlang >}}
+%% config/sys.config.src
+[
+ {opentelemetry,
+  [{span_processor, batch},
+   {traces_exporter, otlp}]},
+
+ {opentelemetry_exporter,
+  [{otlp_protocol, http_protobuf},
+   {otlp_endpoint, "http://localhost:4318"}]}]}
+].
+{{< /tab >}}
+
+{{< tab Elixir >}}
+# config/runtime.exs
+config :opentelemetry,
+  span_processor: :batch,
+  traces_exporter: :otlp
+
+config :opentelemetry_exporter,
+  otlp_protocol: :http_protobuf,
+  otlp_endpoint: "http://localhost:4318"
+{{< /tab >}}
+
+{{< /tabpane >}}
+<!-- prettier-ignore-end -->

--- a/content/en/docs/instrumentation/erlang/getting-started.md
+++ b/content/en/docs/instrumentation/erlang/getting-started.md
@@ -292,8 +292,8 @@ codebase. This allows you to customize the observability data your application
 emits.
 
 You'll also want to configure an appropriate exporter to
-[export your telemetry data](/docs/instrumentation/erlang/getting-started#exporting-to-the-opentelemetry-collector)
-to one or more telemetry backends.
+[export your telemetry data](/docs/instrumentation/erlang/exporters) to one or
+more telemetry backends.
 
 ## Creating a New Mix/Rebar Project
 
@@ -561,120 +561,11 @@ iex(2)>
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-## Exporting to the OpenTelemetry Collector
+## Next Steps
 
-The [Collector](/docs/collector/) provides a vendor agnostic way to receive,
-process and export telemetry data. The package
-[opentelemetry_exporter](https://hex.pm/packages/opentelemetry_exporter)
-provides support for both exporting over both HTTP (the default) and gRPC to the
-collector, which can then export Spans to a self-hosted service like Zipkin or
-Jaeger, as well as commercial services. For a full list of available exporters,
-see the [registry](/ecosystem/registry/?component=exporter).
+Enrich your instrumentation with more
+[manual instrumentation](/docs/instrumentation/erlang/manual).
 
-For testing purposes the `opentelemetry-erlang` repo has a Collector
-configuration,
-[config/otel-collector-config.yaml](https://github.com/open-telemetry/opentelemetry-erlang/blob/main/config/otel-collector-config.yaml)
-that can be used as a starting point. This configuration is used in
-[docker-compose.yml](https://github.com/open-telemetry/opentelemetry-erlang/blob/main/docker-compose.yml)
-to start the Collector with receivers for both HTTP and gRPC that then export to
-Zipkin also run by [docker-compose](https://docs.docker.com/compose/).
-
-To export to the running Collector the `opentelemetry_exporter` package must be
-added to the project's dependencies:
-
-<!-- prettier-ignore-start -->
-{{< tabpane langEqualsHeader=true >}}
-
-{{< tab Erlang >}}
-{deps, [{opentelemetry_api, "~> 1.3"},
-        {opentelemetry, "~> 1.3"},
-        {opentelemetry_exporter, "~> 1.4"}]}.
-{{< /tab >}}
-
-{{< tab Elixir >}}
-def deps do
-  [
-    {:opentelemetry_api, "~> 1.3"},
-    {:opentelemetry, "~> 1.3"},
-    {:opentelemetry_exporter, "~> 1.4"}
-  ]
-end
-{{< /tab >}}
-
-{{< /tabpane >}}
-<!-- prettier-ignore-end -->
-
-It should then be added to the configuration of the Release before the SDK
-Application to ensure the exporter's dependencies are started before the SDK
-attempts to initialize and use the exporter.
-
-Example of Release configuration in `rebar.config` and for
-[mix's Release task](https://hexdocs.pm/mix/Mix.Tasks.Release.html):
-
-<!-- prettier-ignore-start -->
-{{< tabpane langEqualsHeader=true >}}
-
-{{< tab Erlang >}}
-%% rebar.config
-{relx, [{release, {my_instrumented_release, "0.1.0"},
-         [opentelemetry_exporter,
-	      {opentelemetry, temporary},
-          my_instrumented_app]},
-
-       ...]}.
-{{< /tab >}}
-
-{{< tab Elixir >}}
-# mix.exs
-def project do
-  [
-    releases: [
-      my_instrumented_release: [
-        applications: [opentelemetry_exporter: :permanent, opentelemetry: :temporary]
-      ],
-
-      ...
-    ]
-  ]
-end
-{{< /tab >}}
-
-{{< /tabpane >}}
-<!-- prettier-ignore-end -->
-
-Finally, the runtime configuration of the `opentelemetry` and
-`opentelemetry_exporter` Applications are set to export to the Collector. The
-configurations below show the defaults that are used if none are set, which are
-the HTTP protocol with endpoint of `localhost` on port `4318`. If using `grpc`
-for the `otlp_protocol` the endpoint should be changed to
-`http://localhost:4317`.
-
-<!-- prettier-ignore-start -->
-{{< tabpane langEqualsHeader=true >}}
-
-{{< tab Erlang >}}
-%% config/sys.config.src
-[
- {opentelemetry,
-  [{span_processor, batch},
-   {traces_exporter, otlp}]},
-
- {opentelemetry_exporter,
-  [{otlp_protocol, http_protobuf},
-   {otlp_endpoint, "http://localhost:4318"}]}]}
-].
-{{< /tab >}}
-
-{{< tab Elixir >}}
-# config/runtime.exs
-config :opentelemetry,
-  span_processor: :batch,
-  traces_exporter: :otlp
-
-config :opentelemetry_exporter,
-  otlp_protocol: :http_protobuf,
-  otlp_endpoint: "http://localhost:4318"
-{{< /tab >}}
-
-{{< /tabpane >}}
-<!-- prettier-ignore-end -->
+You'll also want to configure an appropriate exporter to
+[export your telemetry data](/docs/instrumentation/erlang/exporters) to one or
+more telemetry backends.

--- a/content/en/docs/instrumentation/erlang/manual.md
+++ b/content/en/docs/instrumentation/erlang/manual.md
@@ -7,7 +7,27 @@ description: Manual instrumentation for OpenTelemetry Erlang/Elixir
 
 {{% docs/instrumentation/manual-intro %}}
 
-## Tracing
+## Setup
+
+Add the following dependencies to your project:
+
+- `opentelemetry_api`: contains the interfaces you'll use to instrument your
+  code. Things like `Tracer.with_span` and `Tracer.set_attribute` are defined
+  here.
+- `opentelemetry`: contains the SDK that implements the interfaces defined in
+  the API. Without it, all the functions in the API are no-ops.
+
+```elixir
+# mix.exs
+def deps do
+  [
+    {:opentelemetry, "~> 1.3"},
+    {:opentelemetry_api, "~> 1.2"},
+  ]
+end
+```
+
+## Traces
 
 ### Initialize Tracing
 
@@ -353,11 +373,23 @@ Tracer.set_status(:error, "this is not ok")
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-## Creating Metrics
+## Metrics
 
 The metrics API, found in `apps/opentelemetry_experimental_api` of the
 [opentelemetry-erlang](https://github.com/open-telemetry/opentelemetry-erlang)
 repository, is currently unstable, documentation TBA.
+
+## Logs
+
+The logs API, found in `apps/opentelemetry_experimental_api` of the
+[opentelemetry-erlang](https://github.com/open-telemetry/opentelemetry-erlang)
+repository, is currently unstable, documentation TBA.
+
+## Next Steps
+
+You’ll also want to configure an appropriate exporter to
+[export your telemetry data](/docs/instrumentation/erlang/exporters) to one or
+more telemetry backends.
 
 [opentelemetry specification]: /docs/specs/otel/
 [trace semantic conventions]: /docs/specs/otel/trace/semantic_conventions/

--- a/content/en/docs/instrumentation/go/manual.md
+++ b/content/en/docs/instrumentation/go/manual.md
@@ -10,11 +10,13 @@ description: Manual instrumentation for OpenTelemetry Go
 
 {{% docs/instrumentation/manual-intro %}}
 
-## Getting a Tracer
+## Setup
+
+## Traces
+
+### Getting a Tracer
 
 To create spans, you'll need to acquire or initialize a tracer first.
-
-### Initializing a new tracer
 
 Ensure you have the right packages installed:
 
@@ -91,7 +93,7 @@ func main() {
 
 You can now access `tracer` to manually instrument your code.
 
-## Creating Spans
+### Creating Spans
 
 Spans are created by tracers. If you don't have one initialized, you'll need to
 do that.
@@ -267,11 +269,7 @@ It is highly recommended that you also set a span's status to `Error` when using
 operation as an error span. The `RecordError` function does **not**
 automatically set a span status when called.
 
-## Creating Metrics
-
-The metrics API is currently unstable, documentation TBA.
-
-## Propagators and Context
+### Propagators and Context
 
 Traces can extend beyond a single process. This requires _context propagation_,
 a mechanism where identifiers for a trace are sent to remote processes.
@@ -295,6 +293,20 @@ otel.SetTextMapPropagator(propagation.TraceContext{})
 After configuring context propagation, you'll most likely want to use automatic
 instrumentation to handle the behind-the-scenes work of actually managing
 serializing the context.
+
+## Metrics
+
+The metrics API is currently unstable, documentation TBA.
+
+## Logs
+
+The logs API is currently unstable, documentation TBA.
+
+## Next Steps
+
+You’ll also want to configure an appropriate exporter to
+[export your telemetry data](/docs/instrumentation/go/exporters) to one or more
+telemetry backends.
 
 [opentelemetry specification]: /docs/specs/otel/
 [trace semantic conventions]: /docs/specs/otel/trace/semantic_conventions/

--- a/content/en/docs/instrumentation/java/manual.md
+++ b/content/en/docs/instrumentation/java/manual.md
@@ -138,7 +138,9 @@ reason, you can fall back to using an instance from the `GlobalOpenTelemetry`
 class. Note that you can't force end-users to configure the global, so this is
 the most brittle option for library instrumentation.
 
-## Acquiring a Tracer
+## Traces
+
+### Acquiring a Tracer
 
 To do [Tracing](/docs/concepts/signals/traces/) you'll need to acquire a
 [`Tracer`](/docs/concepts/signals/traces/#tracer).

--- a/content/en/docs/instrumentation/js/manual.md
+++ b/content/en/docs/instrumentation/js/manual.md
@@ -10,7 +10,7 @@ description: Manual instrumentation for OpenTelemetry JavaScript
 
 {{% docs/instrumentation/manual-intro %}}
 
-## Tracing
+## Traces
 
 ### Initialize Tracing
 
@@ -1116,6 +1116,10 @@ const meterProvider = new MeterProvider({
   views: [limitAttributesView, dropView, histogramView],
 });
 ```
+
+## Logs
+
+The logs API & SDK are currently under development.
 
 ## Next steps
 

--- a/content/en/docs/instrumentation/net/manual.md
+++ b/content/en/docs/instrumentation/net/manual.md
@@ -22,13 +22,15 @@ are covered here as well as the `System.Diagnostics` API.
 If you prefer to use OpenTelemetry APIs instead of `System.Diagnostics` APIs,
 you can refer to the [OpenTelemetry API Shim docs for tracing](../shim).
 
-## Initializing tracing
+## Traces
+
+### Initializing tracing
 
 There are two main ways to initialize [tracing](/docs/concepts/signals/traces/),
 depending on whether you're using a console app or something that's ASP.NET
 Core-based.
 
-### Console app
+#### Console app
 
 To start tracing in a console app, you need to create a tracer provider.
 
@@ -69,7 +71,7 @@ This is also where you can configure instrumentation libraries.
 Note that this sample uses the Console Exporter. If you are exporting to another
 endpoint, you'll have to use a different exporter.
 
-### ASP.NET Core
+#### ASP.NET Core
 
 To start tracing in an ASP.NET Core-based app, use the OpenTelemetry extensions
 for ASP.NET Core setup.
@@ -126,7 +128,7 @@ This is also where you can configure instrumentation libraries.
 Note that this sample uses the Console Exporter. If you are exporting to another
 endpoint, you'll have to use a different exporter.
 
-## Setting up an ActivitySource
+### Setting up an ActivitySource
 
 Once tracing is initialized, you can configure an
 [`ActivitySource`](/docs/concepts/signals/traces/#tracer), which will be how you
@@ -154,7 +156,7 @@ public static class Telemetry
 You can instantiate several `ActivitySource`s if that suits your scenario,
 although it is generally sufficient to just have one defined per service.
 
-## Creating Activities
+### Creating Activities
 
 To create an [`Activity`](/docs/concepts/signals/traces/#spans), give it a name
 and create it from your
@@ -166,7 +168,7 @@ using var myActivity = MyActivitySource.StartActivity("SayHello");
 // do work that 'myActivity' will now track
 ```
 
-## Creating nested Activities
+### Creating nested Activities
 
 If you have a distinct sub-operation you'd like to track as a part of another
 one, you can create activities to represent the relationship.
@@ -220,7 +222,7 @@ In the preceding example, `childActivity` is ended because the scope of the
 `using` block is explicitly defined, rather than scoped to `DoWork` itself like
 `parentActivity`.
 
-## Creating independent Activities
+### Creating independent Activities
 
 The previous examples showed how to create Activities that follow a nested
 hierarchy. In some cases, you'll want to create independent Activities that are
@@ -246,7 +248,7 @@ public static void DoWork()
 }
 ```
 
-## Creating new root Activities
+### Creating new root Activities
 
 If you wish to create a new root Activity, you'll need to "de-parent" from the
 current activity.
@@ -264,7 +266,7 @@ public static void DoWork()
 }
 ```
 
-## Get the current Activity
+### Get the current Activity
 
 Sometimes it's helpful to access whatever the current `Activity` is at a point
 in time so you can enrich it with more information.
@@ -277,7 +279,7 @@ var activity = Activity.Current;
 Note that `using` is not used in the prior example. Doing so will end current
 `Activity`, which is not likely to be desired.
 
-## Add tags to an Activity
+### Add tags to an Activity
 
 Tags (the equivalent of
 [`Attributes`](/docs/concepts/signals/traces/#attributes) in OpenTelemetry) let
@@ -295,7 +297,7 @@ activity?.SetTag("operation.other-stuff", new int[] { 1, 2, 3 });
 We recommend that all Tag names are defined in constants rather than defined
 inline as this provides both consistency and also discoverability.
 
-## Adding events
+### Adding events
 
 An [event](/docs/concepts/signals/traces/#span-events) is a human-readable
 message on an `Activity` that represents "something happening" during its
@@ -334,7 +336,7 @@ var eventTags = new Dictionary<string, object?>
 myActivity?.AddEvent(new("Gonna try it!", DateTimeOffset.Now, new(eventTags)));
 ```
 
-## Adding links
+### Adding links
 
 An `Activity` can be created with zero or more
 [`ActivityLink`s](/docs/concepts/signals/traces/#span-links) that are causally
@@ -358,7 +360,7 @@ using var anotherActivity =
 // do some work
 ```
 
-## Set Activity status
+### Set Activity status
 
 A [status](/docs/concepts/signals/traces/#span-status) can be set on an
 activity, typically used to specify that an activity has not completed
@@ -380,6 +382,16 @@ catch (Exception ex)
     myActivity.SetStatus(ActivityStatusCode.Error, "Something bad happened!");
 }
 ```
+
+## Metrics
+
+The documentation for the metrics API & SDK is missing, you can help make it
+available by
+[editing this page](https://github.com/open-telemetry/opentelemetry.io/edit/main/content/en/docs/instrumentation/net/manual.md).
+
+## Logs
+
+The logs API & SDK are currently under development.
 
 ## Next steps
 

--- a/content/en/docs/instrumentation/php/manual.md
+++ b/content/en/docs/instrumentation/php/manual.md
@@ -146,30 +146,7 @@ function as part of PHP's shutdown process:
 \OpenTelemetry\SDK\Common\Util\ShutdownHandler::register([$loggerProvider, 'shutdown']);
 ```
 
-## Logging and Error Handling
-
-### Default
-
-By default, OpenTelemetry will log errora and warnings via PHP's
-[`error_log`](https://www.php.net/manual/en/function.error-log.php) function.
-The verbosity can be controlled or disabled via the `OTEL_LOG_LEVEL` setting.
-
-Messages sent to `error_log` will be at a level no higher than `E_USER_WARNING`,
-to avoid breaking applications.
-
-### PSR-3
-
-You can optionally configure OpenTelemetry to instead log via a PSR-3 logger:
-
-```php
-$logger = new \Example\Psr3Logger(LogLevel::INFO);
-\OpenTelemetry\API\LoggerHolder::set($logger);
-```
-
-For more fine-grained control and special case handling, custom handlers and
-filters can be applied to the logger (if the logger offers this ability).
-
-## Tracing
+## Traces
 
 ### Acquiring a Tracer
 
@@ -559,7 +536,7 @@ $reader->collect();
 
 </details>
 
-## Logging
+## Logs
 
 As logging is a mature and well-established function, the
 [OpenTelemetry approach](/docs/concepts/signals/logs/) is a little different for
@@ -758,3 +735,28 @@ $monolog->error('oh no', [
 ```
 
 </details>
+
+## Error Handling
+
+By default, OpenTelemetry will log errors and warnings via PHP's
+[`error_log`](https://www.php.net/manual/en/function.error-log.php) function.
+The verbosity can be controlled or disabled via the `OTEL_LOG_LEVEL` setting.
+
+Messages sent to `error_log` will be at a level no higher than `E_USER_WARNING`,
+to avoid breaking applications.
+
+You can optionally configure OpenTelemetry to instead log via a PSR-3 logger:
+
+```php
+$logger = new \Example\Psr3Logger(LogLevel::INFO);
+\OpenTelemetry\API\LoggerHolder::set($logger);
+```
+
+For more fine-grained control and special case handling, custom handlers and
+filters can be applied to the logger (if the logger offers this ability).
+
+## Next steps
+
+You'll also want to configure an appropriate exporter to
+[export your telemetry data](/docs/instrumentation/php/exporters) to one or more
+telemetry backends.

--- a/content/en/docs/instrumentation/python/manual.md
+++ b/content/en/docs/instrumentation/python/manual.md
@@ -7,14 +7,18 @@ description: Manual instrumentation for OpenTelemetry Python
 
 {{% docs/instrumentation/manual-intro %}}
 
-## Initializing the SDK
+## Setup
 
 First, ensure you have the API and SDK packages:
 
-```
+```shell
 pip install opentelemetry-api
 pip install opentelemetry-sdk
 ```
+
+## Traces
+
+### Acquire Tracer
 
 To start tracing, you'll need to initialize a
 [`TracerProvider`](/docs/concepts/signals/traces/#tracer-provider) and
@@ -60,8 +64,6 @@ metrics.set_meter_provider(provider)
 # Creates a meter from the global meter provider
 meter = metrics.get_meter("my.meter.name")
 ```
-
-## Tracing
 
 ### Creating spans
 
@@ -313,6 +315,13 @@ set_global_textmap(B3Format())
 
 Note that environment variables will override what's configured in code.
 
+### Further Reading
+
+- [Trace Concepts](/docs/concepts/signals/traces/)
+- [Trace Specification](/docs/specs/otel/overview/#tracing-signal)
+- [Python Trace API Documentation](https://opentelemetry-python.readthedocs.io/en/latest/api/trace.html)
+- [Python Trace SDK Documentation](https://opentelemetry-python.readthedocs.io/en/latest/sdk/trace.html)
+
 ## Metrics
 
 ### Creating and using synchronous instruments
@@ -385,15 +394,19 @@ meter.create_observable_gauge(
 )
 ```
 
-## Additional References
+### Further Reading
 
-- Trace
-  - [Trace Concepts](/docs/concepts/signals/traces/)
-  - [Trace Specification](/docs/specs/otel/overview/#tracing-signal)
-  - [Python Trace API Documentation](https://opentelemetry-python.readthedocs.io/en/latest/api/trace.html)
-  - [Python Trace SDK Documentation](https://opentelemetry-python.readthedocs.io/en/latest/sdk/trace.html)
-- Metrics
-  - [Metrics Concepts](/docs/concepts/signals/metrics/)
-  - [Metrics Specification](/docs/specs/otel/metrics/)
-  - [Python Metrics API Documentation](https://opentelemetry-python.readthedocs.io/en/latest/api/metrics.html)
-  - [Python Metrics SDK Documentation](https://opentelemetry-python.readthedocs.io/en/latest/sdk/metrics.html)
+- [Metrics Concepts](/docs/concepts/signals/metrics/)
+- [Metrics Specification](/docs/specs/otel/metrics/)
+- [Python Metrics API Documentation](https://opentelemetry-python.readthedocs.io/en/latest/api/metrics.html)
+- [Python Metrics SDK Documentation](https://opentelemetry-python.readthedocs.io/en/latest/sdk/metrics.html)
+
+## Logs
+
+The logs API & SDK are currently under development.
+
+## Next Steps
+
+You’ll also want to configure an appropriate exporter to
+[export your telemetry data](/docs/instrumentation/python/exporters) to one or
+more telemetry backends.

--- a/content/en/docs/instrumentation/ruby/manual.md
+++ b/content/en/docs/instrumentation/ruby/manual.md
@@ -11,7 +11,7 @@ description: Manual instrumentation for OpenTelemetry Ruby
 
 {{% docs/instrumentation/manual-intro %}}
 
-## Initializing the SDK
+## Setup
 
 First, ensure you have the SDK package installed:
 
@@ -21,6 +21,8 @@ gem install opentelemetry-sdk
 
 Then include configuration code that runs when your program initializes. Make
 sure that `service.name` is set by configuring a service name.
+
+## Traces
 
 ### Acquiring a Tracer
 
@@ -46,8 +48,6 @@ MyAppTracer = OpenTelemetry.tracer_provider.tracer('<YOUR_TRACER_NAME>')
 ```
 
 With a `Tracer` acquired, you can manually trace code.
-
-## Tracing
 
 ### Get the current span
 
@@ -316,7 +316,7 @@ Exceptions can also be recorded with additional attributes:
 current_span.record_exception(ex, attributes: { "some.attribute" => 12 })
 ```
 
-## Context Propagation
+### Context Propagation
 
 > Distributed Tracing tracks the progression of a single Request, called a
 > Trace, as it is handled by Services that make up an Application. A Distributed
@@ -347,6 +347,20 @@ dependencies to your Gemfile, e.g.:
 ```ruby
 gem 'opentelemetry-propagator-b3'
 ```
+
+## Metrics
+
+The metrics API & SDK are currently under development.
+
+## Logs
+
+The logs API & SDK are currently under development.
+
+## Next Steps
+
+You’ll also want to configure an appropriate exporter to
+[export your telemetry data](/docs/instrumentation/ruby/exporters) to one or
+more telemetry backends.
 
 [glossary]: /docs/concepts/glossary/
 [propagators]:

--- a/content/en/docs/instrumentation/swift/manual.md
+++ b/content/en/docs/instrumentation/swift/manual.md
@@ -59,7 +59,9 @@ OpenTelemetry.registerMeterProvider(meterProvider: MeterProviderBuilder()
 After configuring the MeterProvider & TracerProvider all subsequently
 initialized instrumentation will be exporting using this OTLP exporter.
 
-## Acquiring a Tracer
+## Traces
+
+### Acquiring a Tracer
 
 To do tracing, you will need a tracer. A tracer is acquired through the tracer
 provider and is responsible for creating spans. The OpenTelemetry manages the
@@ -210,6 +212,16 @@ do {
 }
 span.end()
 ```
+
+## Metrics
+
+The documentation for the metrics API & SDK is missing, you can help make it
+available by
+[editing this page](https://github.com/open-telemetry/opentelemetry.io/edit/main/content/en/docs/instrumentation/swift/manual.md).
+
+## Logs
+
+The logs API & SDK are currently under development.
 
 ## SDK Configuration
 


### PR DESCRIPTION
Another consistency update for the manual instrumentation pages. After this PR gets merged:

* all languages more or less have the same structure:
  ```
  Setup
  Traces
  Metrics
  Logs
  ...
  Next Steps
  ```
* if a signal is not yet stable or documentation is missing, this is called out in place. if the signal is stable, readers are asked to contribute
* Moved the section about OTLP Exporter for erlang to a separate page to follow the structure of other languages
* Some other structural updates to create consistency