### PR TITLE
chore: add missing ':'s in registry cSpell ignore lists

### DIFF
--- a/data/registry/collector-exporter-apiclarity.yml
+++ b/data/registry/collector-exporter-apiclarity.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore apiclarity
+# cSpell:ignore: apiclarity
 title: APIClarity HTTP Exporter
 registryType: exporter
 isThirdParty: true

--- a/data/registry/collector-exporter-coralogix.yml
+++ b/data/registry/collector-exporter-coralogix.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore coralogix
+# cSpell:ignore: coralogix
 title: Coralogix Collector Exporter
 registryType: exporter
 isThirdParty: true

--- a/data/registry/collector-exporter-honeycombmarker.yml
+++ b/data/registry/collector-exporter-honeycombmarker.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore honeycombmarker
+# cSpell:ignore: honeycombmarker
 title: Honeycomb Marker Exporter
 registryType: exporter
 isThirdParty: false

--- a/data/registry/collector-exporter-kinetica.yml
+++ b/data/registry/collector-exporter-kinetica.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore kinetica
+# cSpell:ignore: kinetica
 title: Kinetica OpenTelemetry Collector Exporter Plug-In
 registryType: exporter
 isThirdParty: false

--- a/data/registry/collector-exporter-logicmonitor.yml
+++ b/data/registry/collector-exporter-logicmonitor.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore logicmonitor
+# cSpell:ignore: logicmonitor
 title: LogicMonitor Exporter
 registryType: exporter
 isThirdParty: false

--- a/data/registry/collector-exporter-logzio.yml
+++ b/data/registry/collector-exporter-logzio.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore logz
+# cSpell:ignore: logz
 title: Logz.io Exporter
 registryType: exporter
 isThirdParty: false

--- a/data/registry/collector-exporter-mezmo.yml
+++ b/data/registry/collector-exporter-mezmo.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore mezmo
+# cSpell:ignore: mezmo
 title: Mezmo Exporter
 registryType: exporter
 isThirdParty: false

--- a/data/registry/collector-exporter-qryn.yml
+++ b/data/registry/collector-exporter-qryn.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore qryn loki
+# cSpell:ignore: qryn loki
 title: qryn exporter
 registryType: exporter
 isThirdParty: true

--- a/data/registry/collector-exporter-sapm.yml
+++ b/data/registry/collector-exporter-sapm.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore sapm
+# cSpell:ignore: sapm
 title: SAPM Exporter
 registryType: exporter
 isThirdParty: false

--- a/data/registry/collector-exporter-skywalking.yml
+++ b/data/registry/collector-exporter-skywalking.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore skywalking
+# cSpell:ignore: skywalking
 title: SkyWalking gRPC Exporter
 registryType: exporter
 isThirdParty: false

--- a/data/registry/collector-exporter-splunk-apm.yml
+++ b/data/registry/collector-exporter-splunk-apm.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore sapm
+# cSpell:ignore: sapm
 title: Splunk APM (SAPM) Exporter
 registryType: exporter
 isThirdParty: true

--- a/data/registry/collector-exporter-splunk-sapm.yml
+++ b/data/registry/collector-exporter-splunk-sapm.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore sapm
+# cSpell:ignore: sapm
 title: Splunk SAPM Collector Exporter
 registryType: exporter
 isThirdParty: true

--- a/data/registry/collector-exporter-tanzu-observability.yml
+++ b/data/registry/collector-exporter-tanzu-observability.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore tanzu
+# cSpell:ignore: tanzu
 title: Tanzu Observability Collector Traces Exporter
 registryType: exporter
 isThirdParty: true

--- a/data/registry/collector-extension-basicauth.yml
+++ b/data/registry/collector-extension-basicauth.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore basicauth configauth
+# cSpell:ignore: basicauth configauth
 title: Basic Authenticator
 registryType: extension
 isThirdParty: false

--- a/data/registry/collector-extension-oidcauth.yml
+++ b/data/registry/collector-extension-oidcauth.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore oidc
+# cSpell:ignore: oidc
 title: OIDC authenticator extension
 registryType: extension
 isThirdParty: false

--- a/data/registry/collector-extension-sigv4auth.yml
+++ b/data/registry/collector-extension-sigv4auth.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore sigv4
+# cSpell:ignore: sigv4
 title: Authenticator - SigV4
 registryType: extension
 isThirdParty: false

--- a/data/registry/collector-processor-remoteobserver.yml
+++ b/data/registry/collector-processor-remoteobserver.yml
@@ -13,4 +13,4 @@ description:
   allows data to pass through to the next component.
 authors: OpenTelemetry Authors
 otVersion: latest
-# cSpell:ignore remoteobserver
+# cSpell:ignore: remoteobserver

--- a/data/registry/collector-receiver-aerospike.yml
+++ b/data/registry/collector-receiver-aerospike.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore aerospike
+# cSpell:ignore: aerospike
 title: Aerospike Receiver
 registryType: receiver
 isThirdParty: false

--- a/data/registry/collector-receiver-awscloudwatchmetrics.yml
+++ b/data/registry/collector-receiver-awscloudwatchmetrics.yml
@@ -13,4 +13,4 @@ description:
   Logs
 authors: OpenTelemetry Authors
 otVersion: latest
-# cSpell:ignore awscloudwatchmetrics
+# cSpell:ignore: awscloudwatchmetrics

--- a/data/registry/collector-receiver-chrony.yml
+++ b/data/registry/collector-receiver-chrony.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore chrony chronyc
+# cSpell:ignore: chrony chronyc
 title: Chrony Receiver
 registryType: receiver
 isThirdParty: false

--- a/data/registry/collector-receiver-cloudflare.yml
+++ b/data/registry/collector-receiver-cloudflare.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore cloudflare
+# cSpell:ignore: cloudflare
 title: Cloudflare Receiver
 registryType: receiver
 isThirdParty: false

