### PR TITLE
Add Embrace to vendors list

### DIFF
--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -385,3 +385,9 @@
   contact: 'info@vunetsystems.com'
   oss: false
   commercial: true
+- name: Embrace
+  nativeOTLP: true
+  url: 'https://github.com/embrace-io/embrace-apple-sdk/blob/main/GETTING_STARTED.md#exporting-logs-and-traces-to-opentelemetry-vendors'
+  contact: 'product@embrace.io'
+  oss: true
+  commercial: true


### PR DESCRIPTION
Adds Embrace to the list of vendors who natively support OpenTelemetry.