### PR TITLE
Cleaning up Python documentation typos

### DIFF
--- a/content/en/docs/languages/python/getting-started.md
+++ b/content/en/docs/languages/python/getting-started.md
@@ -21,7 +21,7 @@ Ensure that you have the following installed locally:
 ## Example Application
 
 The following example uses a basic [Flask](https://flask.palletsprojects.com/)
-application. If you are not using Flask, that's OK — you can use OpenTelemetry
+application. If you have not used Flask before or prefer a different framework, that's OK — you can use OpenTelemetry
 Python with other web frameworks as well, such as Django and FastAPI. For a
 complete list of libraries for supported frameworks, see the
 [registry](/ecosystem/registry/?component=instrumentation&language=python).
@@ -118,7 +118,7 @@ opentelemetry-instrument \
 ```
 
 Open <http://localhost:8080/rolldice> in your web browser and reload the page a
-few times. After a while you should see the spans printed in the console, such
+few times. After a while you should see the [spans](/docs/concepts/signals/traces/#spans) printed in the console, such
 as the following:
 
 <details>
@@ -436,7 +436,7 @@ import logging
 
 # Acquire a tracer
 tracer = trace.get_tracer("diceroller.tracer")
-# Acquire a meter.
+# Acquire a meter
 meter = metrics.get_meter("diceroller.meter")
 
 # Now create a counter instrument to make measurements with
@@ -640,14 +640,11 @@ emitted to the console, with separate counts for each roll value:
 
 ## Send telemetry to an OpenTelemetry Collector
 
-The [OpenTelemetry Collector](/docs/collector/getting-started/) is a critical
-component of most production deployments. Some examples of when it's beneficial
-to use a collector:
+The [OpenTelemetry Collector](/docs/collector/getting-started/) is a critical component of most production deployments. Some examples of when it's beneficial to use a collector include:
 
-- A single telemetry sink shared by multiple services, to reduce overhead of
-  switching exporters
+- Creating a single telemetry sink shared by multiple services, to reduce overhead of switching exporters
 - Aggregating traces across multiple services, running on multiple hosts
-- A central place to process traces prior to exporting them to a backend
+- Creating a central place to process traces prior to exporting them to a backend
 
 Unless you have just a single service or are experimenting, you'll want to use a
 collector in production deployments.

--- a/content/en/docs/languages/python/getting-started.md
+++ b/content/en/docs/languages/python/getting-started.md
@@ -21,7 +21,8 @@ Ensure that you have the following installed locally:
 ## Example Application
 
 The following example uses a basic [Flask](https://flask.palletsprojects.com/)
-application. If you have not used Flask before or prefer a different framework, that's OK — you can use OpenTelemetry
+application. If you have not used Flask before or prefer a different framework,
+you can use OpenTelemetry
 Python with other web frameworks as well, such as Django and FastAPI. For a
 complete list of libraries for supported frameworks, see the
 [registry](/ecosystem/registry/?component=instrumentation&language=python).

--- a/content/en/docs/languages/python/instrumentation.md
+++ b/content/en/docs/languages/python/instrumentation.md
@@ -139,7 +139,7 @@ current_span.set_attribute("operation.other-stuff", [1, 2, 3])
 ### Add semantic attributes
 
 [Semantic Attributes](/docs/specs/semconv/general/trace/) are pre-defined
-[Attributes](/docs/concepts/signals/traces/#attributes) that are well-known
+[attributes](/docs/concepts/signals/traces/#attributes) that use well-known
 naming conventions for common kinds of data. Using Semantic Attributes lets you
 normalize this kind of information across your systems.
 
@@ -344,9 +344,9 @@ below increments the count by one, using the work item's type as an attribute.
 
 ```python
 def do_work(work_item):
-    # count the work being doing
+    # Count the work being done
     work_counter.add(1, {"work.type": work_item.work_type})
-    print("doing some work...")
+    print("Doing some work...")
 ```
 
 ### Creating and using asynchronous instruments

--- a/layouts/shortcodes/docs/languages/span-status-preamble.md
+++ b/layouts/shortcodes/docs/languages/span-status-preamble.md
@@ -1,6 +1,6 @@
-A [Status](/docs/concepts/signals/traces/#span-status) can be set on a
-[Span](/docs/concepts/signals/traces/#spans), typically used to specify that a
-Span has not completed successfully - `Error`. By default, all spans are
+A [status](/docs/concepts/signals/traces/#span-status) can be set on a
+[span](/docs/concepts/signals/traces/#spans), typically used to specify that a
+span has not completed successfully - `Error`. By default, all spans are
 `Unset`, which means a span completed without error. The `Ok` status is reserved
 for when you need to explicitly mark a span as successful rather than stick with
 the default of `Unset` (i.e., "without error").


### PR DESCRIPTION
Updated Python getting-started.md and instrumentation.md pages to fix a mix of typos, grammatical errors. Also re-wrote a couple sentences for clarity.