### PR TITLE
[pt] Translate shortcode snippets /languages/exporters

### DIFF
--- a/content/pt/docs/concepts/components.md
+++ b/content/pt/docs/concepts/components.md
@@ -75,7 +75,7 @@ Para mais informações, consulte
 
 ### Exporters {#exporters}
 
-{{% docs/languages/exporters/intro %}}
+{{% pt/docs/languages/exporters/intro %}}
 
 ### Instrumentação sem código {#zero-code-instrumentation}
 

--- a/content/pt/docs/languages/go/exporters.md
+++ b/content/pt/docs/languages/go/exporters.md
@@ -7,7 +7,7 @@ default_lang_commit: 5e2a0b43c1f9f42824a024206e797cf7041ed9db
 cSpell:ignore: otlplog otlploggrpc otlploghttp otlpmetric otlpmetricgrpc otlpmetrichttp otlptrace otlptracegrpc otlptracehttp promhttp stdoutlog stdouttrace
 ---
 
-{{% docs/languages/exporters/intro go %}}
+{{% pt/docs/languages/exporters/intro go %}}
 
 ## Console
 

--- a/layouts/shortcodes/pt/docs/languages/exporters/intro.md
+++ b/layouts/shortcodes/pt/docs/languages/exporters/intro.md
@@ -97,5 +97,5 @@ Em seguida, execute o Collector em um contêiner Docker através do seguinte com
 docker run -p 4317:4317 -p 4318:4318 --rm -v $(pwd)/collector-config.yaml:/etc/otelcol/config.yaml otel/opentelemetry-collector
 ```
 
-Em alguns instantes, o Collector estará disponível para receber dados de telemetria via OTLP. Mais tarde, você também poderá querer [configurar o Collector](/docs/collector/configuration) para enviar os seus dados de telemetria para o seu _backend_ de observabilidade.
+Este Collector agora é capaz receber dados de telemetria via OTLP. Mais tarde, você também poderá [configurar o Collector](/docs/collector/configuration) para enviar os seus dados de telemetria para o seu _backend_ de observabilidade.
 {{ end -}}

--- a/layouts/shortcodes/pt/docs/languages/exporters/intro.md
+++ b/layouts/shortcodes/pt/docs/languages/exporters/intro.md
@@ -1,0 +1,101 @@
+{{/* cSpell:ignore cond */ -}} Envie dados de telemetria para o [OpenTelemetry Collector](/docs/collector/) para garantir que estes dados serão exportados corretamente. A utilização de um Collector em ambientes produtivos é a melhor prática. Para visualizar os dados de telemetria que foram gerados, realize a exportação para um ou mais _backends_ como [Jaeger](https://jaegertracing.io/), [Zipkin](https://zipkin.io/),
+[Prometheus](https://prometheus.io/), ou um backend 
+[específico de um fornecedor](/ecosystem/vendors/).
+
+{{ $lang := .Get 0 | default "" -}}
+
+{{ $name := "" -}}
+
+{{ if $lang -}}
+
+{{ $name = (index $.Site.Data.instrumentation $lang).name -}}
+
+## Exportadores disponíveis {#available-exporters}
+
+O registro oferece uma [lista de exportadores para {{ $name }}][reg].
+
+{{ else -}}
+
+O registro oferece uma [lista de exportadores específicos para a linguagem][reg].
+
+{{ end -}}
+
+Entre os exportadores, os exportadores do [OpenTelemetry Protocol (OTLP)][OTLP] são projetados tendo em mente o modelo de dados do OpenTelemetry, emitindo dados OTel sem qualquer perda de informação. Além disso, muitas ferramentas que operam com dados de telemetria suportam o formato OTLP (como [Prometheus][Prometheus], [Jaeger][Jaeger] e a maioria dos [fornecedores][vendors]), proporcionando um alto grau de flexibilidade quando necessário. Para saber mais sobre o OTLP, consulte a [Especificação do OTLP][OTLP].
+
+[Jaeger]: /blog/2022/jaeger-native-otlp/
+[OTLP]: /docs/specs/otlp/
+[Prometheus]:
+  https://prometheus.io/docs/prometheus/latest/feature_flags/#otlp-receiver
+[vendors]: /ecosystem/vendors/
+
+[reg]: /ecosystem/registry/?component=exporter&language={{ $lang }}
+
+{{ if $name -}}
+
+Esta página reúne informações sobre os principais exportadores do OpenTelemetry {{ $name }} e como configurá-los.
+
+{{ end -}}
+
+{{ $l := cond (eq $lang "dotnet") "net" $lang }}
+{{ with $.Page.GetPage (print "/docs/zero-code/" $l "/configuration" ) }}
+
+<div class="alert alert-info" role="alert"><h4 class="alert-heading">Nota</h4>
+
+Caso você esteja utilizando [instrumentação sem código](/docs/zero-code/{{ $l }}), você poderá aprender a configurar os exporters através do [Guia de Configurações](/docs/zero-code/{{ $l }}/configuration/).
+
+</div>
+
+{{ end -}}
+
+{{/*
+ below list needs to grow until all languages are updated to a consistent structure.
+ */ -}}
+
+{{ if in (slice "python" "js" "java" "cpp" "dotnet") $lang -}}
+
+## OTLP
+
+### Configuração do Collector {#collector-setup}
+
+<div class="alert alert-info" role="alert"><h4 class="alert-heading">Nota</h4>
+
+Caso já possua um coletor ou _backend_ OTLP configurado, poderá pular para [configurar as dependências do exportador OTLP](#otlp-dependencies) para a sua aplicação.
+
+</div>
+
+Para testar e validar os seus exportadores OTLP, é possível executar o Collector em um contêiner Docker que escreve os dados diretamente no console.
+
+Em uma pasta vazia, crie um arquivo chamado `collector-config.yaml` e adicione o seguinte conteúdo:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+exporters:
+  debug:
+    verbosity: detailed
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [debug]
+    metrics:
+      receivers: [otlp]
+      exporters: [debug]
+    logs:
+      receivers: [otlp]
+      exporters: [debug]
+```
+
+Em seguida, execute o Collector em um contêiner Docker através do seguinte comando:
+
+```shell
+docker run -p 4317:4317 -p 4318:4318 --rm -v $(pwd)/collector-config.yaml:/etc/otelcol/config.yaml otel/opentelemetry-collector
+```
+
+Em alguns instantes, o Collector estará disponível para receber dados de telemetria via OTLP. Mais tarde, você também poderá querer [configurar o Collector](/docs/collector/configuration) para enviar os seus dados de telemetria para o seu _backend_ de observabilidade.
+{{ end -}}

