### PR TITLE
New blogpost for GC 2024 candidates

### DIFF
--- a/content/en/blog/2024/gc-candidates.md
+++ b/content/en/blog/2024/gc-candidates.md
@@ -1,5 +1,6 @@
 ---
-title: Announcing the 2024 OpenTelemetry Governance Committee Election Candidates
+title:
+  Announcing the 2024 OpenTelemetry Governance Committee Election Candidates
 linkTitle: 2024 GC Candidates
 date: 2024-10-15
 author: OpenTelemetry Governance Committee
@@ -16,8 +17,7 @@ casting your vote between 21 October 2024 00:00 UTC and 23 October 2024 23:59
 UTC. You'll be selecting your preferred candidates to fill the four available
 seats in this year's election.
 
-You can find the candidates' pictures, profile link, and descriptions on
-the
+You can find the candidates' pictures, profile link, and descriptions on the
 [candidates page](https://github.com/open-telemetry/community/blob/main/elections/2024/governance-committee-candidates.md).
 Here are their names:
 
@@ -31,6 +31,6 @@ Here are their names:
 - Trask Stalnaker
 
 You can check your eligibility by reviewing
-[this GitHub issue](https://github.com/open-telemetry/community/issues/2329).
-If you are not listed there but believe you have the right to vote, kindly
+[this GitHub issue](https://github.com/open-telemetry/community/issues/2329). If
+you are not listed there but believe you have the right to vote, kindly
 [fill out this registration form](https://forms.gle/LBvyRpNwZvqcJxUbA).

--- a/content/en/blog/2024/gc-candidates.md
+++ b/content/en/blog/2024/gc-candidates.md
@@ -3,6 +3,7 @@ title: Announcing the 2024 OpenTelemetry Governance Committee Election Candidate
 linkTitle: 2024 GC Candidates
 date: 2024-10-15
 author: OpenTelemetry Governance Committee
+cSpell:ignore: Baeyens Danielson Marylia
 ---
 
 The OpenTelemetry election committee is excited to announce the final list of

--- a/content/en/blog/2024/gc-candidates.md
+++ b/content/en/blog/2024/gc-candidates.md
@@ -1,0 +1,35 @@
+---
+title: Announcing the 2024 OpenTelemetry Governance Committee Election Candidates
+linkTitle: 2024 GC Candidates
+date: 2024-10-15
+author: OpenTelemetry Governance Committee
+---
+
+The OpenTelemetry election committee is excited to announce the final list of
+candidates for the upcoming 2024 OpenTelemetry Governance Committee Election!
+
+If you are an
+[eligible voter](https://github.com/open-telemetry/community/blob/main/elections/2024/governance-committee-election.md#voter-eligibility),
+you’ll have the opportunity to continue shaping the future of OpenTelemetry by
+casting your vote between 21 October 2024 00:00 UTC and 23 October 2024 23:59
+UTC. You'll be selecting your preferred candidates to fill the four available
+seats in this year's election.
+
+You can find the candidates' pictures, profile link, and descriptions on
+the
+[candidates page](https://github.com/open-telemetry/community/blob/main/elections/2024/governance-committee-candidates.md).
+Here are their names:
+
+- Adriana Villela
+- Alolita Sharma
+- Daniel Dyla
+- Jamie Danielson
+- Marylia Gutierrez
+- Morgan McLean
+- Pablo Baeyens Fernández
+- Trask Stalnaker
+
+You can check your eligibility by reviewing
+[this GitHub issue](https://github.com/open-telemetry/community/issues/2329).
+If you are not listed there but believe you have the right to vote, kindly
+[fill out this registration form](https://forms.gle/LBvyRpNwZvqcJxUbA).

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -5899,6 +5899,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-23T20:33:47.852068252Z"
   },
+  "https://github.com/open-telemetry/community/issues/2329": {
+    "StatusCode": 200,
+    "LastSeen": "2024-10-15T15:52:36.027937+01:00"
+  },
   "https://github.com/open-telemetry/community/issues/828": {
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:37:16.771654-05:00"


### PR DESCRIPTION
Adds a new blogpost with information about the 2024 GC Election candidates.