### PR TITLE
Rename collectorVersion param, following Java rework

### DIFF
--- a/.github/workflows/auto-update-versions.yml
+++ b/.github/workflows/auto-update-versions.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Auto-update
         run: |
-          .github/workflows/scripts/auto-update-version.sh opentelemetry-collector-releases collectorVersion content/en/docs/collector/_index.md
+          .github/workflows/scripts/auto-update-version.sh opentelemetry-collector-releases vers content/en/docs/collector/_index.md
           .github/workflows/scripts/auto-update-version.sh opentelemetry-java otel content/en/docs/instrumentation/java/_index.md
           .github/workflows/scripts/auto-update-version.sh opentelemetry-java-instrumentation instrumentation content/en/docs/instrumentation/java/_index.md
           .github/workflows/scripts/auto-update-version.sh opentelemetry-specification spec scripts/content-modules/adjust-pages.pl

--- a/content/en/docs/collector/_index.md
+++ b/content/en/docs/collector/_index.md
@@ -3,7 +3,7 @@ title: Collector
 description: Vendor-agnostic way to receive, process and export telemetry data.
 aliases: [collector/about]
 cascade:
-  collectorVersion: 0.88.0
+  vers: 0.88.0
 weight: 10
 ---
 

--- a/content/en/docs/collector/custom-collector.md
+++ b/content/en/docs/collector/custom-collector.md
@@ -39,7 +39,7 @@ Open your terminal and type the following commands to accomplish both
 operations:
 
 ```cmd
-mv ocb_{{% param collectorVersion %}}_darwin_amd64 ocb
+mv ocb_{{% param vers %}}_darwin_amd64 ocb
 chmod 777 ocb
 ```
 
@@ -64,7 +64,7 @@ Here are the tags for the `dist` map:
 | module:          | The module name for the new distribution, following Go mod conventions. Optional, but recommended. | Yes      | `go.opentelemetry.io/collector/cmd/builder`                                       |
 | name:            | The binary name for your distribution                                                              | Yes      | `otelcol-custom`                                                                  |
 | description:     | A long name for the application.                                                                   | Yes      | `Custom OpenTelemetry Collector distribution`                                     |
-| otelcol_version: | The OpenTelemetry Collector version to use as base for the distribution.                           | Yes      | `{{% param collectorVersion %}}`                                                  |
+| otelcol_version: | The OpenTelemetry Collector version to use as base for the distribution.                           | Yes      | `{{% param vers %}}`                                                              |
 | output_path:     | The path to write the output (sources and binary).                                                 | Yes      | `/var/folders/86/s7l1czb16g124tng0d7wyrtw0000gn/T/otelcol-distribution3618633831` |
 | version:         | The version for your custom OpenTelemetry Collector.                                               | Yes      | `1.0.0`                                                                           |
 | go:              | Which Go binary to use to compile the generated sources.                                           | Yes      | go from the PATH                                                                  |
@@ -111,22 +111,22 @@ dist:
   name: otelcol-dev
   description: Basic OTel Collector distribution for Developers
   output_path: ./otelcol-dev
-  otelcol_version: {{% param collectorVersion %}}
+  otelcol_version: {{% param vers %}}
 
 exporters:
   - gomod:
       # NOTE: Prior to v0.86.0 use the `loggingexporter` instead of `debugexporter`.
-      go.opentelemetry.io/collector/exporter/debugexporter v{{% param collectorVersion %}}
+      go.opentelemetry.io/collector/exporter/debugexporter v{{% param vers %}}
   - gomod:
-      go.opentelemetry.io/collector/exporter/otlpexporter v{{% param collectorVersion %}}
+      go.opentelemetry.io/collector/exporter/otlpexporter v{{% param vers %}}
 
 processors:
   - gomod:
-      go.opentelemetry.io/collector/processor/batchprocessor v{{% param collectorVersion %}}
+      go.opentelemetry.io/collector/processor/batchprocessor v{{% param vers %}}
 
 receivers:
   - gomod:
-      go.opentelemetry.io/collector/receiver/otlpreceiver v{{% param collectorVersion %}}
+      go.opentelemetry.io/collector/receiver/otlpreceiver v{{% param vers %}}
 ```
 
 ## Step 3 - Generating the Code and Building your Collector's distribution
@@ -142,7 +142,7 @@ If everything went well, here is what the output of the command should look
 like:
 
 ```nocode
