### PR TITLE
Adjust reference path for php library

### DIFF
--- a/content/en/docs/instrumentation/php/manual.md
+++ b/content/en/docs/instrumentation/php/manual.md
@@ -432,7 +432,7 @@ First, create a `MeterProvider`:
 ```php
 <?php
 
-use OpenTelemetry\Contrib\Otlp\ConsoleMetricExporterFactory;
+use OpenTelemetry\SDK\Metrics\MetricExporter\ConsoleMetricExporterFactory;
 use OpenTelemetry\SDK\Metrics\MeterProvider;
 use OpenTelemetry\SDK\Metrics\MetricReader\ExportingReader;
 


### PR DESCRIPTION
## What
Adjust reference path for php library:
* OpenTelemetry\Contrib\Otlp\ConsoleMetricExporterFactory;

## Why 
The following path was changed in opentelemetry-php PR https://github.com/open-telemetry/opentelemetry-php/pull/1055

https://github.com/open-telemetry/opentelemetry.io/blob/7fa1b1433b08bbb37e08a9cd22f94289e94111ab/content/en/docs/instrumentation/php/manual.md?plain=1#L451


## Docs PR Checklist

<!--- Just making sure... -->

- [ ] This PR is for a documentation page whose authoritative copy is in the
      opentelemetry.io repository.
