### PR TITLE
zero-code/python: add django applications notes in operator doc

### DIFF
--- a/content/en/docs/zero-code/python/operator.md
+++ b/content/en/docs/zero-code/python/operator.md
@@ -26,3 +26,13 @@ specific Python version. The
 provides images for a single Python version based on the glibc C library. If you
 want to use it you might need to build your own image operator Docker image for
 Python auto-instrumentation.
+
+#### Django applications
+
+Applications that run from their own executable like Django requires to set in
+your deployment file two environment variables:
+
+- `PYTHONPATH`, with the path to the Django application root directory, e.g.
+  "/app"
+- `DJANGO_SETTINGS_MODULE`, with the name of the Django settings module, e.g.
+  "myapp.settings"

--- a/content/en/docs/zero-code/python/operator.md
+++ b/content/en/docs/zero-code/python/operator.md
@@ -3,8 +3,8 @@ title: Using the OpenTelemetry Operator to Inject Auto-Instrumentation
 linkTitle: Operator
 aliases: [/docs/languages/python/automatic/operator]
 weight: 30
-cSpell:ignore:
-  PYTHONPATH distro grpcio mkdir myapp psutil uninstrumented virtualenv
+# prettier-ignore
+cSpell:ignore: PYTHONPATH distro grpcio mkdir myapp psutil uninstrumented virtualenv
 ---
 
 If you run your Python service in Kubernetes, you can take advantage of the

--- a/content/en/docs/zero-code/python/operator.md
+++ b/content/en/docs/zero-code/python/operator.md
@@ -3,7 +3,7 @@ title: Using the OpenTelemetry Operator to Inject Auto-Instrumentation
 linkTitle: Operator
 aliases: [/docs/languages/python/automatic/operator]
 weight: 30
-cSpell:ignore: distro grpcio mkdir psutil uninstrumented virtualenv
+cSpell:ignore: PYTHONPATH distro grpcio mkdir myapp psutil uninstrumented virtualenv
 ---
 
 If you run your Python service in Kubernetes, you can take advantage of the

--- a/content/en/docs/zero-code/python/operator.md
+++ b/content/en/docs/zero-code/python/operator.md
@@ -4,7 +4,7 @@ linkTitle: Operator
 aliases: [/docs/languages/python/automatic/operator]
 weight: 30
 # prettier-ignore
-cSpell:ignore: PYTHONPATH distro grpcio mkdir myapp psutil uninstrumented virtualenv
+cSpell:ignore: distro grpcio mkdir myapp psutil PYTHONPATH uninstrumented virtualenv
 ---
 
 If you run your Python service in Kubernetes, you can take advantage of the

--- a/content/en/docs/zero-code/python/operator.md
+++ b/content/en/docs/zero-code/python/operator.md
@@ -3,7 +3,8 @@ title: Using the OpenTelemetry Operator to Inject Auto-Instrumentation
 linkTitle: Operator
 aliases: [/docs/languages/python/automatic/operator]
 weight: 30
-cSpell:ignore: PYTHONPATH distro grpcio mkdir myapp psutil uninstrumented virtualenv
+cSpell:ignore:
+  PYTHONPATH distro grpcio mkdir myapp psutil uninstrumented virtualenv
 ---
 
 If you run your Python service in Kubernetes, you can take advantage of the


### PR DESCRIPTION
Django applications require special treatment with operator based autoinstrumentation.