### PR TITLE
Add native/firstParty flag to collector exporters

### DIFF
--- a/data/registry/collector-exporter-alertmanager.yml
+++ b/data/registry/collector-exporter-alertmanager.yml
@@ -14,6 +14,7 @@ description:
   backend to notify Errors or Change events.
 authors:
   - name: OpenTelemetry Authors
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alertmanagerexporter

--- a/data/registry/collector-exporter-alibaba-cloud-log-service.yml
+++ b/data/registry/collector-exporter-alibaba-cloud-log-service.yml
@@ -14,6 +14,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/alibabacloudlogserviceexporter
 createdAt: 2021-02-24
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter

--- a/data/registry/collector-exporter-apiclarity.yml
+++ b/data/registry/collector-exporter-apiclarity.yml
@@ -15,3 +15,4 @@ authors:
 urls:
   repo: https://github.com/openclarity/apiclarity/tree/master/plugins/otel-collector
 createdAt: 2022-11-28
+isNative: true

--- a/data/registry/collector-exporter-aws-xray.yml
+++ b/data/registry/collector-exporter-aws-xray.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awsxrayexporter
 createdAt: 2020-06-06
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter

--- a/data/registry/collector-exporter-awscloudwatchlogs.yml
+++ b/data/registry/collector-exporter-awscloudwatchlogs.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awscloudwatchlogsexporter
 createdAt: 2020-11-05
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter

--- a/data/registry/collector-exporter-awsemf.yml
+++ b/data/registry/collector-exporter-awsemf.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awsemfexporter
 createdAt: 2020-06-06
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter

--- a/data/registry/collector-exporter-awskinesis.yml
+++ b/data/registry/collector-exporter-awskinesis.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awskinesisexporter
 createdAt: 2020-06-06
+isFirstParty: true

--- a/data/registry/collector-exporter-awss3.yml
+++ b/data/registry/collector-exporter-awss3.yml
@@ -14,6 +14,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awss3exporter
 createdAt: 2020-11-05
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter

--- a/data/registry/collector-exporter-azure-monitor.yml
+++ b/data/registry/collector-exporter-azure-monitor.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/azuremonitorexporter
 createdAt: 2020-06-06
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter

--- a/data/registry/collector-exporter-azuredataexplorer.yml
+++ b/data/registry/collector-exporter-azuredataexplorer.yml
@@ -14,6 +14,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/azuredataexplorerexporter
 createdAt: 2020-11-05
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuredataexplorerexporter

--- a/data/registry/collector-exporter-carbon.yml
+++ b/data/registry/collector-exporter-carbon.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/carbonexporter
 createdAt: 2020-06-06
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter

--- a/data/registry/collector-exporter-cassandra.yml
+++ b/data/registry/collector-exporter-cassandra.yml
@@ -14,6 +14,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/cassandraexporter
 createdAt: 2020-11-05
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/cassandraexporter

--- a/data/registry/collector-exporter-clickhouse.yml
+++ b/data/registry/collector-exporter-clickhouse.yml
@@ -14,6 +14,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/clickhouseexporter
 createdAt: 2020-11-05
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter

--- a/data/registry/collector-exporter-coralogix.yml
+++ b/data/registry/collector-exporter-coralogix.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/coralogixexporter
 createdAt: 2020-11-05
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter

--- a/data/registry/collector-exporter-datadog.yml
+++ b/data/registry/collector-exporter-datadog.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter
 createdAt: 2020-06-06
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter

--- a/data/registry/collector-exporter-dataset.yml
+++ b/data/registry/collector-exporter-dataset.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datasetexporter
 createdAt: 2020-06-06
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datasetexporter

--- a/data/registry/collector-exporter-debug.yml
+++ b/data/registry/collector-exporter-debug.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/debugexporter
 createdAt: 2020-11-05
+isFirstParty: true
 package:
   registry: go-collector
   name: go.opentelemetry.io/collector/exporter/debugexporter

--- a/data/registry/collector-exporter-elasticsearch.yml
+++ b/data/registry/collector-exporter-elasticsearch.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/elasticsearchexporter
 createdAt: 2020-11-05
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter

--- a/data/registry/collector-exporter-file.yml
+++ b/data/registry/collector-exporter-file.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/fileexporter
 createdAt: 2020-11-05
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter

--- a/data/registry/collector-exporter-googlecloud.yml
+++ b/data/registry/collector-exporter-googlecloud.yml
@@ -14,6 +14,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudexporter
 createdAt: 2020-06-06
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter

--- a/data/registry/collector-exporter-googlecloudpubsub.yml
+++ b/data/registry/collector-exporter-googlecloudpubsub.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudpubsubexporter
 createdAt: 2020-11-05
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter

