### PR TITLE
Update Docsy to v0.10.0-37-g7478e1a1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/google/docsy.git
-	docsy-pin = v0.10.0-26-g79511949
+	docsy-pin = v0.10.0-37-g7478e1a1
 	docsy-note = "2024-04-01 Switching to google/docsy.git from cncf/docsy.git since we don't have any CNCF customizations."
 	docsy-reminder = "Ensure that any tag referenced by `docsy-pin` is present in the remote repo (url), otherwise add (push) the tags to the repo."
 [submodule "content-modules/opentelemetry-specification"]


### PR DESCRIPTION
- In prep for Hugo upgrade to be done for #5153
- Brings in a fix to meta descriptions. For details see:
  https://github.com/google/docsy/pull/2100