### PR TITLE
fix version update script

### DIFF
--- a/content/en/docs/collector/_index.md
+++ b/content/en/docs/collector/_index.md
@@ -3,7 +3,8 @@ title: Collector
 description: Vendor-agnostic way to receive, process and export telemetry data.
 aliases: [collector/about]
 cascade:
-  vers: 0.115.1
+  vers:
+    collector: 0.115.1
 weight: 270
 ---
 

--- a/content/en/docs/collector/installation.md
+++ b/content/en/docs/collector/installation.md
@@ -10,13 +10,14 @@ systems and architectures. The following instructions show how to download and
 install the latest stable version of the Collector.
 
 If you aren't familiar with the deployment models, components, and repositories
-applicable to the OpenTelemetry Collector, first review the [Data Collection][]
-and [Deployment Methods][] page.
+applicable to the OpenTelemetry Collector, first review the [Data Collection][] and
+[Deployment Methods][] page.
 
 ## Docker
 
 The following commands pull a Docker image and run the Collector in a container.
-Replace `{{% param vers.collector %}}` with the version of the Collector you want to run.
+Replace `{{% param vers.collector %}}` with the version of the Collector you
+want to run.
 
 {{< tabpane text=true >}} {{% tab DockerHub %}}
 

--- a/content/en/docs/collector/installation.md
+++ b/content/en/docs/collector/installation.md
@@ -85,10 +85,10 @@ The previous example is meant to serve as a starting point, to be extended and
 customized before actual production usage. For production-ready customization
 and installation, see [OpenTelemetry Helm Charts][].
 
-You can also use the [OpenTelemetry Operator][] to provision and maintain an
-OpenTelemetry Collector instance, with features such as automatic upgrade
-handling, `Service` configuration based on the OpenTelemetry configuration,
-automatic sidecar injection into deployments, and more.
+You can also use the [OpenTelemetry Operator][] to provision and maintain an OpenTelemetry
+Collector instance, with features such as automatic upgrade handling, `Service` configuration
+based on the OpenTelemetry configuration, automatic sidecar injection into deployments,
+and more.
 
 For guidance on how to use the Collector with Kubernetes, see
 [Kubernetes Getting Started](/docs/kubernetes/getting-started/).

--- a/content/en/docs/collector/installation.md
+++ b/content/en/docs/collector/installation.md
@@ -10,8 +10,8 @@ systems and architectures. The following instructions show how to download and
 install the latest stable version of the Collector.
 
 If you aren't familiar with the deployment models, components, and repositories
-applicable to the OpenTelemetry Collector, first review the [Data Collection][] and
-[Deployment Methods][] page.
+applicable to the OpenTelemetry Collector, first review the [Data Collection][]
+and [Deployment Methods][] page.
 
 ## Docker
 
@@ -85,10 +85,10 @@ The previous example is meant to serve as a starting point, to be extended and
 customized before actual production usage. For production-ready customization
 and installation, see [OpenTelemetry Helm Charts][].
 
-You can also use the [OpenTelemetry Operator][] to provision and maintain an OpenTelemetry
-Collector instance, with features such as automatic upgrade handling, `Service` configuration
-based on the OpenTelemetry configuration, automatic sidecar injection into deployments,
-and more.
+You can also use the [OpenTelemetry Operator][] to provision and maintain an
+OpenTelemetry Collector instance, with features such as automatic upgrade
+handling, `Service` configuration based on the OpenTelemetry configuration,
+automatic sidecar injection into deployments, and more.
 
 For guidance on how to use the Collector with Kubernetes, see
 [Kubernetes Getting Started](/docs/kubernetes/getting-started/).

--- a/content/en/docs/collector/installation.md
+++ b/content/en/docs/collector/installation.md
@@ -16,20 +16,20 @@ and [Deployment Methods][] page.
 ## Docker
 
 The following commands pull a Docker image and run the Collector in a container.
-Replace `{{% param vers %}}` with the version of the Collector you want to run.
+Replace `{{% param vers.collector %}}` with the version of the Collector you want to run.
 
 {{< tabpane text=true >}} {{% tab DockerHub %}}
 
 ```sh
-docker pull otel/opentelemetry-collector-contrib:{{% param vers %}}
-docker run otel/opentelemetry-collector-contrib:{{% param vers %}}
+docker pull otel/opentelemetry-collector-contrib:{{% param vers.collector %}}
+docker run otel/opentelemetry-collector-contrib:{{% param vers.collector %}}
 ```
 
 {{% /tab %}} {{% tab ghcr.io %}}
 
 ```sh
-docker pull ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{% param vers %}}
-docker run ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{% param vers %}}
+docker pull ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{% param vers.collector %}}
+docker run ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{% param vers.collector %}}
 ```
 
 {{% /tab %}} {{< /tabpane >}}
