### PR TITLE
[CI] Check links into github.com, excluding 4XXs for now

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -55,4 +55,5 @@ dictionaries:
   # Other
   - companies
 words: # Valid words across all locales
+  - Docsy
   - htmltest

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -56,13 +56,16 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   # YouTube playlists sometimes give a 404, although they give a 200 when accessed via browser:
   - ^https://www.youtube.com/playlist\?list=
 
-  # Ignore Docsy-generated GitHub links for now
-  - ^https?://github\.com/.*?/.*?/(new|edit)/ # view-page, edit-source etc
-  # TODO: drop after fix to https://github.com/google/docsy/issues/1432
-  - ^https://github.com/open-telemetry/opentelemetry.io/commit/ # last mod
+  # Ignore Docsy-generated GitHub links for now, until
+  # https://github.com/google/docsy/issues/1432 is fixed
+  - ^https?://github\.com/.*?/.*?/(new|edit|issues/new\?title)/ # view-page, edit-source etc
+  - ^https?://github\.com/open-telemetry/opentelemetry.io/tree/
 
-  # Ignore links to GH repo content for now.
-  - ^https?://github\.com/.*?/.*?/(blob|tree)/
+  # Ignore some links to GH repo content for now, most 4XX
+  - ^https?://github\.com/(OpenObservability|opentracing|openzipkin|[pP]rometheus|prometheus-community|prometheus-operator|avillela|census-instrumentation|cloudevents|dotnet|googleapis|in-toto|w3c)/
+  - ^https?://github\.com/open-telemetry/(build-tools|community|opentelemetry-collector-contrib|opentelemetry-collector|opentelemetry-dotnet-instrumentation|opentelemetry-helm-charts|opentelemetry-java-instrumentation|opentelemetry-java|opentelemetry-operator|opentelemetry-proto|opentelemetry-python-contrib|opentelemetry-specification|oteps|semantic-conventions|sig-end-user|weaver)/
+  - ^https?://github\.com/open-telemetry/opentelemetry-demo/
+  # - ^https?://github\.com/.*?/.*?/(blob|tree)/
 
   # Too many redirects as the server tries to figure out the country and language,
   # e.g.: https://www.microsoft.com/en-ca/sql-server.

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -64,7 +64,7 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   # Ignore some links to GH repo content for now, most 4XX
   - ^https?://github\.com/(OpenObservability|opentracing|openzipkin|[pP]rometheus|prometheus-community|prometheus-operator|avillela|census-instrumentation|cloudevents|dotnet|googleapis|in-toto|w3c)/
   - ^https?://github\.com/open-telemetry/(build-tools|community|opentelemetry-collector-contrib|opentelemetry-collector|opentelemetry-dotnet-instrumentation|opentelemetry-helm-charts|opentelemetry-java-instrumentation|opentelemetry-java|opentelemetry-operator|opentelemetry-proto|opentelemetry-python-contrib|opentelemetry-specification|oteps|semantic-conventions|sig-end-user|weaver)/
-  - ^https?://github\.com/open-telemetry/opentelemetry-demo/
+  - ^https?://github\.com/open-telemetry/opentelemetry-demo/blob/main/src/(imageprovider|loadgenerator|otelcollector|.*service)
   # - ^https?://github\.com/.*?/.*?/(blob|tree)/
 
   # Too many redirects as the server tries to figure out the country and language,

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,4 +1,4 @@
-CacheExpires: 9000h # ~ 12 months
+CacheExpires: 13300h # ~ 18 months
 DirectoryPath: public
 IgnoreDirectoryMissingTrailingSlash: true
 IgnoreAltMissing: true

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -6535,6 +6535,38 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-30T15:26:24.629708-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-demo/blob/06f020c97f78ae9625d3a4a5d1107c55045c567f/docker-compose.yml#L665-L668": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:53:34.783222-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-demo/blob/main/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:53:00.929329-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/ad/": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:53:03.08475-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/frontend/": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:53:00.941653-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/kafka/": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:53:01.328807-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/otel-collector/otelcol-config.yml": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:53:13.345763-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/react-native-app/": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:53:03.257474-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/recommendation/": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:53:03.587225-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-demo/pull/1345": {
     "StatusCode": 200,
     "LastSeen": "2024-02-26T10:53:40.03196+01:00"
@@ -6554,6 +6586,10 @@
   "https://github.com/open-telemetry/opentelemetry-demo/pull/950": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T06:06:25.745017-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-demo/tree/main/test": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:53:02.046047-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet": {
     "StatusCode": 200,

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -3659,6 +3659,42 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-09T11:17:09.018721+02:00"
   },
+  "https://github.com/Arize-ai/openinference/tree/main/js/packages/openinference-instrumentation-langchain": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:42.779332-05:00"
+  },
+  "https://github.com/Arize-ai/openinference/tree/main/js/packages/openinference-instrumentation-openai": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:49.617823-05:00"
+  },
+  "https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-bedrock": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:11.587083-05:00"
+  },
+  "https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-dspy": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:13.22858-05:00"
+  },
+  "https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-haystack": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:14.23107-05:00"
+  },
+  "https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-langchain": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:15.116258-05:00"
+  },
+  "https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-llama-index": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:15.985663-05:00"
+  },
+  "https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-mistralai": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:17.324183-05:00"
+  },
+  "https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-openai": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:18.664626-05:00"
+  },
   "https://github.com/ArthurSens": {
     "StatusCode": 200,
     "LastSeen": "2024-11-06T19:17:42.252918Z"
@@ -3671,9 +3707,49 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-07T15:44:38.219108+02:00"
   },