--- a/data/registry/collector-receiver-couchdb.yml
+++ b/data/registry/collector-receiver-couchdb.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore couchdb
+# cSpell:ignore: couchdb
 title: CouchDB Receiver
 registryType: receiver
 isThirdParty: false

--- a/data/registry/collector-receiver-elasticsearch.yml
+++ b/data/registry/collector-receiver-elasticsearch.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore statsendpoints
+# cSpell:ignore: statsendpoints
 title: Elasticsearch Receiver
 registryType: receiver
 isThirdParty: false

--- a/data/registry/collector-receiver-expvar.yml
+++ b/data/registry/collector-receiver-expvar.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore expvar
+# cSpell:ignore: expvar
 title: Expvar Receiver
 registryType: receiver
 isThirdParty: false

--- a/data/registry/collector-receiver-filelog.yml
+++ b/data/registry/collector-receiver-filelog.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore filelog
+# cSpell:ignore: filelog
 title: Filelog Collector Receiver
 registryType: receiver
 isThirdParty: false

--- a/data/registry/collector-receiver-filestats.yml
+++ b/data/registry/collector-receiver-filestats.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore filestats
+# cSpell:ignore: filestats
 title: File Stats Receiver
 registryType: receiver
 isThirdParty: false

--- a/data/registry/collector-receiver-flinkmetrics.yml
+++ b/data/registry/collector-receiver-flinkmetrics.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore flink jobmanager taskmanager
+# cSpell:ignore: flink jobmanager taskmanager
 title: FlinkMetrics Receiver
 registryType: receiver
 isThirdParty: false

--- a/data/registry/collector-receiver-git-trace2.yml
+++ b/data/registry/collector-receiver-git-trace2.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore Hostetler
+# cSpell:ignore: Hostetler
 title: Trace2 Receiver
 registryType: receiver
 isThirdParty: true

--- a/data/registry/collector-receiver-k8sobjects.yml
+++ b/data/registry/collector-receiver-k8sobjects.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore k8sobjects
+# cSpell:ignore: k8sobjects
 title: Kubernetes Objects Receiver
 registryType: receiver
 isThirdParty: false

--- a/data/registry/collector-receiver-kubelet-stats.yml
+++ b/data/registry/collector-receiver-kubelet-stats.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore kubelet
+# cSpell:ignore: kubelet
 title: Kubelet Stats Collector Receiver
 registryType: receiver
 isThirdParty: true

--- a/data/registry/collector-receiver-loki.yml
+++ b/data/registry/collector-receiver-loki.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore loki
+# cSpell:ignore: loki
 title: Loki Receiver
 registryType: receiver
 isThirdParty: false

--- a/data/registry/collector-receiver-mysql.yml
+++ b/data/registry/collector-receiver-mysql.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore inno
+# cSpell:ignore: inno
 title: MySQL Receiver
 registryType: receiver
 isThirdParty: false

--- a/data/registry/collector-receiver-purefa.yml
+++ b/data/registry/collector-receiver-purefa.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore purefa
+# cSpell:ignore: purefa
 title: Pure Storage FlashArray Receiver
 registryType: receiver
 isThirdParty: false

--- a/data/registry/collector-receiver-purefb.yml
+++ b/data/registry/collector-receiver-purefb.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore purefb
+# cSpell:ignore: purefb
 title: Pure Storage FlashBlade Receiver
 registryType: receiver
 isThirdParty: false

--- a/data/registry/collector-receiver-riak.yml
+++ b/data/registry/collector-receiver-riak.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore riak
+# cSpell:ignore: riak
 title: Riak Receiver
 registryType: receiver
 isThirdParty: false

--- a/data/registry/collector-receiver-saphana.yml
+++ b/data/registry/collector-receiver-saphana.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore hana
+# cSpell:ignore: hana
 title: SAP HANA Receiver
 registryType: receiver
 isThirdParty: false

--- a/data/registry/collector-receiver-sapm.yml
+++ b/data/registry/collector-receiver-sapm.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore sapm
+# cSpell:ignore: sapm
 title: SAPM Collector Receiver
 registryType: receiver
 isThirdParty: true

--- a/data/registry/collector-receiver-skywalking.yml
+++ b/data/registry/collector-receiver-skywalking.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore skywalking
+# cSpell:ignore: skywalking
 title: Skywalking Receiver
 registryType: receiver
 isThirdParty: false

--- a/data/registry/collector-receiver-splunkenterprise.yml
+++ b/data/registry/collector-receiver-splunkenterprise.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore splunkenterprise
+# cSpell:ignore: splunkenterprise
 title: splunkenterprise
 registryType: receiver
 isThirdParty: false

--- a/data/registry/collector-receiver-sqlserver.yml
+++ b/data/registry/collector-receiver-sqlserver.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore sqlserver
+# cSpell:ignore: sqlserver
 title: Microsoft SQL Server Receiver
 registryType: receiver
 isThirdParty: false

--- a/data/registry/collector-receiver-syslog.yml
+++ b/data/registry/collector-receiver-syslog.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore Syslogs
+# cSpell:ignore: Syslogs
 title: Syslog Receiver
 registryType: receiver
 isThirdParty: false

--- a/data/registry/collector-receiver-webhookevent.yml
+++ b/data/registry/collector-receiver-webhookevent.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore webhookevent
+# cSpell:ignore: webhookevent
 title: Webhook Event Receiver
 registryType: receiver
 isThirdParty: false

--- a/data/registry/collector-receiver-zookeeper.yml
+++ b/data/registry/collector-receiver-zookeeper.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore mntr
+# cSpell:ignore: mntr
 title: Zookeeper Collector Receiver
 registryType: receiver
 isThirdParty: true

