### PR TITLE
Improve erlang/elixir config examples

### DIFF
--- a/content/en/docs/instrumentation/erlang/resources.md
+++ b/content/en/docs/instrumentation/erlang/resources.md
@@ -33,14 +33,14 @@ Application configuration:
 
 ```erlang
 %% sys.config
-{resource_detectors, [otel_resource_env_var, otel_resource_app_env]}
+{opentelemetry, {resource_detectors, [otel_resource_env_var, otel_resource_app_env]}}
 ```
 
 {{% /tab %}} {{% tab Elixir %}}
 
 ```elixir
 ## runtime.exs
-resource_detectors: [:otel_resource_env_var, :otel_resource_app_env]
+config :opentelemetry, resource_detectors: [:otel_resource_env_var, :otel_resource_app_env]
 ```
 
 {{% /tab %}} {{< /tabpane >}}
@@ -74,14 +74,14 @@ Alternatively, use the `resource` Application environment under the
 
 ```erlang
 %% sys.config
-{resource, #{deployment => #{environment => <<"development">>}}
+{opentelemetry, {resource, #{deployment => #{environment => <<"development">>}}}}
 ```
 
 {{% /tab %}} {{% tab Elixir %}}
 
 ```elixir
 ## runtime.exs
-resource: %{deployment: %{environment: "development" }}
+config :opentelemetry, resource: %{deployment: %{environment: "development" }}
 ```
 
 {{% /tab %}} {{< /tabpane >}}

--- a/content/en/docs/instrumentation/erlang/sampling.md
+++ b/content/en/docs/instrumentation/erlang/sampling.md
@@ -62,22 +62,22 @@ Traces and using the parent decision in the other cases:
 
 ```erlang
 %% config/sys.config.src
-{sampler, {parent_based, #{root => {trace_id_ratio_based, 0.10},
-                           remote_parent_sampled => always_on,
-                           remote_parent_not_sampled => always_off,
-                           local_parent_sampled => always_on,
-                           local_parent_not_sampled => always_off}}}
+{opentelemetry, {sampler, {parent_based, #{root => {trace_id_ratio_based, 0.10},
+                                          remote_parent_sampled => always_on,
+                                          remote_parent_not_sampled => always_off,
+                                          local_parent_sampled => always_on,
+                                          local_parent_not_sampled => always_off}}}}
 ```
 
 {{% /tab %}} {{% tab Elixir %}}
 
 ```elixir
 # config/runtime.exs
-sampler: {:parent_based, %{root: {:trace_id_ratio_based, 0.10},
-                           remote_parent_sampled: :always_on,
-                           remote_parent_not_sampled: :always_off,
-                           local_parent_sampled: :always_on,
-                           local_parent_not_sampled: :always_off}}
+config :opentelemetry, sampler: {:parent_based, %{root: {:trace_id_ratio_based, 0.10},
+                                                  remote_parent_sampled: :always_on,
+                                                  remote_parent_not_sampled: :always_off,
+                                                  local_parent_sampled: :always_on,
+                                                  local_parent_not_sampled: :always_off}}
 
 ```
 
@@ -112,22 +112,22 @@ always samples and using the parent decision in the other cases:
 
 ```erlang
 %% config/sys.config.src
-{sampler, {parent_based, #{root => always_on,
-                           remote_parent_sampled => always_on,
-                           remote_parent_not_sampled => always_off,
-                           local_parent_sampled => always_on,
-                           local_parent_not_sampled => always_off}}}
+{opentelemetry, {sampler, {parent_based, #{root => always_on,
+                                          remote_parent_sampled => always_on,
+                                          remote_parent_not_sampled => always_off,
+                                          local_parent_sampled => always_on,
+                                          local_parent_not_sampled => always_off}}}}
 ```
 
 {{% /tab %}} {{% tab Elixir %}}
 
 ```elixir
 # config/runtime.exs
-sampler: {:parent_based, %{root: :always_on,
-                           remote_parent_sampled: :always_on,
-                           remote_parent_not_sampled: :always_off,
-                           local_parent_sampled: :always_on,
-                           local_parent_not_sampled: :always_off}}
+config :opentelemetry, sampler: {:parent_based, %{root: :always_on,
+                                                  remote_parent_sampled: :always_on,
+                                                  remote_parent_not_sampled: :always_off,
+                                                  local_parent_sampled: :always_on,
+                                                  local_parent_not_sampled: :always_off}}
 
 ```
 
@@ -207,13 +207,13 @@ URL requested is `/healthcheck`:
 {{< tabpane text=true langEqualsHeader=true >}} {{% tab Erlang %}}
 
 ```erlang
-{sampler, {attributes_sampler, #{'http.target' => <<"/healthcheck">>}}}
+{opentelemetry, {sampler, {attributes_sampler, #{'http.target' => <<"/healthcheck">>}}}}
 ```
 
 {{% /tab %}} {{% tab Elixir %}}
 
 ```elixir
-sampler: {AttributesSampler, %{"http.target": "/healthcheck"}}
+config :opentelemetry, sampler: {AttributesSampler, %{"http.target": "/healthcheck"}}
 ```
 
 {{% /tab %}} {{< /tabpane >}}


### PR DESCRIPTION
Adding the OTP app name to the config examples so that they can simply be copy/pasted and don't cause any confusion. 