### PR TITLE
Add `uv` package manager instructions to Python zero-code docs

### DIFF
--- a/content/en/docs/zero-code/python/_index.md
+++ b/content/en/docs/zero-code/python/_index.md
@@ -135,16 +135,15 @@ uv pip install opentelemetry-distro opentelemetry-exporter-otlp
 
 Now, you can install the auto instrumentation:
 
-```
+```sh
 uv run opentelemetry-bootstrap -a requirements | uv pip install --requirement -
 ```
 
 Finally, use `uv run` to start your application (see [Configuring the agent](#configuring-the-agent)):
 
-```
+```sh
 uv run opentelemetry-instrument python myapp.py
 ```
 
 Please note that you have to reinstall the auto instrumentation every time you run `uv sync` or update existing packages.
 It is therefore recommended to make the installation part of your build pipeline.
-

--- a/content/en/docs/zero-code/python/_index.md
+++ b/content/en/docs/zero-code/python/_index.md
@@ -121,9 +121,9 @@ export GRPC_TRACE=http,call_error,connectivity_state
 opentelemetry-instrument python YOUR_APP.py
 ```
 
-### Bootstrap using astral/uv
+### Bootstrap using uv
 
-When using the [uv](https://docs.astral.sh/uv/) package manager. You might face some difficulty when running `opentelemetry-bootstrap -a install`.
+When using the [uv](https://docs.astral.sh/uv/) package manager, you might face some difficulty when running `opentelemetry-bootstrap -a install`.
 
 Instead, you can generate the requirements dynamically and install them using `uv`.
 

--- a/content/en/docs/zero-code/python/_index.md
+++ b/content/en/docs/zero-code/python/_index.md
@@ -120,3 +120,31 @@ export GRPC_VERBOSITY=debug
 export GRPC_TRACE=http,call_error,connectivity_state
 opentelemetry-instrument python YOUR_APP.py
 ```
+
+### Bootstrap using astral/uv
+
+When using the [uv](https://docs.astral.sh/uv/) package manager. You might face some difficulty when running `opentelemetry-bootstrap -a install`.
+
+Instead, you can generate the requirements dynamically and install them using `uv`.
+
+First, install the appropriate packages (or add them to your project file and run `uv sync`):
+
+```sh
+uv pip install opentelemetry-distro opentelemetry-exporter-otlp
+```
+
+Now, you can install the auto instrumentation:
+
+```
+uv run opentelemetry-bootstrap -a requirements | uv pip install --requirement -
+```
+
+Finally, use `uv run` to start your application (see [Configuring the agent](#configuring-the-agent)):
+
+```
+uv run opentelemetry-instrument python myapp.py
+```
+
+Please note that you have to reinstall the auto instrumentation every time you run `uv sync` or update existing packages.
+It is therefore recommended to make the installation part of your build pipeline.
+

--- a/content/en/docs/zero-code/python/_index.md
+++ b/content/en/docs/zero-code/python/_index.md
@@ -123,11 +123,14 @@ opentelemetry-instrument python YOUR_APP.py
 
 ### Bootstrap using uv
 
-When using the [uv](https://docs.astral.sh/uv/) package manager, you might face some difficulty when running `opentelemetry-bootstrap -a install`.
+When using the [uv](https://docs.astral.sh/uv/) package manager, you might face
+some difficulty when running `opentelemetry-bootstrap -a install`.
 
-Instead, you can generate the requirements dynamically and install them using `uv`.
+Instead, you can generate the requirements dynamically and install them using
+`uv`.
 
-First, install the appropriate packages (or add them to your project file and run `uv sync`):
+First, install the appropriate packages (or add them to your project file and
+run `uv sync`):
 
 ```sh
 uv pip install opentelemetry-distro opentelemetry-exporter-otlp
@@ -139,11 +142,13 @@ Now, you can install the auto instrumentation:
 uv run opentelemetry-bootstrap -a requirements | uv pip install --requirement -
 ```
 
-Finally, use `uv run` to start your application (see [Configuring the agent](#configuring-the-agent)):
+Finally, use `uv run` to start your application (see
+[Configuring the agent](#configuring-the-agent)):
 
 ```sh
 uv run opentelemetry-instrument python myapp.py
 ```
 
-Please note that you have to reinstall the auto instrumentation every time you run `uv sync` or update existing packages.
-It is therefore recommended to make the installation part of your build pipeline.
+Please note that you have to reinstall the auto instrumentation every time you
+run `uv sync` or update existing packages. It is therefore recommended to make
+the installation part of your build pipeline.

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -2339,6 +2339,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-30T17:38:37.903633988Z"
   },
+  "https://docs.astral.sh/uv/": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-21T10:24:48.633652602+01:00"
+  },
   "https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-metadata.html#sqs-message-system-attributes": {
     "StatusCode": 206,
     "LastSeen": "2024-01-18T08:53:50.0122-05:00"


### PR DESCRIPTION
<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->

When using https://docs.astral.sh/uv/ the default instructions fail because the shell syntax and method of running scripts is a bit different.

pip install also doesnt work like it would normally, and you wouldn't really want to use it anyways because uv is faster and uses its own venvs

This PR adds instructions to the troubleshooting section.