### PR TITLE
Update vendors.yaml to add VictoriaMetrics

### DIFF
--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -351,7 +351,7 @@
   commercial: true
 - name: VictoriaMetrics
   distribution: false
-  nativeOTLP: false
+  nativeOTLP: true
   url: 'https://github.com/VictoriaMetrics/VictoriaMetrics/tree/master/docs#sending-data-via-opentelemetry'
   contact: 'https://github.com/hagen1778'
   oss: true

--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -349,3 +349,10 @@
   contact: 'otel@tingyun.com'
   oss: false
   commercial: true
+- name: VictoriaMetrics
+  distribution: false
+  nativeOTLP: false
+  url: 'https://github.com/VictoriaMetrics/VictoriaMetrics/tree/master/docs#sending-data-via-opentelemetry'
+  contact: 'https://github.com/hagen1778'
+  oss: true
+  commercial: true


### PR DESCRIPTION
Hi! Adding VictoriaMetrics to OpenTelemetry vendor list, per the vendor docs instructions.

**Link to the documentation that details how your offering consumes OpenTelemetry natively via OTLP.**
VictoriaMetrics supports [metrics format for ingestion](https://docs.victoriametrics.com/#sending-data-via-opentelemetry).

**Link to your distribution, if applicable**
N/A

**Link that proves that your offering is open source, if applicable. An open source distribution does not qualify your offering to be marked “open source”.**
https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/LICENSE

**GitHub handle or email address as a point of contact so that we can reach out in case we have questions**
@hagen1778