### PR TITLE
[IA] Auto-Update rust versions in docs from registry

### DIFF
--- a/content/en/docs/languages/rust/exporters.md
+++ b/content/en/docs/languages/rust/exporters.md
@@ -9,11 +9,12 @@ cSpell:ignore: chrono millis ostream
 ## OTLP endpoint
 
 To send trace data to a OTLP endpoint (like the [collector](/docs/collector) or
-Jaeger) you'll want to use an exporter crate, such as `opentelemetry_otlp`:
+Jaeger) you'll want to use an exporter crate, such as
+[`opentelemetry-otlp`](https://crates.io/crates/opentelemetry-otlp):
 
 ```toml
 [dependencies]
-opentelemetry-otlp = { version = "0.13", features = ["default"] }
+opentelemetry-otlp = { version = "{{% version-from-registry exporter-rust-otlp %}}", features = ["default"] }
 ```
 
 Next, configure the exporter to point at an OTLP endpoint. For example you can

--- a/content/en/docs/languages/rust/exporters.md
+++ b/content/en/docs/languages/rust/exporters.md
@@ -10,7 +10,7 @@ cSpell:ignore: chrono millis ostream
 
 To send trace data to a OTLP endpoint (like the [collector](/docs/collector) or
 Jaeger) you'll want to use an exporter crate, such as
-[`opentelemetry-otlp`](https://crates.io/crates/opentelemetry-otlp):
+[opentelemetry-otlp](https://crates.io/crates/opentelemetry-otlp):
 
 ```toml
 [dependencies]

--- a/content/en/docs/languages/rust/getting-started.md
+++ b/content/en/docs/languages/rust/getting-started.md
@@ -103,11 +103,14 @@ Listening on 127.0.0.1:8080
 ## Instrumentation
 
 To add OpenTelemetry to your application, update the `Cargo.toml` with the
-following additional dependencies:
+dependencies for the OpenTelemetry Rust SDK
+[`opentelemetry`](https://crates.io/crates/opentelemetry) and the OpenTelemetry
+Stdout Exporter
+[`opentelemetry-stdout`](https://crates.io/crates/opentelemetry-stdout):
 
 ```toml
-opentelemetry = { version = "0.20", features = ["trace"] }
-opentelemetry-stdout = { version = "0.1", features = ["trace"] }
+opentelemetry = { version = "{{% version-from-registry otel-rust %}}", features = ["trace"] }
+opentelemetry-stdout = { version = "{{% version-from-registry exporter-rust-stdout %}}", features = ["trace"] }
 ```
 
 Update the `dice_server.rs` file with code to initialize a tracer and to emit

--- a/data/registry/otel-rust.yml
+++ b/data/registry/otel-rust.yml
@@ -10,3 +10,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-rust
 createdAt: 2020-02-04
+package:
+  registry: crates
+  name: opentelemetry
+  version: 0.21.0

--- a/layouts/shortcodes/version-from-registry.md
+++ b/layouts/shortcodes/version-from-registry.md
@@ -1,0 +1,17 @@
+{{ $name := (.Get 0) -}}
+
+{{ with $name -}}
+    {{ $registryEntry := (index $.Site.Data.registry .) -}}
+    {{ with $registryEntry -}}
+        {{ $version := .package.version -}}
+        {{ with $version }}
+            {{- . -}}
+        {{- else -}}
+            {{ errorf "No 'package.version' in registry entry %q: %s" $name $.Position -}}
+        {{- end -}}
+    {{- else -}}
+        {{ errorf "Registry entry %q not found: %s" $name $.Position -}}
+    {{- end -}}
+{{- else -}}
+  {{ errorf "Missing registry entry name: %s" $.Position -}}
+{{- end -}}

--- a/layouts/shortcodes/version-from-registry.md
+++ b/layouts/shortcodes/version-from-registry.md
@@ -1,17 +1,15 @@
 {{ $name := (.Get 0) -}}
 
 {{ with $name -}}
-    {{ $registryEntry := (index $.Site.Data.registry .) -}}
-    {{ with $registryEntry -}}
-        {{ $version := .package.version -}}
-        {{ with $version }}
-            {{- . -}}
-        {{- else -}}
-            {{ errorf "No 'package.version' in registry entry %q: %s" $name $.Position -}}
-        {{- end -}}
-    {{- else -}}
-        {{ errorf "Registry entry %q not found: %s" $name $.Position -}}
-    {{- end -}}
-{{- else -}}
-  {{ errorf "Missing registry entry name: %s" $.Position -}}
-{{- end -}}
+  {{ with index $.Site.Data.registry . -}}
+    {{ with .package.version -}}
+      {{ . -}}
+    {{ else -}}
+      {{ errorf "No 'package.version' in registry entry %q: %s" $name $.Position -}}
+    {{ end -}}
+  {{ else -}}
+    {{ errorf "Registry entry %q not found: %s" $name $.Position -}}
+  {{ end -}}
+{{ else -}}
+  {{ errorf "Shortcode parameter 'name' is missing %s: " $.Position -}}
+{{ end -}}


### PR DESCRIPTION
My goal was to create version updating similar to Java for a few other languages. I wanted to start with rust, since this is a part of our docs that is still manageable. While doing so, I figured that our [current mechanism](https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/workflows/auto-update-versions.yml) will not work:

* The versions for the OTLP and stdout exporter are not available from the repos
* The tagged SDK version ([v0.21.2](https://github.com/open-telemetry/opentelemetry-rust/releases/tag/v0.21.2)) is out of sync with the version on crates.io ([v0.21.0](https://crates.io/crates/opentelemetry))

By accident I stumbled upon the fact that those version are available (and auto-updated!) via the registry now! So with this PR I propose a short code that is able to extract the version of a package from a registry entry and then show how this may work using rust as an example:

```text
opentelemetry = { version = "{{% version-from-registry otel-rust %}}", features = ["trace"] }
opentelemetry-stdout = { version = "{{% version-from-registry exporter-rust-stdout %}}", features = ["trace"] }
```

@chalin wdyt?

---

**Preview**: https://deploy-preview-3944--opentelemetry.netlify.app/docs/languages/rust/