### PR TITLE
Some updates to status page and language index page

### DIFF
--- a/.cspell/en-words.txt
+++ b/.cspell/en-words.txt
@@ -8,6 +8,7 @@ adservice
 alibaba
 Alolita
 APAC
+apidocs
 appdynamics
 appender
 appenders

--- a/content/en/api-docs.md
+++ b/content/en/api-docs.md
@@ -1,7 +1,6 @@
 ---
 title: API Documentation
 linkTitle: Docs
-cSpell:ignore: apidocs
 ---
 
 {{% blocks/section color="white" %}}

--- a/content/en/docs/languages/_index.md
+++ b/content/en/docs/languages/_index.md
@@ -11,12 +11,12 @@ redirects: [{ from: /docs/instrumentation/*, to: ':splat' }]
 OpenTelemetry code [instrumentation][] is supported for the languages listed in
 the [Statuses and Releases](#status-and-releases) table below. Unofficial
 implementations for [other languages](/docs/languages/other) are available as
-well – you can find them in the
+well. You can find them in the
 [registry](http://localhost:1313/ecosystem/registry/).
 
 For Go, .NET, PHP, Python, Java and JavaScript you can use
 [zero-code solutions](/docs/zero-code) to add instrumentation to your
-application without cod changes.
+application without code changes.
 
 If you are using Kubernetes, you can use the [OpenTelemetry Operator for
 Kubernetes][otel-op] to [inject these zero-code solutions][zero-code] into your
@@ -41,18 +41,17 @@ specification], your data flow might be subject to **breaking changes**.
 
 {{% telemetry-support-table " " %}}
 
-## API References
+## API references
 
-Special Interest Groups (SIGs) implementing the OpenTelemetry API & SDK in a
-specific language, als publish API references for developers. The following
+Special Interest Groups (SIGs) implementing the OpenTelemetry API and SDK in a
+specific language also publish API references for developers. The following
 references are available:
 
 {{% apidocs %}}
 
 {{% alert title="Tip" color="info" %}}
 
-Remember <https://opentelemetry.io/api-docs> to always have the list of
-available API references at hand.
+You can find a list of available API references at <https://opentelemetry.io/api-docs>.
 
 {{% /alert %}}
 

--- a/content/en/docs/languages/_index.md
+++ b/content/en/docs/languages/_index.md
@@ -8,17 +8,19 @@ aliases: [/docs/instrumentation]
 redirects: [{ from: /docs/instrumentation/*, to: ':splat' }]
 ---
 
-OpenTelemetry code [instrumentation][] is supported for the languages listed
-below. Depending on the language, topics covered will include some or all of the
-following:
+OpenTelemetry code [instrumentation][] is supported for the languages listed in
+the [Statuses and Releases](#status-and-releases) table below. Unofficial
+implementations for [other languages](/docs/languages/other) are available as
+well – you can find them in the
+[registry](http://localhost:1313/ecosystem/registry/).
 
-- Automatic instrumentation
-- Manual instrumentation
-- Exporting data
+For Go, .NET, PHP, Python, Java and JavaScript you can use
+[zero-code solutions](/docs/zero-code) to add instrumentation to your
+application without cod changes.
 
 If you are using Kubernetes, you can use the [OpenTelemetry Operator for
-Kubernetes][otel-op] to [inject auto-instrumentation libraries][auto] for .NET,
-Java, Node.js, Python, Go into your application.
+Kubernetes][otel-op] to [inject these zero-code solutions][zero-code] into your
+application.
 
 ## Status and Releases
 
@@ -39,6 +41,21 @@ specification], your data flow might be subject to **breaking changes**.
 
 {{% telemetry-support-table " " %}}
 
-[auto]: /docs/kubernetes/operator/automatic/
+## API References
+
+Special Interest Groups (SIGs) implementing the OpenTelemetry API & SDK in a
+specific language, als publish API references for developers. The following
+references are available:
+
+{{% apidocs %}}
+
+{{% alert title="Tip" color="info" %}}
+
+Remember <https://opentelemetry.io/api-docs> to always have the list of
+available API references at hand.
+
+{{% /alert %}}
+
+[zero-code]: /docs/kubernetes/operator/automatic/
 [instrumentation]: /docs/concepts/instrumentation/
 [otel-op]: /docs/kubernetes/operator/

--- a/content/en/docs/languages/_index.md
+++ b/content/en/docs/languages/_index.md
@@ -51,7 +51,8 @@ references are available:
 
 {{% alert title="Tip" color="info" %}}
 
-You can find a list of available API references at <https://opentelemetry.io/api-docs>.
+You can find a list of available API references at
+<https://opentelemetry.io/api-docs>.
 
 {{% /alert %}}
 

--- a/content/en/status.md
+++ b/content/en/status.md
@@ -19,7 +19,7 @@ SDK.
 ## Language APIs & SDKs
 
 For the development status, or maturity level, of a
-[language API and SDK](/docs/languages/), see the following table:
+[language API or SDK](/docs/languages/), see the following table:
 
 {{% telemetry-support-table " " %}}
 

--- a/content/en/status.md
+++ b/content/en/status.md
@@ -16,10 +16,10 @@ status from the right component page. For example, the status of a signal in the
 specification may not be the same as the signal status in a particular language
 SDK.
 
-## Language SDKs
+## Language APIs & SDKs
 
 For the development status, or maturity level, of a
-[language SDK](/docs/languages/), see the following table:
+[language API and SDK](/docs/languages/), see the following table:
 
 {{% telemetry-support-table " " %}}
 

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -9643,6 +9643,10 @@
     "StatusCode": 206,
     "LastSeen": "2024-06-04T17:29:59.050384645+02:00"
   },
+  "https://opentelemetry.io/api-docs": {
+    "StatusCode": 206,
+    "LastSeen": "2024-09-16T14:16:13.499994+02:00"
+  },
   "https://opentelemetry.io/blog/2022/jaeger-native-otlp/": {
     "StatusCode": 206,
     "LastSeen": "2024-04-27T13:39:35.171666-04:00"


### PR DESCRIPTION
Some minor updates to the status page and language api&sdk index page:

* Status page: Say "APIs & SDKs" instead of only "SDKs" like in the page navigation
* Language Index page: Rewording + mention /api-docs