### PR TITLE
Add cspell:ignore to registry entry

### DIFF
--- a/data/registry/exporter-js-sap-cloud-logging.yml
+++ b/data/registry/exporter-js-sap-cloud-logging.yml
@@ -1,3 +1,4 @@
+# cSpell:ignore: Dinse
 title: OpenTelemetry exporter for SAP Cloud Logging for Node.js
 registryType: exporter
 language: js


### PR DESCRIPTION
Fixes a spelling issue that's causing CI to fail on other PRs.