### PR TITLE
Update custom-collector.md

### DIFF
--- a/content/en/docs/collector/custom-collector.md
+++ b/content/en/docs/collector/custom-collector.md
@@ -166,11 +166,11 @@ receivers:
       go.opentelemetry.io/collector/receiver/otlpreceiver {{% version-from-registry collector-receiver-otlp %}}
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.16.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.16.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v0.110.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.110.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.110.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.17.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.17.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.17.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.17.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.17.0
 ```
 
 {{% alert color="primary" title="Tip" %}}


### PR DESCRIPTION
update providers in builder-config.yaml to match stable versions.

Per https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.111.0, more `providers` are marked as stable. Updating custom collector documentation to use the latest stable components by default