### PR TITLE
Bump netlify version (17.16.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "path": "^0.12.7"
   },
   "optionalDependencies": {
-    "netlify-cli": "^17.0.1"
+    "netlify-cli": "^17.16.1"
   },
   "enginesComment": "Ensure that engines.node value stays consistent with the project's .nvmrc",
   "engines": {


### PR DESCRIPTION
Trying to roll out all potential root causes for why the netlify build is not working, so I want to bump that version to latest. We may revert it if this is not helpful/making things worse, because builds are broken already.