### PR TITLE
Add Jamie's other o11y talk to kubecon schedule

### DIFF
--- a/content/en/blog/2023/kubecon-na.md
+++ b/content/en/blog/2023/kubecon-na.md
@@ -40,6 +40,8 @@ OpenTelemetry maintainers in making OpenTelemetry better for everyone during the
 - **[Leverage Contextual and Structured Logging in K8s for Enhanced Monitoring](https://sched.co/1R2oQ)**<br>
   by Patrick Ohly, Intel & Shivanshu Raj Shrivastava, Independent<br> Tuesday,
   November 7 • 3:25pm - 4:00pm
+- **[Build in Observability While Developing](https://sched.co/1R2oA)**<br>
+  by Jamie Danielson, Honeycomb.io<br> Tuesday, November 7 • 3:25pm - 4:00pm
 - **[E2E Observability for Connected Vehicle Service via Distributed Tracing](https://sched.co/1R2oh)**<br>
   by Kota Endo, KDDI Corporation & Masanori Itoh, Toyota Motor Corporation<br>
   Tuesday, November 7 • 4:30pm - 5:05pm

--- a/content/en/blog/2023/kubecon-na.md
+++ b/content/en/blog/2023/kubecon-na.md
@@ -40,8 +40,8 @@ OpenTelemetry maintainers in making OpenTelemetry better for everyone during the
 - **[Leverage Contextual and Structured Logging in K8s for Enhanced Monitoring](https://sched.co/1R2oQ)**<br>
   by Patrick Ohly, Intel & Shivanshu Raj Shrivastava, Independent<br> Tuesday,
   November 7 • 3:25pm - 4:00pm
-- **[Build in Observability While Developing](https://sched.co/1R2oA)**<br>
-  by Jamie Danielson, Honeycomb.io<br> Tuesday, November 7 • 3:25pm - 4:00pm
+- **[Build in Observability While Developing](https://sched.co/1R2oA)**<br> by
+  Jamie Danielson, Honeycomb.io<br> Tuesday, November 7 • 3:25pm - 4:00pm
 - **[E2E Observability for Connected Vehicle Service via Distributed Tracing](https://sched.co/1R2oh)**<br>
   by Kota Endo, KDDI Corporation & Masanori Itoh, Toyota Motor Corporation<br>
   Tuesday, November 7 • 4:30pm - 5:05pm

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -4875,6 +4875,10 @@
     "StatusCode": 200,
     "LastSeen": "2023-09-11T17:29:33.640586+02:00"
   },
+  "https://sched.co/1R2oA": {
+    "StatusCode": 200,
+    "LastSeen": "2023-10-10T17:29:25.395063132Z"
+  },
   "https://sched.co/1R2oQ": {
     "StatusCode": 200,
     "LastSeen": "2023-09-11T17:29:34.788404+02:00"


### PR DESCRIPTION
Just came across this and noticed only one of my talks is listed on here - think they should both be there?

[This talk](https://sched.co/1R2oA) is on building observability [with OpenTelemetry] into the dev workflow