### PR TITLE
minor fixes for cspell

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -94,6 +94,7 @@ jobs:
       contains(github.event.comment.body, '/fix:refcache')
     permissions:
       contents: write
+      pull-requests: write
 
     env:
       DEPTH: --depth 100 # submodule clone depth

--- a/data/registry/instrumentation-java-pekkoactor.yml
+++ b/data/registry/instrumentation-java-pekkoactor.yml
@@ -1,4 +1,4 @@
-# cspell:ignore pekko
+# cSpell:ignore pekko
 title: Apache Pekko Actor Instrumentation
 registryType: instrumentation
 isThirdParty: false

--- a/data/registry/instrumentation-java-pekkohttp.yml
+++ b/data/registry/instrumentation-java-pekkohttp.yml
@@ -1,4 +1,4 @@
-# cspell:ignore pekko
+# cSpell:ignore pekko
 title: Apache Pekko HTTP
 registryType: instrumentation
 isThirdParty: false

--- a/layouts/shortcodes/docs/instrumentation/exporters-intro.md
+++ b/layouts/shortcodes/docs/instrumentation/exporters-intro.md
@@ -1,4 +1,4 @@
-<!-- cspell:ignore isset cond -->
+<!-- cSpell:ignore isset cond -->
 
 {{ $lang := .Get 0 -}} {{ $data := index $.Site.Data.instrumentation $lang }}
 {{ $name := cond (isset $.Site.Data.instrumentation $lang) (printf "OpenTelemetry %s" $data.name) "the language specific implementations" -}}

--- a/templates/registry-entry.yml
+++ b/templates/registry-entry.yml
@@ -1,3 +1,4 @@
+# cSpell:ignore # add words unknown to cspell, remove this line if not required
 title: My OpenTelemetry Integration # the name of your project
 registryType: <exporter/core/instrumentation> # the type of integration; is this an exporter, plugin, API package, or something else?
 isThirdParty: <false/true> # this is only true if the project is not maintained by the OpenTelemetry project


### PR DESCRIPTION
Makes sure that cSpell is used consistently, add cSpell:ignore example to registry template