### PR TITLE
[CI] Merge dup cSpell entries in front matter, run word normalization in other locales

### DIFF
--- a/content/en/blog/2022/knative/index.md
+++ b/content/en/blog/2022/knative/index.md
@@ -2,9 +2,9 @@
 title: Distributed tracing in Knative
 linkTitle: Tracing in Knative
 date: 2022-04-12
+author: '[Pavol Loffay](https://github.com/pavolloffay)'
 # prettier-ignore
 cSpell:ignore: apng Cloudevents datacontenttype httpbody khtml knativearrivaltime pavolloffay spanid specversion traceid webp
-author: '[Pavol Loffay](https://github.com/pavolloffay)'
 ---
 
 In this article, you will learn how distributed tracing works in Knative and we

--- a/content/en/blog/2023/ecs-otel-semconv-convergence.md
+++ b/content/en/blog/2023/ecs-otel-semconv-convergence.md
@@ -4,8 +4,8 @@ title:
   Convention Convergence
 linkTitle: ECS and OTel SemConv Convergence
 date: 2023-04-17
-cSpell:ignore: ECS Reiley SemConv Yang
 author: '[Reiley Yang](https://github.com/reyang)'
+cSpell:ignore: ECS Reiley SemConv Yang
 ---
 
 Today, we're very excited to make a joint announcement with

--- a/content/en/blog/2023/exponential-histograms.md
+++ b/content/en/blog/2023/exponential-histograms.md
@@ -2,8 +2,8 @@
 title: Exponential Histograms
 date: 2023-05-22
 author: '[Daniel Dyla](https://github.com/dyladan)'
-cSpell:ignore: Ganesh Ruslan subsetting Vernekar Vovalov
 canonical_url: https://dyladan.me/histograms/2023/05/04/exponential-histograms/
+cSpell:ignore: Ganesh Ruslan subsetting Vernekar Vovalov
 ---
 
 Previously, in [Why Histograms?][] and [Histograms vs Summaries][], I went over

--- a/content/en/blog/2023/histograms-vs-summaries/index.md
+++ b/content/en/blog/2023/histograms-vs-summaries/index.md
@@ -2,8 +2,8 @@
 title: Histograms vs Summaries
 date: 2023-05-15
 author: '[Daniel Dyla](https://github.com/dyladan)'
-cSpell:ignore: aggregatable Björn Ganesh Kovalov Rabenstein Ruslan Vernekar
 canonical_url: https://dyladan.me/histograms/2023/05/03/histograms-vs-summaries/
+cSpell:ignore: aggregatable Björn Ganesh Kovalov Rabenstein Ruslan Vernekar
 ---
 
 In many ways, histograms and summaries appear quite similar. They both roll up

--- a/content/en/blog/2023/kubecon-eu.md
+++ b/content/en/blog/2023/kubecon-eu.md
@@ -2,9 +2,9 @@
 title: Join us for OpenTelemetry Talks and Activities at KubeCon EU 2023
 linkTitle: KubeCon EU '23
 date: 2023-04-03
+author: '[Severin Neumann](https://github.com/svrnm)'
 # prettier-ignore
 cSpell:ignore: Aiven Benedikt Bongartz Jaglowski Kowall observ Oliveira Pathak Vider Xiaochun
-author: '[Severin Neumann](https://github.com/svrnm)'
 ---
 
 The OpenTelemetry project maintainers, members of the governance committee, and

--- a/content/en/blog/2023/kubecon-na.md
+++ b/content/en/blog/2023/kubecon-na.md
@@ -2,9 +2,9 @@
 title: Join us for OpenTelemetry Talks and Activities at KubeCon NA 2023
 linkTitle: KubeCon NA '23
 date: 2023-10-02
+author: '[Severin Neumann](https://github.com/svrnm) (Cisco)'
 # prettier-ignore
 cSpell:ignore: Anusha Aronoff Benedikt Bongartz Broadbridge Contribfest Coralogix Danielson Endo Flamegraphs Hrabovcak Itiel Itoh Jaglowski Kanal Komodor Kota Masanori Matej Mirabella Narapureddy observ Ohly Pivotto Purvi Reddy Sharone Shishi Shivanshu Shrivastava Shwartz Zitzman
