### PR TITLE
Add git sub module pin for java examples

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -27,7 +27,8 @@
 [submodule "content-modules/opentelemetry-go"]
 	path = content-modules/opentelemetry-go
 	url = https://github.com/open-telemetry/opentelemetry-go
-    go-pin = v1.27.0
+	go-pin = v1.27.0
 [submodule "content-modules/opentelemetry-java-examples"]
 	path = content-modules/opentelemetry-java-examples
 	url = https://github.com/open-telemetry/opentelemetry-java-examples.git
+	javaexamples-pin = 8112da5


### PR DESCRIPTION
Had an issue with the java examples locally, that couldn't be fixed with `npm run sync`, I saw that it hadn't have a pin yet, so this provides that pin. cc @chalin 