### PR TITLE
update blog contribution policy

### DIFF
--- a/archetypes/blog.md
+++ b/archetypes/blog.md
@@ -9,6 +9,8 @@ author: >- # If you have only one author, then add the single name on this line 
 draft: true # TODO: remove this line once your post is ready to be published
 # canonical_url: http://somewhere.else/ # TODO: if this blog post has been posted somewhere else already, uncomment & provide the canonical URL here.
 body_class: otel-with-contributions-from # TODO: remove this line if there are no secondary contributing authors
+issue: the issue ID for this blog post # TODO: See https://opentelemetry.io/docs/contributing/blog/ for details
+sig: SIG Name # TODO: add the name of the SIG that sponsors this blog post 
 ---
 
 <!-- If your post doesn't have secondary authors, then delete the following paragraph: -->

--- a/content/en/docs/contributing/blog.md
+++ b/content/en/docs/contributing/blog.md
@@ -6,13 +6,25 @@ weight: 30
 
 The [OpenTelemetry blog](/blog/) communicates new features, community reports,
 and any news that might be relevant to the OpenTelemetry community. This
-includes end users and developers. Anyone can write a blog post and submit it
-for review.
+includes end users and developers. Anyone can write a blog post, read below what
+the requirements are.
+
+## Documentation or blog post?
+
+Before writing a blog post, ask yourself if your content also might be a good
+addition to the documentation. If the answer is "yes", create a new issue or
+pull request (PR) with your content to get it added to the docs.
+
+Note, that the focus of maintainers and approvers of the OpenTelemetry Website
+is to improve the documentation of the project, so your blog post will have a
+lower priority for review.
 
 ## Before submitting a blog post
 
 Blog posts should not be commercial in nature and should consist of original
-content that applies broadly to the OpenTelemetry community.
+content that applies broadly to the OpenTelemetry community. Blog posts should
+follow the policies outlined in the
+[Social Media Guide](https://github.com/open-telemetry/community/blob/main/social-media-guide.md).
 
 Verify that your intended content broadly applies to the OpenTelemetry Community
 . Appropriate content includes:
@@ -27,15 +39,28 @@ Unsuitable content includes:
 
 - Vendor product pitches
 
-To submit a blog post,
+If your blog post fits into the list of appropriate content,
 [raise an issue](https://github.com/open-telemetry/opentelemetry.io/issues/new?title=New%20Blog%20Post:%20%3Ctitle%3E)
-with the title and a short description of your blog post. If you are not a
-[Member](https://github.com/open-telemetry/community/blob/main/community-membership.md#member),
-you also need to provide a _sponsor_ for your blog post, who is a Member (by
-that definition) and who is willing to provide a first review of your blog post.
+with the following details:
 
-If you do not raise an issue before providing your PR, we may request you to do
-so before providing a review.
+- Title of the blog post
+- Short description and outline of your blog post
+- If applicable, list the technologies used in your blog post. Make sure that
+  all of them are open source, and prefer CNCF projects over non-CNCF projects
+  (e.g. use Jaeger for trace visualization, and Prometheus for metric
+  visualization)
+- Name of a [SIG](https://github.com/open-telemetry/community/), which is
+  related to this blog post
+- Name of a sponsor (maintainer or approver) from this SIG, who will help to
+  review that PR
+
+Maintainers of SIG Communication will verify, that your blog post satisfies all
+the requirements for being accepted. If you can not name a SIG/sponsor in your
+initial issue details, they will also point you to an appropriate SIG, you can
+reach out to for sponsorship.
+
+If your issue has everything needed, a maintainer will verify that you can go
+ahead and submit your blog post.
 
 ## Submit a blog post
 
@@ -43,10 +68,6 @@ You can submit a blog post either by forking this repository and writing it
 locally or by using the GitHub UI. In both cases we ask you to follow the
 instructions provided by the
 [blog post template](https://github.com/open-telemetry/opentelemetry.io/tree/main/archetypes/blog.md).
-
-**Note**: Before writing a blog post, ask yourself if your content also might be
-a good addition to the documentation. If the answer is "yes", create a new issue
-or pull request (PR) with your content to get it added to the docs.
 
 ### Fork and write locally
 

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -2923,6 +2923,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-30T05:18:13.185301-05:00"
   },
+  "https://github.com/open-telemetry/community/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-05-10T13:05:22.581509+02:00"
+  },
   "https://github.com/open-telemetry/community/discussions/1203": {
     "StatusCode": 200,
     "LastSeen": "2024-01-18T20:05:24.761684-05:00"


### PR DESCRIPTION
This introduces a stricter policy on how we accept blog posts:

1. It still makes sure that **anyone** can create a blog post
2. It requires an issue to be raised **before** a PR is made (we had that already)
3. It asks authors to list technologies they use
4. It requires a related SIG to sponsor[^1] a PR, and a SIG approver/maintainer to provide review 

The big changes come with 3. and 4. By listing the technologies we can verify early that no commercial software is used or that the technology used is "appropriate" (e.g. they use Jaeger and not another semi-commercial trace visualization). By asking them to provide a SIG that is "sponsoring" the blog post, we ensure the following:

- Nothing changes for SIGs when they contribute blog posts (see the collector roadmap + collector survey blog post, both have sponsors easily since they come out of the SIG)
- No blog posts are introduced that go against what a SIG would say about a certain topic (e.g. if someone would push a blog post with an alternative automatic instrumentation for a language which is for reasons unknown to SIG Comms not what the language SIG wants to be pushed)
- No blog posts are handed in as a PR directly and we as maintainers/approvers need to feel bad for rejecting it.

[^1]: Looks like "sponsor" is word of the year in otel land ...