### PR TITLE
[IA] Move detailed SDK config out of Concepts

### DIFF
--- a/content/en/blog/2023/end-user-q-and-a-02.md
+++ b/content/en/blog/2023/end-user-q-and-a-02.md
@@ -85,7 +85,7 @@ started by getting developers to add
 [OpenTelemetry (structured) logs](/docs/specs/otel/logs/) to all of the services
 across their various platforms. In order to leverage OTel logs, developers had
 to add the
-[OpenTelemetry language-specific SDKs](/docs/concepts/sdk-configuration/) into
+[OpenTelemetry language-specific SDKs](/docs/languages/sdk-configuration/) into
 their code. Once they got past that initial hump and got the SDKs into their
 code, it then became easier for developers to add
 [other signals](/docs/concepts/signals/) (such as

--- a/content/en/docs/languages/js/automatic/module-config.md
+++ b/content/en/docs/languages/js/automatic/module-config.md
@@ -14,7 +14,7 @@ and more.
 ## SDK and exporter configuration
 
 SDK and exporter configuration can be set using environment variables. More
-information can be found [here](/docs/concepts/sdk-configuration/).
+information can be found [here](/docs/languages/sdk-configuration/).
 
 ## SDK resource detector configuration
 

--- a/content/en/docs/languages/php/sdk.md
+++ b/content/en/docs/languages/php/sdk.md
@@ -76,7 +76,7 @@ If all configuration comes from environment variables (or `php.ini`), you can
 use SDK autoloading to automatically configure and globally register an SDK. The
 only requirement for this is that you set `OTEL_PHP_AUTOLOAD_ENABLED=true`, and
 provide any required/non-standard configuration as set out in
-[sdk-configuration](/docs/concepts/sdk-configuration/).
+[SDK configuration](/docs/languages/sdk-configuration/).
 
 For example:
 
@@ -99,10 +99,10 @@ SDK autoloading happens as part of the composer autoloader.
 
 ## Configuration
 
-The PHP SDK supports most of the
-[available configurations](/docs/concepts/sdk-configuration/). Our conformance
-to the specification is listed in the
-[spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md).
+The PHP SDK supports most of the available
+[configuration options](/docs/languages/sdk-configuration/). For conformance
+details, see the
+[compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md).
 
 There are also a number of PHP-specific configurations:
 

--- a/content/en/docs/languages/python/automatic/agent-config.md
+++ b/content/en/docs/languages/python/automatic/agent-config.md
@@ -44,13 +44,13 @@ Here's an explanation of what each configuration does:
   omitted, the default [Collector](/docs/collector/) endpoint will be used,
   which is `0.0.0.0:4317` for gRPC and `0.0.0.0:4318` for HTTP.
 - `exporter_otlp_headers` is required depending on your chosen Observability
-  backend. More info exporter OTLP headers be found
-  [here](/docs/concepts/sdk-configuration/otlp-exporter-configuration/#otel_exporter_otlp_headers).
+  backend. For more information on OTLP exporter headers, see
+  [OTEL_EXPORTER_OTLP_HEADERS](/docs/languages/sdk-configuration/otlp-exporter/#otel_exporter_otlp_headers).
 
 ## Environment Variables
 
 In some cases, configuring via
-[environment variables](/docs/concepts/sdk-configuration/) is more preferred.
+[environment variables](/docs/languages/sdk-configuration/) is more preferred.
 Any setting configurable with a command-line argument can also be configured
 with an Environment Variable.
 

--- a/content/en/docs/languages/sdk-configuration/_index.md
+++ b/content/en/docs/languages/sdk-configuration/_index.md
@@ -1,9 +1,12 @@
 ---
 title: SDK Configuration
-weight: 101
+linkTitle: SDK Config
+aliases: [/docs/concepts/sdk-configuration]
+redirects: [{ from: /docs/concepts/sdk-configuration/*, to: ':splat' }]
+weight: 1
 ---
 
 OpenTelemetry SDKs support configuration in each language and with environment
 variables. The following pages describe the environment variables you can use to
 configure your SDK. Values set with environment variables override equivalent
-configuration done in code using SDK APIs.
+configuration in code using SDK APIs.

--- a/content/en/docs/languages/sdk-configuration/general.md
+++ b/content/en/docs/languages/sdk-configuration/general.md
@@ -1,8 +1,7 @@
 ---
 title: General SDK Configuration
-description: >-
-  General-purpose environment variables for configuring an OpenTelemetry SDK.
-weight: 1
+linkTitle: General
+aliases: [general-sdk-configuration]
 cSpell:ignore: ottrace
 ---
 

--- a/content/en/docs/languages/sdk-configuration/otlp-exporter.md
+++ b/content/en/docs/languages/sdk-configuration/otlp-exporter.md
@@ -1,7 +1,7 @@
 ---
 title: OTLP Exporter Configuration
-description: Environment variables for configuring your OTLP Exporter.
-weight: 2
+linkTitle: OTLP Exporter
+aliases: [otlp-exporter-configuration]
 ---
 
 ## Endpoint Configuration


### PR DESCRIPTION
- It doesn't make sense IMHO for detailed SDK config pages to be under **Concepts**. This PR proposes a move of those detailed SDK config pages into the "Language APIs & SDKs" section, which feels like a better home.
  Comments on this IA reorg are most welcome.
- ~The PR link checking will fail: I'll fix that if/once there is buy-in regarding the reorg.~

**Preview**: https://deploy-preview-3888--opentelemetry.netlify.app/docs/languages/sdk-configuration/

**Redirect tests**:

- https://deploy-preview-3888--opentelemetry.netlify.app/docs/concepts/sdk-configuration/
- https://deploy-preview-3888--opentelemetry.netlify.app/docs/concepts/sdk-configuration/general-sdk-configuration
- https://deploy-preview-3888--opentelemetry.netlify.app/docs/concepts/sdk-configuration/otlp-exporter-configuration

### Screenshot

> <img width="242" alt="image" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/d5ef9e0b-405a-41a6-b4b9-d4f6dd556878">

