### PR TITLE
[zh] Strip away embedded HTML en fragments

### DIFF
--- a/content/zh/docs/concepts/semantic-conventions.md
+++ b/content/zh/docs/concepts/semantic-conventions.md
@@ -4,35 +4,12 @@ description: 不同类型的操作和数据的通用名称。
 weight: 30
 ---
 
-<!--
----
-title: Semantic Conventions
-description: Common names for different kinds of operations and data.
-weight: 30
----
--->
-
-<!--
-OpenTelemetry defines [Semantic Conventions](/docs/specs/semconv/) (sometimes
-called Semantic Attributes) that specify common names for different kinds of
-operations and data. The benefit of using Semantic Conventions is in following a
-common naming scheme that can be standardized across a codebase, libraries, and
-platforms.
-
-Semantic Conventions are available for traces, metrics, logs, and resources:
--->
 OpenTelemetry 定义了[语义约定](/docs/specs/semconv/)，
 为不同类型的操作和数据指定通用名称。
 使用语义约定的好处是遵循通用的命名方案，可以在代码库、库和平台之间实现标准化。
 
 语义约定适用于链路追踪、指标、日志和资源：
 
-<!--
-- [Trace Semantic Conventions](/docs/specs/semconv/general/trace/)
-- [Metric Semantic Conventions](/docs/specs/semconv/general/metrics/)
-- [Log Semantic Conventions](/docs/specs/semconv/general/logs/)
-- [Resource Semantic Conventions](/docs/specs/semconv/resource/)
--->
 - [链路追踪语义约定](/docs/specs/semconv/general/trace/)
 - [指标语义约定](/docs/specs/semconv/general/metrics/)
 - [日志语义约定](/docs/specs/semconv/general/logs/)

--- a/content/zh/docs/demo/_index.md
+++ b/content/zh/docs/demo/_index.md
@@ -7,30 +7,9 @@ weight: 2
 cSpell:ignore: OLJCESPC
 ---
 
-<!--
----
-title: OpenTelemetry Demo Documentation
-linkTitle: Demo
-cascade:
-  repo: https://github.com/open-telemetry/opentelemetry-demo
-weight: 2
-cSpell:ignore: OLJCESPC
----
--->
-
-<!--
-Welcome to the [OpenTelemetry Demo](/ecosystem/demo/) documentation, which
-covers how to install and run the demo, and some scenarios you can use to view
-OpenTelemetry in action.
--->
 欢迎使用 [OpenTelemetry 演示](/ecosystem/demo/)文档，
 此文档介绍了如何安装和运行演示，以及一些可用来查看 OpenTelemetry 实际运行情况的场景。
 
-<!--
-## Running the Demo
-
-Want to deploy the demo and see it in action? Start here.
--->
 ## 运行演示
 
 想要部署演示并查看其实际效果吗？从这里开始：
@@ -38,30 +17,10 @@ Want to deploy the demo and see it in action? Start here.
 - [Docker](docker-deployment/)
 - [Kubernetes](kubernetes-deployment/)
 
-<!--
-## Language Feature Reference
-
-Want to understand how a particular language's instrumentation works? Start
-here.
--->
 ## 语言特性参考
 
 想要了解特定编程语言的工具是如何工作的？从这里开始：
 
-<!--
-| Language   | Automatic Instrumentation                          | Instrumentation Libraries                                                                                                                | Manual Instrumentation                                                                       |
-| ---------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| .NET       |                                                    | [Cart Service](services/cart/)                                                                                                           | [Cart Service](services/cart/)                                                               |
-| C++        |                                                    |                                                                                                                                          | [Currency Service](services/currency/)                                                       |
-| Go         |                                                    | [Accounting Service](services/accounting/), [Checkout Service](services/checkout/), [Product Catalog Service](services/product-catalog/) | [Checkout Service](services/checkout/), [Product Catalog Service](services/product-catalog/) |
-| Java       | [Ad Service](services/ad/)                         |                                                                                                                                          | [Ad Service](services/ad/)                                                                   |
-| JavaScript |                                                    | [Frontend](services/frontend/)                                                                                                           | [Frontend](services/frontend/), [Payment Service](services/payment/)                         |
-| Kotlin     |                                                    | [Fraud Detection Service](services/fraud-detection/)                                                                                     |                                                                                              |
-| PHP        |                                                    | [Quote Service](services/quote/)                                                                                                         | [Quote Service](services/quote/)                                                             |
-| Python     | [Recommendation Service](services/recommendation/) |                                                                                                                                          | [Recommendation Service](services/recommendation/)                                           |
-| Ruby       |                                                    | [Email Service](services/email/)                                                                                                         | [Email Service](services/email/)                                                             |
-| Rust       |                                                    | [Shipping Service](services/shipping/)                                                                                                   | [Shipping Service](services/shipping/)                                                       |
--->
 | 语言        | 自动插桩            | 插桩库                 | 手动插桩                              |
 | ---------- | ------------------- | -------------------- | ------------------------------------ |
 | .NET       |                                                    | [购物车服务](services/cart/)                                                                                                              | [购物车服务](services/cart/)                                                                    |
