### PR TITLE
fix typo in signals:metrics

### DIFF
--- a/content/en/docs/concepts/signals/metrics.md
+++ b/content/en/docs/concepts/signals/metrics.md
@@ -4,8 +4,8 @@ weight: 2
 ---
 
 A **metric** is a **measurement** of a service captured at runtime. The moment
-of capturing a measurements is known as a **metric event**, which consists not
-only of the measurement itself, but also the time at which it was captured and
+of capturing a measurement is known as a **metric event**, which consists of
+not only the measurement itself but also the time at which it was captured and
 associated metadata.
 
 Application and request metrics are important indicators of availability and


### PR DESCRIPTION
`measurements` -> `measurement` to maintain the singular/plural agreement.