### PR TITLE
[cleanup] Add autoinstrumentation into the main dictionary

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -36,6 +36,7 @@ words:
   - aspecto
   - autoconfigure
   - autoconfiguration
+  - autoinstrumentation
   - autoload
   - autoloaded
   - autoloader

--- a/content/en/blog/2023/otel-in-focus-09.md
+++ b/content/en/blog/2023/otel-in-focus-09.md
@@ -4,7 +4,7 @@ linkTitle: OTel in Focus 2023/09
 date: 2023-10-01
 author: '[Austin Parker](https://github.com/austinlparker)'
 # prettier-ignore
-cSpell:ignore: attributesprocessor autoinstrumentation Autoscaler checkapi Contribfest coreinternal gopkg jaegerthrifthttp obsreport ottl resourcedetection resourceprocessor structs tailsampling ucum unmanaged
+cSpell:ignore: attributesprocessor Autoscaler checkapi Contribfest coreinternal gopkg jaegerthrifthttp obsreport ottl resourcedetection resourceprocessor structs tailsampling ucum unmanaged
 ---
 
 Welcome back to **OpenTelemetry in Focus** for September, 2023! The autumn winds

--- a/content/en/docs/concepts/signals/logs.md
+++ b/content/en/docs/concepts/signals/logs.md
@@ -1,9 +1,8 @@
 ---
 title: Logs
-weight: 3
 description: A recording of an event.
-# prettier-ignore
-cSpell:ignore: autoinstrumentation filelogreceiver semistructured Semistructured transformprocessor
+weight: 3
+cSpell:ignore: filelogreceiver semistructured transformprocessor
 ---
 
 A **log** is a timestamped text record, either structured (recommended) or
@@ -30,9 +29,9 @@ The [OpenTelemetry Collector](/docs/collector) provides several tools to work
 with logs:
 
 - Several receivers which parse logs from specific, known sources of log data.
-- The filelogreceiver, which reads logs from any file and provides features to
+- The `filelogreceiver`, which reads logs from any file and provides features to
   parse them from different formats or use a regular expression.
-- Processors like the transformprocessor which lets you parse nested data,
+- Processors like the `transformprocessor` which lets you parse nested data,
   flatten nested structures, add/remove/update values, and more.
 - Exporters that let you emit log data in a non-OpenTelemetry format.
 

--- a/content/en/docs/kubernetes/operator/automatic.md
+++ b/content/en/docs/kubernetes/operator/automatic.md
@@ -5,7 +5,7 @@ weight: 11
 description:
   An implementation of auto-instrumentation using the OpenTelemetry Operator.
 # prettier-ignore
-cSpell:ignore: autoinstrumentation GRPCNETCLIENT k8sattributesprocessor otelinst otlpreceiver PTRACE REDISCALA Werkzeug
+cSpell:ignore: GRPCNETCLIENT k8sattributesprocessor otelinst otlpreceiver PTRACE REDISCALA Werkzeug
 ---
 
 The OpenTelemetry Operator supports injecting and configuring

--- a/content/en/docs/languages/js/getting-started/nodejs.md
+++ b/content/en/docs/languages/js/getting-started/nodejs.md
@@ -2,7 +2,7 @@
 title: Node.js
 description: Get telemetry for your app in less than 5 minutes!
 aliases: [/docs/js/getting_started/nodejs]
-cSpell:ignore: autoinstrumentation autoinstrumentations KHTML rolldice
+cSpell:ignore: autoinstrumentations KHTML rolldice
 weight: 10
 ---
 

--- a/content/en/docs/languages/js/libraries.md
+++ b/content/en/docs/languages/js/libraries.md
@@ -3,7 +3,7 @@ title: Using instrumentation libraries
 linkTitle: Libraries
 weight: 40
 description: How to instrument libraries an app depends on
-cSpell:ignore: autoinstrumentation metapackage metapackages
+cSpell:ignore: metapackage metapackages
 ---
 
 {{% docs/languages/libraries-intro JavaScript %}}

--- a/content/en/docs/zero-code/net/nuget-packages.md
+++ b/content/en/docs/zero-code/net/nuget-packages.md
@@ -2,7 +2,7 @@
 title: Using the OpenTelemetry.AutoInstrumentation NuGet packages
 linkTitle: NuGet Packages
 weight: 40
-cSpell:ignore: autoinstrumentation buildtasks
+cSpell:ignore: buildtasks
 ---
 
 Use the NuGet packages in the following scenarios:


### PR DESCRIPTION
- Followup to #4956
- Moves "autoinstrumentation" into the main dictionary, since it's used quite often
- Other minor tweaks to the Logs page. /cc @cartermp  