### PR TITLE
Fix registry version updater

### DIFF
--- a/data/registry/instrumentation-php-cakephp.yml
+++ b/data/registry/instrumentation-php-cakephp.yml
@@ -1,3 +1,4 @@
+# cSpell:ignore cakephp
 title: OpenTelemetry CakePHP instrumentation library
 registryType: instrumentation
 language: php

--- a/data/registry/instrumentation-php-cakephp.yml
+++ b/data/registry/instrumentation-php-cakephp.yml
@@ -14,4 +14,8 @@ description:
 authors:
   - name: OpenTelemetry Authors
 createdAt: 2024-07-08
+package:
+  registry: packagist
+  name: open-telemetry/opentelemetry-auto-cakephp
+  version: 0.0.3
 isFirstParty: false

--- a/data/registry/instrumentation-php-curl.yml
+++ b/data/registry/instrumentation-php-curl.yml
@@ -18,6 +18,6 @@ authors:
 createdAt: 2024-11-18
 package:
   registry: packagist
-  name: opentelemetry-auto-curl
+  name: open-telemetry/opentelemetry-auto-curl
   version: 0.0.1
 isFirstParty: false

--- a/data/registry/instrumentation-php-extrdkafka.yml
+++ b/data/registry/instrumentation-php-extrdkafka.yml
@@ -19,6 +19,6 @@ authors:
 createdAt: 2024-11-18
 package:
   registry: packagist
-  name: opentelemetry-auto-ext-rdkafka
+  name: open-telemetry/opentelemetry-auto-ext-rdkafka
   version: 0.0.1
 isFirstParty: false

--- a/data/registry/instrumentation-php-psr6.yml
+++ b/data/registry/instrumentation-php-psr6.yml
@@ -14,4 +14,8 @@ description:
 authors:
   - name: OpenTelemetry Authors
 createdAt: 2024-07-08
+package:
+  registry: packagist
+  name: open-telemetry/opentelemetry-auto-psr6
+  version: 0.0.3
 isFirstParty: false

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -10563,13 +10563,25 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-09T11:02:21.246316-04:00"
   },
+  "https://packagist.org/packages/open-telemetry/opentelemetry-auto-cakephp": {
+    "StatusCode": 200,
+    "LastSeen": "2024-12-03T11:06:06.86216+01:00"
+  },
   "https://packagist.org/packages/open-telemetry/opentelemetry-auto-codeigniter": {
     "StatusCode": 200,
     "LastSeen": "2024-01-19T13:15:35.481102+01:00"
   },
+  "https://packagist.org/packages/open-telemetry/opentelemetry-auto-curl": {
+    "StatusCode": 200,
+    "LastSeen": "2024-12-03T10:13:27.914323+01:00"
+  },
   "https://packagist.org/packages/open-telemetry/opentelemetry-auto-ext-amqp": {
     "StatusCode": 200,
     "LastSeen": "2024-01-19T13:15:35.677617+01:00"
+  },
+  "https://packagist.org/packages/open-telemetry/opentelemetry-auto-ext-rdkafka": {
+    "StatusCode": 200,
+    "LastSeen": "2024-12-03T10:13:28.648777+01:00"
   },
   "https://packagist.org/packages/open-telemetry/opentelemetry-auto-guzzle": {
     "StatusCode": 200,
@@ -10618,6 +10630,10 @@
   "https://packagist.org/packages/open-telemetry/opentelemetry-auto-psr3": {
     "StatusCode": 200,
     "LastSeen": "2024-01-19T13:15:37.331332+01:00"
+  },
+  "https://packagist.org/packages/open-telemetry/opentelemetry-auto-psr6": {
+    "StatusCode": 200,
+    "LastSeen": "2024-12-03T10:13:31.800557+01:00"
   },
   "https://packagist.org/packages/open-telemetry/opentelemetry-auto-slim": {
     "StatusCode": 200,


### PR DESCRIPTION
The workflow to update versions in the registry was broken due to some errors introduced by PHP packages missing the `open-telemetry` prefix. I fixed those files, but also introduced 2 additional changes:

* A way to catch errors if getting the latest version for a package fails, so a situation like this will not break the workflow again 
* A way to check if any versions have been updated and only if a new PR will be created, otherwise the script will always terminate with error