+  "https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/core/azure-core-tracing-opentelemetry": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:30.842593-05:00"
+  },
+  "https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/spring/spring-cloud-azure-starter-monitor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:37.991781-05:00"
+  },
+  "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/instrumentation/opentelemetry-instrumentation-azure-sdk": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:33.396894-05:00"
+  },
+  "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/monitor/monitor-opentelemetry": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:38.753747-05:00"
+  },
+  "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/monitor/monitor-opentelemetry-exporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:40.368224-05:00"
+  },
   "https://github.com/Azure/azure-sdk-for-net": {
     "StatusCode": 200,
     "LastSeen": "2024-04-23T14:33:23.6880679Z"
+  },
+  "https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:36.805156-05:00"
+  },
+  "https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:08.701767-05:00"
+  },
+  "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/core/azure-core-tracing-opentelemetry": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:11.144102-05:00"
+  },
+  "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:39.831295-05:00"
+  },
+  "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry-exporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:45.508324-05:00"
   },
   "https://github.com/Causely/documentation": {
     "StatusCode": 200,
@@ -3778,6 +3854,42 @@
   "https://github.com/GoogleCloudPlatform/guest-agent": {
     "StatusCode": 200,
     "LastSeen": "2024-08-09T10:47:20.891063-04:00"
+  },
+  "https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/tree/main/exporter/metric": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:32.473319-05:00"
+  },
+  "https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/tree/main/exporter/trace": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:33.826841-05:00"
+  },
+  "https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/tree/main/exporters/trace": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:39.319403-05:00"
+  },
+  "https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/tree/main/packages/opentelemetry-cloud-monitoring-exporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:41.072154-05:00"
+  },
+  "https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/tree/main/packages/opentelemetry-cloud-trace-exporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:41.542495-05:00"
+  },
+  "https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/tree/main/opentelemetry-exporter-gcp-monitoring": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:46.108168-05:00"
+  },
+  "https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/tree/main/opentelemetry-exporter-gcp-trace": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:46.46078-05:00"
+  },
+  "https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/tree/main/opentelemetry-propagator-gcp": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:54.584498-05:00"
+  },
+  "https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/tree/main/opentelemetry-resourcedetector-gcp": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:55.149089-05:00"
   },
   "https://github.com/GregMefford": {
     "StatusCode": 200,
@@ -3935,6 +4047,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:23:41.86291+02:00"
   },
+  "https://github.com/Seldaek/monolog/blob/3.4.0/doc/01-usage.md#leveraging-channels": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:04.469079-05:00"
+  },
   "https://github.com/SergeyKanzhelev": {
     "StatusCode": 206,
     "LastSeen": "2025-01-15T11:26:30.451562-05:00"
@@ -3995,6 +4111,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:14:59.740523-05:00"
   },
+  "https://github.com/VictoriaMetrics/VictoriaMetrics/tree/master/docs#sending-data-via-opentelemetry": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:37.143225-05:00"
+  },
   "https://github.com/VihasMakwana": {
     "StatusCode": 200,
     "LastSeen": "2024-11-18T23:18:26.791425218Z"
@@ -4018,6 +4138,10 @@
   "https://github.com/XSAM/otelsql": {
     "StatusCode": 206,
     "LastSeen": "2025-01-07T10:32:26.164923-05:00"
+  },
+  "https://github.com/XSAM/otelsql/blob/main/README.md#metric-instruments": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:13.04957-05:00"
   },
   "https://github.com/XSAM/otelsql/issues": {
     "StatusCode": 200,
@@ -4058,6 +4182,18 @@
   "https://github.com/aboguszewski-sumo": {
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:19:51.252375+02:00"
+  },
+  "https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:41.194349-05:00"
+  },
+  "https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2004-Readme.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:43.147843-05:00"
+  },
+  "https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:42.464166-05:00"
   },
   "https://github.com/addname": {
     "StatusCode": 200,
@@ -4123,6 +4259,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:14:53.99317-05:00"
   },
+  "https://github.com/angular/angular/tree/main/packages/zone.js": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:41.941513-05:00"
+  },
   "https://github.com/anosek-an": {
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:19:37.834068+02:00"
@@ -4130,6 +4270,14 @@
   "https://github.com/anunarapureddy": {
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:20:01.407163+02:00"
+  },
+  "https://github.com/apache/apisix/blob/master/apisix/plugins/opentelemetry.lua": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:59.774071-05:00"
+  },
+  "https://github.com/apache/cassandra/blob/cassandra-5.0/doc/native_protocol_v5.spec": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:48.285303-05:00"
   },
   "https://github.com/apache/dubbo": {
     "StatusCode": 200,
@@ -4166,6 +4314,30 @@
   "https://github.com/ashu658": {
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:20:06.94615+02:00"
+  },
+  "https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/instrumentation-elasticsearch": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:37.93723-05:00"
+  },
+  "https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/instrumentation-kafkajs": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:41.166271-05:00"
+  },
+  "https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/instrumentation-neo4j": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:47.024712-05:00"
+  },
+  "https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/instrumentation-node-cache": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:49.099077-05:00"
+  },
+  "https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/instrumentation-sequelize": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:55.302766-05:00"
+  },
+  "https://github.com/aspecto-io/opentelemetry-ext-js/tree/master/packages/instrumentation-typeorm": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:56.814462-05:00"
   },
   "https://github.com/asuresh4": {
     "StatusCode": 200,
@@ -4214,6 +4386,10 @@
   "https://github.com/baronfel/otel-startup-hook": {
     "StatusCode": 200,
     "LastSeen": "2024-02-01T19:02:28.4090231Z"
+  },
+  "https://github.com/baronfel/otel-startup-hook/blob/main/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:18.240312-05:00"
   },
   "https://github.com/beam-telemetry/telemetry/": {
     "StatusCode": 200,
@@ -4319,6 +4495,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:17:44.561975+02:00"
   },
+  "https://github.com/census-ecosystem/opencensus-go-exporter-prometheus/blob/v0.4.1/prometheus.go#L227": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:03.030875-05:00"
+  },
   "https://github.com/census-instrumentation/opencensus-specs": {
     "StatusCode": 206,
     "LastSeen": "2025-01-07T10:32:17.841095-05:00"
@@ -4330,6 +4510,10 @@
   "https://github.com/cerbos/cerbos-sdk-javascript/": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T15:25:16.58574-05:00"
+  },
+  "https://github.com/cerbos/cerbos-sdk-javascript/tree/main/packages/opentelemetry": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:34.959161-05:00"
   },
   "https://github.com/chalin": {
     "StatusCode": 200,
@@ -4375,6 +4559,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-07T15:43:33.131439+02:00"
   },
+  "https://github.com/cloudfoundry/cf-deployment/blob/main/operations/experimental/add-otel-collector.yml": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:38.353308-05:00"
+  },
   "https://github.com/cloudfoundry/loggregator-agent-release/pull/396": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:05:14.62923-05:00"
@@ -4386,6 +4574,18 @@
   "https://github.com/cloudwego": {
     "StatusCode": 200,
     "LastSeen": "2024-08-07T15:44:41.772995+02:00"
+  },
+  "https://github.com/cncf/artwork/tree/master/projects/opentelemetry": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:37.992043-05:00"
+  },
+  "https://github.com/cncf/foundation/blob/main/code-of-conduct.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:38.183934-05:00"
+  },
+  "https://github.com/cncf/tag-observability/blob/whitepaper-v1.0.0/whitepaper.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:38.098959-05:00"
   },
   "https://github.com/cnnradams": {
     "StatusCode": 200,
@@ -4435,6 +4635,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-07T15:52:33.125917+02:00"
   },
