### PR TITLE
Add rspec-otel to registry

### DIFF
--- a/data/registry/tools-ruby-rspec-matcher.yml
+++ b/data/registry/tools-ruby-rspec-matcher.yml
@@ -1,3 +1,4 @@
+# cSpell:ignore Damien Mathieu
 title: RSpec matchers
 registryType: utilities
 language: ruby

--- a/data/registry/tools-ruby-rspec-matcher.yml
+++ b/data/registry/tools-ruby-rspec-matcher.yml
@@ -10,7 +10,7 @@ description:
   The RSpec matchers tool provides a set of matchers to make it easier to write
   unit tests checking the presence of telemetry data.
 authors:
-  - name: Damien MATHIEU # cspell:disable-line
+  - name: Damien Mathieu
     email: 42@dmathieu.com
 urls:
   repo: https://github.com/dmathieu/rspec-otel

--- a/data/registry/tools-ruby-rspec-matcher.yml
+++ b/data/registry/tools-ruby-rspec-matcher.yml
@@ -18,4 +18,4 @@ createdAt: 2024-02-13
 package:
   registry: gems
   name: rspec-otel
-  version: 5.16.1
+  version: 0.0.1

--- a/data/registry/tools-ruby-rspec-matcher.yml
+++ b/data/registry/tools-ruby-rspec-matcher.yml
@@ -1,0 +1,20 @@
+title: RSpec matchers
+registryType: utilities
+language: ruby
+tags:
+  - ruby
+  - rspec
+license: MIT
+description:
+  The RSpec matchers tool provides a set of matchers to make it easier to write
+  unit tests checking the presence of telemetry data.
+authors:
+  - name: Damien MATHIEU
+    email: 42@dmathieu.com
+urls:
+  repo: https://github.com/dmathieu/rspec-otel
+createdAt: 2024-02-13
+package:
+  registry: gems
+  name: rspec-otel
+  version: 5.16.1

--- a/data/registry/tools-ruby-rspec-matcher.yml
+++ b/data/registry/tools-ruby-rspec-matcher.yml
@@ -11,7 +11,7 @@ description:
   unit tests checking the presence of telemetry data.
 authors:
   - name: Damien Mathieu
-    email: 42@dmathieu.com
+    url: https://github.com/dmathieu
 urls:
   repo: https://github.com/dmathieu/rspec-otel
 createdAt: 2024-02-13

--- a/data/registry/tools-ruby-rspec-matcher.yml
+++ b/data/registry/tools-ruby-rspec-matcher.yml
@@ -9,7 +9,7 @@ description:
   The RSpec matchers tool provides a set of matchers to make it easier to write
   unit tests checking the presence of telemetry data.
 authors:
-  - name: Damien MATHIEU
+  - name: Damien MATHIEU # cspell:disable-line
     email: 42@dmathieu.com
 urls:
   repo: https://github.com/dmathieu/rspec-otel

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -2243,6 +2243,14 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-18T20:05:04.809604-05:00"
   },
+  "https://github.com/dmathieu": {
+    "StatusCode": 200,
+    "LastSeen": "2024-02-14T08:44:43.625674121Z"
+  },
+  "https://github.com/dmathieu/rspec-otel": {
+    "StatusCode": 200,
+    "LastSeen": "2024-02-14T08:44:42.583247623Z"
+  },
   "https://github.com/dmsolr": {
     "StatusCode": 200,
     "LastSeen": "2024-01-18T20:04:59.339712-05:00"
@@ -6706,6 +6714,10 @@
   "https://rubygems.org/gems/opentelemetry-instrumentation-trilogy": {
     "StatusCode": 200,
     "LastSeen": "2024-01-22T15:38:54.618612+01:00"
+  },
+  "https://rubygems.org/gems/rspec-otel": {
+    "StatusCode": 200,
+    "LastSeen": "2024-02-14T08:44:44.34346372Z"
   },
   "https://rubygems.org/gems/sentry-opentelemetry": {
     "StatusCode": 200,


### PR DESCRIPTION
This adds the rspec-otel gem to the registry.
https://rubygems.org/gems/rspec-otel