### PR TITLE
Add Causely to vendors.yaml

### DIFF
--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -1,4 +1,4 @@
-# cSpell:ignore Coralogix Cribl ITRS Kloud Logz Crowdstrike Humio Lumigo observ Uptrace Greptime KloudMate qryn ClickHouse Tracetest opensource OneUptime
+# cSpell:ignore Causely Coralogix Cribl ITRS Kloud Logz Crowdstrike Humio Lumigo observ Uptrace Greptime KloudMate qryn ClickHouse Tracetest opensource OneUptime
 - name: AppDynamics (Cisco)
   nativeOTLP: true
   url: 'https://docs.appdynamics.com/latest/en/application-monitoring/appdynamics-for-opentelemetry'
@@ -33,6 +33,13 @@
   nativeOTLP: true
   url: https://betterstack.com/docs/logs/open-telemetry/#2-setup
   contact: 'hello@betterstack.com'
+  oss: false
+  commercial: true
+- name: Causely
+  distribution: false
+  nativeOTLP: true
+  url: 'https://github.com/Causely/documentation'
+  contact: 'support@causely.io'
   oss: false
   commercial: true
 - name: Control Plane

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -2051,6 +2051,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-30T05:18:56.239248-05:00"
   },
+  "https://github.com/Causely/documentation": {
+    "StatusCode": 200,
+    "LastSeen": "2024-03-15T20:34:22.210208944Z"
+  },
   "https://github.com/DataDog/dd-opentelemetry-exporter-ruby": {
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:10:56.414699-05:00"


### PR DESCRIPTION
Read [LinkedIn post](https://www.linkedin.com/posts/jpkroehling_opentelemetry-graduation-by-austinlparker-activity-7172873030925332480-FvMW) from @jpkrohling and requested to include us in the vendors list,
as we have been leveraging, consuming OpenTelemetry traces in the Causely product.

Thanks!