### PR TITLE
correct metric type for http req/res sizes

### DIFF
--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -242,13 +242,13 @@ categorized by instrumentation type.
 | `http_client_active_requests`     | Number of active HTTP client requests.                                                    | Counter   |
 | `http_client_connection_duration` | Measures the duration of the successfully established outbound HTTP connections.          | Histogram |
 | `http_client_open_connections`    | Number of outbound HTTP connections that are active or idle on the client.                | Counter   |
-| `http_client_request_size`        | Measures the size of HTTP client request bodies.                                          | Histogram |
+| `http_client_request_size`        | Measures the size of HTTP client request bodies.                                          | Counter   |
 | `http_client_duration`            | Measures the duration of HTTP client requests.                                            | Histogram |
-| `http_client_response_size`       | Measures the size of HTTP client response bodies.                                         | Histogram |
+| `http_client_response_size`       | Measures the size of HTTP client response bodies.                                         | Counter   |
 | `http_server_active_requests`     | Number of active HTTP server requests.                                                    | Counter   |
-| `http_server_request_size`        | Measures the size of HTTP server request bodies.                                          | Histogram |
+| `http_server_request_size`        | Measures the size of HTTP server request bodies.                                          | Counter   |
 | `http_server_duration`            | Measures the duration of HTTP server requests.                                            | Histogram |
-| `http_server_response_size`       | Measures the size of HTTP server response bodies.                                         | Histogram |
+| `http_server_response_size`       | Measures the size of HTTP server response bodies.                                         | Counter   |
 | `rpc_client_duration`             | Measures the duration of outbound RPC.                                                    | Histogram |
 | `rpc_client_request_size`         | Measures the size of RPC request messages (uncompressed).                                 | Histogram |
 | `rpc_client_requests_per_rpc`     | Measures the number of messages received per RPC. Should be 1 for all non-streaming RPCs. | Histogram |


### PR DESCRIPTION
It took me a while to find out these docs were wrong, reading the OTLP receiver code, then the obs reporter helper, then the opentelemetry-go-contrib which holds the instrumentation for the HTTP servers. Thought I would save someone else the time.

These are counters, not histogram. Here is the code that records this: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/18eaff6c5acc512a4b53748c78bda978844c4fe4/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler.go#L154 

Interestingly, the gRPC code uses a histogram: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/18eaff6c5acc512a4b53748c78bda978844c4fe4/instrumentation/google.golang.org/grpc/otelgrpc/stats_handler.go#L154 