### PR TITLE
Fix typo in Python getting-started.md

### DIFF
--- a/content/en/docs/languages/python/getting-started.md
+++ b/content/en/docs/languages/python/getting-started.md
@@ -418,7 +418,7 @@ automatically created one:
 
 </details>
 
-The `parent_id` of `roll` is the same is the `span_id` for `/rolldice`,
+The `parent_id` of `roll` is the same as the `span_id` for `/rolldice`,
 indicating a parent-child relationship!
 
 ### Metrics


### PR DESCRIPTION
A typo in getting-started.md of Python.

> The `parent_id` of `roll` is the same is the `span_id` for `/rolldice`

`is the same is` -> `is the same as`