### PR TITLE
Update custom-collector.md

### DIFF
--- a/content/en/docs/collector/custom-collector.md
+++ b/content/en/docs/collector/custom-collector.md
@@ -171,6 +171,7 @@ providers:
   - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v0.110.0
   - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.110.0
   - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.110.0
+```
 
 {{% alert color="primary" title="Tip" %}}
 

--- a/content/en/docs/collector/custom-collector.md
+++ b/content/en/docs/collector/custom-collector.md
@@ -164,7 +164,8 @@ processors:
 receivers:
   - gomod:
       go.opentelemetry.io/collector/receiver/otlpreceiver {{% version-from-registry collector-receiver-otlp %}}
-```providers:
+
+providers:
   - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.16.0
   - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.16.0
   - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v0.110.0

--- a/content/en/docs/collector/custom-collector.md
+++ b/content/en/docs/collector/custom-collector.md
@@ -164,7 +164,12 @@ processors:
 receivers:
   - gomod:
       go.opentelemetry.io/collector/receiver/otlpreceiver {{% version-from-registry collector-receiver-otlp %}}
-```
+```providers:
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.16.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.16.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v0.110.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.110.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.110.0
 
 {{% alert color="primary" title="Tip" %}}
 


### PR DESCRIPTION
To resolve the versioning issues, it is necessary to update the builder-config.yaml to include a providers block specifying compatible versions for the envprovider and fileprovider

This change ensures that the correct versions of the providers are referenced, thus preventing errors during the build process.

The doc has been updated to include that. @tiffany76 @radar @jf @dazuma 

Fixes #5259.