### PR TITLE
Fix link to "Building a Connector" on custom-collector.md

### DIFF
--- a/content/en/docs/collector/custom-collector.md
+++ b/content/en/docs/collector/custom-collector.md
@@ -219,7 +219,7 @@ your components.
 Further reading:
 
 - [Building a Trace Receiver](/docs/collector/building/receiver)
-- [Building a Connector](/docs/collector/building/receiver)
+- [Building a Connector](/docs/collector/building/connector)
 
 [ocb]:
   https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder


### PR DESCRIPTION
Link for "Building a Connector" on custom collector instruction page currently links to "Building a Trace Receiver." 

This commit fixes the link to redirect to the connector instructions.