### PR TITLE
Unnecessary word 'd' in metrics.md

### DIFF
--- a/content/en/docs/concepts/signals/metrics.md
+++ b/content/en/docs/concepts/signals/metrics.md
@@ -7,7 +7,7 @@ description: A measurement captured at runtime
 A **metric** is a **measurement** of a service captured at runtime. The moment
 of capturing a measurements is known as a **metric event**, which consists not
 only of the measurement itself, but also the time at which it was captured and
-associated metadata.d
+associated metadata.
 
 Application and request metrics are important indicators of availability and
 performance. Custom metrics can provide insights into how availability


### PR DESCRIPTION
There is an unnecessary 'd' there which is a typo.