### PR TITLE
Update CODEOWNERS with new SIG End User group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,7 @@ content-modules/opentelemetry-proto      @open-telemetry/docs-maintainers @open-
 content-modules/opentelemetry-specification  @open-telemetry/docs-maintainers @open-telemetry/specs-approvers
 content-modules/semantic-conventions     @open-telemetry/docs-maintainers @open-telemetry/specs-semconv-approvers
 content/en/blog/                         @open-telemetry/docs-maintainers
-content/en/community/end-user/           @open-telemetry/docs-approvers @open-telemetry/end-user-wg
+content/en/community/end-user/           @open-telemetry/docs-approvers @open-telemetry/sig-end-user-approvers
 content/en/docs/collector                @open-telemetry/docs-approvers @open-telemetry/collector-approvers
 content/en/docs/demo                     @open-telemetry/docs-approvers @open-telemetry/demo-approvers
 content/en/docs/languages/cpp/     @open-telemetry/docs-approvers @open-telemetry/cpp-approvers


### PR DESCRIPTION
follow up to https://github.com/open-telemetry/community/issues/2004