### PR TITLE
Update java context propagation example to use Context.wrap

### DIFF
--- a/content/en/docs/languages/java/instrumentation.md
+++ b/content/en/docs/languages/java/instrumentation.md
@@ -988,14 +988,12 @@ The following example demonstrates how to propagate the context between threads:
 
 ```java
 io.opentelemetry.context.Context context = io.opentelemetry.context.Context.current();
-Thread thread = new Thread(new Runnable() {
+Thread thread = new Thread(context.wrap(new Runnable() {
   @Override
   public void run() {
-    try (Scope scope = context.makeCurrent()) {
-      // Code for which you want to propagate the context
-    }
+    // Code for which you want to propagate the context
   }
-});
+}));
 thread.start();
 ```
 


### PR DESCRIPTION
I noticed that the java example for propagating context across threads is more complicated that it needs to be. We have helper functions specifically for this situation. Updating to be more succinct. 