### PR TITLE
Update semantic-conventions version to 1.23.1

### DIFF
--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -21,7 +21,7 @@ my $path_base_for_github_subdir = "content/en$specBasePath";
 my %versions = qw(
   spec: 1.27.0
   otlp: 1.0.0
-  semconv: 1.23.0
+  semconv: 1.23.1
 );
 my $otelSpecVers = $versions{'spec:'};
 my $otlpSpecVers = $versions{'otlp:'};


### PR DESCRIPTION
Update semantic-conventions version to `1.23.1`.

See https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.23.1.

---

**Preview**:

- https://deploy-preview-3567--opentelemetry.netlify.app/docs/specs/semconv/
- https://deploy-preview-3567--opentelemetry.netlify.app/schemas/1.23.1
- https://deploy-preview-3567--opentelemetry.netlify.app/schemas/latest