### PR TITLE
Update demo architecture

### DIFF
--- a/content/en/docs/demo/architecture.md
+++ b/content/en/docs/demo/architecture.md
@@ -38,7 +38,7 @@ queue[(queue<br/>&#40Kafka&#41)]
 Internet -->|HTTP| frontendproxy
 frontendproxy -->|HTTP| frontend
 frontendproxy -->|HTTP| featureflagservice
-loadgenerator -->|HTTP| frontend
+loadgenerator -->|HTTP| frontendproxy
 
 accountingservice -->|TCP| queue
 
@@ -144,17 +144,17 @@ subgraph tdf[Telemetry Data Flow]
             oc-http[/"OTLP Receiver<br/>listening on <br/>http://localhost:4318/<br/>https://localhost:4318/"/]
             oc-proc(Processors)
             oc-prom[/"Prometheus Exporter<br/>listening on<br/>http://localhost:9464/"/]
-            oc-jag[/"Jaeger Exporter"/]
+            oc-otlp[/"OTLP Exporter"/]
 
             oc-grpc --> oc-proc
             oc-http --> oc-proc
 
             oc-proc --> oc-prom
-            oc-proc --> oc-jag
+            oc-proc --> oc-otlp
         end
 
         oc-prom -->|"http://localhost:9464/metrics"| pr-sc
-        oc-jag -->|gRPC| ja-col
+        oc-otlp -->|gRPC| ja-col
 
         subgraph pr[Prometheus]
             style pr fill:#e75128,color:black;

--- a/content/en/docs/demo/architecture.md
+++ b/content/en/docs/demo/architecture.md
@@ -131,7 +131,7 @@ subgraph tdf[Telemetry Data Flow]
     subgraph subgraph_padding [ ]
         style subgraph_padding fill:none,stroke:none;
         %% padding to stop the titles clashing
-        subgraph od[Open Telemetry Demo]
+        subgraph od[OpenTelemetry Demo]
         ms(Microservice)
         end
 


### PR DESCRIPTION
Loadgenerator now sends requests through FrontEndProxy. 
And OTelCollector is using OTLPExporter instead of JaegerExporter (which was deprecated) for traces.