### PR TITLE
[CI] Report an error when URLs are missing from an integrations registry entry

### DIFF
--- a/layouts/shortcodes/ecosystem/integrations-table.md
+++ b/layouts/shortcodes/ecosystem/integrations-table.md
@@ -12,9 +12,32 @@
 Name[^1]     | OSS | Component |  Learn more
 ------------ | --- | ---------- |  ----------
 {{- range sort (sort $integrations ".title") ".oss" "desc" }}
-{{ $lang := cond (eq .language "collector") (dict "name" "Collector") (index $.Site.Data.instrumentation .language) -}}
-{{ $cncfTag := cond (isset . "cncfProjectLevel") (printf "<img alt=\"CNCF %s Project\" title=\"CNCF %s Project\" style=\"display: inline-block; padding-left: 8px; border: none; width: 16; height: 16px;\" src=\"/img/cncf-icon-color.svg\">" (humanize .cncfProjectLevel) (humanize .cncfProjectLevel)) "" -}}
-[{{ .title }}]({{ .urls.website }}){{ $cncfTag }} | {{- cond (eq .license "Commercial") "No" "Yes" }} | {{ $lang.name }} | [{{ replace .urls.docs "https://" "" }}]({{ .urls.docs }})
+{{ $lang := cond
+    (eq .language "collector")
+    (dict "name" "Collector")
+    (index $.Site.Data.instrumentation .language)
+-}}
+{{ $cncfTag := cond
+    (isset . "cncfProjectLevel")
+    (printf "<img alt=\"CNCF %s Project\" title=\"CNCF %s Project\" style=\"display: inline-block; padding-left: 8px; border: none; width: 16; height: 16px;\" src=\"/img/cncf-icon-color.svg\">"
+      (humanize .cncfProjectLevel)
+      (humanize .cncfProjectLevel))
+    "" -}}
+
+{{ if not .urls.website -}}
+  {{ errorf "Website URL is missing for integrations registry entry '%s'" .title -}}
+{{ end -}}
+{{ if not .urls.docs -}}
+  {{ errorf "Docs URL is missing for integrations registry entry '%s'" .title -}}
+{{ end -}}
+
+{{/* Each line below is a table column */ -}}
+
+[{{ .title }}]({{ .urls.website }})
+  {{- $cncfTag }} |
+  {{- cond (eq .license "Commercial") "No" "Yes" }} |
+  {{- $lang.name -}}
+  | [{{ replace .urls.docs "https://" "" }}]({{ .urls.docs }})
 {{- end }}
 
 [^1]: Listed alphabetically


### PR DESCRIPTION
- Reformats shortcode to make it easier to read
- Adds to checks for missing URLs, and reports an error (fails the build), when they are missing. (This should probably be a warning, but it matches the other checks that are done.

Note: I know that another partial does similar checks, but maybe not for Integration entries? Anyhow, these checks are now closer to their point of use.

/cc @svrnm 

The generated site files are the same (other than the site-build timestamp).

```console
$ (cd public && git diff)                                                                          
diff --git a/site/index.html b/site/index.html
index 4555d76f20..6ed7ea752e 100644
--- a/site/index.html
+++ b/site/index.html
@@ -226,7 +226,7 @@ Attribute Value Netlify built false Deploy context local ">
 <script>
 document.addEventListener("DOMContentLoaded", function() {
   var options = { hour: '2-digit', hour12: false, minute: '2-digit', timeZoneName: 'short' };
-  var buildDate = new Date("2024-08-26T18:49:33-04:00");
+  var buildDate = new Date("2024-08-26T19:26:49-04:00");
   document.getElementById("local-time").innerText = buildDate.toLocaleString(undefined, options);
 });
 </script>
```