### PR TITLE
Update NPM packages, including Hugo to 0.133.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,16 +117,16 @@
     "ajv-errors": "^3.0.0",
     "ajv-formats": "^3.0.1",
     "autoprefixer": "^10.4.20",
-    "cspell": "^8.13.1",
+    "cspell": "^8.14.2",
     "gulp": "^5.0.0",
-    "hugo-extended": "0.131.0",
+    "hugo-extended": "0.133.0",
     "js-yaml": "^4.1.0",
     "markdown-link-check": "^3.12.2",
     "markdownlint": "^0.34.0",
     "postcss-cli": "^11.0.0",
     "prettier": "^3.3.3",
     "require-dir": "^1.2.0",
-    "textlint": "^14.0.4",
+    "textlint": "^14.2.0",
     "textlint-filter-rule-allowlist": "^4.0.0",
     "textlint-filter-rule-comments": "^1.2.2",
     "textlint-rule-terminology": "^5.2.6",
@@ -143,12 +143,12 @@
     "@opentelemetry/resources": "^1.25.1",
     "@opentelemetry/sdk-trace-base": "^1.25.1",
     "@opentelemetry/sdk-trace-web": "^1.25.1",
-    "@opentelemetry/semantic-conventions": "^1.25.1",
+    "@opentelemetry/semantic-conventions": "^1.26.0",
     "path": "^0.12.7"
   },
   "optionalDependencies": {
-    "netlify-cli": "^17.33.5",
-    "npm-check-updates": "^17.0.3"
+    "netlify-cli": "^17.34.3",
+    "npm-check-updates": "^17.1.0"
   },
   "enginesComment": "Ensure that engines.node value stays consistent with the project's .nvmrc",
   "engines": {


### PR DESCRIPTION
The main (only?) change in the generated files seems to be due to a fix in the encoding of `<meta description>` values. E.g.,

```console
$ (cd public && git diff -b -w --ignore-blank-lines -I "meta description")
```
```diff
diff --git a/blog/2022/apisix/index.html b/blog/2022/apisix/index.html
index b82feef160..14ac9df5ba 100644
--- a/blog/2022/apisix/index.html
+++ b/blog/2022/apisix/index.html
@@ -15,7 +15,7 @@
 <meta name="theme-color" content="#4f62ad">
 
 <title>Apache APISIX Integrates with OpenTelemetry to Collect Tracing Data | OpenTelemetry</title>
-<meta name="description" content="This article introduces the Apache APISIX&amp;rsquo;s opentelemetry plugin concept and how to enable and deploy the plugin.
+<meta name="description" content="This article introduces the Apache APISIX&rsquo;s opentelemetry plugin concept and how to enable and deploy the plugin.
```