### PR TITLE
Add blog post on opentelemetry.io after alpha release of opentelemetry…

### DIFF
--- a/content/en/blog/2023/go-instrumentation-first-alpha.md
+++ b/content/en/blog/2023/go-instrumentation-first-alpha.md
@@ -1,0 +1,13 @@
+---
+title: OpenTelemetry Go Automatic Instrumentation Releases its first Alpha
+linkTitle: Go Auto-instrumentation Alpha
+date: 2022-05-12
+author: OpenTelemetry Go Automatic Instrumentation Team
+cSpell:ignore: devopsnote librarysupport
+---
+
+We're excited to announce the
+[first alpha release](https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.2.2-alpha)
+of the
+[OpenTelemetry Go Automatic Instrumentation](https://github.com/open-telemetry/opentelemetry-go-instrumentation)
+project!


### PR DESCRIPTION
Add blog post on opentelemetry.io after alpha release of opentelemetry-go-instrumentation

try to resolve: https://github.com/open-telemetry/opentelemetry-go-instrumentation/issues/236