### PR TITLE
Registry data cleanup: add urls to all authors

### DIFF
--- a/data/registry/application-integration-python-cisco-nso.yml
+++ b/data/registry/application-integration-python-cisco-nso.yml
@@ -13,6 +13,7 @@ description:
   The NSO Observability Exporter supports export of progress traces using OTLP.
 authors:
   - name: Cisco
+    url: https://www.cisco.com/
 urls:
   website: https://www.cisco.com/c/en/us/products/cloud-systems-management/network-services-orchestrator/index.html
   docs: https://developer.cisco.com/docs/nso/#!observability-exporter/

--- a/data/registry/collector-exporter-alibaba-cloud-log-service.yml
+++ b/data/registry/collector-exporter-alibaba-cloud-log-service.yml
@@ -10,7 +10,7 @@ license: Apache 2.0
 description:
   The Alibaba Cloud Log Service Exporter for the OpenTelemetry Collector.
 authors:
-  - name: Alibaba Cloud
+  - name: OpenTelemetry Authors
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/alibabacloudlogserviceexporter
 createdAt: 2021-02-24

--- a/data/registry/collector-exporter-apiclarity.yml
+++ b/data/registry/collector-exporter-apiclarity.yml
@@ -11,7 +11,8 @@ license: Apache 2.0
 description:
   Exports traces and/or metrics via HTTP to an APIClarity endpoint for analysis.
 authors:
-  - name: Cisco Systems
+  - name: Cisco
+    url: https://www.cisco.com
 urls:
   repo: https://github.com/openclarity/apiclarity/tree/master/plugins/otel-collector
 createdAt: 2022-11-28

--- a/data/registry/collector-exporter-aws-xray.yml
+++ b/data/registry/collector-exporter-aws-xray.yml
@@ -9,7 +9,7 @@ tags:
 license: Apache 2.0
 description: The AWS X-Ray Tracing Exporter for the OpenTelemetry Collector.
 authors:
-  - name: Amazon Web Services
+  - name: OpenTelemetry Authors
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awsxrayexporter
 createdAt: 2020-06-06

--- a/data/registry/collector-exporter-awsemf.yml
+++ b/data/registry/collector-exporter-awsemf.yml
@@ -9,7 +9,7 @@ tags:
 license: Apache 2.0
 description: The AWS CloudWatch EMF Exporter for the OpenTelemetry Collector.
 authors:
-  - name: Amazon Web Services
+  - name: OpenTelemetry Authors
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awsemfexporter
 createdAt: 2020-06-06

--- a/data/registry/collector-exporter-coralogix.yml
+++ b/data/registry/collector-exporter-coralogix.yml
@@ -9,7 +9,7 @@ tags:
 license: Apache 2.0
 description: The Coralogix Exporter for the OpenTelemetry Collector.
 authors:
-  - name: Coralogix
+  - name: OpenTelemetry Authors
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/coralogixexporter
 createdAt: 2020-11-05

--- a/data/registry/collector-exporter-datadog.yml
+++ b/data/registry/collector-exporter-datadog.yml
@@ -9,7 +9,7 @@ tags:
 license: Apache 2.0
 description: The Datadog Exporter for the OpenTelemetry Collector.
 authors:
-  - name: Datadog
+  - name: OpenTelemetry Authors
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter
 createdAt: 2020-06-06

--- a/data/registry/collector-exporter-dataset.yml
+++ b/data/registry/collector-exporter-dataset.yml
@@ -9,7 +9,7 @@ tags:
 license: Apache 2.0
 description: The Dataset Exporter for the OpenTelemetry Collector.
 authors:
-  - name: Dataset
+  - name: OpenTelemetry Authors
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datasetexporter
 createdAt: 2020-06-06

--- a/data/registry/collector-exporter-googlecloud.yml
+++ b/data/registry/collector-exporter-googlecloud.yml
@@ -11,6 +11,7 @@ description:
   The Google Cloud Operations Exporter for the OpenTelemetry Collector.
 authors:
   - name: Google
+    url: https://github.com/GoogleCloudPlatform/
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudexporter
 createdAt: 2020-06-06

--- a/data/registry/collector-exporter-googlemanagedprometheus.yml
+++ b/data/registry/collector-exporter-googlemanagedprometheus.yml
@@ -12,6 +12,7 @@ description:
   Service for Prometheus.
 authors:
   - name: Google
+    url: https://github.com/GoogleCloudPlatform/
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlemanagedprometheusexporter
 createdAt: 2022-10-27

--- a/data/registry/collector-exporter-instana.yml
+++ b/data/registry/collector-exporter-instana.yml
@@ -9,7 +9,7 @@ tags:
 license: Apache 2.0
 description: The Instana Exporter for the OpenTelemetry Collector.
 authors:
-  - name: Instana Authors
+  - name: OpenTelemetry Authors
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/instanaexporter
 createdAt: 2020-06-06

--- a/data/registry/collector-exporter-logzio.yml
+++ b/data/registry/collector-exporter-logzio.yml
@@ -9,7 +9,7 @@ tags:
 license: Apache 2.0
 description: The OpenTelemetry Collector Exporter for Logz.io
 authors:
-  - name: Logz.io
+  - name: OpenTelemetry Authors
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/logzioexporter
 createdAt: 2020-10-22

--- a/data/registry/collector-exporter-sentry.yml
+++ b/data/registry/collector-exporter-sentry.yml
@@ -9,7 +9,7 @@ tags:
 license: Apache 2.0
 description: The Sentry Exporter for the OpenTelemetry Collector.
 authors:
-  - name: Sentry
+  - name: OpenTelemetry Authors
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/sentryexporter
 createdAt: 2020-06-06

--- a/data/registry/collector-exporter-signalfx.yml
+++ b/data/registry/collector-exporter-signalfx.yml
@@ -9,7 +9,7 @@ tags:
 license: Apache 2.0
 description: The SignalFx Exporter for the OpenTelemetry Collector.
 authors:
-  - name: Splunk
+  - name: OpenTelemetry Authors
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/signalfxexporter
 createdAt: 2020-06-06

--- a/data/registry/collector-exporter-splunk-apm.yml
+++ b/data/registry/collector-exporter-splunk-apm.yml
@@ -9,7 +9,7 @@ tags:
 license: Apache 2.0
 description: The OpenTelemetry Splunk APM Exporter for Go.
 authors:
-  - name: Splunk Authors
+  - name: OpenTelemetry Authors
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/sapmexporter
 createdAt: 2020-06-06

--- a/data/registry/collector-exporter-splunk-hec.yml
+++ b/data/registry/collector-exporter-splunk-hec.yml
@@ -11,7 +11,7 @@ description:
   The Splunk HTTP Event Collector (HEC) Exporter for the OpenTelemetry
   Collector.
 authors:
-  - name: Splunk
+  - name: OpenTelemetry Authors
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/splunkhecexporter
 createdAt: 2020-06-06

--- a/data/registry/collector-exporter-splunk-imm.yml
+++ b/data/registry/collector-exporter-splunk-imm.yml
@@ -9,7 +9,7 @@ tags:
 license: Apache 2.0
 description: The OpenTelemetry Splunk Infrastructure Monitoring Exporter for Go.
 authors:
-  - name: Splunk Authors
+  - name: OpenTelemetry Authors
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/signalfxexporter
 createdAt: 2020-11-05

