### PR TITLE
Docsy upupdate + drop `tabpane.persistLang` parameter

### DIFF
--- a/content/en/docs/collector/deployment/agent.md
+++ b/content/en/docs/collector/deployment/agent.md
@@ -37,7 +37,7 @@ The collector serving at `collector.example.com:4318` would then be configured
 like so:
 
 <!-- prettier-ignore-start -->
-{{< tabpane lang=yaml persistLang=false >}}
+{{< tabpane lang=yaml >}}
 {{< tab Traces >}}
 receivers:
   otlp: # the OTLP receiver the app is sending traces to

--- a/content/en/docs/collector/deployment/gateway.md
+++ b/content/en/docs/collector/deployment/gateway.md
@@ -113,7 +113,7 @@ shown below:
 
 <!-- prettier-ignore-start -->
 
-{{< tabpane lang=yaml persistLang=false >}}
+{{< tabpane lang=yaml >}}
 {{< tab Static >}}
 receivers:
   otlp:

--- a/content/en/docs/collector/getting-started.md
+++ b/content/en/docs/collector/getting-started.md
@@ -31,7 +31,7 @@ Pull a docker image and run the collector in a container. Replace
 run.
 
 <!-- prettier-ignore-start -->
-{{< tabpane lang=shell persistLang=false >}}
+{{< tabpane lang=shell >}}
 {{< tab DockerHub >}}
 docker pull otel/opentelemetry-collector-contrib:{{% param collectorVersion %}}
 docker run otel/opentelemetry-collector-contrib:{{% param collectorVersion %}}
@@ -48,7 +48,7 @@ To load your custom configuration `config.yaml` from your current working
 directory, mount that file as a volume:
 
 <!-- prettier-ignore-start -->
-{{< tabpane lang=shell persistLang=false >}}
+{{< tabpane lang=shell >}}
 {{< tab DockerHub >}}
 docker run -v $(pwd)/config.yaml:/etc/otelcol-contrib/config.yaml otel/opentelemetry-collector-contrib:{{% param collectorVersion %}}
 {{< /tab >}}
@@ -117,7 +117,7 @@ To get started on alpine systems run the following replacing
 run.
 
 <!-- prettier-ignore-start -->
-{{< tabpane lang=shell persistLang=false >}}
+{{< tabpane lang=shell >}}
 {{< tab AMD64 >}}
 apk update
 apk add wget shadow
@@ -148,7 +148,7 @@ To get started on Debian systems run the following replacing
 run and `amd64` with the appropriate architecture.
 
 <!-- prettier-ignore-start -->
-{{< tabpane lang=shell persistLang=false >}}
+{{< tabpane lang=shell >}}
 {{< tab AMD64 >}}
 sudo apt-get update
 sudo apt-get -y install wget systemctl
@@ -179,7 +179,7 @@ To get started on Red Hat systems run the following replacing
 run and `x86_64` with the appropriate architecture.
 
 <!-- prettier-ignore-start -->
-{{< tabpane lang=shell persistLang=false >}}
+{{< tabpane lang=shell >}}
 {{< tab AMD64 >}}
 sudo yum update
 sudo yum -y install wget systemctl
@@ -210,7 +210,7 @@ download the archive containing the binary and install it on your machine
 manually:
 
 <!-- prettier-ignore-start -->
-{{< tabpane lang=shell persistLang=false >}}
+{{< tabpane lang=shell >}}
 {{< tab AMD64 >}}
 curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param collectorVersion %}}/otelcol_{{% param collectorVersion %}}_linux_amd64.tar.gz
 tar -xvf otelcol_{{% param collectorVersion %}}_linux_amd64.tar.gz
@@ -263,7 +263,7 @@ packaged as gzipped tarballs (`.tar.gz`) and will need to be unpacked with a
 tool that supports this compression format:
 
 <!-- prettier-ignore-start -->
