### PR TITLE
Update Ruby metrics and logs status to "in development"

### DIFF
--- a/data/instrumentation.yaml
+++ b/data/instrumentation.yaml
@@ -49,8 +49,8 @@ ruby:
   name: Ruby
   status:
     traces: stable
-    metrics: not yet implemented
-    logs: not yet implemented
+    metrics: in development
+    logs: in development
 js:
   name: JavaScript
   status:


### PR DESCRIPTION
The [opentelemetry-ruby](https://github.com/open-telemetry/opentelemetry-ruby) repository receives active contributions implementing logs and metrics features. I think an appropriate status is "in development".