### PR TITLE
Fix ansible role name misspelling

### DIFF
--- a/content/en/blog/2024/scaling-collectors.md
+++ b/content/en/blog/2024/scaling-collectors.md
@@ -89,7 +89,7 @@ Create a file named `deploy-opentelemetry.yml` in the same directory as your
   tasks:
     - name: Install OpenTelemetry Collector
       ansible.builtin.include_role:
-        name: opentelemetry_collectorr
+        name: opentelemetry_collector
       vars:
         otel_collector_receivers:
           hostmetrics:


### PR DESCRIPTION
The ansible role is named opentelemetry_collector without the extra r

I found this spelling error while searching for an example of setting up the collector with ansible.