@@ -75,30 +34,10 @@ here.
 | Ruby       |                                                    | [电子邮件服务](services/email/)                                                                                                            | [电子邮件服务](services/email/)                                                             |
 | Rust       |                                                    | [发货服务](services/shipping/)                                                                                                            | [发货服务](services/shipping/)                                                       |
 
-<!--
-## Service Documentation
-
-Specific information about how OpenTelemetry is deployed in each service can be
-found here:
--->
 ## 服务文档
 
 有关如何在每个服务中部署 OpenTelemetry 的具体信息可以在此处找到：
 
-<!--
-- [Ad Service](services/ad/)
-- [Cart Service](services/cart/)
-- [Checkout Service](services/checkout/)
-- [Email Service](services/email/)
-- [Frontend](services/frontend/)
-- [Load Generator](services/load-generator/)
-- [Payment Service](services/payment/)
-- [Product Catalog Service](services/product-catalog/)
-- [Quote Service](services/quote/)
-- [Recommendation Service](services/recommendation/)
-- [Shipping Service](services/shipping/)
-- [Image Provider Service](services/imageprovider/)
--->
 - [广告服务](services/ad/)
 - [购物车服务](services/cart/)
 - [结账服务](services/checkout/)
@@ -112,20 +51,6 @@ found here:
 - [发货服务](services/shipping/)
 - [图片提供商服务](services/imageprovider/)
 
-<!--
-## Scenarios
-
-How can you solve problems with OpenTelemetry? These scenarios walk you through
-some pre-configured problems and show you how to interpret OpenTelemetry data to
-solve them.
-
-We'll be adding more scenarios over time.
-
-- Generate a [Product Catalog error](feature-flags) for `GetProduct` requests
-  with product id: `OLJCESPC7Z` using the Feature Flag service
-- Discover a memory leak and diagnose it using metrics and traces.
-  [Read more](scenarios/recommendation-cache/)
--->
 ## 应用场景
 
 如何使用 OpenTelemetry 解决问题？这些场景将引导你解决一些预先配置的问题，
@@ -136,22 +61,6 @@ We'll be adding more scenarios over time.
 - 使用功能标志服务为产品 ID 为 `OLJCESPC7Z` 的 `GetProduct` 请求生成[产品目录错误](feature-flags)
 - 发现内存泄漏并使用指标和追踪对其进行诊断，[阅读更多](scenarios/recommendation-cache/)
 
-<!--
-## Reference
-
-Project reference documentation, like requirements and feature matrices.
-
-- [Architecture](architecture/)
-- [Development](development/)
-- [Feature Flags Reference](feature-flags/)
-- [Metric Feature Matrix](telemetry-features/metric-coverage/)
-- [Requirements](./requirements/)
-- [Screenshots](screenshots/)
-- [Services](services/)
-- [Span Attributes Reference](telemetry-features/manual-span-attributes/)
-- [Tests](tests/)
-- [Trace Feature Matrix](telemetry-features/trace-coverage/)
--->
 ## 参考
 
 项目参考文档，例如需求和功能矩阵：

--- a/content/zh/docs/kubernetes/_index.md
+++ b/content/zh/docs/kubernetes/_index.md
@@ -5,24 +5,6 @@ weight: 11
 description: Using OpenTelemetry with Kubernetes
 ---
 
-<!--
----
-title: OpenTelemetry with Kubernetes
-linkTitle: Kubernetes
-weight: 11
-description: Using OpenTelemetry with Kubernetes
----
--->
-
-<!--
-## Introduction
-
-[Kubernetes](https://kubernetes.io/) is an open source system for automating
-deployment, scaling, and management of containerized applications. It has become
-a widely-adopted, industry tool, leading to an increased need for observability
-tooling. In response, OpenTelemetry has created many different tools to help
-Kubernetes users observe their clusters and services.
--->
 ## 介绍
 
 [Kubernetes](https://kubernetes.io/)


### PR DESCRIPTION
Follow through of:

- https://github.com/open-telemetry/opentelemetry.io/pull/4536#discussion_r1626069609
- #4582

For the record, here are the commands I used:

```bash
find content/zh -name '*.md' -exec perl -i -0777 -pe 's/<!--.*?-->//gs' {} \;
find content/zh -name '*.md' -print0 | xargs -0 perl -i -0777 -pe 's/\n{2,}/\n\n/gs'
```