### PR TITLE
doc: Remove `/v1/traces` from OTEL_EXPORTER_OTLP_ENDPOINT

### DIFF
--- a/content/en/docs/instrumentation/ruby/exporters.md
+++ b/content/en/docs/instrumentation/ruby/exporters.md
@@ -52,7 +52,7 @@ can change the endpoint by setting the `OTEL_EXPORTER_OTLP_ENDPOINT`
 accordingly:
 
 ```sh
-env OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318/v1/traces" rails server -p 8080
+env OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318" rails server -p 8080
 ```
 
 To try out the OTLP exporter quickly and see your traces visualized at the


### PR DESCRIPTION
`OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318/v1/traces"` did not work as expected.

```
E, [2023-12-01T20:15:29.518443 #15315] ERROR -- : OpenTelemetry error: OTLP exporter received http.code=404 for uri: '/v1/v1/traces'
E, [2023-12-01T20:15:29.518806 #15315] ERROR -- : OpenTelemetry error: Unable to export 1 spans
```

It works correctly when removing "/v1/traces" from the endpoint.