+  "https://github.com/containerd/containerd/blob/main/docs/tracing.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:38.93343-05:00"
+  },
   "https://github.com/coreybutler/nvm-windows": {
     "StatusCode": 200,
     "LastSeen": "2024-06-12T11:21:31.676115+02:00"
@@ -4454,6 +4658,10 @@
   "https://github.com/cri-o/cri-o/": {
     "StatusCode": 200,
     "LastSeen": "2024-08-07T15:52:41.612834+02:00"
+  },
+  "https://github.com/cri-o/cri-o/blob/main/docs/crio.conf.5.md#criotracing-table": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:39.355168-05:00"
   },
   "https://github.com/crobert-1": {
     "StatusCode": 200,
@@ -4506,6 +4714,10 @@
   "https://github.com/davidB/": {
     "StatusCode": 200,
     "LastSeen": "2024-11-14T11:48:33.612051+01:00"
+  },
+  "https://github.com/davidB/tracing-opentelemetry-instrumentation-sdk/tree/main/axum-tracing-opentelemetry": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:43.62114-05:00"
   },
   "https://github.com/davidgs": {
     "StatusCode": 200,
@@ -4815,6 +5027,22 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:21:12.53011+02:00"
   },
+  "https://github.com/getsentry/sentry-dotnet/tree/main/src/Sentry.OpenTelemetry": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:52.877388-05:00"
+  },
+  "https://github.com/getsentry/sentry-java/tree/main/sentry-opentelemetry": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:53.820366-05:00"
+  },
+  "https://github.com/getsentry/sentry-python/tree/master/sentry_sdk/integrations/opentelemetry": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:55.705257-05:00"
+  },
+  "https://github.com/getsentry/sentry-ruby/tree/master/sentry-opentelemetry": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:56.160984-05:00"
+  },
   "https://github.com/git-ecosystem/trace2receiver": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:04:52.804061-05:00"
@@ -4827,9 +5055,17 @@
     "StatusCode": 200,
     "LastSeen": "2024-11-14T11:47:49.456005+01:00"
   },
+  "https://github.com/go-pg/pg/tree/v10/extra/pgotel": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:17.309514-05:00"
+  },
   "https://github.com/gofiber/": {
     "StatusCode": 200,
     "LastSeen": "2024-11-14T11:47:48.179159+01:00"
+  },
+  "https://github.com/gofiber/contrib/tree/main/otelfiber": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:16.35078-05:00"
   },
   "https://github.com/goharbor": {
     "StatusCode": 200,
@@ -4875,6 +5111,14 @@
     "StatusCode": 206,
     "LastSeen": "2024-12-19T14:40:49.726333554+01:00"
   },
+  "https://github.com/grafana/docker-otel-lgtm/tree/main/examples/java/json-logging-otlp": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:13.947924-05:00"
+  },
+  "https://github.com/grafana/grafana-ansible-collection/tree/main/roles/opentelemetry_collector": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:11.484071-05:00"
+  },
   "https://github.com/grafana/grafana-opentelemetry-dotnet": {
     "StatusCode": 200,
     "LastSeen": "2024-04-10T00:09:49.944628+02:00"
@@ -4918,6 +5162,18 @@
   "https://github.com/grpc/grpc-java#transport": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T15:25:32.8124-05:00"
+  },
+  "https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:56.576478-05:00"
+  },
+  "https://github.com/grpc/grpc/tree/master/src/php": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:43.658211-05:00"
+  },
+  "https://github.com/grpc/proposal/blob/master/A66-otel-stats.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:59.089327-05:00"
   },
   "https://github.com/gyliu513": {
     "StatusCode": 200,
@@ -4991,6 +5247,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-11-14T11:48:15.408686+01:00"
   },
+  "https://github.com/http4k/http4k/tree/master/core/opentelemetry": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:31.36569-05:00"
+  },
   "https://github.com/huikang": {
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:21:35.311401+02:00"
@@ -5011,6 +5271,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:21:44.466345+02:00"
   },
+  "https://github.com/hyperium/tonic/blob/master/examples/helloworld-tutorial.md#writing-our-server": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:37.737198-05:00"
+  },
   "https://github.com/iNikem": {
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:17:02.832648+02:00"
@@ -5026,6 +5290,10 @@
   "https://github.com/ibm-messaging/": {
     "StatusCode": 200,
     "LastSeen": "2024-11-14T11:47:58.064055+01:00"
+  },
+  "https://github.com/ibm-messaging/mq-metric-samples/tree/master/cmd/mq_otel": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:19.371805-05:00"
   },
   "https://github.com/ibmmqmet": {
     "StatusCode": 200,
@@ -5059,9 +5327,17 @@
     "StatusCode": 200,
     "LastSeen": "2025-01-06T11:32:46.912502-05:00"
   },
+  "https://github.com/instana/nodejs/tree/main/packages/opentelemetry-exporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:42.108962-05:00"
+  },
   "https://github.com/instana/otel-database-dc": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:14:36.112572-05:00"
+  },
+  "https://github.com/instana/otel-dc/tree/main/llm": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:00.408787-05:00"
   },
   "https://github.com/iredelmeier": {
     "StatusCode": 200,
@@ -5098,6 +5374,14 @@
   "https://github.com/jaegertracing/jaeger-client-java#via-http-headers": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T15:24:50.932894-05:00"
+  },
+  "https://github.com/jaegertracing/jaeger-idl/blob/main/proto/api_v2/sampling.proto": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:41.542412-05:00"
+  },
+  "https://github.com/jaegertracing/jaeger-idl/blob/master/proto/api_v2/sampling.proto": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:06.508222-05:00"
   },
   "https://github.com/james-bebbington": {
     "StatusCode": 200,
@@ -5279,6 +5563,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-25T09:39:26.927388436Z"
   },
+  "https://github.com/justindsmith/opentelemetry-instrumentations-js/tree/main/packages/instrumentation-remix": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:53.717084-05:00"
+  },
   "https://github.com/justinfoote": {
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:22:10.893702+02:00"
@@ -5386,6 +5674,10 @@
   "https://github.com/kubernetes": {
     "StatusCode": 200,
     "LastSeen": "2024-08-07T15:44:18.966819+02:00"
+  },
+  "https://github.com/kubernetes/cri-api/blob/c75ef5b473bbe2d0a4fc92f82235efd665ea8e9f/pkg/apis/runtime/v1/api.proto#L1237-L1238": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:55.617771-05:00"
   },
   "https://github.com/kubewarden": {
     "StatusCode": 200,
@@ -5595,9 +5887,17 @@
     "StatusCode": 200,
     "LastSeen": "2024-04-19T17:43:49.897716918Z"
   },
