### PR TITLE
Adjust-pages: fix regex to avoid warning + tweak alias order

### DIFF
--- a/content/en/ecosystem/registry/_index.md
+++ b/content/en/ecosystem/registry/_index.md
@@ -5,8 +5,8 @@ description: >-
   OpenTelemetry.
 aliases:
   # Catch-all for old registry entries; we don't publish individual entry pages anymore.
-  - /registry/*
   - /ecosystem/registry/*
+  - /registry/*
 type: default
 layout: registry
 outputs: [html, json]

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -121,7 +121,7 @@ while(<>) {
   s|(\]:\s+\|\()https://github.com/open-telemetry/opentelemetry-specification/\w+/(main\|v$otelSpecVers)/specification(.*?\)?)|$1$specBasePath/otel$3|;
 
   # Match links to OTLP
-  s|(\]:\s+\|\()?https://github.com/open-telemetry/opentelemetry-proto/(\w+/.*?/)?docs/specification.md(\))?|$1$specBasePath/otlp/$3|g;
+  s|(\]:\s+\|\()?https://github.com/open-telemetry/opentelemetry-proto/(\w+/.*?/)?docs/specification.md(\)?)|$1$specBasePath/otlp/$3|g;
   s|github.com/open-telemetry/opentelemetry-proto/docs/specification.md|OTLP|g;
 
   # Images


### PR DESCRIPTION
- Followup to #3021
- Eliminates adjust-pages.pl warning
- Adjusts aliases path order -- Netlify staff recommendation to help debug https://github.com/open-telemetry/opentelemetry.io/issues/3013#user-content-fn-1-edc581236bf4ec19e880c101ccc439bc