-2022-06-13T14:25:03.037-0500	INFO	internal/command.go:85	OpenTelemetry Collector distribution builder	{"version": "{{% param collectorVersion %}}", "date": "2023-01-03T15:05:37Z"}
+2022-06-13T14:25:03.037-0500	INFO	internal/command.go:85	OpenTelemetry Collector distribution builder	{"version": "{{% param vers %}}", "date": "2023-01-03T15:05:37Z"}
 2022-06-13T14:25:03.039-0500	INFO	internal/command.go:108	Using config file	{"path": "builder-config.yaml"}
 2022-06-13T14:25:03.040-0500	INFO	builder/config.go:99	Using go	{"go-executable": "/usr/local/go/bin/go"}
 2022-06-13T14:25:03.041-0500	INFO	builder/main.go:76	Sources created	{"path": "./otelcol-dev"}

--- a/content/en/docs/collector/getting-started.md
+++ b/content/en/docs/collector/getting-started.md
@@ -28,8 +28,8 @@ To follow this tutorial you need the following
    container:
 
    ```sh
-   docker pull otel/opentelemetry-collector:{{% param collectorVersion %}}
-   docker run -p 127.0.0.1:4317:4317 -p 127.0.0.1:55679:55679 otel/opentelemetry-collector:{{% param collectorVersion %}}
+   docker pull otel/opentelemetry-collector:{{% param vers %}}
+   docker run -p 127.0.0.1:4317:4317 -p 127.0.0.1:55679:55679 otel/opentelemetry-collector:{{% param vers %}}
    ```
 
 2. Download and install the `telemetrygen` utility from the

--- a/content/en/docs/collector/installation.md
+++ b/content/en/docs/collector/installation.md
@@ -16,21 +16,20 @@ and [Deployment Methods][] page.
 ## Docker
 
 The following commands pull a Docker image and run the Collector in a container.
-Replace `{{% param collectorVersion %}}` with the version of the Collector you
-want to run.
+Replace `{{% param vers %}}` with the version of the Collector you want to run.
 
 {{< tabpane text=true >}} {{% tab DockerHub %}}
 
 ```sh
-docker pull otel/opentelemetry-collector-contrib:{{% param collectorVersion %}}
-docker run otel/opentelemetry-collector-contrib:{{% param collectorVersion %}}
+docker pull otel/opentelemetry-collector-contrib:{{% param vers %}}
+docker run otel/opentelemetry-collector-contrib:{{% param vers %}}
 ```
 
 {{% /tab %}} {{% tab ghcr.io %}}
 
 ```sh
-docker pull ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{% param collectorVersion %}}
-docker run ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{% param collectorVersion %}}
+docker pull ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{% param vers %}}
+docker run ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{% param vers %}}
 ```
 
 {{% /tab %}} {{< /tabpane >}}
@@ -41,13 +40,13 @@ as a volume:
 {{< tabpane text=true >}} {{% tab DockerHub %}}
 
 ```sh
-docker run -v $(pwd)/config.yaml:/etc/otelcol-contrib/config.yaml otel/opentelemetry-collector-contrib:{{% param collectorVersion %}}
+docker run -v $(pwd)/config.yaml:/etc/otelcol-contrib/config.yaml otel/opentelemetry-collector-contrib:{{% param vers %}}
 ```
 
 {{% /tab %}} {{% tab ghcr.io %}}
 
 ```sh
-docker run -v $(pwd)/config.yaml:/etc/otelcol-contrib/config.yaml ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{% param collectorVersion %}}
+docker run -v $(pwd)/config.yaml:/etc/otelcol-contrib/config.yaml ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{% param vers %}}
 ```
 
 {{% /tab %}} {{< /tabpane >}}
@@ -115,8 +114,8 @@ To get started on Alpine systems run the following commands:
 ```sh
 apk update
 apk add wget shadow
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param collectorVersion %}}/otelcol_{{% param collectorVersion %}}_linux_amd64.apk
-apk add --allow-untrusted otelcol_{{% param collectorVersion %}}_linux_amd64.apk
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_linux_amd64.apk
+apk add --allow-untrusted otelcol_{{% param vers %}}_linux_amd64.apk
 ```
 
 {{% /tab %}} {{% tab ARM64 %}}
