### PR TITLE
Make sig-security-maintainers code owners for security docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,4 +39,5 @@ content/en/docs/instrumentation/swift/   @open-telemetry/docs-approvers @open-te
 content/en/docs/kubernetes/operator/     @open-telemetry/docs-approvers @open-telemetry/operator-approvers
 content/en/docs/kubernetes/helm/         @open-telemetry/docs-approvers @open-telemetry/helm-approvers
 content/en/docs/specs/                   @open-telemetry/docs-approvers @open-telemetry/specs-approvers
+content/en/docs/security/                @open-telemetry/docs-approvers @open-telemetry/sig-security-maintainers
 content/en/ecosystem/demo/               @open-telemetry/demo-approvers @open-telemetry/demo-approvers


### PR DESCRIPTION
@open-telemetry/sig-security-maintainers  PTAL

This will make sure that changes to /docs/security will ask you for code review