### PR TITLE
[Hugo] Don't auto-linkify in prose & fix registry links

### DIFF
--- a/data/registry/instrumentation-erlang-req.yml
+++ b/data/registry/instrumentation-erlang-req.yml
@@ -6,8 +6,7 @@ tags:
   - instrumentation
   - erlang
 license: Apache 2.0
-description:
-  See https://hex.pm/packages/opentelemetry_req for usage instructions.
+description: For details, see <https://hex.pm/packages/opentelemetry_req>.
 authors:
   - name: OpenTelemetry Authors
 urls:

--- a/data/registry/instrumentation-go-mongodb.yml
+++ b/data/registry/instrumentation-go-mongodb.yml
@@ -9,7 +9,7 @@ tags:
 license: Apache 2.0
 description:
   Package mongo-driver provides functions to trace the
-  go.mongodb.org/mongo-driver/mongo(https://github.com/mongodb/mongo-go-driver)
+  [go.mongodb.org/mongo-driver/mongo](https://github.com/mongodb/mongo-go-driver)
   package.
 authors:
   - name: OpenTelemetry Authors

--- a/data/registry/instrumentation-php-psr14.yml
+++ b/data/registry/instrumentation-php-psr14.yml
@@ -10,7 +10,7 @@ urls:
 license: Apache 2.0
 description:
   This is a read-only subtree split of
-  https://github.com/open-telemetry/opentelemetry-php-contrib.
+  <https://github.com/open-telemetry/opentelemetry-php-contrib>.
 authors:
   - name: OpenTelemetry Authors
 createdAt: 2024-01-19

--- a/data/registry/tools-go-propagator-datadog.yml
+++ b/data/registry/tools-go-propagator-datadog.yml
@@ -9,8 +9,7 @@ tags:
 license: Apache 2.0
 description: >
   This library provides support for propagating trace context in the Datadog
-  X-Datadog-* format.
-
+  `X-Datadog-*` format.
 authors:
   - name: Tony Li
     url: https://github.com/tonglil

--- a/data/registry/tools-php-propagator-b3.yml
+++ b/data/registry/tools-php-propagator-b3.yml
@@ -9,7 +9,6 @@ tags:
 license: Apache 2.0
 description: >
   This library provides support for propagating trace context in the B3 format.
-
 authors:
   - name: OpenTelemetry Authors
 urls:

--- a/data/registry/tools-python-propagator-gcp.yml
+++ b/data/registry/tools-python-propagator-gcp.yml
@@ -10,8 +10,7 @@ tags:
 license: Apache 2.0
 description: >
   This library provides support for propagating trace context in the Google
-  Cloud X-Cloud-Trace-Context format.
-
+  Cloud `X-Cloud-Trace-Context` format.
 authors:
   - name: Google
 urls:

--- a/data/registry/tools-rust-propagator-jaeger.yml
+++ b/data/registry/tools-rust-propagator-jaeger.yml
@@ -8,10 +8,8 @@ tags:
   - propagator
 license: Apache 2.0
 description: >
-  This library provides support for propagating trace context in the Jaeger
-  https://www.jaegertracing.io/docs/1.20/client-libraries/#propagation-format
-  format.
-
+  This library provides support for propagating trace context in the [Jaeger
+  format](https://www.jaegertracing.io/docs/1.20/client-libraries/#propagation-format).
 authors:
   - name: OpenTelemetry Authors
 urls:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -22,6 +22,8 @@ imaging:
 
 markup:
   goldmark:
+    extensions:
+      linkify: false
     parser:
       attribute:
         block: true


### PR DESCRIPTION
- An upcoming semconv spec changes breaks the build because [Hugo is configured by default to linkify plain-text URLs](https://gohugo.io/getting-started/configuration-markup/#goldmark) -- there is a fictitious raw URL given as an example in prose that is treated as an external link and so link checking fails. That shouldn't happen.
  **Use the markdown sytnax `<URL>` in prose to introduce the raw URL as a link.** /cc @theletterf et al.
- Turns off the Goldmark [linkify](https://github.github.com/gfm/#autolinks-extension-) extension.
- Fixes some affected links in registry YAML files
- Other minor copyedits in a few registry YAML files
- **Preview**, e.g.:
  - https://deploy-preview-4067--opentelemetry.netlify.app/ecosystem/registry/?s=OpenTelemetry+Jaeger+context+propagation