### PR TITLE
Fix the endering of http urls in architecture.md's mermaid diagram

### DIFF
--- a/content/en/docs/demo/architecture.md
+++ b/content/en/docs/demo/architecture.md
@@ -129,7 +129,7 @@ subgraph tdf[Telemetry Data Flow]
         subgraph oc[OTel Collector]
             style oc fill:#97aef3,color:black;
             oc-grpc[/"OTLP Receiver<br/>listening on<br/>grpc://localhost:4317/"/]
-            oc-http[/"OTLP Receiver<br/>listening on <br/>http​://localhost:4318/<br/>https://localhost:4318/"/]
+            oc-http[/"OTLP Receiver<br/>listening on <br/>http​://localhost:4318/<br/>https​://localhost:4318/"/]
             oc-proc(Processors)
             oc-prom[/"OTLP HTTP Exporter"/]
             oc-otlp[/"OTLP Exporter"/]

--- a/content/en/docs/demo/architecture.md
+++ b/content/en/docs/demo/architecture.md
@@ -129,7 +129,7 @@ subgraph tdf[Telemetry Data Flow]
         subgraph oc[OTel Collector]
             style oc fill:#97aef3,color:black;
             oc-grpc[/"OTLP Receiver<br/>listening on<br/>grpc://localhost:4317/"/]
-            oc-http[/"OTLP Receiver<br/>listening on <br/>http://localhost:4318/<br/>https://localhost:4318/"/]
+            oc-http[/"OTLP Receiver<br/>listening on <br/>http​://localhost:4318/<br/>https://localhost:4318/"/]
             oc-proc(Processors)
             oc-prom[/"OTLP HTTP Exporter"/]
             oc-otlp[/"OTLP Exporter"/]
@@ -141,27 +141,27 @@ subgraph tdf[Telemetry Data Flow]
             oc-proc --> oc-otlp
         end
 
-        oc-prom -->|"http://localhost:9090/api/v1/otlp"| pr-sc
+        oc-prom -->|"http​://localhost:9090/api/v1/otlp"| pr-sc
         oc-otlp -->|gRPC| ja-col
 
         subgraph pr[Prometheus]
             style pr fill:#e75128,color:black;
             pr-sc[/"Prometheus OTLP Write Receiver"/]
             pr-tsdb[(Prometheus TSDB)]
-            pr-http[/"Prometheus HTTP<br/>listening on<br/>http://localhost:9090"/]
+            pr-http[/"Prometheus HTTP<br/>listening on<br/>http​://localhost:9090"/]
 
             pr-sc --> pr-tsdb
             pr-tsdb --> pr-http
         end
 
         pr-b{{"Browser<br/>Prometheus UI"}}
-        pr-http ---->|"http://localhost:9090/graph"| pr-b
+        pr-http ---->|"http​://localhost:9090/graph"| pr-b
 
         subgraph ja[Jaeger]
             style ja fill:#60d0e4,color:black;
             ja-col[/"Jaeger Collector<br/>listening on<br/>grpc://jaeger:4317/"/]
             ja-db[(Jaeger DB)]
-            ja-http[/"Jaeger HTTP<br/>listening on<br/>http://localhost:16686"/]
+            ja-http[/"Jaeger HTTP<br/>listening on<br/>http​://localhost:16686"/]
 
             ja-col --> ja-db
             ja-db --> ja-http
@@ -170,19 +170,19 @@ subgraph tdf[Telemetry Data Flow]
         subgraph gr[Grafana]
             style gr fill:#f8b91e,color:black;
             gr-srv["Grafana Server"]
-            gr-http[/"Grafana HTTP<br/>listening on<br/>http://localhost:3000"/]
+            gr-http[/"Grafana HTTP<br/>listening on<br/>http​://localhost:3000"/]
 
             gr-srv --> gr-http
         end
 
-        pr-http --> |"http://localhost:9090/api"| gr-srv
-        ja-http --> |"http://localhost:16686/api"| gr-srv
+        pr-http --> |"http​://localhost:9090/api"| gr-srv
+        ja-http --> |"http​://localhost:16686/api"| gr-srv
 
         ja-b{{"Browser<br/>Jaeger UI"}}
-        ja-http ---->|"http://localhost:16686/search"| ja-b
+        ja-http ---->|"http​://localhost:16686/search"| ja-b
 
         gr-b{{"Browser<br/>Grafana UI"}}
-        gr-http -->|"http://localhost:3000/dashboard"| gr-b
+        gr-http -->|"http​://localhost:3000/dashboard"| gr-b
     end
 end
 ```


### PR DESCRIPTION
Hey,

The diagram here is currently broken > https://opentelemetry.io/docs/demo/architecture/

What I did (and I think this is probably a terrible idea) was adding a Zero-width space before the colon in the urls.

I also tested adding a <span> and it also allows the rending to take place.

I'm not super familiar with Mermaid so there might exist a better way to do this (I hope so at least).

Raising this for awareness, if you are aware of an easy fix let me know and I can fix it quickly. Otherwise I will try to look into it whenever I have time available.