### PR TITLE
Update C++ logs to 'stable'

### DIFF
--- a/data/instrumentation.yaml
+++ b/data/instrumentation.yaml
@@ -8,7 +8,7 @@ cpp:
   status:
     traces: stable
     metrics: stable
-    logs: experimental
+    logs: stable
 dotnet:
   name: .NET
   status:


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-cpp/releases/tag/v1.11.0

> Logs are declared as stable in this release.

@open-telemetry/cpp-approvers please confirm