### PR TITLE
rework php zero-code page

### DIFF
--- a/content/en/docs/languages/php/exporters.md
+++ b/content/en/docs/languages/php/exporters.md
@@ -10,7 +10,7 @@ cSpell:ignore: fastcgi pecl
 
 If you use [zero-code instrumentation](/docs/zero-code/php/) you can set up
 exporters with
-[zero-code configuration to setup exporters](/docs/zero-code/php#zero-code-configuration-for-automatic-instrumentation).
+[zero-code configuration to setup exporters](/docs/zero-code/php#configuration).
 
 {{% /alert %}}
 

--- a/content/en/docs/languages/php/getting-started.md
+++ b/content/en/docs/languages/php/getting-started.md
@@ -116,7 +116,7 @@ Next, you’ll use the OpenTelemetry PHP extension to
 
    {{% alert title="Note" color="warning" %}}Alternative methods of installing
    the extension are detailed in
-   [zero-code instrumentation](/docs/zero-code/php/#installation).
+   [zero-code instrumentation](/docs/zero-code/php/#install-the-opentelemetry-extension).
    {{% /alert %}}
 
 3. Add the extension to your `php.ini` file:

--- a/content/en/docs/zero-code/php.md
+++ b/content/en/docs/zero-code/php.md
@@ -11,17 +11,16 @@ cSpell:ignore: centos configurator democlass epel myapp pecl phar remi unindente
 
 Automatic instrumentation with PHP requires:
 
-- PHP 8.0 or later
-- the
-  [OpenTelemetry PHP extension](https://github.com/open-telemetry/opentelemetry-php-instrumentation)
-- [composer autoloading](https://getcomposer.org/doc/01-basic-usage.md#autoloading)
-- the [OpenTelemetry SDK](https://packagist.org/packages/open-telemetry/sdk)
-- one or more
+- PHP 8.0 or higher
+- [OpenTelemetry PHP extension](https://github.com/open-telemetry/opentelemetry-php-instrumentation)
+- [Composer autoloading](https://getcomposer.org/doc/01-basic-usage.md#autoloading)
+- [OpenTelemetry SDK](https://packagist.org/packages/open-telemetry/sdk)
+- One or more
   [instrumentation libraries](/ecosystem/registry/?component=instrumentation&language=php)
-- [configuration](#configuration)
+- [Configuration](#configuration)
 
 {{% alert title="Important" color="warning" %}}Installing the OpenTelemetry
-extension by itself will not generate traces. {{% /alert %}}
+extension by itself does not generate traces. {{% /alert %}}
 
 ## Install the OpenTelemetry extension
 
@@ -125,10 +124,10 @@ php --ri opentelemetry
 
 ## Install SDK and instrumentation libraries
 
-Now that the extension is installed, you should install the OpenTelemetry SDK
+Now that the extension is installed, install the OpenTelemetry SDK
 and one or more instrumentation libraries.
 
-Automatic Instrumentation is available for a number commonly used PHP libraries.
+Automatic instrumentation is available for a number commonly used PHP libraries.
 For the full list, see
 [instrumentation libraries on packagist](https://packagist.org/search/?query=open-telemetry&tags=instrumentation).
 
@@ -146,9 +145,9 @@ composer require \
 ## Configuration
 
 When used in conjunction with the OpenTelemetry SDK, you can use environment
-variables or `php.ini` to configure auto-instrumentation.
+variables or the `php.ini` file to configure auto-instrumentation.
 
-### Via environment
+### Environment configuration
 
 ```sh
 OTEL_PHP_AUTOLOAD_ENABLED=true \
@@ -160,7 +159,7 @@ OTEL_PROPAGATORS=baggage,tracecontext \
 php myapp.php
 ```
 
-### Via php.ini
+### php.ini configuration
 
 Append the following to `php.ini`, or another `ini` file that will be processed
 by PHP:
@@ -176,19 +175,19 @@ OTEL_PROPAGATORS=baggage,tracecontext
 
 ## Run your application
 
-Once all of the above is installed and configured, you can start your
+After all of the above is installed and configured, start your
 application as you normally would.
 
-The traces you see exported to the OpenTelemetry Collector will depend on the
+The traces you see exported to the OpenTelemetry Collector depend on the
 instrumentation libraries you have installed, and the code path that was taken
-inside the application. In the example above, using Slim Framework and PSR-18
-instrumentation libraries, you should expect to see spans such as:
+inside the application. In the previous example, using Slim Framework and
+PSR-18 instrumentation libraries, you should expect to see spans such as:
 
-- a root span representing the HTTP transaction
-- a span for the action that was executed
-- a span for each HTTP transaction that the PSR-18 client sent
+- A root span representing the HTTP transaction
+- A span for the action that was executed
+- A span for each HTTP transaction that the PSR-18 client sent
 
-It's also worth noting that the PSR-18 client instrumentation will append
+Note that the PSR-18 client instrumentation appends
 [distributed tracing](/docs/concepts/context-propagation/#propagation) headers
 to outgoing HTTP requests.
 
@@ -198,13 +197,13 @@ to outgoing HTTP requests.
 you just want to get up and running quickly, and there are suitable
 instrumentation libraries for your application. {{% /alert %}}
 
-The extension enables registering observer functions (as PHP code) against
+The extension enables registering observer functions as PHP code against
 classes and methods, and executing those functions before and after the observed
 method runs.
 
 If there is not an instrumentation library for your framework or application,
-you can write your own. The following example provides some code which we wish
-to auto-instrument, and then illustrates how to use the OpenTelemetry extension
+you can write your own. The following example provides some code to be
+instrumented, and then illustrates how to use the OpenTelemetry extension
 to trace the execution of that code.
 
 ```php
@@ -253,13 +252,13 @@ $demo = new DemoClass();
 $demo->run();
 ```
 
-In the example above we define `DemoClass`, then register `pre` and `post` hook
-functions on its `run` method. The hook functions will run before and after each
-execution of the `DemoClass::run()` method. The `pre` function starts and
-activates a span, and the `post` function ends it.
+The previous example defines `DemoClass`, then registers `pre` and `post`
+hook functions on its `run` method. The hook functions run before and after
+each execution of the `DemoClass::run()` method. The `pre` function starts
+and activates a span, while the `post` function ends it.
 
-If an exception was thrown by `DemoClass::run()`, the `post` function will
-record it, without affecting exception propagation.
+If `DemoClass::run()` throws an exception, the `post` function
+records it without affecting exception propagation.
 
 ## Next steps
 

--- a/content/en/docs/zero-code/php.md
+++ b/content/en/docs/zero-code/php.md
@@ -124,8 +124,8 @@ php --ri opentelemetry
 
 ## Install SDK and instrumentation libraries
 
-Now that the extension is installed, install the OpenTelemetry SDK
-and one or more instrumentation libraries.
+Now that the extension is installed, install the OpenTelemetry SDK and one or
+more instrumentation libraries.
 
 Automatic instrumentation is available for a number commonly used PHP libraries.
 For the full list, see
@@ -175,13 +175,13 @@ OTEL_PROPAGATORS=baggage,tracecontext
 
 ## Run your application
 
-After all of the above is installed and configured, start your
-application as you normally would.
+After all of the above is installed and configured, start your application as
+you normally would.
 
 The traces you see exported to the OpenTelemetry Collector depend on the
 instrumentation libraries you have installed, and the code path that was taken
-inside the application. In the previous example, using Slim Framework and
-PSR-18 instrumentation libraries, you should expect to see spans such as:
+inside the application. In the previous example, using Slim Framework and PSR-18
+instrumentation libraries, you should expect to see spans such as:
 
 - A root span representing the HTTP transaction
 - A span for the action that was executed
@@ -197,14 +197,14 @@ to outgoing HTTP requests.
 you just want to get up and running quickly, and there are suitable
 instrumentation libraries for your application. {{% /alert %}}
 
-The extension enables registering observer functions as PHP code against
-classes and methods, and executing those functions before and after the observed
-method runs.
+The extension enables registering observer functions as PHP code against classes
+and methods, and executing those functions before and after the observed method
+runs.
 
 If there is not an instrumentation library for your framework or application,
 you can write your own. The following example provides some code to be
-instrumented, and then illustrates how to use the OpenTelemetry extension
-to trace the execution of that code.
+instrumented, and then illustrates how to use the OpenTelemetry extension to
+trace the execution of that code.
 
 ```php
 <?php
@@ -252,13 +252,13 @@ $demo = new DemoClass();
 $demo->run();
 ```
 
-The previous example defines `DemoClass`, then registers `pre` and `post`
-hook functions on its `run` method. The hook functions run before and after
-each execution of the `DemoClass::run()` method. The `pre` function starts
-and activates a span, while the `post` function ends it.
+The previous example defines `DemoClass`, then registers `pre` and `post` hook
+functions on its `run` method. The hook functions run before and after each
+execution of the `DemoClass::run()` method. The `pre` function starts and
+activates a span, while the `post` function ends it.
 
-If `DemoClass::run()` throws an exception, the `post` function
-records it without affecting exception propagation.
+If `DemoClass::run()` throws an exception, the `post` function records it
+without affecting exception propagation.
 
 ## Next steps
 

--- a/content/en/docs/zero-code/php.md
+++ b/content/en/docs/zero-code/php.md
@@ -7,78 +7,23 @@ aliases: [/docs/languages/php/automatic]
 cSpell:ignore: centos configurator democlass epel myapp pecl phar remi unindented userland
 ---
 
-Automatic instrumentation with PHP requires at least PHP 8.0, and the
-[OpenTelemetry PHP extension](https://github.com/open-telemetry/opentelemetry-php-instrumentation).
-The extension enables registering observer functions (as PHP code) against
-classes and methods, and executing those functions before and after the observed
-method runs.
+## Requirements
+
+Automatic instrumentation with PHP requires:
+
+- PHP 8.0 or later
+- the
+  [OpenTelemetry PHP extension](https://github.com/open-telemetry/opentelemetry-php-instrumentation)
+- [composer autoloading](https://getcomposer.org/doc/01-basic-usage.md#autoloading)
+- the [OpenTelemetry SDK](https://packagist.org/packages/open-telemetry/sdk)
+- one or more
+  [instrumentation libraries](/ecosystem/registry/?component=instrumentation&language=php)
+- [configuration](#configuration)
 
 {{% alert title="Important" color="warning" %}}Installing the OpenTelemetry
-extension by itself will not generate traces. You must also install the
-[SDK](https://packagist.org/packages/open-telemetry/sdk) **and** one or more
-[instrumentation libraries](/ecosystem/registry/?component=instrumentation&language=php)
-for the frameworks and libraries that you are using, or alternatively write your
-own.
+extension by itself will not generate traces. {{% /alert %}}
 
-You also _must_ use
-[composer autoloading](https://getcomposer.org/doc/01-basic-usage.md#autoloading),
-as this is the mechanism all instrumentation libraries use to register
-themselves. {{% /alert %}}
-
-## Example
-
-```php
-<?php
-
-use OpenTelemetry\API\Common\Instrumentation\CachedInstrumentation;
-use OpenTelemetry\API\Trace\Span;
-use OpenTelemetry\API\Trace\StatusCode;
-use OpenTelemetry\Context\Context;
-
-require 'vendor/autoload.php';
-
-class DemoClass
-{
-    public function run(): void
-    {
-        echo 'Hello, world';
-    }
-}
-
-OpenTelemetry\Instrumentation\hook(
-    class: DemoClass::class,
-    function: 'run',
-    pre: static function (DemoClass $demo, array $params, string $class, string $function, ?string $filename, ?int $lineno) {
-        static $instrumentation;
-        $instrumentation ??= new CachedInstrumentation('example');
-        $span = $instrumentation->tracer()->spanBuilder('democlass-run')->startSpan();
-        Context::storage()->attach($span->storeInContext(Context::getCurrent()));
-    },
-    post: static function (DemoClass $demo, array $params, $returnValue, ?Throwable $exception) {
-        $scope = Context::storage()->scope();
-        $scope->detach();
-        $span = Span::fromContext($scope->context());
-        if ($exception) {
-            $span->recordException($exception);
-            $span->setStatus(StatusCode::STATUS_ERROR);
-        }
-        $span->end();
-    }
-);
-
-$demo = new DemoClass();
-$demo->run();
-```
-
-In the example above we define `DemoClass`, then register `pre` and `post` hook
-functions on its `run` method. The hook functions will run before and after each
-execution of the `DemoClass::run()` method. The `pre` function starts and
-activates a span, and the `post` function ends it.
-
-If an exception was thrown by `DemoClass::run()`, the `post` function will
-record it, without affecting exception propagation.
-
-## Installation
+## Install the OpenTelemetry extension
 
 The extension can be installed via pecl,
 [pickle](https://github.com/FriendsOfPHP/pickle) or
@@ -178,10 +123,32 @@ php --ri opentelemetry
    php -m | grep opentelemetry
    ```
 
-## Zero-code configuration for automatic instrumentation
+## Install SDK and instrumentation libraries
+
+Now that the extension is installed, you should install the OpenTelemetry SDK
+and one or more instrumentation libraries.
+
+Automatic Instrumentation is available for a number commonly used PHP libraries.
+For the full list, see
+[instrumentation libraries on packagist](https://packagist.org/search/?query=open-telemetry&tags=instrumentation).
+
+Let's assume that your application uses Slim Framework and a PSR-18 HTTP client.
+You would then install the SDK and corresponding auto-instrumentation packages
+for these:
+
+```shell
+composer require \
+    open-telemetry/sdk \
+    open-telemetry/opentelemetry-auto-slim \
+    open-telemetry/opentelemetry-auto-psr18
+```
+
+## Configuration
 
 When used in conjunction with the OpenTelemetry SDK, you can use environment
-variables or `php.ini` to configure auto-instrumentation:
+variables or `php.ini` to configure auto-instrumentation.
+
+### Via environment
 
 ```sh
 OTEL_PHP_AUTOLOAD_ENABLED=true \
@@ -193,37 +160,106 @@ OTEL_PROPAGATORS=baggage,tracecontext \
 php myapp.php
 ```
 
-## Manual setup for automatic instrumentation
+### Via php.ini
+
+Append the following to `php.ini`, or another `ini` file that will be processed
+by PHP:
+
+```ini
+OTEL_PHP_AUTOLOAD_ENABLED=true
+OTEL_SERVICE_NAME=your-service-name
+OTEL_TRACES_EXPORTER=otlp
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4317
+OTEL_PROPAGATORS=baggage,tracecontext
+```
+
+## Run your application
+
+Once all of the above is installed and configured, you can start your
+application as you normally would.
+
+The traces you see exported to the OpenTelemetry Collector will depend on the
+instrumentation libraries you have installed, and the code path that was taken
+inside the application. In the example above, using Slim Framework and PSR-18
+instrumentation libraries, you should expect to see spans such as:
+
+- a root span representing the HTTP transaction
+- a span for the action that was executed
+- a span for each HTTP transaction that the PSR-18 client sent
+
+It's also worth noting that the PSR-18 client instrumentation will append
+[distributed tracing](/docs/concepts/context-propagation/#propagation) headers
+to outgoing HTTP requests.
+
+## How it works
+
+{{% alert title="Optional" color="info" %}} You can skip over this section if
+you just want to get up and running quickly, and there are suitable
+instrumentation libraries for your application. {{% /alert %}}
+
+The extension enables registering observer functions (as PHP code) against
+classes and methods, and executing those functions before and after the observed
+method runs.
+
+If there is not an instrumentation library for your framework or application,
+you can write your own. The following example provides some code which we wish
+to auto-instrument, and then illustrates how to use the OpenTelemetry extension
+to trace the execution of that code.
 
 ```php
 <?php
-OpenTelemetry\API\Globals::registerInitializer(function (Configurator $configurator) {
-    $propagator = TraceContextPropagator::getInstance();
-    $spanProcessor = new BatchSpanProcessor(/*params*/);
-    $tracerProvider = (new TracerProviderBuilder())
-        ->addSpanProcessor($spanProcessor)
-        ->setSampler(new ParentBased(new AlwaysOnSampler()))
-        ->build();
 
-    ShutdownHandler::register([$tracerProvider, 'shutdown']);
+use OpenTelemetry\API\Common\Instrumentation\CachedInstrumentation;
+use OpenTelemetry\API\Trace\Span;
+use OpenTelemetry\API\Trace\StatusCode;
+use OpenTelemetry\Context\Context;
 
-    return $configurator
-        ->withTracerProvider($tracerProvider)
-        ->withPropagator($propagator);
-});
+require 'vendor/autoload.php';
 
-//instrumentation libraries can access the configured providers (or a no-op implementation) via `Globals`
-$tracer = Globals::tracerProvider()->getTracer('example');
-//or, via CachedInstrumentation which uses `Globals` internally
-$instrumentation = new CachedInstrumentation('example');
-$tracer = $instrumentation->tracer();
+/* The class to be instrumented */
+class DemoClass
+{
+    public function run(): void
+    {
+        echo 'Hello, world';
+    }
+}
+
+/* The auto-instrumentation code */
+OpenTelemetry\Instrumentation\hook(
+    class: DemoClass::class,
+    function: 'run',
+    pre: static function (DemoClass $demo, array $params, string $class, string $function, ?string $filename, ?int $lineno) {
+        static $instrumentation;
+        $instrumentation ??= new CachedInstrumentation('example');
+        $span = $instrumentation->tracer()->spanBuilder('democlass-run')->startSpan();
+        Context::storage()->attach($span->storeInContext(Context::getCurrent()));
+    },
+    post: static function (DemoClass $demo, array $params, $returnValue, ?Throwable $exception) {
+        $scope = Context::storage()->scope();
+        $scope->detach();
+        $span = Span::fromContext($scope->context());
+        if ($exception) {
+            $span->recordException($exception);
+            $span->setStatus(StatusCode::STATUS_ERROR);
+        }
+        $span->end();
+    }
+);
+
+/* Run the instrumented code, which will generate a trace */
+$demo = new DemoClass();
+$demo->run();
 ```
 
-## Supported libraries and frameworks
+In the example above we define `DemoClass`, then register `pre` and `post` hook
+functions on its `run` method. The hook functions will run before and after each
+execution of the `DemoClass::run()` method. The `pre` function starts and
+activates a span, and the `post` function ends it.
 
-Automatic Instrumentation is available for a number of instrumentation libraries
-for commonly used PHP libraries. For the full list, see
-[instrumentation libraries on packagist](https://packagist.org/search/?query=open-telemetry&tags=instrumentation).
+If an exception was thrown by `DemoClass::run()`, the `post` function will
+record it, without affecting exception propagation.
 
 ## Next steps
 


### PR DESCRIPTION
Addresses some of the feedback raised in https://github.com/open-telemetry/opentelemetry.io/issues/4926

- move example code to page bottom, and note that it can be skipped
- break the page up more into discrete steps to follow
- some editorial improvements
- example of ini-based config