### PR TITLE
Add redirects to collector/language-specific registry entries

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -9,7 +9,8 @@ IgnoreDirs:
   - ^blog/(\d+/)?page/\d+
 IgnoreInternalURLs: # list of paths
 IgnoreURLs: # list of regexs of paths or URLs to be ignored
-  - ^/docs/languages/\w+/(api|examples)/$
+  - ^/docs/languages/\w+/(api|examples|registry)/$
+  - ^/docs/collector/registry/$
   - ^/docs/languages/net/(metrics-api|traces-api)/
   - ^/community/end-user/feedback-survey/$
   - ^(/docs/migration/)?opencensus/$

--- a/content/en/docs/collector/registry.md
+++ b/content/en/docs/collector/registry.md
@@ -1,0 +1,9 @@
+---
+title: Registry
+linkTitle: Registry
+description: Exporters, processors, receivers and other useful components for the OpenTelemetry Collector
+redirect: https://opentelemetry.io/ecosystem/registry/?language=collector
+manualLinkTarget: _blank
+_build: { render: link }
+weight: 300
+---

--- a/content/en/docs/collector/registry.md
+++ b/content/en/docs/collector/registry.md
@@ -1,7 +1,9 @@
 ---
 title: Registry
 linkTitle: Registry
-description: Exporters, processors, receivers and other useful components for the OpenTelemetry Collector
+description:
+  Exporters, processors, receivers and other useful components for the
+  OpenTelemetry Collector
 redirect: https://opentelemetry.io/ecosystem/registry/?language=collector
 manualLinkTarget: _blank
 _build: { render: link }

--- a/content/en/docs/collector/registry.md
+++ b/content/en/docs/collector/registry.md
@@ -1,11 +1,9 @@
 ---
 title: Registry
-linkTitle: Registry
 description:
   Exporters, processors, receivers and other useful components for the
   OpenTelemetry Collector
-redirect: https://opentelemetry.io/ecosystem/registry/?language=collector
-manualLinkTarget: _blank
+redirect: /ecosystem/registry/?language=collector
 _build: { render: link }
 weight: 300
 ---

--- a/content/en/docs/languages/cpp/registry.md
+++ b/content/en/docs/languages/cpp/registry.md
@@ -2,8 +2,8 @@
 title: Registry
 description:
   Instrumentation libraries, exporters and other useful components for
-  OpenTelemetry PHP
-redirect: /ecosystem/registry/?language=php
+  OpenTelemetry C++
+redirect: /ecosystem/registry/?language=cpp
 _build: { render: link }
 weight: 300
 ---

--- a/content/en/docs/languages/erlang/registry.md
+++ b/content/en/docs/languages/erlang/registry.md
@@ -2,8 +2,8 @@
 title: Registry
 description:
   Instrumentation libraries, exporters and other useful components for
-  OpenTelemetry PHP
-redirect: /ecosystem/registry/?language=php
+  OpenTelemetry Erlang/Elixir
+redirect: /ecosystem/registry/?language=erlang
 _build: { render: link }
 weight: 300
 ---

--- a/content/en/docs/languages/go/registry.md
+++ b/content/en/docs/languages/go/registry.md
@@ -2,8 +2,8 @@
 title: Registry
 description:
   Instrumentation libraries, exporters and other useful components for
-  OpenTelemetry PHP
-redirect: /ecosystem/registry/?language=php
+  OpenTelemetry Go
+redirect: /ecosystem/registry/?language=go
 _build: { render: link }
 weight: 300
 ---

--- a/content/en/docs/languages/java/registry.md
+++ b/content/en/docs/languages/java/registry.md
@@ -2,8 +2,8 @@
 title: Registry
 description:
   Instrumentation libraries, exporters and other useful components for
-  OpenTelemetry PHP
-redirect: /ecosystem/registry/?language=php
+  OpenTelemetry Java
+redirect: /ecosystem/registry/?language=java
 _build: { render: link }
 weight: 300
 ---

--- a/content/en/docs/languages/js/registry.md
+++ b/content/en/docs/languages/js/registry.md
@@ -2,8 +2,8 @@
 title: Registry
 description:
   Instrumentation libraries, exporters and other useful components for
-  OpenTelemetry PHP
-redirect: /ecosystem/registry/?language=php
+  OpenTelemetry JavaScript
+redirect: /ecosystem/registry/?language=js
 _build: { render: link }
 weight: 300
 ---

