### PR TITLE
Refactoring of data/instrumentation.yaml and associated shortcodes

### DIFF
--- a/data/instrumentation.yaml
+++ b/data/instrumentation.yaml
@@ -1,78 +1,71 @@
-languages:
-  cpp:
-    name: C++
-    urlName: cpp
-    status:
-      traces: stable
-      metrics: stable
-      logs: experimental
-  dotnet:
-    name: .NET
-    urlName: dotnet
-    status:
-      traces: stable
-      metrics: stable
-      logs: mixed*
-  erlang:
-    name: Erlang/Elixir
-    urlName: erlang
-    status:
-      traces: stable
-      metrics: experimental
-      logs: experimental
-  go:
-    name: Go
-    urlName: go
-    status:
-      traces: stable
-      metrics: mixed (beta SDK & stable API)
-      logs: not yet implemented
-  java:
-    name: Java
-    urlName: java
-    status:
-      traces: stable
-      metrics: stable
-      logs: stable
-  php:
-    name: PHP
-    urlName: php
-    status:
-      traces: beta
-      metrics: beta
-      logs: alpha
-  python:
-    name: Python
-    urlName: python
-    status:
-      traces: stable
-      metrics: stable
-      logs: experimental
-  ruby:
-    name: Ruby
-    urlName: ruby
-    status:
-      traces: stable
-      metrics: not yet implemented
-      logs: not yet implemented
-  js:
-    name: JavaScript
-    urlName: js
-    status:
-      traces: stable
-      metrics: stable
-      logs: Development
-  rust:
-    name: Rust
-    urlName: rust
-    status:
-      traces: beta
-      metrics: alpha
-      logs: not yet implemented
-  swift:
-    name: Swift
-    urlName: swift
-    status:
-      traces: stable
-      metrics: experimental
-      logs: in development
+# Instrumentation language SIG statuses as a YAML map.
+#
+# Note: the key is the language's folder name under
+# `content/en/docs/concepts/instrumentation`.
+
+cpp:
+  name: C++
+  status:
+    traces: stable
+    metrics: stable
+    logs: experimental
+dotnet:
+  name: .NET
+  status:
+    traces: stable
+    metrics: stable
+    logs: mixed*
+erlang:
+  name: Erlang/Elixir
+  status:
+    traces: stable
+    metrics: experimental
+    logs: experimental
+go:
+  name: Go
+  status:
+    traces: stable
+    metrics: mixed (beta SDK & stable API)
+    logs: not yet implemented
+java:
+  name: Java
+  status:
+    traces: stable
+    metrics: stable
+    logs: stable
+php:
+  name: PHP
+  status:
+    traces: beta
+    metrics: beta
+    logs: alpha
+python:
+  name: Python
+  status:
+    traces: stable
+    metrics: stable
+    logs: experimental
+ruby:
+  name: Ruby
+  status:
+    traces: stable
+    metrics: not yet implemented
+    logs: not yet implemented
+js:
+  name: JavaScript
+  status:
+    traces: stable
+    metrics: stable
+    logs: Development
+rust:
+  name: Rust
+  status:
+    traces: beta
+    metrics: alpha
+    logs: not yet implemented
+swift:
+  name: Swift
+  status:
+    traces: stable
+    metrics: experimental
+    logs: in development

