### PR TITLE
Java JDBI is first party not native

### DIFF
--- a/data/registry/instrumentation-java-jdbi.yml
+++ b/data/registry/instrumentation-java-jdbi.yml
@@ -17,4 +17,5 @@ authors:
   - name: JDBI Authors
     url: https://github.com/jdbi
 createdAt: '2024-11-02'
-isNative: true
+isNative: false
+isFirstParty: true


### PR DESCRIPTION
follow up for #5512:

based on the documentation (https://jdbi.org/#_opentelemetry_tracing) the otel integration requires a plugin and is not a native integration:

> The OpenTelemetry project provides a SDK to implement distributed tracing. Installing the JdbiOpenTelemetryPlugin from the jdbi3-opentelemetry artifact will cause Jdbi statements to emit trace spans recording data similarly as JFR events above. Additionally, it will add the trace id to JFR events.

cc @jaydeluca