### PR TITLE
[CI] htmltest config: sort files before processing

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -8,11 +8,11 @@ CheckMailto: false
 TestFilesConcurrently: true
 IgnoreDirs:
   # DO NOT EDIT! IgnoreDirs list is auto-generated from markdown file front matter.
+  - ^blog/(\d+/)?page/\d+
   # TODO drop next line after https://github.com/open-telemetry/opentelemetry.io/issues/5423 is fixed for ja pages:
   - ^ja/docs/concepts/instrumentation/libraries/
   # TODO drop next line after https://github.com/open-telemetry/opentelemetry.io/issues/5423 is fixed for pt pages:
   - ^pt/docs/concepts/instrumentation/libraries/
-  - ^blog/(\d+/)?page/\d+
   # DO NOT EDIT! IgnoreDirs list is auto-generated from markdown file front matter.
 IgnoreInternalURLs: # list of paths
 IgnoreURLs: # list of regexs of paths or URLs to be ignored

--- a/scripts/htmltest-config.pl
+++ b/scripts/htmltest-config.pl
@@ -15,7 +15,7 @@ sub main {
 sub collect_htmltest_config_from_front_matter {
     my ($ignore_dirs_ref, @files) = @_;
 
-    foreach my $file_path (@files) {
+    foreach my $file_path (sort @files) {
         my @htmltest_config = extract_htmltest_config($file_path);
         next unless @htmltest_config;
         push @$ignore_dirs_ref, @htmltest_config;


### PR DESCRIPTION
- Sort the list of files processed while collecting `htmltest` config entries, so that the resulting config file is consistent across development environments (like Cloud IDEs).
- No changes to generated site files.