### PR TITLE
Fix the number of available seats for GC Elections

### DIFF
--- a/content/en/blog/2023/gc-candidates.md
+++ b/content/en/blog/2023/gc-candidates.md
@@ -7,7 +7,7 @@ cSpell:ignore: Blanco Sirianni Vijay
 ---
 
 The OpenTelemetry election committee is pleased to announce the final list of
-candidates running for one of the four available seats. We encourage all voters
+candidates running for one of the five available seats. We encourage all voters
 to take a moment and review all candidates, picking the one that best represents
 your interest. You can find their pictures, profile link, and descriptions on
 the


### PR DESCRIPTION
This PR fixes the information about the number of available seats for this GC election.

Source: https://github.com/open-telemetry/community/blob/main/elections/2023/governance-committee-election.md#vacancies

> Five people must be elected in this election, each with two-year terms


Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

