### PR TITLE
[CI] remove global dict words from page-local dictionaries + handle more cases

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -7,7 +7,7 @@ show_banner: true
 developer_note:
   The blocks/cover shortcode (used below) will use as a background image any
   image file containing "background" in its name.
-cSpell:ignore: Quarkus shortcode
+cSpell:ignore: Quarkus
 ---
 
 <div class="d-none"><a rel="me" href="https://fosstodon.org/@opentelemetry"></a></div>

--- a/content/en/blog/2022/apisix/index.md
+++ b/content/en/blog/2022/apisix/index.md
@@ -4,8 +4,7 @@ linkTitle: Apache APISIX-Opentelemetry Integration
 date: 2022-03-26
 author: '[Haochao Zhuang](https://github.com/dmsolr), Fei Han'
 canonical_url: https://apisix.apache.org/blog/2022/02/28/apisix-integration-opentelemetry-plugin/
-# prettier-ignore
-cSpell:ignore: APISIX Haochao httpbin openzipkin pprof roundrobin Zhuang zpages
+cSpell:ignore: APISIX Haochao httpbin pprof roundrobin Zhuang zpages
 ---
 
 This article introduces the Apache APISIX's `opentelemetry` plugin concept and

--- a/content/en/blog/2022/exponential-histograms/index.md
+++ b/content/en/blog/2022/exponential-histograms/index.md
@@ -4,7 +4,6 @@ linkTitle: Exponential Histograms
 date: 2022-08-24
 author: '[Jack Berg](https://github.com/jack-berg)'
 canonical_url: https://newrelic.com/blog/best-practices/opentelemetry-histograms
-cSpell:ignore: proto
 ---
 
 Histograms are a powerful tool in the observability tool belt. OpenTelemetry

--- a/content/en/blog/2022/go-web-app-instrumentation/index.md
+++ b/content/en/blog/2022/go-web-app-instrumentation/index.md
@@ -4,9 +4,8 @@ linkTitle: Go App Instrumentation
 date: 2022-08-23
 author: '[Naveh Mevorach](https://github.com/NavehMevorach) (Aspecto)'
 canonical_url: https://www.aspecto.io/blog/opentelemetry-go-getting-started/
-spelling: >-
-  cSpell:ignore Naveh Mevorach Mandalorian bson gonic otelgin otelmongo
-  cSpell:ignore sdktrace semconv todos dogz aspecto
+# prettier-ignore
+cSpell:ignore: bson dogz gonic Mandalorian Mevorach Naveh otelgin otelmongo sdktrace todos
 ---
 
 In this blog post, you will learn hands-on how to create and visualize traces

--- a/content/en/blog/2022/instrument-apache-httpd-server/index.md
+++ b/content/en/blog/2022/instrument-apache-httpd-server/index.md
@@ -3,7 +3,7 @@ title: Learn how to instrument Apache Http Server with OpenTelemetry
 linkTitle: Instrument Apache Http Server
 date: 2022-05-27
 # prettier-ignore
-cSpell:ignore: Centos centos7 Debajit debuggability libmod linux uncompress webserver
+cSpell:ignore: Centos centos7 Debajit debuggability libmod uncompress webserver
 author: '[Debajit Das](https://github.com/DebajitDas) (Cisco)'
 ---
 

--- a/content/en/blog/2022/k8s-metadata/index.md
+++ b/content/en/blog/2022/k8s-metadata/index.md
@@ -3,9 +3,8 @@ title: Improved troubleshooting using k8s metadata
 linkTitle: Kubernetes metadata
 date: 2022-06-29
 author: '[Ruben Vargas](https://github.com/rubenvp8510)'
-spelling:
-  cSpell:ignore k8sattributes k8sattributesprocessor K8sattributes k8sprocessor
-  cSpell:ignore K8sprocessor KUBE resourcedetection replicaset
+# prettier-ignore
+cSpell:ignore: k8sattributes k8sattributesprocessor k8sprocessor KUBE replicaset resourcedetection
 ---
 
 Attaching Kubernetes resource metadata to OpenTelemetry traces is useful to

--- a/content/en/blog/2022/knative/index.md
+++ b/content/en/blog/2022/knative/index.md
@@ -3,7 +3,7 @@ title: Distributed tracing in Knative
 linkTitle: Tracing in Knative
 date: 2022-04-12
 # prettier-ignore
