### PR TITLE
Add Link to Support Policies in Status and Releases Section of OpenTelemetry Collector Documentation

### DIFF
--- a/content/en/docs/collector/_index.md
+++ b/content/en/docs/collector/_index.md
@@ -54,14 +54,14 @@ you launch a collector it will automatically start receiving telemetry.
 
 ## Status and releases
 
-The **collector** status is: [mixed][], since core collector components
-currently have mixed [stability levels][].
+The **collector** status is: [mixed][], since core collector components currently have mixed [stability levels][].
 
-**Collector components** differ in their maturity levels. Each component has its
-stability documented in its `README.md`. You can find a list of all available
-collector components in the [registry][].
+**Collector components** differ in their maturity levels. Each component has its stability documented in its `README.md`. You can find a list of all available collector components in the [registry][].
+
+Support is guaranteed for Collector software artifacts for a certain time period based on the artifact's intended audience. This support includes, at minimum, fixes for critical bugs and security issues. See the [support policies](https://github.com/open-telemetry/opentelemetry-collector/blob/main/VERSIONING.md) for more details.
 
 {{% docs/latest-release collector-releases /%}}
+
 
 [registry]: /ecosystem/registry/?language=collector
 [mixed]: /docs/specs/otel/document-status/#mixed


### PR DESCRIPTION
PR Description: Add Link to Support Policies in Status and Releases Section

This PR enhances the "Status and releases" section of the OpenTelemetry Collector documentation by:

Adding a statement clarifying the guaranteed support for Collector software artifacts, including critical bug fixes and security issue resolutions.
Providing a direct link to the VERSIONING.md file in the Collector repository, which details the support policies for various Collector artifacts.
These updates align with the clarified support policies in preparation for the upcoming Collector v1.0 release, offering clear guidance to users about the stability and support levels of Collector components.

Related Issue: #5197 Add link to VERSIONING.md in Collector docs