### PR TITLE
Add subsections in service configuration

### DIFF
--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -502,7 +502,7 @@ consists of three sub-sections:
 - pipelines
 - telemetry
 
-### Extensions
+### Extensions  {#service-extensions}
 
 Extensions consist of a list of all extensions to enable. For example:
 

--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -502,12 +502,16 @@ consists of three sub-sections:
 - pipelines
 - telemetry
 
+### Extensions
+
 Extensions consist of a list of all extensions to enable. For example:
 
 ```yaml
 service:
   extensions: [health_check, pprof, zpages]
 ```
+
+### Pipelines
 
 Pipelines can be of the following types:
 
@@ -539,6 +543,8 @@ service:
       processors: [batch]
       exporters: [opencensus, zipkin]
 ```
+
+### Telemetry
 
 Telemetry is where the telemetry for the collector itself can be configured. It
 has two subsections: `logs` and `metrics`.

--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -502,7 +502,7 @@ consists of three sub-sections:
 - pipelines
 - telemetry
 
-### Extensions  {#service-extensions}
+### Extensions {#service-extensions}
 
 Extensions consist of a list of all extensions to enable. For example:
 


### PR DESCRIPTION
Adds subsections in the Service configuration section:
- Extensions
- Pipelines
- Telemetry

I've been finding myself wanting to get a link to e.g. the "telemetry" section, but without a subsection, it's not possible. I believe these subsections make sense.