### PR TITLE
add click on "flag icon" for additional filtering

### DIFF
--- a/assets/js/registrySearch.js
+++ b/assets/js/registrySearch.js
@@ -113,6 +113,7 @@ if (pathName.includes('registry')) {
     applyFilterTag();
 >>>>>>> 1e42a0f0 (Add the applyFilterTag func and updated the executeSearch func to call applyFilterTag.)
   });
+  
 }
 
 function showBody() {

--- a/assets/js/registrySearch.js
+++ b/assets/js/registrySearch.js
@@ -45,7 +45,6 @@ parseUrlParams();
 if (pathName.includes('registry')) {
   // Run search or display default body
   if (searchQuery) {
-    alert("Executing initial search with query: " + searchQuery);
     executeSearch(searchQuery);
   } else {
     showBody();

--- a/assets/js/registrySearch.js
+++ b/assets/js/registrySearch.js
@@ -75,6 +75,7 @@ if (pathName.includes('registry')) {
       executeSearch(searchQuery);
     });
 
+
     let searchInput = document.getElementById('input-s');
     searchInput.addEventListener('keyup', function (evt) {
       autoSuggest(evt.target.value);
@@ -107,6 +108,21 @@ if (pathName.includes('registry')) {
       }),
     );
   });
+  
+  // Filter by clicking tags
+  function applyTagFilter(filterValue) {
+    document.getElementById('input-s').value = filterValue;
+    document.getElementById('input-language').value = 'all';
+    document.getElementById('input-component').value = 'all';
+
+    document.getElementById('searchForm').dispatchEvent(new Event('submit'));
+  }
+  document.querySelectorAll('[data-filter-value]').forEach((element) => {
+    element.addEventListener('click', (evt) => {
+      let filterValue = evt.currentTarget.getAttribute('data-filter-value');
+      applyTagFilter(filterValue);
+    });
+  });
 }
 
 function showBody() {
@@ -124,7 +140,6 @@ function executeSearch(searchQuery) {
     showBody();
     return;
   }
-
   document.title = searchQuery + ' at ' + originalDocumentTitle;
   document.querySelector('#input-s').value = searchQuery;
   document.querySelector('#default-body').style.display = 'none';

--- a/assets/js/registrySearch.js
+++ b/assets/js/registrySearch.js
@@ -107,7 +107,11 @@ if (pathName.includes('registry')) {
         updateFilters();
       }),
     );
+<<<<<<< HEAD
     applyFilterTag()
+=======
+    applyFilterTag();
+>>>>>>> 1e42a0f0 (Add the applyFilterTag func and updated the executeSearch func to call applyFilterTag.)
   });
 
 }
@@ -158,7 +162,11 @@ function executeSearch(searchQuery) {
 
       if (results.length > 0) {
         populateResults(results);
+<<<<<<< HEAD
         applyFilterTag()
+=======
+        applyFilterTag();
+>>>>>>> 1e42a0f0 (Add the applyFilterTag func and updated the executeSearch func to call applyFilterTag.)
 
       } else {
         document.querySelector('#search-results').innerHTML +=

--- a/assets/js/registrySearch.js
+++ b/assets/js/registrySearch.js
@@ -133,7 +133,7 @@ function applyFilterTag() {
       // Remove any existing search input and add the new clicked value
       searchInput.value = filterValue;
 
-      // Set the new input value as the search query and the update URL parameters
+      // Set the new input value as the search query and update URL parameters
       setInput('s', filterValue);
       parseUrlParams();
       executeSearch(filterValue);

--- a/assets/js/registrySearch.js
+++ b/assets/js/registrySearch.js
@@ -107,11 +107,7 @@ if (pathName.includes('registry')) {
         updateFilters();
       }),
     );
-<<<<<<< HEAD
-    applyFilterTag()
-=======
     applyFilterTag();
->>>>>>> 1e42a0f0 (Add the applyFilterTag func and updated the executeSearch func to call applyFilterTag.)
   });
 }
 
