### PR TITLE
add a base page for go zero code instrumentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,6 +41,7 @@ content/en/docs/languages/rust/          @open-telemetry/docs-approvers @open-te
 content/en/docs/languages/swift/         @open-telemetry/docs-approvers @open-telemetry/swift-approvers
 content/en/docs/security/                @open-telemetry/docs-approvers @open-telemetry/sig-security-maintainers
 content/en/docs/specs/                   @open-telemetry/docs-approvers @open-telemetry/specs-approvers
+content/en/docs/zero-code/go             @open-telemetry/docs-approvers @open-telemetry/go-approvers @open-telemetry/go-instrumentation-approvers
 content/en/docs/zero-code/java/          @open-telemetry/docs-approvers @open-telemetry/java-approvers @open-telemetry/java-instrumentation-approvers
 content/en/docs/zero-code/js/            @open-telemetry/docs-approvers @open-telemetry/javascript-approvers
 content/en/docs/zero-code/net/           @open-telemetry/docs-approvers @open-telemetry/dotnet-approvers @open-telemetry/dotnet-instrumentation-approvers

--- a/.github/component-label-map.yml
+++ b/.github/component-label-map.yml
@@ -26,6 +26,7 @@ sig:go:
   - changed-files:
       - any-glob-to-any-file:
           - content/en/docs/languages/go/**
+          - content/en/docs/zero-code/go/**
 sig:java:
   - changed-files:
       - any-glob-to-any-file:

--- a/content/en/docs/concepts/instrumentation/zero-code.md
+++ b/content/en/docs/concepts/instrumentation/zero-code.md
@@ -45,6 +45,7 @@ Other configuration options are available, including:
 Automatic instrumentation is available for the following languages:
 
 - [.NET](/docs/zero-code/net/)
+- [Go](/docs/zero-code/go)
 - [Java](/docs/zero-code/java/)
 - [JavaScript](/docs/zero-code/js/)
 - [PHP](/docs/languages/php/automatic/)

--- a/content/en/docs/zero-code/go.md
+++ b/content/en/docs/zero-code/go.md
@@ -1,0 +1,13 @@
+---
+title: Go zero-code instrumentation
+linkTitle: Go
+weight: 16
+---
+
+Zero-code instrumentation for Go provides a way to instrument any Go application
+and capture telemetry data from many popular libraries and frameworks without
+any code changes.
+
+This project is currently work in progress and you can visit the
+[opentelemetry-go-instrumentation repository](https://github.com/open-telemetry/opentelemetry-go-instrumentation/)
+to learn more.


### PR DESCRIPTION
Contributes to  #4427 but also makes people aware that this solution exists. 