### PR TITLE
CI: gulp task in support of refcache cleanup & some refcache updates

### DIFF
--- a/gulp-src/README.txt
+++ b/gulp-src/README.txt
@@ -1,0 +1,3 @@
+# Gulp task files
+
+All files in this directory, except for `helpers.js`, are gulp tasks.

--- a/gulp-src/_util.js
+++ b/gulp-src/_util.js
@@ -1,0 +1,9 @@
+const yargs = require('yargs/yargs');
+const { hideBin } = require('yargs/helpers');
+
+exports.taskArgs = () =>
+  yargs(hideBin(process.argv).slice(1))
+    .strict()
+    .help('info')
+    // To avoid "task did not complete" errors, prevent help option from exiting
+    .exitProcess(false);

--- a/gulp-src/default.js
+++ b/gulp-src/default.js
@@ -1,0 +1,15 @@
+const gulp = require('gulp');
+
+const usage = `
+Usage:
+  npx gulp --tasks # for a list of tasks
+  npx gulp <task> --info for task argument info`;
+
+const usageTask = (done) => {
+  console.log(usage);
+  done();
+};
+
+usageTask.description = 'Display usage instructions';
+
+gulp.task('default', usageTask);

--- a/gulp-src/prune.js
+++ b/gulp-src/prune.js
@@ -1,0 +1,57 @@
+// cSpell:ignore refcache
+
+const gulp = require('gulp');
+const fs = require('fs').promises;
+const { taskArgs } = require('./_util');
+
+const refcacheFile = 'static/refcache.json';
+const n_default = 25;
+
+// The refcacheFile is a JSON map with each map entry of the form, e.g.:
+//
+// "https://cncf.io": {
+//     "StatusCode": 206,
+//     "LastSeen": "2023-06-29T13:38:47.996793-04:00"
+//   },
+
+// Prune the oldest <n> entries from refcacheFile in a way that avoids
+// reordering entries (makes diffs easier to manage).
+async function pruneTask() {
+  const argv = taskArgs().options({
+    num: {
+      alias: 'n',
+      type: 'number',
+      description: 'Number of oldest refcache entries to drop.',
+      default: n_default,
+    },
+  }).argv;
+
+  const n = argv.num > 0 ? argv.num : n_default;
+
+  if (argv.info) return; // Info was already displayed
+
+  try {
+    const json = await fs.readFile(refcacheFile, 'utf8');
+    const entries = JSON.parse(json);
+
+    // Create a sorted array of URL keys and `LastSeen` dates
+    const sortedUrlsAndDates = Object.keys(entries)
+      .map((url) => [url, entries[url].LastSeen])
+      .sort((a, b) => new Date(a[1]) - new Date(b[1]));
+
+    // Get oldest argv.num keys
+    const oldestKeys = sortedUrlsAndDates.slice(0, n).map((item) => item[0]);
+
+    // Remove oldest entries
+    oldestKeys.forEach((key) => delete entries[key]);
+
+    const prettyJson = JSON.stringify(entries, null, 2) + '\n';
+    await fs.writeFile(refcacheFile, prettyJson, 'utf8');
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+pruneTask.description = `Prune the oldest '--num <n>' entries from ${refcacheFile} file (default ${n_default}).`;
+
+gulp.task('prune', pruneTask);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,3 @@
+const requireDir = require('require-dir');
+
+requireDir('./gulp-src');

--- a/package.json
+++ b/package.json
@@ -67,11 +67,13 @@
   "devDependencies": {
     "autoprefixer": "^10.4.14",
     "cspell": "^6.31.1",
+    "gulp": "^4.0.2",
     "hugo-extended": "0.113.0",
     "netlify-cli": "^15.0.1",
     "npm-run-all": "^4.1.5",
     "postcss-cli": "^10.1.0",
     "prettier": "^2.8.4",
+    "require-dir": "^1.2.0",
     "textlint": "^13.1.4",
     "textlint-filter-rule-allowlist": "^4.0.0",
     "textlint-filter-rule-comments": "^1.2.2",

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -17,11 +17,11 @@
   },
   "http://docs.couchdb.org/en/stable/api/document/common.html#get--db-docid": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:07:22.728274-05:00"
+    "LastSeen": "2023-06-29T15:49:12.005204-04:00"
   },
   "http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:09:05.748522-05:00"
+    "LastSeen": "2023-06-29T15:50:41.988361-04:00"
   },
   "http://github.com/open-telemetry/semantic-conventions": {
     "StatusCode": 200,
@@ -173,7 +173,7 @@
   },
   "https://calendar.google.com/calendar/embed": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:41:36.268773-05:00"
+    "LastSeen": "2023-06-29T15:55:02.67164-04:00"
   },
   "https://cdn.jsdelivr.net/npm/mermaid@9.2.2/dist/mermaid.min.js": {
     "StatusCode": 206,
@@ -213,7 +213,7 @@
   },
   "https://cloud-native.slack.com/archives/C01NFPCV44V": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:41:25.308776-05:00"
+    "LastSeen": "2023-06-29T15:54:52.249011-04:00"
   },
   "https://cloud-native.slack.com/archives/C01NL1GRPQR": {
     "StatusCode": 200,
@@ -221,7 +221,7 @@
   },
   "https://cloud-native.slack.com/archives/C01NP3BV26R": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:41:14.840246-05:00"
+    "LastSeen": "2023-06-29T15:55:13.772857-04:00"
   },
   "https://cloud-native.slack.com/archives/C01NR1YLSE7": {
     "StatusCode": 200,
@@ -241,7 +241,7 @@
   },
   "https://cloud-native.slack.com/archives/C01SF4LCYK1": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:41:20.065121-05:00"
+    "LastSeen": "2023-06-29T15:54:46.832264-04:00"
   },
   "https://cloud-native.slack.com/archives/C02UN96HZH6": {
     "StatusCode": 200,
@@ -249,11 +249,11 @@
   },
   "https://cloud-native.slack.com/archives/C031SAMGV2A": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:41:57.400898-05:00"
+    "LastSeen": "2023-06-29T15:55:35.172728-04:00"
   },
   "https://cloud-native.slack.com/archives/C03B4CWV4DA": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:41:03.78002-05:00"
+    "LastSeen": "2023-06-29T15:54:41.365133-04:00"
   },
   "https://cloud-native.slack.com/archives/C041APFBYQP": {
     "StatusCode": 200,
@@ -285,15 +285,15 @@
   },
   "https://cloud-native.slack.com/team/U02EUCBFK8A": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:41:46.886013-05:00"
+    "LastSeen": "2023-06-29T15:55:24.597335-04:00"
   },
   "https://cloud-native.slack.com/team/U03FU45JA1M": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:41:52.129826-05:00"
+    "LastSeen": "2023-06-29T15:55:29.873456-04:00"
   },
   "https://cloud-native.slack.com/team/U03UARAJ405": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:41:41.67371-05:00"
+    "LastSeen": "2023-06-29T15:55:19.306529-04:00"
   },
   "https://cloud.google.com/": {
     "StatusCode": 200,
@@ -401,7 +401,7 @@
   },
   "https://communityinviter.com/apps/cloud-native/cncf": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:41:09.591716-05:00"
+    "LastSeen": "2023-06-29T15:55:08.258786-04:00"
   },
   "https://conan.io/center/opentelemetry-cpp": {
     "StatusCode": 200,
@@ -453,7 +453,7 @@
   },
   "https://datatracker.ietf.org/doc/html/rfc7230#section-2.7.1": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:09:50.310882-05:00"
+    "LastSeen": "2023-06-29T15:51:51.336198-04:00"
   },
   "https://datatracker.ietf.org/doc/html/rfc7231#page-63": {
     "StatusCode": 200,
@@ -461,7 +461,7 @@
   },
   "https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.3": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:09:55.695289-05:00"
+    "LastSeen": "2023-06-29T15:51:56.448422-04:00"
   },
   "https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.3": {
     "StatusCode": 200,
@@ -521,11 +521,11 @@
   },
   "https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:04:48.265472-05:00"
+    "LastSeen": "2023-06-29T15:53:59.660121-04:00"
   },
   "https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:04:42.891544-05:00"
+    "LastSeen": "2023-06-29T15:53:54.514307-04:00"
   },
   "https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded": {
     "StatusCode": 206,
@@ -533,7 +533,7 @@
   },
   "https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:09:22.411492-05:00"
+    "LastSeen": "2023-06-29T15:50:58.127035-04:00"
   },
   "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200": {
     "StatusCode": 206,
@@ -541,7 +541,7 @@
   },
   "https://developers.google.com/protocol-buffers/docs/encoding": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:09:38.6321-05:00"
+    "LastSeen": "2023-06-29T15:51:15.428896-04:00"
   },
   "https://developers.google.com/protocol-buffers/docs/encoding#varints": {
     "StatusCode": 206,
@@ -549,7 +549,7 @@
   },
   "https://developers.google.com/protocol-buffers/docs/overview": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:09:33.425461-05:00"
+    "LastSeen": "2023-06-29T15:51:10.194645-04:00"
   },
   "https://developers.google.com/protocol-buffers/docs/proto3": {
     "StatusCode": 206,
@@ -557,7 +557,7 @@
   },
   "https://developers.google.com/protocol-buffers/docs/proto3#json": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:09:43.885827-05:00"
+    "LastSeen": "2023-06-29T15:51:20.598962-04:00"
   },
   "https://devstats.cncf.io/": {
     "StatusCode": 206,
@@ -569,11 +569,11 @@
   },
   "https://docs.appdynamics.com/latest/en/application-monitoring/appdynamics-for-opentelemetry": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:01:48.974397-05:00"
+    "LastSeen": "2023-06-29T15:45:56.613628-04:00"
   },
   "https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-metadata.html#sqs-message-system-attributes": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:08:27.150414-05:00"
+    "LastSeen": "2023-06-29T15:50:10.274715-04:00"
   },
   "https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-access-control-overview-cwl.html#CWL_ARN_Format": {
     "StatusCode": 206,
@@ -581,7 +581,7 @@
   },
   "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Lambda-Insights-metrics.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:06:18.702609-05:00"
+    "LastSeen": "2023-06-29T15:48:06.832764-04:00"
   },
   "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_instances.html": {
     "StatusCode": 206,
@@ -599,13 +599,9 @@
     "StatusCode": 206,
     "LastSeen": "2023-02-15T21:11:39.805847-05:00"
   },
-  "https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-override-request-response-parameters.html": {
-    "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:08:16.770406-05:00"
-  },
   "https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:08:21.991813-05:00"
+    "LastSeen": "2023-06-29T15:50:05.116028-04:00"
   },
   "https://docs.aws.amazon.com/cli/latest/reference/s3api/abort-multipart-upload.html": {
     "StatusCode": 206,
@@ -673,7 +669,7 @@
   },
   "https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:10:57.863646-05:00"
