### PR TITLE
Update the organization of internal telemetry page

### DIFF
--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -282,34 +282,48 @@ libraries. {{% /alert %}}
 | `rpc_server_response_size`        | Measures the size of RPC response messages (uncompressed).                                | Histogram |
 | `rpc_server_responses_per_rpc`    | Measures the number of messages sent per RPC. Should be 1 for all non-streaming RPCs.     | Histogram |
 
-### Telemetry maturity levels
+### Events observable with internal logs
 
-#### Traces
+The Collector logs the following internal events:
+
+- A Collector instance starts or stops.
+- Data dropping begins due to throttling for a specified reason, such as local
+  saturation, downstream saturation, downstream unavailable, etc.
+- Data dropping due to throttling stops.
+- Data dropping begins due to invalid data. A sample of the invalid data is
+  included.
+- Data dropping due to invalid data stops.
+- A crash is detected, differentiated from a clean stop. Crash data is included
+  if available.
+
+## Telemetry maturity levels
+
+### Traces
 
 Tracing instrumentation is still under active development, and changes might be
 made to span names, attached attributes, instrumented endpoints, or other
 aspects of the telemetry. Until this feature graduates to stable, there are no
 guarantees of backwards compatibility for tracing instrumentation.
 
-#### Metrics
+### Metrics
 
 The Collector's metrics follow a four-stage lifecycle:
 
 > Alpha metric → Stable metric → Deprecated metric → Deleted metric
 
-##### Alpha
+#### Alpha
 
 Alpha metrics have no stability guarantees. These metrics can be modified or
 deleted at any time.
 
-##### Stable
+#### Stable
 
 Stable metrics are guaranteed to not change. This means:
 
 - A stable metric without a deprecated signature will not be deleted or renamed.
 - A stable metric's type and attributes will not be modified.
 
-##### Deprecated
+#### Deprecated
 
 Deprecated metrics are slated for deletion but are still available for use. The
 description of these metrics include an annotation about the version in which
@@ -331,28 +345,14 @@ After deprecation:
 otelcol_exporter_queue_size 0
 ```
 
-##### Deleted
+#### Deleted
 
 Deleted metrics are no longer published and cannot be used.
 
-#### Logs
+### Logs
 
 Individual log entries and their formatting might change from one release to the
 next. There are no stability guarantees at this time.
-
-### Events observable with internal logs
-
-The Collector logs the following internal events:
-
-- A Collector instance starts or stops.
-- Data dropping begins due to throttling for a specified reason, such as local
-  saturation, downstream saturation, downstream unavailable, etc.
-- Data dropping due to throttling stops.
-- Data dropping begins due to invalid data. A sample of the invalid data is
-  included.
-- Data dropping due to invalid data stops.
-- A crash is detected, differentiated from a clean stop. Crash data is included
-  if available.
 
 ## Use internal telemetry to monitor the Collector
 


### PR DESCRIPTION
This PR is a follow-up to #5092. It moves the [maturity level](https://opentelemetry.io/docs/collector/internal-telemetry/#telemetry-maturity-levels) section out of the [types of internal telemetry](https://opentelemetry.io/docs/collector/internal-telemetry/#types-of-internal-telemetry) section and into its own ##-level section.