### PR TITLE
Introduce component owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,35 +14,3 @@
 
 # Global owners, will be the owners for everything in the repo.
 * @open-telemetry/docs-approvers
-
-# content owners
-content-modules/                         @open-telemetry/docs-maintainers
-content-modules/opamp-spec               @open-telemetry/docs-maintainers @open-telemetry/opamp-spec-approvers
-content-modules/opentelemetry-proto      @open-telemetry/docs-maintainers @open-telemetry/specs-approvers
-content-modules/opentelemetry-specification  @open-telemetry/docs-maintainers @open-telemetry/specs-approvers
-content-modules/semantic-conventions     @open-telemetry/docs-maintainers @open-telemetry/specs-semconv-approvers
-content/en/blog/                         @open-telemetry/docs-maintainers
-content/en/community/end-user/           @open-telemetry/docs-approvers @open-telemetry/sig-end-user-approvers
-content/en/docs/collector                @open-telemetry/docs-approvers @open-telemetry/collector-approvers
-content/en/docs/contributing/            @open-telemetry/docs-approvers @open-telemetry/docs-maintainers
-content/en/docs/demo                     @open-telemetry/docs-approvers @open-telemetry/demo-approvers
-content/en/docs/kubernetes/helm/         @open-telemetry/docs-approvers @open-telemetry/helm-approvers
-content/en/docs/kubernetes/operator/     @open-telemetry/docs-approvers @open-telemetry/operator-approvers
-content/en/docs/languages/cpp/           @open-telemetry/docs-approvers @open-telemetry/cpp-approvers
-content/en/docs/languages/erlang/        @open-telemetry/docs-approvers @open-telemetry/erlang-approvers
-content/en/docs/languages/go/            @open-telemetry/docs-approvers @open-telemetry/go-approvers @open-telemetry/go-instrumentation-approvers
-content/en/docs/languages/java/          @open-telemetry/docs-approvers @open-telemetry/java-approvers @open-telemetry/java-instrumentation-approvers
-content/en/docs/languages/js/            @open-telemetry/docs-approvers @open-telemetry/javascript-approvers
-content/en/docs/languages/net/           @open-telemetry/docs-approvers @open-telemetry/dotnet-approvers @open-telemetry/dotnet-instrumentation-approvers
-content/en/docs/languages/php/           @open-telemetry/docs-approvers @open-telemetry/php-approvers
-content/en/docs/languages/python/        @open-telemetry/docs-approvers @open-telemetry/python-approvers
-content/en/docs/languages/ruby/          @open-telemetry/docs-approvers @open-telemetry/ruby-approvers @open-telemetry/ruby-contrib-approvers
-content/en/docs/languages/rust/          @open-telemetry/docs-approvers @open-telemetry/rust-approvers
-content/en/docs/languages/swift/         @open-telemetry/docs-approvers @open-telemetry/swift-approvers
-content/en/docs/security/                @open-telemetry/docs-approvers @open-telemetry/sig-security-maintainers
-content/en/docs/specs/                   @open-telemetry/docs-approvers @open-telemetry/specs-approvers
-content/en/docs/zero-code/java/          @open-telemetry/docs-approvers @open-telemetry/java-approvers @open-telemetry/java-instrumentation-approvers
-content/en/docs/zero-code/js/            @open-telemetry/docs-approvers @open-telemetry/javascript-approvers
-content/en/docs/zero-code/net/           @open-telemetry/docs-approvers @open-telemetry/dotnet-approvers @open-telemetry/dotnet-instrumentation-approvers
-content/en/ecosystem/demo/               @open-telemetry/demo-approvers @open-telemetry/demo-approvers
-content/zh/                              @open-telemetry/docs-maintainers @open-telemetry/docs-zh-approvers

