### PR TITLE
Apply textlint rules to registry

### DIFF
--- a/.textlintrc.json
+++ b/.textlintrc.json
@@ -17,8 +17,7 @@
         "github.com/open-telemetry",
         "#opentelemetry",
         "/^(?:language|repo): .*$/m",
-        "/tags:([\\n\\r\\s]*-[\\s\\S]*?[\\n\\r]+)*/m",
-        "Instrumentation for net/http"
+        "/tags:([\\n\\r\\s]*-[\\s\\S]*?[\\n\\r]+)*/m"
       ]
     }
   },

--- a/.textlintrc.json
+++ b/.textlintrc.json
@@ -17,8 +17,7 @@
         "github.com/open-telemetry",
         "#opentelemetry",
         "/  - .*/",
-        "/(?:language|repo): .*/",
-        "net/http"
+        "^/(?:language|repo): .*/",
       ]
     }
   },

--- a/.textlintrc.json
+++ b/.textlintrc.json
@@ -15,7 +15,10 @@
         "/<http://.*>/",
         "medium.com/opentelemetry",
         "github.com/open-telemetry",
-        "#opentelemetry"
+        "#opentelemetry",
+        "/  - .*/",
+        "/(?:language|repo): .*/",
+        "net/http"
       ]
     }
   },
@@ -42,13 +45,15 @@
         "PHP",
         "PostgreSQL",
         "protobuf",
+        "SQLite",
         "Thanos",
         "Traefik",
+        "Zend",
         "Zipkin",
         ["[^\\.]json", "JSON"],
         ["[Nn]ode\\.?[Jj][sS]", "Node.js"],
         ["open-source", "open source"],
-        ["[Oo]pen[- ][Tt]elemetry", "OpenTelemetry"],
+        ["[Oo]pen[- ]?[Tt]elemetry", "OpenTelemetry"],
         ["regexes", "regular expressions"]
       ]
     }

--- a/.textlintrc.json
+++ b/.textlintrc.json
@@ -16,8 +16,9 @@
         "medium.com/opentelemetry",
         "github.com/open-telemetry",
         "#opentelemetry",
-        "/  - .*/",
-        "^/(?:language|repo): .*/",
+        "/^(?:language|repo): .*$/m",
+        "/tags:([\\n\\r\\s]*-[\\s\\S]*?[\\n\\r]+)*/m",
+        "Instrumentation for net/http"
       ]
     }
   },

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -102,6 +102,7 @@
     "semconv",
     "shippingservice",
     "snmp",
+    "sqlite",
     "subdir",
     "tabpane",
     "textlint",
@@ -113,6 +114,7 @@
     "traceparent",
     "traefik",
     "upstreamed",
+    "zend",
     "zipkin"
   ]
 }

--- a/data/registry/collector-extension-observer.yml
+++ b/data/registry/collector-extension-observer.yml
@@ -11,6 +11,6 @@ license: Apache 2.0
 description:
   Observers are implemented as an extension to discover networked endpoints like
   a Kubernetes pod, Docker container, or local listening port. Currently
-  available are observers for docker, ecs, ecs_task, host and k8s.
+  available are observers for docker, ecs, ecs_task, host and K8s.
 authors: OpenTelemetry Authors
 otVersion: latest

--- a/data/registry/collector-processor-k8sattributes.yml
+++ b/data/registry/collector-processor-k8sattributes.yml
@@ -10,7 +10,7 @@ repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/mai
 license: Apache 2.0
 description:
   The K8s Attribute Processor for the OpenTelemetry Collector automatically
-  discovers k8s resources (pods), extracts metadata from them and adds the
+  discovers K8s resources (pods), extracts metadata from them and adds the
   extracted metadata to the relevant spans, metrics and logs.
 authors: OpenTelemetry Authors
 otVersion: latest

--- a/data/registry/collector-receiver-jmx.yml
+++ b/data/registry/collector-receiver-jmx.yml
@@ -11,6 +11,6 @@ license: Apache 2.0
 description:
   The JMX Receiver will work in conjunction with the OpenTelemetry JMX Metric
   Gatherer to report metrics from a target MBean server using a built-in or your
-  custom otel helper-utilizing Groovy script.
+  custom OpenTelemetry helper-utilizing Groovy script.
 authors: OpenTelemetry Authors
 otVersion: latest

--- a/data/registry/collector-receiver-k8sevents.yml
+++ b/data/registry/collector-receiver-k8sevents.yml
@@ -8,6 +8,6 @@ tags:
   - collector
 repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8seventsreceiver
 license: Apache 2.0
-description: The kubernetes Events receiver collects events from the Kubernetes
+description: The Kubernetes Events receiver collects events from the Kubernetes
 authors: OpenTelemetry Authors
 otVersion: latest

