### PR TITLE
[CI] PR-actions: escape PR comment special char

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Report success and ask to run full checks
         if: ${{ !failure() && !cancelled() }}
         run: |
-          gh pr comment $PR_NUM -b "fix:${PR_ACTION} was [successful]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID).\n### NOW RUN `/fix:all` to ensure that there are no other check issues."
+          gh pr comment $PR_NUM -b "fix:${PR_ACTION} was [successful]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID).\\n### NOW (RE-)RUN \`/fix:all\` to ensure that there are no other check issues."
         env:
           GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
 


### PR DESCRIPTION
- Followup to #5122
  - For an example of the success comment, see: https://github.com/open-telemetry/opentelemetry.io/pull/5116#issuecomment-2319052868
- Escapes special characters in `gh pr comment` comment string
  - https://github.com/open-telemetry/opentelemetry.io/actions/runs/10622918753/job/29448244561 shows the need for escaping, given the error: `sh: line 1: /fix:all: No such file or directory`

/cc @tiffany76 