+  "https://github.com/microsoft/vcpkg/tree/master/ports/opentelemetry-cpp": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:51.950246-05:00"
+  },
   "https://github.com/mishmash-io/opentelemetry-server-embedded": {
     "StatusCode": 200,
     "LastSeen": "2024-10-18T16:50:17.016614951+03:00"
+  },
+  "https://github.com/mishmash-io/opentelemetry-server-embedded/tree/main/druid-otlp-format": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:53.308697-05:00"
   },
   "https://github.com/mjwolf": {
     "StatusCode": 200,
@@ -5719,6 +6019,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-30T15:25:22.157083-05:00"
   },
+  "https://github.com/nginxinc/nginx-otel/tree/main": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:38.068088-05:00"
+  },
   "https://github.com/nhatthm": {
     "StatusCode": 200,
     "LastSeen": "2024-11-14T11:48:01.492253+01:00"
@@ -5743,6 +6047,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:17:23.391947+02:00"
   },
+  "https://github.com/nvm-sh/nvm/blob/master/README.md#installing-and-updating": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:40.486941-05:00"
+  },
   "https://github.com/oatpp": {
     "StatusCode": 200,
     "LastSeen": "2024-02-09T11:48:44.797303+01:00"
@@ -5754,6 +6062,10 @@
   "https://github.com/obecny": {
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:23:01.576532+02:00"
+  },
+  "https://github.com/observIQ/bindplane-agent/tree/main/docs": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:41.411777-05:00"
   },
   "https://github.com/observIQ/observiq-otel-collector": {
     "StatusCode": 206,
@@ -5867,9 +6179,21 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-13T11:43:24.09422-05:00"
   },
