### PR TITLE
Upgrade Docsy to v0.11.0-22-g2f361b2b

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,8 @@
+# cSpell:ignore docsy javaexamples
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/google/docsy.git
-	docsy-pin = v0.11.0-2-g68aa7b3
+	docsy-pin = v0.11.0-22-g2f361b2b
 	docsy-note = "2024-04-01 Switching to google/docsy.git from cncf/docsy.git since we don't have any CNCF customizations."
 	docsy-reminder = "Ensure that any tag referenced by `docsy-pin` is present in the remote repo (url), otherwise add (push) the tags to the repo."
 [submodule "content-modules/opentelemetry-specification"]


### PR DESCRIPTION
- Upgrades Docsy to v0.11.0-22-g2f361b2b in prep for further changes
- Contributes to #4781 for `ja` via https://github.com/google/docsy/pull/2149. Thank you @rinsuki! For example:
  > <img width="300" alt="image" src="https://github.com/user-attachments/assets/613d09dd-41e4-4a5e-b27a-f1c64a291321" />

/cc @open-telemetry/docs-ja-approvers 