### PR TITLE
Update kubernetes-deployment.md

### DIFF
--- a/content/en/docs/demo/kubernetes-deployment.md
+++ b/content/en/docs/demo/kubernetes-deployment.md
@@ -41,7 +41,6 @@ The following command will install the demo application to your Kubernetes
 cluster.
 
 ```shell
-kubectl create namespace otel-demo
 kubectl apply --namespace otel-demo -f https://raw.githubusercontent.com/open-telemetry/opentelemetry-demo/main/kubernetes/opentelemetry-demo.yaml
 ```
 
@@ -158,7 +157,6 @@ following sub-paths:
 
 - Web store: `/` (base)
 - Grafana: `/grafana`
-- Feature Flags UI: `/feature`
 - Load Generator UI: `/loadgen/` (must include trailing slash)
 - Jaeger UI: `/jaeger/ui`
 


### PR DESCRIPTION
Namespace iis not required to be manually created anymore, and FeatureFlag endpoint was recently removed from the demo.