--- a/data/registry/collector-receiver-k8sobjects.yml
+++ b/data/registry/collector-receiver-k8sobjects.yml
@@ -9,7 +9,7 @@ tags:
 repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver
 license: Apache 2.0
 description:
-  The kubernetes Objects receiver collects(pull/watch) objects from the
+  The Kubernetes Objects receiver collects(pull/watch) objects from the
   Kubernetes API server.
 authors: OpenTelemetry Authors
 otVersion: latest

--- a/data/registry/collector-receiver-nginx.yml
+++ b/data/registry/collector-receiver-nginx.yml
@@ -10,6 +10,6 @@ repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/mai
 license: Apache 2.0
 description:
   The NGINX Receiver for the OpenTelemetry Collector can fetch stats from a
-  Nginx instance using a mod_status endpoint.
+  NGINX instance using a mod_status endpoint.
 authors: OpenTelemetry Authors
 otVersion: latest

--- a/data/registry/exporter-python-otlpprotogrpc.yml
+++ b/data/registry/exporter-python-otlpprotogrpc.yml
@@ -10,6 +10,6 @@ repo: https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/
 license: Apache 2.0
 description:
   This library allows to export data to the OpenTelemetry Collector using the
-  OpenTelemetry Protocol using Protobuf over gRPC.
+  OpenTelemetry Protocol using protobuf over gRPC.
 authors: OpenTelemetry Authors
 otVersion: latest

--- a/data/registry/exporter-python-otlpprotohttp.yml
+++ b/data/registry/exporter-python-otlpprotohttp.yml
@@ -10,6 +10,6 @@ repo: https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/
 license: Apache 2.0
 description:
   This library allows to export data to the OpenTelemetry Collector using the
-  OpenTelemetry Protocol using Protobuf over HTTP.
+  OpenTelemetry Protocol using protobuf over HTTP.
 authors: OpenTelemetry Authors
 otVersion: latest

--- a/data/registry/exporter-python-zipkinprotohttp.yml
+++ b/data/registry/exporter-python-zipkinprotohttp.yml
@@ -9,7 +9,7 @@ tags:
 repo: https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-zipkin-proto-http
 license: Apache 2.0
 description:
-  This library allows export of tracing data to Zipkin using Protobuf for
+  This library allows export of tracing data to Zipkin using protobuf for
   serialization.
 authors: OpenTelemetry Authors
 otVersion: latest

--- a/data/registry/exporter-ruby-otlpgrpc.yml
+++ b/data/registry/exporter-ruby-otlpgrpc.yml
@@ -9,7 +9,7 @@ tags:
 repo: https://github.com/open-telemetry/opentelemetry-ruby/tree/main/exporter/otlp-grpc
 license: Apache 2.0
 description:
-  The `opentelemetry-exporter-otlp-grpc` gem provides an OTLP exporter over GRPC
+  The `opentelemetry-exporter-otlp-grpc` gem provides an OTLP exporter over gRPC
   for OpenTelemetry Ruby.
 authors: OpenTelemetry Authors
 otVersion: latest

--- a/data/registry/instrumentation-cpp-nginx.yml
+++ b/data/registry/instrumentation-cpp-nginx.yml
@@ -1,14 +1,15 @@
-title: Nginx Instrumentation
+title: NGINX Instrumentation
 registryType: instrumentation
 isThirdParty: true
 language: cpp
 tags:
   - c++
+  - nginx
   - instrumentation
 repo: https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/main/instrumentation/nginx
 license: Apache 2.0
 description:
-  Nginx OpenTelemetry module to add OpenTelemetry distributed tracing support to
-  nginx.
+  NGINX OpenTelemetry module to add OpenTelemetry distributed tracing support to
+  NGINX.
 authors: OpenTelemetry Authors
 otVersion: latest

--- a/data/registry/instrumentation-cpp-otel-webserver-module.yml
+++ b/data/registry/instrumentation-cpp-otel-webserver-module.yml
@@ -11,6 +11,6 @@ tags:
 repo: https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/main/instrumentation/otel-webserver-module
 license: Apache 2.0
 description:
-  The OTEL webserver module comprises of both Apache and Nginx instrumentation.
+  The OTel web server module comprises of both Apache HTTP Server and NGINX instrumentation.
 authors: OpenTelemetry Authors
 otVersion: latest

--- a/data/registry/instrumentation-cpp-otel-webserver-module.yml
+++ b/data/registry/instrumentation-cpp-otel-webserver-module.yml
@@ -11,6 +11,7 @@ tags:
 repo: https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/main/instrumentation/otel-webserver-module
 license: Apache 2.0
 description:
