### PR TITLE
Fix default collector deployment receiver endpoint

### DIFF
--- a/content/en/docs/collector/deployment/agent.md
+++ b/content/en/docs/collector/deployment/agent.md
@@ -42,8 +42,8 @@ like so:
 receivers:
   otlp: # the OTLP receiver the app is sending traces to
     protocols:
-      grpc:
-        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
 
 processors:
   batch:
@@ -66,8 +66,8 @@ service:
 receivers:
   otlp: # the OTLP receiver the app is sending metrics to
     protocols:
-      grpc:
-        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
 
 processors:
   batch:
@@ -90,8 +90,8 @@ service:
 receivers:
   otlp: # the OTLP receiver the app is sending logs to
     protocols:
-      grpc:
-        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
 
 processors:
   batch:


### PR DESCRIPTION
In the [default deployment example](https://opentelemetry.io/docs/collector/deployment/agent/#example) the export configuration is expecting to use OTLP over HTTP on port 4318.
```
export OTEL_EXPORTER_OTLP_ENDPOINT=http://collector.example.com:4318
```

 The collector examples though is then showing configuration for receivers on gRPC over 4317, instead of 4318.
 
 I assume this was just an oversight when HTTP became the default.