### PR TITLE
Add docs-zh-approvers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,3 +42,4 @@ content/en/docs/specs/                   @open-telemetry/docs-approvers @open-te
 content/en/docs/security/                @open-telemetry/docs-approvers @open-telemetry/sig-security-maintainers
 content/en/ecosystem/demo/               @open-telemetry/demo-approvers @open-telemetry/demo-approvers
 content/en/docs/contributing/       @open-telemetry/docs-approvers @open-telemetry/docs-maintainers
+content/zh/                         @open-telemetry/docs-zh-approvers


### PR DESCRIPTION
Adds @open-telemetry/docs-zh-approvers as codeowners for docs/zh, since @open-telemetry/docs-zh-maintainers is a subteam they inherit that ownership and do not need to be mentioned