--- a/data/registry/collector-exporter-splunk-sapm.yml
+++ b/data/registry/collector-exporter-splunk-sapm.yml
@@ -9,7 +9,7 @@ tags:
 license: Apache 2.0
 description: The Splunk SAPM Exporter for the OpenTelemetry Collector.
 authors:
-  - name: Splunk
+  - name: OpenTelemetry Authors
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/sapmexporter
 createdAt: 2020-06-06

--- a/data/registry/collector-exporter-sumologic.yml
+++ b/data/registry/collector-exporter-sumologic.yml
@@ -9,7 +9,7 @@ tags:
 license: Apache 2.0
 description: The OpenTelemetry Collector Exporter for Sumo Logic
 authors:
-  - name: Sumo Logic
+  - name: OpenTelemetry Authors
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/sumologicexporter
 createdAt: 2020-10-22

--- a/data/registry/collector-receiver-aws-ecs-container-metrics.yml
+++ b/data/registry/collector-receiver-aws-ecs-container-metrics.yml
@@ -13,7 +13,7 @@ description:
   generates resource usage metrics (such as CPU, memory, network, and disk) from
   them.
 authors:
-  - name: Amazon Web Services
+  - name: OpenTelemetry Authors
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awsecscontainermetricsreceiver
 createdAt: 2021-02-26

--- a/data/registry/collector-receiver-aws-xray.yml
+++ b/data/registry/collector-receiver-aws-xray.yml
@@ -12,7 +12,7 @@ description:
   spans) in the X-Ray Segment format. This enables the collector to receive
   spans emitted by the existing X-Ray SDK.
 authors:
-  - name: Amazon Web Services
+  - name: OpenTelemetry Authors
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awsxrayreceiver
 createdAt: 2021-02-26

--- a/data/registry/collector-receiver-git-trace2.yml
+++ b/data/registry/collector-receiver-git-trace2.yml
@@ -15,6 +15,7 @@ description:
   components.
 authors:
   - name: Jeff Hostetler
+    url: https://github.com/jeffhostetler
 urls:
   repo: https://github.com/git-ecosystem/trace2receiver
 createdAt: 2023-10-17

--- a/data/registry/collector-receiver-openllmetry.yml
+++ b/data/registry/collector-receiver-openllmetry.yml
@@ -13,6 +13,7 @@ description:
   are based on predefined OpenTelemetry Semantic Conventions.
 authors:
   - name: IBM Instana
+    url: https://github.com/instana
 urls:
   repo: https://github.com/instana/otel-dc/tree/main/llm
 createdAt: 2024-05-07

--- a/data/registry/collector-receiver-sapm.yml
+++ b/data/registry/collector-receiver-sapm.yml
@@ -11,7 +11,7 @@ description:
   The SAPM Receiver for the OpenTelemetry Collector receive traces from other
   collectors or the SignalFx Smart Agent.
 authors:
-  - name: Splunk
+  - name: OpenTelemetry Authors
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sapmreceiver
 createdAt: 2021-02-26

--- a/data/registry/collector-receiver-signalfx.yml
+++ b/data/registry/collector-receiver-signalfx.yml
@@ -11,7 +11,7 @@ description:
   The SignalFx Receiver for the OpenTelemetry Collector accepts metrics in the
   SignalFx proto format and events (Logs) in the SignalFx proto format.
 authors:
-  - name: Splunk
+  - name: OpenTelemetry Authors
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/signalfxreceiver
 createdAt: 2021-02-26

--- a/data/registry/collector-receiver-splunk-hec.yml
+++ b/data/registry/collector-receiver-splunk-hec.yml
@@ -11,7 +11,7 @@ description:
   The Splunk HEC Receiver for the OpenTelemetry Collector accepts metrics,
   traces, and logs in the Splunk HEC format.
 authors:
-  - name: Splunk
+  - name: OpenTelemetry Authors
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/splunkhecreceiver
 createdAt: 2021-02-26

--- a/data/registry/exporter-dotnet-azure.yml
+++ b/data/registry/exporter-dotnet-azure.yml
@@ -10,6 +10,7 @@ license: MIT
 description: The OpenTelemetry Azure Monitor Exporter for .NET
 authors:
   - name: Microsoft Authors
+    url: https://www.microsoft.com
 package:
   name: Azure.Monitor.OpenTelemetry.Exporter
   registry: nuget

--- a/data/registry/exporter-go-google-cloud-monitoring.yml
+++ b/data/registry/exporter-go-google-cloud-monitoring.yml
@@ -8,6 +8,7 @@ license: Apache 2.0
 description: The OpenTelemetry Google Cloud Monitoring Exporter for Go.
 authors:
   - name: Google Authors
+    url: https://github.com/GoogleCloudPlatform/
 urls:
   repo: https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/tree/main/exporter/metric
 createdAt: 2020-04-01

--- a/data/registry/exporter-go-google-cloud-trace.yml
+++ b/data/registry/exporter-go-google-cloud-trace.yml
@@ -8,6 +8,7 @@ license: Apache 2.0
 description: The OpenTelemetry Google Cloud Trace Exporter for Go.
 authors:
   - name: Google Authors
+    url: https://github.com/GoogleCloudPlatform/
 urls:
   repo: https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/tree/main/exporter/trace
 createdAt: 2020-04-01

--- a/data/registry/exporter-go-instana.yml
+++ b/data/registry/exporter-go-instana.yml
@@ -9,6 +9,7 @@ license: MIT
 description: The Instana Go OpenTelemetry Exporter.
 authors:
   - name: Instana Authors
+    url: https://github.com/instana/
 urls:
   repo: https://github.com/instana/go-otel-exporter
 createdAt: 2022-10-10

--- a/data/registry/exporter-go-lightstep.yml
+++ b/data/registry/exporter-go-lightstep.yml
@@ -7,7 +7,8 @@ tags:
 license: Apache 2.0
 description: The OpenTelemetry Lightstep Exporter for Go.
 authors:
-  - name: Lightstep Authors
+  - name: Lightstep
+    url: https://github.com/lightstep
 urls:
   repo: https://github.com/lightstep/opentelemetry-exporter-go
 createdAt: 2020-02-05

--- a/data/registry/exporter-go-otlpr.yml
+++ b/data/registry/exporter-go-otlpr.yml
@@ -12,6 +12,7 @@ license: Apache 2.0
 description: Provides a `logr.Logger` that exports messages as OTLP logs.
 authors:
   - name: MrAlias
+    url: https://github.com/MrAlias
 urls:
   repo: https://github.com/MrAlias/otlpr
 createdAt: 2023-05-06

--- a/data/registry/exporter-java-google-cloud.yml
+++ b/data/registry/exporter-java-google-cloud.yml
@@ -11,6 +11,7 @@ license: Apache 2.0
 description: The OpenTelemetry Google Cloud Monitoring/Trace Exporters for Java.
 authors:
   - name: Google
+    url: https://github.com/GoogleCloudPlatform/
 urls:
   repo: https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/tree/main/exporters/trace
 createdAt: 2020-08-13

--- a/data/registry/exporter-js-azure.yml
+++ b/data/registry/exporter-js-azure.yml
@@ -10,6 +10,7 @@ license: MIT
 description: The OpenTelemetry Azure Monitor Exporter for JavaScript (Node.js)
 authors:
   - name: Microsoft Authors
