### PR TITLE
Move context propagation into dedicated page

### DIFF
--- a/content/en/docs/concepts/context-propagation.md
+++ b/content/en/docs/concepts/context-propagation.md
@@ -1,0 +1,44 @@
+---
+title: Context Propagation
+weight: 10
+description: Learn about the concept that enables Distributed Tracing.
+---
+
+With Context Propagation, [Signals](/docs/concepts/signals) can be correlated
+with each other, regardless of where they are generated. Although not limited to
+tracing, it is what allows [traces](/docs/concepts/signals/traces) to build
+causal information about a system across services that are arbitrarily
+distributed across. process and network boundaries.
+
+We define Context Propagation by two sub-concepts: Context and Propagation.
+
+## Context
+
+A **Context** is an object that contains the information for the sending and
+receiving service (or
+[execution unit](/docs/specs/otel/glossary/#execution-unit)) to correlate one
+signal with another.
+
+For example, if Service A calls Service B, then a span from Service A whose ID
+is in context will be used as the parent span for the next span created in
+Service B. The trace ID that is in context will be used for the next span
+created in Service B as well, which signifies that the span is part of the same
+trace as the span from Service A.
+
+## Propagation
+
+**Propagation** is the mechanism that moves context between services and
+processes. It serializes or deserializes the context object and provides the
+relevant information to be propagated from one service to another. Propagation
+is usually handled by instrumentation libraries and is transparent to the user,
+but in the event that you need to manually propagate context, you can use
+Propagation APIs.
+
+OpenTelemetry maintains several official propagators. The default propagator is
+using the headers specified by the
+[W3C TraceContext](https://www.w3.org/TR/trace-context/) specification.
+
+## Specification
+
+To learn more about Context Propagation, see the
+[Context specification](/docs/specs/otel/context/).

--- a/content/en/docs/concepts/signals/traces.md
+++ b/content/en/docs/concepts/signals/traces.md
@@ -151,35 +151,9 @@ source or vendor backend of your choice.
 
 Context Propagation is the core concept that enables Distributed Tracing. With
 Context Propagation, Spans can be correlated with each other and assembled into
-a trace, regardless of where Spans are generated. We define Context Propagation
-by two sub-concepts: Context and Propagation.
-
-A **Context** is an object that contains the information for the sending and
-receiving service to correlate one span with another and associate it with the
-trace overall. For example, if Service A calls Service B, then a span from
-Service A whose ID is in context will be used as the parent span for the next
-span created in Service B. The trace ID that is in context will be used for the
-next span created in Service B as well, which signifies that the span is part of
-the same trace as the span from Service A.
-
-**Propagation** is the mechanism that moves context between services and
-processes. It serializes or deserializes the context object and provides the
-relevant Trace information to be propagated from one service to another.
-Propagation is usually handled by instrumentation libraries and is transparent
-to the user, but in the event that you need to manually propagate context, you
-can use Propagation APIs.
-
-OpenTelemetry supports several different context formats. The default format
-used in OpenTelemetry tracing is called
-[W3C TraceContext](https://www.w3.org/TR/trace-context/). Each context object is
-stored in a span. See [Span Context](#span-context) for details on the context
-object and what other information is available..
-
-By combining Context and Propagation, you now can assemble a Trace.
-
-> For more information, see the [traces specification][]
-
-[traces specification]: /docs/specs/otel/overview/#tracing-signal
+a trace, regardless of where Spans are generated. To learn more about this
+topic, see the concept page on
+[Context Propagation](/docs/concepts/context-propagation).
 
 ## Spans
 
@@ -368,3 +342,8 @@ a local job handled by an event listener.
 
 Consumer spans represent the processing of a job created by a producer and may
 start long after the producer span has already ended.
+
+## Specification
+
+For more information, see the
+[traces specification](/docs/specs/otel/overview/#tracing-signal).


### PR DESCRIPTION
This PR moves the concept of context propagation out of traces into a dedicated page. I tried to fix some of the wording to make it clear that this concept is not exclusive to tracing/for all signals, but overall I tried to keep the text untouched as far as possible, as this may require a follow up PR to cleanup (so this is a "perfect is the enemy of good" PR)