### PR TITLE
Use collector contrib in quickstart

### DIFF
--- a/content/en/docs/collector/quick-start.md
+++ b/content/en/docs/collector/quick-start.md
@@ -40,10 +40,10 @@ preferred shell.
 
 ## Set up the environment
 
-1. Pull in the OpenTelemetry Collector Docker image:
+1. Pull in the OpenTelemetry Collector Contrib Docker image:
 
    ```sh
-   docker pull otel/opentelemetry-collector:{{% param vers %}}
+   docker pull otel/opentelemetry-collector-contrib:{{% param vers %}}
    ```
 
 2. Install the [telemetrygen] utility:
@@ -63,7 +63,7 @@ preferred shell.
    docker run \
      -p 127.0.0.1:4317:4317 \
      -p 127.0.0.1:55679:55679 \
-     otel/opentelemetry-collector:{{% param vers %}} \
+     otel/opentelemetry-collector-contrib:{{% param vers %}} \
      2>&1 | tee collector-output.txt # Optionally tee output for easier search later
    ```
 


### PR DESCRIPTION
We regularly see the following problem with organizations adopting OTel in my workplace:

1. We tell them to install an OTel Collector, or they come with one, and it's basically just routing data ... no processing
2. They then need some kind of component in contrib. A receiver for some external data source, or a processor to redact info or transform telemetry, etc.
3. They then get an error because that component doesn't exist, so they're confused and frustrated and it's a _whole thing_ to get them to realize that they actually needed the contrib image or should have used OCB
4. We find out that they learned how to install the collector via Google --> landing on this page

And so, I'm proposing that we change this to be contrib, like the rest of our installation guides for the collector.

Separately, we should have a page or some content somewhere that explains when you really do want the base image, contrib, or to use OCB. There are valid use cases for all three, but by default I think we should stick with the one that's more feature-rich. Over time, people can pare back the size of the collector they have when they decide it's too big.