### PR TITLE
Set author in auto-update-community-members.yml

### DIFF
--- a/.github/workflows/auto-update-community-members.yml
+++ b/.github/workflows/auto-update-community-members.yml
@@ -35,6 +35,9 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           add-paths: 'data/community/members.yaml'
+          author:
+            opentelemetrybot
+            <107717825+opentelemetrybot@users.noreply.github.com>
           committer:
             opentelemetrybot
             <107717825+opentelemetrybot@users.noreply.github.com>


### PR DESCRIPTION
fixes an issue where the author is the merge queue bot(?) in https://github.com/open-telemetry/opentelemetry.io/pull/5757

