### PR TITLE
[CI] Update Hugo to 0.139.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "autoprefixer": "^10.4.20",
     "cspell": "^8.16.1",
     "gulp": "^5.0.0",
-    "hugo-extended": "0.139.2",
+    "hugo-extended": "0.139.4",
     "js-yaml": "^4.1.0",
     "markdown-link-check": "^3.13.6",
     "markdownlint": "^0.36.1",


### PR DESCRIPTION
Updates Hugo to [0.139.4](https://github.com/gohugoio/hugo/releases/tag/v0.139.4). The main change that has an impact is:

> - tpl/tplimpl: Escape Markdown attributes in render hooks and shortcodes https://github.com/gohugoio/hugo/commit/54398f8d572c689f9785d59e907fd910a23401b0 `@jmooring`

The generated site-file diff:

```console
$ (cd public && git diff -bw -I 'img src|img alt|iframe|Hugo 0' -- . ':(exclude)*.xml') | grep ^diff
diff --git a/blog/2023/euwg-future-of-observability-panel/index.html b/blog/2023/euwg-future-of-observability-panel/index.html
diff --git a/blog/2023/humans-of-otel/index.html b/blog/2023/humans-of-otel/index.html
diff --git a/blog/2024/humans-of-otel-eu-2024/index.html b/blog/2024/humans-of-otel-eu-2024/index.html
diff --git a/site/index.html b/site/index.html
```

The blog pages contain `iframe` element cleanup (I can't get the `-I` expression to ignore those), and the main index is listed because of the timestamp.