### PR TITLE
docs: Remove references to processor metrics that are no longer available

### DIFF
--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -379,7 +379,7 @@ next. There are no stability guarantees at this time.
 This section recommends best practices for monitoring the Collector using its
 own telemetry.
 
-### Secondary monitoring
+### Monitoring
 
 #### Queue length
 

--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -379,17 +379,6 @@ next. There are no stability guarantees at this time.
 This section recommends best practices for monitoring the Collector using its
 own telemetry.
 
-### Critical monitoring
-
-#### Data loss
-
-Use the rate of `otelcol_processor_dropped_log_records > 0`,
-`otelcol_processor_dropped_spans > 0`, and
-`otelcol_processor_dropped_metric_points > 0` to detect data loss. Depending on
-your project's requirements, select a narrow time window before alerting begins
-to avoid notifications for small losses that are within the desired reliability
-range and not considered outages.
-
 ### Secondary monitoring
 
 #### Queue length


### PR DESCRIPTION
Remove references to the metrics representing the number of dropped items in the monitoring guide that were deprecated in [v0.110.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.110.0)

<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->
