### PR TITLE
Fix registry entry for Go OTLP

### DIFF
--- a/data/registry/exporter-go-otlp.yml
+++ b/data/registry/exporter-go-otlp.yml
@@ -5,7 +5,7 @@ language: go
 tags:
   - go
   - exporter
-repo: https://github.com/open-telemetry/opentelemetry-java/tree/main/exporters/otlp
+repo: https://github.com/open-telemetry/opentelemetry-go/tree/main/exporters/otlp
 license: Apache 2.0
 description:
   This library allows exporting telemetry data in the OpenTelemetry Protocol


### PR DESCRIPTION
exporter-go-otlp.yml pointed to the Java repository instead of the Go repository.