### PR TITLE
Remove processor from glossary

### DIFF
--- a/content/en/docs/concepts/glossary.md
+++ b/content/en/docs/concepts/glossary.md
@@ -227,12 +227,6 @@ Short form for [OpenTelemetry Collector](#collector).
 
 Short for [OpenTelemetry Protocol](/docs/specs/otlp/).
 
-### **Processor**
-
-The operation performed on data between being received and being exported. For
-example, batching. Used by the
-[Collector](/docs/collector/configuration/#processors).
-
 ### **Propagators**
 
 Used to serialize and deserialize specific parts of telemetry data such as span


### PR DESCRIPTION
https://opentelemetry.io/docs/concepts/glossary/#processor talks about Instrumentation Library, but we should remove it, as it is a collector specific term.