### PR TITLE
Some improvements for JavaScript Docs

### DIFF
--- a/content/en/docs/instrumentation/js/_index.md
+++ b/content/en/docs/instrumentation/js/_index.md
@@ -14,8 +14,32 @@ weight: 20
 {{% alert title="Warning" color="warning" %}}
 {{% _param notes.browser-instrumentation %}} {{% /alert %}}
 
-## Further Reading
+## Version Support
 
-- [OpenTelemetry for JavaScript on GitHub](https://github.com/open-telemetry/opentelemetry-js)
-- [Getting Started](getting-started/)
-- [SDK and API Reference](https://open-telemetry.github.io/opentelemetry-js)
+OpenTelemetry JavaScript supports all active or maintenance LTS versions of
+Node.js. Previous versions of Node.js may work, but are not tested by
+OpenTelemetry.
+
+OpenTelemetry JavaScript has no official supported list of browsers. It is aimed
+to work on currently supported versions of major browsers.
+
+For more details on runtime support see
+[ths overview](https://github.com/open-telemetry/opentelemetry-js#supported-runtimes).
+
+## Repositories
+
+OpenTelemetry JavaScript consists of the following repositories:
+
+- [opentelemetry-js](https://github.com/open-telemetry/opentelemetry-js), core
+  repository containing the core distribution API and SDK.
+- [opentelemetry-js-contrib](https://github.com/open-telemetry/opentelemetry-js-contrib),
+  contributions that are not part of the core distribution of the API and SDK.
+
+## Help or Feedback
+
+If you have questions about OpenTelemetry JavaScript, please reach out via
+[GitHub Discussions](https://github.com/open-telemetry/opentelemetry-js/discussions)
+or the [#otel-js] channel on [CNCF Slack](https://slack.cncf.io/).
+
+If you want to contribute to OpenTelemetry JavaScript, see the
+[contributing instructions](https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md)

--- a/content/en/docs/instrumentation/js/api.md
+++ b/content/en/docs/instrumentation/js/api.md
@@ -1,6 +1,7 @@
 ---
 title: API reference
 linkTitle: API
+description: Read the OpenTelemetry JavaScript API reference _(external page)_
 redirect: https://open-telemetry.github.io/opentelemetry-js/
 manualLinkTarget: _blank
 _build: { render: link }

--- a/content/en/docs/instrumentation/js/automatic/_index.md
+++ b/content/en/docs/instrumentation/js/automatic/_index.md
@@ -1,6 +1,8 @@
 ---
 title: Automatic Instrumentation
 linkTitle: Automatic
+description:
+  Capture telemetry from your application with zero source code modifications
 weight: 20
 ---
 
@@ -44,9 +46,9 @@ export NODE_OPTIONS="--require @opentelemetry/auto-instrumentations-node/registe
 node app.js
 ```
 
-By default, all SDK resource detectors are used. You can use the environment
-variable `OTEL_NODE_RESOURCE_DETECTORS` to enable only certain detectors, or
-completely disable them.
+By default, all SDK [resource detectors](/docs/instrumentation/js/resources/)
+are used. You can use the environment variable `OTEL_NODE_RESOURCE_DETECTORS` to
+enable only certain detectors, or completely disable them.
 
 To see the full range of configuration options, see
 [Module Configuration](module-config).
@@ -55,7 +57,7 @@ To see the full range of configuration options, see
 
 A number of popular Node.js libraries are auto-instrumented. For the full list,
 see
-[Supported instrumentation](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/metapackages/auto-instrumentations-node#supported-instrumentations).
+[supported instrumentation](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/metapackages/auto-instrumentations-node#supported-instrumentations).
 
 ## Troubleshooting
 
@@ -69,12 +71,15 @@ to one of the following:
 - `debug`
 - `verbose`
 - `all`
-- The default level is `info`.
 
-> **NOTES:**
->
-> - In a production environment, it is recommended to set `OTEL_LOG_LEVEL` to
->   info.
-> - Logs are always sent to console, no matter the environment, or debug level.
-> - Debug logs are extremely verbose and can negatively impact the performance
->   of your application. Enable debug logging only when needed.
+The default level is `info`.
+
+{{% alert title="Notes" color="info" %}}
+
+- In a production environment, it is recommended to set `OTEL_LOG_LEVEL` to
+  `info``.
+- Logs are always sent to `console`, no matter the environment, or debug level.
+- Debug logs are extremely verbose and can negatively impact the performance of
+  your application. Enable debug logging only when needed.
+
+{{% /alert %}}

--- a/content/en/docs/instrumentation/js/automatic/module-config.md
+++ b/content/en/docs/instrumentation/js/automatic/module-config.md
@@ -1,6 +1,7 @@
 ---
 title: Automatic Instrumentation Configuration
 linkTitle: Configuration
+description: Learn how to configure Automatic Instrumentation for Node.js
 weight: 10
 ---
 

--- a/content/en/docs/instrumentation/js/examples.md
+++ b/content/en/docs/instrumentation/js/examples.md
@@ -1,6 +1,8 @@
 ---
 title: Examples
 aliases: [/docs/instrumentation/js/instrumentation_examples]
+description:
+  Explore more examples for OpenTelemetry JavaScript _(external page)_
 redirect: https://github.com/open-telemetry/opentelemetry-js/tree/main/example
 manualLinkTarget: _blank
 _build: { render: link }

--- a/content/en/docs/instrumentation/js/exporters.md
+++ b/content/en/docs/instrumentation/js/exporters.md
@@ -1,6 +1,7 @@
 ---
 title: Exporters
 weight: 50
+description: Process and export your telemetry data
 ---
 
 {{% docs/instrumentation/exporters-intro js %}}

--- a/content/en/docs/instrumentation/js/getting-started/_index.md
+++ b/content/en/docs/instrumentation/js/getting-started/_index.md
@@ -2,12 +2,8 @@
 title: Getting Started
 aliases: [/docs/js/getting_started]
 weight: 10
+description: Get started with OpenTelemetry in Node.Js and in the browser.
 ---
 
-These two guides for Node.js and the browser use simple examples in javascript
-to get you started with OpenTelemetry. Both will show you the following steps:
-
-- Install the required OpenTelemetry libraries
-- Initialize a global [tracer](/docs/specs/otel/trace/api/#tracer)
-- Initialize and register a
-  [span exporter](/docs/specs/otel/trace/sdk/#span-exporter)
+These two guides for Node.js and the browser use basic examples in JavaScript to
+get you started with OpenTelemetry.

--- a/content/en/docs/instrumentation/js/getting-started/browser.md
+++ b/content/en/docs/instrumentation/js/getting-started/browser.md
@@ -1,6 +1,7 @@
 ---
 title: Browser
 aliases: [/docs/js/getting_started/browser]
+description: Learn how to add OpenTelemetry to your browser app
 weight: 20
 ---
 

--- a/content/en/docs/instrumentation/js/resources.md
+++ b/content/en/docs/instrumentation/js/resources.md
@@ -2,6 +2,7 @@
 title: Resources
 weight: 70
 cSpell:ignore: myhost SIGINT uuidgen WORKDIR
+description: Add details about your applications' environment to your telemetry
 ---
 
 A [resource][] represents the entity producing telemetry as resource attributes.
@@ -114,8 +115,12 @@ const sdk = new opentelemetry.NodeSDK({
 ...
 ```
 
-**Note**: If you set your resource attributes via environment variable and code,
-the values set via the environment variable take precedence.
+{{% alert title="Note" class="info" %}}
+
+If you set your resource attributes via environment variable and code, the
+values set via the environment variable take precedence.
+
+{{% /alert %}}
 
 ## Container Resource Detection
 

--- a/content/en/docs/instrumentation/js/sampling.md
+++ b/content/en/docs/instrumentation/js/sampling.md
@@ -1,6 +1,7 @@
 ---
 title: Sampling
 weight: 80
+description: Reduce the amount of telemetry created
 ---
 
 [Sampling](/docs/concepts/sampling/) is a process that restricts the amount of

--- a/content/en/docs/instrumentation/js/serverless.md
+++ b/content/en/docs/instrumentation/js/serverless.md
@@ -1,6 +1,7 @@
 ---
 title: Serverless
 weight: 100
+description: Instrument your serverless functions with OpenTelemetry JavaScript
 cSpell:ignore: otelwrapper
 ---
 
@@ -9,8 +10,15 @@ OpenTelemetry instrumentation libraries.
 
 ## AWS Lambda
 
+{{% alert title="Note" color="info" %}}
+
+You can also automatically instrument your AWS Lambda functions by using the
+[community provided Lambda layers](/docs/faas/lambda-auto-instrument/).
+
+{{% /alert %}}
+
 The following show how to use Lambda wrappers with OpenTelemetry to instrument
-AWS Lambda functions and send traces to a configured backend.
+AWS Lambda functions manually and send traces to a configured backend.
 
 If you are interested in a plug and play user experience, see
 [OpenTelemetry Lambda Layers](https://github.com/open-telemetry/opentelemetry-lambda).

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -2851,6 +2851,10 @@
     "StatusCode": 200,
     "LastSeen": "2023-06-30T08:35:23.378554-04:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-js#supported-runtimes": {
+    "StatusCode": 200,
+    "LastSeen": "2023-09-21T09:40:56.039903+02:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-js-contrib": {
     "StatusCode": 200,
     "LastSeen": "2023-06-30T08:46:07.079949-04:00"


### PR DESCRIPTION
A set of additions & changes to the OpenTelemetry JavaScript pages:

* Add a description to all pages
* Add some extra details to the index page (version support, how to get help, etc.)
* Some cosmetic changes