### PR TITLE
Refcache entries refreshed up to 2024-01-01 & normalize-cspell-front-matter.pl: ensure words are unique

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -59,3 +59,11 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - ^https://oncallmemaybe.com
   # TODO drop after https://github.com/open-telemetry/opentelemetry-specification/pull/3834 is merged
   - ^https://wikipedia\.org/wiki/Monotonic_function
+  # TODO drop after https://github.com/open-telemetry/opamp-spec/pull/179 is merged into this repo
+  - ^http://www.watersprings.org/
+  # TODO move into content/en/blog/2023/humans-of-otel.md once https://github.com/open-telemetry/opentelemetry.io/issues/3889 is implemented
+  - ^https://shorturl.at/osHRX$
+  # TODO drop after https://github.com/open-telemetry/semantic-conventions/pull/678 is merged:
+  - ^https://wikipedia.org/wiki/(S.M.A.R.T|Hop_)
+  # TODO move into content/en/blog/2023/contributing-to-otel/index.md once https://github.com/open-telemetry/opentelemetry.io/issues/3889 is implemented
+  - ^https://shorturl.at/vLYZ0$

--- a/content/en/blog/2022/otel-demo-app-nomad/index.md
+++ b/content/en/blog/2022/otel-demo-app-nomad/index.md
@@ -350,11 +350,8 @@ Before I wrap this up, I do want to give a HUGE shoutout to
 [Luiz Aoqui](https://www.linkedin.com/in/luizaoqui/) of HashiCorp, who helped me
 tweak my Nomad jobspecs, and to
 [Riaan Nolan](https://www.linkedin.com/in/riaannolan/), for his continued work
-on HashiQube. (Aside, both
-[Luiz](https://oncallmemaybe.com/episodes/opentelemetry-nomad-with-luiz-aoqui-of-hashicorp)
-and
-[Riaan](https://oncallmemaybe.com/episodes/adventures-in-open-source-software-with-riaan-nolan-of-servian)
-were my guests on the [On-Call Me Maybe Podcast](https://oncallmemaybe.com)!)
+on HashiQube. (Aside, both [Luiz] and [Riaan] were my guests on the [On-Call Me
+Maybe Podcast]!)
 
 I will now leave you with a picture of Phoebe the rat, peering out of a pink
 basket. Doesn’t she look cute? 🥰
@@ -372,8 +369,12 @@ Have questions about the OTel Demo App on Nomad? Feel free to connect through
 ---
 
 The OpenTelemetry community is always looking for contributions!
-[Join us](https://github.com/open-telemetry/community)! If you're on Mastodon,
-be sure to follow
-[OpenTelemetry on Mastodon](https://fosstodon.org/@opentelemetry)
+[Join us](/community/#special-interest-groups)! If you're on Mastodon, be sure
+to follow [OpenTelemetry on Mastodon](https://fosstodon.org/@opentelemetry)
 
+[Luiz]:
+  https://open.spotify.com/episode/7ww8y3fy49MgEbcyFGvsNV?si=BMvp8u-dRgyPEkTkYxfDAA
 [nomad]: https://www.nomadproject.io
+[On-Call Me Maybe Podcast]: https://open.spotify.com/show/4ZI6pQwChwm4sVULdtHFMe
+[Riaan]:
+  https://open.spotify.com/episode/5YrBEsXoJV3UjrHRrLRqBP?si=BpWISRD0SLytJF-vJ02sSA

--- a/content/en/blog/2023/contributing-to-otel/index.md
+++ b/content/en/blog/2023/contributing-to-otel/index.md
@@ -2,9 +2,7 @@
 title: Thinking about contributing to OpenTelemetry? Here's how I did it.
 linkTitle: Contributing to OTel
 date: 2023-09-18
-author:
-  >- # If you have only one author, then add the single name on this line in quotes.
-  [Adriana Villela](https://github.com/avillela) (Lightstep),
+author: '[Adriana Villela](https://github.com/avillela) (Lightstep)'
 canonical_url: https://medium.com/cloud-native-daily/how-to-contribute-to-opentelemetry-5962e8b2447e
 cSpell:ignore: EUWG sayin
 ---
@@ -27,10 +25,9 @@ projects? I don't know about you, but for me, up until last year, the prospect
 of contributing to open source was just plain _scary_!! I mean, when you open up
 a
 [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)
-(PR),
-_[you are putting yourself out there](https://oncallmemaybe.com/episodes/adventures-in-open-source-software-with-riaan-nolan-of-servian)_,
-to be judged by those little GitHub avatars that make up the approvers list for
-the repository you're contributing to. YIKES!
+(PR), _[you are putting yourself out there]_, to be judged by those little
+GitHub avatars that make up the approvers list for the repository you're
+contributing to. YIKES!
 
 But as scary as the thought of opening a PR might be, it's also SO VERY
 SATISFYING to see your contributions merged into a codebase. And most
@@ -194,3 +191,6 @@ findings and discoveries. Obviously, I do that too. But please also share these
 findings by contributing directly to the OTel docs and blog, to ensure that we
 have a single source of truth, and so that everyone, whether they're new to OTel
 or advanced practitioners, can benefit.
+
+[you are putting yourself out there]:
+  https://open.spotify.com/episode/5YrBEsXoJV3UjrHRrLRqBP?si=BpWISRD0SLytJF-vJ02sSA

--- a/content/en/blog/2023/humans-of-otel.md
+++ b/content/en/blog/2023/humans-of-otel.md
@@ -2,10 +2,9 @@
 title: The Humans of OpenTelemetry
 linkTitle: Humans of OTel
 date: 2023-12-22
-author: >-
-  [Adriana Villela](https://github.com/avillela) (Lightstep),
+author: '[Adriana Villela](https://github.com/avillela) (Lightstep)'
 # prettier-ignore
-cSpell:ignore: ADIANA ALEX Alex ARONOFF Aronoff BOGDAN Bogdan BOTEN Boten CARAMANOLIS Caramanolis CONSTANCE Constance Dapr DRUTU Drutu JACOB Jacob JURACI KANAL Kanal KRÖHLING PAIXĀO Paixāo PURVI Purvi TYLER Tyler utopic VILLELA YAHN Yahn youtube
+cSpell:ignore: adiana alex aronoff bogdan bogdan boten boten caramanolis caramanolis constance constance dapr drutu drutu jacob jacob juraci kanal kanal kröhling paixāo paixāo purvi purvi tyler tyler utopic villela yahn yahn youtube
 ---
 
 What a year it has been for OpenTelemetry!

--- a/content/en/blog/2023/humans-of-otel.md
+++ b/content/en/blog/2023/humans-of-otel.md
@@ -4,7 +4,7 @@ linkTitle: Humans of OTel
 date: 2023-12-22
 author: '[Adriana Villela](https://github.com/avillela) (Lightstep)'
 # prettier-ignore
-cSpell:ignore: adiana alex aronoff bogdan bogdan boten boten caramanolis caramanolis constance constance dapr drutu drutu jacob jacob juraci kanal kanal kröhling paixāo paixāo purvi purvi tyler tyler utopic villela yahn yahn youtube
+cSpell:ignore: adiana alex aronoff bogdan boten caramanolis constance dapr drutu jacob juraci kanal kröhling paixāo purvi tyler utopic villela yahn youtube
 ---
 
 What a year it has been for OpenTelemetry!

--- a/content/en/docs/collector/building/connector.md
+++ b/content/en/docs/collector/building/connector.md
@@ -3,7 +3,7 @@ title: Building a Connector
 aliases: [/docs/collector/build-connector/]
 weight: 30
 # prettier-ignore
-cSpell:ignore: batchprocessor debugexporter Errorf exampleconnector gomod gord Jaglowski loggingexporter mapstructure mapstructure otlpreceiver pdata pmetric ptrace servicegraph spanmetrics struct uber
+cSpell:ignore: batchprocessor debugexporter Errorf exampleconnector gomod gord Jaglowski loggingexporter mapstructure otlpreceiver pdata pmetric ptrace servicegraph spanmetrics struct uber
 ---
 
 ## Connectors in OpenTelemetry

--- a/content/en/docs/kubernetes/helm/collector.md
+++ b/content/en/docs/kubernetes/helm/collector.md
@@ -2,7 +2,7 @@
 title: OpenTelemetry Collector Chart
 linkTitle: Collector Chart
 # prettier-ignore
-cSpell:ignore: debugexporter filelog filelogreceiver filelogreceiver hostmetricsreceiver kubelet kubeletstats kubeletstatsreceiver otlphttp sattributesprocessor sclusterreceiver sobjectsreceiver statefulset
+cSpell:ignore: debugexporter filelog filelogreceiver hostmetricsreceiver kubelet kubeletstats kubeletstatsreceiver otlphttp sattributesprocessor sclusterreceiver sobjectsreceiver statefulset
 ---
 
 ## Introduction

--- a/data/ecosystem/integrations.yaml
+++ b/data/ecosystem/integrations.yaml
@@ -40,7 +40,7 @@
   components: [Go, PHP]
   oss: true
 - name: Kong API Gateway
-  url: http://www.konghq.com/
+  url: https://www.konghq.com/
   docsUrl: https://docs.konghq.com/hub/kong-inc/opentelemetry/
   components: []
   oss: false

--- a/scripts/normalize-cspell-front-matter.pl
+++ b/scripts/normalize-cspell-front-matter.pl
@@ -20,6 +20,9 @@ while (<>) {
 
   if (@words && ($ARGV ne $last_file || eof)) {
     @words = grep { !/^\s*(cSpell:ignore|spelling):?\s*$/ && !$dictionary{$_} } @words;
+    # Ensure all words are unique.
+    my %duplicates;
+    @words = grep { !$duplicates{$_}++ } @words;
     if (@words) {
       my $words = join(' ', sort {lc($a) cmp lc($b)} @words);
       my $line = "cSpell:ignore: $words\n";

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -31,17 +31,9 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:06:57.663411-05:00"
   },
-  "http://www.konghq.com/": {
-    "StatusCode": 206,
-    "LastSeen": "2023-09-15T16:58:35.304923+02:00"
-  },
-  "http://www.watersprings.org/pub/id/draft-moriarty-acme-client-01.html": {
-    "StatusCode": 206,
-    "LastSeen": "2024-01-18T08:07:41.019978-05:00"
-  },
   "http://www.zstd.net/": {
     "StatusCode": 206,
-    "LastSeen": "2023-11-14T11:45:04.323681+01:00"
+    "LastSeen": "2024-01-30T16:15:09.743434-05:00"
   },
   "https://access.redhat.com/products/ansible-tower-red-hat": {
     "StatusCode": 200,
@@ -69,7 +61,7 @@
   },
   "https://app.netlify.com/sites/opentelemetry/overview": {
     "StatusCode": 206,
-    "LastSeen": "2023-12-13T15:27:13.292839+01:00"
+    "LastSeen": "2024-01-30T16:15:41.7727-05:00"
   },
   "https://app.telemetryhub.com/docs": {
     "StatusCode": 200,
@@ -85,11 +77,11 @@
   },
   "https://arrow.apache.org/blog/2023/04/11/our-journey-at-f5-with-apache-arrow-part-1/": {
     "StatusCode": 206,
-    "LastSeen": "2023-11-14T11:45:10.344644+01:00"
+    "LastSeen": "2024-01-30T16:15:48.26506-05:00"
   },
   "https://arrow.apache.org/blog/2023/06/26/our-journey-at-f5-with-apache-arrow-part-2/": {
     "StatusCode": 206,
-    "LastSeen": "2023-11-14T11:45:10.48389+01:00"
+    "LastSeen": "2024-01-30T16:15:53.713332-05:00"
   },
   "https://avajs.dev": {
     "StatusCode": 200,
@@ -149,7 +141,7 @@
   },
   "https://azure.github.io/azure-sdk/releases/latest/index.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-09-06T15:04:23.411053+02:00"
+    "LastSeen": "2024-01-30T15:24:54.938182-05:00"
   },
   "https://azure.microsoft.com/": {
     "StatusCode": 200,
@@ -161,7 +153,7 @@
   },
   "https://azure.microsoft.com/global-infrastructure/geographies/": {
     "StatusCode": 206,
-    "LastSeen": "2023-11-08T07:23:05.338824-05:00"
+    "LastSeen": "2024-01-30T16:14:48.685761-05:00"
   },
   "https://azure.microsoft.com/products/cosmos-db/": {
     "StatusCode": 200,
@@ -173,7 +165,7 @@
   },
   "https://betterstack.com/docs/logs/open-telemetry/#2-setup": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-30T09:17:13.941735+01:00"
+    "LastSeen": "2024-01-30T16:14:47.668996-05:00"
   },
   "https://blog.logrocket.com/understanding-schema-stitching-graphql/": {
     "StatusCode": 200,
@@ -181,11 +173,11 @@
   },
   "https://blog.remirepo.net/pages/PECL-extensions-RPM-status": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-27T06:45:35.961013628Z"
+    "LastSeen": "2024-01-30T15:25:00.717767-05:00"
   },
   "https://brew.sh/": {
     "StatusCode": 206,
-    "LastSeen": "2023-09-06T18:09:47.863432+02:00"
+    "LastSeen": "2024-01-30T15:25:24.128818-05:00"
   },
   "https://bundler.io/": {
     "StatusCode": 206,
@@ -207,13 +199,9 @@
     "StatusCode": 206,
     "LastSeen": "2024-01-08T12:17:27.412252+01:00"
   },
-  "https://cdnjs.cloudflare.com/ajax/libs/fuse.js/6.6.2/fuse.min.js": {
-    "StatusCode": 200,
-    "LastSeen": "2023-12-23T20:37:24.220193+01:00"
-  },
   "https://cerbos.dev/": {
     "StatusCode": 206,
-    "LastSeen": "2023-09-15T16:58:31.234644+02:00"
+    "LastSeen": "2024-01-30T15:24:42.717338-05:00"
   },
   "https://cert-manager.io/": {
     "StatusCode": 206,
@@ -237,7 +225,7 @@
   },
   "https://cloud-native.slack.com/archives/C014L2KCTE3": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-08T11:19:16.128163+01:00"
+    "LastSeen": "2024-01-30T16:15:05.306086-05:00"
   },
   "https://cloud-native.slack.com/archives/C01N5UCHTEH": {
     "StatusCode": 200,
@@ -405,7 +393,7 @@
   },
   "https://cloud.google.com/pubsub": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-16T15:01:22.242699861Z"
+    "LastSeen": "2024-01-30T16:14:31.021318-05:00"
   },
   "https://cloud.google.com/run/docs/container-contract#jobs-env-vars": {
     "StatusCode": 200,
@@ -441,7 +429,7 @@
   },
   "https://code.visualstudio.com/": {
     "StatusCode": 206,
-    "LastSeen": "2023-12-15T20:50:17.619291+08:00"
+    "LastSeen": "2024-01-30T16:14:52.723964-05:00"
   },
   "https://collectd.org/wiki/index.php/Binary_protocol": {
     "StatusCode": 206,
@@ -449,11 +437,11 @@
   },
   "https://colocatedeventsna2023.sched.com/overview/type/Observability+Day": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-01T12:48:08.791661-04:00"
+    "LastSeen": "2024-01-30T16:04:58.233769-05:00"
   },
   "https://commonmark.org/": {
     "StatusCode": 206,
-    "LastSeen": "2023-12-13T14:56:57.912039+01:00"
+    "LastSeen": "2024-01-30T16:15:04.197679-05:00"
   },
   "https://community.cncf.io/end-user-community/": {
     "StatusCode": 200,
@@ -461,7 +449,7 @@
   },
   "https://community.tyk.io/": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-26T12:18:59.472082+02:00"
+    "LastSeen": "2024-01-30T16:05:21.372209-05:00"
   },
   "https://communityinviter.com/apps/cloud-native/cncf": {
     "StatusCode": 200,
@@ -469,7 +457,7 @@
   },
   "https://conan.io/center/recipes/opentelemetry-cpp": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-19T17:13:13.020744+02:00"
+    "LastSeen": "2024-01-30T15:25:27.607441-05:00"
   },
   "https://connect.build/docs/protocol/#error-codes": {
     "StatusCode": 206,
@@ -493,11 +481,11 @@
   },
   "https://cortexmetrics.io/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-16T20:09:46.197579+02:00"
+    "LastSeen": "2024-01-30T16:04:10.74433-05:00"
   },
   "https://cortexmetrics.io/docs/guides/tracing/#opentelemetry": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-16T20:09:46.38714+02:00"
+    "LastSeen": "2024-01-30T16:04:53.700061-05:00"
   },
   "https://couchdb.apache.org/": {
     "StatusCode": 206,
@@ -521,15 +509,19 @@
   },
   "https://dapr.io/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-16T20:09:47.43077+02:00"
+    "LastSeen": "2024-01-30T16:05:00.554354-05:00"
   },
   "https://dart.dev": {
     "StatusCode": 206,
     "LastSeen": "2024-01-18T19:02:14.984552-05:00"
   },
+  "https://datatracker.ietf.org/doc/draft-moriarty-acme-client/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-01-30T15:58:56.463638-05:00"
+  },
   "https://datatracker.ietf.org/doc/html/rfc3986#section-3": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-16T15:16:56.545821944Z"
+    "LastSeen": "2024-01-30T16:14:34.46762-05:00"
   },
   "https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.1": {
     "StatusCode": 200,
@@ -537,11 +529,11 @@
   },
   "https://datatracker.ietf.org/doc/html/rfc5246#appendix-A.5": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-16T15:01:19.944428842Z"
+    "LastSeen": "2024-01-30T16:14:26.509887-05:00"
   },
   "https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-16T15:01:27.664727091Z"
+    "LastSeen": "2024-01-30T16:14:42.820746-05:00"
   },
   "https://datatracker.ietf.org/doc/html/rfc6455": {
     "StatusCode": 200,
@@ -593,7 +585,7 @@
   },
   "https://dev.mysql.com/doc/refman/8.1/en/telemetry-trace.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-16T20:10:00.385651+02:00"
