### PR TITLE
Vendor page copyedits

### DIFF
--- a/content/en/ecosystem/vendors.md
+++ b/content/en/ecosystem/vendors.md
@@ -2,19 +2,19 @@
 title: Vendors
 description: Vendors who natively support OpenTelemetry
 aliases: [/vendors]
-# Note: the keywords after 'cSpell:ignore' must be on the same line, no wrapping, hence the Prettier ignore directive
 ---
 
-A non-exhaustive list of organizations, offering solutions that consume
-OpenTelemetry natively via via [OTLP](/docs/specs/otlp/), such as observability
+A non-exhaustive list of organizations offering solutions that consume
+OpenTelemetry natively via [OTLP](/docs/specs/otlp/), such as observability
 backends and observability pipelines.
 
-These solutions may be open source, commercial, or both. Some organizations
-provide a [distribution](/docs/concepts/distributions/) (of customized
-OpenTelemetry components), that provides additional capabilities or for improved
-ease of use.
+Some organizations provide a [distribution](/docs/concepts/distributions/) (of
+customized OpenTelemetry components), that provides additional capabilities or
+for improved ease of use.
 
 {{% ecosystem/vendor-table %}}
+
+## Add your organization
 
 To have your organization listed, submit a PR with an entry added to the
 [vendors list](https://github.com/open-telemetry/opentelemetry.io/tree/main/data/ecosystem/vendors.yaml).

--- a/layouts/shortcodes/ecosystem/vendor-table.md
+++ b/layouts/shortcodes/ecosystem/vendor-table.md
@@ -1,21 +1,28 @@
-{{/* cSpell:ignore distri bution cond */}}
-{{ $data := sort (sort (sort $.Site.Data.ecosystem.vendors "name") "oss" "desc") "commercial" }}
-| Organization[^1] | Open Source | Commercial | Distri&shy;bution | Native OTLP | Learn more  |
+{{/* cSpell:ignore distri bution cond */ -}}
+{{ $data := sort (sort (sort $.Site.Data.ecosystem.vendors "name") "oss" "desc") "commercial" -}}
+
+| Organization[^org] | OSS | Com&shy;mer&shy;cial | Distri&shy;bution | Native OTLP | Learn more  |
 | ----------- | ----------- | ---------- | ----------------- | ----------- | ----------- |
 {{- range $data }}
-{{- $shortUrl := .shortUrl -}}
-{{- if not $shortUrl  }}
-    {{- $tmp := split (replace .url "https://" "") "/"  }}
-    {{- $shortUrl = (index $tmp 0) }}
-    {{- if gt (len $tmp) 1  }}
-        {{- $shortUrl = printf "%s/…" $shortUrl  }}
-    {{- end }}
-{{- end }}
-{{ .name }} | {{ cond (.oss) "Yes" "No" }} | {{ cond (.commercial) "Yes" "No" }} | {{ cond (.distribution) "Yes" "No" }} | {{ cond (.nativeOTLP) "Yes" "No" }} | [{{ $shortUrl }}]({{ .url }}) |
+  {{- $shortUrl := .shortUrl -}}
+  {{- if not $shortUrl  }}
+      {{- $tmp := split (replace .url "https://" "") "/"  }}
+      {{- $shortUrl = (index $tmp 0) }}
+      {{- if gt (len $tmp) 1  }}
+          {{- $shortUrl = printf "%s/…" $shortUrl  }}
+      {{- end }}
+  {{- end }}
+  {{/* Each line below is a column: */ -}}
+  {{ .name }} |
+  {{- cond .oss "Yes" "No" }} |
+  {{- cond .commercial "Yes" "No" }} |
+  {{- cond .distribution "Yes" "No" }} |
+  {{- cond .nativeOTLP "Yes" "No" }} |
+  {{- /* */}} [{{ $shortUrl }}]({{ .url }}) |
 {{- end }}
 
-[^1]: Organizations are listed as follows:
-    - pure OSS offerings
-    - mixed offerings
-    - commercial offerings
-    - alphabetical within those groups
+[^org]: Organizations are grouped as follows based on their OTel support:
+    - Pure OSS
+    - Mixed OSS/commercial
+    - Commercial
+    - Alphabetical within each group


### PR DESCRIPTION
- Vendor page copyedits, in particular removes the stutter "via via"
- Adds a heading for "Add your organization", which more clearly separates the instructions from the table, and gives us a linkable target
- **Preview**: https://deploy-preview-3092--opentelemetry.netlify.app/ecosystem/vendors/