### PR TITLE
make native and first party searchable in registry

### DIFF
--- a/assets/js/registrySearch.js
+++ b/assets/js/registrySearch.js
@@ -5,6 +5,7 @@ const miniSearchOptions = {
     '_key',
     'tags',
     'package.name',
+    'flags',
     'license',
     'language',
     'registryType',

--- a/layouts/ecosystem/registry.json.json
+++ b/layouts/ecosystem/registry.json.json
@@ -1,7 +1,17 @@
 {{ $counter := 0 -}}
 {{ $entries := slice -}}
 {{ range $key, $entry := .Site.Data.registry -}}
-  {{ $entry = merge $entry (dict "_key" $key "id" $counter) -}}
+  {{ $flags := slice -}}
+  {{ if .isNative -}}
+    {{ $flags = $flags | append "native" -}}
+  {{ end -}}
+  {{ if .isFirstParty -}}
+    {{ $flags = $flags | append "first party" -}}
+  {{ end -}}
+  {{ if .deprecated -}}
+    {{ $flags = $flags | append "deprecated" -}}
+  {{ end -}}
+  {{ $entry = merge $entry (dict "_key" $key "id" $counter "flags" $flags) -}}
   {{ $entries = $entries | append $entry -}}
   {{ $counter = add $counter 1 }}
 {{ end -}}

--- a/layouts/shortcodes/ecosystem/registry/search-form.html
+++ b/layouts/shortcodes/ecosystem/registry/search-form.html
@@ -106,5 +106,5 @@ ecosystem. If you are a project maintainer, you can <a href="/ecosystem/registry
   </ul>
 </div>
 
-<script src="https://cdn.jsdelivr.net/npm/minisearch@6.3.0/dist/umd/index.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/minisearch@7.1.0/dist/umd/index.min.js" integrity="sha384-58p1D2xuw/76VRFUgDMRcrtnJAW5LWLE02ihn8aITu65c4vgo+BLy7raRKNC7KaL" crossorigin="anonymous"></script>
 {{ partial "script.html" (dict "src" "js/registrySearch.js") -}}

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -303,6 +303,10 @@
     "StatusCode": 206,
     "LastSeen": "2024-01-08T12:17:27.412252+01:00"
   },
+  "https://cdn.jsdelivr.net/npm/minisearch@7.1.0/dist/umd/index.min.js": {
+    "StatusCode": 206,
+    "LastSeen": "2024-08-07T17:27:34.715582+02:00"
+  },
   "https://cerbos.dev/": {
     "StatusCode": 206,
     "LastSeen": "2024-01-30T15:24:42.717338-05:00"


### PR DESCRIPTION
Partially addresses #4987: this PR allows users to search for "native" and "first party" and find the registry entries.

This PR also includes an update of the used search engine (minisearch) + pinning the hash