### PR TITLE
[demo] - document how to change demo port number for docker deploy

### DIFF
--- a/content/en/docs/demo/docker-deployment.md
+++ b/content/en/docs/demo/docker-deployment.md
@@ -72,6 +72,25 @@ Once the images are built and containers are started you can access:
 - Jaeger UI: <http://localhost:8080/jaeger/ui/>
 - Tracetest UI: <http://localhost:11633/>, only when using `make start-odd`
 
+## Changing the demo's primary port number
+
+By default, the demo application will start a proxy for all browser traffic bound to port 8080. To change the port
+number, set the `ENVOY_PORT` environment variable before starting the demo. For example, to use port 8081:
+
+    {{< tabpane text=true >}} {{% tab Make %}}
+
+```shell
+ENVOY_PORT=8081 make start
+```
+
+    {{% /tab %}} {{% tab Docker %}}
+
+```shell
+ENVOY_PORT=8081 docker compose up --force-recreate --remove-orphans --detach
+```
+
+    {{% /tab %}} {{< /tabpane >}}
+
 ## Bring your own backend
 
 Likely you want to use the web store as a demo application for an observability

--- a/content/en/docs/demo/docker-deployment.md
+++ b/content/en/docs/demo/docker-deployment.md
@@ -76,9 +76,11 @@ Once the images are built and containers are started you can access:
 
 By default, the demo application will start a proxy for all browser traffic
 bound to port 8080. To change the port number, set the `ENVOY_PORT` environment
-variable before starting the demo. For example, to use port 8081:
+variable before starting the demo.
 
-    {{< tabpane text=true >}} {{% tab Make %}}
+- For example, to use port 8081[^1]:
+
+  {{< tabpane text=true >}} {{% tab Make %}}
 
 ```shell
 ENVOY_PORT=8081 make start

--- a/content/en/docs/demo/docker-deployment.md
+++ b/content/en/docs/demo/docker-deployment.md
@@ -74,8 +74,9 @@ Once the images are built and containers are started you can access:
 
 ## Changing the demo's primary port number
 
-By default, the demo application will start a proxy for all browser traffic bound to port 8080. To change the port
-number, set the `ENVOY_PORT` environment variable before starting the demo. For example, to use port 8081:
+By default, the demo application will start a proxy for all browser traffic
+bound to port 8080. To change the port number, set the `ENVOY_PORT` environment
+variable before starting the demo. For example, to use port 8081:
 
     {{< tabpane text=true >}} {{% tab Make %}}
 


### PR DESCRIPTION
Fixes: #3473 

Add instructions on changing the port number when deploying the demo, as the machine may already have a conflict on the default port. This only affects docker deployments on local machines.