### PR TITLE
Add page redirects feature and fix registry catch-all

### DIFF
--- a/content/en/ecosystem/registry/_index.md
+++ b/content/en/ecosystem/registry/_index.md
@@ -3,10 +3,15 @@ title: Registry
 description: >-
   Find libraries, plugins, integrations, and other useful tools for extending
   OpenTelemetry.
-aliases:
-  # Catch-all for old registry entries; we don't publish individual entry pages anymore.
-  - /ecosystem/registry/*
-  - /registry/*
+# The redirects and aliases implement catch-all rules for old registry entries;
+# we don't publish individual entry pages anymore.
+#
+# We can't use the catch-all `/ecosystem/registry/*`, because that creates a
+# self-loop with `/ecosystem/registry/index.html`. So we use the following
+# redirect rule to avoid the loop, as suggested by Netlify support
+# (email support ID 159489):
+redirects: [{ from: ./*, to: '?' }]
+aliases: [/registry/*]
 type: default
 layout: registry
 outputs: [html, json]

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -1,7 +1,19 @@
 # Netlify redirects. See https://www.netlify.com/docs/redirects/
-{{/* cSpell:ignore wordmark */ -}}
+{{/* cSpell:ignore cond wordmark */ -}}
 
 {{ range $p := .Site.Pages -}}
+
+{{ range $p.Params.redirects -}}
+  {{ $permaLink := $p.RelPermalink | strings.TrimSuffix "/" -}}
+  {{ $from := cond
+      (strings.HasPrefix .from "./")
+      (print $permaLink (strings.TrimPrefix "./" .from))
+      .from -}}
+  {{ $to := cond (strings.HasPrefix .to "/")
+      .to
+      (print $permaLink .to) -}}
+  {{ $from | printf "%-35s" }} {{ $to }}
+{{ end -}}
 
 {{ range $p.Aliases -}}
   {{ . | printf "%-35s" }} {{ $p.RelPermalink }}


### PR DESCRIPTION
- Closes #3013
- Adds support for page-specific `redirects` rules that have `from` and `to` URL parameters; the page permalink is assumed for these parameters, unless they start with a `/`.

### Tests

- [x] https://deploy-preview-3038--opentelemetry.netlify.app/ecosystem/registry/xyz - should work now
- [x] https://deploy-preview-3038--opentelemetry.netlify.app/registry/collector-exporter-elastic/ - should still work