### PR TITLE
Update Rust logs,metrics status to beta

### DIFF
--- a/data/instrumentation.yaml
+++ b/data/instrumentation.yaml
@@ -61,8 +61,8 @@ rust:
   name: Rust
   status:
     traces: beta
-    metrics: alpha
-    logs: alpha
+    metrics: beta
+    logs: beta
 swift:
   name: Swift
   status:


### PR DESCRIPTION
Update status from alpha to beta reflecting the repo: https://github.com/open-telemetry/opentelemetry-rust?tab=readme-ov-file#project-status
