### PR TITLE
Remove SYS_PTRACE from otel go autoinstrumentation

### DIFF
--- a/content/en/docs/kubernetes/operator/automatic.md
+++ b/content/en/docs/kubernetes/operator/automatic.md
@@ -531,9 +531,6 @@ permissions:
 
 ```yaml
 securityContext:
-  capabilities:
-    add:
-      - SYS_PTRACE
   privileged: true
   runAsUser: 0
 ```


### PR DESCRIPTION
This is not needed, see https://github.com/open-telemetry/opentelemetry.io/issues/5889