### PR TITLE
Streamline API references list

### DIFF
--- a/layouts/shortcodes/apidocs.md
+++ b/layouts/shortcodes/apidocs.md
@@ -15,5 +15,15 @@
 {{ end -}}
 
 {{ range $pages }}
-* [{{ .lang.name }} &mdash; {{ .page.Title }}]({{ .page.Permalink }})
-{{ end -}}
+{{ $title := replaceRE `API reference` "" .page.Title -}}
+
+- [
+    {{- .lang.name }}
+    {{ with $title -}}
+      &mdash; {{ . }}
+    {{ end -}}
+  ](
+    {{- .page.Permalink -}}
+  )
+
+{{- end -}}


### PR DESCRIPTION
- Makes the API-references list more compact, and only displays the language name

### Screenshots

Before:

> <img width="510" alt="image" src="https://github.com/user-attachments/assets/816a9989-f2ed-4f6d-8093-113b53583062">

After:

> <img width="501" alt="image" src="https://github.com/user-attachments/assets/a28a17ac-16e8-419c-a8bb-1f6fcad418b3">
