### PR TITLE
Refactor layouts/index.redirects

### DIFF
--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -1,78 +1,14 @@
 # Netlify redirects. See https://www.netlify.com/docs/redirects/
-{{/* cSpell:ignore cond wordmark */ -}}
+{{ partial "redirects/pages.txt" . | partial "func/trim-lines.html" -}}
+{{ partial "redirects/languages.txt" . | partial "func/trim-lines.html" -}}
 
-{{ range $p := .Site.Pages -}}
-
-{{ range $p.Params.redirects -}}
-  {{ $from := cond (strings.HasPrefix .from "/")
-      .from
-      (print $p.RelPermalink .from) -}}
-  {{ $to := cond (strings.HasPrefix .to "/")
-      .to
-      (print $p.RelPermalink .to) -}}
-  {{ $from | printf "%-35s" }} {{ $to }}
-{{ end -}}
-
-{{ range $p.Aliases -}}
-{{/* Temporary workaround for semconv alias errors */ -}}
-{{ if strings.HasPrefix . "docs/specs/semconv/general" -}}
-{{ . | printf "%-35s" }} {{ $p.RelPermalink }}
-{{ else -}}
-{{ $alias := cond (strings.HasPrefix . "/")
-    .
-    (partial "relative-redirects-alias" (dict "alias" . "p" $p.Parent)) -}}
-{{ $alias | printf "%-35s" }} {{ $p.RelPermalink }}
-{{ end -}}
-{{ end -}}
-
-{{ with $p.Params.redirect -}}
-  {{ $p.RelPermalink | printf "%-35s" }} {{ . }}
-{{ end -}}
-
-{{ end }}{{/* range $p */ -}}
-
-{{ $languages := (.Site.GetPage "/docs/instrumentation").Pages -}}
-{{ range $languages -}}
-{{ $lang := .File.ContentBaseName -}}
-{{ if ne $lang "other" -}}
-/docs/{{ $lang }}   /docs/instrumentation/{{ $lang }}
-/docs/{{ $lang }}/*  /docs/instrumentation/{{ $lang }}/:splat
-{{ end -}}
-{{ end -}}
-
+{{/* TODO: move the following into the spec index file. */ -}}
 /docs/reference/specification    /docs/specs/otel
 /docs/reference/specification/*  /docs/specs/otel/:splat
 /docs/specification/otel/*       /docs/specs/otel/:splat
 
-{{ $schemaFiles := partial "schema-file-list" . -}}
-{{ $latestSchemaFile := index $schemaFiles 0 -}}
+{{ partial "redirects/schemas.txt" . }}
 
-/schemas/latest  /schemas/{{ $latestSchemaFile.Name }}
+{{ partial "redirects/social-media.txt" . }}
 
-{{/*
-  Social-media image redirects. As mentioned in
-  https://developers.facebook.com/docs/sharing/webmasters/images, we need to
-  preserve og:image (and other social media image) URLs forever.
-*/ -}}
-
-{{ $og_image_current := `/img/social/logo-wordmark-001.png` -}}
-
-/featured-background.jpg  {{ $og_image_current }} {{- /* homepage og:image used prior to 2022/08 */}}
-
-{{- define "partials/relative-redirects-alias" -}}
-  {{ $result := "" }}
-  {{ if strings.HasPrefix .alias "../" }}
-    {{ $result = (partial "relative-redirects-alias"
-          (dict
-            "alias" (strings.TrimPrefix "../" .alias)
-            "p" .p.Parent ))
-    }}
-  {{ else }}
-    {{ $result = path.Join .p.RelPermalink .alias }}
-  {{ end }}
-  {{ return $result }}
-{{ end }}
-
-{{/* Multilingual support */ -}}
-
-{{ partial "redirects/sites.redirects" . | partial "func/trim-lines.html" -}}
+{{ partial "redirects/localization.txt" . | partial "func/trim-lines.html" }}

--- a/layouts/partials/func/trim-lines.html
+++ b/layouts/partials/func/trim-lines.html
@@ -1,3 +1,5 @@
 {{ range split . "\n" -}}
-{{ trim . " \t" }}
+{{ with trim . " \t" -}}
+{{ . }}
+{{ end -}}
 {{ end -}}

--- a/layouts/partials/redirects/aliases.txt
+++ b/layouts/partials/redirects/aliases.txt
@@ -1,0 +1,29 @@
+{{/* Generate rules for `aliases` page param. */ -}}
+{{/* cSpell:ignore cond */ -}}
+
+{{ $p := . -}}
+{{ range $p.Aliases -}}
+  {{/* Temporary workaround for semconv alias errors */ -}}
+  {{ if strings.HasPrefix . "docs/specs/semconv/general" -}}
+   {{ . | printf "%-35s" }} {{ $p.RelPermalink }}
+  {{ else -}}
+    {{ $alias := cond (strings.HasPrefix . "/")
+        .
+        (partial "relative-redirects-alias" (dict "alias" . "p" $p.Parent)) -}}
+    {{ $alias | printf "%-35s" }} {{ $p.RelPermalink }}
+  {{ end -}}
+{{ end -}}
+
+{{- define "partials/relative-redirects-alias" -}}
+  {{ $result := "" }}
+  {{ if strings.HasPrefix .alias "../" }}
+    {{ $result = (partial "relative-redirects-alias"
+          (dict
+            "alias" (strings.TrimPrefix "../" .alias)
+            "p" .p.Parent ))
+    }}
+  {{ else }}
+    {{ $result = path.Join .p.RelPermalink .alias }}
+  {{ end }}
+  {{ return $result }}
+{{ end -}}

