### PR TITLE
[CI] Refactor OTel-Java related front-matter version keys + autoupdate script changes

### DIFF
--- a/.github/workflows/auto-update-versions.yml
+++ b/.github/workflows/auto-update-versions.yml
@@ -26,12 +26,12 @@ jobs:
       - name: Auto-update
         run: |
           .github/workflows/scripts/auto-update-version.sh opentelemetry-collector-releases collectorVersion content/en/docs/collector/_index.md
-          .github/workflows/scripts/auto-update-version.sh opentelemetry-java javaVersion content/en/docs/instrumentation/java/_index.md
-          .github/workflows/scripts/auto-update-version.sh opentelemetry-java-instrumentation javaInstrumentationVersion content/en/docs/instrumentation/java/automatic/annotations.md
+          .github/workflows/scripts/auto-update-version.sh opentelemetry-java otel content/en/docs/instrumentation/java/_index.md
+          .github/workflows/scripts/auto-update-version.sh opentelemetry-java-instrumentation instrumentation content/en/docs/instrumentation/java/_index.md
           .github/workflows/scripts/auto-update-version.sh opentelemetry-specification spec scripts/content-modules/adjust-pages.pl
           .github/workflows/scripts/auto-update-version.sh opentelemetry-proto otlp scripts/content-modules/adjust-pages.pl
           .github/workflows/scripts/auto-update-version.sh semantic-conventions semconv scripts/content-modules/adjust-pages.pl
-          .github/workflows/scripts/auto-update-version.sh semantic-conventions-java semconvJavaVersion content/en/docs/instrumentation/java/_index.md
+          .github/workflows/scripts/auto-update-version.sh semantic-conventions-java semconv content/en/docs/instrumentation/java/_index.md
         env:
           # change this to secrets.GITHUB_TOKEN when testing against a fork
           GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}

--- a/.github/workflows/scripts/auto-update-version.sh
+++ b/.github/workflows/scripts/auto-update-version.sh
@@ -63,8 +63,8 @@ See https://github.com/open-telemetry/$repo/releases/tag/v$latest_version."
 
 existing_pr_count=$(gh pr list --state all --search "in:title $message" | wc -l)
 if [ "$existing_pr_count" -gt 0 ]; then
-    echo "PR(s) for version $latest_version of $repo already exist:"
-    gh pr list --state all --search "in:title $message"
+    echo "PR(s) already exist for '$message'"
+    gh pr list --state all --search "\"$message\" in:title"
     echo "So we won't create another. Exiting."
     exit 0
 fi

--- a/content/en/docs/instrumentation/java/_index.md
+++ b/content/en/docs/instrumentation/java/_index.md
@@ -4,10 +4,12 @@ description: >-
   <img width="35" class="img-initial" src="/img/logos/32x32/Java_SDK.svg"
   alt="Java"> A language-specific implementation of OpenTelemetry in Java.
 aliases: [/java, /java/metrics, /java/tracing]
-weight: 18
 cascade:
-  javaVersion: 1.31.0
-  semconvJavaVersion: 1.22.0
+  vers:
+    instrumentation: 1.31.0
+    otel: 1.31.0
+    semconv: 1.22.0
+weight: 18
 ---
 
 {{% docs/instrumentation/index-intro java /%}}
@@ -47,7 +49,7 @@ using our BOM to keep the versions of the various components in sync.
       <dependency>
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-bom</artifactId>
-        <version>{{% param javaVersion %}}</version>
+        <version>{{% param vers.otel %}}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -66,7 +68,7 @@ using our BOM to keep the versions of the various components in sync.
 
 ```kotlin
 dependencies {
-  implementation(platform("io.opentelemetry:opentelemetry-bom:{{% param javaVersion %}}"))
+  implementation(platform("io.opentelemetry:opentelemetry-bom:{{% param vers.otel %}}"))
   implementation("io.opentelemetry:opentelemetry-api")
 }
 ```

