### PR TITLE
registry: Add Missing Rust Crates

### DIFF
--- a/data/registry/exporter-rust-datadog.yml
+++ b/data/registry/exporter-rust-datadog.yml
@@ -1,0 +1,19 @@
+# cSpell:ignore Datadog
+title: Datadog Exporter
+registryType: exporter
+language: rust
+tags:
+  - rust
+  - exporter
+  - propagators
+license: Apache 2.0
+description: A Rust OpenTelemetry exporter and propagators for Datadog
+authors:
+  - name: OpenTelemetry Authors
+urls:
+  repo: https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-datadog
+createdAt: 2021-03-24
+package:
+  registry: crates
+  name: opentelemetry-datadog
+  version: 0.10.0

--- a/data/registry/exporter-rust-stackdriver.yml
+++ b/data/registry/exporter-rust-stackdriver.yml
@@ -1,5 +1,5 @@
 # cSpell:ignore jacobkiesel stackdriver
-title: Google StackDrive Exporter
+title: Google StackDriver Exporter
 registryType: exporter
 language: rust
 tags:
@@ -9,8 +9,9 @@ license: Apache 2.0 OR MIT
 description: A Rust OpenTelemetry exporter for Google StackDriver
 authors:
   - name: jacobkiesel
+  - name: OpenTelemetry Authors
 urls:
-  repo: https://github.com/vivint-smarthome/opentelemetry-stackdriver
+  repo: https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-stackdriver
 createdAt: 2020-08-28
 package:
   registry: crates

--- a/data/registry/exporter-rust-user-events-logs.yml
+++ b/data/registry/exporter-rust-user-events-logs.yml
@@ -1,0 +1,21 @@
+title: User Events Logs Exporter
+registryType: exporter
+language: rust
+tags:
+  - rust
+  - exporter
+  - linux
+  - user_events
+license: Apache 2.0 OR MIT
+description:
+  A Rust OpenTelemetry Log exporter for
+  https://docs.kernel.org/trace/user_events.html
+authors:
+  - name: OpenTelemetry Authors
+urls:
+  repo: https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-user-events-logs
+createdAt: 2023-07-29
+package:
+  registry: crates
+  name: opentelemetry-user-events-logs
+  version: 0.3.0

--- a/data/registry/exporter-rust-user-events-logs.yml
+++ b/data/registry/exporter-rust-user-events-logs.yml
@@ -1,4 +1,4 @@
-title: User Events Logs Exporter
+title: user_events Logs Exporter
 registryType: exporter
 language: rust
 tags:
@@ -8,8 +8,8 @@ tags:
   - user_events
 license: Apache 2.0 OR MIT
 description:
