### PR TITLE
fixed the duplicated text: localhost 4318 on Otel collector image

### DIFF
--- a/content/en/docs/demo/architecture.md
+++ b/content/en/docs/demo/architecture.md
@@ -129,7 +129,7 @@ subgraph tdf[Telemetry Data Flow]
         subgraph oc[OTel Collector]
             style oc fill:#97aef3,color:black;
             oc-grpc[/"OTLP Receiver<br/>listening on<br/>grpc://localhost:4317"/]
-            oc-http[/"OTLP Receiver<br/>listening on <br/>localhost:4318<br/>localhost:4318"/]
+            oc-http[/"OTLP Receiver<br/>listening on <br/>localhost:4318<br/>"/]
             oc-proc(Processors)
             oc-prom[/"OTLP HTTP Exporter"/]
             oc-otlp[/"OTLP Exporter"/]


### PR DESCRIPTION
The Otel collector image in demo architecture, had a duplicate of text: localhost 4318, I edited it and fixed it

Fixes #5238. 