### PR TITLE
Removes deprecated ErrNilNextConsumer and solves type error for typeStr

### DIFF
--- a/content/en/docs/collector/building/receiver.md
+++ b/content/en/docs/collector/building/receiver.md
@@ -399,6 +399,9 @@ Go ahead and add the following code to your `factory.go` file:
 ```go
 var (
 	typeStr         = component.MustNewType("tailtracer")
+)
+
+const (
 	defaultInterval = 1 * time.Minute
 )
 ```
@@ -435,6 +438,9 @@ import (
 
 var (
 	typeStr         = component.MustNewType("tailtracer")
+)
+
+const (
 	defaultInterval = 1 * time.Minute
 )
 
@@ -546,6 +552,9 @@ import (
 
 var (
 	typeStr         = component.MustNewType("tailtracer")
+)
+
+const (
 	defaultInterval = 1 * time.Minute
 )
 
@@ -885,6 +894,9 @@ import (
 
 var (
 	typeStr         = component.MustNewType("tailtracer")
+)
+
+const (
 	defaultInterval = 1 * time.Minute
 )
 

--- a/content/en/docs/collector/building/receiver.md
+++ b/content/en/docs/collector/building/receiver.md
@@ -397,8 +397,8 @@ value for it so it can be used as part of the default settings.
 Go ahead and add the following code to your `factory.go` file:
 
 ```go
-const (
-	typeStr         = "tailtracer"
+var (
+	typeStr         = component.MustNewType("tailtracer")
 	defaultInterval = 1 * time.Minute
 )
 ```
@@ -433,8 +433,8 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-const (
-	typeStr         = "tailtracer"
+var (
+	typeStr         = component.MustNewType("tailtracer")
 	defaultInterval = 1 * time.Minute
 )
 
@@ -544,8 +544,8 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-const (
-	typeStr         = "tailtracer"
+var (
+	typeStr         = component.MustNewType("tailtracer")
 	defaultInterval = 1 * time.Minute
 )
 
@@ -860,11 +860,6 @@ pipeline and the factory is responsible to make sure the next consumer (either a
 processor or exporter) in the pipeline is valid otherwise it should generate an
 error.
 
-The Collector's API provides some standard error types to help the factory
-handle pipeline configurations. Your receiver factory should throw a
-`component.ErrNilNextConsumer` in case the next consumer has an issue and is
-passed as nil.
-
 The `createTracesReceiver()` function will need a guard clause to make that
 validation.
 
@@ -888,8 +883,8 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-const (
-	typeStr         = "tailtracer"
+var (
+	typeStr         = component.MustNewType("tailtracer")
 	defaultInterval = 1 * time.Minute
 )
 
@@ -900,9 +895,6 @@ func createDefaultConfig() component.Config {
 }
 
 func createTracesReceiver(_ context.Context, params receiver.CreateSettings, baseCfg component.Config, consumer consumer.Traces) (receiver.Traces, error) {
-	if consumer == nil {
-		return nil, component.ErrNilNextConsumer
-	}
 
 	logger := params.Logger
 	tailtracerCfg := baseCfg.(*Config)
@@ -927,8 +919,6 @@ func NewFactory() receiver.Factory {
 
 {{% alert title="Check your work" color="primary" %}}
 
-- Added a guard clause that verifies if the consumer is properly instantiated
-  and if not returns the `component.ErrNilNextConsumer`error.
 - Added a variable called `logger` and initialized it with the Collector's
   logger that is available as a field named `Logger` within the
   `receiver.CreateSettings` reference.


### PR DESCRIPTION
This PR corrects type error for typeStr on Custom Receiver documentation, as well as removes ErrNilNextConsumer checks.

As of version 0.97.0 for dependencies when creating a custom receiver, using typeStr directly as a string was throwing an error of `cannot use typeStr (variable of type string) as component.Type value in argument to receiver.NewFactory ` which should now be done using `component.MustNewType("tailtracer")`, in a var declaration.

Also, as in [Issue 9322](https://github.com/open-telemetry/opentelemetry-collector/issues/9322) and later on accept as [PR 9779](https://github.com/open-telemetry/opentelemetry-collector/pull/9779) and [PR 31793](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31793),` component.ErrNilNextConsumer` is not a valid error type.