### PR TITLE
[i18n] Render-link fix: prepend lang code when page exists

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -10,10 +10,44 @@ IgnoreDirs:
   # DO NOT EDIT! IgnoreDirs list is auto-generated from markdown file front matter.
   # Ignore blog index pages for all locales and in all blog sections (top-level and years)
   - ^(../)?blog/(\d+/)?page/\d+
+  # TODO drop next lines after https://github.com/open-telemetry/opentelemetry.io/issues/5555 is fixed for these pages:
+  - ^es/docs/concepts/glossary/
+  - ^es/docs/concepts/instrumentation/zero-code/
+  - ^es/docs/concepts/signals/baggage/
+  - ^es/docs/zero-code/php/
+  # TODO drop next lines after https://github.com/open-telemetry/opentelemetry.io/issues/5555 is fixed for these pages:
+  - ^fr/docs/concepts/glossary/
+  # TODO drop next lines after https://github.com/open-telemetry/opentelemetry.io/issues/5555 is fixed for these pages:
+  - ^ja/docs/concepts/components/
+  - ^ja/docs/concepts/glossary/
+  - ^ja/docs/concepts/signals/baggage/
+  - ^ja/docs/languages/erlang/sampling/
+  - ^ja/docs/languages/js/sampling/
+  - ^ja/docs/languages/ruby/sampling/
+  - ^ja/docs/zero-code/php/
   # TODO drop next line after https://github.com/open-telemetry/opentelemetry.io/issues/5423 is fixed for ja pages:
   - ^ja/docs/concepts/instrumentation/libraries/
+  # TODO drop next lines after https://github.com/open-telemetry/opentelemetry.io/issues/5555 is fixed for these pages:
+  - ^pt/docs/concepts/components/
+  - ^pt/docs/concepts/glossary/
+  - ^pt/docs/concepts/signals/baggage/
+  - ^pt/docs/languages/erlang/instrumentation/
+  - ^pt/docs/languages/erlang/sampling/
+  - ^pt/docs/languages/js/instrumentation/
+  - ^pt/docs/languages/js/sampling/
+  - ^pt/docs/languages/net/instrumentation/
+  - ^pt/docs/languages/net/libraries/
+  - ^pt/docs/languages/net/shim/
+  - ^pt/docs/languages/php/instrumentation/
+  - ^pt/docs/languages/python/instrumentation/
+  - ^pt/docs/languages/ruby/instrumentation/
+  - ^pt/docs/languages/ruby/sampling/
+  - ^pt/docs/zero-code/php/
   # TODO drop next line after https://github.com/open-telemetry/opentelemetry.io/issues/5423 is fixed for pt pages:
   - ^pt/docs/concepts/instrumentation/libraries/
+  # TODO drop next lines after https://github.com/open-telemetry/opentelemetry.io/issues/5555 is fixed for these pages:
+  - ^zh/docs/concepts/signals/baggage/
+  - ^zh/docs/zero-code/php/
   # DO NOT EDIT! IgnoreDirs list is auto-generated from markdown file front matter.
 IgnoreInternalURLs: # list of paths
 IgnoreURLs: # list of regexs of paths or URLs to be ignored

--- a/content/es/docs/_index.md
+++ b/content/es/docs/_index.md
@@ -2,6 +2,13 @@
 title: Documentación
 linkTitle: Docs
 menu: { main: { weight: 10 } }
+htmltest:
+  IgnoreDirs:
+    # TODO drop next lines after https://github.com/open-telemetry/opentelemetry.io/issues/5555 is fixed for these pages:
+    - ^es/docs/concepts/glossary/
+    - ^es/docs/concepts/instrumentation/zero-code/
+    - ^es/docs/concepts/signals/baggage/
+    - ^es/docs/zero-code/php/
 default_lang_commit: f7cb8b65a478450d80d703b34c8473c579702108
 ---
 

--- a/content/fr/docs/what-is-opentelemetry.md
+++ b/content/fr/docs/what-is-opentelemetry.md
@@ -3,6 +3,10 @@ title: Qu'est-ce qu'OpenTelemetry ?
 description:
   Une brève explication de ce qu'est OpenTelemetry, et de ce qu'il n'est pas.
 weight: 150
+htmltest:
+  IgnoreDirs:
+    # TODO drop next lines after https://github.com/open-telemetry/opentelemetry.io/issues/5555 is fixed for these pages:
+    - ^fr/docs/concepts/glossary/
 default_lang_commit: 71833a5f8b84110dadf1e98604b87a900724ac33
 ---
 

--- a/content/ja/docs/_index.md
+++ b/content/ja/docs/_index.md
@@ -1,6 +1,16 @@
 ---
 title: ドキュメント
 menu: { main: { weight: 10 } }
+htmltest:
+  IgnoreDirs:
+    # TODO drop next lines after https://github.com/open-telemetry/opentelemetry.io/issues/5555 is fixed for these pages:
+    - ^ja/docs/concepts/components/
+    - ^ja/docs/concepts/glossary/
+    - ^ja/docs/concepts/signals/baggage/
+    - ^ja/docs/languages/erlang/sampling/
+    - ^ja/docs/languages/js/sampling/
+    - ^ja/docs/languages/ruby/sampling/
+    - ^ja/docs/zero-code/php/
 default_lang_commit: c2cd5b14
 ---
 

--- a/content/pt/docs/_index.md
+++ b/content/pt/docs/_index.md
@@ -2,6 +2,24 @@
 title: Documentação
 linkTitle: Docs
 menu: { main: { weight: 10 } }
