### PR TITLE
[CI] Component-owners workflow: remove PR trigger

### DIFF
--- a/.github/workflows/component-owners.yml
+++ b/.github/workflows/component-owners.yml
@@ -1,6 +1,7 @@
 name: Component owners
 on:
-  pull_request_target:
+  workflow_dispatch:
+  # pull_request_target:
 
 jobs:
   run_self:


### PR DESCRIPTION
- In scope of the work for #3581
- Disables the PR trigger
- Enables workflow_dispatch trigger in the meantime simply because the `on` component can't be empty

/cc @svrnm 