### PR TITLE
Better DRAFT watermark position for all screens

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -265,7 +265,7 @@ body.td-page--draft .td-content {
   &::after {
     content: 'Draft';
     position: absolute;
-    top: 80px;
+    top: 10vw;
     left: 50%;
     transform: translate(-50%, 0) rotate(-45deg);
     color: rgba(255, 0, 0, 0.3);


### PR DESCRIPTION
- Followup to #3008
- Ensures that the watermark is better positioned for very wide displays (currently is moves above the top edge of the view). It also improves positioning on mobile.