### PR TITLE
update embrace link in vendors

### DIFF
--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -399,7 +399,7 @@
   commercial: true
 - name: Embrace
   nativeOTLP: true
-  url: 'https://github.com/embrace-io/embrace-apple-sdk/blob/main/GETTING_STARTED.md#exporting-logs-and-traces-to-opentelemetry-vendors'
+  url: 'https://embrace.io/opentelemetry-for-mobile/'
   contact: 'product@embrace.io'
   oss: true
   commercial: true

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -1735,6 +1735,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:14:47.246698-05:00"
   },
+  "https://embrace.io/opentelemetry-for-mobile/": {
+    "StatusCode": 206,
+    "LastSeen": "2024-04-25T10:29:55.539338+02:00"
+  },
   "https://en.cppreference.com/w/cpp/container/set": {
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:02:25.398061-05:00"


### PR DESCRIPTION
Hello - I am looking to update the the page linked to Embrace Mobile in the [vendors](https://opentelemetry.io/ecosystem/vendors/) list with a more-helpful page about this vendor.