### PR TITLE
firstParty flag for Lua/Perl/Rust/Swift

### DIFF
--- a/data/registry/instrumentation-lua-apache-apisix.yml
+++ b/data/registry/instrumentation-lua-apache-apisix.yml
@@ -14,3 +14,4 @@ authors:
 urls:
   repo: https://github.com/apache/apisix/blob/master/apisix/plugins/opentelemetry.lua
 createdAt: 2022-03-27
+isFirstParty: true

--- a/data/registry/instrumentation-perl-mojolicious.yml
+++ b/data/registry/instrumentation-perl-mojolicious.yml
@@ -12,3 +12,4 @@ authors:
 urls:
   repo: https://github.com/jjatria/mojolicious-plugin-opentelemetry
 createdAt: 2023-12-05
+isFirstParty: false

--- a/data/registry/instrumentation-perl-plack.yml
+++ b/data/registry/instrumentation-perl-plack.yml
@@ -12,3 +12,4 @@ authors:
 urls:
   repo: https://github.com/abh/Plack-Middleware-OpenTelemetry
 createdAt: 2023-12-05
+isFirstParty: false

--- a/data/registry/instrumentation-rust-actix-web.yml
+++ b/data/registry/instrumentation-rust-actix-web.yml
@@ -16,3 +16,4 @@ package:
   registry: crates
   name: actix-web-opentelemetry
   version: 0.16.0
+isFirstParty: false

--- a/data/registry/instrumentation-rust-axum.yml
+++ b/data/registry/instrumentation-rust-axum.yml
@@ -17,3 +17,4 @@ package:
   registry: crates
   name: axum-tracing-opentelemetry
   version: 0.16.0
+isFirstParty: false

--- a/data/registry/instrumentation-rust-tide.yml
+++ b/data/registry/instrumentation-rust-tide.yml
@@ -16,3 +16,4 @@ package:
   registry: crates
   name: opentelemetry-tide
   version: 0.12.0
+isFirstParty: false

--- a/data/registry/instrumentation-rust-tracing.yml
+++ b/data/registry/instrumentation-rust-tracing.yml
@@ -17,3 +17,4 @@ package:
   registry: crates
   name: tracing-opentelemetry
   version: 0.22.0
+isFirstParty: false

--- a/data/registry/instrumentation-rust-trillium.yml
+++ b/data/registry/instrumentation-rust-trillium.yml
@@ -16,3 +16,4 @@ package:
   registry: crates
   name: opentelemetry-trillium-opentelemetry
   version: 0.2.16
+isFirstParty: true

--- a/data/registry/instrumentation-swift-urlsession.yml
+++ b/data/registry/instrumentation-swift-urlsession.yml
@@ -16,3 +16,4 @@ authors:
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-swift/tree/main/Sources/Instrumentation/URLSession
 createdAt: 2021-06-22
+isFirstParty: false

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -2467,6 +2467,10 @@
     "StatusCode": 206,
     "LastSeen": "2024-08-09T10:44:31.007449-04:00"
   },
+  "https://docs.bugsnag.com/performance/distributed-tracing": {
+    "StatusCode": 206,
+    "LastSeen": "2024-09-24T06:19:31.410753499Z"
+  },
   "https://docs.centreon.com/pp/integrations/plugin-packs/getting-started/how-to-guides/telegraf/": {
     "StatusCode": 206,
     "LastSeen": "2024-07-27T17:54:47.061938869Z"


### PR DESCRIPTION
To address #4795, this is part of a series of PRs that add isFirstParty or isNative flags to instrumentation registries that lack them.

This batch touches Lua/Perl/Rust/Swift instrumentation registries.