### PR TITLE
Update observability-driven testing commands in documentation

### DIFF
--- a/content/en/docs/demo/docker-deployment.md
+++ b/content/en/docs/demo/docker-deployment.md
@@ -2,7 +2,7 @@
 title: Docker deployment
 linkTitle: Docker
 aliases: [docker_deployment]
-cSpell:ignore: otelcollector otlphttp spanmetrics tracetest
+cSpell:ignore: otelcollector otlphttp spanmetrics tracetest tracetesting
 ---
 
 <!-- markdownlint-disable code-block-style ol-prefix -->

--- a/content/en/docs/demo/docker-deployment.md
+++ b/content/en/docs/demo/docker-deployment.md
@@ -69,7 +69,8 @@ Once the images are built and containers are started you can access:
 - Grafana: <http://localhost:8080/grafana/>
 - Load Generator UI: <http://localhost:8080/loadgen/>
 - Jaeger UI: <http://localhost:8080/jaeger/ui/>
-- Tracetest UI: <http://localhost:11633/>, only when using `make run-tracetesting`
+- Tracetest UI: <http://localhost:11633/>, only when using
+  `make run-tracetesting`
 
 ## Changing the demo's primary port number
 

--- a/content/en/docs/demo/docker-deployment.md
+++ b/content/en/docs/demo/docker-deployment.md
@@ -50,13 +50,13 @@ docker compose up --force-recreate --remove-orphans --detach
     {{< tabpane text=true >}} {{% tab Make %}}
 
 ```shell
-make start-odd
+make run-tracetesting
 ```
 
     {{% /tab %}} {{% tab Docker %}}
 
 ```shell
-docker compose --profile odd up --force-recreate --remove-orphans --detach
+docker compose -f docker-compose-tests.yml run traceBasedTests
 ```
 
     {{% /tab %}} {{< /tabpane >}}
@@ -69,7 +69,7 @@ Once the images are built and containers are started you can access:
 - Grafana: <http://localhost:8080/grafana/>
 - Load Generator UI: <http://localhost:8080/loadgen/>
 - Jaeger UI: <http://localhost:8080/jaeger/ui/>
-- Tracetest UI: <http://localhost:11633/>, only when using `make start-odd`
+- Tracetest UI: <http://localhost:11633/>, only when using `make run-tracetesting`
 
 ## Changing the demo's primary port number
 


### PR DESCRIPTION
Replaced the `make start-odd` and related Docker command in the "Enable API observability-driven testing" section with updated commands (`make run-tracetestings` and `docker compose -f docker-compose-tests.yml run traceBasedTests`) to reflect current available commands. The previous `make start-odd` command no longer exists.