### PR TITLE
Add examples link to swift docs

### DIFF
--- a/content/en/docs/instrumentation/swift/_index.md
+++ b/content/en/docs/instrumentation/swift/_index.md
@@ -12,4 +12,3 @@ weight: 28
 
 - [OpenTelemetry for Swift on GitHub](https://github.com/open-telemetry/opentelemetry-swift)
 - [Installation](https://github.com/open-telemetry/opentelemetry-swift#installation)
-- [Examples](https://github.com/open-telemetry/opentelemetry-swift/tree/main/Examples)

--- a/content/en/docs/instrumentation/swift/examples.md
+++ b/content/en/docs/instrumentation/swift/examples.md
@@ -1,0 +1,7 @@
+---
+title: Examples
+redirect: https://github.com/open-telemetry/opentelemetry-swift/tree/main/Examples
+manualLinkTarget: _blank
+_build: { render: link }
+weight: 220
+---


### PR DESCRIPTION
Adding this for completeness & consistency with other languages