### PR TITLE
add example for exporting logs over otlp + http

### DIFF
--- a/content/en/docs/languages/go/exporters.md
+++ b/content/en/docs/languages/go/exporters.md
@@ -3,7 +3,7 @@ title: Exporters
 aliases: [exporting_data]
 weight: 50
 # prettier-ignore
-cSpell:ignore: otlpmetric otlpmetricgrpc otlpmetrichttp otlptrace otlptracegrpc otlptracehttp promhttp stdoutlog stdouttrace
+cSpell:ignore: otlplog otlploghttp otlpmetric otlpmetricgrpc otlpmetrichttp otlptrace otlptracegrpc otlptracehttp promhttp stdoutlog stdouttrace
 ---
 
 {{% docs/languages/exporters/intro go %}}
@@ -192,3 +192,22 @@ func newExporter(ctx context.Context) (metric.Reader, error) {
 
 To learn more on how to use the Prometheus exporter, try the
 [prometheus example](https://github.com/open-telemetry/opentelemetry-go/tree/main/example/prometheus)
+
+### OTLP logs over HTTP (Experimental)
+
+[`go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp)
+contains an implementation of OTLP logs exporter using HTTP with binary protobuf
+payloads.
+
+Here's how you can create an exporter with default configuration:
+
+```go
+import (
+	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
+	"go.opentelemetry.io/otel/sdk/log"
+)
+
+func newExporter(ctx context.Context) (log.Exporter, error) {
+	return otlploghttp.New(ctx)
+}
+```

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -6859,6 +6859,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:10:29.862565-05:00"
   },
+  "https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp": {
+    "StatusCode": 200,
+    "LastSeen": "2024-04-25T07:21:16.712986-07:00"
+  },
   "https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T15:25:43.27652-05:00"


### PR DESCRIPTION
Similar to examples for other signals, marked as experimental.