### PR TITLE
[i18n & CI] Add `default_lang_commit` to front matter of all non `en` pages

### DIFF
--- a/content/ja/_index.md
+++ b/content/ja/_index.md
@@ -4,6 +4,7 @@ description: >-
   効果的な観測を可能にする、高品質でユビキタスかつポータブルなテレメトリー
 developer_note:
   blocks/coverコラム（以下で使用）は、ファイル名に "background" を含む画像ファイルを背景画像として使用します。
+default_lang_commit: 902043db
 ---
 
 <div class="d-none"><a rel="me" href="https://fosstodon.org/@opentelemetry"></a></div>

--- a/content/zh/_index.md
+++ b/content/zh/_index.md
@@ -6,6 +6,7 @@ show_banner: true
 developer_note:
   下文所用的 blocks/cover 短代码将使用文件名中包含 "background"
   的图像文件作为背景图。
+default_lang_commit: 6e35a949
 ---
 
 <div class="d-none"><a rel="me" href="https://fosstodon.org/@opentelemetry"></a></div>

--- a/content/zh/docs/_index.md
+++ b/content/zh/docs/_index.md
@@ -1,6 +1,7 @@
 ---
 title: 文档
 menu: { main: { weight: 10 } }
+default_lang_commit: 6e35a949
 ---
 
 OpenTelemetry 也被称为 OTel，是一个供应商中立的、开源的[可观测性](concepts/observability-primer/#what-is-observability)框架，

--- a/content/zh/docs/concepts/_index.md
+++ b/content/zh/docs/concepts/_index.md
@@ -4,6 +4,7 @@ linkTitle: 概念
 description: OpenTelemetry 核心概念
 aliases: [concepts/overview]
 weight: 170
+default_lang_commit: d638c386
 ---
 
 在本节中，你将了解 OpenTelemetry 项目的数据来源和关键组件。

--- a/content/zh/docs/concepts/components.md
+++ b/content/zh/docs/concepts/components.md
@@ -3,6 +3,7 @@ title: 组件
 description: 构成 OpenTelemetry 的主要组件
 aliases: [data-collection]
 weight: 20
+default_lang_commit: 1ca30b4d
 ---
 
 OpenTelemetry 项目目前由以下几个主要部分构成：

--- a/content/zh/docs/concepts/context-propagation.md
+++ b/content/zh/docs/concepts/context-propagation.md
@@ -2,6 +2,7 @@
 title: 上下文传播
 weight: 10
 description: 了解实现分布式追踪的概念。
+default_lang_commit: 7bb7dbb6
 ---
 
 通过上下文传播，[信号](/docs/concepts/signals)可以相互关联，

--- a/content/zh/docs/concepts/semantic-conventions.md
+++ b/content/zh/docs/concepts/semantic-conventions.md
@@ -2,7 +2,7 @@
 title: 语义约定
 description: 不同类型的操作和数据的通用名称。
 weight: 30
-default_lang_commit: 1d9a1df8
+default_lang_commit: 71d813acaa3dcb7d8ae3f96451406276f84242f4
 ---
 
 OpenTelemetry 定义了[语义约定](/docs/specs/semconv/)，

--- a/content/zh/docs/concepts/semantic-conventions.md
+++ b/content/zh/docs/concepts/semantic-conventions.md
@@ -2,6 +2,7 @@
 title: 语义约定
 description: 不同类型的操作和数据的通用名称。
 weight: 30
+default_lang_commit: 1d9a1df8
 ---
 
 OpenTelemetry 定义了[语义约定](/docs/specs/semconv/)，

--- a/content/zh/docs/demo/_index.md
+++ b/content/zh/docs/demo/_index.md
@@ -5,7 +5,7 @@ cascade:
   repo: https://github.com/open-telemetry/opentelemetry-demo
 weight: 2
 cSpell:ignore: OLJCESPC
-default_lang_commit: 1d9a1df8
+default_lang_commit: b7ee690154aacc8d6e43636af00743994fb6dc27
 ---
 
 欢迎使用 [OpenTelemetry 演示](/ecosystem/demo/)文档，

--- a/content/zh/docs/demo/_index.md
+++ b/content/zh/docs/demo/_index.md
@@ -5,6 +5,7 @@ cascade:
   repo: https://github.com/open-telemetry/opentelemetry-demo
 weight: 2
 cSpell:ignore: OLJCESPC
+default_lang_commit: 1d9a1df8
 ---
 
 欢迎使用 [OpenTelemetry 演示](/ecosystem/demo/)文档，

--- a/content/zh/docs/kubernetes/_index.md
+++ b/content/zh/docs/kubernetes/_index.md
@@ -3,6 +3,7 @@ title: 使用 Kubernetes 部署 OpenTelemetry
 linkTitle: Kubernetes
 weight: 11
 description: Using OpenTelemetry with Kubernetes
+default_lang_commit: 1d9a1df8
 ---
 
 ## 介绍

--- a/content/zh/docs/kubernetes/_index.md
+++ b/content/zh/docs/kubernetes/_index.md
@@ -3,7 +3,7 @@ title: 使用 Kubernetes 部署 OpenTelemetry
 linkTitle: Kubernetes
 weight: 11
 description: Using OpenTelemetry with Kubernetes
-default_lang_commit: 1d9a1df8
+default_lang_commit: 54bc7873eaf53af1314feef7f91797d5d261a57b
 ---
 
 ## 介绍

--- a/content/zh/docs/what-is-opentelemetry.md
+++ b/content/zh/docs/what-is-opentelemetry.md
@@ -2,6 +2,7 @@
 title: 什么是 OpenTelemetry？
 description: 简短说明 OpenTelemetry 是什么，不是什么。
 weight: 150
+default_lang_commit: d638c386
 ---
 
 OpenTelemetry


### PR DESCRIPTION
- Contributes to #4582
- For each i18n page:
  - Adds the commit ref of the `en` page version from which the i18n page was translated from
- Updates `scripts/i18n-check.sh`:
  - Add `-u` flag used to update or add the `default_lang_commit` field value to i18n pages
  - Adds support for default target of `content`

Other than the script, all other files were updated by running the following command:

```console
$ ./scripts/i18n-check.sh -u                           
1       1       content/en/docs/demo/_index.md - content/zh/docs/demo/_index.md
30      30      content/en/docs/concepts/components.md - content/zh/docs/concepts/components.md
1       1       content/en/docs/kubernetes/_index.md - content/zh/docs/kubernetes/_index.md
13      1       content/en/_index.md - content/zh/_index.md
```

**Note**: whenever a new i18n page is added or an existing page is updated, its `default_lang_commit` field value must be updated as well to match the `main` commit from which the i18n page addition/updates are based on.