### PR TITLE
Fix error in `defaultInterval`

### DIFF
--- a/content/en/docs/collector/trace-receiver.md
+++ b/content/en/docs/collector/trace-receiver.md
@@ -438,7 +438,7 @@ file:
 ```go
 func createDefaultConfig() component.Config {
 	return &Config{
-		Interval: string(defaultInterval),
+		Interval: defaultInterval.String(),
 	}
 }
 ```
@@ -465,7 +465,7 @@ const (
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		Interval: string(defaultInterval),
+		Interval: defaultInterval.String(),
 	}
 }
 
@@ -578,7 +578,7 @@ const (
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		Interval: string(defaultInterval),
+		Interval: defaultInterval.String(),
 	}
 }
 
@@ -1052,7 +1052,7 @@ const (
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		Interval: string(defaultInterval),
+		Interval: defaultInterval.String(),
 	}
 }
 


### PR DESCRIPTION
Converting Time.Duration into string must use the https://pkg.go.dev/time#Duration.String function.

Steps to reproduce the issue: run ./otelcol-dev --config config.yaml with no defaultInterval : the program raises an invalid value for defaultInterval but the setting should be optional.