### PR TITLE
Fix vendors table (remove distros from table heading)

### DIFF
--- a/layouts/shortcodes/ecosystem/vendor-table.md
+++ b/layouts/shortcodes/ecosystem/vendor-table.md
@@ -3,7 +3,7 @@ cSpell:ignore: bution cial cond distri
 */ -}}
 {{ $data := sort (sort (sort $.Site.Data.ecosystem.vendors "name") "oss" "desc") "commercial" -}}
 
-| Organization[^org] | OSS | Com&shy;mer&shy;cial | Distri&shy;bution | Native OTLP | Learn more  |
+| Organization[^org] | OSS | Com&shy;mer&shy;cial | Native OTLP | Learn more  |
 | ----------- | ----------- | ---------- | ----------------- | ----------- | ----------- |
 {{- range $data }}
   {{- $shortUrl := .shortUrl -}}


### PR DESCRIPTION
We removed the distribution column, but we didn't remove it in the heading which breaks the table, this PR fixes that:

https://opentelemetry.io/ecosystem/vendors/ 