### PR TITLE
Add missing link to demo architecture diagram

### DIFF
--- a/content/en/docs/demo/architecture.md
+++ b/content/en/docs/demo/architecture.md
@@ -41,13 +41,15 @@ loadgenerator -->|HTTP| frontendproxy
 
 accountingservice -->|TCP| queue
 
+cartservice --->|gRPC| featureflagservice
+
 checkoutservice --->|gRPC| cartservice --> cache
 checkoutservice --->|gRPC| productcatalogservice
 checkoutservice --->|gRPC| currencyservice
 checkoutservice --->|HTTP| emailservice
 checkoutservice --->|gRPC| paymentservice
 checkoutservice -->|gRPC| shippingservice
-checkoutservice ---->|TCP| queue
+checkoutservice --->|TCP| queue
 
 frontend -->|gRPC| adservice
 frontend -->|gRPC| cartservice
@@ -59,7 +61,7 @@ frontend -->|gRPC| shippingservice -->|HTTP| quoteservice
 
 frauddetectionservice -->|TCP| queue
 
-adservice -->|gRPC| featureflagservice
+adservice --->|gRPC| featureflagservice
 
 productcatalogservice -->|gRPC| featureflagservice
 


### PR DESCRIPTION
The cartservice calls the featureflagservice (see open-telemetry/opentelemetry-demo#824). This adds a gRPC link between those services. I adjusted a couple link lengths to try to get a cleaner diagram.

![image](https://github.com/open-telemetry/opentelemetry.io/assets/7519484/09aa3d99-21cf-4109-9069-e6ccaa5c8a4c)
