### PR TITLE
[CI] After a `fix:*` command, tell user to rerun full checks

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -101,9 +101,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
 
+      - name: Report success and ask to run full checks
+        if: ${{ !failure() && !cancelled() }}
+        run: |
+          gh pr comment $PR_NUM -b "fix:${PR_ACTION} was [successful]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID).\n### NOW RUN `/fix:all` to ensure that there are no other check issues."
+        env:
+          GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+
       - name: Report an error in the case of failure
         if: ${{ failure() || cancelled() }}
         run: |
-          gh pr comment $PR_NUM -b "fix:${PR_ACTION} run failed, please check $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID for details"
+          gh pr comment $PR_NUM -b "fix:${PR_ACTION} failed or was cancelled. For details, see $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID."
         env:
           GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
- A step towards aleveating the pain of #4339
- Reports successful runs of `fix:*` commands, and instructs the user to run `fix:all` to ensure that all checks are passing. This isn't a perfect solution, but it will hopefully help avoid issues like https://github.com/open-telemetry/opentelemetry.io/pull/5119#issuecomment-2318012101.

/cc @cartermp @svrnm 