### PR TITLE
Update .NET docs to reference process instrumentation

### DIFF
--- a/content/en/docs/demo/services/cart.md
+++ b/content/en/docs/demo/services/cart.md
@@ -85,6 +85,7 @@ Action<ResourceBuilder> appResourceBuilder =
 builder.Services.AddOpenTelemetry()
     .ConfigureResource(appResourceBuilder)
     .WithMetrics(meterBuilder => meterBuilder
+        .AddProcessInstrumentation()
         .AddRuntimeInstrumentation()
         .AddAspNetCoreInstrumentation()
         .AddOtlpExporter());


### PR DESCRIPTION
Update .NET docs to reference process instrumentation. New instrumentation will be added in a [demo PR](https://github.com/open-telemetry/opentelemetry-demo/pull/1265).