### PR TITLE
Fix JS propagation page link

### DIFF
--- a/content/en/docs/languages/js/propagation.md
+++ b/content/en/docs/languages/js/propagation.md
@@ -455,7 +455,7 @@ the client and server behave as if OpenTelemetry is not used.
 
 This is especially important if your server and client code are libraries, since
 they should only use the OpenTelemetry API. To understand why, read the [concept
-page on how to add instrumentation to your library]((/docs/concepts/instrumentation/libraries/).
+page on how to add instrumentation to your library](/docs/concepts/instrumentation/libraries/).
 
 {{% /alert %}}
 

--- a/content/en/docs/languages/js/propagation.md
+++ b/content/en/docs/languages/js/propagation.md
@@ -454,8 +454,8 @@ the client and server behave as if OpenTelemetry is not used.
 {{% alert title="Note" color="warning" %}}
 
 This is especially important if your server and client code are libraries, since
-they should only use the OpenTelemetry API. To understand why, read the [concept
-page on how to add instrumentation to your library](/docs/concepts/instrumentation/libraries/).
+they should only use the OpenTelemetry API. To understand why, read the
+[concept page on how to add instrumentation to your library](/docs/concepts/instrumentation/libraries/).
 
 {{% /alert %}}
 


### PR DESCRIPTION
I was reviewing the [JS propagation page](https://opentelemetry.io/docs/languages/js/propagation/) and noticed this broken markdown link:

<img width="993" alt="image" src="https://github.com/user-attachments/assets/d4e0488a-1247-4ace-a613-0a549eb7e1c4">
