### PR TITLE
Add cross references to Collector security docs

### DIFF
--- a/content/en/docs/collector/_index.md
+++ b/content/en/docs/collector/_index.md
@@ -52,6 +52,11 @@ It is also easier to [setup a collector](quick-start) than you might think: the
 default OTLP exporters in each language assume a local collector endpoint, so if
 you launch a collector it will automatically start receiving telemetry.
 
+## Collector security
+
+Follow best practices to make sure your collectors are [hosted] and [configured]
+securely.
+
 ## Status and releases
 
 The **Collector** status is: [mixed][], since core Collector components
@@ -70,6 +75,8 @@ for more details.
 {{% docs/latest-release collector-releases /%}}
 
 [registry]: /ecosystem/registry/?language=collector
+[hosted]: /docs/security/hosting-best-practices/
+[configured]: /docs/security/config-best-practices/
 [mixed]: /docs/specs/otel/document-status/#mixed
 [stability levels]:
   https://github.com/open-telemetry/opentelemetry-collector#stability-levels

--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -14,7 +14,8 @@ the following content:
 
 - [Data collection concepts][dcc], to understand the repositories applicable to
   the OpenTelemetry Collector.
-- [Security guidance](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md)
+- [Security guidance for end users](/docs/security/config-best-practices/)
+- [Security guidance for component developers](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md)
 
 ## Location {#location}
 

--- a/content/en/docs/collector/deployment/_index.md
+++ b/content/en/docs/collector/deployment/_index.md
@@ -8,6 +8,8 @@ The OpenTelemetry Collector consists of a single binary which you can use in
 different ways, for different use cases. This section describes deployment
 patterns, their use cases along with pros and cons and best practices for
 collector configurations for cross-environment and multi-backend deployments.
+For deployment security considerations, see [Collector hosting best
+practices][security].
 
 ## Resources
 
@@ -15,6 +17,7 @@ collector configurations for cross-environment and multi-backend deployments.
   Patterns][y-patterns]
 - [Deployment Patterns][gh-patterns] accompanying the talk
 
+[security]: /docs/security/hosting-best-practices/
 [gh-patterns]:
   https://github.com/jpkrohling/opentelemetry-collector-deployment-patterns/
 [y-patterns]: https://www.youtube.com/watch?v=WhRrwSHDBFs


### PR DESCRIPTION
Now that #5209 is merged, this PR adds references to it from the Collector docs. The references are added to the following pages (links are previews):

- The [Collector landing page](https://deploy-preview-5524--opentelemetry.netlify.app/docs/collector/) links to both the security hosting and configuration pages
- The [Deployment landing page](https://deploy-preview-5524--opentelemetry.netlify.app/docs/collector/deployment/) links to the security hosting page.
- The [Configuration page](https://deploy-preview-5524--opentelemetry.netlify.app/docs/collector/configuration/) links to the security configuration page.

Tracking issue: #3479 