### PR TITLE
[CI] fix:dict - ensure workflow fails if files have changed

### DIFF
--- a/.github/workflows/check-spelling.yml
+++ b/.github/workflows/check-spelling.yml
@@ -25,3 +25,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: npm run fix:dict
+      - name: Any changed files?
+        run: |
+          CHANGES=`git status --porcelain`
+          if [[ $CHANGES ]]; then
+            echo "Locally run `npm run fix:dict` and commit the changes:"
+            echo "$CHANGES"
+            exit 1
+          else
+            echo "All page-local dictionaries are well formatted."
+          fi

--- a/content/en/docs/collector/build-connector.md
+++ b/content/en/docs/collector/build-connector.md
@@ -1,9 +1,7 @@
 ---
 title: Building a Connector
-spelling:
-  cSpell:ignore spanmetrics servicegraph exampleconnector struct Errorf
-  cSpell:ignore mapstructure pdata mapstructure pmetric ptrace uber gord
-  cSpell:ignore gomod loggingexporter batchprocessor otlpreceiver Jaglowski
+# prettier-ignore
+cSpell:ignore: batchprocessor Errorf exampleconnector gomod gord Jaglowski loggingexporter mapstructure mapstructure otlpreceiver pdata pmetric ptrace servicegraph spanmetrics struct uber
 ---
 
 ## Connectors in OpenTelemetry


### PR DESCRIPTION
- Contributes to #3083
- Adds a check after running `fix:dict` to ensure that no files have been updated; if files have changed, the workflow fails and gives instructions
- ~**NOTE**: the action will fail now because some files don't have their dictionaries normalized~