### PR TITLE
Add explanation of double colons to Collector config page

### DIFF
--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -38,9 +38,13 @@ otelcol --config=env:MY_CONFIG_IN_AN_ENVVAR --config=https://server/config.yaml
 otelcol --config="yaml:exporters::debug::verbosity: normal"
 ```
 
+{{% alert title="Tip" color="primary" %}}
+
 When referring to nested keys in YAML paths, make sure to use double colons (::)
 to avoid confusion with namespaces that contain dots. For example:
 `receivers::docker_stats::metrics::container.cpu.utilization::enabled: false`.
+
+{{% /alert %}}
 
 To validate a configuration file, use the `validate` command. For example:
 

--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -30,13 +30,17 @@ example:
 otelcol --config=customconfig.yaml
 ```
 
-You can also provide configurations using environment variables, YAML paths, or
-HTTP URIs. For example:
+You can also provide configurations using environment variables, HTTP URIs, or
+YAML paths. For example:
 
 ```shell
 otelcol --config=env:MY_CONFIG_IN_AN_ENVVAR --config=https://server/config.yaml
 otelcol --config="yaml:exporters::debug::verbosity: normal"
 ```
+
+When referring to nested keys in YAML paths, make sure to use double colons (::)
+to avoid confusion with namespaces that contain dots. For example:
+`receivers::docker_stats::metrics::container.cpu.utilization::enabled: false`.
 
 To validate a configuration file, use the `validate` command. For example:
 


### PR DESCRIPTION
Fixes #4484.

This PR adds an explanation for the use of double colons to refer to nested keys in YAML config paths.

---
**Preview**: https://deploy-preview-4524--opentelemetry.netlify.app/docs/collector/configuration/#location
