### PR TITLE
[ja & zh] Normalize links & update some hashes

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -33,7 +33,7 @@ show_banner: true
 </div>
 
 <div class="h3 mt-4">
-<a class="text-secondary" href="/docs/getting-started/">Get started</a> based on your role
+<a class="text-secondary" href="docs/getting-started/">Get started</a> based on your role
 </div>
 <div class="l-get-started-buttons">
 

--- a/content/ja/_index.md
+++ b/content/ja/_index.md
@@ -4,7 +4,7 @@ description: >-
   効果的な観測を可能にする、高品質でユビキタスかつポータブルなテレメトリー
 developer_note: blocks/coverコラム（以下で使用）は、ファイル名に "background" を含む画像ファイルを背景画像として使用します。
 show_banner: true
-default_lang_commit: 902043db
+default_lang_commit: c2cd5b14
 ---
 
 <div class="d-none"><a rel="me" href="https://fosstodon.org/@opentelemetry"></a></div>
@@ -21,19 +21,19 @@ default_lang_commit: 902043db
 
 <div class="l-primary-buttons mt-5">
 
-- [より詳しく学ぶ](/docs/what-is-opentelemetry/)
-- [デモを試す](/docs/demo/)
-- [インテグレーションを探す](/ecosystem/integrations)
+- [より詳しく学ぶ](docs/what-is-opentelemetry/)
+- [デモを試す](docs/demo/)
+- [インテグレーションを探す](/ecosystem/integrations/)
 
 </div>
 
 <div class="h3 mt-4">
-あなたのロールに応じて<a class="text-secondary" href="/docs/getting-started/">始めてみましょう</a>
+あなたのロールに応じて<a class="text-secondary" href="docs/getting-started/">始めてみましょう</a>
 </div>
 <div class="l-get-started-buttons">
 
-- [開発者（Dev）](/docs/getting-started/dev/)
-- [運用担当者（Ops）](/docs/getting-started/ops/)
+- [開発者（Dev）](docs/getting-started/dev/)
+- [運用担当者（Ops）](docs/getting-started/ops/)
 
 </div>
 {{< /blocks/cover >}}
@@ -43,7 +43,7 @@ default_lang_commit: 902043db
 OpenTelemetry は API、SDK、ツールのコレクションです。
 テレメトリーデータ（メトリクス、ログ、トレース）の計装、生成、収集、エクスポートに使用し、ソフトウェアのパフォーマンスや動作の分析に役立てましょう。
 
-> OpenTelemetryは[いくつかの言語](/docs/languages/)で **一般的に利用可能** で、使用に適しています。
+> OpenTelemetryは[いくつかの言語](docs/languages/)で **一般的に利用可能** で、使用に適しています。
 
 {{% /blocks/lead %}}
 

--- a/content/ja/announcements/otel-community-day.md
+++ b/content/ja/announcements/otel-community-day.md
@@ -3,7 +3,7 @@ title: OTel Community Day
 date: 2024-04-05
 expiryDate: 2024-06-25
 weight: -1 # top
-default_lang_commit: 788509efd404ba35dd113b4f37bae96ca7558e3e
+default_lang_commit: 8603bc8e
 ---
 
 <i class="fas fa-bullhorn"></i>

--- a/content/ja/docs/_index.md
+++ b/content/ja/docs/_index.md
@@ -1,11 +1,11 @@
 ---
 title: ドキュメント
 menu: { main: { weight: 10 } }
-default_lang_commit: 93ab1301
+default_lang_commit: c2cd5b14
 ---
 
