### PR TITLE
[IA] Zero-code Java Agent: canonicalize links + copyedits

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -72,6 +72,3 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - ^https://wikipedia.org/wiki/(S.M.A.R.T|Hop_)
   # TODO move into content/en/blog/2023/contributing-to-otel/index.md once https://github.com/open-telemetry/opentelemetry.io/issues/3889 is implemented
   - ^https://shorturl.at/vLYZ0$
-  # FIXME(@chalin) drop this temporary rule
-  - ^/docs/languages/java/automatic
-  - ^\.\./automatic

--- a/content/en/blog/2022/debug-otel-with-otel/index.md
+++ b/content/en/blog/2022/debug-otel-with-otel/index.md
@@ -260,5 +260,5 @@ COPY opentelemetry_module.conf /etc/nginx/conf.d
 [v1.0.1 release of the otel-webserver-module]:
   https://github.com/open-telemetry/opentelemetry-cpp-contrib/releases/tag/webserver%2Fv1.0.1
 [java]:
-  /docs/languages/java/automatic/configuration/#capturing-http-request-and-response-headers
+  /docs/zero-code/java/agent/configuration/#capturing-http-request-and-response-headers
 [python]: /docs/languages/python/automatic/

--- a/content/en/blog/2023/spring-native/index.md
+++ b/content/en/blog/2023/spring-native/index.md
@@ -7,8 +7,8 @@ author: >-
 cSpell:ignore: bisutti datasource logback
 ---
 
