### PR TITLE
Edits to Collector docs following the new Get Started

### DIFF
--- a/content/en/docs/collector/deployment/_index.md
+++ b/content/en/docs/collector/deployment/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Deployment
 description: Patterns you can apply to deploy the OpenTelemetry collector
-weight: 2
+weight: 3
 ---
 
 The OpenTelemetry Collector consists of a single binary which you can use in

--- a/content/en/docs/collector/getting-started.md
+++ b/content/en/docs/collector/getting-started.md
@@ -1,6 +1,7 @@
 ---
 title: Getting Started
 cSpell:ignore: docker dokey dpkg okey telemetrygen
+description: Test the OpenTelemetry Collector in five minutes
 weight: 1
 ---
 

--- a/content/en/docs/collector/installation.md
+++ b/content/en/docs/collector/installation.md
@@ -2,7 +2,7 @@
 title: Install the Collector
 # prettier-ignore
 cSpell:ignore: darwin dpkg GOARCH journalctl kubectl otelcorecol pprof tlsv zpages
-weight: 18
+weight: 2
 ---
 
 You can deploy the OpenTelemetry Collector on a wide variety of operating


### PR DESCRIPTION
Follows up https://github.com/open-telemetry/opentelemetry.io/pull/3426 with a couple of improvements for Collector docs:

* Raises the "Installation" section above "Deployment"
* Adds a description to the Getting Started doc