--- a/.github/component-owners.yml
+++ b/.github/component-owners.yml
@@ -1,0 +1,73 @@
+# This file is used to define the owners of the content modules in the OpenTelemetry repository.
+components:
+  content-modules:
+  - "@open-telemetry/docs-maintainers"
+  content-modules/opamp-spec:
+  - "@open-telemetry/docs-maintainers"
+  - "@open-telemetry/opamp-spec-approvers"
+  content-modules/opentelemetry-proto:
+  - "@open-telemetry/docs-maintainers"
+  - "@open-telemetry/specs-approvers"
+  content-modules/opentelemetry-specification:
+  - "@open-telemetry/docs-maintainers"
+  - "@open-telemetry/specs-approvers"
+  content-modules/semantic-conventions:
+  - "@open-telemetry/docs-maintainers"
+  - "@open-telemetry/specs-semconv-approvers"
+  content/en/blog:
+  - "@open-telemetry/docs-maintainers"
+  content/en/community/end-user:
+  - "@open-telemetry/sig-end-user-approvers"
+  content/en/docs/collector:
+  - "@open-telemetry/collector-approvers"
+  content/en/docs/contributing:
+  - "@open-telemetry/docs-maintainers"
+  content/en/docs/demo:
+  - "@open-telemetry/demo-approvers"
+  content/en/docs/kubernetes/helm:
+  - "@open-telemetry/helm-approvers"
+  content/en/docs/kubernetes/operator:
+  - "@open-telemetry/operator-approvers"
+  content/en/docs/languages/cpp:
+  - "@open-telemetry/cpp-approvers"
+  content/en/docs/languages/erlang:
+  - "@open-telemetry/erlang-approvers"
+  content/en/docs/languages/go:
+  - "@open-telemetry/go-approvers"
+  - "@open-telemetry/go-instrumentation-approvers"
+  content/en/docs/languages/java:
+  - "@open-telemetry/java-approvers"
+  - "@open-telemetry/java-instrumentation-approvers"
+  content/en/docs/languages/js:
+  - "@open-telemetry/javascript-approvers"
+  content/en/docs/languages/net:
+  - "@open-telemetry/dotnet-approvers"
+  - "@open-telemetry/dotnet-instrumentation-approvers"
+  content/en/docs/languages/php:
+  - "@open-telemetry/php-approvers"
+  content/en/docs/languages/python:
+  - "@open-telemetry/python-approvers"
+  content/en/docs/languages/ruby:
+  - "@open-telemetry/ruby-approvers" 
+  - "@open-telemetry/ruby-contrib-approvers"
+  content/en/docs/languages/rust:
+  - "@open-telemetry/rust-approvers"
+  content/en/docs/languages/swift:
+  - "@open-telemetry/swift-approvers"
+  content/en/docs/security:
+  - "@open-telemetry/sig-security-maintainers"
+  content/en/docs/specs:
+  - "@open-telemetry/specs-approvers"
+  content/en/docs/zero-code/java:
+  - "@open-telemetry/java-approvers"
+  - "@open-telemetry/java-instrumentation-approvers"
+  content/en/docs/zero-code/js:
+  - "@open-telemetry/javascript-approvers"
+  content/en/docs/zero-code/net:
+  - "@open-telemetry/dotnet-approvers"
+  - "@open-telemetry/dotnet-instrumentation-approvers"
+  content/en/ecosystem/demo:
+  - "@open-telemetry/demo-approvers"
+  content/zh:
+  - "@open-telemetry/docs-maintainers"
+  - "@open-telemetry/docs-zh-approvers"

--- a/.github/workflows/component-owners.yml
+++ b/.github/workflows/component-owners.yml
@@ -1,0 +1,13 @@
+name: 'Component Owners'
+on:
+  pull_request_target:
+
+jobs:
+  run_self:
+    runs-on: ubuntu-latest
+    name: Auto Assign Owners
+    steps:
+      - uses: dyladan/component-owners@main
+        with:
+          config-file: .github/component-owners.yml
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
fixes #3581

This is a disruptive change, so when we roll it out we should monitor it carefully and roll it back/fix it quickly if anything misbehaves.

@dyladan to verify that, is component-owners compatible with github teams? In your examples I only saw individual usernames 