### PR TITLE
Fix broken contribution links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ is hosted on [Netlify][].
 ## Get involved
 
 To learn how to contribute fixes and new content to this project, read the
-[Contributor's guide](/content/en/docs/contributing), which includes a style
+[Contributor's guide](https://opentelemetry.io/docs/contributing/), which includes a style
 guide and useful information on the review process.
 
 If you are new to OpenTelemetry and just get started with it, you are in a
@@ -18,7 +18,7 @@ missing [let us know][].
 ### Submit a blog post
 
 For guidance on how to write and submit a blog post, see
-[Submit a blog post](/content/en/docs/contributing/blog).
+[Submit a blog post](https://opentelemetry.io/docs/contributing/blog/).
 
 ### Add a project to the OpenTelemetry [Registry]
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ is hosted on [Netlify][].
 ## Get involved
 
 To learn how to contribute fixes and new content to this project, read the
-[Contributor's guide](https://opentelemetry.io/docs/contributing/), which includes a style
-guide and useful information on the review process.
+[Contributor's guide](https://opentelemetry.io/docs/contributing/), which
+includes a style guide and useful information on the review process.
 
 If you are new to OpenTelemetry and just get started with it, you are in a
 perfect position to help us get better: the website and documentation is the


### PR DESCRIPTION
- Fixes #3907

Replacing relative links (that won't render in GitHub) with absolute URLs. Open to suggestions for a better approach (I'd rather not send folks to the docs source if we've a rendered site).