+    "LastSeen": "2023-06-29T15:49:28.341718-04:00"
   },
   "https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html": {
     "StatusCode": 206,
@@ -681,7 +677,7 @@
   },
   "https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:08:32.449921-05:00"
+    "LastSeen": "2023-06-29T15:50:15.454651-04:00"
   },
   "https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html": {
     "StatusCode": 206,
@@ -689,11 +685,11 @@
   },
   "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:07:39.347899-05:00"
+    "LastSeen": "2023-06-29T15:49:33.501728-04:00"
   },
   "https://docs.aws.amazon.com/lambda/latest/dg/monitoring-metrics.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:06:13.345934-05:00"
+    "LastSeen": "2023-06-29T15:48:01.663228-04:00"
   },
   "https://docs.aws.amazon.com/lambda/latest/dg/welcome.html": {
     "StatusCode": 200,
@@ -701,15 +697,15 @@
   },
   "https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:05:38.098959-05:00"
+    "LastSeen": "2023-06-29T15:51:33.6032-04:00"
   },
   "https://docs.aws.amazon.com/xray/latest/devguide/xray-console-sampling.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:05:32.93043-05:00"
+    "LastSeen": "2023-06-29T15:51:38.773776-04:00"
   },
   "https://docs.bindplane.observiq.com": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:02:45.393767-05:00"
+    "LastSeen": "2023-06-29T15:46:39.593412-04:00"
   },
   "https://docs.daocloud.io/en/insight/06UserGuide/01quickstart/otel/otel/": {
     "StatusCode": 206,
@@ -717,27 +713,27 @@
   },
   "https://docs.datadoghq.com/tracing/connect_logs_and_traces/java/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:10:28.89744-05:00"
+    "LastSeen": "2023-06-29T15:52:27.851719-04:00"
   },
   "https://docs.datadoghq.com/tracing/setup_overview/open_standards": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:02:17.677376-05:00"
+    "LastSeen": "2023-06-29T15:46:17.849368-04:00"
   },
   "https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:07:28.257089-05:00"
+    "LastSeen": "2023-06-29T15:49:17.52216-04:00"
   },
   "https://docs.docker.com": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:03:07.421142-05:00"
+    "LastSeen": "2023-06-29T15:47:01.30768-04:00"
   },
   "https://docs.docker.com/compose/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:04:59.102477-05:00"
+    "LastSeen": "2023-06-29T15:54:11.204968-04:00"
   },
   "https://docs.docker.com/compose/install/#install-compose": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:03:17.781026-05:00"
+    "LastSeen": "2023-06-29T15:47:12.022774-04:00"
   },
   "https://docs.docker.com/compose/migrate/": {
     "StatusCode": 206,
@@ -745,7 +741,7 @@
   },
   "https://docs.docker.com/desktop": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:03:12.654004-05:00"
+    "LastSeen": "2023-06-29T15:47:06.701768-04:00"
   },
   "https://docs.docker.com/desktop/settings/linux/": {
     "StatusCode": 206,
@@ -765,11 +761,11 @@
   },
   "https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:02:56.509378-05:00"
+    "LastSeen": "2023-06-29T15:46:50.059623-04:00"
   },
   "https://docs.google.com/document/d/15vR7D1x2tKd7u3zaTF0yH1WaHkUr2T4hhr7OyiZgmBg/edit#heading=h.4xuru5ljcups": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:10:34.824386-05:00"
+    "LastSeen": "2023-06-29T15:52:33.514228-04:00"
   },
   "https://docs.google.com/document/d/187XYoQcXQ9JxS_5v2wvZ0NEysaJ02xoOYNXj08pT0zc": {
     "StatusCode": 200,
@@ -785,15 +781,15 @@
   },
   "https://docs.google.com/document/d/1KtH5atZQUs9Achbce6LiOaJxLbksNJenvgvyKLsJrkc/edit#heading=h.ioikt02qpy5f": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:03:45.532027-05:00"
+    "LastSeen": "2023-06-29T15:52:58.148125-04:00"
   },
   "https://docs.google.com/document/d/1LPhVRSFkGNSuU1fBd81ulhsCPR4hkSZyyBj1SZ8fWOM/edit#heading=h.3p42p5s8n0ui": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:05:44.456135-05:00"
+    "LastSeen": "2023-06-29T15:51:27.40951-04:00"
   },
   "https://docs.google.com/document/d/1WQDz1jF0yKBXe3OibXWfy3g6lor9SvjZ4xT-8uuDCiA/edit": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:10:52.240729-05:00"
+    "LastSeen": "2023-06-29T15:52:50.25617-04:00"
   },
   "https://docs.google.com/document/d/1eDYC97LfvE428cpIf3A_hSGirdNzglPurlxgKCmw8o4": {
     "StatusCode": 200,
@@ -821,7 +817,7 @@
   },
   "https://docs.google.com/document/d/1ix9_4TQO3o-qyeyNhcOmqAc1MTyr-wnXxxsdWgCMn9c/edit": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:10:46.512264-05:00"
+    "LastSeen": "2023-06-29T15:52:44.714019-04:00"
   },
   "https://docs.google.com/document/d/1jt47KPwgDG_-4kR4J5GtFSCEhQO3CHgUdAwpCKTQHO8/edit": {
     "StatusCode": 200,
@@ -841,7 +837,7 @@
   },
   "https://docs.honeycomb.io/getting-data-in/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:02:22.862266-05:00"
+    "LastSeen": "2023-06-29T15:46:23.100526-04:00"
   },
   "https://docs.itrsgroup.com/docs/geneos/data-collection/opentelemetry/current/opentelemetry.html": {
     "StatusCode": 206,
@@ -849,39 +845,39 @@
   },
   "https://docs.jboss.org/jbossas/guides/webguide/r2/en/html/ch06.html": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:09:16.994306-05:00"
+    "LastSeen": "2023-06-29T15:50:52.866106-04:00"
   },
   "https://docs.locust.io/en/stable/writing-a-locustfile.html": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:03:23.344658-05:00"
+    "LastSeen": "2023-06-29T15:47:17.793642-04:00"
   },
   "https://docs.logz.io/shipping/tracing-sources/opentelemetry.html#overview": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:02:28.7356-05:00"
+    "LastSeen": "2023-06-29T15:46:28.486784-04:00"
   },
   "https://docs.lumigo.io/docs/opentelemetry": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:02:34.403659-05:00"
+    "LastSeen": "2023-06-29T15:46:33.888823-04:00"
   },
   "https://docs.microsoft.com/aspnet/core": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:03:02.156397-05:00"
+    "LastSeen": "2023-06-29T15:46:55.73361-04:00"
   },
   "https://docs.microsoft.com/azure/azure-monitor/app/opentelemetry-overview": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:02:05.52255-05:00"
+    "LastSeen": "2023-06-29T15:46:12.472701-04:00"
   },
   "https://docs.microsoft.com/azure/azure-monitor/platform/metrics-supported": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:06:24.433953-05:00"
+    "LastSeen": "2023-06-29T15:48:12.137355-04:00"
   },
   "https://docs.microsoft.com/dotnet/api/microsoft.extensions.logging.ilogger": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:03:51.379712-05:00"
+    "LastSeen": "2023-06-29T15:53:04.266877-04:00"
   },
   "https://docs.microsoft.com/dotnet/api/system.diagnostics": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:04:25.858857-05:00"
+    "LastSeen": "2023-06-29T15:53:37.193001-04:00"
   },
   "https://docs.microsoft.com/dotnet/core/diagnostics/metrics-instrumentation": {
     "StatusCode": 200,
@@ -889,7 +885,7 @@
   },
   "https://docs.microsoft.com/en-us/archive/blogs/askcore/windows-performance-monitor-disk-counters-explained#windows-performance-monitor-disk-counters-explained:~:text=%25%20Idle%20Time,Idle%5c%29%20to%200%20%28meaning%20always%20busy%29.": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:06:35.608047-05:00"
+    "LastSeen": "2023-06-29T15:48:22.856518-04:00"
   },
   "https://docs.microsoft.com/en-us/azure/application-gateway/application-gateway-websocket": {
     "StatusCode": 200,
@@ -897,19 +893,19 @@
   },
   "https://docs.microsoft.com/en-us/azure/azure-functions/manage-connections#static-clients": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:07:44.902091-05:00"
+    "LastSeen": "2023-06-29T15:49:38.851793-04:00"
   },
   "https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:04:20.278538-05:00"
+    "LastSeen": "2023-06-29T15:53:31.646819-04:00"
   },
   "https://docs.microsoft.com/en-us/dotnet/api/system.exception.tostring": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:07:59.731752-05:00"
+    "LastSeen": "2023-06-29T15:49:49.401478-04:00"
   },
   "https://docs.microsoft.com/en-us/dotnet/api/system.servicemodel.servicesecuritycontext": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:09:11.394651-05:00"
+    "LastSeen": "2023-06-29T15:50:47.449686-04:00"
   },
   "https://docs.microsoft.com/en-us/rest/api/resources/resources/get-by-id": {
     "StatusCode": 200,
@@ -917,39 +913,35 @@
   },
   "https://docs.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:06:58.32278-05:00"
+    "LastSeen": "2023-06-29T15:48:48.92501-04:00"
   },
   "https://docs.microsoft.com/en-us/windows/win32/api/netioapi/nf-netioapi-getifentry2": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:06:46.768121-05:00"
+    "LastSeen": "2023-06-29T15:48:33.395977-04:00"
   },
   "https://docs.microsoft.com/en-us/windows/win32/api/netioapi/ns-netioapi-mib_if_row2": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:06:41.250229-05:00"
-  },
-  "https://docs.microsoft.com/windows/win32/api/winsock/ns-winsock-sockaddr": {
-    "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:08:38.032274-05:00"
+    "LastSeen": "2023-06-29T15:48:28.159167-04:00"
   },
   "https://docs.microsoft.com/windows/win32/api/winsock2/nf-winsock2-bind": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:08:54.900201-05:00"
+    "LastSeen": "2023-06-29T15:50:36.741227-04:00"
   },
   "https://docs.microsoft.com/windows/win32/api/winsock2/nf-winsock2-connect": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:08:43.743881-05:00"
+    "LastSeen": "2023-06-29T15:50:20.866205-04:00"
   },
   "https://docs.microsoft.com/windows/win32/api/winsock2/nf-winsock2-getpeername": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:08:49.32236-05:00"
+    "LastSeen": "2023-06-29T15:50:26.114818-04:00"
   },
   "https://docs.microsoft.com/windows/win32/api/winsock2/nf-winsock2-getsockname": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:09:00.541704-05:00"
+    "LastSeen": "2023-06-29T15:50:31.423958-04:00"
   },
   "https://docs.mongodb.com/manual/reference/command/#database-operations": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:07:08.927867-05:00"
+    "LastSeen": "2023-06-29T15:48:59.284487-04:00"
   },
   "https://docs.nginx.com/nginx-ingress-controller/": {
     "StatusCode": 200,
@@ -961,15 +953,15 @@
   },
   "https://docs.openfaas.com/architecture/metrics/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:06:30.02865-05:00"
