### PR TITLE
[CI] Auto-update-versions: fix action + pin gitmodules

### DIFF
--- a/.github/workflows/auto-update-versions.yml
+++ b/.github/workflows/auto-update-versions.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.repository == 'open-telemetry/opentelemetry.io'
     env:
-      DEPTH: --depth 100 # submodule clone depth
+      DEPTH: --depth 500 # submodule clone depth
 
     steps:
       - name: Checkout
@@ -23,15 +23,7 @@ jobs:
           git config user.name opentelemetrybot
           git config user.email 107717825+opentelemetrybot@users.noreply.github.com
 
-      - name: Auto-update
-        run: |
-          .github/workflows/scripts/auto-update-version.sh opentelemetry-collector-releases vers content/en/docs/collector/_index.md
-          .github/workflows/scripts/auto-update-version.sh opentelemetry-java otel content/en/docs/instrumentation/java/_index.md
-          .github/workflows/scripts/auto-update-version.sh opentelemetry-java-instrumentation instrumentation content/en/docs/instrumentation/java/_index.md
-          .github/workflows/scripts/auto-update-version.sh opentelemetry-specification spec scripts/content-modules/adjust-pages.pl
-          .github/workflows/scripts/auto-update-version.sh opentelemetry-proto otlp scripts/content-modules/adjust-pages.pl
-          .github/workflows/scripts/auto-update-version.sh semantic-conventions semconv scripts/content-modules/adjust-pages.pl
-          .github/workflows/scripts/auto-update-version.sh semantic-conventions-java semconv content/en/docs/instrumentation/java/_index.md
+      - run: ./scripts/auto-update/all-versions.sh
         env:
           # change this to secrets.GITHUB_TOKEN when testing against a fork
           GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,19 +1,24 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/cncf/docsy.git
-	branch = opentelemetry.io
+	docsy-pin = v0.8.0-11-gce52bb0
 [submodule "content-modules/opentelemetry-specification"]
 	path = content-modules/opentelemetry-specification
 	url = https://github.com/open-telemetry/opentelemetry-specification.git
+	spec-pin = v1.29.0
 [submodule "content-modules/community"]
 	path = content-modules/community
 	url = https://github.com/open-telemetry/community
+	community-pin = 0cb6dca
 [submodule "content-modules/opentelemetry-proto"]
 	path = content-modules/opentelemetry-proto
 	url = https://github.com/open-telemetry/opentelemetry-proto
+	otlp-pin = v1.1.0
 [submodule "content-modules/semantic-conventions"]
 	path = content-modules/semantic-conventions
 	url = https://github.com/open-telemetry/semantic-conventions
+	semconv-pin = v1.24.0
 [submodule "content-modules/opamp-spec"]
 	path = content-modules/opamp-spec
 	url = https://github.com/open-telemetry/opamp-spec
+	opamp-pin = v0.8.0-5-g0360da8

--- a/scripts/auto-update/all-versions.sh
+++ b/scripts/auto-update/all-versions.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+
+function auto_update_versions() {
+  local cmd="./scripts/auto-update/version-in-file.sh"
+  local updates=(
+      "opentelemetry-collector-releases vers content/en/docs/collector/_index.md"
+      "opentelemetry-java otel content/en/docs/languages/java/_index.md"
+      "opentelemetry-java-instrumentation instrumentation content/en/docs/languages/java/_index.md"
+      "opentelemetry-specification spec scripts/content-modules/adjust-pages.pl .gitmodules"
+      "opentelemetry-proto otlp scripts/content-modules/adjust-pages.pl .gitmodules"
+      "semantic-conventions semconv scripts/content-modules/adjust-pages.pl .gitmodules"
+      "semantic-conventions-java semconv content/en/docs/languages/java/_index.md"
+  )
+
+  for args in "${updates[@]}"; do
+      echo "> $cmd $args"
+      $cmd $args
+      echo
+  done
+}
+
+auto_update_versions

--- a/scripts/auto-update/version-in-file.sh
+++ b/scripts/auto-update/version-in-file.sh
@@ -21,16 +21,22 @@ repo=$1
 variable_name=$2
 file_names=("${@:3}") # remaining args
 