+    url: https://www.microsoft.com
 package:
   name: '@azure/monitor-opentelemetry-exporter'
   registry: npm

--- a/data/registry/exporter-js-google-cloud-monitoring.yml
+++ b/data/registry/exporter-js-google-cloud-monitoring.yml
@@ -8,6 +8,7 @@ license: Apache 2.0
 description: The OpenTelemetry Google Cloud Metric Exporter for Node.js.
 authors:
   - name: Google Authors
+    url: https://github.com/GoogleCloudPlatform/
 urls:
   repo: https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/tree/main/packages/opentelemetry-cloud-monitoring-exporter
 createdAt: 2020-04-01

--- a/data/registry/exporter-js-google-cloud-trace.yml
+++ b/data/registry/exporter-js-google-cloud-trace.yml
@@ -8,6 +8,7 @@ license: Apache 2.0
 description: The OpenTelemetry Google Cloud Trace Exporter for Node.js.
 authors:
   - name: Google Authors
+    url: https://github.com/GoogleCloudPlatform/
 urls:
   repo: https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/tree/main/packages/opentelemetry-cloud-trace-exporter
 createdAt: 2020-04-01

--- a/data/registry/exporter-js-instana.yml
+++ b/data/registry/exporter-js-instana.yml
@@ -9,6 +9,7 @@ license: MIT
 description: The Instana Node.js OpenTelemetry Exporter.
 authors:
   - name: Instana Authors
+    url: https://github.com/instana/
 urls:
   repo: https://github.com/instana/nodejs/tree/main/packages/opentelemetry-exporter
 createdAt: 2022-04-18

--- a/data/registry/exporter-js-sap-cloud-logging.yml
+++ b/data/registry/exporter-js-sap-cloud-logging.yml
@@ -17,6 +17,7 @@ description:
   traces to SAP Cloud Logging.
 authors:
   - name: Christian Dinse
+    url: https://github.com/christiand93
 createdAt: 2024-08-20
 isNative: true
 isFirstParty: false

--- a/data/registry/exporter-perl-otlp.yml
+++ b/data/registry/exporter-perl-otlp.yml
@@ -9,6 +9,7 @@ license: Artistic-1.0-Perl
 description: An unofficial implementation of the OTLP Exporter in Perl.
 authors:
   - name: jjatria
+    url: https://github.com/jjatria
 urls:
   repo: https://github.com/jjatria/perl-opentelemetry-exporter-otlp
 createdAt: 2023-12-05

--- a/data/registry/exporter-python-azure.yml
+++ b/data/registry/exporter-python-azure.yml
@@ -10,6 +10,7 @@ license: MIT
 description: The OpenTelemetry Azure Monitor Exporter for Python
 authors:
   - name: Microsoft Authors
+    url: https://www.microsoft.com
 package:
   name: azure-monitor-opentelemetry-exporter
   registry: pip

--- a/data/registry/exporter-python-gcp-monitoring.yml
+++ b/data/registry/exporter-python-gcp-monitoring.yml
@@ -10,6 +10,7 @@ license: Apache 2.0
 description: The OpenTelemetry Google Cloud Monitoring Exporters for Python.
 authors:
   - name: Google
+    url: https://github.com/GoogleCloudPlatform/
 urls:
   repo: https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/tree/main/opentelemetry-exporter-gcp-monitoring
 createdAt: 2020-08-13

--- a/data/registry/exporter-python-gcp-trace.yml
+++ b/data/registry/exporter-python-gcp-trace.yml
@@ -10,6 +10,7 @@ license: Apache 2.0
 description: The OpenTelemetry Google Cloud Trace Exporters for Python.
 authors:
   - name: Google
+    url: https://github.com/GoogleCloudPlatform/
 urls:
   repo: https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/tree/main/opentelemetry-exporter-gcp-trace
 createdAt: 2020-08-13

--- a/data/registry/exporter-python-lightstep.yml
+++ b/data/registry/exporter-python-lightstep.yml
@@ -8,6 +8,7 @@ license: Apache 2.0
 description: The OpenTelemetry Lightstep Exporter for Python.
 authors:
   - name: Lightstep Authors
+    url: https://github.com/lightstep/
 urls:
   repo: https://github.com/lightstep/opentelemetry-exporter-python
 createdAt: 2020-02-05

--- a/data/registry/exporter-ruby-datadog.yml
+++ b/data/registry/exporter-ruby-datadog.yml
@@ -9,6 +9,7 @@ license: Apache 2.0
 description: The OpenTelemetry Datadog Exporter for Ruby.
 authors:
   - name: Datadog, Inc.
+    url: https://github.com/DataDog/
 urls:
   repo: https://github.com/DataDog/dd-opentelemetry-exporter-ruby
 createdAt: 2020-09-02

--- a/data/registry/exporter-rust-application-insights.yml
+++ b/data/registry/exporter-rust-application-insights.yml
@@ -9,6 +9,7 @@ license: MIT
 description: OpenTelemetry exporter for Azure Application Insights
 authors:
   - name: Jan Kuehle
+    url: https://github.com/frigus02/
 urls:
   repo: https://github.com/frigus02/opentelemetry-application-insights
 createdAt: 2020-08-28

--- a/data/registry/exporter-rust-stackdriver.yml
+++ b/data/registry/exporter-rust-stackdriver.yml
@@ -8,7 +8,6 @@ tags:
 license: Apache 2.0 OR MIT
 description: A Rust OpenTelemetry exporter for Google StackDriver
 authors:
-  - name: jacobkiesel
   - name: OpenTelemetry Authors
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-stackdriver

--- a/data/registry/instrumentation-go-connect-rpc.yml
+++ b/data/registry/instrumentation-go-connect-rpc.yml
@@ -10,6 +10,7 @@ license: Apache 2.0
 description: Go contrib plugin for Connect RPC
 authors:
   - name: Connect Authors
+    url: https://github.com/connectrpc/
 urls:
   repo: https://github.com/connectrpc/otelconnect-go
 createdAt: 2023-01-19

--- a/data/registry/instrumentation-go-fiber.yml
+++ b/data/registry/instrumentation-go-fiber.yml
@@ -10,6 +10,7 @@ license: MIT
 description: Go contrib plugin for the gofiber/fiber package.
 authors:
   - name: gofiber authors & contributors
+    url: https://github.com/gofiber/
 urls:
   repo: https://github.com/gofiber/contrib/tree/main/otelfiber
 createdAt: 2022-01-14

--- a/data/registry/instrumentation-go-go-pg.yml
+++ b/data/registry/instrumentation-go-go-pg.yml
@@ -9,6 +9,7 @@ license: BSD-2-Clause
 description: Instrumentation for go-pg PostgreSQL client.
 authors:
   - name: go-pg Authors
+    url: https://github.com/go-pg/
 urls:
   repo: https://github.com/go-pg/pg/tree/v10/extra/pgotel
 createdAt: 2021-04-19

--- a/data/registry/instrumentation-go-go-redis.yml
+++ b/data/registry/instrumentation-go-go-redis.yml
@@ -8,7 +8,8 @@ tags:
 license: BSD-2-Clause
 description: Instrumentation for go-redis Redis client.
 authors:
-  - name: go-redis Authors
+  - name: Redis
+    url: https://github.com/redis/
 urls:
   repo: https://github.com/redis/go-redis/tree/master/extra/redisotel
 createdAt: 2021-04-19

