### PR TITLE
Improve documentation

### DIFF
--- a/content/en/docs/languages/net/instrumentation.md
+++ b/content/en/docs/languages/net/instrumentation.md
@@ -281,6 +281,13 @@ var activity = Activity.Current;
 Note that `using` is not used in the prior example. Doing so will end current
 `Activity`, which is not likely to be desired.
 
+Alternatively you can use the `Tracer` class to obtain the current `TelemetrySpan` to stay within the OpenTelemetry namespace.
+
+```csharp
+var span = Tracer.CurrentSpan;
+// may be null if there is none
+```
+
 ### Add tags to an Activity
 
 Tags (the equivalent of


### PR DESCRIPTION
The documentation is mostly referencing the OpenTelemetry namespace classes, however, not for the current active span retrieval. Here is a small extension to the documentation to make this more clear or rather shows that it is also possible to retrieve the active span using the Tracer of the OpenTelemetry namespace.