+    "LastSeen": "2024-01-30T16:07:28.613756-05:00"
   },
   "https://devcenter.heroku.com/articles/dyno-metadata": {
     "StatusCode": 206,
@@ -601,11 +593,11 @@
   },
   "https://developer.android.com/guide/components/activities/activity-lifecycle#lc": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-08T07:23:26.997244-05:00"
+    "LastSeen": "2024-01-30T16:14:48.113033-05:00"
   },
   "https://developer.android.com/guide/topics/manifest/uses-sdk-element#ApiLevels": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-16T14:13:38.873062-04:00"
+    "LastSeen": "2024-01-30T16:04:54.2591-05:00"
   },
   "https://developer.android.com/reference/android/os/Build#MANUFACTURER": {
     "StatusCode": 200,
@@ -617,7 +609,7 @@
   },
   "https://developer.apple.com/documentation/uikit/uiapplicationdelegate#1656902": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-08T07:23:21.699535-05:00"
+    "LastSeen": "2024-01-30T16:14:30.548265-05:00"
   },
   "https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor": {
     "StatusCode": 200,
@@ -625,7 +617,7 @@
   },
   "https://developer.cisco.com/docs/nso/#!observability-exporter/": {
     "StatusCode": 206,
-    "LastSeen": "2023-09-15T16:58:33.549843+02:00"
+    "LastSeen": "2024-01-30T15:25:38.765451-05:00"
   },
   "https://developer.confluent.io/learn-kafka/apache-kafka/topics/": {
     "StatusCode": 206,
@@ -649,27 +641,27 @@
   },
   "https://developer.mozilla.org/docs/Web/HTTP/Headers/Forwarded#for": {
     "StatusCode": 206,
-    "LastSeen": "2023-11-03T03:04:16.900109-04:00"
+    "LastSeen": "2024-01-30T16:14:59.644653-05:00"
   },
   "https://developer.mozilla.org/docs/Web/HTTP/Headers/Forwarded#host": {
     "StatusCode": 206,
-    "LastSeen": "2023-11-03T03:04:48.340922-04:00"
+    "LastSeen": "2024-01-30T16:14:59.637885-05:00"
   },
   "https://developer.mozilla.org/docs/Web/HTTP/Headers/Forwarded#proto": {
     "StatusCode": 206,
-    "LastSeen": "2023-11-03T03:04:27.385988-04:00"
+    "LastSeen": "2024-01-30T16:14:19.581377-05:00"
   },
   "https://developer.mozilla.org/docs/Web/HTTP/Headers/X-Forwarded-For": {
     "StatusCode": 206,
-    "LastSeen": "2023-11-03T03:04:11.582225-04:00"
+    "LastSeen": "2024-01-30T16:14:53.767172-05:00"
   },
   "https://developer.mozilla.org/docs/Web/HTTP/Headers/X-Forwarded-Host": {
     "StatusCode": 206,
-    "LastSeen": "2023-11-03T03:04:43.193675-04:00"
+    "LastSeen": "2024-01-30T16:15:05.615061-05:00"
   },
   "https://developer.mozilla.org/docs/Web/HTTP/Headers/X-Forwarded-Proto": {
     "StatusCode": 206,
-    "LastSeen": "2023-11-03T03:04:22.148405-04:00"
+    "LastSeen": "2024-01-30T16:14:36.650417-05:00"
   },
   "https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS": {
     "StatusCode": 206,
@@ -705,7 +697,7 @@
   },
   "https://developers.google.com/style": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-12T09:04:54.694842+01:00"
+    "LastSeen": "2024-01-30T16:14:37.419722-05:00"
   },
   "https://devstats.cncf.io/": {
     "StatusCode": 206,
@@ -713,7 +705,7 @@
   },
   "https://doc.rust-lang.org/cargo/": {
     "StatusCode": 206,
-    "LastSeen": "2023-08-03T17:44:09.893503+02:00"
+    "LastSeen": "2024-01-30T15:25:16.911518-05:00"
   },
   "https://doc.rust-lang.org/std/io/trait.Write.html": {
     "StatusCode": 206,
@@ -721,7 +713,7 @@
   },
   "https://doc.traefik.io/traefik-hub/operations/telemetry/overview/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-25T11:13:58.633523+02:00"
+    "LastSeen": "2024-01-30T16:07:39.690877-05:00"
   },
   "https://docs.appdynamics.com/latest/en/application-monitoring/appdynamics-for-opentelemetry": {
     "StatusCode": 200,
@@ -746,6 +738,10 @@
   "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/clusters.html": {
     "StatusCode": 206,
     "LastSeen": "2024-01-18T19:01:53.905326-05:00"
+  },
+  "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html#ecs-resource-ids": {
+    "StatusCode": 206,
+    "LastSeen": "2024-01-30T16:34:04.046613-05:00"
   },
   "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html": {
     "StatusCode": 206,
@@ -849,7 +845,7 @@
   },
   "https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-12-16T15:01:07.235334819Z"
+    "LastSeen": "2024-01-30T16:14:28.171642-05:00"
   },
   "https://docs.aws.amazon.com/lambda/latest/dg/welcome.html": {
     "StatusCode": 206,
@@ -867,9 +863,13 @@
     "StatusCode": 206,
     "LastSeen": "2024-01-18T08:53:34.715996-05:00"
   },
+  "https://docs.couchdb.org/en/stable/api/document/common.html#get--db-docid": {
+    "StatusCode": 200,
+    "LastSeen": "2024-01-30T16:34:02.790002-05:00"
+  },
   "https://docs.cribl.io/stream/sources-otel": {
     "StatusCode": 206,
-    "LastSeen": "2023-09-08T11:50:59.486005+02:00"
+    "LastSeen": "2024-01-30T15:25:04.933047-05:00"
   },
   "https://docs.daocloud.io/en/insight/06UserGuide/01quickstart/otel/otel/": {
     "StatusCode": 206,
@@ -877,7 +877,7 @@
   },
   "https://docs.dapr.io/operations/observability/tracing/otel-collector/open-telemetry-collector/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-16T20:09:48.385662+02:00"
+    "LastSeen": "2024-01-30T16:05:06.380053-05:00"
   },
   "https://docs.datadoghq.com/tracing/connect_logs_and_traces/java/": {
     "StatusCode": 206,
@@ -933,7 +933,7 @@
   },
   "https://docs.docker.com/engine/api/v1.43/#tag/Image/operation/ImageInspect": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-16T14:13:22.14114-04:00"
+    "LastSeen": "2024-01-30T16:03:49.19576-05:00"
   },
   "https://docs.docker.com/engine/reference/run/#container-identification": {
     "StatusCode": 206,
@@ -941,7 +941,7 @@
   },
   "https://docs.docker.com/registry/spec/manifest-v2-2/#example-image-manifest": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-16T14:13:33.061931-04:00"
+    "LastSeen": "2024-01-30T16:04:54.134692-05:00"
   },
   "https://docs.fluentbit.io/manual/pipeline/inputs/opentelemetry/": {
     "StatusCode": 206,
@@ -949,7 +949,7 @@
   },
   "https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests": {
     "StatusCode": 206,
-    "LastSeen": "2023-09-08T10:57:00.851277-04:00"
+    "LastSeen": "2024-01-30T15:25:17.633498-05:00"
   },
   "https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request": {
     "StatusCode": 206,
@@ -957,7 +957,7 @@
   },
   "https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork": {
     "StatusCode": 206,
-    "LastSeen": "2023-12-13T15:27:14.272624+01:00"
+    "LastSeen": "2024-01-30T16:15:52.403553-05:00"
   },
   "https://docs.google.com/document/d/15vR7D1x2tKd7u3zaTF0yH1WaHkUr2T4hhr7OyiZgmBg/edit#heading=h.4xuru5ljcups": {
     "StatusCode": 200,
@@ -965,7 +965,7 @@
   },
   "https://docs.google.com/document/d/16Vsdh-DM72AfMg_FIt9yT9ExEWF4A_vRbQ3jRNBe09w": {
     "StatusCode": 200,
-    "LastSeen": "2023-08-04T21:04:45.864244999Z"
+    "LastSeen": "2024-01-30T15:25:00.919396-05:00"
   },
   "https://docs.google.com/document/d/187XYoQcXQ9JxS_5v2wvZ0NEysaJ02xoOYNXj08pT0zc": {
     "StatusCode": 200,
@@ -989,11 +989,11 @@
   },
   "https://docs.google.com/document/d/1M8VLNe_sv1MIfu5bUR5OV_vrMBnAI7IJN-7-IAr37JY/": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-23T22:46:49.329066+02:00"
+    "LastSeen": "2024-01-30T16:05:16.715217-05:00"
   },
   "https://docs.google.com/document/d/1Unbs2qp_j5kp8FfL_lRH-ld7i5EOQpsq0I4djkOOSL4/": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-23T22:46:50.70436+02:00"
+    "LastSeen": "2024-01-30T16:05:22.514127-05:00"
   },
   "https://docs.google.com/document/d/1WQDz1jF0yKBXe3OibXWfy3g6lor9SvjZ4xT-8uuDCiA/edit": {
     "StatusCode": 200,
@@ -1049,7 +1049,7 @@
   },
   "https://docs.greptime.com/user-guide/clients/otlp": {
     "StatusCode": 200,
-    "LastSeen": "2023-08-30T23:00:58.002196+08:00"
+    "LastSeen": "2024-01-30T15:24:43.194115-05:00"
   },
   "https://docs.honeycomb.io/getting-data-in/": {
     "StatusCode": 206,
@@ -1065,15 +1065,15 @@
   },
   "https://docs.kloudmate.com/using-opentelemetry-collector": {
     "StatusCode": 200,
-    "LastSeen": "2023-08-31T11:09:01.973245767Z"
+    "LastSeen": "2024-01-30T15:25:17.098548-05:00"
   },
   "https://docs.konghq.com/hub/kong-inc/opentelemetry/": {
     "StatusCode": 206,
-    "LastSeen": "2023-09-15T16:58:35.759747+02:00"
+    "LastSeen": "2024-01-30T15:25:59.36407-05:00"
   },
   "https://docs.linuxfoundation.org/lfx/easycla/contributors": {
     "StatusCode": 206,
-    "LastSeen": "2023-12-12T09:05:05.806034+01:00"
+    "LastSeen": "2024-01-30T16:15:11.937332-05:00"
   },
   "https://docs.locust.io/en/stable/writing-a-locustfile.html": {
     "StatusCode": 200,
@@ -1093,7 +1093,7 @@
   },
   "https://docs.microsoft.com/azure/azure-functions/manage-connections#static-clients": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-08T07:22:17.430061-05:00"
+    "LastSeen": "2024-01-30T16:14:53.676713-05:00"
   },
   "https://docs.microsoft.com/azure/azure-monitor/app/opentelemetry-overview": {
     "StatusCode": 200,
@@ -1109,19 +1109,19 @@
   },
   "https://docs.microsoft.com/dotnet/api/system.exception.tostring": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-08T07:22:23.190616-05:00"
+    "LastSeen": "2024-01-30T16:14:25.529146-05:00"
   },
   "https://docs.microsoft.com/dotnet/api/system.net.http.httpclient": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:28.468986+02:00"
+    "LastSeen": "2024-01-30T15:25:39.705809-05:00"
   },
   "https://docs.microsoft.com/dotnet/api/system.net.httpwebrequest": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:29.255967+02:00"
+    "LastSeen": "2024-01-30T15:25:40.340887-05:00"
   },
   "https://docs.microsoft.com/dotnet/api/system.servicemodel.servicesecuritycontext": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-08T07:21:40.065749-05:00"
+    "LastSeen": "2024-01-30T16:14:48.160616-05:00"
   },
   "https://docs.microsoft.com/dotnet/core/diagnostics/metrics-instrumentation": {
     "StatusCode": 200,
@@ -1129,7 +1129,7 @@
   },
   "https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/web-config#set-environment-variables": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:11.667001+02:00"
+    "LastSeen": "2024-01-30T15:25:28.633822-05:00"
   },
   "https://docs.microsoft.com/en-us/azure/application-gateway/application-gateway-websocket": {
     "StatusCode": 200,
@@ -1137,11 +1137,11 @@
   },
   "https://docs.microsoft.com/en-us/dotnet/api/System.IO.Path.GetTempPath": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:17.596711+02:00"
+    "LastSeen": "2024-01-30T15:25:39.854699-05:00"
   },
   "https://docs.microsoft.com/en-us/dotnet/api/system.appdomain.unhandledexception": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:15.999069+02:00"
+    "LastSeen": "2024-01-30T15:25:28.579678-05:00"
   },
   "https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics": {
     "StatusCode": 200,
@@ -1149,31 +1149,31 @@
   },
   "https://docs.microsoft.com/en-us/dotnet/api/system.type.assemblyqualifiedname": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:16.691705+02:00"
+    "LastSeen": "2024-01-30T15:25:34.197156-05:00"
   },
   "https://docs.microsoft.com/en-us/dotnet/core/deploying/runtime-store": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:17.048409+02:00"
+    "LastSeen": "2024-01-30T15:25:34.390389-05:00"
   },
   "https://docs.microsoft.com/en-us/iis/configuration/system.applicationhost/applicationpools/add/environmentvariables/": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:11.982841+02:00"
+    "LastSeen": "2024-01-30T15:25:34.070633-05:00"
   },
   "https://docs.microsoft.com/rest/api/resources/resources/get-by-id": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-08T07:22:12.212546-05:00"
+    "LastSeen": "2024-01-30T16:14:41.535288-05:00"
   },
   "https://docs.microsoft.com/sql/connect/jdbc/building-the-connection-url": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-08T07:21:07.811418-05:00"
+    "LastSeen": "2024-01-30T16:14:19.755465-05:00"
   },
   "https://docs.microsoft.com/windows/win32/api/netioapi/nf-netioapi-getifentry2": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-08T07:22:44.999744-05:00"
+    "LastSeen": "2024-01-30T16:14:42.022025-05:00"
   },
   "https://docs.microsoft.com/windows/win32/api/netioapi/ns-netioapi-mib_if_row2": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-08T07:22:39.742787-05:00"
+    "LastSeen": "2024-01-30T16:14:28.823734-05:00"
   },
   "https://docs.microsoft.com/windows/win32/api/winsock2/nf-winsock2-bind": {
     "StatusCode": 200,
@@ -1233,11 +1233,11 @@
   },
   "https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/ThreadInfo.html#isDaemon%28%29": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-08T07:22:01.424324-05:00"
+    "LastSeen": "2024-01-30T16:15:04.430781-05:00"
   },
   "https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/HttpClient.html": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-14T09:36:38.052527-05:00"
+    "LastSeen": "2024-01-30T15:25:22.088043-05:00"
   },
   "https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/HttpHeaders.html": {
     "StatusCode": 200,
@@ -1253,7 +1253,7 @@
   },
   "https://docs.oracle.com/en/java/javase/17/docs/api/java.management/java/lang/management/OperatingSystemMXBean.html#getSystemLoadAverage%28%29": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-16T14:12:45.788489-04:00"
+    "LastSeen": "2024-01-30T16:04:47.364366-05:00"
   },
   "https://docs.oracle.com/en/java/javase/17/docs/api/jdk.management/com/sun/management/OperatingSystemMXBean.html#getCpuLoad%28%29": {
     "StatusCode": 200,
@@ -1285,7 +1285,7 @@
   },
   "https://docs.oracle.com/javase/8/docs/api/java/lang/Runtime.html#availableProcessors--": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-16T14:12:40.31885-04:00"
+    "LastSeen": "2024-01-30T16:04:00.071297-05:00"
   },
   "https://docs.oracle.com/javase/8/docs/api/java/lang/management/BufferPoolMXBean.html#getCount--": {
     "StatusCode": 200,
@@ -1329,15 +1329,15 @@
   },
   "https://docs.oracle.com/javase/8/docs/api/java/lang/management/ThreadInfo.html#getThreadState--": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-08T07:21:56.320234-05:00"
+    "LastSeen": "2024-01-30T16:14:58.644053-05:00"
   },
   "https://docs.oracle.com/javase/8/docs/api/java/lang/management/ThreadMXBean.html#getAllThreadIds--": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-08T07:21:46.130999-05:00"
+    "LastSeen": "2024-01-30T16:14:30.054965-05:00"
   },
   "https://docs.oracle.com/javase/8/docs/api/java/lang/management/ThreadMXBean.html#getThreadInfo-long:A-": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-08T07:21:51.21529-05:00"