--- a/data/registry/instrumentation-go-go-resty.yml
+++ b/data/registry/instrumentation-go-go-resty.yml
@@ -11,6 +11,7 @@ description: Custom instrumentation for the `go-resty` HTTP client library.
 authors:
   - name: dubonzi
     email: eduardobonzi.dev@gmail.com
+    url: https://github.com/dubonzi
 urls:
   repo: https://github.com/dubonzi/otelresty
 createdAt: 2023-07-13

--- a/data/registry/instrumentation-go-graphql.yml
+++ b/data/registry/instrumentation-go-graphql.yml
@@ -12,7 +12,8 @@ description:
   Instrumentation for graphql-go GraphQL Server that records GraphQL operations
   using OpenTelemetry Tracing API.
 authors:
-  - name: Benjamin Ziehms
+  - name: Uptrace
+    url: https://github.com/uptrace
 urls:
   repo: https://github.com/uptrace/opentelemetry-go-extra/tree/main/otelgraphql
 createdAt: 2021-10-25

--- a/data/registry/instrumentation-go-grpc-metrics.yml
+++ b/data/registry/instrumentation-go-grpc-metrics.yml
@@ -13,6 +13,7 @@ description:
   Handler interface.
 authors:
   - name: Amin Mahboubi
+    url: https://github.com/mahboubii/
 urls:
   repo: https://github.com/mahboubii/grpcmetrics
 createdAt: 2023-04-06

--- a/data/registry/instrumentation-go-ibmmq.yml
+++ b/data/registry/instrumentation-go-ibmmq.yml
@@ -14,7 +14,10 @@ description:
   This package extracts metrics from an IBM MQ queue manager and forwards them
   to an OpenTelemetry environment.
 authors:
-  - name: Mark Taylor, IBM MQ Development
+  - name: Mark Taylor
+    url: https://github.com/ibmmqmet
+  - name: IBM MQ Development
+    url: https://github.com/ibm-messaging/
 createdAt: 2024-03-26
 isNative: false
 isFirstParty: true

--- a/data/registry/instrumentation-go-logrus.yml
+++ b/data/registry/instrumentation-go-logrus.yml
@@ -11,6 +11,7 @@ license: BSD-2-Clause
 description: Instrumentation for logrus logging library.
 authors:
   - name: Vladimir Mihailenco
+    url: https://github.com/vmihailenco
 urls:
   repo: https://github.com/uptrace/opentelemetry-go-extra/tree/main/otellogrus
 createdAt: 2021-10-25

--- a/data/registry/instrumentation-go-nhatthm-otelsql.yml
+++ b/data/registry/instrumentation-go-nhatthm-otelsql.yml
@@ -13,6 +13,7 @@ description:
   interactions with the database.
 authors:
   - name: nhatthm
+    url: https://github.com/nhatthm
 urls:
   repo: https://github.com/nhatthm/otelsql
 createdAt: 2022-01-27

--- a/data/registry/instrumentation-go-otelpgx.yml
+++ b/data/registry/instrumentation-go-otelpgx.yml
@@ -13,6 +13,7 @@ description:
   Provides OpenTelemetry tracing implementation for the pgx PostgreSQL package.
 authors:
   - name: Exaring AG.
+    url: https://github.com/exaring
 urls:
   repo: https://github.com/exaring/otelpgx
 createdAt: 2022-09-27

--- a/data/registry/instrumentation-go-otelsqlx.yml
+++ b/data/registry/instrumentation-go-otelsqlx.yml
@@ -14,6 +14,7 @@ description:
   metrics.
 authors:
   - name: Vladimir Mihailenco
+    url: https://github.com/vmihailenco
 urls:
   repo: https://github.com/uptrace/opentelemetry-go-extra/tree/main/otelsqlx
 createdAt: 2021-10-25

--- a/data/registry/instrumentation-go-splunkbuntdb.yml
+++ b/data/registry/instrumentation-go-splunkbuntdb.yml
@@ -10,6 +10,7 @@ license: Apache 2.0
 description: Instrumentation for the `github.com/tidwall/buntdb` package.
 authors:
   - name: Splunk Inc.
+    url: https://www.splunk.com/
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/tidwall/buntdb/splunkbuntdb
 createdAt: 2022-01-20

--- a/data/registry/instrumentation-go-splunkchi.yml
+++ b/data/registry/instrumentation-go-splunkchi.yml
@@ -10,6 +10,7 @@ license: Apache 2.0
 description: Instrumentation for the `github.com/go-chi/chi` package.
 authors:
   - name: Splunk Inc.
+    url: https://www.splunk.com/
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/go-chi/chi/splunkchi
 createdAt: 2022-01-20

--- a/data/registry/instrumentation-go-splunkclient-go.yml
+++ b/data/registry/instrumentation-go-splunkclient-go.yml
@@ -10,6 +10,7 @@ license: Apache 2.0
 description: Instrumentation for the `k8s.io/client-go` package.
 authors:
   - name: Splunk Inc.
+    url: https://www.splunk.com/
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/k8s.io/client-go/splunkclient-go
 createdAt: 2022-01-20

--- a/data/registry/instrumentation-go-splunkdns.yml
+++ b/data/registry/instrumentation-go-splunkdns.yml
@@ -10,6 +10,7 @@ license: Apache 2.0
 description: Instrumentation for the `github.com/miekg/dns` package.
 authors:
   - name: Splunk Inc.
+    url: https://www.splunk.com/
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/miekg/dns/splunkdns
 createdAt: 2022-01-20

--- a/data/registry/instrumentation-go-splunkelastic.yml
+++ b/data/registry/instrumentation-go-splunkelastic.yml
@@ -11,6 +11,7 @@ license: Apache 2.0
 description: Instrumentation for the `gopkg.in/olivere/elastic` package.
 authors:
   - name: Splunk Inc.
+    url: https://www.splunk.com/
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/gopkg.in/olivere/elastic/splunkelastic
 createdAt: 2022-01-20

--- a/data/registry/instrumentation-go-splunkgorm.yml
+++ b/data/registry/instrumentation-go-splunkgorm.yml
@@ -10,6 +10,7 @@ license: Apache 2.0
 description: Instrumentation for the `github.com/jinzhu/gorm` package.
 authors:
   - name: Splunk Inc.
+    url: https://www.splunk.com/
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/jinzhu/gorm/splunkgorm
 createdAt: 2022-01-20

--- a/data/registry/instrumentation-go-splunkgraphql.yml
+++ b/data/registry/instrumentation-go-splunkgraphql.yml
@@ -11,6 +11,7 @@ description:
   Instrumentation for the `github.com/graph-gophers/graphql-go` package.
 authors:
   - name: Splunk Inc.
+    url: https://www.splunk.com/
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql
 createdAt: 2022-01-20

--- a/data/registry/instrumentation-go-splunkhttp.yml
+++ b/data/registry/instrumentation-go-splunkhttp.yml
@@ -10,6 +10,7 @@ license: Apache 2.0
 description: Splunk specific instrumentation for the Golang `net/http` package.
 authors:
   - name: Splunk Inc.
+    url: https://www.splunk.com/
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/net/http/splunkhttp
 createdAt: 2022-01-20

--- a/data/registry/instrumentation-go-splunkhttprouter.yml
+++ b/data/registry/instrumentation-go-splunkhttprouter.yml
@@ -12,6 +12,7 @@ description:
   Instrumentation for the `github.com/julienschmidt/httprouter` package.
 authors:
   - name: Splunk Inc.
