### PR TITLE
firstParty/native flag for elixir/erlang/go

### DIFF
--- a/data/registry/instrumentation-elixir-ecto.yml
+++ b/data/registry/instrumentation-elixir-ecto.yml
@@ -14,6 +14,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_ecto
 createdAt: 2022-03-23
+isFirstParty: false
 package:
   registry: hex
   name: opentelemetry_ecto

--- a/data/registry/instrumentation-elixir-oban.yml
+++ b/data/registry/instrumentation-elixir-oban.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_oban
 createdAt: 2022-03-23
+isFirstParty: false

--- a/data/registry/instrumentation-elixir-phoenix.yml
+++ b/data/registry/instrumentation-elixir-phoenix.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_phoenix
 createdAt: 2022-03-23
+isFirstParty: false

--- a/data/registry/instrumentation-elixir-redix.yml
+++ b/data/registry/instrumentation-elixir-redix.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_redix
 createdAt: 2022-03-23
+isFirstParty: false

--- a/data/registry/instrumentation-erlang-bandit.yml
+++ b/data/registry/instrumentation-erlang-bandit.yml
@@ -14,6 +14,7 @@ description:
 authors:
   - name: OpenTelemetry Authors
 createdAt: 2024-04-18
+isFirstParty: false
 package:
   registry: hex
   name: opentelemetry_bandit

--- a/data/registry/instrumentation-erlang-cowboy.yml
+++ b/data/registry/instrumentation-erlang-cowboy.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_cowboy
 createdAt: 2022-03-23
+isFirstParty: false

--- a/data/registry/instrumentation-erlang-dataloader.yml
+++ b/data/registry/instrumentation-erlang-dataloader.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_dataloader
 createdAt: 2022-03-23
+isFirstParty: false

--- a/data/registry/instrumentation-erlang-ecto.yml
+++ b/data/registry/instrumentation-erlang-ecto.yml
@@ -14,6 +14,7 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_ecto
 createdAt: 2022-03-23
+isFirstParty: false
 package:
   registry: hex
   name: opentelemetry_ecto

--- a/data/registry/instrumentation-erlang-elli.yml
+++ b/data/registry/instrumentation-erlang-elli.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_elli
 createdAt: 2022-03-23
+isFirstParty: false

--- a/data/registry/instrumentation-erlang-finch.yml
+++ b/data/registry/instrumentation-erlang-finch.yml
@@ -14,3 +14,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_finch
 createdAt: 2022-03-23
+isFirstParty: false

--- a/data/registry/instrumentation-erlang-grpcbox.yml
+++ b/data/registry/instrumentation-erlang-grpcbox.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_grpcbox
 createdAt: 2022-03-23
+isFirstParty: false

--- a/data/registry/instrumentation-erlang-httpoison.yml
+++ b/data/registry/instrumentation-erlang-httpoison.yml
@@ -14,3 +14,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_httpoison
 createdAt: 2022-03-23
+isFirstParty: false

--- a/data/registry/instrumentation-erlang-nebulex.yml
+++ b/data/registry/instrumentation-erlang-nebulex.yml
@@ -14,3 +14,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_nebulex
 createdAt: 2022-03-23
+isFirstParty: false

--- a/data/registry/instrumentation-erlang-oban.yml
+++ b/data/registry/instrumentation-erlang-oban.yml
@@ -15,3 +15,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_oban
 createdAt: 2022-03-23
+isFirstParty: false

--- a/data/registry/instrumentation-erlang-phoenix.yml
+++ b/data/registry/instrumentation-erlang-phoenix.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_phoenix
 createdAt: 2022-03-23
+isFirstParty: false

--- a/data/registry/instrumentation-erlang-redix.yml
+++ b/data/registry/instrumentation-erlang-redix.yml
@@ -15,3 +15,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_redix
 createdAt: 2022-03-23
+isFirstParty: false

--- a/data/registry/instrumentation-erlang-req.yml
+++ b/data/registry/instrumentation-erlang-req.yml
@@ -12,3 +12,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_req
 createdAt: 2022-03-23
+isFirstParty: false

--- a/data/registry/instrumentation-erlang-tesla.yml
+++ b/data/registry/instrumentation-erlang-tesla.yml
@@ -14,3 +14,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_tesla
 createdAt: 2022-10-27
