### PR TITLE
Fix opentelemetry-operator helm install command

### DIFF
--- a/content/en/docs/kubernetes/helm/operator.md
+++ b/content/en/docs/kubernetes/helm/operator.md
@@ -24,7 +24,7 @@ helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm
 helm install my-opentelemetry-operator open-telemetry/opentelemetry-operator \
   --set "manager.collectorImage.repository=otel/opentelemetry-collector-k8s" \
   --set admissionWebhooks.certManager.enabled=false \
-  --set admissionWebhooks.certManager.autoGenerateCert.enabled=true
+  --set admissionWebhooks.autoGenerateCert.enabled=true
 ```
 
 This will install an OpenTelemetry Operator with a self-signed certificate and


### PR DESCRIPTION
This PR corrects an attribute in the Helm chart installation.

**Changes**:

The attribute `--set admissionWebhooks.certManager.autoGenerateCert.enabled=true` is updated to `--set admissionWebhooks.autoGenerateCert.enabled=true` for accurate configuration.

**Reason for Change**:

This change resolves the error: 
```shell
Error: INSTALLATION FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
opentelemetry-operator:
- admissionWebhooks.certManager: Additional property autoGenerateCert is not allowed
```