### PR TITLE
Tiny doc fix in the .NET manual instrumentation doc.

### DIFF
--- a/content/en/docs/instrumentation/net/manual.md
+++ b/content/en/docs/instrumentation/net/manual.md
@@ -119,7 +119,7 @@ builder.Services.AddOpenTelemetry()
       .ConfigureResource(resource =>
           resource.AddService(
             serviceName: serviceName,
-            serviceVersion: serviceVersion))
+            serviceVersion: serviceVersion));
   });
 ```
 


### PR DESCRIPTION
This code is in a `{ ... }` block, so a `;` is needed to compile.