### PR TITLE
Remove temp registry .highlight style override

### DIFF
--- a/assets/scss/_registry.scss
+++ b/assets/scss/_registry.scss
@@ -39,31 +39,3 @@
 .registry-entry {
   @extend .shadow;
 }
-
-// fix me: the registry seems not to load the main.min.css with the extended
-// styles, so we need to define the styles here again.
-.highlight {
-  margin: 1rem 0;
-  padding: 0;
-  position: relative;
-  max-width: 95%;
-  border: var(--bs-card-border-width) solid var(--bs-card-border-color);
-  border-radius: var(--bs-card-border-radius);
-  & pre {
-    padding: 1rem;
-    margin: 0;
-    display: block;
-    text-align: right;
-    overflow-y: auto;
-    & button.td-click-to-copy {
-      position: absolute;
-      color: #ced4da;
-      border-radius: 3px;
-      border-width: 0;
-      background-color: inherit;
-      box-shadow: 1px 1px #ced4da;
-      right: 4px;
-      top: 2px;
-    }
-  }
-}

--- a/content/en/ecosystem/registry/_index.md
+++ b/content/en/ecosystem/registry/_index.md
@@ -15,7 +15,7 @@ aliases: [/registry/*]
 type: default
 layout: registry
 outputs: [html, json]
-body_class: registry
+body_class: registry td-content
 weight: 20
 ---
 


### PR DESCRIPTION
- Fixes #4389
- Prepares for #4023
- **Preview**: https://deploy-preview-4390--opentelemetry.netlify.app/ecosystem/registry/?s=alert

/cc @svrnm 

### Screenshots

There is not much of a difference between the before and after images (which is what we want).

Before:

> <img width="940" alt="image" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/9856b26e-a49c-4cb6-9cd2-b742b3706ffe">


After:

> <img width="938" alt="image" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/16d11924-03b8-4258-83fb-2440e83b6258">
