### PR TITLE
update go metric status

### DIFF
--- a/data/instrumentation.yaml
+++ b/data/instrumentation.yaml
@@ -25,7 +25,7 @@ languages:
     urlName: go
     status:
       traces: stable
-      metrics: beta
+      metrics: stable
       logs: not yet implemented
   java:
     name: Java

--- a/data/instrumentation.yaml
+++ b/data/instrumentation.yaml
@@ -25,7 +25,7 @@ languages:
     urlName: go
     status:
       traces: stable
-      metrics: stable
+      metrics: mixed (beta SDK & stable API)
       logs: not yet implemented
   java:
     name: Java


### PR DESCRIPTION
Accordingly to release v1.16.0 of Open Telemetry Go, `metrics` is now stable. Updating the docs to reflect that.

Reference
* https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.16.0
  > This release contains the first stable release of the OpenTelemetry Go [metric AP](https://pkg.go.dev/go.opentelemetry.io/otel/metric) 

---

**Preview**: https://deploy-preview-3075--opentelemetry.netlify.app/docs/instrumentation/go/#status-and-releases