### PR TITLE
.NET - getting started avoid prereleases for OpenTelemetry.Instrumentation.AspNetCore

### DIFF
--- a/content/en/docs/languages/net/getting-started.md
+++ b/content/en/docs/languages/net/getting-started.md
@@ -114,7 +114,7 @@ that will generate the telemetry, and set them up.
 
    ```sh
    dotnet add package OpenTelemetry.Extensions.Hosting
-   dotnet add package OpenTelemetry.Instrumentation.AspNetCore --prerelease
+   dotnet add package OpenTelemetry.Instrumentation.AspNetCore
    dotnet add package OpenTelemetry.Exporter.Console
    ```
 


### PR DESCRIPTION
OpenTelemetry.Instrumentation.AspNetCore has already stable versions