### PR TITLE
Blogpost to annoucing 2024 OTel Community Awards winners

### DIFF
--- a/content/en/blog/2024/community-awards-winners.md
+++ b/content/en/blog/2024/community-awards-winners.md
@@ -3,7 +3,8 @@ title: Announcing 2024 OpenTelemetry Community Awards Winners
 linkTitle: OpenTelemetry Community Awards Winners
 date: 2024-11-15
 author: OpenTelemetry Governance Committee
-cSpell:ignore: serkan ozal Serkan Özal anunarapureddy Anusha Narapureddy avillela codeboten emdneto
+# prettier-ignore
+cSpell:ignore: anunarapureddy Anusha avillela codeboten emdneto Narapureddy ozal serkan Serkan Özal
 ---
 
 We are excited to announce the winners of the first-ever **OpenTelemetry

--- a/content/en/blog/2024/community-awards-winners.md
+++ b/content/en/blog/2024/community-awards-winners.md
@@ -3,6 +3,7 @@ title: Announcing 2024 OpenTelemetry Community Awards Winners
 linkTitle: OpenTelemetry Community Awards Winners
 date: 2024-11-15
 author: OpenTelemetry Governance Committee
+cSpell:ignore: serkan ozal Serkan Özal anunarapureddy Anusha Narapureddy avillela codeboten emdneto
 ---
 
 We are exicted to announce the winners of the first-ever **OpenTelemetry
@@ -21,7 +22,7 @@ Let's congratulate our 2024 OpenTelemetry Community Awards winners:
 - [@codeboten](https://github.com/codeboten) (Alex Boten)
 - [@emdneto](https://github.com/emdneto) (Emídio Neto)
 
-We have collected any attached comments (some of them summarised) from all
+We have collected any attached comments (some of them summarized) from all
 received nominations. These demonstrate the great appreciation from the
 community towards all nominated individuals. You can find those comments in the
 following

--- a/content/en/blog/2024/community-awards-winners.md
+++ b/content/en/blog/2024/community-awards-winners.md
@@ -1,0 +1,32 @@
+---
+title: Announcing 2024 OpenTelemetry Community Awards Winners
+linkTitle: OpenTelemetry Community Awards Winners
+date: 2024-11-15
+author: OpenTelemetry Governance Committee
+---
+
+We are exicted to announce the winners of the first-ever **OpenTelemetry
+Community Awards**! These awards recognize individuals who have made a notable
+impact to OpenTelemetry project over the past year, whether it's through code,
+documentation, project management, outreach, adoption, or simply helping others
+answer technical questions on our [CNCF Slack](https://slack.cncf.io/). We
+received many nominations from the community, and we are delighted to share the
+winners with you.
+
+Let's congratulate our 2024 OpenTelemetry Community Awards winners:
+
+- [@serkan-ozal](https://github.com/serkan-ozal) (Serkan Ozal)
+- [@anunarapureddy](https://github.com/anunarapureddy) (Anusha Narapureddy)
+- [@avillela](https://github.com/avillela) (Adriana Villela)
+- [@codeboten](https://github.com/codeboten) (Alex Boten)
+- [@emdneto](https://github.com/emdneto) (Emídio Neto)
+
+We have collected any attached comments (some of them summarised) from all
+received nominations. These demonstrate the great appreciation from the
+community towards all nominated individuals. You can find those comments in the
+following
+[presentation slides](https://docs.google.com/presentation/d/1YaJvAWnNcUJd1RNsqvEYCcqvJUoj0TDd).
+
+We would like to thank everyone who participated in the nomination process, and
+we congratulate the winners for their outstanding contributions to the
+OpenTelemetry project.

--- a/content/en/blog/2024/community-awards-winners.md
+++ b/content/en/blog/2024/community-awards-winners.md
@@ -15,7 +15,7 @@ winners with you.
 
 Let's congratulate our 2024 OpenTelemetry Community Awards winners:
 
-- [@serkan-ozal](https://github.com/serkan-ozal) (Serkan Ozal)
+- [@serkan-ozal](https://github.com/serkan-ozal) (Serkan Özal)
 - [@anunarapureddy](https://github.com/anunarapureddy) (Anusha Narapureddy)
 - [@avillela](https://github.com/avillela) (Adriana Villela)
 - [@codeboten](https://github.com/codeboten) (Alex Boten)

--- a/content/en/blog/2024/community-awards-winners.md
+++ b/content/en/blog/2024/community-awards-winners.md
@@ -6,7 +6,7 @@ author: OpenTelemetry Governance Committee
 cSpell:ignore: serkan ozal Serkan Özal anunarapureddy Anusha Narapureddy avillela codeboten emdneto
 ---
 
-We are exicted to announce the winners of the first-ever **OpenTelemetry
+We are excited to announce the winners of the first-ever **OpenTelemetry
 Community Awards**! These awards recognize individuals who have made a notable
 impact to OpenTelemetry project over the past year, whether it's through code,
 documentation, project management, outreach, adoption, or simply helping others

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -2743,6 +2743,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-04-16T16:28:02.021217686Z"
   },
+  "https://docs.google.com/presentation/d/1YaJvAWnNcUJd1RNsqvEYCcqvJUoj0TDd": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-15T15:28:20.886935-07:00"
+  },
   "https://docs.google.com/spreadsheets/d/1E23Dkz1B2us71BtlQq8oG4o_QFsTeLPeh-X2uVnlubg/edit": {
     "StatusCode": 200,
     "LastSeen": "2024-11-04T16:12:37.723458+01:00"


### PR DESCRIPTION
Adding a blogpost to announce the 2024 OTel Community Awards winners, adding a link to slides presented during KubeCon at the OTel Observatory.