### PR TITLE
Update header in k8s operator autoinstrumentation doc

### DIFF
--- a/content/en/docs/kubernetes/operator/automatic.md
+++ b/content/en/docs/kubernetes/operator/automatic.md
@@ -502,7 +502,7 @@ your auto-instrumentation. This can be the result of any of the following:
 Be sure to check the output of `kubectl get events` for any errors, as these
 might help point to the issue.
 
-### **4- Is the auto-instrumentation annotation correct?**
+### Is the auto-instrumentation annotation correct?
 
 Sometimes auto-instrumentation can fail due to errors in the
 auto-instrumentation annotation.


### PR DESCRIPTION
Fixes a mistype and bolding that we missed in review.

![image](https://github.com/open-telemetry/opentelemetry.io/assets/6309070/6e372a9b-f40e-4586-8078-383f68d141ff)
