### PR TITLE
Upgrade to docsy v0.8.0-49-g621fb34, prep for v0.9.0, streamline footer-center page + copyright date range

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/cncf/docsy.git
-	docsy-pin = v0.8.0-21-g435b2e0
+	docsy-pin = v0.8.0-49-g621fb34
 [submodule "content-modules/opentelemetry-specification"]
 	path = content-modules/opentelemetry-specification
 	url = https://github.com/open-telemetry/opentelemetry-specification.git

--- a/assets/scss/_external_link.scss
+++ b/assets/scss/_external_link.scss
@@ -23,6 +23,10 @@ a.external-link:after {
   @include external-link-icon();
 }
 
+.td-footer a.external-link:after {
+  display: none !important;
+}
+
 // Can't quite use this yet since (1) breadcrumbs currently use external links,
 // (2) we can't currently easily turn this off for footer icons.
 //

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -148,12 +148,12 @@
   }
 }
 
-.td-page-meta--child {
+.td-page-meta__child {
   display: none !important;
 }
 
 .otel-docs-spec {
-  .td-page-meta--edit {
+  .td-page-meta__edit {
     display: none !important;
   }
 }

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -47,8 +47,11 @@ outputs:
   section: [HTML]
 
 params:
-  copyright: >-
-    The OpenTelemetry Authors | Documentation Distributed under CC BY 4.0 |
+  copyright:
+    authors: >-
+      OpenTelemetry Authors | Docs [CC BY
+      4.0](https://creativecommons.org/licenses/by/4.0)
+    from_year: 2019
   tagline: Effective observability requires high-quality telemetry
   sub_tagline: >-
     **OpenTelemetry** makes robust, portable telemetry a built-in feature of
@@ -72,7 +75,6 @@ params:
     - img/social/logo-wordmark-001.png
 
   ui:
-    footer_about_disable: true
     navbar_logo: true
     navbar_translucent_over_cover_disable: true
     sidebar_menu_compact: true

--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,0 +1,1 @@
+{{ template "_default/_markup/td-render-heading.html" . }}

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -199,10 +199,6 @@
     "StatusCode": 206,
     "LastSeen": "2024-01-30T06:06:13.672811-05:00"
   },
-  "https://cdn.jsdelivr.net/npm/mermaid@9.3.0/dist/mermaid.min.js": {
-    "StatusCode": 206,
-    "LastSeen": "2024-01-18T19:55:45.920342-05:00"
-  },
   "https://cdn.jsdelivr.net/npm/minisearch@6.3.0/dist/umd/index.min.js": {
     "StatusCode": 206,
     "LastSeen": "2024-01-08T12:17:27.412252+01:00"
@@ -506,6 +502,10 @@
   "https://crates.io/": {
     "StatusCode": 206,
     "LastSeen": "2024-01-22T11:00:04.617082+01:00"
+  },
+  "https://creativecommons.org/licenses/by/4.0": {
+    "StatusCode": 206,
+    "LastSeen": "2024-02-08T18:57:44.500266-05:00"
   },
   "https://cri-o.io/": {
     "StatusCode": 206,


### PR DESCRIPTION
- Upgrade docsy to a **pre-v.0.9.0 release**. For a list of breaking changes, see https://github.com/google/docsy/blob/main/CHANGELOG.md#090
- Note that the **copyright** notice now has a **date range**, and it has been streamlined:
> <img width="1199" alt="image" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/5da1b22c-1be9-4d33-9ce4-af2ecb7fd01a">
- Other notable changes:
  - Docsy now follows recommended accessibility practice: page-body **links are underlined**
  - Heading self-link icon is now generated at build time, rather than client-side. The default icon is a hash character.

**Preview**: https://deploy-preview-3967--opentelemetry.netlify.app
