### PR TITLE
docs(integrations): update Kong integration details

### DIFF
--- a/data/ecosystem/integrations.yaml
+++ b/data/ecosystem/integrations.yaml
@@ -42,8 +42,8 @@
 - name: Kong API Gateway
   url: http://www.konghq.com/
   docsUrl: https://docs.konghq.com/hub/kong-inc/opentelemetry/
-  components: []
-  oss: false
+  components: [Lua]
+  oss: true
 - name: NGINX Web Server
   url: https://nginx.org/
   docsUrl: https://github.com/nginxinc/nginx-otel

--- a/data/ecosystem/integrations.yaml
+++ b/data/ecosystem/integrations.yaml
@@ -42,7 +42,7 @@
 - name: Kong API Gateway
   url: http://www.konghq.com/
   docsUrl: https://docs.konghq.com/hub/kong-inc/opentelemetry/
-  components: [Lua]
+  components: []
   oss: true
 - name: NGINX Web Server
   url: https://nginx.org/


### PR DESCRIPTION
Kong's Opentelemetry integration is [open source](https://github.com/Kong/kong/tree/master/kong/plugins/opentelemetry): updating the `oss` flag accordingly.