+    url: https://www.splunk.com/
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter
 createdAt: 2022-01-20

--- a/data/registry/instrumentation-go-splunkkafka.yml
+++ b/data/registry/instrumentation-go-splunkkafka.yml
@@ -14,6 +14,7 @@ description:
   `github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka` package.
 authors:
   - name: Splunk Inc.
+    url: https://www.splunk.com/
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka
 createdAt: 2022-01-20

--- a/data/registry/instrumentation-go-splunkleveldb.yml
+++ b/data/registry/instrumentation-go-splunkleveldb.yml
@@ -12,6 +12,7 @@ description:
   Instrumentation for the `github.com/syndtr/goleveldb/leveldb` package.
 authors:
   - name: Splunk Inc.
+    url: https://www.splunk.com/
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb
 createdAt: 2022-01-20

--- a/data/registry/instrumentation-go-splunkmysql.yml
+++ b/data/registry/instrumentation-go-splunkmysql.yml
@@ -11,6 +11,7 @@ license: Apache 2.0
 description: Instrumentation for the `github.com/go-sql-driver/mysql` package.
 authors:
   - name: Splunk Inc.
+    url: https://www.splunk.com/
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/go-sql-driver/mysql/splunkmysql
 createdAt: 2022-01-20

--- a/data/registry/instrumentation-go-splunkpgx.yml
+++ b/data/registry/instrumentation-go-splunkpgx.yml
@@ -11,6 +11,7 @@ license: Apache 2.0
 description: Instrumentation for the `github.com/jackc/pgx` package.
 authors:
   - name: Splunk Inc.
+    url: https://www.splunk.com/
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/jackc/pgx/splunkpgx
 createdAt: 2022-01-20

--- a/data/registry/instrumentation-go-splunkpq.yml
+++ b/data/registry/instrumentation-go-splunkpq.yml
@@ -11,6 +11,7 @@ license: Apache 2.0
 description: Instrumentation for the `github.com/lib/pq` package.
 authors:
   - name: Splunk Inc.
+    url: https://www.splunk.com/
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/lib/pq/splunkpq
 createdAt: 2022-01-20

--- a/data/registry/instrumentation-go-splunkredigo.yml
+++ b/data/registry/instrumentation-go-splunkredigo.yml
@@ -11,6 +11,7 @@ license: Apache 2.0
 description: Instrumentation for the `github.com/gomodule/redigo` package.
 authors:
   - name: Splunk Inc.
+    url: https://www.splunk.com/
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/gomodule/redigo/splunkredigo
 createdAt: 2022-01-20

--- a/data/registry/instrumentation-go-splunksql.yml
+++ b/data/registry/instrumentation-go-splunksql.yml
@@ -11,6 +11,7 @@ license: Apache 2.0
 description: Instrumentation for the Golang `database/sql` package.
 authors:
   - name: Splunk Inc.
+    url: https://www.splunk.com/
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/database/sql/splunksql
 createdAt: 2021-10-12

--- a/data/registry/instrumentation-go-splunksqlx.yml
+++ b/data/registry/instrumentation-go-splunksqlx.yml
@@ -10,6 +10,7 @@ license: Apache 2.0
 description: Instrumentation for the `github.com/jmoiron/sqlx` package.
 authors:
   - name: Splunk Inc.
+    url: https://www.splunk.com/
 urls:
   repo: https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/jmoiron/sqlx/splunksqlx
 createdAt: 2022-01-20

--- a/data/registry/instrumentation-go-uptrace-otelsql.yml
+++ b/data/registry/instrumentation-go-uptrace-otelsql.yml
@@ -13,6 +13,7 @@ description:
   statements) and reports DBStats metrics.
 authors:
   - name: Vladimir Mihailenco
+    url: https://github.com/vmihailenco
 urls:
   repo: https://github.com/uptrace/opentelemetry-go-extra/tree/main/otelsql
 createdAt: 2021-10-25

--- a/data/registry/instrumentation-go-zap.yml
+++ b/data/registry/instrumentation-go-zap.yml
@@ -11,6 +11,7 @@ license: BSD-2-Clause
 description: Instrumentation for Zap logging library.
 authors:
   - name: Vladimir Mihailenco
+    url: https://github.com/vmihailenco
 urls:
   repo: https://github.com/uptrace/opentelemetry-go-extra/tree/main/otelzap
 createdAt: 2021-10-25

--- a/data/registry/instrumentation-java-apache-dubbo.yml
+++ b/data/registry/instrumentation-java-apache-dubbo.yml
@@ -10,6 +10,7 @@ license: Apache-2.0
 description: ''
 authors:
   - name: Apache Dubbo Authors
+    url: https://dubbo.apache.org/
 urls:
   website: https://github.com/apache/dubbo
   docs: https://cn.dubbo.apache.org/en/blog/2024/01/31/tracing-dubbo-with-opentelemetry/

--- a/data/registry/instrumentation-java-azure-sdk.yml
+++ b/data/registry/instrumentation-java-azure-sdk.yml
@@ -10,6 +10,7 @@ license: MIT
 description: Instrumentation for Azure SDK for Java (Track 2 libraries).
 authors:
   - name: Microsoft Authors
+    url: https://www.microsoft.com/
 urls:
   repo: https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/core/azure-core-tracing-opentelemetry
 createdAt: 2021-12-16

--- a/data/registry/instrumentation-java-http4k.yml
+++ b/data/registry/instrumentation-java-http4k.yml
@@ -10,6 +10,7 @@ description:
   OpenTelemetry.
 authors:
   - name: http4k Authors
+    url: https://github.com/http4k/
 urls:
   repo: https://github.com/http4k/http4k/tree/master/http4k-opentelemetry
 createdAt: 2022-10-27

--- a/data/registry/instrumentation-js-azure-sdk.yml
+++ b/data/registry/instrumentation-js-azure-sdk.yml
@@ -12,6 +12,7 @@ license: MIT
 description: Instrumentation for Azure SDK for JavaScript (Track 2 libraries).
 authors:
   - name: Microsoft Authors
+    url: https://www.microsoft.com/
 urls:
   repo: https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk
 package:

--- a/data/registry/instrumentation-lua-apache-apisix.yml
+++ b/data/registry/instrumentation-lua-apache-apisix.yml
@@ -11,6 +11,7 @@ description:
   standard, and sends it to OpenTelemetry Collector through HTTP protocol.
 authors:
   - name: Apache APISIX Authors
+    url: https://apisix.apache.org/
 urls:
   repo: https://github.com/apache/apisix/blob/master/apisix/plugins/opentelemetry.lua
 createdAt: 2022-03-27

--- a/data/registry/instrumentation-perl-mojolicious.yml
+++ b/data/registry/instrumentation-perl-mojolicious.yml
@@ -9,6 +9,7 @@ license: Artistic-1.0-Perl
 description: An OpenTelemetry plugin for Perl's Mojolicious.
 authors:
   - name: jjatria
+    url: https://github.com/jjatria
 urls:
   repo: https://github.com/jjatria/mojolicious-plugin-opentelemetry
 createdAt: 2023-12-05

