### PR TITLE
Revert "Update opentelemetry-specification version to 1.29.0"

### DIFF
--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -19,7 +19,7 @@ my $semConvRef = "$otelSpecRepoUrl/blob/main/semantic_conventions/README.md";
 my $specBasePath = '/docs/specs';
 my $path_base_for_github_subdir = "content/en$specBasePath";
 my %versions = qw(
-  spec: 1.29.0
+  spec: 1.28.0
   otlp: 1.0.0
   semconv: 1.24.0
 );

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -6987,10 +6987,6 @@
     "StatusCode": 206,
     "LastSeen": "2023-06-29T18:41:53.764072-04:00"
   },
-  "https://www.w3.org/TR/baggage/#baggage-string": {
-    "StatusCode": 206,
-    "LastSeen": "2024-01-11T06:07:13.666570443Z"
-  },
   "https://www.w3.org/TR/baggage/#header-content": {
     "StatusCode": 206,
     "LastSeen": "2023-12-16T15:16:50.350520378Z"
@@ -7058,10 +7054,6 @@
   "https://www.youtube.com/watch": {
     "StatusCode": 200,
     "LastSeen": "2023-06-29T18:43:02.782058-04:00"
-  },
-  "https://yaml.org/spec/1.2.2/": {
-    "StatusCode": 206,
-    "LastSeen": "2024-01-11T06:07:16.115841487Z"
   },
   "https://youtu.be/9iaGG-YZw5I": {
     "StatusCode": 200,


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry.io#3755, the legacy links are breaking the "Warnings in build logs" check:

https://github.com/open-telemetry/opentelemetry.io/actions/runs/7486415031/job/20376788178?pr=3731

Not sure why this was not caught by the cheks in #3755

for context: https://github.com/open-telemetry/opentelemetry-specification/pull/3794#discussion_r1427690941