### PR TITLE
[CI] GH action config tweak: spell-check all files

### DIFF
--- a/.github/workflows/check-spelling.yml
+++ b/.github/workflows/check-spelling.yml
@@ -17,6 +17,7 @@ jobs:
             layouts/**/*.md
             data/**/*
           config: .cspell.yml
+          incremental_files_only: false
 
   dict-check:
     name: CSPELL:IGNORE check


### PR DESCRIPTION
- Fixes #4963, I hope
- It won't take that much longer to check all files rather than let the plugin figure out which file list to check