### PR TITLE
[CI] [Java agent] Ensure pkg versions get updated under zero-code

### DIFF
--- a/.github/workflows/auto-update-versions.yml
+++ b/.github/workflows/auto-update-versions.yml
@@ -15,8 +15,7 @@ jobs:
       DEPTH: --depth 500 # submodule clone depth
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Use CLA approved github bot
         run: |

--- a/content/en/docs/zero-code/java/_index.md
+++ b/content/en/docs/zero-code/java/_index.md
@@ -4,12 +4,10 @@ linkTitle: Java
 aliases:
   - /docs/java/automatic_instrumentation
   - /docs/languages/java/automatic_instrumentation
-# FIXME: ensure version update script targets this file too
 cascade:
   vers:
     instrumentation: 2.4.0
     otel: 1.38.0
-cSpell:ignore: Dotel myapp
 ---
 
 Zero-code instrumentation with Java uses a Java agent JAR or Spring Boot

--- a/scripts/auto-update/all-versions.sh
+++ b/scripts/auto-update/all-versions.sh
@@ -5,7 +5,9 @@ function auto_update_versions() {
   local updates=(
       "opentelemetry-collector-releases vers content/en/docs/collector/_index.md"
       "opentelemetry-java otel content/en/docs/languages/java/_index.md"
+      "opentelemetry-java otel content/en/docs/zero-code/java/_index.md"
       "opentelemetry-java-instrumentation instrumentation content/en/docs/languages/java/_index.md"
+      "opentelemetry-java-instrumentation instrumentation content/en/docs/zero-code/java/_index.md"
       "opentelemetry-specification spec scripts/content-modules/adjust-pages.pl .gitmodules"
       "opentelemetry-proto otlp scripts/content-modules/adjust-pages.pl .gitmodules"
       "semantic-conventions semconv scripts/content-modules/adjust-pages.pl .gitmodules"


### PR DESCRIPTION
- Contributes to #4428
- Ensures that all package `vers` entries get auto-updated for `content/en/docs/zero-code/java/_index.md`
- Cleans up `.github/workflows/auto-update-versions.yml`
- I tested this locally