### PR TITLE
Update community members in README

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,7 +20,7 @@ content-modules/opamp-spec               @open-telemetry/docs-approvers @open-te
 content-modules/opentelemetry-proto      @open-telemetry/docs-approvers @open-telemetry/specs-approvers
 content-modules/opentelemetry-specification  @open-telemetry/docs-approvers @open-telemetry/specs-approvers
 content-modules/semantic-conventions     @open-telemetry/docs-approvers @open-telemetry/specs-semconv-approvers
-content/en/blog/                         @open-telemetry/docs-approvers @open-telemetry/blog-approvers
+content/en/blog/                         @open-telemetry/docs-maintainers
 content/en/community/end-user/           @open-telemetry/docs-approvers @open-telemetry/end-user-wg
 content/en/docs/collector                @open-telemetry/docs-approvers @open-telemetry/collector-approvers
 content/en/docs/demo                     @open-telemetry/docs-approvers @open-telemetry/demo-approvers

--- a/README.md
+++ b/README.md
@@ -90,12 +90,12 @@ Here is a list of community roles with current and previous members:
 
 - Emeritus approvers:
 
-  - [Paul Bruce](https://github.com/paulsbruce), Tricentis
+  - [Paul Bruce](https://github.com/paulsbruce)
 
 - Emeritus maintainers:
 
-  - [Steve Flanders](https://github.com/flands), Splunk
-  - [Morgan McLean](https://github.com/mtwo), Splunk
+  - [Steve Flanders](https://github.com/flands)
+  - [Morgan McLean](https://github.com/mtwo)
   - [jparsana](https://github.com/jparsana)
 
 Learn more about roles in the [community repository][]. Thanks to [all who have

--- a/README.md
+++ b/README.md
@@ -74,11 +74,29 @@ schedule.
 Meeting notes are available as a public [Google doc][]. If you have trouble
 accessing the doc, please get in touch on [Slack][].
 
-Roles:
+Here is a list of community roles with current and previous members:
 
 - Approvers: [@open-telemetry/docs-approvers][]
+
+  - [Fabrizio Ferri-Benedetti](https://github.com/theletterf), Splunk
+  - [Michael Hausenblas](https://github.com/mhausenblas), Amazon
+
 - Maintainers: [@open-telemetry/docs-maintainers][]
-- Blog approvers: [@open-telemetry/blog-approvers][]
+
+  - [Austin Parker](https://github.com/austinlparker), Honeycomb
+  - [Patrice Chalin](https://github.com/chalin), CNCF
+  - [Phillip Carter](https://github.com/cartermp), Honeycomb
+  - [Severin Neumann](https://github.com/svrnm), Cisco
+
+- Emeritus approvers:
+
+  - [Paul Bruce](https://github.com/paulsbruce), Tricentis
+
+- Emeritus maintainers:
+
+  - [Steve Flanders](https://github.com/flands), Splunk
+  - [Morgan McLean](https://github.com/mtwo), Splunk
+  - [jparsana](https://github.com/jparsana)
 
 Learn more about roles in the [community repository][]. Thanks to [all who have
 already contributed][contributors]!
@@ -91,8 +109,6 @@ already contributed][contributors]!
 [adding to the registry]: https://opentelemetry.io/ecosystem/registry/adding/
 [let us know]:
   https://github.com/open-telemetry/opentelemetry.io/issues/new/choose
-[@open-telemetry/blog-approvers]:
-  https://github.com/orgs/open-telemetry/teams/blog-approvers
 [@open-telemetry/docs-approvers]:
   https://github.com/orgs/open-telemetry/teams/docs-approvers
 [@open-telemetry/docs-maintainers]:


### PR DESCRIPTION
I would like to update the approvers & maintainers for our repository and at the same team structure the README similar to what other SIGs have on their repos (see https://github.com/open-telemetry/community/blob/main/community-members.md)

This should then also be reflected in changing @open-telemetry/docs-approvers , @open-telemetry/blog-approvers and @open-telemetry/docs-maintainers:

* Drop @open-telemetry/blog-approvers and replace it with docs-maintainers (i.e. a maintainer needs to approve a blog post, an approver is not enough)
* Update @open-telemetry/docs-maintainers to reflect the current state: keep @austinlparker, @chalin, @cartermp and me. Remove @mtwo, @flands & @jparsana except they want to stay on that group explicitly.
* Update @open-telemetry/docs-approvers, I'd like to nominate @theletterf and @mhausenblas to be included, since both have contributed consistently over the last few months and both are willing to continue to help reviewing future PRs. Remove @paulsbruce except they want to stay on that group explicitly.

If this PR gets merged, I would raise a follow-up PR to reflect that change in the community repo as well:

https://github.com/open-telemetry/community/compare/main...svrnm:community:update-docs-section-in-members   