### PR TITLE
Add imports to instrumentations example in browser usage docs

### DIFF
--- a/content/en/docs/languages/js/getting-started/browser.md
+++ b/content/en/docs/languages/js/getting-started/browser.md
@@ -242,9 +242,37 @@ developer toolbar you should see some traces being exported:
 If you want to instrument Ajax requests, User Interactions and others, you can
 register additional instrumentations for those:
 
+```shell
+npm install @opentelemetry/instrumentation-user-interaction \
+  @opentelemetry/instrumentation-xml-http-request
+```
+
+
 ```javascript
+import {
+  ConsoleSpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
+import { DocumentLoadInstrumentation } from '@opentelemetry/instrumentation-document-load';
+import { ZoneContextManager } from '@opentelemetry/context-zone';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { UserInteractionInstrumentation } from '@opentelemetry/instrumentation-user-interaction';
+import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
+
+const provider = new WebTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(new ConsoleSpanExporter())],
+});
+
+provider.register({
+  // Changing default contextManager to use ZoneContextManager - supports asynchronous operations - optional
+  contextManager: new ZoneContextManager(),
+});
+
+// Registering instrumentations
 registerInstrumentations({
   instrumentations: [
+    new DocumentLoadInstrumentation(),
     new UserInteractionInstrumentation(),
     new XMLHttpRequestInstrumentation(),
   ],


### PR DESCRIPTION
Fixes #4951.

This PR adds missing imports in docs example. As a OTEL beginner, the instrumentation libraries that should be installed are not trivial. I've added these imports as a small improvement to the docs.
