### PR TITLE
Ensure that semconv pages are preview only, not in production + add watermark

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -263,7 +263,7 @@ body.td-page--draft .td-content {
   position: relative;
 
   &::after {
-    content: 'PREVIEW-ONLY';
+    content: 'Draft';
     position: absolute;
     top: 80px;
     left: 50%;

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -258,3 +258,23 @@
     }
   }
 }
+
+body.td-page--draft .td-content {
+  position: relative;
+
+  &::after {
+    content: 'PREVIEW-ONLY';
+    position: absolute;
+    top: 80px;
+    left: 50%;
+    transform: translate(-50%, 0) rotate(-45deg);
+    color: rgba(255, 0, 0, 0.3);
+    font-size: 18vw;
+    z-index: 9999;
+    pointer-events: none;
+    text-transform: uppercase;
+    font-weight: bold;
+    text-align: center;
+    max-width: max-content;
+  }
+}

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -36,6 +36,9 @@ sub printTitleAndFrontMatter() {
     $frontMatterFromFile =~ s/(title|linkTitle): .*/$& $otlpSpecVers/g;
     # TODO: add to spec landing page
     $frontMatterFromFile .= "weight: 20\n" if $frontMatterFromFile !~ /^\s*weight/;
+  } elsif ($ARGV =~ /semconv\/docs\/_index.md$/) {
+    $frontMatterFromFile =~ s/body_class: .*/$& td-page--draft/;
+    $frontMatterFromFile =~ s/cascade:\n/$&  draft: true\n/;
   }
   my $titleMaybeQuoted = ($title =~ ':') ? "\"$title\"" : $title;
   print "title: $titleMaybeQuoted\n" if $frontMatterFromFile !~ /title: /;


### PR DESCRIPTION
@jsuereth @joaopgrassi - my apologies, but #2984 inadvertently caused the semconv pages to be published to the production server (confusion arose as I switched to using the name-title adjustment script and forgot that I had dropped the `draft: true` front matter field).

This PR:

- Adds a DRAFT ~(was: PREVIEW-ONLY)~ wartermark for the semconv draft pages
- Drops the semconv pages from the production server

Given that the semconv pages are pretty much in their final form (given that the reorg is done), maybe we can keep the pages in production, but with the watermark. Or even just forget about the watermark too? Your call, let me know.

**Preview**: https://deploy-preview-3008--opentelemetry.netlify.app/docs/specs/semconv/

**Screenshot**:

> <img width="971" alt="image" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/c51dd601-66ae-4e72-ad1d-b0d0b00ab63f">

<!--
> <img width="1213" alt="image" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/92c2ddc2-2046-4fe9-85ec-79ffd7b46cc8">
-->
