### PR TITLE
Add Skyscanner to adopters lists

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -144,6 +144,7 @@ words:
   - Sharma
   - shippingservice
   - shortcode
+  - Skyscanner
   - snmp
   - Socha
   - sqlite

--- a/.cspell.yml
+++ b/.cspell.yml
@@ -144,7 +144,6 @@ words:
   - Sharma
   - shippingservice
   - shortcode
-  - Skyscanner
   - snmp
   - Socha
   - sqlite

--- a/data/ecosystem/adopters.yaml
+++ b/data/ecosystem/adopters.yaml
@@ -14,6 +14,11 @@
   components: [Collector, Python]
   reference: ''
   contact: ''
+- name: Dropbox DocSend
+  url: https://www.docsend.com/
+  components: [Ruby]
+  reference: ''
+  contact: ''
 - name: eBay
   url: https://www.ebay.com
   components: [Collector, Java, JavaScript, Go]
@@ -32,6 +37,22 @@
   reference: /blog/2023/end-user-q-and-a-03/
   referenceTitle: blog post
   contact: ''
+- name: Fulcrum
+  url: https://www.fulcrumapp.com/
+  components: [Ruby]
+  reference: ''
+  contact: ''
+- name: GitHub
+  url: https://github.com
+  components: [Ruby]
+  reference: 'https://github.blog/2021-05-26-why-and-how-github-is-adopting-opentelemetry/'
+  referenceTitle: blog post
+  contact: ''
+- name: Heroku
+  url: https://heroku.com
+  components: [Ruby]
+  reference: ''
+  contact: ''
 - name: OrderMyGear
   url: https://www.ordermygear.com/
   components: []
@@ -40,6 +61,11 @@
 - name: PITS Globale Datenrettungsdienste
   url: https://www.pitsdatenrettung.de/
   components: [Python]
+  reference: ''
+  contact: ''
+- name: Puppet
+  url: https://puppet.com/
+  components: [Ruby]
   reference: ''
   contact: ''
 - name: Shopify
@@ -53,6 +79,11 @@
   reference: https://www.infoq.com/presentations/opentelemetry-observability/
   referenceTitle: presentation
   contact: https://github.com/danielgblanco/
+- name: TableCheck
+  url: https://www.tablecheck.com/
+  components: [Ruby]
+  reference: ''
+  contact: ''
 - name: Transit
   url: https://transitapp.com/
   components: []
@@ -72,36 +103,5 @@
 - name: Zocdoc
   url: https://www.zocdoc.com/
   components: []
-  reference: ''
-  contact: ''
-- name: Heroku
-  url: https://heroku.com
-  components: [Ruby]
-  reference: ''
-  contact: ''
-- name: GitHub
-  url: https://github.com
-  components: [Ruby]
-  reference: 'https://github.blog/2021-05-26-why-and-how-github-is-adopting-opentelemetry/'
-  referenceTitle: blog post
-  contact: ''
-- name: Fulcrum
-  url: https://www.fulcrumapp.com/
-  components: [Ruby]
-  reference: ''
-  contact: ''
-- name: Puppet
-  url: https://puppet.com/
-  components: [Ruby]
-  reference: ''
-  contact: ''
-- name: TableCheck
-  url: https://www.tablecheck.com/
-  components: [Ruby]
-  reference: ''
-  contact: ''
-- name: Dropbox DocSend
-  url: https://www.docsend.com/
-  components: [Ruby]
   reference: ''
   contact: ''

--- a/data/ecosystem/adopters.yaml
+++ b/data/ecosystem/adopters.yaml
@@ -1,4 +1,4 @@
-# cSpell:ignore Farfetch Globale Datenrettungsdienste Uplight Wandera Zocdoc
+# cSpell:ignore Farfetch Globale Datenrettungsdienste Uplight Wandera Zocdoc Skyscanner
 - name: AppDirect
   url: https://www.appdirect.com/
   components: [Collector]

--- a/data/ecosystem/adopters.yaml
+++ b/data/ecosystem/adopters.yaml
@@ -47,6 +47,12 @@
   components: [Collector, Go, Ruby]
   reference: ''
   contact: ''
+- name: Skyscanner
+  url: https://www.skyscanner.net/
+  components: [Collector, Go, Java, Javascript, Python]
+  reference: https://www.infoq.com/presentations/opentelemetry-observability/
+  referenceTitle: presentation
+  contact: https://github.com/danielgblanco/
 - name: Transit
   url: https://transitapp.com/
   components: []

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -7399,6 +7399,10 @@
     "StatusCode": 206,
     "LastSeen": "2024-01-30T16:05:10.329813-05:00"
   },
+  "https://www.infoq.com/presentations/opentelemetry-observability/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-02-09T09:36:03.77411329Z"
+  },
   "https://www.investopedia.com/terms/p/personally-identifiable-information-pii.asp": {
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:55:46.183893-05:00"


### PR DESCRIPTION
This change:

- Adds Skyscanner to the adopters list
- Sorts the list of adopters alphabetically. It seems it was sorted alphabetically and then at some point stopped being sorted alphabetically. Happy to revert that commit if it's not the intention of this list to be sorted alphabetically.