### PR TITLE
Update table in Observability primer

### DIFF
--- a/content/en/docs/concepts/observability-primer.md
+++ b/content/en/docs/concepts/observability-primer.md
@@ -2,7 +2,7 @@
 title: Observability Primer
 description: Core observability concepts.
 weight: 9
-cSpell:ignore:  webshop
+cSpell:ignore: webshop
 ---
 
 ## What is Observability?

--- a/content/en/docs/concepts/observability-primer.md
+++ b/content/en/docs/concepts/observability-primer.md
@@ -2,7 +2,7 @@
 title: Observability Primer
 description: Core observability concepts.
 weight: 9
-cSpell:ignore: KHTML webshop
+cSpell:ignore:  webshop
 ---
 
 ## What is Observability?

--- a/content/en/docs/concepts/observability-primer.md
+++ b/content/en/docs/concepts/observability-primer.md
@@ -2,7 +2,7 @@
 title: Observability Primer
 description: Core observability concepts.
 weight: 9
-cSpell:ignore: KHTML
+cSpell:ignore: KHTML webshop
 ---
 
 ## What is Observability?
@@ -40,7 +40,7 @@ the system doesn't always add black pants, then the system would be said to be
 **Metrics** are aggregations over a period of time of numeric data about your
 infrastructure or application. Examples include: system error rate, CPU
 utilization, request rate for a given service. For more on metrics and how they
-pertain to OTel, see [Metrics](/docs/concepts/signals/metrics/).
+pertain to OpenTelemetry, see [Metrics](/docs/concepts/signals/metrics/).
 
 **SLI**, or Service Level Indicator, represents a measurement of a service's
 behavior. A good SLI measures your service from the perspective of your users.
@@ -92,23 +92,22 @@ to provide information about the operation it tracks.
 
 The following table contains examples of span attributes:
 
-| Key              | Value                                                                                                                   |
-| ---------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| net.transport    | `IP.TCP`                                                                                                                |
-| net.peer.ip      | `10.244.0.1`                                                                                                            |
-| net.peer.port    | `10243`                                                                                                                 |
-| net.host.name    | `localhost`                                                                                                             |
-| http.method      | `GET`                                                                                                                   |
-| http.target      | `/cart`                                                                                                                 |
-| http.server_name | `frontend`                                                                                                              |
-| http.route       | `/cart`                                                                                                                 |
-| http.scheme      | `http`                                                                                                                  |
-| http.host        | `localhost`                                                                                                             |
-| http.flavor      | `1.1`                                                                                                                   |
-| http.status_code | `200`                                                                                                                   |
-| http.user_agent  | `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36` |
+| Key                         | Value                                                                              |
+| :-------------------------- | :--------------------------------------------------------------------------------- |
+| `http.request.method`       | `"GET"`                                                                            |
+| `network.protocol.version`  | `"1.1"`                                                                            |
+| `url.path`                  | `"/webshop/articles/4"`                                                            |
+| `url.query`                 | `"?s=1"`                                                                           |
+| `server.address`            | `"example.com"`                                                                    |
+| `server.port`               | `8080`                                                                             |
+| `url.scheme`                | `"https"`                                                                          |
+| `http.route`                | `"/webshop/articles/:article_id"`                                                  |
+| `http.response.status_code` | `200`                                                                              |
+| `client.address`            | `"192.0.2.4"`                                                                      |
+| `client.socket.address`     | `"192.0.2.5"` (the client goes through a proxy)                                    |
+| `user_agent.original`       | `"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:72.0) Gecko/20100101 Firefox/72.0"` |
 
-For more on spans and how they pertain to OTel, see
+For more on spans and how they pertain to OpenTelemetry, see
 [Spans](/docs/concepts/signals/traces/#spans).
 
 ### Distributed Traces
@@ -143,5 +142,5 @@ Waterfall diagrams show the parent-child relationship between a root span and
 its child spans. When a span encapsulates another span, this also represents a
 nested relationship.
 
-For more on traces and how they pertain to OTel, see
+For more on traces and how they pertain to OpenTelemetry, see
 [Traces](/docs/concepts/signals/traces/).


### PR DESCRIPTION
With HTTP semantic conventions stable I updated the observability primer with a set of example keys&values from there such that we don't have to make sure they are up-to-date anymore.

Also some OTel -> OpenTelemetry, because why not?