--- a/content/en/docs/languages/net/registry.md
+++ b/content/en/docs/languages/net/registry.md
@@ -1,6 +1,5 @@
 ---
 title: Registry
-linkTitle: Registry
 description:
   Instrumentation libraries, exporters and other useful components for
   OpenTelemetry .NET

--- a/content/en/docs/languages/net/registry.md
+++ b/content/en/docs/languages/net/registry.md
@@ -4,7 +4,7 @@ linkTitle: Registry
 description:
   Instrumentation libraries, exporters and other useful components for
   OpenTelemetry .NET
-redirect: https://opentelemetry.io/ecosystem/registry/?language=dotnet
+redirect: /ecosystem/registry/?language=dotnet
 manualLinkTarget: _blank
 _build: { render: link }
 weight: 300

--- a/content/en/docs/languages/net/registry.md
+++ b/content/en/docs/languages/net/registry.md
@@ -4,7 +4,6 @@ description:
   Instrumentation libraries, exporters and other useful components for
   OpenTelemetry .NET
 redirect: /ecosystem/registry/?language=dotnet
-manualLinkTarget: _blank
 _build: { render: link }
 weight: 300
 ---

--- a/content/en/docs/languages/net/registry.md
+++ b/content/en/docs/languages/net/registry.md
@@ -1,7 +1,9 @@
 ---
 title: Registry
 linkTitle: Registry
-description: Instrumentation libraries, exporters and other useful components for OpenTelemetry .NET
+description:
+  Instrumentation libraries, exporters and other useful components for
+  OpenTelemetry .NET
 redirect: https://opentelemetry.io/ecosystem/registry/?language=dotnet
 manualLinkTarget: _blank
 _build: { render: link }

--- a/content/en/docs/languages/net/registry.md
+++ b/content/en/docs/languages/net/registry.md
@@ -1,0 +1,9 @@
+---
+title: Registry
+linkTitle: Registry
+description: Instrumentation libraries, exporters and other useful components for OpenTelemetry .NET
+redirect: https://opentelemetry.io/ecosystem/registry/?language=dotnet
+manualLinkTarget: _blank
+_build: { render: link }
+weight: 300
+---

--- a/content/en/docs/languages/php/registry.md
+++ b/content/en/docs/languages/php/registry.md
@@ -1,7 +1,9 @@
 ---
 title: Registry
 linkTitle: Registry
-description: Instrumentation libraries, exporters and other useful components for OpenTelemetry PHP
+description:
+  Instrumentation libraries, exporters and other useful components for
+  OpenTelemetry PHP
 redirect: https://opentelemetry.io/ecosystem/registry/?language=php
 manualLinkTarget: _blank
 _build: { render: link }

--- a/content/en/docs/languages/php/registry.md
+++ b/content/en/docs/languages/php/registry.md
@@ -4,7 +4,7 @@ linkTitle: Registry
 description:
   Instrumentation libraries, exporters and other useful components for
   OpenTelemetry PHP
-redirect: https://opentelemetry.io/ecosystem/registry/?language=php
+redirect: /ecosystem/registry/?language=php
 manualLinkTarget: _blank
 _build: { render: link }
 weight: 300

--- a/content/en/docs/languages/php/registry.md
+++ b/content/en/docs/languages/php/registry.md
@@ -1,0 +1,9 @@
+---
+title: Registry
+linkTitle: Registry
+description: Instrumentation libraries, exporters and other useful components for OpenTelemetry PHP
+redirect: https://opentelemetry.io/ecosystem/registry/?language=php
+manualLinkTarget: _blank
+_build: { render: link }
+weight: 300
+---

--- a/content/en/docs/languages/php/registry.md
+++ b/content/en/docs/languages/php/registry.md
@@ -1,6 +1,5 @@
 ---
 title: Registry
-linkTitle: Registry
 description:
   Instrumentation libraries, exporters and other useful components for
   OpenTelemetry PHP

--- a/content/en/docs/languages/python/registry.md
+++ b/content/en/docs/languages/python/registry.md
@@ -1,0 +1,9 @@
+---
+title: Registry
+linkTitle: Registry
+description: Instrumentation libraries, exporters and other useful components for OpenTelemetry Python
+redirect: https://opentelemetry.io/ecosystem/registry/?language=python
+manualLinkTarget: _blank
+_build: { render: link }
+weight: 300
+---