-The [OpenTelemetry Java agent](/docs/languages/java/automatic) is a convenient
-and well-established way to instrument Java applications. However, as of today
+The [OpenTelemetry Java agent](/docs/zero-code/java/agent/) is a convenient and
+well-established way to instrument Java applications. However, as of today
 [it is not possible to use it with GraalVM Native Images](https://github.com/oracle/graal/issues/1065).
 
 To provide you with an easy and seamless way for Spring Boot Native Image
@@ -53,8 +53,8 @@ spring.datasource.url=jdbc:otel:h2:mem:db
 spring.datasource.driver-class-name=io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver
 ```
 
-Read the [documentation](/docs/languages/java/automatic/spring-boot/) of the
-OpenTelemetry Spring Boot Starter to learn more. You can use
+To learn more, see
+[Spring Boot Starter](/docs/zero-code/java/spring-boot-starter/). You can use
 [opentelemetry-java-examples/spring-native](https://github.com/open-telemetry/opentelemetry-java-examples/tree/main/spring-native)
 to run a Spring Boot Native Image application and look at the generated logs as
 well as HTTP and database telemetry data.

--- a/content/en/docs/faas/lambda-auto-instrument.md
+++ b/content/en/docs/faas/lambda-auto-instrument.md
@@ -56,7 +56,7 @@ variables:
   instrumentations, see [Suppressing specific agent instrumentation][1].
 
   [1]:
-    /docs/languages/java/automatic/configuration/#suppressing-specific-agent-instrumentation
+    /docs/zero-code/java/agent/configuration/#suppressing-specific-agent-instrumentation
 
 For example, to only enable auto-instrumentation for Lambda and the AWS SDK, you
 would set the following environment variables:

--- a/content/en/docs/kubernetes/operator/automatic.md
+++ b/content/en/docs/kubernetes/operator/automatic.md
@@ -212,7 +212,7 @@ Therefore, the example uses `http://demo-collector:4318`, which connects to the
 #### Excluding auto-instrumentation {#java-excluding-auto-instrumentation}
 
 By default, the Java auto-instrumentation ships with
-[many instrumentation libraries](/docs/languages/java/automatic/#supported-libraries-frameworks-application-services-and-jvms).
+[many instrumentation libraries](/docs/zero-code/java/agent/#supported-libraries-frameworks-application-services-and-jvms).
 This makes instrumentation easy, but could result in too much or unwanted data.
 If there are any libraries you do not want to use you can set the
 `OTEL_INSTRUMENTATION_[NAME]_ENABLED=false` where `[NAME]` is the name of the
@@ -221,7 +221,7 @@ the default libraries by setting
 `OTEL_INSTRUMENTATION_COMMON_DEFAULT_ENABLED=false` and then use
 `OTEL_INSTRUMENTATION_[NAME]_ENABLED=true` where `[NAME]` is the name of the
 library. For more details, see
-[Suppressing specific auto-instrumentation](/docs/languages/java/automatic/configuration/#suppressing-specific-auto-instrumentation).
+[Suppressing specific instrumentation](/docs/zero-code/java/agent/configuration/#suppressing-specific-instrumentation).
 
 ```yaml
 apiVersion: opentelemetry.io/v1alpha1
@@ -248,7 +248,7 @@ spec:
 #### Learn more {#java-learn-more}
 
 For more details, see
-[Java agent Configuration](/docs/languages/java/automatic/configuration/).
+[Java agent Configuration](/docs/zero-code/java/agent/configuration/).
 
 ### Node.js
 

--- a/content/en/docs/languages/java/getting-started.md
+++ b/content/en/docs/languages/java/getting-started.md
@@ -121,9 +121,9 @@ java -jar ./build/libs/java-simple.jar
 
 ## Instrumentation
 
-Next, you'll use a [Java agent to automatically instrument](../automatic) the
-application at launch time. While you can [configure the Java agent][] in a
-number of ways, the steps below use environment variables.
+Next, you'll use a [Java agent](/docs/zero-code/java/agent/) to automatically
+instrument the application at launch time. While you can [configure the Java
+agent][] in a number of ways, the steps below use environment variables.
 
 1. Download [opentelemetry-javaagent.jar][] from [Releases][] of the
    `opentelemetry-java-instrumentation` repository. The JAR file contains the
@@ -237,7 +237,8 @@ value=8192, exemplars=[]}], monotonic=false, aggregationTemporality=CUMULATIVE}}
 For more:
 
 - Run this example with another [exporter][] for telemetry data.
-- Try [automatic instrumentation](../automatic/) on one of your own apps.
+- Try [zero-code instrumentation](/docs/zero-code/java/agent/) on one of your
+  own apps.
 - For light-weight customized telemetry, try [annotations][].
 - Learn about [manual instrumentation][] and try out more
   [examples](/docs/languages/java/examples/).
@@ -248,8 +249,8 @@ For more:
 [traces]: /docs/concepts/signals/traces/
 [metrics]: /docs/concepts/signals/metrics/
 [logs]: /docs/concepts/signals/logs/
-[annotations]: ../automatic/annotations/
-[configure the java agent]: ../automatic/#configuring-the-agent
+[annotations]: /docs/zero-code/java/agent/annotations/
+[configure the java agent]: /docs/zero-code/java/agent/#configuring-the-agent
 [console exporter]:
   https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#logging-exporter
 [exporter]:

--- a/content/en/docs/languages/java/instrumentation.md
+++ b/content/en/docs/languages/java/instrumentation.md
@@ -19,9 +19,8 @@ cSpell:ignore: Autowired customizer logback loggable multivalued rolldice spring
 
 On this page you will learn how you can add traces, metrics and logs to your
 code _manually_. But, you are not limited to only use one kind of
-instrumentation: use
-[automatic instrumentation](/docs/languages/java/automatic/) to get started and
-then enrich your code with manual instrumentation as needed.
+instrumentation: use [zero-code instrumentation](/docs/zero-code/java/agent/) to
+get started and then enrich your code with manual instrumentation as needed.
 
 Note, that especially if you cannot modify the source code of your app, you can
 skip manual instrumentation and only use automatic instrumentation.

--- a/content/en/docs/languages/java/libraries.md
+++ b/content/en/docs/languages/java/libraries.md
@@ -16,7 +16,7 @@ in order to generate telemetry data for a library or framework.
 The Java agent for automatic instrumentation includes instrumentation libraries
 for many common Java frameworks. Most are turned on by default. If you need to
 turn off certain instrumentation libraries, you can
-[suppress them](../automatic/configuration/#suppressing-specific-auto-instrumentation).
+[suppress them](/docs/zero-code/java/agent/configuration/#suppressing-specific-instrumentation).
 
 If you use [code-based instrumentation](../instrumentation), you can leverage
 some instrumentation libraries for your dependencies standalone. To find out
@@ -184,8 +184,7 @@ You might also want to configure an appropriate exporter to
 [export your telemetry data](/docs/languages/java/exporters) to one or more
 telemetry backends.
 
-You can also check the
-[automatic instrumentation for Java](/docs/languages/java/automatic) for
-existing library instrumentations.
+For existing library instrumentations, also see
+[Java agent](/docs/zero-code/java/agent/).
 
 [opentelemetry-java](https://github.com/open-telemetry/opentelemetry-java)

--- a/content/en/docs/languages/java/resources.md
+++ b/content/en/docs/languages/java/resources.md
@@ -7,9 +7,9 @@ cSpell:ignore: getenv myhost SIGINT uuidgen WORKDIR
 {{% docs/languages/resources-intro %}}
 
 If you use the Java agent for
-[automatic instrumentation](/docs/languages/java/automatic) you can learn how to
-setup resource detection following the
-[Agent Configuration Guide](/docs/languages/java/automatic/configuration).
+[zero-code instrumentation](/docs/zero-code/java/agent/) you can setup resource
+detection through
+[agent configuration](/docs/zero-code/java/agent/configuration).
 
 For manual instrumentation, you will find some introductions on how to set up
 resource detection below.

--- a/content/en/docs/zero-code/java/agent/configuration.md
+++ b/content/en/docs/zero-code/java/agent/configuration.md
@@ -308,7 +308,7 @@ default=SCOPE_
 %}} Prefix of granted authorities identifying scopes to capture in the `enduser.scopes`
 semantic attribute. {{% /config_option %}}
 
-## Suppressing specific auto-instrumentation
+## Suppressing specific instrumentation
 
 ### Disabling the agent entirely
 

--- a/content/en/docs/zero-code/java/spring-boot-starter/sdk-configuration.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/sdk-configuration.md
@@ -13,7 +13,7 @@ IDE.
 ## General configuration
 
 The OpenTelemetry Starter supports all the
-[SDK Autoconfiguration](/docs/languages/java/automatic/configuration/#sdk-autoconfiguration)
+[SDK Autoconfiguration](/docs/zero-code/java/agent/configuration/#sdk-autoconfiguration)
 (since 2.2.0).
 
 You can update the configuration with properties in the `application.properties`
@@ -189,7 +189,7 @@ The OpenTelemetry Starter includes the same resource providers as the Java
 agent:
 
 - [Common resource providers](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/resources/library)
-- [Resource providers that are disabled by default](/docs/languages/java/automatic/configuration/#enable-resource-providers-that-are-disabled-by-default)
+- [Resource providers that are disabled by default](/docs/zero-code/java/agent/configuration/#enable-resource-providers-that-are-disabled-by-default)
 
 In addition, the OpenTelemetry Starter includes the following Spring Boot
 specific resource providers:


### PR DESCRIPTION
- Contributes to #4428
- Drops temporary link-checker ignore rules
- Canonicalizes links to the Java agent pages
- Copyedits to cope with the switch from "automatic" to "zero-code"