+    "LastSeen": "2024-01-30T16:14:47.417732-05:00"
   },
   "https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html": {
     "StatusCode": 200,
@@ -1377,11 +1377,11 @@
   },
   "https://docs.otterize.com/reference/configuration/network-mapper/helm-chart#opentelemetry-exporter-parameters": {
     "StatusCode": 206,
-    "LastSeen": "2023-11-17T16:32:53.695431+01:00"
+    "LastSeen": "2024-01-30T16:15:20.577253-05:00"
   },
   "https://docs.particular.net/samples/open-telemetry/prometheus-grafana/#reporting-metric-values": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:50.067993+02:00"
+    "LastSeen": "2024-01-30T15:27:00.101487-05:00"
   },
   "https://docs.php-http.org/en/latest/clients.html": {
     "StatusCode": 200,
@@ -1445,15 +1445,15 @@
   },
   "https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/htmlsingle/": {
     "StatusCode": 206,
-    "LastSeen": "2023-12-15T18:44:53.694369+01:00"
+    "LastSeen": "2024-01-30T16:15:09.437464-05:00"
   },
   "https://docs.spring.io/spring-boot/docs/current/reference/html/using.html#using.auto-configuration": {
     "StatusCode": 206,
-    "LastSeen": "2023-11-14T09:30:48.194902-05:00"
+    "LastSeen": "2024-01-30T16:15:14.908906-05:00"
   },
   "https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#using.build-systems.starters": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-14T09:30:42.69906-05:00"
+    "LastSeen": "2024-01-30T16:14:53.797365-05:00"
   },
   "https://docs.thousandeyes.com/product-documentation/api/opentelemetry": {
     "StatusCode": 206,
@@ -1461,7 +1461,7 @@
   },
   "https://docs.tracetest.io/configuration/connecting-to-data-stores/opentelemetry-collector": {
     "StatusCode": 206,
-    "LastSeen": "2023-12-11T14:19:28.382469+01:00"
+    "LastSeen": "2024-01-30T16:14:30.370824-05:00"
   },
   "https://docs.vmware.com/en/vRealize-Log-Insight/8.4/com.vmware.log-insight.agent.admin.doc/GUID-40C13E10-1554-4F1B-B832-69CEBF85E7A0.html": {
     "StatusCode": 206,
@@ -1475,13 +1475,9 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-18T08:54:02.060787-05:00"
   },
-  "https://dotnet.microsoft.com/download": {
-    "StatusCode": 200,
-    "LastSeen": "2023-08-14T07:27:50.575755318Z"
-  },
   "https://dotnet.microsoft.com/download/dotnet": {
     "StatusCode": 200,
-    "LastSeen": "2023-08-01T12:16:39.990619752Z"
+    "LastSeen": "2024-01-30T15:24:59.411684-05:00"
   },
   "https://dotnet.microsoft.com/download/dotnet-framework": {
     "StatusCode": 200,
@@ -1501,7 +1497,7 @@
   },
   "https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:10.243793+02:00"
+    "LastSeen": "2024-01-30T15:24:54.677789-05:00"
   },
   "https://dyladan.me/histograms/2023/05/02/why-histograms/": {
     "StatusCode": 206,
@@ -1521,7 +1517,7 @@
   },
   "https://elastic.co/blog/ecs-elastic-common-schema-otel-opentelemetry-announcement": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-29T05:19:30.624412-05:00"
+    "LastSeen": "2024-01-30T16:14:47.246698-05:00"
   },
   "https://en.cppreference.com/w/cpp/container/set": {
     "StatusCode": 200,
@@ -1549,7 +1545,7 @@
   },
   "https://en.wikipedia.org/wiki/Bat-Signal": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-22T10:12:58.908659-05:00"
+    "LastSeen": "2024-01-30T16:15:58.015235-05:00"
   },
   "https://en.wikipedia.org/wiki/COBOL": {
     "StatusCode": 200,
@@ -1583,6 +1579,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:02:32.211817-05:00"
   },
+  "https://en.wikipedia.org/wiki/Hop_%28networking%29": {
+    "StatusCode": 200,
+    "LastSeen": "2024-01-30T16:34:03.225974-05:00"
+  },
   "https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol": {
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:02:21.989727-05:00"
@@ -1605,7 +1605,7 @@
   },
   "https://en.wikipedia.org/wiki/Monkey_patch#:~:text=Monkey%20patching%20is%20a%20technique,Python%2C%20Groovy%2C%20etc.": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:19.705306+02:00"
+    "LastSeen": "2024-01-30T15:25:15.493598-05:00"
   },
   "https://en.wikipedia.org/wiki/Monotonic_function": {
     "StatusCode": 200,
@@ -1651,9 +1651,13 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:01:58.408622-05:00"
   },
+  "https://en.wikipedia.org/wiki/S.M.A.R.T.": {
+    "StatusCode": 200,
+    "LastSeen": "2024-01-30T16:34:03.475531-05:00"
+  },
   "https://en.wikipedia.org/wiki/Special_interest_group": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-08T10:57:02.340092-04:00"
+    "LastSeen": "2024-01-30T15:26:36.551258-05:00"
   },
   "https://en.wikipedia.org/wiki/Subnormal_number": {
     "StatusCode": 200,
@@ -1665,7 +1669,7 @@
   },
   "https://erinmeyer.com/books/the-culture-map/": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-20T20:38:10.039508+02:00"
+    "LastSeen": "2024-01-30T15:25:08.777656-05:00"
   },
   "https://erlang.org/doc/design_principles/applications.html#configuring-an-application": {
     "StatusCode": 206,
@@ -1717,15 +1721,15 @@
   },
   "https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/co-located-events/observability-day/": {
     "StatusCode": 206,
-    "LastSeen": "2023-09-11T17:29:46.070686+02:00"
+    "LastSeen": "2024-01-30T15:26:27.502307-05:00"
   },
   "https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/program/schedule/": {
     "StatusCode": 206,
-    "LastSeen": "2023-09-06T23:25:00.17696-04:00"
+    "LastSeen": "2024-01-30T15:25:07.611962-05:00"
   },
   "https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/register/": {
     "StatusCode": 206,
-    "LastSeen": "2023-09-11T17:29:46.304917+02:00"
+    "LastSeen": "2024-01-30T15:26:34.508123-05:00"
   },
   "https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/venue-travel/": {
     "StatusCode": 206,
@@ -1753,11 +1757,11 @@
   },
   "https://f5.com": {
     "StatusCode": 206,
-    "LastSeen": "2023-11-14T11:45:06.021428+01:00"
+    "LastSeen": "2024-01-30T16:15:21.332226-05:00"
   },
   "https://farfetch.github.io/kafkaflow/docs/guides/open-telemetry": {
     "StatusCode": 206,
-    "LastSeen": "2023-12-20T20:11:28.620683848Z"
+    "LastSeen": "2024-01-30T16:15:09.553856-05:00"
   },
   "https://fastapi.tiangolo.com": {
     "StatusCode": 200,
@@ -1765,7 +1769,7 @@
   },
   "https://flagd.dev/reference/monitoring/#opentelemetry": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-05T19:46:14.848958+02:00"
+    "LastSeen": "2024-01-30T16:06:38.046811-05:00"
   },
   "https://flask.palletsprojects.com/": {
     "StatusCode": 200,
@@ -1773,7 +1777,7 @@
   },
   "https://flipt.io/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-05T19:46:12.612166+02:00"
+    "LastSeen": "2024-01-30T16:05:16.780781-05:00"
   },
   "https://fluentbit.io": {
     "StatusCode": 206,
@@ -1785,7 +1789,7 @@
   },
   "https://forms.gle/GWuGZKku326pCLUo6": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-19T14:27:33.161684-04:00"
+    "LastSeen": "2024-01-30T16:05:05.581183-05:00"
   },
   "https://forms.gle/aUuJg5DQwNzncJ4s8": {
     "StatusCode": 200,
@@ -1793,7 +1797,7 @@
   },
   "https://forms.gle/ajNv8jGs12coDUjG8": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-02T11:25:35.410217+02:00"
+    "LastSeen": "2024-01-30T16:05:22.448487-05:00"
   },
   "https://forms.gle/mEDWyn6G7iCe4bvJ7": {
     "StatusCode": 200,
@@ -1801,7 +1805,7 @@
   },
   "https://formulae.brew.sh/formula/coreutils": {
     "StatusCode": 206,
-    "LastSeen": "2023-09-06T15:04:11.166651+02:00"
+    "LastSeen": "2024-01-30T15:25:17.570481-05:00"
   },
   "https://fosstodon.org/@opentelemetry": {
     "StatusCode": 206,
@@ -1829,15 +1833,15 @@
   },
   "https://git-scm.com/": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-12T09:04:54.723883+01:00"
+    "LastSeen": "2024-01-30T16:14:48.288563-05:00"
   },
   "https://git-scm.com/book/en/v2/Getting-Started-Installing-Git": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-12T09:05:05.965228+01:00"
+    "LastSeen": "2024-01-30T16:15:17.318405-05:00"
   },
   "https://git-scm.com/docs/git-merge#_how_conflicts_are_presented": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-12T09:05:07.954292+01:00"
+    "LastSeen": "2024-01-30T16:15:57.799143-05:00"
   },
   "https://github.blog/2021-05-26-why-and-how-github-is-adopting-opentelemetry/": {
     "StatusCode": 200,
@@ -1849,7 +1853,7 @@
   },
   "https://github.com/": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-13T14:56:57.330463+01:00"
+    "LastSeen": "2024-01-30T16:14:58.646823-05:00"
   },
   "https://github.com/Aneurysm9": {
     "StatusCode": 200,
@@ -1869,7 +1873,7 @@
   },
   "https://github.com/Farfetch/kafkaflow": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-20T20:11:28.212921105Z"
+    "LastSeen": "2024-01-30T16:15:03.991436-05:00"
   },
   "https://github.com/FriendsOfPHP/pickle": {
     "StatusCode": 200,
@@ -1909,7 +1913,7 @@
   },
   "https://github.com/MrAlias/": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-22T10:12:55.071939-05:00"
+    "LastSeen": "2024-01-30T16:15:21.467181-05:00"
   },
   "https://github.com/MrAlias/flow": {
     "StatusCode": 200,
@@ -1949,15 +1953,15 @@
   },
   "https://github.com/SonjaChevre": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-26T12:18:57.59078+02:00"
+    "LastSeen": "2024-01-30T16:04:58.532112-05:00"
   },
   "https://github.com/TykTechnologies/tyk": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-26T12:18:58.23681+02:00"
+    "LastSeen": "2024-01-30T16:05:03.674296-05:00"
   },
   "https://github.com/TylerHelmuth": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-24T16:20:25.682993+01:00"
+    "LastSeen": "2024-01-30T16:14:59.740523-05:00"
   },
   "https://github.com/Workiva/opentelemetry-dart": {
     "StatusCode": 200,
@@ -1977,7 +1981,7 @@
   },
   "https://github.com/abh/Plack-Middleware-OpenTelemetry": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-05T11:57:23.574007+01:00"
+    "LastSeen": "2024-01-30T16:16:13.201088-05:00"
   },
   "https://github.com/adnanrahic": {
     "StatusCode": 200,
@@ -2001,11 +2005,11 @@
   },
   "https://github.com/andykellr": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-23T22:46:46.531254+02:00"
+    "LastSeen": "2024-01-30T16:05:04.258697-05:00"
   },
   "https://github.com/aneurysm9/": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-11T05:03:21.470685-08:00"
+    "LastSeen": "2024-01-30T16:14:53.99317-05:00"
   },
   "https://github.com/apache/apisix/discussions": {
     "StatusCode": 200,
@@ -2065,7 +2069,7 @@
   },
   "https://github.com/brettmc/": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-12T10:33:56.166498179Z"
+    "LastSeen": "2024-01-30T15:25:06.510641-05:00"
   },
   "https://github.com/bufbuild/connect-opentelemetry-go": {
     "StatusCode": 200,
@@ -2077,7 +2081,7 @@
   },
   "https://github.com/ccaraman": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-22T10:12:56.711911-05:00"
+    "LastSeen": "2024-01-30T16:15:31.632309-05:00"
   },
   "https://github.com/census-instrumentation/opencensus-python": {
     "StatusCode": 200,
@@ -2089,7 +2093,7 @@
   },
   "https://github.com/cerbos/cerbos-sdk-javascript/": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-13T14:29:23.953529+02:00"
+    "LastSeen": "2024-01-30T15:25:16.58574-05:00"
   },
   "https://github.com/cloudflare/cfssl": {
     "StatusCode": 200,
@@ -2097,11 +2101,11 @@
   },
   "https://github.com/cloudfoundry/loggregator-agent-release/pull/396": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-31T22:49:01.880645499Z"
+    "LastSeen": "2024-01-30T16:05:14.62923-05:00"
   },
   "https://github.com/codeboten": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-19T15:39:47.072063934Z"
+    "LastSeen": "2024-01-30T15:25:07.042795-05:00"
   },
   "https://github.com/containerd/containerd": {
     "StatusCode": 200,
@@ -2121,7 +2125,7 @@
   },
   "https://github.com/ctlong": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-31T22:49:01.035555602Z"
+    "LastSeen": "2024-01-30T16:05:04.635237-05:00"
   },
   "https://github.com/damemi": {
     "StatusCode": 200,
@@ -2133,11 +2137,11 @@
   },
   "https://github.com/danielgblanco": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-26T15:30:24.247671-04:00"
+    "LastSeen": "2024-01-30T16:04:53.110577-05:00"
   },
   "https://github.com/dash0hq/otelbin": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-15T18:13:58.823155+01:00"
+    "LastSeen": "2024-01-30T16:16:24.299955-05:00"
   },
   "https://github.com/dashpole": {
     "StatusCode": 200,
@@ -2145,7 +2149,7 @@
   },
   "https://github.com/davidgs": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-16T15:02:09.869589-05:00"
+    "LastSeen": "2024-01-30T16:14:54.185189-05:00"
   },
   "https://github.com/dcxp/opentelemetry-kotlin": {
     "StatusCode": 200,
@@ -2197,7 +2201,7 @@
   },
   "https://github.com/equinix-labs/otel-cli": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-22T10:12:58.650448-05:00"
+    "LastSeen": "2024-01-30T16:15:52.594088-05:00"
   },
   "https://github.com/etcd-io/etcd": {
     "StatusCode": 200,
@@ -2217,7 +2221,7 @@
   },
   "https://github.com/evan-bradley": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-23T22:46:45.695277+02:00"
+    "LastSeen": "2024-01-30T16:04:58.72146-05:00"
   },
   "https://github.com/exaring/otelpgx": {
     "StatusCode": 200,
@@ -2237,11 +2241,11 @@
   },
   "https://github.com/git-ecosystem/trace2receiver": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-16T20:37:05.720755+02:00"
+    "LastSeen": "2024-01-30T16:04:52.804061-05:00"
   },
   "https://github.com/go-gorm/opentelemetry": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-14T12:26:21.00653-04:00"
+    "LastSeen": "2024-01-30T16:14:59.006242-05:00"
   },
   "https://github.com/gosnmp/gosnmp": {
     "StatusCode": 200,
@@ -2249,11 +2253,11 @@
   },
   "https://github.com/grpc/grpc-java": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-14T09:36:39.160279-05:00"
+    "LastSeen": "2024-01-30T15:25:27.417894-05:00"
   },
   "https://github.com/grpc/grpc-java#transport": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-14T09:36:39.672623-05:00"
+    "LastSeen": "2024-01-30T15:25:32.8124-05:00"
   },
   "https://github.com/hashicorp/nomad-open-telemetry-getting-started": {
     "StatusCode": 200,
@@ -2285,7 +2289,7 @@
   },
   "https://github.com/hossko": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-17T10:59:22.431031Z"
+    "LastSeen": "2024-01-30T16:15:04.170576-05:00"
   },
   "https://github.com/imandra-ai/ocaml-opentelemetry/": {
     "StatusCode": 200,
@@ -2297,7 +2301,7 @@
   },
   "https://github.com/instana/otel-database-dc": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-13T15:04:38.19765+01:00"
+    "LastSeen": "2024-01-30T16:14:36.112572-05:00"
   },
   "https://github.com/jack-berg": {
     "StatusCode": 200,
@@ -2309,7 +2313,7 @@
   },
   "https://github.com/jaegertracing/jaeger-client-java#via-http-headers": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-13T20:22:01.799413+02:00"
+    "LastSeen": "2024-01-30T15:24:50.932894-05:00"
   },
   "https://github.com/jaegertracing/vertx-create-span": {
     "StatusCode": 200,
@@ -2317,11 +2321,11 @@
   },
   "https://github.com/jaronoff97": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-23T22:46:44.940049+02:00"
+    "LastSeen": "2024-01-30T16:05:03.376611-05:00"
   },
   "https://github.com/jeanbisutti": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-08T11:19:13.539577+01:00"
+    "LastSeen": "2024-01-30T16:14:42.388742-05:00"
   },
   "https://github.com/jenniferplusplus/opentelemetry-instrumentation-bullmq": {
     "StatusCode": 200,
@@ -2329,7 +2333,7 @@
   },
   "https://github.com/jjatria/mojolicious-plugin-opentelemetry": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-05T11:57:22.182586+01:00"
