### PR TITLE
php updates

### DIFF
--- a/content/en/docs/instrumentation/php/automatic.md
+++ b/content/en/docs/instrumentation/php/automatic.md
@@ -96,7 +96,7 @@ The extension can be installed via pecl,
 <!-- The remaining shortcode lines must be unindented so that tab content is unindented in the generated page -->
 <!-- prettier-ignore-start -->
 {{< tab pickle >}}
-php pickle.phar install --source https://github.com/open-telemetry/opentelemetry-php-instrumentation.git#1.0.0beta2
+php pickle.phar install opentelemetry
 {{< /tab >}}
 
 {{< tab "php-extension-installer (docker)" >}}
@@ -128,6 +128,7 @@ variables or `php.ini` to configure auto-instrumentation:
 OTEL_PHP_AUTOLOAD_ENABLED=true \
 OTEL_SERVICE_NAME=your-service-name \
 OTEL_TRACES_EXPORTER=otlp \
+OTEL_METRICS_EXPORTER=none \
 OTEL_EXPORTER_OTLP_PROTOCOL=grpc \
 OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4317 \
 OTEL_PROPAGATORS=baggage,tracecontext \

--- a/content/en/docs/instrumentation/php/automatic.md
+++ b/content/en/docs/instrumentation/php/automatic.md
@@ -128,7 +128,6 @@ variables or `php.ini` to configure auto-instrumentation:
 OTEL_PHP_AUTOLOAD_ENABLED=true \
 OTEL_SERVICE_NAME=your-service-name \
 OTEL_TRACES_EXPORTER=otlp \
-OTEL_METRICS_EXPORTER=none \
 OTEL_EXPORTER_OTLP_PROTOCOL=grpc \
 OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4317 \
 OTEL_PROPAGATORS=baggage,tracecontext \

--- a/content/en/docs/instrumentation/php/manual.md
+++ b/content/en/docs/instrumentation/php/manual.md
@@ -3,7 +3,7 @@ title: Manual Instrumentation
 linkTitle: Manual
 weight: 30
 description: Manual instrumentation for OpenTelemetry PHP
-spelling: cSpell:ignore myapp autoload
+spelling: cSpell:ignore myapp autoload guzzlehttp
 ---
 
 {{% docs/instrumentation/manual-intro %}}
@@ -16,11 +16,10 @@ console.
 
 To use the OpenTelemetry SDK for PHP you need packages that satisfy the
 dependencies for `psr/http-client-implementation` and
-`psr/http-factory-implementation`. Here we will use the Guzzle 7 HTTP Adapter
-which satisfies both:
+`psr/http-factory-implementation`. Here we will use Guzzle, which provides both:
 
 ```sh
-composer require php-http/guzzle7-adapter
+composer require guzzlehttp/guzzle
 ```
 
 Now you can install the OpenTelemetry SDK, and OTLP exporter:


### PR DESCRIPTION
* use guzzle http client to satisfy simplified http client/message requirements
* update pickle installation instructions to work now that we've moved the extension source
into a subdirectory
* disable metrics by default, since it often trips up users trying out tracing