### PR TITLE
API & SDK signal status: update terminology and links

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -72,5 +72,3 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - ^https://wikipedia.org/wiki/(S.M.A.R.T|Hop_)
   # TODO move into content/en/blog/2023/contributing-to-otel/index.md once https://github.com/open-telemetry/opentelemetry.io/issues/3889 is implemented
   - ^https://shorturl.at/vLYZ0$
-  # TODO remove while or after fixing https://github.com/open-telemetry/opentelemetry.io/issues/4656
-  - ^/docs/specs/otel/versioning-and-stability/#experimental

--- a/content/en/docs/concepts/instrumentation/libraries.md
+++ b/content/en/docs/concepts/instrumentation/libraries.md
@@ -115,7 +115,7 @@ You may be rightfully concerned about adding new dependencies, here are some
 considerations to help you decide how to minimize dependency hell:
 
 - OpenTelemetry Trace API reached stability in early 2021, it follows
-  [Semantic Versioning 2.0](/docs/specs/otel/versioning-and-stability) and we
+  [Semantic Versioning 2.0](/docs/specs/otel/versioning-and-stability/) and we
   take API stability seriously.
 - When taking dependency, use the earliest stable OpenTelemetry API (1.0.\*) and
   avoid updating it unless you have to use new features.

--- a/layouts/partials/docs/get-signal-status.html
+++ b/layouts/partials/docs/get-signal-status.html
@@ -1,0 +1,31 @@
+{{/*
+
+  Returns the maturity status of the given signal for the given language.
+
+  Arguments:
+
+  .lang the instrumentation language
+  .signal the signal name; must be a legal field of the Instrumentation data file.
+
+  */ -}}
+
+{{ $status := "-" -}}
+{{ $signal := .signal -}}
+
+{{ with index site.Data.instrumentation .lang -}}
+  {{ with index .status $signal -}}
+    {{ $statusWeCanLinkTo := "stable development" -}}
+    {{ $status = cond (or (eq "experimental" .) (eq "in development" .)) "development" . -}}
+    {{ $humanizedStatus := humanize $status -}}
+    {{ $status = cond (in $statusWeCanLinkTo $status)
+          (printf "[%s](/docs/specs/otel/versioning-and-stability/#%s)" $humanizedStatus $status)
+          (cond (in "alpha beta" $status)
+            (printf "[%s](https://github.com/open-telemetry/oteps/blob/main/text/0232-maturity-of-otel.md#%s)" $humanizedStatus $status)
+            $humanizedStatus)
+    -}}
+  {{ end -}}
+{{ else -}}
+  {{ errorf "The site.Data.instrumentation map has no language key '%s'." .lang -}}
+{{ end -}}
+
+{{ return $status -}}

--- a/layouts/shortcodes/docs/languages/index-intro.md
+++ b/layouts/shortcodes/docs/languages/index-intro.md
@@ -5,18 +5,10 @@
 {{ $lang := .Get 0 -}}
 {{ $data := index $.Site.Data.instrumentation $lang }}
 {{ $name := $data.name -}}
-{{ $tracesStatus := $data.status.traces | humanize -}}
-{{ $metricsStatus := $data.status.metrics | humanize -}}
-{{ $logsStatus := $data.status.logs | humanize -}}
-{{ if in "Stable Experimental" $tracesStatus -}}
-    {{ $tracesStatus = printf "[%s](/docs/specs/otel/versioning-and-stability/#%s)" $tracesStatus $data.status.traces -}}
-{{ end -}}
-{{ if in "Stable Experimental" $metricsStatus -}}
-    {{ $metricsStatus = printf "[%s](/docs/specs/otel/versioning-and-stability/#%s)" $metricsStatus $data.status.metrics -}}
-{{ end -}}
-{{ if in "Stable Experimental" $logsStatus -}}
-    {{ $logsStatus = printf "[%s](/docs/specs/otel/versioning-and-stability/#%s)" $logsStatus $data.status.logs -}}
-{{ end -}}
+
+{{ $tracesStatus := partial "docs/get-signal-status.html" (dict "lang" $lang "signal" "traces") -}}
+{{ $metricsStatus := partial "docs/get-signal-status.html" (dict "lang" $lang "signal" "metrics") -}}
+{{ $logsStatus := partial "docs/get-signal-status.html" (dict "lang" $lang "signal" "logs") -}}
 
 This is the OpenTelemetry {{ $name }} documentation. OpenTelemetry is an
 observability framework -- an API, SDK, and tools that are designed to aid in


### PR DESCRIPTION
- Followup to #4655
- Contributes to #4656
- API & SDK status section, under languages, will now display the following status, with links into the spec at http://localhost:1313/docs/specs/otel/versioning-and-stability/#signal-lifecycle:
  - "In development" --> "Development"
  - "Experimental" --> "Development"
- Links to https://github.com/open-telemetry/oteps/blob/main/text/0232-maturity-of-otel.md as a source of truth for statuses "alpha" and "beta"
  - If/once the following is fixed, then we can link into the website-local [Versioning and stability](https://opentelemetry.io/docs/specs/otel/versioning-and-stability/#signal-lifecycle) page: 
    https://github.com/open-telemetry/opentelemetry-specification/issues/4076
- Drops temporary `htmltest` ignore rule
- One link normalization
- For preview links, see the first column of the table below
- NOTE: I have voluntarily _not_ updated the instrumentation status YAML file. I'll do that in a followup PR.

/cc @open-telemetry/specs-approvers 

### Screenshots

| Lang | Before | After |
|-----|---|--------|
| [Swift](https://deploy-preview-4657--opentelemetry.netlify.app/docs/languages/swift/#status-and-releases) | <img width="428" alt="image" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/cc6ef415-d366-480b-a7b1-b9da86b24ba3"> | <img width="427" alt="image" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/0579b670-59a7-43cb-970f-5e8e71fa18bf"> 
| [Rust](https://deploy-preview-4657--opentelemetry.netlify.app/docs/languages/rust/#status-and-releases) | <img width="440" alt="image" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/4c56c73e-94e4-4b81-b6fc-096c4d74f44f"> | <img width="430" alt="image" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/66bdc94e-e08e-4ab9-8a70-3b2c7f8ac114"> |

### Related

- https://github.com/open-telemetry/opentelemetry-specification/issues/4076