### PR TITLE
[kubernetes] Add hostmetrics recevier doc

### DIFF
--- a/content/en/docs/kubernetes/collector/components.md
+++ b/content/en/docs/kubernetes/collector/components.md
@@ -669,15 +669,15 @@ subjects:
 | Deployment Pattern   | Usable                                                        |
 | -------------------- | ------------------------------------------------------------- |
 | DaemonSet (Agent)    | Preferred                                                     |
-| Deployment (Gateway) | but will only collect metrics from the node it is deployed on |
+| Deployment (Gateway) | Only collects metrics from the node it is deployed on |
 | Sidecar              | No                                                            |
 
 The Host Metrics Receiver collects metrics from a host using a variety of
-scrappers. There is some overlap with the
-[Kubeletstats Receiver](#kubeletstats-receiver) so if you decide to use both it
-may be worth it to disable these duplicate metrics.
+scrapers. There is some overlap with the
+[Kubeletstats Receiver](#kubeletstats-receiver) so if you decide to use both,
+it may be worth it to disable these duplicate metrics.
 
-In Kubernetes the receiver needs access to the `hostfs` volume to work properly.
+In Kubernetes, the receiver needs access to the `hostfs` volume to work properly.
 If you're using the [OpenTelemetry Collector Helm chart](../../helm/collector/)
 you can use the
 [`hostMetrics` preset](../../helm/collector/#host-metrics-preset) to get

--- a/content/en/docs/kubernetes/collector/components.md
+++ b/content/en/docs/kubernetes/collector/components.md
@@ -22,6 +22,7 @@ Components covered in this page:
   cluster-level metrics and entity events.
 - [Kubernetes Objects Receiver](#kubernetes-objects-receiver): collects objects,
   such as events, from the Kubernetes API server.
+- [Host Metrics Receiver](#host-metrics-receiver): scrapes host metrics from Kubernetes nodes.
 
 For application traces, metrics, or logs, we recommend the
 [OTLP receiver](https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/otlpreceiver),
@@ -661,3 +662,11 @@ subjects:
     name: otel-collector-opentelemetry-collector
     namespace: default
 ```
+
+## Host Metrics Receiver
+
+| Deployment Pattern   | Usable                                                   |
+| -------------------- | -------------------------------------------------------- |
+| DaemonSet (Agent)    | Preferred                   |
+| Deployment (Gateway) | but will only collect metrics from the node it is deployed on  |
+| Sidecar              | No                                                       |

--- a/content/en/docs/kubernetes/collector/components.md
+++ b/content/en/docs/kubernetes/collector/components.md
@@ -666,36 +666,39 @@ subjects:
 
 ## Host Metrics Receiver
 
-| Deployment Pattern   | Usable                                                        |
-| -------------------- | ------------------------------------------------------------- |
-| DaemonSet (Agent)    | Preferred                                                     |
-| Deployment (Gateway) | Only collects metrics from the node it is deployed on |
-| Sidecar              | No                                                            |
+| Deployment Pattern   | Usable                                                         |
+| -------------------- | -------------------------------------------------------------- |
+| DaemonSet (Agent)    | Preferred                                                      |
+| Deployment (Gateway) | Yes, but only collects metrics from the node it is deployed on |
+| Sidecar              | No                                                             |
 
 The Host Metrics Receiver collects metrics from a host using a variety of
 scrapers. There is some overlap with the
-[Kubeletstats Receiver](#kubeletstats-receiver) so if you decide to use both,
-it may be worth it to disable these duplicate metrics.
+[Kubeletstats Receiver](#kubeletstats-receiver) so if you decide to use both, it
+may be worth it to disable these duplicate metrics.
 
-In Kubernetes, the receiver needs access to the `hostfs` volume to work properly.
-If you're using the [OpenTelemetry Collector Helm chart](../../helm/collector/)
-you can use the
+In Kubernetes, the receiver needs access to the `hostfs` volume to work
+properly. If you're using the
+[OpenTelemetry Collector Helm chart](../../helm/collector/) you can use the
 [`hostMetrics` preset](../../helm/collector/#host-metrics-preset) to get
 started.
 
 The available scrapers are:
 
-| Scraper      | Supported OSs                | Description                                            |
-| ------------ | ---------------------------- | ------------------------------------------------------ |
-| [cpu]        | All except Mac<sup>[1]</sup> | CPU utilization metrics                                |
-| [disk]       | All except Mac<sup>[1]</sup> | Disk I/O metrics                                       |
-| [load]       | All                          | CPU load metrics                                       |
-| [filesystem] | All                          | File System utilization metrics                        |
-| [memory]     | All                          | Memory utilization metrics                             |
-| [network]    | All                          | Network interface I/O metrics & TCP connection metrics |
-| [paging]     | All                          | Paging/Swap space utilization and I/O metrics          |
-| [processes]  | Linux, Mac                   | Process count metrics                                  |
-| [process]    | Linux, Windows, Mac          | Per process CPU, Memory, and Disk I/O metrics          |
+| Scraper    | Supported OSs       | Description                                            |
+| ---------- | ------------------- | ------------------------------------------------------ |
+| cpu        | All except Mac[^1]  | CPU utilization metrics                                |
+| disk       | All except Mac[^1]  | Disk I/O metrics                                       |
+| load       | All                 | CPU load metrics                                       |
+| filesystem | All                 | File System utilization metrics                        |
+| memory     | All                 | Memory utilization metrics                             |
+| network    | All                 | Network interface I/O metrics & TCP connection metrics |
+| paging     | All                 | Paging/Swap space utilization and I/O metrics          |
+| processes  | Linux, Mac          | Process count metrics                                  |
+| process    | Linux, Windows, Mac | Per process CPU, Memory, and Disk I/O metrics          |
+
+[^1] Not supported on Mac when compiled without cgo, which is the default for
+the images released by the Collector SIG.
 
 For specific details about which metrics are collected and specific
 configuration details, see

--- a/content/en/docs/kubernetes/collector/components.md
+++ b/content/en/docs/kubernetes/collector/components.md
@@ -2,7 +2,7 @@
 title: Important Components for Kubernetes
 linkTitle: Components
 # prettier-ignore
-cSpell:ignore: containerd crio filelog gotime horizontalpodautoscalers iostream k8sattributes kubelet kubeletstats logtag replicasets replicationcontrollers resourcequotas statefulsets varlibdockercontainers varlogpods
+cSpell:ignore: containerd crio filelog gotime horizontalpodautoscalers hostfs hostmetrics iostream k8sattributes kubelet kubeletstats logtag replicasets replicationcontrollers resourcequotas statefulsets varlibdockercontainers varlogpods
 ---
 
 The [OpenTelemetry Collector](/docs/collector/) supports many different
@@ -22,7 +22,8 @@ Components covered in this page:
   cluster-level metrics and entity events.
 - [Kubernetes Objects Receiver](#kubernetes-objects-receiver): collects objects,
   such as events, from the Kubernetes API server.
-- [Host Metrics Receiver](#host-metrics-receiver): scrapes host metrics from Kubernetes nodes.
+- [Host Metrics Receiver](#host-metrics-receiver): scrapes host metrics from
+  Kubernetes nodes.
 
 For application traces, metrics, or logs, we recommend the
 [OTLP receiver](https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/otlpreceiver),
@@ -665,8 +666,87 @@ subjects:
 
 ## Host Metrics Receiver
 
-| Deployment Pattern   | Usable                                                   |
-| -------------------- | -------------------------------------------------------- |
-| DaemonSet (Agent)    | Preferred                   |
-| Deployment (Gateway) | but will only collect metrics from the node it is deployed on  |
-| Sidecar              | No                                                       |
+| Deployment Pattern   | Usable                                                        |
+| -------------------- | ------------------------------------------------------------- |
+| DaemonSet (Agent)    | Preferred                                                     |
+| Deployment (Gateway) | but will only collect metrics from the node it is deployed on |
+| Sidecar              | No                                                            |
+
+The Host Metrics Receiver collects metrics from a host using a variety of
+scrappers. There is some overlap with the
+[Kubeletstats Receiver](#kubeletstats-receiver) so if you decide to use both it
+may be worth it to disable these duplicate metrics.
+
+In Kubernetes the receiver needs access to the `hostfs` volume to work properly.
+If you're using the [OpenTelemetry Collector Helm chart](../../helm/collector/)
+you can use the
+[`hostMetrics` preset](../../helm/collector/#host-metrics-preset) to get
+started.
+
+The available scrapers are:
+
+| Scraper      | Supported OSs                | Description                                            |
+| ------------ | ---------------------------- | ------------------------------------------------------ |
+| [cpu]        | All except Mac<sup>[1]</sup> | CPU utilization metrics                                |
+| [disk]       | All except Mac<sup>[1]</sup> | Disk I/O metrics                                       |
+| [load]       | All                          | CPU load metrics                                       |
+| [filesystem] | All                          | File System utilization metrics                        |
+| [memory]     | All                          | Memory utilization metrics                             |
+| [network]    | All                          | Network interface I/O metrics & TCP connection metrics |
+| [paging]     | All                          | Paging/Swap space utilization and I/O metrics          |
+| [processes]  | Linux, Mac                   | Process count metrics                                  |
+| [process]    | Linux, Windows, Mac          | Per process CPU, Memory, and Disk I/O metrics          |
+
+For specific details about which metrics are collected and specific
+configuration details, see
+[Host Metrics Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver).
+
+If you need to configure the component yourself, make sure to mount the `hostfs`
+volume if you want to collect the node's metrics and not the container's.
+
+```yaml
+---
+apiVersion: apps/v1
+kind: DaemonSet
+...
+spec:
+  ...
+  template:
+    ...
+    spec:
+      ...
+      containers:
+        - name: opentelemetry-collector
+          ...
+          volumeMounts:
+            ...
+            - name: hostfs
+              mountPath: /hostfs
+              readOnly: true
+              mountPropagation: HostToContainer
+      volumes:
+        ...
+        - name: hostfs
+          hostPath:
+            path: /
+      ...
+```
+
+and then configure the Host Metrics Receiver to use the `volumeMount`:
+
+```yaml
+receivers:
+  hostmetrics:
+    root_path: /hostfs
+    collection_interval: 10s
+    scrapers:
+      cpu:
+      load:
+      memory:
+      disk:
+      filesystem:
+      network:
+```
+
+For more details about using the receiver in a container, see
+[Collecting host metrics from inside a container (Linux only)](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#collecting-host-metrics-from-inside-a-container-linux-only)

--- a/content/en/docs/kubernetes/collector/components.md
+++ b/content/en/docs/kubernetes/collector/components.md
@@ -734,8 +734,8 @@ The available scrapers are:
 
 | Scraper    | Supported OSs       | Description                                            |
 | ---------- | ------------------- | ------------------------------------------------------ |
-| cpu        | All except Mac\*    | CPU utilization metrics                                |
-| disk       | All except Mac\*    | Disk I/O metrics                                       |
+| cpu        | All except Mac[^1]  | CPU utilization metrics                                |
+| disk       | All except Mac[^1]  | Disk I/O metrics                                       |
 | load       | All                 | CPU load metrics                                       |
 | filesystem | All                 | File System utilization metrics                        |
 | memory     | All                 | Memory utilization metrics                             |
@@ -744,8 +744,9 @@ The available scrapers are:
 | processes  | Linux, Mac          | Process count metrics                                  |
 | process    | Linux, Windows, Mac | Per process CPU, Memory, and Disk I/O metrics          |
 
-\* Not supported on Mac when compiled without cgo, which is the default for the
-images released by the Collector SIG.
+[^1]:
+    Not supported on Mac when compiled without cgo, which is the default for the
+    images released by the Collector SIG.
 
 For specific details about which metrics are collected and specific
 configuration details, see

--- a/content/en/docs/kubernetes/collector/components.md
+++ b/content/en/docs/kubernetes/collector/components.md
@@ -734,8 +734,8 @@ The available scrapers are:
 
 | Scraper    | Supported OSs       | Description                                            |
 | ---------- | ------------------- | ------------------------------------------------------ |
-| cpu        | All except Mac[^1]  | CPU utilization metrics                                |
-| disk       | All except Mac[^1]  | Disk I/O metrics                                       |
+| cpu        | All except Mac\*    | CPU utilization metrics                                |
+| disk       | All except Mac\*    | Disk I/O metrics                                       |
 | load       | All                 | CPU load metrics                                       |
 | filesystem | All                 | File System utilization metrics                        |
 | memory     | All                 | Memory utilization metrics                             |
@@ -744,8 +744,8 @@ The available scrapers are:
 | processes  | Linux, Mac          | Process count metrics                                  |
 | process    | Linux, Windows, Mac | Per process CPU, Memory, and Disk I/O metrics          |
 
-[^1] Not supported on Mac when compiled without cgo, which is the default for
-the images released by the Collector SIG.
+\* Not supported on Mac when compiled without cgo, which is the default for the
+images released by the Collector SIG.
 
 For specific details about which metrics are collected and specific
 configuration details, see


### PR DESCRIPTION
Adds documentation for the host metrics receiver.

Related to https://github.com/open-telemetry/opentelemetry.io/issues/3005

---

**Preview**: https://deploy-preview-3118--opentelemetry.netlify.app/docs/kubernetes/collector/components/#prometheus-receiver