### PR TITLE
Update Grafana distributions links

### DIFF
--- a/data/ecosystem/distributions.yaml
+++ b/data/ecosystem/distributions.yaml
@@ -7,10 +7,18 @@
   url: https://aws.amazon.com/otel/
   docsUrl: https://aws-otel.github.io/docs/getting-started/collector
   components: [Collector]
-- name: Grafana Agent
-  url: https://github.com/grafana/agent
-  docsUrl: https://grafana.com/docs/agent/latest/
+- name: Grafana Alloy
+  url: https://github.com/grafana/alloy
+  docsUrl: https://grafana.com/docs/alloy/latest/
   components: [Collector]
+- name: Grafana Distribution of OpenTelemetry for .NET
+  url: https://github.com/grafana/grafana-opentelemetry-dotnet
+  docsUrl: https://grafana.com/docs/grafana-cloud/monitor-applications/application-observability/setup/instrument/dotnet/
+  components: [.NET]
+- name: Grafana Distribution of OpenTelemetry for Java
+  url: https://github.com/grafana/grafana-opentelemetry-java
+  docsUrl: https://grafana.com/docs/grafana-cloud/monitor-applications/application-observability/setup/instrument/java/
+  components: [Java]
 - name: observIQ BindPlane Agent
   url: https://github.com/observIQ/observiq-otel-collector
   docsUrl: https://github.com/observIQ/bindplane-agent/tree/main/docs

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -2531,6 +2531,18 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-24T14:54:54.282464+01:00"
   },
+  "https://github.com/grafana/alloy": {
+    "StatusCode": 200,
+    "LastSeen": "2024-04-10T00:09:46.144495+02:00"
+  },
+  "https://github.com/grafana/grafana-opentelemetry-dotnet": {
+    "StatusCode": 200,
+    "LastSeen": "2024-04-10T00:09:49.944628+02:00"
+  },
+  "https://github.com/grafana/grafana-opentelemetry-java": {
+    "StatusCode": 200,
+    "LastSeen": "2024-04-10T00:09:52.054124+02:00"
+  },
   "https://github.com/grpc/grpc-java": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T15:25:27.417894-05:00"
@@ -4462,6 +4474,18 @@
   "https://grafana.com/docs/agent/latest/": {
     "StatusCode": 200,
     "LastSeen": "2024-01-24T14:54:56.149229+01:00"
+  },
+  "https://grafana.com/docs/alloy/latest/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-04-10T00:09:47.949842+02:00"
+  },
+  "https://grafana.com/docs/grafana-cloud/monitor-applications/application-observability/setup/instrument/dotnet/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-04-10T00:09:50.125651+02:00"
+  },
+  "https://grafana.com/docs/grafana-cloud/monitor-applications/application-observability/setup/instrument/java/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-04-10T00:09:55.400731+02:00"
   },
   "https://grafana.com/oss/opentelemetry/": {
     "StatusCode": 200,


### PR DESCRIPTION
This PR updates the distribution status for Grafana to point to grafana/alloy as well as include our .NET and Java SDK distributions.