### PR TITLE
Add 2024 GC Election results blogpost

### DIFF
--- a/content/en/blog/2024/gc-election-results.md
+++ b/content/en/blog/2024/gc-election-results.md
@@ -1,0 +1,32 @@
+---
+title: Announcing the 2024 Governance Committee Election Results
+linkTitle: 2024 GC Election Results
+date: 2024-10-24
+author: OpenTelemetry Governance Committee
+cSpell:ignore: Baeyens
+---
+
+We are delighted to announce the results of the
+[2024 OpenTelemetry Governance Committee Election](https://github.com/open-telemetry/community/blob/main/elections/2024/governance-committee-election.md)!
+
+The OpenTelemetry project continues to bring together an exceptionally vibrant
+community, who are shaping the future of observability with their contributions.
+This year, active contributors have shown their commitment again by
+participating in our election process, and they've done it in great numbers.
+
+701 contributors were eligible to vote this year, and 299 of them cast their
+ballot. This is a new record for the project! With a participation rate of 43%,
+it represents a significant increase from the 2023 election, where 206 ballots
+were cast with 616 eligible voters, proof of OpenTelemetry's healthy growth and
+engagement.
+
+Four positions were up for election in this year's Governance Committee
+selection process. Without further ado, please join us in congratulating
+[Alolita Sharma](https://github.com/alolita),
+[Morgan McLean](https://github.com/mtwo),
+[Pablo Baeyens Fernández](https://github.com/mx-psi), and
+[Trask Stalnaker](https://github.com/trask)! All will serve a two-year term.
+
+We'd like to thank everyone who participated -- candidates, voters, and the
+election organizers -- for their efforts. You can find the
+[full results of the election here](https://vote.heliosvoting.org/helios/elections/176e7ca8-647d-11ef-9b9a-2a30e2a223da/view).


### PR DESCRIPTION
Adds new blog post announcing the results of the 2024 OpenTelemetry Governance Committee Elections.

cc @open-telemetry/governance-committee 