@@ -124,8 +123,8 @@ apk add --allow-untrusted otelcol_{{% param collectorVersion %}}_linux_amd64.apk
 ```sh
 apk update
 apk add wget shadow
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param collectorVersion %}}/otelcol_{{% param collectorVersion %}}_linux_arm64.apk
-apk add --allow-untrusted otelcol_{{% param collectorVersion %}}_linux_arm64.apk
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_linux_arm64.apk
+apk add --allow-untrusted otelcol_{{% param vers %}}_linux_arm64.apk
 ```
 
 {{% /tab %}} {{% tab i386 %}}
@@ -133,8 +132,8 @@ apk add --allow-untrusted otelcol_{{% param collectorVersion %}}_linux_arm64.apk
 ```sh
 apk update
 apk add wget shadow
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param collectorVersion %}}/otelcol_{{% param collectorVersion %}}_linux_386.apk
-apk add --allow-untrusted otelcol_{{% param collectorVersion %}}_linux_386.apk
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_linux_386.apk
+apk add --allow-untrusted otelcol_{{% param vers %}}_linux_386.apk
 ```
 
 {{% /tab %}} {{< /tabpane >}}
@@ -148,8 +147,8 @@ To get started on Debian systems run the following commands:
 ```sh
 sudo apt-get update
 sudo apt-get -y install wget systemctl
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param collectorVersion %}}/otelcol_{{% param collectorVersion %}}_linux_amd64.deb
-sudo dpkg -i otelcol_{{% param collectorVersion %}}_linux_amd64.deb
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_linux_amd64.deb
+sudo dpkg -i otelcol_{{% param vers %}}_linux_amd64.deb
 ```
 
 {{% /tab %}} {{% tab ARM64 %}}
@@ -157,8 +156,8 @@ sudo dpkg -i otelcol_{{% param collectorVersion %}}_linux_amd64.deb
 ```sh
 sudo apt-get update
 sudo apt-get -y install wget systemctl
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param collectorVersion %}}/otelcol_{{% param collectorVersion %}}_linux_arm64.deb
-sudo dpkg -i otelcol_{{% param collectorVersion %}}_linux_arm64.deb
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_linux_arm64.deb
+sudo dpkg -i otelcol_{{% param vers %}}_linux_arm64.deb
 ```
 
 {{% /tab %}} {{% tab i386 %}}
@@ -166,8 +165,8 @@ sudo dpkg -i otelcol_{{% param collectorVersion %}}_linux_arm64.deb
 ```sh
 sudo apt-get update
 sudo apt-get -y install wget systemctl
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param collectorVersion %}}/otelcol_{{% param collectorVersion %}}_linux_386.deb
-sudo dpkg -i otelcol_{{% param collectorVersion %}}_linux_386.deb
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_linux_386.deb
+sudo dpkg -i otelcol_{{% param vers %}}_linux_386.deb
 ```
 
 {{% /tab %}} {{< /tabpane >}}
@@ -181,8 +180,8 @@ To get started on Red Hat systems run the following commands:
 ```sh
 sudo yum update
 sudo yum -y install wget systemctl
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param collectorVersion %}}/otelcol_{{% param collectorVersion %}}_linux_amd64.rpm
-sudo rpm -ivh otelcol_{{% param collectorVersion %}}_linux_amd64.rpm
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_linux_amd64.rpm
+sudo rpm -ivh otelcol_{{% param vers %}}_linux_amd64.rpm
 ```
 
 {{% /tab %}} {{% tab ARM64 %}}
@@ -190,8 +189,8 @@ sudo rpm -ivh otelcol_{{% param collectorVersion %}}_linux_amd64.rpm
 ```sh
 sudo yum update
 sudo yum -y install wget systemctl
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param collectorVersion %}}/otelcol_{{% param collectorVersion %}}_linux_arm64.rpm
-sudo rpm -ivh otelcol_{{% param collectorVersion %}}_linux_arm64.rpm
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_linux_arm64.rpm
+sudo rpm -ivh otelcol_{{% param vers %}}_linux_arm64.rpm
 ```
 
 {{% /tab %}} {{% tab i386 %}}
@@ -199,8 +198,8 @@ sudo rpm -ivh otelcol_{{% param collectorVersion %}}_linux_arm64.rpm
 ```sh
 sudo yum update
 sudo yum -y install wget systemctl
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param collectorVersion %}}/otelcol_{{% param collectorVersion %}}_linux_386.rpm
-sudo rpm -ivh otelcol_{{% param collectorVersion %}}_linux_386.rpm
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_linux_386.rpm
+sudo rpm -ivh otelcol_{{% param vers %}}_linux_386.rpm
 ```
 
 {{% /tab %}} {{< /tabpane >}}
