### PR TITLE
[kubernetes] Add demo helm chart docs

### DIFF
--- a/content/en/docs/kubernetes/helm/collector.md
+++ b/content/en/docs/kubernetes/helm/collector.md
@@ -147,8 +147,8 @@ ports:
     enabled: false
 ```
 
-All the configuration options (with comments) available in the chart can be view
-in its
+All the configuration options (with comments) available in the chart can be
+viewed in its
 [values.yaml file](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/values.yaml).
 
 ### Presets

--- a/content/en/docs/kubernetes/helm/demo.md
+++ b/content/en/docs/kubernetes/helm/demo.md
@@ -1,0 +1,60 @@
+---
+title: OpenTelemetry Demo Chart
+linkTitle: Demo Chart
+spelling:
+  cSpell:ignore Webstore
+---
+
+## Introduction
+
+The [OpenTelemetry Demo](/docs/demo) is a microservice-based distributed system
+intended to illustrate the implementation of OpenTelemetry in a near real-world
+environment. As part of that effort, the OpenTelemetry community create the
+[OpenTelemetry Demo Helm Chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-demo)
+so that it can be easily installed in kubernetes.
+
+### Installing the Chart
+
+To install the chart with the release name my-otel-demo, run the following
+command:
+
+```sh
+helm install my-otel-demo open-telemetry/opentelemetry-demo
+```
+
+Once installed, all services are made available via the Frontend proxy
+(`http://localhost:8080`) by running these commands:
+
+```sh
+kubectl port-forward svc/my-otel-demo-frontendproxy 8080:8080
+```
+
+Once the proxy is exposed, you can also visit the following paths
+
+| Component         | Path                             |
+| ----------------- | -------------------------------- |
+| Webstore          | http://localhost:8080/           |
+| Grafana           | http://localhost:8080/grafana/   |
+| Feature Flags UI  | http://localhost:8080/feature/   |
+| Load Generator UI | http://localhost:8080/loadgen/   |
+| Jaeger UI         | http://localhost:8080/jaeger/ui/ |
+
+In order for spans from the Webstore to be collected you must expose the
+OpenTelemetry Collector OTLP/HTTP receiver:
+
+```sh
+kubectl port-forward svc/my-otel-demo-otelcol 4318:4318
+```
+
+### Configuration
+
+The Demo helm chart's default `values.yaml` is ready to be installed. All
+components have had their memory limits tuned to optimize performance, which may
+cause issues if your cluster is not large enough. The entire installation is
+restricted to ~3.5 Gi of memory, but may use less.
+
+All the configuration options (with comments) available in the chart can be
+viewed in its
+[values.yaml file](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/values.yaml),
+and detailed descriptions can be found in the
+[chart's README](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-demo#chart-parameters).

--- a/content/en/docs/kubernetes/helm/demo.md
+++ b/content/en/docs/kubernetes/helm/demo.md
@@ -31,18 +31,21 @@ Once the proxy is exposed, you can also visit the following paths
 
 | Component         | Path                             |
 | ----------------- | -------------------------------- |
-| Web store          | http://localhost:8080/           |
+| Web store         | http://localhost:8080/           |
 | Grafana           | http://localhost:8080/grafana/   |
 | Feature Flags UI  | http://localhost:8080/feature/   |
 | Load Generator UI | http://localhost:8080/loadgen/   |
 | Jaeger UI         | http://localhost:8080/jaeger/ui/ |
 
-In order for spans from the Webstore to be collected you must expose the
+In order for spans from the Web store to be collected you must expose the
 OpenTelemetry Collector OTLP/HTTP receiver:
 
 ```sh
 kubectl port-forward svc/my-otel-demo-otelcol 4318:4318
 ```
+
+For more details on using the demo in Kubernetes see the
+[Demo documentation](/docs/demo/kubernetes-deployment/).
 
 ### Configuration
 

--- a/content/en/docs/kubernetes/helm/demo.md
+++ b/content/en/docs/kubernetes/helm/demo.md
@@ -1,7 +1,6 @@
 ---
 title: OpenTelemetry Demo Chart
 linkTitle: Demo Chart
-spelling: cSpell:ignore Webstore
 ---
 
 ## Introduction
@@ -14,7 +13,7 @@ so that it can be easily installed in Kubernetes.
 
 ### Installing the Chart
 
-To install the chart with the release name my-otel-demo, run the following
+To install the chart with the release name `my-otel-demo`, run the following
 command:
 
 ```sh
@@ -32,7 +31,7 @@ Once the proxy is exposed, you can also visit the following paths
 
 | Component         | Path                             |
 | ----------------- | -------------------------------- |
-| Webstore          | http://localhost:8080/           |
+| Web store          | http://localhost:8080/           |
 | Grafana           | http://localhost:8080/grafana/   |
 | Feature Flags UI  | http://localhost:8080/feature/   |
 | Load Generator UI | http://localhost:8080/loadgen/   |
@@ -50,7 +49,7 @@ kubectl port-forward svc/my-otel-demo-otelcol 4318:4318
 The Demo helm chart's default `values.yaml` is ready to be installed. All
 components have had their memory limits tuned to optimize performance, which may
 cause issues if your cluster is not large enough. The entire installation is
-restricted to ~3.5 Gi of memory, but may use less.
+restricted to ~3.5 Gigabytes of memory, but may use less.
 
 All the configuration options (with comments) available in the chart can be
 viewed in its

--- a/content/en/docs/kubernetes/helm/demo.md
+++ b/content/en/docs/kubernetes/helm/demo.md
@@ -1,8 +1,7 @@
 ---
 title: OpenTelemetry Demo Chart
 linkTitle: Demo Chart
-spelling:
-  cSpell:ignore Webstore
+spelling: cSpell:ignore Webstore
 ---
 
 ## Introduction
@@ -11,7 +10,7 @@ The [OpenTelemetry Demo](/docs/demo) is a microservice-based distributed system
 intended to illustrate the implementation of OpenTelemetry in a near real-world
 environment. As part of that effort, the OpenTelemetry community create the
 [OpenTelemetry Demo Helm Chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-demo)
-so that it can be easily installed in kubernetes.
+so that it can be easily installed in Kubernetes.
 
 ### Installing the Chart
 

--- a/content/en/docs/kubernetes/helm/operator.md
+++ b/content/en/docs/kubernetes/helm/operator.md
@@ -65,6 +65,6 @@ generate/configure the required TLS certificate.
   `.Values.admissionWebhooks.create` and setting env var to
   `ENABLE_WEBHOOKS: "false"`
 
-All the configuration options (with comments) available in the chart can be view
-in its
+All the configuration options (with comments) available in the chart can be
+viewed in its
 [values.yaml file](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/values.yaml).


### PR DESCRIPTION
Adds new documentation for the Demo helm chart.

Related to https://github.com/open-telemetry/opentelemetry.io/issues/3005