### PR TITLE
Updated instrumentation.md to replace deprecated Logger::info with Level::info

### DIFF
--- a/content/en/docs/languages/php/instrumentation.md
+++ b/content/en/docs/languages/php/instrumentation.md
@@ -74,6 +74,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Log\LogLevel;
 use Slim\Factory\AppFactory;
 use Monolog\Logger;
+use Monolog\Level;
 use Monolog\Handler\StreamHandler;
 
 require __DIR__ . '/vendor/autoload.php';
@@ -81,7 +82,7 @@ require __DIR__ . '/vendor/autoload.php';
 require('dice.php');
 
 $logger = new Logger('dice-server');
-$logger->pushHandler(new StreamHandler('php://stdout', Logger::INFO));
+$logger->pushHandler(new StreamHandler('php://stdout', Level::INFO));
 
 $app = AppFactory::create();
 


### PR DESCRIPTION
The Logger::info is deprecated.
Thus as suggested in the docblock I made the necessary change.
You can find details here: 
https://github.com/Seldaek/monolog/blob/main/src/Monolog/Logger.php#L51