### PR TITLE
Fix broken links to JS library instrumentation page

### DIFF
--- a/content/en/blog/2023/end-user-discussions-03.md
+++ b/content/en/blog/2023/end-user-discussions-03.md
@@ -192,7 +192,7 @@ agent to the host metrics receiver for infrastructure monitoring.
   that are used by applications. Auto-instrumentation is also available for
   [Python](/docs/instrumentation/python/automatic/),
   [.NET](/docs/instrumentation/net/automatic/), and
-  [Node.js](/docs/instrumentation/js/libraries/#node-autoinstrumentation-package).
+  [Node.js](/docs/instrumentation/js/automatic).
 - If you’re using Kubernetes, they can use the
   [OTel operator](https://github.com/open-telemetry/opentelemetry-operator),
   which takes care of instrumentations for applications deployed on K8s. The

--- a/content/en/docs/kubernetes/operator/automatic.md
+++ b/content/en/docs/kubernetes/operator/automatic.md
@@ -272,7 +272,7 @@ image you must either supply your own image that includes only the packages you
 want or use manual instrumentation.
 
 For more details, see
-[Node.js auto-instrumentation](/docs/instrumentation/js/libraries/#node-autoinstrumentation-package).
+[Node.js auto-instrumentation](/docs/instrumentation/js/libraries/#registration).
 
 ### Python
 


### PR DESCRIPTION
follow up to #2988 there are 2 references to an anchor that doesn't exist anymore

https://github.com/open-telemetry/opentelemetry.io/actions/runs/5823034717/job/15789009119

```
htmltest started at 03:25:00 on public
========================================================================
docs/kubernetes/operator/automatic/index.html
  hash does not exist --- docs/kubernetes/operator/automatic/index.html --> /docs/instrumentation/js/libraries/#node-autoinstrumentation-package
docs/specs/otel/logs/supplementary-guidelines/index.html
  hitting --- docs/specs/otel/logs/supplementary-guidelines/index.html --> https://javadoc.io/doc/org.apache.logging.log4j/log4j-api/latest/org.apache.logging.log4j/org/apache/logging/log4j/Logger.html
blog/2023/end-user-discussions-03/index.html
  hash does not exist --- blog/2023/end-user-discussions-03/index.html --> /docs/instrumentation/js/libraries/#node-autoinstrumentation-package
========================================================================
✘✘✘ failed in 48.935641881s
```