### PR TITLE
Issue #4292 link to community guidelines at the top

### DIFF
--- a/content/en/docs/contributing/_index.md
+++ b/content/en/docs/contributing/_index.md
@@ -7,7 +7,8 @@ cSpell:ignore: prepopulated spacewhite
 ---
 
 This document is related to contributing do documentation.
-If you are looking on how to contribute to the OpenTelemetry project in general see the [OpenTelemetry Contributor Guide](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md)
+If you are looking on how to contribute to the OpenTelemetry project in general see the
+[OpenTelemetry Contributor Guide](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md)
 , which provides details on the Contributor License Agreement and the Code of
 Conduct.
 

--- a/content/en/docs/contributing/_index.md
+++ b/content/en/docs/contributing/_index.md
@@ -6,7 +6,12 @@ weight: 200
 cSpell:ignore: prepopulated spacewhite
 ---
 
-You can open an issue about OpenTelemetry documentation, or contribute a change
+This document is related to contributing do documentation.
+If you are looking on how to contribute to the OpenTelemetry project in general see the [OpenTelemetry Contributor Guide](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md)
+, which provides details on the Contributor License Agreement and the Code of
+Conduct.
+
+For documentation, you can open an issue about OpenTelemetry, or contribute a change
 with a pull request (PR) to the
 [`opentelemetry.io` GitHub repository](https://github.com/open-telemetry/opentelemetry.io).
 
@@ -16,11 +21,6 @@ OpenTelemetry documentation contributors:
 - Create new content.
 - Update the OpenTelemetry Registry.
 - Improve the code that builds the site.
-
-See also the general
-[OpenTelemetry Contributor Guide](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md)
-, which provides details on the Contributor License Agreement and the Code of
-Conduct.
 
 ## Requirements
 

--- a/content/en/docs/contributing/_index.md
+++ b/content/en/docs/contributing/_index.md
@@ -7,7 +7,7 @@ cSpell:ignore: prepopulated spacewhite
 ---
 
 The following guide describes how to contribute to OpenTelemetry documentation.
-If you are looking on how to contribute to the OpenTelemetry project in general see the
+For guidance on how to contribute to the OpenTelemetry project in general, see the
 [OpenTelemetry Contributor Guide](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md)
 , which provides details on the Contributor License Agreement and the Code of
 Conduct.

--- a/content/en/docs/contributing/_index.md
+++ b/content/en/docs/contributing/_index.md
@@ -6,7 +6,7 @@ weight: 200
 cSpell:ignore: prepopulated spacewhite
 ---
 
-This document is related to contributing do documentation.
+The following guide describes how to contribute to OpenTelemetry documentation.
 If you are looking on how to contribute to the OpenTelemetry project in general see the
 [OpenTelemetry Contributor Guide](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md)
 , which provides details on the Contributor License Agreement and the Code of

--- a/content/en/docs/contributing/_index.md
+++ b/content/en/docs/contributing/_index.md
@@ -11,6 +11,8 @@ For guidance on how to contribute to the OpenTelemetry project in general, see t
 [OpenTelemetry Contributor Guide](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md)
 , which provides details on the Contributor License Agreement and the Code of
 Conduct.
+In extent, every language implementation, collector, and conventions
+[repository](https://github.com/open-telemetry/) has their own specific contributing guides.
 
 For documentation, you can open an issue about OpenTelemetry, or contribute a change
 with a pull request (PR) to the

--- a/content/en/docs/contributing/_index.md
+++ b/content/en/docs/contributing/_index.md
@@ -7,15 +7,16 @@ cSpell:ignore: prepopulated spacewhite
 ---
 
 The following guide describes how to contribute to OpenTelemetry documentation.
-For guidance on how to contribute to the OpenTelemetry project in general, see the
+For guidance on how to contribute to the OpenTelemetry project in general, see
+the
 [OpenTelemetry Contributor Guide](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md)
 , which provides details on the Contributor License Agreement and the Code of
-Conduct.
-In extent, every language implementation, collector, and conventions
-[repository](https://github.com/open-telemetry/) has their own specific contributing guides.
+Conduct. In extent, every language implementation, collector, and conventions
+[repository](https://github.com/open-telemetry/) has their own specific
+contributing guides.
 
-For documentation, you can open an issue about OpenTelemetry, or contribute a change
-with a pull request (PR) to the
+For documentation, you can open an issue about OpenTelemetry, or contribute a
+change with a pull request (PR) to the
 [`opentelemetry.io` GitHub repository](https://github.com/open-telemetry/opentelemetry.io).
 
 OpenTelemetry documentation contributors:


### PR DESCRIPTION
Reference: #4292 

The page under https://opentelemetry.io/docs/contributing/ talks about contributing to docs, although people might expect a page on how to contribute to the OpenTelemetry project in general. You have to read down a little bit to run into See also the general [OpenTelemetry Contributor Guide](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md), which provides details on the Contributor License Agreement and the Code of Conduct.

I think we should have this at the very top that this document is for contributing to docs and that the other document is where people find general guidelines.