### PR TITLE
Registry - fix link for .NET AWS Instrumentation package

### DIFF
--- a/data/registry/instrumentation-dotnet-instrumentation-aws.yml
+++ b/data/registry/instrumentation-dotnet-instrumentation-aws.yml
@@ -6,7 +6,7 @@ tags:
   - instrumentation-aws
   - instrumentation
   - dotnet
-repo: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Contrib.Instrumentation.AWS
+repo: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.AWS
 license: Apache 2.0
 description: AWS SDK client instrumentation for OpenTelemetry .NET
 authors: OpenTelemetry Authors


### PR DESCRIPTION
Based on https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1275