### PR TITLE
[Docsy] Upgrade to v0.10.0-22-g2295188b

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/google/docsy.git
-	docsy-pin = v0.10.0-6-g102892d
+	docsy-pin = v0.10.0-22-g2295188b
 	docsy-note = "2024-04-01 Switching to google/docsy.git from cncf/docsy.git since we don't have any CNCF customizations."
 	docsy-reminder = "Ensure that any tag referenced by `docsy-pin` is present in the remote repo (url), otherwise add (push) the tags to the repo."
 [submodule "content-modules/opentelemetry-specification"]


### PR DESCRIPTION
- Upgrades Docsy to v0.10.0-22-g2295188b
- There are no significant changes to the generated files, other than updates due to the new version of FontAwesome:
  ```console
  $ (cd public && git diff -bw --ignore-blank-lines) | grep ^diff                 
  diff --git a/scss/main.css b/scss/main.css
  diff --git a/scss/main.css.map b/scss/main.css.map
  diff --git a/site/index.html b/site/index.html
  ```