+    "LastSeen": "2023-06-29T15:48:17.443141-04:00"
   },
   "https://docs.openfeature.dev/docs/specification/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:07:33.967528-05:00"
+    "LastSeen": "2023-06-29T15:49:22.900644-04:00"
   },
   "https://docs.oracle.com/cd/E12058_01/doc/doc.1014/e12030/cron_expressions.htm": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:07:53.932768-05:00"
+    "LastSeen": "2023-06-29T15:49:44.05648-04:00"
   },
   "https://docs.oracle.com/en-us/iaas/application-performance-monitoring/doc/configure-open-source-tracing-systems.html#GUID-4D941163-F357-4839-8B06-688876D4C61F": {
     "StatusCode": 200,
@@ -977,27 +969,27 @@
   },
   "https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Set.html": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:10:17.969025-05:00"
+    "LastSeen": "2023-06-29T15:52:17.195382-04:00"
   },
   "https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/BufferPoolMXBean.html#getName%28%29": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:05:56.485197-05:00"
+    "LastSeen": "2023-06-29T15:47:56.223273-04:00"
   },
   "https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryPoolMXBean.html#getName%28%29": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:05:50.908115-05:00"
+    "LastSeen": "2023-06-29T15:47:40.319503-04:00"
   },
   "https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/HttpHeaders.html": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:05:21.537777-05:00"
+    "LastSeen": "2023-06-29T15:54:32.716302-04:00"
   },
   "https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcAction%28%29": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:06:08.13686-05:00"
+    "LastSeen": "2023-06-29T15:47:50.696582-04:00"
   },
   "https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcName%28%29": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:06:02.416793-05:00"
+    "LastSeen": "2023-06-29T15:47:45.601398-04:00"
   },
   "https://docs.oracle.com/en/java/javase/17/docs/api/jdk.management/com/sun/management/OperatingSystemMXBean.html#getCpuLoad%28%29": {
     "StatusCode": 200,
@@ -1017,15 +1009,15 @@
   },
   "https://docs.oracle.com/javase/7/docs/api/java/lang/Throwable.html#printStackTrace%28%29": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:08:06.175077-05:00"
+    "LastSeen": "2023-06-29T15:49:54.660465-04:00"
   },
   "https://docs.oracle.com/javase/7/docs/api/java/util/logging/Logger.html#getLogger%28java.lang.String%29": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:10:40.58721-05:00"
+    "LastSeen": "2023-06-29T15:52:38.805131-04:00"
   },
   "https://docs.oracle.com/javase/7/docs/api/java/util/logging/package-summary.html": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:05:27.201201-05:00"
+    "LastSeen": "2023-06-29T15:51:44.10099-04:00"
   },
   "https://docs.oracle.com/javase/8/docs/api/java/lang/management/BufferPoolMXBean.html#getCount--": {
     "StatusCode": 200,
@@ -1077,11 +1069,11 @@
   },
   "https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:05:04.694703-05:00"
+    "LastSeen": "2023-06-29T15:54:17.103682-04:00"
   },
   "https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:05:10.377544-05:00"
+    "LastSeen": "2023-06-29T15:54:22.283563-04:00"
   },
   "https://docs.oracle.com/javase/8/docs/jre/api/management/extension/com/sun/management/GarbageCollectionNotificationInfo.html": {
     "StatusCode": 200,
@@ -1093,19 +1085,19 @@
   },
   "https://docs.oracle.com/javase/8/docs/jre/api/net/httpserver/spec/com/sun/net/httpserver/HttpExchange.html": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:05:15.93283-05:00"
+    "LastSeen": "2023-06-29T15:54:27.591788-04:00"
   },
   "https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:06:52.667514-05:00"
+    "LastSeen": "2023-06-29T15:48:38.702478-04:00"
   },
   "https://docs.oracle.com/javase/specs/jls/se7/html/jls-10.html": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:10:06.977402-05:00"
+    "LastSeen": "2023-06-29T15:52:07.030565-04:00"
   },
   "https://docs.oracle.com/javase/tutorial/java/javaOO/enum.html": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:10:01.379627-05:00"
+    "LastSeen": "2023-06-29T15:52:01.907278-04:00"
   },
   "https://docs.oracle.com/javase/tutorial/jmx/mbeans/index.html": {
     "StatusCode": 200,
@@ -1125,31 +1117,31 @@
   },
   "https://docs.python.org/3/library/traceback.html#traceback.format_exc": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:08:11.568854-05:00"
+    "LastSeen": "2023-06-29T15:49:59.850331-04:00"
   },
   "https://docs.python.org/3/tutorial/datastructures.html#more-on-lists": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:10:12.366638-05:00"
+    "LastSeen": "2023-06-29T15:52:12.112978-04:00"
   },
   "https://docs.python.org/3/tutorial/datastructures.html#sets": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:10:23.328218-05:00"
+    "LastSeen": "2023-06-29T15:52:22.246246-04:00"
   },
   "https://docs.rs/opentelemetry": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:04:53.855457-05:00"
+    "LastSeen": "2023-06-29T15:54:05.839643-04:00"
   },
   "https://docs.rs/opentelemetry/0.17.0/opentelemetry/trace/struct.SpanRef.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:03:34.279346-05:00"
+    "LastSeen": "2023-06-29T15:47:28.898412-04:00"
   },
   "https://docs.rs/opentelemetry/latest/opentelemetry/struct.ContextGuard.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:03:28.887973-05:00"
+    "LastSeen": "2023-06-29T15:47:23.619773-04:00"
   },
   "https://docs.rs/opentelemetry/latest/opentelemetry/trace/trait.Span.html#method.add_event": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:03:39.650397-05:00"
+    "LastSeen": "2023-06-29T15:47:34.095212-04:00"
   },
   "https://docs.sentry.io/platforms/java/performance/instrumentation/opentelemetry/": {
     "StatusCode": 206,
@@ -1189,19 +1181,19 @@
   },
   "https://docs.wavefront.com/opentelemetry_tracing.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:01:54.460528-05:00"
+    "LastSeen": "2023-06-29T15:46:02.121284-04:00"
   },
   "https://documentation.solarwinds.com/en/success_center/observability/default.htm#cshid=third-otel-integration": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:02:51.040569-05:00"
+    "LastSeen": "2023-06-29T15:46:44.824874-04:00"
   },
   "https://dotnet.microsoft.com/download/dotnet-core": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:04:02.961412-05:00"
+    "LastSeen": "2023-06-29T15:53:15.185132-04:00"
   },
   "https://dotnet.microsoft.com/download/dotnet-framework": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:04:14.407229-05:00"
+    "LastSeen": "2023-06-29T15:53:25.969958-04:00"
   },
   "https://dotnet.microsoft.com/en-us/": {
     "StatusCode": 200,
@@ -1209,11 +1201,11 @@
   },
   "https://dotnet.microsoft.com/en-us/learn/dotnet/what-is-dotnet": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:04:31.347803-05:00"
+    "LastSeen": "2023-06-29T15:53:42.646318-04:00"
   },
   "https://dotnet.microsoft.com/en-us/learn/dotnet/what-is-dotnet-framework": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:04:36.825244-05:00"
+    "LastSeen": "2023-06-29T15:53:48.047513-04:00"
   },
   "https://dyladan.me/histograms/2023/05/02/why-histograms/": {
     "StatusCode": 206,

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -9,7 +9,7 @@
   },
   "http://agile.coffee/#b3b37364-d40e-4029-847c-8ee059d60855": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T20:22:09.914772-05:00"
+    "LastSeen": "2023-06-29T13:40:23.627844-04:00"
   },
   "http://connect.build": {
     "StatusCode": 206,
@@ -69,31 +69,31 @@
   },
   "https://access.redhat.com/products/ansible-tower-red-hat": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:22:21.474303-05:00"
+    "LastSeen": "2023-06-29T13:40:07.523402-04:00"
   },
   "https://agilecoffee.com/leancoffee/": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:22:04.741763-05:00"
+    "LastSeen": "2023-06-29T13:39:51.475961-04:00"
   },
   "https://apisix.apache.org/blog/2022/02/28/apisix-integration-opentelemetry-plugin/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T20:21:19.719799-05:00"
+    "LastSeen": "2023-06-29T12:28:39.410511-04:00"
   },
   "https://apisix.apache.org/docs/apisix/next/plugins/opentelemetry/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T20:21:25.181783-05:00"
+    "LastSeen": "2023-06-29T13:39:34.486291-04:00"
   },
   "https://apisix.apache.org/docs/apisix/next/plugins/opentelemetry/#attributes": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T20:21:30.54251-05:00"
+    "LastSeen": "2023-06-29T13:39:39.542991-04:00"
   },
   "https://apisix.apache.org/docs/general/join/#subscribe-to-the-mailing-list": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T20:35:40.55131-05:00"
+    "LastSeen": "2023-06-29T13:39:44.708765-04:00"
   },
   "https://app.telemetryhub.com/docs": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:20:27.656229-05:00"
+    "LastSeen": "2023-06-29T12:27:18.815688-04:00"
   },
   "https://arc.net/e/18897C6F-3A57-4769-A929-902A18AB1B04": {
     "StatusCode": 206,
@@ -101,11 +101,11 @@
   },
   "https://avajs.dev": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:20:38.73133-05:00"
+    "LastSeen": "2023-06-29T12:27:30.178352-04:00"
   },
   "https://aws-otel.github.io": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T20:20:22.109017-05:00"
+    "LastSeen": "2023-06-29T12:27:13.017869-04:00"
   },
   "https://aws-otel.github.io/": {
     "StatusCode": 206,
@@ -117,19 +117,19 @@
   },
   "https://aws.amazon.com/": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:20:57.179898-05:00"
+    "LastSeen": "2023-06-29T12:27:39.099158-04:00"
   },
   "https://aws.amazon.com/about-aws/global-infrastructure/regions_az/": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:21:08.412189-05:00"
+    "LastSeen": "2023-06-29T12:27:59.045206-04:00"
   },
   "https://aws.amazon.com/about-aws/whats-new/2021/10/cdk-kubernetes-cdk8s-available/": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:22:26.56737-05:00"
+    "LastSeen": "2023-06-29T13:40:12.65651-04:00"
   },
   "https://aws.amazon.com/cli/": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:20:49.970492-05:00"
+    "LastSeen": "2023-06-29T12:28:29.851646-04:00"
   },
   "https://aws.amazon.com/cloudwatch/": {
     "StatusCode": 200,
@@ -137,11 +137,11 @@
   },
   "https://aws.amazon.com/console/": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:20:44.797617-05:00"
+    "LastSeen": "2023-06-29T12:28:24.723237-04:00"
   },
   "https://aws.amazon.com/ecs/": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:22:15.105647-05:00"
