### PR TITLE
Demo Docs: Update the name of recommendation cache feature flag

### DIFF
--- a/content/en/docs/demo/feature-flags.md
+++ b/content/en/docs/demo/feature-flags.md
@@ -13,11 +13,11 @@ feature flag service that supports [OpenFeature](https://openfeature.dev). Flag
 values are stored in the `demo.flagd.json` file. To enable a flag, change the
 `defaultVariant` value in the config file for a given flag to "on".
 
-| Feature Flag                        | Service(s)      | Description                                                                                                   |
-| ----------------------------------- | --------------- | -------------------------------------------------------------------------------------------------------------- |
-| `adServiceFailure`                  | Ad Service      | Generate an error for `GetAds` 1/10th of the time                                                             |
-| `cartServiceFailure`                | Cart Service    | Generate an error for `EmptyCart` 1/10th of the time                                                          |
-| `productCatalogFailure`             | Product Catalog | Generate an error for `GetProduct` requests with product id: `OLJCESPC7Z`                                     |
+| Feature Flag                        | Service(s)      | Description                                                                                              |
+| ----------------------------------- | --------------- | -------------------------------------------------------------------------------------------------------- |
+| `adServiceFailure`                  | Ad Service      | Generate an error for `GetAds` 1/10th of the time                                                        |
+| `cartServiceFailure`                | Cart Service    | Generate an error for `EmptyCart` 1/10th of the time                                                     |
+| `productCatalogFailure`             | Product Catalog | Generate an error for `GetProduct` requests with product id: `OLJCESPC7Z`                                |
 | `recommendationServiceCacheFailure` | Recommendation  | Create a memory leak due to an exponentially growing cache. 1.4x growth, 50% of requests trigger growth. |
 
 ## Feature Flag Architecture

--- a/content/en/docs/demo/feature-flags.md
+++ b/content/en/docs/demo/feature-flags.md
@@ -13,12 +13,12 @@ feature flag service that supports [OpenFeature](https://openfeature.dev). Flag
 values are stored in the `demo.flagd.json` file. To enable a flag, change the
 `defaultVariant` value in the config file for a given flag to "on".
 
-| Feature Flag                        | Service(s)       | Description                                                                                              |
-| ----------------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------- |
-| `adServiceFailure`                  | Ad Service       | Generate an error for `GetAds` 1/10th of the time                                                        |
-| `cartServiceFailure`                | Cart Service     | Generate an error for `EmptyCart` 1/10th of the time                                                     |
-| `productCatalogFailure`             | Product Catalog  | Generate an error for `GetProduct` requests with product id: `OLJCESPC7Z`                                |
-| `recommendationServiceCacheFailure` | Recommendation   | Create a memory leak due to an exponentially growing cache. 1.4x growth, 50% of requests trigger growth. |
+| Feature Flag                        | Service(s)       | Description                                                                                               |
+| ----------------------------------- | ---------------- | --------------------------------------------------------------------------------------------------------- |
+| `adServiceFailure`                  | Ad Service       | Generate an error for `GetAds` 1/10th of the time                                                         |
+| `cartServiceFailure`                | Cart Service     | Generate an error for `EmptyCart` 1/10th of the time                                                      |
+| `productCatalogFailure`             | Product Catalog  | Generate an error for `GetProduct` requests with product id: `OLJCESPC7Z`                                 |
+| `recommendationServiceCacheFailure` | Recommendation   | Create a memory leak due to an exponentially growing cache. 1.4x growth, 50% of requests trigger growth.  |
 | `paymentServiceFailure`             | Payment Service  | Generate an error when calling the `charge` method                                                        |
 | `paymentServiceUnreachable`         | Checkout Service | Use a bad address when calling the PaymentService to make it seem like the PaymentService is unavailable. |
 

--- a/content/en/docs/demo/feature-flags.md
+++ b/content/en/docs/demo/feature-flags.md
@@ -13,12 +13,12 @@ feature flag service that supports [OpenFeature](https://openfeature.dev). Flag
 values are stored in the `demo.flagd.json` file. To enable a flag, change the
 `defaultVariant` value in the config file for a given flag to "on".
 
-| Feature Flag                        | Service(s)      | Description                                                                                              |
-| ----------------------------------- | --------------- | -------------------------------------------------------------------------------------------------------- |
-| `adServiceFailure`                  | Ad Service      | Generate an error for `GetAds` 1/10th of the time                                                        |
-| `cartServiceFailure`                | Cart Service    | Generate an error for `EmptyCart` 1/10th of the time                                                     |
-| `productCatalogFailure`             | Product Catalog | Generate an error for `GetProduct` requests with product id: `OLJCESPC7Z`                                |
-| `recommendationServiceCacheFailure` | Recommendation  | Create a memory leak due to an exponentially growing cache. 1.4x growth, 50% of requests trigger growth. |
+| Feature Flag                        | Service(s)       | Description                                                                                              |
+| ----------------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------- |
+| `adServiceFailure`                  | Ad Service       | Generate an error for `GetAds` 1/10th of the time                                                        |
+| `cartServiceFailure`                | Cart Service     | Generate an error for `EmptyCart` 1/10th of the time                                                     |
+| `productCatalogFailure`             | Product Catalog  | Generate an error for `GetProduct` requests with product id: `OLJCESPC7Z`                                |
+| `recommendationServiceCacheFailure` | Recommendation   | Create a memory leak due to an exponentially growing cache. 1.4x growth, 50% of requests trigger growth. |
 | `paymentServiceFailure`             | Payment Service  | Generate an error when calling the `charge` method                                                        |
 | `paymentServiceUnreachable`         | Checkout Service | Use a bad address when calling the PaymentService to make it seem like the PaymentService is unavailable. |
 

--- a/content/en/docs/demo/feature-flags.md
+++ b/content/en/docs/demo/feature-flags.md
@@ -13,12 +13,12 @@ feature flag service that supports [OpenFeature](https://openfeature.dev). Flag
 values are stored in the `demo.flagd.json` file. To enable a flag, change the
 `defaultVariant` value in the config file for a given flag to "on".
 
-| Feature Flag            | Service(s)      | Description                                                                                              |
-| ----------------------- | --------------- | -------------------------------------------------------------------------------------------------------- |
-| `adServiceFailure`      | Ad Service      | Generate an error for `GetAds` 1/10th of the time                                                        |
-| `cartServiceFailure`    | Cart Service    | Generate an error for `EmptyCart` 1/10th of the time                                                     |
-| `productCatalogFailure` | Product Catalog | Generate an error for `GetProduct` requests with product id: `OLJCESPC7Z`                                |
-| `recommendationCache`   | Recommendation  | Create a memory leak due to an exponentially growing cache. 1.4x growth, 50% of requests trigger growth. |
+| Feature Flag                        | Service(s)      | Description                                                                                                   |
+| ----------------------------------- | --------------- | -------------------------------------------------------------------------------------------------------------- |
+| `adServiceFailure`                  | Ad Service      | Generate an error for `GetAds` 1/10th of the time                                                             |
+| `cartServiceFailure`                | Cart Service    | Generate an error for `EmptyCart` 1/10th of the time                                                          |
+| `productCatalogFailure`             | Product Catalog | Generate an error for `GetProduct` requests with product id: `OLJCESPC7Z`                                     |
+| `recommendationServiceCacheFailure` | Recommendation  | Create a memory leak due to an exponentially growing cache. 1.4x growth, 50% of requests trigger growth. |
 
 ## Feature Flag Architecture
 


### PR DESCRIPTION
This PR updates the demo docs to reference the correct name of the feature flag for the recommendation service cache failure. It's not a significant change but brings the docs in line with the flag name in the `demo.flagd.json` file.