### PR TITLE
[CI] Textlint: properly check for Java capitalization & more

### DIFF
--- a/.textlintrc.json
+++ b/.textlintrc.json
@@ -1,6 +1,6 @@
 {
   "plugins": {
-    "@textlint/text": {
+    "@textlint/markdown": {
       "extensions": [".yml"]
     }
   },
@@ -20,8 +20,7 @@
         "Open Agent Management Protocol",
         "SignalFx Smart Agent",
         "/^(?:language|repo): .*$/m",
-        "/tags:([\\n\\r\\s]*-[\\s\\S]*?[\\n\\r]+)*/m",
-        "/\\.java\\b/"
+        "/tags:([\\n\\r\\s]*-[\\s\\S]*?[\\n\\r]+)*/m"
       ]
     }
   },
@@ -54,7 +53,6 @@
         "HTTP",
         "HTTPS",
         "Jaeger",
-        "Java",
         "JavaScript",
         "JBoss",
         "Jetty",
@@ -115,6 +113,7 @@
         ["he/she", "they"],
         ["\\(s\\)he", "they"],
         ["id['’]?s", "IDs"],
+        ["(?<![.-])java\\b(?![.])", "Java"],
         ["java[- ]?agent", "Java agent"],
         ["mac ?os", "macOS"],
         ["meta[- ]data", "metadata"],

--- a/.textlintrc.json
+++ b/.textlintrc.json
@@ -20,7 +20,7 @@
         "Open Agent Management Protocol",
         "SignalFx Smart Agent",
         "/^(?:language|repo): .*$/m",
-        "/tags:([\\n\\r\\s]*-[\\s\\S]*?[\\n\\r]+)*/m"
+        "/^tags:(\\s*-.+$)*/m"
       ]
     }
   },

--- a/content/en/blog/2022/debug-otel-with-otel/index.md
+++ b/content/en/blog/2022/debug-otel-with-otel/index.md
@@ -44,7 +44,7 @@ application.
 ### Steps to reproduce
 
 Follow the instructions on how you can [put NGINX between two services][].
-Replace the java-based application with a Python application, e.g. put following
+Replace the Java-based application with a Python application, e.g. put following
 three files into the `backend` folder instead:
 
 - `app.py`:

--- a/content/en/docs/instrumentation/java/manual.md
+++ b/content/en/docs/instrumentation/java/manual.md
@@ -199,9 +199,9 @@ dependencies {
 }
 ```
 
-Throughout this documentation you will add additional dependencies. For a full
-list of artifact coordinates, see [releases]. For semantic convention releases,
-see [semantic-conventions-java].
+Throughout this documentation you will add dependencies. For a full list of
+artifact coordinates, see [releases]. For semantic convention releases, see
+[semantic-conventions-java].
 
 [releases]: https://github.com/open-telemetry/opentelemetry-java#releases
 [semantic-conventions-java]:

--- a/content/en/docs/instrumentation/java/manual.md
+++ b/content/en/docs/instrumentation/java/manual.md
@@ -200,8 +200,8 @@ dependencies {
 ```
 
 Throughout this documentation you will add additional dependencies. For a full
-list of artifact coordinates see [releases][releases] and for semantic
-convention releases see [semantic-conventions-java][semantic-conventions-java].
+list of artifact coordinates see [releases] and for semantic convention releases
+see [semantic-conventions-java].
 
 {{% /tab %}} {{% tab Maven %}}
 

--- a/content/en/docs/instrumentation/java/manual.md
+++ b/content/en/docs/instrumentation/java/manual.md
@@ -200,8 +200,12 @@ dependencies {
 ```
 
 Throughout this documentation you will add additional dependencies. For a full
-list of artifact coordinates see [releases] and for semantic convention releases
+list of artifact coordinates, see [releases]. For semantic convention releases,
 see [semantic-conventions-java].
+
+[releases]: https://github.com/open-telemetry/opentelemetry-java#releases
+[semantic-conventions-java]:
+  https://github.com/open-telemetry/semantic-conventions-java/releases
 
 {{% /tab %}} {{% tab Maven %}}
 
@@ -1652,8 +1656,5 @@ io.opentelemetry.sdk.trace.export.BatchSpanProcessor = io.opentelemetry.extensio
 [opentelemetry registry]: /ecosystem/registry/?component=exporter&language=java
 [parentbased]:
   https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/ParentBasedSampler.java
-[releases]: https://github.com/open-telemetry/opentelemetry-java#releases
-[semantic-conventions-java]:
-  https://github.com/open-telemetry/semantic-conventions-java/releases
 [traceidratiobased]:
   https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/TraceIdRatioBasedSampler.java


### PR DESCRIPTION
- Fixes #3498
- Contributes to #3458
- Followup and alternative (better) solution to #3492
- Adds a proper patter to `terminology` to recognize and fix "Java" mis-capitalizations. In particular, it avoids reporting false positives:
  - File names: `file.java`
  - Repo names: `opentelemetry-java`
  - IDs: `java.util.List`, as they might appear, e.g., in markdown link-text 
- Drops `allow` pattern
- Drops "Java" word from terminology list
- Makes fixes to doc pages
- Switches to interpreting `.yml` files a markdown. This gives us better checking, with fewer false positives, especially for fields that contain markdown
- Improves on registry-`tags` allow pattern

**Preview**: e.g.,

- https://deploy-preview-3497--opentelemetry.netlify.app/docs/instrumentation/java/manual/