### PR TITLE
[i18n] Ensure fallback pages have `en` lang

### DIFF
--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -1,0 +1,35 @@
+{{/* Docsy override */ -}}
+{{ $lang := partial "i18n/lang.html" . -}}
+
+<!doctype html>
+<html itemscope itemtype="http://schema.org/WebPage" lang="{{ $lang }}" class="no-js">
+  <head>
+    {{ partial "head.html" . }}
+  </head>
+  <body class="td-{{ .Kind }}{{ with .Page.Params.body_class }} {{ . }}{{ end }}">
+    <header>
+      {{ partial "navbar.html" . }}
+    </header>
+    <div class="container-fluid td-outer">
+      <div class="td-main">
+        <div class="row flex-xl-nowrap">
+          <aside class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
+            {{ partial "sidebar.html" . }}
+          </aside>
+          <aside class="d-none d-xl-block col-xl-2 td-sidebar-toc d-print-none">
+            {{ partial "page-meta-links.html" . }}
+            {{ partial "toc.html" . }}
+            {{ partial "taxonomy_terms_clouds.html" . }}
+          </aside>
+          <main class="col-12 col-md-9 col-xl-8 ps-md-5" role="main">
+            {{ partial "version-banner.html" . }}
+            {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
+            {{ block "main" . }}{{ end }}
+          </main>
+        </div>
+      </div>
+      {{ partial "footer.html" . }}
+    </div>
+    {{ partial "scripts.html" . }}
+  </body>
+</html>

--- a/layouts/partials/i18n/fallback-page.html
+++ b/layouts/partials/i18n/fallback-page.html
@@ -1,0 +1,25 @@
+{{/*
+
+  Returns the fallback page of this page, if it has one.
+  A fallback page, is a page in the default site language
+  that has been mounted under this locale as a fallback
+  when this locale is missing a translation.
+
+*/ -}}
+
+{{ $result := false -}}
+
+{{ if and .Site.IsMultiLingual .File -}}
+  {{ $defaultLang := .Site.Sites.Default.Language.Lang -}}
+
+  {{ $resultsArray := where .Translations "Lang" $defaultLang -}}
+  {{ $defaultLangPage := index $resultsArray 0 -}}
+  {{ if and $defaultLangPage
+            $defaultLangPage.File
+            (eq .File.Filename $defaultLangPage.File.Filename)
+  -}}
+    {{ $result = $defaultLangPage -}}
+  {{ end -}}
+{{ end -}}
+
+{{ return $result -}}

--- a/layouts/partials/i18n/lang.html
+++ b/layouts/partials/i18n/lang.html
@@ -1,0 +1,6 @@
+{{ $fallbackPage := partial "i18n/fallback-page.html" . -}}
+{{ $lang := .Site.Language.Lang -}}
+{{ with $fallbackPage -}}
+  {{ $lang = .Language.Lang -}}
+{{ end -}}
+{{ return $lang -}}


### PR DESCRIPTION
- Fixes #4664
- Adds partial functions used to determine if a page is a fallback page, and what the true `lang` code is for such pages
- Adds a Docsy override of `layouts/docs/baseof.html`
- Non-functional tweaks to `scripts/check-i18n.sh`

### Before and after

```console
$ curl -s https://opentelemetry.io/ja/docs/getting-started/ | perl -nle 'print $1 if /html[^>]*(lang=\S+)/i' 
lang=ja
$ curl -s https://deploy-preview-4683--opentelemetry.netlify.app/ja/docs/getting-started/ | perl -nle 'print $1 if /html[^>]*(lang=\S+)/i' 
lang=en
```

### Preview

- E.g., https://deploy-preview-4683--opentelemetry.netlify.app/ja/docs/getting-started/