### PR TITLE
Fix typo in monitoring section of Internal telemetry page

### DIFF
--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -332,4 +332,4 @@ with the network or backend receiving the data.
 
 You can monitor data ingress with the `otelcol_receiver_accepted_spans` and
 `otelcol_receiver_accepted_metric_points` metrics and data egress with the
-`otecol_exporter_sent_spans` and `otelcol_exporter_sent_metric_points` metrics.
+`otelcol_exporter_sent_spans` and `otelcol_exporter_sent_metric_points` metrics.


### PR DESCRIPTION
This PR fixes a tiny typo in the [Internal telemetry](https://opentelemetry.io/docs/collector/internal-telemetry/#data-flow) page of the Collector documentation.

Added: see [#10455](https://github.com/open-telemetry/opentelemetry-collector/pull/10455), which makes the same change in the Collector repo doc that'll soon be [replaced with a link to the website](https://github.com/open-telemetry/opentelemetry-collector/pull/10454).