### PR TITLE
Fix code license, add NOTICE

### DIFF
--- a/LICENSE-CODE
+++ b/LICENSE-CODE
@@ -187,9 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 The KEDA Authors.
-
-   and others that have contributed code to the public domain.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,6 @@
+OpenTelemetry Website & Blog
+Copyright 2019-2023 The OpenTelemetry Authors
+
+This project includes software developed and documentation written at
+The Cloud Native Foundation (https://www.cncf.io/).
+

--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,0 @@
-OpenTelemetry Website & Blog
-Copyright 2019-2023 The OpenTelemetry Authors
-
-This project includes software developed and documentation written at
-The Cloud Native Foundation (https://www.cncf.io/).
-


### PR DESCRIPTION
The LICENSE-CODE file has a copy&paste error, fixed by this. I checked with other projects and the meaning of the license and the `Copyright [yyyy] [name of copyright owner]` should **not** be replaced by a project name.

I also added a NOTICE file as suggested by the apache license, see [section 4.4](https://www.apache.org/licenses/LICENSE-2.0.html#redistribution) for details. Although our repo does not have a lot of content, I think it still helps to improve potential attributions.