+htmltest:
+  IgnoreDirs:
+    # TODO drop next lines after https://github.com/open-telemetry/opentelemetry.io/issues/5555 is fixed for these pages:
+    - ^pt/docs/concepts/components/
+    - ^pt/docs/concepts/glossary/
+    - ^pt/docs/concepts/signals/baggage/
+    - ^pt/docs/languages/erlang/instrumentation/
+    - ^pt/docs/languages/erlang/sampling/
+    - ^pt/docs/languages/js/instrumentation/
+    - ^pt/docs/languages/js/sampling/
+    - ^pt/docs/languages/net/instrumentation/
+    - ^pt/docs/languages/net/libraries/
+    - ^pt/docs/languages/net/shim/
+    - ^pt/docs/languages/php/instrumentation/
+    - ^pt/docs/languages/python/instrumentation/
+    - ^pt/docs/languages/ruby/instrumentation/
+    - ^pt/docs/languages/ruby/sampling/
+    - ^pt/docs/zero-code/php/
 default_lang_commit: 2d88c10e1a14220a88a6e4859acb4047f49b6519
 ---
 

--- a/content/zh/docs/_index.md
+++ b/content/zh/docs/_index.md
@@ -1,6 +1,11 @@
 ---
 title: 文档
 menu: { main: { weight: 10 } }
+htmltest:
+  IgnoreDirs:
+    # TODO drop next lines after https://github.com/open-telemetry/opentelemetry.io/issues/5555 is fixed for these pages:
+    - ^zh/docs/concepts/signals/baggage/
+    - ^zh/docs/zero-code/php/
 default_lang_commit: 6e35a949
 ---
 

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -4,37 +4,44 @@
 
   Localization link processing
 
-  The following code block will prefix the page language code to an
-  absolute path when:
+  The following code will prefix $url with the language code of this page when:
 
   - This page's localization isn't the default localization (English)
-  - The URL is an absolute path that doesn't start with any of the following:
-    - A language code, such as `ja`
-    - A path segment other than `docs`, since current OTel localizations only
-      offer translations for at most doc pages.
+  - $url is an absolute path -- that is, it starts with /
+  - The $url target page exists in this locale
 
   */ -}}
 
-{{ $defaultLang := "en" -}} {{/* TODO: can we avoid hard coding this value? */ -}}
-{{ $lang := .Page.Language.Lang -}}
-{{ if ne $lang $defaultLang -}}
-  {{ $langPathPrefix := add "/" $lang "/" -}}
-  {{ if and (hasPrefix $url $langPathPrefix) .Page.File -}}
-    {{ warnf "File %s: avoid prefixing the following link path with '%s': %s"
-             .Page.File.Filename $langPathPrefix $url -}}
-  {{ else if and (hasPrefix $url "/")
-            (not (findRE "^/(blog|community|docs/specs|ecosystem|status)/?" $url))
-  -}}
-    {{ if and false (not (findRE "^/[a-z][a-z](-[a-zA-Z]{2})?/" $url)) -}}
-      {{ $url = add $langPathPrefix (strings.TrimPrefix "/" $url) -}}
+{{ if hasPrefix $url "/" -}}
+  {{/* Hard-coded default lang since it's what's most efficient and won't change :) */ -}}
+  {{ $defaultLang := "en" -}}
+  {{ $lang := .Page.Language.Lang -}}
+  {{ if ne $lang $defaultLang -}}
+    {{ $langPathPrefix := add "/" $lang "/" -}}
+    {{ if and (hasPrefix $url $langPathPrefix) .Page.File -}}
+      {{ warnf "File %s: drop unnecessary '%s' prefix from %s"
+              .Page.File.Filename $langPathPrefix $url -}}
+    {{ else -}}
+      {{ $u := urls.Parse $url -}}
+      {{ $localizedPagePath := add $langPathPrefix (strings.TrimPrefix "/" $url) -}}
+      {{/*
+        Look for the page (referenced by $url) in this page's locale's site.
+        Note that .Page.GetPage exclusively looks for the given path in the same locale as .Page.
+      */ -}}
+      {{ with .Page.GetPage $u.Path -}}
+        {{/* warnf "Found url %s -> page %s. -- relRef %s" $localizedPagePath . (.RelRef (dict "path" $url))*/ -}}
+        {{/* Assert (eq $localizedPagePath (.RelRef (dict "path" $url))) */ -}}
+        {{ $url = $localizedPagePath -}}
+      {{ else -}}
+        {{/* Use $url as is, letting the link checker report any issues. */ -}}
+        {{/* warnf "Render-link: locale %s doesn't have the page %s (%s)" $lang $url $localizedPagePath */ -}}
+      {{ end -}}
     {{ end -}}
   {{ end -}}
 {{ end -}}
 
-
 {{/* General link-render processing */ -}}
 
-{{ $url := .Destination -}}
 {{ $isExternal := hasPrefix $url "http" -}}
 {{ if $isExternal -}}
   {{ if findRE "^https://opentelemetry.io/\\w" $url -}}
@@ -61,4 +68,8 @@
 >
   {{- .Text | safeHTML -}}
 </a>
-{{- /* This comment ensures that all trailing whitespace is trimmed. */ -}}
+
+{{- /*
+  cSpell:ignore warnf
+  This comment ensures that all trailing whitespace is trimmed.
+*/ -}}


### PR DESCRIPTION
- Fixes #5553
- Render-link hook: adds the language code prefix to absolute paths of links that appear in non-`en` pages
  - As a consequence of this fix, link-check failures are now reported and will need to be fixed.
- Adds `IgnoreDir` regexs so that the offending non-`en` are temporarily excluded from link-checking