### PR TITLE
Fix broken semantic convention links

### DIFF
--- a/content/en/docs/concepts/semantic-conventions.md
+++ b/content/en/docs/concepts/semantic-conventions.md
@@ -4,13 +4,14 @@ description: Common names for different kinds of operations and data.
 weight: 30
 ---
 
-OpenTelemetry defines Semantic Conventions (sometimes called Semantic
-Attributes) that specify common names for different kinds of operations and
-data. The benefit to using Semantic Conventions is in following a common naming
-scheme that can be standardized across a codebase, libraries, and platforms.
+OpenTelemetry defines [Semantic Conventions](/docs/specs/semconv/general/trace/)
+(sometimes called Semantic Attributes) that specify common names for different
+kinds of operations and data. The benefit to using Semantic Conventions is in
+following a common naming scheme that can be standardized across a codebase,
+libraries, and platforms.
 
 Currently, Semantic Conventions are available for traces, metrics and resources:
 
-- [Trace Semantic Conventions](/docs/specs/otel/trace/semantic_conventions/)
-- [Metric Semantic Conventions](/docs/specs/otel/metrics/semantic_conventions/)
-- [Resource Semantic Conventions](/docs/specs/otel/resource/semantic_conventions/)
+- [Trace Semantic Conventions](/docs/specs/semconv/general/trace/)
+- [Metric Semantic Conventions](/docs/specs/semconv/general/metrics/)
+- [Resource Semantic Conventions](/docs/specs/semconv/resource/)


### PR DESCRIPTION
addresses #3393, but not yet a final fix: @chalin can we have aliases for pages in the semantic convention such that the old URLs are pointing to the new pages? 