--- a/layouts/shortcodes/docs/instrumentation/index-intro.md
+++ b/layouts/shortcodes/docs/instrumentation/index-intro.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 ` -}}
 {{ $lang := .Get 0 -}}
-{{ $data := index $.Site.Data.instrumentation.languages $lang }}
+{{ $data := index $.Site.Data.instrumentation $lang }}
 {{ $name := $data.name -}}
 {{ $tracesStatus := $data.status.traces | humanize -}}
 {{ $metricsStatus := $data.status.metrics | humanize -}}

--- a/layouts/shortcodes/logs-support-table.md
+++ b/layouts/shortcodes/logs-support-table.md
@@ -1,4 +1,4 @@
-{{ $data := $.Site.Data.instrumentation.languages }}
+{{ $data := $.Site.Data.instrumentation }}
 
 Language | Logs |
 | --- | --- |

--- a/layouts/shortcodes/metrics-support-table.md
+++ b/layouts/shortcodes/metrics-support-table.md
@@ -1,4 +1,4 @@
-{{ $data := $.Site.Data.instrumentation.languages }}
+{{ $data := $.Site.Data.instrumentation }}
 
 Language | Metrics |
 | --- | --- |

--- a/layouts/shortcodes/sampling-support-list.md
+++ b/layouts/shortcodes/sampling-support-list.md
@@ -1,7 +1,10 @@
-{{ $data := $.Site.Data.instrumentation.languages }}
+{{- range $lang, $data := $.Site.Data.instrumentation }}
+  {{- $path := printf "/docs/instrumentation/%s/sampling.md" $lang }}
+  {{- with site.GetPage $path }}
+    {{- template "list-item" (dict "name" $data.name "page" .) }}
+  {{- end }}
+{{- end }}
 
-{{ range $data }}
-  {{ $path := printf "docs/instrumentation/%s/sampling.md" .urlName }}
-  {{ $name := .name }}
-  {{ with site.GetPage $path }}- [{{ $name }}]({{ .RelPermalink }}){{ end }}
-{{ end }}
+{{ define "list-item" -}}
+- [{{ .name }}]({{ .page.RelPermalink }})
+{{ end -}}

--- a/layouts/shortcodes/telemetry-support-table.md
+++ b/layouts/shortcodes/telemetry-support-table.md
@@ -1,4 +1,4 @@
-{{ $data := $.Site.Data.instrumentation.languages }}
+{{ $data := $.Site.Data.instrumentation }}
 
 Language | Traces | Metrics | Logs |
 | --- | --- | --- | --- |


### PR DESCRIPTION
- Prep for #3077 
- Simplifies `data/instrumentation.yaml`:
  - Drops top-level `languages` key
  - Drops `urlName` since it always matches the key; adds a comment to that effect
- Updates all shortcodes that make use of `data/instrumentation.yaml`
- Fixes `layouts/shortcodes/sampling-support-list.md` so that the markdown list that it generates doesn't have any extra spacing.

---

Other than the page using `sampling-support-list.md`, the generated site files are the same:

```console
$ (cd public && git diff) | grep ^diff | grep -v '\.xml$'
diff --git a/docs/concepts/sampling/index.html b/docs/concepts/sampling/index.html
```

Here's the diff of the concepts sampling page:

```diff
diff --git a/docs/concepts/sampling/index.html b/docs/concepts/sampling/index.html
index b7b6ddd85..e7e71525d 100644
--- a/docs/concepts/sampling/index.html
+++ b/docs/concepts/sampling/index.html
@@ -2060,18 +2060,10 @@ done in the interest of protecting the telemetry pipeline from being overloaded.
 <p>For the individual language specific implementations of the OpenTelemetry API &amp;
 SDK you will find support for sampling at the respective documentation pages:</p>
 <ul>
-<li>
-<p><a href="/docs/instrumentation/erlang/sampling/">Erlang/Elixir</a></p>
-</li>
-<li>
-<p><a href="/docs/instrumentation/go/sampling/">Go</a></p>
-</li>
-<li>
-<p><a href="/docs/instrumentation/js/sampling/">JavaScript</a></p>
-</li>
-<li>
-<p><a href="/docs/instrumentation/ruby/sampling/">Ruby</a></p>
-</li>
+<li><a href="/docs/instrumentation/erlang/sampling/">Erlang/Elixir</a></li>
+<li><a href="/docs/instrumentation/go/sampling/">Go</a></li>
+<li><a href="/docs/instrumentation/js/sampling/">JavaScript</a></li>
+<li><a href="/docs/instrumentation/ruby/sampling/">Ruby</a></li>
 </ul>
```

| Before | After |
|--------|--------|
<img width="300" alt="image" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/9500fa70-cc1d-4cbf-9422-149fa372a8a0"> |  <img width="300" alt="image" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/a6b53b4e-6f49-4537-9690-5125606c3438">


**Preview**: https://deploy-preview-3078--opentelemetry.netlify.app/docs/concepts/sampling/#language-sdks