### PR TITLE
fix bug in config_option shortcode

### DIFF
--- a/content/en/docs/zero-code/java/agent/configuration.md
+++ b/content/en/docs/zero-code/java/agent/configuration.md
@@ -123,7 +123,7 @@ is the name of a remote service to which a connection is made. It corresponds to
 `service.name` in the [resource](/docs/specs/semconv/resource/#service) for the
 local service.
 
-{{% config_option name="otel.instrumentation.common.peer-service-mapping" %}}
+{{< config_option name="otel.instrumentation.common.peer-service-mapping" >}}
 
 Used to specify a mapping from host names or IP addresses to peer services, as a
 comma-separated list of `<host_or_ip>=<user_assigned_name>` pairs. The peer
@@ -150,7 +150,7 @@ while `1.2.3.4:443` will have have `peer.service` of `cats-service` and requests
 to `dogs-abcdef123.serverlessapis.com:80/api/v1` will have an attribute of
 `dogs-api`.
 
-{{% /config_option %}}
+{{< /config_option >}}
 
 ### DB statement sanitization
 

--- a/layouts/shortcodes/config_option.html
+++ b/layouts/shortcodes/config_option.html
@@ -16,5 +16,5 @@
   <span class="label">Default</span>: {{ .Get "default" }}<br>
 {{ end -}}
 <span class="label">Description</span>:
-{{ trim .InnerDeindent "\n " }}
+{{ trim .InnerDeindent "\n " | markdownify }}
 </div>


### PR DESCRIPTION
This addresses #4230. Note that this PR is not yet finalized, but to begin with it demonstrates the underlying issue.

There seems to be an issue with hugo "re-markdownifying" (see https://github.com/gohugoio/hugo/issues/5774#issuecomment-486425783), so this applies the same suggestions:

1. Use {{< request >}} instead of {{% request %}}, so Hugo stops trying to re-markdownify
2. Manually markdownify the content

cc @chalin 