### PR TITLE
`GitHub` adjusted to the correct name

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,15 @@ Put assets, if any, like images into the folder created.
 
 Once your post is ready, submit it through a [pull request][].
 
-### Using the Github UI
+### Using the GitHub UI
 
 - Go to the [blog post template](archetypes/blog.md) and click on
-  `Copy raw content` at the top right of the menu
-- [Create a new file](https://github.com/open-telemetry/opentelemetry.io/new/main)
-- Paste the content from the template
+  `Copy raw content` at the top right of the menu.
+- [Create a new file](https://github.com/open-telemetry/opentelemetry.io/new/main).
+- Paste the content from the template.
 - Name your file, e.g.
   `content/en/blog/2022/short-name-for-your-blog-post/index.md`
-- Start editing the markdown file
+- Start editing the markdown file.
 - Once your post is ready click on `Propose changes` at the bottom.
 
 ## Contributing

--- a/content/en/blog/2022/go-web-app-instrumentation/index.md
+++ b/content/en/blog/2022/go-web-app-instrumentation/index.md
@@ -410,7 +410,7 @@ further investigate on your own:
 ## Summary
 
 That’s all folks! We hope this guide was informative and easy to follow. You can
-find all files ready to use in our Github
+find all files ready to use in our GitHub
 [repository](https://github.com/aspecto-io/opentelemetry-examples/tree/master/go).
 
 _A version of this article was [originally posted][] on the Aspecto blog._

--- a/content/en/blog/2023/end-user-discussions-03.md
+++ b/content/en/blog/2023/end-user-discussions-03.md
@@ -247,7 +247,7 @@ CNCF’s Slack instance.
 
 **Q:** Where do you go to find documentation and answers to your questions?
 
-**A:** We have many resources, including official documentation and Github
+**A:** We have many resources, including official documentation and GitHub
 repositories.
 
 To help us improve our resources, it would be helpful to gather feedback from


### PR DESCRIPTION
The correct name for GitHub is indeed "GitHub," and it should be adjusted to its proper trademarked name.
Ref: [GitHub](https://github.com/),[GitHub Wiki](https://en.wikipedia.org/wiki/GitHub)