### PR TITLE
[Registry] Add missing resource detectors for Java

### DIFF
--- a/data/registry/resource-detector-java-contrib.yml
+++ b/data/registry/resource-detector-java-contrib.yml
@@ -1,0 +1,21 @@
+title: OpenTelemetry Contributed Resource Detectors
+registryType: resource-detector
+language: java
+tags:
+  - contrib
+  - glassFish
+  - jetty
+  - tomcat
+  - tomEE
+  - resource-detector
+  - java
+license: Apache 2.0
+description:
+  Various ResourceProvider implementations contributed to OpenTelemetry.
+authors:
+  - name: OpenTelemetry Authors
+urls:
+  repo: https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/resource-providers
+createdAt: 2024-03-30
+isNative: false
+isFirstParty: false

--- a/data/registry/resource-detector-java-spring-boot.yml
+++ b/data/registry/resource-detector-java-spring-boot.yml
@@ -1,0 +1,16 @@
+title: OpenTelemetry Resource Detector for Spring Boot
+registryType: resource-detector
+language: java
+tags:
+  - spring-boot
+  - resource-detector
+  - java
+license: Apache 2.0
+description: Spring Boot specific resource providers.
+authors:
+  - name: OpenTelemetry Authors
+urls:
+  repo: https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/spring/spring-boot-resources
+createdAt: 2024-03-30
+isNative: false
+isFirstParty: false


### PR DESCRIPTION
Adds the missing resource detectors for Java to OpenTelemetry Registry.