### PR TITLE
[demo] add link to github repo

### DIFF
--- a/content/en/docs/demo/development.md
+++ b/content/en/docs/demo/development.md
@@ -4,6 +4,8 @@ title: Development
 cSpell:ignore: grpcio intellij libcurl libprotobuf nlohmann openssl protoc rebar
 ---
 
+[OpenTelemetry Demo GitHub repository](https://github.com/open-telemetry/opentelemetry-demo)
+
 Development for this demo requires tooling in several programming languages.
 Minimum required versions will be noted where possible, but it is recommended to
 update to the latest version for all tooling. The OpenTelemetry demo team will


### PR DESCRIPTION
Fixes #5508 by adding a link to the github repo for the demo