+    "LastSeen": "2023-06-29T13:39:56.688276-04:00"
   },
   "https://aws.amazon.com/elasticloadbalancing/features/": {
     "StatusCode": 200,
@@ -149,7 +149,7 @@
   },
   "https://azure.microsoft.com/": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:21:03.223444-05:00"
+    "LastSeen": "2023-06-29T12:27:53.526561-04:00"
   },
   "https://azure.microsoft.com/en-ca/products/monitor": {
     "StatusCode": 200,
@@ -157,15 +157,15 @@
   },
   "https://azure.microsoft.com/en-us/global-infrastructure/geographies/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T20:21:13.997942-05:00"
+    "LastSeen": "2023-06-29T12:28:09.411462-04:00"
   },
   "https://bazel.build/": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:36:37.678778-05:00"
+    "LastSeen": "2023-06-29T13:39:27.033525-04:00"
   },
   "https://blog.logrocket.com/understanding-schema-stitching-graphql/": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:36:46.174243-05:00"
+    "LastSeen": "2023-06-29T13:40:18.37311-04:00"
   },
   "https://bundler.io/": {
     "StatusCode": 206,
@@ -185,15 +185,15 @@
   },
   "https://cdnjs.cloudflare.com/ajax/libs/fuse.js/3.2.0/fuse.min.js": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:37:53.05407-05:00"
+    "LastSeen": "2023-06-29T13:38:37.508148-04:00"
   },
   "https://cert-manager.io/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T20:39:58.266842-05:00"
+    "LastSeen": "2023-06-29T13:45:46.681919-04:00"
   },
   "https://cert-manager.io/docs/installation/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T20:38:51.346491-05:00"
+    "LastSeen": "2023-06-29T13:45:41.481947-04:00"
   },
   "https://circleci.com": {
     "StatusCode": 200,
@@ -205,11 +205,11 @@
   },
   "https://cloud-native.slack.com/archives/C01N6P7KR6W": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:38:10.77116-05:00"
+    "LastSeen": "2023-06-29T13:39:05.791696-04:00"
   },
   "https://cloud-native.slack.com/archives/C01N7PP1THC": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:39:22.43751-05:00"
+    "LastSeen": "2023-06-29T13:45:09.066895-04:00"
   },
   "https://cloud-native.slack.com/archives/C01NFPCV44V": {
     "StatusCode": 200,
@@ -217,7 +217,7 @@
   },
   "https://cloud-native.slack.com/archives/C01NL1GRPQR": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:40:37.575087-05:00"
+    "LastSeen": "2023-06-29T13:46:24.981518-04:00"
   },
   "https://cloud-native.slack.com/archives/C01NP3BV26R": {
     "StatusCode": 200,
@@ -225,7 +225,7 @@
   },
   "https://cloud-native.slack.com/archives/C01NR1YLSE7": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:40:03.562398-05:00"
+    "LastSeen": "2023-06-29T13:45:51.983719-04:00"
   },
   "https://cloud-native.slack.com/archives/C01PD4HUVBL": {
     "StatusCode": 200,
@@ -233,11 +233,11 @@
   },
   "https://cloud-native.slack.com/archives/C01QZFGMLQ7": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:38:46.086789-05:00"
+    "LastSeen": "2023-06-29T13:45:35.739211-04:00"
   },
   "https://cloud-native.slack.com/archives/C01RT3MSWGZ": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:40:58.48341-05:00"
+    "LastSeen": "2023-06-29T13:46:45.964425-04:00"
   },
   "https://cloud-native.slack.com/archives/C01SF4LCYK1": {
     "StatusCode": 200,
@@ -245,7 +245,7 @@
   },
   "https://cloud-native.slack.com/archives/C02UN96HZH6": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:40:08.820911-05:00"
+    "LastSeen": "2023-06-29T13:45:57.466093-04:00"
   },
   "https://cloud-native.slack.com/archives/C031SAMGV2A": {
     "StatusCode": 200,
@@ -261,7 +261,7 @@
   },
   "https://cloud-native.slack.com/archives/C0422FSELH0": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:40:32.32299-05:00"
+    "LastSeen": "2023-06-29T13:46:19.652129-04:00"
   },
   "https://cloud-native.slack.com/archives/C0476L7UJT1": {
     "StatusCode": 200,
@@ -277,11 +277,11 @@
   },
   "https://cloud-native.slack.com/archives/CJFCJHG4Q": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:37:30.005524-05:00"
+    "LastSeen": "2023-06-29T13:38:21.321696-04:00"
   },
   "https://cloud-native.slack.com/messages/opentelemetry-bootcamp": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:40:42.822488-05:00"
+    "LastSeen": "2023-06-29T13:46:30.268457-04:00"
   },
   "https://cloud-native.slack.com/team/U02EUCBFK8A": {
     "StatusCode": 200,
@@ -297,11 +297,11 @@
   },
   "https://cloud.google.com/": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:39:29.128858-05:00"
+    "LastSeen": "2023-06-29T13:44:41.918875-04:00"
   },
   "https://cloud.google.com/about/locations": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:39:53.035347-05:00"
+    "LastSeen": "2023-06-29T13:44:59.195408-04:00"
   },
   "https://cloud.google.com/apis/design/resource_names#full_resource_name": {
     "StatusCode": 200,
@@ -313,15 +313,15 @@
   },
   "https://cloud.google.com/artifact-registry": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:40:21.583943-05:00"
+    "LastSeen": "2023-06-29T13:46:09.03307-04:00"
   },
   "https://cloud.google.com/blog/products/serverless/cloud-functions-2nd-generation-now-generally-available": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:38:22.827963-05:00"
+    "LastSeen": "2023-06-29T13:39:18.970763-04:00"
   },
   "https://cloud.google.com/build": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:40:15.875102-05:00"
+    "LastSeen": "2023-06-29T13:46:03.59664-04:00"
   },
   "https://cloud.google.com/compute/docs/instances/custom-hostname-vm": {
     "StatusCode": 200,
@@ -337,27 +337,27 @@
   },
   "https://cloud.google.com/error-reporting/reference/rest/v1beta1/projects.events/report": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:39:17.120733-05:00"
+    "LastSeen": "2023-06-29T13:44:34.811846-04:00"
   },
   "https://cloud.google.com/functions/docs/concepts/exec#function_scope_versus_global_scope": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:39:11.263101-05:00"
+    "LastSeen": "2023-06-29T13:44:29.250421-04:00"
   },
   "https://cloud.google.com/functions/docs/env-var#runtime_environment_variables_set_automatically": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:39:46.625392-05:00"
+    "LastSeen": "2023-06-29T13:44:53.577918-04:00"
   },
   "https://cloud.google.com/functions/docs/writing/write-http-functions": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:38:17.256823-05:00"
+    "LastSeen": "2023-06-29T13:39:13.706761-04:00"
   },
   "https://cloud.google.com/iam/docs/full-resource-names": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:39:34.981744-05:00"
+    "LastSeen": "2023-06-29T13:44:23.334783-04:00"
   },
   "https://cloud.google.com/monitoring/api/metrics_gcp#gcp-cloudfunctions": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:39:04.971548-05:00"
+    "LastSeen": "2023-06-29T13:44:17.243376-04:00"
   },
   "https://cloud.google.com/run/docs/container-contract#jobs-env-vars": {
     "StatusCode": 200,
@@ -369,31 +369,27 @@
   },
   "https://cloud.google.com/run/docs/managing/revisions": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:39:40.667513-05:00"
+    "LastSeen": "2023-06-29T13:44:47.543255-04:00"
   },
   "https://cloud.google.com/vpc/docs/configure-serverless-vpc-access": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:38:28.673313-05:00"
+    "LastSeen": "2023-06-29T13:45:21.135372-04:00"
   },
   "https://cloudevents.io": {
-    "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:40:27.051848-05:00"
+    "StatusCode": 206,
+    "LastSeen": "2023-06-29T13:46:14.28228-04:00"
   },
   "https://cmake.org/": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:38:40.470178-05:00"
+    "LastSeen": "2023-06-29T13:45:28.939754-04:00"
   },
   "https://cncf-branding.netlify.app/projects/opentelemetry/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T20:37:24.740326-05:00"
+    "LastSeen": "2023-06-29T13:38:15.97776-04:00"
   },
   "https://cncf.io": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T20:38:04.920603-05:00"
-  },
-  "https://code.jquery.com/jquery-3.6.0.min.js": {
-    "StatusCode": 206,
-    "LastSeen": "2023-02-15T20:37:19.225321-05:00"
+    "LastSeen": "2023-06-29T13:38:47.996793-04:00"
   },
   "https://code.jquery.com/jquery-3.6.3.min.js": {
     "StatusCode": 206,
@@ -403,17 +399,13 @@
     "StatusCode": 200,
     "LastSeen": "2023-03-06T12:31:47.297962-05:00"
   },
-  "https://collectd.org/wiki/index.php/Binary_protocol#:~:text=The%20binary%20protocol%20is%20the,some%20documentation%20to%20reimplement%20it": {
-    "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:38:58.467493-05:00"
-  },
   "https://communityinviter.com/apps/cloud-native/cncf": {
     "StatusCode": 200,
     "LastSeen": "2023-02-15T20:41:09.591716-05:00"
   },
   "https://conan.io/center/opentelemetry-cpp": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:37:47.678543-05:00"
+    "LastSeen": "2023-06-29T13:38:32.244963-04:00"
   },
   "https://connect.build/docs/protocol/#error-codes": {
     "StatusCode": 206,
@@ -421,11 +413,11 @@
   },
   "https://consul.io": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T20:40:53.214342-05:00"
+    "LastSeen": "2023-06-29T13:46:40.656541-04:00"
   },
   "https://coralogix.com/docs/opentelemetry/": {
-    "StatusCode": 200,
-    "LastSeen": "2023-02-15T20:37:41.946671-05:00"
+    "StatusCode": 206,
+    "LastSeen": "2023-06-29T13:38:26.570786-04:00"
   },
   "https://danielabaron.me": {
     "StatusCode": 206,

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -29,7 +29,7 @@
   },
   "http://mypy-lang.org/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:15:20.756374-05:00"
+    "LastSeen": "2023-06-29T16:11:09.498147-04:00"
   },
   "http://nginx.org/en/docs/http/ngx_http_core_module.html#server_name": {
     "StatusCode": 206,
@@ -421,15 +421,15 @@
   },
   "https://danielabaron.me": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:12:36.204053-05:00"
+    "LastSeen": "2023-06-29T16:16:03.628698-04:00"
   },
   "https://danielabaron.me/blog/nomad-tips-and-tricks/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:12:30.77453-05:00"
+    "LastSeen": "2023-06-29T16:15:58.495962-04:00"
   },
   "https://dart.dev": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:13:29.941423-05:00"
+    "LastSeen": "2023-06-29T16:19:47.798342-04:00"
   },
   "https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.1": {
     "StatusCode": 200,
@@ -473,7 +473,7 @@
   },
   "https://datatracker.ietf.org/doc/html/rfc7617": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:12:19.647161-05:00"
