### PR TITLE
Ensure all links to semconv pages are localized

### DIFF
--- a/.warnings-skip-list.txt
+++ b/.warnings-skip-list.txt
@@ -1,1 +1,0 @@
-docs/specs/otel/common/attribute-requirement-level.md

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -128,8 +128,8 @@ while(<>) {
   s|(\]:\s+\|\()?https://github.com/open-telemetry/opentelemetry-proto/(\w+/.*?/)?docs/specification.md(\)?)|$1$specBasePath/otlp/$3|g;
   s|github.com/open-telemetry/opentelemetry-proto/docs/specification.md|OTLP|g;
 
-  # Match links to semconv
-  s|(\]:\s+\|\()https://github.com/open-telemetry/semantic-conventions/\w+/(main\|v$semconvVers)/docs(.*?\)?)|$1$specBasePath/semconv$3|;
+  # Localize links to semconv
+  s|(\]:\s+\|\()https://github.com/open-telemetry/semantic-conventions/\w+/(main\|v$semconvVers)/docs(.*?\)?)|$1$specBasePath/semconv$3|g;
 
   # Images
   s|(\.\./)?internal(/img/[-\w]+\.png)|$2|g;


### PR DESCRIPTION
- Contributes to #3392
- Ensures that even lines with more than one link into the semconv repo docs get converted to a local page reference (the `g` regex qualifier was missing)
- This change makes the build warning go away 