### PR TITLE
Ecosystem policy updates

### DIFF
--- a/content/en/ecosystem/adopters.md
+++ b/content/en/ecosystem/adopters.md
@@ -20,7 +20,7 @@ To have your organization listed, submit a PR with an entry added to the
 [adopters list](https://github.com/open-telemetry/opentelemetry.io/tree/main/data/ecosystem/adopters.yaml).
 The entry should include the following:
 
-- Link to a blog post that describes how your organization makes use of
+- Link to a blog post or other resource that describes how your organization makes use of
   OpenTelemetry
 - GitHub handle or email address as a point of contact so that we can reach out
   in case we have questions

--- a/content/en/ecosystem/adopters.md
+++ b/content/en/ecosystem/adopters.md
@@ -20,8 +20,8 @@ To have your organization listed, submit a PR with an entry added to the
 [adopters list](https://github.com/open-telemetry/opentelemetry.io/tree/main/data/ecosystem/adopters.yaml).
 The entry should include the following:
 
-- Link to a blog post or other resource that describes how your organization makes use of
-  OpenTelemetry
+- Link to a blog post or other resource that describes how your organization
+  makes use of OpenTelemetry
 - GitHub handle or email address as a point of contact so that we can reach out
   in case we have questions
 

--- a/content/en/ecosystem/adopters.md
+++ b/content/en/ecosystem/adopters.md
@@ -18,7 +18,7 @@ have adopted OpenTelemetry for
 
 To have your organization listed, submit a PR with an entry added to the
 [adopters list](https://github.com/open-telemetry/opentelemetry.io/tree/main/data/ecosystem/adopters.yaml).
-The entry must include the following[^grace-period-2024-01-01]:
+The entry should include the following:
 
 - Link to a blog post that describes how your organization makes use of
   OpenTelemetry
@@ -34,7 +34,3 @@ through OpenTelemetry, see [Integrations](/ecosystem/integrations/).
 
 If your organization provides a solution that consumes OpenTelemetry to offer
 **Observability to end users**, see [Vendors](/ecosystem/vendors).
-
-[^grace-period-2024-01-01]:
-    Organizations listed before July 2023 are exempt from these requirements
-    until January 1, 2024, after which they will be removed unless updated.

--- a/content/en/ecosystem/distributions.md
+++ b/content/en/ecosystem/distributions.md
@@ -26,7 +26,7 @@ is provided as a convenience for the community. {{% /alert %}}
 
 To have your distribution listed, submit a PR with an entry added to the
 [distributions list](https://github.com/open-telemetry/opentelemetry.io/tree/main/data/ecosystem/distributions.yaml).
-The entry must include the following:
+The entry should include the following:
 
 - Link to the main page of your distribution
 - Link to the documentation that explains how to use the distribution

--- a/content/en/ecosystem/integrations.md
+++ b/content/en/ecosystem/integrations.md
@@ -20,7 +20,7 @@ provide a first-party plugin that fits into their own extensibility ecosystem.
 To have your library, service, or app listed, submit a PR with an entry added to
 the
 [integrations list](https://github.com/open-telemetry/opentelemetry.io/tree/main/data/ecosystem/integrations.yaml).
-The entry must include the following:
+The entry should include the following:
 
 - Link to the main page of your library, service, or app
 - Link to the documentation that explains how enable observability using

--- a/content/en/ecosystem/vendors.md
+++ b/content/en/ecosystem/vendors.md
@@ -18,7 +18,7 @@ for improved ease of use.
 
 To have your organization listed, submit a PR with an entry added to the
 [vendors list](https://github.com/open-telemetry/opentelemetry.io/tree/main/data/ecosystem/vendors.yaml).
-The entry must include the following[^grace-period-2024-01-01]:
+The entry should include the following:
 
 - Link to the documentation that details how your offering consumes
   OpenTelemetry natively via [OTLP](/docs/specs/otlp/).
@@ -37,7 +37,3 @@ you do not provide any kind of services around OpenTelemetry, see
 
 If you provide a library, service, or app that is made observable through
 OpenTelemetry, see [Integrations](/ecosystem/integrations).
-
-[^grace-period-2024-01-01]:
-    Organizations listed before July 2023 are exempt from these requirements
-    until January 1, 2024, after which they will be removed unless updated.


### PR DESCRIPTION
This replaces all "must" with "should" in the requirements for being added to vendors, integrations, adopters
It removes the grace periode note, since we never enforced that.