### PR TITLE
update go metrics status to stable

### DIFF
--- a/data/instrumentation.yaml
+++ b/data/instrumentation.yaml
@@ -25,7 +25,7 @@ go:
   name: Go
   status:
     traces: stable
-    metrics: mixed (beta SDK & stable API)
+    metrics: stable
     logs: not yet implemented
 java:
   name: Java


### PR DESCRIPTION

Accordingly to release v1.19.0 of Open Telemetry Go, `metrics` SDK is now stable. Updating the docs to reflect that.

Reference
* https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.19.0
  > This release contains the first stable release of the OpenTelemetry Go [metric SDK](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric).

---

Preview
https://deploy-preview-3330--opentelemetry.netlify.app/