-author: '[Severin Neumann](https://github.com/svrnm) (Cisco)'
 ---
 
 The OpenTelemetry project maintainers, members of the governance committee, and

--- a/content/en/blog/2023/why-histograms/index.md
+++ b/content/en/blog/2023/why-histograms/index.md
@@ -2,8 +2,8 @@
 title: Why Histograms?
 date: 2023-05-08
 author: '[Daniel Dyla](https://github.com/dyladan)'
-cSpell:ignore: reimplementation
 canonical_url: https://dyladan.me/histograms/2023/05/02/why-histograms/
+cSpell:ignore: reimplementation
 ---
 
 A histogram is a multi-value counter that summarizes the distribution of data

--- a/content/en/blog/2024/collector-roadmap/index.md
+++ b/content/en/blog/2024/collector-roadmap/index.md
@@ -2,9 +2,9 @@
 title: The roadmap to v1 for the OpenTelemetry Collector
 linkTitle: Collector Roadmap
 date: 2024-05-06
+author: '[Alex Boten](https://github.com/codeboten) (Honeycomb)'
 # prettier-ignore
 cSpell:ignore: Antipatterns Boten Broadbridge Helmuth Hrabovcak Ishan Jaglowski OTTL Pantuza pushback Shishi Vijay
-author: '[Alex Boten](https://github.com/codeboten) (Honeycomb)'
 ---
 
 The [OpenTelemetry Collector](/docs/collector/) is a very popular component in

--- a/content/en/blog/2024/elastic-contributes-continuous-profiling-agent.md
+++ b/content/en/blog/2024/elastic-contributes-continuous-profiling-agent.md
@@ -2,8 +2,6 @@
 title: Elastic Contributes its Continuous Profiling Agent to OpenTelemetry
 linkTitle: Elastic Contributes Profiling Agent
 date: 2024-06-07
