### PR TITLE
[CI/textlint] "Auto Config*" rewrite-rule capitalization fix

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -33,6 +33,7 @@ words:
   - appender
   - appenders
   - aspecto
+  - autoconfigure
   - autoconfiguration
   - autoload
   - autoloaded
@@ -44,6 +45,7 @@ words:
   - cartservice
   - cassandra
   - checkoutservice
+  - classpath
   - cncf
   - currencyservice
   - daemonset

--- a/.textlintrc.yml
+++ b/.textlintrc.yml
@@ -113,7 +113,7 @@ rules:
       # https://github.com/sapegin/textlint-rule-terminology/blob/ca36a645c56d21f27cb9d902b5fb9584030c59e3/index.js#L137-L142.
       #
       - ['3rd[- ]party', third-party]
-      - ['auto[- ](configur)(es?|ations?)', 'auto$1$2'] # cspell:ignore ations configur
+      - ['auto[- ]c(onfigur)(es?|ations?)', 'autoc$1$2'] # cspell:ignore autoc ations onfigur
       - ['back[- ]end(s)?', 'backend$1']
       - ['bugfix', 'bug fix']
       - [cpp, C++]

--- a/content/en/blog/2022/instrument-kafka-clients/index.md
+++ b/content/en/blog/2022/instrument-kafka-clients/index.md
@@ -3,7 +3,7 @@ title: Instrumenting Apache Kafka clients with OpenTelemetry
 linkTitle: Instrumenting Apache Kafka clients
 date: 2022-09-06
 author: '[Paolo Patierno](https://github.com/ppatierno)'
-cSpell:ignore: -Dotel autoconfigure classpath Paolo Patierno
+cSpell:ignore: Paolo Patierno
 ---
 
 Nowadays, [Apache Kafka](https://kafka.apache.org/) is chosen as the nervous

--- a/content/en/blog/2023/otel-in-focus-06.md
+++ b/content/en/blog/2023/otel-in-focus-06.md
@@ -3,8 +3,7 @@ title: OpenTelemetry in Focus, June 2023
 linkTitle: OTel in Focus 2023/06
 date: 2023-07-01
 author: '[Austin Parker](https://github.com/austinlparker)'
-# prettier-ignore
-cSpell:ignore: autoconfigure Dyrmishi Farfetch Inet Ktor Logback scraperhelper Skywalking
+cSpell:ignore: Dyrmishi Farfetch Inet Ktor Logback scraperhelper Skywalking
 ---
 
 Welcome back to **OpenTelemetry in Focus** for June, 2023! It's officially

--- a/content/en/blog/2023/otel-in-focus-09.md
+++ b/content/en/blog/2023/otel-in-focus-09.md
@@ -4,7 +4,7 @@ linkTitle: OTel in Focus 2023/09
 date: 2023-10-01
 author: '[Austin Parker](https://github.com/austinlparker)'
 # prettier-ignore
-cSpell:ignore: attributesprocessor Autoconfigure autoinstrumentation Autoscaler checkapi Contribfest coreinternal gopkg jaegerthrifthttp obsreport ottl resourcedetection resourceprocessor structs tailsampling ucum unmanaged
+cSpell:ignore: attributesprocessor autoinstrumentation Autoscaler checkapi Contribfest coreinternal gopkg jaegerthrifthttp obsreport ottl resourcedetection resourceprocessor structs tailsampling ucum unmanaged
 ---
 
 Welcome back to **OpenTelemetry in Focus** for September, 2023! The autumn winds

--- a/content/en/docs/languages/java/automatic/spring-boot.md
+++ b/content/en/docs/languages/java/automatic/spring-boot.md
@@ -3,7 +3,7 @@ title: Spring Boot
 linkTitle: Spring Boot
 weight: 30
 description: Spring Boot instrumentation for OpenTelemetry Java
-cSpell:ignore: autoconfigure datasource logback springboot springframework
+cSpell:ignore: datasource logback springboot springframework
 ---
 
 The [OpenTelemetry Java agent](..) with byte code instrumentation can cover most

--- a/content/en/docs/languages/java/automatic/spring-boot.md
+++ b/content/en/docs/languages/java/automatic/spring-boot.md
@@ -1,9 +1,8 @@
 ---
 title: Spring Boot
-linkTitle: Spring Boot
-weight: 30
 description: Spring Boot instrumentation for OpenTelemetry Java
-cSpell:ignore: datasource logback springboot springframework
+cSpell:ignore: datasource logback
+weight: 30
 ---
 
 The [OpenTelemetry Java agent](..) with byte code instrumentation can cover most

--- a/content/en/docs/languages/java/exporters.md
+++ b/content/en/docs/languages/java/exporters.md
@@ -1,7 +1,7 @@
 ---
 title: Exporters
 weight: 50
-cSpell:ignore: autoconfigure classpath okhttp springframework
+cSpell:ignore: okhttp
 ---
 
 {{% docs/languages/exporters-intro java %}}

--- a/content/en/docs/languages/java/getting-started.md
+++ b/content/en/docs/languages/java/getting-started.md
@@ -1,8 +1,6 @@
 ---
 title: Getting Started
 description: Get telemetry for your app in less than 5 minutes!
-# prettier-ignore
-cSpell:ignore: aarch autoconfigure autoreconfigure darwin helloworld Nanos rolldice springframework webmvc
 weight: 10
 ---
 

--- a/content/en/docs/languages/java/instrumentation.md
+++ b/content/en/docs/languages/java/instrumentation.md
@@ -8,7 +8,7 @@ aliases:
 weight: 20
 description: Manual instrumentation for OpenTelemetry Java
 # prettier-ignore
-cSpell:ignore: autoconfigure Autowired classpath customizer logback loggable multivalued rolldice springframework
+cSpell:ignore: Autowired customizer logback loggable multivalued rolldice springframework
 ---
 
 <!-- markdownlint-disable no-duplicate-heading -->

--- a/content/en/docs/languages/java/libraries.md
+++ b/content/en/docs/languages/java/libraries.md
@@ -2,7 +2,7 @@
 title: Using instrumentation libraries
 linkTitle: Libraries
 weight: 40
-cSpell:ignore: autoconfigure getenv httpclient println
+cSpell:ignore: getenv httpclient println
 ---
 
 When you develop an app, you use third-party libraries and frameworks to


### PR DESCRIPTION
- Completes the fix for #3891
- Fixes the "Auto Config*" rewrite-rule so that it forces the "c" in "config*" to be in lowercase
- Scrubs some page-local dictionaries