### PR TITLE
Fix typo in blog post K8s Runtime Observability

### DIFF
--- a/content/en/blog/2023/k8s-runtime-observability/index.md
+++ b/content/en/blog/2023/k8s-runtime-observability/index.md
@@ -355,7 +355,7 @@ k3d cluster create tracingcluster \
   --k3s-arg '--kubelet-arg=config=/etc/kube-tracing/kubelet-tracing.yaml@server:*'
 ```
 
-This command will create a Kubernetes cluster with version `v1.17.1`, and set up
+This command will create a Kubernetes cluster with version `v1.27.1`, and set up
 in three docker containers on your machine. If you run the command
 `kubectl cluster-info` now, you will see this output:
 


### PR DESCRIPTION
Fix the command description to match the value specified in the image option of `k3d cluster create` command (`rancher/k3s:v1.27.1-k3s1`)