### PR TITLE
[CI] Set user info before calling git cmd in fix:refcache

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -51,10 +51,10 @@ jobs:
 
       - name: Commit and push changes, if any
         run: |
+          git config --local user.email "$USER_EMAIL"
+          git config --local user.name "$USER_NAME"
           if [[ $(git status --porcelain) ]]; then
             git add -A
-            git config --local user.email "$USER_EMAIL"
-            git config --local user.name "$USER_NAME"
             current_branch=$(git rev-parse --abbrev-ref HEAD)
             echo current_branch=$current_branch
             git commit -m 'Results from /fix:format'


### PR DESCRIPTION
- Contributes to #3122
- Fixes "Please tell me who you are" error reported by git; e.g., see https://github.com/open-telemetry/opentelemetry.io/actions/runs/5833875186/job/15822229807