### PR TITLE
[ja] Fix the link to the contribution guide

### DIFF
--- a/content/ja/docs/contributing/_index.md
+++ b/content/ja/docs/contributing/_index.md
@@ -15,7 +15,7 @@ OpenTelemetryドキュメントコントリビューターは以下を行ない�
 
 以下の手引はOpenTelemetryドキュメントへのコントリビュート方法について説明します。
 
-OpenTelemetryプロジェクトへの一般的なコントリビュートの手引には、[OpenTelemetryコントリビューターガイド](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md)を参照ください。
+OpenTelemetryプロジェクトへの一般的なコントリビュートの手引には、[OpenTelemetryコントリビューターガイド](https://github.com/open-telemetry/community/blob/main/guides/contributor/README.md)を参照ください。
 コントリビューターライセンス規約(Contributor License Agreement)と行動規範(Code of Conduct)の詳細が記されています。
 すべての言語の実装、コレクター、規約の[レポジトリ](https://github.com/open-telemetry/)は独自のコントリビュートの手引があります。
 


### PR DESCRIPTION
## Docs PR Checklist

<!--- Just making sure... -->

- [X] This PR is for a documentation page whose authoritative copy is in the
      opentelemetry.io repository.

Fixes #5068