### PR TITLE
Revert "Testing out a temporary token for component-owners"

### DIFF
--- a/.github/workflows/component-owners.yml
+++ b/.github/workflows/component-owners.yml
@@ -14,5 +14,5 @@ jobs:
       - uses: dyladan/component-owners@v0.1.0
         with:
           config-file: .github/component-owners.yml
-          repo-token: ${{ secrets.SVRNM_TEST_TOKEN }}
+          repo-token: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
           assign-owners: false


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry.io#4888

https://github.com/open-telemetry/opentelemetry.io/actions/runs/10100116486/job/27930816597 worked just fine, trying now with the OPENTELEMETRYBOT_GITHUB_TOKEN once again