### PR TITLE
[CI] Clone submodules more deeply for `/fix:refache`

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -74,6 +74,7 @@ jobs:
     env:
       PR_NUM: ${{ github.event.issue.number }}
       COMMENT: ${{ github.event.comment.body }}
+      DEPTH: 100 # submodule clone depth
 
     steps:
       - name: Context info


### PR DESCRIPTION
`/fix:refcache` is still failing, for example: https://github.com/open-telemetry/opentelemetry.io/actions/runs/5693957168/job/15434151382: git can't find a submodule commit. The most likely reason is that we're doing shallow clones, so let's clone more deeply :). The number I use is arbitrary, but it should be sufficient for more than 80% of the cases.