--- a/data/registry/instrumentation-perl-plack.yml
+++ b/data/registry/instrumentation-perl-plack.yml
@@ -9,6 +9,7 @@ license: MIT
 description: An OpenTelemetry middleware for Perl's Plack.
 authors:
   - name: abh
+    url: https://github.com/abh
 urls:
   repo: https://github.com/abh/Plack-Middleware-OpenTelemetry
 createdAt: 2023-12-05

--- a/data/registry/instrumentation-python-azure-sdk.yml
+++ b/data/registry/instrumentation-python-azure-sdk.yml
@@ -10,6 +10,7 @@ license: MIT
 description: Instrumentation for Azure SDK for Python (Track 2 libraries).
 authors:
   - name: Microsoft Authors
+    url: https://www.microsoft.com/
 urls:
   repo: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/core/azure-core-tracing-opentelemetry
 createdAt: 2021-12-16

--- a/data/registry/instrumentation-rust-actix-web.yml
+++ b/data/registry/instrumentation-rust-actix-web.yml
@@ -9,6 +9,7 @@ license: MIT
 description: OpenTelemetry integration for Actix Web.
 authors:
   - name: Julian Tescher
+    url: https://github.com/jtescher
 urls:
   repo: https://github.com/OutThereLabs/actix-web-opentelemetry
 createdAt: 2020-08-28

--- a/data/registry/instrumentation-rust-axum.yml
+++ b/data/registry/instrumentation-rust-axum.yml
@@ -10,6 +10,7 @@ license: CC0 1.0
 description: Middlewares to integrate axum + tracing + opentelemetry.
 authors:
   - name: David Bernard
+    url: https://github.com/davidB/
 urls:
   repo: https://github.com/davidB/tracing-opentelemetry-instrumentation-sdk/tree/main/axum-tracing-opentelemetry
 createdAt: 2020-08-28

--- a/data/registry/instrumentation-rust-tide.yml
+++ b/data/registry/instrumentation-rust-tide.yml
@@ -9,6 +9,7 @@ license: Apache 2.0 OR MIT
 description: OpenTelemetry integration for the Tide web framework.
 authors:
   - name: Christoph Grabo
+    url: https://github.com/asaaki/
 urls:
   repo: https://github.com/asaaki/opentelemetry-tide
 createdAt: 2020-08-28

--- a/data/registry/instrumentation-rust-tracing.yml
+++ b/data/registry/instrumentation-rust-tracing.yml
@@ -1,3 +1,4 @@
+# cSpell:ignore Tescher
 title: Tracing Instrumentation
 registryType: instrumentation
 language: rust
@@ -8,8 +9,7 @@ license: MIT
 description: Utilities for adding OpenTelemetry interoperability to tracing.
 authors:
   - name: Julian Tescher
-# cSpell:ignore Tescher
-
+    url: https://github.com/jtescher
 urls:
   repo: https://github.com/tokio-rs/tracing-opentelemetry
 createdAt: 2020-08-28

--- a/data/registry/instrumentation-rust-trillium.yml
+++ b/data/registry/instrumentation-rust-trillium.yml
@@ -9,6 +9,7 @@ license: Apache 2.0 OR MIT
 description: OpenTelemetry integration for the Trillium web framework.
 authors:
   - name: Jacob Rothstein
+    url: https://github.com/jbr
 urls:
   repo: https://github.com/trillium-rs/trillium-opentelemetry
 createdAt: 2021-04-25

--- a/data/registry/otel-clojure.yml
+++ b/data/registry/otel-clojure.yml
@@ -11,6 +11,7 @@ description:
   applications using OpenTelemetry.
 authors:
   - name: Steffan Westcott
+    url: https://github.com/steffan-westcott/
 urls:
   repo: https://github.com/steffan-westcott/clj-otel
 createdAt: 2022-03-04

--- a/data/registry/otel-crystal.yml
+++ b/data/registry/otel-crystal.yml
@@ -9,6 +9,7 @@ license: Apache 2.0
 description: An unofficial implementation of OpenTelemetry in Crystal.
 authors:
   - name: wyhaines
+    url: https://github.com/wyhaines
 urls:
   repo: https://github.com/wyhaines/opentelemetry-api.cr
 createdAt: 2022-12-17

--- a/data/registry/otel-dart.yml
+++ b/data/registry/otel-dart.yml
@@ -9,6 +9,7 @@ license: Apache 2.0
 description: An unofficial implementation of OpenTelemetry in Dart.
 authors:
   - name: Workiva
+    url: https://github.com/Workiva/
 urls:
   repo: https://github.com/Workiva/opentelemetry-dart
 createdAt: 2022-12-17

--- a/data/registry/otel-haskell.yml
+++ b/data/registry/otel-haskell.yml
@@ -9,6 +9,7 @@ license: Apache 2.0
 description: An unofficial implementation of OpenTelemetry in Haskell.
 authors:
   - name: ethercrow
+    url: https://github.com/ethercrow/
 urls:
   repo: https://github.com/ethercrow/opentelemetry-haskell
 createdAt: 2022-12-17

--- a/data/registry/otel-kotlin.yml
+++ b/data/registry/otel-kotlin.yml
@@ -9,7 +9,8 @@ tags:
 license: Apache 2.0
 description: The OpenTelemetry API and SDK for Kotlin.
 authors:
-  - name: SNK; OpenTelemetry Authors
+  - name: SNK
+    url: https://www.snk.de/en/
 urls:
   repo: https://github.com/dcxp/opentelemetry-kotlin
 createdAt: 2022-02-18

--- a/data/registry/otel-perl-api.yml
+++ b/data/registry/otel-perl-api.yml
@@ -9,6 +9,7 @@ license: Artistic-1.0-Perl
 description: An unofficial implementation of OpenTelemetry in Perl.
 authors:
   - name: jjatria
+    url: https://github.com/jjatria/
 urls:
   repo: https://github.com/jjatria/perl-opentelemetry
 createdAt: 2022-12-17

--- a/data/registry/otel-perl-sdk.yml
+++ b/data/registry/otel-perl-sdk.yml
@@ -9,6 +9,7 @@ license: Artistic-1.0-Perl
 description: An unofficial implementation of the OpenTelemetry SDK in Perl.
 authors:
   - name: jjatria
+    url: https://github.com/jjatria/
 urls:
   repo: https://github.com/jjatria/perl-opentelemetry-sdk
 createdAt: 2023-12-05

--- a/data/registry/span-processor-go-mralias-flow.yml
+++ b/data/registry/span-processor-go-mralias-flow.yml
@@ -11,6 +11,7 @@ description:
   metrics.
 authors:
   - name: MrAlias
+    url: https://github.com/MrAlias/
 urls:
   repo: https://github.com/MrAlias/flow
 createdAt: 2022-03-08

--- a/data/registry/tools-ansible-grafana.yml
+++ b/data/registry/tools-ansible-grafana.yml
@@ -14,6 +14,7 @@ authors:
   - name: Ishan Jain
     url: https://github.com/ishanjainn
   - name: Grafana Labs
+    url: https://github.com/grafana/
 urls:
   repo: https://github.com/grafana/grafana-ansible-collection/tree/main/roles/opentelemetry_collector
   docs: https://galaxy.ansible.com/ui/repo/published/grafana/grafana/content/role/opentelemetry_collector

