### PR TITLE
Add MLflow entry to the OpenTelemetry integrations registry

### DIFF
--- a/data/registry/application-integration-python-mlflow.yml
+++ b/data/registry/application-integration-python-mlflow.yml
@@ -7,8 +7,8 @@ tags:
   - LLMs
 license: Apache-2.0
 description:
-  The MLflow tracing feature is built using OpenTelemetry, and allows
-  users to trace the execution of their generative AI applications.
+  The MLflow tracing feature is built using OpenTelemetry, and allows users to
+  trace the execution of their generative AI applications.
 authors:
   - name: MLflow Authors
     url: https://github.com/mlflow

--- a/data/registry/application-integration-python-mlflow.yml
+++ b/data/registry/application-integration-python-mlflow.yml
@@ -1,0 +1,20 @@
+title: MLflow
+registryType: application integration
+language: python
+tags:
+  - python
+  - MLflow
+  - LLMs
+license: Apache-2.0
+description:
+  The MLflow tracing feature is built using OpenTelemetry, and allows
+  users to trace the execution of their generative AI applications.
+authors:
+  - name: MLflow Authors
+    url: https://github.com/mlflow
+urls:
+  website: https://mlflow.org/
+  repo: https://github.com/mlflow/mlflow/
+  docs: https://mlflow.org/docs/latest/llms/tracing/index.html
+createdAt: '2024-09-04'
+isNative: true

--- a/data/registry/application-integration-python-mlflow.yml
+++ b/data/registry/application-integration-python-mlflow.yml
@@ -16,5 +16,5 @@ urls:
   website: https://mlflow.org/
   repo: https://github.com/mlflow/mlflow/
   docs: https://mlflow.org/docs/latest/llms/tracing/index.html
-createdAt: '2024-09-04'
+createdAt: '2024-10-24'
 isNative: true

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -5671,6 +5671,14 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:04:58.425652-05:00"
   },
+  "https://github.com/mlflow": {
+    "StatusCode": 200,
+    "LastSeen": "2024-10-24T09:04:39.209525077Z"
+  },
+  "https://github.com/mlflow/mlflow/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-10-24T09:04:36.357311431Z"
+  },
   "https://github.com/mlocati/docker-php-extension-installer": {
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:55:35.599232-05:00"
@@ -9226,6 +9234,14 @@
   "https://mishmash.io": {
     "StatusCode": 200,
     "LastSeen": "2024-10-18T16:50:17.995881058+03:00"
+  },
+  "https://mlflow.org/": {
+    "StatusCode": 206,
+    "LastSeen": "2024-10-24T09:04:26.938953245Z"
+  },
+  "https://mlflow.org/docs/latest/llms/tracing/index.html": {
+    "StatusCode": 206,
+    "LastSeen": "2024-10-24T09:04:29.562895157Z"
   },
   "https://mobyproject.org/": {
     "StatusCode": 206,


### PR DESCRIPTION
Hi all! This is a follow-up to #5150. We've built an OTel exporter and have [instructions in the doc page](https://mlflow.org/docs/latest/llms/tracing/index.html#using-opentelemetry-collector-for-exporting-traces) on how to use it 😄. As for semantic conventions, due to historical reasons (some downstream applications are relying on the existing data format) it's a little difficult to migrate immediately, but we're keeping an eye on the spec and where it makes sense to integrate.