### PR TITLE
✅[outreachy] Registry : Add to favorites #5447

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -8,11 +8,11 @@ CheckMailto: false
 TestFilesConcurrently: true
 IgnoreDirs:
   # DO NOT EDIT! IgnoreDirs list is auto-generated from markdown file front matter.
+  - ^blog/(\d+/)?page/\d+
   # TODO drop next line after https://github.com/open-telemetry/opentelemetry.io/issues/5423 is fixed for ja pages:
   - ^ja/docs/concepts/instrumentation/libraries/
   # TODO drop next line after https://github.com/open-telemetry/opentelemetry.io/issues/5423 is fixed for pt pages:
   - ^pt/docs/concepts/instrumentation/libraries/
-  - ^blog/(\d+/)?page/\d+
   # DO NOT EDIT! IgnoreDirs list is auto-generated from markdown file front matter.
 IgnoreInternalURLs: # list of paths
 IgnoreURLs: # list of regexs of paths or URLs to be ignored

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -8,11 +8,11 @@ CheckMailto: false
 TestFilesConcurrently: true
 IgnoreDirs:
   # DO NOT EDIT! IgnoreDirs list is auto-generated from markdown file front matter.
-  - ^blog/(\d+/)?page/\d+
   # TODO drop next line after https://github.com/open-telemetry/opentelemetry.io/issues/5423 is fixed for ja pages:
   - ^ja/docs/concepts/instrumentation/libraries/
   # TODO drop next line after https://github.com/open-telemetry/opentelemetry.io/issues/5423 is fixed for pt pages:
   - ^pt/docs/concepts/instrumentation/libraries/
+  - ^blog/(\d+/)?page/\d+
   # DO NOT EDIT! IgnoreDirs list is auto-generated from markdown file front matter.
 IgnoreInternalURLs: # list of paths
 IgnoreURLs: # list of regexs of paths or URLs to be ignored

--- a/assets/js/addToFavorites.js
+++ b/assets/js/addToFavorites.js
@@ -1,0 +1,29 @@
+document.addEventListener('DOMContentLoaded', function () {        
+    let favorites = JSON.parse(localStorage.getItem('favorites')) || [];
+
+    document.querySelectorAll('.favorite-btn').forEach(function(button) {
+        const registryId = button.getAttribute('data-registry-id');
+
+        if (favorites.includes(registryId)) {
+            button.innerHTML = '<i class="fa-solid fa-star"></i>';
+            button.classList.add('btn-success');
+            button.classList.remove('btn-outline-primary');
+        }
+
+        button.addEventListener('click', function() {
+            if (favorites.includes(registryId)) {
+                favorites = favorites.filter(id => id !== registryId);
+                localStorage.setItem('favorites', JSON.stringify(favorites));
+                button.innerHTML = '<i class="fa-regular fa-star"></i> Add to favorites';
+                button.classList.add('btn-outline-primary');
+                button.classList.remove('btn-success');
+            } else {
+                favorites.push(registryId);
+                localStorage.setItem('favorites', JSON.stringify(favorites));
+                button.innerHTML = '<i class="fa-solid fa-star"></i>';
+                button.classList.add('btn-success');
+                button.classList.remove('btn-outline-primary');
+            }
+        });
+    });
+});

--- a/assets/js/addToFavorites.js
+++ b/assets/js/addToFavorites.js
@@ -5,7 +5,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const registryId = button.getAttribute('data-registry-id');
 
     if (favorites.includes(registryId)) {
-      button.innerHTML = '<i class="fa-solid fa-star"></i>';
+      button.innerHTML = '<i class="fa-solid fa-star"></i> Remove from Favorites';
       button.classList.add('btn-success');
       button.classList.remove('btn-outline-primary');
     }
