### PR TITLE
Add jdbi to native java instrumentation registry

### DIFF
--- a/data/registry/instrumentation-java-jdbi.yml
+++ b/data/registry/instrumentation-java-jdbi.yml
@@ -1,0 +1,21 @@
+# cSpell:ignore JDBI
+
+title: JDBI
+registryType: instrumentation
+language: java
+tags:
+  - java
+  - jdbi
+urls:
+  repo: https://github.com/jdbi/jdbi
+  docs: https://jdbi.org/#_opentelemetry_tracing
+  website: https://jdbi.org/
+license: Apache-2.0
+description:
+  Installing the JdbiOpenTelemetryPlugin enables Jdbi statements to emit trace
+  spans recording metadata like SQL, parameters, and execution time.
+authors:
+  - name: JDBI Authors
+    url: https://github.com/jdbi
+createdAt: '2024-11-02'
+isNative: true

--- a/data/registry/instrumentation-java-jdbi.yml
+++ b/data/registry/instrumentation-java-jdbi.yml
@@ -1,5 +1,4 @@
-# cSpell:ignore JDBI
-
+# cSpell:ignore JDBI jdbi Jdbi
 title: JDBI
 registryType: instrumentation
 language: java

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -5247,6 +5247,14 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:18:28.014809+02:00"
   },
+  "https://github.com/jdbi": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-02T06:14:06.865612-04:00"
+  },
+  "https://github.com/jdbi/jdbi": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-02T06:14:05.661704-04:00"
+  },
   "https://github.com/jeanbisutti": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:14:42.388742-05:00"
@@ -8610,6 +8618,14 @@
   "https://javadoc.io/doc/org.apache.logging.log4j/log4j-api/latest/org.apache.logging.log4j/org/apache/logging/log4j/Logger.html": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T15:25:04.309715-05:00"
+  },
+  "https://jdbi.org/": {
+    "StatusCode": 206,
+    "LastSeen": "2024-11-02T06:13:48.275274-04:00"
+  },
+  "https://jdbi.org/#_opentelemetry_tracing": {
+    "StatusCode": 206,
+    "LastSeen": "2024-11-02T06:13:48.208691-04:00"
   },
   "https://jessitron.com/": {
     "StatusCode": 200,


### PR DESCRIPTION
As of [release 3.46.0](https://github.com/jdbi/jdbi/releases/tag/v3.46.0), JDBI added native [OTel instrumentation](https://jdbi.org/#_opentelemetry_tracing).

This PR adds jdbi to the registry so that it will be listed on the Instrumentation ecosystem page under [Native Instrumentation](https://opentelemetry.io/docs/languages/java/instrumentation/#native-instrumentation)