### PR TITLE
[CI] Textlint: allow `.java`

### DIFF
--- a/.textlintrc.json
+++ b/.textlintrc.json
@@ -20,7 +20,8 @@
         "Open Agent Management Protocol",
         "SignalFx Smart Agent",
         "/^(?:language|repo): .*$/m",
-        "/tags:([\\n\\r\\s]*-[\\s\\S]*?[\\n\\r]+)*/m"
+        "/tags:([\\n\\r\\s]*-[\\s\\S]*?[\\n\\r]+)*/m",
+        "/\\.java\\b/"
       ]
     }
   },


### PR DESCRIPTION
- Addresses the issue reported at https://github.com/open-telemetry/opentelemetry.io/pull/3470#issuecomment-1791673382
- Allows `.java`