### PR TITLE
Upgrade Docsy to 0.7.2

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -103,10 +103,6 @@
   }
 }
 
-.foldable-nav {
-  padding-top: 0.5rem;
-} // TODO: propagate this fix to Docsy. Also class name should be prefixed with td
-
 // Adjust the spacing of page-meta and page-TOC (https://github.com/open-telemetry/opentelemetry.io/pull/354)
 // TODO: upstream
 .td-toc #TableOfContents {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "autoprefixer": "^10.4.16",
     "cspell": "^7.3.8",
     "gulp": "^4.0.2",
-    "hugo-extended": "0.120.3",
+    "hugo-extended": "0.120.4",
     "markdown-link-check": "^3.11.2",
     "markdownlint": "^0.31.1",
     "postcss-cli": "^10.1.0",


### PR DESCRIPTION
- Fixes #3157. For details and screenshots, see the issue comments
- Upgrades to Docsy 0.7.2
- Closes #3522 by superseding it -- since Docsy 0.7.2 requires Hugo 0.120.4

**Preview**: https://deploy-preview-3519--opentelemetry.netlify.app

```console
$ (cd public && git diff -bw --ignore-blank-lines -I "Create child page" -I "foldable-nav" -- . ':(exclude)*.xml') | grep ^diff | grep -v site/index
diff --git a/scss/main.css b/scss/main.css
diff --git a/scss/main.css.map b/scss/main.css.map
```