### PR TITLE
Add Docker as a prerequisite to Collector quick start example

### DIFF
--- a/content/en/docs/collector/quick-start.md
+++ b/content/en/docs/collector/quick-start.md
@@ -26,6 +26,7 @@ Make sure that your developer environment has the following. This page assumes
 that you're using `bash`. Adapt configuration and commands as necessary for your
 preferred shell.
 
+- [Docker](https://www.docker.com/)
 - [Go](https://go.dev/) 1.20 or higher
 - [`GOBIN` environment variable][gobin] is set; if unset, initialize it
   appropriately, for example[^1]:

--- a/content/en/docs/collector/quick-start.md
+++ b/content/en/docs/collector/quick-start.md
@@ -26,7 +26,7 @@ Make sure that your developer environment has the following. This page assumes
 that you're using `bash`. Adapt configuration and commands as necessary for your
 preferred shell.
 
-- [Docker](https://www.docker.com/)
+- [Docker](https://www.docker.com/) or any compatible containers' runtime.
 - [Go](https://go.dev/) 1.20 or higher
 - [`GOBIN` environment variable][gobin] is set; if unset, initialize it
   appropriately, for example[^1]:


### PR DESCRIPTION
This PR proposes to add Docker as a prerequisite for the Collector quick start example. Althought Docker is ubitquitous for running applications, if it is not installed on the user's machine, it requires setup prior to running this example.