### PR TITLE
Rename .NET Core to .NET

### DIFF
--- a/content/en/docs/instrumentation/net/_index.md
+++ b/content/en/docs/instrumentation/net/_index.md
@@ -17,7 +17,7 @@ stable, the [OTLP Log Exporter][] is still non-stable.
 ## Version Support
 
 OpenTelemetry for .NET supports all officially supported versions of
-[.NET Core](https://dotnet.microsoft.com/download/dotnet-core) and
+[.NET](https://dotnet.microsoft.com/download/dotnet-core) and
 [.NET Framework](https://dotnet.microsoft.com/download/dotnet-framework) except
 for .NET Framework 3.5 SP1.
 

--- a/content/en/docs/instrumentation/net/_index.md
+++ b/content/en/docs/instrumentation/net/_index.md
@@ -17,7 +17,7 @@ stable, the [OTLP Log Exporter][] is still non-stable.
 ## Version Support
 
 OpenTelemetry for .NET supports all officially supported versions of
-[.NET](https://dotnet.microsoft.com/download/dotnet-core) and
+[.NET](https://dotnet.microsoft.com/download/dotnet) and
 [.NET Framework](https://dotnet.microsoft.com/download/dotnet-framework) except
 for .NET Framework 3.5 SP1.
 

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -1255,6 +1255,10 @@
     "StatusCode": 200,
     "LastSeen": "2023-06-29T15:46:44.824874-04:00"
   },
+  "https://dotnet.microsoft.com/download/dotnet": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-01T12:16:39.990619752Z"
+  },
   "https://dotnet.microsoft.com/download/dotnet-core": {
     "StatusCode": 200,
     "LastSeen": "2023-06-29T15:53:15.185132-04:00"


### PR DESCRIPTION
Rename .NET Core to .NET
.NET Core is legacy name and was renamed to .NET in 5.0 release