### PR TITLE
Add missing contrib processors, add auto version update for opentelemetry-java-contrib

### DIFF
--- a/content/en/docs/languages/java/_index.md
+++ b/content/en/docs/languages/java/_index.md
@@ -8,7 +8,7 @@ cascade:
   vers:
     instrumentation: 2.10.0
     otel: 1.44.1
-    contrib: 1.38.0
+    contrib: 1.41.0
     semconv: 1.28.0
 weight: 18
 ---

--- a/content/en/docs/languages/java/sdk.md
+++ b/content/en/docs/languages/java/sdk.md
@@ -325,6 +325,7 @@ Span processors built-in to the SDK and maintained by the community in
 | `BaggageSpanProcessor`    | `io.opentelemetry.contrib:opentelemetry-baggage-processor:{{% param vers.contrib %}}-alpha` | Enriches spans with baggage.                                              |
 | `JfrSpanProcessor`        | `io.opentelemetry.contrib:opentelemetry-jfr-events:{{% param vers.contrib %}}-alpha`        | Creates JFR events from spans.                                            |
 | `StackTraceSpanProcessor` | `io.opentelemetry.contrib:opentelemetry-span-stacktrace:{{% param vers.contrib %}}-alpha`   | Enriches select spans with stack trace data.                              |
+| `InferredSpansProcessor`  | `io.opentelemetry.contrib:opentelemetry-inferred-spans:{{% param vers.contrib %}}-alpha`    | Generates spans from async profiler instead of instrumentation.           |
 
 The following code snippet demonstrates `SpanProcessor` programmatic
 configuration:
@@ -998,10 +999,11 @@ other applications such as data enrichment.
 Log record processors built-in to the SDK and maintained by the community in
 `opentelemetry-java-contrib`:
 
-| Class                      | Artifact                                                     | Description                                                                  |
-| -------------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------- |
-| `BatchLogRecordProcessor`  | `io.opentelemetry:opentelemetry-sdk:{{% param vers.otel %}}` | Batches log records and exports them via a configurable `LogRecordExporter`. |
-| `SimpleLogRecordProcessor` | `io.opentelemetry:opentelemetry-sdk:{{% param vers.otel %}}` | Exports each log record a via a configurable `LogRecordExporter`.            |
+| Class                      | Artifact                                                                             | Description                                                                  |
+| -------------------------- | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| `BatchLogRecordProcessor`  | `io.opentelemetry:opentelemetry-sdk:{{% param vers.otel %}}`                         | Batches log records and exports them via a configurable `LogRecordExporter`. |
+| `SimpleLogRecordProcessor` | `io.opentelemetry:opentelemetry-sdk:{{% param vers.otel %}}`                         | Exports each log record a via a configurable `LogRecordExporter`.            |
+| `EventToSpanEventBridge`   | `io.opentelemetry.contrib:opentelemetry-processors:{{% param vers.contrib %}}-alpha` | Records event log records as span events on the current span.                |
 
 The following code snippet demonstrates `LogRecordProcessor` programmatic
 configuration:

--- a/scripts/auto-update/all-versions.sh
+++ b/scripts/auto-update/all-versions.sh
@@ -8,6 +8,7 @@ function auto_update_versions() {
       "opentelemetry-java otel content/en/docs/zero-code/java/_index.md"
       "opentelemetry-java-instrumentation instrumentation content/en/docs/languages/java/_index.md"
       "opentelemetry-java-instrumentation instrumentation content/en/docs/zero-code/java/_index.md"
+      "opentelemetry-java-contrib contrib content/en/docs/languages/java/_index.md"
       "opentelemetry-specification spec scripts/content-modules/adjust-pages.pl .gitmodules"
       "opentelemetry-proto otlp scripts/content-modules/adjust-pages.pl .gitmodules"
       "semantic-conventions semconv scripts/content-modules/adjust-pages.pl .gitmodules"


### PR DESCRIPTION
A couple of processors have recently been added to `opentelemetry-java-contrib` which are missing from the docs. This updates them.

Also noticed that the contrib version was lagging behind and that there was no automation to automatically update it, so I updated to the latest and added automation for updating. 

---

**Preview**: https://deploy-preview-5664--opentelemetry.netlify.app/docs/languages/java/sdk/#sampler