### PR TITLE
Add missing step to howto guide for adding a vendor

### DIFF
--- a/.cspell/en-words.txt
+++ b/.cspell/en-words.txt
@@ -108,6 +108,7 @@ quarkus
 quoteservice
 recommendationservice
 redis
+refcache
 relref
 Rexed
 runbook

--- a/content/en/ecosystem/vendors.md
+++ b/content/en/ecosystem/vendors.md
@@ -32,6 +32,9 @@ The entry should include the following:
   source distribution does not qualify your offering to be marked "open source".
 - GitHub handle or email address as a point of contact so that we can reach out
   in case we have questions
+- make sure you have [set up](/docs/contributing/development/) your local clone
+  for development (`nvm install`/`nvm use` & `npm install`) and run
+  `npm run log:check:links` to update the file `static/refcache.json`
 
 Note that this list is for organizations that consume OpenTelemetry and offer
 Observability to [end users](https://community.cncf.io/end-user-community/).


### PR DESCRIPTION
The required check "Links / REFCACHE updates? (pull_request)" will fail if you follow the current instructions to add a new vendor to the list of OTel vendors; because a required step is missing - updating the file static/refcache.json. This change adds instructions on how to update the file after updating `data/ecosystem/vendors.yaml`.