+    "LastSeen": "2024-01-30T16:16:07.775541-05:00"
   },
   "https://github.com/jjatria/perl-opentelemetry": {
     "StatusCode": 200,
@@ -2337,15 +2341,15 @@
   },
   "https://github.com/jjatria/perl-opentelemetry-exporter-otlp": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-05T11:57:20.083522+01:00"
+    "LastSeen": "2024-01-30T16:15:04.18117-05:00"
   },
   "https://github.com/jjatria/perl-opentelemetry-sdk": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-05T11:57:24.494338+01:00"
+    "LastSeen": "2024-01-30T16:16:18.910498-05:00"
   },
   "https://github.com/jmacd": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-14T11:45:03.706414+01:00"
+    "LastSeen": "2024-01-30T16:14:54.527183-05:00"
   },
   "https://github.com/joshleecreates/": {
     "StatusCode": 200,
@@ -2357,7 +2361,7 @@
   },
   "https://github.com/jpkrohling/": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-11T05:03:20.712823-08:00"
+    "LastSeen": "2024-01-30T16:14:42.664553-05:00"
   },
   "https://github.com/jpkrohling/opentelemetry-collector-deployment-patterns/": {
     "StatusCode": 200,
@@ -2413,11 +2417,11 @@
   },
   "https://github.com/lmolkova": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-03T03:04:54.119611-04:00"
+    "LastSeen": "2024-01-30T16:15:15.341223-05:00"
   },
   "https://github.com/lquerel": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-14T11:45:02.674064+01:00"
+    "LastSeen": "2024-01-30T16:14:42.384622-05:00"
   },
   "https://github.com/mahboubii/grpcmetrics": {
     "StatusCode": 200,
@@ -2429,11 +2433,11 @@
   },
   "https://github.com/martinkuba": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-04T11:32:20.86746-04:00"
+    "LastSeen": "2024-01-30T16:14:42.253423-05:00"
   },
   "https://github.com/metrico/otel-collector": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-17T15:13:11.067528+02:00"
+    "LastSeen": "2024-01-30T16:04:05.309796-05:00"
   },
   "https://github.com/mhausenblas": {
     "StatusCode": 200,
@@ -2441,7 +2445,7 @@
   },
   "https://github.com/mkocher": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-31T22:49:00.168214153Z"
+    "LastSeen": "2024-01-30T16:04:58.425652-05:00"
   },
   "https://github.com/mlocati/docker-php-extension-installer": {
     "StatusCode": 200,
@@ -2453,7 +2457,7 @@
   },
   "https://github.com/mongodb/mongo-go-driver": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-01T16:02:51.932405+01:00"
+    "LastSeen": "2024-01-30T16:15:31.368305-05:00"
   },
   "https://github.com/mtwo": {
     "StatusCode": 200,
@@ -2473,7 +2477,7 @@
   },
   "https://github.com/nginxinc/nginx-otel": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-15T16:58:32.138615+02:00"
+    "LastSeen": "2024-01-30T15:25:22.157083-05:00"
   },
   "https://github.com/nhatthm/otelsql": {
     "StatusCode": 200,
@@ -2501,7 +2505,7 @@
   },
   "https://github.com/open-telemetry/": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-08T15:19:55.887939-08:00"
+    "LastSeen": "2024-01-30T16:14:19.178532-05:00"
   },
   "https://github.com/open-telemetry/community": {
     "StatusCode": 200,
@@ -2545,7 +2549,7 @@
   },
   "https://github.com/open-telemetry/community/issues/1332": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-14T11:45:07.905452+01:00"
+    "LastSeen": "2024-01-30T16:15:26.308104-05:00"
   },
   "https://github.com/open-telemetry/community/issues/1400": {
     "StatusCode": 200,
@@ -2553,7 +2557,7 @@
   },
   "https://github.com/open-telemetry/community/issues/1561": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-19T14:27:28.755346-04:00"
+    "LastSeen": "2024-01-30T16:04:53.024867-05:00"
   },
   "https://github.com/open-telemetry/community/issues/828": {
     "StatusCode": 200,
@@ -2613,7 +2617,7 @@
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/workflows/load-tests.yml": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-04T11:32:21.428206-04:00"
+    "LastSeen": "2024-01-30T16:14:54.058976-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16462": {
     "StatusCode": 200,
@@ -2633,7 +2637,7 @@
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16594": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-23T22:46:48.280538+02:00"
+    "LastSeen": "2024-01-30T16:05:10.646669-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/7112": {
     "StatusCode": 200,
@@ -2665,23 +2669,23 @@
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.82.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-08-03T12:58:04.290922-04:00"
+    "LastSeen": "2024-01-30T15:25:27.707528-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.84.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T23:24:57.917147-04:00"
+    "LastSeen": "2024-01-30T15:25:22.203568-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.86.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-01T12:48:05.307263-04:00"
+    "LastSeen": "2024-01-30T16:05:09.119228-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.88.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-01T21:52:01.79874-04:00"
+    "LastSeen": "2024-01-30T16:15:04.100016-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-releases": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:15.511399+02:00"
+    "LastSeen": "2024-01-30T15:25:16.731433-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-releases/pkgs/container/opentelemetry-collector-releases%2Fopentelemetry-collector-contrib": {
     "StatusCode": 200,
@@ -2705,15 +2709,15 @@
   },
   "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/tag/v0.85.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-19T15:39:47.556871528Z"
+    "LastSeen": "2024-01-30T15:25:16.602131-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/tag/v0.86.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-01T12:48:04.831958-04:00"
+    "LastSeen": "2024-01-30T16:05:03.624373-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/tag/v0.88.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-01T21:52:01.329725-04:00"
+    "LastSeen": "2024-01-30T16:14:58.909754-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/": {
     "StatusCode": 200,
@@ -2733,7 +2737,7 @@
   },
   "https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.63.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-04T17:14:46.78217-07:00"
+    "LastSeen": "2024-01-30T16:04:58.261649-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.70.0": {
     "StatusCode": 200,
@@ -2749,11 +2753,11 @@
   },
   "https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.82.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-08-03T12:57:58.816099-04:00"
+    "LastSeen": "2024-01-30T15:25:21.975121-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.84.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T23:24:56.468774-04:00"
+    "LastSeen": "2024-01-30T15:25:16.610744-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-configuration": {
     "StatusCode": 200,
@@ -2813,7 +2817,7 @@
   },
   "https://github.com/open-telemetry/opentelemetry-demo#welcome-to-the-opentelemetry-astronomy-shop-demo": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-08T10:57:02.070547-04:00"
+    "LastSeen": "2024-01-30T15:26:24.629708-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-demo-webstore#local-quickstart": {
     "StatusCode": 200,
@@ -2857,7 +2861,7 @@
   },
   "https://github.com/open-telemetry/opentelemetry-demo/pull/432": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-12T11:14:54.891852-04:00"
+    "LastSeen": "2024-01-30T15:26:30.96845-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-demo/pull/877": {
     "StatusCode": 200,
@@ -2893,31 +2897,31 @@
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1744": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:18.843001+02:00"
+    "LastSeen": "2024-01-30T15:24:51.105859-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1906#issuecomment-1376292814": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:20.674839+02:00"
+    "LastSeen": "2024-01-30T15:25:22.054233-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/2181": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:10.901193+02:00"
+    "LastSeen": "2024-01-30T15:25:06.361236-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/2269": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:21.710963+02:00"
+    "LastSeen": "2024-01-30T15:25:27.775104-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/2296": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:22.530942+02:00"
+    "LastSeen": "2024-01-30T15:25:32.905045-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/2310": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:12.906854+02:00"
+    "LastSeen": "2024-01-30T15:25:38.285125-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/2833": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:19.559944+02:00"
+    "LastSeen": "2024-01-30T15:25:00.795436-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/new": {
     "StatusCode": 200,
@@ -2925,11 +2929,7 @@
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases": {
     "StatusCode": 200,
-    "LastSeen": "2023-08-14T07:27:52.35566079Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest/download/otel-dotnet-auto-install.sh": {
-    "StatusCode": 206,
-    "LastSeen": "2023-08-14T07:27:51.68749521Z"
+    "LastSeen": "2024-01-30T15:25:22.100602-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v0.1.0-beta.1": {
     "StatusCode": 200,
@@ -2941,11 +2941,11 @@
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.0.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-14T12:03:28.110678+02:00"
+    "LastSeen": "2024-01-30T15:25:16.569943-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet/issues/4243": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:47.658447+02:00"
+    "LastSeen": "2024-01-30T15:26:54.792726-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet/releases": {
     "StatusCode": 200,
@@ -2969,19 +2969,19 @@
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.6.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-01T12:48:08.321994-04:00"
+    "LastSeen": "2024-01-30T16:05:41.374213-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.6.0-alpha.1": {
     "StatusCode": 200,
-    "LastSeen": "2023-08-03T12:58:31.402565-04:00"
+    "LastSeen": "2024-01-30T15:25:54.422863-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.6.0-rc.1": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T23:25:00.040812-04:00"
+    "LastSeen": "2024-01-30T15:25:54.271175-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.7.0-alpha.1": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-01T21:52:03.81232-04:00"
+    "LastSeen": "2024-01-30T16:15:25.802104-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-erlang": {
     "StatusCode": 200,
@@ -3021,7 +3021,7 @@
   },
   "https://github.com/open-telemetry/opentelemetry-go/compare/v1.18.0...v1.19.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-01T12:48:07.452046-04:00"
+    "LastSeen": "2024-01-30T16:05:30.739686-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-go/projects": {
     "StatusCode": 200,
@@ -3057,11 +3057,11 @@
   },
   "https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.17.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T23:24:59.667769-04:00"
+    "LastSeen": "2024-01-30T15:25:43.593-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.19.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-01T12:48:06.997625-04:00"
+    "LastSeen": "2024-01-30T16:04:58.205917-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-helm-charts": {
     "StatusCode": 200,
@@ -3069,7 +3069,7 @@
   },
   "https://github.com/open-telemetry/opentelemetry-helm-charts/pull/531": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-12T11:57:08.111198-04:00"
+    "LastSeen": "2024-01-30T15:26:48.348347-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-helm-charts/pull/760": {
     "StatusCode": 200,
@@ -3133,23 +3133,23 @@
   },
   "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.28.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-08-03T12:58:15.192972-04:00"
+    "LastSeen": "2024-01-30T15:25:38.287668-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.29.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T23:24:58.846736-04:00"
+    "LastSeen": "2024-01-30T15:25:32.809812-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.30.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-01T12:48:06.579275-04:00"
+    "LastSeen": "2024-01-30T16:05:25.305838-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.31.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-01T21:52:02.990981-04:00"
+    "LastSeen": "2024-01-30T16:15:15.015409-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-java/discussions": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-08T11:19:15.572149+01:00"
+    "LastSeen": "2024-01-30T16:14:59.104759-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-java/releases": {
     "StatusCode": 200,
@@ -3185,19 +3185,19 @@
   },
   "https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.28.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-08-03T12:58:09.66053-04:00"
+    "LastSeen": "2024-01-30T15:25:32.858269-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.29.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T23:24:58.360584-04:00"
+    "LastSeen": "2024-01-30T15:25:27.460208-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.30.1": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-01T12:48:06.126841-04:00"
+    "LastSeen": "2024-01-30T16:05:19.85955-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.31.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-01T21:52:02.56201-04:00"
+    "LastSeen": "2024-01-30T16:15:09.842104-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-js": {
     "StatusCode": 200,
@@ -3205,7 +3205,7 @@
   },
   "https://github.com/open-telemetry/opentelemetry-js#supported-runtimes": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-21T09:40:56.039903+02:00"
+    "LastSeen": "2024-01-30T15:25:11.498435-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-js-contrib": {
     "StatusCode": 200,
@@ -3217,7 +3217,7 @@
   },
   "https://github.com/open-telemetry/opentelemetry-js/": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-03T11:24:51.825628-07:00"
+    "LastSeen": "2024-01-30T16:04:52.867297-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-js/discussions": {
     "StatusCode": 200,
@@ -3241,15 +3241,15 @@
   },
   "https://github.com/open-telemetry/opentelemetry-js/releases/tag/v1.15.1": {
     "StatusCode": 200,
-    "LastSeen": "2023-08-03T12:58:26.063534-04:00"
+    "LastSeen": "2024-01-30T15:25:48.956887-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-js/releases/tag/v1.17.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-01T12:48:07.83784-04:00"
+    "LastSeen": "2024-01-30T16:05:36.047473-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-js/releases/tag/v1.17.1": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-01T21:52:03.390422-04:00"
+    "LastSeen": "2024-01-30T16:15:20.392944-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-lambda": {
     "StatusCode": 200,
@@ -3265,7 +3265,7 @@
   },
   "https://github.com/open-telemetry/opentelemetry-operator#controlling-instrumentation-capabilities": {
     "StatusCode": 200,
-    "LastSeen": "2023-08-28T19:08:27.997056-06:00"
+    "LastSeen": "2024-01-30T15:25:00.99793-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-operator#deployment-modes": {
     "StatusCode": 200,
@@ -3313,11 +3313,11 @@
   },
   "https://github.com/open-telemetry/opentelemetry-operator/releases/tag/v0.85.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-01T12:48:05.717569-04:00"
+    "LastSeen": "2024-01-30T16:05:14.451389-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-operator/releases/tag/v0.88.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-01T21:52:02.137465-04:00"
+    "LastSeen": "2024-01-30T16:15:04.533615-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-php": {
     "StatusCode": 200,
@@ -3329,11 +3329,11 @@
   },
   "https://github.com/open-telemetry/opentelemetry-php-contrib": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-12T10:34:00.748754957Z"
+    "LastSeen": "2024-01-30T15:25:21.979129-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-php-contrib/": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-12T17:21:56.853351123Z"
+    "LastSeen": "2024-01-30T15:25:32.786112-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-php-instrumentation": {
     "StatusCode": 200,
@@ -3341,19 +3341,15 @@
   },
   "https://github.com/open-telemetry/opentelemetry-php-instrumentation/": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-12T17:21:58.240075768Z"
+    "LastSeen": "2024-01-30T15:25:43.651626-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-php/": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-12T17:21:57.859077407Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-php/issues": {
-    "StatusCode": 200,
-    "LastSeen": "2023-09-12T10:34:00.300283393Z"
+    "LastSeen": "2024-01-30T15:25:16.537654-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-php/issues/": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-12T17:21:57.410272057Z"
+    "LastSeen": "2024-01-30T15:25:38.151177-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-php/releases": {
     "StatusCode": 200,
@@ -3413,11 +3409,11 @@
   },
   "https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.19.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-08-03T12:58:20.648046-04:00"
+    "LastSeen": "2024-01-30T15:25:43.50776-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.20.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T23:24:59.277655-04:00"
+    "LastSeen": "2024-01-30T15:25:38.140496-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-ruby": {
     "StatusCode": 200,
@@ -3457,7 +3453,7 @@
   },
   "https://github.com/open-telemetry/opentelemetry-specification/": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-22T10:12:58.088255-05:00"
+    "LastSeen": "2024-01-30T16:15:47.109383-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-specification/#change--contribution-process": {
     "StatusCode": 200,
@@ -3477,11 +3473,11 @@
   },
   "https://github.com/open-telemetry/opentelemetry-specification/compare/v1.24.0...v1.25.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-01T12:48:04.394314-04:00"
+    "LastSeen": "2024-01-30T16:04:58.243312-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-specification/compare/v1.25.0...v1.26.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-01T21:52:00.483708-04:00"
+    "LastSeen": "2024-01-30T16:14:42.331955-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-specification/discussions/2695": {
     "StatusCode": 200,
@@ -3537,11 +3533,11 @@
   },
   "https://github.com/open-telemetry/opentelemetry-specification/releases/tag/v1.23.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-08-03T12:57:48.12961-04:00"
+    "LastSeen": "2024-01-30T15:25:11.19724-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-specification/releases/tag/v1.24.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T23:24:56.046952-04:00"
+    "LastSeen": "2024-01-30T15:25:05.874801-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-swift": {
     "StatusCode": 200,
@@ -3561,7 +3557,7 @@
   },
   "https://github.com/open-telemetry/opentelemetry.io": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-12T09:04:54.562763+01:00"
+    "LastSeen": "2024-01-30T16:14:35.956188-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry.io#adding-a-project-to-the-opentelemetry-registry": {
     "StatusCode": 200,
@@ -3573,15 +3569,15 @@
   },
   "https://github.com/open-telemetry/opentelemetry.io#submitting-a-blog-post": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-08T10:57:01.381266-04:00"
+    "LastSeen": "2024-01-30T15:26:19.094836-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry.io/": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-12T09:05:06.564186+01:00"
+    "LastSeen": "2024-01-30T16:15:20.42238-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry.io/fork": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-13T15:27:13.947245+01:00"
+    "LastSeen": "2024-01-30T16:15:47.00387-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry.io/issues/new": {
     "StatusCode": 200,
@@ -3589,27 +3585,27 @@
   },
   "https://github.com/open-telemetry/opentelemetry.io/pull/2130": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-12T11:57:07.17132-04:00"
+    "LastSeen": "2024-01-30T15:26:13.725828-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry.io/pull/3098": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-12T11:57:05.910172-04:00"
+    "LastSeen": "2024-01-30T15:26:07.231266-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry.io/pull/3195": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-12T11:57:04.702626-04:00"
+    "LastSeen": "2024-01-30T15:26:01.154768-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry.io/pulls": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-12T09:05:07.270135+01:00"
+    "LastSeen": "2024-01-30T16:15:25.833527-05:00"
   },
   "https://github.com/open-telemetry/otel-arrow": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-14T11:45:08.675719+01:00"
+    "LastSeen": "2024-01-30T16:15:31.46184-05:00"
   },
   "https://github.com/open-telemetry/otel-arrow/pull/82": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-14T11:45:09.854807+01:00"
+    "LastSeen": "2024-01-30T16:15:37.308714-05:00"
   },
   "https://github.com/open-telemetry/oteps/issues/197": {
     "StatusCode": 200,
@@ -3653,11 +3649,11 @@
   },
   "https://github.com/open-telemetry/semantic-conventions-java/releases": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-13T09:15:50.916636+02:00"
+    "LastSeen": "2024-01-30T15:25:06.008653-05:00"
   },
   "https://github.com/open-telemetry/semantic-conventions/issues": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-04T16:21:02.354732+02:00"
+    "LastSeen": "2024-01-30T16:04:52.840828-05:00"
   },
   "https://github.com/open-telemetry/semantic-conventions/issues/new": {
     "StatusCode": 200,
@@ -3665,19 +3661,19 @@
   },
   "https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.21.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-08-03T12:57:53.46166-04:00"
+    "LastSeen": "2024-01-30T15:25:16.567964-05:00"
   },
   "https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.22.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-01T21:52:00.884558-04:00"
+    "LastSeen": "2024-01-30T16:14:53.688233-05:00"
   },
   "https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.23.0": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-03T20:22:42.689401141Z"
+    "LastSeen": "2024-01-30T16:14:42.076218-05:00"
   },
   "https://github.com/open-telemetry/sig-security": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-07T16:14:09.891942-08:00"
+    "LastSeen": "2024-01-30T16:14:36.015951-05:00"
   },
   "https://github.com/opentracing": {
     "StatusCode": 200,
@@ -3701,7 +3697,7 @@
   },
   "https://github.com/oracle/graal/issues/1065": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-08T11:19:14.694346+01:00"
+    "LastSeen": "2024-01-30T16:14:54.102977-05:00"
   },
   "https://github.com/orgs/open-telemetry/projects/41/views/1": {
     "StatusCode": 200,
@@ -3709,23 +3705,23 @@
   },
   "https://github.com/orgs/open-telemetry/teams/technical-committee": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-16T12:14:31.82439-08:00"
+    "LastSeen": "2024-01-30T16:15:03.796394-05:00"
   },
   "https://github.com/orishoshan": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-16T15:02:08.644309-05:00"
