### PR TITLE
Footer: update OTel-logos label and description

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -96,10 +96,10 @@ params:
         url: https://stackoverflow.com/questions/tagged/open-telemetry
         icon: fab fa-stack-overflow
         desc: Practical questions and curated answers
-      - name: CNCF branding
+      - name: OTel logos
         url: https://github.com/cncf/artwork/tree/master/projects/opentelemetry
         icon: fas fa-image
-        desc: Check out the CNCF logo page for OpenTelemetry
+        desc: Official OpenTelemetry logos
       - name: Meeting Recordings
         url: https://docs.google.com/spreadsheets/d/1SYKfjYhZdm2Wh2Cl6KVQalKg_m4NhTPZqq-8SzEVO6s
         icon: fas fa-video


### PR DESCRIPTION
- Contributes to #3081
- Replaces the "CNCF branding" label by "OTel logos" because the link that actually refers to logos :)