@@ -21,7 +21,7 @@ document.addEventListener('DOMContentLoaded', function () {
       } else {
         favorites.push(registryId);
         localStorage.setItem('favorites', JSON.stringify(favorites));
-        button.innerHTML = '<i class="fa-solid fa-star"></i>';
+        button.innerHTML = '<i class="fa-solid fa-star"></i> Remove from Favorites';
         button.classList.add('btn-success');
         button.classList.remove('btn-outline-primary');
       }

--- a/assets/js/addToFavorites.js
+++ b/assets/js/addToFavorites.js
@@ -1,29 +1,30 @@
-document.addEventListener('DOMContentLoaded', function () {        
-    let favorites = JSON.parse(localStorage.getItem('favorites')) || [];
+document.addEventListener('DOMContentLoaded', function () {
+  let favorites = JSON.parse(localStorage.getItem('favorites')) || [];
 
-    document.querySelectorAll('.favorite-btn').forEach(function(button) {
-        const registryId = button.getAttribute('data-registry-id');
+  document.querySelectorAll('.favorite-btn').forEach(function (button) {
+    const registryId = button.getAttribute('data-registry-id');
 
-        if (favorites.includes(registryId)) {
-            button.innerHTML = '<i class="fa-solid fa-star"></i>';
-            button.classList.add('btn-success');
-            button.classList.remove('btn-outline-primary');
-        }
+    if (favorites.includes(registryId)) {
+      button.innerHTML = '<i class="fa-solid fa-star"></i>';
+      button.classList.add('btn-success');
+      button.classList.remove('btn-outline-primary');
+    }
 
-        button.addEventListener('click', function() {
-            if (favorites.includes(registryId)) {
-                favorites = favorites.filter(id => id !== registryId);
-                localStorage.setItem('favorites', JSON.stringify(favorites));
-                button.innerHTML = '<i class="fa-regular fa-star"></i> Add to favorites';
-                button.classList.add('btn-outline-primary');
-                button.classList.remove('btn-success');
-            } else {
-                favorites.push(registryId);
-                localStorage.setItem('favorites', JSON.stringify(favorites));
-                button.innerHTML = '<i class="fa-solid fa-star"></i>';
-                button.classList.add('btn-success');
-                button.classList.remove('btn-outline-primary');
-            }
-        });
+    button.addEventListener('click', function () {
+      if (favorites.includes(registryId)) {
+        favorites = favorites.filter((id) => id !== registryId);
+        localStorage.setItem('favorites', JSON.stringify(favorites));
+        button.innerHTML =
+          '<i class="fa-regular fa-star"></i> Add to favorites';
+        button.classList.add('btn-outline-primary');
+        button.classList.remove('btn-success');
+      } else {
+        favorites.push(registryId);
+        localStorage.setItem('favorites', JSON.stringify(favorites));
+        button.innerHTML = '<i class="fa-solid fa-star"></i>';
+        button.classList.add('btn-success');
+        button.classList.remove('btn-outline-primary');
+      }
     });
+  });
 });

--- a/assets/js/registrySearch.js
+++ b/assets/js/registrySearch.js
@@ -239,3 +239,27 @@ function parseUrlParams() {
   selectedLanguage = urlParams.get('language') || 'all';
   selectedComponent = urlParams.get('component') || 'all';
 }
+
+document.addEventListener('DOMContentLoaded', function () {
+  const filterBtn = document.getElementById('filter-favorites-btn');
+  const registryItems = document.querySelectorAll('.registry-entry');
+
+  filterBtn.addEventListener('click', function () {
+    let favorites = JSON.parse(localStorage.getItem('favorites')) || [];
+
+    if (filterBtn.textContent.includes('Show Favorites')) {
+      registryItems.forEach(function (item) {
+        const registryId = item.getAttribute('data-registry-id');
+        if (!favorites.includes(registryId)) {
+          item.style.display = 'none';
+        }
+      });
+      filterBtn.textContent = 'Show All';
+    } else {
+      registryItems.forEach(function (item) {
+        item.style.display = '';
+      });
+      filterBtn.textContent = 'Show Favorites';
+    }
+  });
+});

--- a/layouts/partials/ecosystem/registry/entry.html
+++ b/layouts/partials/ecosystem/registry/entry.html
@@ -217,6 +217,13 @@
         {{ $demoUrl := printf "href=%q" (printf .) | safeHTMLAttr -}}
         <a {{ $demoUrl }} target="_blank" rel="noopener" class="card-link"><i class="fa-solid fa-shapes" aria-hidden="true"></i>&nbsp;Demo Service</a>
         {{- end -}}
+        <!-- Add to Favorites Button -->
+        <div class="text-end">
+            <button class="btn btn-link p-0 favorite-btn" data-registry-id="{{ ._key }}">
+                <i class="fa-regular fa-star"></i> Add to favorites
+            </button>
+        </div>
         </div>
     </li>
   {{ end -}}
+{{ partial "script.html" (dict "src" "js/addToFavorites.js") -}}

--- a/layouts/shortcodes/ecosystem/registry/search-form.html
+++ b/layouts/shortcodes/ecosystem/registry/search-form.html
@@ -57,6 +57,11 @@ ecosystem. If you are a project maintainer, you can <a href="/ecosystem/registry
       <button type="button" class="btn btn-outline-danger"
         onclick="document.getElementById('input-s').value = ''; document.getElementById('input-language').value = 'all';document.getElementById('input-component').value = 'all';document.getElementById('searchForm').submit();">Reset</button>
 
+      <!-- Show Favorites Button -->
+      <button type="button" id="filter-favorites-btn" class="btn" style="border-color: #6a0dad; color: #6a0dad;">
+        Show Favorites
+      </button>
+
       <button class="btn btn-outline-secondary dropdown-toggle" id="languageDropdown" type="button"
         data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Language</button>
       <div class="dropdown-menu" id="languageFilter">


### PR DESCRIPTION
## Fixes
- Fixes #5447 by @svrnm

## Description
- This PR introduces a "Add to Favorites" feature, allowing users to quickly mark registry entries as favorites. Favorites are stored locally in local storage, ensuring persistence across sessions.
    - Implemented a button for adding/removing items from favorites.
    - Favorites are stored in local storage for better user experience.
    - Integrated the functionality using a `favorite-btn` that updates dynamically.

## Technical details
- Partial for JavaScript: Moved JavaScript functionality to a separate `js/addToFavorites.js file`, loaded via a partial in the layout for better maintainability and performance.

- Local Storage Logic: The local storage checks if an item is already marked as a favorite, and updates the button's appearance accordingly. This avoids the need for server-side calls, keeping it fast and client-side focused.

## Screenshots

![SS1](https://github.com/user-attachments/assets/61a1bc18-4f7a-4434-8097-a2dfa86c9f68)

![SS2](https://github.com/user-attachments/assets/3255efb4-b3ad-47f9-a6a8-7f1659ba710d)

![SS3](https://github.com/user-attachments/assets/ed374bed-e42d-4729-b707-9f2d019df582)