### PR TITLE
[CI] add workflow to update community members

### DIFF
--- a/.github/workflows/auto-update-community-members.yml
+++ b/.github/workflows/auto-update-community-members.yml
@@ -1,0 +1,41 @@
+name: Auto-update community members page
+
+on:
+  workflow_dispatch:
+  schedule:
+    # At 03:41, every day
+    - cron: 41 3 * * *
+
+jobs:
+  auto-update-versions:
+    name: Auto-update community members page
+    runs-on: ubuntu-24.04
+    # Remove the if statement below when testing againt a fork
+    # if: github.repository == 'open-telemetry/opentelemetry.io'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        working-directory: ./scripts/generate-community-data
+        run: npm install
+
+      - name: Run script
+        working-directory: ./scripts/generate-community-data
+        run: node generate.js ../../data/community/members.yaml
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          add-paths: 'data/community/members.yaml'
+          committer: opentelemetrybot <107717825+opentelemetrybot@users.noreply.github.com>
+          token: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+          branch: update-community-members
+          title: Update community members
+          body: |
+            This pull request contains automated updates to files by the GitHub Action.

--- a/.github/workflows/auto-update-community-members.yml
+++ b/.github/workflows/auto-update-community-members.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Run script
         working-directory: ./scripts/generate-community-data
         run: node generate.js ../../data/community/members.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
This adds a workflow that checks for updates in the community on a daily basis.

Note that this makes use of https://github.com/peter-evans/create-pull-request/ to create the PR, which also comes with a feature for updating existing PRs. If this works as expected we might want to use it for other workflows as well 