### PR TITLE
Add End User Q&A series companies to adopters

### DIFF
--- a/content/en/ecosystem/adopters.md
+++ b/content/en/ecosystem/adopters.md
@@ -2,7 +2,7 @@
 title: Adopters
 description: Organizations that use OpenTelemetry
 # prettier-ignore
-spelling: cSpell:ignore Dapr Datenrettungsdienste Globale Logicmonitor Logz Wandera Zocdoc
+spelling: cSpell:ignore Dapr Datenrettungsdienste Globale Logicmonitor Logz Wandera Zocdoc Farfetch Uplight
 # All spelling entries must be on a single line
 ---
 
@@ -17,11 +17,13 @@ Organization                                      | Components                  
 [Care.com](https://www.care.com)                  | Collector, Go, Java, JS, .NET   |
 [Cloud Scale](https://www.cloudscaleinc.com)      | Collector, Python    |
 [EcoBee](https://www.ecobee.com/)                 | Collector, Java                 |  [blog post](https://www.honeycomb.io/blog/bees-working-together-how-ecobees-engineers-adopted-honeycomb-for-visibility-into-system-optimization-and-customer-experience)
+[Farfetch](https://www.farfetch.com/)             | Collector, Java, .NET, Node.js, Python, Operator | [blog post](/blog/2023/end-user-q-and-a-03/)
 [F5](https://www.f5.com/)                         | Collector.                      |
 [OrderMyGear](https://www.ordermygear.com/)       |                                 |
 [PITS Globale Datenrettungsdienste](https://www.pitsdatenrettung.de/) | Python      |
 [Shopify](https://www.shopify.com/)               | Collector, Go, Ruby             |
 [Transit](https://transitapp.com/)                |                                 |
+[Uplight](https://uplight.com/)                   | Collector, Ruby, Java, Python, .NET | [blog post](/blog/2023/end-user-q-and-a-02/)
 [Wandera](https://www.wandera.com/)               | Collector                       |
 [Zocdoc](https://www.zocdoc.com/)                 |                                 |
 <!-- prettier-ignore-end -->

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -4175,6 +4175,10 @@
     "StatusCode": 206,
     "LastSeen": "2023-06-30T09:37:36.11784-04:00"
   },
+  "https://uplight.com/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-07-07T17:13:24.95734+02:00"
+  },
   "https://uptrace.dev": {
     "StatusCode": 206,
     "LastSeen": "2023-06-29T18:37:28.48076-04:00"
@@ -4394,6 +4398,10 @@
   "https://www.farfetch.com": {
     "StatusCode": 200,
     "LastSeen": "2023-06-01T15:55:17.477011-04:00"
+  },
+  "https://www.farfetch.com/": {
+    "StatusCode": 200,
+    "LastSeen": "2023-07-07T17:13:23.688913+02:00"
   },
   "https://www.fulcrumapp.com": {
     "StatusCode": 206,


### PR DESCRIPTION
this adds the 2 companies we had in the End User Q&A blog posts to the adopters pages

cc @open-telemetry/end-user-wg 