### PR TITLE
Fix redirects (in pt) and add note to en page

### DIFF
--- a/content/en/docs/languages/_index.md
+++ b/content/en/docs/languages/_index.md
@@ -5,7 +5,7 @@ description:
   languages
 weight: 250
 aliases: [/docs/instrumentation]
-redirects: [{ from: /docs/instrumentation/*, to: ':splat' }]
+redirects: [{ from: /docs/instrumentation/*, to: ':splat' }] # Only for `en`
 ---
 
 OpenTelemetry code [instrumentation][] is supported for the languages listed in


### PR DESCRIPTION
- Contributes to #5531
- Thankfully, it seems to still pick the `en` redirect
  - Redirect test: https://opentelemetry.io/docs/instrumentation/
  - So I'll follow up later (rather than in this PR) with a change to the corresponding `pt` file (or @open-telemetry/docs-pt-approvers can do it)
