### PR TITLE
add confmap provider to registry.json

### DIFF
--- a/data/registry-schema.json
+++ b/data/registry-schema.json
@@ -17,7 +17,6 @@
       "description": "The type of the entry",
       "enum": [
         "application integration",
-        "confmap converter",
         "confmap provider",
         "core",
         "exporter",

--- a/data/registry-schema.json
+++ b/data/registry-schema.json
@@ -17,6 +17,8 @@
       "description": "The type of the entry",
       "enum": [
         "application integration",
+        "confmap converter",
+        "confmap provider",
         "core",
         "exporter",
         "extension",

--- a/data/registry/collector-confmap-provider-envprovider.yml
+++ b/data/registry/collector-confmap-provider-envprovider.yml
@@ -1,0 +1,21 @@
+# cSpell:ignore confmap, envprovider
+title: Collector Environment Variable Provider
+registryType: confmap provider
+language: collector
+tags:
+  - go
+  - confmap
+  - provider
+  - collector
+  - env
+license: Apache 2.0
+description: Environment variable provider for OpenTelemetry Collector confmaps.
+authors:
+  - name: OpenTelemetry Authors
+urls:
+  repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/confmap/provider/envprovider
+createdAt: 2024-11-20
+package:
+  registry: go-collector
+  name: go.opentelemetry.io/collector/confmap/provider/envprovider
+  version: v1.20.0

--- a/data/registry/collector-confmap-provider-envprovider.yml
+++ b/data/registry/collector-confmap-provider-envprovider.yml
@@ -9,7 +9,8 @@ tags:
   - collector
   - env
 license: Apache 2.0
-description: Environment variable provider for OpenTelemetry Collector configuration maps.
+description:
+  Environment variable provider for OpenTelemetry Collector configuration maps.
 authors:
   - name: OpenTelemetry Authors
 urls:

--- a/data/registry/collector-confmap-provider-envprovider.yml
+++ b/data/registry/collector-confmap-provider-envprovider.yml
@@ -9,7 +9,7 @@ tags:
   - collector
   - env
 license: Apache 2.0
-description: Environment variable provider for OpenTelemetry Collector confmaps.
+description: Environment variable provider for OpenTelemetry Collector configuration maps.
 authors:
   - name: OpenTelemetry Authors
 urls:

--- a/data/registry/collector-confmap-provider-fileprovider.yml
+++ b/data/registry/collector-confmap-provider-fileprovider.yml
@@ -9,7 +9,7 @@ tags:
   - collector
   - file
 license: Apache 2.0
-description: File provider for OpenTelemetry Collector confmaps.
+description: File provider for OpenTelemetry Collector configuration maps.
 authors:
   - name: OpenTelemetry Authors
 urls:

--- a/data/registry/collector-confmap-provider-fileprovider.yml
+++ b/data/registry/collector-confmap-provider-fileprovider.yml
@@ -1,0 +1,21 @@
+# cSpell:ignore confmap, fileprovider
+title: Collector File Provider
+registryType: confmap provider
+language: collector
+tags:
+  - go
+  - confmap
+  - provider
+  - collector
+  - file
+license: Apache 2.0
+description: File provider for OpenTelemetry Collector confmaps.
+authors:
+  - name: OpenTelemetry Authors
+urls:
+  repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/confmap/provider/fileprovider
+createdAt: 2024-11-20
+package:
+  registry: go-collector
+  name: go.opentelemetry.io/collector/confmap/provider/fileprovider
+  version: v1.20.0

--- a/data/registry/collector-confmap-provider-httpprovider.yml
+++ b/data/registry/collector-confmap-provider-httpprovider.yml
@@ -1,0 +1,21 @@
+# cSpell:ignore confmap, httpprovider
+title: Collector HTTP Provider
+registryType: confmap provider
+language: collector
+tags:
+  - go
+  - confmap
+  - provider
+  - collector
+  - http
+license: Apache 2.0
+description: HTTP provider for OpenTelemetry Collector confmaps.
+authors:
+  - name: OpenTelemetry Authors
+urls:
+  repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/confmap/provider/httpprovider
+createdAt: 2024-11-20
+package:
+  registry: go-collector
+  name: go.opentelemetry.io/collector/confmap/provider/httpprovider
+  version: v1.20.0

--- a/data/registry/collector-confmap-provider-httpprovider.yml
+++ b/data/registry/collector-confmap-provider-httpprovider.yml
@@ -9,7 +9,7 @@ tags:
   - collector
   - http
 license: Apache 2.0
-description: HTTP provider for OpenTelemetry Collector confmaps.
+description: HTTP provider for OpenTelemetry Collector configuration maps.
 authors:
   - name: OpenTelemetry Authors
 urls:

--- a/data/registry/collector-confmap-provider-httpsprovider.yml
+++ b/data/registry/collector-confmap-provider-httpsprovider.yml
@@ -1,0 +1,21 @@
+# cSpell:ignore confmap, httpsprovider
+title: Collector HTTPS Provider
+registryType: confmap provider
+language: collector
+tags:
+  - go
+  - confmap
+  - provider
+  - collector
+  - https
+license: Apache 2.0
+description: HTTPS provider for OpenTelemetry Collector confmaps.
+authors:
+  - name: OpenTelemetry Authors
+urls:
+  repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/confmap/provider/httpsprovider
+createdAt: 2024-11-20
+package:
+  registry: go-collector
+  name: go.opentelemetry.io/collector/confmap/provider/httpsprovider
+  version: v1.20.0

--- a/data/registry/collector-confmap-provider-httpsprovider.yml
+++ b/data/registry/collector-confmap-provider-httpsprovider.yml
@@ -9,7 +9,7 @@ tags:
   - collector
   - https
 license: Apache 2.0
-description: HTTPS provider for OpenTelemetry Collector confmaps.
+description: HTTPS provider for OpenTelemetry Collector configuration maps.
 authors:
   - name: OpenTelemetry Authors
 urls:

--- a/data/registry/collector-confmap-provider-yamlprovider.yml
+++ b/data/registry/collector-confmap-provider-yamlprovider.yml
@@ -1,0 +1,21 @@
+# cSpell:ignore confmap, yamlprovider
+title: Collector YAML Provider
+registryType: confmap provider
+language: collector
+tags:
+  - go
+  - confmap
+  - provider
+  - collector
+  - yaml
+license: Apache 2.0
+description: YAML provider for OpenTelemetry Collector confmaps.
+authors:
+  - name: OpenTelemetry Authors
+urls:
+  repo: https://github.com/open-telemetry/opentelemetry-collector/tree/main/confmap/provider/yamlprovider
+createdAt: 2024-11-20
+package:
+  registry: go-collector
+  name: go.opentelemetry.io/collector/confmap/provider/yamlprovider
+  version: v1.20.0

--- a/data/registry/collector-confmap-provider-yamlprovider.yml
+++ b/data/registry/collector-confmap-provider-yamlprovider.yml
@@ -9,7 +9,7 @@ tags:
   - collector
   - yaml
 license: Apache 2.0
-description: YAML provider for OpenTelemetry Collector confmaps.
+description: YAML provider for OpenTelemetry Collector configuration maps.
 authors:
   - name: OpenTelemetry Authors
 urls:

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -11527,6 +11527,26 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-18T19:07:49.734386-05:00"
   },
+  "https://pkg.go.dev/go.opentelemetry.io/collector/confmap/provider/envprovider": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-19T13:34:41.905691-05:00"
+  },
+  "https://pkg.go.dev/go.opentelemetry.io/collector/confmap/provider/fileprovider": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-19T13:34:42.093539-05:00"
+  },
+  "https://pkg.go.dev/go.opentelemetry.io/collector/confmap/provider/httpprovider": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-19T13:34:42.280695-05:00"
+  },
+  "https://pkg.go.dev/go.opentelemetry.io/collector/confmap/provider/httpsprovider": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-19T13:34:42.965663-05:00"
+  },
+  "https://pkg.go.dev/go.opentelemetry.io/collector/confmap/provider/yamlprovider": {
+    "StatusCode": 200,
+    "LastSeen": "2024-11-19T13:34:43.403526-05:00"
+  },
   "https://pkg.go.dev/go.opentelemetry.io/collector/exporter/debugexporter": {
     "StatusCode": 200,
     "LastSeen": "2024-03-01T16:49:31.744795+01:00"


### PR DESCRIPTION
<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->
As mentioned in #5387, there are more components that are compatible with the OpenTelemetry Collector.
These include `confmap.Converter` and `confmap.Provider` types. 

confmap.Converter: https://github.com/open-telemetry/opentelemetry-collector/issues/11582

confmap.Provider: https://github.com/open-telemetry/opentelemetry-collector/issues/4567

There are currently [five confmap.Providers that are maintained in the OpenTelemetry Collector core repository](https://github.com/open-telemetry/opentelemetry-collector/tree/main/confmap/provider) and while there is only one Converter there and it is deprecated, there are vendors that make use of converters and it is possible they would choose to publish them in the registry once this is available.

As I am not super familiar with the registry and changes necessary to update the same, I may have missed file(s) that need to be changed and will happily make these changes if suggested.

Additionally, I don't feel strongly about calling them "confmap converter" vs. "converter" or provider, but it seemed slightly more descriptive. Open to feedback there as well.