+    "LastSeen": "2023-06-29T16:10:56.695282-04:00"
   },
   "https://datatracker.ietf.org/doc/html/rfc8555": {
     "StatusCode": 200,
@@ -481,7 +481,7 @@
   },
   "https://deno.land": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:14:20.22294-05:00"
+    "LastSeen": "2023-06-29T16:19:42.584991-04:00"
   },
   "https://devcenter.heroku.com/articles/dyno-metadata": {
     "StatusCode": 200,
@@ -489,15 +489,15 @@
   },
   "https://developer.android.com/reference/android/os/Build#MANUFACTURER": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:12:02.911089-05:00"
+    "LastSeen": "2023-06-29T16:08:18.483355-04:00"
   },
   "https://developer.android.com/training/articles/user-data-ids": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:11:57.218557-05:00"
+    "LastSeen": "2023-06-29T16:08:12.4633-04:00"
   },
   "https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor": {
-    "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:11:51.638506-05:00"
+    "StatusCode": 200,
+    "LastSeen": "2023-06-29T16:08:06.985321-04:00"
   },
   "https://developer.confluent.io/learn-kafka/apache-kafka/topics/": {
     "StatusCode": 206,
@@ -505,11 +505,11 @@
   },
   "https://developer.hashicorp.com/nomad/docs/commands/job/run#detach": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:13:13.431884-05:00"
+    "LastSeen": "2023-06-29T16:16:40.01449-04:00"
   },
   "https://developer.hashicorp.com/nomad/docs/commands/operator/scheduler/set-config#memory-oversubscription": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:13:08.137059-05:00"
+    "LastSeen": "2023-06-29T16:16:34.791447-04:00"
   },
   "https://developer.hashicorp.com/nomad/downloads": {
     "StatusCode": 206,
@@ -537,7 +537,7 @@
   },
   "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:13:58.262461-05:00"
+    "LastSeen": "2023-06-29T16:18:55.463854-04:00"
   },
   "https://developers.google.com/protocol-buffers/docs/encoding": {
     "StatusCode": 206,
@@ -561,11 +561,11 @@
   },
   "https://devstats.cncf.io/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:14:43.763922-05:00"
+    "LastSeen": "2023-06-29T16:21:23.471592-04:00"
   },
   "https://docker.com": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:12:46.673559-05:00"
+    "LastSeen": "2023-06-29T16:16:13.965986-04:00"
   },
   "https://docs.appdynamics.com/latest/en/application-monitoring/appdynamics-for-opentelemetry": {
     "StatusCode": 200,
@@ -577,7 +577,7 @@
   },
   "https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-access-control-overview-cwl.html#CWL_ARN_Format": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:11:44.989177-05:00"
+    "LastSeen": "2023-06-29T16:08:01.492753-04:00"
   },
   "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Lambda-Insights-metrics.html": {
     "StatusCode": 206,
@@ -585,19 +585,19 @@
   },
   "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_instances.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:11:24.137165-05:00"
+    "LastSeen": "2023-06-29T16:07:40.747436-04:00"
   },
   "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/clusters.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:11:29.293256-05:00"
+    "LastSeen": "2023-06-29T16:07:45.902951-04:00"
   },
   "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:11:34.469896-05:00"
+    "LastSeen": "2023-06-29T16:07:51.065552-04:00"
   },
   "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definitions.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:11:39.805847-05:00"
+    "LastSeen": "2023-06-29T16:07:56.278067-04:00"
   },
   "https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format": {
     "StatusCode": 206,
@@ -665,7 +665,7 @@
   },
   "https://docs.aws.amazon.com/eks/latest/userguide/clusters.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:14:08.832435-05:00"
+    "LastSeen": "2023-06-29T16:19:06.120883-04:00"
   },
   "https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html": {
     "StatusCode": 206,
@@ -673,7 +673,7 @@
   },
   "https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:11:03.023914-05:00"
+    "LastSeen": "2023-06-29T16:05:48.019003-04:00"
   },
   "https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime": {
     "StatusCode": 206,
@@ -681,7 +681,7 @@
   },
   "https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:11:13.789437-05:00"
+    "LastSeen": "2023-06-29T16:07:29.929638-04:00"
   },
   "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html": {
     "StatusCode": 206,
@@ -692,8 +692,8 @@
     "LastSeen": "2023-06-29T15:48:01.663228-04:00"
   },
   "https://docs.aws.amazon.com/lambda/latest/dg/welcome.html": {
-    "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:14:03.670815-05:00"
+    "StatusCode": 206,
+    "LastSeen": "2023-06-29T16:19:00.956838-04:00"
   },
   "https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader": {
     "StatusCode": 206,
@@ -745,19 +745,19 @@
   },
   "https://docs.docker.com/desktop/settings/linux/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:13:02.153352-05:00"
+    "LastSeen": "2023-06-29T16:16:29.541918-04:00"
   },
   "https://docs.docker.com/desktop/settings/mac/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:12:51.850021-05:00"
+    "LastSeen": "2023-06-29T16:16:19.145232-04:00"
   },
   "https://docs.docker.com/desktop/settings/windows/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:12:56.987934-05:00"
+    "LastSeen": "2023-06-29T16:16:24.371007-04:00"
   },
   "https://docs.docker.com/engine/reference/run/#container-identification": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:11:18.927856-05:00"
+    "LastSeen": "2023-06-29T16:07:35.082785-04:00"
   },
   "https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request": {
     "StatusCode": 206,
@@ -797,7 +797,7 @@
   },
   "https://docs.google.com/document/d/1eDYC97LfvE428cpIf3A_hSGirdNzglPurlxgKCmw8o4/edit": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:13:47.324967-05:00"
+    "LastSeen": "2023-06-29T16:20:04.582136-04:00"
   },
   "https://docs.google.com/document/d/1fh4RWyZ-ScWdwrgpRHO9mnfqLSKfxUTf4wZGdUvnnUM": {
     "StatusCode": 200,
@@ -805,15 +805,15 @@
   },
   "https://docs.google.com/document/d/1fh4RWyZ-ScWdwrgpRHO9mnfqLSKfxUTf4wZGdUvnnUM/edit": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:13:41.600892-05:00"
+    "LastSeen": "2023-06-29T16:19:58.924217-04:00"
   },
   "https://docs.google.com/document/d/1ghvajKaipiNZso3fDtyNxU7x1zx0_Eyd02OGpMGEpLE": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:14:37.923052-05:00"
+    "LastSeen": "2023-06-29T16:20:10.043789-04:00"
   },
   "https://docs.google.com/document/d/1ghvajKaipiNZso3fDtyNxU7x1zx0_Eyd02OGpMGEpLE/edit": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:14:14.712036-05:00"
+    "LastSeen": "2023-06-29T16:19:37.402928-04:00"
   },
   "https://docs.google.com/document/d/1ix9_4TQO3o-qyeyNhcOmqAc1MTyr-wnXxxsdWgCMn9c/edit": {
     "StatusCode": 200,
@@ -821,7 +821,7 @@
   },
   "https://docs.google.com/document/d/1jt47KPwgDG_-4kR4J5GtFSCEhQO3CHgUdAwpCKTQHO8/edit": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:13:24.776932-05:00"
+    "LastSeen": "2023-06-29T16:18:02.371172-04:00"
   },
   "https://docs.google.com/document/d/1p_FoGbLiDC9VPqqLblJqQtHBn3tr-aPxhu2GaIykU6k": {
     "StatusCode": 200,
@@ -829,7 +829,7 @@
   },
   "https://docs.google.com/document/d/1p_FoGbLiDC9VPqqLblJqQtHBn3tr-aPxhu2GaIykU6k/edit": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:13:35.77217-05:00"
+    "LastSeen": "2023-06-29T16:19:53.36338-04:00"
   },
   "https://docs.google.com/forms/d/e/1FAIpQLSdKm6oLYRXlZOhEZMVmjoIn4eBToVYNmF6fwpm5GAIipQmPxA/viewform": {
     "StatusCode": 200,
@@ -881,7 +881,7 @@
   },
   "https://docs.microsoft.com/dotnet/core/diagnostics/metrics-instrumentation": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:13:19.007688-05:00"
+    "LastSeen": "2023-06-29T16:17:12.119364-04:00"
   },
   "https://docs.microsoft.com/en-us/archive/blogs/askcore/windows-performance-monitor-disk-counters-explained#windows-performance-monitor-disk-counters-explained:~:text=%25%20Idle%20Time,Idle%5c%29%20to%200%20%28meaning%20always%20busy%29.": {
     "StatusCode": 200,
@@ -909,7 +909,7 @@
   },
   "https://docs.microsoft.com/en-us/rest/api/resources/resources/get-by-id": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:11:08.591792-05:00"
+    "LastSeen": "2023-06-29T16:05:58.534622-04:00"
   },
   "https://docs.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url": {
     "StatusCode": 200,
@@ -944,8 +944,8 @@
     "LastSeen": "2023-06-29T15:48:59.284487-04:00"
   },
   "https://docs.nginx.com/nginx-ingress-controller/": {
-    "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:12:25.207145-05:00"
+    "StatusCode": 206,
+    "LastSeen": "2023-06-29T16:14:11.227253-04:00"
   },
   "https://docs.observeinc.com/en/latest/content/integrations/otel/opentelemetry.html": {
     "StatusCode": 200,
@@ -1101,7 +1101,7 @@
   },
   "https://docs.oracle.com/javase/tutorial/jmx/mbeans/index.html": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:14:26.223031-05:00"
+    "LastSeen": "2023-06-29T16:18:12.959612-04:00"
   },
   "https://docs.php-http.org/en/latest/clients.html": {
     "StatusCode": 200,
@@ -1109,11 +1109,11 @@
   },
   "https://docs.python.org/3/library/sys.html#sys.implementation": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:12:08.314891-05:00"
+    "LastSeen": "2023-06-29T16:08:34.255663-04:00"
   },
   "https://docs.python.org/3/library/sys.html#sys.version": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:12:13.678516-05:00"
+    "LastSeen": "2023-06-29T16:08:39.31052-04:00"
   },
   "https://docs.python.org/3/library/traceback.html#traceback.format_exc": {
     "StatusCode": 206,
@@ -1197,7 +1197,7 @@
   },
   "https://dotnet.microsoft.com/en-us/": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:13:52.840205-05:00"
+    "LastSeen": "2023-06-29T16:18:34.910908-04:00"
   },
   "https://dotnet.microsoft.com/en-us/learn/dotnet/what-is-dotnet": {
     "StatusCode": 200,
@@ -1229,31 +1229,31 @@
   },
   "https://en.cppreference.com/w/cpp/container/set": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:19:49.382146-05:00"
+    "LastSeen": "2023-06-29T16:10:28.50163-04:00"
   },
   "https://en.cppreference.com/w/cpp/container/vector": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:19:43.82917-05:00"
