### PR TITLE
[zh] Ensure zh fallback pages specify en page as canonical source

### DIFF
--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -6,6 +6,22 @@
 
   {{ $canonicalURL := .Permalink -}}
 
+  {{ $defaultLang := "en" -}}
+  {{ if and (ne .Language.Lang $defaultLang) .File -}}
+    {{/* This page is in a non-default-language section */ -}}
+    {{ $pagePath := strings.TrimPrefix (add hugo.WorkingDir "/content/") .File.Filename -}}
+    {{ if hasPrefix $pagePath $defaultLang -}}
+
+      {{/* This page is actually a default-language fallback page. Use the link
+      to the origin of the fallback page as canonical reference. */ -}}
+
+      {{ $translationPages := where .Translations "Lang" $defaultLang -}}
+      {{ $translation := index $translationPages 0 -}}
+      {{ with $translation -}}
+        {{ $canonicalURL = .Permalink -}}
+      {{ end -}}
+    {{ end -}}
+  {{ end -}}
   <link rel="canonical" href="{{ $canonicalURL }}">
 
 {{- end -}}


### PR DESCRIPTION
- Contributes to #4487, well, it actually solves it, but I want to refactor the code. I'll do that later. I wanted to get this fix in before Google indexes the site :)

### Test pages

Look at the page source to ensure that the canonical link is appropriately set:

- **Preview**: https://deploy-preview-4494--opentelemetry.netlify.app/

#### Before

```console

$ curl -s https://opentelemetry.io/zh/docs/getting-started/ | perl -nle 'print $1 if /(canonical"?\s+href=.*?)>/i'
canonical href=https://opentelemetry.io/zh/docs/getting-started/
```

#### After

```console
$ curl -s https://deploy-preview-4494--opentelemetry.netlify.app/zh/docs/getting-started/ | perl -nle 'print $1 if /(canonical"?\s+href=.*?)>/i'
canonical href=https://deploy-preview-4494--opentelemetry.netlify.app/docs/getting-started/
```