### PR TITLE
[CI] Update package.json: tweak script and minor pkg vers update

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "fix:text": "npm run check:text -- --fix",
     "fix": "npm run fix:all",
     "format": "npm run _check:format -- --write && npm run _check:format:ja+zh -- --write",
-    "get:submodule": "npm run _get:${GET:-submodule}",
+    "get:submodule": "npm run _get:${GET:-submodule} --",
     "log:check:links": "npm run check:links | tee tmp/build-log.txt",
     "make:public": "make public ls-public",
     "netlify-build:preview": "npm run seq -- build:preview diff:check",
@@ -129,7 +129,7 @@
     "textlint": "^14.2.0",
     "textlint-filter-rule-allowlist": "^4.0.0",
     "textlint-filter-rule-comments": "^1.2.2",
-    "textlint-rule-terminology": "^5.2.9",
+    "textlint-rule-terminology": "^5.2.12",
     "through2": "^4.0.2",
     "yargs": "^17.7.2"
   },
@@ -147,7 +147,7 @@
     "path": "^0.12.7"
   },
   "optionalDependencies": {
-    "netlify-cli": "^17.36.2",
+    "netlify-cli": "^17.36.4",
     "npm-check-updates": "^17.1.3"
   },
   "enginesComment": "Ensure that engines.node value stays consistent with the project's .nvmrc",


### PR DESCRIPTION
With this update, you can now run `npm run get:submodule -- --remote` to force fetch the latest available version of all submodules.