### PR TITLE
Update semantic-conventions

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -33,6 +33,10 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   # Ignore links to GH repo content for now.
   - ^https?://github\.com/.*?/.*?/(blob|tree)/
 
+  # Too many redirects as the server tries to figure out the country and language,
+  # e.g.: https://www.microsoft.com/en-ca/sql-server.
+  - ^https://www.microsoft.com/sql-server$
+
   # TODO: drop after fix to https://github.com/rust-lang/crates.io/issues/788
   - ^https://crates\.io/crates
   # TODO: drop after fix to https://github.com/micrometer-metrics/micrometer-docs/issues/239

--- a/content/en/docs/specs/semconv/_index.md
+++ b/content/en/docs/specs/semconv/_index.md
@@ -1,6 +1,0 @@
----
-title: OpenTelemetry Semantic Conventions
-linkTitle: Semantic Conventions
-cascade:
-  draft: true
----

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -187,14 +187,8 @@ module:
       target: content/docs/specs/otlp/_index.md
     - source: tmp/otlp/docs/img
       target: content/docs/specs/otlp/img
-    - source: tmp/semconv/specification/logs
-      target: content/docs/specs/semconv/logs
-    - source: tmp/semconv/specification/metrics
-      target: content/docs/specs/semconv/metrics
-    - source: tmp/semconv/specification/resource
-      target: content/docs/specs/semconv/resource
-    - source: tmp/semconv/specification/trace
-      target: content/docs/specs/semconv/trace
+    - source: tmp/semconv/docs
+      target: content/docs/specs/semconv
     - source: tmp/community/mission-vision-values.md
       target: content/community/mission.md
     - source: tmp/community/roadmap.md

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -97,6 +97,13 @@ while(<>) {
     next;
   }
 
+  ## Semconv
+
+  if ($ARGV =~ /\/semconv/) {
+    s|(\]\()/docs/|$1$specBasePath/semconv/|g;
+    s|(\]:\s*)/docs/|$1$specBasePath/semconv/|;
+  }
+
   # SPECIFICATION custom processing
 
   s|\(https://github.com/open-telemetry/opentelemetry-specification\)|($specBasePath/otel/)|;

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -102,6 +102,9 @@ while(<>) {
   if ($ARGV =~ /\/semconv/) {
     s|(\]\()/docs/|$1$specBasePath/semconv/|g;
     s|(\]:\s*)/docs/|$1$specBasePath/semconv/|;
+
+    # TODO: drop once semconv pages are fixed:
+    s|(/resource/faas\.md)#function-as-a-service|$1|;
   }
 
   # SPECIFICATION custom processing

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -115,6 +115,9 @@ sub printTitleAndFrontMatter() {
     print "path_base_for_github_subdir:\n";
     print "  from: $path_base_for_github_subdir/semconv/$1_index.md\n";
     print "  to: $1README.md\n";
+    if ($linkTitle eq 'General') {
+      print "weight: -1\n";
+    }
   }
   print "---\n";
 }

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -14,6 +14,7 @@ my $gD = 0;
 my $otelSpecRepoUrl = 'https://github.com/open-telemetry/opentelemetry-specification';
 my $otlpSpecRepoUrl = 'https://github.com/open-telemetry/opentelemetry-proto';
 my $opAmpSpecRepoUrl = 'https://github.com/open-telemetry/opamp-spec';
+my $semconvSpecRepoUrl = 'https://github.com/open-telemetry/semantic-conventions';
 my $semConvRef = "$otelSpecRepoUrl/blob/main/semantic_conventions/README.md";
 my $specBasePath = '/docs/specs';
 my $path_base_for_github_subdir = "content/en$specBasePath";
