### PR TITLE
Drop unnecessary `api/propagation` aliases and local dictionary

### DIFF
--- a/content/en/docs/languages/js/propagation.md
+++ b/content/en/docs/languages/js/propagation.md
@@ -1,9 +1,7 @@
 ---
 title: Propagation
 description: Context propagation for the JS SDK
-aliases: [api/propagation]
 weight: 65
-cSpell:ignore: tracestate
 ---
 
 Propagation is the mechanism that moves data between services and processes.

--- a/content/en/docs/languages/python/propagation.md
+++ b/content/en/docs/languages/python/propagation.md
@@ -1,9 +1,7 @@
 ---
 title: Propagation
 description: Context propagation for the Python SDK
-aliases: [api/propagation]
 weight: 65
-cSpell:ignore: tracestate
 ---
 
 Propagation is the mechanism that moves data between services and processes.


### PR DESCRIPTION
- Followup to:
  - #3716
  - #1951
- In each of the PRs listed above, a new `propagation.md` page is introduced. Generally for new pages we don't need an alias. This PR removes the superfluous aliases, and cleans up the page-local dictionary while we're there.

/cc @cartermp 