+isFirstParty: false

--- a/data/registry/instrumentation-go-beego.yml
+++ b/data/registry/instrumentation-go-beego.yml
@@ -15,3 +15,4 @@ authors:
 urls:
   repo: https://go.opentelemetry.io/contrib/instrumentation/github.com/astaxie/beego
 createdAt: 2022-12-07
+isFirstParty: true

--- a/data/registry/instrumentation-go-connect-rpc.yml
+++ b/data/registry/instrumentation-go-connect-rpc.yml
@@ -11,5 +11,6 @@ description: Go contrib plugin for Connect RPC.
 authors:
   - name: Buf
 urls:
-  repo: https://github.com/bufbuild/connect-opentelemetry-go
+  repo: https://github.com/connectrpc/otelconnect-go
 createdAt: 2023-01-19
+isFirstParty: true

--- a/data/registry/instrumentation-go-echo.yml
+++ b/data/registry/instrumentation-go-echo.yml
@@ -12,3 +12,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/github.com/labstack/echo
 createdAt: 2020-06-08
+isFirstParty: false

--- a/data/registry/instrumentation-go-fiber.yml
+++ b/data/registry/instrumentation-go-fiber.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://github.com/gofiber/contrib/tree/main/otelfiber
 createdAt: 2022-01-14
+isFirstParty: false

--- a/data/registry/instrumentation-go-gin.yml
+++ b/data/registry/instrumentation-go-gin.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/github.com/gin-gonic/gin
 createdAt: 2020-06-08
+isFirstParty: false

--- a/data/registry/instrumentation-go-go-pg.yml
+++ b/data/registry/instrumentation-go-go-pg.yml
@@ -12,3 +12,4 @@ authors:
 urls:
   repo: https://github.com/go-pg/pg/tree/v10/extra/pgotel
 createdAt: 2021-04-19
+isFirstParty: true

--- a/data/registry/instrumentation-go-go-redis.yml
+++ b/data/registry/instrumentation-go-go-redis.yml
@@ -12,3 +12,4 @@ authors:
 urls:
   repo: https://github.com/redis/go-redis/tree/master/extra/redisotel
 createdAt: 2021-04-19
+isFirstParty: true

--- a/data/registry/instrumentation-go-go-resty.yml
+++ b/data/registry/instrumentation-go-go-resty.yml
@@ -14,3 +14,4 @@ authors:
 urls:
   repo: https://github.com/dubonzi/otelresty
 createdAt: 2023-07-13
+isFirstParty: true

--- a/data/registry/instrumentation-go-gocql.yml
+++ b/data/registry/instrumentation-go-gocql.yml
@@ -14,3 +14,4 @@ authors:
 urls:
   repo: https://go.opentelemetry.io/contrib/instrumentation/github.com/gocql/gocql
 createdAt: 2022-12-07
+isFirstParty: true

--- a/data/registry/instrumentation-go-gomemcache.yml
+++ b/data/registry/instrumentation-go-gomemcache.yml
@@ -15,3 +15,4 @@ authors:
 urls:
   repo: https://go.opentelemetry.io/contrib/instrumentation/github.com/bradfitz/gomemcache
 createdAt: 2022-12-07
+isFirstParty: true

--- a/data/registry/instrumentation-go-gorm.yml
+++ b/data/registry/instrumentation-go-gorm.yml
@@ -17,3 +17,4 @@ authors:
 urls:
   repo: https://github.com/uptrace/opentelemetry-go-extra/tree/main/otelgorm
 createdAt: 2021-10-25
+isFirstParty: true

--- a/data/registry/instrumentation-go-gqlgen.yml
+++ b/data/registry/instrumentation-go-gqlgen.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://github.com/ravilushqa/otelgqlgen
 createdAt: 2021-11-03
+isFirstParty: true

--- a/data/registry/instrumentation-go-graphql.yml
+++ b/data/registry/instrumentation-go-graphql.yml
@@ -16,3 +16,4 @@ authors:
 urls:
   repo: https://github.com/uptrace/opentelemetry-go-extra/tree/main/otelgraphql
 createdAt: 2021-10-25
+isFirstParty: true

