### PR TITLE
[CI] Don't check links on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,8 +78,6 @@
     "make:public": "make public ls-public",
     "netlify-build:preview": "npm run seq -- build:preview diff:check",
     "netlify-build:production": "npm run build:production",
-    "postbuild:preview": "npm run _check:links--warn",
-    "postbuild:production": "npm run _check:links--warn",
     "postget:submodule": "git submodule",
     "postnetlify-build:production": "git restore .htmltest.yml && npm run diff:check",
     "prebuild:preview": "npm run _prebuild",


### PR DESCRIPTION
- Avoids `postbuild` processing, which currently does link checking. We don't look anything for PRs since GH actions check links anyways. For more details, read below.

Context & discussion: I used to think that it was useful to have the links checked (esp. for production builds), so that we could track down issues by inspecting logs. And we're waiting other GH workflow checks in the case of PRs anyways. I've changed my mind. We can debug production build glitches locally, if ever they occur. And for PR builds, it'll be nice to get previews faster.