### PR TITLE
Normalize vendors.yaml, and don't spell-check it

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -5,6 +5,7 @@ version: '0.2'
 caseSensitive: true
 ignorePaths:
   - '*.svg'
+  - 'vendors.yaml'
 # words here are only listed for their spelling, if there is a certain way
 # to write a word (e.g. OpenTelemetry vs Opentelemetry or cloud native vs
 # cloud-native), edit the text-lint rules in .textlintrc.yml

--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -1,394 +1,393 @@
-# cSpell:ignore Causely Coralogix Cribl ITRS Kloud Logz Crowdstrike Humio Lumigo observ Uptrace Greptime KloudMate qryn ClickHouse Tracetest opensource OneUptime
 - name: AppDynamics (Cisco)
   nativeOTLP: true
-  url: 'https://docs.appdynamics.com/latest/en/application-monitoring/appdynamics-for-opentelemetry'
-  contact: ''
+  url: https://docs.appdynamics.com/latest/en/application-monitoring/appdynamics-for-opentelemetry
+  contact:
   oss: false
   commercial: true
 - name: Aria by VMware (Wavefront)
   nativeOTLP: true
-  url: 'https://docs.wavefront.com/opentelemetry_tracing.html'
-  contact: ''
+  url: https://docs.wavefront.com/opentelemetry_tracing.html
+  contact:
   oss: false
   commercial: true
 - name: Aspecto
   nativeOTLP: true
-  url: 'https://www.aspecto.io'
-  contact: ''
+  url: https://www.aspecto.io
+  contact:
   oss: false
   commercial: true
 - name: AWS
   nativeOTLP: false
-  url: 'https://aws-otel.github.io'
-  contact: ''
+  url: https://aws-otel.github.io
+  contact:
   oss: false
   commercial: true
 - name: Azure
   nativeOTLP: false
-  url: 'https://docs.microsoft.com/azure/azure-monitor/app/opentelemetry-overview'
-  contact: ''
+  url: https://docs.microsoft.com/azure/azure-monitor/app/opentelemetry-overview
+  contact:
   oss: false
   commercial: true
 - name: Better Stack
   nativeOTLP: true
   url: https://betterstack.com/docs/logs/open-telemetry/#2-setup
-  contact: 'hello@betterstack.com'
+  contact: hello@betterstack.com
   oss: false
   commercial: true
 - name: Causely
   distribution: false
   nativeOTLP: true
-  url: 'https://github.com/Causely/documentation'
-  contact: 'support@causely.io'
+  url: https://github.com/Causely/documentation
+  contact: support@causely.io
   oss: false
   commercial: true
 - name: Chronosphere
   distribution: false
   nativeOTLP: true
-  url: 'https://docs.chronosphere.io/ingest/otel/otel-ingest'
-  contact: 'support@chronosphere.io'
+  url: https://docs.chronosphere.io/ingest/otel/otel-ingest
+  contact: support@chronosphere.io
   oss: false
   commercial: true
 - name: Control Plane
   nativeOTLP: true
-  url: 'https://docs.controlplane.com/reference/org#tracing'
-  contact: 'support@controlplane.com'
+  url: https://docs.controlplane.com/reference/org#tracing
+  contact: support@controlplane.com
   oss: false
   commercial: true
 - name: Coralogix
   nativeOTLP: true
-  url: 'https://coralogix.com/docs/opentelemetry/'
-  contact: ''
+  url: https://coralogix.com/docs/opentelemetry/
+  contact:
   oss: false
   commercial: true
 - name: Cribl
   nativeOTLP: true
-  url: 'https://docs.cribl.io/stream/sources-otel'
-  contact: 'hello@cribl.io'
+  url: https://docs.cribl.io/stream/sources-otel
+  contact: hello@cribl.io
   oss: false
   commercial: true
 - name: DaoCloud
   nativeOTLP: true
-  url: 'https://docs.daocloud.io/en/insight/06UserGuide/01quickstart/otel/otel/'
-  contact: ''
+  url: https://docs.daocloud.io/en/insight/06UserGuide/01quickstart/otel/otel/
+  contact:
   oss: false
   commercial: true
 - name: Datadog
   nativeOTLP: true
