### PR TITLE
Adding mishmash io to vendors list

### DIFF
--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -234,6 +234,12 @@
   contact: hello@middleware.io
   oss: false
   commercial: true
+- name: mishmash io
+  nativeOTLP: true
+  url: https://github.com/mishmash-io/opentelemetry-server-embedded
+  contact: https://github.com/mishmash-io
+  oss: true
+  commercial: false
 - name: New Relic
   nativeOTLP: true
   url: https://newrelic.com/solutions/opentelemetry


### PR DESCRIPTION
Adding [mishmash io](https://mishmash.io/) to the vendors list.

Generally, we use OpenTelemetry as a [tool in our software development process.](https://mishmash.io/open_source/opentelemetry) Recently we started open-sourcing our code here:

https://github.com/mishmash-io/opentelemetry-server-embedded

At the moment the repository above contains only a few tools:
- a simple java OTLP server
- an Apache Druid ingestion extension - to load OTLP data into Apache Druid

Coming up:

- Apache Superset visualizations
- ... a few more integrations...

All of the above is released under Apache lincense.

Would be nice to add some links, hopefully people might find our tools helpful! :)
