### PR TITLE
[CI] Spell check `en` pages only

### DIFF
--- a/.github/workflows/check-spelling.yml
+++ b/.github/workflows/check-spelling.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           # Files should be consistent with check:spelling files
           files: |
-            content/**/*.md
+            content/en/*.md
             layouts/**/*.md
             data/**/*
           config: .cspell.yml

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "check:links:internal": "npm run _check:links:internal",
     "check:links": "npm run _check:links",
     "check:markdown": "scripts/check-markdown-wrapper.sh",
-    "check:spelling": "npx cspell --no-progress -c .cspell.yml content data 'layouts/**/*.md'",
+    "check:spelling": "npx cspell --no-progress -c .cspell.yml content/en data 'layouts/**/*.md'",
     "check:text": "npm run _check:text -- ",
     "check": "npm run seq -- $(npm run -s _list:check:*)",
     "clean": "make clean",


### PR DESCRIPTION
- Contributes to #4467
- In support of #4794 
- Spell checks English pages only. We might want to do better later, but for now, this will allow us to make progress with our i18n support