### PR TITLE
Change wording to suit global audience

### DIFF
--- a/content/en/docs/concepts/observability-primer.md
+++ b/content/en/docs/concepts/observability-primer.md
@@ -33,8 +33,8 @@ can come in the form of [traces](/docs/concepts/signals/traces/),
 
 **Reliability** answers the question: "Is the service doing what users expect it
 to be doing?” A system could be up 100% of the time, but if, when a user clicks
-"Add to Cart” to add a black pair of pants to their shopping cart, and instead,
-the system doesn't always add black pants, then the system would be said to be
+"Add to Cart” to add a black pair of shoes to their shopping cart, and instead,
+the system doesn't always add black shoes, then the system would be said to be
 **un**reliable.
 
 **Metrics** are aggregations over a period of time of numeric data about your


### PR DESCRIPTION
This PR makes a tiny change to the reliability example on the [Observability Primer](https://opentelemetry.io/docs/concepts/observability-primer/) page. A pair of pants means something different in the UK. :)