### PR TITLE
Remove note regarding load-balancing exporter

### DIFF
--- a/content/en/docs/collector/deployment/gateway.md
+++ b/content/en/docs/collector/deployment/gateway.md
@@ -35,9 +35,6 @@ Let's have a look at such a case where we are using the load-balancing exporter:
    signals to a group of collectors.
 3. The collectors are configured to send telemetry data to one or more backends.
 
-{{% alert title="Note" color="info" %}} Currently, the load-balancing exporter
-only supports pipelines of the `traces` type. {{% /alert %}}
-
 ## Examples
 
 ### NGINX as an "out-of-the-box" load balancer


### PR DESCRIPTION
Fixes #4223

Note that only metrics are in development now. I think a note is not required, though. https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/loadbalancingexporter/README.md