### PR TITLE
fix date for kubecon blog post

### DIFF
--- a/content/en/blog/2024/kubecon-na.md
+++ b/content/en/blog/2024/kubecon-na.md
@@ -1,7 +1,7 @@
 ---
 title: Join us for OpenTelemetry Talks and Activities at KubeCon NA 2024
 linkTitle: KubeCon NA '24
-date: 2024-10-15
+date: 2024-11-05
 # prettier-ignore
 cSpell:ignore: Arnell Ashok Chandrasekar Clario Contribfest Ekansh Grabner Haeussler Helmuth Jernigan Kalkanis Kats Kowall Kruthika Liudmila Mclean Molkova Novatec OTTL Prasanna Shivanshu Shrivastava simha Woerner
 author: '[Severin Neumann](https://github.com/svrnm) (Cisco)'


### PR DESCRIPTION
I forgot to set the date for the kubecon blog post to today, so it's not at the top of the blog posts list