### PR TITLE
Fix missing package name in Gradle dependencies for auto-configuration

### DIFF
--- a/content/en/docs/instrumentation/java/manual.md
+++ b/content/en/docs/instrumentation/java/manual.md
@@ -316,8 +316,8 @@ dependencies {
     implementation("io.opentelemetry:opentelemetry-sdk-metrics:{{% param javaVersion %}}");
     implementation("io.opentelemetry:opentelemetry-exporter-logging:{{% param javaVersion %}}");
     implementation("io.opentelemetry.semconv:opentelemetry-semconv:{{% param semconvJavaVersion %}}-alpha")
-    implementation("opentelemetry-sdk-extension-autoconfigure:{{% param javaVersion %}}");
-    implementation("opentelemetry-sdk-extension-autoconfigure-spi:{{% param javaVersion %}}");
+    implementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:{{% param javaVersion %}}");
+    implementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:{{% param javaVersion %}}");
 }
 ```
 


### PR DESCRIPTION
There's a typo in the documentation regarding the Gradle dependency definition for auto-configuration.