--- a/data/registry/exporter-cpp-fluentd.yml
+++ b/data/registry/exporter-cpp-fluentd.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore fluentd
+# cSpell:ignore: fluentd
 title: Fluentd Exporter
 registryType: exporter
 isThirdParty: true

--- a/data/registry/exporter-dotnet-inmemory.yml
+++ b/data/registry/exporter-dotnet-inmemory.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore inmemory
+# cSpell:ignore: inmemory
 title: In-memory Exporter for OpenTelemetry .NET
 registryType: exporter
 isThirdParty: false

--- a/data/registry/exporter-dotnet-onecollector.yml
+++ b/data/registry/exporter-dotnet-onecollector.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore onecollector
+# cSpell:ignore: onecollector
 title: OneCollector Exporter for OpenTelemetry .NET
 registryType: exporter
 isThirdParty: false

--- a/data/registry/exporter-dotnet-prometheus-aspnetcore.yml
+++ b/data/registry/exporter-dotnet-prometheus-aspnetcore.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore aspnetcore
+# cSpell:ignore: aspnetcore
 title: Prometheus Exporter ASP.NET Core for OpenTelemetry .NET
 registryType: exporter
 isThirdParty: false

--- a/data/registry/exporter-dotnet-prometheus-httplistener.yml
+++ b/data/registry/exporter-dotnet-prometheus-httplistener.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore httplistener
+# cSpell:ignore: httplistener
 title: Prometheus Exporter HttpListener for OpenTelemetry .NET
 registryType: exporter
 isThirdParty: false

--- a/data/registry/exporter-dotnet-stackdriver.yml
+++ b/data/registry/exporter-dotnet-stackdriver.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore stackdriver
+# cSpell:ignore: stackdriver
 title: Stackdriver Exporter for OpenTelemetry .NET
 registryType: exporter
 isThirdParty: false

--- a/data/registry/exporter-go-otlpr.yml
+++ b/data/registry/exporter-go-otlpr.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore otlpr logr
+# cSpell:ignore: otlpr logr
 title: otlpr - A logr implementation backed by OTLP
 registryType: exporter
 isThirdParty: true

--- a/data/registry/exporter-python-jaegerprotogrpc.yml
+++ b/data/registry/exporter-python-jaegerprotogrpc.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore
+# cSpell:ignore:
 title: OpenTelemetry Jaeger protobuf Exporter
 registryType: exporter
 isThirdParty: false

--- a/data/registry/exporter-rust-application-insights.yml
+++ b/data/registry/exporter-rust-application-insights.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore kuehle
+# cSpell:ignore: kuehle
 title: Azure Application Insights Exporter
 registryType: exporter
 isThirdParty: true

--- a/data/registry/exporter-rust-stackdriver.yml
+++ b/data/registry/exporter-rust-stackdriver.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore jacobkiesel
+# cSpell:ignore: jacobkiesel
 title: Google StackDrive Exporter
 registryType: exporter
 isThirdParty: true

--- a/data/registry/instrumentation-cpp-otel-webserver-module.yml
+++ b/data/registry/instrumentation-cpp-otel-webserver-module.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore webserver
+# cSpell:ignore: webserver
 title: OpenTelemetry Webserver Module
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-dotnet-masstransit.yml
+++ b/data/registry/instrumentation-dotnet-masstransit.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore masstransit
+# cSpell:ignore: masstransit
 title: MassTransit Instrumentation for OpenTelemetry .NET
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-dotnet-mysqldata.yml
+++ b/data/registry/instrumentation-dotnet-mysqldata.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore mysqldata
+# cSpell:ignore: mysqldata
 title: MySqlData Instrumentation for OpenTelemetry
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-dotnet-owin.yml
+++ b/data/registry/instrumentation-dotnet-owin.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore owin katana
+# cSpell:ignore: owin katana
 title: OWIN Instrumentation for OpenTelemetry .NET
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-dotnet-sqlclient.yml
+++ b/data/registry/instrumentation-dotnet-sqlclient.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore sqlclient
+# cSpell:ignore: sqlclient
 title: SqlClient Instrumentation for OpenTelemetry
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-dotnet-stackexchangeredis.yml
+++ b/data/registry/instrumentation-dotnet-stackexchangeredis.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore stackexchange
+# cSpell:ignore: stackexchange
 title: StackExchange.Redis Instrumentation for OpenTelemetry
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-elixir-ecto.yml
+++ b/data/registry/instrumentation-elixir-ecto.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore ecto
+# cSpell:ignore: ecto
 title: Ecto Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-elixir-oban.yml
+++ b/data/registry/instrumentation-elixir-oban.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore oban
+# cSpell:ignore: oban
 title: Oban Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-elixir-redix.yml
+++ b/data/registry/instrumentation-elixir-redix.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore redix
+# cSpell:ignore: redix
 title: Redix Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-erlang-ecto.yml
+++ b/data/registry/instrumentation-erlang-ecto.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore ecto
+# cSpell:ignore: ecto
 title: Ecto Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-erlang-elli.yml
+++ b/data/registry/instrumentation-erlang-elli.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore elli
+# cSpell:ignore: elli
 title: Elli Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-erlang-grpcbox.yml
+++ b/data/registry/instrumentation-erlang-grpcbox.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore grpcbox
+# cSpell:ignore: grpcbox
 title: grpcbox Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-erlang-httpoison.yml
+++ b/data/registry/instrumentation-erlang-httpoison.yml
@@ -11,4 +11,4 @@ license: Apache 2.0
 description: OpentelemetryHTTPoison is an Instrumentation Library for HTTPoison.
 authors: OpenTelemetry Authors
 otVersion: latest
-# cSpell:ignore httpoison
+# cSpell:ignore: httpoison