-latest_version=$(gh api -q .tag_name "repos/open-telemetry/$repo/releases/latest" | sed 's/^v//')
+latest_version=$(gh api -q .tag_name "repos/open-telemetry/$repo/releases/latest")
+latest_vers_no_v="${latest_version#v}" # Remove leading 'v'
 
 echo "REPO:            $repo"
 echo "LATEST VERSION:  $latest_version"
 
-# Version line regex, to match entire line -- works under Linux and macOS:
-vers_match_regex="^ *$variable_name:"
-
 for file_name in "${file_names[@]}"
 do
+  # Version line regex `vers_match_regex` to match version specifier -- works under Linux and macOS.
+  if [[ $file_name == ".gitmodules" ]]; then
+    vers_match_regex="$variable_name-pin ="
+    vers="$latest_version"
+  else
+    vers_match_regex="^ *$variable_name:"
+    vers="$latest_vers_no_v"
+  fi
   echo "SEARCHING for:   '$vers_match_regex' in $file_name"
   if ! grep -q "$vers_match_regex" "$file_name"; then
     echo "Could not find regex \"$vers_match_regex\" in $file_name. Aborting."
@@ -39,27 +45,27 @@ do
   current_version=$(grep "$vers_match_regex" "$file_name")
   echo "CURRENT VERSION: $current_version"
 
-  (set -x; sed -i.bak -e "s/\($vers_match_regex\) .*/\1 $latest_version/" "$file_name")
+  (set -x; sed -i.bak -e "s/\($vers_match_regex\) .*/\1 $vers/" "$file_name")
 
   if [[ -e "$file_name".bak ]]; then
     rm "$file_name".bak
   fi
 done
 
-if git diff --quiet $file_names; then
+if git diff --quiet "${file_names[@]}"; then
   echo "Already at the latest version. Exiting"
   exit 0
 else
   echo
   echo "Version update necessary:"
-  git diff $file_names
+  git diff "${file_names[@]}"
   echo
 fi
 
 message="Update $repo version to $latest_version"
 body="Update $repo version to \`$latest_version\`.
 
-See https://github.com/open-telemetry/$repo/releases/tag/v$latest_version."
+See https://github.com/open-telemetry/$repo/releases/tag/$latest_version."
 
 existing_pr_count=$(gh pr list --state all --search "in:title $message" | wc -l)
 if [ "$existing_pr_count" -gt 0 ]; then
@@ -72,12 +78,12 @@ fi
 if [[ "$repo" == "opentelemetry-specification"
    || "$repo" == "opentelemetry-proto"
    || "$repo" == "semantic-conventions" ]]; then
-  echo "Switching to $repo at tag v$latest_version"
+  echo "Switching to $repo at tag $latest_version"
   ( set -x;
     npm run get:submodule -- content-modules/$repo &&
     cd content-modules/$repo &&
     git fetch &&
-    git switch --detach v$latest_version
+    git switch --detach $latest_version
   )
 fi
 

--- a/scripts/sync-submodules.pl
+++ b/scripts/sync-submodules.pl
@@ -1,0 +1,29 @@
+#!/usr/bin/perl -w
+
+use strict;
+use warnings;
+use FileHandle;
+
+my $file = '.gitmodules';
+my $fh = FileHandle->new($file, 'r') or die "Error opening $file: $!";
+my $content = do { local $/; <$fh> };
+$fh->close or die "Error closing $file: $!";
+
+# Extract submodule paths and pin values
+my @submodules = $content =~ /\[submodule "(.*?)".*?\w+-pin = ([^\s]+)/gs;
+
+# Iterate through submodules
+for (my $i = 0; $i < @submodules; $i += 2) {
+    my $submodule_path = $submodules[$i];
+    my $commit = $submodules[$i + 1];
+
+    my $command = "cd $submodule_path && git switch --detach $commit";
+    print "> $command\n";
+    system($command);
+
+    if ($? == -1) {
+        die "Failed to execute command: $!";
+    } elsif ($? >> 8) {
+        die "Command exited with error: $!";
+    }
+}


### PR DESCRIPTION
- Fixes #3910 
  The failure was due to the rename of `instrumentation` to `languages`
- Fixes #3909
- Adds "pin" versions/commits to `.gitmodules`
- Contributes to #3149 by adding a "force" sync-submodules script using the specified version/commit "pin" in `.gitmodules`. The script isn't hooked up to anywhere yet.