@@ -213,29 +212,29 @@ file containing the binary and install it on your machine manually:
 {{< tabpane text=true >}} {{% tab AMD64 %}}
 
 ```sh
-curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param collectorVersion %}}/otelcol_{{% param collectorVersion %}}_linux_amd64.tar.gz
-tar -xvf otelcol_{{% param collectorVersion %}}_linux_amd64.tar.gz
+curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_linux_amd64.tar.gz
+tar -xvf otelcol_{{% param vers %}}_linux_amd64.tar.gz
 ```
 
 {{% /tab %}} {{% tab ARM64 %}}
 
 ```sh
-curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param collectorVersion %}}/otelcol_{{% param collectorVersion %}}_linux_arm64.tar.gz
-tar -xvf otelcol_{{% param collectorVersion %}}_linux_arm64.tar.gz
+curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_linux_arm64.tar.gz
+tar -xvf otelcol_{{% param vers %}}_linux_arm64.tar.gz
 ```
 
 {{% /tab %}} {{% tab i386 %}}
 
 ```sh
-curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param collectorVersion %}}/otelcol_{{% param collectorVersion %}}_linux_386.tar.gz
-tar -xvf otelcol_{{% param collectorVersion %}}_linux_386.tar.gz
+curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_linux_386.tar.gz
+tar -xvf otelcol_{{% param vers %}}_linux_386.tar.gz
 ```
 
 {{% /tab %}} {{% tab ppc64le %}}
 
 ```sh
-curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param collectorVersion %}}/otelcol_{{% param collectorVersion %}}_linux_ppc64le.tar.gz
-tar -xvf otelcol_{{% param collectorVersion %}}_linux_ppc64le.tar.gz
+curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_linux_ppc64le.tar.gz
+tar -xvf otelcol_{{% param vers %}}_linux_ppc64le.tar.gz
 ```
 
 {{% /tab %}} {{< /tabpane >}}
@@ -273,15 +272,15 @@ commands:
 {{< tabpane text=true >}} {{% tab Intel %}}
 
 ```sh
-curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param collectorVersion %}}/otelcol_{{% param collectorVersion %}}_darwin_amd64.tar.gz
-tar -xvf otelcol_{{% param collectorVersion %}}_darwin_amd64.tar.gz
+curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_darwin_amd64.tar.gz
+tar -xvf otelcol_{{% param vers %}}_darwin_amd64.tar.gz
 ```
 
 {{% /tab %}} {{% tab ARM %}}
 
 ```sh
-curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param collectorVersion %}}/otelcol_{{% param collectorVersion %}}_darwin_arm64.tar.gz
-tar -xvf otelcol_{{% param collectorVersion %}}_darwin_arm64.tar.gz
+curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_darwin_arm64.tar.gz
+tar -xvf otelcol_{{% param vers %}}_darwin_arm64.tar.gz
 ```
 
 {{% /tab %}} {{< /tabpane >}}

--- a/content/en/docs/collector/trace-receiver.md
+++ b/content/en/docs/collector/trace-receiver.md
@@ -236,7 +236,7 @@ Now that you have access to the settings, you can provide any kind of validation
 needed for those values by implementing the `Validate` method according to the
 optional
 [ConfigValidator](https://github.com/open-telemetry/opentelemetry-collector/blob/{{%
-param collectorVersion %}}/component/config.go#L50) interface.
+param vers %}}/component/config.go#L50) interface.
 
 In this case, the `interval` value will be optional (we will look at generating
 default values later) but when defined should be at least 1 minute (1m) and the
@@ -287,8 +287,7 @@ func (cfg *Config) Validate() error {
 If you want to take a closer look at the structs and interfaces involved in the
 configuration aspects of a component, take a look at the
 [component/config.go](https://github.com/open-telemetry/opentelemetry-collector/blob/{{%
-param collectorVersion %}}/component/config.go) file inside the Collector's
-GitHub project.
+param vers %}}/component/config.go) file inside the Collector's GitHub project.
 
 ## Enabling the Collector to instantiate your receiver
 
