### PR TITLE
[ux] Rework OTel-highlights ribbon, move Integrations to ribbon

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -125,8 +125,11 @@
       max-width: 80%;
     }
 
-    a.external-link:after {
-      display: none;
+    a {
+      color: white;
+      &.external-link:after {
+        display: none;
+      }
     }
   }
 }

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -58,7 +58,7 @@ you analyze your software's performance and behavior.
 {{% blocks/feature icon="fas fa-chart-line" title="Traces, Metrics, Logs" url="docs/concepts/observability-primer/" %}}
 
 Create and collect telemetry from your services and software, then forward
-them to a variety of analysis tools.
+it to a variety of analysis tools.
 
 {{% /blocks/feature %}}
 

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -28,7 +28,6 @@ show_banner: true
 
 - [Learn more](docs/what-is-opentelemetry/)
 - [Try the demo](docs/demo/)
-- [Explore integrations](/ecosystem/integrations/)
 
 </div>
 
@@ -49,32 +48,37 @@ OpenTelemetry is a collection of APIs, SDKs, and tools. Use it to instrument,
 generate, collect, and export telemetry data (metrics, logs, and traces) to help
 you analyze your software's performance and behavior.
 
-> OpenTelemetry is **generally available** across
-> [several languages](docs/languages/) and is suitable for use.
+> OpenTelemetry is [generally available](/status/) across
+> [several languages](docs/languages/) and is suitable for production use.
 
 {{% /blocks/lead %}}
 
 {{% blocks/section color="dark" type="row" %}}
 
-{{% blocks/feature icon="fas fa-chart-line" title="Traces, Metrics, Logs"%}}
+{{% blocks/feature icon="fas fa-chart-line" title="Traces, Metrics, Logs" url="docs/concepts/observability-primer/" %}}
 
 Create and collect telemetry data from your services and software, then forward
-them to a variety of analysis tools. {{% /blocks/feature %}}
+them to a variety of analysis tools.
 
-{{% blocks/feature icon="fas fa-magic" title="Drop-In Instrumentation"%}}
+{{% /blocks/feature %}}
 
-OpenTelemetry integrates with popular libraries and frameworks such as
-[Spring](https://spring.io),
-[ASP.NET Core](https://docs.microsoft.com/aspnet/core),
-[Express](https://expressjs.com), [Quarkus](https://quarkus.io), and more!
-Installation and integration can be as simple as a few lines of code.
+{{% blocks/feature icon="fas fa-magic" title="Drop-in Instrumentation & Integrations" %}}
+
+OpenTelemetry [integrates] with many popular libraries and frameworks, and
+supports _code-based and zero-code_ [instrumentation].
+
+[instrumentation]: /docs/concepts/instrumentation/
+[integrates]: /ecosystem/integrations/
 
 {{% /blocks/feature %}}
 
 {{% blocks/feature icon="fab fa-github" title="Open Source, Vendor Neutral" %}}
 
-100% Free and Open Source, OpenTelemetry is adopted and supported by
-[industry leaders](/ecosystem/vendors/) in the observability space.
+100% free and open source, OpenTelemetry is [adopted] and supported by [industry
+leaders] in the observability space.
+
+[adopted]: /ecosystem/adopters/
+[industry leaders]: /ecosystem/vendors/
 
 {{% /blocks/feature %}}
 

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -57,7 +57,7 @@ you analyze your software's performance and behavior.
 
 {{% blocks/feature icon="fas fa-chart-line" title="Traces, Metrics, Logs" url="docs/concepts/observability-primer/" %}}
 
-Create and collect telemetry data from your services and software, then forward
+Create and collect telemetry from your services and software, then forward
 them to a variety of analysis tools.
 
 {{% /blocks/feature %}}

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -57,8 +57,8 @@ you analyze your software's performance and behavior.
 
 {{% blocks/feature icon="fas fa-chart-line" title="Traces, Metrics, Logs" url="docs/concepts/observability-primer/" %}}
 
-Create and collect telemetry from your services and software, then forward
-it to a variety of analysis tools.
+Create and collect telemetry from your services and software, then forward it to
+a variety of analysis tools.
 
 {{% /blocks/feature %}}
 

--- a/content/en/ecosystem/integrations.md
+++ b/content/en/ecosystem/integrations.md
@@ -18,8 +18,8 @@ ultimately all applications should either integrate the OpenTelemetry APIs and
 SDKs directly for native telemetry, or provide a first-party plugin that fits
 into the ecosystem of the given software.
 
-On this page you will find a sample of libraries, services and apps, that
-provide such a native instrumentation or first class plugin.
+This page contains a sample of libraries, services, and apps providing native
+instrumentation or first class plugins.
 
 ## Libraries
 
@@ -36,9 +36,9 @@ The following list contains a sample of libraries, services, and apps that have
 either integrated OpenTelemetry APIs and SDKs directly for native telemetry or
 provide a first-party plugin that fits into their own extensibility ecosystem.
 
-You will find open source (OSS) projects at the beginning of the list;
-commercial projects follow. Projects which are part of the
-[CNCF](https://www.cncf.io/) show a small CNCF logo beside their name.
+Open source projects (OSS) are at the beginning of the list, and commercial
+projects follow. Projects which are part of the [CNCF](https://www.cncf.io/)
+have a CNCF logo beside their name.
 
 {{% ecosystem/integrations-table "application integrations" %}}
 


### PR DESCRIPTION
Contributes to:

- #5155 

For **motivation**, see that issue's description. IMHO, there is more work to be done, but this is a low hanging fruit, which eliminates the Integrations CTA

This PR reworks the OTel-highlights "ribbon", in particular makes these changes for the three ribbon entries (for screenshots, see below):

- Telemetry ribbon entry (the first one): adds a "read more" link to the OTel primer
- Second ribbon entry changed to link to the Integrations page. Adds a link to the Instrumentation page
- Third entry: adds link to Adopters page

### Ribbon screenshots

Before:

> <img width="1487" alt="image" src="https://github.com/user-attachments/assets/cb9d4dce-0126-4bda-bb77-19422073e293">

After:

> <img width="1238" alt="image" src="https://github.com/user-attachments/assets/0a8c680c-4c12-4e0d-ad00-ea2ba1360fbb">

### CTA screenshots

Before:

> <img width="444" alt="image" src="https://github.com/user-attachments/assets/8a24e3b2-dac8-4f56-a5c8-4465cdc47154">

After:

> <img width="444" alt="image" src="https://github.com/user-attachments/assets/fcbe9a76-4e68-4de8-8fe5-d770788fb685">
