### PR TITLE
Remove reference of Feature Flag UI

### DIFF
--- a/content/en/docs/demo/screenshots/index.md
+++ b/content/en/docs/demo/screenshots/index.md
@@ -30,10 +30,6 @@ aliases: [demo_screenshots]
 | --------------------------------------------- | ------------------------------------- |
 | ![Grafana-Prometheus](grafana-prometheus.png) | ![Grafana-jaeger](gragana-jaeger.png) |
 
-## Feature Flag UI
-
-![feature-flag-ui](feature-flag-ui.png)
-
 ## Load Generator UI
 
 ![load-generator-ui](load-generator-ui.png)


### PR DESCRIPTION
Fix: #4265

Feature Flag UI was removed from the demo.