### PR TITLE
add console log export details for go

### DIFF
--- a/content/en/docs/languages/go/exporters.md
+++ b/content/en/docs/languages/go/exporters.md
@@ -49,7 +49,7 @@ func newExporter() (metric.Exporter, error) {
 }
 ```
 
-### Console logs (Experimental)
+### Console logs (Experimental) {#console-logs}
 
 The [`go.opentelemetry.io/otel/exporters/stdout/stdoutlog`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/stdout/stdoutlog) package
 contains an implementation of the console log exporter.

--- a/content/en/docs/languages/go/exporters.md
+++ b/content/en/docs/languages/go/exporters.md
@@ -3,7 +3,7 @@ title: Exporters
 aliases: [exporting_data]
 weight: 50
 # prettier-ignore
-cSpell:ignore: otlpmetric otlpmetricgrpc otlpmetrichttp otlptrace otlptracegrpc otlptracehttp promhttp stdouttrace
+cSpell:ignore: otlpmetric otlpmetricgrpc otlpmetrichttp otlptrace otlptracegrpc otlptracehttp promhttp stdouttrace stdoutlog
 ---
 
 {{% docs/languages/exporters/intro go %}}

--- a/content/en/docs/languages/go/exporters.md
+++ b/content/en/docs/languages/go/exporters.md
@@ -51,7 +51,7 @@ func newExporter() (metric.Exporter, error) {
 
 ### Console logs (Experimental)
 
-[`go.opentelemetry.io/otel/exporters/stdout/stdoutlog`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/stdout/stdoutlog)
+The [`go.opentelemetry.io/otel/exporters/stdout/stdoutlog`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/stdout/stdoutlog) package
 contains an implementation of the console log exporter.
 
 Here's how you can create an exporter with default configuration:

--- a/content/en/docs/languages/go/exporters.md
+++ b/content/en/docs/languages/go/exporters.md
@@ -3,7 +3,7 @@ title: Exporters
 aliases: [exporting_data]
 weight: 50
 # prettier-ignore
-cSpell:ignore: otlpmetric otlpmetricgrpc otlpmetrichttp otlptrace otlptracegrpc otlptracehttp promhttp stdouttrace stdoutlog
+cSpell:ignore: otlpmetric otlpmetricgrpc otlpmetrichttp otlptrace otlptracegrpc otlptracehttp promhttp stdoutlog stdouttrace
 ---
 
 {{% docs/languages/exporters/intro go %}}

--- a/content/en/docs/languages/go/exporters.md
+++ b/content/en/docs/languages/go/exporters.md
@@ -49,6 +49,24 @@ func newExporter() (metric.Exporter, error) {
 }
 ```
 
+### Console logs (Experimental)
+
+[`go.opentelemetry.io/otel/exporters/stdout/stdoutlog`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/stdout/stdoutlog)
+contains an implementation of the console log exporter.
+
+Here's how you can create an exporter with default configuration:
+
+```go
+import (
+	"go.opentelemetry.io/otel/exporters/stdout/stdoutlog"
+	"go.opentelemetry.io/otel/sdk/log"
+)
+
+func newExporter() (log.Exporter, error) {
+	return stdoutlog.New()
+}
+```
+
 ## OTLP
 
 To send trace data to an OTLP endpoint (like the [collector](/docs/collector) or

--- a/content/en/docs/languages/go/exporters.md
+++ b/content/en/docs/languages/go/exporters.md
@@ -51,8 +51,9 @@ func newExporter() (metric.Exporter, error) {
 
 ### Console logs (Experimental) {#console-logs}
 
-The [`go.opentelemetry.io/otel/exporters/stdout/stdoutlog`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/stdout/stdoutlog) package
-contains an implementation of the console log exporter.
+The
+[`go.opentelemetry.io/otel/exporters/stdout/stdoutlog`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/stdout/stdoutlog)
+package contains an implementation of the console log exporter.
 
 Here's how you can create an exporter with default configuration:
 

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -6875,6 +6875,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:07:44.890589-05:00"
   },
+  "https://pkg.go.dev/go.opentelemetry.io/otel/exporters/stdout/stdoutlog": {
+    "StatusCode": 200,
+    "LastSeen": "2024-04-24T13:46:14.851022-07:00"
+  },
   "https://pkg.go.dev/go.opentelemetry.io/otel/exporters/stdout/stdoutmetric": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T15:25:21.196671-05:00"


### PR DESCRIPTION
This follows the examples for trace/metrics and marks log export support as experimental.

---

**Preview**: https://deploy-preview-4357--opentelemetry.netlify.app/docs/languages/go/exporters/#console