@@ -24,6 +25,7 @@ my %versions = qw(
 my $otelSpecVers = $versions{'spec:'};
 my $otlpSpecVers = $versions{'otlp:'};
 my $unused;
+
 # TODO: remove once OpAMP spec has been updated
 my $opampFrontMatter = << "EOS";
 title: Open Agent Management Protocol
@@ -34,6 +36,21 @@ github_project_repo: *repo
 path_base_for_github_subdir:
   from: content/en/docs/specs/opamp/index.md
   to: specification.md
+EOS
+
+# TODO: remove once Semconv spec has been updated
+my $semconvFrontMatter = << "EOS";
+linkTitle: Semantic Conventions
+no_list: true
+cascade:
+  body_class: otel-docs-spec
+  github_repo: &repo $semconvSpecRepoUrl
+  github_subdir: docs
+  path_base_for_github_subdir: content/en/docs/specs/semconv/
+  github_project_repo: *repo
+path_base_for_github_subdir:
+  from: content/en/docs/specs/semconv/_index.md
+  to: docs/README.md
 EOS
 
 sub printTitleAndFrontMatter() {
@@ -49,6 +66,8 @@ sub printTitleAndFrontMatter() {
     $frontMatterFromFile .= "weight: 20\n" if $frontMatterFromFile !~ /^\s*weight/;
   } elsif ($title eq 'OpAMP: Open Agent Management Protocol') {
     $frontMatterFromFile = $opampFrontMatter unless $frontMatterFromFile;
+  } elsif ($title eq 'OpenTelemetry Semantic Conventions') {
+    $frontMatterFromFile = $semconvFrontMatter unless $frontMatterFromFile;
   }
   my $titleMaybeQuoted = ($title =~ ':') ? "\"$title\"" : $title;
   print "title: $titleMaybeQuoted\n" if $frontMatterFromFile !~ /title: /;

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -94,12 +94,10 @@ sub printTitleAndFrontMatter() {
   print "title: $titleMaybeQuoted\n" if $frontMatterFromFile !~ /title: /;
   if ($title =~ /^OpenTelemetry (Protocol )?(.*)/) {
     $linkTitle = $2;
-  } elsif ($title =~ /^(\w+) Semantic Conventions?$/i) {
+  } elsif ($title =~ /^(.*?) Semantic Conventions?$/i) {
     $linkTitle = toTitleCase($1);
   } elsif ($title =~ /^Semantic Conventions? for (.*)$/i) {
     $linkTitle = toTitleCase($1);
-  } elsif ($title =~ /^(System) semantic conventions$/i) {
-    $linkTitle = $1;
   } elsif ($title =~ /^Function as a Service$/i) {
     $linkTitle = 'FaaS';
   }

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -48,9 +48,6 @@ cascade:
   github_subdir: docs
   path_base_for_github_subdir: content/en/docs/specs/semconv/
   github_project_repo: *repo
-path_base_for_github_subdir:
-  from: content/en/docs/specs/semconv/_index.md
-  to: README.md
 EOS
 
 sub printTitleAndFrontMatter() {
@@ -79,6 +76,10 @@ sub printTitleAndFrontMatter() {
   if ($ARGV =~ /otel\/specification\/(.*?)_index.md$/) {
     print "path_base_for_github_subdir:\n";
     print "  from: $path_base_for_github_subdir/otel/$1_index.md\n";
+    print "  to: $1README.md\n";
+  } elsif ($ARGV =~ /tmp\/semconv\/docs\/(.*?)_index.md$/) {
+    print "path_base_for_github_subdir:\n";
+    print "  from: $path_base_for_github_subdir/semconv/$1_index.md\n";
     print "  to: $1README.md\n";
   }
   print "---\n";

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -47,6 +47,7 @@ cascade:
   github_subdir: docs
   path_base_for_github_subdir: content/en/docs/specs/semconv/
   github_project_repo: *repo
+  draft: true
 EOS
 
 # Adjust semconv title capitalization

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -50,7 +50,7 @@ cascade:
   github_project_repo: *repo
 path_base_for_github_subdir:
   from: content/en/docs/specs/semconv/_index.md
-  to: docs/README.md
+  to: README.md
 EOS
 
 sub printTitleAndFrontMatter() {

--- a/scripts/content-modules/cp-pages.sh
+++ b/scripts/content-modules/cp-pages.sh
@@ -68,8 +68,8 @@ echo "COMMUNITY pages: copied and processed"
 
 ## Semantic Conventions
 
-SRC=content-modules/semantic-conventions/specification
-DEST=$DEST_BASE/semconv/specification
+SRC=content-modules/semantic-conventions/docs
+DEST=$DEST_BASE/semconv/docs
 
 rm -Rf $DEST
 mkdir -p $DEST

--- a/scripts/content-modules/normalize-titles.pl
+++ b/scripts/content-modules/normalize-titles.pl
@@ -1,0 +1,180 @@
+#!/usr/bin/perl -w -i
+#
+# DRAFT script used to normalize semconv doc-page tiles and add Hugo front matter
+#
+
+$^W = 1;
+
+use strict;
+use warnings;
+use diagnostics;
+
+my $file = '';
+my $frontMatterFromFile = '';
+my $title = '';
+my $linkTitle = '';
+my $gD = 0;
+my $otelSpecRepoUrl = 'https://github.com/open-telemetry/opentelemetry-specification';
+my $otlpSpecRepoUrl = 'https://github.com/open-telemetry/opentelemetry-proto';
+my $opAmpSpecRepoUrl = 'https://github.com/open-telemetry/opamp-spec';
+my $semconvSpecRepoUrl = 'https://github.com/open-telemetry/semantic-conventions';
+my $semConvRef = "$otelSpecRepoUrl/blob/main/semantic_conventions/README.md";
+my $specBasePath = '/docs/specs';
+my $path_base_for_github_subdir = "content/en$specBasePath";
+my %versions = qw(
+  spec: 1.22.0
+  otlp: 1.0.0
+);
+my $otelSpecVers = $versions{'spec:'};
+my $otlpSpecVers = $versions{'otlp:'};
+
+# TODO: remove once OpAMP spec has been updated
+my $opampFrontMatter = << "EOS";
+title: Open Agent Management Protocol
+linkTitle: OpAMP
+body_class: otel-docs-spec
+github_repo: &repo $opAmpSpecRepoUrl
+github_project_repo: *repo
+path_base_for_github_subdir:
+  from: content/en/docs/specs/opamp/index.md
+  to: specification.md
+EOS
+
+# TODO: remove once Semconv spec has been updated
+my $semconvFrontMatter = << "EOS";
+linkTitle: Semantic Conventions
+# no_list: true
+cascade:
+  body_class: otel-docs-spec
+  github_repo: &repo $semconvSpecRepoUrl
+  github_subdir: docs
+  path_base_for_github_subdir: content/en/docs/specs/semconv/
+  github_project_repo: *repo
+EOS
+
+# Adjust semconv title capitalization
+sub toTitleCase($) {
+    my $str = shift;
+    my @specialCaseWords = qw(
+        CloudEvents
+        CouchDB
+        DynamoDB
+        FaaS
+        GraphQL
+        gRPC
+        HBase
+        MongoDB
+        OpenTelemetry
+        RabbitMQ
+        RocketMQ
+    );
+    my %specialCases = map { lc($_) => $_ } @specialCaseWords;
+    while ($str =~ /(\b[A-Z]+\b)/g) {
+        $specialCases{lc $1} = $1;
+    }
+    $str =~ s/(\w+)/\u\L$1/g;
+    while (my ($key, $value) = each %specialCases) {
+        $str =~ s/\b\u\L$key\b/$value/g;
+    }
+    $str =~ s/\b(A|And|As|For|In|On)\b/\L$1/g;
+    return $str;
+}
+
+sub printTitleAndFrontMatter() {
+  my $frontMatter = '';
+  my $originalTitle = $title;
+  if ($frontMatterFromFile) {
+    # printf STDOUT "> $file has front matter:\n$frontMatterFromFile\n"; # if $gD;
+    $frontMatterFromFile = '' unless $ARGV =~ /\/system\/[^R]/;
+    # printf STDOUT "> $file\n" if $ARGV =~ /\/system\b/;
+  }
+  if ($title eq 'OpenTelemetry Semantic Conventions') {
+    $frontMatterFromFile = $semconvFrontMatter unless $frontMatterFromFile;
+  } elsif ($ARGV =~ /json-rpc/) {
+    $title = 'Semantic Conventions for JSON-RPC';
+  }
+  $title = toTitleCase($title);
+  my $titleMaybeQuoted = ($title =~ ':') ? "\"$title\"" : $title;
+  # $frontMatter .= "title: $titleMaybeQuoted\n" if $frontMatterFromFile !~ /title: /;
+  if ($title =~ /^OpenTelemetry (Protocol )?(.*)/) {
+    $linkTitle = $2;
+  } elsif ($title =~ /^(.*?) Semantic Conventions?$/i) {
+    $linkTitle = toTitleCase($1);
+  } elsif ($title =~ /^Semantic Conventions? for (.*)$/i) {
+    $linkTitle = toTitleCase($1);
+  }
+  if ($linkTitle =~ /^Function.as.a.Service$/i) {
+    $linkTitle = 'FaaS';
+  }
+  $linkTitle = 'Database' if $title =~ /Database Calls and Systems$/i;
+  if ($linkTitle =~ /^Database (.*)$/i) {
+    $linkTitle = "$1";
+  } elsif ($linkTitle =~ /^FaaS (.*)$/i) {
+    $linkTitle = "$1";
+  } elsif ($linkTitle =~ /^HTTP (.*)$/i) {
+    $linkTitle = "$1";
+  } elsif ($linkTitle =~ /^Microsoft (.*)$/i) {
+    $linkTitle = "$1";
+  } elsif ($linkTitle =~ /^RPC (.*)$/i) {
+    $linkTitle = "$1";
+  } elsif ($linkTitle =~ /^(Exceptions|Feature Flags) .. (.*)$/i) {
+    $linkTitle = "$2";
+  }
+  if ($linkTitle =~ /^(.*) Attributes$/i && $title ne 'General Attributes') {
+    $linkTitle = "$1";
+  }
+  $linkTitle = 'Attributes' if $title eq 'General Attributes';
+  $linkTitle = 'Events' if $linkTitle eq 'Event';
+  $linkTitle = 'Logs' if $title =~ /Logs Attributes$/;
+  $linkTitle = 'Connect' if $title =~ /Connect RPC$/;
+  $linkTitle = 'SQL' if $title =~ /SQL Databases$/;
+  $title = 'Semantic Conventions for Function-as-a-Service' if $title eq 'Semantic Conventions for FaaS';
+  $linkTitle = 'Tracing Compatibility' if $linkTitle eq 'Tracing Compatibility Components';
+  if ($title =~ /Semantic Convention\b/) {
+    $title =~ s/Semantic Convention\b/$&s/g;
+    printf STDOUT "> $title -> $linkTitle\n";
+  }
+
+  $frontMatter .= "linkTitle: $linkTitle\n" if $linkTitle and $frontMatterFromFile !~ /linkTitle: /;
+  $frontMatter .= $frontMatterFromFile if $frontMatterFromFile;
+  if ($ARGV =~ /docs\/(.*?)README.md$/) {
+    $frontMatter .= "path_base_for_github_subdir:\n";
+    $frontMatter .= "  from: $path_base_for_github_subdir/semconv/$1_index.md\n";
+    $frontMatter .= "  to: $1README.md\n";
+  }
+  $frontMatter .= "weight: -1\n" if $title eq 'General Semantic Conventions';
+  if ($frontMatter) {
+    $frontMatter = "<!--- Hugo front matter used to generate the website version of this page:\n" . $frontMatter;
+    $frontMatter .= "--->\n";
+    print "$frontMatter\n";
+  }
+  print "# $title\n"
+}
+
+# main
+
+while(<>) {
+  # printf STDOUT "$ARGV Got: $_" if $gD;
+
+  if ($file ne $ARGV) {
+    $file = $ARGV;
+    # printf STDOUT "> $file\n"; # if $gD;
+    $frontMatterFromFile = '';
+    $title = '';
+    if (/^<!---? Hugo/) {
+        while(<>) {
+          last if /^-?-->/;
+          $frontMatterFromFile .= $_;
+        }
+        next;
+    }
+  }
+  if(! $title) {
+    ($title) = /^#\s+(.*)/;
+    $linkTitle = '';
+    printTitleAndFrontMatter() if $title;
+    next;
+  }
+
+  print;
+}

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -2835,6 +2835,10 @@
     "StatusCode": 200,
     "LastSeen": "2023-06-30T11:43:23.38558-04:00"
   },
+  "https://github.com/open-telemetry/semantic-conventions/issues/new": {
+    "StatusCode": 200,
+    "LastSeen": "2023-07-06T18:29:34.673526-04:00"
+  },
   "https://github.com/opentracing": {
     "StatusCode": 200,
     "LastSeen": "2023-06-30T08:40:39.909083-04:00"

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -123,6 +123,10 @@
     "StatusCode": 200,
     "LastSeen": "2023-06-29T12:28:24.723237-04:00"
   },
+  "https://aws.amazon.com/dynamodb/": {
+    "StatusCode": 200,
+    "LastSeen": "2023-07-06T17:57:47.141869-04:00"
+  },
   "https://aws.amazon.com/ecs/": {
     "StatusCode": 200,
     "LastSeen": "2023-06-29T13:39:56.688276-04:00"
@@ -147,6 +151,10 @@
     "StatusCode": 206,
     "LastSeen": "2023-06-29T12:28:09.411462-04:00"
   },
+  "https://azure.microsoft.com/products/cosmos-db/": {
+    "StatusCode": 200,
+    "LastSeen": "2023-07-06T17:58:02.342209-04:00"
+  },
   "https://bazel.build/": {
     "StatusCode": 200,
     "LastSeen": "2023-06-29T13:39:27.033525-04:00"
@@ -162,6 +170,10 @@
   "https://calendar.google.com/calendar/embed": {
     "StatusCode": 200,
     "LastSeen": "2023-06-29T15:55:02.67164-04:00"
+  },
+  "https://cassandra.apache.org/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-07-06T17:58:07.715816-04:00"
   },
   "https://cdn.jsdelivr.net/npm/mermaid@9.3.0/dist/mermaid.min.js": {
     "StatusCode": 206,
@@ -410,6 +422,10 @@
   "https://coralogix.com/docs/opentelemetry/": {
     "StatusCode": 206,
     "LastSeen": "2023-06-29T13:38:26.570786-04:00"
+  },
+  "https://couchdb.apache.org/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-07-06T17:57:36.620937-04:00"
   },
   "https://danielabaron.me": {
     "StatusCode": 206,
@@ -750,6 +766,10 @@
   "https://docs.docker.com/desktop/settings/windows/": {
     "StatusCode": 206,
     "LastSeen": "2023-06-29T16:16:24.371007-04:00"
+  },
+  "https://docs.docker.com/engine/api/v1.43/#tag/Container/operation/ContainerInspect": {
+    "StatusCode": 206,
+    "LastSeen": "2023-07-06T17:58:46.994822-04:00"
   },
   "https://docs.docker.com/engine/reference/run/#container-identification": {
     "StatusCode": 206,
@@ -3087,6 +3107,10 @@
     "StatusCode": 206,
     "LastSeen": "2023-06-29T16:15:53.26896-04:00"
   },
+  "https://hbase.apache.org/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-07-06T17:58:13.148749-04:00"
+  },
   "https://helm.sh": {
     "StatusCode": 206,
     "LastSeen": "2023-06-29T16:04:48.516571-04:00"
@@ -3911,6 +3935,10 @@
     "StatusCode": 206,
     "LastSeen": "2023-06-29T18:38:09.870827-04:00"
   },
+  "https://raw.githubusercontent.com/elastic/elasticsearch-specification/main/output/schema/schema.json": {
+    "StatusCode": 206,
+    "LastSeen": "2023-07-06T17:58:33.547228-04:00"
+  },
   "https://reactivex.io/RxJava/2.x/javadoc/index.html": {
     "StatusCode": 206,
     "LastSeen": "2023-06-29T18:48:07.197849-04:00"
@@ -3918,6 +3946,10 @@
   "https://redhat.com/": {
     "StatusCode": 200,
     "LastSeen": "2023-06-30T16:26:43.920023-04:00"
+  },
+  "https://redis.com/": {
+    "StatusCode": 200,
+    "LastSeen": "2023-07-06T17:57:41.927739-04:00"
   },
   "https://redis.io/commands/hmset": {
     "StatusCode": 206,
@@ -3934,6 +3966,10 @@
   "https://reflectoring.io/upstream-downstream/": {
     "StatusCode": 206,
     "LastSeen": "2023-06-30T09:40:22.564248-04:00"
+  },
+  "https://rocketmq.apache.org/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-07-06T17:58:59.087632-04:00"
   },
   "https://rubiksqube.com/#/": {
     "StatusCode": 206,
@@ -4367,6 +4403,10 @@
     "StatusCode": 206,
     "LastSeen": "2023-06-30T09:33:47.364453-04:00"
   },
+  "https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html": {
+    "StatusCode": 206,
+    "LastSeen": "2023-07-06T17:58:38.92195-04:00"
+  },
   "https://www.envoyproxy.io": {
     "StatusCode": 206,
     "LastSeen": "2023-06-30T08:51:02.248507-04:00"
@@ -4603,6 +4643,10 @@
     "StatusCode": 206,
     "LastSeen": "2023-06-30T16:26:05.762975-04:00"
   },
+  "https://www.mongodb.com/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-07-06T17:57:52.359895-04:00"
+  },
   "https://www.nomadproject.io": {
     "StatusCode": 206,
     "LastSeen": "2023-06-30T08:50:51.721695-04:00"
@@ -4754,6 +4798,10 @@
   "https://www.python.org/dev/peps/pep-3333/": {
     "StatusCode": 206,
     "LastSeen": "2023-06-30T08:38:26.348608-04:00"
+  },
+  "https://www.rabbitmq.com/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-07-06T17:58:53.682551-04:00"
   },
   "https://www.reactive-streams.org/reactive-streams-1.0.1-javadoc/org/reactivestreams/Publisher.html": {
     "StatusCode": 206,


### PR DESCRIPTION
- Contributes to #2721
- Updates semantic-conventions under `/docs/specs/semconv` using the new organization brought in by https://github.com/open-telemetry/semantic-conventions/pull/166

> ~**IMPORTANT NOTE**: if this PR is merged, then the semantic-conventions will be **published to the production server**. Are y'all ok with that @jsuereth @joaopgrassi @open-telemetry/specs-semconv-approvers?~

**Preview**: https://deploy-preview-2982--opentelemetry.netlify.app/docs/specs/semconv/