-{{< tabpane lang=shell persistLang=false >}}
+{{< tabpane lang=shell >}}
 {{< tab Intel >}}
 curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param collectorVersion %}}/otelcol_{{% param collectorVersion %}}_darwin_amd64.tar.gz
 tar -xvf otelcol_{{% param collectorVersion %}}_darwin_amd64.tar.gz

--- a/content/en/docs/instrumentation/cpp/getting-started.md
+++ b/content/en/docs/instrumentation/cpp/getting-started.md
@@ -22,7 +22,7 @@ install some dependencies:
 
 <!-- prettier-ignore-start -->
 
-{{< tabpane lang=shell persistLang=false >}}
+{{< tabpane lang=shell >}}
 
 {{< tab "Linux (apt)" >}}
 sudo apt-get install git cmake g++ libcurl4-openssl-dev

--- a/content/en/docs/instrumentation/js/getting-started/browser.md
+++ b/content/en/docs/instrumentation/js/getting-started/browser.md
@@ -84,7 +84,7 @@ as appropriate, based on the language you've chosen to write your app in. Add
 the following code to your HTML right before the `</body>` closing tag:
 
 <!-- prettier-ignore-start -->
-{{< tabpane lang=html persistLang=false >}}
+{{< tabpane lang=html >}}
 {{< tab TypeScript >}}
 <script type="module" src="document-load.ts"></script>
 {{< /tab >}}

--- a/content/en/docs/instrumentation/js/getting-started/nodejs.md
+++ b/content/en/docs/instrumentation/js/getting-started/nodejs.md
@@ -40,7 +40,7 @@ npm init -y
 Next, install Express dependencies.
 
 <!-- prettier-ignore-start -->
-{{< tabpane lang=shell persistLang=false >}}
+{{< tabpane lang=shell >}}
 
 {{< tab TypeScript >}}
 npm install typescript \
@@ -112,7 +112,7 @@ Run the application with the following command and open
 <http://localhost:8080/rolldice> in your web browser to ensure it is working.
 
 <!-- prettier-ignore-start -->
-{{< tabpane lang=console persistLang=false >}}
+{{< tabpane lang=console >}}
 
 {{< tab TypeScript >}}
 $ npx ts-node app.ts
@@ -215,7 +215,7 @@ Now you can run your application as you normally would, but you can use the
 `--require` flag to load the instrumentation before the application code.
 
 <!-- prettier-ignore-start -->
-{{< tabpane lang=console persistLang=false >}}
+{{< tabpane lang=console >}}
 
 {{< tab TypeScript >}}
 $ npx ts-node --require ./instrumentation.ts app.ts

--- a/content/en/docs/instrumentation/js/manual.md
+++ b/content/en/docs/instrumentation/js/manual.md
@@ -112,7 +112,7 @@ Next, ensure that `tracing.js|ts` is required in your node invocation. This is
 also required if you're registering instrumentation libraries. For example:
 
 <!-- prettier-ignore-start -->
-{{< tabpane lang=shell persistLang=false >}}
+{{< tabpane lang=shell >}}
 
 {{< tab TypeScript >}}
 ts-node --require ./tracing.ts <app-file.ts>
@@ -798,7 +798,7 @@ opentelemetry.metrics.setGlobalMeterProvider(myServiceMeterProvider)
 You'll need to `--require` this file when you run your app, such as:
 
 <!-- prettier-ignore-start -->
-{{< tabpane lang=shell persistLang=false >}}
+{{< tabpane lang=shell >}}
 
 {{< tab TypeScript >}}
 ts-node --require ./instrumentation.ts <app-file.ts>

--- a/content/en/docs/instrumentation/js/sampling.md
+++ b/content/en/docs/instrumentation/js/sampling.md
@@ -35,7 +35,7 @@ You can also configure the TraceIdRatioBasedSampler in code. Here's an example
 for Node.js:
 
 <!-- prettier-ignore-start -->
-{{< tabpane lang=shell persistLang=false >}}
+{{< tabpane lang=shell >}}
 
 {{< tab TypeScript >}}
 import { TraceIdRatioBasedSampler } from '@opentelemetry/sdk-trace-node';
