### PR TITLE
Add SAP Cloud Logging Exporter to registry

### DIFF
--- a/data/registry/exporter-js-sap-cloud-logging.yml
+++ b/data/registry/exporter-js-sap-cloud-logging.yml
@@ -1,0 +1,22 @@
+title: OpenTelemetry exporter for SAP Cloud Logging for Node.js
+registryType: exporter
+language: js
+tags:
+  - Node.js
+  - exporter
+  - SAP
+  - SAP Cloud Logging
+urls:
+  repo: https://github.com/SAP/opentelemetry-exporter-for-sap-cloud-logging-for-nodejs
+  docs: https://github.com/SAP/opentelemetry-exporter-for-sap-cloud-logging-for-nodejs#readme
+license: Apache 2.0
+description: OpenTelemetry exporter for SAP Cloud Logging is a Node.js package providing a set of auto-configured OpenTelemetry exporters for shipping logs, metrics and traces to SAP Cloud Logging.
+authors:
+  - name: Christian Dinse
+createdAt: 2024-08-20
+isNative: true 
+isFirstParty: false
+package:
+  registry: npm
+  name: '@sap/opentelemetry-exporter-for-sap-cloud-logging'
+  version: 0.1.1

--- a/data/registry/exporter-js-sap-cloud-logging.yml
+++ b/data/registry/exporter-js-sap-cloud-logging.yml
@@ -10,11 +10,14 @@ urls:
   repo: https://github.com/SAP/opentelemetry-exporter-for-sap-cloud-logging-for-nodejs
   docs: https://github.com/SAP/opentelemetry-exporter-for-sap-cloud-logging-for-nodejs#readme
 license: Apache 2.0
-description: OpenTelemetry exporter for SAP Cloud Logging is a Node.js package providing a set of auto-configured OpenTelemetry exporters for shipping logs, metrics and traces to SAP Cloud Logging.
+description:
+  OpenTelemetry exporter for SAP Cloud Logging is a Node.js package providing a
+  set of auto-configured OpenTelemetry exporters for shipping logs, metrics and
+  traces to SAP Cloud Logging.
 authors:
   - name: Christian Dinse
 createdAt: 2024-08-20
-isNative: true 
+isNative: true
 isFirstParty: false
 package:
   registry: npm

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -2451,6 +2451,14 @@
     "StatusCode": 200,
     "LastSeen": "2024-06-06T19:18:46.659794+02:00"
   },
+  "https://github.com/SAP/opentelemetry-exporter-for-sap-cloud-logging-for-nodejs": {
+    "StatusCode": 200,
+    "LastSeen": "2024-08-20T13:16:13.951088019Z"
+  },
+  "https://github.com/SAP/opentelemetry-exporter-for-sap-cloud-logging-for-nodejs#readme": {
+    "StatusCode": 200,
+    "LastSeen": "2024-08-20T13:16:17.8990432Z"
+  },
   "https://github.com/Samudraneel24": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T05:18:13.282737-05:00"
@@ -6634,6 +6642,10 @@
   "https://npmjs.com/package/@prisma/instrumentation": {
     "StatusCode": 200,
     "LastSeen": "2024-01-22T14:34:48.66209+01:00"
+  },
+  "https://npmjs.com/package/@sap/opentelemetry-exporter-for-sap-cloud-logging": {
+    "StatusCode": 200,
+    "LastSeen": "2024-08-20T13:16:23.955663593Z"
   },
   "https://npmjs.com/package/opentelemetry-instrumentation-remix": {
     "StatusCode": 200,


### PR DESCRIPTION
Adds the OpenTelemetry exporter for
SAP Cloud Logging for Node.js to the registry.

c.f.
https://www.npmjs.com/package/@sap/opentelemetry-exporter-for-sap-cloud-logging
https://discovery-center.cloud.sap/index.html#/serviceCatalog/cloud-logging?service_plan=overall-(large,-standard,-and-dev)&region=all&commercialModel=btpea