--- a/data/registry/instrumentation-erlang-nebulex.yml
+++ b/data/registry/instrumentation-erlang-nebulex.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore nebulex
+# cSpell:ignore: nebulex
 title: OpentelemetryNebulex
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-erlang-oban.yml
+++ b/data/registry/instrumentation-erlang-oban.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore oban
+# cSpell:ignore: oban
 title: Oban Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-erlang-redix.yml
+++ b/data/registry/instrumentation-erlang-redix.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore redix
+# cSpell:ignore: redix
 title: Redix Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-go-echo.yml
+++ b/data/registry/instrumentation-go-echo.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore labstack
+# cSpell:ignore: labstack
 title: Echo Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-go-fiber.yml
+++ b/data/registry/instrumentation-go-fiber.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore gofiber
+# cSpell:ignore: gofiber
 title: Fiber Instrumentation
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-gin.yml
+++ b/data/registry/instrumentation-go-gin.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore gonic
+# cSpell:ignore: gonic
 title: Gin-gonic Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-go-go-restful.yml
+++ b/data/registry/instrumentation-go-go-restful.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore emicklei
+# cSpell:ignore: emicklei
 title: Go-restful Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-go-go-resty.yml
+++ b/data/registry/instrumentation-go-go-resty.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore resty dubonzi
+# cSpell:ignore: resty dubonzi
 title: Go-Resty Instrumentation
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-gorm.yml
+++ b/data/registry/instrumentation-go-gorm.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore gorm mihailenco
+# cSpell:ignore: gorm mihailenco
 title: GORM instrumentation
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-gqlgen.yml
+++ b/data/registry/instrumentation-go-gqlgen.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore gqlgen ravil galaktionov
+# cSpell:ignore: gqlgen ravil galaktionov
 title: Gqlgen Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-go-graphql.yml
+++ b/data/registry/instrumentation-go-graphql.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore ziehms
+# cSpell:ignore: ziehms
 title: GraphQL-Go instrumentation
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-grpc-metrics.yml
+++ b/data/registry/instrumentation-go-grpc-metrics.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore mahboubi
+# cSpell:ignore: mahboubi
 title: Go gRPC metric instrumentation
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-kotel-franz-go.yml
+++ b/data/registry/instrumentation-go-kotel-franz-go.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore kotel franz gerassimou
+# cSpell:ignore: kotel franz gerassimou
 title: Kotel - Instrumentation plugin for franz-go
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-labstack.yml
+++ b/data/registry/instrumentation-go-labstack.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore labstack
+# cSpell:ignore: labstack
 title: Labstack Echo instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-go-lambda.yml
+++ b/data/registry/instrumentation-go-lambda.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore otellambda
+# cSpell:ignore: otellambda
 title: otellambda
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-go-logrus.yml
+++ b/data/registry/instrumentation-go-logrus.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore logrus mihailenco
+# cSpell:ignore: logrus mihailenco
 title: logrus instrumentation
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-macaron.yml
+++ b/data/registry/instrumentation-go-macaron.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore macaron gopkg
+# cSpell:ignore: macaron gopkg
 title: Macaron Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-go-neo4j.yml
+++ b/data/registry/instrumentation-go-neo4j.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore mennes
+# cSpell:ignore: mennes
 title: Golang OpenTelemetry Neo4j Instrumentation
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-nhatthm-otelsql.yml
+++ b/data/registry/instrumentation-go-nhatthm-otelsql.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore nhatthm otelsql
+# cSpell:ignore: nhatthm otelsql
 title: nhatthm/otelsql -- OpenTelemetry SQL database driver wrapper for Go
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-otelpgx.yml
+++ b/data/registry/instrumentation-go-otelpgx.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore otelpgx jackc exaring
+# cSpell:ignore: otelpgx jackc exaring
 title: otelpgx - tracing support for github.com/jackc/pgx
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-otelsqlx.yml
+++ b/data/registry/instrumentation-go-otelsqlx.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore jmoiron sqlx mihailenco
+# cSpell:ignore: jmoiron sqlx mihailenco
 title: jmoiron/sqlx instrumentation
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-riandyrn-go-chi-chi.yml
+++ b/data/registry/instrumentation-go-riandyrn-go-chi-chi.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore otelchi riandy
+# cSpell:ignore: otelchi riandy
 title: otelchi --- Instrumentation for go-chi/chi
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-splunkbuntdb.yml
+++ b/data/registry/instrumentation-go-splunkbuntdb.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore splunkbuntdb tidwall buntdb
+# cSpell:ignore: splunkbuntdb tidwall buntdb
 title: splunkbuntdb -- Instrumentation for github.com/tidwall/buntdb
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-splunkchi.yml
+++ b/data/registry/instrumentation-go-splunkchi.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore splunkchi
+# cSpell:ignore: splunkchi
 title: splunkchi -- Instrumentation for github.com/go-chi/chi
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-splunkclient-go.yml
+++ b/data/registry/instrumentation-go-splunkclient-go.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore splunkclient
+# cSpell:ignore: splunkclient
 title: splunkclient-go -- Instrumentation for k8s.io/client-go
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-splunkdns.yml
+++ b/data/registry/instrumentation-go-splunkdns.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore splunkdns miekg
+# cSpell:ignore: splunkdns miekg
 title: splunkdns -- Instrumentation for github.com/miekg/dns
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-splunkelastic.yml
+++ b/data/registry/instrumentation-go-splunkelastic.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore splunkelastic gopkg olivere
+# cSpell:ignore: splunkelastic gopkg olivere
 title: splunkelastic -- Instrumentation for gopkg.in/olivere/elastic
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-splunkgorm.yml
+++ b/data/registry/instrumentation-go-splunkgorm.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore splunkgorm jinzhu gorm
+# cSpell:ignore: splunkgorm jinzhu gorm
 title: splunkgorm -- Instrumentation for github.com/jinzhu/gorm
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-splunkgraphql.yml
+++ b/data/registry/instrumentation-go-splunkgraphql.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore splunkgraphql
+# cSpell:ignore: splunkgraphql
 title: splunkgraphql -- Instrumentation for github.com/graph-gophers/graphql-go
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-splunkhttp.yml
+++ b/data/registry/instrumentation-go-splunkhttp.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore splunkhttp
+# cSpell:ignore: splunkhttp
 title: splunkhttp -- Instrumentation for `net/http`
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-splunkhttprouter.yml
+++ b/data/registry/instrumentation-go-splunkhttprouter.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore splunkhttprouter httprouter julienschmidt
+# cSpell:ignore: splunkhttprouter httprouter julienschmidt
 title:
   splunkhttprouter -- Instrumentation for github.com/julienschmidt/httprouter
 registryType: instrumentation

