### PR TITLE
Update semconv, adjust link-checks, and more

### DIFF
--- a/content/en/blog/2023/end-user-q-and-a-03.md
+++ b/content/en/blog/2023/end-user-q-and-a-03.md
@@ -211,9 +211,8 @@ stable.
 
 ### How are you collecting the metrics signal?
 
-Auto-instrumentation emits some
-[OTLP](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md)
-metrics; however, the majority of metrics still come from Prometheus.
+Auto-instrumentation emits some [OTLP](/docs/specs/otlp/) metrics; however, the
+majority of metrics still come from Prometheus.
 
 The team currently uses the
 [Prometheus Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/prometheusreceiver/README.md)

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -3,7 +3,11 @@
   {{ if findRE "^https://opentelemetry.io/\\w" .Destination -}}
     {{ warnf "%s: use a local path, not an external URL, for the following reference to a site local page: %s"
         .Page.File.Path .Destination -}}
-  {{ else if findRE "^https://github.com/open-telemetry/opentelemetry-specification/(blob|tree)/main/specification/\\w" .Destination -}}
+  {{ else if or
+    (findRE "^https://github.com/open-telemetry/opentelemetry-specification/(blob|tree)/main/specification/\\w" .Destination)
+    (findRE "^https://github.com/open-telemetry/opentelemetry-proto/(blob|tree)/main/docs/specification" .Destination)
+    (findRE "^https://github.com/open-telemetry/semantic-conventions/(blob|tree)/main/docs" .Destination)
+    -}}
     {{ warnf "%s: use a local path, not an external URL, for the following reference to a local specification page: %s"
     .Page.File.Path .Destination -}}
   {{ end -}}

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -116,9 +116,13 @@ while(<>) {
     ) {
     printf STDOUT "WARNING: link to spec page encoded as an external URL, but should be a local path, fix this upstream;\n  File: $ARGV \n  Link: $1\n";
   }
-  s|\(https://github.com/open-telemetry/opentelemetry-specification/\w+/(main\|v$otelSpecVers)/specification(.*?)\)|($specBasePath/otel$2)|;
 
-  s|(https://)?github.com/open-telemetry/opentelemetry-proto/((blob\|tree)/.*?/)?docs/specification.md|$specBasePath/otlp/|g;
+  # Match markdown inline links or link definitions to OTel spec pages: "[...](URL)" or "[...]: URL"
+  s|(\]:\s+\|\()https://github.com/open-telemetry/opentelemetry-specification/\w+/(main\|v$otelSpecVers)/specification(.*?\)?)|$1$specBasePath/otel$3|;
+
+  # Match links to OTLP
+  s|(\]:\s+\|\()?https://github.com/open-telemetry/opentelemetry-proto/(\w+/.*?/)?docs/specification.md(\))?|$1$specBasePath/otlp/$3|g;
+  s|github.com/open-telemetry/opentelemetry-proto/docs/specification.md|OTLP|g;
 
   # Images
   s|(\.\./)?internal(/img/[-\w]+\.png)|$2|g;


### PR DESCRIPTION
- Updates semconv submodule
  - Brings in https://github.com/open-telemetry/semantic-conventions/pull/185
- Adds Hugo build warning for pages containing external links to OTLP spec or semconv pages
- Adjust-pages: enhances regex used to replace external links to OTel and OTLP pages; the regex now matches inline markdown links and markdown link-definitions
- Fixes link in blog post to refer to local OTLP page
- Note that semconv pages are still **only in preview**: 
  https://deploy-preview-3021--opentelemetry.netlify.app/docs/specs/semconv

There are no changes other than more instances of external spec-page links being replaced by local paths (the two changed files are expected):

```console
$ (cd public && git diff -bw -I "(blob|tree)/v1.2" -I "href=\"/docs" -- . ':(exclude)*.xml') | grep ^diff
diff --git a/blog/2023/end-user-q-and-a-03/index.html b/blog/2023/end-user-q-and-a-03/index.html
diff --git a/docs/specs/otel/protocol/otlp/index.html b/docs/specs/otel/protocol/otlp/index.html
```
