### PR TITLE
Another fix for survey-on-merged-pr.yml

### DIFF
--- a/.github/workflows/survey-on-merged-pr.yml
+++ b/.github/workflows/survey-on-merged-pr.yml
@@ -1,7 +1,7 @@
 name: Survey on Merged PR by Non-Member
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 env:
@@ -17,6 +17,7 @@ jobs:
       pull-requests: write
     if: github.event.pull_request.merged == true
     steps:
+      - uses: actions/checkout@v4
       - name: Check if user is a member of the org
         id: check-membership
         run: |


### PR DESCRIPTION
The workflow is still not working, there is an authentication issue, but I am not sure what the root cause for this is. This introduces 2 changes:

* Change from `pull_request` to `pull_request_target`
* Add checkout action, because I suspect that `git`/`gh` is not setup properly. https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/workflows/pr-actions.yml does it before sending the first comment, so maybe the checkout action does something that's missing.