### PR TITLE
Update metrics.md - fix typo on Gauge (a-synchronous)

### DIFF
--- a/content/en/docs/concepts/signals/metrics.md
+++ b/content/en/docs/concepts/signals/metrics.md
@@ -68,7 +68,7 @@ The instrument kind is one of the following:
   continuous changes, but only to the aggregated value (e.g., current queue
   size).
 - **Gauge**: Measures a current value at the time it is read. An example would
-  be the fuel gauge in a vehicle. Gauges are asynchronous.
+  be the fuel gauge in a vehicle. Gauges are synchronous.
 - **Asynchronous Gauge**: Same as the **Gauge**, but is collected once for each
   export. Could be used if you don't have access to the continuous changes, but
   only to the aggregated value.


### PR DESCRIPTION
Description of Gauge was misleading due to a typo between asynchronous and synchronous.

Fix #5774 

<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->
