### PR TITLE
List available schemas in 404 response to `/schemas`

### DIFF
--- a/content/en/schemas.md
+++ b/content/en/schemas.md
@@ -1,0 +1,17 @@
+---
+title: OpenTelemetry Schemas
+linkTitle: Schemas
+---
+
+{{% blocks/section color="white" %}}
+
+## {{% param title %}}
+
+Available schemas are listed below. To learn more about schemas, see [Telemetry
+Schemas][].
+
+{{% schemas %}}
+
+{{% /blocks/section %}}
+
+[Telemetry Schemas]: /docs/specs/otel/schemas/#opentelemetry-schema

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -48,6 +48,7 @@
 {{ $latestSchemaFile := index $schemaFiles 0 -}}
 
 /schemas/latest  /schemas/{{ $latestSchemaFile.Name }}
+/schemas /schemas/ 404!
 
 {{/*
   Social-media image redirects. As mentioned in

--- a/layouts/shortcodes/schemas.md
+++ b/layouts/shortcodes/schemas.md
@@ -1,0 +1,4 @@
+{{ $schemaFiles := partial "schema-file-list.html" . -}}
+{{ range $schemaFiles }}
+- [`{{ .Name }}`](/schemas/{{ .Name }})
+{{- end -}}


### PR DESCRIPTION
- Fixes #3468 by adding an index page, if semconv and spec folks agree to this feature. 
  Note that the list is autogenerated from `content-modules/semantic-conventions/schemas`
- ~Fixes #3256~ moved to #3475
- ~Fixes #3416~ moved to #3474

---

**Preview**: https://deploy-preview-3469--opentelemetry.netlify.app/schemas/

### Screenshot (mobile)

> <img width="392" alt="image" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/93ac1140-6eba-4cfe-926f-332de71ae44a">
