### PR TITLE
Link to LF trademark guidelines in footer

### DIFF
--- a/content/en/community/marketing-guidelines.md
+++ b/content/en/community/marketing-guidelines.md
@@ -31,7 +31,7 @@ There are three high-level focus areas for these goals and guidelines.
 - Do’s:
   - Use project collateral such as logo and name in line with the Linux
     Foundation’s branding and
-    [trademark usage guidelines](https://www.linuxfoundation.org/trademark-usage/)
+    [trademark usage guidelines](https://www.linuxfoundation.org/legal/trademark-usage)
   - Emphasize that OTel would not be possible without collaboration from many
     contributors who happen to work for competing vendors and providers
   - Cite names of the other contributors and vendors involved with OTel efforts

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -126,6 +126,10 @@ params:
         desc: >-
           CNCF works in close association with Linux Foundation. Read the
           privacy policy here
+      - name: Trademark Usage
+        url: https://www.linuxfoundation.org/legal/trademark-usage
+        icon: fa-solid fa-trademark
+        desc: Linux Foundation’s trademarks policy and guidelines.
       - name: Marketing Guidelines
         url: /community/marketing-guidelines/
         icon: fas fa-bullhorn
@@ -135,6 +139,7 @@ params:
       - name: Site-build info
         url: /site/
         icon: fa-solid fa-hammer
+        desc: Site-build information.
 
   logos:
     hero: opentelemetry-horizontal-color.png

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -5677,11 +5677,11 @@
   },
   "https://www.linuxfoundation.org/legal/privacy-policy": {
     "StatusCode": 200,
-    "LastSeen": "2023-06-29T18:36:29.596108-04:00"
+    "LastSeen": "2023-10-18T10:57:26.960512-04:00"
   },
-  "https://www.linuxfoundation.org/trademark-usage/": {
+  "https://www.linuxfoundation.org/legal/trademark-usage": {
     "StatusCode": 200,
-    "LastSeen": "2023-06-30T08:53:04.661984-04:00"
+    "LastSeen": "2023-10-18T10:57:32.375541-04:00"
   },
   "https://www.logicmonitor.com/": {
     "StatusCode": 206,


### PR DESCRIPTION
- Contributes to #1269, not in the way I way hoping (which was to bring in the gRPC footer, but going for a quick solution here)
  - I'll the issue once https://clomonitor.io/projects/cncf/open-telemetry says that it's happy for legal
- Add Trademark link to the footer
- Switched to using a canonical link for the LF TM