### PR TITLE
Add Traefik Hub to the integrations

### DIFF
--- a/data/ecosystem/integrations.yaml
+++ b/data/ecosystem/integrations.yaml
@@ -144,3 +144,8 @@
   docsUrl: https://www.mathworks.com/matlabcentral/fileexchange/130979-opentelemetry-matlab
   components: [C++]
   oss: false
+- name: Traefik Hub API Management
+  url: https://traefik.io/traefik-hub/
+  docsUrl: https://doc.traefik.io/traefik-hub/operations/telemetry/overview/
+  components: [Go]
+  oss: false

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -667,6 +667,10 @@
     "StatusCode": 206,
     "LastSeen": "2023-08-03T17:44:09.893503+02:00"
   },
+  "https://doc.traefik.io/traefik-hub/operations/telemetry/overview/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-10-25T11:13:58.633523+02:00"
+  },
   "https://docker.com": {
     "StatusCode": 206,
     "LastSeen": "2023-06-29T16:16:13.965986-04:00"
@@ -5294,6 +5298,10 @@
   "https://traefik.io": {
     "StatusCode": 206,
     "LastSeen": "2023-06-29T18:51:12.996932-04:00"
+  },
+  "https://traefik.io/traefik-hub/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-10-25T11:13:58.185985+02:00"
   },
   "https://transitapp.com/": {
     "StatusCode": 200,


### PR DESCRIPTION
Add [Traefik Hub](https://traefik.io/traefik-hub/) ([docs](https://doc.traefik.io/traefik-hub/operations/telemetry/overview/)) to the integrations page (related to https://github.com/open-telemetry/opentelemetry.io/issues/3221) 