### PR TITLE
Warn when blog posts are outdated

### DIFF
--- a/layouts/blog/content.html
+++ b/layouts/blog/content.html
@@ -1,0 +1,35 @@
+{{/* Docsy override (temporary) */ -}}
+
+<div class="td-content">
+	<h1>{{ .Title }}</h1>
+	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
+	<div class="td-byline mb-4">
+		{{ with .Params.author }}{{ T "post_byline_by" }} <b>{{ . | markdownify }}</b> |{{ end}}
+		<time datetime="{{  $.Date.Format "2006-01-02" }}" class="text-body-secondary">{{ $.Date.Format $.Site.Params.time_format_blog  }}</time>
+	</div>
+  <header class="article-meta">
+		{{ partial "taxonomy_terms_article_wrapper.html" . -}}
+		{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) -}}
+			{{ partial "reading-time.html" . -}}
+		{{ end -}}
+	</header>
+  {{ if .Date.Before (now.AddDate -1 0 0) -}}
+  <div class="pageinfo pageinfo-warning">
+    <p>
+      <i class="fa-solid fa-triangle-exclamation"></i>
+      Blog posts are not updated after publication. This post is more
+      than a year old, so its content may be outdated, and some links may be
+      invalid. Cross-verify any information before relying on it.
+    </p>
+  </div>
+  {{ end -}}
+	{{ .Content }}
+	{{ if (.Site.Config.Services.Disqus.Shortname) -}}
+		<br />
+		{{- partial "disqus-comment.html" . -}}
+		<br />
+	{{ end -}}
+
+	{{ partial "pager.html" . }}
+	{{ partial "page-meta-lastmod.html" . -}}
+</div>


### PR DESCRIPTION
- Contributes to, and is a first proposal to resolve #3493
- Overrides the blog `content.html` layout to add a `pageinfo` div `{{ if .Date.Before (now.AddDate -1 0 0) -}}`, that is, if the post if more than a year old. The warning text is added just before the content starts, and below the breadcrumbs, title, and author. I find that it looks better this way (as compared to have a warning before the breadcrumbs).

**Preview**:

- Not outdated (as of today): https://deploy-preview-5883--opentelemetry.netlify.app/blog/2024/year-in-review/
- Outdated:
  - https://deploy-preview-5883--opentelemetry.netlify.app/blog/2023/humans-of-otel/
  - https://deploy-preview-5883--opentelemetry.netlify.app/blog/2023/otel-in-focus-break/

### Screenshot

> <img width="777" alt="image" src="https://github.com/user-attachments/assets/71bd59a6-f486-46bc-a3e6-5a6bdf128b06" />



