### PR TITLE
Update missing log docs for C++

### DIFF
--- a/content/en/docs/instrumentation/cpp/manual.md
+++ b/content/en/docs/instrumentation/cpp/manual.md
@@ -227,7 +227,7 @@ p->AddView(std::move(observable_instrument_selector), std::move(observable_meter
 
 ## Logs
 
-The documentation for the metrics API & SDK is missing, you can help make it
+The documentation for the logs API & SDK is missing, you can help make it
 available by
 [editing this page](https://github.com/open-telemetry/opentelemetry.io/edit/main/content/en/docs/instrumentation/cpp/manual.md).
 

--- a/content/en/docs/instrumentation/cpp/manual.md
+++ b/content/en/docs/instrumentation/cpp/manual.md
@@ -227,7 +227,9 @@ p->AddView(std::move(observable_instrument_selector), std::move(observable_meter
 
 ## Logs
 
-The logs API & SDK are currently under development.
+The documentation for the metrics API & SDK is missing, you can help make it
+available by
+[editing this page](https://github.com/open-telemetry/opentelemetry.io/edit/main/content/en/docs/instrumentation/cpp/manual.md).
 
 ## Next Steps
 


### PR DESCRIPTION
Quick fix for a sentence that is not accurate anymore, as a follow-up it would be great if the C++ manual instrumentation docs could get some love following https://github.com/open-telemetry/opentelemetry.io/issues/3229