### PR TITLE
[demo] update helm prerequisite

### DIFF
--- a/content/en/docs/demo/kubernetes-deployment.md
+++ b/content/en/docs/demo/kubernetes-deployment.md
@@ -15,7 +15,7 @@ Helm's [documentation](https://helm.sh/docs/) to get started.
 
 - Kubernetes 1.24+
 - 6 GB of free RAM for the application
-- Helm 3.9+ (for Helm installation method only)
+- Helm 3.14+ (for Helm installation method only)
 
 ## Install using Helm (recommended)
 


### PR DESCRIPTION
As part of updating the Demo's Helm chart to version 1.12.0 of the Demo, we had to raise the Helm version prerequisite to `3.14+`.