@@ -40,13 +40,13 @@ as a volume:
 {{< tabpane text=true >}} {{% tab DockerHub %}}
 
 ```sh
-docker run -v $(pwd)/config.yaml:/etc/otelcol-contrib/config.yaml otel/opentelemetry-collector-contrib:{{% param vers %}}
+docker run -v $(pwd)/config.yaml:/etc/otelcol-contrib/config.yaml otel/opentelemetry-collector-contrib:{{% param vers.collector %}}
 ```
 
 {{% /tab %}} {{% tab ghcr.io %}}
 
 ```sh
-docker run -v $(pwd)/config.yaml:/etc/otelcol-contrib/config.yaml ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{% param vers %}}
+docker run -v $(pwd)/config.yaml:/etc/otelcol-contrib/config.yaml ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{% param vers.collector %}}
 ```
 
 {{% /tab %}} {{< /tabpane >}}
@@ -77,7 +77,7 @@ The following command deploys an agent as a daemonset and a single gateway
 instance:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector/v{{% param vers %}}/examples/k8s/otel-config.yaml
+kubectl apply -f https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector/v{{% param vers.collector %}}/examples/k8s/otel-config.yaml
 ```
 
 The previous example is meant to serve as a starting point, to be extended and
@@ -114,8 +114,8 @@ To get started on Debian systems run the following commands:
 ```sh
 sudo apt-get update
 sudo apt-get -y install wget
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_linux_amd64.deb
-sudo dpkg -i otelcol_{{% param vers %}}_linux_amd64.deb
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers.collector %}}/otelcol_{{% param vers.collector %}}_linux_amd64.deb
+sudo dpkg -i otelcol_{{% param vers.collector %}}_linux_amd64.deb
 ```
 
 {{% /tab %}} {{% tab ARM64 %}}
@@ -123,8 +123,8 @@ sudo dpkg -i otelcol_{{% param vers %}}_linux_amd64.deb
 ```sh
 sudo apt-get update
 sudo apt-get -y install wget
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_linux_arm64.deb
-sudo dpkg -i otelcol_{{% param vers %}}_linux_arm64.deb
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers.collector %}}/otelcol_{{% param vers.collector %}}_linux_arm64.deb
+sudo dpkg -i otelcol_{{% param vers.collector %}}_linux_arm64.deb
 ```
 
 {{% /tab %}} {{% tab i386 %}}
@@ -132,8 +132,8 @@ sudo dpkg -i otelcol_{{% param vers %}}_linux_arm64.deb
 ```sh
 sudo apt-get update
 sudo apt-get -y install wget
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_linux_386.deb
-sudo dpkg -i otelcol_{{% param vers %}}_linux_386.deb
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers.collector %}}/otelcol_{{% param vers.collector %}}_linux_386.deb
+sudo dpkg -i otelcol_{{% param vers.collector %}}_linux_386.deb
 ```
 
 {{% /tab %}} {{< /tabpane >}}
@@ -147,8 +147,8 @@ To get started on Red Hat systems run the following commands:
 ```sh
 sudo yum update
 sudo yum -y install wget systemctl
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_linux_amd64.rpm
-sudo rpm -ivh otelcol_{{% param vers %}}_linux_amd64.rpm
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers.collector %}}/otelcol_{{% param vers.collector %}}_linux_amd64.rpm
+sudo rpm -ivh otelcol_{{% param vers.collector %}}_linux_amd64.rpm
 ```
 
 {{% /tab %}} {{% tab ARM64 %}}
@@ -156,8 +156,8 @@ sudo rpm -ivh otelcol_{{% param vers %}}_linux_amd64.rpm
 ```sh
 sudo yum update
 sudo yum -y install wget systemctl
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_linux_arm64.rpm
-sudo rpm -ivh otelcol_{{% param vers %}}_linux_arm64.rpm
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers.collector %}}/otelcol_{{% param vers.collector %}}_linux_arm64.rpm
+sudo rpm -ivh otelcol_{{% param vers.collector %}}_linux_arm64.rpm
 ```
 
 {{% /tab %}} {{% tab i386 %}}
@@ -165,8 +165,8 @@ sudo rpm -ivh otelcol_{{% param vers %}}_linux_arm64.rpm
 ```sh
 sudo yum update
 sudo yum -y install wget systemctl
-wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_linux_386.rpm
-sudo rpm -ivh otelcol_{{% param vers %}}_linux_386.rpm
+wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers.collector %}}/otelcol_{{% param vers.collector %}}_linux_386.rpm
+sudo rpm -ivh otelcol_{{% param vers.collector %}}_linux_386.rpm
 ```
 
 {{% /tab %}} {{< /tabpane >}}
@@ -179,29 +179,29 @@ file containing the binary and install it on your machine manually:
 {{< tabpane text=true >}} {{% tab AMD64 %}}
 
 ```sh
-curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_linux_amd64.tar.gz
-tar -xvf otelcol_{{% param vers %}}_linux_amd64.tar.gz
+curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers.collector %}}/otelcol_{{% param vers.collector %}}_linux_amd64.tar.gz
+tar -xvf otelcol_{{% param vers.collector %}}_linux_amd64.tar.gz
 ```
 
 {{% /tab %}} {{% tab ARM64 %}}
 
 ```sh
-curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_linux_arm64.tar.gz
-tar -xvf otelcol_{{% param vers %}}_linux_arm64.tar.gz
+curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers.collector %}}/otelcol_{{% param vers.collector %}}_linux_arm64.tar.gz
+tar -xvf otelcol_{{% param vers.collector %}}_linux_arm64.tar.gz
 ```
 
 {{% /tab %}} {{% tab i386 %}}
 
 ```sh
-curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_linux_386.tar.gz
-tar -xvf otelcol_{{% param vers %}}_linux_386.tar.gz
+curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers.collector %}}/otelcol_{{% param vers.collector %}}_linux_386.tar.gz
+tar -xvf otelcol_{{% param vers.collector %}}_linux_386.tar.gz
 ```
 
 {{% /tab %}} {{% tab ppc64le %}}
 
 ```sh
-curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_linux_ppc64le.tar.gz
-tar -xvf otelcol_{{% param vers %}}_linux_ppc64le.tar.gz
+curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers.collector %}}/otelcol_{{% param vers.collector %}}_linux_ppc64le.tar.gz
+tar -xvf otelcol_{{% param vers.collector %}}_linux_ppc64le.tar.gz
 ```
 
 {{% /tab %}} {{< /tabpane >}}
@@ -239,15 +239,15 @@ commands:
 {{< tabpane text=true >}} {{% tab Intel %}}
 
 ```sh
-curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_darwin_amd64.tar.gz
-tar -xvf otelcol_{{% param vers %}}_darwin_amd64.tar.gz
+curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers.collector %}}/otelcol_{{% param vers.collector %}}_darwin_amd64.tar.gz
+tar -xvf otelcol_{{% param vers.collector %}}_darwin_amd64.tar.gz
 ```
 
 {{% /tab %}} {{% tab ARM %}}
 
 ```sh
-curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_darwin_arm64.tar.gz
-tar -xvf otelcol_{{% param vers %}}_darwin_arm64.tar.gz
+curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers.collector %}}/otelcol_{{% param vers.collector %}}_darwin_arm64.tar.gz
+tar -xvf otelcol_{{% param vers.collector %}}_darwin_arm64.tar.gz
 ```
 
 {{% /tab %}} {{< /tabpane >}}

--- a/content/en/docs/collector/quick-start.md
+++ b/content/en/docs/collector/quick-start.md
@@ -43,7 +43,7 @@ preferred shell.
 1. Pull in the OpenTelemetry Collector Contrib Docker image:
 
    ```sh
-   docker pull otel/opentelemetry-collector-contrib:{{% param vers %}}
+   docker pull otel/opentelemetry-collector-contrib:{{% param vers.collector %}}
    ```
 
 2. Install the [telemetrygen] utility:
@@ -65,7 +65,7 @@ preferred shell.
      -p 127.0.0.1:4317:4317 \
      -p 127.0.0.1:4318:4318 \
      -p 127.0.0.1:55679:55679 \
-     otel/opentelemetry-collector-contrib:{{% param vers %}} \
+     otel/opentelemetry-collector-contrib:{{% param vers.collector %}} \
      2>&1 | tee collector-output.txt # Optionally tee output for easier search later
    ```
 

--- a/content/en/docs/security/_index.md
+++ b/content/en/docs/security/_index.md
@@ -1,7 +1,8 @@
 ---
 title: Security
 cascade:
-  collector_vers: 0.115.1
+  vers:
+    collector: 0.115.1
 weight: 970
 ---
 

--- a/content/en/docs/security/config-best-practices.md
+++ b/content/en/docs/security/config-best-practices.md
@@ -139,7 +139,7 @@ host) by connecting to `127.0.0.1:4567`. Here is an example `docker run`
 command:
 
 ```shell
-docker run --hostname my-hostname --name container-name -p 127.0.0.1:4567:4317 otel/opentelemetry-collector:{{% param collector_vers %}}
+docker run --hostname my-hostname --name container-name -p 127.0.0.1:4567:4317 otel/opentelemetry-collector:{{% param vers.collector %}}
 ```
 
 #### Docker Compose