-OTelの略称でも知られるOpenTelemetryは、[トレース](/docs/concepts/signals/traces/)、[メトリクス](/docs/concepts/signals/metrics/)、[ログ](/docs/concepts/signals/logs/)のようなテレメトリーデータを計装、生成、収集、エクスポートするためのベンダー非依存なオープンソースの[オブザーバビリティ](/docs/concepts/observability-primer/#what-is-observability)フレームワークです。
+OTelの略称でも知られるOpenTelemetryは、[トレース](concepts/signals/traces/)、[メトリクス](concepts/signals/metrics/)、[ログ](concepts/signals/logs/)のようなテレメトリーデータを計装、生成、収集、エクスポートするためのベンダー非依存なオープンソースの[オブザーバビリティ](concepts/observability-primer/#what-is-observability)フレームワークです。
 
-業界標準として、OpenTelemetryは[40以上のオブザーバビリティベンダーによってサポートされ](/ecosystem/vendors/)、多くの[ライブラリ、サービス、アプリ](/ecosystem/integrations)によって統合され、[多くのエンドユーザー](/ecosystem/adopters)によって採用されています。
+業界標準として、OpenTelemetryは[40以上のオブザーバビリティベンダーによってサポートされ](/ecosystem/vendors/)、多くの[ライブラリ、サービス、アプリ](/ecosystem/integrations/)によって統合され、[多くのエンドユーザー](/ecosystem/adopters/)によって採用されています。
 
 ![OpenTelemetry Reference Architecture](/img/otel-diagram.svg)

--- a/content/zh/_index.md
+++ b/content/zh/_index.md
@@ -7,7 +7,7 @@ developer_note:
   下文所用的 blocks/cover 短代码将使用文件名中包含 "background"
   的图像文件作为背景图。
 show_banner: true
-default_lang_commit: 6e35a949
+default_lang_commit: c2cd5b14
 ---
 
 <div class="d-none"><a rel="me" href="https://fosstodon.org/@opentelemetry"></a></div>
@@ -24,19 +24,19 @@ default_lang_commit: 6e35a949
 
 <div class="l-primary-buttons mt-5">
 
-- [了解更多](/zh/docs/what-is-opentelemetry/)
-- [尝试 Demo](/zh/docs/demo/)
-- [探索集成组件](/ecosystem/integrations)
+- [了解更多](docs/what-is-opentelemetry/)
+- [尝试 Demo](docs/demo/)
+- [探索集成组件](/ecosystem/integrations/)
 
 </div>
 
 <div class="h3 mt-4">
-<a class="text-secondary" href="/docs/getting-started/">为各种角色定制的入门指南</a>
+<a class="text-secondary" href="docs/getting-started/">为各种角色定制的入门指南</a>
 </div>
 <div class="l-get-started-buttons">
 
-- [开发人员](/zh/docs/getting-started/dev/)
-- [运维人员](/zh/docs/getting-started/ops/)
+- [开发人员](docs/getting-started/dev/)
+- [运维人员](docs/getting-started/ops/)
 
 </div>
 {{< /blocks/cover >}}
@@ -45,7 +45,7 @@ default_lang_commit: 6e35a949
 
 OpenTelemetry 是各类 API、SDK 和工具形成的集合。可用于插桩、生成、采集和导出遥测数据（链路、指标和日志），帮助你分析软件的性能和行为。
 
-> OpenTelemetry 在[多种编程语言](/zh/docs/languages/)均达到 **GA** 级别，普适性很高。
+> OpenTelemetry 在[多种编程语言](docs/languages/)均达到 **GA** 级别，普适性很高。
 
 {{% /blocks/lead %}}
 

--- a/content/zh/announcements/otel-community-day.md
+++ b/content/zh/announcements/otel-community-day.md
@@ -3,7 +3,7 @@ title: OTel Community Day
 date: 2024-04-05
 expiryDate: 2024-06-25
 weight: -1 # top
-default_lang_commit: 788509efd404ba35dd113b4f37bae96ca7558e3e
+default_lang_commit: c2cd5b14
 ---
 
 <i class="fas fa-bullhorn"></i>

--- a/content/zh/docs/_index.md
+++ b/content/zh/docs/_index.md
@@ -5,10 +5,10 @@ default_lang_commit: 6e35a949
 ---
 
 OpenTelemetry 也被称为 OTel，是一个供应商中立的、开源的[可观测性](concepts/observability-primer/#what-is-observability)框架，
-可用于插桩、生成、采集和导出[链路](/zh/docs/concepts/signals/traces/)、
-[指标](/zh/docs/concepts/signals/metrics/)和[日志](/zh/docs/concepts/signals/logs/)等遥测数据。
+可用于插桩、生成、采集和导出[链路](concepts/signals/traces/)、
+[指标](concepts/signals/metrics/)和[日志](concepts/signals/logs/)等遥测数据。
 
 OpenTelemetry 作为一个行业标准，得到了 40 多个可观测供应商的支持，
-被许多[代码库、服务和应用](/ecosystem/integrations)集成，被众多[最终用户](/ecosystem/adopters)采用。
+被许多[代码库、服务和应用](/ecosystem/integrations/)集成，被众多[最终用户](/ecosystem/adopters/)采用。
 
 ![OpenTelemetry 基准架构](/img/otel-diagram.svg)

--- a/content/zh/docs/demo/_index.md
+++ b/content/zh/docs/demo/_index.md
@@ -3,9 +3,9 @@ title: OpenTelemetry 演示文档
 linkTitle: 演示
 cascade:
   repo: https://github.com/open-telemetry/opentelemetry-demo
-weight: 2
+weight: 180
 cSpell:ignore: OLJCESPC
-default_lang_commit: b7ee690154aacc8d6e43636af00743994fb6dc27
+default_lang_commit: c2cd5b14
 ---
 
 欢迎使用 [OpenTelemetry 演示](/ecosystem/demo/)文档，

--- a/content/zh/docs/kubernetes/_index.md
+++ b/content/zh/docs/kubernetes/_index.md
@@ -1,9 +1,9 @@
 ---
 title: 使用 Kubernetes 部署 OpenTelemetry
 linkTitle: Kubernetes
-weight: 11
+weight: 350
 description: Using OpenTelemetry with Kubernetes
-default_lang_commit: 54bc7873eaf53af1314feef7f91797d5d261a57b
+default_lang_commit: c2cd5b14
 ---
 
 ## 介绍


### PR DESCRIPTION
- Contributes to #4467
- Syncs some of the `ja` and `zh` pages and updates the hashes. The syncs mainly bring in link normalization. That is, the use of locale-relative links when possible.
- Updates page weights to match `en` pages