### PR TITLE
Upgrade to Hugo 0.125.7, Docsy at HEAD

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/google/docsy.git
-	docsy-pin = v0.10.0
+	docsy-pin = v0.10.0-2-g6f7e81d
 	docsy-note = "2024-04-01 Switching to google/docsy.git from cncf/docsy.git since we don't have any CNCF customizations."
 	docsy-reminder = "Ensure that any tag referenced by `docsy-pin` is present in the remote repo (url), otherwise add (push) the tags to the repo."
 [submodule "content-modules/opentelemetry-specification"]

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "autoprefixer": "^10.4.19",
     "cspell": "^8.0.0",
     "gulp": "^4.0.2",
-    "hugo-extended": "0.125.4",
+    "hugo-extended": "github:chalin/hugo-extended#v0.125.7",
     "markdown-link-check": "^3.12.1",
     "markdownlint": "^0.34.0",
     "postcss-cli": "^11.0.0",


### PR DESCRIPTION
- In support of debugging config issues of #4443
- No changes to the generated site files other than generator ID and site timestamp