### PR TITLE
Fix typo in Java instrumentation doc

### DIFF
--- a/content/en/docs/languages/java/instrumentation.md
+++ b/content/en/docs/languages/java/instrumentation.md
@@ -650,7 +650,7 @@ public class Dice {
   }
 
   public Dice(int min, int max) {
-    this(min, max, OpenTelemetry.noop())
+    this(min, max, OpenTelemetry.noop());
   }
 
   // ...


### PR DESCRIPTION
A typo in the [Java instrumentation doc](https://opentelemetry.io/docs/languages/java/instrumentation/#acquiring-a-tracer) was [reported](https://cloud-native.slack.com/archives/C02UN96HZH6/p1715199466471439) by @austinlparker. 

> ...the line `this(min, max, OpenTelemetry.noop())` needs a semicolon after it

This PR adds the missing semicolon.
