### PR TITLE
Added Elasticsearch Java API Client to the integrations

### DIFF
--- a/data/ecosystem/integrations.yaml
+++ b/data/ecosystem/integrations.yaml
@@ -11,6 +11,10 @@
   url: https://github.com/docker/buildx
   docsUrl: https://docs.docker.com/build/building/opentelemetry/
   components: [Go]
+- name: Elasticsearch Java API Client
+  url: https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/index.html
+  docsUrl: https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/opentelemetry.html
+  components: [Java]
 - name: Kubernetes
   url: https://kubernetes.io/
   docsUrl: https://kubernetes.io/docs/concepts/cluster-administration/system-traces/

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -4911,6 +4911,14 @@
     "StatusCode": 206,
     "LastSeen": "2023-06-30T09:33:47.364453-04:00"
   },
+  "https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/index.html": {
+    "StatusCode": 206,
+    "LastSeen": "2023-09-13T08:18:13.777841+02:00"
+  },
+  "https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/opentelemetry.html": {
+    "StatusCode": 206,
+    "LastSeen": "2023-09-13T08:18:14.600801+02:00"
+  },
   "https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html": {
     "StatusCode": 206,
     "LastSeen": "2023-07-06T17:58:38.92195-04:00"


### PR DESCRIPTION
The Elasticsearch Java API Client comes with a native OpenTelemetry instrumentation.

This PR adds it to the list of integrations in the OTel ecosystem.