### PR TITLE
Update instrumentation.md

### DIFF
--- a/content/en/docs/languages/js/instrumentation.md
+++ b/content/en/docs/languages/js/instrumentation.md
@@ -115,7 +115,7 @@ add the following code to it:
 
 ```ts
 /*app.ts*/
-import express, { Request, Express } from 'express';
+import express, { Express } from 'express';
 import { rollTheDice } from './dice';
 
 const PORT: number = parseInt(process.env.PORT || '8080');


### PR DESCRIPTION
import express, { Request, Express } from 'express';

I think 'Request' is not needed.  To mislead readers, we should delete it.
