### PR TITLE
Adjust-pages: drop OTel spec fixes now that 1.23 has landed

### DIFF
--- a/scripts/content-modules/cp-pages.sh
+++ b/scripts/content-modules/cp-pages.sh
@@ -10,8 +10,8 @@ DEST=$DEST_BASE/otel/specification
 
 rm -Rf $DEST
 mkdir -p $DEST
-FIX_FILES=$(find $SRC -name "*.md" -not -path '*/semantic_conventions/*')
-$SCRIPT_DIR/otel-spec-fix.pl $FIX_FILES
+# FIX_FILES=$(find $SRC -name "*.md" -not -path '*/semantic_conventions/*')
+# $SCRIPT_DIR/otel-spec-fix.pl $FIX_FILES
 cp -R $SRC/* $DEST/
 
 find $DEST/ -name "README.md" -exec sh -c 'f="{}"; mv -- "$f" "${f%README.md}_index.md"' \;
@@ -20,9 +20,7 @@ find $DEST/ -name "README.md" -exec sh -c 'f="{}"; mv -- "$f" "${f%README.md}_in
 FILES=$(find $DEST -name "*.md")
 
 $SCRIPT_DIR/adjust-pages.pl $FILES
-if [[ -z $NO_GIT_RESTORE ]]; then
-  (cd $SRC/.. && git restore .)
-fi
+# if [[ -z $NO_GIT_RESTORE ]]; then (cd $SRC/.. && git restore .); fi
 
 echo "OTEL SPEC pages: copied and processed"
 


### PR DESCRIPTION
Followup to:

- #3023

No changes to the generated site files:

```console
$ (cd public && git diff)
$
```