### PR TITLE
Add post for Go OTel metric SDK reaching stable status

### DIFF
--- a/content/en/blog/2023/otel-go-metrics-sdk-stable.md
+++ b/content/en/blog/2023/otel-go-metrics-sdk-stable.md
@@ -6,7 +6,7 @@ author: '[Fabrizio Ferri-Benedetti](https://github.com/theletterf/) (Splunk)'
 cSpell:ignore: Benedetti Fabrizio Ferri
 ---
 
-The Go metric SDK has finally reached stable status with version 1.19.0 of
+The Go metrics SDK has finally reached stable status with version 1.19.0 of
 OpenTelemetry Go. Project stability guarantees now apply to the
 [go.opentelemetry.io/otel/sdk/metric](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric)
 package.

--- a/content/en/blog/2023/otel-go-metrics-sdk-stable.md
+++ b/content/en/blog/2023/otel-go-metrics-sdk-stable.md
@@ -9,7 +9,7 @@ cSpell:ignore: Benedetti Fabrizio Ferri
 The Go metrics SDK has finally reached stable status with version 1.19.0 of
 OpenTelemetry Go. Project stability guarantees now apply to the
 [go.opentelemetry.io/otel/sdk/metric](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric)
-package.
+module.
 
 To get started with OTel Go metrics,
 [read the documentation](/docs/instrumentation/go/manual) or browse the

--- a/content/en/blog/2023/otel-go-metrics-sdk-stable.md
+++ b/content/en/blog/2023/otel-go-metrics-sdk-stable.md
@@ -6,8 +6,9 @@ author: '[Fabrizio Ferri-Benedetti](https://github.com/theletterf/) (Splunk)'
 cSpell:ignore: Benedetti Fabrizio Ferri
 ---
 
-The Go metrics SDK has finally reached stable status with version 1.19.0 of
-OpenTelemetry Go. Project stability guarantees now apply to the
+The Go metrics SDK has finally reached stable status with
+[version 1.19.0](https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.19.0)
+of OpenTelemetry Go. Project stability guarantees now apply to the
 [go.opentelemetry.io/otel/sdk/metric](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric)
 module.
 

--- a/content/en/blog/2023/otel-go-metrics-sdk-stable.md
+++ b/content/en/blog/2023/otel-go-metrics-sdk-stable.md
@@ -12,5 +12,6 @@ of OpenTelemetry Go. Project stability guarantees now apply to the
 [go.opentelemetry.io/otel/sdk/metric](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric)
 module.
 
-To learn more check the [getting started](/docs/instrumentation/go/getting-started)
-and [manual metrics](/docs/instrumentation/go/manual#metrics) documentation.
+To learn more check the
+[getting started](/docs/instrumentation/go/getting-started) and
+[manual metrics](/docs/instrumentation/go/manual#metrics) documentation.

--- a/content/en/blog/2023/otel-go-metrics-sdk-stable.md
+++ b/content/en/blog/2023/otel-go-metrics-sdk-stable.md
@@ -1,0 +1,18 @@
+---
+title: First stable release of OTel Go metric SDK
+linkTitle: Go Metric SDK is Stable
+date: 2023-09-29
+author: '[Fabrizio Ferri-Benedetti](https://github.com/theletterf/) (Splunk)'
+cSpell:ignore: Benedetti Fabrizio Ferri
+---
+
+The Go metric SDK has finally reached stable status with version 1.19.0 of
+OpenTelemetry Go. Project stability guarantees now apply to the
+[go.opentelemetry.io/otel/sdk/metric](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric)
+package.
+
+To get started with OTel Go metrics,
+[read the documentation](/docs/instrumentation/go/manual) or browse the
+[examples](https://github.com/open-telemetry/opentelemetry-go/tree/main/example)
+for demonstrations of different instrumentation scenarios covered by the
+OpenTelemetry Go Instrumentation.

--- a/content/en/blog/2023/otel-go-metrics-sdk-stable.md
+++ b/content/en/blog/2023/otel-go-metrics-sdk-stable.md
@@ -1,7 +1,7 @@
 ---
 title: First stable release of OTel Go metric SDK
 linkTitle: Go Metric SDK is Stable
-date: 2023-09-29
+date: 2023-10-02
 author: '[Fabrizio Ferri-Benedetti](https://github.com/theletterf/) (Splunk)'
 cSpell:ignore: Benedetti Fabrizio Ferri
 ---

--- a/content/en/blog/2023/otel-go-metrics-sdk-stable.md
+++ b/content/en/blog/2023/otel-go-metrics-sdk-stable.md
@@ -11,8 +11,5 @@ OpenTelemetry Go. Project stability guarantees now apply to the
 [go.opentelemetry.io/otel/sdk/metric](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric)
 module.
 
-To get started with OTel Go metrics,
-[read the documentation](/docs/instrumentation/go/manual) or browse the
-[examples](https://github.com/open-telemetry/opentelemetry-go/tree/main/example)
-for demonstrations of different instrumentation scenarios covered by the
-OpenTelemetry Go Instrumentation.
+To learn more check the [getting started](/docs/instrumentation/go/getting-started)
+and [manual metrics](/docs/instrumentation/go/manual#metrics) documentation.


### PR DESCRIPTION
A simple notice announcing the stability of the Go Otel metric SDK.