-  url: 'https://docs.datadoghq.com/opentelemetry/'
-  contact: ''
+  url: https://docs.datadoghq.com/opentelemetry/
+  contact:
   oss: false
   commercial: true
 - name: Dynatrace
   nativeOTLP: true
-  url: 'https://www.dynatrace.com/support/help/how-to-use-dynatrace/transactions-and-services/service-monitoring-settings/opentelemetry/'
-  contact: ''
+  url: https://www.dynatrace.com/support/help/how-to-use-dynatrace/transactions-and-services/service-monitoring-settings/opentelemetry/
+  contact:
   oss: false
   commercial: true
 - name: Elastic
   nativeOTLP: true
-  url: 'https://www.elastic.co/guide/en/apm/get-started/current/open-telemetry-elastic.html'
-  contact: ''
+  url: https://www.elastic.co/guide/en/apm/get-started/current/open-telemetry-elastic.html
+  contact:
   oss: false
   commercial: true
 - name: F5
   nativeOTLP: true
-  url: 'https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/f5cloudexporter'
-  contact: ''
+  url: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/f5cloudexporter
+  contact:
   oss: false
   commercial: true
 - name: Google Cloud Platform
   nativeOTLP: true
-  url: 'https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudexporter'
-  contact: ''
+  url: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudexporter
+  contact:
   oss: false
   commercial: true
 - name: Grafana Labs
   nativeOTLP: true
-  url: 'https://grafana.com/oss/opentelemetry/'
-  contact: 'https://github.com/jpkrohling/'
+  url: https://grafana.com/oss/opentelemetry/
+  contact: https://github.com/jpkrohling/
   oss: true
   commercial: true
 - name: Helios
   nativeOTLP: true
-  url: 'https://gethelios.dev/'
-  contact: ''
+  url: https://gethelios.dev/
+  contact:
   oss: false
   commercial: true
 - name: Highlight
   nativeOTLP: true
-  url: 'https://www.highlight.io/docs/general/company/open-source/contributing/adding-an-sdk/'
-  contact: 'support@highlight.io'
+  url: https://www.highlight.io/docs/general/company/open-source/contributing/adding-an-sdk/
+  contact: support@highlight.io
   oss: true
   commercial: true
 - name: Honeycomb
   nativeOTLP: true
-  url: 'https://docs.honeycomb.io/getting-data-in/'
-  contact: ''
+  url: https://docs.honeycomb.io/getting-data-in/
+  contact:
   oss: false
   commercial: true
 - name: HyperDX
   nativeOTLP: true
-  url: 'https://www.hyperdx.io/docs/install/opentelemetry'
-  contact: 'support@hyperdx.io'
+  url: https://www.hyperdx.io/docs/install/opentelemetry
+  contact: support@hyperdx.io
   oss: true
   commercial: true
 - name: Immersive Fusion
   nativeOTLP: true
-  url: 'https://docs.immersivefusion.com/instrument'
-  contact: 'support@immersivefusion.com'
+  url: https://docs.immersivefusion.com/instrument
+  contact: support@immersivefusion.com
   oss: false
   commercial: true
 - name: Instana
   nativeOTLP: true
-  url: 'https://www.ibm.com/docs/en/obi/current?topic=apis-opentelemetry'
-  contact: ''
+  url: https://www.ibm.com/docs/en/obi/current?topic=apis-opentelemetry
+  contact:
   oss: false
   commercial: true
 - name: ITRS
   nativeOTLP: true
-  url: 'https://docs.itrsgroup.com/docs/geneos/data-collection/opentelemetry/current/opentelemetry.html'
-  contact: ''
+  url: https://docs.itrsgroup.com/docs/geneos/data-collection/opentelemetry/current/opentelemetry.html
+  contact:
   oss: false
   commercial: true
 - name: KloudFuse
   nativeOTLP: true
-  url: 'https://kloudfuse.atlassian.net/wiki/spaces/EX/pages/753860609/APM#Sending-traces-to-Kloudfuse-data-plane%3A'
-  contact: ''
+  url: https://kloudfuse.atlassian.net/wiki/spaces/EX/pages/753860609/APM#Sending-traces-to-Kloudfuse-data-plane%3A
+  contact:
   oss: false
   commercial: true
 - name: KloudMate
   nativeOTLP: true
