### PR TITLE
[CI] Don't check spelling inside some code blocks

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -8,6 +8,19 @@ ignorePaths:
 # words here are only listed for their spelling, if there is a certain way
 # to write a word (e.g. OpenTelemetry vs Opentelemetry or cloud native vs
 # cloud-native), edit the text-lint rules in .textlintrc.yml
+patterns:
+  - name: CodeBlock
+    pattern: |
+      /
+          ^(\s*[~`]{3,})   # code-block start
+          (bash|console|cmd|docker|go|log|mermaid|nocode|sh(ell)?|yaml) # languages
+          [\s\S]*?         # content
+          \1               # code-block end
+      /igmx
+languageSettings:
+  - languageId: markdown
+    ignoreRegExpList:
+      - CodeBlock
 words:
   - accountingservice
   - adservice

--- a/.cspell.yml
+++ b/.cspell.yml
@@ -13,7 +13,7 @@ patterns:
     pattern: |
       /
           ^(\s*[~`]{3,})   # code-block start
-          (bash|console|cmd|docker|go|log|mermaid|nocode|sh(ell)?|yaml) # languages
+          .*               # all languages and options, e.g. shell {hl_lines=[12]}
           [\s\S]*?         # content
           \1               # code-block end
       /igmx

--- a/content/en/blog/2022/instrument-nginx/index.md
+++ b/content/en/blog/2022/instrument-nginx/index.md
@@ -3,12 +3,10 @@ title: Learn how to instrument NGINX with OpenTelemetry
 linkTitle: Instrument Nginx
 date: 2022-08-22
 author: >-
-  [Debajit Das](https://github.com/debajitdas),  [Kumar
-  Pratyus](https://github.com/kpratyus),
-
-  [Severin Neumann](https://github.com/svrnm) (Cisco)
-# prettier-ignore
-cSpell:ignore: catalina Debajit Kumar Pratyus realip tracestate webserver WORKDIR xvfz
+  [Debajit Das](https://github.com/debajitdas), [Kumar
+  Pratyus](https://github.com/kpratyus), [Severin
+  Neumann](https://github.com/svrnm) (Cisco)
+cSpell:ignore: Debajit Kumar Pratyus webserver
 ---
 
 Apache HTTP Server and NGINX are the most popular web servers. It's most likely

--- a/content/en/blog/2023/any-metric-receiver.md
+++ b/content/en/blog/2023/any-metric-receiver.md
@@ -3,8 +3,7 @@ title: Receive any custom metric with the OpenTelemetry Collector
 linkTitle: Any Metric Receiver
 date: 2023-11-30
 author: '[Severin Neumann](https://github.com/svrnm), Cisco'
-# prettier-ignore
-cSpell:ignore: carbonreceiver datapoint debugexporter enddate gomod helmuth noout openssl otlpexporter otlphttpexporter otlpreceiver ottl servername transformprocessor webserver
+cSpell:ignore: helmuth openssl ottl transformprocessor webserver
 ---
 
 While OpenTelemetry (OTel) is here to help you with troubleshooting and handling

--- a/content/en/blog/2023/logs-collection/index.md
+++ b/content/en/blog/2023/logs-collection/index.md
@@ -3,8 +3,7 @@ title: Collecting Logs with OpenTelemetry Python
 linkTitle: Python Logs Collection
 date: 2023-11-21
 author: '[Michael Hausenblas](https://github.com/mhausenblas) (AWS)'
-# prettier-ignore
-cSpell:ignore: asctime Chehab exgru fileconsumer filelog Grogu grogu hossko Houssam levelname logfile otelbin Padawan svrnm WORKDIR yoda
+cSpell:ignore: asctime Chehab filelog grogu Houssam levelname padawan yoda
 ---
 
 In the following, we will walk through how to do

--- a/content/en/docs/collector/building/receiver.md
+++ b/content/en/docs/collector/building/receiver.md
@@ -3,7 +3,7 @@ title: Building a receiver
 weight: 20
 aliases: [/docs/collector/trace-receiver/]
 # prettier-ignore
-cSpell:ignore: amzn atmxph backendsystem batchprocessor chicago comcast crand debugexporter devs Errorf gogl Intn ispnetwork loggingexporter loglevel mapstructure mcrsft otelcontribcol otlpexporter otlpreceiver pcommon pdata protogen ptrace Rcvr rquedas sanfrancisco serialnumber slrs stateid struct structs Subchannel tailtracer telemetrygen uber wndws zapgrpc
+cSpell:ignore: backendsystem crand debugexporter loggingexporter mapstructure pcommon pdata protogen ptrace rcvr struct structs tailtracer telemetrygen uber
 ---
 
 <!-- markdownlint-disable heading-increment no-duplicate-heading -->
@@ -57,7 +57,7 @@ copy the `builder-config.yaml` described on
 and run the builder. As an outcome you should now have a folder structure like
 this:
 
-```console
+```text
 .
 ├── builder-config.yaml
 ├── ocb

--- a/content/en/docs/demo/architecture.md
+++ b/content/en/docs/demo/architecture.md
@@ -3,8 +3,6 @@ title: Demo Architecture
 linkTitle: Architecture
 aliases: [current_architecture]
 body_class: otel-mermaid-max-width
-# prettier-ignore
-cSpell:ignore: cppsvc dotnetsvc erlangsvc featureflagstore golangsvc javascriptsvc javasvc kotlinsvc loadgenerator phpsvc pythonsvc rubysvc rustsvc tsdb typescriptsvc
 ---
 
 **OpenTelemetry Demo** is composed of microservices written in different


### PR DESCRIPTION
- Fixes #3747
- For example, `content/en/docs/demo/architecture.md` no longer needs a local-page dictionary after we ignore some code blocks.
- I'll file a separate PR for the cleanup of the page-local dictionaries, if/once this gets merged.