### PR TITLE
Blog RSS workaround via redirect using 302 status code

### DIFF
--- a/content/en/blog/_index.md
+++ b/content/en/blog/_index.md
@@ -3,9 +3,9 @@ title: Blog
 menu: { main: { weight: 50 } }
 redirects:
   # Every January, update the year number in the paths below
-  - { from: '', to: '2024/ 301!' }
+  - { from: '', to: '2024/ 302!' }
   # Workaround to https://github.com/open-telemetry/opentelemetry.io/issues/4440:
-  - { from: 'index.xml', to: '2024/index.xml 301!' }
+  - { from: 'index.xml', to: '2024/index.xml 302!' }
 outputs: [HTML, RSS]
 htmltest:
   # 2024-11-07 DO NOT COPY the following IgnoreDirs to non-en pages because handles all locales.


### PR DESCRIPTION
- Followup to #5520
- Contributes to #5651
- Thanks to @jord1e for point that out. /cc @dmathieu. Can you confirm that it still works for you (it should).
  Once I get a confirmation, I'll double check other 301s to see if they should be 302s.

**Redirect test**:

- https://deploy-preview-5652--opentelemetry.netlify.app/blog
- https://deploy-preview-5652--opentelemetry.netlify.app/blog/index.xml

```console
$ curl -I https://deploy-preview-5652--opentelemetry.netlify.app/blog/index.xml 
HTTP/2 302 
...
location: /blog/2024/index.xml
...
```