### PR TITLE
[CI/textlint] Enforce "backend" as one word

### DIFF
--- a/.textlintrc.yml
+++ b/.textlintrc.yml
@@ -113,6 +113,7 @@ rules:
       # https://github.com/sapegin/textlint-rule-terminology/blob/ca36a645c56d21f27cb9d902b5fb9584030c59e3/index.js#L137-L142.
       #
       - ['3rd[- ]party', third-party]
+      - ['back end(s)?', 'backend$1']
       - [cpp, C++]
       - # dotnet|.net -> .NET, but NOT for strings like:
         # - File extension: file.net

--- a/content/en/docs/concepts/signals/metrics.md
+++ b/content/en/docs/concepts/signals/metrics.md
@@ -37,7 +37,7 @@ Providers.
 
 Metric Exporters send metric data to a consumer. This consumer can be standard
 output for debugging during development, the OpenTelemetry Collector, or any
-open source or vendor back end of your choice.
+open source or vendor backend of your choice.
 
 ## Metric Instruments
 


### PR DESCRIPTION
- Fixes #3882