### PR TITLE
Update Apache Skywalking vendor link

### DIFF
--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -344,7 +344,7 @@
   commercial: true
 - name: Apache SkyWalking
   nativeOTLP: true
-  url: https://skywalking.apache.org/docs/main/v9.0.0/en/setup/backend/opentelemetry-receiver/
+  url: https://skywalking.apache.org/docs/main/latest/en/setup/backend/otlp-trace/
   contact:
   oss: true
   commercial: false


### PR DESCRIPTION
Fixes #5139.

Previous link produced `404` status code. This PR updates the link to one provided by an Apache Skywalker maintainer.

Based on @svrnm's recommendation, I chose the link for OTLP traces (see discussion in referenced issue). 