### PR TITLE
Fix typo in transforming-telemetry.md and collector.md

### DIFF
--- a/content/en/docs/collector/transforming-telemetry.md
+++ b/content/en/docs/collector/transforming-telemetry.md
@@ -9,7 +9,7 @@ The OpenTelemetry Collector is a convenient place to transform data before
 sending it to a vendor or other systems. This is frequently done for data
 quality, governance, cost, and security reasons.
 
-Processors available from the the
+Processors available from the
 [Collector Contrib repository](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor)
 support dozens of different transformations on metric, span and log data. The
 following sections provide some basic examples on getting started with a few

--- a/content/en/docs/kubernetes/helm/collector.md
+++ b/content/en/docs/kubernetes/helm/collector.md
@@ -2,7 +2,7 @@
 title: OpenTelemetry Collector Chart
 linkTitle: Collector Chart
 # prettier-ignore
-cSpell:ignore: filelog filelogreceiver filelogreceiver hostmetricsreceiver kubelet kubeletstats kubeletstatsreceiver kuberenetes loggingexporter otlphttp sattributesprocessor sclusterreceiver sobjectsreceiver statefulset
+cSpell:ignore: filelog filelogreceiver filelogreceiver hostmetricsreceiver kubelet kubeletstats kubeletstatsreceiver loggingexporter otlphttp sattributesprocessor sclusterreceiver sobjectsreceiver statefulset
 ---
 
 ## Introduction
@@ -151,7 +151,7 @@ viewed in its
 ### Presets
 
 Many of the important components the OpenTelemetry Collector uses to monitor
-Kubernetes require special setup in the Collector's own Kuberenetes deployment.
+Kubernetes require special setup in the Collector's own Kubernetes deployment.
 In order to make using these components easier, the OpenTelemetry Collector
 Chart comes with some presets that, when enabled, handle the complex setup for
 these important components.
@@ -381,5 +381,5 @@ presets:
     enabled: true
 ```
 
-[^1] due to some overlap with the kubeletMetrics preset some filesystem types
+[^1] due to some overlap with the `kubeletMetrics` preset some filesystem types
 and mount points are excluded by default.


### PR DESCRIPTION
The reasons for this correction are as follows:

- Correction of the word "kubernetes" from its original spelling mistake to the correct form.
- Rectification of some grammatical errors, such as the addition of periods or the removal of redundant words.