### PR TITLE
Add `/schemas` in YAML, `/schemas/list` in HTML, and a 404 page for the rest

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -5,6 +5,7 @@ IgnoreAltMissing: true
 IgnoreCanonicalBrokenLinks: false
 CheckMailto: false
 IgnoreInternalURLs: # list of paths
+  - /schemas/latest
 IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - ^/docs/instrumentation/\w+/(api|examples)/$
   - ^/docs/instrumentation/net/(metrics-api|traces-api)/

--- a/assets/scss/_schema.scss
+++ b/assets/scss/_schema.scss
@@ -1,0 +1,22 @@
+.ot-schema-list,
+.ot-schemas-404 {
+  // Hide the sidebar. Add the sidebar's number of col to `main`
+  main {
+    @extend .col-md-10;
+  }
+
+  .td-sidebar {
+    display: none;
+  }
+
+  main td code {
+    background-color: inherit;
+  }
+
+  // Fixes https://github.com/open-telemetry/opentelemetry.io/issues/1102
+  // TODO: upstream
+  .td-sidebar-toc {
+    margin-top: 4rem;
+    top: 0;
+  }
+}

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -4,6 +4,7 @@
 @import 'registry';
 @import 'tabs';
 @import 'external_link';
+@import 'schema';
 
 .td-home {
   .otel-logo {

--- a/content/en/schemas/_index.md
+++ b/content/en/schemas/_index.md
@@ -1,0 +1,25 @@
+---
+title: 404 - Schema not found
+linkTitle: Schemas
+type: docs
+no_list: true
+body_class: ot-schemas-404
+outputs: [HTML, YAML]
+#
+# Note:
+#   The paths to the `list` and `latest` are absolute below since we
+#   don't know from which URL this 404 page will be served.
+#
+---
+
+The page or schema you requested doesn't exist. Maybe you're looking for one of
+these:
+
+- [List of schemas](/schemas/list/) hosted on this site, also available in
+  [YAML format](/schemas/index.yaml)
+- [Latest](/schemas/latest) schema
+- More information about [Telemetry Schemas] in general, or [OpenTelemetry
+  Schema] in particular.
+
+[OpenTelemetry Schema]: /docs/specs/otel/schemas/#opentelemetry-schema
+[Telemetry Schemas]: /docs/specs/otel/schemas/

--- a/content/en/schemas/_index.md
+++ b/content/en/schemas/_index.md
@@ -15,8 +15,8 @@ outputs: [HTML, YAML]
 The page or schema you requested doesn't exist. Maybe you're looking for one of
 these:
 
-- [List of schemas](/schemas/list/) hosted on this site, also available in
-  [YAML format](/schemas/index.yaml)
+- [List of schemas](/schemas/index.yaml) hosted on this site, also available in
+  a [human-readable format](/schemas/list/)
 - [Latest](/schemas/latest) schema
 - More information about [Telemetry Schemas] in general, or [OpenTelemetry
   Schema] in particular.

--- a/content/en/schemas/list.md
+++ b/content/en/schemas/list.md
@@ -5,13 +5,6 @@ type: docs
 body_class: ot-schema-list
 ---
 
-{{% alert title="<i class=\"fa-solid fa-triangle-exclamation\"></i> Warning" color="warning" %}}
-
-This page, its content, and formatting are **non-normative** and **subject to
-change**. In particular it is not meant for automated processing.
-
-{{% /alert %}}
-
 The OpenTelemetry schemas hosted on this site are listed below. To learn more
 about schemas, see [Telemetry Schemas][]. The list is also available in
 [YAML format](/schemas/index.yaml).

--- a/content/en/schemas/list.md
+++ b/content/en/schemas/list.md
@@ -1,0 +1,21 @@
+---
+title: OpenTelemetry Schemas
+linkTitle: List
+type: docs
+body_class: ot-schema-list
+---
+
+{{% alert title="<i class=\"fa-solid fa-triangle-exclamation\"></i> Warning" color="warning" %}}
+
+This page, its content, and formatting are **non-normative** and **subject to
+change**. In particular it is not meant for automated processing.
+
+{{% /alert %}}
+
+The OpenTelemetry schemas hosted on this site are listed below. To learn more
+about schemas, see [Telemetry Schemas][]. The list is also available in
+[YAML format](/schemas/index.yaml).
+
+{{% schemas %}}
+
+[Telemetry Schemas]: /docs/specs/otel/schemas/

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -32,15 +32,18 @@ markup:
     # noClasses: false
     style: tango
 
-# Netlify _redirects file
 mediaTypes:
-  text/netlify: {}
+  text/netlify: {} # Netlify _redirects file
+  text/yaml: {}
 
 outputFormats:
   REDIRECTS:
     mediaType: text/netlify
     baseName: _redirects
     notAlternative: true
+  YAML: # Yaml for Schemas index page
+    mediaType: text/yaml
+    baseName: index.yaml
 
 outputs:
   home: [HTML, REDIRECTS, RSS]

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -47,7 +47,10 @@
 {{ $schemaFiles := partial "schema-file-list" . -}}
 {{ $latestSchemaFile := index $schemaFiles 0 -}}
 
+/schemas         /schemas/index.yaml
 /schemas/latest  /schemas/{{ $latestSchemaFile.Name }}
+/schemas/list    /schemas/list/ 200 # Explicit rule to avoid the next catch all
+/schemas/*       /schemas/?     404 # Report 404 for anything else that's missing
 
 {{/*
   Social-media image redirects. As mentioned in

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -47,10 +47,10 @@
 {{ $schemaFiles := partial "schema-file-list" . -}}
 {{ $latestSchemaFile := index $schemaFiles 0 -}}
 
-/schemas         /schemas/index.yaml
+/schemas         /schemas/index.yaml 301!
 /schemas/latest  /schemas/{{ $latestSchemaFile.Name }}
 /schemas/list    /schemas/list/ 200 # Explicit rule to avoid the next catch all
-/schemas/*       /schemas/?     404 # Report 404 for anything else that's missing
+/schemas/*       /schemas/index.html 404 # Report 404 for anything else that's missing
 
 {{/*
   Social-media image redirects. As mentioned in

--- a/layouts/schemas/section.yaml
+++ b/layouts/schemas/section.yaml
@@ -1,9 +1,9 @@
 {{ $schemaFiles := partial "schema-file-list" . -}}
 {{ $latestSchemaFile := index $schemaFiles 0 -}}
-# OpenTelemetry Schemas
+# OpenTelemetry Schemas v{{ $latestSchemaFile.Name }}
 #
-# https://github.com/open-telemetry/semantic-conventions/tree/v{{ $latestSchemaFile.Name }}/schemas
-#
+# For details, see https://opentelemetry.io/schemas/list
+
 {{ $schemaFiles := partial "schema-file-list.html" . -}}
 {{- range $schemaFiles -}}
 - {{ .Name }}

--- a/layouts/schemas/section.yaml
+++ b/layouts/schemas/section.yaml
@@ -1,0 +1,10 @@
+{{ $schemaFiles := partial "schema-file-list" . -}}
+{{ $latestSchemaFile := index $schemaFiles 0 -}}
+# OpenTelemetry Schemas
+#
+# https://github.com/open-telemetry/semantic-conventions/tree/v{{ $latestSchemaFile.Name }}/schemas
+#
+{{ $schemaFiles := partial "schema-file-list.html" . -}}
+{{- range $schemaFiles -}}
+- {{ .Name }}
+{{ end -}}

--- a/layouts/shortcodes/schemas.md
+++ b/layouts/shortcodes/schemas.md
@@ -1,0 +1,10 @@
+{{- $schemaFiles := partial "schema-file-list.html" . -}}
+
+| Version |
+|---------|
+{{ range $i, $schema := $schemaFiles -}}
+| [`{{ $schema.Name }}`](/schemas/{{ $schema.Name }})
+{{- if eq $i 0 -}}
+  ([latest](/schemas/latest))
+{{- end -}} |
+{{ end -}}

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,7 +15,29 @@ from = "https://blog.opentelemetry.io/*"
 to = "https://opentelemetry.io/blog/:splat"
 force = true
 
+# Schemas
+
 [[headers]]
-  for = "/schemas/:version"
+  for = "/schemas/"
+  [headers.values]
+    content-type = "text/yaml"
+
+# Ensure that there is a header entry for each major version of the published
+# schemas. (If this becomes too bothersome to update, we can automate the
+# creation of these schema header entries in a `_headers` file using Hugo
+# templating constructs.)
+
+[[headers]]
+  for = "/schemas/1.*"
+  [headers.values]
+    content-type = "application/yaml"
+
+[[headers]]
+  for = "/schemas/2.*"
+  [headers.values]
+    content-type = "application/yaml"
+
+[[headers]]
+  for = "/schemas/3.*"
   [headers.values]
     content-type = "application/yaml"

--- a/netlify.toml
+++ b/netlify.toml
@@ -18,7 +18,7 @@ force = true
 # Schemas
 
 [[headers]]
-  for = "/schemas/"
+  for = "/schemas/index.yaml"
   [headers.values]
     content-type = "text/yaml"
 


### PR DESCRIPTION
- Proposal for https://github.com/open-telemetry/opentelemetry-specification/issues/3762
- Fixes #3468
- Adds `/schemas`, the list of schemas published on the site, in **YAML format**
- Adds `/schemas/list`, the lists of published schemas in human-readable form
- Adds a custom 404 page for any URL `/schemas/*` that isn't a valid schema, or the pages `list` or `latest`

**Previews**

- https://deploy-preview-3537--opentelemetry.netlify.app/schemas - schemas list as YAML
- https://deploy-preview-3537--opentelemetry.netlify.app/schemas/ - schemas list as YAML
- https://deploy-preview-3537--opentelemetry.netlify.app/schemas/list/ - shows schemas list page

**Redirect tests**

- https://deploy-preview-3537--opentelemetry.netlify.app/schemas/latest --> 1.23.0 (as of the time of writing)
- https://deploy-preview-3537--opentelemetry.netlify.app/schemas/latest/ --> 1.23.0 (as of the time of writing)
- https://deploy-preview-3537--opentelemetry.netlify.app/schemas/x.y.z - nonexistent version --> schemas 404

### Screenshots / output

**YAML** list ([`/schemas`](https://deploy-preview-3537--opentelemetry.netlify.app/schemas)):

```yaml
# OpenTelemetry Schemas v1.23.0
#
# For details, see https://opentelemetry.io/schemas/list

- 1.23.0
- 1.22.0
- 1.21.0
- 1.20.0
- 1.19.0
- 1.18.0
- 1.17.0
- 1.16.0
- 1.15.0
- 1.14.0
- 1.13.0
- 1.12.0
- 1.11.0
- 1.10.0
- 1.9.0
- 1.8.0
- 1.7.0
- 1.6.1
- 1.5.0
- 1.4.0
```

**List page** ([`/schemas/list`](https://deploy-preview-3537--opentelemetry.netlify.app/schemas/list)):

> <img width="1027" alt="image" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/9b251b48-a04f-4d63-857d-472bc288b4f8">

**404 page** ([`/schemas/x.y.z`](https://deploy-preview-3537--opentelemetry.netlify.app/schemas/x.y.z)):

> <img width="1024" alt="image" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/4102adb0-9acf-4da7-b433-2bd367ae461a">

### HTTP status tests

```console
$ curl -sI https://deploy-preview-3537--opentelemetry.netlify.app/schemas/x.y.z | grep -E 'HTTP|-type|location' 
HTTP/2 404 
content-type: text/html; charset=UTF-8
```

```console
$ curl -sI https://deploy-preview-3537--opentelemetry.netlify.app/schemas/1.23.0 | grep -E 'HTTP|-type|location' 
HTTP/2 200 
content-type: application/yaml
```