### PR TITLE
docs: fixed a minor typo in k8s operator docs

### DIFF
--- a/content/en/docs/kubernetes/operator/automatic.md
+++ b/content/en/docs/kubernetes/operator/automatic.md
@@ -205,7 +205,7 @@ EOF
 ```
 
 By default, the Instrumentation resource that auto-instruments Java services
-uses `otlp` with the `http+protobuf` protocol. This means that the configured
+uses `otlp` with the `http/protobuf` protocol. This means that the configured
 endpoint must be able to receive OTLP over `http` via `protobuf` payloads.
 Therefore, the example uses `http://demo-collector:4318`, which connects to the
 `http` port of the otlpreceiver of the Collector created in the previous step.


### PR DESCRIPTION
Java instrumentation now defaults to `http/protobuf` starting from 2.0.0. There was a typo when this readme file was recently updated.