--- a/data/registry/instrumentation-go-splunkkafka.yml
+++ b/data/registry/instrumentation-go-splunkkafka.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore splunkkafka confluentinc
+# cSpell:ignore: splunkkafka confluentinc
 title:
   splunkkafka -- Instrumentation for
   github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka

--- a/data/registry/instrumentation-go-splunkleveldb.yml
+++ b/data/registry/instrumentation-go-splunkleveldb.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore splunkleveldb syndtr goleveldb leveldb
+# cSpell:ignore: splunkleveldb syndtr goleveldb leveldb
 title: splunkleveldb -- Instrumentation for github.com/syndtr/goleveldb/leveldb
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-splunkmysql.yml
+++ b/data/registry/instrumentation-go-splunkmysql.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore splunkmysql
+# cSpell:ignore: splunkmysql
 title: splunkmysql -- Instrumentation for the MySQL Driver Package
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-splunkpgx.yml
+++ b/data/registry/instrumentation-go-splunkpgx.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore splunkpgx jackc
+# cSpell:ignore: splunkpgx jackc
 title: splunkpgx -- Instrumentation for github.com/jackc/pgx
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-splunkpq.yml
+++ b/data/registry/instrumentation-go-splunkpq.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore splunkpq
+# cSpell:ignore: splunkpq
 title: splunkpq -- Instrumentation for github.com/lib/pq
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-splunkredigo.yml
+++ b/data/registry/instrumentation-go-splunkredigo.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore redigo gomodule splunkredigo
+# cSpell:ignore: redigo gomodule splunkredigo
 title: splunkredigo -- Instrumentation for github.com/gomodule/redigo
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-splunksql.yml
+++ b/data/registry/instrumentation-go-splunksql.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore splunksql
+# cSpell:ignore: splunksql
 title: splunksql -- Instrumentation for `database/sql`
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-splunksqlx.yml
+++ b/data/registry/instrumentation-go-splunksqlx.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore splunksqlx jmoiron sqlx
+# cSpell:ignore: splunksqlx jmoiron sqlx
 title: splunksqlx -- Instrumentation for github.com/jmoiron/sqlx
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-uptrace-otelsql.yml
+++ b/data/registry/instrumentation-go-uptrace-otelsql.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore Mihailenco
+# cSpell:ignore: Mihailenco
 title: SQL instrumentation
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-xsam-database-sql.yml
+++ b/data/registry/instrumentation-go-xsam-database-sql.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore otelsql xsam
+# cSpell:ignore: otelsql xsam
 title: otelsql -- Instrumentation for `database/sql`
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-go-zap.yml
+++ b/data/registry/instrumentation-go-zap.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore Mihailenco
+# cSpell:ignore: Mihailenco
 title: Zap instrumentation
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-java-akka-actor-fork-join.yml
+++ b/data/registry/instrumentation-java-akka-actor-fork-join.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore akka
+# cSpell:ignore: akka
 title: Akka Actor Fork Join Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-akka-actor.yml
+++ b/data/registry/instrumentation-java-akka-actor.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore akka
+# cSpell:ignore: akka
 title: Akka Actor Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-akka-http.yml
+++ b/data/registry/instrumentation-java-akka-http.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore akka
+# cSpell:ignore: akka
 title: Akka HTTP Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-apachedbcp.yml
+++ b/data/registry/instrumentation-java-apachedbcp.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore dbcp
+# cSpell:ignore: dbcp
 title: Apache DBCP Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-apachedubbo.yml
+++ b/data/registry/instrumentation-java-apachedubbo.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore dubbo
+# cSpell:ignore: dubbo
 title: Apache Dubbo Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-armeria.yml
+++ b/data/registry/instrumentation-java-armeria.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore Armeria
+# cSpell:ignore: Armeria
 title: Armeria Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-couchbase.yml
+++ b/data/registry/instrumentation-java-couchbase.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore couchbase
+# cSpell:ignore: couchbase
 title: Couchbase Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-dropwizard.yml
+++ b/data/registry/instrumentation-java-dropwizard.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore dropwizard
+# cSpell:ignore: dropwizard
 title: Dropwizard Instrumentation Library
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-finatra.yml
+++ b/data/registry/instrumentation-java-finatra.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore finatra
+# cSpell:ignore: finatra
 title: Finatra Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-hikaricp.yml
+++ b/data/registry/instrumentation-java-hikaricp.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore hikaricp
+# cSpell:ignore: hikaricp
 title: Hikaricp Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-hystrix.yml
+++ b/data/registry/instrumentation-java-hystrix.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore hystrix
+# cSpell:ignore: hystrix
 title: Hystrix Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-jaxrs-client.yml
+++ b/data/registry/instrumentation-java-jaxrs-client.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore jaxrs
+# cSpell:ignore: jaxrs
 title: JAXRS Client Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-jaxrs.yml
