### PR TITLE
[kubernetes] Update helm install commands

### DIFF
--- a/content/en/docs/kubernetes/getting-started.md
+++ b/content/en/docs/kubernetes/getting-started.md
@@ -156,6 +156,9 @@ The following `values.yaml` is what we'll use
 ```yaml
 mode: daemonset
 
+image:
+  repository: otel/opentelemetry-collector-k8s
+
 presets:
   # enables the k8sattributesprocessor and adds it to the traces, metrics, and logs pipelines
   kubernetesAttributes:
@@ -239,6 +242,9 @@ The following `values.yaml` is what we'll use:
 
 ```yaml
 mode: deployment
+
+image:
+  repository: otel/opentelemetry-collector-k8s
 
 # We only want one of these collectors - any more and we'd produce duplicate data
 replicaCount: 1

--- a/content/en/docs/kubernetes/helm/collector.md
+++ b/content/en/docs/kubernetes/helm/collector.md
@@ -23,7 +23,8 @@ following commands:
 ```sh
 helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 helm install my-opentelemetry-collector open-telemetry/opentelemetry-collector \
-   --set mode=<daemonset|deployment|statefulset>
+   --set image.repository="otel/opentelemetry-collector-k8s" \
+   --set mode=<daemonset|deployment|statefulset> \
 ```
 
 ### Configuration

--- a/content/en/docs/kubernetes/helm/operator.md
+++ b/content/en/docs/kubernetes/helm/operator.md
@@ -22,6 +22,7 @@ following commands:
 ```console
 helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 helm install my-opentelemetry-operator open-telemetry/opentelemetry-operator \
+  --set "manager.collectorImage.repository=otel/opentelemetry-collector-k8s" \
   --set admissionWebhooks.certManager.enabled=false \
   --set admissionWebhooks.certManager.autoGenerateCert.enabled=true
 ```


### PR DESCRIPTION
The collector and operator helm charts have had a breaking change that needs addressed in our examples:
- https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1154
- https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1148

This PR updates the docs to set the image repository so that the chart can be installed.