### PR TITLE
fix exporter intro shortcode for automatic to zero-code

### DIFF
--- a/layouts/shortcodes/docs/languages/exporters/intro.md
+++ b/layouts/shortcodes/docs/languages/exporters/intro.md
@@ -47,12 +47,12 @@ them up.
 {{ end -}}
 
 {{ $l := cond (eq $lang "dotnet") "net" $lang }}
-{{ with $.Page.GetPage (print "/docs/zero-code/" $l ) }}
+{{ with $.Page.GetPage (print "/docs/zero-code/" $l "/configuration" ) }}
 
 <div class="alert alert-info" role="alert"><h4 class="alert-heading">Note</h4>
 
-If you use [zero-code instrumentation](/docs/zero-code/{{ $l }}) you can
-learn how to setup exporters following the [Configuration
+If you use [zero-code instrumentation](/docs/zero-code/{{ $l }}) you can learn how
+to setup exporters following the [Configuration
 Guide](/docs/zero-code/{{ $l }}/configuration/).
 
 </div>

--- a/layouts/shortcodes/docs/languages/exporters/intro.md
+++ b/layouts/shortcodes/docs/languages/exporters/intro.md
@@ -51,8 +51,8 @@ them up.
 
 <div class="alert alert-info" role="alert"><h4 class="alert-heading">Note</h4>
 
-If you use [zero-code instrumentation](/docs/zero-code/{{ $l }}) you can learn how
-to setup exporters following the [Configuration
+If you use [zero-code instrumentation](/docs/zero-code/{{ $l }}), you can learn how
+to set up exporters by following the [Configuration
 Guide](/docs/zero-code/{{ $l }}/configuration/).
 
 </div>

--- a/layouts/shortcodes/docs/languages/exporters/intro.md
+++ b/layouts/shortcodes/docs/languages/exporters/intro.md
@@ -46,14 +46,14 @@ them up.
 
 {{ end -}}
 
-{{ with $.Page.GetPage "automatic/configuration" }}
 {{ $l := cond (eq $lang "dotnet") "net" $lang }}
+{{ with $.Page.GetPage (print "/docs/zero-code/" $l ) }}
 
 <div class="alert alert-info" role="alert"><h4 class="alert-heading">Note</h4>
 
-If you use [automatic instrumentation](/docs/languages/{{ $l }}/automatic) you can
+If you use [zero-code instrumentation](/docs/zero-code/{{ $l }}) you can
 learn how to setup exporters following the [Configuration
-Guide](/docs/languages/{{ $l }}/automatic/configuration/).
+Guide](/docs/zero-code/{{ $l }}/configuration/).
 
 </div>
 


### PR DESCRIPTION
One of the disadvantages of using some "magic", this shortcode was broken for a while apparently, this should fix it