### PR TITLE
[adservice] add new adservice ff to demo docs

### DIFF
--- a/content/en/docs/demo/feature-flags.md
+++ b/content/en/docs/demo/feature-flags.md
@@ -16,6 +16,7 @@ values are stored in the `demo.flagd.json` file. To enable a flag, change the
 | Feature Flag                        | Service(s)       | Description                                                                                               |
 | ----------------------------------- | ---------------- | --------------------------------------------------------------------------------------------------------- |
 | `adServiceFailure`                  | Ad Service       | Generate an error for `GetAds` 1/10th of the time                                                         |
+| `adServiceManualGc`                 | Ad Service       | Trigger full manual garbage collections in the ad service                                                 |
 | `cartServiceFailure`                | Cart Service     | Generate an error for `EmptyCart` 1/10th of the time                                                      |
 | `productCatalogFailure`             | Product Catalog  | Generate an error for `GetProduct` requests with product id: `OLJCESPC7Z`                                 |
 | `recommendationServiceCacheFailure` | Recommendation   | Create a memory leak due to an exponentially growing cache. 1.4x growth, 50% of requests trigger growth.  |


### PR DESCRIPTION
This commit add the adServiceManualGc feature flag to the opentelemetry demo docs.

The feature flag triggers full manual garbage collections in the ad service.

Upstream PR can be found here: https://github.com/open-telemetry/opentelemetry-demo/pull/1463