### PR TITLE
Add entry for baronfel/otel-startup-hook

### DIFF
--- a/data/registry/exporter-dotnet-oltp-hook.yml
+++ b/data/registry/exporter-dotnet-oltp-hook.yml
@@ -1,0 +1,23 @@
+# cSpell:ignore OLTP oltp Chet
+title: OLTP Exporter for .NET via Startup Hooks
+registryType: exporter
+language: dotnet
+tags:
+  - oltp
+  - exporter
+  - dotnet
+  - startup hook
+urls:
+  repo: https://github.com/baronfel/otel-startup-hook
+  docs: https://github.com/baronfel/otel-startup-hook/blob/main/README.md
+license: MIT
+description:
+  A ready-to-use .NET CLR Startup Hook for applications that are instrumented with
+  System.Diagnostic.Activity tracing that sends traces to an OpenTelemetry Collector
+  via the OLTP Exporter without adding direct references to the OpenTelemetry SDK.
+authors:
+  - name: Chet Husk
+    url: https://github.com/baronfel
+createdAt: 2024-02-01
+isNative: false
+isFirstParty: false

--- a/data/registry/exporter-dotnet-otlp-hook.yml
+++ b/data/registry/exporter-dotnet-otlp-hook.yml
@@ -12,9 +12,10 @@ urls:
   docs: https://github.com/baronfel/otel-startup-hook/blob/main/README.md
 license: MIT
 description:
-  A ready-to-use .NET CLR Startup Hook for applications that are instrumented with
-  System.Diagnostic.Activity tracing that sends traces to an OpenTelemetry Collector
-  via the OTLP Exporter without adding direct references to the OpenTelemetry SDK.
+  A ready-to-use .NET CLR Startup Hook for applications that are instrumented
+  with System.Diagnostic.Activity tracing that sends traces to an OpenTelemetry
+  Collector via the OTLP Exporter without adding direct references to the
+  OpenTelemetry SDK.
 authors:
   - name: Chet Husk
     url: https://github.com/baronfel

--- a/data/registry/exporter-dotnet-otlp-hook.yml
+++ b/data/registry/exporter-dotnet-otlp-hook.yml
@@ -1,5 +1,5 @@
 # cSpell:ignore OLTP oltp Chet
-title: OLTP Exporter for .NET via Startup Hooks
+title: OTLP Exporter for .NET via Startup Hooks
 registryType: exporter
 language: dotnet
 tags:
@@ -14,7 +14,7 @@ license: MIT
 description:
   A ready-to-use .NET CLR Startup Hook for applications that are instrumented with
   System.Diagnostic.Activity tracing that sends traces to an OpenTelemetry Collector
-  via the OLTP Exporter without adding direct references to the OpenTelemetry SDK.
+  via the OTLP Exporter without adding direct references to the OpenTelemetry SDK.
 authors:
   - name: Chet Husk
     url: https://github.com/baronfel

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -2103,6 +2103,14 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-24T14:54:51.229664+01:00"
   },
+  "https://github.com/baronfel": {
+    "StatusCode": 200,
+    "LastSeen": "2024-02-01T19:02:28.92421992Z"
+  },
+  "https://github.com/baronfel/otel-startup-hook": {
+    "StatusCode": 200,
+    "LastSeen": "2024-02-01T19:02:28.4090231Z"
+  },
   "https://github.com/bhs": {
     "StatusCode": 200,
     "LastSeen": "2024-01-18T20:05:35.426558-05:00"


### PR DESCRIPTION
I've created a standalone .NET CLR Startup Hook that uses the OLTP exporter to push spans to an OLTP Collector (via the OTel SDKs of course). This is useful for applications that are instrumented with System.Diagnostics.Activity, but for whatever reason can't take direct dependencies on the OTel SDK.