### PR TITLE
add links to demo services from getting started pages

### DIFF
--- a/content/en/docs/instrumentation/cpp/getting-started.md
+++ b/content/en/docs/instrumentation/cpp/getting-started.md
@@ -177,3 +177,7 @@ customized observability data.
 You'll also want to configure an appropriate exporter to
 [export your telemetry data](/docs/instrumentation/cpp/exporters) to one or more
 telemetry backends.
+
+If you'd like to explore a more complex example, take a look at the
+[OpenTelemetry Demo](/docs/demo/), which includes the C++ based
+[Currency Service](/docs/demo/services/currency/).

--- a/content/en/docs/instrumentation/erlang/getting-started.md
+++ b/content/en/docs/instrumentation/erlang/getting-started.md
@@ -585,3 +585,7 @@ Enrich your instrumentation with more
 You'll also want to configure an appropriate exporter to
 [export your telemetry data](/docs/instrumentation/erlang/exporters) to one or
 more telemetry backends.
+
+If you'd like to explore a more complex example, take a look at the
+[OpenTelemetry Demo](/docs/demo/), which includes the Erlang/Elixir based
+[Feature Flag Service](/docs/demo/services/feature-flag/).

--- a/content/en/docs/instrumentation/go/getting-started.md
+++ b/content/en/docs/instrumentation/go/getting-started.md
@@ -682,7 +682,7 @@ You'll also want to configure an appropriate exporter to
 telemetry backends.
 
 If you'd like to explore a more complex example, take a look at the
-[OpenTelemetry Demo](/docs/demo/), which includes the go based
+[OpenTelemetry Demo](/docs/demo/), which includes the Go based
 [Checkout Service](/docs/demo/services/feature-flag/),
 [Product Catalog Service](/docs/demo/services/product-catalog/) and
 [Accounting Service](/docs/demo/services/accounting/)

--- a/content/en/docs/instrumentation/go/getting-started.md
+++ b/content/en/docs/instrumentation/go/getting-started.md
@@ -681,6 +681,12 @@ You'll also want to configure an appropriate exporter to
 [export your telemetry data](/docs/instrumentation/go/exporters/) to one or more
 telemetry backends.
 
+If you'd like to explore a more complex example, take a look at the
+[OpenTelemetry Demo](/docs/demo/), which includes the go based
+[Checkout Service](/docs/demo/services/feature-flag/),
+[Product Catalog Service](/docs/demo/services/product-catalog/) and
+[Accounting Service](/docs/demo/services/accounting/)
+
 [`go.opentelemetry.io/otel/trace`]:
   https://pkg.go.dev/go.opentelemetry.io/otel/trace
 [`go.opentelemetry.io/otel/sdk`]:

--- a/content/en/docs/instrumentation/java/getting-started.md
+++ b/content/en/docs/instrumentation/java/getting-started.md
@@ -239,6 +239,9 @@ For more:
 - For light-weight customized telemetry, try [annotations][].
 - Learn about [manual instrumentation][] and try out more
   [examples](/docs/instrumentation/java/examples/).
+- Take a look at the [OpenTelemetry Demo](/docs/demo/), which includes Java
+  based [Ad Service](/docs/demo/services/ad/) and Kotlin based
+  [Fraud Detection Service](/docs/demo/services/fraud-detection/)
 
 [traces]: /docs/concepts/signals/traces/
 [metrics]: /docs/concepts/signals/metrics/

--- a/content/en/docs/instrumentation/js/getting-started/nodejs.md
+++ b/content/en/docs/instrumentation/js/getting-started/nodejs.md
@@ -471,6 +471,11 @@ You'll also want to configure an appropriate exporter to
 [export your telemetry data](/docs/instrumentation/js/exporters) to one or more
 telemetry backends.
 
+If you'd like to explore a more complex example, take a look at the
+[OpenTelemetry Demo](/docs/demo/), which includes the JavaScript based
+[Payment Service](/docs/demo/services/payment/) and the TypeScript based
+[Frontend Service](/docs/demo/services/frontend/).
+
 ## Troubleshooting
 
 Did something go wrong? You can enable diagnostic logging to validate that

--- a/content/en/docs/instrumentation/net/getting-started.md
+++ b/content/en/docs/instrumentation/net/getting-started.md
@@ -385,3 +385,7 @@ telemetry backends.
 You can also check the
 [automatic instrumentation for .NET](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation),
 which is currently in beta.
+
+If you'd like to explore a more complex example, take a look at the
+[OpenTelemetry Demo](/docs/demo/), which includes the .NET based
+[Cart Service](/docs/demo/services/cart/).

--- a/content/en/docs/instrumentation/php/getting-started.md
+++ b/content/en/docs/instrumentation/php/getting-started.md
@@ -492,6 +492,8 @@ For more:
 - Try [automatic instrumentation](../automatic/) on one of your own apps.
 - Learn more about [manual instrumentation][] and try out some
   [examples](/docs/instrumentation/php/examples/).
+- Take a look at the [OpenTelemetry Demo](/docs/demo/), which includes the PHP
+  based [Quote Service](/docs/demo/services/quote/).
 
 [traces]: /docs/concepts/signals/traces/
 [metrics]: /docs/concepts/signals/metrics/

--- a/content/en/docs/instrumentation/python/getting-started.md
+++ b/content/en/docs/instrumentation/python/getting-started.md
@@ -699,9 +699,14 @@ There's a lot more to manual instrumentation than just creating a child span. To
 learn details about initializing manual instrumentation and many more parts of
 the OpenTelemetry API you can use, see [Manual Instrumentation](../manual/).
 
-Finally, there are several options for exporting your telemetry data with
-OpenTelemetry. To learn how to export your data to a preferred backend, see
+There are several options for exporting your telemetry data with OpenTelemetry.
+To learn how to export your data to a preferred backend, see
 [Exporters](../exporters/).
+
+If you'd like to explore a more complex example, take a look at the
+[OpenTelemetry Demo](/docs/demo/), which includes the Python based
+[Recommendation Service](/docs/demo/services/recommendation/) and
+[Load Generator](/docs/demo/services/load-generator/).
 
 [traces]: /docs/concepts/signals/traces/
 [metrics]: /docs/concepts/signals/metrics/

--- a/content/en/docs/instrumentation/ruby/getting-started.md
+++ b/content/en/docs/instrumentation/ruby/getting-started.md
@@ -192,6 +192,8 @@ a few more features that will allow you gain even deeper insights!
   represents "something happening" during its lifetime.
 - [Manual instrumentation][manual] will give provide you the ability to enrich
   your traces with domain specific data.
+- [The OpenTelemetry Demo](/docs/demo/) includes the Ruby based
+  [Email Service](/docs/demo/services/email/).
 
 [traces]: /docs/concepts/signals/traces/
 [metrics]: /docs/concepts/signals/metrics/


### PR DESCRIPTION
@open-telemetry/docs-approvers & @open-telemetry/go-approvers  please take a look first, wdyt? I thought it would be nice to link from each language to the respective services within the demo