### PR TITLE
Add vendor blurb to sampling doc

### DIFF
--- a/content/en/docs/concepts/sampling/index.md
+++ b/content/en/docs/concepts/sampling/index.md
@@ -141,6 +141,6 @@ SDK, you will find support for sampling in the respective documentation pages:
 ### Vendors
 
 Many [vendors](/ecosystem/vendors) offer comprehensive sampling solutions that
-incorporate Head Sampling, Tail Sampling, and other features that can support
-sophisticated sampling needs. If you are sending telemetry to a vendor, it may
-be beneficial to use their sampling solutions.
+incorporate head sampling, tail sampling, and other features that can support
+sophisticated sampling needs. If you are sending telemetry to a vendor, consider
+using their sampling solutions.

--- a/content/en/docs/concepts/sampling/index.md
+++ b/content/en/docs/concepts/sampling/index.md
@@ -142,5 +142,6 @@ SDK, you will find support for sampling in the respective documentation pages:
 
 Many [vendors](/ecosystem/vendors) offer comprehensive sampling solutions that
 incorporate head sampling, tail sampling, and other features that can support
-sophisticated sampling needs. If you are sending telemetry to a vendor, consider
+sophisticated sampling needs. These solutions may also be optimized specifically
+for the vendor's backend. If you are sending telemetry to a vendor, consider
 using their sampling solutions.

--- a/content/en/docs/concepts/sampling/index.md
+++ b/content/en/docs/concepts/sampling/index.md
@@ -137,3 +137,10 @@ For the individual language-specific implementations of the OpenTelemetry API &
 SDK, you will find support for sampling in the respective documentation pages:
 
 {{% sampling-support-list " " %}}
+
+### Vendors
+
+Many [vendors](/ecosystem/vendors) offer comprehensive sampling solutions that
+incorporate Head Sampling, Tail Sampling, and other features that can support
+sophisticated sampling needs. If you are sending telemetry to a vendor, it may
+be beneficial to use their sampling solutions.


### PR DESCRIPTION
Most vendors tend to have more sophisticated solutions for sampling, and these are usually the right things to use. Adding some of that softer language here.