### PR TITLE
Update opentelemetry-spring-boot-starter version with -alpha

### DIFF
--- a/content/en/docs/instrumentation/java/automatic/spring-boot.md
+++ b/content/en/docs/instrumentation/java/automatic/spring-boot.md
@@ -37,7 +37,7 @@ auto-configuration, see the configuration [README].
 	<dependency>
 		<groupId>io.opentelemetry.instrumentation</groupId>
 		<artifactId>opentelemetry-spring-boot-starter</artifactId>
-		<version>{{% param vers.instrumentation %}}</version>
+		<version>{{% param vers.instrumentation %}}-alpha</version>
 	</dependency>
 </dependencies>
 ```
@@ -46,7 +46,7 @@ auto-configuration, see the configuration [README].
 
 ```groovy
 dependencies {
-	implementation('io.opentelemetry.instrumentation:opentelemetry-spring-boot-starter:{{% param vers.instrumentation %}}')
+	implementation('io.opentelemetry.instrumentation:opentelemetry-spring-boot-starter:{{% param vers.instrumentation %}}-alpha')
 }
 ```
 


### PR DESCRIPTION
Update opentelemetry-spring-boot-starter version with -alpha

As below screenshot, the version should append -alpha in central repository
![image](https://github.com/open-telemetry/opentelemetry.io/assets/3264250/3e874422-b8e2-4ee8-a5c1-6e4e2bc328c6)

![image](https://github.com/open-telemetry/opentelemetry.io/assets/3264250/ef6e31a1-b1b1-43e1-b688-f30affc26289)

