### PR TITLE
Fix telemetry config example for public interfaces

### DIFF
--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -36,11 +36,11 @@ service:
   telemetry:
     metrics:
       readers:
-        pull:
-          exporter:
-            prometheus:
-              host: '0.0.0.0'
-              port: 8888
+        - pull:
+            exporter:
+              prometheus:
+                host: '0.0.0.0'
+                port: 8888
 ```
 
 You can adjust the verbosity of the Collector metrics output by setting the


### PR DESCRIPTION
The original version results in error:
```
error decoding 'service.telemetry': decoding failed due to the following error(s):

'metrics.readers': source data must be an array or slice, got map
```

Converting that inner element to an array, similar to other examples in the page, results in the telemetry working again.