+    "LastSeen": "2024-01-30T16:14:42.567089-05:00"
   },
   "https://github.com/otterize": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-16T15:02:10.831177-05:00"
+    "LastSeen": "2024-01-30T16:15:09.792383-05:00"
   },
   "https://github.com/otterize/network-mapper": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-16T15:02:12.356594-05:00"
+    "LastSeen": "2024-01-30T16:15:15.05171-05:00"
   },
   "https://github.com/otterize/network-mapper/pull/141": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-16T15:02:13.899173-05:00"
+    "LastSeen": "2024-01-30T16:15:26.681189-05:00"
   },
   "https://github.com/pavolloffay": {
     "StatusCode": 200,
@@ -3741,7 +3737,7 @@
   },
   "https://github.com/pkanal": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-22T10:12:57.554103-05:00"
+    "LastSeen": "2024-01-30T16:15:37.215985-05:00"
   },
   "https://github.com/ppatierno": {
     "StatusCode": 200,
@@ -3825,7 +3821,7 @@
   },
   "https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-with-GraalVM": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-08T11:19:16.63837+01:00"
+    "LastSeen": "2024-01-30T16:15:09.784881-05:00"
   },
   "https://github.com/statsd/statsd": {
     "StatusCode": 200,
@@ -3849,7 +3845,7 @@
   },
   "https://github.com/tedsuo": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-26T15:30:24.735802-04:00"
+    "LastSeen": "2024-01-30T16:04:58.240402-05:00"
   },
   "https://github.com/thanos-io/thanos": {
     "StatusCode": 200,
@@ -3857,7 +3853,7 @@
   },
   "https://github.com/theletterf/": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-14T12:03:27.555281+02:00"
+    "LastSeen": "2024-01-30T15:25:01.244997-05:00"
   },
   "https://github.com/tigrannajaryan": {
     "StatusCode": 200,
@@ -3865,7 +3861,7 @@
   },
   "https://github.com/tobert": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-22T10:12:55.948206-05:00"
+    "LastSeen": "2024-01-30T16:15:26.044724-05:00"
   },
   "https://github.com/tokio-rs/tracing-opentelemetry": {
     "StatusCode": 200,
@@ -3893,7 +3889,7 @@
   },
   "https://github.com/tylerhelmuth": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-11T05:03:22.717836-08:00"
+    "LastSeen": "2024-01-30T16:15:00.058188-05:00"
   },
   "https://github.com/typelevel/otel4s": {
     "StatusCode": 200,
@@ -3901,7 +3897,7 @@
   },
   "https://github.com/udhos/opentelemetry-trace-sqs": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-25T09:39:37.545568+02:00"
+    "LastSeen": "2024-01-30T16:05:03.785027-05:00"
   },
   "https://github.com/ulid/spec": {
     "StatusCode": 200,
@@ -3937,7 +3933,7 @@
   },
   "https://go.dev/": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-25T10:17:08.450210292Z"
+    "LastSeen": "2024-01-30T15:25:10.378732-05:00"
   },
   "https://go.dev/doc/code#Command": {
     "StatusCode": 200,
@@ -3949,7 +3945,7 @@
   },
   "https://go.dev/doc/tutorial/workspaces": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-15T20:50:17.016966+08:00"
+    "LastSeen": "2024-01-30T16:14:37.275036-05:00"
   },
   "https://go.dev/ref/mod#go-mod-file-replace": {
     "StatusCode": 200,
@@ -3957,11 +3953,11 @@
   },
   "https://go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-01T16:02:54.37261+01:00"
+    "LastSeen": "2024-01-30T16:16:02.15181-05:00"
   },
   "https://go.opentelemetry.io/contrib/instrumentation/github.com/astaxie/beego": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-01T16:02:49.351999+01:00"
+    "LastSeen": "2024-01-30T16:15:09.40597-05:00"
   },
   "https://go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda": {
     "StatusCode": 200,
@@ -3969,39 +3965,39 @@
   },
   "https://go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-01T16:02:52.667303+01:00"
+    "LastSeen": "2024-01-30T16:15:41.63615-05:00"
   },
   "https://go.opentelemetry.io/contrib/instrumentation/github.com/bradfitz/gomemcache": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-01T16:02:50.560804+01:00"
+    "LastSeen": "2024-01-30T16:15:19.669721-05:00"
   },
   "https://go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-01T16:02:53.698206+01:00"
+    "LastSeen": "2024-01-30T16:15:57.028574-05:00"
   },
   "https://go.opentelemetry.io/contrib/instrumentation/github.com/go-kit/kit/otelkit": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-01T16:02:52.997073+01:00"
+    "LastSeen": "2024-01-30T16:15:46.768456-05:00"
   },
   "https://go.opentelemetry.io/contrib/instrumentation/github.com/gocql/gocql": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-01T16:02:49.910545+01:00"
+    "LastSeen": "2024-01-30T16:15:14.54684-05:00"
   },
   "https://go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-01T16:02:52.172876+01:00"
+    "LastSeen": "2024-01-30T16:15:36.502523-05:00"
   },
   "https://go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-01T16:02:51.363834+01:00"
+    "LastSeen": "2024-01-30T16:15:29.938068-05:00"
   },
   "https://go.opentelemetry.io/contrib/instrumentation/gopkg.in/macaron.v1/otelmacaron": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-01T16:02:53.323307+01:00"
+    "LastSeen": "2024-01-30T16:15:51.90066-05:00"
   },
   "https://go.opentelemetry.io/contrib/instrumentation/net/http": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-01T16:02:51.080037+01:00"
+    "LastSeen": "2024-01-30T16:15:24.805763-05:00"
   },
   "https://godoc.org/google.golang.org/genproto/googleapis/rpc/status#Status": {
     "StatusCode": 200,
@@ -4017,19 +4013,19 @@
   },
   "https://goharbor.io/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-16T20:09:48.802546+02:00"
+    "LastSeen": "2024-01-30T16:05:27.677232-05:00"
   },
   "https://goharbor.io/docs/edge/administration/distributed-tracing/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-16T20:09:49.097202+02:00"
+    "LastSeen": "2024-01-30T16:05:33.151121-05:00"
   },
   "https://golang.org/ref/spec#Slice_types": {
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:02:17.04578-05:00"
   },
   "https://gorm.io/": {
-    "StatusCode": 200,
-    "LastSeen": "2023-11-14T12:26:21.00653-04:00"
+    "StatusCode": 206,
+    "LastSeen": "2024-01-30T16:14:47.910122-05:00"
   },
   "https://gradle.org/": {
     "StatusCode": 206,
@@ -4053,7 +4049,7 @@
   },
   "https://graphite.readthedocs.io/en/stable/feeding-carbon.html#the-plaintext-protocol": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-24T16:20:23.626654+01:00"
+    "LastSeen": "2024-01-30T16:14:41.834592-05:00"
   },
   "https://graphql.org": {
     "StatusCode": 206,
@@ -4078,10 +4074,6 @@
   "https://grpc.io/": {
     "StatusCode": 206,
     "LastSeen": "2024-01-18T08:53:34.433352-05:00"
-  },
-  "https://grpc.io/docs/languages/java/": {
-    "StatusCode": 206,
-    "LastSeen": "2023-09-19T12:20:32.380645+02:00"
   },
   "https://guava.dev/releases/10.0/api/docs/com/google/common/util/concurrent/ListenableFuture.html": {
     "StatusCode": 206,
@@ -4113,7 +4105,7 @@
   },
   "https://helm.sh/docs/intro/install/": {
     "StatusCode": 206,
-    "LastSeen": "2023-08-04T15:01:28.513871-06:00"
+    "LastSeen": "2024-01-30T15:25:18.500479-05:00"
   },
   "https://help.github.com/articles/about-pull-requests/": {
     "StatusCode": 206,
@@ -4121,7 +4113,7 @@
   },
   "https://help.sumologic.com/docs/send-data/opentelemetry-collector/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-09T19:36:59.126993+02:00"
+    "LastSeen": "2024-01-30T16:04:38.147971-05:00"
   },
   "https://heroku.com": {
     "StatusCode": 206,
@@ -4213,7 +4205,7 @@
   },
   "https://hyper.rs/": {
     "StatusCode": 200,
-    "LastSeen": "2023-08-03T17:44:10.601039+02:00"
+    "LastSeen": "2024-01-30T15:25:23.119442-05:00"
   },
   "https://imandra.ai": {
     "StatusCode": 200,
@@ -4221,11 +4213,11 @@
   },
   "https://img.shields.io/badge/-deprecated-red": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-16T15:01:13.954765472Z"
+    "LastSeen": "2024-01-30T16:14:52.798893-05:00"
   },
   "https://img.shields.io/badge/-stable-lightgreen": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-08T07:21:29.389953-05:00"
+    "LastSeen": "2024-01-30T16:14:23.500512-05:00"
   },
   "https://jaegertracing.io": {
     "StatusCode": 206,
@@ -4233,7 +4225,7 @@
   },
   "https://jaegertracing.io/": {
     "StatusCode": 206,
-    "LastSeen": "2023-09-15T12:25:23.145551+02:00"
+    "LastSeen": "2024-01-30T15:25:09.456322-05:00"
   },
   "https://jakarta.ee/specifications/platform/8/apidocs/javax/servlet/http/HttpServletRequest.html": {
     "StatusCode": 206,
@@ -4241,23 +4233,23 @@
   },
   "https://javadoc.io/doc/io.opentelemetry/opentelemetry-exporter-prometheus/latest": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-17T12:19:45.412666+01:00"
+    "LastSeen": "2024-01-30T16:14:53.216459-05:00"
   },
   "https://javadoc.io/doc/io.opentelemetry/opentelemetry-exporter-prometheus/latest/io/opentelemetry/exporter/prometheus/PrometheusHttpServer.html": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-27T22:03:28.673499+01:00"
+    "LastSeen": "2024-01-30T16:14:37.413134-05:00"
   },
   "https://javadoc.io/doc/io.opentelemetry/opentelemetry-exporter-zipkin/latest": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-17T12:19:46.0091+01:00"
+    "LastSeen": "2024-01-30T16:14:59.255692-05:00"
   },
   "https://javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-trace/latest/io/opentelemetry/sdk/trace/export/SpanExporter.html": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-17T12:19:46.216357+01:00"
+    "LastSeen": "2024-01-30T16:15:05.491682-05:00"
   },
   "https://javadoc.io/doc/org.apache.logging.log4j/log4j-api/latest/org.apache.logging.log4j/org/apache/logging/log4j/Logger.html": {
     "StatusCode": 200,
-    "LastSeen": "2023-08-10T19:39:55.351559+02:00"
+    "LastSeen": "2024-01-30T15:25:04.309715-05:00"
   },
   "https://jessitron.com/": {
     "StatusCode": 200,
@@ -4293,15 +4285,15 @@
   },
   "https://kccncna2023.sched.com/event/1R2rQ": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-01T12:48:09.135563-04:00"
+    "LastSeen": "2024-01-30T16:05:03.736848-05:00"
   },
   "https://keda.sh/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-16T20:09:49.93756+02:00"
+    "LastSeen": "2024-01-30T16:05:49.759787-05:00"
   },
   "https://keda.sh/docs/2.12/operate/opentelemetry/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-16T20:09:50.218385+02:00"
+    "LastSeen": "2024-01-30T16:05:55.229872-05:00"
   },
   "https://kind.sigs.k8s.io/": {
     "StatusCode": 206,
@@ -4309,7 +4301,7 @@
   },
   "https://kind.sigs.k8s.io/#installation-and-usage": {
     "StatusCode": 206,
-    "LastSeen": "2023-08-04T15:01:28.031106-06:00"
+    "LastSeen": "2024-01-30T15:25:11.997568-05:00"
   },
   "https://kloudfuse.atlassian.net/wiki/spaces/EX/pages/753860609/APM#Sending-traces-to-Kloudfuse-data-plane%3A": {
     "StatusCode": 200,
@@ -4317,7 +4309,7 @@
   },
   "https://knative.dev/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-16T20:09:51.699957+02:00"
+    "LastSeen": "2024-01-30T16:06:00.387325-05:00"
   },
   "https://knative.dev/docs/": {
     "StatusCode": 206,
@@ -4329,7 +4321,7 @@
   },
   "https://knative.dev/docs/eventing/observability/metrics/collecting-metrics/#about-opentelemetry": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-16T20:09:52.000286+02:00"
+    "LastSeen": "2024-01-30T16:06:05.487035-05:00"
   },
   "https://knative.dev/docs/serving/accessing-traces/": {
     "StatusCode": 206,
@@ -4413,7 +4405,7 @@
   },
   "https://kubernetes.io/docs/contribute/style/style-guide/": {
     "StatusCode": 206,
-    "LastSeen": "2023-12-12T09:04:54.259484+01:00"
+    "LastSeen": "2024-01-30T16:14:53.147946-05:00"
   },
   "https://kubernetes.io/docs/reference/kubectl/": {
     "StatusCode": 206,
@@ -4425,11 +4417,11 @@
   },
   "https://kyverno.io/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-16T20:09:52.67724+02:00"
+    "LastSeen": "2024-01-30T16:06:10.681585-05:00"
   },
   "https://kyverno.io/docs/monitoring/opentelemetry/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-16T20:09:53.171107+02:00"
+    "LastSeen": "2024-01-30T16:06:15.993792-05:00"
   },
   "https://laravel.com/docs/10.x/installation": {
     "StatusCode": 200,
@@ -4441,59 +4433,55 @@
   },
   "https://learn.microsoft.com/archive/blogs/askcore/windows-performance-monitor-disk-counters-explained#windows-performance-monitor-disk-counters-explained": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-08T07:22:34.14265-05:00"
+    "LastSeen": "2024-01-30T16:14:18.163457-05:00"
   },
   "https://learn.microsoft.com/aspnet/core/tutorials/min-web-api": {
     "StatusCode": 200,
-    "LastSeen": "2023-08-14T07:27:51.174082501Z"
+    "LastSeen": "2024-01-30T15:25:14.866011-05:00"
   },
   "https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.diagnostics.iexceptionhandler": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-16T15:01:14.346421601Z"
+    "LastSeen": "2024-01-30T16:14:24.003181-05:00"
   },
   "https://learn.microsoft.com/dotnet/api/system.net.endpoint": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-16T15:01:15.422929001Z"
+    "LastSeen": "2024-01-30T16:14:23.701401-05:00"
   },
   "https://learn.microsoft.com/dotnet/api/system.net.http.httprequesterror": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-16T15:01:22.726482149Z"