--- a/data/registry/instrumentation-go-grpc-metrics.yml
+++ b/data/registry/instrumentation-go-grpc-metrics.yml
@@ -16,3 +16,4 @@ authors:
 urls:
   repo: https://github.com/mahboubii/grpcmetrics
 createdAt: 2023-04-06
+isFirstParty: true

--- a/data/registry/instrumentation-go-grpc.yml
+++ b/data/registry/instrumentation-go-grpc.yml
@@ -12,3 +12,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/google.golang.org/grpc
 createdAt: 2020-06-08
+isFirstParty: false

--- a/data/registry/instrumentation-go-host.yml
+++ b/data/registry/instrumentation-go-host.yml
@@ -11,3 +11,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/host
 createdAt: 2020-06-08
+isFirstParty: false

--- a/data/registry/instrumentation-go-http.yml
+++ b/data/registry/instrumentation-go-http.yml
@@ -15,3 +15,4 @@ authors:
 urls:
   repo: https://go.opentelemetry.io/contrib/instrumentation/net/http
 createdAt: 2023-12-05
+isFirstParty: true

--- a/data/registry/instrumentation-go-ibm-sarama.yml
+++ b/data/registry/instrumentation-go-ibm-sarama.yml
@@ -17,6 +17,7 @@ authors:
 urls:
   repo: https://github.com/dnwe/otelsarama
 createdAt: 2024-11-25
+isFirstParty: false
 package:
   name: github.com/dnwe/otelsarama
   registry: go

--- a/data/registry/instrumentation-go-kotel-franz-go.yml
+++ b/data/registry/instrumentation-go-kotel-franz-go.yml
@@ -19,3 +19,4 @@ authors:
 urls:
   repo: https://github.com/twmb/franz-go/tree/master/plugin/kotel
 createdAt: 2023-02-09
+isFirstParty: true

--- a/data/registry/instrumentation-go-labstack.yml
+++ b/data/registry/instrumentation-go-labstack.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/github.com/labstack/echo
 createdAt: 2020-06-08
+isFirstParty: false

--- a/data/registry/instrumentation-go-logrus.yml
+++ b/data/registry/instrumentation-go-logrus.yml
@@ -14,3 +14,4 @@ authors:
 urls:
   repo: https://github.com/uptrace/opentelemetry-go-extra/tree/main/otellogrus
 createdAt: 2021-10-25
+isFirstParty: false

--- a/data/registry/instrumentation-go-mongodb.yml
+++ b/data/registry/instrumentation-go-mongodb.yml
@@ -16,3 +16,4 @@ authors:
 urls:
   repo: https://go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver
 createdAt: 2020-06-08
+isFirstParty: true

--- a/data/registry/instrumentation-go-mux.yml
+++ b/data/registry/instrumentation-go-mux.yml
@@ -12,3 +12,4 @@ authors:
 urls:
   repo: https://go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux
 createdAt: 2022-12-07
+isFirstParty: true

--- a/data/registry/instrumentation-go-neo4j.yml
+++ b/data/registry/instrumentation-go-neo4j.yml
@@ -15,3 +15,4 @@ authors:
 urls:
   repo: https://github.com/raito-io/neo4j-tracing
 createdAt: 2023-05-26
+isFirstParty: true

--- a/data/registry/instrumentation-go-nhatthm-otelsql.yml
+++ b/data/registry/instrumentation-go-nhatthm-otelsql.yml
@@ -16,3 +16,4 @@ authors:
 urls:
   repo: https://github.com/nhatthm/otelsql
 createdAt: 2022-01-27
+isFirstParty: true

--- a/data/registry/instrumentation-go-otelaws.yml
+++ b/data/registry/instrumentation-go-otelaws.yml
@@ -12,3 +12,4 @@ authors:
 urls:
   repo: https://go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws
 createdAt: 2020-06-08
+isFirstParty: true

--- a/data/registry/instrumentation-go-otelkit.yml
+++ b/data/registry/instrumentation-go-otelkit.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://go.opentelemetry.io/contrib/instrumentation/github.com/go-kit/kit/otelkit
 createdAt: 2022-12-07
+isFirstParty: true

--- a/data/registry/instrumentation-go-otellambda.yml
+++ b/data/registry/instrumentation-go-otellambda.yml
@@ -15,3 +15,4 @@ authors:
 urls:
   repo: https://go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda
 createdAt: 2022-12-07
+isFirstParty: true

