### PR TITLE
Update adopters.yaml

### DIFF
--- a/data/ecosystem/adopters.yaml
+++ b/data/ecosystem/adopters.yaml
@@ -14,6 +14,11 @@
   components: [Collector, Go, Java, JavaScript, .NET]
   reference: ''
   contact: ''
+- name: CloudRaft
+  url: https://www.cloudraft.io
+  components: [Collector, Go, Python, JavaScript]
+  reference: 'https://www.cloudraft.io/blog/cicd-observability-using-opentelemetry'
+  contact: 'https://github.com/esainath96'
 - name: Cloud Scale
   url: https://www.cloudscaleinc.com
   components: [Collector, Python]


### PR DESCRIPTION
Updated adopters.yml with the link to the blog that describes how we used OpenTelemetry for Ci/Cd observability. It's a guide for anyone who wants to use it.