### PR TITLE
Replace "oteps" repo references with "opentelemetry-specification" repo

### DIFF
--- a/content/en/blog/2023/otel-arrow/index.md
+++ b/content/en/blog/2023/otel-arrow/index.md
@@ -140,7 +140,7 @@ aligning OpenTelemetry more closely with modern data pipelines that are
 increasingly pivoting towards Apache Arrow.
 
 A specification for this protocol (OTEP 0156) can be found
-[here](https://github.com/open-telemetry/oteps/blob/main/text/0156-columnar-encoding.md).
+[here](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/0156-columnar-encoding.md).
 A reference implementation of the encoding/decoding function can be accessed
 [here](https://github.com/open-telemetry/otel-arrow).
 
@@ -269,7 +269,7 @@ invaluable assistance.
 ## Links
 
 - OpenTelemetry Protocol with Apache Arrow Specification -
-  [OTEP 0156](https://github.com/open-telemetry/oteps/blob/main/text/0156-columnar-encoding.md)
+  [OTEP 0156](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/0156-columnar-encoding.md)
 - OpenTelemetry Protocol with Apache Arrow (encoder/decoder)
   [repository](https://github.com/open-telemetry/otel-arrow).
 - Receiver

--- a/content/en/blog/2024/otel-arrow-production/index.md
+++ b/content/en/blog/2024/otel-arrow-production/index.md
@@ -54,7 +54,7 @@ The compression bridge consists of two OpenTelemetry Collectors labeled exporter
 and receiver, or they could equally be two pools of load-balanced collectors.
 
 As described in the
-[OTEP 0156 design document](https://github.com/open-telemetry/oteps/blob/main/text/0156-columnar-encoding.md#mapping-otel-entities-to-arrow-records),
+[OTEP 0156 design document](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/0156-columnar-encoding.md#mapping-otel-entities-to-arrow-records),
 the exporter converts arbitrary OpenTelemetry data into an Arrow record batch.
 The Arrow record batch is a block of memory, with a standardized layout, making
 it possible to exchange data across address spaces and virtual process

--- a/content/en/blog/2024/profiling.md
+++ b/content/en/blog/2024/profiling.md
@@ -58,7 +58,7 @@ utilization at a code-level and allows for this profiling data to be stored,
 queried, and analyzed over time and across different attributes. It’s an
 important technique for developers and performance engineers to understand
 exactly what’s happening in their code. OpenTelemetry’s
-[profiling signal](https://github.com/open-telemetry/oteps/blob/main/text/profiles/0239-profiles-data-model.md)
+[profiling signal](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/profiles/0239-profiles-data-model.md)
 expands upon the work that has been done in this space and, as a first for the
 industry, connects profiles with other telemetry signals from applications and
 infrastructure. This allows developers and operators to correlate resource

--- a/content/en/docs/concepts/instrumentation/libraries.md
+++ b/content/en/docs/concepts/instrumentation/libraries.md
@@ -115,7 +115,7 @@ to help you decide how to minimize dependency conflicts:
 - While your instrumentation stabilizes, consider shipping it as a separate
   package, so that it never causes issues for users who don't use it. You can
   keep it in your repository, or
-  [add it to OpenTelemetry](https://github.com/open-telemetry/oteps/blob/main/text/0155-external-modules.md#contrib-components),
+  [add it to OpenTelemetry](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/0155-external-modules.md#contrib-components),
   so it ships with other instrumentation libraries.
 - Semantic conventions are [stable, but subject to evolution][]: while this does
   not cause any functional issues, you might need to update your instrumentation

--- a/content/en/docs/concepts/signals/_index.md
+++ b/content/en/docs/concepts/signals/_index.md
@@ -20,7 +20,7 @@ OpenTelemetry currently supports [traces](/docs/concepts/signals/traces),
 [metrics](/docs/concepts/signals/metrics), [logs](/docs/concepts/signals/logs)
 and [baggage](/docs/concepts/signals/baggage). _Events_ are a specific type of
 log, and
-[_profiles_ are being worked on](https://github.com/open-telemetry/oteps/blob/main/text/profiles/0212-profiling-vision.md)
+[_profiles_ are being worked on](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/profiles/0212-profiling-vision.md)
 by the Profiling Working Group.
 
 [signals]: /docs/specs/otel/glossary/#signals

--- a/content/ja/docs/concepts/instrumentation/libraries.md
+++ b/content/ja/docs/concepts/instrumentation/libraries.md
@@ -87,7 +87,7 @@ OpenTelemetry API は、抽象化と動作しない実装のセットです。
 - OpenTelemetry Trace APIは2021年初めに安定版に達しました。このAPIは[Semantic Versioning 2.0](/docs/specs/otel/versioning-and-stability/)にしがたっていて、開発チームはAPIの安定性を真剣に受け止めています。
 - 依存する場合は、もっとも早い安定版の OpenTelemetry API (1.0.\*)を使用し、新機能を使用する必要がない限り、アップデートは避けてください。
 - あなたの計装が安定するまでの間、それを別のパッケージとしてリリースすることを検討してください。
-  あなたのレポジトリに置いておくこともできますし、[OpenTelemetryに追加](https://github.com/open-telemetry/oteps/blob/main/text/0155-external-modules.md#contrib-components) して、他の計装パッケージと一緒にリリースすることもできます。
+  あなたのレポジトリに置いておくこともできますし、[OpenTelemetryに追加](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/0155-external-modules.md#contrib-components) して、他の計装パッケージと一緒にリリースすることもできます。
 - セマンティック規約は[安定していますが、徐々に発展しています][stable, but subject to evolution]。
   機能的な問題は発生しませんが、ときどき、計装をアップデートする必要があるかもしれません。
   プレビュープラグインか、OpenTelemetry contrib リポジトリにそれを置くことで、ユーザの変更を壊すことなく、規約を最新に保つことができるかもしれません。

--- a/content/ja/docs/concepts/signals/_index.md
+++ b/content/ja/docs/concepts/signals/_index.md
@@ -11,6 +11,6 @@ OpenTelemetryの目的は、**[シグナル][signals]** を収集、処理、エ
 異なるシグナルをグループ化して、同じテクノロジーの内部動作を異なる角度から観察することもできる。
 
 OpenTelemetry は現在、[トレース](/docs/concepts/signals/traces)、[メトリクス](/docs/concepts/signals/metrics)、[ログ](/docs/concepts/signals/logs)と[バゲッジ](/docs/concepts/signals/baggage)をサポートしています。
-_イベント_ は特定の種類のログで、_プロファイル_ はProfiling Working Groupによって[現在策定中](https://github.com/open-telemetry/oteps/blob/main/text/profiles/0212-profiling-vision.md)です。
+_イベント_ は特定の種類のログで、_プロファイル_ はProfiling Working Groupによって[現在策定中](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/profiles/0212-profiling-vision.md)です。
 
 [signals]: /docs/specs/otel/glossary/#signals

--- a/content/pt/docs/concepts/instrumentation/libraries.md
+++ b/content/pt/docs/concepts/instrumentation/libraries.md
@@ -133,7 +133,7 @@ algumas considerações para ajudar a minimizar problemas com dependências:
 - Enquanto sua instrumentação se estabiliza, considere lançá-la como um pacote
   separado, para que isso não cause problemas para usuários que não a utilizam.
   Você pode mantê-la em seu repositório ou
-  [adicioná-la ao OpenTelemetry](https://github.com/open-telemetry/oteps/blob/main/text/0155-external-modules.md#contrib-components),
+  [adicioná-la ao OpenTelemetry](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/0155-external-modules.md#contrib-components),
   para que seja distribuída junto com outras bibliotecas de instrumentação.
 - As Convenções Semânticas são [estáveis, mas sujeitas à evolução][]: embora
   isso não cause problemas funcionais, pode ser necessário atualizar sua

--- a/content/pt/docs/concepts/signals/_index.md
+++ b/content/pt/docs/concepts/signals/_index.md
@@ -19,7 +19,7 @@ O OpenTelemetry atualmente suporta [rastros](/docs/concepts/signals/traces),
 [métricas](/docs/concepts/signals/metrics), [logs](/docs/concepts/signals/logs)
 e [bagagem](/docs/concepts/signals/baggage). Eventos são um tipo específico de
 log, e o
-[perfilamento está sendo trabalhado](https://github.com/open-telemetry/oteps/blob/main/text/profiles/0212-profiling-vision.md)
+[perfilamento está sendo trabalhado](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/profiles/0212-profiling-vision.md)
 pelo Grupo de Trabalho de Perfilamento _(Profiling Working Group)_.
 
 [sinais]: /docs/specs/otel/glossary/#signals

--- a/content/zh/docs/concepts/signals/_index.md
+++ b/content/zh/docs/concepts/signals/_index.md
@@ -22,6 +22,6 @@ OpenTelemetry 的目的是收集、处理和导出 **[信号][]** 。
 - [行李 (Baggage)](/docs/concepts/signals/baggage)
 
 **事件**是一种特定类型的日志，而
-[**profiles** 正在由 Profiling 工作组开发](https://github.com/open-telemetry/oteps/blob/main/text/profiles/0212-profiling-vision.md)。
+[**profiles** 正在由 Profiling 工作组开发](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/profiles/0212-profiling-vision.md)。
 
 [信号]: /docs/specs/otel/glossary/#signals

--- a/layouts/partials/docs/get-signal-status.html
+++ b/layouts/partials/docs/get-signal-status.html
@@ -20,7 +20,7 @@
     {{ $status = cond (in $statusWeCanLinkTo $status)
           (printf "[%s](/docs/specs/otel/versioning-and-stability/#%s)" $humanizedStatus $status)
           (cond (in "alpha beta" $status)
-            (printf "[%s](https://github.com/open-telemetry/oteps/blob/main/text/0232-maturity-of-otel.md#%s)" $humanizedStatus $status)
+            (printf "[%s](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/0232-maturity-of-otel.md#%s)" $humanizedStatus $status)
             $humanizedStatus)
     -}}
   {{ end -}}


### PR DESCRIPTION
This PR replaces references from the "oteps" repo with ones from the "opentelemetry-specification" repo as the former has been archived.