### PR TITLE
[Registry] Add resource detectors for Java

### DIFF
--- a/data/registry/resource-detector-java-aws.yml
+++ b/data/registry/resource-detector-java-aws.yml
@@ -1,0 +1,20 @@
+title: OpenTelemetry Resource Detector for AWS
+registryType: resource-detector
+language: java
+tags:
+  - aws
+  - ec2
+  - ecs
+  - eks
+  - lambda
+  - resource-detector
+  - java
+license: Apache 2.0
+description: AWS resource detectors for Java.
+authors:
+  - name: OpenTelemetry Authors
+urls:
+  repo: https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/aws-resources
+createdAt: 2024-03-25
+isNative: false
+isFirstParty: false

--- a/data/registry/resource-detector-java-gcp.yml
+++ b/data/registry/resource-detector-java-gcp.yml
@@ -1,0 +1,16 @@
+title: OpenTelemetry Resource Detector for GCP
+registryType: resource-detector
+language: java
+tags:
+  - gcp
+  - resource-detector
+  - java
+license: Apache 2.0
+description: The GCP resource detector for Java.
+authors:
+  - name: OpenTelemetry Authors
+urls:
+  repo: https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/gcp-resources
+createdAt: 2024-03-25
+isNative: false
+isFirstParty: false


### PR DESCRIPTION
Add resource detectors available for Java in [opentelemetry-java-contrib](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main) to OpenTelemetry Registry.

Fixes #4203