### PR TITLE
Update integrations.yaml

### DIFF
--- a/data/ecosystem/integrations.yaml
+++ b/data/ecosystem/integrations.yaml
@@ -186,3 +186,8 @@
   docsUrl: https://cn.dubbo.apache.org/en/blog/2024/01/31/tracing-dubbo-with-opentelemetry/
   components: [Java]
   oss: true
+- name: Microcks
+  url: https://microcks.io/
+  docsUrl: https://microcks.io/documentation/using/monitoring/
+  components: [Java]
+  oss: true


### PR DESCRIPTION
Add Microcks (CNCF Sandbox project) to the OpenTelemetry integration list.