### PR TITLE
[demo] Add and recover aliases for service-table + copyedit

### DIFF
--- a/content/en/docs/demo/services/_index.md
+++ b/content/en/docs/demo/services/_index.md
@@ -1,9 +1,10 @@
 ---
 title: Services
+aliases: [service_table, service-table]
 cSpell:ignore: loadgenerator
 ---
 
-View [Service Graph](../architecture/) to visualize request flows.
+To visualize request flows, see the [Service Diagram](../architecture/).
 
 | Service                                   | Language      | Description                                                                                                                                  |
 | ----------------------------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
- Fixes #3874
- Minor copy edit to Services page
- Recovers `service_table` alias
- Adds `service-table` alias since the page was dropped/merged via #3833

**Preview & redirect tests**:

- https://deploy-preview-3875--opentelemetry.netlify.app/docs/demo/services/
- https://deploy-preview-3875--opentelemetry.netlify.app/docs/demo/service_table/ --> `services/`
- https://deploy-preview-3875--opentelemetry.netlify.app/docs/demo/service-table/ --> `services/`