### PR TITLE
adding opentext to vendor list

### DIFF
--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -241,7 +241,7 @@
   distribution: true
   nativeOTLP: true
   url: 'https://docs.microfocus.com/doc/OBS/SaaS/ConfigureOTELCollector'
-  contact: ''
+  contact: 'skotagiri@opentext.com'
   oss: false
   commercial: true
 - name: Oracle

--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -237,6 +237,13 @@
   contact: 'hello@openobserve.ai'
   oss: true
   commercial: true
+- name: OpenText
+  distribution: true
+  nativeOTLP: true
+  url: 'https://docs.microfocus.com/doc/OBS/SaaS/ConfigureOTELCollector'
+  contact: ''
+  oss: false
+  commercial: true
 - name: Oracle
   distribution: false
   nativeOTLP: true

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -1115,6 +1115,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-18T08:51:59.704962-05:00"
   },
+  "https://docs.microfocus.com/doc/OBS/SaaS/ConfigureOTELCollector": {
+    "StatusCode": 206,
+    "LastSeen": "2024-02-17T16:19:07.140338072Z"
+  },
   "https://docs.microsoft.com/aspnet/core": {
     "StatusCode": 200,
     "LastSeen": "2024-01-18T08:53:25.01054-05:00"


### PR DESCRIPTION
We are introducing Application Observability as a new capability to OpenText Operations Bridge. Release announcement is at https://docs.microfocus.com/doc/OBS/SaaS/ReleaseNotes. Hence adding OpenText as one of the Vendors supporting OpenTelemetry.