### PR TITLE
[demo] - clarify demo upgrade capability in Kubernetes

### DIFF
--- a/content/en/docs/demo/kubernetes-deployment.md
+++ b/content/en/docs/demo/kubernetes-deployment.md
@@ -32,6 +32,10 @@ command:
 helm install my-otel-demo open-telemetry/opentelemetry-demo
 ```
 
+> **Note** The OpenTelemetry Demo Helm chart does not support being upgraded
+> from one version to another. If you need to upgrade the chart, you must first
+> delete the existing release and then install the new version.
+
 > **Note** The OpenTelemetry Demo Helm chart version 0.11.0 or greater is
 > required to perform all usage methods mentioned below.
 
@@ -43,6 +47,10 @@ cluster.
 ```shell
 kubectl apply --namespace otel-demo -f https://raw.githubusercontent.com/open-telemetry/opentelemetry-demo/main/kubernetes/opentelemetry-demo.yaml
 ```
+
+> **Note** The OpenTelemetry Demo Kubernetes manifests do not support being
+> upgraded from one version to another. If you need to upgrade the chart, you
+> must first delete the existing resources and then install the new version.
 
 > **Note** These manifests are generated from the Helm chart and are provided
 > for convenience. It is recommended to use the Helm chart for installation.
@@ -143,23 +151,6 @@ components:
       - name: PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
         value: http://otel-demo.my-domain.com/otlp-http/v1/traces
 ```
-
-#### Installation with a values file
-
-To install the Helm chart with a custom `my-values-file.yaml` values file use:
-
-```shell
-helm install my-otel-demo open-telemetry/opentelemetry-demo --values my-values-file.yaml
-```
-
-With the frontendproxy and Collector exposed, you can access the demo UI at the
-base path for the frontendproxy. Other demo components can be accessed at the
-following sub-paths:
-
-- Web store: `/` (base)
-- Grafana: `/grafana`
-- Load Generator UI: `/loadgen/` (must include trailing slash)
-- Jaeger UI: `/jaeger/ui`
 
 ## Bring your own backend
 


### PR DESCRIPTION
When the demo is started in a Kubernetes world, we use init-containers to ensure the order of services to be started (e.g., Kafka before fraud detection). However, when upgrading the demo, the order in which services are restarted can not be guaranteed. Because of this, the demo install in Kubernetes has never supported an upgrade operation, and this PR adds a note to clarify that.