### PR TITLE
[CI] Spec vers: clone deep enough to find tag

### DIFF
--- a/.github/workflows/auto-update-versions.yml
+++ b/.github/workflows/auto-update-versions.yml
@@ -9,9 +9,11 @@ on:
 jobs:
   auto-update-versions:
     name: Auto-update versions
-    # restrict forks from running this workflow
-    if: github.repository == 'open-telemetry/opentelemetry.io'
     runs-on: ubuntu-20.04
+    if: github.repository == 'open-telemetry/opentelemetry.io'
+    env:
+      DEPTH: --depth 100 # submodule clone depth
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
- Closes #3384
- Ensures that submodule clones are deep enough for the script to be able to find version tags of repos that have been updated.
- This is similar to the issue we hit with #3103