### PR TITLE
Support page-relative aliases

### DIFF
--- a/content/en/blog/2022/gc-candidates.md
+++ b/content/en/blog/2022/gc-candidates.md
@@ -3,7 +3,7 @@ title: Final list of candidates for the 2022 OpenTelemetry Governance Committee
 linkTitle: 2022 GC Candidates
 date: 2022-10-13
 author: OpenTelemetry Governance Committee
-aliases: [/blog/2022/gc-elections-2022-list-of-candidates]
+aliases: [gc-elections-2022-list-of-candidates]
 cSpell:ignore: Finnigan Marciniak Reiley Vijay Yahn
 ---
 

--- a/content/en/blog/2022/gc-elections.md
+++ b/content/en/blog/2022/gc-elections.md
@@ -3,7 +3,7 @@ title: Announcing the 2022 OpenTelemetry Governance Committee Election
 linkTitle: 2022 GC Election
 date: 2022-09-15
 author: OpenTelemetry Governance Committee
-aliases: [/blog/2022/gc-elections-2022]
+aliases: [gc-elections-2022]
 cSpell:ignore: bogdandrutu Fong jpkrohling
 ---
 

--- a/content/en/blog/2023/end-user-discussions-01.md
+++ b/content/en/blog/2023/end-user-discussions-01.md
@@ -3,7 +3,7 @@ title: OpenTelemetry End-User Discussions Summary for January 2023
 linkTitle: End-User Discussions Jan 2023
 date: 2023-01-27
 author: '[Adriana Villela](https://github.com/avillela) (Lightstep)'
-aliases: [/blog/2023/otel-end-user-discussions-january-2023]
+aliases: [otel-end-user-discussions-january-2023]
 body_class: otel-with-contributions-from
 cSpell:ignore: january OTTL
 ---

--- a/content/en/blog/2023/gc-elections.md
+++ b/content/en/blog/2023/gc-elections.md
@@ -3,7 +3,7 @@ title: Announcing the 2023 OpenTelemetry Governance Committee Election
 linkTitle: 2023 GC Election
 date: 2023-09-29
 author: OpenTelemetry Governance Committee
-aliases: [/blog/2023/gc-elections-2023]
+aliases: [gc-elections-2023]
 cSpell:ignore: Bogdan Drutu dyladan mtwo Paxão Shkuro Sigelman trask
 ---
 

--- a/content/en/blog/2023/new-apac-meetings.md
+++ b/content/en/blog/2023/new-apac-meetings.md
@@ -2,7 +2,7 @@
 title: New APAC Collector-SIG meetings
 date: 2023-02-27
 author: '[Sean Marciniak](https://github.com/MovieStoreGuy) (Atlassian)'
-aliases: [/blog/2023/additional-collector-sig/]
+aliases: [additional-collector-sig/]
 cSpell:ignore: Marciniak
 ---
 

--- a/content/en/docs/collector/_index.md
+++ b/content/en/docs/collector/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Collector
 description: Vendor-agnostic way to receive, process and export telemetry data.
-aliases: [/docs/collector/about]
+aliases: [collector/about]
 cascade:
   collectorVersion: 0.87.0
 weight: 10

--- a/content/en/docs/concepts/_index.md
+++ b/content/en/docs/concepts/_index.md
@@ -2,7 +2,7 @@
 title: OpenTelemetry Concepts
 linkTitle: Concepts
 description: Key concepts in OpenTelemetry
-aliases: [/docs/concepts/overview]
+aliases: [concepts/overview]
 weight: 2
 ---
 

--- a/content/en/docs/concepts/components.md
+++ b/content/en/docs/concepts/components.md
@@ -1,7 +1,7 @@
 ---
 title: Components
 description: The main components that make up OpenTelemetry
-aliases: [/docs/concepts/data-collection]
+aliases: [data-collection]
 weight: 20
 ---
 

--- a/content/en/docs/concepts/instrumentation/_index.md
+++ b/content/en/docs/concepts/instrumentation/_index.md
@@ -3,7 +3,7 @@ title: Instrumentation
 description: >-
   How OpenTelemetry facilitates automatic and manual instrumentation of
   applications.
-aliases: [/docs/concepts/instrumenting]
+aliases: [instrumenting]
 weight: 15
 ---
 

--- a/content/en/docs/concepts/instrumentation/libraries.md
+++ b/content/en/docs/concepts/instrumentation/libraries.md
@@ -1,7 +1,7 @@
 ---
 title: Libraries
 description: Learn how to add native instrumentation to your library.
