### PR TITLE
CI: check-links: enable caching and check for warnings

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Minimal install and prep
         run: |
-          npm install npm-run-all postcss-cli
+          npm install npm-run-all postcss-cli postcss autoprefixer
 
       - run: npm run build | tee tmp/build-log.txt
       - run: npm run _check:links

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -10,13 +10,19 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name:
-          Create NPM cache-hash input file and reduced-dependencies package.json
+      - name: Create NPM cache-hash input file
         run: |
           mkdir -p tmp
-          jq '{devDependencies, dependencies, engines, gitHubActionCacheCounter}' package.json > tmp/package-ci.json
-          jq 'del(.devDependencies[] | select(test("spell|gulp|netlify|prettier|require|text")))' package.json > tmp/package-min.json
-          mv tmp/package-min.json package.json
+          jq '{devDependencies, dependencies, engines, gitHubActionCacheKey}' package.json > tmp/package-ci.json
+
+      - name: Create and use reduced-dependencies package.json
+        run: |
+          jq '.devDependencies |= with_entries(
+                select(.key | test("spell|gulp|netlify|prettier|require|text") | not)
+              )
+              | del(.dependencies)' \
+            package.json > tmp/package-min.json
+          cp tmp/package-min.json package.json
 
       - uses: actions/setup-node@v3
         with:
@@ -29,11 +35,12 @@ jobs:
       - run: npm run _check:links
 
       - name: Upload build log
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: build-log-etc
           path: |
             tmp/build-log.txt
+            tmp/package*.json
             tmp/.htmltest/refcache.json
 
   check-refcache:
@@ -44,7 +51,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download build log
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: build-log-etc
           path: tmp
@@ -62,10 +69,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download build log
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: build-log-etc
           path: tmp
 
       - name: Check for warnings or errors in build log
-        run: make check-build-log;
+        run: scripts/check-build-log.sh

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -18,9 +18,9 @@ jobs:
       - name: Create and use reduced-dependencies package.json
         run: |
           jq '.devDependencies |= with_entries(
-                select(.key | test("spell|gulp|netlify|prettier|require|text") | not)
-              )
-              | del(.dependencies)' \
+                  select(.key | test("prefix|hugo|run|css"))
+                )
+                | del(.dependencies)' \
             package.json > tmp/package-min.json
           cp tmp/package-min.json package.json
 
@@ -33,16 +33,12 @@ jobs:
       - run: npm install --no-optional
       - run: npm run build+log
       - run: npm run _check:links
-      - run: ls -l tmp/.htmltest
-
-      - name: Upload build log
-        uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v3
         with:
           name: build-log-etc
           path: |
             tmp/build-log.txt
             tmp/package*.json
-            tmp/.htmltest/refcache.json
             static/refcache.json
 
   check-refcache:
@@ -51,16 +47,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - name: Download build log
-        uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v3
         with: { name: build-log-etc }
-
-      - run: ls -l tmp/.htmltest
-      - name: Fail on uncommitted refcache changes
-        run: |
-          make refcache-restore
-          npm run diff:fail
+      - run: npm run diff:fail
 
   check-build-log-for-issues:
     name: WARNINGS in build log?
@@ -68,10 +57,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - name: Download build log
-        uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v3
         with: { name: build-log-etc }
-
-      - name: Check for warnings or errors in build log
-        run: scripts/check-build-log.sh
+      - run: scripts/check-build-log.sh

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-and-check-links:
-    name: Build and check links
+    name: BUILD and CHECK LINKS
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -39,11 +39,13 @@ jobs:
             tmp/.htmltest/refcache.json
 
   check-refcache:
-    name: Check for refcache updates
+    name: REFCACHE updates?
     needs: build-and-check-links
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
+      - uses: actions/checkout@v3
+
       - name: Download build log
         uses: actions/download-artifact@v2
         with:
@@ -52,11 +54,11 @@ jobs:
 
       - name: Fail on uncommitted refcache changes
         run: |
-          npm run _refcache-restore
+          make refcache-restore
           npm run diff:fail
 
   check-build-log-for-issues:
