### PR TITLE
js docs: update doc on auto instrumentation

### DIFF
--- a/content/en/docs/languages/js/automatic/configuration.md
+++ b/content/en/docs/languages/js/automatic/configuration.md
@@ -27,9 +27,11 @@ detectors, or completely disable them:
 - `host`
 - `os`
 - `process`
+- `serviceinstance`
 - `container`
 - `alibaba`
 - `aws`
+- `azure`
 - `gcp`
 - `all` - enables all resource detectors
 - `none` - disables resource detection

--- a/content/en/docs/languages/js/automatic/configuration.md
+++ b/content/en/docs/languages/js/automatic/configuration.md
@@ -4,6 +4,7 @@ linkTitle: Configuration
 description: Learn how to configure Automatic Instrumentation for Node.js
 aliases: [module-config]
 weight: 10
+cSpell:ignore: serviceinstance
 ---
 
 This module is highly configurable by setting


### PR DESCRIPTION
Update Automatic Instrumentation Configuration for Node.js with recent changes to match README on its [repo](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/metapackages/auto-instrumentations-node).