### PR TITLE
Add CVE page

### DIFF
--- a/content/en/docs/cve.md
+++ b/content/en/docs/cve.md
@@ -32,12 +32,7 @@ is refreshed daily.
       var url = 'https://raw.githubusercontent.com/open-telemetry/sig-security/data-source/published_output.json';
       return fetch(url)
         .then(function(response) {
-          return response.text();
-        })
-        .then(data => {
-          data = data.replace(/}\s*{/g, '},{');
-          var json = JSON.parse('[' + data + ']');
-          return json
+          return response.json();
         });
     }
 

--- a/content/en/docs/cve.md
+++ b/content/en/docs/cve.md
@@ -1,0 +1,78 @@
+---
+title: Common Vulnerabilities and Exposures
+weight: 102
+---
+
+This is a list of reported CVEs across all repositories in the OpenTelemetry org
+on GitHub. The raw data is stored in
+[this GitHub repository](https://github.com/open-telemetry/sig-security), and it
+is refreshed daily.
+
+  <table id="cve-table">
+    <thead>
+      <tr>
+        <th>CVE ID</th>
+        <th>Issue Summary</th>
+        <th>Severity</th>
+        <th>Repository</th>
+      </tr>
+    </thead>
+    <tbody>
+    </tbody>
+  </table>
+
+<script id="main-script">
+  'use strict';
+  (function() {
+    function fetchAndRender() {
+      fetchData()
+        .then(renderTable);
+    }
+
+    function fetchData() {
+      var url = 'https://raw.githubusercontent.com/open-telemetry/sig-security/data-source/published_output.json';
+      return fetch(url)
+        .then(function(response) {
+          return response.text();
+        })
+        .then(data => {
+          data = data.replace(/}\s*{/g, '},{');
+          var json = JSON.parse('[' + data + ']');
+          return json
+        });
+    }
+
+    function renderTable(data) {
+      console.log(data)
+      var table = document.getElementById('cve-table').querySelector('tbody');
+
+      data.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+      data.forEach(item => {
+        var row = table.insertRow();
+
+        const cell1 = row.insertCell(0);
+        const link = document.createElement('a');
+        link.href = item['html_url'];
+        link.target = '_blank';
+        link.textContent = item['cve_id'];
+        cell1.appendChild(link);
+
+        const cell2 = row.insertCell(1);
+        cell2.textContent = item['summary'];
+        const cell3 = row.insertCell(2);
+        cell3.textContent = item['severity'];
+
+        const cell4 = row.insertCell(3);
+        // cell4.textContent = item['repo'];
+        const link2 = document.createElement('a');
+        link2.href = 'https://www.github.com/open-telemetry/' + item['repo'] + '/security/advisories';
+        link2.target = '_blank';
+        link2.textContent = item['repo'];
+        cell4.appendChild(link2);
+      });
+    }
+
+    fetchAndRender();
+  })();
+</script>

--- a/content/en/docs/cve.md
+++ b/content/en/docs/cve.md
@@ -3,9 +3,8 @@ title: Common Vulnerabilities and Exposures
 weight: 102
 ---
 
-This is a list of reported CVEs across all repositories in the OpenTelemetry org
-on GitHub. The raw data is stored in
-[this GitHub repository](https://github.com/open-telemetry/sig-security), and it
+This is a list of reported Common Vulnerabilities and Exposures (CVEs) across all repositories in the [OpenTelemetry organisation on GitHub](https://github.com/open-telemetry/). The raw data is stored in
+the [open-telemetry/sig-security](https://github.com/open-telemetry/sig-security) repository, and it
 is refreshed daily.
 
   <table id="cve-table">

--- a/content/en/docs/security/_index.md
+++ b/content/en/docs/security/_index.md
@@ -1,0 +1,4 @@
+---
+title: Security
+weight: 150
+---

--- a/content/en/docs/security/cve.md
+++ b/content/en/docs/security/cve.md
@@ -3,7 +3,7 @@ title: Common Vulnerabilities and Exposures
 weight: 102
 ---
 
-This is a list of reported Common Vulnerabilities and Exposures (CVEs) across all repositories in the [OpenTelemetry organisation on GitHub](https://github.com/open-telemetry/). The raw data is stored in
+This is a list of reported Common Vulnerabilities and Exposures (CVEs) across all repositories in the [OpenTelemetry organization on GitHub](https://github.com/open-telemetry/). The raw data is stored in
 the [open-telemetry/sig-security](https://github.com/open-telemetry/sig-security) repository, and it
 is refreshed daily.
 

--- a/content/en/docs/security/cve.md
+++ b/content/en/docs/security/cve.md
@@ -10,18 +10,18 @@ raw data is stored in the
 [sig-security](https://github.com/open-telemetry/sig-security) repository, and
 it is refreshed daily.
 
-  <table id="cve-table">
-    <thead>
-      <tr>
-        <th>CVE ID</th>
-        <th>Issue Summary</th>
-        <th>Severity</th>
-        <th>Repository</th>
-      </tr>
-    </thead>
-    <tbody>
-    </tbody>
-  </table>
+<table id="cve-table">
+  <thead>
+    <tr>
+      <th>CVE ID</th>
+      <th>Issue Summary</th>
+      <th>Severity</th>
+      <th>Repository</th>
+    </tr>
+  </thead>
+  <tbody>
+  </tbody>
+</table>
 
 <script id="main-script">
   'use strict';

--- a/content/en/docs/security/cve.md
+++ b/content/en/docs/security/cve.md
@@ -40,7 +40,6 @@ it is refreshed daily.
     }
 
     function renderTable(data) {
-      console.log(data)
       var table = document.getElementById('cve-table').querySelector('tbody');
 
       data.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));

--- a/content/en/docs/security/cve.md
+++ b/content/en/docs/security/cve.md
@@ -4,7 +4,7 @@ weight: 102
 ---
 
 This is a list of reported Common Vulnerabilities and Exposures (CVEs) across all repositories in the [OpenTelemetry organization on GitHub](https://github.com/open-telemetry/). The raw data is stored in
-the [open-telemetry/sig-security](https://github.com/open-telemetry/sig-security) repository, and it
+the [sig-security](https://github.com/open-telemetry/sig-security) repository, and it
 is refreshed daily.
 
   <table id="cve-table">

--- a/content/en/docs/security/cve.md
+++ b/content/en/docs/security/cve.md
@@ -3,9 +3,12 @@ title: Common Vulnerabilities and Exposures
 weight: 102
 ---
 
-This is a list of reported Common Vulnerabilities and Exposures (CVEs) across all repositories in the [OpenTelemetry organization on GitHub](https://github.com/open-telemetry/). The raw data is stored in
-the [sig-security](https://github.com/open-telemetry/sig-security) repository, and it
-is refreshed daily.
+This is a list of reported Common Vulnerabilities and Exposures (CVEs) across
+all repositories in the
+[OpenTelemetry organization on GitHub](https://github.com/open-telemetry/). The
+raw data is stored in the
+[sig-security](https://github.com/open-telemetry/sig-security) repository, and
+it is refreshed daily.
 
   <table id="cve-table">
     <thead>

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -2543,6 +2543,10 @@
     "StatusCode": 200,
     "LastSeen": "2023-06-30T08:31:22.656334-04:00"
   },
+  "https://github.com/open-telemetry/": {
+    "StatusCode": 200,
+    "LastSeen": "2023-12-08T15:19:55.887939-08:00"
+  },
   "https://github.com/open-telemetry/community": {
     "StatusCode": 200,
     "LastSeen": "2023-06-30T09:28:03.502113-04:00"

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -3711,6 +3711,10 @@
     "StatusCode": 200,
     "LastSeen": "2023-11-03T20:22:42.689401141Z"
   },
+  "https://github.com/open-telemetry/sig-security": {
+    "StatusCode": 200,
+    "LastSeen": "2023-12-07T16:14:09.891942-08:00"
+  },
   "https://github.com/opentracing": {
     "StatusCode": 200,
     "LastSeen": "2023-06-30T08:40:39.909083-04:00"


### PR DESCRIPTION
This is adding a page with a list of published security vulnerabilities across all repositories, similar to [Kubernetes docs](https://kubernetes.io/docs/reference/issues-security/official-cve-feed/).