### PR TITLE
doc(k8s-operator): document customizing enabled auto-instrumentations for nodejs with kubernetes-operator

### DIFF
--- a/content/en/docs/kubernetes/operator/automatic.md
+++ b/content/en/docs/kubernetes/operator/automatic.md
@@ -282,12 +282,24 @@ must be able to receive OTLP over `grpc`. Therefore, the example uses
 
 #### Excluding auto-instrumentation {#js-excluding-auto-instrumentation}
 
-By default, the Node.js auto-instrumentation ships with
-[many instrumentation libraries](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/metapackages/auto-instrumentations-node/README.md#supported-instrumentations).
-At the moment, there is no way to opt-in to only specific packages or disable
-specific packages. If you don't want to use a package included by the default
-image you must either supply your own image that includes only the packages you
-want or use manual instrumentation.
+By default, the Node.js auto-instrumentation has all the instrumentation
+libraries enabled.
+
+To enable only specific instrumentations you can use the
+`OTEL_NODE_ENABLED_INSTRUMENTATIONS` environment variable as documented in the
+[Node.js auto-instrumentation documentation](/docs/languages/js/automatic/configuration/#excluding-auto-instrumentation).
+
+```yaml
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+# ... other fields skipped from this example
+spec:
+  # ... other fields skipped from this example
+  nodejs:
+    env:
+      - name: OTEL_NODE_ENABLED_INSTRUMENTATIONS
+        value: http,nestjs-core # comma-separated list of the instrumentation package names without the `@opentelemetry/instrumentation-` prefix.
+```
 
 #### Learn more {#js-learn-more}
 

--- a/content/en/docs/languages/js/automatic/configuration.md
+++ b/content/en/docs/languages/js/automatic/configuration.md
@@ -39,3 +39,22 @@ For example, to only enable the `env` and `host` detectors, you can set:
 ```shell
 OTEL_NODE_RESOURCE_DETECTORS=env,host
 ```
+
+### Excluding auto-instrumentation
+
+By default, all
+[supported instrumentation libraries](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/metapackages/auto-instrumentations-node/README.md#supported-instrumentations)
+are enabled, but you can use the environment variable
+`OTEL_NODE_ENABLED_INSTRUMENTATIONS` to enable only certain instrumentations by
+providing a comma-separated list of the instrumentation package names without
+the `@opentelemetry/instrumentation-` prefix.
+
+For example, to enable only
+[@opentelemetry/instrumentation-http](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-instrumentation-http)
+and
+[@opentelemetry/instrumentation-express](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-express)
+instrumentations:
+
+```shell
+OTEL_NODE_ENABLED_INSTRUMENTATIONS="http,express"
+```


### PR DESCRIPTION
# The change
Current documentation states that it isn't possible to disable specific nodejs auto-instrumentation packages when using kubernetes-operator, but that isn't true after next kubernetes operator release, that allows enabling instrumentations based on `OTEL_NODE_ENABLED_INSTRUMENTATIONS` environment variable.

# [UPDATE:] Dependancy PRs released for now
This documentation change is caused by feature enabled by merged [PR](https://github.com/open-telemetry/opentelemetry-operator/pull/2745)
**that currently isn't released (hence the DRAFT status of this PR),**
and another [PR](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1953) that built the foundation for it.