### PR TITLE
Schema content-type fix

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -14,3 +14,8 @@ force = true
 from = "https://blog.opentelemetry.io/*"
 to = "https://opentelemetry.io/blog/:splat"
 force = true
+
+[[headers]]
+  for = "/schemas/:version"
+  [headers.values]
+    content-type = "application/x-yaml"

--- a/netlify.toml
+++ b/netlify.toml
@@ -18,4 +18,4 @@ force = true
 [[headers]]
   for = "/schemas/:version"
   [headers.values]
-    content-type = "application/x-yaml"
+    content-type = "application/yaml"


### PR DESCRIPTION
- Fixes #3416
- (Was formerly a part of #3469)
- **Content-type** fix confirmed:
  ```console
  $ curl -sI https://deploy-preview-3474--opentelemetry.netlify.app/schemas/1.20.0 | grep type
  content-type: application/yaml
  ```
- **Download tests**: 
  - https://deploy-preview-3474--opentelemetry.netlify.app/schemas/1.20.0