@@ -161,11 +157,7 @@ function executeSearch(searchQuery) {
 
       if (results.length > 0) {
         populateResults(results);
-<<<<<<< HEAD
-        applyFilterTag()
-=======
         applyFilterTag();
->>>>>>> 1e42a0f0 (Add the applyFilterTag func and updated the executeSearch func to call applyFilterTag.)
 
       } else {
         document.querySelector('#search-results').innerHTML +=

--- a/assets/js/registrySearch.js
+++ b/assets/js/registrySearch.js
@@ -113,7 +113,6 @@ if (pathName.includes('registry')) {
     applyFilterTag();
 >>>>>>> 1e42a0f0 (Add the applyFilterTag func and updated the executeSearch func to call applyFilterTag.)
   });
-
 }
 
 function showBody() {
@@ -134,7 +133,7 @@ function applyFilterTag() {
       // Remove any existing search input and add the new clicked value
       searchInput.value = filterValue;
 
-      // Set the new input value as the search query and update URL parameters
+      // Set the new input value as the search query and the update URL parameters
       setInput('s', filterValue);
       parseUrlParams();
       executeSearch(filterValue);

--- a/assets/js/registrySearch.js
+++ b/assets/js/registrySearch.js
@@ -113,7 +113,6 @@ if (pathName.includes('registry')) {
     applyFilterTag();
 >>>>>>> 1e42a0f0 (Add the applyFilterTag func and updated the executeSearch func to call applyFilterTag.)
   });
-  
 }
 
 function showBody() {

--- a/assets/js/registrySearch.js
+++ b/assets/js/registrySearch.js
@@ -107,22 +107,36 @@ if (pathName.includes('registry')) {
         updateFilters();
       }),
     );
-  });
-  
-  // Filter by clicking tags
-  function applyTagFilter(filterValue) {
-    document.getElementById('input-s').value = filterValue;
-    document.getElementById('input-language').value = 'all';
-    document.getElementById('input-component').value = 'all';
+    let filterLabel = document.querySelectorAll('[data-filter-value]');
 
-    document.getElementById('searchForm').dispatchEvent(new Event('submit'));
-  }
-  document.querySelectorAll('[data-filter-value]').forEach((element) => {
-    element.addEventListener('click', (evt) => {
-      let filterValue = evt.currentTarget.getAttribute('data-filter-value');
-      applyTagFilter(filterValue);
+    filterLabel.forEach((element) => {
+      element.addEventListener('click', (evt) => {
+        let filterValue = evt.target.getAttribute('data-filter-value');
+        let searchInput = document.getElementById('input-s');
+        let currentSearchValue = searchInput.value.trim();
+
+
+        if (!currentSearchValue.includes(filterValue)) {
+
+          if (currentSearchValue.length > 0) {
+            currentSearchValue += ' ' + filterValue;
+          } else {
+            currentSearchValue = filterValue;
+          }
+
+          searchInput.value = currentSearchValue;
+
+          setInput('s', currentSearchValue);
+
+          parseUrlParams();
+
+          executeSearch(currentSearchValue);
+        }
+      });
     });
   });
+
+
 }
 
 function showBody() {

--- a/assets/js/registrySearch.js
+++ b/assets/js/registrySearch.js
@@ -107,35 +107,8 @@ if (pathName.includes('registry')) {
         updateFilters();
       }),
     );
-    let filterLabel = document.querySelectorAll('[data-filter-value]');
-
-    filterLabel.forEach((element) => {
-      element.addEventListener('click', (evt) => {
-        let filterValue = evt.target.getAttribute('data-filter-value');
-        let searchInput = document.getElementById('input-s');
-        let currentSearchValue = searchInput.value.trim();
-
-
-        if (!currentSearchValue.includes(filterValue)) {
-
-          if (currentSearchValue.length > 0) {
-            currentSearchValue += ' ' + filterValue;
-          } else {
-            currentSearchValue = filterValue;
-          }
-
-          searchInput.value = currentSearchValue;
-
-          setInput('s', currentSearchValue);
-
-          parseUrlParams();
-
-          executeSearch(currentSearchValue);
-        }
-      });
-    });
+    applyFilterTag()
   });
-
 
 }
 
@@ -146,6 +119,23 @@ function showBody() {
   if (defaultBody.style.display === 'none') {
     defaultBody.style.display = 'block';
   }
+}
+
+function applyFilterTag() {
+  document.querySelectorAll('[data-filter-value]').forEach((element) => {
+    element.addEventListener('click', (evt) => {
+      let filterValue = evt.target.getAttribute('data-filter-value');
+      let searchInput = document.getElementById('input-s');
+
+      // Remove any existing search input and add the new clicked value
+      searchInput.value = filterValue;
+
+      // Set the new input value as the search query and update URL parameters
+      setInput('s', filterValue);
+      parseUrlParams();
+      executeSearch(filterValue);
+      });
+  });
 }
 
 // Runs search through Fuse for fuzzy search
