### PR TITLE
[CI] textlint workflow: use npm script for same coverage

### DIFF
--- a/.github/workflows/scripts/textlint.sh
+++ b/.github/workflows/scripts/textlint.sh
@@ -2,16 +2,16 @@
 
 # Run textlint and translate the JSON output into a format that provides file annotations for github PRs
 # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
-ERRORS=$(npx textlint -f json content/en/*.md | jq -r  '
-    .[] | 
-    ( .filePath | sub(env.PWD + "/"; "")  ) as $fp | 
-    .messages[] | 
+ERRORS=$(npm run --silent _check:text -- -f json | jq -r  '
+    .[] |
+    ( .filePath | sub(env.PWD + "/"; "")  ) as $fp |
+    .messages[] |
     .message as $message |
-    {line, file: $fp, column, endLine: .loc.end.line, endColumn: .loc.end.column, title: "textlint terminology error" } 
-    | . as $in 
-    | keys 
-    | map("\(.)=\($in[.])") 
-    | join(",") 
+    {line, file: $fp, column, endLine: .loc.end.line, endColumn: .loc.end.column, title: "textlint terminology error" }
+    | . as $in
+    | keys
+    | map("\(.)=\($in[.])")
+    | join(",")
     | "::error \(.)::\($message)" '
 )
 

--- a/content/en/docs/instrumentation/php/automatic.md
+++ b/content/en/docs/instrumentation/php/automatic.md
@@ -98,9 +98,10 @@ The extension can be installed via pecl,
    {{< tabpane lang=shell >}}
 
    {{< tab pecl >}}pecl install opentelemetry-beta{{< /tab >}}
+   <!-- prettier-ignore-start -->
 
    {{< tab pickle >}}php pickle.phar install opentelemetry{{< /tab >}}
-
+   <!-- prettier-ignore-end -->
    <!-- prettier-ignore -->
    {{< tab "php-extension-installer (docker)" >}}install-php-extensions opentelemetry{{< /tab >}}
 


### PR DESCRIPTION
- Closes #3119
- Uses `npm run _check:text` rather than raw call to textlint, so that we get the same files checked as when we run `check:text`
- ~**NOTE**: if all goes well, this PR's textlint action will report an error.~
- Adds ignore directives to a PHP file that textlint reports an issue on
