### PR TITLE
Fix internal link in community/members.md

### DIFF
--- a/content/en/community/members.md
+++ b/content/en/community/members.md
@@ -39,7 +39,7 @@ the OpenTelemetry project.
 
 Specification sponsors are trusted collaborators of the technical committee, and
 work to review, approve, and sponsor
-[OpenTelemetry specification](https://opentelemetry.io/docs/specs/otel/) issues
+[OpenTelemetry specification](/docs/specs/otel/) issues
 and PRs.
 
 {{% community/members-list "spec-sponsors" %}}

--- a/content/en/community/members.md
+++ b/content/en/community/members.md
@@ -39,8 +39,7 @@ the OpenTelemetry project.
 
 Specification sponsors are trusted collaborators of the technical committee, and
 work to review, approve, and sponsor
-[OpenTelemetry specification](/docs/specs/otel/) issues
-and PRs.
+[OpenTelemetry specification](/docs/specs/otel/) issues and PRs.
 
 {{% community/members-list "spec-sponsors" %}}
 


### PR DESCRIPTION
Not sure why this was not breaking the PR before merging, it now affects other PRs, so here is a quick fix.