### PR TITLE
Add workflow to comment on new PRs

### DIFF
--- a/.github/workflows/pr-opened-help-message.yml
+++ b/.github/workflows/pr-opened-help-message.yml
@@ -1,0 +1,31 @@
+name: Pull Request Opened Help Message
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  pr-opened-help-message:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Hello 👋! Thanks for opening a pull request. 
+              
+              Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/). 
+                
+              We will run some checks on your PR. If they fail, take a look in to our [guide on pr-checks](https://opentelemetry.io/docs/contributing/pr-checks/). 
+              Most issues can be resolved by running \`npm run fix:all\` locally and pushing the changes. 
+              But please note that it is not your responsibility to fix all the issues. We will help you with that. 
+                
+              If you have any questions, feel free to ask.`
+            })


### PR DESCRIPTION
this is a follow up to #5489 and a different approach to address the issue: when contributors raise a PR with our project they were often struggle with our CI checks, since there are many of them and they are often not aware of the capabilities we have to auto-fix the most common issues. At the same time we want to let them know that they do not have to worry about failed CI checks, since we can help them with addressing them (often I actually prefer fixing them myself before merging a PR).

Currently a PR submitter will not get this information if they do not read deep into our contribution guidelines. So instead of leaving them lost when they submit a PR, I suggest 2 solutions (we can have both):

1. Put an automated comment under each PR that shares this information with the PR submitter (this PR)
2. Update the PULL_REQUEST_TEMPLATE to hold this information (will submit another PR for that)

Personally I would prefer having both options, but the downside of (1) is that it will comment on **every** new PR. There are ways to reduce that to first time contributors or we could only comment if CI checks fail, but I wanted to put this out for discussion first.

Here is a comment how it would look like: 

https://github.com/svrnm/opentelemetry.io/pull/189#issuecomment-2461722935