-cSpell:ignore: apng Cloudevents datacontenttype httpbody istio khtml knativearrivaltime pavolloffay spanid specversion traceid webp
+cSpell:ignore: apng Cloudevents datacontenttype httpbody khtml knativearrivaltime pavolloffay spanid specversion traceid webp
 author: '[Pavol Loffay](https://github.com/pavolloffay)'
 ---
 

--- a/content/en/blog/2022/otel-demo-app-nomad/index.md
+++ b/content/en/blog/2022/otel-demo-app-nomad/index.md
@@ -5,7 +5,7 @@ date: 2022-12-12
 author: >-
   [Adriana Villela](https://github.com/avillela) (Lightstep)
 # prettier-ignore
-cSpell:ignore: Aoqui Daniela entrypoints ffspostgres hashi hashiqube jobspec jobspecs loadgenerator lookin Luiz macbook mozy qube Riaan servian shoutout Villela
+cSpell:ignore: Aoqui Daniela entrypoints ffspostgres hashi hashiqube jobspec jobspecs loadgenerator lookin Luiz macbook mozy qube Riaan servian shoutout
 ---
 
 Y’all… I’m so excited, because I finally got to work on an item on my tech

--- a/content/en/blog/2022/otel-tuesday-v1-sunset.md
+++ b/content/en/blog/2022/otel-tuesday-v1-sunset.md
@@ -2,7 +2,6 @@
 title: OpenTelemetry Tuesdays, Signing Off!
 date: 2022-03-21
 author: '[Austin Parker](https://github.com/austinlparker)'
-cSpell:ignore: discoverability otel-comms
 ---
 
 When we started running OpenTelemetry Tuesday live streams back in 2019, the

--- a/content/en/blog/2022/troubleshooting-nodejs.md
+++ b/content/en/blog/2022/troubleshooting-nodejs.md
@@ -4,7 +4,7 @@ linkTitle: TroublesShooting Node.js Tracing Issues
 date: 2022-02-22
 canonical_url: https://www.aspecto.io/blog/checklist-for-troubleshooting-opentelemetry-nodejs-tracing-issues
 author: '[Amir Blum](https://github.com/blumamir) (Aspecto)'
-cSpell:ignore: bootcamp Parentfor Preconfigured proto
+cSpell:ignore: bootcamp Parentfor Preconfigured
 ---
 
 I’ll try to make this one short and to the point. You are probably here because

--- a/content/en/blog/2023/end-user-q-and-a-03.md
+++ b/content/en/blog/2023/end-user-q-and-a-03.md
@@ -4,7 +4,7 @@ linkTitle: 'End-User Q&A: OTel at Farfetch'
 date: 2023-06-07
 author: '[Adriana Villela](https://github.com/avillela) (Lightstep)'
 body_class: otel-with-contributions-from
-cSpell:ignore: Dyrmishi Farfetch Thanos
+cSpell:ignore: Dyrmishi Farfetch
 ---
 
 With contributions from [Rynn Mancuso](https://github.com/musingvirtual)

--- a/content/en/blog/2023/kubecon-eu.md
+++ b/content/en/blog/2023/kubecon-eu.md
@@ -2,9 +2,8 @@
 title: Join us for OpenTelemetry Talks and Activities at KubeCon EU 2023
 linkTitle: KubeCon EU '23
 date: 2023-04-03
-spelling:
-  cSpell:ignore Kowall Aiven Vider Xiaochun Benedikt Bongartz Oliveira Pathak
-  cSpell:ignore Jaglowski observ
+# prettier-ignore
+cSpell:ignore: Aiven Benedikt Bongartz Jaglowski Kowall observ Oliveira Pathak Vider Xiaochun
 author: '[Severin Neumann](https://github.com/svrnm)'
 ---
 

--- a/content/en/blog/2023/php-auto-instrumentation/index.md
+++ b/content/en/blog/2023/php-auto-instrumentation/index.md
@@ -3,7 +3,7 @@ title: OpenTelemetry PHP Auto-Instrumentation
 linkTitle: PHP Auto-Instrumentation
 date: 2023-03-21
 author: '[Przemek Delewski](https://github.com/pdelewski/) (Sumo Logic)'
-cSpell:ignore: classname Delewski functionname laravel Przemek zend
+cSpell:ignore: classname Delewski functionname laravel Przemek
 ---
 
 Automatic Instrumentation is a process of adding tracing capabilities into user

--- a/content/en/docs/acknowledgements/_index.md
+++ b/content/en/docs/acknowledgements/_index.md
@@ -1,7 +1,6 @@
 ---
 title: Acknowledgements
 description: Acknowledgements for sources for content on this site
-cSpell:ignore: otel
 aliases: [/acknowledgements]
 weight: 200
 cSpell:ignore: Pigram

--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -2,7 +2,7 @@
 title: Configuration
 weight: 20
 # prettier-ignore
-cSpell:ignore: cfssl cfssljson fluentforward gencert genkey hostmetrics initca loglevel OIDC oidc opencensus otlphttp pprof prodevent prometheus prometheusremotewrite servicegraph spanevents spanmetrics upsert zipkin zpages
+cSpell:ignore: cfssl cfssljson fluentforward gencert genkey hostmetrics initca loglevel OIDC oidc otlphttp pprof prodevent prometheusremotewrite servicegraph spanevents spanmetrics upsert zpages
 ---
 
 <!-- markdownlint-disable link-fragments -->

--- a/content/en/docs/collector/getting-started.md
+++ b/content/en/docs/collector/getting-started.md
@@ -1,8 +1,7 @@
 ---
 title: Getting Started
-spelling:
-  - cSpell:ignore darwin dpkg GOARCH journalctl kubectl linux otelcorecol pprof
-  - cSpell:ignore zpages tlsv
+# prettier-ignore
+cSpell:ignore: darwin dpkg GOARCH journalctl kubectl otelcorecol pprof tlsv zpages
 weight: 1
 ---
 

--- a/content/en/docs/collector/trace-receiver.md
+++ b/content/en/docs/collector/trace-receiver.md
@@ -2,8 +2,7 @@
 title: Building a Trace Receiver
 weight: 98
 # prettier-ignore
-cSpell:ignore: amzn atmxph backendsystem batchprocessor chicago comcast crand devs Errorf gogl Intn ispnetwork jaegerexporter linux loggingexporter mapstructure mcrsft otlpreceiver pcommon pdata protogen ptrace Rcvr rquedas sanfrancisco semconv serialnumber slrs stateid struct structs tailtracer uber wndws
-spelling: cSpell:ignore
+cSpell:ignore: amzn atmxph backendsystem batchprocessor chicago comcast crand devs Errorf gogl Intn ispnetwork jaegerexporter loggingexporter mapstructure mcrsft otlpreceiver pcommon pdata protogen ptrace Rcvr rquedas sanfrancisco serialnumber slrs stateid struct structs tailtracer uber wndws
 ---
 
 <!-- markdownlint-disable heading-increment no-duplicate-heading -->

--- a/content/en/docs/demo/requirements/architecture.md
+++ b/content/en/docs/demo/requirements/architecture.md
@@ -2,8 +2,7 @@
 title: Architecture Requirements
 linkTitle: Architecture
 aliases: [/docs/demo/requirements/architecture_requirements]
-# prettier-ignore
-cSpell:ignore: currencyservice dockerstatsreceiver emailservice shippingservice
+cSpell:ignore: dockerstatsreceiver
 ---
 
 ## Summary

--- a/content/en/docs/demo/scenarios/recommendation-cache/index.md
+++ b/content/en/docs/demo/scenarios/recommendation-cache/index.md
@@ -2,7 +2,6 @@
 title: Using Metrics and Traces to diagnose a memory leak
 linkTitle: Diagnosing memory leaks
 aliases: [/docs/demo/scenarios/recommendation_cache]
-cSpell:ignore: recommendationservice
 ---
 
 Application telemetry, such as the kind that OpenTelemetry can provide, is very

--- a/content/en/docs/instrumentation/cpp/exporters.md
+++ b/content/en/docs/instrumentation/cpp/exporters.md
@@ -1,7 +1,7 @@
 ---
 title: Exporters
 weight: 50
-cSpell:ignore: chrono jaegertracing millis ostream
+cSpell:ignore: chrono millis ostream
 ---
 
 <!-- markdownlint-disable no-duplicate-heading -->

--- a/content/en/docs/instrumentation/cpp/getting-started.md
+++ b/content/en/docs/instrumentation/cpp/getting-started.md
@@ -2,7 +2,7 @@
 title: Getting Started
 weight: 10
 # prettier-ignore
-cSpell:ignore: Bazel DBUILD devel DWITH helloworld libcurl openssl traceparent tracestate xcode
+cSpell:ignore: Bazel DBUILD devel DWITH helloworld libcurl openssl tracestate xcode
 ---
 
 Welcome to the OpenTelemetry C++ getting started guide! This guide will walk you

--- a/content/en/docs/instrumentation/erlang/exporters.md
+++ b/content/en/docs/instrumentation/erlang/exporters.md
@@ -1,7 +1,7 @@
 ---
 title: Exporters
 weight: 50
-cSpell:ignore: chrono jaegertracing millis ostream rebar relx
+cSpell:ignore: chrono millis ostream rebar relx
 ---
 
 In order to visualize and analyze your [traces](/docs/concepts/signals/traces/)

--- a/content/en/docs/instrumentation/go/exporters.md
+++ b/content/en/docs/instrumentation/go/exporters.md
@@ -2,7 +2,7 @@
 title: Exporters
 aliases: [/docs/instrumentation/go/exporting_data]
 weight: 50
-cSpell:ignore: errorf otlptrace otlptracehttp
+cSpell:ignore: otlptrace otlptracehttp
 ---
 
 In order to visualize and analyze your [traces](/docs/concepts/signals/traces/)

--- a/content/en/docs/instrumentation/go/getting-started.md
+++ b/content/en/docs/instrumentation/go/getting-started.md
@@ -1,7 +1,7 @@
 ---
 title: Getting Started
 weight: 10
-cSpell:ignore: chan codebases errorf fscanf println stdouttrace strconv struct
+cSpell:ignore: chan codebases fscanf println stdouttrace strconv struct
 ---
 
 Welcome to the OpenTelemetry for Go getting started guide! This guide will walk

--- a/content/en/docs/instrumentation/java/automatic/_index.md
+++ b/content/en/docs/instrumentation/java/automatic/_index.md
@@ -4,7 +4,7 @@ linkTitle: Automatic
 aliases:
   - /docs/java/automatic_instrumentation
   - /docs/instrumentation/java/automatic_instrumentation
-cSpell:ignore: Dotel javaagent myapp
+cSpell:ignore: Dotel myapp
 weight: 20
 ---
 

--- a/content/en/docs/instrumentation/java/automatic/agent-config.md
+++ b/content/en/docs/instrumentation/java/automatic/agent-config.md
@@ -2,14 +2,8 @@
 title: Agent Configuration
 linkTitle: Configuration
 weight: 10
-spelling:
-  cSpell:ignore akka autoconfiguration Autoconfiguration Dotel HSET javaagent
-  cSpell:ignore serverlessapis servlet Customizer classloaders logback
-  cSpell:ignore jdbc cassandra dbcp dubbo httpclient httpasyncclient myfaces
-  cSpell:ignore rocketmq armeria couchbase dropwizard mojarra vertx hikari
-  cSpell:ignore hikaricp jaxrs logmanager jaxws jboss jodd kotlinx hystrix vibur
-  cSpell:ignore okhttp oshi rabbitmq ratpack jedis rediscala redisson restlet
-  cSpell:ignore webflux webmvc spymemcached twilio finatra vaadin datasource
+# prettier-ignore
+cSpell:ignore: akka armeria autoconfiguration Autoconfiguration cassandra classloaders couchbase Customizer datasource dbcp Dotel dropwizard dubbo finatra hikari hikaricp HSET httpasyncclient httpclient hystrix jaxrs jaxws jboss jedis jodd kotlinx logback logmanager mojarra myfaces okhttp oshi rabbitmq ratpack rediscala redisson restlet rocketmq serverlessapis servlet spymemcached twilio vaadin vertx vibur webflux webmvc
 ---
 
 ## SDK Autoconfiguration

--- a/content/en/docs/instrumentation/java/getting-started.md
+++ b/content/en/docs/instrumentation/java/getting-started.md
@@ -2,7 +2,7 @@
 title: Getting Started
 description: Get telemetry for your app in less than 5 minutes!
 # prettier-ignore
-cSpell:ignore: aarch autoconfigure autoreconfigure darwin helloworld javaagent kotlin Nanos rolldice springframework webmvc
+cSpell:ignore: aarch autoconfigure autoreconfigure darwin helloworld Nanos rolldice springframework webmvc
 weight: 10
 ---
 

--- a/content/en/docs/instrumentation/js/automatic/module-config.md
+++ b/content/en/docs/instrumentation/js/automatic/module-config.md
@@ -2,7 +2,6 @@
 title: Automatic Instrumentation Configuration
 linkTitle: Configuration
 weight: 10
-cSpell:ignore: alibaba
 ---
 
 This module is highly configurable by setting

--- a/content/en/docs/instrumentation/js/exporters.md
+++ b/content/en/docs/instrumentation/js/exporters.md
@@ -1,7 +1,6 @@
 ---
 title: Exporters
 weight: 50
-cSpell:ignore: nginx openzipkin proto
 ---
 
 In order to visualize and analyze your traces, you will need to export them to a

--- a/content/en/docs/instrumentation/js/propagation.md
+++ b/content/en/docs/instrumentation/js/propagation.md
@@ -3,7 +3,7 @@ title: Propagation
 description: Context propagation for the JS SDK
 aliases: [/docs/instrumentation/js/api/propagation]
 weight: 65
-cSpell:ignore: traceparent tracestate
+cSpell:ignore: tracestate
 ---
 
 Propagation is the mechanism that moves data between services and processes.

--- a/content/en/docs/instrumentation/net/exporters.md
+++ b/content/en/docs/instrumentation/net/exporters.md
@@ -1,7 +1,6 @@
 ---
 title: Exporters
 weight: 50
-cSpell:ignore: dotnet openzipkin
 ---
 
 In order to visualize and analyze your [traces](/docs/concepts/signals/traces/)

--- a/content/en/docs/instrumentation/net/manual.md
+++ b/content/en/docs/instrumentation/net/manual.md
@@ -3,7 +3,6 @@ title: Manual Instrumentation
 linkTitle: Manual
 weight: 30
 description: Manual instrumentation for OpenTelemetry .NET
-cSpell:ignore: discoverability
 ---
 
 {{% docs/instrumentation/manual-intro %}}

--- a/content/en/docs/instrumentation/php/_index.md
+++ b/content/en/docs/instrumentation/php/_index.md
@@ -4,7 +4,7 @@ description: >-
   <img width="35" class="img-initial" src="/img/logos/32x32/PHP.svg" alt="PHP">
   A language-specific implementation of OpenTelemetry in PHP.
 weight: 21
-cSpell:ignore: autoload mbstring opcache packagist symfony zend
+cSpell:ignore: autoload mbstring opcache packagist symfony
 ---
 
 {{% docs/instrumentation/index-intro php /%}}

--- a/content/en/docs/instrumentation/php/automatic.md
+++ b/content/en/docs/instrumentation/php/automatic.md
@@ -3,7 +3,7 @@ title: Automatic Instrumentation
 linkTitle: Automatic
 weight: 20
 # prettier-ignore
-cSpell:ignore: autoload autoloading configurator democlass myapp packagist pecl phar shortcode tracecontext unindented userland
+cSpell:ignore: autoload autoloading configurator democlass myapp packagist pecl phar unindented userland
 ---
 
 Automatic instrumentation with PHP requires at least PHP 8.0, and the

--- a/content/en/docs/instrumentation/python/exporters.md
+++ b/content/en/docs/instrumentation/python/exporters.md
@@ -1,7 +1,7 @@
 ---
 title: Exporters
 weight: 50
-cSpell:ignore: LOWMEMORY proto
+cSpell:ignore: LOWMEMORY
 ---
 
 <!-- markdownlint-disable no-duplicate-heading -->

--- a/content/en/docs/instrumentation/ruby/exporters.md
+++ b/content/en/docs/instrumentation/ruby/exporters.md
@@ -1,7 +1,6 @@
 ---
 title: Exporters
 weight: 50
-cSpell:ignore: jaegertracing openzipkin Zipkin zipkin
 ---
 
 In order to visualize and analyze your traces, you will need to export them to a

--- a/content/en/docs/instrumentation/rust/_index.md
+++ b/content/en/docs/instrumentation/rust/_index.md
@@ -4,7 +4,7 @@ description: >-
   <img width="35" class="img-initial" src="/img/logos/32x32/Rust.svg"
   alt="Rust"> A language-specific implementation of OpenTelemetry in Rust.
 weight: 26
-cSpell:ignore: datadog dynatrace stackdriver
+cSpell:ignore: stackdriver
 ---
 
 {{% docs/instrumentation/index-intro rust /%}}

--- a/content/en/docs/kubernetes/helm/collector.md
+++ b/content/en/docs/kubernetes/helm/collector.md
@@ -1,11 +1,8 @@
 ---
 title: OpenTelemetry Collector Chart
 linkTitle: Collector Chart
-spelling:
-  cSpell:ignore statefulset kuberenetes filelogreceiver loggingexporter
-  cSpell:ignore filelogreceiver otlphttp sattributesprocessor kubelet
-  cSpell:ignore kubeletstatsreceiver sclusterreceiver sobjectsreceiver
-  cSpell:ignore hostmetricsreceiver
+# prettier-ignore
+cSpell:ignore: filelogreceiver filelogreceiver hostmetricsreceiver kubelet kubeletstatsreceiver kuberenetes loggingexporter otlphttp sattributesprocessor sclusterreceiver sobjectsreceiver statefulset
 ---
 
 ## Introduction

--- a/content/en/docs/migration/opentracing.md
+++ b/content/en/docs/migration/opentracing.md
@@ -1,7 +1,7 @@
 ---
 title: Migrating from OpenTracing
 linkTitle: OpenTracing
-cSpell:ignore: codebases opentracing
+cSpell:ignore: codebases
 weight: 2
 ---
 

--- a/scripts/normalize-cspell-front-matter.pl
+++ b/scripts/normalize-cspell-front-matter.pl
@@ -2,28 +2,68 @@
 
 use strict;
 use warnings;
+use JSON;
+use FileHandle;
 
 my @words;
 my $lineLenLimit = 79;
-my $last_file = "";
-my $last_line = "";
+my $last_file = '';
+my $last_line = '';
+my %dictionary = getSiteWideDictWords('.vscode/cspell.json', '.textlintrc.json');
 
 while (<>) {
-  if (/^(spelling: )?cSpell:ignore:? (.+)$/) {
+  if (/^\s*(spelling: |-\s*)?cSpell:ignore:?(.*)$/
+      || (/^(\s+)(\S.*)$/ && @words)
+  ) {
     push @words, split ' ', $2;
     next;
   }
 
   if (@words && ($ARGV ne $last_file || eof)) {
-    my $line = "cSpell:ignore: " . join(' ', sort {lc($a) cmp lc($b)} @words) . "\n";
-    # Only add `# prettier-ignore` if line is too long
-    print "# prettier-ignore\n" if length($line) > $lineLenLimit;
-    print $line;
-    @words = ();
+    @words = grep { !/^\s*(cSpell:ignore|spelling):?\s*$/ && !$dictionary{$_} } @words;
+    if (@words) {
+      my $words = join(' ', sort {lc($a) cmp lc($b)} @words);
+      my $line = "cSpell:ignore: $words\n";
+      # Only add `# prettier-ignore` if line is too long
+      print "# prettier-ignore\n" if length($line) > $lineLenLimit;
+      print $line;
+      @words = ();
+    }
   }
 
-  print unless /^# prettier-ignore$/;
+  print unless /^# prettier-ignore$/ || /^spelling:\s*[|>-]*$/;
 
   $last_line = $_;
   $last_file = $ARGV if eof;
+}
+
+sub getSiteWideDictWords {
+  my $dictionary_file = shift;
+  my $textlintrc_file = shift;
+
+  # Read the cspell.json file
+  my $fh = FileHandle->new($dictionary_file, "r") or die "Could not open file '$dictionary_file': $!";
+  my $json_text = join "", $fh->getlines();
+
+  # Remove JSON comments
+  $json_text =~ s/^\s*\/\/.*$//mg;
+
+  my $json = JSON->new;
+  my $data = $json->decode($json_text);
+  my %dictionary = map { $_ => 1 } @{ $data->{words} };
+
+  # Read the .textlintrc.json file
+  $fh = FileHandle->new($textlintrc_file, "r") or die "Could not open file '$textlintrc_file': $!";
+  $json_text = join "", $fh->getlines();
+
+  # Remove JSON comments
+  $json_text =~ s/^\s*\/\/.*$//mg;
+
+  $data = $json->decode($json_text);
+
+  # Add terms from .textlintrc.json to dictionary
+  my @terms = @{ $data->{rules}->{terminology}->{terms} };
+  @dictionary{@terms} = (1) x @terms;
+
+  return %dictionary;
 }


### PR DESCRIPTION
- Contributes to #3083
- Handles more corner cases. For example, see `content/en/blog/2022/go-web-app-instrumentation/index.md`
- Removes from the page-local list of words, any words that appear in the site-wide cSpell and textline config files
- Dang this is fast: it takes 1/3 of a second to run the normalization script on my machine. Nice!
