### PR TITLE
php: fix namespace of Globals

### DIFF
--- a/content/en/docs/instrumentation/php/automatic.md
+++ b/content/en/docs/instrumentation/php/automatic.md
@@ -193,7 +193,7 @@ php myapp.php
 
 ```php
 <?php
-OpenTelemetry\API\Common\Instrumentation\Globals::registerInitializer(function (Configurator $configurator) {
+OpenTelemetry\API\Globals::registerInitializer(function (Configurator $configurator) {
     $propagator = TraceContextPropagator::getInstance();
     $spanProcessor = new BatchSpanProcessor(/*params*/);
     $tracerProvider = (new TracerProviderBuilder())

--- a/content/en/docs/instrumentation/php/getting-started.md
+++ b/content/en/docs/instrumentation/php/getting-started.md
@@ -228,7 +228,7 @@ Replace `index.php` with the following code:
 ```php
 <?php
 
-use OpenTelemetry\API\Common\Instrumentation\Globals;
+use OpenTelemetry\API\Globals;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Factory\AppFactory;
@@ -281,7 +281,7 @@ Replace the `index.php` file with the following code:
 <?php
 
 use Monolog\Logger;
-use OpenTelemetry\API\Common\Instrumentation\Globals;
+use OpenTelemetry\API\Globals;
 use OpenTelemetry\Contrib\Logs\Monolog\Handler;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;

--- a/content/en/docs/instrumentation/php/manual.md
+++ b/content/en/docs/instrumentation/php/manual.md
@@ -51,7 +51,7 @@ producing the telemetry; in particular the `service.name` attribute.
 ```php
 <?php
 
-use OpenTelemetry\API\Common\Instrumentation\Globals;
+use OpenTelemetry\API\Globals;
 use OpenTelemetry\API\Logs\EventLogger;
 use OpenTelemetry\API\Logs\LogRecord;
 use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;

--- a/content/en/docs/instrumentation/php/sdk.md
+++ b/content/en/docs/instrumentation/php/sdk.md
@@ -91,8 +91,8 @@ php example.php
 <?php
 require 'vendor/autoload.php'; //sdk autoloading happens as part of composer initialization
 
-$tracer = OpenTelemetry\API\Common\Instrumentation\Globals::tracerProvider()->getTracer('name', 'version', 'schema.url', [/*attributes*/]);
-$meter = OpenTelemetry\API\Common\Instrumentation\Globals::meterProvider()->getMeter('name', 'version', 'schema.url', [/*attributes*/]);
+$tracer = OpenTelemetry\API\Globals::tracerProvider()->getTracer('name', 'version', 'schema.url', [/*attributes*/]);
+$meter = OpenTelemetry\API\Globals::meterProvider()->getMeter('name', 'version', 'schema.url', [/*attributes*/]);
 ```
 
 SDK autoloading happens as part of the composer autoloader.


### PR DESCRIPTION
Globals was moved just prior to going GA, but the documentation was not updated accordingly.