### PR TITLE
Define who is part of the Fix Team

### DIFF
--- a/content/en/docs/security/security-response.md
+++ b/content/en/docs/security/security-response.md
@@ -67,15 +67,15 @@ unlikely to make a public disclosure less damaging.
 
 The Fix Team is made up of people with the following roles:
 
-1. Incident commander, the person who will manage the communication around the
+- Incident commander, the person who manages the communication around the
    incident.
-2. Incident investigator(s), typically one or more maintainers of the affected
+- Incident investigator(s), typically one or more maintainers of the affected
    repositories.
-3. Subject matter experts, typically includes the reporter and other
-   contributors, such as the code owners for the affected components, or
-   repository approvers who'll provide prompt code reviews for the proposed
+- Subject matter experts, typically includes the reporter and other
+   contributors, such as the code owners for the affected components or
+   repository approvers who provide prompt code reviews for the proposed
    fixes.
-4. Other stakeholders, such as other SIGs that might need to consume the fix.
+- Other stakeholders, such as other SIGs that might need to consume the fix.
 
 ### TC Role
 

--- a/content/en/docs/security/security-response.md
+++ b/content/en/docs/security/security-response.md
@@ -65,7 +65,16 @@ unlikely to make a public disclosure less damaging.
 
 ### Fix Team Organization
 
-The Fix Team is made up of the relevant repository maintainers.
+The Fix Team is made up of people with the following roles:
+
+1. Incident commander, the person who will manage the communication around the
+   incident.
+2. Incident investigator(s), typically one or more maintainers of the affected
+   repositories.
+3. Subject matter experts, typically includes the reporter and other
+   contributors, such as the code owners for the affected components, or
+   repository approvers who'll provide prompt code reviews for the proposed
+   fixes.
 
 ### TC Role
 

--- a/content/en/docs/security/security-response.md
+++ b/content/en/docs/security/security-response.md
@@ -68,13 +68,12 @@ unlikely to make a public disclosure less damaging.
 The Fix Team is made up of people with the following roles:
 
 - Incident commander, the person who manages the communication around the
-   incident.
+  incident.
 - Incident investigator(s), typically one or more maintainers of the affected
-   repositories.
+  repositories.
 - Subject matter experts, typically includes the reporter and other
-   contributors, such as the code owners for the affected components or
-   repository approvers who provide prompt code reviews for the proposed
-   fixes.
+  contributors, such as the code owners for the affected components or
+  repository approvers who provide prompt code reviews for the proposed fixes.
 - Other stakeholders, such as other SIGs that might need to consume the fix.
 
 ### TC Role

--- a/content/en/docs/security/security-response.md
+++ b/content/en/docs/security/security-response.md
@@ -75,6 +75,7 @@ The Fix Team is made up of people with the following roles:
    contributors, such as the code owners for the affected components, or
    repository approvers who'll provide prompt code reviews for the proposed
    fixes.
+4. Other stakeholders, such as other SIGs that might need to consume the fix.
 
 ### TC Role
 


### PR DESCRIPTION
This PR fixes https://github.com/open-telemetry/sig-security/issues/60 by better defining who's part of the fix team. This uses common roles from the regular incident response management playbook, applying the concepts to our use-case.

This also fixes https://github.com/open-telemetry/sig-security/issues/62 , by adding "other sigs" as part of "other stakeholders".

cc @mx-psi

## Docs PR Checklist

- [x] This PR is for a documentation page whose authoritative copy is in the
      opentelemetry.io repository.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
