### PR TITLE
Upgrade docsy & hugo + add NPM sync script

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/cncf/docsy.git
-	docsy-pin = v0.8.0-11-gce52bb0
+	docsy-pin = v0.8.0-17-g91efe35
 [submodule "content-modules/opentelemetry-specification"]
 	path = content-modules/opentelemetry-specification
 	url = https://github.com/open-telemetry/opentelemetry-specification.git

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "serve:hugo": "npm run _serve:hugo",
     "serve:netlify": "npm run _serve:netlify",
     "serve": "npm run serve:hugo",
+    "sync": "./scripts/sync-submodules.pl",
     "test-and-fix": "npm run seq -- check fix:dict fix:filenames",
     "test": "npm run check",
     "update:pkg:docsy-dep": "npm install --save-dev autoprefixer@latest postcss-cli@latest",
@@ -83,10 +84,10 @@
     "update:submodule": "set -x && git submodule update --remote ${DEPTH:- --depth 1}"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.16",
+    "autoprefixer": "^10.4.17",
     "cspell": "^8.0.0",
     "gulp": "^4.0.2",
-    "hugo-extended": "0.121.2",
+    "hugo-extended": "0.122.0",
     "markdown-link-check": "^3.11.2",
     "markdownlint": "^0.33.0",
     "postcss-cli": "^11.0.0",


### PR DESCRIPTION
- Upgrades:
  - Docsy to v0.8.0-17-g91efe35 -- e.g., brings in FontAwesome (minor/patch) upgrade
  - Hugo to 0.122.0
- Contributes to #3149 by adding an NPM script named `sync` (I'm choosing to keep the name short since atm the only thing we're syncing are submodules).
- Closes #3872

Process followed for Docsy (/cc @svrnm):

- Updated `.gitmodules` with the new Docsy version pin
- Ran `npm run sync`