+  "https://github.com/open-telemetry/opamp-spec/blob/main/proto/opamp.proto": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:07.885812-05:00"
+  },
+  "https://github.com/open-telemetry/opamp-spec/blob/main/specification.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:41.130906-05:00"
+  },
   "https://github.com/open-telemetry/opamp-spec/issues/new": {
     "StatusCode": 200,
     "LastSeen": "2024-08-09T10:45:27.443528-04:00"
+  },
+  "https://github.com/open-telemetry/opamp-spec/tree/main/specification.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:04.32664-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector": {
     "StatusCode": 200,
@@ -5990,6 +6314,14 @@
   "https://github.com/open-telemetry/opentelemetry-collector-releases/tags": {
     "StatusCode": 200,
     "LastSeen": "2024-08-28T18:43:05.252902-04:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:39.785648-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-k8s": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:09.824638-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/": {
     "StatusCode": 206,
@@ -6119,6 +6451,18 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-15T13:17:30.212185-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-configuration/blob/670901762dd5cce1eecee423b8660e69f71ef4be/examples/kitchen-sink.yaml#L438-L439": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:57.968089-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-configuration/blob/f38ac7c3a499ae5f81924ef9c455c27a56130562/schema/tracer_provider.json#L22": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:59.699463-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-configuration/blob/main/examples/kitchen-sink.yaml": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:42.816792-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-cpp": {
     "StatusCode": 200,
     "LastSeen": "2025-01-06T11:32:23.983579-05:00"
@@ -6127,6 +6471,30 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-13T12:10:36.918825-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/main/exporters/fluentd": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:07.192234-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/main/instrumentation": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:43.583215-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/main/instrumentation/httpd": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:57.091103-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/main/instrumentation/nginx": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:57.820668-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/main/instrumentation/otel-webserver-module": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:58.252156-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-cpp/blob/main/INSTALL.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:42.938944-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-cpp/releases": {
     "StatusCode": 206,
     "LastSeen": "2025-01-13T11:43:32.786542-05:00"
@@ -6134,6 +6502,30 @@
   "https://github.com/open-telemetry/opentelemetry-cpp/releases/latest": {
     "StatusCode": 206,
     "LastSeen": "2025-01-13T11:43:29.884157-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-cpp/tree/main/examples/metrics_simple": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:42.689496-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-cpp/tree/main/exporters/etw": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:06.365837-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-cpp/tree/main/exporters/otlp": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:07.977726-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-cpp/tree/main/exporters/prometheus": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:44.325998-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-cpp/tree/main/exporters/zipkin": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:45.041257-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-cpp/tree/main/opentracing-shim": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:46.633337-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-demo": {
     "StatusCode": 200,
@@ -6170,6 +6562,162 @@
   "https://github.com/open-telemetry/opentelemetry-dotnet-contrib": {
     "StatusCode": 206,
     "LastSeen": "2025-01-13T11:43:26.44481-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/Instrumentation.AspNet-1.9.0-beta.1/src/OpenTelemetry.Instrumentation.AspNet/README.md#list-of-metrics-produced": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:40.110043-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/Instrumentation.AspNetCore-1.9.0/src/OpenTelemetry.Instrumentation.AspNetCore/README.md#list-of-metrics-produced": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:40.774765-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/Instrumentation.Http-1.9.0/src/OpenTelemetry.Instrumentation.Http/README.md#list-of-metrics-produced": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:41.452403-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/Instrumentation.Process-0.5.0-beta.6/src/OpenTelemetry.Instrumentation.Process/README.md#metrics": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:43.820937-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/Instrumentation.Runtime-1.9.0/src/OpenTelemetry.Instrumentation.Runtime/README.md#metrics": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:42.260803-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/Resources.Azure-1.0.0-beta.9/src/OpenTelemetry.Resources.Azure/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:40.256391-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/Resources.Container-1.0.0-beta.9/src/OpenTelemetry.Resources.Container/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:41.322556-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/Resources.Host-0.1.0-beta.3/src/OpenTelemetry.Resources.Host/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:41.968258-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/Resources.OperatingSystem-0.1.0-alpha.4/src/OpenTelemetry.Resources.OperatingSystem/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:42.749034-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/Resources.Process-0.1.0-beta.3/src/OpenTelemetry.Resources.Process/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:43.524136-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/Resources.ProcessRuntime-0.1.0-beta.2/src/OpenTelemetry.Resources.ProcessRuntime/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:44.55147-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Exporter.Geneva": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:11.498677-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Exporter.InfluxDB": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:12.155225-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Exporter.Instana": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:14.118272-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Exporter.OneCollector": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:15.452229-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Exporter.Stackdriver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:25.260257-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.AWS": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:00.21622-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.AWSLambda": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:00.610899-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.AspNet": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:58.779656-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:59.248633-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.AspNetCore": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:59.684142-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.Cassandra": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:01.352082-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.ConfluentKafka": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:01.827551-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.ElasticsearchClient": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:02.328412-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.EntityFrameworkCore": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:02.726926-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.EventCounters": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:03.274483-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.GrpcCore": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:03.802503-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.GrpcNetClient": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:04.254869-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.Hangfire": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:04.718578-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.Http": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:05.102342-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.MassTransit": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:05.502255-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.MySqlData": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:05.964919-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.Owin": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:06.466482-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.Process": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:06.940345-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.Quartz": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:07.400029-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.Runtime": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:07.808359-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.SqlClient": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:08.332011-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.StackExchangeRedis": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:08.75232-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.Wcf": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:09.252498-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation": {
     "StatusCode": 206,
@@ -6215,6 +6763,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-30T15:25:16.569943-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:40.586492-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-dotnet/issues/4243": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T15:26:54.792726-05:00"
@@ -6247,6 +6799,46 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:15:25.802104-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-dotnet/tree/core-1.5.0-rc.1/src/OpenTelemetry.Exporter.Prometheus.HttpListener": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:46.513441-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet/tree/core-1.5.1/src/OpenTelemetry.Exporter.OpenTelemetryProtocol#environment-variables": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:45.165787-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet/tree/core-1.5.1/src/OpenTelemetry.Exporter.Zipkin#configuration-using-environment-variables": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:46.837639-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/logs/correlation": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:44.134635-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Exporter.Console": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:10.07219-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Exporter.InMemory": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:13.463706-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Exporter.OpenTelemetryProtocol": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:16.264564-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Exporter.Prometheus.AspNetCore": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:21.07251-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Exporter.Prometheus.HttpListener": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:21.58408-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Exporter.Zipkin": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:27.610217-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-ebpf-profiler": {
     "StatusCode": 200,
     "LastSeen": "2024-10-24T15:10:22.597683+02:00"
@@ -6263,6 +6855,86 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-13T11:43:31.702442-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/examples/roll_dice": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:41.082551-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_bandit": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:10.644655-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_broadway": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:11.145575-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_cowboy": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:43.65816-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_dataloader": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:11.597687-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_ecto": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:44.573932-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_elli": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:44.432489-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_finch": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:13.032876-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_grpcbox": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:13.482393-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_httpoison": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:13.977146-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_nebulex": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:14.553589-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_oban": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:09.776124-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_phoenix": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:42.565603-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_redix": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:10.304822-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_req": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:14.984697-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_tesla": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:45.041243-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/instrumentation/opentelemetry_xandra": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:15.422175-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-erlang/blob/main/apps/opentelemetry/include/otel_span.hrl#L19": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:41.656375-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-erlang/blob/main/config/otel-collector-config.yaml": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:41.638058-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-erlang/blob/main/docker-compose.yml": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:42.172772-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-erlang/pull/733": {
     "StatusCode": 200,
     "LastSeen": "2024-08-02T13:14:54.012411-04:00"
@@ -6275,6 +6947,14 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-13T11:43:27.614136-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-erlang/tree/main/apps/opentelemetry_exporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:28.621936-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-erlang/tree/main/apps/opentelemetry_zipkin": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:30.963558-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-go": {
     "StatusCode": 206,
     "LastSeen": "2025-01-07T10:33:12.688711-05:00"
@@ -6283,9 +6963,45 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-07T10:31:43.730419-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-go-contrib/blob/main/CONTRIBUTING.md#code-owners": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:11.841222-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-go-contrib/issues/new": {
     "StatusCode": 200,
     "LastSeen": "2024-05-27T10:19:47.859082+02:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/detectors/aws": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:46.409097-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/detectors/gcp": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:46.835103-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/examples/prometheus": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:41.797471-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/github.com/gin-gonic/gin": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:16.803395-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/github.com/labstack/echo": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:15.843822-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/google.golang.org/grpc": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:18.550849-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/host": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:18.959116-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/runtime": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:21.099654-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-go-instrumentation": {
     "StatusCode": 200,
@@ -6295,6 +7011,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-09T10:44:15.667174-04:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-go-instrumentation/blob/main/docs/how-it-works.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:46.811839-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-go-vanityurls": {
     "StatusCode": 200,
     "LastSeen": "2024-08-23T20:33:46.750242014Z"
@@ -6302,6 +7022,18 @@
   "https://github.com/open-telemetry/opentelemetry-go-vanityurls/issues/new": {
     "StatusCode": 200,
     "LastSeen": "2024-08-26T22:28:51.200439921Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-go/blob/8ba6da8f3e5380629fcd72057fe0f827a9e23493/sdk/resource/os.go#L50": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:03.772861-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-go/blob/main/sdk/trace/span.go": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:12.537474-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-go/blob/main/sdk/trace/span.go#L445-L467": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:14.129115-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-go/compare/v1.18.0...v1.19.0": {
     "StatusCode": 200,
@@ -6322,6 +7054,22 @@
   "https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.19.0": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:04:58.205917-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-go/tree/main/exporters/otlp": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:35.925346-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-go/tree/main/exporters/prometheus": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:41.381903-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-go/tree/main/exporters/zipkin": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:38.601751-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-go/tree/main/semconv/": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:54.798013-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-helm-charts": {
     "StatusCode": 206,
@@ -6351,13 +7099,61 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-13T11:43:26.584947-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/RELEASING.md#release-cadence": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:42.188845-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/aws-resources": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:38.952312-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/gcp-resources": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:39.709614-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/micrometer-meter-provider": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:44.1039-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/prometheus-client-bridge": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:43.309122-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/resource-providers": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:47.236991-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-java-docs#java-opentelemetry-examples": {
     "StatusCode": 206,
     "LastSeen": "2025-01-13T11:44:08.464556-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-java-docs/tree/main/log-appender": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:45.041175-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-java-docs/tree/main/otlp": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:39.020612-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-java-examples": {
     "StatusCode": 200,
     "LastSeen": "2024-10-23T20:19:13.793874-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-java-examples/tree/main/declarative-configuration": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:46.452153-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-java-examples/tree/main/javaagent": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:40.449725-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-java-examples/tree/main/javaagent#declarative-configuration": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:46.046777-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-java-examples/tree/main/spring-native": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:37.326402-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-java-instrumentation": {
     "StatusCode": 206,
@@ -6455,9 +7251,229 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-13T11:43:28.039624-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/GUIDELINES.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:42.047119-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/metapackages/auto-instrumentations-node/README.md#supported-instrumentations": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:41.090752-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/archive/opentelemetry-browser-extension-autoinjection": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:51.129965-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:42.643576-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-alibaba-cloud": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:47.744785-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-aws": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:48.164699-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-azure": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:48.681516-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-container": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:49.08505-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-gcp": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:49.501101-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-github": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:49.89747-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-instana": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:50.29364-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/metapackages/auto-instrumentations-node#supported-instrumentations": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:38.791049-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-amqplib": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:31.909108-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-cucumber": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:35.72653-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-dataloader": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:36.276663-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-fs": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:43.088777-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-lru-memoizer": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:43.860538-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-mongoose": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:45.519694-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-runtime-node": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:54.75628-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-socket.io": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:55.793418-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-tedious": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:56.34055-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-undici": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:57.529249-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-aws-lambda": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:32.368568-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-aws-sdk": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:32.869828-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-bunyan": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:33.92546-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-cassandra": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:34.378411-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-connect": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:35.32671-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-dns": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:36.848624-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-express": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:42.15101-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-express#express-instrumentation-options": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:40.563144-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-fastify": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:38.360617-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-generic-pool": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:39.347828-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-graphql": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:39.876087-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-hapi": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:40.307826-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-ioredis": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:40.754959-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-knex": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:41.789927-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-koa": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:42.280287-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-memcached": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:44.350277-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-mongodb": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:44.858666-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-mysql": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:46.10613-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-mysql2": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:46.53617-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-nestjs-core": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:47.580767-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-net": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:48.079304-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-pg": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:50.193601-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-pino": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:51.434079-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-redis": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:52.764607-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-redis-4": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:53.226909-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-restify": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:50.808776-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-router": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:54.330903-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-winston": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:58.62194-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/web/opentelemetry-instrumentation-document-load": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:37.486944-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/web/opentelemetry-instrumentation-long-task": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:43.247999-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/web/opentelemetry-instrumentation-user-interaction": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:58.072428-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/web/opentelemetry-plugin-react-load": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:52.315617-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-js/": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:04:52.867297-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:42.172729-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-js/discussions": {
     "StatusCode": 206,
@@ -6494,6 +7510,38 @@
   "https://github.com/open-telemetry/opentelemetry-js/releases/tag/v1.17.1": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:15:20.392944-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/opentelemetry-web": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:42.389939-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-prometheus": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:43.136791-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-fetch": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:38.857955-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-grpc": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:43.713991-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-http": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:41.62276-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-xml-http-request": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:59.091501-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-jaeger": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:42.61478-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-zipkin": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:43.637886-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-lambda": {
     "StatusCode": 206,
@@ -6575,6 +7623,106 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-30T15:25:32.786112-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/examples": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:44.93646-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/CakePHP": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:00.184524-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/CodeIgniter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:00.606307-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/Curl": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:01.161494-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/ExtAmqp": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:01.677859-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/ExtRdKafka": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:02.179239-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/Guzzle": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:02.643868-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/HttpAsyncClient": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:03.070493-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/IO": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:03.70522-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/Laravel": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:42.970106-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/MongoDB": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:04.1211-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/OpenAIPHP": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:04.616214-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/PDO": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:05.155999-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/Psr14": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:05.608257-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/Psr15": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:06.093472-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/Psr16": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:06.489108-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/Psr18": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:06.968933-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/Psr3": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:07.533855-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/Psr6": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:08.018955-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/Slim": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:08.461401-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/Symfony": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:08.888448-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/Wordpress": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:09.277355-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation/Yii": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:09.843979-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Logs/Monolog": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:44.045848-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/ResourceDetectors/Container": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:50.649389-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-php-instrumentation": {
     "StatusCode": 200,
     "LastSeen": "2025-01-06T11:32:22.532755-05:00"
@@ -6598,6 +7746,42 @@
   "https://github.com/open-telemetry/opentelemetry-php/releases/latest": {
     "StatusCode": 206,
     "LastSeen": "2025-01-07T10:31:45.424523-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php/tree/main/examples": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:42.99138-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php/tree/main/src/API": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:44.537166-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php/tree/main/src/Context": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:45.137253-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php/tree/main/src/Contrib/Grpc": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:44.165056-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php/tree/main/src/Contrib/Otlp": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:44.57622-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php/tree/main/src/Contrib/Zipkin": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:45.025941-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php/tree/main/src/Extension/Propagator/B3": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:54.189025-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php/tree/main/src/SDK": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:45.573963-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php/tree/main/src/SemConv": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:46.017066-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-proto": {
     "StatusCode": 206,
@@ -6639,6 +7823,22 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-09T10:45:33.002838-04:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-python/blob/main/README.md#supported-runtimes": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:39.078649-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-python/blob/main/docs/examples/logs/otel-collector-config.yaml": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:40.000766-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-python/blob/main/exporter/": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:43.324243-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-python/blob/stable/docs/examples/logs/example.py": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:39.359537-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-python/pull/4091": {
     "StatusCode": 200,
     "LastSeen": "2024-08-02T13:14:45.150789-04:00"
@@ -6659,6 +7859,50 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-30T15:25:38.140496-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples/auto-instrumentation": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:40.523105-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples/logs": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:39.357171-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-opencensus": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:46.921333-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:47.412196-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp-proto-grpc": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:47.800489-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp-proto-http": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:48.221038-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-prometheus": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:48.595907-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-zipkin": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:49.072772-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-zipkin-json": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:49.53652-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-zipkin-proto-http": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:50.032751-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-python/tree/main/shim/opentelemetry-opentracing-shim": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:19.175177-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-ruby": {
     "StatusCode": 206,
     "LastSeen": "2025-01-07T10:31:49.58882-05:00"
@@ -6666,6 +7910,190 @@
   "https://github.com/open-telemetry/opentelemetry-ruby#instrumentation-libraries": {
     "StatusCode": 206,
     "LastSeen": "2025-01-13T11:43:26.982761-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:42.668113-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/action_mailer": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:23.713329-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/action_pack": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:22.75846-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/action_view": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:23.272396-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/active_job": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:24.171239-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/active_model_serializers": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:24.828327-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/active_record": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:25.306968-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/active_support": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:25.79232-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/all": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:26.17777-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/aws_lambda": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:27.220488-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/aws_sdk": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:26.668008-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/base": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:27.668533-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/bunny": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:28.239065-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/concurrent_ruby": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:28.74478-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/dalli": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:29.224901-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/delayed_job": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:29.773634-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/ethon": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:30.259844-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/excon": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:30.729582-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/faraday": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:31.167217-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/grape": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:31.640535-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/graphql": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:32.057858-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/gruf": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:32.446561-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/http": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:32.937858-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/http_client": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:33.449139-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/httpx": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:33.875645-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/koala": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:34.275831-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/lmdb": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:34.733966-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/mongo": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:35.176529-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/mysql2": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:35.626157-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/net_http": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:36.126353-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/pg": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:36.495611-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/que": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:36.910703-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/racecar": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:37.34715-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/rack": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:37.816671-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/rails": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:38.29741-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/rake": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:38.867289-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/rdkafka": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:39.316011-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/redis": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:39.737573-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/resque": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:40.285938-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/restclient": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:40.733723-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/rspec": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:41.13651-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/ruby_kafka": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:41.774024-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/sidekiq": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:42.433696-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/sinatra": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:42.830151-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation/trilogy": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:43.301792-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby/blob/main/README.md#compatibility": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:39.785684-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-ruby/releases": {
     "StatusCode": 206,
@@ -6675,6 +8103,34 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-13T11:43:27.477433-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-ruby/tree/main/exporter/jaeger": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:50.74861-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby/tree/main/exporter/otlp": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:51.156378-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby/tree/main/exporter/otlp-grpc": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:51.476699-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby/tree/main/exporter/otlp-http": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:51.948679-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby/tree/main/exporter/otlp-metrics": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:52.364572-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby/tree/main/exporter/zipkin": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:52.849108-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ruby/tree/main/propagator": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:43.288385-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-rust": {
     "StatusCode": 206,
     "LastSeen": "2025-01-13T11:44:20.947445-05:00"
@@ -6683,6 +8139,26 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-13T11:43:30.237443-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-aws": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:56.564877-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-datadog": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:53.216787-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-stackdriver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:54.626319-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-user-events-logs": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:55.5955-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-rust-contrib/tree/main/opentelemetry-user-events-metrics": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:56.054548-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-rust/releases": {
     "StatusCode": 206,
     "LastSeen": "2025-01-13T11:43:29.447952-05:00"
@@ -6690,6 +8166,26 @@
   "https://github.com/open-telemetry/opentelemetry-rust/releases/latest": {
     "StatusCode": 206,
     "LastSeen": "2025-01-13T11:43:27.60405-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-jaeger-propagator": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:57.084843-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-otlp": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:53.646512-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-prometheus": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:54.134433-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-stdout": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:55.152155-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-zipkin": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:56.477817-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-specification": {
     "StatusCode": 206,
@@ -6767,6 +8263,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-13T12:10:36.848641-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-swift/blob/main/Sources/OpenTelemetryApi/OpenTelemetry.swift#L11": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:44.053229-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-swift/releases": {
     "StatusCode": 206,
     "LastSeen": "2025-01-13T11:43:30.967969-05:00"
@@ -6774,6 +8274,18 @@
   "https://github.com/open-telemetry/opentelemetry-swift/releases/latest": {
     "StatusCode": 206,
     "LastSeen": "2025-01-13T11:43:27.603742-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-swift/tree/main/Sources/Exporters": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:44.577558-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-swift/tree/main/Sources/Instrumentation": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:44.239209-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-swift/tree/main/Sources/Instrumentation/URLSession": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:43.421097-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry.io": {
     "StatusCode": 200,
@@ -6790,6 +8302,30 @@
   "https://github.com/open-telemetry/opentelemetry.io/": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:15:20.42238-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry.io/blob/main/.cspell.yml": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:39.616287-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry.io/blob/main/.markdownlint.json": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:39.078757-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry.io/blob/main/.textlintrc.yml": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:37.992036-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry.io/blob/main/CONTRIBUTING.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:25.701246-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry.io/blob/main/content/en/_index.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:41.088879-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry.io/blob/main/hugo.yaml": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:41.394462-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry.io/commits/main/": {
     "StatusCode": 200,
@@ -6963,6 +8499,18 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:14:36.015951-05:00"
   },
+  "https://github.com/openclarity/apiclarity/tree/master/plugins/otel-collector": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:45.041259-05:00"
+  },
+  "https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:57.552106-05:00"
+  },
+  "https://github.com/opencontainers/image-spec/blob/main/manifest.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:57.154158-05:00"
+  },
   "https://github.com/openfga": {
     "StatusCode": 200,
     "LastSeen": "2024-08-08T20:12:23.279486+02:00"
@@ -7135,6 +8683,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-07T10:33:07.125592-05:00"
   },
+  "https://github.com/prisma/prisma/tree/main/packages/instrumentation": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:51.88017-05:00"
+  },
   "https://github.com/prometheus-operator/prometheus-operator": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T06:06:42.1819-05:00"
@@ -7159,6 +8711,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-09-04T09:48:35.996317+02:00"
   },
+  "https://github.com/protocolbuffers/protobuf/tree/main/php": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:44.400811-05:00"
+  },
   "https://github.com/puckpuck": {
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:14:10.823026+02:00"
@@ -7170,6 +8726,10 @@
   "https://github.com/purview-dev/purview-telemetry-sourcegenerator/": {
     "StatusCode": 200,
     "LastSeen": "2024-04-26T09:57:49.687508317+01:00"
+  },
+  "https://github.com/purview-dev/purview-telemetry-sourcegenerator/blob/main/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:52.473775-05:00"
   },
   "https://github.com/pyohannes": {
     "StatusCode": 200,
@@ -7206,6 +8766,10 @@
   "https://github.com/redis/": {
     "StatusCode": 200,
     "LastSeen": "2024-11-14T11:47:51.884226+01:00"
+  },
+  "https://github.com/redis/go-redis/tree/master/extra/redisotel": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:17.741257-05:00"
   },
   "https://github.com/reese-lee": {
     "StatusCode": 206,
@@ -7254,6 +8818,10 @@
   "https://github.com/rquedas": {
     "StatusCode": 200,
     "LastSeen": "2024-08-09T11:17:45.240828+02:00"
+  },
+  "https://github.com/rquedas/otel4devs/tree/main/collector/receiver/trace-receiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:39.350401-05:00"
   },
   "https://github.com/rrschulze": {
     "StatusCode": 200,
@@ -7339,6 +8907,74 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-30T12:13:55.649214+01:00"
   },
+  "https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/database/sql/splunksql": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:28.507272-05:00"
+  },
+  "https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/confluentinc/confluent-kafka-go/kafka/splunkkafka": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:25.857233-05:00"
+  },
+  "https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/go-chi/chi/splunkchi": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:22.112722-05:00"
+  },
+  "https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/go-sql-driver/mysql/splunkmysql": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:26.7784-05:00"
+  },
+  "https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/gomodule/redigo/splunkredigo": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:28.123607-05:00"
+  },
+  "https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/graph-gophers/graphql-go/splunkgraphql": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:24.389421-05:00"
+  },
+  "https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/jackc/pgx/splunkpgx": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:27.222572-05:00"
+  },
+  "https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/jinzhu/gorm/splunkgorm": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:23.877479-05:00"
+  },
+  "https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/jmoiron/sqlx/splunksqlx": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:28.95536-05:00"
+  },
+  "https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/julienschmidt/httprouter/splunkhttprouter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:25.358937-05:00"
+  },
+  "https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/lib/pq/splunkpq": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:27.675748-05:00"
+  },
+  "https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/miekg/dns/splunkdns": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:23.056492-05:00"
+  },
+  "https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/syndtr/goleveldb/leveldb/splunkleveldb": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:26.329424-05:00"
+  },
+  "https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/github.com/tidwall/buntdb/splunkbuntdb": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:21.64888-05:00"
+  },
+  "https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/gopkg.in/olivere/elastic/splunkelastic": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:23.440416-05:00"
+  },
+  "https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/k8s.io/client-go/splunkclient-go": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:22.646025-05:00"
+  },
+  "https://github.com/signalfx/splunk-otel-go/tree/main/instrumentation/net/http/splunkhttp": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:24.911768-05:00"
+  },
   "https://github.com/signalfx/splunk-otel-java": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T12:13:59.355694+01:00"
