### PR TITLE
Update operator links and texts

### DIFF
--- a/content/en/docs/collector/getting-started.md
+++ b/content/en/docs/collector/getting-started.md
@@ -350,10 +350,8 @@ These commands may vary slightly for other shells.
 [deployment methods]: ../deployment/
 [readme.md]:
   https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/examples/demo
-[opentelemetry helm charts]:
-  https://github.com/open-telemetry/opentelemetry-helm-charts
-[opentelemetry operator]:
-  https://github.com/open-telemetry/opentelemetry-operator
+[opentelemetry helm charts]: /docs/kubernetes/helm/
+[opentelemetry operator]: /docs/kubernetes/operator/
 [getting started with opentelemetry on hashicorp nomad]:
   https://github.com/hashicorp/nomad-open-telemetry-getting-started
 [releases]:

--- a/content/en/docs/collector/scaling.md
+++ b/content/en/docs/collector/scaling.md
@@ -243,9 +243,10 @@ namespace or specific labels on the workloads.
 
 Another way of scaling the Prometheus receiver is to use the
 [Target Allocator](/docs/kubernetes/operator/target-allocator/): it’s an extra
-binary that can be deployed as part of the OpenTelemetry Operator and will distribute Prometheus scrape targets for a given configuration across the cluster of
-Collectors. You can use a Custom Resource
-(CR) like the following to make use of the Target Allocator:
+binary that can be deployed as part of the OpenTelemetry Operator and will
+distribute Prometheus scrape targets for a given configuration across the
+cluster of Collectors. You can use a Custom Resource (CR) like the following to
+make use of the Target Allocator:
 
 ```yaml
 apiVersion: opentelemetry.io/v1alpha1

--- a/content/en/docs/collector/scaling.md
+++ b/content/en/docs/collector/scaling.md
@@ -243,9 +243,8 @@ namespace or specific labels on the workloads.
 
 Another way of scaling the Prometheus receiver is to use the
 [Target Allocator](/docs/kubernetes/operator/target-allocator/): it’s an extra
-binary that can be deployed as part of the OpenTelemetry Operator and will split
-the share of Prometheus jobs for a given configuration across the cluster of
-Collectors using a consistent hashing algorithm. You can use a Custom Resource
+binary that can be deployed as part of the OpenTelemetry Operator and will distribute Prometheus scrape targets for a given configuration across the cluster of
+Collectors. You can use a Custom Resource
 (CR) like the following to make use of the Target Allocator:
 
 ```yaml

--- a/content/en/docs/collector/scaling.md
+++ b/content/en/docs/collector/scaling.md
@@ -242,11 +242,11 @@ Collector. For instance, each Collector could be responsible for one Kubernetes
 namespace or specific labels on the workloads.
 
 Another way of scaling the Prometheus receiver is to use the
-[Target Allocator](https://github.com/open-telemetry/opentelemetry-operator#target-allocator):
-it’s an extra binary that can be deployed as part of the OpenTelemetry Operator
-and will split the share of Prometheus jobs for a given configuration across the
-cluster of Collectors using a consistent hashing algorithm. You can use a Custom
-Resource (CR) like the following to make use of the Target Allocator:
+[Target Allocator](/docs/kubernetes/operator/target-allocator/): it’s an extra
+binary that can be deployed as part of the OpenTelemetry Operator and will split
+the share of Prometheus jobs for a given configuration across the cluster of
+Collectors using a consistent hashing algorithm. You can use a Custom Resource
+(CR) like the following to make use of the Target Allocator:
 
 ```yaml
 apiVersion: opentelemetry.io/v1alpha1

--- a/content/en/docs/instrumentation/_index.md
+++ b/content/en/docs/instrumentation/_index.md
@@ -15,8 +15,8 @@ following:
 - Exporting data
 
 If you are using Kubernetes, you can use the [OpenTelemetry Operator for
-Kubernetes][otel-op] to [inject auto-instrumentation libraries][auto] for Java,
-Node.js and Python into your application.
+Kubernetes][otel-op] to [inject auto-instrumentation libraries][auto] for .NET,
+Java, Node.js, Python, Go into your application.
 
 ## Status and Releases
 
@@ -25,7 +25,6 @@ follows:
 
 {{% telemetry-support-table " " %}}
 
-[auto]:
-  https://github.com/open-telemetry/opentelemetry-operator#opentelemetry-auto-instrumentation-injection
+[auto]: /docs/kubernetes/operator/automatic/
 [instrumentation]: /docs/concepts/instrumentation/
-[otel-op]: https://github.com/open-telemetry/opentelemetry-operator
+[otel-op]: /docs/kubernetes/operator/

--- a/content/en/docs/instrumentation/net/automatic/_index.md
+++ b/content/en/docs/instrumentation/net/automatic/_index.md
@@ -221,7 +221,7 @@ For an example of Docker container instrumentation, see
 on GitHub.
 
 You can also use the
-[Kubernetes Operator for OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-operator).
+[OpenTelemetry Operator for Kubernetes](/docs/kubernetes/operator/).
 
 ## Configuring the agent
 

--- a/content/en/docs/what-is-opentelemetry.md
+++ b/content/en/docs/what-is-opentelemetry.md
@@ -37,7 +37,9 @@ OpenTelemetry consists of the following major components:
 - The [OpenTelemetry Collector](/docs/collector), a proxy that receives,
   processes, and exports telemetry data
 - Various other tools, such as the
-  [OpenTelemetry Operator for Kubernetes](/docs/kubernetes/operator/)
+  [OpenTelemetry Operator for Kubernetes](/docs/kubernetes/operator/),
+  [OpenTelemetry Helm Charts](/docs/kubernetes/helm/), and
+  [community assets for FaaS](/docs/faas/)
 
 OpenTelemetry is compatible with a wide variety of open source
 [ecosystem integrations](/ecosystem/integrations/).


### PR DESCRIPTION
This PR changes some links to the operator repository to the documentation on opentelemetry.io