### PR TITLE
Enable page-feedback form for doc pages

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -98,7 +98,7 @@ params:
     feedback:
       enable: true
       'yes': >-
-        Thank you, your feedback is appreciated!
+        Thank you. Your feedback is appreciated!
       # prettier-ignore
       'no': >-
         Please let us know <a class="external-link" target="_blank" rel="noopener"

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -95,7 +95,15 @@ params:
     sidebar_menu_compact: true
     sidebar_menu_foldable: true
     sidebar_search_disable: true
-
+    feedback:
+      enable: true
+      'yes': >-
+        Thank you, your feedback is appreciated!
+      # prettier-ignore
+      'no': >-
+        Please let us know <a class="external-link" target="_blank" rel="noopener"
+        href="https://github.com/open-telemetry/opentelemetry.io/issues/new?title=Page%20feedback&body=Suggested%20improvements%20for%20page:%20ADD%20PAGE-URL-HERE">how
+        we can improve this page</a>. Your feedback is appreciated!
   links:
     user:
       - name: Mailing Lists


### PR DESCRIPTION
- Contributes to #4769
- **Preview**: e.g., https://deploy-preview-4772--opentelemetry.netlify.app/docs/getting-started/

### Screenshots

> <img width="617" alt="Screen Shot 2024-07-01 at 17 56 22" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/137cc2e1-9617-47a7-8f08-1872aab7af25">
> <img width="343" alt="Screen Shot 2024-07-01 at 17 56 35" src="https://github.com/open-telemetry/opentelemetry.io/assets/4140793/cfd6e37d-fb0c-4f5b-b89d-78e8101f1bc0">