@@ -7394,6 +9030,14 @@
   "https://github.com/statsd/statsd": {
     "StatusCode": 206,
     "LastSeen": "2025-01-13T11:43:45.346321-05:00"
+  },
+  "https://github.com/statsd/statsd/blob/master/docs/metric_types.md#counting": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:59.318264-05:00"
+  },
+  "https://github.com/statsd/statsd/blob/master/stats.js#L281": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:38:00.873895-05:00"
   },
   "https://github.com/steffan-westcott/": {
     "StatusCode": 200,
@@ -7527,6 +9171,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:24:04.789814+02:00"
   },
+  "https://github.com/torvalds/linux/blob/e4cbce4d131753eca271d9d67f58c6377f27ad21/kernel/sched/loadavg.c#L11-L18": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:58.275919-05:00"
+  },
   "https://github.com/toumorokoshi": {
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:24:07.590358+02:00"
@@ -7538,6 +9186,74 @@
   "https://github.com/traceloop/jest-opentelemetry": {
     "StatusCode": 206,
     "LastSeen": "2025-01-13T12:11:28.537623-05:00"
+  },
+  "https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-anthropic": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:10.546821-05:00"
+  },
+  "https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-chromadb": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:12.155787-05:00"
+  },
+  "https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-cohere": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:12.706593-05:00"
+  },
+  "https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-haystack": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:13.70774-05:00"
+  },
+  "https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-langchain": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:14.695467-05:00"
+  },
+  "https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-llamaindex": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:15.50495-05:00"
+  },
+  "https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-milvus": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:16.487217-05:00"
+  },
+  "https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-mistralai": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:16.89736-05:00"
+  },
+  "https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-ollama": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:17.826074-05:00"
+  },
+  "https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-openai": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:18.15092-05:00"
+  },
+  "https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-pinecone": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:19.596049-05:00"
+  },
+  "https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-qdrant": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:20.038856-05:00"
+  },
+  "https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-replicate": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:20.422944-05:00"
+  },
+  "https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-transformers": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:20.812109-05:00"
+  },
+  "https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-vertexai": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:21.270669-05:00"
+  },
+  "https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-watsonx": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:21.842524-05:00"
+  },
+  "https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-weaviate": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:40:22.374038-05:00"
   },
   "https://github.com/trask": {
     "StatusCode": 206,
@@ -7558,6 +9274,10 @@
   "https://github.com/tsloughter": {
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:11:49.651414+02:00"
+  },
+  "https://github.com/twmb/franz-go/tree/master/plugin/kotel": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:19.761299-05:00"
   },
   "https://github.com/tydhot": {
     "StatusCode": 200,
@@ -7587,6 +9307,30 @@
     "StatusCode": 200,
     "LastSeen": "2024-11-14T11:47:53.880645+01:00"
   },
