### PR TITLE
Kubecon blog: fix markdown link def placement so it renders properly

### DIFF
--- a/content/en/blog/2024/kubecon-eu.md
+++ b/content/en/blog/2024/kubecon-eu.md
@@ -93,6 +93,9 @@ You need an _in-person all-access_ pass for on-site access to **Observability
 Day**. For details, see [KubeCon registration][]. If you have a virtual ticket,
 you will be able to follow **Observability Day** through a live stream.
 
+[kubecon registration]:
+  https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/register/
+
 {{% /alert %}}
 
 ## OpenTelemetry Observatory
@@ -142,5 +145,3 @@ See you in Paris!
   https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/
 [Observability Day]:
   https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/co-located-events/observability-day/
-[kubecon registration]:
-  https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/register/


### PR DESCRIPTION
- Followup to #3983
- Fixes:
  > <img width="604" alt="Screen Shot 2024-02-28 at 13 01 34" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/4918290c-2731-4915-a117-6869f6928e9b">
- **Preview**: https://deploy-preview-4065--opentelemetry.netlify.app/blog/2024/kubecon-eu/#observability-day