### PR TITLE
Remove random 'a' character in java instrumentation

### DIFF
--- a/content/en/docs/languages/java/instrumentation.md
+++ b/content/en/docs/languages/java/instrumentation.md
@@ -1310,8 +1310,6 @@ public class MyController {
 }
 ```
 
-a
-
 ### Using Counters
 
 Counters can be used to measure non-negative, increasing values.


### PR DESCRIPTION
Came across this random "a" character:

<img width="1058" alt="image" src="https://github.com/user-attachments/assets/28d4ebef-06ad-49d1-8729-c8740ccbc973">