+  "https://github.com/uptrace/opentelemetry-go-extra/tree/main/otelgorm": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:29.429672-05:00"
+  },
+  "https://github.com/uptrace/opentelemetry-go-extra/tree/main/otelgraphql": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:18.166808-05:00"
+  },
+  "https://github.com/uptrace/opentelemetry-go-extra/tree/main/otellogrus": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:20.208999-05:00"
+  },
+  "https://github.com/uptrace/opentelemetry-go-extra/tree/main/otelsql": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:29.910105-05:00"
+  },
+  "https://github.com/uptrace/opentelemetry-go-extra/tree/main/otelsqlx": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:20.701466-05:00"
+  },
+  "https://github.com/uptrace/opentelemetry-go-extra/tree/main/otelzap": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:30.325467-05:00"
+  },
   "https://github.com/utpilla": {
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:15:31.954992+02:00"
@@ -7594,6 +9338,10 @@
   "https://github.com/vercel": {
     "StatusCode": 200,
     "LastSeen": "2024-07-05T23:26:49.504427+02:00"
+  },
+  "https://github.com/vercel/next.js/tree/canary/packages/next/src/server/lib/trace": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:39:48.531073-05:00"
   },
   "https://github.com/vishweshbankwar": {
     "StatusCode": 200,
@@ -7691,6 +9439,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-09T11:16:38.566794+02:00"
   },
+  "https://github.com/yuin/goldmark/blob/master/README.md#headings": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:39.70967-05:00"
+  },
   "https://github.com/yuriolisa": {
     "StatusCode": 200,
     "LastSeen": "2024-08-09T11:16:53.968727+02:00"
@@ -7698,6 +9450,10 @@
   "https://github.com/yurishkuro": {
     "StatusCode": 200,
     "LastSeen": "2024-08-09T11:16:05.181396+02:00"
+  },
+  "https://github.com/yurishkuro/opentracing-tutorial/tree/master/python": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T11:37:39.566431-05:00"
   },
   "https://github.com/zacharycmontoya": {
     "StatusCode": 200,


### PR DESCRIPTION
- This lays a foundation for, and contributes to #5951
- Updates refcache with many links into `github.com`
- Ignores URLs to `github.com` orgs and users that result in 400 statuses