### PR TITLE
Add final End User Feedback Session

### DIFF
--- a/content/en/blog/2024/kubecon-eu.md
+++ b/content/en/blog/2024/kubecon-eu.md
@@ -125,8 +125,10 @@ Time (CET).
   [End User Feedback Session - Semantic Conventions](https://calendly.com/euwg-user-feedback-session/end-user-feedback-session-semantic-conventions?month=2024-03)
 - **March 21st, 14:30-15:30:**
   [End User Feedback Session - Comms (website, docs)](https://calendly.com/euwg-user-feedback-session/end-user-feedback-session-comms?month=2024-03)
-- **March 21th, 15:00-16:00:**
+- **March 21st, 15:00-16:00:**
   [End User Feedback Session - Profiling](https://calendly.com/euwg-user-feedback-session/end-user-feedback-session-profiling?month=2024-03)
+- **March 21st, 15:30-16:30:**
+  [End User Feedback Session - Client-side](https://calendly.com/euwg-user-feedback-session/end-user-feedback-session-client-side)
 
 A maximum of 5 participants will join one SIG maintainer to provide feedback for
 that SIG. Sessions will be recorded and posted on the

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -199,6 +199,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-03-12T07:55:41.183146657Z"
   },
+  "https://calendly.com/euwg-user-feedback-session/end-user-feedback-session-client-side": {
+    "StatusCode": 200,
+    "LastSeen": "2024-03-13T05:57:38.524559976Z"
+  },
   "https://calendly.com/euwg-user-feedback-session/end-user-feedback-session-comms": {
     "StatusCode": 200,
     "LastSeen": "2024-03-12T07:55:43.02820199Z"


### PR DESCRIPTION
We had one more confirmation! for End User Feedback Session: Client-side. This PR adds it to the roster. 