--- a/layouts/shortcodes/pt/docs/languages/exporters/intro.md
+++ b/layouts/shortcodes/pt/docs/languages/exporters/intro.md
@@ -1,5 +1,5 @@
 {{/* cSpell:ignore cond */ -}} Envie dados de telemetria para o [OpenTelemetry Collector](/docs/collector/) para garantir que estes dados sejam exportados corretamente. A utilização de um Collector em ambientes de produção é a melhor prática. Para visualizar os dados de telemetria que foram gerados, exporte-os para um _backend_ como [Jaeger](https://jaegertracing.io/), [Zipkin](https://zipkin.io/),
-[Prometheus](https://prometheus.io/), ou um backend 
+[Prometheus](https://prometheus.io/), ou um _backend_ 
 [específico de um fornecedor](/ecosystem/vendors/).
 
 {{ $lang := .Get 0 | default "" -}}

--- a/layouts/shortcodes/pt/docs/languages/exporters/intro.md
+++ b/layouts/shortcodes/pt/docs/languages/exporters/intro.md
@@ -1,4 +1,4 @@
-{{/* cSpell:ignore cond */ -}} Envie dados de telemetria para o [OpenTelemetry Collector](/docs/collector/) para garantir que estes dados serão exportados corretamente. A utilização de um Collector em ambientes produtivos é a melhor prática. Para visualizar os dados de telemetria que foram gerados, realize a exportação para um ou mais _backends_ como [Jaeger](https://jaegertracing.io/), [Zipkin](https://zipkin.io/),
+{{/* cSpell:ignore cond */ -}} Envie dados de telemetria para o [OpenTelemetry Collector](/docs/collector/) para garantir que estes dados sejam exportados corretamente. A utilização de um Collector em ambientes de produção é a melhor prática. Para visualizar os dados de telemetria que foram gerados, exporte-os para um _backend_ como [Jaeger](https://jaegertracing.io/), [Zipkin](https://zipkin.io/),
 [Prometheus](https://prometheus.io/), ou um backend 
 [específico de um fornecedor](/ecosystem/vendors/).
 

--- a/layouts/shortcodes/pt/docs/languages/exporters/intro.md
+++ b/layouts/shortcodes/pt/docs/languages/exporters/intro.md
@@ -1,6 +1,10 @@
-{{/* cSpell:ignore cond */ -}} Envie dados de telemetria para o [OpenTelemetry Collector](/docs/collector/) para garantir que estes dados sejam exportados corretamente. A utilização de um Collector em ambientes de produção é a melhor prática. Para visualizar os dados de telemetria que foram gerados, exporte-os para um _backend_ como [Jaeger](https://jaegertracing.io/), [Zipkin](https://zipkin.io/),
-[Prometheus](https://prometheus.io/), ou um _backend_ 
-[específico de um fornecedor](/ecosystem/vendors/).
+{{/* cSpell:ignore cond */ -}} Envie dados de telemetria para o
+[OpenTelemetry Collector](/docs/collector/) para garantir que estes dados sejam
+exportados corretamente. A utilização de um Collector em ambientes de produção é
+a melhor prática. Para visualizar os dados de telemetria que foram gerados,
+exporte-os para um _backend_ como [Jaeger](https://jaegertracing.io/),
+[Zipkin](https://zipkin.io/), [Prometheus](https://prometheus.io/), ou um
+_backend_ [específico de um fornecedor](/ecosystem/vendors/).
 
 {{ $lang := .Get 0 | default "" -}}
 
@@ -20,7 +24,13 @@ O registro oferece uma [lista de exportadores específicos de linguagem][reg].
 
 {{ end -}}
 
-Entre os exportadores, os exportadores do [OpenTelemetry Protocol (OTLP)][OTLP] são projetados tendo em mente o modelo de dados do OpenTelemetry, emitindo dados OTel sem qualquer perda de informação. Além disso, muitas ferramentas que operam com dados de telemetria suportam o formato OTLP (como [Prometheus][Prometheus], [Jaeger][Jaeger] e a maioria dos [fornecedores][vendors]), proporcionando um alto grau de flexibilidade quando necessário. Para saber mais sobre o OTLP, consulte a [Especificação do OTLP][OTLP].
+Entre os exportadores, os exportadores do [OpenTelemetry Protocol (OTLP)][OTLP]
+são projetados tendo em mente o modelo de dados do OpenTelemetry, emitindo dados
+OTel sem qualquer perda de informação. Além disso, muitas ferramentas que operam
+com dados de telemetria suportam o formato OTLP (como [Prometheus][Prometheus],
+[Jaeger][Jaeger] e a maioria dos [fornecedores][vendors]), proporcionando um
+alto grau de flexibilidade quando necessário. Para saber mais sobre o OTLP,
+consulte a [Especificação do OTLP][OTLP].
 
 [Jaeger]: /blog/2022/jaeger-native-otlp/
 [OTLP]: /docs/specs/otlp/
@@ -32,7 +42,8 @@ Entre os exportadores, os exportadores do [OpenTelemetry Protocol (OTLP)][OTLP] 
 
 {{ if $name -}}
 
-Esta página reúne informações sobre os principais exportadores do OpenTelemetry {{ $name }} e como configurá-los.
+Esta página reúne informações sobre os principais exportadores do OpenTelemetry
+{{ $name }} e como configurá-los.
 
 {{ end -}}
 
@@ -41,7 +52,10 @@ Esta página reúne informações sobre os principais exportadores do OpenTeleme
 
 <div class="alert alert-info" role="alert"><h4 class="alert-heading">Nota</h4>
 
-Caso você esteja utilizando [instrumentação sem código](/docs/zero-code/{{ $l }}), você poderá aprender a configurar os exporters através do [Guia de Configurações](/docs/zero-code/{{ $l }}/configuration/).
+Caso você esteja utilizando [instrumentação sem
+código](/docs/zero-code/{{ $l }}), você poderá aprender a configurar os
+exporters através do [Guia de
+Configurações](/docs/zero-code/{{ $l }}/configuration/).
 
 </div>
 
@@ -59,13 +73,17 @@ Caso você esteja utilizando [instrumentação sem código](/docs/zero-code/{{ $
 
 <div class="alert alert-info" role="alert"><h4 class="alert-heading">Nota</h4>
 
-Caso já possua um coletor ou _backend_ OTLP configurado, poderá pular para [configurar as dependências do exportador OTLP](#otlp-dependencies) para a sua aplicação.
+Caso já possua um coletor ou _backend_ OTLP configurado, poderá pular para
+[configurar as dependências do exportador OTLP](#otlp-dependencies) para a sua
+aplicação.
 
 </div>
 
-Para testar e validar os seus exportadores OTLP, é possível executar o Collector em um contêiner Docker que escreve os dados diretamente no console.
+Para testar e validar os seus exportadores OTLP, é possível executar o Collector
+em um contêiner Docker que escreve os dados diretamente no console.
 
-Em uma pasta vazia, crie um arquivo chamado `collector-config.yaml` e adicione o seguinte conteúdo:
+Em uma pasta vazia, crie um arquivo chamado `collector-config.yaml` e adicione o
+seguinte conteúdo:
 
 ```yaml
 receivers:
@@ -91,11 +109,14 @@ service:
       exporters: [debug]
 ```
 
-Em seguida, execute o Collector em um contêiner Docker através do seguinte comando:
+Em seguida, execute o Collector em um contêiner Docker através do seguinte
+comando:
 
 ```shell
 docker run -p 4317:4317 -p 4318:4318 --rm -v $(pwd)/collector-config.yaml:/etc/otelcol/config.yaml otel/opentelemetry-collector
 ```
 
-Este Collector agora é capaz receber dados de telemetria via OTLP. Mais tarde, você também poderá [configurar o Collector](/docs/collector/configuration) para enviar os seus dados de telemetria para o seu _backend_ de observabilidade.
+Este Collector agora é capaz receber dados de telemetria via OTLP. Mais tarde,
+você também poderá [configurar o Collector](/docs/collector/configuration) para
+enviar os seus dados de telemetria para o seu _backend_ de observabilidade.
 {{ end -}}

--- a/layouts/shortcodes/pt/docs/languages/exporters/intro.md
+++ b/layouts/shortcodes/pt/docs/languages/exporters/intro.md
@@ -16,7 +16,7 @@ O registro oferece uma [lista de exportadores para {{ $name }}][reg].
 
 {{ else -}}
 
-O registro oferece uma [lista de exportadores específicos para a linguagem][reg].
+O registro oferece uma [lista de exportadores específicos de linguagem][reg].
 
 {{ end -}}
 

--- a/layouts/shortcodes/pt/docs/languages/exporters/intro.md
+++ b/layouts/shortcodes/pt/docs/languages/exporters/intro.md
@@ -48,7 +48,7 @@ Caso você esteja utilizando [instrumentação sem código](/docs/zero-code/{{ $
 {{ end -}}
 
 {{/*
- below list needs to grow until all languages are updated to a consistent structure.
+ a lista a seguir precisa crescer até que todas as línguas sejam atualizadas para uma estrutura consistente.
  */ -}}
 
 {{ if in (slice "python" "js" "java" "cpp" "dotnet") $lang -}}

--- a/layouts/shortcodes/pt/docs/languages/exporters/jaeger.md
+++ b/layouts/shortcodes/pt/docs/languages/exporters/jaeger.md
@@ -1,0 +1,19 @@
+## Jaeger
+
+### Configuração do Backend {#jaeger-backend-setup}
+
+O [Jaeger](https://www.jaegertracing.io/) suporta nativamente o OTLP para receber dados de telemetria. O Jaeger pode ser executado através de um contêiner Docker com uma UI acessível através da porta 16686 e OTLP habilitados nas portas 4317 e 4318:
+
+```shell
+docker run --rm \
+  -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
+  -p 16686:16686 \
+  -p 4317:4317 \
+  -p 4318:4318 \
+  -p 9411:9411 \
+  jaegertracing/all-in-one:latest
+```
+
+### Uso {#jaeger-usage}
+
+Siga as instruções para configurar os [exportadores OTLP](#otlp-dependencies).

--- a/layouts/shortcodes/pt/docs/languages/exporters/jaeger.md
+++ b/layouts/shortcodes/pt/docs/languages/exporters/jaeger.md
@@ -2,7 +2,7 @@
 
 ### Configuração do Backend {#jaeger-backend-setup}
 
-O [Jaeger](https://www.jaegertracing.io/) suporta nativamente o OTLP para receber dados de telemetria. O Jaeger pode ser executado através de um contêiner Docker com uma UI acessível através da porta 16686 e OTLP habilitados nas portas 4317 e 4318:
+O [Jaeger](https://www.jaegertracing.io/) suporta nativamente o OTLP para receber dados de rastros. O Jaeger pode ser executado através de um contêiner Docker com uma UI acessível através da porta 16686 e OTLP habilitados nas portas 4317 e 4318:
 
 ```shell
 docker run --rm \

--- a/layouts/shortcodes/pt/docs/languages/exporters/jaeger.md
+++ b/layouts/shortcodes/pt/docs/languages/exporters/jaeger.md
@@ -2,7 +2,10 @@
 
 ### Configuração do Backend {#jaeger-backend-setup}
 
-O [Jaeger](https://www.jaegertracing.io/) suporta nativamente o OTLP para receber dados de rastros. O Jaeger pode ser executado através de um contêiner Docker com uma UI acessível através da porta 16686 e OTLP habilitados nas portas 4317 e 4318:
+O [Jaeger](https://www.jaegertracing.io/) suporta nativamente o OTLP para
+receber dados de rastros. O Jaeger pode ser executado através de um contêiner
+Docker com uma UI acessível através da porta 16686 e OTLP habilitados nas portas
+4317 e 4318:
 
 ```shell
 docker run --rm \

--- a/layouts/shortcodes/pt/docs/languages/exporters/outro.md
+++ b/layouts/shortcodes/pt/docs/languages/exporters/outro.md
@@ -1,11 +1,16 @@
 {{ $lang := .Get 0 -}} {{ $spanExporterInterfaceUrl := .Get 1 }}
 
-## Exportadores personalizados {#custom-exporters} 
+## Exportadores personalizados {#custom-exporters}
 
-Por fim, também é possível escrever o seu próprio exportador. Para mais informações, consulte [SpanExporter Interface na documentação da API]({{ $spanExporterInterfaceUrl }}).
+Por fim, também é possível escrever o seu próprio exportador. Para mais
+informações, consulte [SpanExporter Interface na documentação da
+API]({{ $spanExporterInterfaceUrl }}).
 
 ## Agrupamento de trechos e registros de log {#batching-span-and-log-records}
 
-O SDK do OpenTelemetry fornece um conjunto de processadores padrão de trechos e registros de log, que permitem emitir trechos um-a-um ("simples") ou em lotes. O uso de agrupamentos é recomendado, mas caso não deseje agrupar seus trechos ou registros de log, é possível utilizar um processador simples da seguinte forma:
+O SDK do OpenTelemetry fornece um conjunto de processadores padrão de trechos e
+registros de log, que permitem emitir trechos um-a-um ("simples") ou em lotes. O
+uso de agrupamentos é recomendado, mas caso não deseje agrupar seus trechos ou
+registros de log, é possível utilizar um processador simples da seguinte forma:
 
-{{ .Inner }} 
+{{ .Inner }}

--- a/layouts/shortcodes/pt/docs/languages/exporters/outro.md
+++ b/layouts/shortcodes/pt/docs/languages/exporters/outro.md
@@ -6,6 +6,6 @@ Por fim, também é possível escrever o seu próprio exportador. Para mais info
 
 ## Agrupamento de Trechos e Registros de Log {#batching-span-and-log-records}
 
-O SDK do OpenTelemetry fornece um conjunto de processadores de Trechos e Registros de Log padrão, que permitem emitir Trechos um-a-um ("simples") ou em lotes. O uso de agrupamentos é recomendado, mas caso não deseje agrupar seus Trechos ou Registros de Log, é possível utilizar um processador simples da seguinte forma:
+O SDK do OpenTelemetry fornece um conjunto de processadores padrão de trechos e registros de log, que permitem emitir trechos um-a-um ("simples") ou em lotes. O uso de agrupamentos é recomendado, mas caso não deseje agrupar seus trechos ou registros de log, é possível utilizar um processador simples da seguinte forma:
 
 {{ .Inner }} 

--- a/layouts/shortcodes/pt/docs/languages/exporters/outro.md
+++ b/layouts/shortcodes/pt/docs/languages/exporters/outro.md
@@ -1,0 +1,11 @@
+{{ $lang := .Get 0 -}} {{ $spanExporterInterfaceUrl := .Get 1 }}
+
+## Exportadores personalizados {#custom-exporters} 
+
+Por fim, também é possível escrever o seu próprio exportador. Para mais informações, consulte [SpanExporter Interface na documentação da API]({{ $spanExporterInterfaceUrl }}).
+
+## Agrupamento de Trechos e Registros de Log {#batching-span-and-log-records}
+
+O SDK do OpenTelemetry fornece um conjunto de processadores de Trechos e Registros de Log padrão, que permitem emitir Trechos um-a-um ("simples") ou em lotes. O uso de agrupamentos é recomendado, mas caso não deseje agrupar seus Trechos ou Registros de Log, é possível utilizar um processador simples da seguinte forma:
+
+{{ .Inner }} 

--- a/layouts/shortcodes/pt/docs/languages/exporters/outro.md
+++ b/layouts/shortcodes/pt/docs/languages/exporters/outro.md
@@ -4,7 +4,7 @@
 
 Por fim, também é possível escrever o seu próprio exportador. Para mais informações, consulte [SpanExporter Interface na documentação da API]({{ $spanExporterInterfaceUrl }}).
 
-## Agrupamento de Trechos e Registros de Log {#batching-span-and-log-records}
+## Agrupamento de trechos e registros de log {#batching-span-and-log-records}
 
 O SDK do OpenTelemetry fornece um conjunto de processadores padrão de trechos e registros de log, que permitem emitir trechos um-a-um ("simples") ou em lotes. O uso de agrupamentos é recomendado, mas caso não deseje agrupar seus trechos ou registros de log, é possível utilizar um processador simples da seguinte forma:
 

--- a/layouts/shortcodes/pt/docs/languages/exporters/prometheus-setup.md
+++ b/layouts/shortcodes/pt/docs/languages/exporters/prometheus-setup.md
@@ -1,6 +1,6 @@
 ## Prometheus
 
-Para enviar dados de métricas para o [Prometheus](https://prometheus.io/), é possível
+Para enviar dados de métricas para o [Prometheus](https://prometheus.io/), você pode
 [ativar o OTLP Receiver do Prometheus](https://prometheus.io/docs/prometheus/latest/feature_flags/#otlp-receiver)
 e utilizar o [exportador OTLP](#otlp) ou utilizar o exportador do Prometheus, um `MetricReader` que inicia um servidor HTTP e coleta métricas, serializando para o formato de texto do Prometheus sob demanda.
 

--- a/layouts/shortcodes/pt/docs/languages/exporters/prometheus-setup.md
+++ b/layouts/shortcodes/pt/docs/languages/exporters/prometheus-setup.md
@@ -2,7 +2,7 @@
 
 Para enviar dados de métricas para o [Prometheus](https://prometheus.io/), você pode
 [ativar o OTLP Receiver do Prometheus](https://prometheus.io/docs/prometheus/latest/feature_flags/#otlp-receiver)
-e utilizar o [exportador OTLP](#otlp) ou utilizar o exportador do Prometheus, um `MetricReader` que inicia um servidor HTTP e coleta métricas, serializando para o formato de texto do Prometheus sob demanda.
+e utilizar o [exportador OTLP](#otlp) ou você pode utilizar o exportador do Prometheus, um `MetricReader` que inicia um servidor HTTP e coleta métricas, serializando para o formato de texto do Prometheus sob demanda.
 
 ### Configuração do Backend {#prometheus-setup}
 

--- a/layouts/shortcodes/pt/docs/languages/exporters/prometheus-setup.md
+++ b/layouts/shortcodes/pt/docs/languages/exporters/prometheus-setup.md
@@ -1,0 +1,39 @@
+## Prometheus
+
+Para enviar dados de métricas para o [Prometheus](https://prometheus.io/), é possível
+[ativar o OTLP Receiver do Prometheus](https://prometheus.io/docs/prometheus/latest/feature_flags/#otlp-receiver)
+e utilizar o [exportador OTLP](#otlp) ou utilizar o exportador do Prometheus, um `MetricReader` que inicia um servidor HTTP e coleta métricas, serializando para o formato de texto do Prometheus sob demanda.
+
+### Configuração do Backend {#prometheus-setup}
+
+<div class="alert alert-info" role="alert"><h4 class="alert-heading">Nota</h4>
+
+Caso já possua o Prometheus ou um backend compatível com Prometheus configurado, poderá pular esta seção e configurar as dependências do exportador [Prometheus](#prometheus-dependencies) ou [OTLP](#otlp-dependencies) para a sua aplicação.
+
+</div>
+
+É possível executar o [Prometheus](https://prometheus.io) em um contêiner Docker acessível na porta `9090` através das seguintes instruções:
+
+Em uma pasta vazia, crie um arquivo chamado `prometheus.yml` e adicione o seguinte conteúdo:
+
+```yaml
+scrape_configs:
+  - job_name: dice-service
+    scrape_interval: 5s
+    static_configs:
+      - targets: [host.docker.internal:9464]
+```
+
+Em seguida, execute o Prometheus em um contêiner Docker que ficará acessível na porta `9090` através do seguinte comando:
+
+```shell
+docker run --rm -v ${PWD}/prometheus.yml:/prometheus/prometheus.yml -p 9090:9090 prom/prometheus --enable-feature=otlp-write-receive
+```
+
+<div class="alert alert-info" role="alert"><h4 class="alert-heading">Nota</h4>
+
+Ao utilizar o OTLP Receiver do Prometheus, certifique-se de definir o endpoint OTLP das métricas em sua aplicação para `http://localhost:9090/api/v1/otlp`.
+
+Nem todos os ambientes Docker suportam `host.docker.internal`. Em alguns casos, será necessário alterar o valor `host.docker.internal` para `localhost` ou o endereço de IP de sua máquina.
+
+</div>

--- a/layouts/shortcodes/pt/docs/languages/exporters/prometheus-setup.md
+++ b/layouts/shortcodes/pt/docs/languages/exporters/prometheus-setup.md
@@ -1,20 +1,28 @@
 ## Prometheus
 
-Para enviar dados de métricas para o [Prometheus](https://prometheus.io/), você pode
+Para enviar dados de métricas para o [Prometheus](https://prometheus.io/), você
+pode
 [ativar o OTLP Receiver do Prometheus](https://prometheus.io/docs/prometheus/latest/feature_flags/#otlp-receiver)
-e utilizar o [exportador OTLP](#otlp) ou você pode utilizar o exportador do Prometheus, um `MetricReader` que inicia um servidor HTTP e coleta métricas, serializando para o formato de texto do Prometheus sob demanda.
+e utilizar o [exportador OTLP](#otlp) ou você pode utilizar o exportador do
+Prometheus, um `MetricReader` que inicia um servidor HTTP e coleta métricas,
+serializando para o formato de texto do Prometheus sob demanda.
 
 ### Configuração do Backend {#prometheus-setup}
 
 <div class="alert alert-info" role="alert"><h4 class="alert-heading">Nota</h4>
 
-Caso já possua o Prometheus ou um _backend_ compatível com Prometheus configurado, poderá pular esta seção e configurar as dependências do exportador [Prometheus](#prometheus-dependencies) ou [OTLP](#otlp-dependencies) para a sua aplicação.
+Caso já possua o Prometheus ou um _backend_ compatível com Prometheus
+configurado, poderá pular esta seção e configurar as dependências do exportador
+[Prometheus](#prometheus-dependencies) ou [OTLP](#otlp-dependencies) para a sua
+aplicação.
 
 </div>
 
-É possível executar o [Prometheus](https://prometheus.io) em um contêiner Docker acessível na porta `9090` através das seguintes instruções:
+É possível executar o [Prometheus](https://prometheus.io) em um contêiner Docker
+acessível na porta `9090` através das seguintes instruções:
 
-Em uma pasta vazia, crie um arquivo chamado `prometheus.yml` e adicione o seguinte conteúdo:
+Em uma pasta vazia, crie um arquivo chamado `prometheus.yml` e adicione o
+seguinte conteúdo:
 
 ```yaml
 scrape_configs:
@@ -24,7 +32,8 @@ scrape_configs:
       - targets: [host.docker.internal:9464]
 ```
 
-Em seguida, execute o Prometheus em um contêiner Docker que ficará acessível na porta `9090` através do seguinte comando:
+Em seguida, execute o Prometheus em um contêiner Docker que ficará acessível na
+porta `9090` através do seguinte comando:
 
 ```shell
 docker run --rm -v ${PWD}/prometheus.yml:/prometheus/prometheus.yml -p 9090:9090 prom/prometheus --enable-feature=otlp-write-receive
@@ -32,8 +41,11 @@ docker run --rm -v ${PWD}/prometheus.yml:/prometheus/prometheus.yml -p 9090:9090
 
 <div class="alert alert-info" role="alert"><h4 class="alert-heading">Nota</h4>
 
-Ao utilizar o OTLP Receiver do Prometheus, certifique-se de definir o endpoint OTLP das métricas em sua aplicação para `http://localhost:9090/api/v1/otlp`.
+Ao utilizar o OTLP Receiver do Prometheus, certifique-se de definir o endpoint
+OTLP das métricas em sua aplicação para `http://localhost:9090/api/v1/otlp`.
 
-Nem todos os ambientes Docker suportam `host.docker.internal`. Em alguns casos, será necessário alterar o valor `host.docker.internal` para `localhost` ou o endereço de IP de sua máquina.
+Nem todos os ambientes Docker suportam `host.docker.internal`. Em alguns casos,
+será necessário alterar o valor `host.docker.internal` para `localhost` ou o
+endereço de IP de sua máquina.
 
 </div>

--- a/layouts/shortcodes/pt/docs/languages/exporters/prometheus-setup.md
+++ b/layouts/shortcodes/pt/docs/languages/exporters/prometheus-setup.md
@@ -8,7 +8,7 @@ e utilizar o [exportador OTLP](#otlp) ou utilizar o exportador do Prometheus, um
 
 <div class="alert alert-info" role="alert"><h4 class="alert-heading">Nota</h4>
 
-Caso já possua o Prometheus ou um backend compatível com Prometheus configurado, poderá pular esta seção e configurar as dependências do exportador [Prometheus](#prometheus-dependencies) ou [OTLP](#otlp-dependencies) para a sua aplicação.
+Caso já possua o Prometheus ou um _backend_ compatível com Prometheus configurado, poderá pular esta seção e configurar as dependências do exportador [Prometheus](#prometheus-dependencies) ou [OTLP](#otlp-dependencies) para a sua aplicação.
 
 </div>
 

--- a/layouts/shortcodes/pt/docs/languages/exporters/zipkin-setup.md
+++ b/layouts/shortcodes/pt/docs/languages/exporters/zipkin-setup.md
@@ -1,0 +1,15 @@
+## Zipkin
+
+### Configuração do Backend {#zipkin-setup}
+
+<div class="alert alert-info" role="alert"><h4 class="alert-heading">Nota</h4>
+
+Caso já possua o Zipkin ou um backend compatível com Zipkin configurado, poderá pular esta seção e configurar as [dependências do exportador Zipkin](#zipkin-dependencies) para a sua aplicação.
+
+</div>
+
+É possível executar o [Zipkin][Zipkin](https://zipkin.io/) em um contêiner Docker através do seguinte comando:
+
+```shell
+docker run --rm -d -p 9411:9411 --name zipkin openzipkin/zipkin
+```

--- a/layouts/shortcodes/pt/docs/languages/exporters/zipkin-setup.md
+++ b/layouts/shortcodes/pt/docs/languages/exporters/zipkin-setup.md
@@ -4,11 +4,14 @@
 
 <div class="alert alert-info" role="alert"><h4 class="alert-heading">Nota</h4>
 
-Caso já possua o Zipkin ou um _backend_ compatível com Zipkin configurado, poderá pular esta seção e configurar as [dependências do exportador Zipkin](#zipkin-dependencies) para a sua aplicação.
+Caso já possua o Zipkin ou um _backend_ compatível com Zipkin configurado,
+poderá pular esta seção e configurar as
+[dependências do exportador Zipkin](#zipkin-dependencies) para a sua aplicação.
 
 </div>
 
-É possível executar o [Zipkin][Zipkin](https://zipkin.io/) em um contêiner Docker através do seguinte comando:
+É possível executar o [Zipkin][Zipkin](https://zipkin.io/) em um contêiner
+Docker através do seguinte comando:
 
 ```shell
 docker run --rm -d -p 9411:9411 --name zipkin openzipkin/zipkin

--- a/layouts/shortcodes/pt/docs/languages/exporters/zipkin-setup.md
+++ b/layouts/shortcodes/pt/docs/languages/exporters/zipkin-setup.md
@@ -4,7 +4,7 @@
 
 <div class="alert alert-info" role="alert"><h4 class="alert-heading">Nota</h4>
 
-Caso já possua o Zipkin ou um backend compatível com Zipkin configurado, poderá pular esta seção e configurar as [dependências do exportador Zipkin](#zipkin-dependencies) para a sua aplicação.
+Caso já possua o Zipkin ou um _backend_ compatível com Zipkin configurado, poderá pular esta seção e configurar as [dependências do exportador Zipkin](#zipkin-dependencies) para a sua aplicação.
 
 </div>
 


### PR DESCRIPTION
* Add new translations:
   - layouts/shortcodes/pt/docs/languages/exporters/intro.md
   - layouts/shortcodes/pt/docs/languages/exporters/jaeger.md
   - layouts/shortcodes/pt/docs/languages/exporters/outro.md
   - layouts/shortcodes/pt/docs/languages/exporters/prometheus-setup.md
   - layouts/shortcodes/pt/docs/languages/exporters/zipkin-setup.md
* Fixes translations for snippets on:
   - content/pt/docs/concepts/components.md (https://opentelemetry.io/pt/docs/concepts/components/#exporters)
   - content/pt/docs/languages/go/exporters.md (https://opentelemetry.io/pt/docs/languages/go/exporters/)

Fixes #5592 