### PR TITLE
Add some common tags to aws sdk instrumentation metadata

### DIFF
--- a/data/registry/instrumentation-dotnet-aws.yml
+++ b/data/registry/instrumentation-dotnet-aws.yml
@@ -4,7 +4,11 @@ language: dotnet
 tags:
   - instrumentation
   - aws
+  - aws-sdk
   - dotnet
+  - sqs
+  - sns
+  - dynamodb
 license: Apache 2.0
 description: This package provides AWS SDK client instrumentation
 authors:

--- a/data/registry/instrumentation-java-aws-sdk.yml
+++ b/data/registry/instrumentation-java-aws-sdk.yml
@@ -4,6 +4,11 @@ language: java
 tags:
   - java
   - instrumentation
+  - aws
+  - aws-sdk
+  - sqs
+  - sns
+  - dynamodb
 license: Apache 2.0
 description:
   This library provides a AWS SDK instrumentation to track requests through

--- a/data/registry/instrumentation-js-aws-sdk.yml
+++ b/data/registry/instrumentation-js-aws-sdk.yml
@@ -6,6 +6,10 @@ tags:
   - instrumentation
   - aws-sdk
   - aws
+  - sqs
+  - sns
+  - dynamodb
+  - lambda
 license: Apache 2.0
 description: aws-sdk instrumentation for Node.js.
 authors:

--- a/data/registry/instrumentation-ruby-aws-sdk.yml
+++ b/data/registry/instrumentation-ruby-aws-sdk.yml
@@ -6,6 +6,8 @@ tags:
   - instrumentation
   - aws-sdk
   - aws
+  - sqs
+  - sns
 license: Apache 2.0
 description: aws-sdk instrumentation for Ruby.
 authors:


### PR DESCRIPTION
This has come up several times at work (almost always when SQS is involved). This should make it more searchable.