### PR TITLE
Update OTel JS Autoinstrumentation env var config

### DIFF
--- a/content/en/docs/languages/js/automatic/_index.md
+++ b/content/en/docs/languages/js/automatic/_index.md
@@ -48,8 +48,10 @@ node app.js
 {{% alert title="Note" color="info" %}}
 
 Currently, only Traces are supported for environment variable configuration. See
-the open issues for [Metrics](https://github.com/open-telemetry/opentelemetry-js/issues/4551) and
-[Logs](https://github.com/open-telemetry/opentelemetry-js/issues/4552) to learn more.
+the open issues for
+[Metrics](https://github.com/open-telemetry/opentelemetry-js/issues/4551) and
+[Logs](https://github.com/open-telemetry/opentelemetry-js/issues/4552) to learn
+more.
 
 {{% /alert %}}
 

--- a/content/en/docs/languages/js/automatic/_index.md
+++ b/content/en/docs/languages/js/automatic/_index.md
@@ -38,13 +38,20 @@ Alternatively, you can use `export` to set environment variables:
 
 ```shell
 export OTEL_TRACES_EXPORTER="otlp"
-export OTEL_METRICS_EXPORTER="otlp"
 export OTEL_EXPORTER_OTLP_ENDPOINT="your-endpoint"
 export OTEL_NODE_RESOURCE_DETECTORS="env,host,os"
 export OTEL_SERVICE_NAME="your-service-name"
 export NODE_OPTIONS="--require @opentelemetry/auto-instrumentations-node/register"
 node app.js
 ```
+
+{{% alert title="Note" color="info" %}}
+
+Currently, only Traces are supported for environment variable configuration. See
+the open issues for [Metrics](https://github.com/open-telemetry/opentelemetry-js/issues/4551) and
+[Logs](https://github.com/open-telemetry/opentelemetry-js/issues/4552) to learn more.
+
+{{% /alert %}}
 
 By default, all SDK [resource detectors](/docs/languages/js/resources/) are
 used. You can use the environment variable `OTEL_NODE_RESOURCE_DETECTORS` to

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -3519,6 +3519,14 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-18T20:05:19.47948-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-js/issues/4551": {
+    "StatusCode": 200,
+    "LastSeen": "2024-03-19T06:37:03.56499722Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/issues/4552": {
+    "StatusCode": 200,
+    "LastSeen": "2024-03-19T06:37:04.053171348Z"
+  },
   "https://github.com/open-telemetry/opentelemetry-js/releases": {
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:37:16.288484-05:00"


### PR DESCRIPTION
Document that only traces are supported today. Fixes #4171