### PR TITLE
[dotnet-auto] Fix link title to .NET (menu)

### DIFF
--- a/content/en/docs/zero-code/net/_index.md
+++ b/content/en/docs/zero-code/net/_index.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Automatic Instrumentation
 description: Send traces and metrics from .NET applications and services.
-linkTitle: Automatic
+linkTitle: .NET
 cSpell:ignore: coreutils HKLM iisreset myapp
 weight: 30
 redirects: [{ from: /docs/languages/net/automatic/*, to: ':splat' }]


### PR DESCRIPTION
Follow up to #4532

Before changes
<img width="589" alt="image" src="https://github.com/open-telemetry/opentelemetry.io/assets/5972917/48aa870b-fcb0-4104-b8eb-350a81b704dd">
