### PR TITLE
spring starter can now use all sdk autoconfig properties

### DIFF
--- a/content/en/docs/languages/java/automatic/spring-boot.md
+++ b/content/en/docs/languages/java/automatic/spring-boot.md
@@ -429,36 +429,6 @@ span by annotating the method parameters with `@SpanAttribute`.
 | ----------- | ------------------------------------------ | ------------- | ------------------ |
 | `@WithSpan` | `otel.instrumentation.annotations.enabled` | true          | WithSpan, Aspect   |
 
-##### Dependency
-
-{{< tabpane text=true >}} {{% tab header="Maven (`pom.xml`)" lang=Maven %}}
-
-```xml
-<dependencies>
-  <dependency>
-    <groupId>org.springframework</groupId>
-    <artifactId>spring-aop</artifactId>
-    <version>SPRING_VERSION</version>
-  </dependency>
-  <dependency>
-    <groupId>io.opentelemetry</groupId>
-    <artifactId>opentelemetry-instrumentation-annotations</artifactId>
-    <version>{{% param vers.instrumentation %}}</version>
-  </dependency>
-</dependencies>
-```
-
-{{% /tab %}} {{% tab header="Gradle (`gradle.build`)" lang=Gradle %}}
-
-```kotlin
-dependencies {
-  implementation("org.springframework:spring-aop:SPRING_VERSION")
-  implementation("io.opentelemetry:opentelemetry-extension-annotations:{{% param vers.otel %}}")
-}
-```
-
-{{% /tab %}} {{< /tabpane>}}
-
 ##### Usage
 
 ```java

--- a/content/en/docs/languages/java/automatic/spring-boot.md
+++ b/content/en/docs/languages/java/automatic/spring-boot.md
@@ -162,7 +162,7 @@ which means that you can see and autocomplete all available properties in your
 IDE.
 
 
-#### General configurations
+#### General configuration
 
 The OpenTelemetry Starter supports all the [SDK Autoconfiguration](/docs/languages/java/automatic/configuration/#sdk-autoconfiguration) (since
 2.2.0). You can use properties set in the `application.properties` or the `application.yaml` file, or environment variables.

--- a/content/en/docs/languages/java/automatic/spring-boot.md
+++ b/content/en/docs/languages/java/automatic/spring-boot.md
@@ -207,7 +207,7 @@ Set the value to `true` to disable the starter, e.g. for testing purposes.
 
 You can use the `AutoConfigurationCustomizerProvider` for programmatic
 configuration. Programmatic configuration is recommended for advanced use cases,
-which are not configurable via properties.
+which are not configurable using properties.
 
 ##### Exclude actuator endpoints from tracing
 

--- a/content/en/docs/languages/java/automatic/spring-boot.md
+++ b/content/en/docs/languages/java/automatic/spring-boot.md
@@ -188,7 +188,7 @@ otel:
       xyz: foo
 ```
 
-environment variables example:
+Environment variables example:
 
 ```shell
 export OTEL_PROPAGATORS="tracecontext,b3"

--- a/content/en/docs/languages/java/automatic/spring-boot.md
+++ b/content/en/docs/languages/java/automatic/spring-boot.md
@@ -164,6 +164,13 @@ This spring starter supports
 which means that you can see and autocomplete all available properties in your
 IDE.
 
+The OpenTelemetry Starter supports all properties from the
+[Configuration](/docs/languages/java/automatic/configuration/) page (since
+2.2.0).
+
+The only difference is that the OpenTelemetry Spring Boot starter uses
+`http/protobuf` as the default protocol for the OTLP exporter (since 2.0.0).
+
 #### Disable the OpenTelemetry Starter
 
 {{% config_option name="otel.sdk.disabled" %}}
@@ -172,57 +179,59 @@ Set the value to `true` to disable the starter, e.g. for testing purposes.
 
 {{% /config_option %}}
 
-#### OpenTelemetry Data Exporters
+#### Spring Boot properties integration
 
-This package provides autoconfiguration the following exporters:
+All OpenTelemetry properties can be set in the `application.properties` or the
+`application.yaml` file.
 
-- OTLP
-- Logging
+Lists and maps can use both the OpenTelemetry and Spring Boot flavors.
 
-All available properties are listed in the
-[Configuration](/docs/languages/java/automatic/configuration/) page.
+##### OpenTelemetry properties style
 
-The only difference is that the OpenTelemetry Spring Boot starter uses
-`http/protobuf` as the default protocol for the OTLP exporter (as of 2.0.0+).
+The OpenTelemetry Starter supports the OpenTelemetry properties as described in
+the
+[specification](/docs/languages/sdk-configuration/general/#otel_resource_attributes):
 
-#### Tracer Properties
-
-| Feature | Property                          | Default Value |
-| ------- | --------------------------------- | ------------- |
-| Tracer  | `otel.traces.sampler.probability` | 1.0           |
-
-#### Resource Properties
-
-| Feature  | Property                           | Default Value |
-| -------- | ---------------------------------- | ------------- |
-| Resource | `otel.springboot.resource.enabled` | true          |
-|          | `otel.resource.attributes`         | empty map     |
-
-`otel.resource.attributes` supports a pattern-based resource configuration in
-the application.properties like this:
+`application.properties`:
 
 ```properties