@@ -68,7 +68,7 @@ You can also configure the TraceIdRatioBasedSampler in code. Here's an example
 for browser apps:
 
 <!-- prettier-ignore-start -->
-{{< tabpane lang=shell persistLang=false >}}
+{{< tabpane lang=shell >}}
 
 {{< tab TypeScript >}}
 import { WebTracerProvider, TraceIdRatioBasedSampler } from '@opentelemetry/sdk-trace-web';

--- a/content/en/docs/instrumentation/php/automatic.md
+++ b/content/en/docs/instrumentation/php/automatic.md
@@ -78,7 +78,7 @@ The extension can be installed via pecl,
 1. Setup development environment. Installing from source requires proper
    development environment and some dependencies:
 
-   {{< tabpane lang=shell persistLang=false >}}
+   {{< tabpane lang=shell >}}
 
    {{< tab "Linux (apt)" >}}sudo apt-get install gcc make autoconf{{< /tab >}}
 
@@ -89,7 +89,7 @@ The extension can be installed via pecl,
 2. Build/install the extension. With your environment set up you can install the
    extension:
 
-   {{< tabpane lang=shell persistLang=false >}}
+   {{< tabpane lang=shell >}}
 
    {{< tab pecl >}}pecl install opentelemetry-beta{{< /tab >}}
 

--- a/content/en/docs/instrumentation/php/getting-started.md
+++ b/content/en/docs/instrumentation/php/getting-started.md
@@ -102,7 +102,7 @@ Next, you’ll use the OpenTelemetry PHP extension to
 1. Since the extension is built from source, you need to install some build
    tools
 
-   {{< tabpane lang=shell persistLang=false >}}
+   {{< tabpane lang=shell >}}
 
    {{< tab "Linux (apt)" >}}sudo apt-get install gcc make autoconf{{< /tab >}}
 

--- a/content/en/docs/instrumentation/php/manual.md
+++ b/content/en/docs/instrumentation/php/manual.md
@@ -338,7 +338,7 @@ The OpenTelemetry SDK provides four samplers:
   sampled. The root sampler can be any of the other samplers.
 
 <!-- prettier-ignore-start -->
-{{< tabpane lang=php persistLang=false >}}
+{{< tabpane lang=php >}}
 {{< tab "TraceId ratio-based" >}}
 //trace 50% of requests
 $sampler = new TraceIdRatioBasedSampler(0.5);

--- a/content/en/docs/instrumentation/ruby/exporters.md
+++ b/content/en/docs/instrumentation/ruby/exporters.md
@@ -18,7 +18,7 @@ To send trace data to a OTLP endpoint (like the [collector](/docs/collector) or
 Jaeger) you'll want to use an exporter package, such as
 `opentelemetry-exporter-otlp`:
 
-{{< tabpane lang=shell persistLang=false >}}
+{{< tabpane lang=shell >}}
 
 {{< tab bundler >}} bundle add opentelemetry-exporter-otlp {{< /tab >}}
 
@@ -86,7 +86,7 @@ docker run --rm -d -p 9411:9411 --name zipkin openzipkin/zipkin
 
 Install the exporter package as a dependency for your application:
 
-{{< tabpane lang=shell persistLang=false >}}
+{{< tabpane lang=shell >}}
 
 {{< tab bundle >}} bundle add opentelemetry-exporter-zipkin {{< /tab >}}
 


### PR DESCRIPTION
- Updates Docsy, which adds support for tab-pane header persistence, rather than only tab-pane language
- Drops `tabpane.persistLang` parameter from all pages in the docs

From the following preview page you can see that the tab choice is persisted (refresh the page and the active tab remains active), and the choice (from any tab pane) is synchronized across all tab-panes:

**Preview**:

- https://deploy-preview-2972--opentelemetry.netlify.app/docs/collector/getting-started/ - persists DockerHub vs ghcr.io, and architecture choice (later in the page)
- https://deploy-preview-2972--opentelemetry.netlify.app/docs/instrumentation/js/getting-started/nodejs/#dependencies -persist Javascript vs Typescript