### PR TITLE
[zh] Show Chinese homepage in production

### DIFF
--- a/content/zh/_index.md
+++ b/content/zh/_index.md
@@ -6,8 +6,6 @@ show_banner: true
 developer_note:
   下文所用的 blocks/cover 短代码将使用文件名中包含 "background"
   的图像文件作为背景图。
-cascade:
-  draft: true
 ---
 
 <div class="d-none"><a rel="me" href="https://fosstodon.org/@opentelemetry"></a></div>


### PR DESCRIPTION
- Folks, I think that we're ready to launch the **homepage** 🚀 . It maybe look a bit strange given that we don't have any docs pages, but those should come soon :) ... and once they do, I'll implement a fallback to `en` pages (#4478)
- Fixes #2402

**Preview**: https://deploy-preview-4477--opentelemetry.netlify.app/zh/

/cc @open-telemetry/docs-cn-approvers @jiekun