### PR TITLE
docs: Update .net framework docs with metrics info

### DIFF
--- a/content/en/docs/instrumentation/net/netframework.md
+++ b/content/en/docs/instrumentation/net/netframework.md
@@ -22,6 +22,8 @@ First, install the following NuGet packages:
 - [OpenTelemetry.Instrumentation.AspNet](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNet)
 - [OpenTelemetry.Exporter.Console](https://www.nuget.org/packages/OpenTelemetry.Exporter.Console)
 
+If you plan to use metrics, you need to add a reference to the ```System.Diagnostics.DiagnosticsSource``` package as well to get access to the backported System.Diagnostics.Metrics namespace.
+
 Next, modify your `Web.Config` file to add a required HttpModule:
 
 ```xml


### PR DESCRIPTION
Took me quite a while to find this information buried on Microsoft's website, so explicitly calling out the package needed for metrics support in legacy .net.