### PR TITLE
[infra] Adjust-pages script cleanup and semconv vers tweak

### DIFF
--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -96,20 +96,16 @@ while(<>) {
     s|(\]\()/docs/|$1$specBasePath/semconv/|g;
     s|(\]:\s*)/docs/|$1$specBasePath/semconv/|;
 
-    s|\((/model/.*?)\)|($semconvSpecRepoUrl/blob/main/$1)|g;
+    s|\((/model/.*?)\)|($semconvSpecRepoUrl/tree/v$semconvVers/$1)|g;
 
-    # TODO: drop after fix of https://github.com/open-telemetry/semantic-conventions/issues/419
+    # TODO: drop after fix of https://github.com/open-telemetry/semantic-conventions/pull/1316
     s|#instrument-advice\b|#instrument-advisory-parameters|g;
-    # TODO: drop after fix of https://github.com/open-telemetry/semantic-conventions/pull/883
-    s|(\]\(process.md)#process(\))|$1$2|g;
 
     # TODO: drop after fix of https://github.com/open-telemetry/semantic-conventions/issues/1313
     s|(/database/database-spans\.md)#batch-operations|$1|g;
     s|(/messaging/messaging-spans\.md)#common-messaging-operations|$1|g;
   }
 
-  # TODO: drop after fix of https://github.com/open-telemetry/semantic-conventions/pull/1065
-  s|opentelemetry-specification/tree/v1\.33\.0/specification/metrics|semantic-conventions/blob/v1\.26\.0/docs/general|g if $ARGV =~ /\/tmp\/semconv\/docs\/system\/container-metrics/;
 
   # SPECIFICATION custom processing
 
@@ -133,15 +129,6 @@ while(<>) {
   s|(\]\()(img/.*?\))|$1../$2|g if $ARGV !~ /(logs|schemas)._index/ && $ARGV !~ /otlp\/docs/;
   s|(\]\()([^)]+\.png\))|$1../$2|g if $ARGV =~ /\/tmp\/semconv\/docs\/general\/attributes/;
   s|(\]\()([^)]+\.png\))|$1../$2|g if $ARGV =~ /\/tmp\/semconv\/docs\/http\/http-spans/;
-
-  # Fix links that are to the title of the .md page
-  # TODO: fix these in the spec
-  s|(/context/api-propagators.md)#propagators-api|$1|g
-    if $otelSpecVers le '1.34.0'; # Ensure that https://github.com/open-telemetry/opentelemetry-specification/pull/4080 is in the new release
-  s|(/resource/sdk.md)#resource-sdk|$1|g
-    if $semconvVers le '1.26.0'; # Ensure that https://github.com/open-telemetry/semantic-conventions/pull/1154 is in the new release
-  s|(event-api.md#)(data-model)|$1event-$2|g
-    if $otelSpecVers le '1.34.0'; # Ensure that https://github.com/open-telemetry/opentelemetry-specification/pull/4075 is in the new release
 
   s|\.\.\/README.md\b|$otelSpecRepoUrl/|g if $ARGV =~ /specification._index/;
   s|\.\.\/README.md\b|..| if $ARGV =~ /specification.library-guidelines.md/;


### PR DESCRIPTION
- Drops patches in `adjust-pages.pl`, now that spec PRs have landed in the Git submodules of this repo
- Semconv: when linking to `model` YAML files, links to the specific semconv version of the file rather than `blob/main`

/cc @open-telemetry/specs-semconv-approvers 

---

```console
$ git diff | grep ^diff
diff --git a/docs/specs/semconv/azure/events/index.html b/docs/specs/semconv/azure/events/index.html
diff --git a/site/index.html b/site/index.html
```

Other than the `site/index.html` timestamp change, here's the only other change to the generated site files:

```console
$ git diff
```
```diff
diff --git a/docs/specs/semconv/azure/events/index.html b/docs/specs/semconv/azure/events/index.html
index 185e4e29ed..10eb31bda4 100644
--- a/docs/specs/semconv/azure/events/index.html
+++ b/docs/specs/semconv/azure/events/index.html
@@ -2728,7 +2728,7 @@ Resource Log events.</p>
 </tbody>
 </table>
 <!-- end of manually added table -->
-<p>See <a href="https://github.com/open-telemetry/semantic-conventions/blob/main//model/logs/azure.yaml" target="_blank" rel="noopener" class="external-link">Azure Resource Log definition</a> for the details.</p>
+<p>See <a href="https://github.com/open-telemetry/semantic-conventions/tree/v1.27.0//model/logs/azure.yaml" target="_blank" rel="noopener" class="external-link">Azure Resource Log definition</a> for the details.</p>
 
        <style>
   .feedback--answer {
```