### PR TITLE
Add 'Building' section to collector docs

### DIFF
--- a/content/en/docs/collector/building/_index.md
+++ b/content/en/docs/collector/building/_index.md
@@ -1,0 +1,11 @@
+---
+title: Building custom components
+description: Instructions on how to build your own collector components
+weight: 90
+---
+
+The OpenTelemetry Collector can not only be extended by existing components, but
+also by custom components, that you develop and build on your own. Here you will
+find instructions on how to build some of those components. For additional
+details take a look into the documents contained within the
+[opentelemetry-collector-contrib repository](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/README.md).

--- a/content/en/docs/collector/building/authenticator-extension.md
+++ b/content/en/docs/collector/building/authenticator-extension.md
@@ -1,6 +1,7 @@
 ---
-title: Building a custom authenticator
-weight: 30
+title: Building an authenticator extension
+weight: 40
+aliases: [/docs/collector/custom-auth/]
 cSpell:ignore: configauth oidc
 ---
 

--- a/content/en/docs/collector/building/connector.md
+++ b/content/en/docs/collector/building/connector.md
@@ -1,5 +1,7 @@
 ---
 title: Building a Connector
+aliases: [/docs/collector/build-connector/]
+weight: 30
 # prettier-ignore
 cSpell:ignore: batchprocessor debugexporter Errorf exampleconnector gomod gord Jaglowski loggingexporter mapstructure mapstructure otlpreceiver pdata pmetric ptrace servicegraph spanmetrics struct uber
 ---
@@ -51,11 +53,11 @@ following links:
 
 ### The Old Architecture:
 
-![Before picture of how processors emitted data directly to another pipelines exporter](../img/otel-collector-before-connector.png)
+![Before picture of how processors emitted data directly to another pipelines exporter](../../img/otel-collector-before-connector.png)
 
 ### New Architecture Using a Connector:
 
-![How the pipeline should work using the connector component](../img/otel-collector-after-connector.png)
+![How the pipeline should work using the connector component](../../img/otel-collector-after-connector.png)
 
 ## Building Example Connector
 

--- a/content/en/docs/collector/building/receiver.md
+++ b/content/en/docs/collector/building/receiver.md
@@ -1,6 +1,7 @@
 ---
-title: Building a Trace Receiver
-weight: 98
+title: Building a receiver
+weight: 20
+aliases: [/docs/collector/trace-receiver/]
 # prettier-ignore
 cSpell:ignore: amzn atmxph backendsystem batchprocessor chicago comcast crand debugexporter devs Errorf gogl Intn ispnetwork loggingexporter loglevel mapstructure mcrsft otelcontribcol otlpexporter otlpreceiver pcommon pdata protogen ptrace Rcvr rquedas sanfrancisco serialnumber slrs stateid struct structs Subchannel tailtracer uber wndws zapgrpc
 ---

--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -698,15 +698,15 @@ Each authentication extension has two possible usages:
 For a list of known authenticators, see the
 [Registry](/ecosystem/registry/?s=authenticator&component=extension). If you're
 interested in developing a custom authenticator, see
-[Building a custom authenticator](../custom-auth).
+[Building an authenticator extension](../building/authenticator-extension).
 
 To add a server authenticator to a receiver in the Collector, follow these
 steps:
 
 1. Add the authenticator extension and its configuration under `.extensions`.
-1. Add a reference to the authenticator to `.services.extensions`, so that it's
+2. Add a reference to the authenticator to `.services.extensions`, so that it's
    loaded by the Collector.
-1. Add a reference to the authenticator under
+3. Add a reference to the authenticator under
    `.receivers.<your-receiver>.<http-or-grpc-config>.auth`.
 
 The following example uses the OIDC authenticator on the receiver side, making

--- a/content/en/docs/collector/distributions.md
+++ b/content/en/docs/collector/distributions.md
@@ -19,9 +19,8 @@ the `manifest.yaml` of each distribution.
 For various reasons the existing distributions provided by the OpenTelemetry
 project may not meet your needs. Whether you want a smaller version, or have the
 need to implement custom functionality like
-[custom authenticators](../custom-auth), receivers, processors, or exporters.
-The tool used to build distributions [ocb][] (OpenTelemetry Collector Builder)
-is available to build your own distributions.
-
-[ocb]:
-  https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder
+[authenticator extensions](../building/authenticator-extension),
+[receivers](../building/receiver), processors, exporters or
+[connectors](../building/connector). The tool used to build distributions
+[ocb](../custom-collector) (OpenTelemetry Collector Builder) is available to
+build your own distributions.


### PR DESCRIPTION
We discussed this a few times already that we should group some of the "Building..." and add a new section for them. Here it is. I thought about including [Building a custom collector](https://opentelemetry.io/docs/collector/custom-collector/) or not, and decided against inclusion: I think it is a very important topic that needs to be at a higher level, and it is  also different to the other as it is not something that requires you to write code. That's why this section is now called "Building custom components"

I also dropped/added some qualifiers:
* All mention of "custom" as this is now given by the top level
* Renamed "trace receiver" to only "receiver", as this is just an example but could be used for other components as well (I actually used it as an entry point to write a processor)
* Renamed "custom authenticator" to "authenticator extension" to highlight that this is about extensions as well and _might_ be helpful for other extensions.