+++ b/data/registry/instrumentation-java-jaxrs.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore jaxrs
+# cSpell:ignore: jaxrs
 title: JAXRS Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-jbosslogmanager.yml
+++ b/data/registry/instrumentation-java-jbosslogmanager.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore logmanager
+# cSpell:ignore: logmanager
 title: JBoss Log Manager Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-jedis.yml
+++ b/data/registry/instrumentation-java-jedis.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore jedis
+# cSpell:ignore: jedis
 title: Jedis Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-joddhttp.yml
+++ b/data/registry/instrumentation-java-joddhttp.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore jodd
+# cSpell:ignore: jodd
 title: Jodd HTTP Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-ktor.yml
+++ b/data/registry/instrumentation-java-ktor.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore ktor
+# cSpell:ignore: ktor
 title: Ktor Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-logback.yml
+++ b/data/registry/instrumentation-java-logback.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore logback
+# cSpell:ignore: logback
 title: Logback Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-oshi.yml
+++ b/data/registry/instrumentation-java-oshi.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore oshi
+# cSpell:ignore: oshi
 title: Oshi Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-payara.yml
+++ b/data/registry/instrumentation-java-payara.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore payara
+# cSpell:ignore: payara
 title: payara
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-pekkoactor.yml
+++ b/data/registry/instrumentation-java-pekkoactor.yml
@@ -1,4 +1,4 @@
-# cspell:ignore pekko
+# cSpell:ignore: pekko
 title: Apache Pekko Actor Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-pekkohttp.yml
+++ b/data/registry/instrumentation-java-pekkohttp.yml
@@ -1,4 +1,4 @@
-# cspell:ignore pekko
+# cSpell:ignore: pekko
 title: Apache Pekko HTTP
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-quarkusresteasyreactive.yml
+++ b/data/registry/instrumentation-java-quarkusresteasyreactive.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore resteasy
+# cSpell:ignore: resteasy
 title: Quarkus RESTeasy Reactive Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-ratpack.yml
+++ b/data/registry/instrumentation-java-ratpack.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore ratpack
+# cSpell:ignore: ratpack
 title: Ratpack Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-rediscala.yml
+++ b/data/registry/instrumentation-java-rediscala.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore rediscala
+# cSpell:ignore: rediscala
 title: Rediscala Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-redisson.yml
+++ b/data/registry/instrumentation-java-redisson.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore redisson
+# cSpell:ignore: redisson
 title: Redisson Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-restlet.yml
+++ b/data/registry/instrumentation-java-restlet.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore restlet
+# cSpell:ignore: restlet
 title: Restlet Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-rocketmq.yml
+++ b/data/registry/instrumentation-java-rocketmq.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore rocketmq
+# cSpell:ignore: rocketmq
 title: RocketMQ Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-runtimetelemetry.yml
+++ b/data/registry/instrumentation-java-runtimetelemetry.yml
@@ -12,4 +12,4 @@ description:
   This package provides an instrumentation library for Runtime Telemetry
 authors: OpenTelemetry Authors
 otVersion: latest
-# cSpell:ignore runtimetelemetry
+# cSpell:ignore: runtimetelemetry

--- a/data/registry/instrumentation-java-spymemcached.yml
+++ b/data/registry/instrumentation-java-spymemcached.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore spymemcached
+# cSpell:ignore: spymemcached
 title: Spymemcached Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-vaadin.yml
+++ b/data/registry/instrumentation-java-vaadin.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore vaadin
+# cSpell:ignore: vaadin
 title: Vaadin Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-viburdbcp.yml
+++ b/data/registry/instrumentation-java-viburdbcp.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore viburdbcp
+# cSpell:ignore: viburdbcp
 title: Viburdbcp  Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-js-amqplib.yml
+++ b/data/registry/instrumentation-js-amqplib.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore amqplib
+# cSpell:ignore: amqplib
 title: OpenTelemetry amqplib Instrumentation (RabbitMQ)
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-js-autotelic-fastify.yml
+++ b/data/registry/instrumentation-js-autotelic-fastify.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore fastify
+# cSpell:ignore: fastify
 title: Fastify OpenTelemetry
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-js-bullmq.yml
+++ b/data/registry/instrumentation-js-bullmq.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore bullmq
+# cSpell:ignore: bullmq
 title: BullMQ Instrumentation
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-js-bunyan.yml
+++ b/data/registry/instrumentation-js-bunyan.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore bunyan
+# cSpell:ignore: bunyan
 title: OpenTelemetry Instrumentation for bunyan
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-js-cerbos.yml
+++ b/data/registry/instrumentation-js-cerbos.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore cerbos
+# cSpell:ignore: cerbos
 title: Instrumentation Library for Cerbos JavaScript SDK
 registryType: instrumentation
 language: js

--- a/data/registry/instrumentation-js-fastify.yml
+++ b/data/registry/instrumentation-js-fastify.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore fastify
+# cSpell:ignore: fastify
 title: Fastify OpenTelemetry
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-js-hapi.yml
+++ b/data/registry/instrumentation-js-hapi.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore hapi
+# cSpell:ignore: hapi
 title: Hapi Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-js-kafkajs.yml
+++ b/data/registry/instrumentation-js-kafkajs.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore kafkajs
+# cSpell:ignore: kafkajs
 title: OpenTelemetry kafkajs Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-js-knex.yml
