### PR TITLE
Custom collector page: link to tagged releases

### DIFF
--- a/content/en/docs/collector/custom-collector.md
+++ b/content/en/docs/collector/custom-collector.md
@@ -26,9 +26,10 @@ get started.
 
 ## Step 1 - Install the builder
 
-The `ocb` binary is available as a downloadable asset from [OpenTelemetry
-Collector releases][releases]. You will find a list of assets named based on OS
-and chipset, so download the one that fits your configuration:
+The `ocb` binary is available as a downloadable asset from OpenTelemetry
+Collector [releases with `cmd/builder` tags][tags]. You will find a list of
+assets named based on OS and chipset, so download the one that fits your
+configuration:
 
 {{< tabpane text=true >}}
 
@@ -223,9 +224,6 @@ Further reading:
 
 [ocb]:
   https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder
-[releases]:
-  https://github.com/open-telemetry/opentelemetry-collector-releases/releases/tag/cmd%2Fbuilder%2F{{%
-
-version-from-registry collector-builder %}}
+[tags]: https://github.com/open-telemetry/opentelemetry-collector-releases/tags
 
 [^1]: Prior to v0.86.0 use the `loggingexporter` instead of `debugexporter`.

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -3751,6 +3751,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:14:58.909754-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-collector-releases/tags": {
+    "StatusCode": 200,
+    "LastSeen": "2024-08-28T18:43:05.252902-04:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-collector/": {
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:36:56.082576-05:00"


### PR DESCRIPTION
- Followup to / inspired by the link-checking failure of #5114 
- Clarifies the details of how to get an `ocb` binary (i.e., to look for releases having a tag that starts with `cmd/builder`), and links to the tags page instead of the specific version. This will make the link checking less brittle.

/cc @theletterf @svrnm 