### PR TITLE
Fix incorrect reference of AttributeKey.stringKey

### DIFF
--- a/content/en/docs/instrumentation/java/manual.md
+++ b/content/en/docs/instrumentation/java/manual.md
@@ -610,7 +610,7 @@ LongCounter counter = meter
       .build();
 
 // It is recommended that the API user keep a reference to Attributes they will record against
-Attributes attributes = Attributes.of(stringKey("Key"), "SomeWork");
+Attributes attributes = Attributes.of(AttributeKey.stringKey("Key"), "SomeWork");
 
 // Record data
 counter.add(123, attributes);
@@ -625,7 +625,7 @@ meter
   .setDescription("CPU Usage")
   .setUnit("ms")
   .buildWithCallback(measurement -> {
-    measurement.record(getCpuUsage(), Attributes.of(stringKey("Key"), "SomeWork"));
+    measurement.record(getCpuUsage(), Attributes.of(AttributeKey.stringKey("Key"), "SomeWork"));
   });
 ```
 


### PR DESCRIPTION
## Context

The example code in the [Java Manual metrics documentation](https://opentelemetry.io/docs/instrumentation/java/manual/#metrics) simply doesn't compile.

It doesn't compile because of the incorrect reference to `stringKey`, a non-existent function.

This PR should fix that as `AttributeKey.stringKey` is used above and in many other places in the same doc.

```java
  // Right, stringKey comes from AttributeKey
  Attributes attributes_right = Attributes.of(AttributeKey.stringKey(message), "SomeWork");        
  
  // Wrong, stringKey is not defined
  Attributes attributes_wrong = Attributes.of(stringKey(message), "SomeWork");
```   
     