### PR TITLE
update links to openmetrics to reference the v1.0.0 release

### DIFF
--- a/content/en/blog/2024/prometheus-compatibility-survey/index.md
+++ b/content/en/blog/2024/prometheus-compatibility-survey/index.md
@@ -121,7 +121,7 @@ should not generally be included in the metric name. Prometheus conventions
 [recommend](https://prometheus.io/docs/practices/naming/#metric-names) that the
 unit be included as a suffix of the metric name. OpenMetrics goes a step further
 and
-[requires this unit suffix](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#unit).
+[requires this unit suffix](https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#unit).
 Currently, when exporting in Prometheus format from an OpenTelemetry SDK, the
 unit is added as a suffix to the metric name.
 


### PR DESCRIPTION
Related to https://github.com/prometheus/OpenMetrics/issues/287

The OM 2.0 effort is kicked off, and will start developing on main. This updates the links to OpenMetrics to reference the 1.0 release. The OM project has also been moved into the prometheus github org.