-aliases: [/docs/concepts/instrumenting-library]
+aliases: [../instrumenting-library]
 weight: 40
 ---
 

--- a/content/en/docs/demo/architecture.md
+++ b/content/en/docs/demo/architecture.md
@@ -1,7 +1,7 @@
 ---
 title: Demo Architecture
 linkTitle: Architecture
-aliases: [/docs/demo/current_architecture]
+aliases: [current_architecture]
 body_class: otel-mermaid-max-width
 # prettier-ignore
 cSpell:ignore: cppsvc dotnetsvc erlangsvc featureflagstore golangsvc javascriptsvc javasvc kotlinsvc loadgenerator phpsvc pythonsvc rubysvc rustsvc tsdb typescriptsvc

--- a/content/en/docs/demo/docker-deployment.md
+++ b/content/en/docs/demo/docker-deployment.md
@@ -1,7 +1,7 @@
 ---
 title: Docker deployment
 linkTitle: Docker
-aliases: [/docs/demo/docker_deployment]
+aliases: [docker_deployment]
 cSpell:ignore: otelcollector otlphttp
 ---
 

--- a/content/en/docs/demo/feature-flags.md
+++ b/content/en/docs/demo/feature-flags.md
@@ -1,6 +1,6 @@
 ---
 title: Feature Flags
-aliases: [/docs/demo/feature_flags]
+aliases: [feature_flags]
 cSpell:ignore: OLJCESPC7Z
 ---
 

--- a/content/en/docs/demo/features.md
+++ b/content/en/docs/demo/features.md
@@ -1,7 +1,7 @@
 ---
 title: Demo Features
 linkTitle: Features
