### PR TITLE
[CI] Only report registry format errors by default

### DIFF
--- a/gulp-src/validate-registry.js
+++ b/gulp-src/validate-registry.js
@@ -10,6 +10,7 @@ const defaultGlobs = ['data/registry/*.yml'];
 
 let numFilesProcessed = 0,
   numFilesWithIssues = 0;
+let debugFlag = false;
 
 const schema = require('../data/registry-schema.json');
 const ajv = new Ajv({
@@ -125,7 +126,7 @@ function validateRegistryEntry(file, enc, cb) {
         console.log(
           `::${logLevel} file=${file.path},line=${lineNumber},endLine=${lineNumber},title=Registry Schema Validation::${error.message}`,
         );
-      } else {
+      } else if (debugFlag) {
         console.log(error);
         console.error(
           `${logLevel} in ${file.path}:${lineNumber}: ${error.message}`,
@@ -165,6 +166,7 @@ function validateRegistry() {
   if (argv.debug) {
     console.log('Globs being used:', globs);
   }
+  debugFlag = argv.debug;
 
   return gulp
     .src(globs, { followSymlinks: false })

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "check:links:internal": "npm run _check:links:internal",
     "check:links": "npm run _check:links",
     "check:markdown": "scripts/check-markdown-wrapper.sh",
-    "check:registry": "npm run _check:registry",
+    "check:registry": "npm run _check:registry -- ",
     "check:spelling": "npx cspell --no-progress -c .cspell.yml content/en data 'layouts/**/*.md'",
     "check:text": "npm run _check:text -- ",
     "check": "npm run seq -- $(npm run -s _list:check:*)",


### PR DESCRIPTION
- Followup to #4805
- When running `check:registery` locally, only display warnings and notices when the `--debug` flag is provided. To do so run the script like this:
  `npm run check:registry -- --debug`

/cc @svrnm 