### PR TITLE
Redirect `/schemas/latest` to latest schema

### DIFF
--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -44,6 +44,11 @@
 /docs/reference/specification/*  /docs/specs/otel/:splat
 /docs/specification/otel/*       /docs/specs/otel/:splat
 
+{{ $schemaFiles := partial "schema-file-list" . -}}
+{{ $latestSchemaFile := index $schemaFiles 0 -}}
+
+/schemas/latest  /schemas/{{ $latestSchemaFile.Name }}
+
 {{/*
   Social-media image redirects. As mentioned in
   https://developers.facebook.com/docs/sharing/webmasters/images, we need to

--- a/layouts/partials/schema-file-list.html
+++ b/layouts/partials/schema-file-list.html
@@ -1,0 +1,13 @@
+{{/*
+  Returns an array of schema files, sorted with the latest first.
+
+  Each schema file name is a semver. Sorting semver can be tricky, so for now we
+  just sort by file size, descending, which gives us the same as a semver sort.
+  This works because each published schema contains the text of all previously
+  published schemas, and hence must be larger in size.
+
+*/ -}}
+
+{{ $schemaFiles := readDir "content-modules/semantic-conventions/schemas" -}}
+{{ $schemaFilesSortedLatestFirst := sort $schemaFiles "Size" "desc" -}}
+{{ return $schemaFilesSortedLatestFirst -}}


### PR DESCRIPTION
- Fixes #3256
- (Was formerly a part of #3469)

**Redirect test**: https://deploy-preview-3475--opentelemetry.netlify.app/schemas/latest

```console
$ curl -sI https://deploy-preview-3475--opentelemetry.netlify.app/schemas/latest | grep -E 'HTTP|loc'
HTTP/2 301 
location: /schemas/1.22.0
```

**Note**: there's a simpler way to get the latest version, by using the semconv spec version. But to do that I'll need to rework some scripts. I'll do that in a followup PR.