### PR TITLE
Fixing broken link in architecture.md

### DIFF
--- a/content/en/docs/demo/architecture.md
+++ b/content/en/docs/demo/architecture.md
@@ -126,7 +126,7 @@ Follow these links for the current state of
 demo applications.
 
 The collector is configured in
-[otelcol-config.yml](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/otelcollector/otelcol-config.yml),
+[otelcol-config.yml](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/otel-collector/otelcol-config.yml),
 alternative exporters can be configured here.
 
 ```mermaid


### PR DESCRIPTION
Fixing broken link to collector config file. 
