### PR TITLE
Add section on null maps to troubleshooting page

### DIFF
--- a/content/en/docs/collector/troubleshooting.md
+++ b/content/en/docs/collector/troubleshooting.md
@@ -2,7 +2,7 @@
 title: Troubleshooting
 description: Recommendations for troubleshooting the Collector
 weight: 25
-cSpell:ignore: pprof tracez zpages
+cSpell:ignore: confmap pprof tracez zpages
 ---
 
 On this page, you can learn how to troubleshoot the health and performance of

--- a/content/en/docs/collector/troubleshooting.md
+++ b/content/en/docs/collector/troubleshooting.md
@@ -359,3 +359,21 @@ container, producing the error message
 the `NO_WINDOWS_SERVICE=1` environment variable must be set to force the
 Collector to start as if it were running in an interactive terminal, without
 attempting to run as a Windows service.
+
+### Collector is experiencing configuration issues
+
+The Collector might experience problems due to configuration issues.
+
+#### Null maps
+
+During configuration resolution of multiple configs, values in earlier configs
+are removed in favor of later configs, even if the later value is null. You can
+fix this issue by
+
+- Using `{}` to represent an empty map, such as `processors: {}` instead of
+  `processors:`.
+- Omitting empty configurations such as `processors:` from the configuration.
+
+See
+[confmap troubleshooting](https://github.com/open-telemetry/opentelemetry-collector/blob/main/confmap/README.md#null-maps)
+for more information.


### PR DESCRIPTION
In the process of reworking the Collector repo docs to finish up [this issue](https://github.com/open-telemetry/opentelemetry-collector/issues/8886), I found that an addition had been made to the [Troubleshooting.md](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/troubleshooting.md#null-maps-in-configuration) file after I copied over the content.

This PR adds the new content to the [Troubleshooting](https://opentelemetry.io/docs/collector/troubleshooting/) page, making it the single source of truth.

---
Preview: https://deploy-preview-4731--opentelemetry.netlify.app/docs/collector/troubleshooting/#collector-is-experiencing-configuration-issues
