### PR TITLE
Blog section for 2025

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -10,6 +10,8 @@ IgnoreDirs:
   # DO NOT EDIT! IgnoreDirs list is auto-generated from markdown file front matter.
   # Ignore blog index pages for all locales and in all blog sections (top-level and years)
   - ^(../)?blog/(\d+/)?page/\d+
+  # Ignore old blog posts
+  - ^(../)?blog/20(19|21|22|23)/
   # TODO drop next lines after https://github.com/open-telemetry/opentelemetry.io/issues/5555 is fixed for these pages:
   - ^zh/docs/concepts/signals/baggage/
   - ^zh/docs/zero-code/php/

--- a/content/en/blog/2025/_index.md
+++ b/content/en/blog/2025/_index.md
@@ -1,0 +1,5 @@
+---
+title: 2025
+weight: -2025
+outputs: [HTML, RSS]
+---

--- a/content/en/blog/_index.md
+++ b/content/en/blog/_index.md
@@ -3,13 +3,15 @@ title: Blog
 menu: { main: { weight: 50 } }
 redirects:
   # Every January, update the year number in the paths below
-  - { from: '', to: '2024/ 302!' }
+  - { from: '', to: '2025/ 302!' }
   # Workaround to https://github.com/open-telemetry/opentelemetry.io/issues/4440:
-  - { from: 'index.xml', to: '2024/index.xml 302!' }
+  - { from: 'index.xml', to: '2025/index.xml 302!' }
 outputs: [HTML, RSS]
 htmltest:
-  # 2024-11-07 DO NOT COPY the following IgnoreDirs to non-en pages because handles all locales.
+  # 2024-11-07 DO NOT COPY the following IgnoreDirs to non-en pages because it handles all locales.
   IgnoreDirs:
     # Ignore blog index pages for all locales and in all blog sections (top-level and years)
     - ^(../)?blog/(\d+/)?page/\d+
+    # Ignore old blog posts
+    - ^(../)?blog/20(19|21|22|23)/
 ---

--- a/content/en/blog/_index.md
+++ b/content/en/blog/_index.md
@@ -3,9 +3,9 @@ title: Blog
 menu: { main: { weight: 50 } }
 redirects:
   # Every January, update the year number in the paths below
-  - { from: '', to: '2025/ 302!' }
+  - { from: '', to: '2024/ 302!' }
   # Workaround to https://github.com/open-telemetry/opentelemetry.io/issues/4440:
-  - { from: 'index.xml', to: '2025/index.xml 302!' }
+  - { from: 'index.xml', to: '2024/index.xml 302!' }
 outputs: [HTML, RSS]
 htmltest:
   # 2024-11-07 DO NOT COPY the following IgnoreDirs to non-en pages because it handles all locales.


### PR DESCRIPTION
- Contributes to:
  - #5017
  - #5873
- Introduces "2025" blog section, including an RSS feed
- Adds link-checker ignore rules for blog sections older than a year
- I'm delaying updating the redirect rules to point to the 2025 section until we have our first 2025 blog post. Otherwise it just looks like the blog section is broken, because no posts are shown.

**Preview and redirect tests**:

- https://deploy-preview-5874--opentelemetry.netlify.app/blog/ --> ~redirect to 2025 section~ still redirects to 2024
- https://deploy-preview-5874--opentelemetry.netlify.app/blog/index.xml --> ~redirect to 2025 RSS feed~ still redirects to 2024 RSS feed
