### PR TITLE
Fix span start typo

### DIFF
--- a/content/en/docs/languages/swift/instrumentation.md
+++ b/content/en/docs/languages/swift/instrumentation.md
@@ -77,7 +77,7 @@ operation. Spans are the building blocks of Traces. To create a span use the
 span builder associated with the tracer:
 
 ```swift
-let span =  let builder = tracer.spanBuilder(spanName: "\(name)").startSpan()
+let span = tracer.spanBuilder(spanName: "\(name)").startSpan()
 ...
 span.end()
 ```


### PR DESCRIPTION
Noticed this typo in the docs where the span is started