### PR TITLE
[i18n] Docs section ordering fix

### DIFF
--- a/content/en/docs/collector/_index.md
+++ b/content/en/docs/collector/_index.md
@@ -4,7 +4,7 @@ description: Vendor-agnostic way to receive, process and export telemetry data.
 aliases: [collector/about]
 cascade:
   vers: 0.101.0
-weight: 10
+weight: 270
 ---
 
 ![OpenTelemetry Collector diagram with Jaeger, OTLP and Prometheus integration](img/otel-collector.svg)

--- a/content/en/docs/concepts/_index.md
+++ b/content/en/docs/concepts/_index.md
@@ -3,7 +3,7 @@ title: OpenTelemetry Concepts
 linkTitle: Concepts
 description: Key concepts in OpenTelemetry
 aliases: [concepts/overview]
-weight: 2
+weight: 170
 ---
 
 This section covers data sources and key components of the OpenTelemetry

--- a/content/en/docs/contributing/_index.md
+++ b/content/en/docs/contributing/_index.md
@@ -2,7 +2,7 @@
 title: Contributing
 description: Learn how to contribute to OpenTelemetry documentation.
 aliases: [/docs/contribution-guidelines]
-weight: 200
+weight: 980
 cSpell:ignore: prepopulated spacewhite
 ---
 

--- a/content/en/docs/demo/_index.md
+++ b/content/en/docs/demo/_index.md
@@ -3,7 +3,7 @@ title: OpenTelemetry Demo Documentation
 linkTitle: Demo
 cascade:
   repo: https://github.com/open-telemetry/opentelemetry-demo
-weight: 2
+weight: 180
 cSpell:ignore: OLJCESPC
 ---
 

--- a/content/en/docs/faas/_index.md
+++ b/content/en/docs/faas/_index.md
@@ -4,7 +4,7 @@ linkTitle: FaaS
 description: >-
   OpenTelemetry supports various methods of monitoring Function-as-a-Service
   provided by different cloud vendors
-weight: 12
+weight: 360
 ---
 
 Functions as a Service (FaaS) is an important serverless compute platform for

--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -2,7 +2,7 @@
 title: Getting Started
 description: Get started with OpenTelemetry based on your role.
 no_list: true
-weight: 1
+weight: 160
 ---
 
 Select a role[^1] to get started:

--- a/content/en/docs/kubernetes/_index.md
+++ b/content/en/docs/kubernetes/_index.md
@@ -1,7 +1,7 @@
 ---
 title: OpenTelemetry with Kubernetes
 linkTitle: Kubernetes
-weight: 11
+weight: 350
 description: Using OpenTelemetry with Kubernetes
 ---
 

--- a/content/en/docs/languages/_index.md
+++ b/content/en/docs/languages/_index.md
@@ -1,9 +1,9 @@
 ---
 title: Language APIs & SDKs
-description: >-
+description:
   OpenTelemetry code instrumentation is supported for many popular programming
   languages
-weight: 2
+weight: 250
 aliases: [/docs/instrumentation]
 redirects: [{ from: /docs/instrumentation/*, to: ':splat' }]
 ---

--- a/content/en/docs/migration/_index.md
+++ b/content/en/docs/migration/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Migration
 description: How to migrate to OpenTelemetry
-weight: 50
+weight: 950
 ---
 
 ## OpenTracing and OpenCensus

--- a/content/en/docs/security/_index.md
+++ b/content/en/docs/security/_index.md
@@ -1,4 +1,4 @@
 ---
 title: Security
-weight: 150
+weight: 970
 ---

--- a/content/en/docs/specs/_index.md
+++ b/content/en/docs/specs/_index.md
@@ -2,7 +2,7 @@
 title: Specifications
 linkTitle: Specs
 aliases: [reference, specification]
-weight: 100
+weight: 960
 # Temporary redirect rules until they are added to the spec pages
 redirects:
   # OTel spec

--- a/content/en/docs/what-is-opentelemetry.md
+++ b/content/en/docs/what-is-opentelemetry.md
@@ -2,7 +2,7 @@
 title: What is OpenTelemetry?
 description: A short explanation of what OpenTelemetry is and isn't.
 aliases: [/about, /docs/concepts/what-is-opentelemetry, /otel]
-weight: -1
+weight: 150
 ---
 
 OpenTelemetry is an

--- a/content/en/docs/zero-code/_index.md
+++ b/content/en/docs/zero-code/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Zero-code Instrumentation
-weight: 2
+weight: 260
 cSpell:ignore: pageinfo
 ---
 

--- a/content/zh/docs/concepts/_index.md
+++ b/content/zh/docs/concepts/_index.md
@@ -1,9 +1,9 @@
 ---
-title: OpenTelemetry 概念 
+title: OpenTelemetry 概念
 linkTitle: 概念
 description: OpenTelemetry 核心概念
 aliases: [concepts/overview]
-weight: 2
+weight: 170
 ---
 
 在本节中，你将了解 OpenTelemetry 项目的数据来源和关键组件。

--- a/content/zh/docs/what-is-opentelemetry.md
+++ b/content/zh/docs/what-is-opentelemetry.md
@@ -1,7 +1,7 @@
 ---
 title: 什么是 OpenTelemetry？
 description: 简短说明 OpenTelemetry 是什么，不是什么。
-weight: -1
+weight: 150
 ---
 
 OpenTelemetry


### PR DESCRIPTION
- Contributes to #4467
- Fixes the order of `zh` top-level sections
  - Fixes #4572 -- see screenshots below
- Redistributes the weights of the top-level `docs` sections, without changing the order of `en` pages.
  Here's proof that the order of pages under `en` hasn't changed:
  ```console
  $ (cd public && git diff -bw --ignore-blank-lines) | grep ^diff | grep -v zh
  diff --git a/_redirects b/_redirects
  diff --git a/en/sitemap.xml b/en/sitemap.xml
  diff --git a/site/index.html b/site/index.html
  ```

**Preview**:

- https://deploy-preview-4573--opentelemetry.netlify.app/docs
- https://deploy-preview-4573--opentelemetry.netlify.app/zh/docs/


### Screenshots

| Before | After |
|--------|--------|
| <img width="319" alt="image" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/c92c308e-d946-44b6-8946-6e0ec8f53889"> | <img width="293" alt="image" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/9475fbfd-b2a1-46ef-97d5-3471c992e309"> | 