@@ -168,6 +158,8 @@ function executeSearch(searchQuery) {
 
       if (results.length > 0) {
         populateResults(results);
+        applyFilterTag()
+
       } else {
         document.querySelector('#search-results').innerHTML +=
           '<p>No matches found</p>';

--- a/layouts/partials/ecosystem/registry/entry.html
+++ b/layouts/partials/ecosystem/registry/entry.html
@@ -97,13 +97,13 @@
           {{ end -}}
 
           {{ if $isNative -}}
-          <button type="button" data-filter-value = "native" class="badge rounded-pill text-bg-success text-white" title="Click to filter by native tag">
+          <button name="flag" type="button" data-filter-value = "native" class="badge rounded-pill text-bg-success text-white" title="Click to filter by native tag">
             <i class="fa-solid fa-puzzle-piece">
           </i> native</button>
           {{ end -}}
 
           {{ if $isFirstParty -}}
-          <button type="button" data-filter-value = "first party integration" class="badge rounded-pill text-bg-success text-white" title="Click to filter by first party tag">
+          <button name="flag" type="button" data-filter-value = "first party integration" class="badge rounded-pill text-bg-success text-white" title="Click to filter by first party tag">
             <i class="fa-solid fa-heart"></i> first party integration</button>
           {{ end -}}
 
@@ -112,12 +112,12 @@
           {{ end -}}
 
           {{ if $deprecated -}}
-          <button type="button" data-filter-value = "deprecated" class="badge rounded-pill text-bg-danger text-white" title="Click to filter by deprecated tag">
+          <button name="flag" type="button" data-filter-value = "deprecated" class="badge rounded-pill text-bg-danger text-white" title="Click to filter by deprecated tag">
             <i class="fa-solid fa-ban"></i> deprecated</button>
           {{ end -}}
 
           {{ if .cncfProjectLevel -}}
-          <button type="button" data-filter-value = "{{ .cncfProjectLevel }}" class="badge rounded-pill text-bg-primary text-white" title="Click to filter by CNCF {{ .cncfProjectLevel}} Project">
+          <button name="flag" type="button" data-filter-value = "{{ .cncfProjectLevel }}" class="badge rounded-pill text-bg-primary text-white" title="Click to filter by CNCF {{ .cncfProjectLevel}} Project">
             <img alt="CNCF" style="display: inline-block; width: 14px; height: 14px; border: none; margin:0px; padding: 0; vertical-align:middle" src="/img/cncf-icon-white.svg"> {{ .cncfProjectLevel }}</button>
           {{ end -}}
           </div>

--- a/layouts/partials/ecosystem/registry/entry.html
+++ b/layouts/partials/ecosystem/registry/entry.html
@@ -1,9 +1,9 @@
 {{ $languageNames := .languageNames -}}
 
 {{ with .value -}}
-    {{ 
+    {{
         $remoteRegistries := dict
-            "npm" (dict 
+            "npm" (dict
                 "urlPattern" "https://npmjs.com/package/%s"
                 "installTemplate" "ecosystem/registry/quickinstall/default.md"
                 "installLine" "npm install %s"
@@ -86,37 +86,48 @@
     {{ end -}}
     {{ $primaryHref := printf "href=%q" $primaryUrl | safeHTMLAttr -}}
     <li class="card my-3 registry-entry {{ $highlightStyle }}" data-registry-id="{{ ._key }}" data-registrytype="{{ .registryType }}" data-registrylanguage="{{ .language }}">
-        <div class="card-body container">
-        <h4 class="card-title mb-0 d-flex flex-row">
-            <a {{ $primaryHref }} target="_blank" rel="noopener" class="me-auto">
-            {{- .title | markdownify -}}
-            </a>
-            <div class="ms-auto">
-            {{ if $isNew -}}
-            <span class="badge rounded-pill text-bg-info"><i class="fa-regular fa-star"></i> new</span>
-            {{ end -}}
-            {{ if $isNative -}}
-            <span class="badge rounded-pill text-bg-success text-white"><i class="fa-solid fa-puzzle-piece"></i> native</span>
-            {{ end -}}
-            {{ if $isFirstParty -}}
-            <span class="badge rounded-pill text-bg-success text-white"><i class="fa-solid fa-heart"></i> first party integration</span>
-            {{ end -}}
-            {{ if $usedInDemo -}}
-            <span class="badge rounded-pill text-bg-secondary text-white" title="This package is used in the OpenTelemetry Demo!"><i class="fa-solid fa-shapes"></i> OTel Demo</span>
-            {{ end -}}
-            {{ if $deprecated -}}
-            <span class="badge rounded-pill text-bg-danger text-white" title=""><i class="fa-solid fa-ban"></i> deprecated</span>
-            {{ end -}}
-            {{ if .cncfProjectLevel -}}
-            <span class="badge rounded-pill text-bg-primary text-white" title="CNCF {{ .cncfProjectLevel}} Project">
-                <img alt="CNCF" style="display: inline-block; width: 14px; height: 14px; border: none; margin:0px; padding: 0; vertical-align:middle" src="/img/cncf-icon-white.svg"> {{ .cncfProjectLevel }}
-            </span>
-            {{ end -}}
-            </div>
+      <div class="card-body container">
+      <h4 class="card-title mb-0 d-flex flex-row">
+          <a {{ $primaryHref }} target="_blank" rel="noopener" class="me-auto">
+          {{- .title | markdownify -}}
+          </a>
+          <div class="ms-auto">
+          {{ if $isNew -}}
+          <span class="badge rounded-pill text-bg-info"><i class="fa-regular fa-star"></i> new</span>
+          {{ end -}}
+
+          {{ if $isNative -}}
+          <button type="button" class="badge rounded-pill text-bg-success text-white"
+          onclick="document.getElementById('input-s').value = 'native'; document.getElementById('input-language').value = 'all';document.getElementById('input-component').value = 'all';document.getElementById('searchForm').submit();">
+          <i class="fa-solid fa-puzzle-piece"></i> native</button>
+          {{ end -}}
+
+          {{ if $isFirstParty -}}
+          <button type="button" class="badge rounded-pill text-bg-success text-white"
+            onclick="document.getElementById('input-s').value = 'first party integration'; document.getElementById('input-language').value = 'all';document.getElementById('input-component').value = 'all';document.getElementById('searchForm').submit();">
+            <i class="fa-solid fa-heart"></i> first party integration</button>
+          {{ end -}}
+
+          {{ if $usedInDemo -}}
+          <span class="badge rounded-pill text-bg-secondary text-white" title="This package is used in the OpenTelemetry Demo!"><i class="fa-solid fa-shapes"></i> OTel Demo</span>
+          {{ end -}}
+
+          {{ if $deprecated -}}
+          <button type="button" class="badge rounded-pill text-bg-danger text-white" title=""
+            onclick="document.getElementById('input-s').value = 'deprecated'; document.getElementById('input-language').value = 'all';document.getElementById('input-component').value = 'all';document.getElementById('searchForm').submit();">
+            <i class="fa-solid fa-ban"></i> deprecated</button>
+          {{ end -}}
+
+          {{ if .cncfProjectLevel -}}
+          <button type="button" class="badge rounded-pill text-bg-primary text-white" title="CNCF {{ .cncfProjectLevel}} Project"
+            onclick="document.getElementById('input-s').value = {{ .cncfProjectLevel }}; document.getElementById('input-language').value = 'all';document.getElementById('input-component').value = 'all';document.getElementById('searchForm').submit();">
+            <img alt="CNCF" style="display: inline-block; width: 14px; height: 14px; border: none; margin:0px; padding: 0; vertical-align:middle" src="/img/cncf-icon-white.svg"> {{ .cncfProjectLevel }}</button>
+          {{ end -}}
+          </div>
         </h4>
         <p class="card-text">
             <small class="text-body-secondary">
-            by 
+            by
             {{ range $index, $author := .authors -}}
                 {{ if $index }}, {{ end }}
                 {{ if eq $author.name "OpenTelemetry Authors" -}}
@@ -158,7 +169,7 @@
                     {{ .package.version }}
                 </div>
                 <small>Version</small>
-                </div>      
+                </div>
             </li>
             {{- end -}}
             {{ with .language -}}
@@ -168,7 +179,7 @@
                     {{ $languageNames.Get . | default (humanize .) }}
                 </div>
                 <small>Language</small>
-                </div>      
+                </div>
             </li>
             {{- end }}
             {{ with .registryType -}}
@@ -178,7 +189,7 @@
                     {{ . | humanize }}
                 </div>
                 <small>Component</small>
-                </div>      
+                </div>
             </li>
             {{- end -}}
             {{ with .license -}}
@@ -188,7 +199,7 @@
                     {{ . }}
                 </div>
                 <small>License</small>
-                </div>      
+                </div>
             </li>
             {{- end -}}
             </div>

--- a/layouts/partials/ecosystem/registry/entry.html
+++ b/layouts/partials/ecosystem/registry/entry.html
@@ -97,14 +97,13 @@
           {{ end -}}
 
           {{ if $isNative -}}
-          <button type="button" class="badge rounded-pill text-bg-success text-white"
-          onclick="document.getElementById('input-s').value = 'native'; document.getElementById('input-language').value = 'all';document.getElementById('input-component').value = 'all';document.getElementById('searchForm').submit();">
-          <i class="fa-solid fa-puzzle-piece"></i> native</button>
+          <button type="button" data-filter-value = "native" class="badge rounded-pill text-bg-success text-white" title="Click to filter by native tag">
+            <i class="fa-solid fa-puzzle-piece">
+          </i> native</button>
           {{ end -}}
 
           {{ if $isFirstParty -}}
-          <button type="button" class="badge rounded-pill text-bg-success text-white"
-            onclick="document.getElementById('input-s').value = 'first party integration'; document.getElementById('input-language').value = 'all';document.getElementById('input-component').value = 'all';document.getElementById('searchForm').submit();">
+          <button type="button" data-filter-value = "first party integration" class="badge rounded-pill text-bg-success text-white" title="Click to filter by first party tag">
             <i class="fa-solid fa-heart"></i> first party integration</button>
           {{ end -}}
 
@@ -113,14 +112,12 @@
           {{ end -}}
 
           {{ if $deprecated -}}
-          <button type="button" class="badge rounded-pill text-bg-danger text-white" title=""
-            onclick="document.getElementById('input-s').value = 'deprecated'; document.getElementById('input-language').value = 'all';document.getElementById('input-component').value = 'all';document.getElementById('searchForm').submit();">
+          <button type="button" data-filter-value = "deprecated" class="badge rounded-pill text-bg-danger text-white" title="Click to filter by deprecated tag">
             <i class="fa-solid fa-ban"></i> deprecated</button>
           {{ end -}}
 
           {{ if .cncfProjectLevel -}}
-          <button type="button" class="badge rounded-pill text-bg-primary text-white" title="CNCF {{ .cncfProjectLevel}} Project"
-            onclick="document.getElementById('input-s').value = {{ .cncfProjectLevel }}; document.getElementById('input-language').value = 'all';document.getElementById('input-component').value = 'all';document.getElementById('searchForm').submit();">
+          <button type="button" data-filter-value = "{{ .cncfProjectLevel }}" class="badge rounded-pill text-bg-primary text-white" title="Click to filter by CNCF {{ .cncfProjectLevel}} Project">
             <img alt="CNCF" style="display: inline-block; width: 14px; height: 14px; border: none; margin:0px; padding: 0; vertical-align:middle" src="/img/cncf-icon-white.svg"> {{ .cncfProjectLevel }}</button>
           {{ end -}}
           </div>


### PR DESCRIPTION
**Task**
This update allows users to filter records by clicking on a tag (like native, sandbox, etc.), enabling quicker access to filtered records without needing to use the search bar. 
closes #5312

**Implementation**

- Replaced `<span>` tags with `<button>` elements in `layouts/partials/ecosystem/registry/entry.html`
- Applied existing Bootstrap styles for consistency with the rest of the project.
- Added a function `applyTagFilter` in `assets/js/registrySearch.js` to handle the filter action when a tag is clicked.
- Added a title to the buttons(tags). On hover, each button displays "Click to filter by [tag name]".

**Result**
The tags **native**, **first party integration**, **sandbox**, **graduated**, and **deprecated** are now clickable buttons.  
Clicking a tag immediately filters the records in the OpenTelemetry registry based on the selected tag, enhancing the filtering experience. 
