### PR TITLE
Group java performance, javadoc, examples, registry under Learn More

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -20,6 +20,8 @@ IgnoreInternalURLs: # list of paths
 IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - ^/api$
   - ^((/..)?/docs/languages/\w+|\.\.)/(api|examples|registry)/$
+  # Java nests ./api/, ./examples/, ./registry/ under ./learn-more/
+  - ^((/..)?/docs/languages/\w+|\.\.)/learn-more/(api|examples|registry)/$
   - ^(/..)?/docs/collector/registry/$
   - ^(/..)?/docs/languages/net/(metrics-api|traces-api)/
   - ^((/..)?/docs/migration/)?opencensus/$

--- a/content/en/docs/languages/java/intro.md
+++ b/content/en/docs/languages/java/intro.md
@@ -61,8 +61,9 @@ The OpenTelemetry Java documentation is organized as follows:
   Most users will use this page like an encyclopedia, consulting the index of
   sections as needed, rather than reading front to back.
 - **Learn More**: Supplementary resources, including end-to-end
-  [examples](../examples/), [Javadoc](../api/), component
-  [registry](../registry/), and a [performance reference](../performance/).
+  [examples](../learn-more/examples/), [Javadoc](../learn-more/api/), component
+  [registry](../learn-more/registry/), and a
+  [performance reference](../learn-more/performance/).
 
 ## Repositories
 

--- a/content/en/docs/languages/java/learn-more/_index.md
+++ b/content/en/docs/languages/java/learn-more/_index.md
@@ -1,0 +1,4 @@
+---
+title: Learn More
+description: Supplementary resources for the OpenTelemetry Java ecosystem
+---

--- a/content/en/docs/languages/java/learn-more/api.md
+++ b/content/en/docs/languages/java/learn-more/api.md
@@ -2,6 +2,8 @@
 title: Javadoc API reference
 linkTitle: Javadoc
 redirect: https://javadoc.io/doc/io.opentelemetry
+aliases:
+  - /docs/java/api
 manualLinkTarget: _blank
 _build: { render: link }
 weight: 210

--- a/content/en/docs/languages/java/learn-more/examples.md
+++ b/content/en/docs/languages/java/learn-more/examples.md
@@ -5,6 +5,7 @@ manualLinkTarget: _blank
 aliases:
   - /docs/java/instrumentation_examples
   - /docs/languages/java/instrumentation_examples
+  - /docs/java/examples
 _build: { render: link }
 weight: 220
 ---

--- a/content/en/docs/languages/java/learn-more/performance.md
+++ b/content/en/docs/languages/java/learn-more/performance.md
@@ -3,6 +3,8 @@ title: Performance
 description: Performance reference for the OpenTelemetry Java agent
 weight: 75
 cSpell:ignore: Dotel
+aliases:
+  - /docs/java/performance
 ---
 
 The OpenTelemetry Java agent instruments your application by running inside the
@@ -40,7 +42,7 @@ the Java agent.
 
 The volume of spans processed by the instrumentation might impact agent
 overhead. You can configure trace sampling to adjust the span volume and reduce
-resource usage. See [Sampling](../sdk/#sampler).
+resource usage. See [Sampling](../../sdk/#sampler).
 
 ### Turn off specific instrumentations
 
@@ -99,7 +101,7 @@ instrumentations, see
 When troubleshooting agent overhead issues, do the following:
 
 - Check minimum requirements. See
-  [Prerequisites](../getting-started/#prerequisites).
+  [Prerequisites](../../getting-started/#prerequisites).
 - Use the latest compatible version of the Java agent.
 - Use the latest compatible version of your JVM.
 

--- a/content/en/docs/languages/java/learn-more/registry.md
+++ b/content/en/docs/languages/java/learn-more/registry.md
@@ -6,4 +6,6 @@ description:
 redirect: /ecosystem/registry/?language=java
 _build: { render: link }
 weight: 300
+aliases:
+  - /docs/java/registry
 ---

--- a/layouts/shortcodes/apidocs.md
+++ b/layouts/shortcodes/apidocs.md
@@ -7,6 +7,10 @@
     {{ with $.Site.GetPage "/docs/languages/net/metrics-api" -}}
         {{ $pages = $pages | append (dict "lang" $value "page" .) }}
     {{ end }}
+    {{ else if eq $key "java" -}}
+    {{ with $.Site.GetPage "/docs/languages/java/learn-more/api" -}}
+        {{ $pages = $pages | append (dict "lang" $value "page" .) }}
+    {{ end }}
     {{ else -}}
     {{ with $.Site.GetPage (printf "/docs/languages/%s/api" $key) -}}
         {{ $pages = $pages | append (dict "lang" $value "page" .) }}


### PR DESCRIPTION
Resolves #5211.

Reduces the prominence of the Java Performance, Javadoc, Examples, and Registry by collecting them under a "Learn More" section. This reduces the number of entries under the Java section by 3, focusing user attention on the pages which are more likely to be useful and hopefully making the navigation less overwhelming. 

![Screenshot 2024-11-04 at 11 25 46 AM](https://github.com/user-attachments/assets/55bd5be1-d40b-42f4-a458-36046fece85c)
