### PR TITLE
nodejs doc: add clarification to node.js getting started

### DIFF
--- a/content/en/docs/languages/js/getting-started/nodejs.md
+++ b/content/en/docs/languages/js/getting-started/nodejs.md
@@ -227,6 +227,9 @@ sdk.start();
 
 Now you can run your application as you normally would, but you can use the
 `--require` flag to load the instrumentation before the application code.
+Make sure you don't have other conflicting `--require` flags such as
+`--require @opentelemetry/auto-instrumentations-node/register` on your `NODE_OPTIONS`
+environment variable.
 
 {{< tabpane text=true >}} {{% tab TypeScript %}}
 

--- a/content/en/docs/languages/js/getting-started/nodejs.md
+++ b/content/en/docs/languages/js/getting-started/nodejs.md
@@ -226,10 +226,10 @@ sdk.start();
 ## Run the instrumented app
 
 Now you can run your application as you normally would, but you can use the
-`--require` flag to load the instrumentation before the application code.
-Make sure you don't have other conflicting `--require` flags such as
-`--require @opentelemetry/auto-instrumentations-node/register` on your `NODE_OPTIONS`
-environment variable.
+`--require` flag to load the instrumentation before the application code. Make
+sure you don't have other conflicting `--require` flags such as
+`--require @opentelemetry/auto-instrumentations-node/register` on your
+`NODE_OPTIONS` environment variable.
 
 {{< tabpane text=true >}} {{% tab TypeScript %}}
 


### PR DESCRIPTION
One common approach to register de API is to set the environment variable `NODE_OPTIONS` with `--require @opentelemetry/auto-instrumentations-node/register`, but if we follow the `Getting Started` for `Node.js`, the step to use `--require ./instrumentation.ts` on command line can cause a conflict, resulting on an error message similar to:

```
Error: @opentelemetry/api: Attempted duplicate registration of API: trace
    at registerGlobal (/Users/maryliag/development/otel/opentelemetry-js/api/src/internal/global-utils.ts:47:17)
    at TraceAPI.setGlobalTracerProvider (/Users/maryliag/development/otel/opentelemetry-js/api/src/api/trace.ts:67:35)
    at NodeTracerProvider.register (/Users/maryliag/development/otel/opentelemetry-js/packages/opentelemetry-sdk-trace-base/src/BasicTracerProvider.ts:153:11)
    at NodeTracerProvider.register (/Users/maryliag/development/otel/opentelemetry-js/packages/opentelemetry-sdk-trace-node/src/NodeTracerProvider.ts:68:11)
    at NodeSDK.start (/Users/maryliag/development/otel/opentelemetry-js/experimental/packages/opentelemetry-sdk-node/src/sdk.ts:355:20)
    at Object.<anonymous> (/Users/maryliag/development/otel/nodejs-test/instrumentation.ts:17:5)
    at Module._compile (node:internal/modules/cjs/loader:1378:14)
    at Module.m._compile (/Users/maryliag/development/otel/nodejs-test/node_modules/ts-node/src/index.ts:1618:23)
    at Module._extensions..js (node:internal/modules/cjs/loader:1437:10)
    at Object.require.extensions.<computed> [as .ts] (/Users/maryliag/development/otel/nodejs-test/node_modules/ts-node/src/index.ts:1621:12)
Error: @opentelemetry/api: Attempted duplicate registration of API: context
    at registerGlobal (/Users/maryliag/development/otel/opentelemetry-js/api/src/internal/global-utils.ts:47:17)
    at ContextAPI.setGlobalContextManager (/Users/maryliag/development/otel/opentelemetry-js/api/src/api/context.ts:53:26)
    at NodeTracerProvider.register (/Users/maryliag/development/otel/opentelemetry-js/packages/opentelemetry-sdk-trace-base/src/BasicTracerProvider.ts:159:15)
    at NodeTracerProvider.register (/Users/maryliag/development/otel/opentelemetry-js/packages/opentelemetry-sdk-trace-node/src/NodeTracerProvider.ts:68:11)
    at NodeSDK.start (/Users/maryliag/development/otel/opentelemetry-js/experimental/packages/opentelemetry-sdk-node/src/sdk.ts:355:20)
    at Object.<anonymous> (/Users/maryliag/development/otel/nodejs-test/instrumentation.ts:17:5)
    at Module._compile (node:internal/modules/cjs/loader:1378:14)
    at Module.m._compile (/Users/maryliag/development/otel/nodejs-test/node_modules/ts-node/src/index.ts:1618:23)
    at Module._extensions..js (node:internal/modules/cjs/loader:1437:10)
    at Object.require.extensions.<computed> [as .ts] (/Users/maryliag/development/otel/nodejs-test/node_modules/ts-node/src/index.ts:1621:12)
Error: @opentelemetry/api: Attempted duplicate registration of API: propagation
    at registerGlobal (/Users/maryliag/development/otel/opentelemetry-js/api/src/internal/global-utils.ts:47:17)
    at PropagationAPI.setGlobalPropagator (/Users/maryliag/development/otel/opentelemetry-js/api/src/api/propagation.ts:67:26)
    at NodeTracerProvider.register (/Users/maryliag/development/otel/opentelemetry-js/packages/opentelemetry-sdk-trace-base/src/BasicTracerProvider.ts:163:19)
    at NodeTracerProvider.register (/Users/maryliag/development/otel/opentelemetry-js/packages/opentelemetry-sdk-trace-node/src/NodeTracerProvider.ts:68:11)
    at NodeSDK.start (/Users/maryliag/development/otel/opentelemetry-js/experimental/packages/opentelemetry-sdk-node/src/sdk.ts:355:20)
    at Object.<anonymous> (/Users/maryliag/development/otel/nodejs-test/instrumentation.ts:17:5)
    at Module._compile (node:internal/modules/cjs/loader:1378:14)
    at Module.m._compile (/Users/maryliag/development/otel/nodejs-test/node_modules/ts-node/src/index.ts:1618:23)
    at Module._extensions..js (node:internal/modules/cjs/loader:1437:10)
    at Object.require.extensions.<computed> [as .ts] (/Users/maryliag/development/otel/nodejs-test/node_modules/ts-node/src/index.ts:1621:12)
```

It can be hard to identify the problem from the error message. So this commit adds a small warning to make sure the requirements are not conflicting.


`Run the instrumented app` after the change:
<img width="871" alt="Screenshot 2024-03-21 at 1 53 30 PM" src="https://github.com/open-telemetry/opentelemetry.io/assets/1017486/d6de5504-06d1-43e3-aeca-02988cad22da">
