### PR TITLE
Drop obsolete hugo config param

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -57,7 +57,6 @@ params:
     collector services to capture distributed traces and metrics from your
     application. You can analyze them using Prometheus, Jaeger, and other
     observability tools.
-  font_awesome_version: 5.8.1
   github_repo: https://github.com/open-telemetry/opentelemetry.io
   github_branch: main
   gcs_engine_id: bde3d634eca9cd335


### PR DESCRIPTION
FontAwesome is a derived dependency, pulled in via Docsy. There should be no mention of FA versions in this repo. I think that the `font_awesome_version` is a vestige from long long ago.

Removing that like doesn't affect generated site files:

```console
$ (cd public && git diff -I 'var buildDate')
$
```