### PR TITLE
Update .prettierignore: drop .gitignore entries + comment tweak

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,25 +1,17 @@
 # Base
 
-/.netlify
 /iconography
 /themes
-/tmp
 
 /layouts/*
 !/layouts/shortcodes
 /layouts/shortcodes/*
 !/layouts/shortcodes/docs
 
-# Ignore content-modules except for Community pages and Go docs
+# Ignore content-modules except for published Community pages
 
 /content-modules/*
 !/content-modules/community
 /content-modules/community/*
 !/content-modules/community/mission-vision-values.md
 !/content-modules/community/roadmap.md
-
-# Ignore generated resources
-
-package-lock.json
-/public
-/resources


### PR DESCRIPTION
- Followup to #3002
- Context: https://prettier.io/blog/2023/07/05/3.0.0.html#ignore-gitignored-files-by-default-14731httpsgithubcomprettierprettierpull14731-by-fiskerhttpsgithubcomfisker