--- a/content/en/docs/instrumentation/java/automatic/annotations.md
+++ b/content/en/docs/instrumentation/java/automatic/annotations.md
@@ -3,7 +3,6 @@ title: Annotations
 description: Using instrumentation annotations with a Java agent.
 aliases: [../annotations]
 weight: 20
-javaInstrumentationVersion: 1.31.0
 cSpell:ignore: Flowable javac reactivestreams reactivex
 ---
 
@@ -25,7 +24,7 @@ annotation.
   <dependency>
     <groupId>io.opentelemetry.instrumentation</groupId>
     <artifactId>opentelemetry-instrumentation-annotations</artifactId>
-    <version>{{% param javaInstrumentationVersion %}}</version>
+    <version>{{% param vers.instrumentation %}}</version>
   </dependency>
 </dependencies>
 ```
@@ -34,7 +33,7 @@ annotation.
 
 ```groovy
 dependencies {
-    implementation('io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:{{% param javaInstrumentationVersion %}}')
+    implementation('io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:{{% param vers.instrumentation %}}')
 }
 ```
 

--- a/content/en/docs/instrumentation/java/exporters.md
+++ b/content/en/docs/instrumentation/java/exporters.md
@@ -29,7 +29,7 @@ For most users, the default artifact will suffice and be the most simple:
 
 ```kotlin
 dependencies {
-    implementation 'io.opentelemetry:opentelemetry-exporter-otlp:{{% param javaVersion %}}'
+    implementation 'io.opentelemetry:opentelemetry-exporter-otlp:{{% param vers.otel %}}'
 }
 ```
 

--- a/content/en/docs/instrumentation/java/manual.md
+++ b/content/en/docs/instrumentation/java/manual.md
@@ -195,7 +195,7 @@ dependencies for the OpenTelemetry API.
 ```kotlin { hl_lines=3 }
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web");
-    implementation("io.opentelemetry:opentelemetry-api:{{% param javaVersion %}}");
+    implementation("io.opentelemetry:opentelemetry-api:{{% param vers.otel %}}");
 }
 ```
 
@@ -216,7 +216,7 @@ artifact coordinates, see [releases]. For semantic convention releases, see
             <dependency>
                 <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-bom</artifactId>
-                <version>{{% param javaVersion %}}</version>
+                <version>{{% param vers.otel %}}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -246,11 +246,11 @@ SDK.
 ```kotlin { hl_lines="4-8" }
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web");
-    implementation("io.opentelemetry:opentelemetry-api:{{% param javaVersion %}}");
-    implementation("io.opentelemetry:opentelemetry-sdk:{{% param javaVersion %}}");
-    implementation("io.opentelemetry:opentelemetry-sdk-metrics:{{% param javaVersion %}}");
-    implementation("io.opentelemetry:opentelemetry-exporter-logging:{{% param javaVersion %}}");
-    implementation("io.opentelemetry:opentelemetry-semconv:{{% param javaVersion %}}-alpha");
+    implementation("io.opentelemetry:opentelemetry-api:{{% param vers.otel %}}");
+    implementation("io.opentelemetry:opentelemetry-sdk:{{% param vers.otel %}}");
+    implementation("io.opentelemetry:opentelemetry-sdk-metrics:{{% param vers.otel %}}");
+    implementation("io.opentelemetry:opentelemetry-exporter-logging:{{% param vers.otel %}}");
+    implementation("io.opentelemetry:opentelemetry-semconv:{{% param vers.otel %}}-alpha");
 }
 ```
 
@@ -263,7 +263,7 @@ dependencies {
             <dependency>
                 <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-bom</artifactId>
-                <version>{{% param javaVersion %}}</version>
+                <version>{{% param vers.otel %}}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -290,7 +290,7 @@ dependencies {
             <!-- Not managed by opentelemetry-bom -->
             <groupId>io.opentelemetry.semconv</groupId>
             <artifactId>opentelemetry-semconv</artifactId>
-            <version>{{% param semconvJavaVersion %}}-alpha</version>
+            <version>{{% param vers.semconv %}}-alpha</version>
         </dependency>
     </dependencies>
 </project>
@@ -315,13 +315,13 @@ To use auto-configuration add the following dependency to your application:
 ```kotlin { hl_lines="9-10" }
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web");
-    implementation("io.opentelemetry:opentelemetry-api:{{% param javaVersion %}}");
-    implementation("io.opentelemetry:opentelemetry-sdk:{{% param javaVersion %}}");
-    implementation("io.opentelemetry:opentelemetry-sdk-metrics:{{% param javaVersion %}}");
-    implementation("io.opentelemetry:opentelemetry-exporter-logging:{{% param javaVersion %}}");
-    implementation("io.opentelemetry.semconv:opentelemetry-semconv:{{% param semconvJavaVersion %}}-alpha")
-    implementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:{{% param javaVersion %}}");
-    implementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:{{% param javaVersion %}}");
+    implementation("io.opentelemetry:opentelemetry-api:{{% param vers.otel %}}");
+    implementation("io.opentelemetry:opentelemetry-sdk:{{% param vers.otel %}}");
+    implementation("io.opentelemetry:opentelemetry-sdk-metrics:{{% param vers.otel %}}");
+    implementation("io.opentelemetry:opentelemetry-exporter-logging:{{% param vers.otel %}}");
+    implementation("io.opentelemetry.semconv:opentelemetry-semconv:{{% param vers.semconv %}}-alpha")
+    implementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:{{% param vers.otel %}}");
+    implementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:{{% param vers.otel %}}");
 }
 ```
 
@@ -849,7 +849,7 @@ First add the semantic conventions as a dependency to your application:
 
 ```kotlin
 dependencies {
-  implementation("io.opentelemetry.semconv:opentelemetry-semconv:{{% param semconvJavaVersion %}}-alpha")
+  implementation("io.opentelemetry.semconv:opentelemetry-semconv:{{% param vers.semconv %}}-alpha")
 }
 ```
 
@@ -859,7 +859,7 @@ dependencies {
 <dependency>
     <groupId>io.opentelemetry.semconv</groupId>
     <artifactId>opentelemetry-semconv</artifactId>
-    <version>{{% param semconvJavaVersion %}}-alpha</version>
+    <version>{{% param vers.semconv %}}-alpha</version>
 </dependency>
 ```
 

