### PR TITLE
CODEOWNERS: sort entries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,26 +24,25 @@ content-modules/semantic-conventions     @open-telemetry/docs-maintainers @open-
 content/en/blog/                         @open-telemetry/docs-maintainers
 content/en/community/end-user/           @open-telemetry/docs-approvers @open-telemetry/sig-end-user-approvers
 content/en/docs/collector                @open-telemetry/docs-approvers @open-telemetry/collector-approvers
+content/en/docs/contributing/            @open-telemetry/docs-approvers @open-telemetry/docs-maintainers
 content/en/docs/demo                     @open-telemetry/docs-approvers @open-telemetry/demo-approvers
-content/en/docs/languages/cpp/     @open-telemetry/docs-approvers @open-telemetry/cpp-approvers
-content/en/docs/languages/erlang/  @open-telemetry/docs-approvers @open-telemetry/erlang-approvers
-content/en/docs/languages/go/      @open-telemetry/docs-approvers @open-telemetry/go-approvers @open-telemetry/go-instrumentation-approvers
-content/en/docs/languages/java/    @open-telemetry/docs-approvers @open-telemetry/java-approvers @open-telemetry/java-instrumentation-approvers
-content/en/docs/languages/js/      @open-telemetry/docs-approvers @open-telemetry/javascript-approvers
-content/en/docs/languages/net/     @open-telemetry/docs-approvers @open-telemetry/dotnet-approvers @open-telemetry/dotnet-instrumentation-approvers
-content/en/docs/languages/php/     @open-telemetry/docs-approvers @open-telemetry/php-approvers
-content/en/docs/languages/python/  @open-telemetry/docs-approvers @open-telemetry/python-approvers
-content/en/docs/languages/ruby/    @open-telemetry/docs-approvers @open-telemetry/ruby-approvers @open-telemetry/ruby-contrib-approvers
-content/en/docs/languages/rust/    @open-telemetry/docs-approvers @open-telemetry/rust-approvers
-content/en/docs/languages/swift/   @open-telemetry/docs-approvers @open-telemetry/swift-approvers
-content/en/docs/kubernetes/operator/     @open-telemetry/docs-approvers @open-telemetry/operator-approvers
 content/en/docs/kubernetes/helm/         @open-telemetry/docs-approvers @open-telemetry/helm-approvers
-content/en/docs/specs/                   @open-telemetry/docs-approvers @open-telemetry/specs-approvers
+content/en/docs/kubernetes/operator/     @open-telemetry/docs-approvers @open-telemetry/operator-approvers
+content/en/docs/languages/cpp/           @open-telemetry/docs-approvers @open-telemetry/cpp-approvers
+content/en/docs/languages/erlang/        @open-telemetry/docs-approvers @open-telemetry/erlang-approvers
+content/en/docs/languages/go/            @open-telemetry/docs-approvers @open-telemetry/go-approvers @open-telemetry/go-instrumentation-approvers
+content/en/docs/languages/java/          @open-telemetry/docs-approvers @open-telemetry/java-approvers @open-telemetry/java-instrumentation-approvers
+content/en/docs/languages/js/            @open-telemetry/docs-approvers @open-telemetry/javascript-approvers
+content/en/docs/languages/net/           @open-telemetry/docs-approvers @open-telemetry/dotnet-approvers @open-telemetry/dotnet-instrumentation-approvers
+content/en/docs/languages/php/           @open-telemetry/docs-approvers @open-telemetry/php-approvers
+content/en/docs/languages/python/        @open-telemetry/docs-approvers @open-telemetry/python-approvers
+content/en/docs/languages/ruby/          @open-telemetry/docs-approvers @open-telemetry/ruby-approvers @open-telemetry/ruby-contrib-approvers
+content/en/docs/languages/rust/          @open-telemetry/docs-approvers @open-telemetry/rust-approvers
+content/en/docs/languages/swift/         @open-telemetry/docs-approvers @open-telemetry/swift-approvers
 content/en/docs/security/                @open-telemetry/docs-approvers @open-telemetry/sig-security-maintainers
+content/en/docs/specs/                   @open-telemetry/docs-approvers @open-telemetry/specs-approvers
+content/en/docs/zero-code/java/          @open-telemetry/docs-approvers @open-telemetry/java-approvers @open-telemetry/java-instrumentation-approvers
+content/en/docs/zero-code/js/            @open-telemetry/docs-approvers @open-telemetry/javascript-approvers
+content/en/docs/zero-code/net/           @open-telemetry/docs-approvers @open-telemetry/dotnet-approvers @open-telemetry/dotnet-instrumentation-approvers
 content/en/ecosystem/demo/               @open-telemetry/demo-approvers @open-telemetry/demo-approvers
-content/en/docs/contributing/       @open-telemetry/docs-approvers @open-telemetry/docs-maintainers
-content/zh/                         @open-telemetry/docs-zh-approvers
-content/en/docs/zero-code/java/    @open-telemetry/docs-approvers @open-telemetry/java-approvers @open-telemetry/java-instrumentation-approvers
-content/en/docs/zero-code/js/      @open-telemetry/docs-approvers @open-telemetry/javascript-approvers
-content/en/docs/zero-code/net/      @open-telemetry/docs-approvers @open-telemetry/dotnet-approvers @open-telemetry/dotnet-instrumentation-approvers
-
+content/zh/                              @open-telemetry/docs-zh-approvers


### PR DESCRIPTION
- Followup to changes made in #4527
- Sorts the `content` entries, in particular so as to not start mixing `en` and `zh` entries
- Fixes indentation
- No other changes