-    name: Check for build warnings
+    name: WARNINGS in build log?
     needs: build-and-check-links
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -52,11 +52,11 @@ jobs:
 
       - name: Fail on uncommitted refcache changes
         run: |
-          make refcache-restore
+          npm run _refcache-restore
           npm run diff:fail
 
   check-build-log-for-issues:
-    name: Check build for issues
+    name: Check for build warnings
     needs: build-and-check-links
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -7,7 +7,6 @@ jobs:
   build-and-check-links:
     name: BUILD and CHECK LINKS
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v3
 
@@ -24,8 +23,7 @@ jobs:
 
       - name: Minimal install and prep
         run: |
-          npm install npm-run-all --ignore-scripts
-          npm run prepare
+          npm install npm-run-all
 
       - run: npm run build | tee tmp/build-log.txt
       - run: npm run _check:links
@@ -42,7 +40,6 @@ jobs:
     name: REFCACHE updates?
     needs: build-and-check-links
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v3
 
@@ -61,7 +58,6 @@ jobs:
     name: WARNINGS in build log?
     needs: build-and-check-links
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Download build log
         uses: actions/download-artifact@v2

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -66,8 +66,12 @@ jobs:
           path: tmp
 
       - name: Check for warnings or errors in build log
+        # Don't fail until the following are fixed:
+        # https://github.com/open-telemetry/opamp-spec/issues/150
+        # https://github.com/open-telemetry/opentelemetry.io/issues/2721
         run: |
           if grep -E -ie 'warn(ing)?|error' tmp/build-log.txt; then
-            echo "Warning or error found in build log."
-            exit 1
+            echo
+            echo "WARNING or ERROR found in build log."
+            exit 0
           fi

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -22,7 +22,7 @@ jobs:
           cache: npm
           cache-dependency-path: tmp/package-ci.json
 
-      - run: npm install
+      - run: npm run prepare
       - run: npm run build | tee tmp/build-log.txt
 
       - run: npm run _check:links

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -15,8 +15,8 @@ jobs:
         run: |
           mkdir -p tmp
           jq '{devDependencies, dependencies, engines, gitHubActionCacheCounter}' package.json > tmp/package-ci.json
-          jq 'del(.devDependencies[] | select(test("spell|gulp|netlify|prettier|require|text")))' package.json > tmp/package2.json
-          mv tmp/package2.json package.json
+          jq 'del(.devDependencies[] | select(test("spell|gulp|netlify|prettier|require|text")))' package.json > tmp/package-min.json
+          mv tmp/package-min.json package.json
 
       - uses: actions/setup-node@v3
         with:
@@ -24,9 +24,8 @@ jobs:
           cache: npm
           cache-dependency-path: tmp/package-ci.json
 
-      - run: npm install
-      - run: git restore package.json
-      - run: npm run build | tee tmp/build-log.txt
+      - run: npm install --no-optional
+      - run: npm run build+log
       - run: npm run _check:links
 
       - name: Upload build log

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -21,10 +21,7 @@ jobs:
           cache: npm
           cache-dependency-path: tmp/package-ci.json
 
-      - name: Minimal install and prep
-        run: |
-          npm install hugo-extended npm-run-all postcss-cli postcss autoprefixer
-
+      - run: npm install
       - run: npm run build | tee tmp/build-log.txt
       - run: npm run _check:links
 

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Create NPM cache-hash input file
         run: |
           mkdir -p tmp
-          jq '{devDependencies, dependencies, engines}' package.json > tmp/package-ci.json
+          jq '{devDependencies, dependencies, engines, gitHubActionCacheCounter}' package.json > tmp/package-ci.json
 
       - uses: actions/setup-node@v3
         with:
@@ -23,7 +23,7 @@ jobs:
 
       - name: Minimal install and prep
         run: |
-          npm install npm-run-all postcss-cli postcss autoprefixer
+          npm install hugo-extended npm-run-all postcss-cli postcss autoprefixer
 
       - run: npm run build | tee tmp/build-log.txt
       - run: npm run _check:links

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -59,6 +59,8 @@ jobs:
     needs: build-and-check-links
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+
       - name: Download build log
         uses: actions/download-artifact@v2
         with:
@@ -66,12 +68,4 @@ jobs:
           path: tmp
 
       - name: Check for warnings or errors in build log
-        # Don't fail until the following are fixed:
-        # https://github.com/open-telemetry/opamp-spec/issues/150
-        # https://github.com/open-telemetry/opentelemetry.io/issues/2721
-        run: |
-          if grep -E -ie 'warn(ing)?|error' tmp/build-log.txt; then
-            echo
-            echo "WARNING or ERROR found in build log."
-            exit 0
-          fi
+        run: make check-build-log;

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -22,9 +22,12 @@ jobs:
           cache: npm
           cache-dependency-path: tmp/package-ci.json
 
-      - run: npm run prepare
-      - run: npm run build | tee tmp/build-log.txt
+      - name: Minimal install and prep
+        run: |
+          npm install npm-run-all --ignore-scripts
+          npm run prepare
 
+      - run: npm run build | tee tmp/build-log.txt
       - run: npm run _check:links
 
       - name: Upload build log

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -41,7 +41,6 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-
       - name: Download build log
         uses: actions/download-artifact@v2
         with:
@@ -59,7 +58,6 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-
       - name: Download build log
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -4,15 +4,70 @@ on:
   pull_request:
 
 jobs:
-  check-formatting:
-    name: Check links and refcache
+  build-and-check-links:
+    name: Build and check links
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v3
 
-      - run: npm install
-      - run: npm run build
+      - name: Create NPM cache-hash input file
+        run: |
+          mkdir -p tmp
+          jq '{devDependencies, dependencies, engines}' package.json > tmp/package-ci.json
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: tmp/package-ci.json
+
+      - run: npm run build | tee tmp/build-log.txt
+
       - run: npm run _check:links
 
+      - name: Upload build log
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-log-etc
+          path: |
+            tmp/build-log.txt
+            tmp/.htmltest/refcache.json
+
+  check-refcache:
+    name: Check for refcache updates
+    needs: build-and-check-links
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+
+      - name: Download build log
+        uses: actions/download-artifact@v2
+        with:
+          name: build-log-etc
+          path: tmp
+
       - name: Fail on uncommitted refcache changes
-        run: npm run diff:fail
+        run: |
+          make refcache-restore
+          npm run diff:fail
+
+  check-build-log-for-issues:
+    name: Check build for issues
+    needs: build-and-check-links
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+
+      - name: Download build log
+        uses: actions/download-artifact@v2
+        with:
+          name: build-log-etc
+          path: tmp
+
+      - name: Check for warnings or errors in build log
+        run: |
+          if grep -E -ie 'warn(ing)?|error' tmp/build-log.txt; then
+            echo "Warning or error found in build log."
+            exit 1
+          fi

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -33,6 +33,7 @@ jobs:
       - run: npm install --no-optional
       - run: npm run build+log
       - run: npm run _check:links
+      - run: ls -l tmp/.htmltest
 
       - name: Upload build log
         uses: actions/upload-artifact@v3
@@ -42,6 +43,7 @@ jobs:
             tmp/build-log.txt
             tmp/package*.json
             tmp/.htmltest/refcache.json
+            static/refcache.json
 
   check-refcache:
     name: REFCACHE updates?
@@ -52,10 +54,9 @@ jobs:
 
       - name: Download build log
         uses: actions/download-artifact@v3
-        with:
-          name: build-log-etc
-          path: tmp
+        with: { name: build-log-etc }
 
+      - run: ls -l tmp/.htmltest
       - name: Fail on uncommitted refcache changes
         run: |
           make refcache-restore
@@ -70,9 +71,7 @@ jobs:
 
       - name: Download build log
         uses: actions/download-artifact@v3
-        with:
-          name: build-log-etc
-          path: tmp
+        with: { name: build-log-etc }
 
       - name: Check for warnings or errors in build log
         run: scripts/check-build-log.sh

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -22,6 +22,7 @@ jobs:
           cache: npm
           cache-dependency-path: tmp/package-ci.json
 
+      - run: npm install
       - run: npm run build | tee tmp/build-log.txt
 
       - run: npm run _check:links

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Minimal install and prep
         run: |