--- a/content/en/docs/languages/python/registry.md
+++ b/content/en/docs/languages/python/registry.md
@@ -4,7 +4,6 @@ description:
   Instrumentation libraries, exporters and other useful components for
   OpenTelemetry Python
 redirect: /ecosystem/registry/?language=python
-manualLinkTarget: _blank
 _build: { render: link }
 weight: 300
 ---

--- a/content/en/docs/languages/python/registry.md
+++ b/content/en/docs/languages/python/registry.md
@@ -4,7 +4,7 @@ linkTitle: Registry
 description:
   Instrumentation libraries, exporters and other useful components for
   OpenTelemetry Python
-redirect: https://opentelemetry.io/ecosystem/registry/?language=python
+redirect: /ecosystem/registry/?language=python
 manualLinkTarget: _blank
 _build: { render: link }
 weight: 300

--- a/content/en/docs/languages/python/registry.md
+++ b/content/en/docs/languages/python/registry.md
@@ -1,6 +1,5 @@
 ---
 title: Registry
-linkTitle: Registry
 description:
   Instrumentation libraries, exporters and other useful components for
   OpenTelemetry Python

--- a/content/en/docs/languages/python/registry.md
+++ b/content/en/docs/languages/python/registry.md
@@ -1,7 +1,9 @@
 ---
 title: Registry
 linkTitle: Registry
-description: Instrumentation libraries, exporters and other useful components for OpenTelemetry Python
+description:
+  Instrumentation libraries, exporters and other useful components for
+  OpenTelemetry Python
 redirect: https://opentelemetry.io/ecosystem/registry/?language=python
 manualLinkTarget: _blank
 _build: { render: link }

--- a/content/en/docs/languages/ruby/registry.md
+++ b/content/en/docs/languages/ruby/registry.md
@@ -2,8 +2,8 @@
 title: Registry
 description:
   Instrumentation libraries, exporters and other useful components for
-  OpenTelemetry PHP
-redirect: /ecosystem/registry/?language=php
+  OpenTelemetry Ruby
+redirect: /ecosystem/registry/?language=ruby
 _build: { render: link }
 weight: 300
 ---

--- a/content/en/docs/languages/rust/registry.md
+++ b/content/en/docs/languages/rust/registry.md
@@ -2,8 +2,8 @@
 title: Registry
 description:
   Instrumentation libraries, exporters and other useful components for
-  OpenTelemetry PHP
-redirect: /ecosystem/registry/?language=php
+  OpenTelemetry C++
+redirect: /ecosystem/registry/?language=cpp
 _build: { render: link }
 weight: 300
 ---

--- a/content/en/docs/languages/rust/registry.md
+++ b/content/en/docs/languages/rust/registry.md
@@ -2,8 +2,8 @@
 title: Registry
 description:
   Instrumentation libraries, exporters and other useful components for
-  OpenTelemetry C++
-redirect: /ecosystem/registry/?language=cpp
+  OpenTelemetry Rust
+redirect: /ecosystem/registry/?language=rust
 _build: { render: link }
 weight: 300
 ---

--- a/content/en/docs/languages/swift/registry.md
+++ b/content/en/docs/languages/swift/registry.md
@@ -2,8 +2,8 @@
 title: Registry
 description:
   Instrumentation libraries, exporters and other useful components for
-  OpenTelemetry PHP
-redirect: /ecosystem/registry/?language=php
+  OpenTelemetry Swift
+redirect: /ecosystem/registry/?language=swift
 _build: { render: link }
 weight: 300
 ---


### PR DESCRIPTION
After revamping the registry, I was thinking about ways to make it easier to find for end-users. This PR suggests to add a link to each language & the collector which directly leads to the registry with the given language (or the collector) being preselected.

I picked Python, PHP, .NET and the collector as examples, but we can easily apply this to all languages. What do you all think?

Preview:

Go to https://deploy-preview-3932--opentelemetry.netlify.app/docs/languages/python/ and see the left-side menu. This also gives us a link like [opentelemetry.io/docs/languages/python/registry](https://deploy-preview-3932--opentelemetry.netlify.app/docs/languages/python/registry/) (real link leads to the preview)
