### PR TITLE
point out that environmental variable support is optional

### DIFF
--- a/content/en/docs/languages/sdk-configuration/general.md
+++ b/content/en/docs/languages/sdk-configuration/general.md
@@ -5,6 +5,8 @@ aliases: [general-sdk-configuration]
 cSpell:ignore: ottrace
 ---
 
+**Note: Support for environment variables is optional.** For detailed information on which environment variables each language implementation supports, please consult the [Implementation Compliance Matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md#environment-variables).
+
 ## `OTEL_SERVICE_NAME`
 
 Sets the value of the [`service.name`](/docs/specs/semconv/resource/#service)

--- a/content/en/docs/languages/sdk-configuration/general.md
+++ b/content/en/docs/languages/sdk-configuration/general.md
@@ -5,7 +5,11 @@ aliases: [general-sdk-configuration]
 cSpell:ignore: ottrace
 ---
 
-**Note: Support for environment variables is optional.** For detailed information on which environment variables each language implementation supports, please consult the [Implementation Compliance Matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md#environment-variables).
+{{% alert title="Note" color="info" %}}
+
+Support for environment variables is optional. For detailed information on which environment variables each language implementation supports, please consult the [Implementation Compliance Matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md#environment-variables).
+
+{{% /alert %}}
 
 ## `OTEL_SERVICE_NAME`
 

--- a/content/en/docs/languages/sdk-configuration/general.md
+++ b/content/en/docs/languages/sdk-configuration/general.md
@@ -7,7 +7,9 @@ cSpell:ignore: ottrace
 
 {{% alert title="Note" color="info" %}}
 
-Support for environment variables is optional. For detailed information on which environment variables each language implementation supports, please consult the [Implementation Compliance Matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md#environment-variables).
+Support for environment variables is optional. For detailed information on which
+environment variables each language implementation supports, please consult the
+[Implementation Compliance Matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md#environment-variables).
 
 {{% /alert %}}
 


### PR DESCRIPTION
and link to the matrix table outlining language support.

Addresses #4059.