-aliases: [/docs/demo/demo_features]
+aliases: [demo_features]
 ---
 
 - **[Kubernetes](https://kubernetes.io/)**: the app is designed to run on

--- a/content/en/docs/demo/kubernetes-deployment.md
+++ b/content/en/docs/demo/kubernetes-deployment.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes deployment
 linkTitle: Kubernetes
-aliases: [/docs/demo/kubernetes_deployment]
+aliases: [kubernetes_deployment]
 cSpell:ignore: loadgen otlphttp
 ---
 

--- a/content/en/docs/demo/manual-span-attributes.md
+++ b/content/en/docs/demo/manual-span-attributes.md
@@ -1,6 +1,6 @@
 ---
 title: Manual Span Attributes
-aliases: [/docs/demo/manual_span_attributes]
+aliases: [manual_span_attributes]
 cSpell:ignore: featureflag
 ---
 

--- a/content/en/docs/demo/metric-features.md
+++ b/content/en/docs/demo/metric-features.md
@@ -1,7 +1,7 @@
 ---
 title: Metric Feature Coverage by Service
 linkTitle: Metric Feature Coverage
-aliases: [/docs/demo/metric_service_features]
+aliases: [metric_service_features]
 ---
 
 | Service         | Language        | Auto-instrumentation | Manual Instrumentation | Multiple Instruments | Views | Custom Attributes | Resource Detection | Trace Exemplars |

--- a/content/en/docs/demo/requirements/application.md
+++ b/content/en/docs/demo/requirements/application.md
@@ -1,7 +1,7 @@
 ---
 title: Application Requirements
 title: Application
-aliases: [/docs/demo/requirements/application_requirements]
+aliases: [application_requirements]
 ---
 
 The following requirements were decided upon to define what OpenTelemetry (OTel)

--- a/content/en/docs/demo/requirements/architecture.md
+++ b/content/en/docs/demo/requirements/architecture.md
@@ -1,7 +1,7 @@
 ---
 title: Architecture Requirements
 linkTitle: Architecture
-aliases: [/docs/demo/requirements/architecture_requirements]
+aliases: [architecture_requirements]
 cSpell:ignore: dockerstatsreceiver
 ---
 

--- a/content/en/docs/demo/requirements/opentelemetry.md
+++ b/content/en/docs/demo/requirements/opentelemetry.md
@@ -1,7 +1,7 @@
 ---
 title: OpenTelemetry Requirements
 linkTitle: OTel Requirements
-aliases: [/docs/demo/requirements/opentelemetry_requirements]
+aliases: [opentelemetry_requirements]
 ---
 
 The following requirements were decided upon to define what OpenTelemetry (OTel)

--- a/content/en/docs/demo/requirements/system.md
+++ b/content/en/docs/demo/requirements/system.md
@@ -1,7 +1,7 @@
 ---
 title: System Requirements
 linkTitle: System
-aliases: [/docs/demo/requirements/system_requirements]
+aliases: [system_requirements]
 ---
 
 To ensure the demo runs correctly please ensure your environment meets the

--- a/content/en/docs/demo/scenarios/recommendation-cache/index.md
+++ b/content/en/docs/demo/scenarios/recommendation-cache/index.md
@@ -1,7 +1,7 @@
 ---
 title: Using Metrics and Traces to diagnose a memory leak
 linkTitle: Diagnosing memory leaks
-aliases: [/docs/demo/scenarios/recommendation_cache]
+aliases: [recommendation_cache]
 ---
 
 Application telemetry, such as the kind that OpenTelemetry can provide, is very

--- a/content/en/docs/demo/screenshots/index.md
+++ b/content/en/docs/demo/screenshots/index.md
@@ -1,7 +1,7 @@
 ---
 title: Demo Screenshots
 linkTitle: Screenshots
-aliases: [/docs/demo/demo_screenshots]
+aliases: [demo_screenshots]
 ---
 
 ## Web store

--- a/content/en/docs/demo/service-table.md
+++ b/content/en/docs/demo/service-table.md
@@ -1,6 +1,6 @@
 ---
 title: Service Roles
-aliases: [/docs/demo/service_table]
+aliases: [service_table]
 cSpell:ignore: loadgenerator
 ---
 

--- a/content/en/docs/demo/services/accounting.md
+++ b/content/en/docs/demo/services/accounting.md
@@ -1,7 +1,7 @@
 ---
 title: Accounting Service
 linkTitle: Accounting
-aliases: [/docs/demo/services/accountingservice]
+aliases: [accountingservice]
 cSpell:ignore: otelsarama otlptracegrpc sarama sdktrace
 ---
 

--- a/content/en/docs/demo/services/ad.md
+++ b/content/en/docs/demo/services/ad.md
@@ -1,7 +1,7 @@
 ---
 title: Ad Service
 linkTitle: Ad
-aliases: [/docs/demo/services/adservice]
+aliases: [adservice]
 ---
 
 This service determines appropriate ads to serve to users based on context keys.

--- a/content/en/docs/demo/services/cart.md
+++ b/content/en/docs/demo/services/cart.md
@@ -1,7 +1,7 @@
 ---
 title: Cart Service
 linkTitle: Cart
-aliases: [/docs/demo/services/cartservice]
+aliases: [cartservice]
 ---
 
 This service maintains items placed in the shopping cart by users. It interacts

--- a/content/en/docs/demo/services/checkout.md
+++ b/content/en/docs/demo/services/checkout.md
@@ -1,7 +1,7 @@
 ---
 title: Checkout Service
 linkTitle: Checkout
-aliases: [/docs/demo/services/checkoutservice]
+aliases: [checkoutservice]
 # prettier-ignore
 cSpell:ignore: fatalf otelgrpc otelsarama otlpmetricgrpc otlptracegrpc sarama sdkmetric sdktrace
 ---

--- a/content/en/docs/demo/services/currency.md
+++ b/content/en/docs/demo/services/currency.md
@@ -1,7 +1,7 @@
 ---
 title: Currency Service
 linkTitle: Currency
-aliases: [/docs/demo/services/currencyservice]
+aliases: [currencyservice]
 cSpell:ignore: chrono decltype labelkv millis noexcept nostd
 ---
 

--- a/content/en/docs/demo/services/email.md
+++ b/content/en/docs/demo/services/email.md
@@ -1,7 +1,7 @@
 ---
 title: Email Service
 linkTitle: Email
-aliases: [/docs/demo/services/emailservice]
+aliases: [emailservice]
 cSpell:ignore: sinatra
 ---
 

--- a/content/en/docs/demo/services/feature-flag.md
+++ b/content/en/docs/demo/services/feature-flag.md
@@ -1,7 +1,7 @@
 ---
 title: Feature Flag Service
 linkTitle: Feature Flag
-aliases: [/docs/demo/services/featureflagservice]
+aliases: [featureflagservice]
 cSpell:ignore: ecto featureflag grpcbox nanos oteldemo protos struct
 ---
 

--- a/content/en/docs/demo/services/fraud-detection.md
+++ b/content/en/docs/demo/services/fraud-detection.md
@@ -1,7 +1,7 @@
 ---
 title: Fraud Detection Service
 linkTitle: Fraud Detection
-aliases: [/docs/demo/services/frauddetectionservice]
+aliases: [frauddetectionservice]
 ---
 
 This service analyses incoming orders and detects malicious customers. This is

--- a/content/en/docs/demo/services/frontend-proxy.md
+++ b/content/en/docs/demo/services/frontend-proxy.md
@@ -1,7 +1,7 @@
 ---
 title: Frontend Proxy (Envoy)
 linkTitle: Frontend Proxy
-aliases: [docs/demo/services/frontendproxy]
+aliases: [frontendproxy]
 cSpell:ignore: upstreams
 ---
 

--- a/content/en/docs/demo/services/load-generator.md
+++ b/content/en/docs/demo/services/load-generator.md
@@ -1,6 +1,6 @@
 ---
 title: Load Generator
-aliases: [/docs/demo/services/loadgenerator]
+aliases: [loadgenerator]
 cSpell:ignore: instrumentor instrumentors loadgenerator locustfile urllib
 ---
 

--- a/content/en/docs/demo/services/payment.md
+++ b/content/en/docs/demo/services/payment.md
@@ -1,7 +1,7 @@
 ---
 title: Payment Service
 linkTitle: Payment
-aliases: [/docs/demo/services/paymentservice]
+aliases: [paymentservice]
 cSpell:ignore: nanos
 ---
 

--- a/content/en/docs/demo/services/product-catalog.md
+++ b/content/en/docs/demo/services/product-catalog.md
@@ -1,7 +1,7 @@
 ---
 title: Product Catalog Service
 linkTitle: Product Catalog
-aliases: [/docs/demo/services/productcatalogservice]
+aliases: [productcatalogservice]
 # prettier-ignore
 cSpell:ignore: fatalf otelcodes otelgrpc otlpmetricgrpc otlptracegrpc sdkmetric sdktrace sprintf
 ---

--- a/content/en/docs/demo/services/quote.md
+++ b/content/en/docs/demo/services/quote.md
@@ -1,7 +1,7 @@
 ---
 title: Quote Service
 linkTitle: Quote
-aliases: [/docs/demo/services/quoteservice]
+aliases: [quoteservice]
 cSpell:ignore: getquote
 ---
 

--- a/content/en/docs/demo/services/recommendation.md
+++ b/content/en/docs/demo/services/recommendation.md
@@ -1,7 +1,7 @@
 ---
 title: Recommendation Service
 linkTitle: Recommendation
-aliases: [/docs/demo/services/recommendationservice]
+aliases: [recommendationservice]
 cSpell:ignore: cpython instrumentor NOTSET
 ---
 

--- a/content/en/docs/demo/services/shipping.md
+++ b/content/en/docs/demo/services/shipping.md
@@ -1,7 +1,7 @@
 ---
 title: Shipping Service
 linkTitle: Shipping
-aliases: [/docs/demo/services/shippingservice]
+aliases: [shippingservice]
 cSpell:ignore: itemct oteldemo reqwest sdktrace semcov shiporder tokio
 ---
 

--- a/content/en/docs/demo/trace-features.md
+++ b/content/en/docs/demo/trace-features.md
@@ -1,7 +1,7 @@
 ---
 title: Trace Feature Coverage by Service
 linkTitle: Trace Feature Coverage
-aliases: [/docs/demo/trace_service_features]
+aliases: [trace_service_features]
 ---
 
 | Service            | Language        | Instrumentation Libraries | Manual Span Creation | Span Data Enrichment | RPC Context Propagation | Span Links | Baggage | Resource Detection |

--- a/content/en/docs/instrumentation/erlang/manual.md
+++ b/content/en/docs/instrumentation/erlang/manual.md
@@ -1,6 +1,6 @@
 ---
 title: Manual
-aliases: [/docs/instrumentation/erlang/instrumentation]
+aliases: [instrumentation]
 weight: 30
 description: Manual instrumentation for OpenTelemetry Erlang/Elixir
 ---

--- a/content/en/docs/instrumentation/go/exporters.md
+++ b/content/en/docs/instrumentation/go/exporters.md
@@ -1,6 +1,6 @@
 ---
 title: Exporters
-aliases: [/docs/instrumentation/go/exporting_data]
+aliases: [exporting_data]
 weight: 50
 # prettier-ignore
 cSpell:ignore: otlpmetric otlpmetricgrpc otlpmetrichttp otlptrace otlptracegrpc otlptracehttp promhttp stdouttrace

--- a/content/en/docs/instrumentation/java/automatic/annotations.md
+++ b/content/en/docs/instrumentation/java/automatic/annotations.md
@@ -1,7 +1,7 @@
 ---
 title: Annotations
 description: Using instrumentation annotations with a Java agent.
-aliases: [/docs/instrumentation/java/annotations]
+aliases: [../annotations]
 weight: 20
 javaInstrumentationVersion: 1.31.0
 cSpell:ignore: Flowable javac reactivestreams reactivex

--- a/content/en/docs/instrumentation/java/automatic/extensions.md
+++ b/content/en/docs/instrumentation/java/automatic/extensions.md
@@ -1,6 +1,6 @@
 ---
 title: Extensions
-aliases: [/docs/instrumentation/java/extensions]
+aliases: [../extensions]
 description: >-
   Extensions add capabilities to the agent without having to create a separate
   distribution.

--- a/content/en/docs/instrumentation/js/context.md
+++ b/content/en/docs/instrumentation/js/context.md
@@ -1,7 +1,7 @@
 ---
 title: Context
 description: OpenTelemetry JavaScript Context API Documentation
-aliases: [/docs/instrumentation/js/api/context]
+aliases: [api/context]
 weight: 60
 ---
 

--- a/content/en/docs/instrumentation/js/examples.md
+++ b/content/en/docs/instrumentation/js/examples.md
@@ -1,6 +1,6 @@
 ---
 title: Examples
-aliases: [/docs/instrumentation/js/instrumentation_examples]
+aliases: [instrumentation_examples]
 description:
   Explore more examples for OpenTelemetry JavaScript _(external page)_
 redirect: https://github.com/open-telemetry/opentelemetry-js/tree/main/examples

--- a/content/en/docs/instrumentation/js/propagation.md
+++ b/content/en/docs/instrumentation/js/propagation.md
@@ -1,7 +1,7 @@
 ---
 title: Propagation
 description: Context propagation for the JS SDK
-aliases: [/docs/instrumentation/js/api/propagation]
+aliases: [api/propagation]
 weight: 65
 cSpell:ignore: tracestate
 ---

--- a/content/en/docs/instrumentation/php/getting-started.md
+++ b/content/en/docs/instrumentation/php/getting-started.md
@@ -1,7 +1,7 @@
 ---
 title: Getting Started
 description: Get up and running with OpenTelemetry for PHP.
-aliases: [/docs/instrumentation/php/getting_started]
+aliases: [getting_started]
 weight: 10
 cSpell:ignore: darwin myapp PECL pecl rolldice strval
 ---

--- a/content/en/docs/instrumentation/ruby/automatic.md
+++ b/content/en/docs/instrumentation/ruby/automatic.md
@@ -1,7 +1,7 @@
 ---
 title: Automatic instrumentation
 linkTitle: Automatic
-aliases: [/docs/instrumentation/ruby/configuring_automatic_instrumentation]
+aliases: [configuring_automatic_instrumentation]
 cSpell:ignore: faraday sinatra
 weight: 20
 ---

--- a/content/en/docs/instrumentation/ruby/getting-started.md
+++ b/content/en/docs/instrumentation/ruby/getting-started.md
@@ -1,7 +1,7 @@
 ---
 title: Getting Started
 description: Get telemetry from your app in less than 5 minutes!
-aliases: [/docs/instrumentation/ruby/getting_started]
+aliases: [getting_started]
 # prettier-ignore
 cSpell:ignore: darwin rolldice sinatra struct Tracestate tracestate truffleruby
 weight: 10

--- a/content/en/docs/specs/_index.md
+++ b/content/en/docs/specs/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Specifications
 linkTitle: Specs
-aliases: [/docs/reference, /docs/specification]
+aliases: [reference, specification]
 weight: 100
 # Temporary redirect rules until they are added to the spec pages
 redirects:

--- a/content/en/docs/specs/status.md
+++ b/content/en/docs/specs/status.md
@@ -1,7 +1,7 @@
 ---
 title: Specification Status Summary
 linkTitle: Status
-aliases: [/docs/specs/otel/status]
+aliases: [otel/status]
 weight: -10
 ---
 

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -4,18 +4,25 @@
 {{ range $p := .Site.Pages -}}
 
 {{ range $p.Params.redirects -}}
-  {{ $permaLink := $p.RelPermalink -}}
   {{ $from := cond (strings.HasPrefix .from "/")
       .from
-      (print $permaLink .from) -}}
+      (print $p.RelPermalink .from) -}}
   {{ $to := cond (strings.HasPrefix .to "/")
       .to
-      (print $permaLink .to) -}}
+      (print $p.RelPermalink .to) -}}
   {{ $from | printf "%-35s" }} {{ $to }}
 {{ end -}}
 
 {{ range $p.Aliases -}}