+    "LastSeen": "2023-06-29T16:10:12.863243-04:00"
   },
   "https://en.wikipedia.org/wiki/Aggregate_function#Decomposable_aggregate_functions": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:18:21.504006-05:00"
+    "LastSeen": "2023-06-29T16:09:27.920899-04:00"
   },
   "https://en.wikipedia.org/wiki/Amazon_ElastiCache": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:21:26.552917-05:00"
+    "LastSeen": "2023-06-29T16:19:21.664861-04:00"
   },
   "https://en.wikipedia.org/wiki/Asynchronous_method_invocation": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:18:48.630585-05:00"
+    "LastSeen": "2023-06-29T16:09:53.910802-04:00"
   },
   "https://en.wikipedia.org/wiki/Basic_Latin_%28Unicode_block%29#Table_of_characters": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:19:54.919624-05:00"
+    "LastSeen": "2023-06-29T16:10:33.693806-04:00"
   },
   "https://en.wikipedia.org/wiki/COBOL": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:21:37.356938-05:00"
+    "LastSeen": "2023-06-29T16:19:31.864503-04:00"
   },
   "https://en.wikipedia.org/wiki/Channel_9_%28Microsoft%29": {
     "StatusCode": 200,
@@ -1261,59 +1261,55 @@
   },
   "https://en.wikipedia.org/wiki/Count_noun": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:19:10.304029-05:00"
+    "LastSeen": "2023-06-29T16:05:10.639583-04:00"
   },
   "https://en.wikipedia.org/wiki/Cross-cutting_concern": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:20:17.044913-05:00"
+    "LastSeen": "2023-06-29T16:10:51.049499-04:00"
   },
   "https://en.wikipedia.org/wiki/Deployment_environment": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:20:11.481451-05:00"
+    "LastSeen": "2023-06-29T16:07:24.595426-04:00"
   },
   "https://en.wikipedia.org/wiki/Directed_acyclic_graph": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:17:32.470731-05:00"
+    "LastSeen": "2023-06-29T16:13:08.02137-04:00"
   },
   "https://en.wikipedia.org/wiki/Double-precision_floating-point_format": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:17:59.755021-05:00"
+    "LastSeen": "2023-06-29T16:09:07.381411-04:00"
   },
   "https://en.wikipedia.org/wiki/Fortran": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:21:31.958033-05:00"
+    "LastSeen": "2023-06-29T16:19:26.768243-04:00"
   },
   "https://en.wikipedia.org/wiki/Function_as_a_service": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:19:04.898161-05:00"
+    "LastSeen": "2023-06-29T16:05:05.543421-04:00"
   },
   "https://en.wikipedia.org/wiki/Futures_and_promises": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:17:26.35172-05:00"
+    "LastSeen": "2023-06-29T16:12:23.37906-04:00"
   },
   "https://en.wikipedia.org/wiki/GraphQL": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:21:21.139846-05:00"
+    "LastSeen": "2023-06-29T16:18:50.19739-04:00"
   },
   "https://en.wikipedia.org/wiki/Hop_%28networking%29": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:19:32.347091-05:00"
+    "LastSeen": "2023-06-29T16:05:42.552717-04:00"
   },
   "https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:17:37.878913-05:00"
+    "LastSeen": "2023-06-29T16:13:18.38631-04:00"
   },
   "https://en.wikipedia.org/wiki/IEEE_754": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:18:32.326752-05:00"
-  },
-  "https://en.wikipedia.org/wiki/Idempotence": {
-    "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:19:37.918487-05:00"
+    "LastSeen": "2023-06-29T16:09:38.12991-04:00"
   },
   "https://en.wikipedia.org/wiki/In-band_signaling": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:20:05.938917-05:00"
+    "LastSeen": "2023-06-29T16:10:44.751669-04:00"
   },
   "https://en.wikipedia.org/wiki/Inter-process_communication": {
     "StatusCode": 200,
@@ -1321,71 +1317,71 @@
   },
   "https://en.wikipedia.org/wiki/JSON": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:17:43.283796-05:00"
+    "LastSeen": "2023-06-29T16:13:23.485389-04:00"
   },
   "https://en.wikipedia.org/wiki/Load_%28computing%29": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:19:26.615809-05:00"
+    "LastSeen": "2023-06-29T16:05:37.110552-04:00"
   },
   "https://en.wikipedia.org/wiki/Log_file": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:20:00.371455-05:00"
+    "LastSeen": "2023-06-29T16:10:39.017584-04:00"
   },
   "https://en.wikipedia.org/wiki/Monotonic_function": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:18:59.441229-05:00"
+    "LastSeen": "2023-06-29T16:10:04.16781-04:00"
   },
   "https://en.wikipedia.org/wiki/Non-uniform_memory_access": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:18:16.09397-05:00"
+    "LastSeen": "2023-06-29T16:09:22.699003-04:00"
   },
   "https://en.wikipedia.org/wiki/Observer_pattern": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:18:54.028526-05:00"
+    "LastSeen": "2023-06-29T16:09:59.01412-04:00"
   },
   "https://en.wikipedia.org/wiki/PL/I": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:21:15.731931-05:00"
+    "LastSeen": "2023-06-29T16:18:40.042379-04:00"
   },
   "https://en.wikipedia.org/wiki/Page_fault": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:18:10.678978-05:00"
+    "LastSeen": "2023-06-29T16:09:17.597134-04:00"
   },
   "https://en.wikipedia.org/wiki/Percentile": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:20:22.557617-05:00"
+    "LastSeen": "2023-06-29T16:14:53.128119-04:00"
   },
   "https://en.wikipedia.org/wiki/Plane_%28Unicode%29": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:18:43.218579-05:00"
+    "LastSeen": "2023-06-29T16:09:48.649981-04:00"
   },
   "https://en.wikipedia.org/wiki/Plane_%28Unicode%29#Basic_Multilingual_Plane": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:18:37.808477-05:00"
+    "LastSeen": "2023-06-29T16:09:43.54413-04:00"
   },
   "https://en.wikipedia.org/wiki/Remote_procedure_call": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:17:54.105129-05:00"
+    "LastSeen": "2023-06-29T16:13:33.703006-04:00"
   },
   "https://en.wikipedia.org/wiki/Representational_state_transfer": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:17:48.697934-05:00"
+    "LastSeen": "2023-06-29T16:13:28.597641-04:00"
   },
   "https://en.wikipedia.org/wiki/Reservoir_sampling": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:18:26.917506-05:00"
+    "LastSeen": "2023-06-29T16:09:33.030309-04:00"
   },
   "https://en.wikipedia.org/wiki/S.M.A.R.T.": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:19:15.720351-05:00"
+    "LastSeen": "2023-06-29T16:05:15.796393-04:00"
   },
   "https://en.wikipedia.org/wiki/Subnormal_number": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:18:05.266786-05:00"
+    "LastSeen": "2023-06-29T16:09:12.492806-04:00"
   },
   "https://en.wikipedia.org/wiki/Transport_layer#Protocols": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:19:21.209086-05:00"
+    "LastSeen": "2023-06-29T16:05:26.503425-04:00"
   },
   "https://eng.uber.com/flipr/": {
     "StatusCode": 200,
@@ -1393,27 +1389,23 @@
   },
   "https://equalitymi.org/": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:20:40.685445-05:00"
+    "LastSeen": "2023-06-29T16:15:42.859025-04:00"
   },
   "https://erlang.org/doc/design_principles/applications.html#configuring-an-application": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:17:20.864518-05:00"
-  },
-  "https://erlang.org/doc/reference_manual/processes.html#process-dictionary": {
-    "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:17:15.279953-05:00"
+    "LastSeen": "2023-06-29T16:12:07.863918-04:00"
   },
   "https://events.linuxfoundation.org/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:21:48.892956-05:00"
+    "LastSeen": "2023-06-29T16:20:28.035698-04:00"
   },
   "https://events.linuxfoundation.org/cloud-native-ebpf-day-north-america/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:20:58.505642-05:00"
+    "LastSeen": "2023-06-29T16:17:45.163643-04:00"
   },
   "https://events.linuxfoundation.org/cloud-native-ebpf-day-north-america/program/schedule/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:21:04.227535-05:00"
+    "LastSeen": "2023-06-29T16:17:50.630994-04:00"
   },
   "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/": {
     "StatusCode": 206,
@@ -1421,7 +1413,7 @@
   },
   "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/cncf-hosted-co-located-events/observability-day/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:21:43.46666-05:00"
+    "LastSeen": "2023-06-29T16:18:24.185545-04:00"
   },
   "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/co-located-events/observability-day/": {
     "StatusCode": 206,
@@ -1445,23 +1437,23 @@
   },
   "https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/venue-travel/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:21:10.233851-05:00"
+    "LastSeen": "2023-06-29T16:17:56.823445-04:00"
   },
   "https://events.linuxfoundation.org/open-observability-day-north-america/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:20:46.491278-05:00"
+    "LastSeen": "2023-06-29T16:17:34.223285-04:00"
   },
   "https://events.linuxfoundation.org/open-observability-day-north-america/program/schedule/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:20:52.352485-05:00"
+    "LastSeen": "2023-06-29T16:17:39.711002-04:00"
   },
   "https://events.linuxfoundation.org/open-telemetry-community-day/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:20:33.806242-05:00"
+    "LastSeen": "2023-06-29T16:15:35.976502-04:00"
   },
   "https://expressjs.com": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:17:02.709221-05:00"
+    "LastSeen": "2023-06-29T16:04:10.083858-04:00"
   },
   "https://expressjs.com/": {
     "StatusCode": 200,
@@ -1477,23 +1469,23 @@
   },
   "https://fluentbit.io/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:22:26.698116-05:00"
+    "LastSeen": "2023-06-29T16:03:49.117652-04:00"
   },
   "https://forms.gle/aUuJg5DQwNzncJ4s8": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:22:42.002069-05:00"
+    "LastSeen": "2023-06-29T16:14:48.01551-04:00"
   },
   "https://forms.gle/mEDWyn6G7iCe4bvJ7": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:22:47.988863-05:00"
+    "LastSeen": "2023-06-29T16:15:04.069551-04:00"
   },
   "https://fosstodon.org/@opentelemetry": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:22:21.214087-05:00"
+    "LastSeen": "2023-06-29T16:03:12.268744-04:00"
   },
   "https://gcc.gnu.org/frontends.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:26:28.637715-05:00"
+    "LastSeen": "2023-06-29T16:08:29.164899-04:00"
   },
   "https://getcomposer.org/": {
     "StatusCode": 200,
@@ -1501,15 +1493,15 @@
   },
   "https://getcomposer.org/download/": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:25:27.904356-05:00"
+    "LastSeen": "2023-06-29T16:18:18.163861-04:00"
   },
   "https://gethelios.dev/": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:24:06.023755-05:00"
+    "LastSeen": "2023-06-29T16:03:22.899199-04:00"
   },
   "https://ghcr.io/open-telemetry/demo": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:29:23.434695-05:00"
