### PR TITLE
[CI] Strip commas from cSpell:ingore word lists

### DIFF
--- a/content/en/blog/2022/instrument-apache-httpd-server/index.md
+++ b/content/en/blog/2022/instrument-apache-httpd-server/index.md
@@ -2,9 +2,9 @@
 title: Learn how to instrument Apache Http Server with OpenTelemetry
 linkTitle: Instrument Apache Http Server
 date: 2022-05-27
+author: '[Debajit Das](https://github.com/DebajitDas) (Cisco)'
 # prettier-ignore
 cSpell:ignore: Centos centos7 Debajit debuggability libmod uncompress webserver
-author: '[Debajit Das](https://github.com/DebajitDas) (Cisco)'
 ---
 
 If you are using Apache HTTP Server and in dire need of some observability tool

--- a/content/en/docs/instrumentation/python/distro.md
+++ b/content/en/docs/instrumentation/python/distro.md
@@ -1,8 +1,8 @@
 ---
-cSpell:ignore: configurator distro distros loglevel
 title: OpenTelemetry Distro
 linkTitle: Distro
 weight: 110
+cSpell:ignore: configurator distro distros loglevel
 ---
 
 In order to make using OpenTelemetry and auto-instrumentation as quick as

--- a/scripts/normalize-cspell-front-matter.pl
+++ b/scripts/normalize-cspell-front-matter.pl
@@ -12,10 +12,10 @@ my $last_line = '';
 my %dictionary = getSiteWideDictWords('.vscode/cspell.json', '.textlintrc.yml');
 
 while (<>) {
-  if (/^\s*(spelling: |-\s*)?cSpell:ignore:?(.*)$/
+  if (/^\s*(spelling: |-\s*)?cSpell:ignore:?\s*(.*)$/
       || (/^(\s+)(\S.*)$/ && @words)
   ) {
-    push @words, split ' ', $2;
+    push @words, split /[,\s]+/, $2;
     next;
   }
 


### PR DESCRIPTION
- Fixes #3501
- Also strips out multiple occurrences of the separators (like multiple spaces), and replaces them by a single space
