### PR TITLE
[Demo] Update diagram

### DIFF
--- a/content/en/docs/demo/architecture.md
+++ b/content/en/docs/demo/architecture.md
@@ -35,7 +35,7 @@ queue[(queue<br/>&#40Kafka&#41)]:::java
 
 adservice ---->|gRPC| flagd
 
-checkoutservice -->|gRPC| cartservice 
+checkoutservice -->|gRPC| cartservice
 checkoutservice --->|TCP| queue
 cartservice --> cache
 cartservice -->|gRPC| flagd

--- a/content/en/docs/demo/architecture.md
+++ b/content/en/docs/demo/architecture.md
@@ -14,7 +14,7 @@ graph TD
 subgraph Service Diagram
 accountingservice(Accounting Service):::dotnet
 adservice(Ad Service):::java
-cache[(Cache<br/>&#40ValKey&#41)]
+cache[(Cache<br/>&#40Valkey&#41)]
 cartservice(Cart Service):::dotnet
 checkoutservice(Checkout Service):::golang
 currencyservice(Currency Service):::cpp

--- a/content/en/docs/demo/architecture.md
+++ b/content/en/docs/demo/architecture.md
@@ -85,7 +85,7 @@ classDef php fill:#4f5d95,color:white;
 classDef python fill:#3572A5,color:white;
 classDef ruby fill:#701516,color:white;
 classDef rust fill:#dea584,color:black;
-classDef typescript fill:#e98516,color:black; 
+classDef typescript fill:#e98516,color:black;
 ```
 
 ```mermaid

--- a/content/en/docs/demo/architecture.md
+++ b/content/en/docs/demo/architecture.md
@@ -14,12 +14,13 @@ graph TD
 subgraph Service Diagram
 accountingservice(Accounting Service):::dotnet
 adservice(Ad Service):::java
-cache[(Cache<br/>&#40redis&#41)]
+cache[(Cache<br/>&#40ValKey&#41)]
 cartservice(Cart Service):::dotnet
 checkoutservice(Checkout Service):::golang
 currencyservice(Currency Service):::cpp
 emailservice(Email Service):::ruby
-flagd(Flagd-ui):::typescript
+flagd(Flagd):::golang
+flagdui(Flagd-ui):::typescript
 frauddetectionservice(Fraud Detection Service):::kotlin
 frontend(Frontend):::typescript
 frontendproxy(Frontend Proxy <br/>&#40Envoy&#41):::cpp
@@ -30,40 +31,52 @@ productcatalogservice(Product Catalog Service):::golang
 quoteservice(Quote Service):::php
 recommendationservice(Recommendation Service):::python
 shippingservice(Shipping Service):::rust
-queue[(queue<br/>&#40Kafka&#41)]
+queue[(queue<br/>&#40Kafka&#41)]:::java
+
+adservice ---->|gRPC| flagd
+
+checkoutservice -->|gRPC| cartservice 
+checkoutservice --->|TCP| queue
+cartservice --> cache
+cartservice -->|gRPC| flagd
+
+checkoutservice -->|gRPC| shippingservice
+checkoutservice -->|gRPC| paymentservice
+checkoutservice --->|HTTP| emailservice
+checkoutservice -->|gRPC| currencyservice
+checkoutservice -->|gRPC| productcatalogservice
+
+frauddetectionservice -->|gRPC| flagd
+
+frontend -->|gRPC| adservice
+frontend -->|gRPC| cartservice
+frontend -->|gRPC| checkoutservice
+frontend ---->|gRPC| currencyservice
+frontend ---->|gRPC| recommendationservice
+frontend -->|gRPC| productcatalogservice
+
+frontendproxy -->|gRPC| flagd
+frontendproxy -->|HTTP| frontend
+frontendproxy -->|HTTP| flagdui
+frontendproxy -->|HTTP| imageprovider
 
 Internet -->|HTTP| frontendproxy
-frontendproxy -->|HTTP| frontend
-frontendproxy -->|HTTP| flagd
+
 loadgenerator -->|HTTP| frontendproxy
-frontendproxy -->|HTTP| imageprovider
+
+paymentservice -->|gRPC| flagd
 
 queue -->|TCP| accountingservice
 queue -->|TCP| frauddetectionservice
 
-frontend -->|gRPC| cartservice
-frontend -->|gRPC| currencyservice
-
-checkoutservice -->|gRPC| cartservice --> cache
-checkoutservice -->|gRPC| productcatalogservice
-checkoutservice -->|gRPC| currencyservice
-checkoutservice -->|HTTP| emailservice
-checkoutservice -->|gRPC| paymentservice
-checkoutservice -->|gRPC| shippingservice
-checkoutservice -->|TCP| queue
-
-frontend -->|gRPC| adservice
-frontend -->|gRPC| productcatalogservice
-frontend --->|gRPC| checkoutservice
-frontend ---->|gRPC| recommendationservice -->|gRPC| productcatalogservice
+recommendationservice -->|gRPC| productcatalogservice
+recommendationservice -->|gRPC| flagd
 
 shippingservice -->|HTTP| quoteservice
-
 end
 
 classDef dotnet fill:#178600,color:white;
 classDef cpp fill:#f34b7d,color:white;
-classDef erlang fill:#b83998,color:white;
 classDef golang fill:#00add8,color:black;
 classDef java fill:#b07219,color:white;
 classDef javascript fill:#f1e05a,color:black;
@@ -72,7 +85,7 @@ classDef php fill:#4f5d95,color:white;
 classDef python fill:#3572A5,color:white;
 classDef ruby fill:#701516,color:white;
 classDef rust fill:#dea584,color:black;
-classDef typescript fill:#e98516,color:black;
+classDef typescript fill:#e98516,color:black; 
 ```
 
 ```mermaid
@@ -80,7 +93,6 @@ graph TD
 subgraph Service Legend
   dotnetsvc(.NET):::dotnet
   cppsvc(C++):::cpp
-  erlangsvc(Erlang/Elixir):::erlang
   golangsvc(Go):::golang
   javasvc(Java):::java
   javascriptsvc(JavaScript):::javascript
@@ -94,7 +106,6 @@ end
 
 classDef dotnet fill:#178600,color:white;
 classDef cpp fill:#f34b7d,color:white;
-classDef erlang fill:#b83998,color:white;
 classDef golang fill:#00add8,color:black;
 classDef java fill:#b07219,color:white;
 classDef javascript fill:#f1e05a,color:black;


### PR DESCRIPTION
This PR adds the missing `flagd` service to the diagram and realigns all services.
Also, we have removed redis from the demo some time ago and replaced with ValKey.