--- a/layouts/partials/redirects/languages.txt
+++ b/layouts/partials/redirects/languages.txt
@@ -1,0 +1,12 @@
+{{/* Generate rules for all languages. */ -}}
+
+{{/* FIXME - redirect to the new canonical links */ -}}
+
+{{ $languages := (.Site.GetPage "/docs/instrumentation").Pages -}}
+{{ range $languages -}}
+  {{ $lang := .File.ContentBaseName -}}
+  {{ if ne $lang "other" -}}
+    /docs/{{ $lang }}   /docs/instrumentation/{{ $lang }}
+    /docs/{{ $lang }}/*  /docs/instrumentation/{{ $lang }}/:splat
+  {{ end -}}
+{{ end -}}

--- a/layouts/partials/redirects/localization.txt
+++ b/layouts/partials/redirects/localization.txt
@@ -1,4 +1,12 @@
-{{/* Redirect for default language when .LanguagePrefix is empty. */ -}}
+{{/* Generate Netlify redirect rules for non-default .Site.Sites */ -}}
+{{/* cSpell:ignore cond */ -}}
+
+{{/*
+  Determine what the default language code is, `en` in most cases. Redirect
+  paths that start with the default language code by effectively stripping the
+  language code from the start of the path. Hugo handles this for the
+  language-code root. The rules below handle it for all other paths using a
+  wildcard. */ -}}
 
 {{ $defaultLang := "" -}}
 {{ with .Site.Sites.Default -}}
@@ -11,7 +19,7 @@
   {{ end -}}
 {{ end -}}
 
-{{/* Process non-default languages. */ -}}
+{{/* Add redirect rules for non-default languages. */ -}}
 
 {{ range after 1 .Sites -}}
 
@@ -19,6 +27,10 @@
 
   # Site localization {{ $siteLang }}
   {{ range $p := .Pages -}}
+
+    {{/* Enable after refactoring is complete:
+    {{ partial "redirects/redirect.txt" $p -}}
+    */ -}}
 
     {{ range $p.Params.redirects -}}
       {{ $fallbackPage := partial "i18n/fallback-page.html" $p -}}

--- a/layouts/partials/redirects/pages.txt
+++ b/layouts/partials/redirects/pages.txt
@@ -1,0 +1,19 @@
+{{/* Generate redirects for all given pages */ -}}
+{{/* cSpell:ignore cond */ -}}
+
+{{ range $p := .Site.Pages -}}
+
+  {{ range $p.Params.redirects -}}
+    {{ $from := cond (strings.HasPrefix .from "/")
+        .from
+        (print $p.RelPermalink .from) -}}
+    {{ $to := cond (strings.HasPrefix .to "/")
+        .to
+        (print $p.RelPermalink .to) -}}
+    {{ $from | printf "%-35s" }} {{ $to }}
+  {{ end -}}
+
+  {{ partial "redirects/aliases.txt" $p -}}
+  {{ partial "redirects/redirect.txt" $p -}}
+
+{{ end -}}

--- a/layouts/partials/redirects/redirect.txt
+++ b/layouts/partials/redirects/redirect.txt
@@ -1,0 +1,6 @@
+{{/* Generate a Netlify redirect rule for pages with a `redirect` param */ -}}
+
+{{ $p := . -}}
+{{ with $p.Params.redirect -}}
+  {{ $p.RelPermalink | printf "%-35s" }} {{ . }}
+{{ end -}}

--- a/layouts/partials/redirects/schemas.txt
+++ b/layouts/partials/redirects/schemas.txt
@@ -1,0 +1,4 @@
+{{ $schemaFiles := partial "schema-file-list" . -}}
+{{ $latestSchemaFile := index $schemaFiles 0 -}}
+
+/schemas/latest  /schemas/{{ $latestSchemaFile.Name -}}

--- a/layouts/partials/redirects/social-media.txt
+++ b/layouts/partials/redirects/social-media.txt
@@ -1,0 +1,12 @@
+{{/*
+  Social-media image redirects. As mentioned in
+  https://developers.facebook.com/docs/sharing/webmasters/images, we need to
+  preserve og:image (and other social media image) URLs forever.
+
+  cSpell:ignore wordmark
+*/ -}}
+
+{{ $og_image_current := `/img/social/logo-wordmark-001.png` -}}
+
+{{/* homepage og:image used prior to 2022/08 */ -}}
+/featured-background.jpg  {{ $og_image_current -}}


### PR DESCRIPTION
- Contributes to #4899
- In prep for:
  - #4629
  - #4898

The generated `_redirects` file is the same before and after this PR:

```console
$ npm run build                          
...
$ (cd public && git diff -bw) | grep ^diff
diff --git a/site/index.html b/site/index.html
```

### Sanity tests or redirect rules

- https://deploy-preview-4900--opentelemetry.netlify.app/vendors
- https://deploy-preview-4900--opentelemetry.netlify.app/en/docs
- https://deploy-preview-4900--opentelemetry.netlify.app/ja/docs/specs/status