-  The OTel web server module comprises of both Apache HTTP Server and NGINX instrumentation.
+  The OTel web server module comprises of both Apache HTTP Server and NGINX
+  instrumentation.
 authors: OpenTelemetry Authors
 otVersion: latest

--- a/data/registry/instrumentation-erlang-dataloader.yml
+++ b/data/registry/instrumentation-erlang-dataloader.yml
@@ -9,6 +9,6 @@ tags:
 repo: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_dataloader
 license: Apache 2.0
 description:
-  Telemetry handler that creates Opentelemetry spans from Dataloader events.
+  Telemetry handler that creates OpenTelemetry spans from Dataloader events.
 authors: OpenTelemetry Authors
 otVersion: latest

--- a/data/registry/instrumentation-erlang-ecto.yml
+++ b/data/registry/instrumentation-erlang-ecto.yml
@@ -9,6 +9,6 @@ tags:
 repo: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_ecto
 license: Apache 2.0
 description:
-  Telemetry handler that creates Opentelemetry spans from Ecto query events.
+  Telemetry handler that creates OpenTelemetry spans from Ecto query events.
 authors: OpenTelemetry Authors
 otVersion: latest

--- a/data/registry/instrumentation-erlang-phoenix.yml
+++ b/data/registry/instrumentation-erlang-phoenix.yml
@@ -9,6 +9,6 @@ tags:
 repo: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_phoenix
 license: Apache 2.0
 description:
-  Telemetry handler that creates Opentelemetry spans from Phoenix events.
+  Telemetry handler that creates OpenTelemetry spans from Phoenix events.
 authors: OpenTelemetry Authors
 otVersion: latest

--- a/data/registry/instrumentation-go-grpc.yml
+++ b/data/registry/instrumentation-go-grpc.yml
@@ -8,6 +8,6 @@ tags:
   - grpc
 repo: https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/google.golang.org/grpc
 license: Apache 2.0
-description: Go contrib plugin for Google's grpc package.
+description: Go contrib plugin for Google's gRPC package.
 authors: OpenTelemetry Authors
 otVersion: latest

--- a/data/registry/instrumentation-go-net-http.yml
+++ b/data/registry/instrumentation-go-net-http.yml
@@ -1,4 +1,4 @@
-title: Go package net/http instrumentation
+title: Go package `net/http` instrumentation
 registryType: instrumentation
 isThirdParty: false
 language: go
@@ -10,7 +10,7 @@ tags:
 repo: https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/net/http
 license: Apache 2.0
 description:
-  Go contrib plugin for trace instrumentation of net/http handlers, http
-  transports and http trace events
+  Go contrib plugin for trace instrumentation of `net/http` handlers, HTTP
+  transports and HTTP trace events
 authors: OpenTelemetry Authors
 otVersion: latest

--- a/data/registry/instrumentation-go-splunkhttp.yml
+++ b/data/registry/instrumentation-go-splunkhttp.yml
@@ -1,4 +1,4 @@
-title: splunkhttp -- Instrumentation for net/http
+title: splunkhttp -- Instrumentation for `net/http`
 registryType: instrumentation
 isThirdParty: true
 language: go

--- a/data/registry/instrumentation-go-splunkmysql.yml
+++ b/data/registry/instrumentation-go-splunkmysql.yml
@@ -1,4 +1,4 @@
-title: splunkmysql -- Instrumentation for github.com/go-sql-driver/mysql
+title: splunkmysql -- Instrumentation for the MySQL Driver Package
 registryType: instrumentation
 isThirdParty: true
 language: go

--- a/data/registry/instrumentation-java-asynchttpclient.yml
+++ b/data/registry/instrumentation-java-asynchttpclient.yml
@@ -1,4 +1,4 @@
-title: Async Http Client Instrumentation
+title: Async HTTP Client Instrumentation
 registryType: instrumentation
 isThirdParty: false
 language: java
@@ -9,6 +9,6 @@ tags:
 repo: https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/async-http-client
 license: Apache 2.0
 description:
-  This package provides an instrumentation library for Async Http Client
+  This package provides an instrumentation library for Async HTTP Client
 authors: OpenTelemetry Authors
 otVersion: latest

--- a/data/registry/instrumentation-js-mysql2.yml
+++ b/data/registry/instrumentation-js-mysql2.yml
@@ -1,4 +1,4 @@
-title: OpenTelemetry Instrumentation for mysql2
+title: OpenTelemetry Instrumentation for MySQL2
 registryType: instrumentation
 isThirdParty: false
 language: js
@@ -11,6 +11,6 @@ tags:
   - database
 repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-mysql2
 license: Apache 2.0