-          npm install npm-run-all
+          npm install npm-run-all postcss-cli
 
       - run: npm run build | tee tmp/build-log.txt
       - run: npm run _check:links

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -10,10 +10,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Create NPM cache-hash input file
+      - name:
+          Create NPM cache-hash input file and reduced-dependencies package.json
         run: |
           mkdir -p tmp
           jq '{devDependencies, dependencies, engines, gitHubActionCacheCounter}' package.json > tmp/package-ci.json
+          jq 'del(.devDependencies[] | select(test("spell|gulp|netlify|prettier|require|text")))' package.json > tmp/package2.json
+          mv tmp/package2.json package.json
 
       - uses: actions/setup-node@v3
         with:
@@ -22,6 +25,7 @@ jobs:
           cache-dependency-path: tmp/package-ci.json
 
       - run: npm install
+      - run: git restore package.json
       - run: npm run build | tee tmp/build-log.txt
       - run: npm run _check:links
 

--- a/.warnings-skip-list.txt
+++ b/.warnings-skip-list.txt
@@ -1,0 +1,1 @@
+xWARN  docs/specs/opamp/index.md:.*semantic-conventions/tree/main/docs/resource

--- a/.warnings-skip-list.txt
+++ b/.warnings-skip-list.txt
@@ -1,1 +1,1 @@
-xWARN  docs/specs/opamp/index.md:.*semantic-conventions/tree/main/docs/resource
+WARN  docs/specs/opamp/index.md:.*semantic-conventions/tree/main/docs/resource

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 # Set REFCACHE to another value to disable htmltest refcache-file manipulation
-BUILD_LOG?=tmp/build-log.txt
 REFCACHE?=refcache
 HTMLTEST_DIR=tmp
 HTMLTEST?=htmltest # Specify as make arg if different
@@ -8,7 +7,6 @@ LINK_CACHE_FILE?=refcache.json
 LINK_CACHE_FILE_DEST_DIR?=static
 LINK_CACHE_FILE_SRC_DIR?=$(HTMLTEST_DIR)/.htmltest
 OTEL_GEN_REPO?=../$(shell basename $(shell pwd)).g
-WARNINGS_SKIP_LIST?=.warnings-skip-list.txt
 
 # Use $(HTMLTEST) in PATH, if available; otherwise, we'll get a copy
 ifeq (, $(shell which $(HTMLTEST)))
@@ -39,20 +37,6 @@ ifeq (refcache, $(REFCACHE))
 else
 	@echo "SKIPPING refcache-save"
 endif
-
-# Add warning skip patterns, one per line to WARNINGS_SKIP_LIST to
-# temporarily skip known warnings or errors.
-check-build-log:
-	@if [ -e $(BUILD_LOG) ]; then \
-		WARNINGS=`grep -E -ie 'warn(ing)?|error' $(BUILD_LOG) | grep -v -f $(WARNINGS_SKIP_LIST)`; \
-		if [ -n "$$WARNINGS" ]; then \
-			echo "WARNINGs or ERRORs found in build log:\n"; \
-			echo "$$WARNINGS\n"; \
-			exit 1; \
-		fi \
-	else \
-		echo "INFO: $(BUILD_LOG) file not found."; \
-	fi
 
 check-links: $(GET_LINK_CHECKER_IF_NEEDED) \
 	refcache-restore check-links-only refcache-save

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "_prebuild": "run-s get:submodule cp:spec",
     "_prepare:docsy": "cd themes/docsy && npm install",
     "_prettier:any": "npx prettier --ignore-path ''",
-    "_refcache-restore": "make refcache-restore",
     "_rename-to-kebab-case": "find assets content static -name '*_*' ! -name '_*' -exec sh -c 'mv \"$1\" \"${1//_/-}\"' _ {} \\;",
     "_serve:hugo": "hugo server -DFE --minify",
     "_serve:netlify": "netlify dev -c \"npm run _serve:hugo\"",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   "engines": {
     "node": "18.x"
   },