@@ -344,9 +343,9 @@ Collector the factories for all its components which is represented by a
 variable called `factories` of type `otelcol.Factories` (here is the declaration
 of the
 [otelcol.Factories](https://github.com/open-telemetry/opentelemetry-collector/blob/{{%
-param collectorVersion %}}/otelcol/factories.go#L27) struct), which will then be
-used to instantiate the components that are configured and consumed by the
-Collector's pipelines.
+param vers %}}/otelcol/factories.go#L27) struct), which will then be used to
+instantiate the components that are configured and consumed by the Collector's
+pipelines.
 
 Notice that `factories.Receivers` is the field holding a map to all the receiver
 factories (instances of `receiver.Factory`), and it currently has the
@@ -357,9 +356,9 @@ The `tailtracer` receiver has to provide a `receiver.Factory` implementation,
 and although you will find a `receiver.Factory` interface (you can find its
 definition in the
 [receiver/receiver.go](https://github.com/open-telemetry/opentelemetry-collector/blob/{{%
-param collectorVersion %}}/receiver/receiver.go#L69) file within the Collector's
-project ), the right way to provide the implementation is by using the functions
-available within the `go.opentelemetry.io/collector/receiver` package.
+param vers %}}/receiver/receiver.go#L69) file within the Collector's project),
+the right way to provide the implementation is by using the functions available
+within the `go.opentelemetry.io/collector/receiver` package.
 
 ### Implementing your receiver.Factory
 
@@ -740,9 +739,9 @@ accomplish that.
 All the receiver APIs responsible to enable the signals are currently declared
 in the
 [receiver/receiver.go](https://github.com/open-telemetry/opentelemetry-collector/blob/{{%
-param collectorVersion %}}/receiver/receiver.go) file within the OTel
-Collector's project in GitHub, open the file and take a minute to browse through
-all the interfaces declared in it.
+param vers %}}/receiver/receiver.go) file within the OTel Collector's project in
+GitHub, open the file and take a minute to browse through all the interfaces
+declared in it.
 
 Notice that `receiver.Traces` (and its siblings `receiver.Metrics` and
 `receiver.Logs`) at this point in time, doesn't describe any specific methods
@@ -1397,7 +1396,7 @@ You will start with a type called `ptrace.ResourceSpans` which represents the
 resource and all the operations that it either originated or received while
 participating in a trace. You can find its definition within the
 [/pdata/internal/data/protogen/trace/v1/trace.pb.go](https://github.com/open-telemetry/opentelemetry-collector/blob/{{%
-param collectorVersion %}}/pdata/internal/data/protogen/trace/v1/trace.pb.go).
+param vers %}}/pdata/internal/data/protogen/trace/v1/trace.pb.go).
 
 `ptrace.Traces` has a method named `ResourceSpans()` which returns an instance
 of a helper type called `ptrace.ResourceSpansSlice`. The
@@ -1458,8 +1457,8 @@ pair format represented by the `pcommon.Map` type.
 You can check the definition of the `pcommon.Map` type and the related helper
 functions to create attribute values using the supported formats in the
 [/pdata/pcommon/common.go](https://github.com/open-telemetry/opentelemetry-collector/blob/{{%
-param collectorVersion %}}/pdata/pcommon/common.go) file within the OTel
-Collector's GitHub project.
+param vers %}}/pdata/pcommon/common.go) file within the OTel Collector's GitHub
+project.
 
 Key/value pairs provide a lot of flexibility to help model your `Resource` data,
 so the OTel specification has some guidelines in place to help organize and
@@ -1521,8 +1520,8 @@ convention to represent that information on its `Resource`.
 All the resource semantic convention attribute names and well known-values are
 kept within the
 [/semconv/v1.9.0/generated_resource.go](https://github.com/open-telemetry/opentelemetry-collector/blob/{{%
-param collectorVersion %}}/semconv/v1.9.0/generated_resource.go) file within the
-Collector's GitHub project.
+param vers %}}/semconv/v1.9.0/generated_resource.go) file within the Collector's
+GitHub project.
 
 Let's create a function to read the field values from an `BackendSystem`
 instance and write them as attributes into a `pcommon.Resource` instance. Open


### PR DESCRIPTION
- This is the Collector counterpart to #3503
- Inside Collector doc pages, `vers` will refer to the Collector version, this
  replaces `collectorVersion`
- There are no meaningful changes to the generated site pages