### PR TITLE
[infra] .prettierignore all languages other than en for now

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,6 +8,11 @@
 /layouts/shortcodes/*
 !/layouts/shortcodes/docs
 
+# Ignore all languages other than en for now
+
+/content/*
+!/content/en
+
 # Ignore content-modules except for published Community pages
 
 /content-modules/*


### PR DESCRIPTION
- Contributes to #4443
- I've double checked that `en` content _is_ being prettified