### PR TITLE
[Blog] Fuzzing blog post - add link to CNCF blog

### DIFF
--- a/content/en/blog/2024/fuzzing-audit-results.md
+++ b/content/en/blog/2024/fuzzing-audit-results.md
@@ -9,10 +9,13 @@ cSpell:ignore: containerd Korczynski
 ---
 
 OpenTelemetry is happy to announce the completion of the Collector's fuzzing
-audit sponsored by [the CNCF](https://www.cncf.io/) and carried out by
+audit [sponsored by the CNCF] and carried out by
 [Ada Logics](https://adalogics.com/). The audit marks a significant step in the
 OpenTelemetry project, ensuring the security and reliability of the Collector
 for its users.
+
+[sponsored by the CNCF]:
+  https://contribute.cncf.io/resources/project-services/audits/
 
 ## What is fuzzing?
 

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -2059,6 +2059,10 @@
     "StatusCode": 206,
     "LastSeen": "2024-01-30T06:05:22.938822-05:00"
   },
+  "https://contribute.cncf.io/resources/project-services/audits/": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-04T17:06:30.360149-05:00"
+  },
   "https://coralogix.com/docs/opentelemetry/": {
     "StatusCode": 206,
     "LastSeen": "2024-08-09T10:46:28.010241-04:00"


### PR DESCRIPTION
- Followup to https://github.com/open-telemetry/opentelemetry.io/pull/5827/files#r1899680772
- Contributes (and maybe closes) #5798
- Adds link to CNCF blog post describing the overall effort and validating the CNCF sponsorship. /cc @AdamKorcz 
- **Preview**: https://deploy-preview-5875--opentelemetry.netlify.app/blog/2024/fuzzing-audit-results/