### PR TITLE
Add redirect rules for main spec 404s

### DIFF
--- a/content/en/docs/specs/_index.md
+++ b/content/en/docs/specs/_index.md
@@ -3,4 +3,23 @@ title: Specifications
 linkTitle: Specs
 aliases: [/docs/reference, /docs/specification]
 weight: 100
+# Temporary redirect rules until they are added to the spec pages
+redirects:
+  # OTel spec
+  - from: otel/logs/semantic_conventions/events
+    to: semconv/general/events/
+  - from: otel/trace/semantic_conventions/http
+    to: semconv/http/http-spans/
+  # Temporarily implement a catch-all for the rest. Later we'll add specific redirects like the one above.
+  - from: otel/logs/semantic_conventions/*
+    to: semconv/general/logs/
+  - from: otel/metrics/semantic_conventions/*
+    to: semconv/general/metrics/
+  - from: otel/resource/semantic_conventions/*
+    to: semconv/resource/
+  - from: otel/trace/semantic_conventions/*
+    to: semconv/general/trace/
+  # Semconv
+  - from: semconv/resource/deployment_environment
+    to: semconv/resource/deployment-environment
 ---

--- a/content/en/docs/specs/status.md
+++ b/content/en/docs/specs/status.md
@@ -113,7 +113,7 @@ same as the **Protocol** status.
     active development.
 
 [baggage]: /docs/specs/otel/baggage/
-[event semantic conventions]: /docs/specs/semconv/general/logs/
+[event semantic conventions]: /docs/specs/semconv/general/events/
 [logging]: /docs/specs/otel/logs/
 [logs data model]: /docs/specs/otel/logs/data-model/
 [metrics]: /docs/specs/otel/metrics/

--- a/content/en/ecosystem/registry/_index.md
+++ b/content/en/ecosystem/registry/_index.md
@@ -10,7 +10,7 @@ description: >-
 # self-loop with `/ecosystem/registry/index.html`. So we use the following
 # redirect rule to avoid the loop, as suggested by Netlify support
 # (email support ID 159489):
-redirects: [{ from: ./*, to: '?' }]
+redirects: [{ from: /ecosystem/registry*, to: '/ecosystem/registry?' }]
 aliases: [/registry/*]
 type: default
 layout: registry

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -4,11 +4,10 @@
 {{ range $p := .Site.Pages -}}
 
 {{ range $p.Params.redirects -}}
-  {{ $permaLink := $p.RelPermalink | strings.TrimSuffix "/" -}}
-  {{ $from := cond
-      (strings.HasPrefix .from "./")
-      (print $permaLink (strings.TrimPrefix "./" .from))
-      .from -}}
+  {{ $permaLink := $p.RelPermalink -}}
+  {{ $from := cond (strings.HasPrefix .from "/")
+      .from
+      (print $permaLink .from) -}}
   {{ $to := cond (strings.HasPrefix .to "/")
       .to
       (print $permaLink .to) -}}
@@ -46,4 +45,4 @@
 
 {{ $og_image_current := `/img/social/logo-wordmark-001.png` -}}
 
-/featured-background.jpg  {{ $og_image_current }} {{/* homepage og:image used prior to 2022/08 */}}
+/featured-background.jpg  {{ $og_image_current }} {{- /* homepage og:image used prior to 2022/08 */}}


### PR DESCRIPTION
- Fixes #3409 by adding catch all rules
- Contributes to #3392
- Adds a few path-specific rewrites. More will be added later. Eventually these will be moved into their respective spec pages.
- Fixes a link to events semconv in the status page

**Preview**: https://deploy-preview-3410--opentelemetry.netlify.app/docs/specs/

**Redirect tests**:

- https://deploy-preview-3410--opentelemetry.netlify.app/docs/specs/otel/logs/semantic_conventions/events
- https://deploy-preview-3410--opentelemetry.netlify.app/docs/specs/otel/trace/semantic_conventions/http
- https://deploy-preview-3410--opentelemetry.netlify.app/docs/specs/otel/logs/semantic_conventions
- https://deploy-preview-3410--opentelemetry.netlify.app/docs/specs/otel/metrics/semantic_conventions
- https://deploy-preview-3410--opentelemetry.netlify.app/docs/specs/otel/resource/semantic_conventions
- https://deploy-preview-3410--opentelemetry.netlify.app/docs/specs/otel/trace/semantic_conventions
- https://deploy-preview-3410--opentelemetry.netlify.app/docs/specs/semconv/resource/deployment_environment

