### PR TITLE
Update Logging signal status for Rust to alpha

### DIFF
--- a/data/instrumentation.yaml
+++ b/data/instrumentation.yaml
@@ -62,7 +62,7 @@ rust:
   status:
     traces: beta
     metrics: alpha
-    logs: not yet implemented
+    logs: alpha
 swift:
   name: Swift
   status:


### PR DESCRIPTION
Logging support got added in the most recent release. https://github.com/open-telemetry/opentelemetry-rust#project-status