### PR TITLE
Update Code of Conduct from CNCF

### DIFF
--- a/content/en/docs/contribution-guidelines.md
+++ b/content/en/docs/contribution-guidelines.md
@@ -39,4 +39,4 @@ current information.
 ## Code of conduct
 
 OpenTelemetry follows the
-[CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+[CNCF Community Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).


### PR DESCRIPTION
Update reference to CNCF Community Code of Conduct

In this commit, we have updated the reference to the CNCF Community Code of Conduct to use the main branch URL. This ensures that we are following the latest version of the code of conduct.
