### PR TITLE
Switch links in java to section-relative paths

### DIFF
--- a/content/en/docs/languages/java/configuration.md
+++ b/content/en/docs/languages/java/configuration.md
@@ -10,11 +10,11 @@ cSpell:ignore: authservice autoconfigured blrp Customizer Dotel ignore LOWMEMORY
 <!-- markdownlint-disable blanks-around-fences -->
 <?code-excerpt path-base="examples/java/configuration"?>
 
-The [SDK](../sdk/) is the built-in reference implementation of the
-[API](../instrumentation/), processing and exporting telemetry produced by
-instrumentation API calls. Configuring the SDK to process and export
-appropriately is an essential step to integrating OpenTelemetry into an
-application.
+The [SDK](/docs/languages/java/sdk/) is the built-in reference implementation of
+the [API](/docs/languages/java/instrumentation/), processing and exporting
+telemetry produced by instrumentation API calls. Configuring the SDK to process
+and export appropriately is an essential step to integrating OpenTelemetry into
+an application.
 
 All SDK components have
 [programmatic configuration APIs](#programmatic-configuration). This is the most
@@ -41,9 +41,9 @@ and Spring starter users. {{% /alert %}}
 ## Programmatic configuration
 
 The programmatic configuration interface is the set of APIs for constructing
-[SDK](../sdk/) components. All SDK components have a programmatic configuration
-API, and all other configuration mechanisms are built on top of this API. For
-example, the
+[SDK](/docs/languages/java/sdk/) components. All SDK components have a
+programmatic configuration API, and all other configuration mechanisms are built
+on top of this API. For example, the
 [autoconfigure environment variable and system property](#environment-variables-and-system-properties)
 configuration interface interprets well-known environment variables and system
 properties into a series of calls to the programmatic configuration API.
@@ -53,9 +53,9 @@ flexibility of writing code expressing the precise configuration required. When
 a particular capability isn't supported by a higher order configuration
 mechanism, you might have no choice but to use programmatic configuration.
 
-The [SDK components](../sdk/#sdk-components) sections demonstrate simple
-programmatic configuration API for key user-facing areas of the SDK. Consult the
-code for complete API reference.
+The [SDK components](/docs/languages/java/sdk/#sdk-components) sections
+demonstrate simple programmatic configuration API for key user-facing areas of
+the SDK. Consult the code for complete API reference.
 
 ## Zero-code SDK autoconfigure
 
@@ -63,8 +63,8 @@ The autoconfigure module (artifact
 `io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:{{% param vers.otel %}}`)
 is a configuration interface built on top of the
 [programmatic configuration interface](#programmatic-configuration), which
-configures [SDK components](../sdk/#sdk-components) with zero code. There are
-two distinct autoconfigure workflows:
+configures [SDK components](/docs/languages/java/sdk/#sdk-components) with zero
+code. There are two distinct autoconfigure workflows:
 
 - [Environment variables and system properties](#environment-variables-and-system-properties)
   interprets environment variables and system properties to create SDK
@@ -100,8 +100,8 @@ and Spring starter users. {{% /alert %}}
 
 {{% alert color="info" %}} The autoconfigure module registers Java shutdown
 hooks to shut down the SDK when appropriate. Because OpenTelemetry Java
-[uses `java.util.logging` for internal logging](../sdk/#internal-logging), some
-logging might be suppressed during shutdown hooks. This is a bug in the JDK
+[uses `java.util.logging` for internal logging](/docs/languages/java/sdk/#internal-logging),
+some logging might be suppressed during shutdown hooks. This is a bug in the JDK
 itself, and not something under the control of OpenTelemetry Java. If you
 require logging during shutdown hooks, consider using `System.out` rather than a
 logging framework which might shut itself down in a shutdown hook, thus
@@ -129,7 +129,7 @@ system property takes priority.
 
 #### Properties: general
 
-Properties for disabling the [SDK](../sdk/#opentelemetrysdk):
+Properties for disabling the [SDK](/docs/languages/java/sdk/#opentelemetrysdk):
 
 | System property     | Description                                       | Default |
 | ------------------- | ------------------------------------------------- | ------- |
@@ -139,7 +139,7 @@ Properties for disabling the [SDK](../sdk/#opentelemetrysdk):
 returns a minimally configured instance (for example,
 `OpenTelemetrySdk.builder().build()`).
 
-Properties for configuring [resource](../sdk/#resource):
+Properties for configuring [resource](/docs/languages/java/sdk/#resource):
 
 | System property                            | Description                                                                                                                             | Default                |
 | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
@@ -156,22 +156,25 @@ set
 See [ResourceProvider](#resourceprovider) for resource provider artifact
 coordinates.
 
-Properties for attribute limits (see [span limits](../sdk/#spanlimits),
-[log limits](../sdk/#loglimits)):
+Properties for attribute limits (see
+[span limits](/docs/languages/java/sdk/#spanlimits),
+[log limits](/docs/languages/java/sdk/#loglimits)):
 
 | System property                     | Description                                                                                                                                                   | Default  |
 | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
 | `otel.attribute.value.length.limit` | The maximum length of attribute values. Applies to spans and logs. Overridden by `otel.span.attribute.value.length.limit`, `otel.span.attribute.count.limit`. | No limit |
 | `otel.attribute.count.limit`        | The maximum number of attributes. Applies to spans, span events, span links, and logs.                                                                        | `128`    |
 
-Properties for [context propagation](../sdk/#textmappropagator):
+Properties for
+[context propagation](/docs/languages/java/sdk/#textmappropagator):
 
 | System property    | Description                                                                                                                                               | Default                      |
 | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
 | `otel.propagators` | Comma-separated list of propagators. Known values include `tracecontext`, `baggage`, `b3`, `b3multi`, `jaeger`, `ottrace`, `xray`, `xray-lambda`. **[1]** | `tracecontext,baggage` (W3C) |
 
 **[1]**: Known propagators and artifacts (see
-[text map propagator](../sdk/#textmappropagator) for artifact coordinates):
+[text map propagator](/docs/languages/java/sdk/#textmappropagator) for artifact
+coordinates):
 
 - `tracecontext` configures `W3CTraceContextPropagator`.
 - `baggage` configures `W3CBaggagePropagator`.
@@ -183,7 +186,8 @@ Properties for [context propagation](../sdk/#textmappropagator):
 
 #### Properties: traces
 
-Properties for [batch span processor(s)](../sdk/#spanprocessor) paired with
+Properties for
+[batch span processor(s)](/docs/languages/java/sdk/#spanprocessor) paired with
 exporters specified via `otel.traces.exporter`:
 
 | System property                  | Description                                                     | Default |
@@ -193,15 +197,15 @@ exporters specified via `otel.traces.exporter`:
 | `otel.bsp.max.export.batch.size` | The maximum batch size.                                         | `512`   |
 | `otel.bsp.export.timeout`        | The maximum allowed time, in milliseconds, to export data.      | `30000` |
 
-Properties for [sampler](../sdk/#sampler):
+Properties for [sampler](/docs/languages/java/sdk/#sampler):
 
 | System property           | Description                                                                                                                                                                                 | Default                 |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
 | `otel.traces.sampler`     | The sampler to use. Known values include `always_on`, `always_off`, `traceidratio`, `parentbased_always_on`, `parentbased_always_off`, `parentbased_traceidratio`, `jaeger_remote`. **[1]** | `parentbased_always_on` |
 | `otel.traces.sampler.arg` | An argument to the configured tracer if supported, for example a ratio.                                                                                                                     |                         |
 
-**[1]**: Known samplers and artifacts (see [sampler](../sdk/#sampler) for
-artifact coordinates):
+**[1]**: Known samplers and artifacts (see
+[sampler](/docs/languages/java/sdk/#sampler) for artifact coordinates):
 
 - `always_on` configures `AlwaysOnSampler`.
 - `always_off` configures `AlwaysOffSampler`.
@@ -215,7 +219,7 @@ artifact coordinates):
   a comma-separated list of args as described in the
   [specification](/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration).
 
-Properties for [span limits](../sdk/#spanlimits):
+Properties for [span limits](/docs/languages/java/sdk/#spanlimits):
 
 | System property                          | Description                                                                                             | Default  |
 | ---------------------------------------- | ------------------------------------------------------------------------------------------------------- | -------- |
@@ -226,7 +230,7 @@ Properties for [span limits](../sdk/#spanlimits):
 
 #### Properties: metrics
 
-Properties for [periodic metric reader](../sdk/#metricreader):
+Properties for [periodic metric reader](/docs/languages/java/sdk/#metricreader):
 
 | System property               | Description                                                              | Default |
 | ----------------------------- | ------------------------------------------------------------------------ | ------- |
@@ -246,8 +250,9 @@ Properties for cardinality limits:
 
 #### Properties: logs
 
-Properties for [log record processor(s)](../sdk/#logrecordprocessor) pared with
-exporters via `otel.logs.exporter`:
+Properties for
+[log record processor(s)](/docs/languages/java/sdk/#logrecordprocessor) pared
+with exporters via `otel.logs.exporter`:
 
 | System property                   | Description                                                     | Default |
 | --------------------------------- | --------------------------------------------------------------- | ------- |
@@ -268,9 +273,10 @@ Properties for setting exporters:
 | `otel.java.experimental.exporter.memory_mode` | If `reusable_data`, enable reusable memory mode (on exporters which support it) to reduce allocations. Known values include `reusable_data`, `immutable_data`. This option is experimental and subject to change or removal. **[2]** | `immutable_data` |
 
 **[1]**: Known exporters and artifacts (see
-[span exporter](../sdk/#spanexporter),
-[metric exporter](../sdk/#metricexporter),
-[log exporter](../sdk/#logrecordexporter) for exporter artifact coordinates):
+[span exporter](/docs/languages/java/sdk/#spanexporter),
+[metric exporter](/docs/languages/java/sdk/#metricexporter),
+[log exporter](/docs/languages/java/sdk/#logrecordexporter) for exporter
+artifact coordinates):
 
 - `otlp` configures `OtlpHttp{Signal}Exporter` / `OtlpGrpc{Signal}Exporter`.
 - `zipkin` configures `ZipkinSpanExporter`.
@@ -412,7 +418,7 @@ The following sections describe the available SPIs. Each SPI section includes:
 ##### ResourceProvider
 
 [ResourceProvider](https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure-spi/latest/io/opentelemetry/sdk/autoconfigure/spi/ResourceProvider.html)s
-contribute to the autoconfigured [resource](../sdk/#resource).
+contribute to the autoconfigured [resource](/docs/languages/java/sdk/#resource).
 
 `ResourceProvider`s built-in to the SDK and maintained by the community in
 `opentelemetry-java-contrib`:

--- a/content/en/docs/languages/java/getting-started.md
+++ b/content/en/docs/languages/java/getting-started.md
@@ -26,7 +26,7 @@ The following example uses a basic [Spring Boot] application. You can use anothe
 web framework, such as Apache Wicket or Play. For a complete list of libraries and
 supported frameworks, consult the [registry](/ecosystem/registry/?component=instrumentation&language=java).
 
-For more elaborate examples, see [examples](../examples/).
+For more elaborate examples, see [examples](/docs/languages/java/examples/).
 
 ### Dependencies
 
@@ -248,7 +248,7 @@ For more:
 - Try [zero-code instrumentation](/docs/zero-code/java/agent/) on one of your
   own apps.
 - For light-weight customized telemetry, try [annotations][].
-- Learn about [manual instrumentation][] and try out more [examples](../examples/).
+- Learn about [manual instrumentation][] and try out more [examples](/docs/languages/java/examples/).
 - Take a look at the [OpenTelemetry Demo](/docs/demo/), which includes Java
   based [Ad Service](/docs/demo/services/ad/) and Kotlin based
   [Fraud Detection Service](/docs/demo/services/fraud-detection/)
@@ -264,7 +264,7 @@ For more:
   https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#exporters
 [java-vers]:
   https://github.com/open-telemetry/opentelemetry-java/blob/main/VERSIONING.md#language-version-compatibility
-[manual instrumentation]: ../instrumentation
+[manual instrumentation]: /docs/languages/java/instrumentation
 [opentelemetry-javaagent.jar]:
   https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar
 [releases]:

--- a/content/en/docs/languages/java/instrumentation.md
+++ b/content/en/docs/languages/java/instrumentation.md
@@ -15,11 +15,12 @@ cSpell:ignore: Autowired customizer logback loggable multivalued rolldice spring
 
 {{% docs/languages/instrumentation-intro %}}
 
-{{% alert title="Note" color="info" %}} See [Manage Telemetry with SDK](../sdk/)
-for a conceptual overview of OpenTelemetry Java SDK concepts. See
-**[Configure the SDK](../configuration/)** for details on SDK configuration,
-including
-[zero-code SDK autoconfigure](../configuration/#zero-code-sdk-autoconfigure).
+{{% alert title="Note" color="info" %}} See
+[Manage Telemetry with SDK](/docs/languages/java/sdk/) for a conceptual overview
+of OpenTelemetry Java SDK concepts. See
+**[Configure the SDK](/docs/languages/java/configuration/)** for details on SDK
+configuration, including
+[zero-code SDK autoconfigure](/docs/languages/java/configuration/#zero-code-sdk-autoconfigure).
 {{% /alert %}}
 
 {{% alert title="Note" color="info" %}}
@@ -34,15 +35,16 @@ skip manual instrumentation and only use automatic instrumentation.
 
 Also, for libraries your code depends on, you don't have to write
 instrumentation code yourself, since they might come with OpenTelemetry built-in
-_natively_ or you can make use of [instrumentation libraries](../libraries/).
+_natively_ or you can make use of
+[instrumentation libraries](/docs/languages/java/libraries/).
 
 {{% /alert %}}
 
 ## Example app preparation {#example-app}
 
 This page uses a modified version of the example app from
-[Getting Started](../getting-started/) to help you learn about manual
-instrumentation.
+[Getting Started](/docs/languages/java/getting-started/) to help you learn about
+manual instrumentation.
 
 You don't have to use the example app: if you want to instrument your own app or
 library, follow the instructions here to adapt the process to your own code.
@@ -275,8 +277,8 @@ dependencies {
 ## Traces
 
 The following sections describe the OpenTelemetry Java tracing API. See
-[SdkTracerProvider](../sdk/#sdktracerprovider) for an overview of trace SDK
-concepts and configuration.
+[SdkTracerProvider](/docs/languages/java/sdk/#sdktracerprovider) for an overview
+of trace SDK concepts and configuration.
 
 ### Acquiring a tracer
 
@@ -913,8 +915,8 @@ instruments register a callback, which is invoked once per collection, and which
 records measurements at that point in time.
 
 The following sections describe the OpenTelemetry Java metrics API. See
-[SdkMeterProvider](../sdk/#sdkmeterprovider) for an overview of metrics SDK
-concepts and configuration.
+[SdkMeterProvider](/docs/languages/java/sdk/#sdkmeterprovider) for an overview
+of metrics SDK concepts and configuration.
 
 ### Acquiring a meter
 
@@ -1111,14 +1113,15 @@ suitable for all applications.
 To use this workflow:
 
 - Install appropriate [Log Appender](#log-appenders).
-- Configure the OpenTelemetry [Log SDK](../sdk/#sdkloggerprovider) to export log
-  records to desired target destination (the
-  [collector][opentelemetry collector] or other).
+- Configure the OpenTelemetry
+  [Log SDK](/docs/languages/java/sdk/#sdkloggerprovider) to export log records
+  to desired target destination (the [collector][opentelemetry collector] or
+  other).
 
 #### Log appenders
 
 A log appender bridges logs from a log framework into the OpenTelemetry
-[Log SDK](../sdk/#sdkloggerprovider) using the [Logs Bridge
+[Log SDK](/docs/languages/java/sdk/#sdkloggerprovider) using the [Logs Bridge
 API][logs bridge API]. Log appenders are available for various popular Java log
 frameworks:
 
@@ -1143,8 +1146,8 @@ log correlation with traces.
 The [Log Appender example][log appender example] demonstrates setup for a
 variety of scenarios.
 
-See [SdkLoggerProvider](../sdk/#sdkloggerprovider) for an overview of log SDK
-concepts and configuration.
+See [SdkLoggerProvider](/docs/languages/java/sdk/#sdkloggerprovider) for an
+overview of log SDK concepts and configuration.
 
 ### Via file or stdout
 

--- a/content/en/docs/languages/java/libraries.md
+++ b/content/en/docs/languages/java/libraries.md
@@ -18,9 +18,10 @@ for many common Java frameworks. Most are turned on by default. If you need to
 turn off certain instrumentation libraries, you can
 [suppress them](/docs/zero-code/java/agent/disable/).
 
-If you use [code-based instrumentation](../instrumentation), you can leverage
-some instrumentation libraries for your dependencies standalone. To find out
-which standalone instrumentation libraries are available, take a look at
+If you use [code-based instrumentation](/docs/languages/java/instrumentation),
+you can leverage some instrumentation libraries for your dependencies
+standalone. To find out which standalone instrumentation libraries are
+available, take a look at
 [this list](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/supported-libraries.md#libraries--frameworks).
 Follow the instructions of each instrumentation library to set them up.
 
@@ -30,7 +31,8 @@ The following example instruments an HTTP client application using library
 instrumentation which calls an HTTP server.
 
 You can use the dice example app as HTTP server from
-[Getting Started](../getting-started/) or you can create your own HTTP server.
+[Getting Started](/docs/languages/java/getting-started/) or you can create your
+own HTTP server.
 
 ### Dependencies
 
@@ -146,7 +148,8 @@ public final class SampleHttpClient {
 
 Set the `EXTERNAL_API_ENDPOINT` environment variable to specify the external API
 endpoint. By default, it points to `http://localhost:8080/rolldice`, where
-[example dice app](../getting-started/#example-application) is running.
+[example dice app](/docs/languages/java/getting-started/#example-application) is
+running.
 
 To check your code, run the app:
 
@@ -164,8 +167,8 @@ When you run the app, the instrumentation libraries do the following:
 - Start a new trace.
 - Generate a span that represents the request made to the external API endpoint.
 - If you use an instrumented HTTP server, as in the
-  [dice app](../getting-started/#example-application), more trace spans are
-  generated with the same trace ID.
+  [dice app](/docs/languages/java/getting-started/#example-application), more
+  trace spans are generated with the same trace ID.
 
 ## Available instrumentation libraries
 
@@ -175,11 +178,11 @@ For a full list of instrumentation libraries, see
 ## Next steps
 
 After you've set up instrumentation libraries, you might want to add
-[additional instrumentation](../instrumentation) to collect custom telemetry
-data.
+[additional instrumentation](/docs/languages/java/instrumentation) to collect
+custom telemetry data.
 
-You might also want to [configure the SDK](../configuration/) to export to one
-or more telemetry backends.
+You might also want to [configure the SDK](/docs/languages/java/configuration/)
+to export to one or more telemetry backends.
 
 For existing library instrumentations, also see
 [Java agent](/docs/zero-code/java/agent/).

--- a/content/en/docs/languages/java/performance.md
+++ b/content/en/docs/languages/java/performance.md
@@ -40,7 +40,7 @@ the Java agent.
 
 The volume of spans processed by the instrumentation might impact agent
 overhead. You can configure trace sampling to adjust the span volume and reduce
-resource usage. See [Sampling](../sdk/#sampler).
+resource usage. See [Sampling](/docs/languages/java/sdk/#sampler).
 
 ### Turn off specific instrumentations
 
@@ -99,7 +99,7 @@ instrumentations, see
 When troubleshooting agent overhead issues, do the following:
 
 - Check minimum requirements. See
-  [Prerequisites](../getting-started/#prerequisites).
+  [Prerequisites](/docs/languages/java/getting-started/#prerequisites).
 - Use the latest compatible version of the Java agent.
 - Use the latest compatible version of your JVM.
 

--- a/content/en/docs/languages/java/sdk.md
+++ b/content/en/docs/languages/java/sdk.md
@@ -8,13 +8,13 @@ cSpell:ignore: autoconfigured FQCNs Interceptable Logback okhttp
 <?code-excerpt path-base="examples/java/configuration"?>
 
 The SDK is the built-in reference implementation of the
-[API](../instrumentation/), processing and exporting telemetry produced by
-instrumentation API calls. This page is a conceptual overview of the SDK,
-including descriptions, links to relevant Javadocs, artifact coordinates, sample
-programmatic configurations and more. See
-**[Configure the SDK](../configuration/)** for details on SDK configuration,
-including
-[zero-code SDK autoconfigure](../configuration/#zero-code-sdk-autoconfigure).
+[API](/docs/languages/java/instrumentation/), processing and exporting telemetry
+produced by instrumentation API calls. This page is a conceptual overview of the
+SDK, including descriptions, links to relevant Javadocs, artifact coordinates,
+sample programmatic configurations and more. See
+**[Configure the SDK](/docs/languages/java/configuration/)** for details on SDK
+configuration, including
+[zero-code SDK autoconfigure](/docs/languages/java/configuration/#zero-code-sdk-autoconfigure).
 
 The SDK consists of the following top level components:
 
@@ -63,7 +63,7 @@ component section includes:
   [plugin extension interface](#sdk-plugin-extension-interfaces), a table of
   available built-in and `opentelemetry-java-contrib` implementations.
 - A simple demonstration of
-  [programmatic-configuration](../configuration/#programmatic-configuration).
+  [programmatic-configuration](/docs/languages/java/configuration/#programmatic-configuration).
 - If the component is a
   [plugin extension interface](#sdk-plugin-extension-interfaces), a simple
   demonstration of a custom implementation.
@@ -120,11 +120,11 @@ associate the same resource with [SdkTracerProvider](#sdktracerprovider),
 [SdkMeterProvider](#sdkmeterprovider), [SdkLoggerProvider](#sdkloggerprovider).
 
 {{% alert color="info" %}}
-[ResourceProviders](../configuration/#resourceprovider) contribute contextual
-information to the
-[autoconfigured](../configuration/#zero-code-sdk-autoconfigure) resource based
-on the environment. See documentation for list of available `ResourceProvider`s.
-{{% /alert %}}
+[ResourceProviders](/docs/languages/java/configuration/#resourceprovider)
+contribute contextual information to the
+[autoconfigured](/docs/languages/java/configuration/#zero-code-sdk-autoconfigure)
+resource based on the environment. See documentation for list of available
+`ResourceProvider`s. {{% /alert %}}
 
 The following code snippet demonstrates `Resource` programmatic configuration:
 


### PR DESCRIPTION
Reviewing this [comment](https://github.com/open-telemetry/opentelemetry.io/pull/5276#discussion_r1783562468), I noticed a bunch of other offending links in the java docs. This PR addresses those so #5276 can stay a little more focused. 