### PR TITLE
remove experimental label on stdout metrics export

### DIFF
--- a/content/en/docs/languages/go/exporters.md
+++ b/content/en/docs/languages/go/exporters.md
@@ -31,7 +31,7 @@ func newExporter() (trace.SpanExporter, error) {
 }
 ```
 
-### Console metrics (Experimental)
+### Console metrics
 
 [`go.opentelemetry.io/otel/exporters/stdout/stdoutmetric`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/stdout/stdoutmetric)
 contains an implementation of the console metrics exporter.


### PR DESCRIPTION
The stdoutmetric package was released as a 1.x, the docs should reflect that