### PR TITLE
OTel diagram: drop fill color in support of dark mode

### DIFF
--- a/static/img/otel-diagram.svg
+++ b/static/img/otel-diagram.svg
@@ -1,6 +1,6 @@
 <svg width="1500" height="996" viewBox="0 0 1500 996" fill="none" xmlns="http://www.w3.org/2000/svg">
 <g clip-path="url(#clip0_452_1024)">
-<rect width="1500" height="996" fill="white"/>
+<rect width="1500" height="996"/>
 <g filter="url(#filter0_d_452_1024)">
 <path d="M675 380C675 374.477 679.477 370 685 370H755V534H686C679.925 534 675 529.075 675 523V380Z" fill="#8EA9EC"/>
 <path d="M706.3 458.9V470.9C706.3 471.65 706.9 472.4 707.8 472.4H730.6C731.35 472.4 732.1 471.8 732.1 470.9V458.9" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>


### PR DESCRIPTION
- Illustrates minimally intrusive solution to #5361
- Drops single `fill` attribute from `svg rect`, in support of dark mode:
  <img width="543" alt="image" src="https://github.com/user-attachments/assets/c98221eb-5ebf-4c40-97b8-45175f330583">
- **Preview**: https://deploy-preview-5436--opentelemetry.netlify.app/docs/

### Screenshots

Before:

> <img width="500" alt="image" src="https://github.com/user-attachments/assets/5b8815dd-74b2-4b48-8851-1c462dfd8b1f">

After:

> <img width="500" alt="image" src="https://github.com/user-attachments/assets/3f25b2a6-abfc-4f8d-8717-6ad36904975c">
