### PR TITLE
[CI] Use Perl Core module JSON::PP

### DIFF
--- a/scripts/normalize-cspell-front-matter.pl
+++ b/scripts/normalize-cspell-front-matter.pl
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use JSON;
+use JSON::PP;
 use FileHandle;
 
 my @words;
@@ -48,7 +48,7 @@ sub getSiteWideDictWords {
   # Remove JSON comments
   $json_text =~ s/^\s*\/\/.*$//mg;
 
-  my $json = JSON->new;
+  my $json = JSON::PP->new;
   my $data = $json->decode($json_text);
   my %dictionary = map { $_ => 1 } @{ $data->{words} };
 


### PR DESCRIPTION
- Closes #3187
- Contributes to #3122
- Switches to using the core Perl module `JSON::PP` instead of `JSON`
- I tested this on GitPod (which doesn't have the `JSON` module installed by default), and it works.
- @julianocosta89 - if you still have issues, I'll find another solution.
