### PR TITLE
[CI] Ensure spec processing works even if path contains a space

### DIFF
--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -127,15 +127,15 @@ while(<>) {
   # Images
   s|(\.\./)?internal(/img/[-\w]+\.png)|$2|g;
   s|(\]\()(img/.*?\))|$1../$2|g if $ARGV !~ /(logs|schemas)._index/ && $ARGV !~ /otlp\/docs/;
-  s|(\]\()([^)]+\.png\))|$1../$2|g if $ARGV =~ /\/tmp\/semconv\/docs\/general\/attributes/;
-  s|(\]\()([^)]+\.png\))|$1../$2|g if $ARGV =~ /\/tmp\/semconv\/docs\/http\/http-spans/;
+  s|(\]\()([^)]+\.png\))|$1../$2|g if $ARGV =~ /\btmp\/semconv\/docs\/general\/attributes/;
+  s|(\]\()([^)]+\.png\))|$1../$2|g if $ARGV =~ /\btmp\/semconv\/docs\/http\/http-spans/;
 
   s|\.\.\/README.md\b|$otelSpecRepoUrl/|g if $ARGV =~ /specification._index/;
   s|\.\.\/README.md\b|..| if $ARGV =~ /specification.library-guidelines.md/;
 
-  s|\.\./(opentelemetry/proto/?.*)|$otlpSpecRepoUrl/tree/v$otlpSpecVers/$1|g if $ARGV =~ /\/tmp\/otlp/;
-  s|\.\./README.md\b|$otlpSpecRepoUrl/|g if $ARGV =~ /\/tmp\/otlp/;
-  s|\.\./examples/README.md\b|$otlpSpecRepoUrl/tree/v$otlpSpecVers/examples/|g if $ARGV =~ /\/tmp\/otlp/;
+  s|\.\./(opentelemetry/proto/?.*)|$otlpSpecRepoUrl/tree/v$otlpSpecVers/$1|g if $ARGV =~ /\btmp\/otlp/;
+  s|\.\./README.md\b|$otlpSpecRepoUrl/|g if $ARGV =~ /\btmp\/otlp/;
+  s|\.\./examples/README.md\b|$otlpSpecRepoUrl/tree/v$otlpSpecVers/examples/|g if $ARGV =~ /\btmp\/otlp/;
 
   s|\bREADME.md\b|_index.md|g if $ARGV !~ /otel\/specification\/protocol\/_index.md/;
 
@@ -144,7 +144,7 @@ while(<>) {
   s|(\.\.\/)+(supplementary-guidelines\/compatibility\/[^)]+)|$otelSpecRepoUrl/tree/v$otelSpecVers/$2|g;
 
   # Rewrite inline links
-  if ($ARGV =~ /\/tmp\/opamp/) {
+  if ($ARGV =~ /\btmp\/opamp/) {
     s|\]\(([^:\)]*?)\.md((#.*?)?)\)|]($1/$2)|g;
   } else {
     s|\]\(([^:\)]*?\.md(#.*?)?)\)|]({{% relref "$1" %}})|g;

--- a/scripts/content-modules/cp-pages.sh
+++ b/scripts/content-modules/cp-pages.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-SCRIPT_DIR="$(cd `dirname $0`; pwd)"
-DEST_BASE="$(cd $SCRIPT_DIR; cd ../../; pwd)/tmp"
+SCRIPT_DIR=$(dirname $0)
+DEST_BASE=tmp
 
 ## OTel specification
 


### PR DESCRIPTION
- Fixes #5359
- My solution was to opt for relative paths inside of the `cp-pages.sh` script, and make the (very reasonable assuption) that the script is being run from the repo root. I can't recall why I opted for absolute path names. None of the directory names inside of the repo contain any spaces, so we're good.
- Closes #5377 by superseding it
- I've tested this from inside a folder whose name contains a space and the build still works. 
  @FatumaA, can you confirm (once this lands)?