### PR TITLE
[CI] When updating submodules, also fetch tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "test": "npm run check",
     "update:pkg:hugo": "npm install --save-dev --save-exact hugo-extended@latest",
     "update:pkgs": "npx npm-check-updates -u",
-    "update:submodule": "set -x && git submodule update --remote ${DEPTH:- --depth 999}"
+    "update:submodule": "set -x && git submodule update --remote ${DEPTH:- --depth 999} && git submodule foreach 'git fetch $(git remote | tail -1) --tags'"
   },
   "devDependencies": {
     "@cspell/dict-es-es": "^3.0.3",


### PR DESCRIPTION
Ensures that `update:submodule` also fetches tags. This command caters to two use cases where developers have submodules with:

- Only one remote (most likely named `origin`). This is likely the case for most devs.
- Two remotes, named `origin` and `upstream` (if you're a dev who also sometimes submit PRs to the submodule). In this case, the given `foreach` command will fetch tags from `upstream`. (The command is a bit brittle, but I don't foresee any likely cases for which this might cause an issue -- and if it does we can adjust at that time.)
