### PR TITLE
[CI] Adjust submodule DEPTH uniformly across scripts

### DIFF
--- a/.github/workflows/auto-update-versions.yml
+++ b/.github/workflows/auto-update-versions.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.repository == 'open-telemetry/opentelemetry.io'
     env:
-      DEPTH: --depth 500 # submodule clone depth
+      DEPTH: --depth 999 # submodule clone depth
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -23,7 +23,7 @@ jobs:
       pull-requests: write
 
     env:
-      DEPTH: --depth 1000 # submodule clone depth
+      DEPTH: --depth 999 # submodule clone depth
 
     steps:
       - name: Extract action name

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "_filename-error": "echo 'ERROR: the following files violate naming conventions; fix using: `npm run fix:filenames`'; echo; npm run -s _ls-bad-filenames; exit 1",
     "_get:no": "echo SKIPPING get operation",
     "_get:submodule:non-lang": "npm run _get:submodule -- content-modules/opentelemetry-specification themes/docsy",
-    "_get:submodule": "set -x && git submodule update --init ${DEPTH:- --depth 1}",
+    "_get:submodule": "set -x && git submodule update --init ${DEPTH:- --depth 999}",
     "_hugo": "hugo --cleanDestinationDir",
     "_install:dict": "npm install -D $(npm run -s _list:dict)",
     "_install:netlify-cli": "npm list netlify-cli || npm install -O netlify-cli",
@@ -108,7 +108,7 @@
     "update:other-pkg": "npm install --save-dev gulp@latest",
     "update:pkgs": "npx npm-check-updates -u",
     "update:submodule:lang": "npm run seq -- update:submodule _get:submodule:non-lang",
-    "update:submodule": "set -x && git submodule update --remote ${DEPTH:- --depth 1}"
+    "update:submodule": "set -x && git submodule update --remote ${DEPTH:- --depth 999}"
   },
   "devDependencies": {
     "@cspell/dict-es-es": "^3.0.0",


### PR DESCRIPTION
- Uniformly sets `DEPTH` to 999 across scripts
- Closes #5084 and should resolve it for 99.9% of the time; to make it work 100% of the time we'd need to fetch the full submodule repos (by _not_ providing a `--depth` flag). But I don't think that it's worth imposing that for everyone who contributes to this repo.
