### PR TITLE
Reword exporters intro to not imply the collector is a viz+analysis backend

### DIFF
--- a/layouts/shortcodes/docs/languages/exporters/intro.md
+++ b/layouts/shortcodes/docs/languages/exporters/intro.md
@@ -1,9 +1,8 @@
-To ensure that your telemetry is exporting correctly, send
-it to the [OpenTelemetry Collector](/docs/collector/). It is also considered a
-best practice to use the Collector in production. To visualize your
-telemetry, export it to a backend such as
-[Jaeger](https://jaegertracing.io/), [Zipkin](https://zipkin.io/),
-[Prometheus](https://prometheus.io/), or a
+To ensure that your telemetry is exporting correctly, send it to the
+[OpenTelemetry Collector](/docs/collector/). It is also considered a best
+practice to use the Collector in production. To visualize your telemetry, export
+it to a backend such as [Jaeger](https://jaegertracing.io/),
+[Zipkin](https://zipkin.io/), [Prometheus](https://prometheus.io/), or a
 [vendor-specific](/ecosystem/vendors/) backend.
 
 {{ $lang := .Get 0 | default "" -}}

--- a/layouts/shortcodes/docs/languages/exporters/intro.md
+++ b/layouts/shortcodes/docs/languages/exporters/intro.md
@@ -1,8 +1,8 @@
-Send telemetry to the [OpenTelemetry Collector](/docs/collector/) to
-make sure it's exported correctly. Using the Collector in production
-environments is a best practice. To visualize your telemetry, export
-it to a backend such as [Jaeger](https://jaegertracing.io/),
-[Zipkin](https://zipkin.io/), [Prometheus](https://prometheus.io/), or a
+Send telemetry to the [OpenTelemetry Collector](/docs/collector/) to make sure
+it's exported correctly. Using the Collector in production environments is a
+best practice. To visualize your telemetry, export it to a backend such as
+[Jaeger](https://jaegertracing.io/), [Zipkin](https://zipkin.io/),
+[Prometheus](https://prometheus.io/), or a
 [vendor-specific](/ecosystem/vendors/) backend.
 
 {{ $lang := .Get 0 | default "" -}}

--- a/layouts/shortcodes/docs/languages/exporters/intro.md
+++ b/layouts/shortcodes/docs/languages/exporters/intro.md
@@ -1,5 +1,7 @@
-To visualize and analyze telemetry, export it to the
-[OpenTelemetry Collector](/docs/collector/), to a backend such as
+To verify your telemetry exports correctly, one of the best things to do is send
+it to an [OpenTelemetry Collector](/docs/collector/). It is also generally a
+best practice to use the Collector in production. If you wisht to visualize your
+telemetry, you can also export it to a backend such as
 [Jaeger](https://jaegertracing.io/), [Zipkin](https://zipkin.io/),
 [Prometheus](https://prometheus.io/), or a
 [vendor-specific](/ecosystem/vendors/) backend.

--- a/layouts/shortcodes/docs/languages/exporters/intro.md
+++ b/layouts/shortcodes/docs/languages/exporters/intro.md
@@ -1,7 +1,7 @@
-To verify your telemetry exports correctly, one of the best things to do is send
-it to an [OpenTelemetry Collector](/docs/collector/). It is also generally a
-best practice to use the Collector in production. If you wisht to visualize your
-telemetry, you can also export it to a backend such as
+To ensure that your telemetry is exporting correctly, send
+it to the [OpenTelemetry Collector](/docs/collector/). It is also considered a
+best practice to use the Collector in production. To visualize your
+telemetry, export it to a backend such as
 [Jaeger](https://jaegertracing.io/), [Zipkin](https://zipkin.io/),
 [Prometheus](https://prometheus.io/), or a
 [vendor-specific](/ecosystem/vendors/) backend.

--- a/layouts/shortcodes/docs/languages/exporters/intro.md
+++ b/layouts/shortcodes/docs/languages/exporters/intro.md
@@ -1,6 +1,6 @@
-To ensure that your telemetry is exporting correctly, send it to the
-[OpenTelemetry Collector](/docs/collector/). It is also considered a best
-practice to use the Collector in production. To visualize your telemetry, export
+Send telemetry to the [OpenTelemetry Collector](/docs/collector/) to
+make sure it's exported correctly. Using the Collector in production
+environments is a best practice. To visualize your telemetry, export
 it to a backend such as [Jaeger](https://jaegertracing.io/),
 [Zipkin](https://zipkin.io/), [Prometheus](https://prometheus.io/), or a
 [vendor-specific](/ecosystem/vendors/) backend.


### PR DESCRIPTION
fixes https://github.com/open-telemetry/opentelemetry.io/issues/3951

---

**Preview**: **Preview**: https://deploy-preview-3963--opentelemetry.netlify.app/docs/languages/java/exporters/
