### PR TITLE
[CI] Update package engines.node to 20.x to fix build warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
   },
   "enginesComment": "Ensure that engines.node value stays consistent with the project's .nvmrc",
   "engines": {
-    "node": "18.x"
+    "node": "20.x"
   },
   "gitHubActionCacheKey": "2023-07-13 - change this key to force cache refresh",
   "private": true,


### PR DESCRIPTION
Fixes build warning. E.g., from https://app.netlify.com/sites/opentelemetry/deploys/653f2f0605f4400008b2daa5:

<pre>
12:20:54 AM: Attempting Node.js version "lts/*" from .nvmrc
12:20:54 AM: v20.9.0 is already installed.
12:20:54 AM: Now using node v20.9.0 (npm v10.1.0)
12:20:55 AM: Enabling Node.js Corepack
12:20:55 AM: Started restoring cached build plugins
12:20:55 AM: Finished restoring cached build plugins
12:20:55 AM: Started restoring cached corepack dependencies
12:20:55 AM: Finished restoring cached corepack dependencies
12:20:55 AM: No npm workspaces detected
12:20:55 AM: Started restoring cached node modules
12:20:55 AM: Finished restoring cached node modules
12:20:55 AM: Installing npm packages using npm version 10.1.0<strong>
12:20:57 AM: npm WARN EBADENGINE Unsupported engine {
12:20:57 AM: npm WARN EBADENGINE   package: undefined,
12:20:57 AM: npm WARN EBADENGINE   required: { node: "18.x" },
12:20:57 AM: npm WARN EBADENGINE   current: { node: "v20.9.0", npm: "10.1.0" }
12:20:57 AM: npm WARN EBADENGINE }</strong>
12:20:59 AM: > prepare
...
</pre>

---

With this fix, the warning goes away, see [build log](https://app.netlify.com/sites/opentelemetry/deploys/65415a1a2787f60008d04b12)

```console
3:49:09 PM: Attempting Node.js version "lts/*" from .nvmrc
3:49:09 PM: v20.9.0 is already installed.
3:49:10 PM: Now using node v20.9.0 (npm v10.1.0)
3:49:10 PM: Enabling Node.js Corepack
3:49:10 PM: Started restoring cached build plugins
3:49:10 PM: Finished restoring cached build plugins
3:49:10 PM: Started restoring cached corepack dependencies
3:49:10 PM: Finished restoring cached corepack dependencies
3:49:10 PM: No npm workspaces detected
3:49:10 PM: Started restoring cached node modules
3:49:10 PM: Finished restoring cached node modules
3:49:10 PM: Installing npm packages using npm version 10.1.0
3:49:14 PM: > prepare
...
```