+    "LastSeen": "2024-01-30T16:14:23.754781-05:00"
   },
   "https://learn.microsoft.com/dotnet/api/system.net.sockets.socketerror": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-16T15:07:48.424957659Z"
-  },
-  "https://learn.microsoft.com/en-us/archive/blogs/askcore/windows-performance-monitor-disk-counters-explained#windows-performance-monitor-disk-counters-explained": {
-    "StatusCode": 200,
-    "LastSeen": "2023-10-16T14:12:52.488179-04:00"
+    "LastSeen": "2024-01-30T16:14:18.196332-05:00"
   },
   "https://learn.microsoft.com/en-us/dotnet/api/system.reflection.assembly.getentryassembly": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:13.518691+02:00"
+    "LastSeen": "2024-01-30T15:24:54.805878-05:00"
   },
   "https://learn.microsoft.com/en-us/dotnet/core/deploying/": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:52.233278+02:00"
+    "LastSeen": "2024-01-30T15:25:16.669441-05:00"
   },
   "https://learn.microsoft.com/en-us/dotnet/core/deploying/#publish-self-contained": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:12.308045+02:00"
+    "LastSeen": "2024-01-30T15:24:54.534441-05:00"
   },
   "https://learn.microsoft.com/en-us/dotnet/core/rid-catalog": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:52.02953+02:00"
+    "LastSeen": "2024-01-30T15:25:14.870052-05:00"
   },
   "https://learn.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#query-the-registry-using-code": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-16T15:01:09.046335374Z"
+    "LastSeen": "2024-01-30T16:14:24.784468-05:00"
   },
   "https://learn.microsoft.com/en-us/nuget/resources/check-project-format#check-the-project-format": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:51.71603+02:00"
+    "LastSeen": "2024-01-30T15:25:09.648079-05:00"
   },
   "https://learn.microsoft.com/rest/api/resources/resources/get-by-id": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-08T07:22:07.040171-05:00"
+    "LastSeen": "2024-01-30T16:14:24.361664-05:00"
   },
   "https://letsencrypt.org/": {
     "StatusCode": 206,
@@ -4561,7 +4549,7 @@
   },
   "https://man7.org/linux/man-pages/man5/proc.5.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-16T14:13:03.195663-04:00"
+    "LastSeen": "2024-01-30T16:04:48.740728-05:00"
   },
   "https://martinfowler.com/bliki/CanaryRelease.html": {
     "StatusCode": 206,
@@ -4569,23 +4557,15 @@
   },
   "https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#bill-of-materials-bom-poms": {
     "StatusCode": 206,
-    "LastSeen": "2023-12-15T18:44:53.040511+01:00"
-  },
-  "https://medium.com/@adri-v/lets-learn-about-the-otel-operator-s-target-allocator-47a2b1f07562": {
-    "StatusCode": 200,
-    "LastSeen": "2023-09-12T11:57:02.842574-04:00"
-  },
-  "https://medium.com/@adri-v/running-the-opentelemetry-demo-app-on-hashicorp-nomad-a3e21e35369d": {
-    "StatusCode": 200,
-    "LastSeen": "2023-09-12T11:57:02.21315-04:00"
+    "LastSeen": "2024-01-30T16:15:00.07395-05:00"
   },
   "https://medium.com/cloud-native-daily/how-to-contribute-to-opentelemetry-5962e8b2447e": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-08T10:56:59.495178-04:00"
+    "LastSeen": "2024-01-30T15:25:07.00961-05:00"
   },
   "https://medium.com/cloud-native-daily/lets-learn-about-otel-python-logging-auto-instrumentation-with-the-otel-operator-663247666570": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-12T11:57:01.212859-04:00"
+    "LastSeen": "2024-01-30T15:37:16.390474-05:00"
   },
   "https://medium.com/jaegertracing/introducing-native-support-for-opentelemetry-in-jaeger-eb661be8183c": {
     "StatusCode": 200,
@@ -4689,7 +4669,7 @@
   },
   "https://nextjs.org/docs/app/building-your-application/optimizing/open-telemetry": {
     "StatusCode": 206,
-    "LastSeen": "2023-09-15T16:58:31.662231+02:00"
+    "LastSeen": "2024-01-30T15:25:12.192795-05:00"
   },
   "https://nextjs.org/docs/app/building-your-application/rendering#fundamentals": {
     "StatusCode": 206,
@@ -4697,7 +4677,7 @@
   },
   "https://nginx.org/": {
     "StatusCode": 206,
-    "LastSeen": "2023-09-15T17:00:40.902027+02:00"
+    "LastSeen": "2024-01-30T15:25:20.687635-05:00"
   },
   "https://nodejs.org/api/async_context.html#async_context_class_asynclocalstorage": {
     "StatusCode": 200,
@@ -4765,7 +4745,7 @@
   },
   "https://npmjs.com/package/@opentelemetry/exporter-zipkin": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-23T20:37:23.122581+01:00"
+    "LastSeen": "2024-01-30T16:14:55.126913-05:00"
   },
   "https://npmjs.com/package/@opentelemetry/instrumentation-amqplib": {
     "StatusCode": 200,
@@ -4997,15 +4977,15 @@
   },
   "https://open-telemetry.github.io/opentelemetry-java/benchmarks/": {
     "StatusCode": 206,
-    "LastSeen": "2023-11-04T11:32:21.536067-04:00"
+    "LastSeen": "2024-01-30T16:15:04.041244-05:00"
   },
   "https://open-telemetry.github.io/opentelemetry-js/benchmarks/": {
     "StatusCode": 206,
-    "LastSeen": "2023-11-04T11:32:21.613865-04:00"
+    "LastSeen": "2024-01-30T16:15:09.534451-05:00"
   },
   "https://open-telemetry.github.io/opentelemetry-js/benchmarks/data.js": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-03T11:24:52.148514-07:00"
+    "LastSeen": "2024-01-30T16:04:59.684021-05:00"
   },
   "https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_api.ContextAPI.html": {
     "StatusCode": 206,
@@ -5021,7 +5001,19 @@
   },
   "https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_sdk_trace_base.SpanExporter.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-06T17:09:40.662318+02:00"
+    "LastSeen": "2024-01-30T16:05:22.694888-05:00"
+  },
+  "https://open.spotify.com/episode/5YrBEsXoJV3UjrHRrLRqBP": {
+    "StatusCode": 200,
+    "LastSeen": "2024-01-30T15:37:15.579021-05:00"
+  },
+  "https://open.spotify.com/episode/7ww8y3fy49MgEbcyFGvsNV": {
+    "StatusCode": 200,
+    "LastSeen": "2024-01-30T15:37:09.980309-05:00"
+  },
+  "https://open.spotify.com/show/4ZI6pQwChwm4sVULdtHFMe": {
+    "StatusCode": 200,
+    "LastSeen": "2024-01-30T15:37:21.465525-05:00"
   },
   "https://opencensus.io": {
     "StatusCode": 206,
@@ -5033,11 +5025,11 @@
   },
   "https://opencontainers.org/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-16T14:13:27.523763-04:00"
+    "LastSeen": "2024-01-30T16:03:38.301664-05:00"
   },
   "https://openfeature.dev/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-05T19:47:00.973306+02:00"
+    "LastSeen": "2024-01-30T16:06:32.46557-05:00"
   },
   "https://openid.net/specs/openid-connect-core-1_0.html#IDToken": {
     "StatusCode": 206,
@@ -5053,11 +5045,11 @@
   },
   "https://opensearch.org/": {
     "StatusCode": 206,
-    "LastSeen": "2023-11-03T10:07:17.047111-04:00"
+    "LastSeen": "2024-01-30T16:14:45.056945-05:00"
   },
   "https://opensearch.org/docs/latest/data-prepper/index/": {
     "StatusCode": 206,
-    "LastSeen": "2023-11-17T10:59:20.51098Z"
+    "LastSeen": "2024-01-30T16:14:58.880711-05:00"
   },
   "https://opentelemetry-cpp.readthedocs.io/en/latest/otel_docs/namespace_opentelemetry__metrics.html": {
     "StatusCode": 200,
@@ -5077,7 +5069,7 @@
   },
   "https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/logging/logging.html": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-17T10:59:23.029679Z"
+    "LastSeen": "2024-01-30T16:15:09.905013-05:00"
   },
   "https://opentelemetry-python.readthedocs.io/en/latest/api/metrics.html": {
     "StatusCode": 200,
@@ -5089,7 +5081,7 @@
   },
   "https://opentelemetry-python.readthedocs.io/en/latest/examples/logs/README.html": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-17T10:59:24.626088Z"
+    "LastSeen": "2024-01-30T16:15:15.462303-05:00"
   },
   "https://opentelemetry-python.readthedocs.io/en/latest/index.html": {
     "StatusCode": 200,
@@ -5101,7 +5093,7 @@
   },
   "https://opentelemetry-python.readthedocs.io/en/latest/sdk/trace.export.html#opentelemetry.sdk.trace.export.SpanExporter": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-08T16:22:53.779771+01:00"
+    "LastSeen": "2024-01-30T16:15:05.361186-05:00"
   },
   "https://opentelemetry-python.readthedocs.io/en/latest/sdk/trace.html": {
     "StatusCode": 200,
@@ -5131,14 +5123,6 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:07:12.98586-05:00"
   },
-  "https://opentelemetry.io/": {
-    "StatusCode": 206,
-    "LastSeen": "2023-09-08T10:56:59.732967-04:00"
-  },
-  "https://opentelemetry.io/docs/instrumentation/java/automatic/spring-boot/": {
-    "StatusCode": 206,
-    "LastSeen": "2023-12-08T11:19:15.011115+01:00"
-  },
   "https://opentracing.io": {
     "StatusCode": 206,
     "LastSeen": "2024-01-18T19:07:33.813401-05:00"
@@ -5165,7 +5149,7 @@
   },
   "https://otterize.com/": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-16T15:02:10.279947-05:00"
+    "LastSeen": "2024-01-30T16:15:04.230377-05:00"
   },
   "https://packagist.org/": {
     "StatusCode": 200,
@@ -5263,10 +5247,6 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-30T06:06:02.615456-05:00"
   },
-  "https://packagist.org/packages/opentelemetry/exporter-otlp": {
-    "StatusCode": 200,
-    "LastSeen": "2023-12-23T20:37:23.469598+01:00"
-  },
   "https://packagist.org/providers/php-http/async-client-implementation": {
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:56:08.488354-05:00"
@@ -5285,7 +5265,7 @@
   },
   "https://parquet.apache.org/": {
     "StatusCode": 206,
-    "LastSeen": "2023-11-14T11:45:10.104631+01:00"
+    "LastSeen": "2024-01-30T16:15:42.782908-05:00"
   },
   "https://pecl.php.net/": {
     "StatusCode": 206,
@@ -5293,7 +5273,7 @@
   },
   "https://pecl.php.net/package/opentelemetry": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-12T10:33:59.774290104Z"
+    "LastSeen": "2024-01-30T15:25:27.390971-05:00"
   },
   "https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs": {
     "StatusCode": 200,
@@ -6057,11 +6037,11 @@
   },
   "https://pkg.go.dev/go.opentelemetry.io/otel": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-11T14:33:25.55139188Z"
+    "LastSeen": "2024-01-30T15:25:20.983758-05:00"
   },
   "https://pkg.go.dev/go.opentelemetry.io/otel#Meter": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-11T14:33:26.091012084Z"
+    "LastSeen": "2024-01-30T15:25:32.14773-05:00"
   },
   "https://pkg.go.dev/go.opentelemetry.io/otel/bridge/opentracing": {
     "StatusCode": 200,
@@ -6069,19 +6049,19 @@
   },
   "https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-27T11:12:33.788950402Z"
+    "LastSeen": "2024-01-30T15:25:43.27652-05:00"
   },
   "https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-27T11:12:33.662712825Z"
+    "LastSeen": "2024-01-30T15:25:37.967464-05:00"
   },
   "https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-27T11:12:33.534988445Z"
+    "LastSeen": "2024-01-30T15:25:32.314529-05:00"
   },
   "https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-27T11:12:33.40195469Z"
+    "LastSeen": "2024-01-30T15:25:26.870024-05:00"
   },
   "https://pkg.go.dev/go.opentelemetry.io/otel/exporters/prometheus": {
     "StatusCode": 200,
@@ -6089,71 +6069,67 @@
   },
   "https://pkg.go.dev/go.opentelemetry.io/otel/exporters/stdout/stdoutmetric": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-11T14:33:25.954024386Z"
+    "LastSeen": "2024-01-30T15:25:21.196671-05:00"
   },
   "https://pkg.go.dev/go.opentelemetry.io/otel/exporters/stdout/stdouttrace": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-27T11:12:33.278510097Z"
+    "LastSeen": "2024-01-30T15:25:12.88079-05:00"
   },
   "https://pkg.go.dev/go.opentelemetry.io/otel/metric": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-11T14:33:25.28571455Z"
+    "LastSeen": "2024-01-30T15:24:56.783398-05:00"
   },
   "https://pkg.go.dev/go.opentelemetry.io/otel/metric#WithAttributeSet": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-11T14:33:26.225649719Z"
+    "LastSeen": "2024-01-30T15:25:37.537759-05:00"
   },
   "https://pkg.go.dev/go.opentelemetry.io/otel/metric#WithAttributes": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-11T14:33:26.416861936Z"
+    "LastSeen": "2024-01-30T15:25:42.951557-05:00"
   },
   "https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-11T14:33:25.420952095Z"
+    "LastSeen": "2024-01-30T15:25:12.503352-05:00"
   },
   "https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#NewView": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-15T09:41:38.164411819Z"
+    "LastSeen": "2024-01-30T15:25:48.381191-05:00"
   },
   "https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#View": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-15T09:41:38.432556144Z"
-  },
-  "https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#With": {
-    "StatusCode": 200,
-    "LastSeen": "2023-09-15T09:41:38.295762202Z"
+    "LastSeen": "2024-01-30T15:25:59.270076-05:00"
   },
   "https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#WithView": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-15T16:34:14.034832295Z"
+    "LastSeen": "2024-01-30T15:25:53.789976-05:00"
   },
   "https://pkg.go.dev/go.opentelemetry.io/otel/sdk/resource": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-11T14:33:25.721659015Z"
+    "LastSeen": "2024-01-30T15:25:26.884831-05:00"
   },
   "https://pkg.go.dev/go.opentelemetry.io/otel/sdk/trace#AlwaysSample": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-27T09:39:52.203079253Z"
+    "LastSeen": "2024-01-30T15:25:20.975941-05:00"
   },
   "https://pkg.go.dev/go.opentelemetry.io/otel/sdk/trace#NeverSample": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-27T09:39:52.327351275Z"
+    "LastSeen": "2024-01-30T15:25:26.711478-05:00"
   },
   "https://pkg.go.dev/go.opentelemetry.io/otel/sdk/trace#ParentBased": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-27T09:39:52.578080474Z"
+    "LastSeen": "2024-01-30T15:25:37.535161-05:00"
   },
   "https://pkg.go.dev/go.opentelemetry.io/otel/sdk/trace#Sampler": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-27T09:39:51.939566324Z"
+    "LastSeen": "2024-01-30T15:24:56.762328-05:00"
   },
   "https://pkg.go.dev/go.opentelemetry.io/otel/sdk/trace#TraceIDRatioBased": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-27T09:39:52.452582667Z"
+    "LastSeen": "2024-01-30T15:25:32.120448-05:00"
   },
   "https://pkg.go.dev/go.opentelemetry.io/otel/sdk/trace#WithSampler": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-27T09:39:52.070515192Z"
+    "LastSeen": "2024-01-30T15:25:12.45117-05:00"
   },
   "https://pkg.go.dev/google.golang.org/grpc/credentials#PerRPCCredentials": {
     "StatusCode": 200,
@@ -6161,7 +6137,7 @@
   },
   "https://pkg.go.dev/net/http": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-25T10:17:08.593410057Z"
+    "LastSeen": "2024-01-30T15:24:51.249653-05:00"
   },
   "https://pkg.go.dev/net/http#RoundTripper": {
     "StatusCode": 200,
@@ -6181,11 +6157,11 @@
   },
   "https://playwright.dev/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-04T17:14:47.324713-07:00"
+    "LastSeen": "2024-01-30T16:05:09.136828-05:00"
   },
   "https://plugins.jenkins.io/opentelemetry/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-05T19:46:14.084327+02:00"
+    "LastSeen": "2024-01-30T16:05:44.189442-05:00"
   },
   "https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html": {
     "StatusCode": 200,
@@ -6209,7 +6185,7 @@
   },
   "https://prometheus.io/docs/alerting/latest/alertmanager/": {
     "StatusCode": 206,
-    "LastSeen": "2023-12-01T16:02:43.039481+01:00"
+    "LastSeen": "2024-01-30T16:14:18.042312-05:00"
   },
   "https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels": {
     "StatusCode": 206,
@@ -6237,7 +6213,7 @@
   },
   "https://prometheus.io/docs/prometheus/latest/feature_flags/#otlp-receiver": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-06T17:09:40.323028+02:00"