+    "LastSeen": "2023-06-29T16:04:43.002783-04:00"
   },
   "https://github.com": {
     "StatusCode": 200,
@@ -3017,27 +3009,27 @@
   },
   "https://go.dev/doc/install/gccgo": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:26:22.8779-05:00"
+    "LastSeen": "2023-06-29T16:08:23.852746-04:00"
   },
   "https://go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:24:16.69044-05:00"
+    "LastSeen": "2023-06-29T16:04:04.854224-04:00"
   },
   "https://godoc.org/google.golang.org/genproto/googleapis/rpc/status#Status": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:26:16.561656-05:00"
+    "LastSeen": "2023-06-29T16:09:01.724558-04:00"
   },
   "https://godoc.org/google.golang.org/grpc/codes": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:26:05.877235-05:00"
+    "LastSeen": "2023-06-29T16:08:49.874111-04:00"
   },
   "https://godoc.org/google.golang.org/grpc/status#Status.WithDetails": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:26:11.140284-05:00"
+    "LastSeen": "2023-06-29T16:08:55.124449-04:00"
   },
   "https://golang.org/ref/spec#Slice_types": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:26:16.922966-05:00"
+    "LastSeen": "2023-06-29T16:10:23.235648-04:00"
   },
   "https://gradle.org/": {
     "StatusCode": 206,
@@ -3049,115 +3041,99 @@
   },
   "https://grafana.com/": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:24:27.889758-05:00"
+    "LastSeen": "2023-06-29T16:04:31.366652-04:00"
   },
   "https://grafana.com/grafana/": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:25:00.432554-05:00"
+    "LastSeen": "2023-06-29T16:11:30.647868-04:00"
   },
   "https://grafana.com/oss/loki/": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:24:49.636523-05:00"
+    "LastSeen": "2023-06-29T16:11:20.447881-04:00"
   },
   "https://grafana.com/oss/opentelemetry/": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:23:59.98428-05:00"
+    "LastSeen": "2023-06-29T16:03:17.397983-04:00"
   },
   "https://grafana.com/oss/tempo/": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:24:55.033041-05:00"
+    "LastSeen": "2023-06-29T16:11:25.544037-04:00"
   },
   "https://graphiteapp.org/": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:24:11.475127-05:00"
+    "LastSeen": "2023-06-29T16:03:54.321095-04:00"
   },
   "https://graphql.org": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:26:39.415784-05:00"
+    "LastSeen": "2023-06-29T16:18:45.102151-04:00"
   },
   "https://graphql.org/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:26:34.342483-05:00"
+    "LastSeen": "2023-06-29T16:18:29.480237-04:00"
   },
   "https://graphql.org/learn/queries/#mutations": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:26:44.489051-05:00"
+    "LastSeen": "2023-06-29T16:19:16.569739-04:00"
   },
   "https://grpc.github.io/grpc/core/md_doc_naming.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:25:34.345612-05:00"
+    "LastSeen": "2023-06-29T16:05:21.212891-04:00"
   },
   "https://grpc.io": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:24:22.459022-05:00"
+    "LastSeen": "2023-06-29T16:13:13.275442-04:00"
   },
   "https://grpc.io/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:25:39.862282-05:00"
-  },
-  "https://grpc.io/docs/languages/java/quickstart/": {
-    "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:25:11.367024-05:00"
-  },
-  "https://grpc.io/docs/languages/java/quickstart/#get-the-example-code": {
-    "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:25:16.785978-05:00"
-  },
-  "https://grpc.io/docs/languages/java/quickstart/#run-the-example": {
-    "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:25:22.295259-05:00"
+    "LastSeen": "2023-06-29T16:04:20.978261-04:00"
   },
   "https://guava.dev/releases/10.0/api/docs/com/google/common/util/concurrent/ListenableFuture.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:25:05.773754-05:00"
+    "LastSeen": "2023-06-29T16:12:28.535657-04:00"
   },
   "https://hachyderm.io/@adrianamvillela": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:48:37.433185-05:00"
+    "LastSeen": "2023-06-29T16:16:45.717847-04:00"
   },
   "https://hashicorp.com": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:48:31.150337-05:00"
+    "LastSeen": "2023-06-29T16:15:53.26896-04:00"
   },
   "https://helm.sh": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:47:01.900597-05:00"
+    "LastSeen": "2023-06-29T16:04:48.516571-04:00"
   },
   "https://helm.sh/docs/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:47:07.325048-05:00"
+    "LastSeen": "2023-06-29T16:04:53.616666-04:00"
   },
   "https://help.github.com/articles/about-pull-requests/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:48:01.742814-05:00"
+    "LastSeen": "2023-06-29T16:13:01.956826-04:00"
   },
   "https://help.sumologic.com/docs/apm/traces/quickstart/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:46:55.810396-05:00"
+    "LastSeen": "2023-06-29T16:03:38.709294-04:00"
   },
   "https://heroku.com": {
-    "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:47:51.013855-05:00"
+    "StatusCode": 206,
+    "LastSeen": "2023-06-29T16:12:39.965089-04:00"
   },
   "https://hex.pm": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:47:13.922817-05:00"
-  },
-  "https://hex.pm/orgs/opentelemetry": {
-    "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:45:14.095356-05:00"
+    "LastSeen": "2023-06-29T16:11:36.065186-04:00"
   },
   "https://hex.pm/packages/opentelemetry": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:47:19.046356-05:00"
+    "LastSeen": "2023-06-29T16:11:46.262345-04:00"
   },
   "https://hex.pm/packages/opentelemetry_api": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:44:58.985332-05:00"
+    "LastSeen": "2023-06-29T16:11:41.155675-04:00"
   },
   "https://hex.pm/packages/opentelemetry_exporter": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:47:24.160442-05:00"
+    "LastSeen": "2023-06-29T16:11:51.357207-04:00"
   },
   "https://hex.pm/packages/opentelemetry_req": {
     "StatusCode": 200,
@@ -3181,7 +3157,7 @@
   },
   "https://hexdocs.pm/mix/Mix.Tasks.Release.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:47:40.349021-05:00"
+    "LastSeen": "2023-06-29T16:11:56.632002-04:00"
   },
   "https://hexdocs.pm/opentelemetry/1.3.0/otel_resource.html": {
     "StatusCode": 206,
@@ -3197,19 +3173,15 @@
   },
   "https://hexdocs.pm/opentelemetry/otel_exporter.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:47:34.984079-05:00"
+    "LastSeen": "2023-06-29T16:12:18.017444-04:00"
   },
   "https://hexdocs.pm/opentelemetry/otel_span_processor.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:45:24.525812-05:00"
+    "LastSeen": "2023-06-29T16:12:12.939416-04:00"
   },
   "https://hexdocs.pm/opentelemetry/otel_tracer_server.html": {
     "StatusCode": 206,
     "LastSeen": "2023-04-18T17:53:23.082563624-06:00"
-  },
-  "https://hexdocs.pm/opentelemetry_api/otel_tracer_provider.html": {
-    "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:47:29.620967-05:00"
   },
   "https://hexdocs.pm/phoenix/installation.html": {
     "StatusCode": 206,
@@ -3221,27 +3193,19 @@
   },
   "https://httpd.apache.org/docs/2.4/mod/core.html#servername": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:48:08.863988-05:00"
+    "LastSeen": "2023-06-29T16:06:36.540216-04:00"
   },
   "https://httpwg.org/specs/rfc7230.html#field.order": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-15T21:48:42.889287-05:00"
+    "LastSeen": "2023-06-29T16:17:01.65961-04:00"
   },
   "https://hub.docker.com/r/apache/apisix": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:48:15.319051-05:00"
+    "LastSeen": "2023-06-29T16:14:58.301793-04:00"
   },
   "https://hub.docker.com/r/otel/opentelemetry-collector-contrib/tags": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:48:20.751646-05:00"
-  },
-  "https://intl.cloud.tencent.com/": {
-    "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:54:31.911988-05:00"
-  },
-  "https://intl.cloud.tencent.com/document/product/213/6091": {
-    "StatusCode": 200,
-    "LastSeen": "2023-02-15T21:54:38.310014-05:00"
+    "LastSeen": "2023-06-29T16:15:09.230771-04:00"
   },
   "https://jaegertracing.io": {
     "StatusCode": 206,
@@ -3249,19 +3213,19 @@
   },
   "https://jakarta.ee/specifications/platform/8/apidocs/javax/servlet/http/HttpServletRequest.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:09:10.105738-05:00"
+    "LastSeen": "2023-06-29T16:06:31.115927-04:00"
   },
   "https://jcp.org/aboutJava/communityprocess/maintenance/jsr053/index2.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:09:16.129724-05:00"
+    "LastSeen": "2023-06-29T16:06:42.58227-04:00"
   },
   "https://jessitron.com/": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:09:22.709776-05:00"
+    "LastSeen": "2023-06-29T16:16:51.277143-04:00"
   },
   "https://joshuamlee.com/submitting-your-first-conference-talk/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:09:33.386443-05:00"
+    "LastSeen": "2023-06-29T16:20:20.534406-04:00"
   },
   "https://json-schema.org/": {
     "StatusCode": 206,
@@ -3277,35 +3241,35 @@
   },
   "https://kafka.apache.org/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:11:34.975001-05:00"
+    "LastSeen": "2023-06-29T16:03:43.932243-04:00"
   },
   "https://kafka.apache.org/documentation/#quickstart": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:13:09.818001-05:00"
+    "LastSeen": "2023-06-29T16:17:28.732044-04:00"
   },
   "https://kafka.apache.org/downloads": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:13:04.246196-05:00"
+    "LastSeen": "2023-06-29T16:17:23.226167-04:00"
   },
   "https://kind.sigs.k8s.io/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:12:27.005244-05:00"
+    "LastSeen": "2023-06-29T16:14:16.4324-04:00"
   },
   "https://kloudfuse.atlassian.net/wiki/spaces/EX/pages/753860609/APM#Sending-traces-to-Kloudfuse-data-plane%3A": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:11:29.484077-05:00"
+    "LastSeen": "2023-06-29T16:03:28.24078-04:00"
   },
   "https://knative.dev/docs/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:12:43.003157-05:00"
+    "LastSeen": "2023-06-29T16:15:14.445409-04:00"
   },
   "https://knative.dev/docs/eventing/accessing-traces/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:12:48.2945-05:00"
+    "LastSeen": "2023-06-29T16:15:19.812667-04:00"
   },
   "https://knative.dev/docs/serving/accessing-traces/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:12:53.588932-05:00"
+    "LastSeen": "2023-06-29T16:15:25.083347-04:00"
   },
   "https://kofo.dev/how-to-mtls-in-golang": {
     "StatusCode": 200,
@@ -3313,23 +3277,23 @@
   },
   "https://kubernetes.github.io/ingress-nginx/examples/grpc/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:12:37.551902-05:00"
