### PR TITLE
Update semantic-conventions repo to 1.23.0

### DIFF
--- a/.github/workflows/scripts/auto-update-version.sh
+++ b/.github/workflows/scripts/auto-update-version.sh
@@ -70,7 +70,8 @@ if [ "$existing_pr_count" -gt 0 ]; then
 fi
 
 if [[ "$repo" == "opentelemetry-specification"
-   || "$repo" == "opentelemetry-proto" ]]; then
+   || "$repo" == "opentelemetry-proto"
+   || "$repo" == "semantic-conventions" ]]; then
   echo "Switching to $repo at tag v$latest_version"
   ( set -x;
     npm run get:submodule -- content-modules/$repo &&

--- a/gulp-src/prune.js
+++ b/gulp-src/prune.js
@@ -71,13 +71,13 @@ async function pruneTask() {
         ([url, date, statusCode]) => 400 <= statusCode && statusCode <= 499,
       );
 
+    var msg = `INFO: ${entriesWith4xxStatus.length} entries with 4XX status.`;
     if (prune4xx && entriesWith4xxStatus.length > 0) {
-      console.log(
-        `INFO: pruning ${entriesWith4xxStatus.length} entries with 4XX status.`,
-      );
+      msg += ' Pruning them.';
       const keysToPrune = entriesWith4xxStatus.map((item) => item[0]);
       keysToPrune.forEach((key) => delete entries[key]);
     }
+    console.log(msg);
     return entriesWith4xxStatus.length;
   }
 
@@ -103,7 +103,11 @@ async function pruneTask() {
       return;
     } else {
       console.log(
-        `INFO: ${pruneCandidatesByDate__sorted.length} entries as prune candidates for given date.`,
+        `INFO: ${
+          pruneCandidatesByDate__sorted.length
+        } entries as prune candidates for before-date ${formattedDate(
+          beforeDate,
+        )}.`,
       );
     }
 
@@ -139,22 +143,28 @@ function listOldest(entries, numberOfEntries) {
 
   oldestEntries.forEach((e) => {
     const date = new Date(e[1]);
-    const formattedDate = date
-      .toLocaleDateString('en-CA', {
-        year: 'numeric',
-        month: '2-digit',
-        day: '2-digit',
-      })
-      .replace(/\//g, '-');
-    const formattedTime = date.toLocaleTimeString('en-CA', {
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false,
-    });
-    console.log(`  ${formattedDate} ${formattedTime} for ${e[0]}`);
+    console.log(`  ${formattedDate(date)} ${formattedTime(date)} for ${e[0]}`);
   });
 }
 
 pruneTask.description = `Prune --num <n> entries from ${refcacheFile} file. For details, use --info.`;
 
 gulp.task('prune', pruneTask);
+
+function formattedDate(date) {
+  return date
+    .toLocaleDateString('en-CA', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    })
+    .replace(/\//g, '-');
+}
+
+function formattedTime(date) {
+  return date.toLocaleTimeString('en-CA', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+}

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -135,6 +135,7 @@ while(<>) {
   s|(\.\./)?internal(/img/[-\w]+\.png)|$2|g;
   s|(\]\()(img/.*?\))|$1../$2|g if $ARGV !~ /(logs|schemas)._index/ && $ARGV !~ /otlp\/docs/;
   s|(\]\()([^)]+\.png\))|$1../$2|g if $ARGV =~ /\/tmp\/semconv\/docs\/general\/attributes/;
+  s|(\]\()([^)]+\.png\))|$1../$2|g if $ARGV =~ /\/tmp\/semconv\/docs\/http\/http-spans/;
 
   # Fix links that are to the title of the .md page
   # TODO: fix these in the spec

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -167,6 +167,10 @@
     "StatusCode": 206,
     "LastSeen": "2023-06-29T12:28:09.411462-04:00"
   },
+  "https://azure.microsoft.com/global-infrastructure/geographies/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-11-08T07:23:05.338824-05:00"
+  },
   "https://azure.microsoft.com/products/cosmos-db/": {
     "StatusCode": 200,
     "LastSeen": "2023-07-06T17:58:02.342209-04:00"
@@ -583,6 +587,10 @@
     "StatusCode": 200,
     "LastSeen": "2023-06-30T09:18:28.374093-04:00"
   },