-# prettier-ignore
-cSpell:ignore: Bahubali Christos Dmitry Filimonov Geisendörfer Halliday Kalkanis Shetti
 author: >
   [Bahubali Shetti](https://github.com/bshetti) (Elastic), [Alexander
   Wert](https://github.com/AlexanderWert) (Elastic), [Morgan
@@ -11,6 +9,8 @@ author: >
   Perry](https://github.com/Rperry2174) (Grafana)
 issue: https://github.com/open-telemetry/community/issues/1918
 sig: Profiling SIG
+# prettier-ignore
+cSpell:ignore: Bahubali Christos Dmitry Filimonov Geisendörfer Halliday Kalkanis Shetti
 ---
 
 Following significant collaboration between

--- a/content/en/blog/2024/hardening-the-collector-one.md
+++ b/content/en/blog/2024/hardening-the-collector-one.md
@@ -3,10 +3,10 @@ title: 'Hardening the Collector Episode 1: A new default bind address'
 linkTitle: A new default bind address for the Collector
 date: 2024-07-02
 author: '[Pablo Baeyens](https://github.com/mx-psi) (OpenTelemetry, Datadog)'
-# prettier-ignore
-cSpell:ignore: awsfirehose awsproxy awsxray Baeyens jaegerremotesampling loki remotetap sapm signalfx skywalking splunk
 issue: 4760
 sig: Collector SIG
+# prettier-ignore
+cSpell:ignore: awsfirehose awsproxy awsxray Baeyens jaegerremotesampling loki remotetap sapm signalfx skywalking splunk
 ---
 
 The OpenTelemetry Collector recently went through a security audit sponsored by

--- a/content/en/blog/2024/kubecon-china.md
+++ b/content/en/blog/2024/kubecon-china.md
@@ -2,10 +2,10 @@
 title: OpenTelemetry Talks at KubeCon China 2024
 linkTitle: KubeCon China 2024
 date: 2024-07-10
-# prettier-ignore
-cSpell:ignore: Alhamdani Censhare EBPF Hrabusa Husni Huxing Jiahang Krom Sianturi Wanqi Zhang Zihao Ziyi
 author: '[Tiffany Hrabusa](https://github.com/tiffany76)'
 sig: Communications SIG
+# prettier-ignore
+cSpell:ignore: Alhamdani Censhare EBPF Hrabusa Husni Huxing Jiahang Krom Sianturi Wanqi Zhang Zihao Ziyi
 ---
 
 Join members of the OpenTelemetry community at

--- a/content/en/blog/2024/kubecon-eu.md
+++ b/content/en/blog/2024/kubecon-eu.md
@@ -4,9 +4,9 @@ title:
   Europe 2024
 linkTitle: KubeCon EU '24
 date: 2024-02-28
+author: '[Severin Neumann](https://github.com/svrnm) (Cisco)'
 # prettier-ignore
 cSpell:ignore: Aiven Alexandre Anusha Arbiv Beemer Benedikt Blanco Bongartz Chekuri Coralogix Cosmonic Dyrmishi Jiekun Joonas Kanal Kolachala Kowall Machado Magno Marcin Matej Mirabella Narapureddy Nenashev Oleg Oluwalolope Outshift Pismo Purvi Quwan Reddy Ridwan Rollouts Ryanair Skyscanner Sodkiewicz Soluções Srikanth Tecnológicas Yosef
-author: '[Severin Neumann](https://github.com/svrnm) (Cisco)'
 ---
 
 The OpenTelemetry project maintainers, members of the governance committee, and

--- a/content/en/blog/2024/kubecon-na.md
+++ b/content/en/blog/2024/kubecon-na.md
@@ -2,9 +2,9 @@
 title: Join us for OpenTelemetry Talks and Activities at KubeCon NA 2024
 linkTitle: KubeCon NA '24
 date: 2024-11-05
+author: '[Severin Neumann](https://github.com/svrnm) (Cisco)'
 # prettier-ignore
 cSpell:ignore: Arnell Ashok Chandrasekar Clario Contribfest Ekansh Grabner Haeussler Helmuth Jernigan Kalkanis Kats Kowall Kruthika Liudmila Mclean Molkova Novatec OTTL Prasanna Shivanshu Shrivastava simha Woerner
-author: '[Severin Neumann](https://github.com/svrnm) (Cisco)'
 ---
 
 The OpenTelemetry project maintainers, members of the governance committee, and

--- a/content/en/blog/2024/otel-arrow-production/index.md
+++ b/content/en/blog/2024/otel-arrow-production/index.md
@@ -5,9 +5,9 @@ date: 2024-09-25
 author: >-
   [Joshua MacDonald](https://github.com/jmacd) (ServiceNow), [Laurent
   Querel](https://github.com/lquerel) (F5)
-cSpell:ignore: Querel Zstd
 issue: 5193
 sig: OpenTelemetry Arrow
+cSpell:ignore: Querel Zstd
 ---
 
 The OpenTelemetry Protocol with Apache Arrow (OTel-Arrow) project's

--- a/content/en/blog/2024/otel-errors/index.md
+++ b/content/en/blog/2024/otel-errors/index.md
@@ -5,8 +5,8 @@ date: 2024-04-19
 author: >-
   [Reese Lee](https://github.com/reese-lee) (New Relic),  [Adriana
   Villela](https://github.com/avillela) (ServiceNow)
-cSpell:ignore: Dalle
 canonical_url: https://newrelic.com/blog/how-to-relic/dude-wheres-my-error
+cSpell:ignore: Dalle
 ---
 
 ![A confused penguin trying to learn about errors and exceptions. Image generated with AI using Dalle3 via Bing Copilot](penguin-chalkboard.jpg)

--- a/content/en/blog/2024/prom-and-otel/index.md
+++ b/content/en/blog/2024/prom-and-otel/index.md
@@ -5,8 +5,8 @@ date: 2024-09-04
 author: >-
   [Reese Lee](https://github.com/reese-lee) (New Relic), [Adriana
   Villela](https://github.com/avillela) (ServiceNow)
-cSpell:ignore: hashmod kubelet sharded targetallocator
 canonical_url: https://newrelic.com/blog/how-to-relic/prometheus-and-opentelemetry-better-together
+cSpell:ignore: hashmod kubelet sharded targetallocator
 ---
 
 ![Image of a Greek god holding a torch with the Prometheus logo, and OTel logo](Prom-and-otel-logos.png)

--- a/content/en/blog/2024/state-profiling.md
+++ b/content/en/blog/2024/state-profiling.md
@@ -2,7 +2,6 @@
 title: The State of Profiling
 linkTitle: Profiling state
 date: 2024-10-25
-cSpell:ignore: Baeyens Florian Geisendörfer Kalkanis Lehner Mathieu Rühsen
 author: >-
   [Damien Mathieu](https://github.com/dmathieu) (Elastic), [Pablo
   Baeyens](https://github.com/mx-psi) (Datadog), [Felix
@@ -13,6 +12,7 @@ author: >-
   Rühsen](https://github.com/rockdaboot) (Elastic)
 issue: https://github.com/open-telemetry/opentelemetry.io/issues/5477
 sig: Profiling SIG
+cSpell:ignore: Baeyens Florian Geisendörfer Kalkanis Lehner Mathieu Rühsen
 ---
 
 A little over six months ago, OpenTelemetry announced

--- a/content/en/community/marketing-guidelines.md
+++ b/content/en/community/marketing-guidelines.md
@@ -1,8 +1,8 @@
 ---
 title: OpenTelemetry Marketing Guidelines for Contributing Organizations
 linkTitle: Marketing Guidelines
-cSpell:ignore: devstats
 weight: 999
+cSpell:ignore: devstats
 ---
 
 OpenTelemetry (aka OTel) is a collaboration among end-users, adjacent OSS

--- a/content/en/docs/collector/installation.md
+++ b/content/en/docs/collector/installation.md
@@ -1,8 +1,8 @@
 ---
 title: Install the Collector
+weight: 2
 # prettier-ignore
 cSpell:ignore: darwin dpkg GOARCH journalctl kubectl otelcorecol pprof tlsv zpages
-weight: 2
 ---
 
 You can deploy the OpenTelemetry Collector on a wide variety of operating

--- a/content/en/docs/collector/quick-start.md
+++ b/content/en/docs/collector/quick-start.md
@@ -1,10 +1,9 @@
 ---
 title: Quick start
-cSpell:ignore: docker dokey dpkg okey telemetrygen
 description: Setup and collect telemetry in minutes!
 aliases: [getting-started]
 weight: 1
-cSpell:ignore: gobin
+cSpell:ignore: docker dokey dpkg gobin okey telemetrygen
 ---
 
 <!-- markdownlint-disable ol-prefix blanks-around-fences -->

--- a/content/en/docs/concepts/signals/traces.md
+++ b/content/en/docs/concepts/signals/traces.md
@@ -1,8 +1,8 @@
 ---
 title: Traces
 weight: 1
-cSpell:ignore: Guten
 description: The path of a request through your application.
+cSpell:ignore: Guten
 ---
 
 **Traces** give us the big picture of what happens when a request is made to an

--- a/content/en/docs/contributing/issues.md
+++ b/content/en/docs/contributing/issues.md
@@ -4,9 +4,9 @@ description:
   How to fix an existing issue, or report a bug, security risk, or potential
   improvement.
 weight: 10
-cSpell:ignore: prepopulated
 _issues: https://github.com/open-telemetry/opentelemetry.io/issues
 _issue: https://github.com/open-telemetry/opentelemetry.io/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A
+cSpell:ignore: prepopulated
 ---
 
 ## Fixing an existing issue

--- a/content/en/docs/languages/cpp/getting-started.md
+++ b/content/en/docs/languages/cpp/getting-started.md
@@ -1,8 +1,8 @@
 ---
 title: Getting Started
 description: Get telemetry for your app in less than 5 minutes!
-cSpell:ignore: oatpp rolldice
 weight: 10
+cSpell:ignore: oatpp rolldice
 ---
 
 This page will show you how to get started with OpenTelemetry in C++.

--- a/content/en/docs/languages/erlang/_index.md
+++ b/content/en/docs/languages/erlang/_index.md
@@ -5,7 +5,6 @@ description: >
   <img width="35" class="img-initial" src="/img/logos/32x32/Erlang_SDK.svg"
   alt="Erlang/Elixir"> A language-specific implementation of OpenTelemetry in
   Erlang/Elixir.
-cSpell:ignore: ecto
 cascade:
   versions:
     otelSdk: 1.3
@@ -14,6 +13,7 @@ cascade:
     otelPhoenix: 1.1
     otelCowboy: 0.2
     otelEcto: 1.2
+cSpell:ignore: ecto
 ---
 
 {{% docs/languages/index-intro erlang %}}

--- a/content/en/docs/languages/js/_index.md
+++ b/content/en/docs/languages/js/_index.md
@@ -5,8 +5,8 @@ description: >-
   alt="JavaScript"> A language-specific implementation of OpenTelemetry in
   JavaScript (for Node.js & the browser).
 aliases: [/js, /js/metrics, /js/tracing]
-cSpell:ignore: Roadmap
 weight: 20
+cSpell:ignore: Roadmap
 ---
 
 {{% docs/languages/index-intro js /%}}

--- a/content/en/docs/languages/js/getting-started/nodejs.md
+++ b/content/en/docs/languages/js/getting-started/nodejs.md
@@ -2,8 +2,8 @@
 title: Node.js
 description: Get telemetry for your app in less than 5 minutes!
 aliases: [/docs/js/getting_started/nodejs]
-cSpell:ignore: autoinstrumentations KHTML rolldice
 weight: 10
+cSpell:ignore: autoinstrumentations KHTML rolldice
 ---
 
 This page will show you how to get started with OpenTelemetry in Node.js.

--- a/content/en/docs/languages/js/instrumentation.md
+++ b/content/en/docs/languages/js/instrumentation.md
@@ -4,8 +4,8 @@ aliases:
   - /docs/languages/js/api/tracing
   - manual
 weight: 30
-cSpell:ignore: dicelib Millis rolldice
 description: Instrumentation for OpenTelemetry JavaScript
+cSpell:ignore: dicelib Millis rolldice
 ---
 
 {{% docs/languages/instrumentation-intro %}}

--- a/content/en/docs/languages/js/resources.md
+++ b/content/en/docs/languages/js/resources.md
@@ -1,8 +1,8 @@
 ---
 title: Resources
 weight: 70
-cSpell:ignore: myhost SIGINT uuidgen WORKDIR
 description: Add details about your applications' environment to your telemetry
+cSpell:ignore: myhost SIGINT uuidgen WORKDIR
 ---
 
 {{% docs/languages/resources-intro %}}

--- a/content/en/docs/languages/net/getting-started.md
+++ b/content/en/docs/languages/net/getting-started.md
@@ -1,8 +1,8 @@
 ---
 title: Getting Started
 description: Get telemetry for your app in less than 5 minutes!
-cSpell:ignore: ASPNETCORE rolldice
 weight: 10
+cSpell:ignore: ASPNETCORE rolldice
 ---
 
 This page will show you how to get started with OpenTelemetry in .NET.

--- a/content/en/docs/languages/php/context.md
+++ b/content/en/docs/languages/php/context.md
@@ -1,8 +1,8 @@
 ---
 title: Context
 weight: 55
-cSpell:ignore: Swoole
 description: Learn how the context API works in instrumented applications.
+cSpell:ignore: Swoole
 ---
 
 OpenTelemetry works by storing and propagating telemetry data. For example, when

--- a/content/en/docs/languages/python/getting-started.md
+++ b/content/en/docs/languages/python/getting-started.md
@@ -1,9 +1,9 @@
 ---
 title: Getting Started
 description: Get telemetry for your app in less than 5 minutes!
+weight: 10
 # prettier-ignore
 cSpell:ignore: debugexporter diceroller distro loglevel maxlen randint rolldice rollspan venv werkzeug
-weight: 10
 ---
 
 This page will show you how to get started with OpenTelemetry in Python.

--- a/content/en/docs/languages/ruby/getting-started.md
+++ b/content/en/docs/languages/ruby/getting-started.md
@@ -2,9 +2,9 @@
 title: Getting Started
 description: Get telemetry from your app in less than 5 minutes!
 aliases: [getting_started]
+weight: 10
 # prettier-ignore
 cSpell:ignore: darwin rolldice sinatra struct Tracestate tracestate truffleruby
-weight: 10
 ---
 
 This page will show you how to get started with OpenTelemetry in Ruby.

--- a/content/en/docs/languages/ruby/libraries.md
+++ b/content/en/docs/languages/ruby/libraries.md
@@ -2,8 +2,8 @@
 title: Using instrumentation libraries
 linkTitle: Libraries
 aliases: [configuring_automatic_instrumentation, automatic]
-cSpell:ignore: faraday metapackage sinatra
 weight: 30
+cSpell:ignore: faraday metapackage sinatra
 ---
 
 {{% docs/languages/libraries-intro ruby %}}

--- a/content/en/docs/languages/rust/getting-started.md
+++ b/content/en/docs/languages/rust/getting-started.md
@@ -1,7 +1,7 @@
 ---
 title: Getting Started
-cSpell:ignore: eprintln println rolldice tokio
 weight: 10
+cSpell:ignore: eprintln println rolldice tokio
 ---
 
 This page will show you how to get started with OpenTelemetry in Rust.

--- a/content/en/docs/languages/swift/getting-started.md
+++ b/content/en/docs/languages/swift/getting-started.md
@@ -1,8 +1,8 @@
 ---
 title: Getting Started
 description: Get telemetry for your app in less than 5 minutes!
-cSpell:ignore: rolldice
 weight: 10
+cSpell:ignore: rolldice
 ---
 
 This page will show you how to get started with OpenTelemetry in Swift.

--- a/content/en/docs/migration/opencensus.md
+++ b/content/en/docs/migration/opencensus.md
@@ -3,6 +3,6 @@ title: Migrating from OpenCensus
 linkTitle: OpenCensus
 redirect: /blog/2023/sunsetting-opencensus/#how-to-migrate-to-opentelemetry
 _build: { render: link }
-cSpell:ignore: sunsetting
 weight: 3
+cSpell:ignore: sunsetting
 ---

--- a/content/en/docs/migration/opentracing.md
+++ b/content/en/docs/migration/opentracing.md
@@ -1,8 +1,8 @@
 ---
 title: Migrating from OpenTracing
 linkTitle: OpenTracing
-cSpell:ignore: codebases
 weight: 2
+cSpell:ignore: codebases
 ---
 
 Backward compatibility with [OpenTracing][] has been a priority for the

--- a/content/en/docs/zero-code/java/spring-boot-starter/other-spring-autoconfig.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/other-spring-autoconfig.md
@@ -1,7 +1,7 @@
 ---
 title: Other Spring autoconfiguration
-cSpell:ignore: autoconfigurations
 weight: 70
+cSpell:ignore: autoconfigurations
 ---
 
 <!-- markdownlint-disable blanks-around-fences -->

--- a/content/en/docs/zero-code/net/_index.md
+++ b/content/en/docs/zero-code/net/_index.md
@@ -2,9 +2,9 @@
 title: .NET zero-code instrumentation
 description: Send traces and metrics from .NET applications and services.
 linkTitle: .NET
-cSpell:ignore: coreutils HKLM iisreset myapp
 weight: 30
 redirects: [{ from: /docs/languages/net/automatic/*, to: ':splat' }]
+cSpell:ignore: coreutils HKLM iisreset myapp
 ---
 
 Use the OpenTelemetry .NET Automatic Instrumentation to send traces and metrics

--- a/content/en/docs/zero-code/net/configuration.md
+++ b/content/en/docs/zero-code/net/configuration.md
@@ -2,9 +2,9 @@
 title: Configuration and settings
 linkTitle: Configuration
 aliases: [/docs/languages/net/automatic/config]
+weight: 20
 # prettier-ignore
 cSpell:ignore: AZUREAPPSERVICE Bitness CLSID CORECLR dylib NETFX OPERATINGSYSTEM PROCESSRUNTIME UNHANDLEDEXCEPTION
-weight: 20
 ---
 
 ## Configuration methods

--- a/content/en/docs/zero-code/net/custom.md
+++ b/content/en/docs/zero-code/net/custom.md
@@ -2,8 +2,8 @@
 title: Create custom traces and metrics
 linkTitle: Custom instrumentation
 description: Custom traces and metrics using .NET automatic instrumentation.
-cSpell:ignore: meterprovider tracerprovider
 weight: 30
+cSpell:ignore: meterprovider tracerprovider
 ---
 
 The automatic instrumentation configures a `TracerProvider` and a

--- a/content/en/docs/zero-code/net/getting-started.md
+++ b/content/en/docs/zero-code/net/getting-started.md
@@ -1,8 +1,8 @@
 ---
 title: Getting Started
 description: Get telemetry for your app in less than 5 minutes!
-cSpell:ignore: ASPNETCORE rolldice
 weight: 5
+cSpell:ignore: ASPNETCORE rolldice
 ---
 
 This page will show you how to get started with OpenTelemetry .NET Automatic

--- a/content/en/ecosystem/adopters.md
+++ b/content/en/ecosystem/adopters.md
@@ -1,9 +1,9 @@
 ---
 title: Adopters
 description: Organizations that use OpenTelemetry
+# All spelling entries must be on a single line
 # prettier-ignore
 cSpell:ignore: Dapr Datenrettungsdienste Farfetch Globale Logicmonitor Logz Uplight Wandera Zocdoc
-# All spelling entries must be on a single line
 ---
 
 OpenTelemetry's mission is to enable effective observability for all its

--- a/content/es/docs/concepts/observability-primer.md
+++ b/content/es/docs/concepts/observability-primer.md
@@ -2,8 +2,8 @@
 title: Introducción a la Observabilidad
 description: Conceptos básicos de observabilidad.
 weight: 9
-cSpell:ignore: webshop
 default_lang_commit: e58a252c44875b04247b53e2394b4634f5a0a84e
+cSpell:ignore: webshop
 ---
 
 ## ¿Qué es la observabilidad? {#what-is-observability}

--- a/content/es/docs/contributing/pull-requests.md
+++ b/content/es/docs/contributing/pull-requests.md
@@ -5,7 +5,7 @@ description:
   editor de código.
 weight: 2
 default_lang_commit: f724c15be360e5059fb89e696d9a5cc8d00496f6
-cSpell:ignore: aplícala vincúlalos solucionándolas
+cSpell:ignore: aplícala solucionándolas vincúlalos
 ---
 
 Para contribuir con nuevas páginas de contenido o mejorar las páginas de

--- a/content/es/docs/demo/_index.md
+++ b/content/es/docs/demo/_index.md
@@ -5,7 +5,7 @@ cascade:
   repo: https://github.com/open-telemetry/opentelemetry-demo
 weight: 180
 default_lang_commit: 9b5e318036fb92e4a1896259cc3bbdad2843e1de
-cSpell:ignore: OLJCESPC preconfigurados diagnostícala
+cSpell:ignore: diagnostícala OLJCESPC preconfigurados
 ---
 
 Aquí tienes la documentación de la [Demo de OpenTelemetry](/ecosystem/demo/),

--- a/content/es/docs/kubernetes/collector/components.md
+++ b/content/es/docs/kubernetes/collector/components.md
@@ -1,9 +1,9 @@
 ---
 title: Componentes clave para Kubernetes
 linkTitle: Componentes
-# prettier-ignore
-cSpell:ignore: alertmanagers containerd crio filelog gotime horizontalpodautoscalers hostfs hostmetrics iostream k8sattributes kubelet kubeletstats logtag replicasets replicationcontrollers resourcequotas statefulsets varlibdockercontainers varlogpods asignador paginación
 default_lang_commit: 3815d1481fe753df10ea3dc26cbe64dba0230579
+# prettier-ignore
+cSpell:ignore: alertmanagers asignador containerd crio filelog gotime horizontalpodautoscalers hostfs hostmetrics iostream k8sattributes kubelet kubeletstats logtag paginación replicasets replicationcontrollers resourcequotas statefulsets varlibdockercontainers varlogpods
 ---
 
 El [OpenTelemetry Collector](/docs/collector/) admite numerosos receptores y

--- a/content/es/docs/languages/python/instrumentation.md
+++ b/content/es/docs/languages/python/instrumentation.md
@@ -3,8 +3,8 @@ title: Instrumentación
 aliases: [manual]
 weight: 20
 description: Instrumentación manual para OpenTelemetry Python
-cSpell:ignore: millis ottrace textmap
 default_lang_commit: 9b53527853049b249f60f12a000c0d85b9e5f5dc
+cSpell:ignore: millis ottrace textmap
 ---
 
 <!-- markdownlint-disable no-duplicate-heading -->

--- a/content/es/docs/what-is-opentelemetry.md
+++ b/content/es/docs/what-is-opentelemetry.md
@@ -3,7 +3,7 @@ title: ¿Qué es OpenTelemetry?
 description: Qué es y qué no es OpenTelemetry, una breve explicación
 weight: 150
 default_lang_commit: 13c2d415e935fac3014344e67c6c61556779fd6f
-cSpell:ignore: microservicios extensibilidad
+cSpell:ignore: extensibilidad microservicios
 ---
 
 OpenTelemetry es:

--- a/content/pt/docs/concepts/observability-primer.md
+++ b/content/pt/docs/concepts/observability-primer.md
@@ -2,8 +2,8 @@
 title: Introdução à Observabilidade
 description: Conceitos essenciais de Observabilidade
 weight: 9
-cSpell:ignore: webshop
 default_lang_commit: 6e3124135e38e749cdda15271d891813d6bc43db
+cSpell:ignore: webshop
 ---
 
 ## O que é Observabilidade? {#what-is-observability}

--- a/content/pt/docs/languages/go/resources.md
+++ b/content/pt/docs/languages/go/resources.md
@@ -1,8 +1,8 @@
 ---
 title: Recursos
 weight: 70
-cSpell:ignore: sdktrace thirdparty
 default_lang_commit: 12f31f62fcc466532513f6ebccb060c9ea5b9fe4
+cSpell:ignore: sdktrace thirdparty
 ---
 
 {{% docs/languages/resources-intro %}}

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "diff:check": "npm run _diff:check || (echo; echo 'WARNING: the files above have not been committed'; echo)",
     "diff:fail": "npm run _diff:check || (echo; echo 'ERROR: the files above have changed. Locally rerun `npm run test-and-fix` and commit changes'; echo; exit 1)",
     "fix:all": "npm run all -- $(npm -s run _list:fix:*)",
-    "fix:dict": "find content/en layouts -name \"*.md\" -print0 | xargs -0 scripts/normalize-cspell-front-matter.pl",
+    "fix:dict": "find content/{en,es,fr,pt} layouts -name \"*.md\" -print0 | xargs -0 scripts/normalize-cspell-front-matter.pl",
     "fix:filenames": "npm run _rename-to-kebab-case",
     "fix:format": "npm run format",
     "fix:htmltest-config": "scripts/htmltest-config.sh",


### PR DESCRIPTION
- Fixes #5764
- Has the side-effect of making the `cSpell:ignore` entry the _last_ entry in the front matter. I wished that I could have avoided this side-effect, but it seems ok as a convention, and it was the simplest solution I could think of atm.
- Normalizes cSpell words list in en, es, fr, and pt now.