### PR TITLE
fix confmap provider name

### DIFF
--- a/data/registry-schema.json
+++ b/data/registry-schema.json
@@ -17,13 +17,13 @@
       "description": "The type of the entry",
       "enum": [
         "application integration",
-        "confmap provider",
         "core",
         "exporter",
         "extension",
         "instrumentation",
         "log-bridge",
         "processor",
+        "provider",
         "receiver",
         "resource-detector",
         "utilities"

--- a/data/registry/collector-confmap-provider-envprovider.yml
+++ b/data/registry/collector-confmap-provider-envprovider.yml
@@ -1,6 +1,6 @@
 # cSpell:ignore confmap, envprovider
 title: Collector Environment Variable Provider
-registryType: confmap provider
+registryType: provider
 language: collector
 tags:
   - go

--- a/data/registry/collector-confmap-provider-fileprovider.yml
+++ b/data/registry/collector-confmap-provider-fileprovider.yml
@@ -1,6 +1,6 @@
 # cSpell:ignore confmap, fileprovider
 title: Collector File Provider
-registryType: confmap provider
+registryType: provider
 language: collector
 tags:
   - go

--- a/data/registry/collector-confmap-provider-httpprovider.yml
+++ b/data/registry/collector-confmap-provider-httpprovider.yml
@@ -1,6 +1,6 @@
 # cSpell:ignore confmap, httpprovider
 title: Collector HTTP Provider
-registryType: confmap provider
+registryType: provider
 language: collector
 tags:
   - go

--- a/data/registry/collector-confmap-provider-httpsprovider.yml
+++ b/data/registry/collector-confmap-provider-httpsprovider.yml
@@ -1,6 +1,6 @@
 # cSpell:ignore confmap, httpsprovider
 title: Collector HTTPS Provider
-registryType: confmap provider
+registryType: provider
 language: collector
 tags:
   - go

--- a/data/registry/collector-confmap-provider-yamlprovider.yml
+++ b/data/registry/collector-confmap-provider-yamlprovider.yml
@@ -1,6 +1,6 @@
 # cSpell:ignore confmap, yamlprovider
 title: Collector YAML Provider
-registryType: confmap provider
+registryType: provider
 language: collector
 tags:
   - go


### PR DESCRIPTION
<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->
This changes the name for Collector Confmap Providers in the registry from "confmap provider" to "provider".

The way the registry shows how to add a component, `confmap provider`, is not the correct way to include a provider with your collector build. While the name is more descriptive, without knowing a way to have a different display name in the drop-down, it seems better to name it `provider` instead to ensure a correct code snippet.

<img width="1088" alt="Screenshot 2024-11-22 at 11 07 07 AM" src="https://github.com/user-attachments/assets/c4a47be5-592c-42c3-8152-5f438c54c8b1">

