### PR TITLE
Blog: OTel Integrations Welcome! + badge

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -290,3 +290,20 @@ body.td-page--draft .td-content {
 details {
   margin-bottom: $paragraph-margin-bottom;
 }
+
+.ot-integration-badge {
+  border-radius: 0 !important;
+
+  position: relative;
+  transform: rotate(6deg);
+  background: hsl(60, 100%, 60%);
+  border-color: hsl(60, 100%, 60%);
+  padding: 1rem;
+  margin: 0 1rem 1rem 1rem;
+
+  &:hover {
+    background: hsl(60, 100%, 60%);
+    transform: rotate(4deg);
+    transition: transform 0.2s linear;
+  }
+}

--- a/content/en/blog/2023/integrations.md
+++ b/content/en/blog/2023/integrations.md
@@ -1,7 +1,7 @@
 ---
 title: OpenTelemetry Integrations Welcome!
 linkTitle: Integrations Welcome!
-date: 2023-11-03
+date: 2023-11-08
 ---
 
 <!-- prettier-ignore -->

--- a/content/en/blog/2023/integrations.md
+++ b/content/en/blog/2023/integrations.md
@@ -1,0 +1,30 @@
+---
+title: OpenTelemetry Integrations Welcome!
+linkTitle: Integrations Welcome!
+date: 2023-11-03
+---
+
+<!-- prettier-ignore -->
+<a type="button"
+  href="/blog/2023/integrations/"
+  class="ot-integration-badge btn shadow float-end"
+  title="Learn more"
+  data-bs-toggle="tooltip" data-bs-title="Learn more">
+  <span class="fw-semibold">OTel integration!</span>
+  <span class="position-absolute top-0 start-100 translate-middle text-warning">
+    <i class="fa-solid fa-circle-info"></i>
+  </span>
+</a>
+
+Embracing OpenTelemetry's [vision](/community/mission/#vision), we are committed
+to enabling high-quality telemetry throughout the entire software stack!
+
+We're thrilled to see an expanding collection of
+[libraries, services, and apps integrating](/ecosystem/integrations/)
+OpenTelemetry, paving the way for inherent observability.
+
+Future blog posts will feature a distinct badge, as showcased in this post, to
+celebrate these integrations. This badge will also serve as a beacon, directing
+readers back to this announcement. If you're keen to have your OpenTelemetry
+integration spotlighted and featured in an upcoming blog, refer to
+[How to add your integration](/ecosystem/integrations/#how-to-add).

--- a/content/en/blog/2023/integrations.md
+++ b/content/en/blog/2023/integrations.md
@@ -16,8 +16,8 @@ date: 2023-11-03
   </span>
 </a>
 
-Embracing OpenTelemetry's [vision](/community/mission/#vision), we are committed
-to enabling high-quality telemetry throughout the entire software stack!
+Embracing OpenTelemetry's [vision], we are committed to enabling high-quality
+telemetry throughout the entire software stack!
 
 We're thrilled to see an expanding collection of
 [libraries, services, and apps integrating](/ecosystem/integrations/)
@@ -28,3 +28,10 @@ celebrate these integrations. This badge will also serve as a beacon, directing
 readers back to this announcement. If you're keen to have your OpenTelemetry
 integration spotlighted and featured in an upcoming blog, refer to
 [How to add your integration](/ecosystem/integrations/#how-to-add).
+
+<!--
+TODO Add #vision anchor to `/community/mission/` once the following lands:
+https://github.com/open-telemetry/community/pull/1776
+-->
+
+[vision]: /community/mission/

--- a/content/en/ecosystem/integrations.md
+++ b/content/en/ecosystem/integrations.md
@@ -15,6 +15,8 @@ provide a first-party plugin that fits into their own extensibility ecosystem.
 
 {{% ecosystem/integrations-table %}}
 
+## How to add your integration {#how-to-add}
+
 To have your library, service, or app listed, submit a PR with an entry added to
 the
 [integrations list](https://github.com/open-telemetry/opentelemetry.io/tree/main/data/ecosystem/integrations.yaml).


### PR DESCRIPTION
- Rather than add a "note" at the top of integration post, I propose that we add a distinctive badge
- This PR adds a blog post that introduces the badge, which we'll be able to use in other posts such as #3466 and #3431
- Clicking the badge refers the reader back to this post.
- If you like the idea, I suggest we merge this. After I'll factor out the badge so that it can be reused in other posts via a shortcode.

**Preview**: https://deploy-preview-3485--opentelemetry.netlify.app/blog/2023/integrations/

### Screenshots

Desktop:

> <img width="662" alt="image" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/cd70ec85-cc54-4ea7-9ec4-3c539a9b1469">

Hovered state:

> <img width="648" alt="image" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/2915d8c8-3a59-4e5f-8a08-f876f14d023a">

Mobile:

> <img width="391" alt="image" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/c62b6a7a-92d0-49b2-a2ef-4d76fa4b993b">

