### PR TITLE
Fixes in getting started pages

### DIFF
--- a/content/en/docs/instrumentation/js/getting-started/nodejs.md
+++ b/content/en/docs/instrumentation/js/getting-started/nodejs.md
@@ -8,8 +8,8 @@ weight: 10
 
 This page will show you how to get started with OpenTelemetry in Node.js.
 
-You will learn how you can instrument a simple application, in
-such a way that [traces][] and [metrics][] are emitted to the console.
+You will learn how you can instrument a simple application, in such a way that
+[traces][] and [metrics][] are emitted to the console.
 
 ## Prerequisites
 

--- a/content/en/docs/instrumentation/js/getting-started/nodejs.md
+++ b/content/en/docs/instrumentation/js/getting-started/nodejs.md
@@ -8,8 +8,8 @@ weight: 10
 
 This page will show you how to get started with OpenTelemetry in Node.js.
 
-You will learn how you can instrument a simple application automatically, in
-such a way that [traces][], [metrics][] and [logs][] are emitted to the console.
+You will learn how you can instrument a simple application, in
+such a way that [traces][] and [metrics][] are emitted to the console.
 
 ## Prerequisites
 
@@ -505,4 +505,3 @@ diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
 
 [traces]: /docs/concepts/signals/traces/
 [metrics]: /docs/concepts/signals/metrics/
-[logs]: /docs/concepts/signals/logs/

--- a/content/en/docs/instrumentation/js/getting-started/nodejs.md
+++ b/content/en/docs/instrumentation/js/getting-started/nodejs.md
@@ -8,8 +8,8 @@ weight: 10
 
 This page will show you how to get started with OpenTelemetry in Node.js.
 
-You will learn how you can instrument a simple application, in such a way that
-[traces][] and [metrics][] are emitted to the console.
+You will learn how you can instrument a simple application automatically, in
+such a way that [traces][], [metrics][] and [logs][] are emitted to the console.
 
 ## Prerequisites
 
@@ -505,3 +505,4 @@ diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
 
 [traces]: /docs/concepts/signals/traces/
 [metrics]: /docs/concepts/signals/metrics/
+[logs]: /docs/concepts/signals/logs/

--- a/content/en/docs/instrumentation/python/getting-started.md
+++ b/content/en/docs/instrumentation/python/getting-started.md
@@ -9,7 +9,7 @@ weight: 10
 This page will show you how to get started with OpenTelemetry in Python.
 
 You will learn how you can instrument a simple application automatically, in
-such a way that [traces][], [metrics][] and [logs][] are emitted to the console.
+such a way that [traces][] and [metrics][] are emitted to the console.
 
 ## Prerequisites
 
@@ -102,7 +102,6 @@ it print to the console for now:
 opentelemetry-instrument \
     --traces_exporter console \
     --metrics_exporter console \
-    --logs_exporter console \
     flask run -p 8080
 ```
 
@@ -710,4 +709,3 @@ If you'd like to explore a more complex example, take a look at the
 
 [traces]: /docs/concepts/signals/traces/
 [metrics]: /docs/concepts/signals/metrics/
-[logs]: /docs/concepts/signals/logs/

--- a/content/en/docs/instrumentation/ruby/getting-started.md
+++ b/content/en/docs/instrumentation/ruby/getting-started.md
@@ -9,8 +9,8 @@ weight: 10
 
 This page will show you how to get started with OpenTelemetry in Ruby.
 
-You will learn how you can instrument a simple application, in
-such a way that [traces][] are emitted to the console.
+You will learn how you can instrument a simple application, in such a way that
+[traces][] are emitted to the console.
 
 ## Prerequisites
 
@@ -190,7 +190,8 @@ a few more features that will allow you gain even deeper insights!
   [Email Service](/docs/demo/services/email/).
 
 [traces]: /docs/concepts/signals/traces/
-[instrumentations]: https://github.com/open-telemetry/opentelemetry-ruby#instrumentation-libraries
+[instrumentations]:
+  https://github.com/open-telemetry/opentelemetry-ruby#instrumentation-libraries
 [config]: ../automatic/#configuring-specific-instrumentation-libraries
 [exporters]: ../exporters/
 [context propagation]: ../manual/#context-propagation

--- a/content/en/docs/instrumentation/ruby/getting-started.md
+++ b/content/en/docs/instrumentation/ruby/getting-started.md
@@ -9,8 +9,8 @@ weight: 10
 
 This page will show you how to get started with OpenTelemetry in Ruby.
 
-You will learn how you can instrument a simple application automatically, in
-such a way that [traces][], [metrics][] and [logs][] are emitted to the console.
+You will learn how you can instrument a simple application, in
+such a way that [traces][] are emitted to the console.
 
 ## Prerequisites
 
@@ -96,7 +96,7 @@ bundle add opentelemetry-sdk opentelemetry-instrumentation-all
 ```
 
 The inclusion of `opentelemetry-instrumentation-all` provides
-[instrumentations][auto] for Rails, Sinatra, several HTTP libraries, and more.
+[instrumentations][] for Rails, Sinatra, several HTTP libraries, and more.
 
 For Rails applications, the usual way to initialize OpenTelemetry is in a Rails
 initializer. For other Ruby services, perform this initialization as early as
@@ -190,10 +190,7 @@ a few more features that will allow you gain even deeper insights!
   [Email Service](/docs/demo/services/email/).
 
 [traces]: /docs/concepts/signals/traces/
-[metrics]: /docs/concepts/signals/metrics/
-[logs]: /docs/concepts/signals/logs/
-[auto]:
-  https://github.com/open-telemetry/opentelemetry-ruby#instrumentation-libraries
+[instrumentations]: https://github.com/open-telemetry/opentelemetry-ruby#instrumentation-libraries
 [config]: ../automatic/#configuring-specific-instrumentation-libraries
 [exporters]: ../exporters/
 [context propagation]: ../manual/#context-propagation


### PR DESCRIPTION
Fixes

1. JS is **not** an **automatic** instrumentation
2. JS getting started does **not** cover logs 
3. Python getting started does **not** cover logs 
4. Ruby is **not** an **automatic** instrumentation
2. Ruby getting started does **not** cover metrics, nor logs 

## Docs PR Checklist

<!--- Just making sure... -->

- [x] This PR is for a documentation page whose authoritative copy is in the
      opentelemetry.io repository.
