### PR TITLE
Update getting-started.md

### DIFF
--- a/content/en/docs/languages/erlang/getting-started.md
+++ b/content/en/docs/languages/erlang/getting-started.md
@@ -103,7 +103,7 @@ plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
 
 We also need to configure the `opentelemetry` application as temporary by adding
 a `releases` section to your project configuration. This will ensure that if it
-terminates, even abnormally, the `roll_dice` application will be terminated.
+terminates, even abnormally, the `roll_dice` application will not be terminated.
 
 ```elixir
 # mix.exs


### PR DESCRIPTION
fix typo about roll_dice application won't be terminated if opentelemetry terminate in erlang getting-started.md