### PR TITLE
[CI] Update pkgs, including Hugo to 0.138.0; use new `comment` shortcode

### DIFF
--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -257,7 +257,20 @@ Prometheus exporter, regardless of their origin, are prefixed with `otelcol_`.
 This includes metrics from both Collector components and instrumentation
 libraries. {{% /alert %}}
 
-<!---To compile this list, configure a Collector instance to emit its own metrics to the localhost:8888/metrics endpoint. Select a metric and grep for it in the Collector core repository. For example, the `otelcol_process_memory_rss` can be found using:`grep -Hrn "memory_rss" .` Make sure to eliminate from your search string any words that might be prefixes. Look through the results until you find the .go file that contains the list of metrics. In the case of `otelcol_process_memory_rss`, it and other process metrics can be found in https://github.com/open-telemetry/opentelemetry-collector/blob/31528ce81d44e9265e1a3bbbd27dc86d09ba1354/service/internal/proctelemetry/process_telemetry.go#L92. Note that the Collector's internal metrics are defined in several different files in the repository.--->
+{{% comment %}}
+
+To compile this list, configure a Collector instance to emit its own metrics to
+the localhost:8888/metrics endpoint. Select a metric and grep for it in the
+Collector core repository. For example, the `otelcol_process_memory_rss` can be
+found using:`grep -Hrn "memory_rss" .` Make sure to eliminate from your search
+string any words that might be prefixes. Look through the results until you find
+the .go file that contains the list of metrics. In the case of
+`otelcol_process_memory_rss`, it and other process metrics can be found in
+<https://github.com/open-telemetry/opentelemetry-collector/blob/31528ce81d44e9265e1a3bbbd27dc86d09ba1354/service/internal/proctelemetry/process_telemetry.go#L92>.
+Note that the Collector's internal metrics are defined in several different
+files in the repository.
+
+{{% /comment %}}
 
 #### `basic`-level metrics
 

--- a/package.json
+++ b/package.json
@@ -113,11 +113,11 @@
     "ajv-errors": "^3.0.0",
     "ajv-formats": "^3.0.1",
     "autoprefixer": "^10.4.20",
-    "cspell": "^8.15.5",
+    "cspell": "^8.16.0",
     "gulp": "^5.0.0",
-    "hugo-extended": "0.136.5",
+    "hugo-extended": "0.138.0",
     "js-yaml": "^4.1.0",
-    "markdown-link-check": "^3.12.2",
+    "markdown-link-check": "^3.13.6",
     "markdownlint": "^0.36.1",
     "postcss-cli": "^11.0.0",
     "prettier": "^3.3.3",
@@ -134,8 +134,8 @@
     "@opentelemetry/auto-instrumentations-web": "^0.42.0",
     "@opentelemetry/context-zone": "^1.27.0",
     "@opentelemetry/core": "^1.27.0",
-    "@opentelemetry/exporter-trace-otlp-http": "^0.54.0",
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.54.2",
+    "@opentelemetry/instrumentation": "^0.54.2",
     "@opentelemetry/resources": "^1.27.0",
     "@opentelemetry/sdk-trace-base": "^1.27.0",
     "@opentelemetry/sdk-trace-web": "^1.27.0",
@@ -144,7 +144,7 @@
   },
   "optionalDependencies": {
     "netlify-cli": "^17.37.2",
-    "npm-check-updates": "^17.1.9"
+    "npm-check-updates": "^17.1.10"
   },
   "enginesComment": "Ensure that engines.node value stays consistent with the project's .nvmrc",
   "engines": {


### PR DESCRIPTION
- Updates to Hugo [v0.138.0](https://github.com/gohugoio/hugo/releases/tag/v0.138.0)
- Illustrates use of the new Hugo [comment](https://gohugo.io/content-management/shortcodes/#comment) shortcode
- There are no changes to generated site files other than:
  - The updated Hugo version as part of the generator ID header element
  - The HTML comment removed from the page where this PR uses the `comment` shortcode instead.