### PR TITLE
Fix pr actions, part 2

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -20,6 +20,7 @@ jobs:
       contains(github.event.comment.body, '/fix:format')
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Context info
@@ -27,13 +28,13 @@ jobs:
           echo $PR_NUM
           echo $COMMENT
 
+      - uses: actions/checkout@v4
+
       - name: Write start comment
         run: |
           gh pr comment $PR_NUM -b "You triggered fix:format action run at $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
         env:
           GH_TOKEN: ${{ github.token }}
-
-      - uses: actions/checkout@v4
 
       - run: gh pr checkout $PR_NUM -b "pr-action-${RANDOM}"
         env:
@@ -65,12 +66,12 @@ jobs:
             echo current_branch=$current_branch
             # gh pr checkout sets some git configs that we can use to make sure
             # we push to the right repo & to the right branch
-            push_remote=$(git config --get branch.${current_branch}.pushremote)
-            echo push_remote=$push_remote
-            push_remote_branch=$(git config --get branch.${current_branch}.merge)
-            echo push_remote_branch=$push_remote_branch
+            remote_repo=$(git config --get branch.${current_branch}.remote)
+            echo remote_repo=$remote_repo
+            remote_branch=$(git config --get branch.${current_branch}.merge)
+            echo remote_branch=$remote_branch
             git commit -m 'Results from /fix:format'
-            git push ${push_remote} HEAD:${push_remote_branch}
+            git push ${remote_repo} HEAD:${remote_branch}
           else
             echo "No changes to commit"
           fi
@@ -103,13 +104,14 @@ jobs:
           echo $PR_NUM
           echo $COMMENT
 
+      - uses: actions/checkout@v4
+
       - name: Write start comment
         run: |
           gh pr comment $PR_NUM -b "You triggered fix:refcache action run at $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - uses: actions/checkout@v4
       # By providing a branch name the checkout will not break if a branch with the
       # same name exists already upstream (e.g. patch-X)
       - run: gh pr checkout $PR_NUM -b "pr-action-${RANDOM}"
@@ -143,12 +145,12 @@ jobs:
             echo current_branch=$current_branch
             # gh pr checkout sets some git configs that we can use to make sure
             # we push to the right repo & to the right branch
-            push_remote=$(git config --get branch.${current_branch}.pushremote)
-            echo push_remote=$push_remote
-            push_remote_branch=$(git config --get branch.${current_branch}.merge)
-            echo push_remote_branch=$push_remote_branch
-            git commit -m 'Results from /fix:recache'
-            git push ${push_remote} HEAD:${push_remote_branch}
+            remote_repo=$(git config --get branch.${current_branch}.remote)
+            echo remote_repo=$remote_repo
+            remote_branch=$(git config --get branch.${current_branch}.merge)
+            echo remote_branch=$remote_branch
+            git commit -m 'Results from /fix:refcache'
+            git push ${remote_repo} HEAD:${remote_branch}
           else
             echo "No changes to commit"
           fi

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -30,6 +30,8 @@ jobs:
       - name: Write start comment
         run: |
           gh pr comment $PR_NUM -b "You triggered fix:format action run at $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - uses: actions/checkout@v4
 
@@ -79,6 +81,8 @@ jobs:
         if: ${{ failure() || cancelled() }}
         run: |
           gh pr comment $PR_NUM -b "fix:format run failed, please check $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID for details"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
   fix-refcache:
     name: /fix:refcache
@@ -102,6 +106,8 @@ jobs:
       - name: Write start comment
         run: |
           gh pr comment $PR_NUM -b "You triggered fix:refcache action run at $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - uses: actions/checkout@v4
       # By providing a branch name the checkout will not break if a branch with the
@@ -153,3 +159,5 @@ jobs:
         if: ${{ failure() || cancelled() }}
         run: |
           gh pr comment $PR_NUM -b "fix:recache run failed, please check $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID for details"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
🙄 I missed a few things with #3590:

* the checkout of the repo needs to happen first
* to comment on PRs permissions are required
* to use `gh` the step needs `github.token`
* the variables set by `gh pr checkout` are different if the repo is upstream or a fork, I compared them and hopefully use the right ones now

Examples: https://github.com/svrnm/opentelemetry.io-pr-test/pulls