### PR TITLE
Update otlp-exporter-configuration.md

### DIFF
--- a/content/en/docs/concepts/sdk-configuration/otlp-exporter-configuration.md
+++ b/content/en/docs/concepts/sdk-configuration/otlp-exporter-configuration.md
@@ -35,8 +35,8 @@ and logs, the following URLs are constructed from the example above:
 
 ### `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
 
-Endpoint URL for trace data only, with an optionally-specified port number. Typically
-ends with `v1/traces` when using OTLP/HTTP.
+Endpoint URL for trace data only, with an optionally-specified port number.
+Typically ends with `v1/traces` when using OTLP/HTTP.
 
 **Default value:**
 
@@ -69,8 +69,8 @@ Typically ends with `v1/metrics` when using OTLP/HTTP.
 
 ### `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`
 
-Endpoint URL for log data only, with an optionally-specified port number. Typically
-ends with `v1/logs` when using OTLP/HTTP.
+Endpoint URL for log data only, with an optionally-specified port number.
+Typically ends with `v1/logs` when using OTLP/HTTP.
 
 **Default value:**
 

--- a/content/en/docs/concepts/sdk-configuration/otlp-exporter-configuration.md
+++ b/content/en/docs/concepts/sdk-configuration/otlp-exporter-configuration.md
@@ -35,8 +35,8 @@ and logs, the following URLs are constructed from the example above:
 
 ### `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
 
-Endpoint URL for trace data only, with an optionally-specified port number. Must
-end with `v1/traces` if using OTLP/HTTP.
+Endpoint URL for trace data only, with an optionally-specified port number. Typically
+ends with `v1/traces` when using OTLP/HTTP.
 
 **Default value:**
 
@@ -53,7 +53,7 @@ end with `v1/traces` if using OTLP/HTTP.
 ### `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`
 
 Endpoint URL for metric data only, with an optionally-specified port number.
-Must end with `v1/metrics` if using OTLP/HTTP.
+Typically ends with `v1/metrics` when using OTLP/HTTP.
 
 **Default value:**
 
@@ -69,8 +69,8 @@ Must end with `v1/metrics` if using OTLP/HTTP.
 
 ### `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`
 
-Endpoint URL for log data only, with an optionally-specified port number. Must
-end with `v1/logs` if using OTLP/HTTP.
+Endpoint URL for log data only, with an optionally-specified port number. Typically
+ends with `v1/logs` when using OTLP/HTTP.
 
 **Default value:**
 


### PR DESCRIPTION
This relaxes the wording around path suffix for some configuration options. This is needed because the docs site makes it sound like this is a requirement, but we don't think this requirement actually exists anywhere.

It is possible for OTLP receivers to exist all over the web at varying URLs even with conflicting/differing paths. The exporter configuration needs to be flexible enough to allow exporters to send to any of these.