### PR TITLE
[Zero-code .NET] Fix page-relative alias path following move to zero-code section

### DIFF
--- a/content/en/docs/zero-code/net/_index.md
+++ b/content/en/docs/zero-code/net/_index.md
@@ -1,5 +1,5 @@
 ---
-title: .NET Automatic Instrumentation
+title: .NET zero-code instrumentation
 description: Send traces and metrics from .NET applications and services.
 linkTitle: .NET
 cSpell:ignore: coreutils HKLM iisreset myapp

--- a/content/en/docs/zero-code/net/configuration.md
+++ b/content/en/docs/zero-code/net/configuration.md
@@ -1,10 +1,10 @@
 ---
 title: Configuration and settings
 linkTitle: Configuration
-weight: 20
-aliases: [config]
+aliases: [/docs/languages/net/automatic/config]
 # prettier-ignore
 cSpell:ignore: AZUREAPPSERVICE Bitness CLSID CORECLR dylib NETFX PROCESSRUNTIME UNHANDLEDEXCEPTION
+weight: 20
 ---
 
 ## Configuration methods


### PR DESCRIPTION
- Contributes to #4427
- This PR is like #4568 but for .NET
- Adjusts .NET zero-code page title to use "zero-code" rather than "automatic"