### PR TITLE
Alias fix for zero-code JS

### DIFF
--- a/content/en/docs/zero-code/js/configuration.md
+++ b/content/en/docs/zero-code/js/configuration.md
@@ -4,7 +4,7 @@ linkTitle: Configuration
 description: Learn how to configure Zero-Code Instrumentation for Node.js
 aliases:
   - /docs/languages/js/automatic/configuration
-  - /docs/languages/js/automatic/module-config]
+  - /docs/languages/js/automatic/module-config
 weight: 10
 cSpell:ignore: serviceinstance
 ---


### PR DESCRIPTION
- Contributes to #4427
- Follow up to #4527
- Fixes typo in alias