### PR TITLE
Update semantic-conventions to 1.21.0, publish all schemas, drop draft status, enable auto-update

### DIFF
--- a/.github/workflows/auto-update-versions.yml
+++ b/.github/workflows/auto-update-versions.yml
@@ -26,6 +26,7 @@ jobs:
           .github/workflows/scripts/auto-update-version.sh opentelemetry-java-instrumentation javaInstrumentationVersion content/en/docs/instrumentation/java/automatic/annotations.md
           .github/workflows/scripts/auto-update-version.sh opentelemetry-specification spec scripts/content-modules/adjust-pages.pl
           .github/workflows/scripts/auto-update-version.sh opentelemetry-proto otlp scripts/content-modules/adjust-pages.pl
+          .github/workflows/scripts/auto-update-version.sh semantic-conventions semconv scripts/content-modules/adjust-pages.pl
         env:
           # change this to secrets.GITHUB_TOKEN when testing against a fork
           GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -197,10 +197,6 @@ module:
       target: static
     - source: content-modules/semantic-conventions/schemas
       target: static/schemas
-      # TODO: drop the excludeFiles line once
-      # https://github.com/open-telemetry/opentelemetry.io/issues/2721
-      # is fully resolved.
-      excludeFiles: [1.21.0]
     - source: static/img
       target: static/img
     - source: content-modules/opentelemetry-specification/internal/img

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -21,9 +21,11 @@ my $path_base_for_github_subdir = "content/en$specBasePath";
 my %versions = qw(
   spec: 1.23.0
   otlp: 1.0.0
+  semconv: 1.21.0
 );
 my $otelSpecVers = $versions{'spec:'};
 my $otlpSpecVers = $versions{'otlp:'};
+my $semconvVers = $versions{'semconv:'};
 
 sub printTitleAndFrontMatter() {
   print "---\n";
@@ -37,8 +39,10 @@ sub printTitleAndFrontMatter() {
     # TODO: add to spec landing page
     $frontMatterFromFile .= "weight: 20\n" if $frontMatterFromFile !~ /^\s*weight/;
   } elsif ($ARGV =~ /semconv\/docs\/_index.md$/) {
-    $frontMatterFromFile =~ s/body_class: .*/$& td-page--draft/;
-    $frontMatterFromFile =~ s/cascade:\n/$&  draft: true\n/;
+    $title .= " $semconvVers";
+    $frontMatterFromFile =~ s/linkTitle: .*/$& $semconvVers/;
+    # $frontMatterFromFile =~ s/body_class: .*/$& td-page--draft/;
+    # $frontMatterFromFile =~ s/cascade:\n/$&  draft: true\n/;
   }
   my $titleMaybeQuoted = ($title =~ ':') ? "\"$title\"" : $title;
   print "title: $titleMaybeQuoted\n" if $frontMatterFromFile !~ /title: /;


### PR DESCRIPTION
- Contributes to #2721
- Updates semconv submodule to 1.21.0
- Enabled the publication of schema for 1.21.0
- Removes `draft` status from semconv pages -- **SEMCONV PAGES WILL APPEAR ON THE PRODUCTION SERVER**
- Enabled auto-update of the semconv version
- Note that the OTel spec is at 1.23.0, so links into the OTel spec at 1.22.0 appear as external links; they do not link to the corresponding OTel website spec page

**Preview**: https://deploy-preview-3033--opentelemetry.netlify.app/docs/specs/semconv

/cc @jsuereth @joaopgrassi 