### PR TITLE
Update Go logs status to beta

### DIFF
--- a/data/instrumentation.yaml
+++ b/data/instrumentation.yaml
@@ -26,7 +26,7 @@ go:
   status:
     traces: stable
     metrics: stable
-    logs: alpha
+    logs: beta
 java:
   name: Java
   status:


### PR DESCRIPTION
OTel Go Logs are already beta since https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.27.0