+    "LastSeen": "2024-01-30T16:04:54.334776-05:00"
   },
   "https://prometheus.io/docs/prometheus/latest/federation/": {
     "StatusCode": 206,
@@ -6245,7 +6221,7 @@
   },
   "https://prometheus.io/docs/prometheus/latest/http_sd/": {
     "StatusCode": 206,
-    "LastSeen": "2023-08-15T11:49:51.507243-06:00"
+    "LastSeen": "2024-01-30T15:25:02.35891-05:00"
   },
   "https://prometheus.io/docs/prometheus/latest/installation/": {
     "StatusCode": 206,
@@ -6265,19 +6241,19 @@
   },
   "https://pypi.org/project/opentelemetry-exporter-prometheus/": {
     "StatusCode": 206,
-    "LastSeen": "2023-11-08T16:22:52.2717+01:00"
+    "LastSeen": "2024-01-30T16:14:35.878589-05:00"
   },
   "https://pypi.org/project/opentelemetry-exporter-zipkin-json/": {
     "StatusCode": 206,
-    "LastSeen": "2023-11-08T16:22:53.166698+01:00"
+    "LastSeen": "2024-01-30T16:14:59.008783-05:00"
   },
   "https://pypi.org/project/opentelemetry-exporter-zipkin-proto-http/": {
     "StatusCode": 206,
-    "LastSeen": "2023-11-08T16:22:52.72657+01:00"
+    "LastSeen": "2024-01-30T16:14:48.105173-05:00"
   },
   "https://qryn.metrico.in/#/support": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-17T15:10:07.18892+02:00"
+    "LastSeen": "2024-01-30T16:03:54.589618-05:00"
   },
   "https://quarkus.io": {
     "StatusCode": 206,
@@ -6321,7 +6297,7 @@
   },
   "https://research.facebook.com/file/877841159827226/holistic-configuration-management-at-facebook.pdf": {
     "StatusCode": 206,
-    "LastSeen": "2023-11-29T05:30:49.447684-05:00"
+    "LastSeen": "2024-01-30T16:14:42.741857-05:00"
   },
   "https://roadrunner.dev/": {
     "StatusCode": 200,
@@ -6545,11 +6521,11 @@
   },
   "https://rust-lang.github.io/rustup/dev-guide/tracing.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-16T20:09:54.979837+02:00"
+    "LastSeen": "2024-01-30T16:06:48.896568-05:00"
   },
   "https://rustup.rs/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-16T20:09:54.794436+02:00"
+    "LastSeen": "2024-01-30T16:06:43.489167-05:00"
   },
   "https://sakshipatle.substack.com/p/outreachy-how-when-and-why": {
     "StatusCode": 200,
@@ -6601,75 +6577,71 @@
   },
   "https://sched.co/1R2m6": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-11T17:29:31.441463+02:00"
+    "LastSeen": "2024-01-30T15:25:20.317483-05:00"
   },
   "https://sched.co/1R2mK": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-11T17:29:30.505711+02:00"
+    "LastSeen": "2024-01-30T15:25:12.219303-05:00"
   },
   "https://sched.co/1R2mo": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-11T17:29:32.60093+02:00"
+    "LastSeen": "2024-01-30T15:25:26.405475-05:00"
   },
   "https://sched.co/1R2nO": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-11T17:29:33.640586+02:00"
+    "LastSeen": "2024-01-30T15:25:31.980116-05:00"
   },
   "https://sched.co/1R2oA": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-10T17:29:25.395063132Z"
+    "LastSeen": "2024-01-30T16:05:09.181824-05:00"
   },
   "https://sched.co/1R2oQ": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-11T17:29:34.788404+02:00"
+    "LastSeen": "2024-01-30T15:25:37.785911-05:00"
   },
   "https://sched.co/1R2oh": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-11T17:29:35.927296+02:00"
+    "LastSeen": "2024-01-30T15:25:43.224791-05:00"
   },
   "https://sched.co/1R2pI": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-11T17:29:37.040277+02:00"
+    "LastSeen": "2024-01-30T15:25:48.622657-05:00"
   },
   "https://sched.co/1R2pr": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-11T17:29:39.781595+02:00"
+    "LastSeen": "2024-01-30T15:25:59.500919-05:00"
   },
   "https://sched.co/1R2q1": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-11T17:29:41.791485+02:00"
+    "LastSeen": "2024-01-30T15:26:10.568498-05:00"
   },
   "https://sched.co/1R2r4": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-11T17:29:40.708188+02:00"
+    "LastSeen": "2024-01-30T15:26:04.896931-05:00"
   },
   "https://sched.co/1R2rQ": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-02T11:25:33.305328+02:00"
+    "LastSeen": "2024-01-30T16:05:03.787439-05:00"
   },
   "https://sched.co/1R2rW": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-05T10:09:18.757465+02:00"
-  },
-  "https://sched.co/1R2s9": {
-    "StatusCode": 200,
-    "LastSeen": "2023-09-11T17:29:42.933019+02:00"
+    "LastSeen": "2024-01-30T16:05:14.592389-05:00"
   },
   "https://sched.co/1R2sI": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-02T11:25:34.163077+02:00"
+    "LastSeen": "2024-01-30T16:05:20.021856-05:00"
   },
   "https://sched.co/1R2sr": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-11T17:29:43.860841+02:00"
+    "LastSeen": "2024-01-30T15:26:16.056458-05:00"
   },
   "https://sched.co/1R2uc": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-11T17:29:44.802803+02:00"
+    "LastSeen": "2024-01-30T15:26:21.453006-05:00"
   },
   "https://sched.co/1R2ur": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-11T17:29:38.712916+02:00"
+    "LastSeen": "2024-01-30T15:25:54.102881-05:00"
   },
   "https://seecfp.com/": {
     "StatusCode": 206,
@@ -6693,7 +6665,7 @@
   },
   "https://shorturl.at/beJ09": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-12T11:14:56.238346-04:00"
+    "LastSeen": "2024-01-30T15:26:42.338496-05:00"
   },
   "https://shorturl.at/cIJT2": {
     "StatusCode": 200,
@@ -6701,23 +6673,15 @@
   },
   "https://shorturl.at/czHST": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-12T12:09:44.772877-04:00"
+    "LastSeen": "2024-01-30T15:25:54.341869-05:00"
   },
   "https://shorturl.at/hlqtE": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-12T12:09:44.031281-04:00"
+    "LastSeen": "2024-01-30T15:25:47.730545-05:00"
   },
   "https://shorturl.at/kAEQX": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-22T15:46:29.596006461Z"
-  },
-  "https://shorturl.at/osHRX": {
-    "StatusCode": 200,
-    "LastSeen": "2023-12-22T15:46:25.223430264Z"
-  },
-  "https://shorturl.at/vLYZ0": {
-    "StatusCode": 200,
-    "LastSeen": "2023-09-12T12:09:42.592065-04:00"
+    "LastSeen": "2024-01-30T16:15:19.756188-05:00"
   },
   "https://signoz.io": {
     "StatusCode": 206,
@@ -6745,11 +6709,11 @@
   },
   "https://spring.io/projects/spring-boot": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-14T09:30:36.981189-05:00"
+    "LastSeen": "2024-01-30T16:14:40.011882-05:00"
   },
   "https://square.github.io/okhttp/": {
     "StatusCode": 206,
-    "LastSeen": "2023-09-14T09:36:37.578867-05:00"
+    "LastSeen": "2024-01-30T15:25:13.019086-05:00"
   },
   "https://stackoverflow.com/questions/5626193/what-is-monkey-patching": {
     "StatusCode": 200,
@@ -6761,7 +6725,7 @@
   },
   "https://standards.ieee.org/wp-content/uploads/import/documents/tutorials/eui.pdf": {
     "StatusCode": 206,
-    "LastSeen": "2023-11-08T07:23:33.211618-05:00"
+    "LastSeen": "2024-01-30T16:14:29.43022-05:00"
   },
   "https://storiesfromtheherd.com/just-in-time-nomad-80f57cd403ca": {
     "StatusCode": 200,
@@ -6773,7 +6737,7 @@
   },
   "https://strimzi.io/docs/operators/latest/deploying#assembly-distributed-tracing-str": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-31T16:02:16.454105-04:00"
+    "LastSeen": "2024-01-30T16:06:54.742438-05:00"
   },
   "https://studio.apollographql.com": {
     "StatusCode": 200,
@@ -6781,7 +6745,7 @@
   },
   "https://superuser.com/a/980821": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-16T14:12:57.75446-04:00"
+    "LastSeen": "2024-01-30T16:04:05.046927-05:00"
   },
   "https://sysdig.com/blog/kubernetes-1-25-whats-new/": {
     "StatusCode": 206,
@@ -6797,11 +6761,11 @@
   },
   "https://thanos.io/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-16T20:09:56.672005+02:00"
+    "LastSeen": "2024-01-30T16:07:00.226904-05:00"
   },
   "https://thanos.io/tip/thanos/tracing.md/#opentelemetry-otlp": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-16T20:09:56.874625+02:00"
+    "LastSeen": "2024-01-30T16:07:05.720805-05:00"
   },
   "https://tinygo.org/": {
     "StatusCode": 206,
@@ -6877,15 +6841,15 @@
   },
   "https://tools.ietf.org/html/rfc9110#section-7.2": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-08T07:23:16.17102-05:00"
+    "LastSeen": "2024-01-30T16:14:53.22207-05:00"
   },
   "https://tools.ietf.org/html/rfc9113#section-8.3.1": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-03T03:04:37.939785-04:00"
+    "LastSeen": "2024-01-30T16:15:09.534458-05:00"
   },
   "https://tracetest.io/": {
     "StatusCode": 206,
-    "LastSeen": "2023-08-14T12:06:16.100357-03:00"
+    "LastSeen": "2024-01-30T15:24:48.98869-05:00"
   },
   "https://tracetest.io/blog/frontend-overhaul-opentelemetry-demo": {
     "StatusCode": 206,
@@ -6897,23 +6861,23 @@
   },
   "https://traefik.io/traefik-hub/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-25T11:13:58.185985+02:00"
+    "LastSeen": "2024-01-30T16:07:34.195677-05:00"
   },
   "https://tyk.io": {
     "StatusCode": 206,
-    "LastSeen": "2023-09-20T10:45:05.852778+02:00"
+    "LastSeen": "2024-01-30T15:25:27.767149-05:00"
   },
   "https://tyk.io/docs/product-stack/tyk-gateway/advanced-configurations/distributed-tracing/open-telemetry/open-telemetry-overview/": {
     "StatusCode": 206,
-    "LastSeen": "2023-09-19T18:15:55.842511+02:00"
+    "LastSeen": "2024-01-30T15:25:10.11516-05:00"
   },
   "https://tyk.io/docs/product-stack/tyk-gateway/advanced-configurations/plugins/otel-plugins/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-26T12:18:59.024513+02:00"
+    "LastSeen": "2024-01-30T16:05:15.785278-05:00"
   },
   "https://tyk.io/docs/tyk-oss-gateway/configuration/#opentelemetry": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-26T12:18:58.666794+02:00"
+    "LastSeen": "2024-01-30T16:05:09.68071-05:00"
   },
   "https://ucum.org/ucum.html#para-curly": {
     "StatusCode": 200,
@@ -6953,11 +6917,11 @@
   },
   "https://vapor.codes": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-04T17:37:06.474654+02:00"
+    "LastSeen": "2024-01-30T16:05:03.5069-05:00"
   },
   "https://vote.heliosvoting.org/helios/elections/1ee70ee4-11ce-11ee-aaf8-0a8c9aac83f9/view": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-28T17:11:11.729958-04:00"
+    "LastSeen": "2024-01-30T15:25:03.975449-05:00"
   },
   "https://vote.heliosvoting.org/helios/elections/76558134-3384-11ed-8688-02871af94755/view": {
     "StatusCode": 200,
@@ -6989,11 +6953,11 @@
   },
   "https://wiki.alpinelinux.org/wiki/Repositories#Testing": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-27T06:45:36.696402804Z"
+    "LastSeen": "2024-01-30T15:25:15.572362-05:00"
   },
   "https://wiki.osdev.org/CPUID": {
-    "StatusCode": 200,
-    "LastSeen": "2023-10-16T14:13:16.464459-04:00"
+    "StatusCode": 206,
+    "LastSeen": "2024-01-30T16:03:33.99649-05:00"
   },
   "https://wiki.python.org/moin/PythonImplementations": {
     "StatusCode": 200,
@@ -7005,39 +6969,31 @@
   },
   "https://wikipedia.org/wiki/Count_noun": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-08T07:21:23.868848-05:00"
+    "LastSeen": "2024-01-30T16:14:47.948329-05:00"
   },
   "https://wikipedia.org/wiki/Deployment_environment": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-08T07:23:39.11906-05:00"
+    "LastSeen": "2024-01-30T16:14:31.776411-05:00"
   },
   "https://wikipedia.org/wiki/Function_as_a_service": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-08T07:21:18.690062-05:00"
-  },
-  "https://wikipedia.org/wiki/Hop_%28networking%29": {
-    "StatusCode": 200,
-    "LastSeen": "2023-11-08T07:21:13.325261-05:00"
+    "LastSeen": "2024-01-30T16:14:31.894871-05:00"
   },
   "https://wikipedia.org/wiki/Inter-process_communication": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-08T07:21:34.564864-05:00"
+    "LastSeen": "2024-01-30T16:14:37.279155-05:00"
   },
   "https://wikipedia.org/wiki/Load_%28computing%29": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-08T07:22:50.172555-05:00"
+    "LastSeen": "2024-01-30T16:14:53.630494-05:00"
   },
   "https://wikipedia.org/wiki/Page_fault": {
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:37:36.964981-05:00"
   },
-  "https://wikipedia.org/wiki/S.M.A.R.T.": {
-    "StatusCode": 200,
-    "LastSeen": "2023-11-08T07:22:28.763824-05:00"
-  },
   "https://wukongdoc.tingyun.com/apm/userguide/deploy_manage/opentelemetry.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-11-01T09:14:51.938778+08:00"
+    "LastSeen": "2024-01-30T16:14:59.93877-05:00"
   },
   "https://www.alibabacloud.com/": {
     "StatusCode": 200,
@@ -7081,27 +7037,23 @@
   },
   "https://www.cisco.com/c/en/us/products/cloud-systems-management/network-services-orchestrator/index.html": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-15T16:58:32.417789+02:00"
+    "LastSeen": "2024-01-30T15:25:33.27752-05:00"
   },
   "https://www.cloudfoundry.org/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-31T22:49:01.12971518Z"
+    "LastSeen": "2024-01-30T16:03:28.110283-05:00"
   },
   "https://www.cloudwego.io/": {
-    "StatusCode": 200,
-    "LastSeen": "2023-11-14T12:26:21.00653-04:00"
+    "StatusCode": 206,
+    "LastSeen": "2024-01-30T16:14:19.048604-05:00"
   },
   "https://www.cloudwego.io/docs/hertz/tutorials/observability/open-telemetry/": {
-    "StatusCode": 200,
-    "LastSeen": "2023-11-14T12:26:21.00653-04:00"
+    "StatusCode": 206,
+    "LastSeen": "2024-01-30T16:14:35.250244-05:00"
   },
   "https://www.cncf.io": {
     "StatusCode": 206,
     "LastSeen": "2024-01-18T19:10:25.924884-05:00"
-  },
-  "https://www.cncf.io/about/contact/": {
-    "StatusCode": 206,
-    "LastSeen": "2023-12-12T09:05:06.564168+01:00"
   },
   "https://www.cncf.io/blog/2019/05/21/a-brief-history-of-opentelemetry-so-far/": {
     "StatusCode": 206,
@@ -7165,11 +7117,11 @@
   },
   "https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/index.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-09-13T08:18:13.777841+02:00"
+    "LastSeen": "2024-01-30T15:24:49.20141-05:00"
   },
   "https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/opentelemetry.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-09-13T08:18:14.600801+02:00"
+    "LastSeen": "2024-01-30T15:24:55.301982-05:00"
   },
   "https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html": {
     "StatusCode": 206,
@@ -7201,15 +7153,15 @@
   },
   "https://www.first.org/cvss/calculator/3.1": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-13T15:40:04.523841-08:00"
+    "LastSeen": "2024-01-30T16:14:50.659493-05:00"
   },
   "https://www.first.org/cvss/specification-document": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-13T15:40:03.612009-08:00"
+    "LastSeen": "2024-01-30T16:14:36.299764-05:00"
   },
   "https://www.flipt.io/docs/configuration/observability#tracing": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-05T19:46:12.968304+02:00"
+    "LastSeen": "2024-01-30T16:05:22.031745-05:00"
   },
   "https://www.fulcrumapp.com/": {
     "StatusCode": 206,
@@ -7229,7 +7181,7 @@
   },
   "https://www.highlight.io/docs/general/company/open-source/contributing/adding-an-sdk/": {
     "StatusCode": 206,
-    "LastSeen": "2023-09-19T23:11:24.486503-07:00"
+    "LastSeen": "2024-01-30T15:24:52.533914-05:00"
   },
   "https://www.honeycomb.io/": {
     "StatusCode": 206,
@@ -7245,15 +7197,15 @@
   },
   "https://www.hyperdx.io/docs/install/opentelemetry": {
     "StatusCode": 206,
-    "LastSeen": "2023-12-18T14:55:25.074987-08:00"
+    "LastSeen": "2024-01-30T16:14:16.496047-05:00"
   },
   "https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-16T15:01:30.066295662Z"
