### PR TITLE
Update collector-exporter-azure-monitor.yml author

### DIFF
--- a/data/registry/collector-exporter-azure-monitor.yml
+++ b/data/registry/collector-exporter-azure-monitor.yml
@@ -9,7 +9,7 @@ tags:
 license: Apache 2.0
 description: The Azure Monitor Exporter for the OpenTelemetry Collector.
 authors:
-  - name: Microsoft
+  - name: OpenTelemetry Authors
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/azuremonitorexporter
 createdAt: 2020-06-06


### PR DESCRIPTION
The component is in otel collector contrib repo. Other components from contrib repo has authors listed as "OpenTelemetry Authors".

(Note : This is not an official Microsoft component: https://learn.microsoft.com/en-us/azure/azure-monitor/app/opentelemetry-enable?tabs=aspnetcore#can-i-use-the-opentelemetry-collector)