+    "LastSeen": "2023-06-29T16:14:32.000793-04:00"
   },
   "https://kubernetes.io/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:12:58.76128-05:00"
+    "LastSeen": "2023-06-29T16:04:15.687682-04:00"
   },
   "https://kubernetes.io/blog/2022/12/01/runtime-observability-opentelemetry/": {
     "StatusCode": 206,
     "LastSeen": "2023-05-25T14:26:34.915073-03:00"
   },
   "https://kubernetes.io/docs/concepts/cluster-administration/system-traces/": {
-    "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:11:40.16064-05:00"
+    "StatusCode": 206,
+    "LastSeen": "2023-06-29T16:03:59.584942-04:00"
   },
   "https://kubernetes.io/docs/concepts/extend-kubernetes/operator/": {
-    "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:11:53.645179-05:00"
+    "StatusCode": 206,
+    "LastSeen": "2023-06-29T16:13:49.919181-04:00"
   },
   "https://kubernetes.io/docs/concepts/overview/components/#kube-apiserver": {
     "StatusCode": 206,
@@ -3340,28 +3304,28 @@
     "LastSeen": "2023-05-25T14:26:35.867723-03:00"
   },
   "https://kubernetes.io/docs/concepts/overview/working-with-objects/names/": {
-    "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:12:05.854488-05:00"
+    "StatusCode": 206,
+    "LastSeen": "2023-06-29T16:07:04.062634-04:00"
   },
   "https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/": {
-    "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:12:00.710403-05:00"
+    "StatusCode": 206,
+    "LastSeen": "2023-06-29T16:06:58.962765-04:00"
   },
   "https://kubernetes.io/docs/concepts/workloads/controllers/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:12:16.084094-05:00"
+    "LastSeen": "2023-06-29T16:07:14.3411-04:00"
   },
   "https://kubernetes.io/docs/concepts/workloads/pods/": {
-    "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:12:10.993931-05:00"
+    "StatusCode": 206,
+    "LastSeen": "2023-06-29T16:07:09.207767-04:00"
   },
   "https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:12:21.169104-05:00"
+    "LastSeen": "2023-06-29T16:07:19.442008-04:00"
   },
   "https://kubernetes.io/docs/concepts/workloads/pods/downward-api/": {
-    "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:12:32.145251-05:00"
+    "StatusCode": 206,
+    "LastSeen": "2023-06-29T16:14:26.894177-04:00"
   },
   "https://kubernetes.io/docs/reference/kubectl/": {
     "StatusCode": 206,
@@ -3377,7 +3341,7 @@
   },
   "https://leancoffee.org": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:14:46.273759-05:00"
+    "LastSeen": "2023-06-29T16:21:28.969704-04:00"
   },
   "https://learn.microsoft.com/en-us/rest/api/resources/resources/get-by-id": {
     "StatusCode": 200,
@@ -3385,35 +3349,35 @@
   },
   "https://letsencrypt.org/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:14:40.123818-05:00"
+    "LastSeen": "2023-06-29T16:14:21.541903-04:00"
   },
   "https://lfcla.com/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:14:16.25452-05:00"
+    "LastSeen": "2023-06-29T16:12:51.637672-04:00"
   },
   "https://library.humio.com/falcon-logscale/log-shippers-opentelemetry.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:13:51.700072-05:00"
+    "LastSeen": "2023-06-29T16:03:33.467924-04:00"
   },
   "https://lightstep.com/blog/apm-is-dying-and-thats-okay": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:14:21.785616-05:00"
+    "LastSeen": "2023-06-29T16:13:44.74498-04:00"
   },
   "https://lightstep.com/blog/observability-mythbusters-how-hard-is-it-to-get-started-with-opentelemetry": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:14:28.980312-05:00"
+    "LastSeen": "2023-06-29T16:13:55.495404-04:00"
   },
   "https://linux.die.net/man/1/base64": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:14:34.675698-05:00"
+    "LastSeen": "2023-06-29T16:14:05.993967-04:00"
   },
   "https://locust.io": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:14:03.151921-05:00"
+    "LastSeen": "2023-06-29T16:04:59.239021-04:00"
   },
   "https://locust.io/": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:13:57.444064-05:00"
+    "LastSeen": "2023-06-29T16:04:26.285813-04:00"
   },
   "https://loom.com": {
     "StatusCode": 206,
@@ -3423,57 +3387,49 @@
     "StatusCode": 206,
     "LastSeen": "2023-03-06T13:39:32.677929+05:30"
   },
-  "https://man7.org/linux/man-pages/man0/sys_socket.h.0p.html": {
-    "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:15:56.522038-05:00"
-  },
   "https://man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:15:50.728175-05:00"
+    "LastSeen": "2023-06-29T16:05:32.004787-04:00"
   },
   "https://man7.org/linux/man-pages/man2/bind.2.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:16:17.969252-05:00"
+    "LastSeen": "2023-06-29T16:06:25.609054-04:00"
   },
   "https://man7.org/linux/man-pages/man2/connect.2.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:16:01.883766-05:00"
+    "LastSeen": "2023-06-29T16:06:04.175179-04:00"
   },
   "https://man7.org/linux/man-pages/man2/getpeername.2.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:16:12.610666-05:00"
+    "LastSeen": "2023-06-29T16:06:14.891546-04:00"
   },
   "https://man7.org/linux/man-pages/man2/getsockname.2.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:16:23.314559-05:00"
-  },
-  "https://man7.org/linux/man-pages/man7/address_families.7.html": {
-    "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:15:45.177962-05:00"
+    "LastSeen": "2023-06-29T16:06:20.249047-04:00"
   },
   "https://man7.org/linux/man-pages/man7/ip.7.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:16:07.25556-05:00"
+    "LastSeen": "2023-06-29T16:06:09.52953-04:00"
   },
   "https://marc.info/": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:16:34.191788-05:00"
+    "LastSeen": "2023-06-29T16:06:53.18731-04:00"
   },
   "https://martinfowler.com/bliki/CanaryRelease.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:17:25.25828-05:00"
+    "LastSeen": "2023-06-29T16:19:11.338797-04:00"
   },
   "https://medium.com/jaegertracing/introducing-native-support-for-opentelemetry-in-jaeger-eb661be8183c": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:16:46.201692-05:00"
+    "LastSeen": "2023-06-29T16:14:37.278284-04:00"
   },
   "https://medium.com/opentelemetry": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:17:08.618437-05:00"
+    "LastSeen": "2023-06-29T16:16:56.527353-04:00"
   },
   "https://medium.com/opentelemetry/announcing-opentelemetry-python-1-0-4e097562b8e0": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:17:42.397576-05:00"
+    "LastSeen": "2023-06-29T16:20:50.118135-04:00"
   },
   "https://medium.com/opentelemetry/announcing-the-2021-opentelemetry-governance-committee-election-26d15c874de7": {
     "StatusCode": 200,
@@ -3481,43 +3437,43 @@
   },
   "https://medium.com/opentelemetry/opentelemetry-c-v1-0-whats-there-and-what-next-67e7392aa239": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:18:04.97685-05:00"
+    "LastSeen": "2023-06-29T16:21:12.781592-04:00"
   },
   "https://medium.com/opentelemetry/opentelemetry-collector-achieves-tracing-stability-milestone-80e34cadbbf5": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:17:47.946051-05:00"
+    "LastSeen": "2023-06-29T16:20:55.957347-04:00"
   },
   "https://medium.com/opentelemetry/opentelemetry-erlang-elixir-javascript-and-ruby-v1-0-3a0c32e0add4": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:17:14.4417-05:00"
+    "LastSeen": "2023-06-29T16:17:17.991257-04:00"
   },
   "https://medium.com/opentelemetry/opentelemetry-governance-committee-explained-860353baba0": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:17:31.109771-05:00"
+    "LastSeen": "2023-06-29T16:20:34.13594-04:00"
   },
   "https://medium.com/opentelemetry/opentelemetry-observes-international-womens-day-2021-4493a157f119": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:17:59.538635-05:00"
+    "LastSeen": "2023-06-29T16:21:07.600449-04:00"
   },
   "https://medium.com/opentelemetry/opentelemetry-swift-1-0-beta-8f729fd058b2": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:18:10.775327-05:00"
+    "LastSeen": "2023-06-29T16:21:17.895102-04:00"
   },
   "https://medium.com/opentelemetry/securing-your-opentelemetry-collector-1a4f9fa5bd6f": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:16:40.709758-05:00"
+    "LastSeen": "2023-06-29T16:14:00.670722-04:00"
   },
   "https://medium.com/opentelemetry/trace-based-testing-with-opentelemetry-meet-open-source-malabi-7ca268788aae": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:17:53.776181-05:00"
+    "LastSeen": "2023-06-29T16:21:01.866482-04:00"
   },
   "https://medium.com/opentelemetry/using-opentelemetry-auto-instrumentation-agents-in-kubernetes-869ec0f42377": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:16:51.708462-05:00"
+    "LastSeen": "2023-06-29T16:15:30.210539-04:00"
   },
   "https://medium.com/opentelemetry/welcome-to-the-incoming-2021-opentelemetry-governance-committee-40b70b9b5f5b": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:17:36.925688-05:00"
+    "LastSeen": "2023-06-29T16:20:39.294413-04:00"
   },
   "https://medium.com/opentracing/a-roadmap-to-convergence-b074e5815289": {
     "StatusCode": 200,
@@ -3529,7 +3485,7 @@
   },
   "https://medium.com/p/42337e994b63": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:15:39.339631-05:00"
+    "LastSeen": "2023-06-29T16:13:39.244303-04:00"
   },
   "https://medium.com/velotio-perspectives/a-comprehensive-tutorial-to-implementing-opentracing-with-jaeger-a01752e1a8ce": {
     "StatusCode": 200,
@@ -3541,15 +3497,15 @@
   },
   "https://micrometer.io/": {
     "StatusCode": 206,
-    "LastSeen": "2023-02-16T17:17:19.983523-05:00"
+    "LastSeen": "2023-06-29T16:18:07.54755-04:00"
   },
   "https://modwsgi.readthedocs.io/en/develop/user-guides/quick-configuration-guide.html": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:16:28.773136-05:00"
+    "LastSeen": "2023-06-29T16:06:47.86717-04:00"
   },
   "https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-namespace-packages": {
     "StatusCode": 200,
-    "LastSeen": "2023-02-16T17:15:26.337822-05:00"
+    "LastSeen": "2023-06-29T16:11:14.600808-04:00"
   },
   "https://newrelic.com/blog/authors/daniel-kim": {
     "StatusCode": 206,


### PR DESCRIPTION
- Contributes to:
  - #2429
  - #2554
- Adds a Gulp task to prune the _n_ oldest entries from the `refcache.json` file.
- Refreshes about 150 entries from the `refcache.json` file. Note that deleted entries are external links that are no longer used.
- The idea will be to eventually setup a cron job to refresh the refcache.