### PR TITLE
feat(): Add Odigos vendor information and update refcache for its documentation

### DIFF
--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -264,6 +264,12 @@
   contact:
   oss: true
   commercial: true
+- name: Odigos
+  nativeOTLP: true
+  url: https://docs.odigos.io
+  contact: engineering@odigos.io
+  oss: true
+  commercial: true
 - name: OneUptime
   nativeOTLP: true
   url: https://oneuptime.com/product/apm

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -3019,6 +3019,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-30T05:18:02.263475-05:00"
   },
+  "https://docs.odigos.io": {
+    "StatusCode": 206,
+    "LastSeen": "2024-12-23T14:51:42.30807+02:00"
+  },
   "https://docs.openfaas.com/architecture/metrics/": {
     "StatusCode": 206,
     "LastSeen": "2024-12-18T05:52:18.080718-05:00"


### PR DESCRIPTION
This pull request includes updates to the `data/ecosystem/vendors.yaml` and `static/refcache.json` files to add a new vendor [Odigos](https://github.com/odigos-io), to the ecosystem and update the status of its documentation URL.

Odigos is an open-source distributed tracing solution, that implements OTLP automatically on k8s applications, and spins up a collectors pipeline to process and transfer the telemetry data to various vendors/destinations.