--- a/data/registry/tools-cpp-alpine-apk.yml
+++ b/data/registry/tools-cpp-alpine-apk.yml
@@ -10,6 +10,7 @@ license: Apache 2.0
 description: Alpine Linux packages in support of opentelemetry-cpp.
 authors:
   - name: Severin Neumann
+    url: https://github.com/svrnm
 urls:
   repo: https://pkgs.alpinelinux.org/packages?name=opentelemetry-cpp-*
 createdAt: 2023-02-13

--- a/data/registry/tools-cpp-conan.yml
+++ b/data/registry/tools-cpp-conan.yml
@@ -10,6 +10,7 @@ license: MIT
 description: Conan package for `opentelemetry-cpp`.
 authors:
   - name: The conan authors
+    url: https://github.com/conan-io/
 urls:
   repo: https://conan.io/center/recipes/opentelemetry-cpp
 createdAt: 2023-02-13

--- a/data/registry/tools-cpp-vcpkg.yml
+++ b/data/registry/tools-cpp-vcpkg.yml
@@ -10,6 +10,7 @@ license: MIT
 description: A vcpkg package for opentelemetry-cpp.
 authors:
   - name: The vcpkg Authors
+    url: https://vcpkg.io
 urls:
   repo: https://github.com/microsoft/vcpkg/tree/master/ports/opentelemetry-cpp
 createdAt: 2023-02-13

--- a/data/registry/tools-go-mralias-redact.yml
+++ b/data/registry/tools-go-mralias-redact.yml
@@ -10,6 +10,7 @@ description:
   tracing data.
 authors:
   - name: MrAlias
+    url: https://github.com/MrAlias/
 urls:
   repo: https://github.com/MrAlias/redact
 createdAt: 2022-09-07

--- a/data/registry/tools-python-propagator-gcp.yml
+++ b/data/registry/tools-python-propagator-gcp.yml
@@ -13,6 +13,7 @@ description: >
   Cloud `X-Cloud-Trace-Context` format.
 authors:
   - name: Google
+    url: https://github.com/GoogleCloudPlatform/
 urls:
   repo: https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/tree/main/opentelemetry-propagator-gcp
 createdAt: 2020-08-13

--- a/gulp-src/validate-registry.js
+++ b/gulp-src/validate-registry.js
@@ -114,14 +114,7 @@ function validateRegistryEntry(file, enc, cb) {
 
       let logLevel = 'error';
 
-      if (error.message === 'An author must have an email or a URL') {
-        logLevel = 'warning';
-      } else if (error.message === 'must match "else" schema') {
-        logLevel = 'notice';
-      } else {
-        // Real error, this counts!
-        hasErrors = true;
-      }
+      hasErrors = true;
 
       if (process.env.GITHUB_ACTIONS) {
         console.log(

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -79,6 +79,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-07-24T10:16:33.431203777Z"
   },
+  "https://apisix.apache.org/": {
+    "StatusCode": 206,
+    "LastSeen": "2024-11-14T11:48:32.189392+01:00"
+  },
   "https://apisix.apache.org/blog/2022/02/28/apisix-integration-opentelemetry-plugin/": {
     "StatusCode": 206,
     "LastSeen": "2024-08-09T10:45:35.069307-04:00"
@@ -3367,6 +3371,10 @@
     "StatusCode": 206,
     "LastSeen": "2024-10-18T16:50:18.107656338+03:00"
   },
+  "https://dubbo.apache.org/": {
+    "StatusCode": 206,
+    "LastSeen": "2024-11-14T11:48:08.284225+01:00"
+  },
   "https://dyladan.me/histograms/2023/05/02/why-histograms/": {
     "StatusCode": 206,
     "LastSeen": "2024-01-30T06:01:18.587594-05:00"
@@ -3919,6 +3927,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-03-28T22:25:36.248769757+08:00"
   },
+  "https://github.com/DataDog/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:47:31.843322+01:00"
+  },
   "https://github.com/DataDog/dd-opentelemetry-exporter-ruby": {
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:10:56.414699-05:00"
@@ -3970,6 +3982,10 @@
   "https://github.com/GoogleCloudPlatform": {
     "StatusCode": 200,
     "LastSeen": "2024-07-08T15:23:37.97537+02:00"
+  },
+  "https://github.com/GoogleCloudPlatform/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:46:59.289244+01:00"
   },
   "https://github.com/GoogleCloudPlatform/guest-agent": {
     "StatusCode": 200,
@@ -4219,6 +4235,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:14:23.091564+02:00"
   },
+  "https://github.com/Workiva/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:48:35.732782+01:00"
+  },
   "https://github.com/Workiva/opentelemetry-dart": {
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:13:07.897717-05:00"
@@ -4250,6 +4270,10 @@
   "https://github.com/aaron-ai": {
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:19:43.925232+02:00"
+  },
+  "https://github.com/abh": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:48:32.56368+01:00"
   },
   "https://github.com/abh/Plack-Middleware-OpenTelemetry": {
     "StatusCode": 200,
@@ -4362,6 +4386,10 @@
   "https://github.com/aryanishan1001": {
     "StatusCode": 200,
     "LastSeen": "2024-09-09T16:57:52.837329315Z"
+  },
+  "https://github.com/asaaki/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:48:34.005723+01:00"
   },
   "https://github.com/asaaki/opentelemetry-tide": {
     "StatusCode": 200,
@@ -4579,6 +4607,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-06-14T09:35:29.965101669Z"
   },
+  "https://github.com/christiand93": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:47:25.995535+01:00"
+  },
   "https://github.com/christos68k": {
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:15:06.876545+02:00"
@@ -4635,6 +4667,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-09T11:17:13.22893+02:00"
   },
+  "https://github.com/conan-io/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:48:37.574508+01:00"
+  },
   "https://github.com/confluentinc/confluent-kafka-go": {
     "StatusCode": 200,
     "LastSeen": "2024-08-25T09:39:34.657068291Z"
@@ -4642,6 +4678,10 @@
   "https://github.com/congim": {
     "StatusCode": 200,
     "LastSeen": "2024-08-09T11:17:14.613711+02:00"
+  },
+  "https://github.com/connectrpc/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:47:44.366624+01:00"
   },
   "https://github.com/connectrpc/otelconnect-go": {
     "StatusCode": 200,
@@ -4743,6 +4783,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:15:40.097509+02:00"
   },
+  "https://github.com/davidB/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:48:33.612051+01:00"
+  },
   "https://github.com/davidgs": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:14:54.185189-05:00"
@@ -4842,6 +4886,10 @@
   "https://github.com/dropwizard/metrics": {
     "StatusCode": 200,
     "LastSeen": "2024-05-24T10:11:29.554091-05:00"
+  },
+  "https://github.com/dubonzi": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:47:52.687065+01:00"
   },
   "https://github.com/dubonzi/otelresty": {
     "StatusCode": 200,
@@ -4967,6 +5015,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-30T06:02:04.533718-05:00"
   },
+  "https://github.com/ethercrow/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:48:36.050516+01:00"
+  },
   "https://github.com/ethercrow/opentelemetry-haskell": {
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:13:18.823545-05:00"
@@ -4974,6 +5026,10 @@
   "https://github.com/evan-bradley": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:04:58.72146-05:00"
+  },
+  "https://github.com/exaring": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:48:03.876549+01:00"
   },
   "https://github.com/exaring/otelpgx": {
     "StatusCode": 200,
@@ -5035,6 +5091,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:21:07.09898+02:00"
   },