+    "LastSeen": "2024-01-30T16:14:58.739442-05:00"
   },
   "https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#table-tls-parameters-4": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-16T15:01:30.296009757Z"
+    "LastSeen": "2024-01-30T16:15:04.543149-05:00"
   },
   "https://www.ibm.com/docs/api/v1/content/SSYKE2_8.0.0/openj9/api/jdk8/jre/management/extension/com/ibm/lang/management/OperatingSystemMXBean.html": {
     "StatusCode": 206,
@@ -7277,7 +7229,7 @@
   },
   "https://www.influxdata.com/time-series-platform/telegraf/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-31T22:49:01.321162658Z"
+    "LastSeen": "2024-01-30T16:05:10.329813-05:00"
   },
   "https://www.investopedia.com/terms/p/personally-identifiable-information-pii.asp": {
     "StatusCode": 200,
@@ -7369,7 +7321,7 @@
   },
   "https://www.jenkins.io/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-05T19:46:13.272129+02:00"
+    "LastSeen": "2024-01-30T16:05:38.60387-05:00"
   },
   "https://www.jsonrpc.org/": {
     "StatusCode": 206,
@@ -7383,13 +7335,17 @@
     "StatusCode": 206,
     "LastSeen": "2024-01-18T19:55:51.649479-05:00"
   },
+  "https://www.konghq.com/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-01-30T15:37:02.403477-05:00"
+  },
   "https://www.linuxfoundation.org/legal/privacy-policy": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-18T10:57:26.960512-04:00"
+    "LastSeen": "2024-01-30T16:04:05.250977-05:00"
   },
   "https://www.linuxfoundation.org/legal/trademark-usage": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-18T10:57:32.375541-04:00"
+    "LastSeen": "2024-01-30T16:04:48.768978-05:00"
   },
   "https://www.logicmonitor.com/support/tracing/getting-started-with-tracing": {
     "StatusCode": 206,
@@ -7400,12 +7356,12 @@
     "LastSeen": "2024-01-18T19:55:56.769343-05:00"
   },
   "https://www.mathworks.com/matlabcentral/fileexchange/130979-opentelemetry-matlab": {
-    "StatusCode": 200,
-    "LastSeen": "2023-10-16T20:09:58.703215+02:00"
+    "StatusCode": 206,
+    "LastSeen": "2024-01-30T16:07:16.475437-05:00"
   },
   "https://www.mathworks.com/products/matlab.html": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-16T20:09:57.720447+02:00"
+    "LastSeen": "2024-01-30T16:07:10.978829-05:00"
   },
   "https://www.meetup.com/opentelemetry-in-practice-meetup-group/": {
     "StatusCode": 206,
@@ -7417,15 +7373,15 @@
   },
   "https://www.mysql.com/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-16T20:09:59.62173+02:00"
+    "LastSeen": "2024-01-30T16:07:22.780855-05:00"
   },
   "https://www.netlify.com/": {
     "StatusCode": 206,
-    "LastSeen": "2023-12-12T09:05:07.468279+01:00"
+    "LastSeen": "2024-01-30T16:15:31.243531-05:00"
   },
   "https://www.netlify.com/blog/2016/07/20/introducing-deploy-previews-in-netlify/": {
     "StatusCode": 206,
-    "LastSeen": "2023-12-13T15:27:12.735575+01:00"
+    "LastSeen": "2024-01-30T16:15:36.666513-05:00"
   },
   "https://www.nomadproject.io": {
     "StatusCode": 206,
@@ -7441,7 +7397,7 @@
   },
   "https://www.npmjs.com/package/@opentelemetry/exporter-prometheus": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-17T14:37:54.256694+02:00"
+    "LastSeen": "2024-01-30T16:05:10.886286-05:00"
   },
   "https://www.npmjs.com/package/@opentelemetry/exporter-trace-otlp-grpc": {
     "StatusCode": 200,
@@ -7457,7 +7413,7 @@
   },
   "https://www.npmjs.com/package/@opentelemetry/exporter-zipkin": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-17T14:37:56.298883+02:00"
+    "LastSeen": "2024-01-30T16:05:17.306892-05:00"
   },
   "https://www.npmjs.com/package/@opentelemetry/instrumentation-aws-lambda": {
     "StatusCode": 200,
@@ -7477,7 +7433,7 @@
   },
   "https://www.npmjs.com/package/@opentelemetry/sdk-metrics": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-17T14:37:52.069158+02:00"
+    "LastSeen": "2024-01-30T16:05:04.40799-05:00"
   },
   "https://www.npmjs.com/package/@opentelemetry/sdk-node": {
     "StatusCode": 200,
@@ -7485,7 +7441,7 @@
   },
   "https://www.npmjs.com/package/@opentelemetry/sdk-trace-node": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-17T14:37:50.222264+02:00"
+    "LastSeen": "2024-01-30T16:04:55.120561-05:00"
   },
   "https://www.npmjs.com/package/@opentelemetry/shim-opentracing": {
     "StatusCode": 200,
@@ -7493,7 +7449,7 @@
   },
   "https://www.nuget.org/packages/": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:25.165623+02:00"
+    "LastSeen": "2024-01-30T15:25:18.124486-05:00"
   },
   "https://www.nuget.org/packages/Azure.Monitor.OpenTelemetry.Exporter": {
     "StatusCode": 200,
@@ -7505,23 +7461,23 @@
   },
   "https://www.nuget.org/packages/Elastic.Clients.Elasticsearch": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:24.3457+02:00"
+    "LastSeen": "2024-01-30T15:25:11.936702-05:00"
   },
   "https://www.nuget.org/packages/Elastic.Transport": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-24T16:16:35.416301352Z"
+    "LastSeen": "2024-01-30T16:04:54.132064-05:00"
   },
   "https://www.nuget.org/packages/GraphQL": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:26.557268+02:00"
+    "LastSeen": "2024-01-30T15:25:26.790582-05:00"
   },
   "https://www.nuget.org/packages/Grpc.Net.Client": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:27.752035+02:00"
+    "LastSeen": "2024-01-30T15:25:32.390995-05:00"
   },
   "https://www.nuget.org/packages/Grpc.Net.Client/": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:14.681431+02:00"
+    "LastSeen": "2024-01-30T15:25:12.378389-05:00"
   },
   "https://www.nuget.org/packages/KafkaFlow.OpenTelemetry": {
     "StatusCode": 200,
@@ -7529,39 +7485,39 @@
   },
   "https://www.nuget.org/packages/MassTransit": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:35.326603+02:00"
+    "LastSeen": "2024-01-30T15:25:53.19635-05:00"
   },
   "https://www.nuget.org/packages/Microsoft.Data.SqlClient": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:44.680556+02:00"
+    "LastSeen": "2024-01-30T15:26:37.706115-05:00"
   },
   "https://www.nuget.org/packages/Microsoft.Extensions.Logging": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:51.22816+02:00"
+    "LastSeen": "2024-01-30T15:27:06.082933-05:00"
   },
   "https://www.nuget.org/packages/MongoDB.Driver.Core": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:36.455034+02:00"
+    "LastSeen": "2024-01-30T15:25:58.82756-05:00"
   },
   "https://www.nuget.org/packages/MySql.Data": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:39.165361+02:00"
+    "LastSeen": "2024-01-30T15:26:11.523571-05:00"
   },
   "https://www.nuget.org/packages/MySqlConnector": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:38.152894+02:00"
+    "LastSeen": "2024-01-30T15:26:05.802946-05:00"
   },
   "https://www.nuget.org/packages/NServiceBus": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:43.766427+02:00"
+    "LastSeen": "2024-01-30T15:26:26.636128-05:00"
   },
   "https://www.nuget.org/packages/Npgsql": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:40.72719+02:00"
+    "LastSeen": "2024-01-30T15:26:17.426269-05:00"
   },
   "https://www.nuget.org/packages/OpenTelemetry.Exporter.Console": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-13T09:34:45.811783+02:00"
+    "LastSeen": "2024-01-30T16:04:59.787702-05:00"
   },
   "https://www.nuget.org/packages/OpenTelemetry.Exporter.Geneva": {
     "StatusCode": 200,
@@ -7613,7 +7569,7 @@
   },
   "https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNet": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-13T09:34:44.998116+02:00"
+    "LastSeen": "2024-01-30T16:04:54.124745-05:00"
   },
   "https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule": {
     "StatusCode": 200,
@@ -7669,7 +7625,7 @@
   },
   "https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Process": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:49.345518+02:00"
+    "LastSeen": "2024-01-30T15:25:00.54516-05:00"
   },
   "https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Quartz": {
     "StatusCode": 200,
@@ -7677,7 +7633,7 @@
   },
   "https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Runtime": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:48.575209+02:00"
+    "LastSeen": "2024-01-30T15:25:11.836127-05:00"
   },
   "https://www.nuget.org/packages/OpenTelemetry.Instrumentation.SqlClient": {
     "StatusCode": 200,
@@ -7693,39 +7649,39 @@
   },
   "https://www.nuget.org/packages/Quartz": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:30.630826+02:00"
+    "LastSeen": "2024-01-30T15:26:32.105686-05:00"
   },
   "https://www.nuget.org/packages/StackExchange.Redis": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:47.003592+02:00"
+    "LastSeen": "2024-01-30T15:26:49.163589-05:00"
   },
   "https://www.nuget.org/packages/System.Data.SqlClient": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-06T15:04:45.63516+02:00"
+    "LastSeen": "2024-01-30T15:26:43.21023-05:00"
   },
   "https://www.nuget.org/profiles/OpenTelemetry": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-08T13:31:10.247781347Z"
+    "LastSeen": "2024-01-30T16:14:40.133322-05:00"
   },
   "https://www.observeany.com/learn/opentelemetry-receiver": {
     "StatusCode": 200,
-    "LastSeen": "2023-08-17T09:39:20.114053+08:00"
+    "LastSeen": "2024-01-30T15:25:23.850674-05:00"
   },
   "https://www.openpolicyagent.org/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-16T20:09:53.677301+02:00"
+    "LastSeen": "2024-01-30T16:06:21.562641-05:00"
   },
   "https://www.openpolicyagent.org/docs/latest/monitoring/#opentelemetry": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-16T20:09:53.898397+02:00"
+    "LastSeen": "2024-01-30T16:06:26.999329-05:00"
   },
   "https://www.openssl.org/docs/man1.1.1/man3/SSL_get_version.html#RETURN-VALUES": {
-    "StatusCode": 200,
-    "LastSeen": "2023-12-16T15:01:24.2501831Z"
+    "StatusCode": 206,
+    "LastSeen": "2024-01-30T16:14:53.526525-05:00"
   },
   "https://www.openssl.org/docs/manmaster/man1/openssl-s_client.html": {
-    "StatusCode": 200,
-    "LastSeen": "2023-11-24T16:20:23.86666+01:00"
+    "StatusCode": 206,
+    "LastSeen": "2024-01-30T16:14:53.429593-05:00"
   },
   "https://www.oracle.com/technical-resources/articles/javase/jmx.html": {
     "StatusCode": 200,
@@ -7733,7 +7689,7 @@
   },
   "https://www.otelbin.io/": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-17T10:59:19.546115Z"
+    "LastSeen": "2024-01-30T16:14:44.039011-05:00"
   },
   "https://www.outreachy.org/": {
     "StatusCode": 200,
@@ -7845,7 +7801,7 @@
   },
   "https://www.rfc-editor.org/rfc/rfc5952.html": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-16T14:13:10.625503-04:00"
+    "LastSeen": "2024-01-30T16:04:54.139913-05:00"
   },
   "https://www.rfc-editor.org/rfc/rfc9110.html": {
     "StatusCode": 200,
@@ -7881,11 +7837,11 @@
   },
   "https://www.rust-lang.org/": {
     "StatusCode": 206,
-    "LastSeen": "2023-08-03T17:44:09.160658+02:00"
+    "LastSeen": "2024-01-30T15:25:04.905602-05:00"
   },
   "https://www.selenium.dev/documentation/grid/advanced_features/observability/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-04T17:14:47.106022-07:00"
+    "LastSeen": "2024-01-30T16:05:03.991313-05:00"
   },
   "https://www.sentrysoftware.com/products/hardware-sentry-opentelemetry-collector.html": {
     "StatusCode": 206,
@@ -7897,7 +7853,7 @@
   },
   "https://www.servicenow.com/products/observability.html": {
     "StatusCode": 200,
-    "LastSeen": "2023-11-14T11:45:06.343243+01:00"
+    "LastSeen": "2024-01-30T16:15:20.662999-05:00"
   },
   "https://www.servicepilot.com/en/doc/apm#opentelemetry": {
     "StatusCode": 200,
@@ -7917,7 +7873,7 @@
   },
   "https://www.swift.org/": {
     "StatusCode": 206,
-    "LastSeen": "2023-10-04T17:37:06.111313+02:00"
+    "LastSeen": "2024-01-30T16:04:54.464334-05:00"
   },
   "https://www.tablecheck.com/": {
     "StatusCode": 200,
@@ -7949,7 +7905,7 @@
   },
   "https://www.thousandeyes.com/": {
     "StatusCode": 200,
-    "LastSeen": "2023-09-15T16:58:35.892267+02:00"
+    "LastSeen": "2024-01-30T15:26:05.099551-05:00"
   },
   "https://www.traceloop.com": {
     "StatusCode": 206,
@@ -7969,7 +7925,7 @@
   },
   "https://www.w3.org/TR/baggage": {
     "StatusCode": 206,
-    "LastSeen": "2023-12-16T15:16:52.921552457Z"
+    "LastSeen": "2024-01-30T16:14:48.570352-05:00"
   },
   "https://www.w3.org/TR/baggage/": {
     "StatusCode": 206,
@@ -7981,11 +7937,11 @@
   },
   "https://www.w3.org/TR/baggage/#header-content": {
     "StatusCode": 206,
-    "LastSeen": "2023-12-16T15:16:50.350520378Z"
+    "LastSeen": "2024-01-30T16:14:34.212872-05:00"
   },
   "https://www.w3.org/TR/trace-context": {
     "StatusCode": 206,
-    "LastSeen": "2023-12-16T15:16:54.299474861Z"
+    "LastSeen": "2024-01-30T16:14:34.417619-05:00"
   },
   "https://www.w3.org/TR/trace-context/": {
     "StatusCode": 206,
@@ -8027,13 +7983,21 @@
     "StatusCode": 206,
     "LastSeen": "2024-01-18T19:37:16.764147-05:00"
   },
+  "https://www.whatsmyua.info": {
+    "StatusCode": 200,
+    "LastSeen": "2024-01-30T16:34:02.591185-05:00"
+  },
   "https://www.youtube.com/embed/coPrhP_7lVU": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-21T18:21:54.553086-05:00"
+    "LastSeen": "2024-01-30T16:15:42.688406-05:00"
   },
   "https://www.youtube.com/embed/zSeKL2-_sVg": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-17T18:03:15.47096-04:00"
+    "LastSeen": "2024-01-30T16:04:54.247319-05:00"
+  },
+  "https://www.youtube.com/playlist": {
+    "StatusCode": 404,
+    "LastSeen": "2024-01-30T16:42:42.793849-05:00"
   },
   "https://www.youtube.com/watch": {
     "StatusCode": 200,
@@ -8049,19 +8013,19 @@
   },
   "https://youtu.be/OEGgmTNfYsU": {
     "StatusCode": 200,
-    "LastSeen": "2023-12-22T10:12:54.130477-05:00"
+    "LastSeen": "2024-01-30T16:14:48.17809-05:00"
   },
   "https://youtu.be/dpXhgZL9tzU": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T06:07:15.717409-05:00"
   },
-  "https://youtu.be/zSeKL2-_sVg": {
-    "StatusCode": 200,
-    "LastSeen": "2023-10-17T17:40:35.689097-04:00"
-  },
   "https://youtube.com/@otel-official": {
     "StatusCode": 200,
-    "LastSeen": "2023-10-17T18:03:15.882928-04:00"
+    "LastSeen": "2024-01-30T16:05:09.10431-05:00"
+  },
+  "https://youtube.com/playlist": {
+    "StatusCode": 404,
+    "LastSeen": "2024-01-30T16:40:22.76972-05:00"
   },
   "https://zipkin.io/": {
     "StatusCode": 206,

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -7995,10 +7995,6 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:04:54.247319-05:00"
   },
-  "https://www.youtube.com/playlist": {
-    "StatusCode": 404,
-    "LastSeen": "2024-01-30T16:42:42.793849-05:00"
-  },
   "https://www.youtube.com/watch": {
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:07:39.018978-05:00"
@@ -8022,10 +8018,6 @@
   "https://youtube.com/@otel-official": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:05:09.10431-05:00"
-  },
-  "https://youtube.com/playlist": {
-    "StatusCode": 404,
-    "LastSeen": "2024-01-30T16:40:22.76972-05:00"
   },
   "https://zipkin.io/": {
     "StatusCode": 206,


### PR DESCRIPTION
- Contributes to #3804
- Fixes #3818
- Refreshes all refcache links so that all timestamps are in 2024! Hurrah, we're done with updates until 24Q3!
- Updates `normalize-cspell-front-matter.pl` to ensure that page-local dictionary words are unique
- Cleans up some page-local cSpell word lists using the updated script

/cc @avillela for the updates to your blog posts