### PR TITLE
Fix K8s operator 404

### DIFF
--- a/content/en/docs/kubernetes/operator/_index.md
+++ b/content/en/docs/kubernetes/operator/_index.md
@@ -9,6 +9,10 @@ aliases:
   - /docs/operator
   - /docs/k8s-operator
   - /docs/kubernetes-operator
+redirects:
+  - { from: /docs/operator/*, to: ':splat' }
+  - { from: /docs/k8s-operator/*, to: ':splat' }
+  - { from: /docs/kubernetes-operator/*, to: ':splat' }
 ---
 
 ## Introduction


### PR DESCRIPTION
- FYI, the top 404 in the past week was `/docs/k8s-operator/automatic/` (16 hits)
- `k8s-operator` pages were moved via #3027. While the index page was redirected, the section pages were not. This addresses the situation.
- Adds redirects for the moved section pages `automatic.md` and `target-allocator.md` using Netlify wildcard syntax

**Preview**: https://deploy-preview-3467--opentelemetry.netlify.app/

**Redirect tests**:

- https://deploy-preview-3467--opentelemetry.netlify.app/docs/k8s-operator/
- https://deploy-preview-3467--opentelemetry.netlify.app/docs/k8s-operator/automatic/
- https://deploy-preview-3467--opentelemetry.netlify.app/docs/k8s-operator/target-allocator/
- https://deploy-preview-3467--opentelemetry.netlify.app/docs/operator/automatic/
