### PR TITLE
Update community repo + link to local marketing guidelines

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -126,7 +126,7 @@ params:
           CNCF works in close association with Linux Foundation. Read the
           privacy policy here
       - name: Marketing Guidelines
-        url: https://github.com/open-telemetry/community/blob/main/marketing-guidelines.md
+        url: /community/marketing-guidelines/
         icon: fas fa-bullhorn
         desc: >-
           Important information on how to represent your personal or corporate

--- a/layouts/shortcodes/community-lists.md
+++ b/layouts/shortcodes/community-lists.md
@@ -22,6 +22,6 @@
 
 {{ define "community-links-list" -}}
 {{ range . }}
-- <a href="{{ .url }}" target="_blank" rel="noopener"><i class="{{ .icon }}"></i> {{ .name }}:</a> {{ .desc -}}
+- [<i class="{{ .icon }}"></i> {{ .name }}]({{ .url }}): {{ .desc -}}
 {{ end -}}
 {{ end }}


### PR DESCRIPTION
- Contributes to #3079
- Updates the community submodule
- Links to the local Marketing Guidelines page in the footer
- Tweaks the community links-list so that external link icons are shown for external links
- **Preview**:
  - https://deploy-preview-3088--opentelemetry.netlify.app/community/
  - Also see the footer of the above page