### PR TITLE
Add context import to examples that use "context"

### DIFF
--- a/content/en/docs/languages/go/exporters.md
+++ b/content/en/docs/languages/go/exporters.md
@@ -86,6 +86,8 @@ Here's how you can create an exporter with default configuration:
 
 ```go
 import (
+  "context"
+
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/sdk/trace"
 )
@@ -104,6 +106,8 @@ Here's how you can create an exporter with default configuration:
 
 ```go
 import (
+  "context"
+
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/sdk/trace"
 )
@@ -138,6 +142,8 @@ Here's how you can create an exporter with default configuration:
 
 ```go
 import (
+  "context"
+
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/sdk/metric"
 )
@@ -156,6 +162,8 @@ Here's how you can create an exporter with default configuration:
 
 ```go
 import (
+  "context"
+
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/sdk/metric"
 )
@@ -178,6 +186,8 @@ default configuration:
 
 ```go
 import (
+  "context"
+
 	"go.opentelemetry.io/otel/exporters/prometheus"
 	"go.opentelemetry.io/otel/sdk/metric"
 )
@@ -202,6 +212,8 @@ Here's how you can create an exporter with default configuration:
 
 ```go
 import (
+  "context"
+
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
 	"go.opentelemetry.io/otel/sdk/log"
 )


### PR DESCRIPTION
Ensure readers copying the code know what "context" package is being referenced.