### PR TITLE
Update docsy to 0.9.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/cncf/docsy.git
-	docsy-pin = v0.9.0
+	docsy-pin = v0.9.1
 	docsy-reminder = "Ensure that all tags from google/docsy are also present in cncf/docsy, otherwise add (push) them."
 [submodule "content-modules/opentelemetry-specification"]
 	path = content-modules/opentelemetry-specification


### PR DESCRIPTION
- Followup to #3973
- Brings in the docsy patch release 0.9.1
- No changes to generated site files, other than the site timestamp.