### PR TITLE
Updates for text linting: Java agent, agent, OpAMP

### DIFF
--- a/.textlintrc.json
+++ b/.textlintrc.json
@@ -16,7 +16,10 @@
         "/<http://.*>/",
         "medium.com/opentelemetry",
         "github.com/open-telemetry",
+        "`javaagent`",
         "#opentelemetry",
+        "Open Agent Management Protocol",
+        "SignalFx Smart Agent",
         "/^(?:language|repo): .*$/m",
         "/tags:([\\n\\r\\s]*-[\\s\\S]*?[\\n\\r]+)*/m"
       ]
@@ -27,6 +30,7 @@
       "defaultTerms": false,
       "skip": [],
       "terms": [
+        "agent",
         "Ajax",
         "Apache",
         "API",
@@ -70,6 +74,7 @@
         "NDJSON",
         "OCaml",
         "OK",
+        "OpAMP",
         "OpenSearch",
         "OpenTelemetry Collector",
         "OTel",
@@ -111,6 +116,7 @@
         ["he/she", "they"],
         ["\\(s\\)he", "they"],
         ["id['’]?s", "IDs"],
+        ["java[- ]?agent", "Java agent"],
         ["mac ?os", "macOS"],
         ["meta[- ]data", "metadata"],
         ["nd-?json", "NDJSON"],

--- a/content/en/blog/2022/apisix/index.md
+++ b/content/en/blog/2022/apisix/index.md
@@ -28,14 +28,14 @@ The `opentelemetry` plugin of Apache APISIX implements Tracing data collection
 and sends it to OpenTelemetry Collector through HTTP protocol. Apache APISIX
 starts to support this feature in v2.13.0.
 
-One of OpenTelemetry's special features is that the Agent/SDK of OpenTelemetry
+One of OpenTelemetry's special features is that the agent/SDK of OpenTelemetry
 is not locked with back-end implementation, which gives users flexibilities on
 choosing their own back-end services. In other words, users can choose the
 backend services they want, such as Zipkin and Jaeger, without affecting the
 application side.
 
-The `opentelemetry` plugin is located on the Agent side. It integrates the
-OpenTelemetry Agent/SDK and adopts its features in Apache APISIX. It can collect
+The `opentelemetry` plugin is located on the agent side. It integrates the
+OpenTelemetry agent/SDK and adopts its features in Apache APISIX. It can collect
 traced requests, generate `trace`, and forward them to the OpenTelemetry
 Collector. It supports the `trace` protocol, and it will support the `logs` and
 `metrics` protocols of OpenTelemetry in the next version.

--- a/content/en/blog/2022/jaeger-native-otlp/index.md
+++ b/content/en/blog/2022/jaeger-native-otlp/index.md
@@ -68,14 +68,14 @@ replacements, although it may require exposing ports 4317 and 4318 if they are
 not already accessible.
 
 Thrift over UDP implies the use of the
-[Jaeger Agent](https://www.jaegertracing.io/docs/1.24/architecture/#agent).
+[Jaeger agent](https://www.jaegertracing.io/docs/1.24/architecture/#agent).
 Users with this deployment configuration will need to make a slightly more
 complicated change, typically one of the following:
 
 1. Direct ingest. Applications will change from using Thrift+UDP to sending OTLP
    traces directly to their `jaeger-collector` instance. This may also have
    sampling implications.
-2. Replacing the Jaeger Agent with a sidecar
+2. Replacing the Jaeger agent with a sidecar
    [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector)
    instance. This could have sampling implications and requires changes to your
    infrastructure deployment code.

--- a/content/en/blog/2022/opamp/index.md
+++ b/content/en/blog/2022/opamp/index.md
@@ -178,7 +178,7 @@ go run .
 ```
 
 Open a browser and visit <http://localhost:8080>. Nothing special will be shown.
-It’s time to add some opamp. Git clone
+It’s time to add some OpAMP. Git clone
 [opamp-go](https://github.com/open-telemetry/opamp-go) and run the server with:
 
 ```shell

--- a/content/en/blog/2023/jmx-metric-insight/index.md
+++ b/content/en/blog/2023/jmx-metric-insight/index.md
@@ -18,7 +18,7 @@ for optimal performance.
 With the addition of the
 [JMX Metric Insight](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/jmx-metrics)
 module into the
-[OpenTelemetry Javaagent](https://github.com/open-telemetry/opentelemetry-java-instrumentation),
+[OpenTelemetry Java agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation),
 we don't need to deploy a separate service just to collect JMX metrics for
 monitoring our application. The agent can now natively collect and export
 metrics exposed by application servers through local

--- a/content/en/blog/2023/opamp-status/index.md
+++ b/content/en/blog/2023/opamp-status/index.md
@@ -38,12 +38,12 @@ different agents. OpAMP currently supports, amongst other things:
 - Agents, such as the OpenTelemetry Collector, can report their properties, for
   example, type and version, or also the host operating system details to the
   Server (OpAMP control plane).
-- The Server can push configurations to Agents and ensures that said
-  configurations are applied, for example through reloading the Agent.
-- You can ingest the Agent's own telemetry (logs and metrics) into an
+- The Server can push configurations to agents and ensures that said
+  configurations are applied, for example through reloading the agent.
+- You can ingest the agent's own telemetry (logs and metrics) into an
   [OTLP](/docs/specs/otlp/)-compliant observability backend.
 - Secure auto-updating capabilities for both upgrading and downgrading of the
-  Agents.
+  agents.
 - Built-in connection credentials management, including client-side TLS
   certificate revocation and rotation.
 

--- a/content/en/blog/2023/otel-in-focus-01.md
+++ b/content/en/blog/2023/otel-in-focus-01.md
@@ -35,7 +35,7 @@ release notes.
 - [Java v1.22.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.22.0)
   includes several fixes and enhancements for exporters, as well as other
   ease-of-use and correctness issues. In addition,
-  [Java Agent v1.22.1](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.22.1)
+  [Java agent v1.22.1](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.22.1)
   has been released to align with the core API and SDK, in addition to new
   instrumentations for Spring Web MVC, JMS 3.0 (Jakarta), and Spring JMS 6.0.
 - [Operator v0.68.0](https://github.com/open-telemetry/opentelemetry-operator/releases/tag/v0.68.0)

--- a/content/en/blog/2023/otel-in-focus-06.md
+++ b/content/en/blog/2023/otel-in-focus-06.md
@@ -101,7 +101,8 @@ has been released, requiring some migrations to be performed.
   of InetSocketAddressNetServerAttributesGetter and
   InetSocketAddressNetClientAttributesGetter, and introduction of new HTTP and
   network semantic conventions.
-- New javaagent instrumentation for Quarkus RESTEasy Reactive and Reactor Kafka.
+- New Java agent instrumentation for Quarkus RESTEasy Reactive and Reactor
+  Kafka.
 - Enhancements including improvements in Micrometer bridge, Ktor
   instrumentations, AWS SDK support, OkHttp 3, Jetty 11, Spring Boot, AWS Lambda
   tracing, and type matching.

--- a/content/en/blog/2023/otel-in-focus-09.md
+++ b/content/en/blog/2023/otel-in-focus-09.md
@@ -136,13 +136,13 @@ alternate `io.opentelemetry.semconv:opentelemetry-semconv:1.21.0-alpha` is now
 introduced from a new repository.
 
 [Java Instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.30.0)
-brings significant changes including the addition of new JavaAgent
+brings significant changes including the addition of new Java agent
 instrumentation, enhancements, and bug fixes. Important changes include the
 splitting of experimental HTTP server metrics into a separate class, renaming of
 `HttpClientResend` and `HttpRouteHolder` to `HttpClientResendCount` and
 `HttpServerRoute`, and removal of a deprecated configuration.
 
-New Java Agent instrumentation has been added for hibernate reactive.
+New Java agent instrumentation has been added for hibernate reactive.
 Enhancements encompass support for AWS Secrets Manager JDBC URLs, improved
 support for semantic convention changes, addition of `javaagent` to
 instrumentation BOM, and more. Several bugs have also been fixed, such as issues

--- a/content/en/docs/concepts/distributions.md
+++ b/content/en/docs/concepts/distributions.md
@@ -84,7 +84,7 @@ might be a good starting point.
 There are language specific extensibility mechanisms to customize the
 instrumentation libraries:
 
-- [Javaagent](../../instrumentation/java/automatic/extensions)
+- [Java agent](../../instrumentation/java/automatic/extensions)
 
 ## What you should know about distributions
 

--- a/content/en/docs/demo/services/ad.md
+++ b/content/en/docs/demo/services/ad.md
@@ -11,7 +11,7 @@ The ads will be for products available in the store.
 
 ## Auto-instrumentation
 
-This service relies on the OpenTelemetry Java Agent to automatically instrument
+This service relies on the OpenTelemetry Java agent to automatically instrument
 libraries such as gRPC, and to configure the OpenTelemetry SDK. The agent is
 passed into the process using the `-javaagent` command line argument. Command
 line arguments are added through the `JAVA_TOOL_OPTIONS` in the `Dockerfile`,

--- a/content/en/docs/demo/services/fraud-detection.md
+++ b/content/en/docs/demo/services/fraud-detection.md
@@ -9,7 +9,7 @@ only mocked and received orders are printed out.
 
 ## Auto-instrumentation
 
-This service relies on the OpenTelemetry Java Agent to automatically instrument
+This service relies on the OpenTelemetry Java agent to automatically instrument
 libraries such as Kafka, and to configure the OpenTelemetry SDK. The agent is
 passed into the process using the `-javaagent` command line argument. Command
 line arguments are added through the `JAVA_TOOL_OPTIONS` in the `Dockerfile`,

--- a/content/en/docs/demo/services/kafka.md
+++ b/content/en/docs/demo/services/kafka.md
@@ -10,7 +10,7 @@ accounting and fraud detection services.
 
 ## Auto-instrumentation
 
-This service relies on the OpenTelemetry Java Agent and the built in
+This service relies on the OpenTelemetry Java agent and the built in
 [JMX Metric Insight Module](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/jmx-metrics/javaagent)
 to capture
 [Kafka broker metrics](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/javaagent/kafka-broker.md)

--- a/content/en/docs/faas/lambda-auto-instrument.md
+++ b/content/en/docs/faas/lambda-auto-instrument.md
@@ -31,13 +31,13 @@ The Lambda layer supports the Java 8, 11, and 17 (Corretto) Lambda runtimes. For
 more information about supported Java versions, see the
 [OpenTelemetry Java documentation](/docs/instrumentation/java/).
 
-**Note:** The Java Auto-instrumentation Agent is in the Lambda layer - Automatic
+**Note:** The Java Auto-instrumentation agent is in the Lambda layer - Automatic
 instrumentation has a notable impact on startup time on AWS Lambda and you will
 generally need to use this along with provisioned concurrency and warmup
 requests to serve production requests without causing timeouts on initial
 requests while it initializes.
 
-By default, the OTel Java Agent in the Layer will try to auto-instrument all the
+By default, the OTel Java agent in the Layer will try to auto-instrument all the
 code in your application. This can have a negative impact on the Lambda cold
 startup time.
 

--- a/content/en/docs/instrumentation/java/resources.md
+++ b/content/en/docs/instrumentation/java/resources.md
@@ -6,7 +6,7 @@ cSpell:ignore: getenv myhost SIGINT uuidgen WORKDIR
 
 {{% docs/instrumentation/resources-intro %}}
 
-If you use the Javaagent for
+If you use the Java agent for
 [automatic instrumentation](/docs/instrumentation/java/automatic) you can learn
 how to setup resource detection following the
 [Agent Configuration Guide](/docs/instrumentation/java/automatic/agent-config).

--- a/content/en/docs/kubernetes/collector/components.md
+++ b/content/en/docs/kubernetes/collector/components.md
@@ -35,8 +35,8 @@ but any receiver that fits your data is appropriate.
 
 | Deployment Pattern   | Usable |
 | -------------------- | ------ |
-| DaemonSet (Agent)    | Yes    |
-| Deployment (Gateway) | Yes    |
+| DaemonSet (agent)    | Yes    |
+| Deployment (gateway) | Yes    |
 | Sidecar              | No     |
 
 The Kubernetes Attributes Processor automatically discovers Kubernetes pods,
@@ -183,8 +183,8 @@ roleRef:
 
 | Deployment Pattern   | Usable                                                             |
 | -------------------- | ------------------------------------------------------------------ |
-| DaemonSet (Agent)    | Preferred                                                          |
-| Deployment (Gateway) | Yes, but will only collect metrics from the node it is deployed on |
+| DaemonSet (agent)    | Preferred                                                          |
+| Deployment (gateway) | Yes, but will only collect metrics from the node it is deployed on |
 | Sidecar              | No                                                                 |
 
 Each Kubernetes node runs a kubelet that includes an API server. The Kubernetes
@@ -258,8 +258,8 @@ subjects:
 
 | Deployment Pattern   | Usable                                                          |
 | -------------------- | --------------------------------------------------------------- |
-| DaemonSet (Agent)    | Preferred                                                       |
-| Deployment (Gateway) | Yes, but will only collect logs from the node it is deployed on |
+| DaemonSet (agent)    | Preferred                                                       |
+| Deployment (gateway) | Yes, but will only collect logs from the node it is deployed on |
 | Sidecar              | Yes, but this would be considered advanced configuration        |
 
 The Filelog Receiver tails and parses logs from files. Although it's not a
@@ -404,8 +404,8 @@ spec:
 
 | Deployment Pattern   | Usable                                                   |
 | -------------------- | -------------------------------------------------------- |
-| DaemonSet (Agent)    | Yes, but will result in duplicate data                   |
-| Deployment (Gateway) | Yes, but more than one replica results in duplicate data |
+| DaemonSet (agent)    | Yes, but will result in duplicate data                   |
+| Deployment (gateway) | Yes, but more than one replica results in duplicate data |
 | Sidecar              | No                                                       |
 
 The Kubernetes Cluster Receiver collects metrics and entity events about the
@@ -533,8 +533,8 @@ subjects:
 
 | Deployment Pattern   | Usable                                                   |
 | -------------------- | -------------------------------------------------------- |
-| DaemonSet (Agent)    | Yes, but will result in duplicate data                   |
-| Deployment (Gateway) | Yes, but more than one replica results in duplicate data |
+| DaemonSet (agent)    | Yes, but will result in duplicate data                   |
+| Deployment (gateway) | Yes, but more than one replica results in duplicate data |
 | Sidecar              | No                                                       |
 
 The Kubernetes Objects receiver collects, either by pulling or watching, objects
@@ -672,8 +672,8 @@ subjects:
 
 | Deployment Pattern   | Usable |
 | -------------------- | ------ |
-| DaemonSet (Agent)    | Yes    |
-| Deployment (Gateway) | Yes    |
+| DaemonSet (agent)    | Yes    |
+| Deployment (gateway) | Yes    |
 | Sidecar              | No     |
 
 Prometheus is a common metrics format for both Kubernetes and services running
@@ -717,8 +717,8 @@ For more information on the design of the receiver, see
 
 | Deployment Pattern   | Usable                                                         |
 | -------------------- | -------------------------------------------------------------- |
-| DaemonSet (Agent)    | Preferred                                                      |
-| Deployment (Gateway) | Yes, but only collects metrics from the node it is deployed on |
+| DaemonSet (agent)    | Preferred                                                      |
+| Deployment (gateway) | Yes, but only collects metrics from the node it is deployed on |
 | Sidecar              | No                                                             |
 
 The Host Metrics Receiver collects metrics from a host using a variety of

--- a/content/en/docs/kubernetes/operator/automatic.md
+++ b/content/en/docs/kubernetes/operator/automatic.md
@@ -247,7 +247,7 @@ spec:
 **Learn more**
 
 For more details, see
-[Java Agent Configuration](/docs/instrumentation/java/automatic/agent-config/).
+[Java agent Configuration](/docs/instrumentation/java/automatic/agent-config/).
 
 ### Node.js
 
@@ -391,7 +391,7 @@ spec:
 
 **Learn more**
 
-[See the Python Agent Configuration docs for more details.](/docs/instrumentation/python/automatic/agent-config/#disabling-specific-instrumentations)
+[See the Python agent Configuration docs for more details.](/docs/instrumentation/python/automatic/agent-config/#disabling-specific-instrumentations)
 
 ### Go
 

--- a/data/registry/collector-receiver-datadog.yml
+++ b/data/registry/collector-receiver-datadog.yml
@@ -8,7 +8,6 @@ tags:
   - collector
 repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/datadogreceiver
 license: Apache 2.0
-description:
-  The Datadog APM Receiver accepts traces in the Datadog Trace Agent Format
+description: The Datadog APM Receiver accepts traces in the Datadog APM format
 authors: OpenTelemetry Authors
 otVersion: latest


### PR DESCRIPTION
Codifies #1661, makes sure that "agent" is written lower case across the docs where applicable. Also adds a rule to detect OpAMP