### PR TITLE
[Java agent] Use absolute alias paths matching original

### DIFF
--- a/content/en/docs/zero-code/java/agent/annotations.md
+++ b/content/en/docs/zero-code/java/agent/annotations.md
@@ -1,7 +1,7 @@
 ---
 title: Annotations
 description: Using instrumentation annotations with a Java agent.
-aliases: [../annotations]
+aliases: [/docs/instrumentation/java/annotations]
 weight: 20
 cSpell:ignore: Flowable javac reactivestreams reactivex
 ---

--- a/content/en/docs/zero-code/java/agent/extensions.md
+++ b/content/en/docs/zero-code/java/agent/extensions.md
@@ -1,7 +1,7 @@
 ---
 title: Extensions
-aliases: [../extensions]
-description: >-
+aliases: [/docs/instrumentation/java/extensions]
+description:
   Extensions add capabilities to the agent without having to create a separate
   distribution.
 weight: 30


### PR DESCRIPTION
- Contributes to #4428
- When the `languages/java/automatic` pages were moved, the page-relative aliases should have been made absolute. This PR addresses this need.
- Absolute paths used in this PR were recovered from:
  - #1232
  - https://github.com/open-telemetry/opentelemetry.io/commit/7f46ec2d7d04170d9aeaa8e2f5ec93408aee2ea5