### PR TITLE
Remove promscale from vendors.yaml

### DIFF
--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -1,4 +1,4 @@
-# cSpell:ignore Coralogix Cribl ITRS Kloud Logz Crowdstrike Humio Lumigo observ Promscale Teletrace Uptrace Greptime KloudMate
+# cSpell:ignore Coralogix Cribl ITRS Kloud Logz Crowdstrike Humio Lumigo observ Teletrace Uptrace Greptime KloudMate
 - name: AppDynamics (Cisco)
   distribution: true
   nativeOTLP: true
@@ -199,13 +199,6 @@
   distribution: false
   nativeOTLP: true
   url: 'https://docs.oracle.com/en-us/iaas/application-performance-monitoring/doc/configure-open-source-tracing-systems.html#GUID-4D941163-F357-4839-8B06-688876D4C61F'
-  contact: ''
-  oss: false
-  commercial: true
-- name: Promscale
-  distribution: false
-  nativeOTLP: true
-  url: 'https://www.timescale.com/promscale'
   contact: ''
   oss: false
   commercial: true


### PR DESCRIPTION
Per their documentation (https://promscale-legacy-docs.timescale.com/):

> Promscale has been discontinued. We strongly recommend that you do not use Promscale in a production environment. Learn more.

Also for reference: https://github.com/timescale/promscale/issues/1836