### PR TITLE
Add script to scan cspell ignore lists

### DIFF
--- a/scripts/cspell-ignore-scanner
+++ b/scripts/cspell-ignore-scanner
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# This script scans directories content, layouts, data for files with "cSpell:ignore" in them and then prints how often a certain word has been added to an ignore list
+# This helps to add new words to the .vscode/cspell.json file
+# 
+
+DIRECTOR=${1:-.}
+grep "cSpell:ignore" content layouts data -Ri ${DIRECTORY} | awk -F"cSpell:ignore" '{ print $2; }' | sed 's/^://; s/^[ \t]*//; s/[*\/}>-]//g'| tr ' ' '\n' | tr '[:upper:]' '[:lower:]' | sort | uniq -c | sort -n

--- a/scripts/cspell-ignore-scanner
+++ b/scripts/cspell-ignore-scanner
@@ -4,5 +4,5 @@
 # This helps to add new words to the .vscode/cspell.json file
 # 
 
-DIRECTOR=${1:-.}
+DIRECTORY=${1:-.}
 grep "cSpell:ignore" content layouts data -Ri ${DIRECTORY} | awk -F"cSpell:ignore" '{ print $2; }' | sed 's/^://; s/^[ \t]*//; s/[*\/}>-]//g'| tr ' ' '\n' | tr '[:upper:]' '[:lower:]' | sort | uniq -c | sort -n


### PR DESCRIPTION
@chalin update to you mentioning recently that we should add some terms (like ott) to our global ignore list. 

The script in this PR can help with that, it will collect all ignore lists and then print out the words with the most files having them in their ignore list, here are all with >5:

```
   6 darwin
   6 debugexporter
   6 farfetch
   6 loggingexporter
   6 loglevel
   6 millis
   6 otlpreceiver
   6 struct
   7 autoconfigure
   7 kubelet
   7 myapp
   8 sdktrace
  11 distro
  13 rolldice
```

Note, that I am not saying that we should add all of them, but the output of the script can help to identify those we should take into consideration.