### PR TITLE
Mention sync gauge in Otel Go metrics docs

### DIFF
--- a/content/en/docs/languages/go/instrumentation.md
+++ b/content/en/docs/languages/go/instrumentation.md
@@ -301,6 +301,8 @@ OpenTelemetry Go currently supports the following instruments:
   increments
 - Histogram, a synchronous instrument that supports arbitrary values that are
   statistically meaningful, such as histograms, summaries, or percentile
+- Synchronous Gauge, a synchronous instrument that supports non-additive values,
+  such as room temperature.
 - Asynchronous Gauge, an asynchronous instrument that supports non-additive
   values, such as room temperature
 - UpDownCounter, a synchronous instrument that supports increments and


### PR DESCRIPTION
Sync gauge was not listed as supported, but the later section of the doc show that it is indeed supported.