### PR TITLE
added lumigo distro for python, node and java to the registry

### DIFF
--- a/data/registry/instrumentation-java-lumigo.yml
+++ b/data/registry/instrumentation-java-lumigo.yml
@@ -1,0 +1,14 @@
+title: Lumigo Java Distribution
+registryType: instrumentation
+isThirdParty: true
+language: java
+tags:
+  - java
+  - instrumentation
+  - lumigo
+  - distribution
+repo: https://github.com/lumigo-io/opentelemetry-java-distro
+license: Apache 2.0
+description: The lumigo Java OpenTelemetry distribution
+authors: lumigo, lumigo authors
+otVersion: latest

--- a/data/registry/instrumentation-js-node-lumigo.yml
+++ b/data/registry/instrumentation-js-node-lumigo.yml
@@ -1,0 +1,15 @@
+title: Lumigo Node.js Distribution
+registryType: instrumentation
+isThirdParty: true
+language: js
+tags:
+  - js
+  - Node.js
+  - instrumentation
+  - lumigo
+  - distro
+repo: https://github.com/lumigo-io/opentelemetry-js-distro
+license: Apache 2.0
+description: The lumigo Node.js OpenTelemetry distribution
+authors: lumigo, lumigo authors
+otVersion: latest

--- a/data/registry/instrumentation-python-lumigo.yml
+++ b/data/registry/instrumentation-python-lumigo.yml
@@ -1,0 +1,14 @@
+title: Lumigo Python Distribution
+registryType: instrumentation
+isThirdParty: true
+language: python
+tags:
+  - python
+  - instrumentation
+  - lumigo
+  - distribution
+repo: https://github.com/lumigo-io/opentelemetry-python-distro
+license: Apache 2.0
+description: The lumigo Python OpenTelemetry distribution
+authors: lumigo, lumigo authors
+otVersion: latest


### PR DESCRIPTION
I am adding lumigo Python, Java and Node.JS language instrumentations (distributions) to the registry.

Note: There didn't appear to be a `distribution` registry type yet, so I've listed them as instrumentations. Is `distribution` something that is going to be added as a registry type (or can it?)