### PR TITLE
[i18n] Improve specs redirects

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -15,6 +15,7 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - ^(/..)?/docs/languages/net/(metrics-api|traces-api)/
   - ^((/..)?/docs/migration/)?opencensus/$
   - ^(/community/end-user/)?feedback-survey/$
+  - ^/../docs/specs/?$ # non-default locale spec redirect
 
   - ^https://deploy-preview-\d+--opentelemetry.netlify.app/
   - ^https://www\.googletagmanager\.com
@@ -72,5 +73,3 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - ^https://wikipedia.org/wiki/(S.M.A.R.T|Hop_)
   # TODO move into content/en/blog/2023/contributing-to-otel/index.md once https://github.com/open-telemetry/opentelemetry.io/issues/3889 is implemented
   - ^https://shorturl.at/vLYZ0$
-  # TODO remove the following temporary ignore rule (@chalin)
-  - ^/en/docs/specs$

--- a/content/ja/docs/specs/_index.md
+++ b/content/ja/docs/specs/_index.md
@@ -1,12 +1,9 @@
 ---
 title: Specifications
 linkTitle: Specs ↗
-description: _Redirect page_
 weight: 960
-# _build: { render: link }
-redirect: /en/docs/specs 301!
-redirects: [{ from: '*', to: '/en/docs/specs/:splat' }]
+_build: { render: link }
+# redirect: /docs/specs 301! # no longer seems necessary, at least not under Netlify-cli dev
+redirects: [{ from: '*', to: '/docs/specs/:splat' }]
 default_lang_commit: 3b44fbfa49ced919daea01123abfaed836d2d0ec
 ---
-
-Netlify redirect target: [{{% param "title" %}}]({{% param "redirect" %}}).

--- a/content/ja/docs/specs/_index.md
+++ b/content/ja/docs/specs/_index.md
@@ -3,7 +3,6 @@ title: Specifications
 linkTitle: Specs ↗
 weight: 960
 _build: { render: link }
-# redirect: /docs/specs 301! # no longer seems necessary, at least not under Netlify-cli dev
 redirects: [{ from: '*', to: '/docs/specs/:splat' }]
 default_lang_commit: 3b44fbfa49ced919daea01123abfaed836d2d0ec
 ---

--- a/layouts/partials/redirects/sites.redirects
+++ b/layouts/partials/redirects/sites.redirects
@@ -13,8 +13,6 @@
 
 {{/* Process non-default languages. */ -}}
 
-/ja/docs/specs  /en/docs/specs/ 301!
-
 {{ range after 1 .Sites -}}
 
   {{ $siteLang := .Language.Lang -}}


### PR DESCRIPTION
Improves the implementation of the redirect of spec pages from non-`en` locales, using `ja` as an example for now.

**Preview**: https://deploy-preview-4895--opentelemetry.netlify.app/ja/docs/

**Redirect tests**

- https://deploy-preview-4895--opentelemetry.netlify.app/ja/docs/specs
- https://deploy-preview-4895--opentelemetry.netlify.app/ja/docs/specs/status
- https://deploy-preview-4895--opentelemetry.netlify.app/ja/docs/specs/opamp



