### PR TITLE
Upgrade Docsy, and Hugo to 0.123+

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/cncf/docsy.git
-	docsy-pin = v0.9.1-4-g020f860
+	docsy-pin = v0.9.1-11-g42dc4ca
 	docsy-reminder = "Ensure that all tags from google/docsy are also present in cncf/docsy, otherwise add (push) them."
 [submodule "content-modules/opentelemetry-specification"]
 	path = content-modules/opentelemetry-specification

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/cncf/docsy.git
-	docsy-pin = v0.9.1
+	docsy-pin = v0.9.1-4-g020f860
 	docsy-reminder = "Ensure that all tags from google/docsy are also present in cncf/docsy, otherwise add (push) them."
 [submodule "content-modules/opentelemetry-specification"]
 	path = content-modules/opentelemetry-specification

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/cncf/docsy.git
-	docsy-pin = v0.9.1-11-g42dc4ca
+	docsy-pin = v0.9.1-17-gb077a74
 	docsy-reminder = "Ensure that all tags from google/docsy are also present in cncf/docsy, otherwise add (push) them."
 [submodule "content-modules/opentelemetry-specification"]
 	path = content-modules/opentelemetry-specification

--- a/package.json
+++ b/package.json
@@ -92,11 +92,11 @@
     "update:submodule": "set -x && git submodule update --remote ${DEPTH:- --depth 1}"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.18",
+    "autoprefixer": "^10.4.19",
     "cspell": "^8.0.0",
     "gulp": "^4.0.2",
-    "hugo-extended": "0.123.8",
-    "markdown-link-check": "^3.11.2",
+    "hugo-extended": "0.124.1",
+    "markdown-link-check": "^3.12.1",
     "markdownlint": "^0.34.0",
     "postcss-cli": "^11.0.0",
     "prettier": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "autoprefixer": "^10.4.18",
     "cspell": "^8.0.0",
     "gulp": "^4.0.2",
-    "hugo-extended": "0.123.7",
+    "hugo-extended": "0.123.8",
     "markdown-link-check": "^3.11.2",
     "markdownlint": "^0.34.0",
     "postcss-cli": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -92,10 +92,10 @@
     "update:submodule": "set -x && git submodule update --remote ${DEPTH:- --depth 1}"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.17",
+    "autoprefixer": "^10.4.18",
     "cspell": "^8.0.0",
     "gulp": "^4.0.2",
-    "hugo-extended": "0.122.0",
+    "hugo-extended": "0.123.7",
     "markdown-link-check": "^3.11.2",
     "markdownlint": "^0.34.0",
     "postcss-cli": "^11.0.0",

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -499,6 +499,10 @@
     "StatusCode": 206,
     "LastSeen": "2024-01-18T19:55:24.935595-05:00"
   },
+  "https://code.jquery.com/jquery-3.7.1.min.js": {
+    "StatusCode": 206,
+    "LastSeen": "2024-03-12T15:13:41.080612-04:00"
+  },
   "https://code.visualstudio.com/": {
     "StatusCode": 206,
     "LastSeen": "2024-01-30T16:14:52.723964-05:00"


### PR DESCRIPTION
- Contributes to #4064
- Closes #4126

Here's the diff in generated site files:

```console
$ (cd public && git diff -bw --ignore-blank-lines -I 'Hugo 0.12|navbar-dark|theme="dark"|code.jquery|sha512-|<img |var params =|class="text-') | grep ^diff | grep -vE '_print|\.xml$' | head
diff --git a/404.html b/404.html
diff --git a/js/main.js b/js/main.js
diff --git a/refcache.json b/refcache.json
diff --git a/scss/main.css b/scss/main.css
diff --git a/scss/main.css.map b/scss/main.css.map
diff --git a/site/index.html b/site/index.html
```

Explanation of differences per file:

- 404 page - b/c of this fix https://github.com/google/docsy/issues/1872
- `main.{js,.css*}` - b/c BS was upgraded to 5.3
- refcache: due to jQuery version upgrade (yes, we want to [drop jQuery in the future](https://github.com/google/docsy/issues/1436))
- Site index due to build timestamp