### PR TITLE
Update Go resource example

### DIFF
--- a/content/en/docs/languages/go/resources.md
+++ b/content/en/docs/languages/go/resources.md
@@ -36,17 +36,20 @@ hosting that operating system instance, or any number of other resource
 attributes.
 
 ```go
-res, err := resource.New(context.Background(),
-	resource.WithFromEnv(),      // Pull attributes from OTEL_RESOURCE_ATTRIBUTES and OTEL_SERVICE_NAME environment variables.
-	resource.WithTelemetrySDK(), // Provide information about the OpenTelemetry SDK used.
+res, err := resource.New(
+	context.Background(),
+	resource.WithFromEnv(),      // Discover and provide attributes from OTEL_RESOURCE_ATTRIBUTES and OTEL_SERVICE_NAME environment variables.
+	resource.WithTelemetrySDK(), // Discover and provide information about the OpenTelemetry SDK used.
 	resource.WithProcess(),      // Discover and provide process information.
 	resource.WithOS(),           // Discover and provide OS information.
 	resource.WithContainer(),    // Discover and provide container information.
-	resource.WithHost(),         // Discover and provide information.
+	resource.WithHost(),         // Discover and provide host information.
 	resource.WithAttributes(attribute.String("foo", "bar")), // Add custom resource attributes.
 	// resource.WithDetectors(thirdparty.Detector{}), // Bring your own external Detector implementation.
 )
-if err != nil {
-	log.Println(err) // Log issues during resource creation. Note that resource.New still returns a resource.
+if errors.Is(err, resource.ErrPartialResource) || errors.Is(err, resource.ErrSchemaURLConflict) {
+	log.Println(err) // Log non-fatal issues.
+} else if err != nil {
+	log.Fatalln(err) // The error may be fatal.
 }
 ```


### PR DESCRIPTION
Follows https://github.com/open-telemetry/opentelemetry-go/pull/4887

@open-telemetry/go-approvers PTAL

Side note: @open-telemetry/docs-approvers, actually it may be better to simply add a reference to  https://pkg.go.dev/go.opentelemetry.io/otel/sdk/resource. But I would rather do it as a separate PR and also right now the example is not published on https://pkg.go.dev/go.opentelemetry.io/otel/sdk/resource.