-  url: 'https://docs.kloudmate.com/using-opentelemetry-collector'
-  contact: 'hello@kloudmate.com'
+  url: https://docs.kloudmate.com/using-opentelemetry-collector
+  contact: hello@kloudmate.com
   oss: false
   commercial: true
 - name: ServiceNow Cloud Observability (Lightstep)
   nativeOTLP: true
-  url: 'https://github.com/lightstep?q=launcher'
-  contact: ''
+  url: https://github.com/lightstep?q=launcher
+  contact:
   oss: false
   commercial: true
 - name: LogicMonitor
   nativeOTLP: true
-  url: 'https://www.logicmonitor.com/support/tracing/getting-started-with-tracing'
-  contact: ''
+  url: https://www.logicmonitor.com/support/tracing/getting-started-with-tracing
+  contact:
   oss: false
   commercial: true
 - name: Logz.io
   nativeOTLP: false
-  url: 'https://docs.logz.io/shipping/tracing-sources/opentelemetry.html#overview'
-  contact: ''
+  url: https://docs.logz.io/shipping/tracing-sources/opentelemetry.html#overview
+  contact:
   oss: false
   commercial: true
 - name: LogScale by Crowdstrike (Humio)
   nativeOTLP: true
-  url: 'https://library.humio.com/falcon-logscale/log-shippers-opentelemetry.html'
-  contact: ''
+  url: https://library.humio.com/falcon-logscale/log-shippers-opentelemetry.html
+  contact:
   oss: false
   commercial: true
 - name: Lumigo
   nativeOTLP: true
-  url: 'https://docs.lumigo.io/docs/opentelemetry'
-  contact: ''
+  url: https://docs.lumigo.io/docs/opentelemetry
+  contact:
   oss: false
   commercial: true
 - name: Middleware
   nativeOTLP: true
-  url: 'https://docs.middleware.io/open-telemetry'
-  contact: 'hello@middleware.io'
+  url: https://docs.middleware.io/open-telemetry
+  contact: hello@middleware.io
   oss: false
   commercial: true
 - name: New Relic
   nativeOTLP: true
-  url: 'https://newrelic.com/solutions/opentelemetry'
-  contact: ''
+  url: https://newrelic.com/solutions/opentelemetry
+  contact:
   oss: false
   commercial: true
 - name: Observe, Inc.
   nativeOTLP: true
-  url: 'https://docs.observeinc.com/en/latest/content/integrations/otel/opentelemetry.html'
-  contact: ''
+  url: https://docs.observeinc.com/en/latest/content/integrations/otel/opentelemetry.html
+  contact:
   oss: false
   commercial: true
 - name: observIQ
   nativeOTLP: true
-  url: 'https://docs.bindplane.observiq.com'
-  contact: ''
+  url: https://docs.bindplane.observiq.com
+  contact:
   oss: true
   commercial: true
 - name: OneUptime
   nativeOTLP: true
-  url: 'https://oneuptime.com/product/apm'
-  contact: 'hello@oneuptime.com'
+  url: https://oneuptime.com/product/apm
+  contact: hello@oneuptime.com
   oss: true
   commercial: true
 - name: OpenObserve
   nativeOTLP: true
-  url: 'https://openobserve.ai/docs/ingestion/logs/otlp/'
-  contact: 'hello@openobserve.ai'
+  url: https://openobserve.ai/docs/ingestion/logs/otlp/
+  contact: hello@openobserve.ai
   oss: true
   commercial: true
 - name: OpenText
   nativeOTLP: true
-  url: 'https://docs.microfocus.com/doc/OBS/SaaS/ConfigureOTELCollector'
-  contact: 'skotagiri@opentext.com'
+  url: https://docs.microfocus.com/doc/OBS/SaaS/ConfigureOTELCollector
+  contact: skotagiri@opentext.com
   oss: false
   commercial: true
 - name: Oracle
   nativeOTLP: true