+++ b/data/registry/instrumentation-js-knex.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore knex
+# cSpell:ignore: knex
 title: OpenTelemetry Instrumentation for knex
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-js-mssql.yml
+++ b/data/registry/instrumentation-js-mssql.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore mssql Nadeem
+# cSpell:ignore: mssql Nadeem
 title: OpenTelemetry MSSQL Instrumentation
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-js-nest.yml
+++ b/data/registry/instrumentation-js-nest.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore nestjs metin seylan
+# cSpell:ignore: nestjs metin seylan
 title: OpenTelemetry Instrumentation for Nest
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-js-nestjs-core.yml
+++ b/data/registry/instrumentation-js-nestjs-core.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore nestjs
+# cSpell:ignore: nestjs
 title: OpenTelemetry NestJS Instrumentation for Node.js
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-js-nestjs.yml
+++ b/data/registry/instrumentation-js-nestjs.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore nestjs
+# cSpell:ignore: nestjs
 title: NestJS OpenTelemetry
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-js-pillarjs-router.yml
+++ b/data/registry/instrumentation-js-pillarjs-router.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore pillarjs
+# cSpell:ignore: pillarjs
 title: OpenTelemetry pillarjs/Router Instrumentation for Node.js
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-js-pino.yml
+++ b/data/registry/instrumentation-js-pino.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore pino
+# cSpell:ignore: pino
 title: OpenTelemetry Instrumentation for pino
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-js-pragmaticivan-nestjs.yml
+++ b/data/registry/instrumentation-js-pragmaticivan-nestjs.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore nestjs
+# cSpell:ignore: nestjs
 title: NestJS OpenTelemetry
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-js-restify.yml
+++ b/data/registry/instrumentation-js-restify.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore restify
+# cSpell:ignore: restify
 title: OpenTelemetry Instrumentation for restify
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-js-sequelize.yml
+++ b/data/registry/instrumentation-js-sequelize.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore sequelize
+# cSpell:ignore: sequelize
 title: OpenTelemetry Sequelize Instrumentation
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-js-typeorm.yml
+++ b/data/registry/instrumentation-js-typeorm.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore typeorm
+# cSpell:ignore: typeorm
 title: OpenTelemetry TypeORM Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-js-winston.yml
+++ b/data/registry/instrumentation-js-winston.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore winston
+# cSpell:ignore: winston
 title: OpenTelemetry Instrumentation for winston
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-lua-apache-apisix.yml
+++ b/data/registry/instrumentation-lua-apache-apisix.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore APISIX
+# cSpell:ignore: APISIX
 title: Apache APISIX Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-php-httpasyncclient.yml
+++ b/data/registry/instrumentation-php-httpasyncclient.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore httpasyncclient
+# cSpell:ignore: httpasyncclient
 title: OpenTelemetry HTTPlug async auto-instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-python-aiohttp-client.yml
+++ b/data/registry/instrumentation-python-aiohttp-client.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore aiohttp
+# cSpell:ignore: aiohttp
 title: OpenTelemetry aiohttp client Integration
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-python-aiopg.yml
+++ b/data/registry/instrumentation-python-aiopg.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore AIOPG
+# cSpell:ignore: AIOPG
 title: AIOPG Middleware Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-python-asgi.yml
+++ b/data/registry/instrumentation-python-asgi.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore ASGI
+# cSpell:ignore: ASGI
 title: ASGI Middleware Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-python-asyncpg.yml
+++ b/data/registry/instrumentation-python-asyncpg.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore asyncpg
+# cSpell:ignore: asyncpg
 title: asyncpg Instrumentation
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-python-boto.yml
+++ b/data/registry/instrumentation-python-boto.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore boto
+# cSpell:ignore: boto
 title: Boto Instrumentation
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-python-boto3sqs.yml
+++ b/data/registry/instrumentation-python-boto3sqs.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore boto
+# cSpell:ignore: boto
 title: OpenTelemetry Boto3 SQS Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-python-botocore.yml
+++ b/data/registry/instrumentation-python-botocore.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore Botocore
+# cSpell:ignore: Botocore
 title: Botocore Instrumentation
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-python-cassandra.yml
+++ b/data/registry/instrumentation-python-cassandra.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore scylla
+# cSpell:ignore: scylla
 title: OpenTelemetry Cassandra Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-python-httpx.yml
+++ b/data/registry/instrumentation-python-httpx.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore httpx
+# cSpell:ignore: httpx
 title: OpenTelemetry HTTPX Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-python-langchain.yml
+++ b/data/registry/instrumentation-python-langchain.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore langchain
+# cSpell:ignore: langchain
 title: LangChain Instrumentation
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-python-mysqlclient.yml
+++ b/data/registry/instrumentation-python-mysqlclient.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore mysqlclient
+# cSpell:ignore: mysqlclient
 title: OpenTelemetry `mysqlclient` Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-python-openai.yml
+++ b/data/registry/instrumentation-python-openai.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore openai
+# cSpell:ignore: openai
 title: OpenAI Instrumentation
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-python-psycopg2.yml
+++ b/data/registry/instrumentation-python-psycopg2.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore psycopg
+# cSpell:ignore: psycopg
 title: Psycopg Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-python-pymemcache.yml
+++ b/data/registry/instrumentation-python-pymemcache.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore pymemcache
+# cSpell:ignore: pymemcache
 title: Pymemcache Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-python-pymongo.yml
+++ b/data/registry/instrumentation-python-pymongo.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore pymongo
+# cSpell:ignore: pymongo
 title: pymongo Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-python-remoulade.yml
+++ b/data/registry/instrumentation-python-remoulade.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore remoulade
+# cSpell:ignore: remoulade
 title: OpenTelemetry Remoulade Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-python-sklearn.yml
+++ b/data/registry/instrumentation-python-sklearn.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore scikit sklearn
+# cSpell:ignore: scikit sklearn
 title: OpenTelemetry Scikit-Learn Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-python-starlette.yml
+++ b/data/registry/instrumentation-python-starlette.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore Starlette
+# cSpell:ignore: Starlette
 title: Starlette Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-python-tortoiseorm.yml
+++ b/data/registry/instrumentation-python-tortoiseorm.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore tortoiseorm
+# cSpell:ignore: tortoiseorm
 title: OpenTelemetry Tortoise ORM Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-python-urllib.yml