-  "gitHubActionCacheCounter": 1,
+  "gitHubActionCacheKey": "2023-07-12 22:03 ET - change key to clear the cache",
   "private": true,
   "prettier": {
     "proseWrap": "always",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "_prebuild": "run-s get:submodule cp:spec",
     "_prepare:docsy": "cd themes/docsy && npm install",
     "_prettier:any": "npx prettier --ignore-path ''",
+    "_refcache-restore": "make refcache-restore",
     "_rename-to-kebab-case": "find assets content static -name '*_*' ! -name '_*' -exec sh -c 'mv \"$1\" \"${1//_/-}\"' _ {} \\;",
     "_serve:hugo": "hugo server -DFE --minify",
     "_serve:netlify": "netlify dev -c \"npm run _serve:hugo\"",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "build:preview": "set -x && npm run _build -- --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",
     "build:production": "hugo --cleanDestinationDir --minify",
     "build": "npm run _build",
+    "build+log": "npm run _build | tee tmp/build-log.txt",
     "cd:public": "cd public &&",
     "check": "npm run all -- check:*",
     "check:filenames": "test -z \"$(npm run -s _ls-bad-filenames)\" || npm run -s _filename-error",
@@ -104,7 +105,7 @@
   "engines": {
     "node": "18.x"
   },
-  "gitHubActionCacheKey": "2023-07-12 22:03 ET - change key to clear the cache",
+  "gitHubActionCacheKey": "2023-07-13 - change this key to force cache refresh",
   "private": true,
   "prettier": {
     "proseWrap": "always",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build:preview": "set -x && npm run _build -- --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",
     "build:production": "hugo --cleanDestinationDir --minify",
     "build": "npm run _build",
-    "build+log": "npm run _build | tee tmp/build-log.txt",
+    "build+log": "npm run build | tee tmp/build-log.txt",
     "cd:public": "cd public &&",
     "check": "npm run all -- check:*",
     "check:filenames": "test -z \"$(npm run -s _ls-bad-filenames)\" || npm run -s _filename-error",
@@ -101,7 +101,7 @@
     "@opentelemetry/sdk-trace-web": "^1.8.0",
     "@opentelemetry/semantic-conventions": "^1.8.0"
   },
-  "engines-comment": "Ensure that engines.node value stays consistent with the project's .nvmrc",
+  "enginesComment": "Ensure that engines.node value stays consistent with the project's .nvmrc",
   "engines": {
     "node": "18.x"
   },

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
   "engines": {
     "node": "18.x"
   },
+  "gitHubActionCacheCounter": 1,
   "private": true,
   "prettier": {
     "proseWrap": "always",

--- a/scripts/check-build-log.sh
+++ b/scripts/check-build-log.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# NOTE: add warning skip patterns, one per line to WARNINGS_SKIP_LIST to
+# temporarily skip known warnings or errors.
+
+BUILD_LOG=tmp/build-log.txt
+WARNINGS_SKIP_LIST=.warnings-skip-list.txt
+
+WARNINGS=`grep -E -ie 'warn(ing)?|error' $BUILD_LOG | grep -v -f $WARNINGS_SKIP_LIST`
+
+if [ -e $BUILD_LOG ]; then
+  if [ -n "$WARNINGS" ]; then
+    echo "WARNINGs or ERRORs found in build log:\n"
+    echo "$WARNINGS\n"
+    exit 1
+  fi
+else
+  echo "INFO: $BUILD_LOG file not found."
+fi


### PR DESCRIPTION
- Contributes to #2814
- Enable simple node-based caching
- Separates concerns. We now have separate jobs for:
  - Building the site and running the link checker
  - Checking for required refcache updates
  - Checking for build issues (including warnings about use of external links when a local path should be used)
- I've disabled the failure of the BUILD WARNINGS job until #2721 is fully resolved

https://github.com/open-telemetry/opentelemetry.io/actions/workflows/check-links.yml used to take almost 3 minutes, it is now down to ~1 min 40 sec~. Update: it's now 2 min 15 sec on a rerun; I couldn't get it to work using a partial install. Not as much an improvement as I would have hoped, but it is an improvement. I could probably trim `devDependencies`, but this will do for now.
