### PR TITLE
[i18n] Don't generate _redirects for non-en languages

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -4,6 +4,9 @@ description: >-
   High-quality, ubiquitous, and portable telemetry to enable effective
   observability
 show_banner: true
+outputs:
+  - HTML
+  - REDIRECTS # Include this `content/en` ONLY
 developer_note:
   The blocks/cover shortcode (used below) will use as a background image any
   image file containing "background" in its name.

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -51,7 +51,7 @@ outputFormats:
     notAlternative: true
 
 outputs:
-  home: [HTML, REDIRECTS]
+  home: [HTML]
   section: [HTML]
 
 params:


### PR DESCRIPTION
- Contributes to #4443
- No change to generated site files (given that `zh` pages aren't in production yet)