### PR TITLE
improve dotnet getting started instructions

### DIFF
--- a/content/en/docs/instrumentation/net/getting-started.md
+++ b/content/en/docs/instrumentation/net/getting-started.md
@@ -46,6 +46,8 @@ code:
 ```csharp
 using System.Globalization;
 
+using Microsoft.AspNetCore.Mvc;
+
 var builder = WebApplication.CreateBuilder(args);
 var app = builder.Build();
 
@@ -63,6 +65,12 @@ string HandleRollDice([FromServices]ILogger<Program> logger, string? player)
     }
 
     return result.ToString(CultureInfo.InvariantCulture);
+}
+
+int RollDice()
+{
+    var rng = new Random();
+    return rng.Next(1, 6);
 }
 
 app.MapGet("/rolldice/{player?}", HandleRollDice);
@@ -114,7 +122,21 @@ that will generate the telemetry, and set them up.
 
 2. Setup the OpenTelemetry code
 
+   In Program.cs, replace the following lines:
+
    ```csharp
+   var builder = WebApplication.CreateBuilder(args);
+   var app = builder.Build();
+   ```
+
+   With:
+
+   ```csharp
+   using OpenTelemetry.Logs;
+   using OpenTelemetry.Metrics;
+   using OpenTelemetry.Resources;
+   using OpenTelemetry.Trace;
+
    var builder = WebApplication.CreateBuilder(args);
 
    const string serviceName = "roll-dice";

--- a/content/en/docs/instrumentation/net/getting-started.md
+++ b/content/en/docs/instrumentation/net/getting-started.md
@@ -69,8 +69,7 @@ string HandleRollDice([FromServices]ILogger<Program> logger, string? player)
 
 int RollDice()
 {
-    var rng = new Random();
-    return rng.Next(1, 6);
+    return Random.Shared.Next(1, 7);
 }
 
 app.MapGet("/rolldice/{player?}", HandleRollDice);


### PR DESCRIPTION
- on the initial instructions, added a function for RollDice() that was referenced, but not included.
- when adding the Open Telemetry code, instructions to replace certain lines of code, including the required using statements.