### PR TITLE
[chore] Remove references to the logging exporter

### DIFF
--- a/content/en/docs/kubernetes/operator/troubleshooting/target-allocator.md
+++ b/content/en/docs/kubernetes/operator/troubleshooting/target-allocator.md
@@ -106,7 +106,7 @@ spec:
       batch: {}
 
     exporters:
-      logging:
+      debug:
         verbosity: detailed
 
     service:
@@ -114,15 +114,15 @@ spec:
         traces:
           receivers: [otlp]
           processors: [batch]
-          exporters: [logging]
+          exporters: [debug]
         metrics:
           receivers: [otlp, prometheus]
           processors: []
-          exporters: [logging]
+          exporters: [debug]
         logs:
           receivers: [otlp]
           processors: [batch]
-          exporters: [logging]
+          exporters: [debug]
 ```
 
 First, set up a `port-forward` in Kubernetes, so that you can expose the Target

--- a/content/en/docs/languages/erlang/exporters.md
+++ b/content/en/docs/languages/erlang/exporters.md
@@ -37,6 +37,7 @@ processors:
     send_batch_size: 1024
     timeout: 5s
 exporters:
+  debug:
   otlp/jaeger:
     endpoint: jaeger-all-in-one:4317
     tls:
@@ -46,7 +47,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, otlp/jaeger]
+      exporters: [debug, otlp/jaeger]
 ```
 
 For a more detailed example, you can view the


### PR DESCRIPTION
Removes old references to the logging exporter, which is being removed.

Related to https://github.com/open-telemetry/opentelemetry-collector/pull/11037