### PR TITLE
Spring Boot starter: Alias fixes and partial copyedits

### DIFF
--- a/content/en/docs/zero-code/java/spring-boot-starter/_index.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/_index.md
@@ -1,10 +1,9 @@
 ---
 title: Spring Boot starter
 aliases:
-  [
-    /docs/languages/java/automatic/spring-boot/,
-    /docs/zero-code/java/spring-boot/,
-  ]
+  - /docs/languages/java/automatic/spring-boot
+  - /docs/zero-code/java/agent/spring-boot
+  - /docs/zero-code/java/spring-boot
 ---
 
 You can use two options to instrument
@@ -24,5 +23,3 @@ OpenTelemetry.
    - **Spring Boot configuration files** (`application.properties`,
      `application.yml`) to configure the OpenTelemetry Spring Boot starter which
      doesn't work with the OpenTelemetry Java agent
-
-## Use the OpenTelemetry starter

--- a/content/en/docs/zero-code/java/spring-boot-starter/additional-instrumentations.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/additional-instrumentations.md
@@ -1,14 +1,14 @@
 ---
-title: Additional instrumentations
+title: Additional instrumentation
 description:
-  Additional instrumentations in addition to the out of the box instrumentation
-  of the starter
+  Instrumentations in addition to the out of the box instrumentation of the
+  starter
 weight: 50
 ---
 
-The OpenTelemetry Spring Boot starter provides of the box
-instrumentation](../out-of-the-box-instrumentation) that you can complete with
-additional instrumentations.
+The OpenTelemetry Spring Boot starter provides
+[out of the box instrumentation](../out-of-the-box-instrumentation) that you can
+augment with additional instrumentations.
 
 ## Log4j2 Instrumentation
 
@@ -36,7 +36,7 @@ instrumentation library.
 | --------------------------------------------- | ------- | ------- | ----------------------------------------------------------------------------------------------- |
 | `otel.instrumentation.log4j-appender.enabled` | Boolean | true    | Enables the configuration of the Log4j OpenTelemetry appender with an `OpenTelemetry` instance. |
 
-## OpenTelemetry instrumentations libraries
+## Instrumentation libraries
 
-You can configure other instrumentations with
-[OpenTelemetry instrumentations libraries](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/supported-libraries.md#libraries--frameworks).
+You can configure other instrumentations using
+[OpenTelemetry instrumentation libraries](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/supported-libraries.md#libraries--frameworks).

--- a/content/en/docs/zero-code/java/spring-boot-starter/annotations.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/annotations.md
@@ -1,7 +1,6 @@
 ---
 title: Annotations
 description: Using instrumentation annotations with the Spring starter.
-aliases: [../annotations]
 weight: 60
 ---
 

--- a/content/en/docs/zero-code/java/spring-boot-starter/getting-started.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/getting-started.md
@@ -1,16 +1,14 @@
 ---
-title: Getting Started
-description: Getting Started of the OpenTelemetry starter
+title: Getting started with the Spring Boot starter
+linkTitle: Getting Started
 weight: 20
 cSpell:ignore: springboot
 ---
 
-## OpenTelemetry Spring Boot starter
-
 {{% alert title="Note" color="info" %}}
 
-You can also use the Java agent to instrument your Spring Boot application. The
-pros and cons are described in the [overview page](..).
+You can also use the [Java agent](../../agent) to instrument your Spring Boot
+application. For the pros and cons, see [Java zero-code instrumentation](..).
 
 {{% /alert %}}
 

--- a/content/en/docs/zero-code/java/spring-boot-starter/other-spring-autoconfig.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/other-spring-autoconfig.md
@@ -1,6 +1,6 @@
 ---
-title: Other Spring autoconfigurations
-description: Spring autoconfigurations without the OpenTelemetry Spring starter
+title: Other Spring autoconfiguration
+description: Spring autoconfiguration without the OpenTelemetry Spring starter
 cSpell:ignore: autoconfigurations
 weight: 70
 ---
@@ -26,9 +26,9 @@ public class OpenTelemetryConfig {}
 ## Zipkin starter
 
 OpenTelemetry Zipkin Exporter Starter is a starter package that includes the
-opentelemetry-api, opentelemetry-sdk, opentelemetry-extension-annotations,
-opentelemetry-logging-exporter, opentelemetry-spring-boot-autoconfigurations and
-spring framework starters required to setup distributed tracing. It also
+`opentelemetry-api`, `opentelemetry-sdk`, `opentelemetry-extension-annotations`,
+`opentelemetry-logging-exporter`, `opentelemetry-spring-boot-autoconfigurations`
+and spring framework starters required to setup distributed tracing. It also
 provides the
 [opentelemetry-exporters-zipkin](https://github.com/open-telemetry/opentelemetry-java/tree/main/exporters/zipkin)
 artifact and corresponding exporter autoconfiguration. Check out

--- a/content/en/docs/zero-code/java/spring-boot-starter/out-of-the-box-instrumentation.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/out-of-the-box-instrumentation.md
@@ -1,7 +1,6 @@
 ---
 title: Out of the box instrumentation
 description: Out of the box instrumentation for the starter
-aliases: [../annotations]
 weight: 40
 cSpell:ignore: autoconfigurations autoconfigures logback webflux webmvc
 ---


### PR DESCRIPTION
- Followup to #4554
- Adds missing alias
- Removes unnecessary aliases
- Includes some copyedits for #4554. I have more copyedits to make but decided to stop so that we can land the alias fixes ASAP
- Closes #4562 by superseding it

**Preview**: https://deploy-preview-4563--opentelemetry.netlify.app/docs/zero-code/java/spring-boot-starter/

**Redirect tests**:

- https://deploy-preview-4563--opentelemetry.netlify.app/docs/instrumentation/java/automatic/spring-boot/
  This confirms the fix for the link failure reported in https://github.com/open-telemetry/opentelemetry-java-examples/actions/runs/9242715195/job/25527124585?pr=416. /cc @zeitlinger 
- https://deploy-preview-4563--opentelemetry.netlify.app/docs/languages/java/automatic/spring-boot/
- https://deploy-preview-4563--opentelemetry.netlify.app/docs/zero-code/java/spring-boot

/cc @jeanbisutti 