### PR TITLE
Fix title for Rust stdout exporter

### DIFF
--- a/data/registry/exporter-rust-stdout.yml
+++ b/data/registry/exporter-rust-stdout.yml
@@ -1,4 +1,4 @@
-title: OTLP Exporter
+title: Stdout Exporter
 registryType: exporter
 language: rust
 tags:
@@ -16,4 +16,4 @@ createdAt: 2024-01-19
 package:
   registry: crates
   name: opentelemetry-stdout
-  version: 0.3.0
+  version: 0.27.0


### PR DESCRIPTION
Fixes the title in the Rust stdout exporter from "OTLP Exporter" => "Stdout Exporter". Update version to latest published crate.
