### PR TITLE
Add GC Election 2024 announcement blog post

### DIFF
--- a/content/en/blog/2024/gc-elections.md
+++ b/content/en/blog/2024/gc-elections.md
@@ -1,0 +1,66 @@
+---
+title: Announcing the 2024 OpenTelemetry Governance Committee Election
+linkTitle: 2024 GC Election
+date: 2024-09-02
+author: OpenTelemetry Governance Committee
+aliases: [gc-elections-2024]
+---
+
+The OpenTelemetry project is excited to announce the 2024 OpenTelemetry
+Governance Committee (GC) election. Nominations are due by 11 October 2024
+23:59 UTC. The list of eligible candidates will be shared on 14 October 2024.
+Voting will take place between 21 October 2024 00:00 UTC and 23 October 2024
+23:59 UTC, and the final election results will be announced 25 October 2024.
+
+## Vote!
+
+If you are a
+[member of standing](https://github.com/open-telemetry/community/blob/main/governance-charter.md#members-of-standing)
+in the OpenTelemetry community, we invite you to participate with your vote in
+this election to ensure that the community is well-represented in the
+Governance Committee. In this election four people must be elected, each with
+two-year terms.
+
+If you have made contributions to our ecosystem not measured by the automatic
+process, you can [request an exception](https://forms.gle/LBvyRpNwZvqcJxUbA)
+to participate in the election before 23:59 UTC on 18 October 2024. The voter
+roll with all members of standing and approved exceptions will be published by 4
+October 2024 and continuously updated until the exception deadline.
+
+Voting will be open between 00:00 UTC on 21 October 2024 00:00 UTC and 23
+October 2024 23:59 UTC on
+[Helios Voting](https://vote.heliosvoting.org/helios/elections/176e7ca8-647d-11ef-9b9a-2a30e2a223da/view);
+voters will need to sign in with their GitHub account.
+
+To learn more about the election process, read about all the details
+[here](https://github.com/open-telemetry/community/blob/main/elections/2024/governance-committee-election.md).
+
+## Interested in joining the Governance Committee?
+
+If you’ve been working on OpenTelemetry and seeing it grow, or are an end-user
+that wants to help us make OpenTelemetry better, now’s the time to consider
+running for a seat on the Governance Committee. You can read about the
+Governance Committee's role in
+[this blog](/blog/2019/opentelemetry-governance-committee-explained/) post or
+refer to the
+[charter document](https://github.com/open-telemetry/community/blob/master/governance-charter.md).
+You may nominate yourself (or others!) by submitting a Pull Request against the
+[list of candidates](https://github.com/open-telemetry/community/blob/main/elections/2024/governance-committee-candidates.md)
+by 11 October 2024 23:59 UTC — more detailed requirements about the nomination
+and ratification process can be found
+[here](https://github.com/open-telemetry/community/blob/main/elections/2024/governance-committee-election.md).
+
+We would like to thank the GC members who have helped grow OpenTelemetry, and
+invite them to run for re-election if they so choose: Alolita Sharma, Daniel
+Dyla, Morgan McLean, and Trask Stalnaker.
+
+## Questions?
+
+For any election related questions, please file an issue on the
+[community repository](https://github.com/open-telemetry/community/issues) tagging the `@open-telemetry/otel-elections` team,
+email us at [cncf-opentelemetry-governance@lists.cncf.io](mailto:cncf-opentelemetry-governance@lists.cncf.io),
+or reach out to us on [CNCF Slack](https://slack.cncf.io/) in
+[#opentelemetry](https://cloud-native.slack.com/archives/CJFCJHG4Q) if you have
+an urgent access issue during voting.
+
+See you at the polls!


### PR DESCRIPTION
Adds a new blog post announces our GC Election 2024.

cc @open-telemetry/governance-committee 