### PR TITLE
fix: adjust dead link

### DIFF
--- a/content/en/ecosystem/adopters.md
+++ b/content/en/ecosystem/adopters.md
@@ -26,7 +26,7 @@ The entry must include the following[^grace-period-2024-01-01]:
   in case we have questions
 
 Note that this list is for
-[_end-user_ organizations](https://community.cncf.io/end-user-community/) that
+[_end-user_ organizations](https://community.cncf.io/) that
 do not provide any OpenTelemetry-related services.
 
 If your organization provides a **library** or **service** made observable

--- a/content/en/ecosystem/adopters.md
+++ b/content/en/ecosystem/adopters.md
@@ -26,8 +26,8 @@ The entry must include the following[^grace-period-2024-01-01]:
   in case we have questions
 
 Note that this list is for
-[_end-user_ organizations](https://community.cncf.io/) that
-do not provide any OpenTelemetry-related services.
+[_end-user_ organizations](https://community.cncf.io/) that do not provide any
+OpenTelemetry-related services.
 
 If your organization provides a **library** or **service** made observable
 through OpenTelemetry, see [Integrations](/ecosystem/integrations/).

--- a/data/ecosystem/adopters.yaml
+++ b/data/ecosystem/adopters.yaml
@@ -1,24 +1,4 @@
 # cSpell:ignore Farfetch Globale Datenrettungsdienste Uplight Wandera Zocdoc Skyscanner
-- name: AppDirect
-  url: https://www.appdirect.com/
-  components: [Collector]
-  reference: ''
-  contact: ''
-- name: Care.com
-  url: https://www.care.com
-  components: [Collector, Go, Java, JavaScript, .NET]
-  reference: ''
-  contact: ''
-- name: Cloud Scale
-  url: https://www.cloudscaleinc.com
-  components: [Collector, Python]
-  reference: ''
-  contact: ''
-- name: Dropbox DocSend
-  url: https://www.docsend.com/
-  components: [Ruby]
-  reference: ''
-  contact: ''
 - name: eBay
   url: https://www.ebay.com
   components: [Collector, Java, JavaScript, Go]
@@ -37,41 +17,11 @@
   reference: /blog/2023/end-user-q-and-a-03/
   referenceTitle: blog post
   contact: ''
-- name: Fulcrum
-  url: https://www.fulcrumapp.com/
-  components: [Ruby]
-  reference: ''
-  contact: ''
 - name: GitHub
   url: https://github.com
   components: [Ruby]
   reference: 'https://github.blog/2021-05-26-why-and-how-github-is-adopting-opentelemetry/'
   referenceTitle: blog post
-  contact: ''
-- name: Heroku
-  url: https://heroku.com
-  components: [Ruby]
-  reference: ''
-  contact: ''
-- name: OrderMyGear
-  url: https://www.ordermygear.com/
-  components: []
-  reference: ''
-  contact: ''
-- name: PITS Globale Datenrettungsdienste
-  url: https://www.pitsdatenrettung.de/
-  components: [Python]
-  reference: ''
-  contact: ''
-- name: Puppet
-  url: https://puppet.com/
-  components: [Ruby]
-  reference: ''
-  contact: ''
-- name: Shopify
-  url: https://www.shopify.com/
-  components: [Collector, Go, Ruby]
-  reference: ''
   contact: ''
 - name: Skyscanner
   url: https://www.skyscanner.net/
@@ -79,29 +29,9 @@
   reference: https://www.infoq.com/presentations/opentelemetry-observability/
   referenceTitle: presentation
   contact: https://github.com/danielgblanco/
-- name: TableCheck
-  url: https://www.tablecheck.com/
-  components: [Ruby]
-  reference: ''
-  contact: ''
-- name: Transit
-  url: https://transitapp.com/
-  components: []
-  reference: ''
-  contact: ''
 - name: Uplight
   url: https://uplight.com/
   components: [Collector, Ruby, Java, Python, .NET]
   reference: /blog/2023/end-user-q-and-a-02/
   referenceTitle: blog post
-  contact: ''
-- name: Wandera
-  url: https://www.wandera.com/
-  components: [Collector]
-  reference: ''
-  contact: ''
-- name: Zocdoc
-  url: https://www.zocdoc.com/
-  components: []
-  reference: ''
   contact: ''

--- a/data/ecosystem/adopters.yaml
+++ b/data/ecosystem/adopters.yaml
@@ -1,4 +1,24 @@
 # cSpell:ignore Farfetch Globale Datenrettungsdienste Uplight Wandera Zocdoc Skyscanner
+- name: AppDirect
+  url: https://www.appdirect.com/
+  components: [Collector]
+  reference: ''
+  contact: ''
+- name: Care.com
+  url: https://www.care.com
+  components: [Collector, Go, Java, JavaScript, .NET]
+  reference: ''
+  contact: ''
+- name: Cloud Scale
+  url: https://www.cloudscaleinc.com
+  components: [Collector, Python]
+  reference: ''
+  contact: ''
+- name: Dropbox DocSend
+  url: https://www.docsend.com/
+  components: [Ruby]
+  reference: ''
+  contact: ''
 - name: eBay
   url: https://www.ebay.com
   components: [Collector, Java, JavaScript, Go]
@@ -17,11 +37,41 @@
   reference: /blog/2023/end-user-q-and-a-03/
   referenceTitle: blog post
   contact: ''
+- name: Fulcrum
+  url: https://www.fulcrumapp.com/
+  components: [Ruby]
+  reference: ''
+  contact: ''
 - name: GitHub
   url: https://github.com
   components: [Ruby]
   reference: 'https://github.blog/2021-05-26-why-and-how-github-is-adopting-opentelemetry/'
   referenceTitle: blog post
+  contact: ''
+- name: Heroku
+  url: https://heroku.com
+  components: [Ruby]
+  reference: ''
+  contact: ''
+- name: OrderMyGear
+  url: https://www.ordermygear.com/
+  components: []
+  reference: ''
+  contact: ''
+- name: PITS Globale Datenrettungsdienste
+  url: https://www.pitsdatenrettung.de/
+  components: [Python]
+  reference: ''
+  contact: ''
+- name: Puppet
+  url: https://puppet.com/
+  components: [Ruby]
+  reference: ''
+  contact: ''
+- name: Shopify
+  url: https://www.shopify.com/
+  components: [Collector, Go, Ruby]
+  reference: ''
   contact: ''
 - name: Skyscanner
   url: https://www.skyscanner.net/
@@ -29,9 +79,29 @@
   reference: https://www.infoq.com/presentations/opentelemetry-observability/
   referenceTitle: presentation
   contact: https://github.com/danielgblanco/
+- name: TableCheck
+  url: https://www.tablecheck.com/
+  components: [Ruby]
+  reference: ''
+  contact: ''
+- name: Transit
+  url: https://transitapp.com/
+  components: []
+  reference: ''
+  contact: ''
 - name: Uplight
   url: https://uplight.com/
   components: [Collector, Ruby, Java, Python, .NET]
   reference: /blog/2023/end-user-q-and-a-02/
   referenceTitle: blog post
+  contact: ''
+- name: Wandera
+  url: https://www.wandera.com/
+  components: [Collector]
+  reference: ''
+  contact: ''
+- name: Zocdoc
+  url: https://www.zocdoc.com/
+  components: []
+  reference: ''
   contact: ''

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -451,6 +451,10 @@
     "StatusCode": 206,
     "LastSeen": "2024-01-30T16:15:04.197679-05:00"
   },
+  "https://community.cncf.io/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-02-22T16:34:09.566865309Z"
+  },
   "https://community.cncf.io/end-user-community/": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T06:05:22.999299-05:00"


### PR DESCRIPTION
I noticed that https://community.cncf.io/end-user-community/ no longer existed, and couldn't find a related page, so pointed to the root of the domain.

~~I also removed all adopters with no blog post as defined in the `grace-period-2024-01-01` footnote.~~