### PR TITLE
chore: mark Uptrace as OSS

### DIFF
--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -308,9 +308,9 @@
   commercial: true
 - name: Uptrace
   nativeOTLP: true
-  url: https://uptrace.dev
+  url: https://uptrace.dev/get/open-source-apm.html
   contact:
-  oss: false
+  oss: true
   commercial: true
 - name: Apache SkyWalking
   nativeOTLP: true

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -7711,7 +7711,7 @@
     "StatusCode": 206,
     "LastSeen": "2024-01-30T06:06:33.174666-05:00"
   },
-  "https://uptrace.dev": {
+  "https://uptrace.dev/get/open-source-apm.html": {
     "StatusCode": 206,
     "LastSeen": "2024-01-18T19:08:12.676498-05:00"
   },


### PR DESCRIPTION
The [license](https://github.com/uptrace/uptrace/blob/master/LICENSE) is  AGPL-3.0.