### PR TITLE
Fix(doc): demo code bug for TS/JS

### DIFF
--- a/content/en/docs/instrumentation/js/libraries.md
+++ b/content/en/docs/instrumentation/js/libraries.md
@@ -251,17 +251,19 @@ with a request hook:
 {{% tab TypeScript %}}
 
 ```typescript
+import { Span } from '@opentelemetry/api';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import {
   ExpressInstrumentation,
   ExpressLayerType,
+  ExpressRequestInfo,
 } from '@opentelemetry/instrumentation-express';
 
 const expressInstrumentation = new ExpressInstrumentation({
   requestHook: function (span: Span, info: ExpressRequestInfo) {
     if (info.layerType === ExpressLayerType.REQUEST_HANDLER) {
-      span.setAttribute([SemanticAttributes.HTTP_METHOD], info.request.method);
-      span.setAttribute([SemanticAttributes.HTTP_URL], info.request.baseUrl);
+      span.setAttribute(SemanticAttributes.HTTP_METHOD, info.request.method);
+      span.setAttribute(SemanticAttributes.HTTP_URL, info.request.baseUrl);
     }
   },
 });
@@ -282,8 +284,8 @@ const {
 const expressInstrumentation = new ExpressInstrumentation({
   requestHook: function (span, info) {
     if (info.layerType === ExpressLayerType.REQUEST_HANDLER) {
-      span.setAttribute([SemanticAttributes.HTTP_METHOD], info.request.method);
-      span.setAttribute([SemanticAttributes.HTTP_URL], info.request.baseUrl);
+      span.setAttribute(SemanticAttributes.HTTP_METHOD, info.request.method);
+      span.setAttribute(SemanticAttributes.HTTP_URL, info.request.baseUrl);
     }
   },
 });


### PR DESCRIPTION
The doc in [configuration](https://opentelemetry.io/docs/instrumentation/js/libraries/) section the example:
* fix the `Span` and `ExpressRequestInfo` import
* the `span.setAttribute` has a type error, which the span type is defined as:
```ts
span.setAttribute(key: string, value: SpanAttributeValue): this
``` 
but the real code is:
```ts
span.setAttribute([SemanticAttributes.HTTP_METHOD], info.request.method);
span.setAttribute([SemanticAttributes.HTTP_URL], info.request.baseUrl);
```