--- a/content/en/docs/instrumentation/java/resources.md
+++ b/content/en/docs/instrumentation/java/resources.md
@@ -29,7 +29,7 @@ To use those providers, add the following dependency:
 
 ```kotlin
 dependencies {
-    implementation("io.opentelemetry.instrumentation:opentelemetry-resources:{{% param javaVersion %}}-alpha");
+    implementation("io.opentelemetry.instrumentation:opentelemetry-resources:{{% param vers.otel %}}-alpha");
 }
 ```
 


### PR DESCRIPTION
- Contributes to:
  - Preparation for #3377
  - #3458
- Refactors the OTel-Java related front-matter version keys so that they are all in `docs/instrumentation/java/_index.md`. This enables all pages in that section to access the variables
- Renames the variables so that they are shorter, given the context. I.e., for pages under the Java section, `vers.semconv` means the version of Java semconv, etc.
- There are **no changes to the generated site files** (modulo timestamps etc):
  ```console
  $ (cd public && git diff) | grep ^diff 
  diff --git a/docs/instrumentation/java/automatic/annotations/index.html b/docs/instrumentation/java/automatic/annotations/index.html
  diff --git a/docs/instrumentation/java/exporters/index.html b/docs/instrumentation/java/exporters/index.html
  diff --git a/docs/instrumentation/java/index.html b/docs/instrumentation/java/index.html
  diff --git a/docs/instrumentation/java/manual/index.html b/docs/instrumentation/java/manual/index.html
  diff --git a/docs/instrumentation/java/resources/index.html b/docs/instrumentation/java/resources/index.html
  diff --git a/site/index.html b/site/index.html
  diff --git a/sitemap.xml b/sitemap.xml
  $ (cd public && git diff -I 'dateModified|lastmod|modified_time|Last modified') | grep ^diff               
  diff --git a/site/index.html b/site/index.html
  ```