### PR TITLE
docs(ecosystem): add tracetest to vendors

### DIFF
--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -356,3 +356,10 @@
   contact: 'https://github.com/hagen1778'
   oss: true
   commercial: true
+- name: Tracetest
+  distribution: false
+  nativeOTLP: true
+  url: 'https://tracetest.io/'
+  contact: 'https://tracetest.io/contact/'
+  oss: true
+  commercial: true


### PR DESCRIPTION
This PR adds Tracetest to the Vendors list in the Ecosystem.