### PR TITLE
GC election 2023 - banner update

### DIFF
--- a/layouts/partials/banner.md
+++ b/layouts/partials/banner.md
@@ -2,7 +2,9 @@
 
 <div class="o-banner">
 
-[Meet us at KubeCon NA in Chicago from November 6 - 9, 2023.](/blog/2023/kubecon-na)
+[Vote](/blog/2023/gc-elections/) for
+OpenTelemetry Governance Committee [candidates](/blog/2023/gc-candidates/)
+starting October 23!
 
 </div>
 {{ end -}}


### PR DESCRIPTION
This sets a banner to announce the elections starting next week. We can get back to the KubeCon banner when voting is closed. 

Preview: https://deploy-preview-3421--opentelemetry.netlify.app/

cc @open-telemetry/otel-elections 