-description: mysql2 instrumentation for Node.js.
+description: MySQL2 instrumentation for Node.js.
 authors: OpenTelemetry Authors
 otVersion: latest

--- a/data/registry/instrumentation-python-starlette.yml
+++ b/data/registry/instrumentation-python-starlette.yml
@@ -9,7 +9,7 @@ repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/i
 license: Apache 2.0
 description:
   This library provides automatic and manual instrumentation of Starlette web
-  frameworks, instrumenting http requests served by applications utilizing the
+  frameworks, instrumenting HTTP requests served by applications utilizing the
   framework.
 authors: OpenTelemetry Authors
 otVersion: latest

--- a/data/registry/instrumentation-python-tortoiseorm.yml
+++ b/data/registry/instrumentation-python-tortoiseorm.yml
@@ -9,7 +9,7 @@ tags:
 repo: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-tortoiseorm
 license: Apache 2.0
 description:
-  This library allows tracing queries made by tortoise ORM backends, mysql,
-  postgres and sqlite.
+  This library allows tracing queries made by tortoise ORM backends, MySQL,
+  PostgreSQL and SQLite.
 authors: OpenTelemetry Authors
 otVersion: latest

--- a/data/registry/otel-ocaml.yml
+++ b/data/registry/otel-ocaml.yml
@@ -1,4 +1,4 @@
-title: ocaml-opentelemetry Opentelemetry exporters and instrumentation for OCaml
+title: ocaml-opentelemetry OpenTelemetry exporters and instrumentation for OCaml
 registryType: instrumentation
 isThirdParty: true
 language: ocaml

--- a/data/registry/otel-php-autoinstrumentation.yml
+++ b/data/registry/otel-php-autoinstrumentation.yml
@@ -9,6 +9,6 @@ repo: https://github.com/open-telemetry/opentelemetry-php-instrumentation
 license: Apache 2.0
 description:
   Experimental extension for OpenTelemetry, to enable auto-instrumentation. It
-  is based on zend_observer and requires php8+
+  is based on zend_observer and requires PHP8+
 authors: OpenTelemetry Authors
 otVersion: latest

--- a/data/registry/resource-detector-js-instana.yml
+++ b/data/registry/resource-detector-js-instana.yml
@@ -10,6 +10,6 @@ repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detec
 license: Apache 2.0
 description:
   This resource detector will detect the Instana agent to register the
-  Opentelemetry as a Node.js process
+  OpenTelemetry as a Node.js process
 authors: OpenTelemetry Authors
 otVersion: latest

--- a/data/registry/tools-python-sentry.yml
+++ b/data/registry/tools-python-sentry.yml
@@ -14,7 +14,6 @@ license: MIT
 description:
   The Sentry OpenTelemetry Python integration provides a processor and
   propagator to send data to Sentry and to associate traces/spans to Sentry
-  errors. For configuration details, see [OpenTelemetry
-  Support](https://docs.sentry.io/platforms/python/performance/instrumentation/opentelemetry/).
+  errors.
 authors: Sentry authors <otel@sentry.io>
 otVersion: latest

--- a/data/registry/tools-python-sentry.yml
+++ b/data/registry/tools-python-sentry.yml
@@ -14,6 +14,7 @@ license: MIT
 description:
   The Sentry OpenTelemetry Python integration provides a processor and
   propagator to send data to Sentry and to associate traces/spans to Sentry
-  errors.
+  errors. For configuration details, see [OpenTelemetry
+  Support](https://docs.sentry.io/platforms/python/performance/instrumentation/opentelemetry/).
 authors: Sentry authors <otel@sentry.io>
 otVersion: latest

--- a/layouts/shortcodes/registry-search-form.html
+++ b/layouts/shortcodes/registry-search-form.html
@@ -94,7 +94,7 @@
   <div class="registry-entry-body">
     <div class="h5">
       <a {{ $href }} target="_blank" rel="noopener">
-        {{- .title -}}
+        {{- .title | markdownify -}}
       </a>
     </div>
     <span class="me-auto">

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "_check:links:internal": "npm run __check:links",
     "_check:links--warn": "npm run _check:links || (echo; echo 'WARNING: see link-checker output for issues.'; echo)",
     "_check:spelling": "npx cspell --no-progress -c .vscode/cspell.json content",
-    "_check:text": "npx textlint content",
+    "_check:text": "npx textlint content data",
     "_get:no": "echo SKIPPING get operation",
     "_get:submodule:non-lang": "npm run _get:submodule -- content-modules/opentelemetry-specification themes/docsy",
     "_get:submodule": "set -x && git submodule update --init ${DEPTH:- --depth 1}",


### PR DESCRIPTION
This PR cleans up all textlint errors in `data/` by fixing registry entries and adding some more rules to the textlintrc