### PR TITLE
Change internal logs config example to use OTLP/HTTP

### DIFF
--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -122,7 +122,7 @@ journalctl | grep otelcol | grep Error
 {{% /tab %}} {{< /tabpane >}}
 
 The following configuration can be used to emit internal logs from the Collector
-to an OTLP/gRPC backend:
+to an OTLP/HTTP backend:
 
 ```yaml
 service:
@@ -132,7 +132,7 @@ service:
         - batch:
             exporter:
               otlp:
-                protocol: grpc/protobuf
+                protocol: http/protobuf
                 endpoint: https://backend:4317
 ```
 


### PR DESCRIPTION
Because of a somewhat outdated dependency, the Collector does not yet have support for exporting internal logs through OTLP/gRPC, only through OTLP/HTTP. Because of this, the example config added to the "Internal telemetry" docs page in PR #5702 does not actually work, and will result in an "unsupported protocol" error. There is [work underway](https://github.com/open-telemetry/opentelemetry-collector/pull/11611) to fix this, but according to @codeboten, it is blocked by other work, and may take some time to be merged.

For this reason, in the meantime, this PR updates the example config to use OTLP/HTTP instead of OTLP/gRPC, to avoid confusing users who try to use the example as-is.