### PR TITLE
Update CONTRIBUTING.md: add missing link definition

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,6 +233,7 @@ approvers and maintainers while doing code reviews:
 [hugo]: https://gohugo.io
 [localhost:1313]: http://localhost:1313
 [localhost:8888]: http://localhost:8888
+[netlify]: https://netlify.com
 [new-issue]:
   https://github.com/open-telemetry/opentelemetry.io/issues/new/choose
 [nodejs-rel]: https://nodejs.org/en/about/previous-releases


### PR DESCRIPTION
Re-adding `[netlify]` that was removed by mistake in the previous round of changes (#3651):

> <img width="478" alt="image" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/b513f59f-3efa-4cd5-ad1c-7efa985ca056">
