### PR TITLE
python: add note to zero-code docs highlighting the need for distro package

### DIFF
--- a/content/en/docs/zero-code/python/_index.md
+++ b/content/en/docs/zero-code/python/_index.md
@@ -25,10 +25,10 @@ The `opentelemetry-distro` package installs the API, SDK, and the
 
 {{% alert title="Note" color="info" %}}
 
-You must install a distro package to get auto instrumentation
-working. The `opentelemetry-distro` package contains the default distro to
-automatically configure some of the common options for users.
-For more information, see [OpenTelemetry distro](/docs/languages/python/distro/).
+You must install a distro package to get auto instrumentation working. The
+`opentelemetry-distro` package contains the default distro to automatically
+configure some of the common options for users. For more information, see
+[OpenTelemetry distro](/docs/languages/python/distro/).
 
 {{% /alert %}}
 
@@ -41,9 +41,8 @@ example, if you already installed the `flask` package, running
 
 {{% alert title="Note" color="info" %}}
 
-If you leave out `-a install`, the command will simply list out the
-recommended instrumentation libraries to be installed. More information can be
-found
+If you leave out `-a install`, the command will simply list out the recommended
+instrumentation libraries to be installed. More information can be found
 [here](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-instrumentation#opentelemetry-bootstrap).
 
 {{% /alert %}}

--- a/content/en/docs/zero-code/python/_index.md
+++ b/content/en/docs/zero-code/python/_index.md
@@ -23,7 +23,7 @@ opentelemetry-bootstrap -a install
 The `opentelemetry-distro` package installs the API, SDK, and the
 `opentelemetry-bootstrap` and `opentelemetry-instrument` tools.
 
-> **NOTE:** You need to install a distro package to get auto instrumentation
+> **NOTE:** You must install a distro package to get auto instrumentation
 > working. The `opentelemetry-distro` package contains the default distro to
 > automatically configure some of the common options for users.
 > For more information about `opentelemetry-distro` check

--- a/content/en/docs/zero-code/python/_index.md
+++ b/content/en/docs/zero-code/python/_index.md
@@ -23,10 +23,14 @@ opentelemetry-bootstrap -a install
 The `opentelemetry-distro` package installs the API, SDK, and the
 `opentelemetry-bootstrap` and `opentelemetry-instrument` tools.
 
-> **NOTE:** You must install a distro package to get auto instrumentation
-> working. The `opentelemetry-distro` package contains the default distro to
-> automatically configure some of the common options for users.
-> For more information, see [OpenTelemetry distro](/docs/languages/python/distro/).
+{{% alert title="Note" color="info" %}}
+
+You must install a distro package to get auto instrumentation
+working. The `opentelemetry-distro` package contains the default distro to
+automatically configure some of the common options for users.
+For more information, see [OpenTelemetry distro](/docs/languages/python/distro/).
+
+{{% /alert %}}
 
 The `opentelemetry-bootstrap -a install` command reads through the list of
 packages installed in your active `site-packages` folder, and installs the
@@ -35,10 +39,14 @@ example, if you already installed the `flask` package, running
 `opentelemetry-bootstrap -a install` will install
 `opentelemetry-instrumentation-flask` for you.
 
-> **NOTE:** If you leave out `-a install`, the command will simply list out the
-> recommended instrumentation libraries to be installed. More information can be
-> found
-> [here](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-instrumentation#opentelemetry-bootstrap).
+{{% alert title="Note" color="info" %}}
+
+If you leave out `-a install`, the command will simply list out the
+recommended instrumentation libraries to be installed. More information can be
+found
+[here](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-instrumentation#opentelemetry-bootstrap).
+
+{{% /alert %}}
 
 ## Configuring the agent
 

--- a/content/en/docs/zero-code/python/_index.md
+++ b/content/en/docs/zero-code/python/_index.md
@@ -26,8 +26,7 @@ The `opentelemetry-distro` package installs the API, SDK, and the
 > **NOTE:** You must install a distro package to get auto instrumentation
 > working. The `opentelemetry-distro` package contains the default distro to
 > automatically configure some of the common options for users.
-> For more information about `opentelemetry-distro` check
-> [here](/docs/languages/python/distro/).
+> For more information, see [OpenTelemetry distro](/docs/languages/python/distro/).
 
 The `opentelemetry-bootstrap -a install` command reads through the list of
 packages installed in your active `site-packages` folder, and installs the

--- a/content/en/docs/zero-code/python/_index.md
+++ b/content/en/docs/zero-code/python/_index.md
@@ -39,13 +39,9 @@ example, if you already installed the `flask` package, running
 `opentelemetry-bootstrap -a install` will install
 `opentelemetry-instrumentation-flask` for you.
 
-{{% alert title="Note" color="info" %}}
-
-If you leave out `-a install`, the command will simply list out the recommended
-instrumentation libraries to be installed. More information can be found
-[here](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-instrumentation#opentelemetry-bootstrap).
-
-{{% /alert %}}
+Running `opentelemetry-bootstrap` without arguments lists the recommended
+instrumentation libraries to be installed. For more information, see
+[`opentelemetry-bootstrap`](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-instrumentation#opentelemetry-bootstrap).
 
 ## Configuring the agent
 

--- a/content/en/docs/zero-code/python/_index.md
+++ b/content/en/docs/zero-code/python/_index.md
@@ -24,8 +24,8 @@ The `opentelemetry-distro` package installs the API, SDK, and the
 `opentelemetry-bootstrap` and `opentelemetry-instrument` tools.
 
 > **NOTE:** You need to install a distro package to get auto instrumentation
-> working. The `opentelemetry-distro` package contains the default distro and
-> configurator to automatically configures some of the common options for users.
+> working. The `opentelemetry-distro` package contains the default distro to
+> automatically configure some of the common options for users.
 > For more information about `opentelemetry-distro` check
 > [here](/docs/languages/python/distro/).
 

--- a/content/en/docs/zero-code/python/_index.md
+++ b/content/en/docs/zero-code/python/_index.md
@@ -23,6 +23,12 @@ opentelemetry-bootstrap -a install
 The `opentelemetry-distro` package installs the API, SDK, and the
 `opentelemetry-bootstrap` and `opentelemetry-instrument` tools.
 
+> **NOTE:** You need to install a distro package to get auto instrumentation working.
+> The `opentelemetry-distro` package contains the default distro and configurator to
+> automatically configures some of the common options for users.
+> For more information about `opentelemetry-distro` check
+> [here](docs/languages/python/distro/).
+
 The `opentelemetry-bootstrap -a install` command reads through the list of
 packages installed in your active `site-packages` folder, and installs the
 corresponding instrumentation libraries for these packages, if applicable. For

--- a/content/en/docs/zero-code/python/_index.md
+++ b/content/en/docs/zero-code/python/_index.md
@@ -25,9 +25,9 @@ The `opentelemetry-distro` package installs the API, SDK, and the
 
 > **NOTE:** You need to install a distro package to get auto instrumentation working.
 > The `opentelemetry-distro` package contains the default distro and configurator to
-> automatically configures some of the common options for users.
-> For more information about `opentelemetry-distro` check
-> [here](docs/languages/python/distro/).
+> automatically configures some of the common options for users. For more information
+> about `opentelemetry-distro` check
+> [here](/docs/languages/python/distro/).
 
 The `opentelemetry-bootstrap -a install` command reads through the list of
 packages installed in your active `site-packages` folder, and installs the

--- a/content/en/docs/zero-code/python/_index.md
+++ b/content/en/docs/zero-code/python/_index.md
@@ -23,10 +23,10 @@ opentelemetry-bootstrap -a install
 The `opentelemetry-distro` package installs the API, SDK, and the
 `opentelemetry-bootstrap` and `opentelemetry-instrument` tools.
 
-> **NOTE:** You need to install a distro package to get auto instrumentation working.
-> The `opentelemetry-distro` package contains the default distro and configurator to
-> automatically configures some of the common options for users. For more information
-> about `opentelemetry-distro` check
+> **NOTE:** You need to install a distro package to get auto instrumentation
+> working. The `opentelemetry-distro` package contains the default distro and
+> configurator to automatically configures some of the common options for users.
+> For more information about `opentelemetry-distro` check
 > [here](/docs/languages/python/distro/).
 
 The `opentelemetry-bootstrap -a install` command reads through the list of


### PR DESCRIPTION
# Description
Although we have in all examples the command to install the `opentelemetry-distro` package, it may still not be so clear to users that they need a distro package to get auto-instrumentation working.

Follow-up for this https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2157