### PR TITLE
Add a warning to browser getting started

### DIFF
--- a/content/en/docs/instrumentation/js/_index.md
+++ b/content/en/docs/instrumentation/js/_index.md
@@ -11,6 +11,9 @@ weight: 20
 
 {{% docs/instrumentation/index-intro js /%}}
 
+{{% alert title="Warning" color="warning" %}}
+{{% _param notes.browser-instrumentation %}} {{% /alert %}}
+
 ## Further Reading
 
 - [OpenTelemetry for JavaScript on GitHub](https://github.com/open-telemetry/opentelemetry-js)

--- a/content/en/docs/instrumentation/js/getting-started/browser.md
+++ b/content/en/docs/instrumentation/js/getting-started/browser.md
@@ -5,10 +5,7 @@ weight: 20
 ---
 
 {{% alert title="Warning" color="warning" %}}
-
-Browser instrumentation **experimental**. If you are interested in helping out, see [Contributing](https://github.com/open-telemetry/opentelemetry-js#contributing).
-
-{{% /alert %}}
+{{% _param notes.browser-instrumentation %}} {{% /alert %}}
 
 While this guide uses the example application presented below, the steps to
 instrument your own application should be similar.

--- a/content/en/docs/instrumentation/js/getting-started/browser.md
+++ b/content/en/docs/instrumentation/js/getting-started/browser.md
@@ -6,12 +6,7 @@ weight: 20
 
 {{% alert title="Warning" color="warning" %}}
 
-Instrumentation for the browser is experimental and this is mostly unspecified:
-this may break in the future. If you want to help changing that, you can join
-the Client Instrumentation SIG on CNCF Slack channel
-[#otel-client-side-telemetry](https://cloud-native.slack.com/archives/C0239SYARD2)
-or by attending
-[their meetings](https://docs.google.com/document/d/16Vsdh-DM72AfMg_FIt9yT9ExEWF4A_vRbQ3jRNBe09w/edit)
+Browser instrumentation **experimental**. If you are interested in helping out, see [Contributing](https://github.com/open-telemetry/opentelemetry-js#contributing).
 
 {{% /alert %}}
 

--- a/content/en/docs/instrumentation/js/getting-started/browser.md
+++ b/content/en/docs/instrumentation/js/getting-started/browser.md
@@ -4,6 +4,17 @@ aliases: [/docs/js/getting_started/browser]
 weight: 20
 ---
 
+{{% alert title="Warning" color="warning" %}}
+
+Instrumentation for the browser is experimental and this is mostly unspecified:
+this may break in the future. If you want to help changing that, you can join
+the Client Instrumentation SIG on CNCF Slack channel
+[#otel-client-side-telemetry](https://cloud-native.slack.com/archives/C0239SYARD2)
+or by attending
+[their meetings](https://docs.google.com/document/d/16Vsdh-DM72AfMg_FIt9yT9ExEWF4A_vRbQ3jRNBe09w/edit)
+
+{{% /alert %}}
+
 While this guide uses the example application presented below, the steps to
 instrument your own application should be similar.
 

--- a/content/en/docs/instrumentation/js/manual.md
+++ b/content/en/docs/instrumentation/js/manual.md
@@ -332,15 +332,7 @@ above, you have a `TracerProvider` setup for you already. You can continue with
 #### Browser
 
 {{% alert title="Warning" color="warning" %}}
-
-Instrumentation for the browser is experimental and this is mostly unspecified:
-this may break in the future. If you want to help changing that, you can join
-the Client Instrumentation SIG on CNCF Slack channel
-[#otel-client-side-telemetry](https://cloud-native.slack.com/archives/C0239SYARD2)
-or by attending
-[their meetings](https://docs.google.com/document/d/16Vsdh-DM72AfMg_FIt9yT9ExEWF4A_vRbQ3jRNBe09w/edit)
-
-{{% /alert %}}
+{{% _param notes.browser-instrumentation %}} {{% /alert %}}
 
 First, ensure you've got the right packages:
 

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -171,6 +171,9 @@ params:
     docker-compose-v2: |
       `docker-compose` is deprecated. For details, see
       [Migrate to Compose V2](https://docs.docker.com/compose/migrate/).
+    browser-instrumentation: |
+      Client instrumentation for the browser is **experimental** and mostly **unspecified**. If you are interested in 
+      helping out, get in touch with the [Client Instrumentation SIG](https://docs.google.com/document/d/16Vsdh-DM72AfMg_FIt9yT9ExEWF4A_vRbQ3jRNBe09w/edit)
 
 services:
   googleAnalytics:


### PR DESCRIPTION
We have the same warning now for [Manual instrumentation - Browser](https://opentelemetry.io/docs/instrumentation/js/manual/#browser), I think the [getting started](https://opentelemetry.io/docs/instrumentation/js/getting-started/browser/) should have it as well, because at least I get ~weekly questions around OTel for browser/mobile/etc.