### PR TITLE
Fix typo in automatic.md

### DIFF
--- a/content/en/docs/kubernetes/operator/automatic.md
+++ b/content/en/docs/kubernetes/operator/automatic.md
@@ -656,7 +656,7 @@ For example:
 ```yaml
 spec:
   exporter:
-    endpoint: http://otel-collector-collector.opentelemetry.svc.cluster.local:4317
+    endpoint: http://otel-collector.opentelemetry.svc.cluster.local:4317
 ```
 
 Here, the Collector endpoint is set to


### PR DESCRIPTION
Correct the endpoint value that differs from the description(`http://otel-collector.opentelemetry.svc.cluster.local:4317`) below.