--- a/data/registry/instrumentation-go-otelmacaron.yml
+++ b/data/registry/instrumentation-go-otelmacaron.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://go.opentelemetry.io/contrib/instrumentation/gopkg.in/macaron.v1/otelmacaron
 createdAt: 2023-12-05
+isFirstParty: true

--- a/data/registry/instrumentation-go-otelpgx.yml
+++ b/data/registry/instrumentation-go-otelpgx.yml
@@ -16,3 +16,4 @@ authors:
 urls:
   repo: https://github.com/exaring/otelpgx
 createdAt: 2022-09-27
+isFirstParty: true

--- a/data/registry/instrumentation-go-otelsqlx.yml
+++ b/data/registry/instrumentation-go-otelsqlx.yml
@@ -17,3 +17,4 @@ authors:
 urls:
   repo: https://github.com/uptrace/opentelemetry-go-extra/tree/main/otelsqlx
 createdAt: 2021-10-25
+isFirstParty: true

--- a/data/registry/instrumentation-go-restful.yml
+++ b/data/registry/instrumentation-go-restful.yml
@@ -15,3 +15,4 @@ authors:
 urls:
   repo: https://go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful
 createdAt: 2022-12-07
+isFirstParty: true

--- a/data/registry/instrumentation-go-riandyrn-go-chi-chi.yml
+++ b/data/registry/instrumentation-go-riandyrn-go-chi-chi.yml
@@ -15,3 +15,4 @@ authors:
 urls:
   repo: https://github.com/riandyrn/otelchi
 createdAt: 2021-10-18
+isFirstParty: true

--- a/data/registry/instrumentation-go-runtime.yml
+++ b/data/registry/instrumentation-go-runtime.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/runtime
 createdAt: 2020-06-08
+isFirstParty: false

--- a/data/registry/instrumentation-go-sarama.yml
+++ b/data/registry/instrumentation-go-sarama.yml
@@ -14,3 +14,4 @@ authors:
 urls:
   repo: https://go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama
 createdAt: 2022-12-07
+isFirstParty: true

--- a/data/registry/instrumentation-go-splunkbuntdb.yml
+++ b/data/registry/instrumentation-go-splunkbuntdb.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/tidwall/buntdb/splunkbuntdb
 createdAt: 2022-01-20
+isFirstParty: true

--- a/data/registry/instrumentation-go-splunkchi.yml
+++ b/data/registry/instrumentation-go-splunkchi.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/go-chi/chi/splunkchi
 createdAt: 2022-01-20
+isFirstParty: true

--- a/data/registry/instrumentation-go-splunkclient-go.yml
+++ b/data/registry/instrumentation-go-splunkclient-go.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/k8s.io/client-go/splunkclient-go
 createdAt: 2022-01-20
+isFirstParty: true

--- a/data/registry/instrumentation-go-splunkdns.yml
+++ b/data/registry/instrumentation-go-splunkdns.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/miekg/dns/splunkdns
 createdAt: 2022-01-20
+isFirstParty: true

--- a/data/registry/instrumentation-go-splunkelastic.yml
+++ b/data/registry/instrumentation-go-splunkelastic.yml
@@ -14,3 +14,4 @@ authors:
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/gopkg.in/olivere/elastic/splunkelastic
 createdAt: 2022-01-20
+isFirstParty: true

--- a/data/registry/instrumentation-go-splunkgorm.yml
+++ b/data/registry/instrumentation-go-splunkgorm.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/jinzhu/gorm/splunkgorm
 createdAt: 2022-01-20
+isFirstParty: true

--- a/data/registry/instrumentation-go-splunkgraphql.yml
+++ b/data/registry/instrumentation-go-splunkgraphql.yml
@@ -14,3 +14,4 @@ authors:
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql
 createdAt: 2022-01-20
+isFirstParty: true

--- a/data/registry/instrumentation-go-splunkhttp.yml
+++ b/data/registry/instrumentation-go-splunkhttp.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/net/http/splunkhttp
 createdAt: 2022-01-20
+isFirstParty: true

--- a/data/registry/instrumentation-go-splunkhttprouter.yml
+++ b/data/registry/instrumentation-go-splunkhttprouter.yml
@@ -15,3 +15,4 @@ authors:
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter
 createdAt: 2022-01-20
