### PR TITLE
Go: Add Registering Views

### DIFF
--- a/content/en/docs/concepts/signals/metrics.md
+++ b/content/en/docs/concepts/signals/metrics.md
@@ -98,10 +98,10 @@ Some examples of use cases for metrics include:
 
 ## Views
 
-A View provides SDK users with the flexibility to customize the metrics that are
-output by the SDK. They can customize which metric instruments are to be
-processed or ignored. They can customize aggregation and what attributes are to
-be reported on metrics.
+A view provides SDK users with the flexibility to customize the metrics output
+by the SDK. You can customize which metric instruments are to be processed or
+ignored. You can also customize aggregation and what attributes you want to
+report on metrics.
 
 ## Language Support
 

--- a/content/en/docs/instrumentation/go/manual.md
+++ b/content/en/docs/instrumentation/go/manual.md
@@ -738,7 +738,7 @@ You can use [`NewView`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#N
 function to create a view and register it using
 [`WithView`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#With) option.
 
-For example, here's how you might ceate a view that renames the `latency`
+For example, here's how you might create a view that renames the `latency`
 instrument from the `v0.34.0` version of the `http` instrumentation library
 to `request.latency`.
 

--- a/content/en/docs/instrumentation/go/manual.md
+++ b/content/en/docs/instrumentation/go/manual.md
@@ -734,13 +734,15 @@ view is replaced by the registered view. Additional registered views that match
 the instrument are additive, and result in multiple exported metrics for the
 instrument.
 
-You can use [`NewView`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#NewView)
+You can use
+[`NewView`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#NewView)
 function to create a view and register it using
-[`WithView`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#With) option.
+[`WithView`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#With)
+option.
 
 For example, here's how you might create a view that renames the `latency`
-instrument from the `v0.34.0` version of the `http` instrumentation library
-to `request.latency`.
+instrument from the `v0.34.0` version of the `http` instrumentation library to
+`request.latency`.
 
 ```go
 view := metric.NewView(metric.Instrument{
@@ -759,8 +761,8 @@ meterProvider := metric.NewMeterProvider(
 The `NewView` function provides convenient creation of common Views
 construction. However, it is limited in what it can create. When `NewView` is
 not able to provide the functionally needed, a custom
-[`View`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#View) can
-be constructed directly.
+[`View`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#View) can be
+constructed directly.
 
 ## Logs
 

--- a/content/en/docs/instrumentation/go/manual.md
+++ b/content/en/docs/instrumentation/go/manual.md
@@ -757,8 +757,8 @@ meterProvider := metric.NewMeterProvider(
 )
 ```
 
-For example, here's how you create a view that makes the `latency` instrument
-of the `http` instrumentation library to be reported as an exponential histogram:
+For example, here's how you create a view that makes the `latency` instrument of
+the `http` instrumentation library to be reported as an exponential histogram:
 
 ```go
 	view := metric.NewView(

--- a/content/en/docs/instrumentation/go/manual.md
+++ b/content/en/docs/instrumentation/go/manual.md
@@ -757,6 +757,9 @@ meterProvider := metric.NewMeterProvider(
 )
 ```
 
+You can find more usage examples in
+[`NewView` documentation](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#NewView)
+
 The `NewView` function provides a convenient way of creating views. If `NewView`
 can't provide the functionalities you need, you can create a custom
 [`View`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#View) directly.
@@ -790,9 +793,6 @@ meterProvider := metric.NewMeterProvider(
 	metric.WithView(view),
 )
 ```
-
-You can find more examples in
-[the metrics SDK package documentation](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#pkg-examples).
 
 ## Logs
 

--- a/content/en/docs/instrumentation/go/manual.md
+++ b/content/en/docs/instrumentation/go/manual.md
@@ -791,6 +791,9 @@ meterProvider := metric.NewMeterProvider(
 )
 ```
 
+You can find more examples in
+[the metrics SDK package documentation](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#pkg-examples).
+
 ## Logs
 
 The logs API is currently unstable, documentation TBA.

--- a/content/en/docs/instrumentation/go/manual.md
+++ b/content/en/docs/instrumentation/go/manual.md
@@ -465,8 +465,7 @@ example).
 
 Counters can be used to measure a non-negative, increasing value.
 
-For example, here's how you report the number of calls for an HTTP
-handler:
+For example, here's how you report the number of calls for an HTTP handler:
 
 ```go
 import (
@@ -537,8 +536,8 @@ func removeItem() {
 
 Histograms are used to measure a distribution of values over time.
 
-For example, here's how you report a distribution of response times for an
-HTTP handler:
+For example, here's how you report a distribution of response times for an HTTP
+handler:
 
 ```go
 import (
@@ -656,8 +655,8 @@ func registerDBMetrics(db *sql.DB, meter metric.Meter, poolName string) (metric.
 
 Observable Gauges should be used to measure non-additive values.
 
-For example, here's how you report memory usage of the heap objects used
-in application:
+For example, here's how you report memory usage of the heap objects used in
+application:
 
 ```go
 import (
@@ -740,8 +739,8 @@ function to create a view and register it using the
 [`WithView`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#With)
 option.
 
-For example, here's how you create a view that renames the `latency`
-instrument from the `v0.34.0` version of the `http` instrumentation library to
+For example, here's how you create a view that renames the `latency` instrument
+from the `v0.34.0` version of the `http` instrumentation library to
 `request.latency`.
 
 ```go
@@ -758,11 +757,9 @@ meterProvider := metric.NewMeterProvider(
 )
 ```
 
-The `NewView` function provides a convenient way of creating views.
-If `NewView` can't provide the functionalities you need, you can create
-a custom
-[`View`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#View)
-directly.
+The `NewView` function provides a convenient way of creating views. If `NewView`
+can't provide the functionalities you need, you can create a custom
+[`View`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#View) directly.
 
 ## Logs
 

--- a/content/en/docs/instrumentation/go/manual.md
+++ b/content/en/docs/instrumentation/go/manual.md
@@ -766,8 +766,9 @@ to ensure all data stream names have a suffix of the units it uses:
 
 ```go
 re := regexp.MustCompile(`[._](ms|byte)$`)
-var view View = func(i Instrument) (Stream, bool) {
-	s := Stream{Name: i.Name, Description: i.Description, Unit: i.Unit}
+var view metric.View = func(i metric.Instrument) (metric.Stream, bool) {
+	// In a custom View function, you need to explicitly copy the name, description, and unit.
+	s := metric.Stream{Name: i.Name, Description: i.Description, Unit: i.Unit}
 	// Any instrument that does not have a unit suffix defined, but has a
 	// dimensional unit defined, update the name with a unit suffix.
 	if re.MatchString(i.Name) {

--- a/content/en/docs/instrumentation/go/manual.md
+++ b/content/en/docs/instrumentation/go/manual.md
@@ -758,7 +758,8 @@ meterProvider := metric.NewMeterProvider(
 ```
 
 For example, here's how you create a view that makes the `latency` instrument
-from the `http` instrumentation library to be reported as an exponential histogram:
+from the `http` instrumentation library to be reported as an exponential
+histogram:
 
 ```go
 view := metric.NewView(

--- a/content/en/docs/instrumentation/go/manual.md
+++ b/content/en/docs/instrumentation/go/manual.md
@@ -761,22 +761,22 @@ For example, here's how you create a view that makes the `latency` instrument of
 the `http` instrumentation library to be reported as an exponential histogram:
 
 ```go
-	view := metric.NewView(
-		metric.Instrument{
-			Name:  "latency",
-			Scope: instrumentation.Scope{Name: "http"},
+view := metric.NewView(
+	metric.Instrument{
+		Name:  "latency",
+		Scope: instrumentation.Scope{Name: "http"},
+	},
+	metric.Stream{
+		Aggregation: metric.AggregationBase2ExponentialHistogram{
+			MaxSize:  160,
+			MaxScale: 20,
 		},
-		metric.Stream{
-			Aggregation: metric.AggregationBase2ExponentialHistogram{
-				MaxSize:  160,
-				MaxScale: 20,
-			},
-		},
-	)
+	},
+)
 
-	meterProvider := metric.NewMeterProvider(
-		metric.WithView(view),
-	)
+meterProvider := metric.NewMeterProvider(
+	metric.WithView(view),
+)
 ```
 
 The `NewView` function provides a convenient way of creating views. If `NewView`

--- a/content/en/docs/instrumentation/go/manual.md
+++ b/content/en/docs/instrumentation/go/manual.md
@@ -722,10 +722,10 @@ func init() {
 
 ### Registering Views
 
-A View provides SDK users with the flexibility to customize the metrics that are
-output by the SDK. They can customize which metric instruments are to be
-processed or ignored. They can customize aggregation and what attributes are to
-be reported on metrics.
+A view provides SDK users with the flexibility to customize the metrics output
+by the SDK. You can customize which metric instruments are to be processed or
+ignored. You can also customize aggregation and what attributes you want to
+report on metrics.
 
 Every instrument has a default view, which retains the original name,
 description, and attributes, and has a default aggregation that is based on the

--- a/content/en/docs/instrumentation/go/manual.md
+++ b/content/en/docs/instrumentation/go/manual.md
@@ -757,8 +757,8 @@ meterProvider := metric.NewMeterProvider(
 )
 ```
 
-For example, here's how you create a view that makes the `latency` instrument of
-the `http` instrumentation library to be reported as an exponential histogram:
+For example, here's how you create a view that makes the `latency` instrument
+from the `http` instrumentation library to be reported as an exponential histogram:
 
 ```go
 view := metric.NewView(

--- a/content/en/docs/instrumentation/go/manual.md
+++ b/content/en/docs/instrumentation/go/manual.md
@@ -734,13 +734,13 @@ view is replaced by the registered view. Additional registered views that match
 the instrument are additive, and result in multiple exported metrics for the
 instrument.
 
-You can use
+You can use the
 [`NewView`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#NewView)
-function to create a view and register it using
+function to create a view and register it using the
 [`WithView`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#With)
 option.
 
-For example, here's how you might create a view that renames the `latency`
+For example, here's how you create a view that renames the `latency`
 instrument from the `v0.34.0` version of the `http` instrumentation library to
 `request.latency`.
 
@@ -758,11 +758,11 @@ meterProvider := metric.NewMeterProvider(
 )
 ```
 
-The `NewView` function provides convenient creation of common Views
-construction. However, it is limited in what it can create. When `NewView` is
-not able to provide the functionally needed, a custom
-[`View`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#View) can be
-constructed directly.
+The `NewView` function provides a convenient way of creating views.
+If `NewView` can't provide the functionalities you need, you can create
+a custom
+[`View`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#View)
+directly.
 
 ## Logs
 

--- a/content/en/docs/instrumentation/go/manual.md
+++ b/content/en/docs/instrumentation/go/manual.md
@@ -757,8 +757,27 @@ meterProvider := metric.NewMeterProvider(
 )
 ```
 
-You can find more usage examples in
-[`NewView` documentation](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#NewView)
+For example, here's how you create a view that makes the `latency` instrument
+of the `http` instrumentation library to be reported as an exponential histogram:
+
+```go
+	view := metric.NewView(
+		metric.Instrument{
+			Name:  "latency",
+			Scope: instrumentation.Scope{Name: "http"},
+		},
+		metric.Stream{
+			Aggregation: metric.AggregationBase2ExponentialHistogram{
+				MaxSize:  160,
+				MaxScale: 20,
+			},
+		},
+	)
+
+	meterProvider := metric.NewMeterProvider(
+		metric.WithView(view),
+	)
+```
 
 The `NewView` function provides a convenient way of creating views. If `NewView`
 can't provide the functionalities you need, you can create a custom

--- a/content/en/docs/instrumentation/go/manual.md
+++ b/content/en/docs/instrumentation/go/manual.md
@@ -720,6 +720,48 @@ func init() {
 }
 ```
 
+### Registering Views
+
+A View provides SDK users with the flexibility to customize the metrics that are
+output by the SDK. They can customize which metric instruments are to be
+processed or ignored. They can customize aggregation and what attributes are to
+be reported on metrics.
+
+Every instrument has a default view, which retains the original name,
+description, and attributes, and has a default aggregation that is based on the
+type of instrument. When a registered view matches an instrument, the default
+view is replaced by the registered view. Additional registered views that match
+the instrument are additive, and result in multiple exported metrics for the
+instrument.
+
+You can use [`NewView`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#NewView)
+function to create a view and register it using
+[`WithView`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#With) option.
+
+For example, here's how you might ceate a view that renames the `latency`
+instrument from the `v0.34.0` version of the `http` instrumentation library
+to `request.latency`.
+
+```go
+view := metric.NewView(metric.Instrument{
+	Name: "latency",
+	Scope: instrumentation.Scope{
+		Name:    "http",
+		Version: "0.34.0",
+	},
+}, metric.Stream{Name: "request.latency"})
+
+meterProvider := metric.NewMeterProvider(
+	metric.WithView(view),
+)
+```
+
+The `NewView` function provides convenient creation of common Views
+construction. However, it is limited in what it can create. When `NewView` is
+not able to provide the functionally needed, a custom
+[`View`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#View) can
+be constructed directly.
+
 ## Logs
 
 The logs API is currently unstable, documentation TBA.

--- a/content/en/docs/instrumentation/go/manual.md
+++ b/content/en/docs/instrumentation/go/manual.md
@@ -767,7 +767,8 @@ to ensure all data stream names have a suffix of the units it uses:
 ```go
 re := regexp.MustCompile(`[._](ms|byte)$`)
 var view metric.View = func(i metric.Instrument) (metric.Stream, bool) {
-	// In a custom View function, you need to explicitly copy the name, description, and unit.
+	// In a custom View function, you need to explicitly copy
+	// the name, description, and unit.
 	s := metric.Stream{Name: i.Name, Description: i.Description, Unit: i.Unit}
 	// Any instrument that does not have a unit suffix defined, but has a
 	// dimensional unit defined, update the name with a unit suffix.

--- a/content/en/docs/instrumentation/go/manual.md
+++ b/content/en/docs/instrumentation/go/manual.md
@@ -465,7 +465,7 @@ example).
 
 Counters can be used to measure a non-negative, increasing value.
 
-For example, here's how you might report the number of calls for an HTTP
+For example, here's how you report the number of calls for an HTTP
 handler:
 
 ```go
@@ -497,7 +497,7 @@ func init() {
 UpDown counters can increment and decrement, allowing you to observe a
 cumulative value that goes up or down.
 
-For example, here's how you might report the number of items of some collection:
+For example, here's how you report the number of items of some collection:
 
 ```go
 import (
@@ -537,7 +537,7 @@ func removeItem() {
 
 Histograms are used to measure a distribution of values over time.
 
-For example, here's how you might report a distribution of response times for an
+For example, here's how you report a distribution of response times for an
 HTTP handler:
 
 ```go
@@ -573,7 +573,7 @@ func init() {
 Observable counters can be used to measure an additive, non-negative,
 monotonically increasing value.
 
-For example, here's how you might report time since the application started:
+For example, here's how you report time since the application started:
 
 ```go
 import (
@@ -604,7 +604,7 @@ func init() {
 Observable UpDown counters can increment and decrement, allowing you to measure
 an additive, non-negative, non-monotonically increasing cumulative value.
 
-For example, here's how you might report some database metrics:
+For example, here's how you report some database metrics:
 
 ```go
 import (
@@ -656,7 +656,7 @@ func registerDBMetrics(db *sql.DB, meter metric.Meter, poolName string) (metric.
 
 Observable Gauges should be used to measure non-additive values.
 
-For example, here's how you might report memory usage of the heap objects used
+For example, here's how you report memory usage of the heap objects used
 in application:
 
 ```go

--- a/content/en/docs/instrumentation/go/manual.md
+++ b/content/en/docs/instrumentation/go/manual.md
@@ -736,7 +736,7 @@ instrument.
 You can use the
 [`NewView`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#NewView)
 function to create a view and register it using the
-[`WithView`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#With)
+[`WithView`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#WithView)
 option.
 
 For example, here's how you create a view that renames the `latency` instrument

--- a/content/en/docs/instrumentation/js/manual.md
+++ b/content/en/docs/instrumentation/js/manual.md
@@ -1452,7 +1452,7 @@ counter.add(-1);
 
 Histograms are used to measure a distribution of values over time.
 
-For example, here's how you might report a distribution of response times for an
+For example, here's how you report a distribution of response times for an
 API route with Express:
 
 {{< tabpane text=true langEqualsHeader=true >}} {{% tab TypeScript %}}

--- a/content/en/docs/instrumentation/js/manual.md
+++ b/content/en/docs/instrumentation/js/manual.md
@@ -1452,8 +1452,8 @@ counter.add(-1);
 
 Histograms are used to measure a distribution of values over time.
 
-For example, here's how you report a distribution of response times for an
-API route with Express:
+For example, here's how you report a distribution of response times for an API
+route with Express:
 
 {{< tabpane text=true langEqualsHeader=true >}} {{% tab TypeScript %}}
 

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -4403,6 +4403,10 @@
     "StatusCode": 200,
     "LastSeen": "2023-09-15T09:41:38.295762202Z"
   },
+  "https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#WithView": {
+    "StatusCode": 200,
+    "LastSeen": "2023-09-15T16:34:14.034832295Z"
+  },
   "https://pkg.go.dev/go.opentelemetry.io/otel/sdk/resource": {
     "StatusCode": 200,
     "LastSeen": "2023-09-11T14:33:25.721659015Z"

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -4379,6 +4379,18 @@
     "StatusCode": 200,
     "LastSeen": "2023-09-11T14:33:25.420952095Z"
   },
+  "https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#NewView": {
+    "StatusCode": 200,
+    "LastSeen": "2023-09-15T09:41:38.164411819Z"
+  },
+  "https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#View": {
+    "StatusCode": 200,
+    "LastSeen": "2023-09-15T09:41:38.432556144Z"
+  },
+  "https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#With": {
+    "StatusCode": 200,
+    "LastSeen": "2023-09-15T09:41:38.295762202Z"
+  },
   "https://pkg.go.dev/go.opentelemetry.io/otel/sdk/resource": {
     "StatusCode": 200,
     "LastSeen": "2023-09-11T14:33:25.721659015Z"


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-go/issues/3186 

I will add examples showing how to drop metrics/attributes in a separate PR when https://github.com/open-telemetry/opentelemetry-go/pull/4527 is merged.

The content is based on:

- first part:  https://opentelemetry.io/docs/concepts/signals/metrics/#views
- second part: https://opentelemetry.io/docs/instrumentation/java/manual/#views
- third part: https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric

## Docs PR Checklist

<!--- Just making sure... -->

- [x] This PR is for a documentation page whose authoritative copy is in the
      opentelemetry.io repository.
