### PR TITLE
[en] fix link zpages content/en/docs/concepts/glossary.md

### DIFF
--- a/content/en/docs/concepts/glossary.md
+++ b/content/en/docs/concepts/glossary.md
@@ -358,4 +358,4 @@ on web pages when requested. See [more][zpages].
 [trace]: /docs/specs/otel/overview#traces
 [tracer]: /docs/specs/otel/trace/api#tracer
 [zpages]:
-  https://github.com/open-telemetry/opentelemetry-specification/blob/main/experimental/trace/zpages.md
+  https://github.com/open-telemetry/opentelemetry-specification/blob/main/development/trace/zpages.md

--- a/content/ja/docs/concepts/glossary.md
+++ b/content/ja/docs/concepts/glossary.md
@@ -336,4 +336,4 @@ OpenTelemetryにおいては[トレース](#trace)、[メトリクス](#metric)�
 [status]: /docs/specs/otel/trace/api#set-status
 [trace]: /docs/specs/otel/overview#traces
 [tracer]: /docs/specs/otel/trace/api#tracer
-[zpages]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/experimental/trace/zpages.md
+[zpages]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/development/trace/zpages.md


### PR DESCRIPTION
Fix link zpages content/en/docs/concepts/glossary.md

![image](https://github.com/user-attachments/assets/314af884-8cf3-462c-b273-c345a34910aa)
