### PR TITLE
.NET Automatic Instrumentation - link to latest release

### DIFF
--- a/content/en/docs/instrumentation/net/automatic/_index.md
+++ b/content/en/docs/instrumentation/net/automatic/_index.md
@@ -47,7 +47,7 @@ Download and run the `.sh` script:
 
 ```shell
 # Download the bash script
-curl -sSfL https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/v1.0.0-rc.2/otel-dotnet-auto-install.sh -O
+curl -sSfL https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest/download/otel-dotnet-auto-install.sh -O
 
 # Install core files
 sh ./otel-dotnet-auto-install.sh
@@ -79,7 +79,7 @@ On Windows, use the PowerShell module as an Administrator:
 ```powershell
 # PowerShell 5.1 or higher is required
 # Download the module
-$module_url = "https://raw.githubusercontent.com/open-telemetry/opentelemetry-dotnet-instrumentation/v1.0.0-rc.2/OpenTelemetry.DotNet.Auto.psm1"
+$module_url = "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest/download/OpenTelemetry.DotNet.Auto.psm1"
 $download_path = Join-Path $env:temp "OpenTelemetry.DotNet.Auto.psm1"
 Invoke-WebRequest -Uri $module_url -OutFile $download_path -UseBasicParsing
 


### PR DESCRIPTION
After 1.0.0 release it should be fine to the latest release which omits prereleased versions.