+otel.propagators=tracecontext,b3
+otel.resource.attributes=environment=dev,xyz=foo
+```
+
+This style is convenient to use in environment variables:
+
+```shell
+export OTEL_PROPAGATORS="tracecontext,b3"
+export OTEL_RESOURCE_ATTRIBUTES="environment=dev,xyz=foo"
+```
+
+##### Native Spring Boot properties style
+
+You can also use the native Spring Boot style:
+
+`application.properties`:
+
+```properties
+otel.propagators=tracecontext,b3
 otel.resource.attributes.environment=dev
 otel.resource.attributes.xyz=foo
 ```
 
-It's also possible to specify the resource attributes in `application.yaml`:
+`application.yaml`:
 
 ```yaml
 otel:
+  propagators:
+    - tracecontext
+    - b3
   resource:
     attributes:
       environment: dev
       xyz: foo
 ```
 
-Finally, the resource attributes can be specified as a comma-separated list, as
-described in the
-[specification](/docs/languages/sdk-configuration/general/#otel_resource_attributes):
-
-```shell
-export OTEL_RESOURCE_ATTRIBUTES="key1=value1,key2=value2"
-```
+#### Service name
 
 The service name is determined by the following precedence rules, in accordance
 with the OpenTelemetry

--- a/content/en/docs/languages/java/automatic/spring-boot.md
+++ b/content/en/docs/languages/java/automatic/spring-boot.md
@@ -165,8 +165,8 @@ IDE.
 
 The OpenTelemetry Starter supports all the
 [SDK Autoconfiguration](/docs/languages/java/automatic/configuration/#sdk-autoconfiguration)
-(since 2.2.0). You can use properties set in the `application.properties` or the
-`application.yaml` file, or environment variables.
+(since 2.2.0). You can set properties in the `application.properties` or the
+`application.yaml` file, or use environment variables.
 
 `application.properties` example:
 

--- a/content/en/docs/languages/java/automatic/spring-boot.md
+++ b/content/en/docs/languages/java/automatic/spring-boot.md
@@ -161,11 +161,12 @@ This spring starter supports
 which means that you can see and autocomplete all available properties in your
 IDE.
 
-
 #### General configuration
 
-The OpenTelemetry Starter supports all the [SDK Autoconfiguration](/docs/languages/java/automatic/configuration/#sdk-autoconfiguration) (since
-2.2.0). You can use properties set in the `application.properties` or the `application.yaml` file, or environment variables.
+The OpenTelemetry Starter supports all the
+[SDK Autoconfiguration](/docs/languages/java/automatic/configuration/#sdk-autoconfiguration)
+(since 2.2.0). You can use properties set in the `application.properties` or the
+`application.yaml` file, or environment variables.
 
 `application.properties` example:
 
@@ -187,8 +188,7 @@ otel:
       xyz: foo
 ```
 
