### PR TITLE
Update JS logs status to experimental

### DIFF
--- a/data/instrumentation.yaml
+++ b/data/instrumentation.yaml
@@ -56,7 +56,7 @@ js:
   status:
     traces: stable
     metrics: stable
-    logs: Development
+    logs: experimental
 rust:
   name: Rust
   status:


### PR DESCRIPTION
These are now released as experimental: https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/sdk-logs

@open-telemetry/javascript-approvers would this make sense to change?