### PR TITLE
Update Go example Tracer/Meter names

### DIFF
--- a/content/en/docs/languages/go/getting-started.md
+++ b/content/en/docs/languages/go/getting-started.md
@@ -391,7 +391,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
-const name = "rolldice"
+const name = "go.opentelemetry.io/otel/example/dice"
 
 var (
 	tracer = otel.Tracer(name)

--- a/content/en/docs/languages/go/instrumentation.md
+++ b/content/en/docs/languages/go/instrumentation.md
@@ -86,7 +86,7 @@ func main() {
 	otel.SetTracerProvider(tp)
 
 	// Finally, set the tracer that can be used for this package.
-	tracer = tp.Tracer("ExampleService")
+	tracer = tp.Tracer("example.io/package/name")
 }
 ```
 
@@ -432,7 +432,7 @@ acquire a meter. For example:
 ```go
 import "go.opentelemetry.io/otel"
 
-var meter = otel.Meter("my-service-meter")
+var meter = otel.Meter("example.io/package/name")
 ```
 
 ### Synchronous and asynchronous instruments


### PR DESCRIPTION
Set the Tracer and Meter names to uniquely identify the instrumentation scope[^1][^2] by using the unique Go import path of the package.

Closes https://github.com/open-telemetry/opentelemetry-go/issues/5412

[^1]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#get-a-tracer
[^2]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#get-a-meter