### PR TITLE
fix java examples pin version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,4 +31,4 @@
 [submodule "content-modules/opentelemetry-java-examples"]
 	path = content-modules/opentelemetry-java-examples
 	url = https://github.com/open-telemetry/opentelemetry-java-examples.git
-	javaexamples-pin = 8112da5
+	javaexamples-pin = 8fe9a11


### PR DESCRIPTION
the pinned version and the version in the repo are not the same leading to issues in some PRs.