### PR TITLE
Blog 2025 section: offer wishes and hope of articles to come

### DIFF
--- a/content/en/blog/2025/_index.md
+++ b/content/en/blog/2025/_index.md
@@ -3,3 +3,7 @@ title: 2025
 weight: -2025
 outputs: [HTML, RSS]
 ---
+
+## Happy New Year!
+
+Amazing post are on their way for 2025 &mdash; check back soon.

--- a/content/en/blog/2025/_index.md
+++ b/content/en/blog/2025/_index.md
@@ -6,4 +6,4 @@ outputs: [HTML, RSS]
 
 ## Happy New Year!
 
-Amazing post are on their way for 2025 &mdash; check back soon.
+Amazing posts are on their way for 2025 &mdash; check back soon.

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,0 +1,43 @@
+{{ define "main" }}
+{{ if (and .Parent .Parent.IsHome) -}}
+  {{ $.Scratch.Set "blog-pages" (where .Site.RegularPages "Section" .Section) -}}
+{{ else -}}
+  {{$.Scratch.Set "blog-pages" .Pages -}}
+{{ end -}}
+
+{{/* Docsy override - temporary */ -}}
+{{ .Content -}}
+
+<div class="td-blog-posts">
+  {{ if .Pages -}}
+    {{ $pag := .Paginate (( $.Scratch.Get "blog-pages").GroupByDate "2006" ) -}}
+    {{ range $pag.PageGroups -}}
+    <div class="h2">{{ T "post_posts_in" }} {{ .Key }}</div>
+    <ul class="td-blog-posts-list">
+      {{ range .Pages -}}
+      <li class="td-blog-posts-list__item">
+        <div class="td-blog-posts-list__body">
+          <h5 class="mt-0 mb-1"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h5>
+          <p class="mb-2 mb-md-3"><small class="text-body-secondary">{{ .Date.Format ($.Param "time_format_blog") }} {{ T "ui_in"}} {{ .CurrentSection.LinkTitle }}</small></p>
+          <header class="article-meta">
+            {{ partial "taxonomy_terms_article_wrapper.html" . -}}
+            {{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) -}}
+              {{ partial "reading-time.html" . -}}
+            {{ end -}}
+          </header>
+          {{ partial "featured-image.html" (dict "p" . "w" 250 "h" 125 "class" "float-start me-3 pt-1 d-none d-md-block") -}}
+          <p class="pt-0 mt-0">{{ .Plain | safeHTML | truncate 250 }}</p>
+          <p class="pt-0"><a href="{{ .RelPermalink }}" aria-label="{{ T "ui_read_more"}} - {{ .LinkTitle }}">{{ T "ui_read_more"}}</a></p>
+        </div>
+      </li>
+      {{ end -}}
+    </ul>
+    {{ end -}}
+  {{ end }}
+</div>
+<div class="td-blog-posts__pagination">
+  {{ if .Pages -}}
+    {{ template "_internal/pagination.html" . -}}
+  {{ end -}}
+</div>
+{{ end -}}


### PR DESCRIPTION
- Followup to #5874
- Ensures that the blog/2025 section isn't empty. Wishes reader a happy new year and invites them back soon. Note that the message can stay a bit even after our first 2025 post (IMHO).

**Preview**: https://deploy-preview-5885--opentelemetry.netlify.app/blog/2025

### Screenshot

> <img width="777" alt="image" src="https://github.com/user-attachments/assets/6cef7b24-1d14-4ccf-9a40-9ff941e3e0c6" />
