### PR TITLE
Update lambda-auto-instrument.md

### DIFF
--- a/content/en/docs/faas/lambda-auto-instrument.md
+++ b/content/en/docs/faas/lambda-auto-instrument.md
@@ -28,7 +28,7 @@ first.
 {{< tabpane text=true >}}
 {{% tab Java %}}
 
-The Lambda layer supports the Java 8, 11, and 17 (Corretto) Lambda runtimes. 
+The Lambda layer supports the Java 8, 11, and 17 (Corretto) Lambda runtimes.
 For more information about supported Java versions, see the
 [OpenTelemetry Java documentation](/docs/instrumentation/java/).
 
@@ -83,7 +83,7 @@ and the package on [PyPi](https://pypi.org/project/opentelemetry-api/).
 
 ### Configure `AWS_LAMBDA_EXEC_WRAPPER`
 
-Change the entry point of your application by setting `AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler` for node.js or java and 
+Change the entry point of your application by setting `AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler` for Node.js or java and
 `AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-instrument` for python.  These wrapper scripts will invoke your lambda application
 with the auto instrumentation package applied.
 

--- a/content/en/docs/faas/lambda-auto-instrument.md
+++ b/content/en/docs/faas/lambda-auto-instrument.md
@@ -48,17 +48,23 @@ libraries/frameworks that are used by your application.
 To enable only specific instrumentations you can use the following environment
 variables:
 
-    * OTEL_INSTRUMENTATION_COMMON_DEFAULT_ENABLED - When set to false, disables auto-instrumentation in the Layer, requiring each instrumentation to be enabled individually.
-    * OTEL_INSTRUMENTATION_[NAME]_ENABLED - Set to true to enable auto-instrumentation for a specific library or framework. [NAME] should be replaced by the instrumentation that you want to enable. The full list of available instrumentations can be found in this link.
+- `OTEL_INSTRUMENTATION_COMMON_DEFAULT_ENABLED` - When set to false, disables
+  auto-instrumentation in the Layer, requiring each instrumentation to be
+  enabled individually.
+- `OTEL_INSTRUMENTATION_[NAME]_ENABLED` - Set to true to enable
+  auto-instrumentation for a specific library or framework. [NAME] should be
+  replaced by the instrumentation that you want to enable. The full list of
+  available instrumentations can be found
+  [here](https://opentelemetry.io/docs/instrumentation/java/automatic/agent-config/#suppressing-specific-agent-instrumentation).
 
 For example, to only enable auto-instrumentation for Lambda and the AWS SDK, you
 would have to set the following environment variables:
 
-    ```bash
-    OTEL_INSTRUMENTATION_COMMON_DEFAULT_ENABLED=false
-    OTEL_INSTRUMENTATION_AWS_LAMBDA_ENABLED=true
-    OTEL_INSTRUMENTATION_AWS_SDK_ENABLED=true
-    ```
+```bash
+OTEL_INSTRUMENTATION_COMMON_DEFAULT_ENABLED=false
+OTEL_INSTRUMENTATION_AWS_LAMBDA_ENABLED=true
+OTEL_INSTRUMENTATION_AWS_SDK_ENABLED=true
+```
 
 <!-- prettier-ignore -->
 {{% /tab %}}

--- a/content/en/docs/faas/lambda-auto-instrument.md
+++ b/content/en/docs/faas/lambda-auto-instrument.md
@@ -83,8 +83,8 @@ and the package on [PyPi](https://pypi.org/project/opentelemetry-api/).
 
 ### Configure `AWS_LAMBDA_EXEC_WRAPPER`
 
-Change the entry point of your application by setting `AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler` for Node.js or java and
-`AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-instrument` for python.  These wrapper scripts will invoke your lambda application
+Change the entry point of your application by setting `AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler` for Node.js or Java, and
+`AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-instrument` for Python.  These wrapper scripts will invoke your Lambda application
 with the auto instrumentation package applied.
 
 ### Add the ARN of Instrumentation Lambda Layer

--- a/content/en/docs/faas/lambda-auto-instrument.md
+++ b/content/en/docs/faas/lambda-auto-instrument.md
@@ -28,8 +28,8 @@ first.
 {{< tabpane text=true >}}
 {{% tab Java %}}
 
-The Lambda layer supports the Java 8, 11, and 17 (Corretto) Lambda runtimes.
-For more information about supported Java versions, see the
+The Lambda layer supports the Java 8, 11, and 17 (Corretto) Lambda runtimes. For
+more information about supported Java versions, see the
 [OpenTelemetry Java documentation](/docs/instrumentation/java/).
 
 **Note:** The Java Auto-instrumentation Agent is in the Lambda layer - Automatic
@@ -83,9 +83,11 @@ and the package on [PyPi](https://pypi.org/project/opentelemetry-api/).
 
 ### Configure `AWS_LAMBDA_EXEC_WRAPPER`
 
-Change the entry point of your application by setting `AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler` for Node.js or Java, and
-`AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-instrument` for Python.  These wrapper scripts will invoke your Lambda application
-with the auto instrumentation package applied.
+Change the entry point of your application by setting
+`AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler` for Node.js or Java, and
+`AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-instrument` for Python. These wrapper scripts
+will invoke your Lambda application with the auto instrumentation package
+applied.
 
 ### Add the ARN of Instrumentation Lambda Layer
 

--- a/content/en/docs/faas/lambda-auto-instrument.md
+++ b/content/en/docs/faas/lambda-auto-instrument.md
@@ -28,9 +28,8 @@ first.
 {{< tabpane text=true >}}
 {{% tab Java %}}
 
-The Lambda layer supports the Java 11 (Corretto) Lambda runtime. It does not
-support the Java 8 Lambda runtimes. For more information about supported Java
-versions, see the
+The Lambda layer supports the Java 8, 11, and 17 (Corretto) Lambda runtimes. 
+For more information about supported Java versions, see the
 [OpenTelemetry Java documentation](/docs/instrumentation/java/).
 
 **Note:** The Java Auto-instrumentation Agent is in the Lambda layer - Automatic
@@ -56,7 +55,6 @@ For example, to only enable auto-instrumentation for Lambda and the AWS SDK, you
 would have to set the following environment variables:
 
     ```bash
-    Copy
     OTEL_INSTRUMENTATION_COMMON_DEFAULT_ENABLED=false
     OTEL_INSTRUMENTATION_AWS_LAMBDA_ENABLED=true
     OTEL_INSTRUMENTATION_AWS_SDK_ENABLED=true
@@ -82,6 +80,12 @@ and the package on [PyPi](https://pypi.org/project/opentelemetry-api/).
 <!-- prettier-ignore -->
 {{% /tab %}}
 {{< /tabpane >}}
+
+### Configure `AWS_LAMBDA_EXEC_WRAPPER`
+
+Change the entry point of your application by setting `AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler` for node.js or java and 
+`AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-instrument` for python.  These wrapper scripts will invoke your lambda application
+with the auto instrumentation package applied.
 
 ### Add the ARN of Instrumentation Lambda Layer
 


### PR DESCRIPTION
Instructions were missing the step to configure `AWS_LAMBDA_EXEC_WRAPPER`.  Also fixed the java supported versions.

cc @cartersocha 

---

**Preview**: https://deploy-preview-2945--opentelemetry.netlify.app/docs/faas/lambda-auto-instrument/
