### PR TITLE
docs: update example links to opentelemetry-go-contrib repository

### DIFF
--- a/content/en/blog/2024/prom-and-otel/index.md
+++ b/content/en/blog/2024/prom-and-otel/index.md
@@ -130,7 +130,7 @@ endpoint. Note that
 The Prometheus exporter allows you to ship data in the Prometheus format, which
 is then scraped by a Prometheus server. It's used to report metrics via the
 Prometheus scrape HTTP endpoint. You can learn more by trying out this
-[example](https://github.com/open-telemetry/opentelemetry-go/tree/main/example/prometheus).
+[example](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/examples/prometheus).
 However, the scraping won't really scale, as all the metrics are sent in a
 single scrape.
 

--- a/content/en/docs/languages/go/examples.md
+++ b/content/en/docs/languages/go/examples.md
@@ -1,6 +1,6 @@
 ---
 title: Examples
-redirect: https://github.com/open-telemetry/opentelemetry-go/tree/main/example
+redirect: https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/examples
 manualLinkTarget: _blank
 _build: { render: link }
 weight: 220

--- a/content/en/docs/languages/go/exporters.md
+++ b/content/en/docs/languages/go/exporters.md
@@ -200,7 +200,7 @@ func newExporter(ctx context.Context) (metric.Reader, error) {
 ```
 
 To learn more on how to use the Prometheus exporter, try the
-[prometheus example](https://github.com/open-telemetry/opentelemetry-go/tree/main/example/prometheus)
+[prometheus example](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/examples/prometheus)
 
 ### OTLP logs over HTTP (Experimental)
 


### PR DESCRIPTION
Go examples has been moved to opentelemetry-go-contrib repository in https://github.com/open-telemetry/opentelemetry-go/issues/5801.

This PR updates docs to point to the new location of the go examples.