### PR TITLE
Update Lightstep name on vendors page

### DIFF
--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -125,7 +125,7 @@
   contact: ''
   oss: false
   commercial: true
-- name: Lightstep
+- name: ServiceNow Cloud Observability (Lightstep)
   distribution: true
   nativeOTLP: true
   url: 'https://github.com/lightstep?q=launcher'


### PR DESCRIPTION
Lightstep is now part of ServiceNow, and the official name is "ServiceNow Cloud Observability".