### PR TITLE
Fix various links that pointed to localhost:1313

### DIFF
--- a/content/en/blog/2024/otel-operator-q-and-a/index.md
+++ b/content/en/blog/2024/otel-operator-q-and-a/index.md
@@ -20,9 +20,8 @@ is a
 that manages OTel for you in your Kubernetes cluster to make life a little
 easier. It does the following:
 
-- Manages deployment of the
-  [OpenTelemetry Collector](/docs/collector/), supported by
-  the
+- Manages deployment of the [OpenTelemetry Collector](/docs/collector/),
+  supported by the
   [`OpenTelemetryCollector`](https://github.com/open-telemetry/opentelemetry-operator?tab=readme-ov-file#getting-started)
   [custom resource (CR)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
 - Manages the configuration of a fleet of OpenTelemetry Collectors via
@@ -42,8 +41,7 @@ cool things, so I thought it might be helpful to share some little OTel Operator
 goodies that I’ve picked up along the way, in the form of a Q&A.
 
 Please note that this post assumes that you have some familiarity with
-OpenTelemetry, the
-[OpenTelemetry Collector](/docs/collector/), the
+OpenTelemetry, the [OpenTelemetry Collector](/docs/collector/), the
 [OpenTelemetry Operator](https://github.com/open-telemetry/opentelemetry-operator)
 (including the
 [Target Allocator](https://adri-v.medium.com/prometheus-opentelemetry-better-together-41dc637f2292)),

--- a/content/en/blog/2024/otel-operator-q-and-a/index.md
+++ b/content/en/blog/2024/otel-operator-q-and-a/index.md
@@ -21,7 +21,7 @@ that manages OTel for you in your Kubernetes cluster to make life a little
 easier. It does the following:
 
 - Manages deployment of the
-  [OpenTelemetry Collector](http://localhost:1313/docs/collector/), supported by
+  [OpenTelemetry Collector](/docs/collector/), supported by
   the
   [`OpenTelemetryCollector`](https://github.com/open-telemetry/opentelemetry-operator?tab=readme-ov-file#getting-started)
   [custom resource (CR)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
@@ -43,7 +43,7 @@ goodies that I’ve picked up along the way, in the form of a Q&A.
 
 Please note that this post assumes that you have some familiarity with
 OpenTelemetry, the
-[OpenTelemetry Collector](http://localhost:1313/docs/collector/), the
+[OpenTelemetry Collector](/docs/collector/), the
 [OpenTelemetry Operator](https://github.com/open-telemetry/opentelemetry-operator)
 (including the
 [Target Allocator](https://adri-v.medium.com/prometheus-opentelemetry-better-together-41dc637f2292)),

--- a/content/en/docs/languages/_index.md
+++ b/content/en/docs/languages/_index.md
@@ -12,7 +12,7 @@ OpenTelemetry code [instrumentation][] is supported for the languages listed in
 the [Statuses and Releases](#status-and-releases) table below. Unofficial
 implementations for [other languages](/docs/languages/other) are available as
 well. You can find them in the
-[registry](http://localhost:1313/ecosystem/registry/).
+[registry](/ecosystem/registry/).
 
 For Go, .NET, PHP, Python, Java and JavaScript you can use
 [zero-code solutions](/docs/zero-code) to add instrumentation to your

--- a/content/en/docs/languages/_index.md
+++ b/content/en/docs/languages/_index.md
@@ -11,8 +11,7 @@ redirects: [{ from: /docs/instrumentation/*, to: ':splat' }]
 OpenTelemetry code [instrumentation][] is supported for the languages listed in
 the [Statuses and Releases](#status-and-releases) table below. Unofficial
 implementations for [other languages](/docs/languages/other) are available as
-well. You can find them in the
-[registry](/ecosystem/registry/).
+well. You can find them in the [registry](/ecosystem/registry/).
 
 For Go, .NET, PHP, Python, Java and JavaScript you can use
 [zero-code solutions](/docs/zero-code) to add instrumentation to your

--- a/content/en/docs/languages/java/configuration.md
+++ b/content/en/docs/languages/java/configuration.md
@@ -685,7 +685,7 @@ Declarative configuration is currently under development. It allows for YAML
 file-based configuration as described in
 [opentelemetry-configuration](https://github.com/open-telemetry/opentelemetry-configuration)
 and
-[declarative configuration](http://localhost:1313/docs/specs/otel/configuration/#declarative-configuration).
+[declarative configuration](/docs/specs/otel/configuration/#declarative-configuration).
 
 To use, include
 `io.opentelemetry:opentelemetry-sdk-extension-incubator:{{% param vers.otel %}}-alpha`


### PR DESCRIPTION
Hi, 

while browsing the docs I found some links pointing to `localhost:1313`. These were likely inserted during local development.

This PR should fix that.

Cheers,
Markus