### PR TITLE
Update README.md to remove Fabrizio's affiliation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Here is a list of community roles with current and previous members:
 - Maintainers: [@open-telemetry/docs-maintainers][]
 
   - [Austin Parker](https://github.com/austinlparker), Honeycomb
-  - [Fabrizio Ferri-Benedetti](https://github.com/theletterf), Splunk
+  - [Fabrizio Ferri-Benedetti](https://github.com/theletterf)
   - [Patrice Chalin](https://github.com/chalin), CNCF
   - [Phillip Carter](https://github.com/cartermp), Honeycomb
   - [Severin Neumann](https://github.com/svrnm), Cisco


### PR DESCRIPTION
Updating my affiliation, since I've signed my individual CLA and I'll no longer be a Splunk employee effective October 4. Feel free to merge it then, if you want!