+isFirstParty: true

--- a/data/registry/instrumentation-go-splunkkafka.yml
+++ b/data/registry/instrumentation-go-splunkkafka.yml
@@ -17,3 +17,4 @@ authors:
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka
 createdAt: 2022-01-20
+isFirstParty: true

--- a/data/registry/instrumentation-go-splunkleveldb.yml
+++ b/data/registry/instrumentation-go-splunkleveldb.yml
@@ -15,3 +15,4 @@ authors:
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb
 createdAt: 2022-01-20
+isFirstParty: true

--- a/data/registry/instrumentation-go-splunkmysql.yml
+++ b/data/registry/instrumentation-go-splunkmysql.yml
@@ -14,3 +14,4 @@ authors:
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/go-sql-driver/mysql/splunkmysql
 createdAt: 2022-01-20
+isFirstParty: true

--- a/data/registry/instrumentation-go-splunkpgx.yml
+++ b/data/registry/instrumentation-go-splunkpgx.yml
@@ -14,3 +14,4 @@ authors:
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/jackc/pgx/splunkpgx
 createdAt: 2022-01-20
+isFirstParty: true

--- a/data/registry/instrumentation-go-splunkpq.yml
+++ b/data/registry/instrumentation-go-splunkpq.yml
@@ -14,3 +14,4 @@ authors:
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/lib/pq/splunkpq
 createdAt: 2022-01-20
+isFirstParty: true

--- a/data/registry/instrumentation-go-splunkredigo.yml
+++ b/data/registry/instrumentation-go-splunkredigo.yml
@@ -14,3 +14,4 @@ authors:
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/gomodule/redigo/splunkredigo
 createdAt: 2022-01-20
+isFirstParty: true

--- a/data/registry/instrumentation-go-splunksql.yml
+++ b/data/registry/instrumentation-go-splunksql.yml
@@ -14,3 +14,4 @@ authors:
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/database/sql/splunksql
 createdAt: 2021-10-12
+isFirstParty: true

--- a/data/registry/instrumentation-go-splunksqlx.yml
+++ b/data/registry/instrumentation-go-splunksqlx.yml
@@ -13,3 +13,4 @@ authors:
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/jmoiron/sqlx/splunksqlx
 createdAt: 2022-01-20
+isFirstParty: true

--- a/data/registry/instrumentation-go-sqs.yml
+++ b/data/registry/instrumentation-go-sqs.yml
@@ -16,3 +16,4 @@ authors:
 urls:
   repo: https://github.com/udhos/opentelemetry-trace-sqs
 createdAt: 2023-10-25
+isFirstParty: true

--- a/data/registry/instrumentation-go-uptrace-otelsql.yml
+++ b/data/registry/instrumentation-go-uptrace-otelsql.yml
@@ -16,3 +16,4 @@ authors:
 urls:
   repo: https://github.com/uptrace/opentelemetry-go-extra/tree/main/otelsql
 createdAt: 2021-10-25
+isFirstParty: true

--- a/data/registry/instrumentation-go-xsam-database-sql.yml
+++ b/data/registry/instrumentation-go-xsam-database-sql.yml
@@ -12,6 +12,7 @@ description: Instrumentation for the Golang `database/sql` package.
 authors:
   - name: Sam Xie
     url: https://github.com/XSAM
+isFirstParty: true
 package:
   name: github.com/XSAM/otelsql
   registry: go

--- a/data/registry/instrumentation-go-zap.yml
+++ b/data/registry/instrumentation-go-zap.yml
@@ -14,3 +14,4 @@ authors:
 urls:
   repo: https://github.com/uptrace/opentelemetry-go-extra/tree/main/otelzap
 createdAt: 2021-10-25
+isFirstParty: true


### PR DESCRIPTION
To address #4795, this is part of a series of PRs that add isFirstParty or isNative flags to instrumentation registries that lack them.

This batch touches Elixir, Erlang, and Go instrumentation registries.

There are a number of repos that belong to individual maintainer as opposed to a corp/foundation entity. Please point out any errors and I will correct.

Oh, about where I placed the line: if there is a `package:` line, then the flag is placed right above it. Otherwise, I placed it under the `createdAt:` line, which makes it usually the last non empty line of the file. I did it this way before I observed this pattern in other files before modifications.

Thanks!