### PR TITLE
Upgrade Hugo to 0.117.0

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -2,7 +2,7 @@
 baseURL: https://opentelemetry.io
 title: &title OpenTelemetry
 description: &desc The OpenTelemetry Project Site
-disableKinds: [taxonomy, taxonomyTerm]
+disableKinds: [taxonomy]
 theme: [docsy]
 disableAliases: true # We do redirects via Netlify's _redirects file
 enableGitInfo: true
@@ -173,7 +173,7 @@ params:
       [Migrate to Compose V2](https://docs.docker.com/compose/migrate/).
     browser-instrumentation: |
       Client instrumentation for the browser is **experimental** and mostly **unspecified**.
-      If you are interested in helping out, get in touch with the 
+      If you are interested in helping out, get in touch with the
       [Client Instrumentation SIG](https://docs.google.com/document/d/16Vsdh-DM72AfMg_FIt9yT9ExEWF4A_vRbQ3jRNBe09w).
 
 services:

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "autoprefixer": "^10.4.14",
     "cspell": "^6.31.1",
     "gulp": "^4.0.2",
-    "hugo-extended": "0.115.4",
+    "hugo-extended": "0.117.0",
     "markdownlint": "^0.29.0",
     "npm-run-all": "^4.1.5",
     "postcss-cli": "^10.1.0",


### PR DESCRIPTION
The only changes in the generated files are minor: they have to do with syntax highlighting (styling correction):

```console
$ git diff -bw --ignore-blank-lines -I "Hugo 0.11" | grep ^diff | grep -v \.xml | grep -v site
diff --git a/blog/2022/exponential-histograms/index.html b/blog/2022/exponential-histograms/index.html
diff --git a/docs/demo/services/ad/index.html b/docs/demo/services/ad/index.html
diff --git a/docs/instrumentation/java/getting-started/index.html b/docs/instrumentation/java/getting-started/index.html
diff --git a/docs/instrumentation/java/manual/index.html b/docs/instrumentation/java/manual/index.html
$ git diff -bw --ignore-blank-lines -I "Hugo 0.11" -I "display:flex" | grep ^diff | grep -v \.xml | grep -v site
$
```