### PR TITLE
Added the Calender view

### DIFF
--- a/content/en/community/end-user/calender-view.md
+++ b/content/en/community/end-user/calender-view.md
@@ -6,4 +6,4 @@ weight: 20
 ---
 We, the OTel Communications SIG, meet every two weeks on Monday at 10:00 PT. Check out the below OpenTelemetry community calendar for the Zoom link and any updates to this schedule.
 
-<iframe src="https://calendar.google.com/calendar/embed?src=rafeyahmed1104%40gmail.com&ctz=Asia%2FKolkata" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+<iframe src="<open-telemetry-google calanders link>" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>

--- a/content/en/community/end-user/calender-view.md
+++ b/content/en/community/end-user/calender-view.md
@@ -1,7 +1,9 @@
 ---
 title: OpenTelemetry MeetUps
-linkTitle: calender-view 
-description: We, the OTel Communications SIG, meet every two weeks on Monday at 10:00 PT.
+linkTitle: Calender 
+description: Lets meet.
 weight: 20
 ---
-We, the OTel Communications SIG, meet every two weeks on Monday at 10:00 PT.
+We, the OTel Communications SIG, meet every two weeks on Monday at 10:00 PT. Check out the below OpenTelemetry community calendar for the Zoom link and any updates to this schedule.
+
+<iframe src="https://calendar.google.com/calendar/embed?src=rafeyahmed1104%40gmail.com&ctz=Asia%2FKolkata" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>

--- a/content/en/community/end-user/calender-view.md
+++ b/content/en/community/end-user/calender-view.md
@@ -1,0 +1,7 @@
+---
+title: OpenTelemetry MeetUps
+linkTitle: calender-view 
+description: We, the OTel Communications SIG, meet every two weeks on Monday at 10:00 PT.
+weight: 20
+---
+We, the OTel Communications SIG, meet every two weeks on Monday at 10:00 PT.


### PR DESCRIPTION
Added a calendar view at this URL (https://opentelemetry.io/community/end-user/calendar). This will help the end users to get the info regarding the meet-ups through the website itself. 

This PR closes #4098 issue 

https://vimeo.com/922744448?share=copy

Follow the above video to add the open telemetry calendar.