### PR TITLE
[Blog] Prepare for 2024 + blog navigation enhancements

### DIFF
--- a/content/en/blog/2024/_index.md
+++ b/content/en/blog/2024/_index.md
@@ -1,5 +1,7 @@
 ---
-title: 2024 - coming soon!
+title: 2024
 weight: -2024
 outputs: [HTML, RSS]
 ---
+
+New posts are coming soon.

--- a/content/en/blog/2024/_index.md
+++ b/content/en/blog/2024/_index.md
@@ -1,0 +1,5 @@
+---
+title: 2024 - coming soon!
+weight: -2024
+outputs: [HTML, RSS]
+---

--- a/content/en/blog/_index.md
+++ b/content/en/blog/_index.md
@@ -2,6 +2,6 @@
 title: Blog
 menu:
   main: { weight: 50 }
-redirects: [{ from: '', to: '2023/ 301!' }]
+redirects: [{ from: '', to: '2024/ 301!' }]
 outputs: [HTML, RSS]
 ---

--- a/content/en/blog/_index.md
+++ b/content/en/blog/_index.md
@@ -2,6 +2,6 @@
 title: Blog
 menu:
   main: { weight: 50 }
-redirects: [{ from: '', to: '2024/ 301!' }]
+# redirects: [{ from: '', to: '2024/ 301!' }]
 outputs: [HTML, RSS]
 ---

--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html itemscope itemtype="http://schema.org/WebPage" lang="{{ .Site.Language.Lang }}" class="no-js">
+  <head>
+    {{ partial "head.html" . }}
+  </head>
+  <body class="td-{{ .Kind }} td-blog {{- with .Page.Params.body_class }} {{ . }}{{ end }}">
+    <header>
+      {{ partial "navbar.html" . }}
+    </header>
+    <div class="container-fluid td-outer">
+      <div class="td-main">
+        <div class="row flex-xl-nowrap">
+          <aside class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
+            {{ partial "sidebar.html" . }}
+          </aside>
+          <aside class="d-none d-xl-block col-xl-2 td-sidebar-toc d-print-none">
+            {{ partial "page-meta-links.html" . }}
+            {{ partial "toc.html" . }}
+            {{ partial "taxonomy_terms_clouds.html" . }}
+          </aside>
+          <main class="col-12 col-md-9 col-xl-8 ps-md-5 pe-md-4" role="main">
+            {{ with .CurrentSection.OutputFormats.Get "rss" -}}
+            <a class="td-rss-button" title="RSS" href="{{ .RelPermalink | safeURL }}" target="_blank" rel="noopener">
+              <i class="fa-solid fa-rss" aria-hidden="true"></i>
+            </a>
+            {{ end -}}
+            {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
+            {{ block "main" . }}{{ end }}
+          </main>
+        </div>
+      </div>
+      {{ partial "footer.html" . }}
+    </div>
+    {{ partial "scripts.html" . }}
+  </body>
+</html>

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,0 +1,51 @@
+{{/* Docsy file override */}}
+
+{{ define "main" -}}
+{{ if (and .Parent .Parent.IsHome) -}}
+  {{ $.Scratch.Set "blog-pages" (where .Site.RegularPages "Section" .Section) -}}
+{{ else -}}
+  {{$.Scratch.Set "blog-pages" .Pages -}}
+{{ end -}}
+
+<div class="td-content">
+{{ $content := .Content -}}
+{{ if $content -}}
+<h1>{{ .Title }}</h1>
+{{ $content }}
+{{ end -}}
+
+{{ if .Pages -}}
+<div class="td-blog-posts">
+    {{ $pag := .Paginate (( $.Scratch.Get "blog-pages").GroupByDate "2006" ) -}}
+    {{ $numPageGroups := len $pag.PageGroups -}}
+    {{ range $pag.PageGroups -}}
+    {{ if or (not $content) (gt $numPageGroups 1)}}
+    <div class="h2">{{ T "post_posts_in" }} {{ .Key }}</div>
+    {{ end -}}
+    <ul class="td-blog-posts-list">
+      {{ range .Pages -}}
+      <li class="td-blog-posts-list__item">
+        <div class="td-blog-posts-list__body">
+          <h5 class="mt-0 mb-1"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h5>
+          <p class="mb-2 mb-md-3"><small class="text-muted">{{ .Date.Format ($.Param "time_format_blog") }} {{ T "ui_in"}} {{ .CurrentSection.LinkTitle }}</small></p>
+          <header class="article-meta">
+            {{ partial "taxonomy_terms_article_wrapper.html" . -}}
+            {{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) -}}
+              {{ partial "reading-time.html" . -}}
+            {{ end -}}
+          </header>
+          {{ partial "featured-image.html" (dict "p" . "w" 250 "h" 125 "class" "float-start me-3 pt-1 d-none d-md-block") -}}
+          <p class="pt-0 mt-0">{{ .Plain | safeHTML | truncate 250 }}</p>
+          <p class="pt-0"><a href="{{ .RelPermalink }}" aria-label="{{ T "ui_read_more"}} - {{ .LinkTitle }}">{{ T "ui_read_more"}}</a></p>
+        </div>
+      </li>
+      {{ end -}}
+    </ul>
+    {{ end -}}
+</div>
+<div class="td-blog-posts__pagination">
+  {{ template "_internal/pagination.html" . -}}
+</div>
+{{ end }}
+</div>
+{{ end -}}


### PR DESCRIPTION
- Fixes #3782
- Adds breadcrumbs to the blog section and post pages
- Adds last-modified info to the bottom of posts.

Related Docsy issues (FYI):

- https://github.com/google/docsy/issues/1789
- https://github.com/google/docsy/issues/1196
  https://github.com/google/docsy/pull/1791

---

**Preview & Redirect test**: https://deploy-preview-3784--opentelemetry.netlify.app/blog/

### Screenshots

#### 2024 - posts coming soon

> <img width="787" alt="image" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/0360f8ed-1458-4e3d-8224-b38f0356801e">

#### Illustrating breadcrumbs

> <img width="787" alt="image" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/17073518-b1a0-46c0-bdc3-e98b3922f0d0">

#### Illustrating page last-mod info

> <img width="788" alt="image" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/857cea9d-5eac-4756-8eae-3cf608b049db">
