### PR TITLE
Fix Java Context API example

### DIFF
--- a/content/en/docs/languages/java/api.md
+++ b/content/en/docs/languages/java/api.md
@@ -147,7 +147,7 @@ public class ContextUsage {
     try (Scope scope = context.makeCurrent()) {
       // The current context now contains the added value
       // output => context value: value
-      System.out.println("context value: " + context.get(exampleContextKey));
+      System.out.println("context value: " + Context.current().get(exampleContextKey));
     }
 
     // The local context var still contains the added value


### PR DESCRIPTION
The Context API example for Java shows how to set a local Context as the current one, and then access a value from the current context, however, the code still access the local one instead of the (just set) current context.