### PR TITLE
Update feature-flags.md

### DIFF
--- a/content/en/docs/demo/feature-flags.md
+++ b/content/en/docs/demo/feature-flags.md
@@ -18,7 +18,7 @@ change the `defaultVariant` value in the config file for a given flag to "on".
 | `adServiceFailure`                  | Ad Service       | Generate an error for `GetAds` 1/10th of the time                                                         |
 | `adServiceManualGc`                 | Ad Service       | Trigger full manual garbage collections in the ad service                                                 |
 | `adServiceHighCpu`                  | Ad Service       | Trigger high cpu load in the ad service. If you want to demo cpu throttling, set cpu resource limits      |
-| `cartServiceFailure`                | Cart Service     | Generate an error for `EmptyCart` 1/10th of the time                                                      |
+| `cartServiceFailure`                | Cart Service     | Generate an error whenever `EmptyCart` is called                                                          |
 | `productCatalogFailure`             | Product Catalog  | Generate an error for `GetProduct` requests with product ID: `OLJCESPC7Z`                                 |
 | `recommendationServiceCacheFailure` | Recommendation   | Create a memory leak due to an exponentially growing cache. 1.4x growth, 50% of requests trigger growth.  |
 | `paymentServiceFailure`             | Payment Service  | Generate an error when calling the `charge` method.                                                       |


### PR DESCRIPTION
Depends on https://github.com/open-telemetry/opentelemetry-demo/pull/1748.

The OTel demo PR changes the behaviour of cart service, which will now fail 100% of the times when `emptyCart` is called.