@@ -152,7 +152,7 @@ The Docker `compose.yaml` file:
 ```yaml
 services:
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:{{% param collector_vers %}}
+    image: otel/opentelemetry-collector-contrib:{{% param vers.collector %}}
     ports:
       - '4567:4317'
 ```
@@ -193,7 +193,7 @@ spec:
     spec:
       containers:
         - name: collector
-          image: otel/opentelemetry-collector:{{% param collector_vers %}}
+          image: otel/opentelemetry-collector:{{% param vers.collector %}}
           ports:
             - containerPort: 4317
               hostPort: 4317

--- a/scripts/auto-update/all-versions.sh
+++ b/scripts/auto-update/all-versions.sh
@@ -2,13 +2,13 @@
 
 function auto_update_versions() {
   local cmd="./scripts/auto-update/version-in-file.sh"
+  ################################################################
+  ##  Each repository must only appear once in the list below!  ##
+  ################################################################
   local updates=(
-      "opentelemetry-collector-releases vers content/en/docs/collector/_index.md"
-      "opentelemetry-collector-releases collector_vers content/en/docs/security/_index.md"
-      "opentelemetry-java otel content/en/docs/languages/java/_index.md"
-      "opentelemetry-java otel content/en/docs/zero-code/java/_index.md"
-      "opentelemetry-java-instrumentation instrumentation content/en/docs/languages/java/_index.md"
-      "opentelemetry-java-instrumentation instrumentation content/en/docs/zero-code/java/_index.md"
+      "opentelemetry-collector-releases collector content/en/docs/collector/_index.md content/en/docs/security/_index.md"
+      "opentelemetry-java otel content/en/docs/languages/java/_index.md content/en/docs/zero-code/java/_index.md"
+      "opentelemetry-java-instrumentation instrumentation content/en/docs/languages/java/_index.md content/en/docs/zero-code/java/_index.md"
       "opentelemetry-java-contrib contrib content/en/docs/languages/java/_index.md"
       "opentelemetry-specification spec scripts/content-modules/adjust-pages.pl .gitmodules"
       "opentelemetry-proto otlp scripts/content-modules/adjust-pages.pl .gitmodules"

--- a/scripts/auto-update/version-in-file.sh
+++ b/scripts/auto-update/version-in-file.sh
@@ -62,15 +62,15 @@ else
   echo
 fi
 
-message="Update $repo version to $latest_version"
-body="Update $repo version to \`$latest_version\`.
+message="Update $repo to $latest_version"
+body="Update $repo to \`$latest_version\`.
 
 See https://github.com/open-telemetry/$repo/releases/tag/$latest_version."
 
-existing_pr_count=$(gh pr list --state all --search "in:title $message" | wc -l)
-if [ "$existing_pr_count" -gt 0 ]; then
+existing_prs=$(gh pr list --state all --search "in:title $message")
+if [ -n "$existing_pr" ]; then
     echo "PR(s) already exist for '$message'"
-    gh pr list --state all --search "\"$message\" in:title"
+    echo "$existing_prs"
     echo "So we won't create another. Exiting."
     exit 0
 fi


### PR DESCRIPTION
The version script expects version updates to be grouped - which they were not

Here's run where a PR has updated only one of the files - and the second results it this:

https://github.com/open-telemetry/opentelemetry.io/actions/runs/12276199179/job/34252893445

```
> ./scripts/auto-update/version-in-file.sh opentelemetry-java-instrumentation instrumentation content/en/docs/zero-code/java/_index.md
HEAD is now at ceecd0f Auto-update registry versions (ba24a4546bf0ce12564c9d0ad7213f784242773e) (#5755)
REPO:            opentelemetry-java-instrumentation
LATEST VERSION:  v2.10.0
SEARCHING for:   '^ *instrumentation:' in content/en/docs/zero-code/java/_index.md
CURRENT VERSION:     instrumentation: 2.6.0
+ sed -i.bak -e 's/\(^ *instrumentation:\) .*/\1 2.10.0/' content/en/docs/zero-code/java/_index.md

Version update necessary:
diff --git a/content/en/docs/zero-code/java/_index.md b/content/en/docs/zero-code/java/_index.md
index f6723a6..2f594fd 100[64](https://github.com/open-telemetry/opentelemetry.io/actions/runs/12276199179/job/34252893445#step:4:65)4
--- a/content/en/docs/zero-code/java/_index.md
+++ b/content/en/docs/zero-code/java/_index.md
@@ -6,7 +6,7 @@ aliases:
   - /docs/languages/java/automatic_instrumentation
 cascade:
   vers:
-    instrumentation: 2.6.0
+    instrumentation: 2.10.0
     otel: 1.40.0
 ---
 

PR(s) already exist for 'Update opentelemetry-java-instrumentation version to v2.10.0'
```