### PR TITLE
Docsy upgrade to v0.9.1-53-ga8e0a1a

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/google/docsy.git
-	docsy-pin = v0.9.1-47-ge59bb58
+	docsy-pin = v0.9.1-53-ga8e0a1a
 	docsy-note = "2024-04-01 Switching to google/docsy.git from cncf/docsy.git since we don't have any CNCF customizations."
 	docsy-reminder = "Ensure that any tag referenced by `docsy-pin` is present in the remote repo (url), otherwise add (push) the tags to the repo."
 [submodule "content-modules/opentelemetry-specification"]


### PR DESCRIPTION
- Prep for #4023, without enabling the dark-mode menu