-  {{ . | printf "%-35s" }} {{ $p.RelPermalink }}
+{{/* Temporary workaround for semconv alias errors */ -}}
+{{ if strings.HasPrefix . "docs/specs/semconv/general" -}}
+{{ . | printf "%-35s" }} {{ $p.RelPermalink }}
+{{ else -}}
+{{ $alias := cond (strings.HasPrefix . "/")
+    .
+    (partial "relative-redirects-alias" (dict "alias" . "p" $p.Parent)) -}}
+{{ $alias | printf "%-35s" }} {{ $p.RelPermalink }}
+{{ end -}}
 {{ end -}}
 
 {{ with $p.Params.redirect -}}
@@ -46,3 +53,17 @@
 {{ $og_image_current := `/img/social/logo-wordmark-001.png` -}}
 
 /featured-background.jpg  {{ $og_image_current }} {{- /* homepage og:image used prior to 2022/08 */}}
+
+{{- define "partials/relative-redirects-alias" -}}
+  {{ $result := "" }}
+  {{ if strings.HasPrefix .alias "../" }}
+    {{ $result = (partial "relative-redirects-alias"
+          (dict
+            "alias" (strings.TrimPrefix "../" .alias)
+            "p" .p.Parent ))
+    }}
+  {{ else }}
+    {{ $result = path.Join .p.RelPermalink .alias }}
+  {{ end }}
+  {{ return $result }}
+{{ end }}