-  A Rust OpenTelemetry Log exporter for
-  https://docs.kernel.org/trace/user_events.html
+  A Rust OpenTelemetry Log exporter for [Linux Kernel
+  user_events](https://docs.kernel.org/trace/user_events.html)
 authors:
   - name: OpenTelemetry Authors
 urls:

--- a/data/registry/exporter-rust-user-events-metrics.yml
+++ b/data/registry/exporter-rust-user-events-metrics.yml
@@ -1,0 +1,21 @@
+title: User Events Metrics Exporter
+registryType: exporter
+language: rust
+tags:
+  - rust
+  - exporter
+  - linux
+  - user_events
+license: Apache 2.0 OR MIT
+description:
+  A Rust OpenTelemetry Metric exporter for
+  https://docs.kernel.org/trace/user_events.html
+authors:
+  - name: OpenTelemetry Authors
+urls:
+  repo: https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-user-events-metrics
+createdAt: 2023-07-29
+package:
+  registry: crates
+  name: opentelemetry-user-events-metrics
+  version: 0.3.0

--- a/data/registry/exporter-rust-user-events-metrics.yml
+++ b/data/registry/exporter-rust-user-events-metrics.yml
@@ -1,4 +1,4 @@
-title: User Events Metrics Exporter
+title: user_events Metrics Exporter
 registryType: exporter
 language: rust
 tags:
@@ -8,8 +8,8 @@ tags:
   - user_events
 license: Apache 2.0 OR MIT
 description:
-  A Rust OpenTelemetry Metric exporter for
-  https://docs.kernel.org/trace/user_events.html
+  A Rust OpenTelemetry Metric exporter for [Linux Kernel
+  user_events](https://docs.kernel.org/trace/user_events.html)
 authors:
   - name: OpenTelemetry Authors
 urls:

--- a/data/registry/instrumentation-rust-trillium.yml
+++ b/data/registry/instrumentation-rust-trillium.yml
@@ -1,0 +1,18 @@
+# cSpell:ignore Rothstein
+title: Trillium Instrumentation
+registryType: instrumentation
+language: rust
+tags:
+  - rust
+  - instrumentation
+license: Apache 2.0 OR MIT
+description: OpenTelemetry integration for the Trillium web framework.
+authors:
+  - name: Jacob Rothstein
+urls:
+  repo: https://github.com/trillium-rs/trillium-opentelemetry
+createdAt: 2021-04-25
+package:
+  registry: crates
+  name: opentelemetry-trillium-opentelemetry
+  version: 0.2.16

--- a/data/registry/tools-rust-aws.yml
+++ b/data/registry/tools-rust-aws.yml
@@ -1,6 +1,6 @@
 title: AWS Utilities
 registryType: utilities
-description: Utilities related to AWS including XRay Propagators.
+description: Utilities related to AWS including XRay Propagator and IDGenerator.
 language: rust
 tags:
   - rust

--- a/data/registry/tools-rust-aws.yml
+++ b/data/registry/tools-rust-aws.yml
@@ -1,0 +1,21 @@
+title: AWS Utilities
+registryType: utilities
+description: Utilities related to AWS including XRay Propagators.
+language: rust
+tags:
+  - rust
+  - utilities
+  - propagator
+  - aws
+  - xray
+license: Apache 2.0
+authors:
+  - name: OpenTelemetry Authors
+
+urls:
+  repo: https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-aws
+createdAt: 2021-02-08
+package:
+  registry: crates
+  name: opentelemetry-aws
+  version: 0.10.0

--- a/data/registry/tools-rust-propagator-jaeger.yml
+++ b/data/registry/tools-rust-propagator-jaeger.yml
@@ -1,0 +1,23 @@
+title: OpenTelemetry Jaeger context propagation
+registryType: utilities
+language: rust
+tags:
+  - rust
+  - jaeger
+  - utilities
+  - propagator
+license: Apache 2.0
+description: >
+  This library provides support for propagating trace context in the Jaeger
+  https://www.jaegertracing.io/docs/1.20/client-libraries/#propagation-format
+  format.
+
+authors:
+  - name: OpenTelemetry Authors
+urls:
+  repo: https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-jaeger-propagator
+createdAt: 2024-02-25
+package:
+  registry: crates
+  name: opentelemetry-jaeger-propagator
+  version: 0.1.0

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -1107,6 +1107,10 @@
     "StatusCode": 206,
     "LastSeen": "2024-01-18T19:56:07.640917-05:00"
   },
+  "https://docs.kernel.org/trace/user_events.html": {
+    "StatusCode": 206,
+    "LastSeen": "2024-02-28T10:02:41.822426963+01:00"
+  },
   "https://docs.kloudmate.com/using-opentelemetry-collector": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T15:25:17.098548-05:00"
@@ -4094,6 +4098,10 @@
   "https://github.com/trask": {
     "StatusCode": 200,
     "LastSeen": "2024-01-18T20:05:14.368028-05:00"
+  },
+  "https://github.com/trillium-rs/trillium-opentelemetry": {
+    "StatusCode": 200,
+    "LastSeen": "2024-02-28T10:02:42.715380297+01:00"
   },
   "https://github.com/tsloughter/grpcbox": {
     "StatusCode": 200,
@@ -7534,6 +7542,10 @@
   "https://www.jaegertracing.io/docs/1.18/client-libraries/#baggage": {
     "StatusCode": 206,
     "LastSeen": "2024-01-18T19:37:16.745648-05:00"
+  },
+  "https://www.jaegertracing.io/docs/1.20/client-libraries/#propagation-format": {
+    "StatusCode": 206,
+    "LastSeen": "2024-02-28T10:02:43.157547031+01:00"
   },
   "https://www.jaegertracing.io/docs/1.21/client-libraries/#propagation-format": {
     "StatusCode": 200,


### PR DESCRIPTION
We recently cleaned up our README, and started referencing the Registry, but we want to make sure that the crates are still in the registry.

Relates https://github.com/open-telemetry/opentelemetry-rust/issues/1582