### PR TITLE
Remove the semconv dependency in Go getting started

### DIFF
--- a/content/en/docs/languages/go/getting-started.md
+++ b/content/en/docs/languages/go/getting-started.md
@@ -117,7 +117,6 @@ go get "go.opentelemetry.io/otel" \
   "go.opentelemetry.io/otel/sdk/metric" \
   "go.opentelemetry.io/otel/sdk/resource" \
   "go.opentelemetry.io/otel/sdk/trace" \
-  "go.opentelemetry.io/otel/semconv/v1.24.0" \
   "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"\
   "go.opentelemetry.io/contrib/bridges/otelslog"
 ```


### PR DESCRIPTION
This dependency is outdated and not used.