+++ b/data/registry/instrumentation-python-urllib.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore urllib
+# cSpell:ignore: urllib
 title: OpenTelemetry urllib Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-python-urllib3.yml
+++ b/data/registry/instrumentation-python-urllib3.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore urllib3
+# cSpell:ignore: urllib3
 title: OpenTelemetry urllib3 Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-ruby-dalli.yml
+++ b/data/registry/instrumentation-ruby-dalli.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore Dalli
+# cSpell:ignore: Dalli
 title: Dalli Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-ruby-ethon.yml
+++ b/data/registry/instrumentation-ruby-ethon.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore Ethon
+# cSpell:ignore: Ethon
 title: Ethon Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-ruby-excon.yml
+++ b/data/registry/instrumentation-ruby-excon.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore excon
+# cSpell:ignore: excon
 title: Excon Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-ruby-gruf.yml
+++ b/data/registry/instrumentation-ruby-gruf.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore gruf
+# cSpell:ignore: gruf
 title: OpenTelemetry gruf Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-ruby-lmdb.yml
+++ b/data/registry/instrumentation-ruby-lmdb.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore lmdb
+# cSpell:ignore: lmdb
 title: LMDB Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-ruby-racecar.yml
+++ b/data/registry/instrumentation-ruby-racecar.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore racecar
+# cSpell:ignore: racecar
 title: OpenTelemetry Racecar Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-ruby-rdkafka.yml
+++ b/data/registry/instrumentation-ruby-rdkafka.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore rdkafka
+# cSpell:ignore: rdkafka
 title: OpenTelemetry rdkafka Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-ruby-resque.yml
+++ b/data/registry/instrumentation-ruby-resque.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore resque
+# cSpell:ignore: resque
 title: Resque Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-ruby-sidekiq.yml
+++ b/data/registry/instrumentation-ruby-sidekiq.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore Sidekiq
+# cSpell:ignore: Sidekiq
 title: Sidekiq Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-rust-actix-web.yml
+++ b/data/registry/instrumentation-rust-actix-web.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore Actix Tescher
+# cSpell:ignore: Actix Tescher
 title: Actix Web Instrumentation
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-rust-tide.yml
+++ b/data/registry/instrumentation-rust-tide.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore Grabo
+# cSpell:ignore: Grabo
 title: Tide Instrumentation
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/instrumentation-rust-tracing.yml
+++ b/data/registry/instrumentation-rust-tracing.yml
@@ -10,4 +10,4 @@ license: MIT
 description: Utilities for adding OpenTelemetry interoperability to tracing.
 authors: Julian Tescher
 otVersion: latest
-# cSpell:ignore Tescher
+# cSpell:ignore: Tescher

--- a/data/registry/otel-clojure.yml
+++ b/data/registry/otel-clojure.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore Steffan Westcott
+# cSpell:ignore: Steffan Westcott
 title: clj-otel - Idiomatic Clojure API for OpenTelemetry
 registryType: extension
 isThirdParty: true

--- a/data/registry/otel-crystal.yml
+++ b/data/registry/otel-crystal.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore wyhaines
+# cSpell:ignore: wyhaines
 title: opentelemetry-api.cr
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/otel-dart.yml
+++ b/data/registry/otel-dart.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore Workiva
+# cSpell:ignore: Workiva
 title: OpenTelemetry for Dart
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/otel-haskell.yml
+++ b/data/registry/otel-haskell.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore ethercrow
+# cSpell:ignore: ethercrow
 title: OpenTelemetry for Haskell
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/otel-lua.yml
+++ b/data/registry/otel-lua.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore yangxikun
+# cSpell:ignore: yangxikun
 title: opentelemetry-lua
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/otel-ocaml.yml
+++ b/data/registry/otel-ocaml.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore Imandra
+# cSpell:ignore: Imandra
 title: ocaml-opentelemetry OpenTelemetry exporters and instrumentation for OCaml
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/otel-perl.yml
+++ b/data/registry/otel-perl.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore jjatria
+# cSpell:ignore: jjatria
 title: OpenTelemetry for Perl
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/otel-scala.yml
+++ b/data/registry/otel-scala.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore typelevel Maksym Ochenashko
+# cSpell:ignore: typelevel Maksym Ochenashko
 title: otel4s
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/resource-detector-js-alibabacloud.yml
+++ b/data/registry/resource-detector-js-alibabacloud.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore alibabacloud
+# cSpell:ignore: alibabacloud
 title: OpenTelemetry Resource Detector for Alibaba Cloud
 registryType: resource-detector
 isThirdParty: false

--- a/data/registry/sdk-swift-nautilustelemetry.yml
+++ b/data/registry/sdk-swift-nautilustelemetry.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore Ladd
+# cSpell:ignore: Ladd
 title: NautilusTelemetry
 registryType: instrumentation
 isThirdParty: true

--- a/data/registry/tools-browser-extension-autoinjection.yml
+++ b/data/registry/tools-browser-extension-autoinjection.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore firefox autoinjection
+# cSpell:ignore: firefox autoinjection
 title: OpenTelemetry Browser Extension Autoinjection
 registryType: utilities
 isThirdParty: false

--- a/data/registry/tools-cpp-conan.yml
+++ b/data/registry/tools-cpp-conan.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore conan
+# cSpell:ignore: conan
 title: Conan Package for OpenTelemetry C++
 registryType: core
 isThirdParty: true

--- a/data/registry/tools-cpp-vcpkg.yml
+++ b/data/registry/tools-cpp-vcpkg.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore vcpkg
+# cSpell:ignore: vcpkg
 title: vcpkg package for OpenTelemetry C++
 registryType: core
 isThirdParty: true


### PR DESCRIPTION
Not mandatory, but this creates consistency with other `cSpell:ignore:` lists we have