### PR TITLE
[ecosystem] Document registry curation policy and responsibilities

### DIFF
--- a/content/en/ecosystem/adopters.md
+++ b/content/en/ecosystem/adopters.md
@@ -18,8 +18,7 @@ OpenTelemetry for [Observability](/docs/concepts/observability-primer/).
 ## Adding your organization as an adopter {#how-to-add}
 
 To have your organization listed, submit a PR with an entry added to the
-[adopters list](https://github.com/open-telemetry/opentelemetry.io/tree/main/data/ecosystem/adopters.yaml).
-The entry should include the following:
+[adopters list]. The entry should include the following:
 
 - Link to a blog post or other resource that describes how your organization
   makes use of OpenTelemetry
@@ -37,3 +36,6 @@ If your organization provides a solution that consumes OpenTelemetry to offer
 **Observability to end users**, see [Vendors](/ecosystem/vendors).
 
 {{% ecosystem/keep-up-to-date adopter %}}
+
+[adopters list]:
+  https://github.com/open-telemetry/opentelemetry.io/tree/main/data/ecosystem/adopters.yaml

--- a/content/en/ecosystem/adopters.md
+++ b/content/en/ecosystem/adopters.md
@@ -15,6 +15,8 @@ OpenTelemetry for [Observability](/docs/concepts/observability-primer/).
 
 {{% ecosystem/adopters-table %}}
 
+## Adding your organization as an adopter {#how-to-add}
+
 To have your organization listed, submit a PR with an entry added to the
 [adopters list](https://github.com/open-telemetry/opentelemetry.io/tree/main/data/ecosystem/adopters.yaml).
 The entry should include the following:
@@ -32,4 +34,6 @@ If your organization provides a **library** or **service** made observable
 through OpenTelemetry, see [Integrations](/ecosystem/integrations/).
 
 If your organization provides a solution that consumes OpenTelemetry to offer
-**Observability to end users**, see [Vendors](/ecosystem/vendors/).
+**Observability to end users**, see [Vendors](/ecosystem/vendors).
+
+{{% ecosystem/keep-up-to-date adopter %}}

--- a/content/en/ecosystem/distributions.md
+++ b/content/en/ecosystem/distributions.md
@@ -25,8 +25,7 @@ is provided as a convenience for the community. {{% /alert %}}
 ## Adding your distribution {#how-to-add}
 
 To have your distribution listed, [submit a PR] with an entry added to the
-[distributions list](https://github.com/open-telemetry/opentelemetry.io/tree/main/data/ecosystem/distributions.yaml).
-The entry should include the following:
+[distributions list]. The entry should include the following:
 
 - Link to the main page of your distribution
 - Link to the documentation that explains how to use the distribution
@@ -50,3 +49,6 @@ The entry should include the following:
 [submit a PR]: /docs/contributing/pull-requests/
 
 {{% ecosystem/keep-up-to-date distribution %}}
+
+[distributions list]:
+  https://github.com/open-telemetry/opentelemetry.io/tree/main/data/ecosystem/distributions.yaml

--- a/content/en/ecosystem/distributions.md
+++ b/content/en/ecosystem/distributions.md
@@ -22,7 +22,7 @@ is provided as a convenience for the community. {{% /alert %}}
 
 {{% ecosystem/distributions-table %}}
 
-## How to add your distribution {#how-to-add}
+## Adding your distribution {#how-to-add}
 
 To have your distribution listed, [submit a PR] with an entry added to the
 [distributions list](https://github.com/open-telemetry/opentelemetry.io/tree/main/data/ecosystem/distributions.yaml).
@@ -48,3 +48,5 @@ The entry should include the following:
 {{% /alert %}}
 
 [submit a PR]: /docs/contributing/pull-requests/
+
+{{% ecosystem/keep-up-to-date distribution %}}

--- a/content/en/ecosystem/integrations.md
+++ b/content/en/ecosystem/integrations.md
@@ -42,7 +42,7 @@ have a CNCF logo beside their name.
 
 {{% ecosystem/integrations-table "application integrations" %}}
 
-## How to add your integration {#how-to-add}
+## Adding your integration {#how-to-add}
 
 To have your library, service, or app listed, [submit a PR] with an entry added
 to the [registry](/ecosystem/registry/adding). The entry should include the
@@ -67,3 +67,5 @@ end users, see [Vendors](/ecosystem/vendors).
 {{% /alert %}}
 
 [submit a PR]: /docs/contributing/pull-requests/
+
+{{% ecosystem/keep-up-to-date integration %}}

--- a/content/en/ecosystem/registry/updating.md
+++ b/content/en/ecosystem/registry/updating.md
@@ -1,11 +1,13 @@
 ---
-title: Keeping registry information current
+title: Keeping registry and list information current
 linkTitle: Updating
 ---
 
-We periodically review registry entry data, such as external links, to ensure
-that only adopters, distributions, integrations, libraries, and vendors actively
-supporting OpenTelemetry are included in the registry.
+We periodically review [registry](..) entry and [list data], such as external
+links, to ensure that only [adopters](../../adopters/),
+[distributions](../../distributions/),
+[integrations, libraries](../../integrations/), and [vendors](../../vendors/)
+actively supporting OpenTelemetry are included in the registry.
 
 Entry authors are encouraged to maintain links to active and up-to-date
 distributions, documentation, and libraries. We reserve the right to update or
@@ -14,3 +16,6 @@ OpenTelemetry. This may happen, for example, when external links become invalid.
 We will attempt to contact the GitHub user who submitted the original entry data
 on a best effort basis, but otherwise reserve the right to edit and remove
 entries and entry data.
+
+[list data]:
+  https://github.com/open-telemetry/opentelemetry.io/tree/main/data/ecosystem

--- a/content/en/ecosystem/registry/updating.md
+++ b/content/en/ecosystem/registry/updating.md
@@ -1,0 +1,16 @@
+---
+title: Keeping registry information current
+linkTitle: Updating
+---
+
+We periodically review registry entry data, such as external links, to ensure
+that only adopters, distributions, integrations, libraries, and vendors actively
+supporting OpenTelemetry are included in the registry.
+
+Entry authors are encouraged to maintain links to active and up-to-date
+distributions, documentation, and libraries. We reserve the right to update or
+remove entries for components that seem to no longer actively support
+OpenTelemetry. This may happen, for example, when external links become invalid.
+We will attempt to contact the GitHub user who submitted the original entry data
+on a best effort basis, but otherwise reserve the right to edit and remove
+entries and entry data.

--- a/content/en/ecosystem/vendors.md
+++ b/content/en/ecosystem/vendors.md
@@ -22,8 +22,7 @@ source product for their customers.
 ## Adding your organization {#how-to-add}
 
 To have your organization listed, [submit a PR] with an entry added to the
-[vendors list](https://github.com/open-telemetry/opentelemetry.io/tree/main/data/ecosystem/vendors.yaml).
-The entry should include the following:
+[vendors list]. The entry should include the following:
 
 - Link to the documentation that details how your offering consumes
   OpenTelemetry natively via [OTLP](/docs/specs/otlp/).
@@ -46,3 +45,6 @@ OpenTelemetry, see [Integrations](/ecosystem/integrations/).
 [submit a PR]: /docs/contributing/pull-requests/
 
 {{% ecosystem/keep-up-to-date vendor %}}
+
+[vendors list]:
+  https://github.com/open-telemetry/opentelemetry.io/tree/main/data/ecosystem/vendors.yaml

--- a/content/en/ecosystem/vendors.md
+++ b/content/en/ecosystem/vendors.md
@@ -19,7 +19,7 @@ source product for their customers.
 
 {{% ecosystem/vendor-table %}}
 
-## Add your organization
+## Adding your organization {#how-to-add}
 
 To have your organization listed, [submit a PR] with an entry added to the
 [vendors list](https://github.com/open-telemetry/opentelemetry.io/tree/main/data/ecosystem/vendors.yaml).
@@ -44,3 +44,5 @@ If you provide a library, service, or app that is made observable through
 OpenTelemetry, see [Integrations](/ecosystem/integrations/).
 
 [submit a PR]: /docs/contributing/pull-requests/
+
+{{% ecosystem/keep-up-to-date vendor %}}

--- a/layouts/shortcodes/ecosystem/keep-up-to-date.md
+++ b/layouts/shortcodes/ecosystem/keep-up-to-date.md
@@ -3,5 +3,8 @@
 ## Keeping {{ $what }} information current
 
 Ensure that you keep your {{ $what }} information up-to-date, otherwise we might
-update or remove it from the registry. For details, see
+update or remove it from the registry or [ecosystem list]. For details, see
 [Keeping registry information current](../registry/updating/).
+
+[ecosystem list]:
+  https://github.com/open-telemetry/opentelemetry.io/tree/main/data/ecosystem

--- a/layouts/shortcodes/ecosystem/keep-up-to-date.md
+++ b/layouts/shortcodes/ecosystem/keep-up-to-date.md
@@ -1,0 +1,7 @@
+{{ $what := .Get 0 | default "organization" -}}
+
+## Keeping {{ $what }} information current
+
+Ensure that you keep your {{ $what }} information up-to-date, otherwise we might
+update or remove it from the registry. For details, see
+[Keeping registry information current](../registry/updating/).


### PR DESCRIPTION
- A proposed solution for #5938, but I'm open to alternatives (let's discuss alternatives in the issue).
- Adds a mention that registry-entry authors are responsible for keeping their data up-to-date
- Failing that, we reserve the right to update and/or remove entries. We'll contact entry authors on a best effort basis
- Adds a page on "Keeping registry information current"

**Preview**:

- https://deploy-preview-5937--opentelemetry.netlify.app/ecosystem/
  - E.g., https://deploy-preview-5937--opentelemetry.netlify.app/ecosystem/adopters/
- https://deploy-preview-5937--opentelemetry.netlify.app/ecosystem/registry/updating/