-  url: 'https://docs.oracle.com/en-us/iaas/application-performance-monitoring/doc/configure-open-source-tracing-systems.html#GUID-4D941163-F357-4839-8B06-688876D4C61F'
-  contact: ''
+  url: https://docs.oracle.com/en-us/iaas/application-performance-monitoring/doc/configure-open-source-tracing-systems.html#GUID-4D941163-F357-4839-8B06-688876D4C61F
+  contact:
   oss: false
   commercial: true
 - name: qryn
   nativeOTLP: true
-  url: 'https://qryn.metrico.in/#/support?id=tempo-api'
-  contact: 'https://github.com/lmangani'
+  url: https://qryn.metrico.in/#/support?id=tempo-api
+  contact: https://github.com/lmangani
   oss: true
   commercial: true
 - name: Sentry
   nativeOTLP: false
-  url: 'https://sentry.io/for/opentelemetry/'
-  contact: ''
+  url: https://sentry.io/for/opentelemetry/
+  contact:
   oss: false
   commercial: true
 - name: Red Hat
   nativeOTLP: true
-  url: 'https://docs.openshift.com/container-platform/4.14/otel/otel-release-notes.html'
-  contact: 'ploffay@redhat.com'
+  url: https://docs.openshift.com/container-platform/4.14/otel/otel-release-notes.html
+  contact: ploffay@redhat.com
   oss: true
   commercial: true
 - name: Sentry Software
   nativeOTLP: true
-  url: 'https://www.sentrysoftware.com/products/hardware-sentry-opentelemetry-collector.html'
-  contact: ''
+  url: https://www.sentrysoftware.com/products/hardware-sentry-opentelemetry-collector.html
+  contact:
   oss: false
   commercial: true
 - name: ServicePilot
   nativeOTLP: true
-  url: 'https://www.servicepilot.com/en/doc/apm#opentelemetry'
-  contact: ''
+  url: https://www.servicepilot.com/en/doc/apm#opentelemetry
+  contact:
   oss: false
   commercial: true
 - name: SigNoz
   nativeOTLP: true
-  url: 'https://signoz.io'
-  contact: ''
+  url: https://signoz.io
+  contact:
   oss: true
   commercial: true
 - name: SolarWinds
   nativeOTLP: true
-  url: 'https://documentation.solarwinds.com/en/success_center/observability/default.htm#cshid=third-otel-integration'
-  contact: ''
+  url: https://documentation.solarwinds.com/en/success_center/observability/default.htm#cshid=third-otel-integration
+  contact:
   oss: false
   commercial: true
 - name: Splunk
   nativeOTLP: true
-  url: 'https://docs.splunk.com/Observability/gdi/opentelemetry/opentelemetry.html'
-  contact: ''
+  url: https://docs.splunk.com/Observability/gdi/opentelemetry/opentelemetry.html
+  contact:
   oss: false
   commercial: true
 - name: Sumo Logic
   nativeOTLP: true
-  url: 'https://help.sumologic.com/docs/send-data/opentelemetry-collector/'
-  contact: 'https://github.com/astencel-sumo'
+  url: https://help.sumologic.com/docs/send-data/opentelemetry-collector/
+  contact: https://github.com/astencel-sumo
   oss: false
   commercial: true
 - name: TelemetryHub
   nativeOTLP: true
-  url: 'https://app.telemetryhub.com/docs'
-  contact: ''
+  url: https://app.telemetryhub.com/docs
+  contact:
   oss: false
   commercial: true
 - name: Traceloop
   nativeOTLP: true
-  url: 'https://www.traceloop.com'
-  contact: ''
+  url: https://www.traceloop.com
+  contact:
   oss: false
   commercial: true
 - name: Uptrace
   nativeOTLP: true
-  url: 'https://uptrace.dev'
-  contact: ''
+  url: https://uptrace.dev
+  contact:
   oss: false
   commercial: true
 - name: Apache SkyWalking
   nativeOTLP: true
-  url: 'https://skywalking.apache.org/docs/main/v9.0.0/en/setup/backend/opentelemetry-receiver/'
-  contact: ''
+  url: https://skywalking.apache.org/docs/main/v9.0.0/en/setup/backend/opentelemetry-receiver/
+  contact:
   oss: true
   commercial: false
 - name: Fluent Bit
   nativeOTLP: true
   url: https://docs.fluentbit.io/manual/pipeline/inputs/opentelemetry/
