### PR TITLE
Deprecate OpenTelemetry Browser Extension Autoinjection in registry

### DIFF
--- a/data/registry/tools-browser-extension-autoinjection.yml
+++ b/data/registry/tools-browser-extension-autoinjection.yml
@@ -18,7 +18,7 @@ description: >
   OpenTelemetry Collector.
 deprecated:
   reason:
-    This browser extensions is permanently deprecated. [Other browser extensions
+    This browser extension is permanently deprecated. [Other browser extensions
     are available that provide similar
     functionality](/ecosystem/registry/?component=utilities&s=browserextension).
 

--- a/data/registry/tools-browser-extension-autoinjection.yml
+++ b/data/registry/tools-browser-extension-autoinjection.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore firefox autoinjection
+# cSpell:ignore firefox autoinjection browserextension
 title: OpenTelemetry Browser Extension Autoinjection
 registryType: utilities
 language: js
@@ -6,6 +6,7 @@ tags:
   - js
   - browser
   - web-ext
+  - browserextension # for search to only find browser extensions and not other types of extensions
   - browser-extension
   - chrome-extension
   - firefox-extension
@@ -15,6 +16,10 @@ description: >
   This browser extension allows you to inject OpenTelemetry instrumentation in
   any web page. It uses the Web SDK and can export data to Zipkin or an
   OpenTelemetry Collector.
+deprecated:
+  reason:
+    This browser extensions is permanently deprecated. [Other browser extensions
+    are available that provide similar functionality](/ecosystem/registry/?component=utilities&s=browserextension).
 
 authors:
   - name: OpenTelemetry Authors

--- a/data/registry/tools-browser-extension-autoinjection.yml
+++ b/data/registry/tools-browser-extension-autoinjection.yml
@@ -19,7 +19,8 @@ description: >
 deprecated:
   reason:
     This browser extensions is permanently deprecated. [Other browser extensions
-    are available that provide similar functionality](/ecosystem/registry/?component=utilities&s=browserextension).
+    are available that provide similar
+    functionality](/ecosystem/registry/?component=utilities&s=browserextension).
 
 authors:
   - name: OpenTelemetry Authors

--- a/data/registry/tools-browser-extension-for-opentelemetry.yml
+++ b/data/registry/tools-browser-extension-for-opentelemetry.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore firefox autoinstrumentation Autoinjection Brockman
+# cSpell:ignore firefox autoinstrumentation Autoinjection Brockman browserextension
 title: Browser Extension for OpenTelemetry
 registryType: utilities
 language: js
@@ -6,6 +6,7 @@ tags:
   - js
   - browser
   - web-ext
+  - browserextension # for search to only find browser extensions and not other types of extensions
   - browser-extension
   - chrome-extension
   - firefox-extension


### PR DESCRIPTION
As discussed with @pichlermarc and @JamieDanielson the browser extension I contributed a few years back will be deprecated permanently and we will list extensions available outside the otel project as alternatives in the registry.