--- a/data/registry/collector-exporter-googlemanagedprometheus.yml
+++ b/data/registry/collector-exporter-googlemanagedprometheus.yml
@@ -15,6 +15,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlemanagedprometheusexporter
 createdAt: 2022-10-27
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter

--- a/data/registry/collector-exporter-honeycombmarker.yml
+++ b/data/registry/collector-exporter-honeycombmarker.yml
@@ -15,6 +15,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/honeycombmarkerexporter
 createdAt: 2023-10-17
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombmarkerexporter

--- a/data/registry/collector-exporter-influxdb.yml
+++ b/data/registry/collector-exporter-influxdb.yml
@@ -14,6 +14,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/influxdbexporter
 createdAt: 2020-11-05
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter

--- a/data/registry/collector-exporter-instana.yml
+++ b/data/registry/collector-exporter-instana.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/instanaexporter
 createdAt: 2020-06-06
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/instanaexporter

--- a/data/registry/collector-exporter-kafka.yml
+++ b/data/registry/collector-exporter-kafka.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/kafkaexporter
 createdAt: 2020-11-05
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter

--- a/data/registry/collector-exporter-kinesis.yml
+++ b/data/registry/collector-exporter-kinesis.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awskinesisexporter
 createdAt: 2020-06-06
+isFirstParty: true

--- a/data/registry/collector-exporter-kinetica.yml
+++ b/data/registry/collector-exporter-kinetica.yml
@@ -15,6 +15,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/kineticaexporter
 createdAt: 2023-09-19
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kineticaexporter

--- a/data/registry/collector-exporter-load-balancing.yml
+++ b/data/registry/collector-exporter-load-balancing.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/loadbalancingexporter
 createdAt: 2020-10-22
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter

--- a/data/registry/collector-exporter-logging.yml
+++ b/data/registry/collector-exporter-logging.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/loggingexporter
 createdAt: 2020-11-05
