### PR TITLE
Fix Traefik Hub documentation link

### DIFF
--- a/data/ecosystem/integrations.yaml
+++ b/data/ecosystem/integrations.yaml
@@ -148,7 +148,7 @@
   oss: false
 - name: Traefik Hub API Management
   url: https://traefik.io/traefik-hub/
-  docsUrl: https://doc.traefik.io/traefik-hub/operations/telemetry/overview/
+  docsUrl: https://doc.traefik.io/traefik-hub/operations/metrics
   components: [Go]
   oss: false
 - name: Strimzi

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -763,7 +763,7 @@
     "StatusCode": 206,
     "LastSeen": "2024-01-22T08:13:47.191476+01:00"
   },
-  "https://doc.traefik.io/traefik-hub/operations/telemetry/overview/": {
+  "https://doc.traefik.io/traefik-hub/operations/metrics": {
     "StatusCode": 206,
     "LastSeen": "2024-01-30T16:07:39.690877-05:00"
   },


### PR DESCRIPTION
Traefik Hub's documentation has been remade with a new docs website; thus, the previous link moved.

cc @svx 

Original PR for reference: https://github.com/open-telemetry/opentelemetry.io/pull/3435