### PR TITLE
Update Hugo to 0.118.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "autoprefixer": "^10.4.15",
     "cspell": "^7.0.0",
     "gulp": "^4.0.2",
-    "hugo-extended": "0.117.0",
+    "hugo-extended": "0.118.2",
     "markdownlint": "^0.30.0",
     "postcss-cli": "^10.1.0",
     "prettier": "^3.0.1",


### PR DESCRIPTION
The latest version has been released, follow the upstream update version information.
Hugo [Releases v0.118.2](https://github.com/gohugoio/hugo/releases) .