+  "https://developer.android.com/guide/components/activities/activity-lifecycle#lc": {
+    "StatusCode": 200,
+    "LastSeen": "2023-11-08T07:23:26.997244-05:00"
+  },
   "https://developer.android.com/guide/topics/manifest/uses-sdk-element#ApiLevels": {
     "StatusCode": 200,
     "LastSeen": "2023-10-16T14:13:38.873062-04:00"
@@ -594,6 +602,10 @@
   "https://developer.android.com/training/articles/user-data-ids": {
     "StatusCode": 200,
     "LastSeen": "2023-06-29T16:08:12.4633-04:00"
+  },
+  "https://developer.apple.com/documentation/uikit/uiapplicationdelegate#1656902": {
+    "StatusCode": 200,
+    "LastSeen": "2023-11-08T07:23:21.699535-05:00"
   },
   "https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor": {
     "StatusCode": 200,
@@ -1067,6 +1079,10 @@
     "StatusCode": 200,
     "LastSeen": "2023-06-29T15:46:55.73361-04:00"
   },
+  "https://docs.microsoft.com/azure/azure-functions/manage-connections#static-clients": {
+    "StatusCode": 200,
+    "LastSeen": "2023-11-08T07:22:17.430061-05:00"
+  },
   "https://docs.microsoft.com/azure/azure-monitor/app/opentelemetry-overview": {
     "StatusCode": 200,
     "LastSeen": "2023-06-29T15:46:12.472701-04:00"
@@ -1083,6 +1099,10 @@
     "StatusCode": 200,
     "LastSeen": "2023-06-29T15:53:37.193001-04:00"
   },
+  "https://docs.microsoft.com/dotnet/api/system.exception.tostring": {
+    "StatusCode": 200,
+    "LastSeen": "2023-11-08T07:22:23.190616-05:00"
+  },
   "https://docs.microsoft.com/dotnet/api/system.net.http.httpclient": {
     "StatusCode": 200,
     "LastSeen": "2023-09-06T15:04:28.468986+02:00"
@@ -1090,6 +1110,10 @@
   "https://docs.microsoft.com/dotnet/api/system.net.httpwebrequest": {
     "StatusCode": 200,
     "LastSeen": "2023-09-06T15:04:29.255967+02:00"
+  },
+  "https://docs.microsoft.com/dotnet/api/system.servicemodel.servicesecuritycontext": {
+    "StatusCode": 200,
+    "LastSeen": "2023-11-08T07:21:40.065749-05:00"
   },
   "https://docs.microsoft.com/dotnet/core/diagnostics/metrics-instrumentation": {
     "StatusCode": 200,
@@ -1159,6 +1183,22 @@
     "StatusCode": 200,
     "LastSeen": "2023-06-29T15:48:28.159167-04:00"
   },
+  "https://docs.microsoft.com/rest/api/resources/resources/get-by-id": {
+    "StatusCode": 200,
+    "LastSeen": "2023-11-08T07:22:12.212546-05:00"
+  },
+  "https://docs.microsoft.com/sql/connect/jdbc/building-the-connection-url": {
+    "StatusCode": 200,
+    "LastSeen": "2023-11-08T07:21:07.811418-05:00"
+  },
+  "https://docs.microsoft.com/windows/win32/api/netioapi/nf-netioapi-getifentry2": {
+    "StatusCode": 200,
+    "LastSeen": "2023-11-08T07:22:44.999744-05:00"
+  },
+  "https://docs.microsoft.com/windows/win32/api/netioapi/ns-netioapi-mib_if_row2": {
+    "StatusCode": 200,
+    "LastSeen": "2023-11-08T07:22:39.742787-05:00"
+  },
   "https://docs.microsoft.com/windows/win32/api/winsock2/nf-winsock2-bind": {
     "StatusCode": 200,
     "LastSeen": "2023-06-29T15:50:36.741227-04:00"
@@ -1218,6 +1258,10 @@
   "https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryPoolMXBean.html#getName%28%29": {
     "StatusCode": 200,
     "LastSeen": "2023-06-29T15:47:40.319503-04:00"
+  },
+  "https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/ThreadInfo.html#isDaemon%28%29": {
+    "StatusCode": 200,
+    "LastSeen": "2023-11-08T07:22:01.424324-05:00"
   },
   "https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/HttpClient.html": {
     "StatusCode": 200,
@@ -1311,6 +1355,14 @@
     "StatusCode": 200,
     "LastSeen": "2023-06-30T11:41:32.736885-04:00"
   },
+  "https://docs.oracle.com/javase/8/docs/api/java/lang/management/ThreadInfo.html#getThreadState--": {
+    "StatusCode": 200,
+    "LastSeen": "2023-11-08T07:21:56.320234-05:00"
+  },
+  "https://docs.oracle.com/javase/8/docs/api/java/lang/management/ThreadMXBean.html#getAllThreadIds--": {
+    "StatusCode": 200,
+    "LastSeen": "2023-11-08T07:21:46.130999-05:00"
+  },
   "https://docs.oracle.com/javase/8/docs/api/java/lang/management/ThreadMXBean.html#getDaemonThreadCount--": {
     "StatusCode": 200,
     "LastSeen": "2023-06-30T11:40:51.871681-04:00"
@@ -1318,6 +1370,10 @@
   "https://docs.oracle.com/javase/8/docs/api/java/lang/management/ThreadMXBean.html#getThreadCount--": {
     "StatusCode": 200,
     "LastSeen": "2023-06-30T11:40:56.959874-04:00"
+  },
+  "https://docs.oracle.com/javase/8/docs/api/java/lang/management/ThreadMXBean.html#getThreadInfo-long:A-": {
+    "StatusCode": 200,
+    "LastSeen": "2023-11-08T07:21:51.21529-05:00"
   },
   "https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html": {
     "StatusCode": 200,
@@ -3971,6 +4027,10 @@
     "StatusCode": 200,
     "LastSeen": "2023-08-03T17:44:10.601039+02:00"
   },
+  "https://img.shields.io/badge/-stable-lightgreen": {
+    "StatusCode": 200,
+    "LastSeen": "2023-11-08T07:21:29.389953-05:00"
+  },
   "https://jaegertracing.io": {
     "StatusCode": 206,
     "LastSeen": "2023-06-01T15:55:20.985886-04:00"
@@ -4167,6 +4227,10 @@
     "StatusCode": 206,
     "LastSeen": "2023-06-29T16:21:28.969704-04:00"
   },
+  "https://learn.microsoft.com/archive/blogs/askcore/windows-performance-monitor-disk-counters-explained#windows-performance-monitor-disk-counters-explained": {
+    "StatusCode": 200,
+    "LastSeen": "2023-11-08T07:22:34.14265-05:00"
+  },
   "https://learn.microsoft.com/aspnet/core/tutorials/min-web-api": {
     "StatusCode": 200,
     "LastSeen": "2023-08-14T07:27:51.174082501Z"
@@ -4198,6 +4262,10 @@
   "https://learn.microsoft.com/en-us/rest/api/resources/resources/get-by-id": {
     "StatusCode": 200,
     "LastSeen": "2023-06-30T09:16:26.155249-04:00"
+  },
+  "https://learn.microsoft.com/rest/api/resources/resources/get-by-id": {
+    "StatusCode": 200,
+    "LastSeen": "2023-11-08T07:22:07.040171-05:00"
   },
   "https://letsencrypt.org/": {
     "StatusCode": 206,
@@ -5267,6 +5335,10 @@
     "StatusCode": 200,
     "LastSeen": "2023-06-29T18:36:13.877675-04:00"
   },
+  "https://standards.ieee.org/wp-content/uploads/import/documents/tutorials/eui.pdf": {
+    "StatusCode": 206,
+    "LastSeen": "2023-11-08T07:23:33.211618-05:00"
+  },
   "https://storiesfromtheherd.com/just-in-time-nomad-80f57cd403ca": {
     "StatusCode": 200,
     "LastSeen": "2023-06-29T18:50:57.528605-04:00"
@@ -5386,6 +5458,10 @@
   "https://tools.ietf.org/html/rfc8174": {
     "StatusCode": 200,
     "LastSeen": "2023-06-29T18:42:20.913106-04:00"
+  },
+  "https://tools.ietf.org/html/rfc9110#section-7.2": {
+    "StatusCode": 200,
+    "LastSeen": "2023-11-08T07:23:16.17102-05:00"
   },
   "https://tools.ietf.org/html/rfc9113#section-8.3.1": {
     "StatusCode": 200,
@@ -5523,6 +5599,30 @@
     "StatusCode": 200,
     "LastSeen": "2023-06-30T08:40:17.830752-04:00"
   },
+  "https://wikipedia.org/wiki/Count_noun": {
+    "StatusCode": 200,
+    "LastSeen": "2023-11-08T07:21:23.868848-05:00"
+  },
+  "https://wikipedia.org/wiki/Deployment_environment": {
+    "StatusCode": 200,
+    "LastSeen": "2023-11-08T07:23:39.11906-05:00"
+  },
+  "https://wikipedia.org/wiki/Function_as_a_service": {
+    "StatusCode": 200,
+    "LastSeen": "2023-11-08T07:21:18.690062-05:00"
+  },
+  "https://wikipedia.org/wiki/Hop_%28networking%29": {
+    "StatusCode": 200,
+    "LastSeen": "2023-11-08T07:21:13.325261-05:00"
+  },
+  "https://wikipedia.org/wiki/Inter-process_communication": {
+    "StatusCode": 200,
+    "LastSeen": "2023-11-08T07:21:34.564864-05:00"
+  },
+  "https://wikipedia.org/wiki/Load_%28computing%29": {
+    "StatusCode": 200,
+    "LastSeen": "2023-11-08T07:22:50.172555-05:00"
+  },
   "https://wikipedia.org/wiki/Monotonic_function": {
     "StatusCode": 200,
     "LastSeen": "2023-06-30T08:40:28.153623-04:00"
@@ -5530,6 +5630,10 @@
   "https://wikipedia.org/wiki/Page_fault": {
     "StatusCode": 200,
     "LastSeen": "2023-06-30T08:40:22.997241-04:00"
+  },
+  "https://wikipedia.org/wiki/S.M.A.R.T.": {
+    "StatusCode": 200,
+    "LastSeen": "2023-11-08T07:22:28.763824-05:00"
   },
   "https://wukongdoc.tingyun.com/apm/userguide/deploy_manage/opentelemetry.html": {
     "StatusCode": 206,


### PR DESCRIPTION
- Fixes #3510
- Followup to #3487
- Fixes auto-update-version script so that it also updates the repo for semconv!
  - I've tested the script locally and it updates the submodule as needed
- Fixes links to images in `http-spans` via `adjust-pages.pl`
- Adjusts INFO messages of the `prune` Gulp task to be a bit more useful
