### PR TITLE
CI: cache dependencies for check-format GH action

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -10,7 +10,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - run: npm install
+      - name: Create NPM cache-hash input file
+        run: |
+          jq '{devDependencies, dependencies, engines}' package.json > package-ci.json
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: package-ci.json
 
       - name: Check file format
-        run: npm run check:format
+        run: npm run check:format --ignore-scripts


### PR DESCRIPTION
I'm not 100% sure that this is properly setup, but it does reduced the action execution time by more than 50%.

The action does contain the following warning, so I'm not sure that `npm install` is actually being called or not:

> npm WARN exec The following package was not found and will be installed: prettier@3.0.0

/cc @trask 

