### PR TITLE
add highlight.io to vendors

### DIFF
--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -104,6 +104,13 @@
   contact: ''
   oss: false
   commercial: true
+- name: Highlight
+  distribution: true
+  nativeOTLP: true
+  url: 'https://www.highlight.io/docs/general/company/open-source/contributing/adding-an-sdk/'
+  contact: 'support@highlight.io'
+  oss: true
+  commercial: true
 - name: Honeycomb
   distribution: true
   nativeOTLP: true

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -5147,6 +5147,10 @@
     "StatusCode": 206,
     "LastSeen": "2023-06-30T08:38:53.148089-04:00"
   },
+  "https://www.highlight.io/docs/general/company/open-source/contributing/adding-an-sdk/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-09-19T23:11:24.486503-07:00"
+  },
   "https://www.honeycomb.io/": {
     "StatusCode": 206,
     "LastSeen": "2023-06-29T18:49:02.31393-04:00"


### PR DESCRIPTION
Hi! Adding [highlight.io](https://app.highlight.io) per the [vendor docs](https://opentelemetry.io/ecosystem/vendors/#add-your-organization).

* Link to the documentation that details how your offering consumes OpenTelemetry natively via [OTLP](http://localhost:1313/docs/specs/otlp/).
    * Described in [detail on our docs](https://www.highlight.io/docs/general/company/open-source/contributing/adding-an-sdk).
* Link to your distribution, if applicable
    * https://app.highlight.io/
* Link that proves that your offering is open source, if applicable. An open source distribution does not qualify your offering to be marked “open source”.
    * [LICENSE](https://github.com/highlight/highlight/blob/3ecd5c367fe8830835cf6977788e8a5ac2b77257/LICENSE)
* GitHub handle or email address as a point of contact so that we can reach out in case we have questions
    * @jay-khatri
    * @vadman97
    * support@highlight.io