-
- environment variables example:
+environment variables example:
 
 ```shell
 export OTEL_PROPAGATORS="tracecontext,b3"

--- a/content/en/docs/languages/java/automatic/spring-boot.md
+++ b/content/en/docs/languages/java/automatic/spring-boot.md
@@ -4,7 +4,7 @@ linkTitle: Spring Boot
 weight: 30
 description: Spring Boot instrumentation for OpenTelemetry Java
 # prettier-ignore
-cSpell:ignore: autoconfigurations autoconfigures datasource logback springboot webflux webmvc
+cSpell:ignore: autoconfigurations autoconfigures customizer datasource distro logback springboot webflux webmvc
 ---
 
 ## How to instrument Spring Boot with OpenTelemetry
@@ -231,7 +231,7 @@ otel:
       xyz: foo
 ```
 
-#### Configuration customizer
+#### Programmatic configuration
 
 You can use the `AutoConfigurationCustomizerProvider` for programmatic
 configuration. Programmatic configuration is recommended for advanced use cases,
@@ -287,10 +287,109 @@ public class Application {
 }
 ```
 
+#### Resource Providers
+
+The OpenTelemetry Starter includes
+[common Resource Providers](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/resources/library)
+and the following Spring Boot specific Resource Providers:
+
+##### Distribution Resource Provider
+
+FQN:
+`io.opentelemetry.instrumentation.spring.autoconfigure.resources.DistroVersionResourceProvider`
+
+| Attribute                  | Value                               |
+| -------------------------- | ----------------------------------- |
+| `telemetry.distro.name`    | `opentelemetry-spring-boot-starter` |
+| `telemetry.distro.version` | version of the starter              |
+
+##### Spring Resource Provider
+
+FQN:
+`io.opentelemetry.instrumentation.spring.autoconfigure.resources.SpringResourceProvider`
+
+| Attribute         | Value                                                                                                         |
+| ----------------- | ------------------------------------------------------------------------------------------------------------- |
+| `service.name`    | `spring.application.name` or `build.version` from `build-info.properties` (see [Service name](#service-name)) |
+| `service.version` | `build.name` from `build-info.properties`                                                                     |
+
+##### AWS Resource Provider
+
+The
+[AWS Resource Provider](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/aws-resources)
+can be added as a dependency:
+
+{{< tabpane text=true >}} {{% tab header="Maven (`pom.xml`)" lang=Maven %}}
+
+```xml
+<dependencies>
+	<dependency>
+		<groupId>io.opentelemetry.contrib</groupId>
+		<artifactId>opentelemetry-aws-resources</artifactId>
+    <version>1.33.0-alpha</version>
+    <exclusions>
+      <exclusion>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+      </exclusion>
+      <exclusion>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp</artifactId>
+      </exclusion>
+    </exclusions>
+	</dependency>
+</dependencies>
+```
+
+{{% /tab %}} {{% tab header="Gradle (`gradle.build`)" lang=Gradle %}}
+
+```kotlin
+implementation("io.opentelemetry.contrib:opentelemetry-aws-resources:1.33.0-alpha") {
+    exclude("com.fasterxml.jackson.core", "jackson-core")
+    exclude("com.squareup.okhttp3", "okhttp")
+}
+```
+
+{{% /tab %}} {{< /tabpane>}}
+
+##### GCP Resource Provider
+
+The
+[GCP Resource Provider](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/gcp-resources)
+can be added as a dependency:
+
+{{< tabpane text=true >}} {{% tab header="Maven (`pom.xml`)" lang=Maven %}}
+
+```xml
+<dependencies>
+	<dependency>
+		<groupId>io.opentelemetry.contrib</groupId>
+		<artifactId>opentelemetry-gcp-resources</artifactId>
+    <version>1.33.0-alpha</version>
+    <exclusions>
+      <exclusion>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+      </exclusion>
+    </exclusions>
+	</dependency>
+</dependencies>
+```
+
+{{% /tab %}} {{% tab header="Gradle (`gradle.build`)" lang=Gradle %}}
+
+```kotlin
+implementation("io.opentelemetry.contrib:opentelemetry-gcp-resources:1.33.0-alpha") {
+    exclude("com.fasterxml.jackson.core", "jackson-core")
+}
+```
+
+{{% /tab %}} {{< /tabpane>}}
+
 #### Service name
 
-The service name is determined by the following precedence rules, in accordance
-with the OpenTelemetry
+Using these resource providers, the service name is determined by the following
+precedence rules, in accordance with the OpenTelemetry
 [specification](/docs/languages/sdk-configuration/general/#otel_service_name):
 
 1. `otel.service.name` spring property or `OTEL_SERVICE_NAME` environment

--- a/content/en/docs/languages/java/automatic/spring-boot.md
+++ b/content/en/docs/languages/java/automatic/spring-boot.md
@@ -132,9 +132,6 @@ Add the dependency given below to enable the OpenTelemetry starter.
 
 The OpenTelemetry starter uses OpenTelemetry Spring Boot
 [autoconfiguration](https://docs.spring.io/spring-boot/docs/current/reference/html/using.html#using.auto-configuration).
-For details concerning supported libraries and features of the OpenTelemetry
-autoconfiguration, see the configuration
-[README](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/spring/spring-boot-autoconfigure/README.md#features).
 
 {{< tabpane text=true >}} {{% tab header="Maven (`pom.xml`)" lang=Maven %}}
 
@@ -164,61 +161,20 @@ This spring starter supports
 which means that you can see and autocomplete all available properties in your
 IDE.
 
-The OpenTelemetry Starter supports all properties from the
-[Configuration](/docs/languages/java/automatic/configuration/) page (since
-2.2.0).
 
-The only difference is that the OpenTelemetry Spring Boot starter uses
-`http/protobuf` as the default protocol for the OTLP exporter (since 2.0.0).
+#### General configurations
 
-#### Disable the OpenTelemetry Starter
+The OpenTelemetry Starter supports all the [SDK Autoconfiguration](/docs/languages/java/automatic/configuration/#sdk-autoconfiguration) (since
+2.2.0). You can use properties set in the `application.properties` or the `application.yaml` file, or environment variables.
 
-{{% config_option name="otel.sdk.disabled" %}}
-
-Set the value to `true` to disable the starter, e.g. for testing purposes.
-
-{{% /config_option %}}
-
-#### Spring Boot properties integration
-
-All OpenTelemetry properties can be set in the `application.properties` or the
-`application.yaml` file.
-
-Lists and maps can use both the OpenTelemetry and Spring Boot flavors.
-
-##### OpenTelemetry properties style
-
-The OpenTelemetry Starter supports the OpenTelemetry properties as described in
-the
-[specification](/docs/languages/sdk-configuration/general/#otel_resource_attributes):
-
-`application.properties`:
+`application.properties` example:
 
 ```properties
 otel.propagators=tracecontext,b3
 otel.resource.attributes=environment=dev,xyz=foo
 ```
 
-This style is convenient to use in environment variables:
-
-```shell
-export OTEL_PROPAGATORS="tracecontext,b3"
-export OTEL_RESOURCE_ATTRIBUTES="environment=dev,xyz=foo"
-```
-
-##### Native Spring Boot properties style
-
-You can also use the native Spring Boot style:
-
-`application.properties`:
-
-```properties
-otel.propagators=tracecontext,b3
-otel.resource.attributes.environment=dev
-otel.resource.attributes.xyz=foo
-```
-
-`application.yaml`:
+`application.yaml` example:
 
 ```yaml
 otel:
@@ -230,6 +186,22 @@ otel:
       environment: dev
       xyz: foo
 ```
+
+
+ environment variables example:
+
+```shell
+export OTEL_PROPAGATORS="tracecontext,b3"
+export OTEL_RESOURCE_ATTRIBUTES="environment=dev,xyz=foo"
+```
+
+Disable the OpenTelemetry Starter:
+
+{{% config_option name="otel.sdk.disabled" %}}
+
+Set the value to `true` to disable the starter, e.g. for testing purposes.
+
+{{% /config_option %}}
 
 #### Programmatic configuration
 


### PR DESCRIPTION
Also 

- annotation dependency is included in starter now
- explain advanced config with the example of "exclude actuator endpoints from tracing"
- explain resource providers