+  "https://github.com/frigus02/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:47:34.542519+01:00"
+  },
   "https://github.com/frigus02/opentelemetry-application-insights": {
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:11:01.862354-05:00"
@@ -5063,6 +5123,14 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:14:59.006242-05:00"
   },
+  "https://github.com/go-pg/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:47:49.456005+01:00"
+  },
+  "https://github.com/gofiber/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:47:48.179159+01:00"
+  },
   "https://github.com/goharbor": {
     "StatusCode": 200,
     "LastSeen": "2024-08-07T15:44:10.160639+02:00"
@@ -5090,6 +5158,10 @@
   "https://github.com/gouthamve": {
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:21:14.184747+02:00"
+  },
+  "https://github.com/grafana/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:48:37.162832+01:00"
   },
   "https://github.com/grafana/agent": {
     "StatusCode": 200,
@@ -5211,6 +5283,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:15:04.170576-05:00"
   },
+  "https://github.com/http4k/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:48:15.408686+01:00"
+  },
   "https://github.com/huikang": {
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:21:35.311401+02:00"
@@ -5243,6 +5319,14 @@
     "StatusCode": 200,
     "LastSeen": "2024-11-06T19:17:40.129419Z"
   },
+  "https://github.com/ibm-messaging/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:47:58.064055+01:00"
+  },
+  "https://github.com/ibmmqmet": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:47:56.944779+01:00"
+  },
   "https://github.com/idvoretskyi": {
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:21:47.047463+02:00"
@@ -5258,6 +5342,14 @@
   "https://github.com/immanuelfodor": {
     "StatusCode": 200,
     "LastSeen": "2024-11-13T13:16:21.346606655Z"
+  },
+  "https://github.com/instana": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:47:17.991776+01:00"
+  },
+  "https://github.com/instana/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:47:21.768615+01:00"
   },
   "https://github.com/instana/go-otel-exporter": {
     "StatusCode": 200,
@@ -5323,6 +5415,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:22:00.700062+02:00"
   },
+  "https://github.com/jbr": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:48:34.362518+01:00"
+  },
   "https://github.com/jcocchi": {
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:18:28.014809+02:00"
@@ -5338,6 +5434,10 @@
   "https://github.com/jeanbisutti": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:14:42.388742-05:00"
+  },
+  "https://github.com/jeffhostetler": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:47:10.41028+01:00"
   },
   "https://github.com/jenkinsci": {
     "StatusCode": 200,
@@ -5366,6 +5466,14 @@
   "https://github.com/jinja2": {
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:18:24.630332+02:00"
+  },
+  "https://github.com/jjatria": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:47:26.844523+01:00"
+  },
+  "https://github.com/jjatria/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:48:36.582107+01:00"
   },
   "https://github.com/jjatria/mojolicious-plugin-opentelemetry": {
     "StatusCode": 200,
@@ -5643,6 +5751,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:10:34.800347-05:00"
   },
+  "https://github.com/lightstep/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:47:28.84942+01:00"
+  },
   "https://github.com/lightstep/opentelemetry-exporter-go": {
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:10:40.120039-05:00"
@@ -5690,6 +5802,10 @@
   "https://github.com/mackjmr": {
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:22:36.495465+02:00"
+  },
+  "https://github.com/mahboubii/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:47:54.977579+01:00"
   },
   "https://github.com/mahboubii/grpcmetrics": {
     "StatusCode": 200,
@@ -5902,6 +6018,10 @@
   "https://github.com/nginxinc/nginx-otel": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T15:25:22.157083-05:00"
+  },
+  "https://github.com/nhatthm": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:48:01.492253+01:00"
   },
   "https://github.com/nhatthm/otelsql": {
     "StatusCode": 200,
@@ -7755,6 +7875,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:11:23.866868-05:00"
   },
+  "https://github.com/redis/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:47:51.884226+01:00"
+  },
   "https://github.com/reese-lee": {
     "StatusCode": 200,
     "LastSeen": "2024-01-18T20:05:14.831297-05:00"
@@ -7959,6 +8083,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:37:16.308411-05:00"
   },
+  "https://github.com/steffan-westcott/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:48:34.682076+01:00"
+  },
   "https://github.com/steffan-westcott/clj-otel": {
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:12:56.889858-05:00"
@@ -8151,6 +8279,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:55:45.931119-05:00"
   },
+  "https://github.com/uptrace": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:47:53.880645+01:00"
+  },
   "https://github.com/utpilla": {
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:15:31.954992+02:00"
@@ -8214,6 +8346,10 @@
   "https://github.com/wph95": {
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:17:47.39929+02:00"
+  },
+  "https://github.com/wyhaines": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:48:35.182459+01:00"
   },
   "https://github.com/wyhaines/opentelemetry-api.cr": {
     "StatusCode": 200,
@@ -12727,6 +12863,10 @@
     "StatusCode": 206,
     "LastSeen": "2024-01-30T16:05:03.5069-05:00"
   },
+  "https://vcpkg.io": {
+    "StatusCode": 206,
+    "LastSeen": "2024-11-14T11:48:37.997877+01:00"
+  },
   "https://vote.heliosvoting.org/helios/elections/176e7ca8-647d-11ef-9b9a-2a30e2a223da/view": {
     "StatusCode": 200,
     "LastSeen": "2024-09-02T11:59:00.266487+01:00"
@@ -12918,6 +13058,14 @@
   "https://www.britannica.com/dictionary/pipeline": {
     "StatusCode": 200,
     "LastSeen": "2024-08-02T13:14:52.279641-04:00"
+  },
+  "https://www.cisco.com": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:46:57.936535+01:00"
+  },
+  "https://www.cisco.com/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:46:57.559713+01:00"
   },
   "https://www.cisco.com/c/en/us/products/cloud-systems-management/network-services-orchestrator/index.html": {
     "StatusCode": 200,
@@ -13615,6 +13763,14 @@
     "StatusCode": 206,
     "LastSeen": "2024-10-11T10:12:52.474776+02:00"
   },
+  "https://www.microsoft.com": {
+    "StatusCode": 206,
+    "LastSeen": "2024-11-14T11:47:19.915126+01:00"
+  },
+  "https://www.microsoft.com/": {
+    "StatusCode": 206,
+    "LastSeen": "2024-11-14T11:48:11.092022+01:00"
+  },
   "https://www.mongodb.com/": {
     "StatusCode": 206,
     "LastSeen": "2024-01-30T06:05:58.268011-05:00"
@@ -14202,6 +14358,14 @@
   "https://www.slimframework.com/": {
     "StatusCode": 206,
     "LastSeen": "2024-01-30T06:01:39.889326-05:00"
+  },
+  "https://www.snk.de/en/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:48:36.207377+01:00"
+  },
+  "https://www.splunk.com/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-14T11:48:05.990449+01:00"
   },
   "https://www.sqlite.org/rescode.html": {
     "StatusCode": 200,


### PR DESCRIPTION
fixes #5601 

a few notes:
* Everything in a repo `https://github.com/open-telemetry/opentelemetry-*` has "OpenTelemetry Authors", since the code is licensed and owned by the project. For the collector contrib repo we can later update this with the code owners, but that's not feasible right now
* Where available I picked github handles, otherwise I looked up an URL or something. It's not 100% consistent but it wasn't consistent before that as well.

I removed the "warning" restriction for the authors.url authors.email with that.