### PR TITLE
OpAMP status blog copy edits and link adjustments

### DIFF
--- a/content/en/blog/2023/opamp-status/index.md
+++ b/content/en/blog/2023/opamp-status/index.md
@@ -8,7 +8,6 @@ author: >-
   Hausenblas](https://github.com/mhausenblas) (AWS), [Andy
   Keller](https://github.com/andykellr) (observIQ, Inc), [Tigran
   Najaryan](https://github.com/tigrannajaryan) (Splunk)
-draft: false
 cSpell:ignore: Aronoff Najaryan observ Tigran
 ---
 
@@ -16,10 +15,9 @@ cSpell:ignore: Aronoff Najaryan observ Tigran
 emerging open standard to manage a fleet of telemetry agents at scale. In 2022,
 Splunk donated OpAMP to the OpenTelemetry (OTel) project, with initial feedback
 from observIQ, based on observIQ’s custom protocol used in BindPlane. The
-[OpAMP specification](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md)
-defines a network protocol for remote management of fleets of agents. These
-agents can really be anything, from telemetry agents such as the
-[OpenTelemetry Collector](/docs/collector/) to
+[OpAMP specification](/docs/specs/opamp/) defines a network protocol for remote
+management of fleets of agents. These agents can really be anything, from
+telemetry agents such as the [OpenTelemetry Collector](/docs/collector/) to
 [Fluent Bit](https://fluentbit.io/) to custom agents you might use in your
 environment.
 
@@ -55,11 +53,10 @@ want to use OpAMP both as an collector extension, with limited functionality, as
 well as as an (collector-external) supervisor that implements a broader set of
 OpAMP capabilities.
 
-{{% alert title="Note" color="info" %}} If you want to dive deeper here, we
-suggest you read the
-[OpAMP for OpenTelemetry Collector document](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/cmd/opampsupervisor/specification)
-which describes how to implement both options while minimizing code
-duplication.{{% /alert %}}
+{{% alert title="Note" color="info" %}} For a deeper dive, see
+[OpAMP for OpenTelemetry Collector document](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/cmd/opampsupervisor/specification),
+which describes how to implement both options while minimizing code duplication.
+{{% /alert %}}
 
 The main idea to support both modes is to implement an extension in the
 collector with a minimal set of OpAMP capabilities. This collector extension can
@@ -138,10 +135,10 @@ which will enable you to easily deploy the bridge into a Kubernetes cluster.
 
 The community has been working on OpAMP now for more than a year and users are
 excited about the opportunities it promises to deliver. If you’re around at
-[KubeCon NA in Chicago, USA](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/)
-between Nov 6 and 9 2023, consider visiting us at the OpenTelemetry maintainers
-booth or find us at any of the many observability-related events such as the
-[Observability day](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/co-located-events/observability-day/).
+[KubeCon NA in Chicago, USA](/blog/2023/kubecon-na/) between Nov 6 and 9 2023,
+consider visiting us at the OpenTelemetry maintainers booth or find us at any of
+the many observability-related events such as the
+[Observability day](https://opentelemetry.io/blog/2023/kubecon-na/#co-located-events).
 We’re super interested to learn from you about non-OTel collectors use cases and
 requirements as well. For now, if you’re a vendor and implementing the OpAMP
 spec please provide feedback and as an end-user you may wish to try out the

--- a/content/en/blog/2023/opamp-status/index.md
+++ b/content/en/blog/2023/opamp-status/index.md
@@ -138,8 +138,8 @@ excited about the opportunities it promises to deliver. If you’re around at
 [KubeCon NA in Chicago, USA](/blog/2023/kubecon-na/) between Nov 6 and 9 2023,
 consider visiting us at the OpenTelemetry maintainers booth or find us at any of
 the many observability-related events such as the
-[Observability day](https://opentelemetry.io/blog/2023/kubecon-na/#co-located-events).
-We’re super interested to learn from you about non-OTel collectors use cases and
+[Observability day](/blog/2023/kubecon-na/#co-located-events). We’re super
+interested to learn from you about non-OTel collectors use cases and
 requirements as well. For now, if you’re a vendor and implementing the OpAMP
 spec please provide feedback and as an end-user you may wish to try out the
 reference implementation of the Server, Supervisor and a simple UI by following


### PR DESCRIPTION
- Followup to #3425
- Replace external links to OpAMP spec by local path to spec
- Replace external KubeCon NA links by local path to KubeCon NA blog post to offer more context for all things OTel at KubeCon NA.
- Ran Prettifier

**Preview**: https://deploy-preview-3460--opentelemetry.netlify.app/blog/2023/opamp-status/