### PR TITLE
[WIP] add php docs rewrite proxy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -15,6 +15,12 @@ from = "https://blog.opentelemetry.io/*"
 to = "https://opentelemetry.io/blog/:splat"
 force = true
 
+[[redirects]]
+from = "https://opentelemetry.io/api/php/*"
+to = "https://main--opentelemetry-php.netlify.app/:splat"
+force = true
+status = 200
+
 [[headers]]
   for = "/schemas/:version"
   [headers.values]

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,12 +16,6 @@ to = "https://opentelemetry.io/blog/:splat"
 force = true
 
 [[redirects]]
-from = "/api/php"
-to = "/api/php/"
-force = true
-status = 301
-
-[[redirects]]
 from = "/api/php/*"
 to = "https://main--opentelemetry-php.netlify.app/:splat"
 force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,6 +16,12 @@ to = "https://opentelemetry.io/blog/:splat"
 force = true
 
 [[redirects]]
+from = "/api/php"
+to = "/api/php/"
+force = true
+status = 301
+
+[[redirects]]
 from = "/api/php/*"
 to = "https://main--opentelemetry-php.netlify.app/:splat"
 force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,7 +16,7 @@ to = "https://opentelemetry.io/blog/:splat"
 force = true
 
 [[redirects]]
-from = "https://opentelemetry.io/api/php/*"
+from = "/api/php/*"
 to = "https://main--opentelemetry-php.netlify.app/:splat"
 force = true
 status = 200


### PR DESCRIPTION
Working towards having PHP API Docs published under opentelemetry.io/api/php.

Current Preview: https://deploy-preview-5413--opentelemetry.netlify.app/api/php/

I am facing two issues:
* If the URL does not end in a `/` the CSS, JS etc is broken
* There are some absolute URLs in the output of PHP Doc, which are broken

looks like netlify and phpdocumentor make our lives hard here:
* https://docs.netlify.com/routing/redirects/redirect-options/: "You cannot use a redirect rule to add or remove a trailing slash. However, you can rely on Netlify’s Pretty URLs feature, which is enabled by default for sites and standardizes your URLs.", however that pretty url feature doesn't do what it promises
* https://github.com/phpDocumentor/phpDocumentor/issues/2847: "We cannot support this use-case since it would not be very common to do something like this."