### PR TITLE
Update JRuby support alert

### DIFF
--- a/content/en/docs/instrumentation/ruby/getting-started.md
+++ b/content/en/docs/instrumentation/ruby/getting-started.md
@@ -19,14 +19,8 @@ Ensure that you have the following installed locally:
 - MRI Ruby >= `3.0`, jruby >= `9.3.2.0`, or truffleruby >= 22.1
 - [Bundler](https://bundler.io/)
 
-{{% alert  title="Warning" color="warning" %}} `jruby` only targets
-compatibility with MRI Ruby 2.6.8, which is EOL. This project does not
-officially support MRI Ruby 2.6.8, and provides `jruby` support on a best-effort
-basis until the `jruby` project supports compatibility with more modern Ruby
-runtimes.
-
-While tested, support for `truffleruby` is on a best-effort basis at this time.
-{{% /alert %}}
+{{% alert  title="Warning" color="warning" %}} While tested, support for `jruby`
+and `truffleruby` are on a best-effort basis at this time. {{% /alert %}}
 
 ## Example Application
 


### PR DESCRIPTION
The previous alert stated the latest JRuby version was mapped to Ruby 2.6.8. This is no longer true. The latest version, 9.4.3.0, maps to Ruby 3.1. This is the version the CI uses.