### PR DESCRIPTION
- Prep for continued work on #3392
- Provides support for page-relative aliases that either:
  - Do not start with "/"
  - Start with one or more "../"
- Includes a workaround for misformatted semconv alias paths (that are missing a leading `/`)

The only file affected is `_redirects` and the changes aren't significant (a leading or trailing `/` was added):

```diff
diff --git a/_redirects b/_redirects
index d6419903f..e22095996 100644
--- a/_redirects
+++ b/_redirects
@@ -101,7 +101,7 @@
 /docs/instrumentation/rust/examples/ https://github.com/open-telemetry/opentelemetry-rust/tree/main/examples
 /docs/instrumentation/swift/examples/ https://github.com/open-telemetry/opentelemetry-swift/tree/main/Examples
 /blog/2023/gc-elections-2023        /blog/2023/gc-elections/
-/blog/2023/additional-collector-sig/ /blog/2023/new-apac-meetings/
+/blog/2023/additional-collector-sig /blog/2023/new-apac-meetings/
 /blog/2023/end-user-q-and-a-series-otel-and-graphql /blog/2023/end-user-q-and-a-01/
 /blog/2023/otel-end-user-q-and-a-series-otel-and-graphql /blog/2023/end-user-q-and-a-01/
 /blog/2023/otel-end-user-discussions-january-2023 /blog/2023/end-user-discussions-01/
@@ -130,7 +130,7 @@ docs/specs/semconv/general/events-general /docs/specs/semconv/general/events/
 /docs/demo/feature_flags            /docs/demo/feature-flags/
 /docs/demo/demo_features            /docs/demo/features/
 /docs/demo/services/frauddetectionservice /docs/demo/services/fraud-detection/
-docs/demo/services/frontendproxy    /docs/demo/services/frontend-proxy/
+/docs/demo/services/frontendproxy   /docs/demo/services/frontend-proxy/
 /integrations                       /ecosystem/integrations/
 /docs/demo/kubernetes_deployment    /docs/demo/kubernetes-deployment/
 /docs/operator                      /docs/kubernetes/operator/
```

**Redirect tests** (a sampling):

- https://deploy-preview-3417--opentelemetry.netlify.app/blog/2022/gc-elections-2022-list-of-candidates
- https://deploy-preview-3417--opentelemetry.netlify.app/docs/concepts/instrumenting-library
- https://deploy-preview-3417--opentelemetry.netlify.app/docs/instrumentation/java/extensions
- https://deploy-preview-3417--opentelemetry.netlify.app/docs/instrumentation/js/api/propagation