### PR TITLE
add collector benchmark page

### DIFF
--- a/content/en/docs/collector/benchmarks.md
+++ b/content/en/docs/collector/benchmarks.md
@@ -2,14 +2,8 @@
 title: Benchmarks
 weight: 99
 ---
-  <style>
 
-    header {
-      width: 100%;
-      display: flex;
-      flex-direction: row;
-      background-color: rgb(79, 98, 173);
-    }
+  <style>
 
     main {
       margin: 8px;
@@ -45,10 +39,6 @@ weight: 99
       align-items: center;
     }
 
-    .header-label {
-      margin-right: 4px;
-    }
-
     .benchmark-set {
       margin: 8px 0;
       width: 100%;
@@ -76,15 +66,6 @@ weight: 99
       max-width: 1000px;
     }
 
-    .logo svg {
-      height: 48px;
-      margin-left: 30px;
-    }
-
-    .header-item {
-      flex: 1;
-    }
-
     div.container {
       max-width: 1012px;
       margin-right: auto;
@@ -92,15 +73,17 @@ weight: 99
     }
   </style>
 
+The OpenTelemetry Collector runs load tests on every commit to the
+[opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/)
+repository. These load tests run the binary of collector with various
+configuration options per test and send traffic through the collector.
+Additional information regarding the testing environment can be found in the
+[repository](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/testbed#opentelemetry-collector-testbed).
+
+A subset of the results are shown below, the full results are available
+[here](https://open-telemetry.github.io/opentelemetry-collector-contrib/benchmarks/loadtests/).
+
   <div class="container">
-    <div>
-      <strong>Last Update:</strong>
-      <span id="last-update"></span>
-    </div>
-    <div>
-      <strong>Repository:</strong>
-      <a id="repository-link" rel="noopener"></a>
-    </div>
     <main id="main"></main>
   </div>
 
@@ -112,7 +95,7 @@ weight: 99
   </footer>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.2/dist/Chart.min.js"></script>
-  <script src="https://mwear.github.io/opentelemetry-collector-contrib/loadtest/data.js"></script>
+  <script src="https://open-telemetry.github.io/opentelemetry-collector-contrib/benchmarks/loadtests/data.js"></script>
   <script id="main-script">
     'use strict';
     (function () {
@@ -140,16 +123,25 @@ weight: 99
             commitIds.push(commitId);
             for (const bench of benches) {
               const result = { commit, date, tool, bench };
-              let byName = byGroup.get(bench.extra);
+              if (!bench.extra.includes("10kDPS") && !bench.extra.includes("10kSPS")){
+                continue
+              }
+              const extraParts = bench.extra.split("/");
+              let benchmarkName = extraParts[0] + " - " + bench.name;
+              let byName = byGroup.get(benchmarkName);
               if (byName === undefined) {
                 byName = new Map();
-                byGroup.set(bench.extra, byName);
+                byGroup.set(benchmarkName, byName);
               }
-              let byCommitId = byName.get(bench.name);
+              let extraName = bench.extra
+              if (extraParts.length > 1) {
+                extraName = extraParts[1].split(" - ")[0]
+              }
+              let byCommitId = byName.get(extraName);
               if (byCommitId === undefined) {
                 byCommitId = new Map();
                 byCommitId.set(commitId, result)
-                byName.set(bench.name, byCommitId);
+                byName.set(extraName, byCommitId);
               } else {
                 byCommitId.set(commitId, result);
               }
@@ -162,12 +154,6 @@ weight: 99
         }
 
         const data = window.BENCHMARK_DATA;
-
-        // Render header
-        document.getElementById('last-update').textContent = new Date(data.lastUpdate).toString();
-        const repoLink = document.getElementById('repository-link');
-        repoLink.href = data.repoUrl;
-        repoLink.textContent = data.repoUrl;
 
         // Render footer
         document.getElementById('dl-button').onclick = () => {
@@ -263,7 +249,8 @@ weight: 99
               }
             },
             legend: {
-              display: true
+              display: true,
+              position: "right"
             }
           };
 

--- a/content/en/docs/collector/benchmarks.md
+++ b/content/en/docs/collector/benchmarks.md
@@ -1,0 +1,306 @@
+---
+title: Benchmarks
+weight: 99
+---
+  <style>
+
+    header {
+      width: 100%;
+      display: flex;
+      flex-direction: row;
+      background-color: rgb(79, 98, 173);
+    }
+
+    main {
+      margin: 8px;
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+    }
+
+    button {
+      color: #fff;
+      background-color: #3298dc;
+      border-color: transparent;
+      cursor: pointer;
+      text-align: center;
+    }
+
+    button:hover {
+      background-color: #2793da;
+      flex: none;
+    }
+
+    .spacer {
+      flex: auto;
+    }
+
+    .small {
+      font-size: 0.75rem;
+    }
+
+    footer {
+      margin-top: 16px;
+      display: flex;
+      align-items: center;
+    }
+
+    .header-label {
+      margin-right: 4px;
+    }
+
+    .benchmark-set {
+      margin: 8px 0;
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .benchmark-title {
+      font-size: 3rem;
+      font-weight: 600;
+      word-break: break-word;
+      text-align: center;
+    }
+
+    .benchmark-graphs {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-around;
+      align-items: center;
+      flex-wrap: wrap;
+      width: 100%;
+    }
+
+    .benchmark-chart {
+      max-width: 1000px;
+    }
+
+    .logo svg {
+      height: 48px;
+      margin-left: 30px;
+    }
+
+    .header-item {
+      flex: 1;
+    }
+
+    div.container {
+      max-width: 1012px;
+      margin-right: auto;
+      margin-left: auto;
+    }
+  </style>
+
+  <div class="container">
+    <div>
+      <strong>Last Update:</strong>
+      <span id="last-update"></span>
+    </div>
+    <div>
+      <strong>Repository:</strong>
+      <a id="repository-link" rel="noopener"></a>
+    </div>
+    <main id="main"></main>
+  </div>
+
+  <footer>
+    <button id="dl-button">Download data as JSON</button>
+    <div class="spacer"></div>
+    <div class="small">Powered by <a rel="noopener"
+        href="https://github.com/marketplace/actions/continuous-benchmark">github-action-benchmark</a></div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.2/dist/Chart.min.js"></script>
+  <script src="https://mwear.github.io/opentelemetry-collector-contrib/loadtest/data.js"></script>
+  <script id="main-script">
+    'use strict';
+    (function () {
+      const COLORS = [
+        "#48aaf9",
+        "#8a3ef2",
+        "#78eeda",
+        "#d78000",
+        "#1248b3",
+        "#97dbfc",
+        "#006174",
+        "#00b6b6",
+        "#854200",
+        "#f3c8ad",
+        "#410472",
+      ];
+
+      function init() {
+        function collectBenchesPerTestCase(entries) {
+          const byGroup = new Map();
+          const commitIds = [];
+          for (const entry of entries) {
+            const { commit, date, tool, benches } = entry;
+            const commitId = commit.id.slice(0, 7);
+            commitIds.push(commitId);
+            for (const bench of benches) {
+              const result = { commit, date, tool, bench };
+              let byName = byGroup.get(bench.extra);
+              if (byName === undefined) {
+                byName = new Map();
+                byGroup.set(bench.extra, byName);
+              }
+              let byCommitId = byName.get(bench.name);
+              if (byCommitId === undefined) {
+                byCommitId = new Map();
+                byCommitId.set(commitId, result)
+                byName.set(bench.name, byCommitId);
+              } else {
+                byCommitId.set(commitId, result);
+              }
+            }
+          }
+          return {
+            commitIds,
+            byGroup
+          };
+        }
+
+        const data = window.BENCHMARK_DATA;
+
+        // Render header
+        document.getElementById('last-update').textContent = new Date(data.lastUpdate).toString();
+        const repoLink = document.getElementById('repository-link');
+        repoLink.href = data.repoUrl;
+        repoLink.textContent = data.repoUrl;
+
+        // Render footer
+        document.getElementById('dl-button').onclick = () => {
+          const dataUrl = 'data:,' + JSON.stringify(data, null, 2);
+          const a = document.createElement('a');
+          a.href = dataUrl;
+          a.download = 'benchmark_data.json';
+          a.click();
+        };
+
+        // Prepare data points for charts
+        return Object.keys(data.entries).map(name => ({
+          name,
+          dataSet: collectBenchesPerTestCase(data.entries[name]),
+        }));
+      }
+
+      function renderAllChars(dataSets) {
+
+        function renderGraph(parent, name, commitIds, byName) {
+          const chartTitle = document.createElement('h3');
+          chartTitle.textContent = name;
+          parent.append(chartTitle);
+
+          const canvas = document.createElement('canvas');
+          canvas.className = 'benchmark-chart';
+          parent.appendChild(canvas);
+
+          const results = [];
+          for (const [name, byCommitId] of byName.entries()) {
+            results.push({
+              name,
+              dataset: commitIds.map(commitId => byCommitId.get(commitId) ?? null)
+            });
+          }
+          results.sort((a, b) => a.name.localeCompare(b.name));
+
+          const data = {
+            labels: commitIds,
+            datasets: results.map(({ name, dataset }, index) => {
+              const color = COLORS[index % COLORS.length];
+
+              return {
+                label: name,
+                data: dataset.map(d => d?.bench.value ?? null),
+                fill: false,
+                borderColor: color,
+                backgroundColor: color,
+              };
+            }),
+          };
+
+          const options = {
+            scales: {
+              xAxes: [
+                {
+                  scaleLabel: {
+                    display: true,
+                    labelString: 'commit',
+                  },
+                }
+              ],
+              yAxes: [
+                {
+                  scaleLabel: {
+                    display: true,
+                    labelString: results?.[0]?.dataset.find(d => d !== null)?.bench.unit ?? '',
+                  },
+                  ticks: {
+                    beginAtZero: true,
+                  }
+                }
+              ],
+            },
+            tooltips: {
+              callbacks: {
+                afterTitle: items => {
+                  const { datasetIndex, index } = items[0];
+                  const data = results[datasetIndex].dataset[index];
+                  return '\n' + data.commit.message + '\n\n' + data.commit.timestamp + ' committed by @' + data.commit.author.username + '\n';
+                },
+                label: item => {
+                  const { datasetIndex, index, value } = item;
+                  const { name, dataset } = results[datasetIndex];
+                  const { range, unit } = dataset[index].bench;
+                  let label = `${name}: ${value}`;
+                  label += unit;
+                  if (range) {
+                    label += ' (' + range + ')';
+                  }
+                  return label;
+                },
+              }
+            },
+            legend: {
+              display: true
+            }
+          };
+
+          new Chart(canvas, {
+            type: 'line',
+            data,
+            options,
+          });
+        }
+
+        function renderBenchSet(name, benchSet, main) {
+          const setElem = document.createElement('div');
+          setElem.className = 'benchmark-set';
+          main.appendChild(setElem);
+
+          const graphsElem = document.createElement('div');
+          graphsElem.className = 'benchmark-graphs';
+          setElem.appendChild(graphsElem);
+
+          const { commitIds, byGroup } = benchSet;
+          const groups = [];
+          for (const [name, byName] of byGroup.entries()) {
+            groups.push({ name, byName });
+          }
+          groups.sort((a, b) => a.name.localeCompare(b.name));
+
+          for (const { name, byName } of groups) {
+            renderGraph(graphsElem, name, commitIds, byName);
+          }
+        }
+
+        const main = document.getElementById('main');
+        for (const { name, dataSet } of dataSets) {
+          renderBenchSet(name, dataSet, main);
+        }
+      }
+
+      renderAllChars(init()); // Start
+    })();
+  </script>

--- a/content/en/docs/collector/trace-receiver.md
+++ b/content/en/docs/collector/trace-receiver.md
@@ -1,5 +1,6 @@
 ---
 title: Building a Trace Receiver
+weight: 98
 spelling: cSpell:ignore struct tailtracer otlpreceiver rquedas devs mapstructure
 spelling: cSpell:ignore Errorf structs loggingexporter jaegerexporter amzn
 spelling: cSpell:ignore batchprocessor Rcvr uber atmxph comcast chicago

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -175,6 +175,10 @@
     "StatusCode": 206,
     "LastSeen": "2023-07-06T17:58:07.715816-04:00"
   },
+  "https://cdn.jsdelivr.net/npm/chart.js@2.9.2/dist/Chart.min.js": {
+    "StatusCode": 206,
+    "LastSeen": "2023-07-07T13:54:44.619063-07:00"
+  },
   "https://cdn.jsdelivr.net/npm/mermaid@9.3.0/dist/mermaid.min.js": {
     "StatusCode": 206,
     "LastSeen": "2023-06-30T09:16:02.918744-04:00"
@@ -1939,6 +1943,10 @@
     "StatusCode": 200,
     "LastSeen": "2023-06-30T09:15:29.922451-04:00"
   },
+  "https://github.com/marketplace/actions/continuous-benchmark": {
+    "StatusCode": 200,
+    "LastSeen": "2023-07-06T11:55:26.882609-07:00"
+  },
   "https://github.com/mhausenblas": {
     "StatusCode": 200,
     "LastSeen": "2023-06-30T09:39:03.127776-04:00"
@@ -2090,6 +2098,10 @@
   "https://github.com/open-telemetry/opentelemetry-collector-contrib#opentelemetry-collector-contrib": {
     "StatusCode": 200,
     "LastSeen": "2023-06-30T09:24:24.785634-04:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/": {
+    "StatusCode": 200,
+    "LastSeen": "2023-07-07T13:45:50.007391-07:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10116": {
     "StatusCode": 200,
@@ -3603,6 +3615,14 @@
     "StatusCode": 206,
     "LastSeen": "2023-06-29T18:51:28.754694-04:00"
   },
+  "https://open-telemetry.github.io/opentelemetry-collector-contrib/benchmarks/loadtests/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-07-07T13:45:50.219326-07:00"
+  },
+  "https://open-telemetry.github.io/opentelemetry-collector-contrib/benchmarks/loadtests/data.js": {
+    "StatusCode": 206,
+    "LastSeen": "2023-07-06T12:14:49.802412-07:00"
+  },
   "https://open-telemetry.github.io/opentelemetry-js": {
     "StatusCode": 206,
     "LastSeen": "2023-06-29T18:46:19.489479-04:00"
@@ -3942,6 +3962,10 @@
   "https://raw.githubusercontent.com/elastic/elasticsearch-specification/main/output/schema/schema.json": {
     "StatusCode": 206,
     "LastSeen": "2023-07-06T17:58:33.547228-04:00"
+  },
+  "https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector-contrib/benchmarks/docs/benchmarks/loadtests/data.js": {
+    "StatusCode": 206,
+    "LastSeen": "2023-07-07T13:54:44.920311-07:00"
   },
   "https://reactivex.io/RxJava/2.x/javadoc/index.html": {
     "StatusCode": 206,


### PR DESCRIPTION
This is based on the work that @mwear started in the collector repository. Rather than publishing a github page from the collector repo, I suggest this should live in the opentelemetry.io repository and be displayed on the website as well.

For reviewers, is including style/html in the markdown ok? Or should this be moved somewhere else?

---

**Preview**: https://deploy-preview-2975--opentelemetry.netlify.app/docs/collector/benchmarks/
