### PR TITLE
[IA] Relocate JavaScript Automatic pages to new Zero-code section + CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,3 +43,5 @@ content/en/docs/security/                @open-telemetry/docs-approvers @open-te
 content/en/ecosystem/demo/               @open-telemetry/demo-approvers @open-telemetry/demo-approvers
 content/en/docs/contributing/       @open-telemetry/docs-approvers @open-telemetry/docs-maintainers
 content/zh/                         @open-telemetry/docs-zh-approvers
+content/en/docs/zero-code/java/    @open-telemetry/docs-approvers @open-telemetry/java-approvers @open-telemetry/java-instrumentation-approvers
+content/en/docs/zero-code/js/      @open-telemetry/docs-approvers @open-telemetry/javascript-approvers

--- a/content/en/blog/2023/end-user-discussions-03.md
+++ b/content/en/blog/2023/end-user-discussions-03.md
@@ -191,8 +191,7 @@ agent to the host metrics receiver for infrastructure monitoring.
   [most libraries](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/supported-libraries.md#libraries--frameworks)
   that are used by applications. Auto-instrumentation is also available for
   [Python](/docs/languages/python/automatic/),
-  [.NET](/docs/languages/net/automatic/), and
-  [Node.js](/docs/languages/js/automatic).
+  [.NET](/docs/languages/net/automatic/), and [Node.js](/docs/zero-code/js/).
 - If you’re using Kubernetes, they can use the
   [OTel operator](https://github.com/open-telemetry/opentelemetry-operator),
   which takes care of instrumentations for applications deployed on K8s. The

--- a/content/en/docs/concepts/instrumentation/zero-code.md
+++ b/content/en/docs/concepts/instrumentation/zero-code.md
@@ -45,7 +45,7 @@ Other configuration options are available, including:
 Automatic instrumentation is available for the following languages:
 
 - [.NET](/docs/languages/net/automatic/)
-- [Java](/docs/languages/java/automatic/)
-- [JavaScript](/docs/languages/js/automatic/)
+- [Java](/docs/zero-code/java/)
+- [JavaScript](/docs/zero-code/js/)
 - [PHP](/docs/languages/php/automatic/)
 - [Python](/docs/languages/python/automatic/)

--- a/content/en/docs/kubernetes/operator/automatic.md
+++ b/content/en/docs/kubernetes/operator/automatic.md
@@ -280,14 +280,14 @@ must be able to receive OTLP over `grpc`. Therefore, the example uses
 `http://demo-collector:4317`, which connects to the `grpc` port of the
 `otlpreceiver` of the Collector created in the previous step.
 
-#### Excluding auto-instrumentation {#js-excluding-auto-instrumentation}
+#### Excluding instrumentation libraries {#js-excluding-instrumentation-libraries}
 
-By default, the Node.js auto-instrumentation has all the instrumentation
+By default, the Node.js zero-code instrumentation has all the instrumentation
 libraries enabled.
 
-To enable only specific instrumentations you can use the
+To enable only specific instrumentation libraries you can use the
 `OTEL_NODE_ENABLED_INSTRUMENTATIONS` environment variable as documented in the
-[Node.js auto-instrumentation documentation](/docs/languages/js/automatic/configuration/#excluding-auto-instrumentation).
+[Node.js zero-code instrumentation documentation](/docs/zero-code/js/configuration/#excluding-instrumentation-libraries).
 
 ```yaml
 apiVersion: opentelemetry.io/v1alpha1

--- a/content/en/docs/languages/js/instrumentation.md
+++ b/content/en/docs/languages/js/instrumentation.md
@@ -14,8 +14,8 @@ description: Instrumentation for OpenTelemetry JavaScript
 
 On this page you will learn how you can add traces, metrics and logs to your
 code _manually_. But, you are not limited to only use one kind of
-instrumentation: use [automatic instrumentation](/docs/languages/js/automatic/)
-to get started and then enrich your code with manual instrumentation as needed.
+instrumentation: use [automatic instrumentation](/docs/zero-code/js/) to get
+started and then enrich your code with manual instrumentation as needed.
 
 Also, for libraries your code depends on, you don't have to write
 instrumentation code yourself, since they might come with OpenTelemetry built-in

--- a/content/en/docs/zero-code/js/_index.md
+++ b/content/en/docs/zero-code/js/_index.md
@@ -1,14 +1,14 @@
 ---
-title: Automatic Instrumentation
-linkTitle: Automatic
+title: JavaScript zero-code instrumentation
+linkTitle: JavaScript
 description:
   Capture telemetry from your application with zero source code modifications
-weight: 30
+aliases: [/docs/languages/js/automatic]
 ---
 
-Automatic instrumentation provides a way to instrument any Node.js application
-and capture telemetry data from many popular libraries and frameworks without
-any code changes.
+Zero-code instrumentation for JavaScript provides a way to instrument any
+Node.js application and capture telemetry data from many popular libraries and
+frameworks without any code changes.
 
 ## Setup
 

--- a/content/en/docs/zero-code/js/configuration.md
+++ b/content/en/docs/zero-code/js/configuration.md
@@ -1,8 +1,10 @@
 ---
-title: Automatic Instrumentation Configuration
+title: Zero-Code Instrumentation Configuration
 linkTitle: Configuration
-description: Learn how to configure Automatic Instrumentation for Node.js
-aliases: [module-config]
+description: Learn how to configure Zero-Code Instrumentation for Node.js
+aliases:
+  - /docs/languages/js/automatic/configuration
+  - /docs/languages/js/automatic/module-config]
 weight: 10
 cSpell:ignore: serviceinstance
 ---
@@ -43,7 +45,7 @@ For example, to only enable the `env` and `host` detectors, you can set:
 OTEL_NODE_RESOURCE_DETECTORS=env,host
 ```
 
-### Excluding auto-instrumentation
+### Excluding instrumentation libraries
 
 By default, all
 [supported instrumentation libraries](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/metapackages/auto-instrumentations-node/README.md#supported-instrumentations)


### PR DESCRIPTION
Contributes to #4427, such that Java is not the only language there for now. 

This PR also introduces updates for CODEOWNERS for both java and javascript