-  contact: ''
+  contact:
   oss: true
   commercial: false
 - name: Jaeger
   nativeOTLP: true
   url: https://www.jaegertracing.io/docs/1.47/getting-started/
-  contact: ''
+  contact:
   oss: true
   commercial: false
 - name: ObserveAny
   nativeOTLP: true
   url: https://www.observeany.com/learn/opentelemetry-receiver
-  contact: 'contact@observeany.com'
+  contact: contact@observeany.com
   oss: false
   commercial: true
 - name: GreptimeDB
   nativeOTLP: true
   url: https://docs.greptime.com/user-guide/clients/otlp
-  contact: 'info@greptime.com'
+  contact: info@greptime.com
   oss: true
   commercial: true
 - name: ClickHouse
   nativeOTLP: false
-  url: 'https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/clickhouseexporter'
-  contact: 'https://github.com/tbragin'
+  url: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/clickhouseexporter
+  contact: https://github.com/tbragin
   oss: true
   commercial: true
 - name: TingYun
   nativeOTLP: true
-  url: 'https://wukongdoc.tingyun.com/apm/userguide/deploy_manage/opentelemetry.html'
-  contact: 'otel@tingyun.com'
+  url: https://wukongdoc.tingyun.com/apm/userguide/deploy_manage/opentelemetry.html
+  contact: otel@tingyun.com
   oss: false
   commercial: true
 - name: VictoriaMetrics
   nativeOTLP: true
-  url: 'https://github.com/VictoriaMetrics/VictoriaMetrics/tree/master/docs#sending-data-via-opentelemetry'
-  contact: 'https://github.com/hagen1778'
+  url: https://github.com/VictoriaMetrics/VictoriaMetrics/tree/master/docs#sending-data-via-opentelemetry
+  contact: https://github.com/hagen1778
   oss: true
   commercial: true
 - name: Tracetest
   nativeOTLP: true
-  url: 'https://docs.tracetest.io/configuration/connecting-to-data-stores/opentelemetry-collector'
-  contact: 'https://github.com/adnanrahic'
+  url: https://docs.tracetest.io/configuration/connecting-to-data-stores/opentelemetry-collector
+  contact: https://github.com/adnanrahic
   oss: true
   commercial: true
 - name: Alibaba Cloud
   nativeOTLP: true
-  url: 'https://www.alibabacloud.com/help/en/arms/tracing-analysis/get-started-with-tracing-analysis'
-  contact: 'opensource@alibaba-inc.com'
+  url: https://www.alibabacloud.com/help/en/arms/tracing-analysis/get-started-with-tracing-analysis
+  contact: opensource@alibaba-inc.com
   oss: false
   commercial: true
 - name: Seq
   nativeOTLP: true
-  url: 'https://docs.datalust.co/docs/opentelemetry-net-sdk-1'
-  contact: 'support@datalust.co'
+  url: https://docs.datalust.co/docs/opentelemetry-net-sdk-1
+  contact: support@datalust.co
   oss: false
   commercial: true
 - name: VuNet Systems
   nativeOTLP: true
-  url: 'https://vunetsystems.com/vuapp360/'
-  contact: 'info@vunetsystems.com'
+  url: https://vunetsystems.com/vuapp360/
+  contact: info@vunetsystems.com
   oss: false
   commercial: true
-- name: Bonree # cspell:ignore Bonree
+- name: Bonree
   distribution: false
   nativeOTLP: true
-  url: 'https://one.bonree.com/open/document/187'
-  contact: 'otel@bonree.com'
+  url: https://one.bonree.com/open/document/187
+  contact: otel@bonree.com
   oss: false
   commercial: true


### PR DESCRIPTION
- The Vendors data file doesn't contain any descriptions. I see little value in running spell-check over it, so I've added the data file name to the sSpell ignore paths list.
- Normalizes the `vendors.yaml` entries -- dropping unnecessary quotes.

There is no change in generated site files (other than the site timestamp):

```console
$ (cd public && git diff -bw --ignore-blank-lines) | grep ^diff
diff --git a/site/index.html b/site/index.html
```