### PR TITLE
[Blog] Keep RSS feed for root and current year only

### DIFF
--- a/content/en/blog/2019/_index.md
+++ b/content/en/blog/2019/_index.md
@@ -1,5 +1,4 @@
 ---
 title: 2019
 weight: -2019
-outputs: [HTML, RSS]
 ---

--- a/content/en/blog/2021/_index.md
+++ b/content/en/blog/2021/_index.md
@@ -1,5 +1,4 @@
 ---
 title: 2021
 weight: -2021
-outputs: [HTML, RSS]
 ---

--- a/content/en/blog/2022/_index.md
+++ b/content/en/blog/2022/_index.md
@@ -1,5 +1,4 @@
 ---
 title: 2022
 weight: -2022
-outputs: [HTML, RSS]
 ---

--- a/content/en/blog/2023/_index.md
+++ b/content/en/blog/2023/_index.md
@@ -1,5 +1,4 @@
 ---
 title: 2023
 weight: -2023
-outputs: [HTML, RSS]
 ---


### PR DESCRIPTION
I was overzealous when I reintroduced RSS feeds; this PR trims out feeds that won't ever change: we don't need RSS feeds for blog sections of previous years since there will never be any new publications in those sections.