### PR TITLE
Remove eroneous reference to a parent span

### DIFF
--- a/content/en/docs/languages/go/sampling.md
+++ b/content/en/docs/languages/go/sampling.md
@@ -34,7 +34,7 @@ Other samplers include:
 - [`ParentBased`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/trace#ParentBased),
   is a sampler decorator which behaves differently, based on the parent of the
   span. If the span has no parent, the decorated sampler is used to make
-  sampling decision based on the parent of the span. By default, `ParentBased`
+  sampling decision. By default, `ParentBased`
   samples spans that have parents that were sampled, and doesn't sample spans
   whose parents were not sampled.
 


### PR DESCRIPTION
Avoid incorrect and confusing reference to an inexistent parent span.