### PR TITLE
Add missing using instrumentation libraries pages: Erlang/Elixir

### DIFF
--- a/content/en/docs/languages/erlang/libraries.md
+++ b/content/en/docs/languages/erlang/libraries.md
@@ -1,0 +1,55 @@
+---
+title: Using instrumentation libraries
+linkTitle: Libraries
+weight: 40
+cSpell:ignore: Hex Ecto
+---
+
+{{% docs/languages/libraries-intro "Erlang" %}}
+
+## Use instrumentation libraries
+
+If a library doesn't include OpenTelemetry support, you can use
+[instrumentation libraries](/docs/specs/otel/glossary/#instrumentation-library)
+to generate telemetry data for a library or framework.
+
+For example,
+[the instrumentation library for Ecto](https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_ecto)
+automatically creates [spans](/docs/concepts/signals/traces/#spans) based on
+queries.
+
+## Setup
+
+Each instrumentation library is distributed as a Hex package. To install an
+instrumentation, add the dependency to your `mix.exs` file. For example:
+
+```elixir
+def deps do
+  [
+    {:opentelemetry_{package}, "~> 1.0"}
+  ]
+end
+```
+
+Where `{package}` is the name of the instrumentation.
+
+Note that some instrumentation packages might have prerequisites. Check the
+documentation of each instrumentation package for further instructions.
+
+## Available instrumentation libraries
+
+For a full list of instrumentation libraries, see the
+[list of Hex packages](https://hex.pm/packages?search=opentelemetry&sort=recent_downloads).
+
+You can also find more instrumentations available in the
+[registry](/ecosystem/registry/?language=erlang&component=instrumentation).
+
+## Next steps
+
+After you have set up instrumentation libraries, you might want to add your own
+[instrumentation](/docs/languages/erlang/instrumentation) to your code, to
+collect custom telemetry data.
+
+You might also want to configure an appropriate exporter to
+[export your telemetry data](/docs/languages/erlang/exporters) to one or more
+telemetry backends.

--- a/content/en/docs/languages/erlang/libraries.md
+++ b/content/en/docs/languages/erlang/libraries.md
@@ -2,7 +2,7 @@
 title: Using instrumentation libraries
 linkTitle: Libraries
 weight: 40
-cSpell:ignore: Hex Ecto
+cSpell:ignore: Ecto Hex
 ---
 
 {{% docs/languages/libraries-intro "Erlang" %}}

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -4655,6 +4655,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:02:09.59825-05:00"
   },
+  "https://hex.pm/packages": {
+    "StatusCode": 200,
+    "LastSeen": "2024-04-26T15:24:12.437103+02:00"
+  },
   "https://hex.pm/packages/opentelemetry": {
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:02:25.352177-05:00"


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry.io/issues/4319

@open-telemetry/erlang-contrib-maintainers Please have a look. Overall structure is based on other languages, though we might want to add further considerations on things like semver, stability, etc.