+isFirstParty: true
 deprecated:
   reason:
     This exporter is being deprecated in favour of the [debug

--- a/data/registry/collector-exporter-logicmonitor.yml
+++ b/data/registry/collector-exporter-logicmonitor.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/logicmonitorexporter
 createdAt: 2020-11-05
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logicmonitorexporter

--- a/data/registry/collector-exporter-logzio.yml
+++ b/data/registry/collector-exporter-logzio.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/logzioexporter
 createdAt: 2020-10-22
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter

--- a/data/registry/collector-exporter-loki.yml
+++ b/data/registry/collector-exporter-loki.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/lokiexporter
 createdAt: 2020-10-22
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter

--- a/data/registry/collector-exporter-mezmo.yml
+++ b/data/registry/collector-exporter-mezmo.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/mezmoexporter
 createdAt: 2020-11-05
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/mezmoexporter

--- a/data/registry/collector-exporter-nop.yml
+++ b/data/registry/collector-exporter-nop.yml
@@ -16,6 +16,7 @@ description:
 authors:
   - name: OpenTelemetry Authors
 createdAt: 2024-04-18
+isFirstParty: true
 package:
   registry: go-collector
   name: go.opentelemetry.io/collector/exporter/nopexporter

--- a/data/registry/collector-exporter-opencensus.yml
+++ b/data/registry/collector-exporter-opencensus.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/opencensusexporter
 createdAt: 2020-11-05
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opencensusexporter

--- a/data/registry/collector-exporter-opensearch.yml
+++ b/data/registry/collector-exporter-opensearch.yml
@@ -15,6 +15,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/opensearchexporter
 createdAt: 2020-11-05
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter

--- a/data/registry/collector-exporter-otelarrow.yml
+++ b/data/registry/collector-exporter-otelarrow.yml
@@ -18,6 +18,7 @@ description:
 authors:
   - name: OpenTelemetry Authors
 createdAt: 2024-02-05
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter

--- a/data/registry/collector-exporter-otlp-http.yml
+++ b/data/registry/collector-exporter-otlp-http.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter
 createdAt: 2020-11-05
+isFirstParty: true

--- a/data/registry/collector-exporter-otlp.yml
+++ b/data/registry/collector-exporter-otlp.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter
 createdAt: 2020-11-05
+isFirstParty: true
 package:
   registry: go-collector
   name: go.opentelemetry.io/collector/exporter/otlpexporter

--- a/data/registry/collector-exporter-prometheus-remote-write.yml
+++ b/data/registry/collector-exporter-prometheus-remote-write.yml
@@ -14,6 +14,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusremotewriteexporter
 createdAt: 2020-11-05
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter

--- a/data/registry/collector-exporter-prometheus.yml
+++ b/data/registry/collector-exporter-prometheus.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusexporter
 createdAt: 2020-11-05
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter

--- a/data/registry/collector-exporter-pulsar.yml
+++ b/data/registry/collector-exporter-pulsar.yml
@@ -15,6 +15,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/pulsarexporter
 createdAt: 2022-10-27
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/pulsarexporter

--- a/data/registry/collector-exporter-qryn.yml
+++ b/data/registry/collector-exporter-qryn.yml
@@ -21,3 +21,4 @@ authors:
 urls:
   repo: https://github.com/metrico/otel-collector
 createdAt: 2023-10-17
+isNative: true

--- a/data/registry/collector-exporter-rabbitmq.yml
+++ b/data/registry/collector-exporter-rabbitmq.yml
@@ -14,6 +14,7 @@ description:
 authors:
   - name: OpenTelemetry Authors
 createdAt: 2024-04-18
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/rabbitmqexporter

--- a/data/registry/collector-exporter-sapm.yml
+++ b/data/registry/collector-exporter-sapm.yml
@@ -15,6 +15,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/sapmexporter
 createdAt: 2020-11-05
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter

--- a/data/registry/collector-exporter-sentry.yml
+++ b/data/registry/collector-exporter-sentry.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/sentryexporter
 createdAt: 2020-06-06
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sentryexporter

--- a/data/registry/collector-exporter-signalfx.yml
+++ b/data/registry/collector-exporter-signalfx.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/signalfxexporter
 createdAt: 2020-06-06
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter

--- a/data/registry/collector-exporter-skywalking.yml
+++ b/data/registry/collector-exporter-skywalking.yml
@@ -15,6 +15,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/skywalkingexporter
 createdAt: 2022-10-27
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/skywalkingexporter

--- a/data/registry/collector-exporter-splunk-apm.yml
+++ b/data/registry/collector-exporter-splunk-apm.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/sapmexporter
 createdAt: 2020-06-06
+isFirstParty: true

--- a/data/registry/collector-exporter-splunk-hec.yml
+++ b/data/registry/collector-exporter-splunk-hec.yml
@@ -15,6 +15,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/splunkhecexporter
 createdAt: 2020-06-06
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter

--- a/data/registry/collector-exporter-splunk-imm.yml
+++ b/data/registry/collector-exporter-splunk-imm.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/signalfxexporter
 createdAt: 2020-11-05
+isFirstParty: true

--- a/data/registry/collector-exporter-splunk-sapm.yml
+++ b/data/registry/collector-exporter-splunk-sapm.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/sapmexporter
 createdAt: 2020-06-06
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter

--- a/data/registry/collector-exporter-sumologic.yml
+++ b/data/registry/collector-exporter-sumologic.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/sumologicexporter
 createdAt: 2020-10-22
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter

--- a/data/registry/collector-exporter-syslog.yml
+++ b/data/registry/collector-exporter-syslog.yml
@@ -14,6 +14,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/syslogexporter
 createdAt: 2020-11-05
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporter

--- a/data/registry/collector-exporter-tencentcloudlogservice.yml
+++ b/data/registry/collector-exporter-tencentcloudlogservice.yml
@@ -14,6 +14,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/tencentcloudlogserviceexporter
 createdAt: 2022-10-27
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tencentcloudlogserviceexporter

--- a/data/registry/collector-exporter-zipkin.yml
+++ b/data/registry/collector-exporter-zipkin.yml
@@ -13,6 +13,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/zipkinexporter
 createdAt: 2020-11-05
+isFirstParty: true
 package:
   registry: go-collector
   name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter

--- a/layouts/partials/ecosystem/registry/entry.html
+++ b/layouts/partials/ecosystem/registry/entry.html
@@ -48,7 +48,7 @@
                 "icon" "fab fa-rust")
     -}}
 
-    {{ $isNativ := and (eq .registryType "instrumentation") (.isNative) }}
+    {{ $isNative := and (eq .registryType "instrumentation") (.isNative) }}
     {{ $isFirstParty := and (eq .registryType "instrumentation") (.isFirstParty) }}
     {{ $currentTime := (time now) -}}
     {{ $delta := $currentTime.Sub (time.AsTime .createdAt) -}}
@@ -64,7 +64,7 @@
     {{ if $isNew -}}
         {{ $highlightStyle = "border-info" -}}
     {{ end -}}
-    {{ if $isNativ -}}
+    {{ if $isNative -}}
         {{ $highlightStyle = "border-success" -}}
     {{ end -}}
     {{ if $isFirstParty -}}
@@ -87,7 +87,7 @@
             {{ if $isNew -}}
             <span class="badge rounded-pill text-bg-info"><i class="fa-regular fa-star"></i> new</span>
             {{ end -}}
-            {{ if $isNativ -}}
+            {{ if $isNative -}}
             <span class="badge rounded-pill text-bg-success text-white"><i class="fa-solid fa-puzzle-piece"></i> native</span>
             {{ end -}}
             {{ if $isFirstParty -}}


### PR DESCRIPTION
To address #4795, this is a series of PRs that add native or first party flags to registries that lack them. This batch touches collector-builder and all collector-exporter-* registries.