### PR TITLE
[CI] Fix some github.com links into OTel org

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -15,6 +15,11 @@ IgnoreDirs:
   # TODO drop next lines after https://github.com/open-telemetry/opentelemetry.io/issues/5555 is fixed for these pages:
   - ^zh/docs/concepts/signals/baggage/
   - ^zh/docs/zero-code/php/
+  # TODO drop the following config once this page is updated to reflect the corresponding `en`
+  # page and the link 404 (detailed below) are resolved:
+  #   zh/docs/contributing/index.html
+  #     Non-OK status: 404 --> https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md
+  - ^zh/docs/contributing/
   # DO NOT EDIT! IgnoreDirs list is auto-generated from markdown file front matter.
 IgnoreInternalURLs: # list of paths
 IgnoreURLs: # list of regexs of paths or URLs to be ignored
@@ -62,7 +67,7 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - ^https?://github\.com/open-telemetry/opentelemetry.io/tree/
 
   # Ignore some links to GH repo content for now, most 4XX
-  - ^https?://github\.com/open-telemetry/(community|opentelemetry-collector-contrib|opentelemetry-collector|opentelemetry-dotnet-instrumentation|opentelemetry-helm-charts|opentelemetry-java-instrumentation|opentelemetry-java|opentelemetry-operator|opentelemetry-proto|opentelemetry-python-contrib|opentelemetry-specification|oteps|semantic-conventions|sig-end-user)/
+  - ^https?://github\.com/open-telemetry/(opentelemetry-collector-contrib|opentelemetry-collector|opentelemetry-dotnet-instrumentation|opentelemetry-helm-charts|opentelemetry-java-instrumentation|opentelemetry-java|opentelemetry-operator|opentelemetry-proto|opentelemetry-python-contrib|opentelemetry-specification|oteps|semantic-conventions|sig-end-user)/
   - ^https?://github\.com/open-telemetry/opentelemetry-demo/blob/main/src/(imageprovider|loadgenerator|otelcollector|.*service)
   # TODO drop the following after https://github.com/open-telemetry/semantic-conventions/pull/1753 is merged and the submodule updated:
   - ^https?://github\.com/in-toto/

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -73,16 +73,6 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
 
   # TODO: drop after fix to https://github.com/rust-lang/crates.io/issues/788
   - ^https://crates\.io/crates
-  # TODO: drop after fix to https://github.com/micrometer-metrics/micrometer-docs/issues/239
-  - ^https://micrometer\.io/docs
-  # TODO: ensure .json isn't set as an alternate in ecosystem/registry/index.html and then drop:
-  - ^https://opentelemetry.io/ecosystem/registry/index.json
-  # TODO drop after fix to https://github.com/open-telemetry/opentelemetry.io/issues/3818
-  - ^https://oncallmemaybe.com
-  # TODO drop after https://github.com/open-telemetry/opentelemetry-specification/pull/3834 is merged
-  - ^https://wikipedia\.org/wiki/Monotonic_function
-  # TODO drop after https://github.com/open-telemetry/opamp-spec/pull/179 is merged into this repo
-  - ^http://www.watersprings.org/
   # TODO move into content/en/blog/2023/humans-of-otel.md once https://github.com/open-telemetry/opentelemetry.io/issues/3889 is implemented
   - ^https://shorturl.at/osHRX$
   # TODO move into content/en/blog/2023/contributing-to-otel/index.md once https://github.com/open-telemetry/opentelemetry.io/issues/3889 is implemented

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -62,7 +62,7 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - ^https?://github\.com/open-telemetry/opentelemetry.io/tree/
 
   # Ignore some links to GH repo content for now, most 4XX
-  - ^https?://github\.com/open-telemetry/(build-tools|community|opentelemetry-collector-contrib|opentelemetry-collector|opentelemetry-dotnet-instrumentation|opentelemetry-helm-charts|opentelemetry-java-instrumentation|opentelemetry-java|opentelemetry-operator|opentelemetry-proto|opentelemetry-python-contrib|opentelemetry-specification|oteps|semantic-conventions|sig-end-user|weaver)/
+  - ^https?://github\.com/open-telemetry/(community|opentelemetry-collector-contrib|opentelemetry-collector|opentelemetry-dotnet-instrumentation|opentelemetry-helm-charts|opentelemetry-java-instrumentation|opentelemetry-java|opentelemetry-operator|opentelemetry-proto|opentelemetry-python-contrib|opentelemetry-specification|oteps|semantic-conventions|sig-end-user|weaver)/
   - ^https?://github\.com/open-telemetry/opentelemetry-demo/blob/main/src/(imageprovider|loadgenerator|otelcollector|.*service)
   # TODO drop the following after https://github.com/open-telemetry/semantic-conventions/pull/1753 is merged and the submodule updated:
   - ^https?://github\.com/in-toto/

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -62,7 +62,7 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - ^https?://github\.com/open-telemetry/opentelemetry.io/tree/
 
   # Ignore some links to GH repo content for now, most 4XX
-  - ^https?://github\.com/open-telemetry/(community|opentelemetry-collector-contrib|opentelemetry-collector|opentelemetry-dotnet-instrumentation|opentelemetry-helm-charts|opentelemetry-java-instrumentation|opentelemetry-java|opentelemetry-operator|opentelemetry-proto|opentelemetry-python-contrib|opentelemetry-specification|oteps|semantic-conventions|sig-end-user|weaver)/
+  - ^https?://github\.com/open-telemetry/(community|opentelemetry-collector-contrib|opentelemetry-collector|opentelemetry-dotnet-instrumentation|opentelemetry-helm-charts|opentelemetry-java-instrumentation|opentelemetry-java|opentelemetry-operator|opentelemetry-proto|opentelemetry-python-contrib|opentelemetry-specification|oteps|semantic-conventions|sig-end-user)/
   - ^https?://github\.com/open-telemetry/opentelemetry-demo/blob/main/src/(imageprovider|loadgenerator|otelcollector|.*service)
   # TODO drop the following after https://github.com/open-telemetry/semantic-conventions/pull/1753 is merged and the submodule updated:
   - ^https?://github\.com/in-toto/

--- a/content/zh/docs/contributing/_index.md
+++ b/content/zh/docs/contributing/_index.md
@@ -2,6 +2,13 @@
 title: 贡献
 description: 了解如何为 OpenTelemetry 文档做贡献。
 weight: 980
+htmltest:
+  IgnoreDirs:
+    # TODO drop the following config once this page is updated to reflect the corresponding `en`
+    # page and the link 404 (detailed below) are resolved:
+    #   zh/docs/contributing/index.html
+    #     Non-OK status: 404 --> https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md
+    - ^zh/docs/contributing/
 default_lang_commit: 8603bc8
 ---
 

--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -120,12 +120,6 @@
   contact:
   oss: true
   commercial: true
-- name: F5
-  nativeOTLP: true
-  url: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/f5cloudexporter
-  contact:
-  oss: false
-  commercial: true
 - name: Google Cloud Platform
   nativeOTLP: true
   url: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudexporter

--- a/data/registry/instrumentation-java-micrometer-tracing.yml
+++ b/data/registry/instrumentation-java-micrometer-tracing.yml
@@ -11,6 +11,6 @@ authors:
     url: https://github.com/micrometer-metrics
 urls:
   website: https://micrometer.io/
-  docs: https://micrometer.io/docs/tracing#_micrometer_tracing_opentelemetry_setup
-createdAt: '2024-08-06'
+  docs: https://docs.micrometer.io/micrometer/reference/implementations/otlp.html
+createdAt: 2024-08-06
 isNative: true

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -159,7 +159,9 @@ while(<>) {
   s|\.\./README.md\b|$otlpSpecRepoUrl/|g if $ARGV =~ /\btmp\/otlp/;
   s|\.\./examples/README.md\b|$otlpSpecRepoUrl/tree/v$otlpSpecVers/examples/|g if $ARGV =~ /\btmp\/otlp/;
 
-  s|\bREADME.md\b|_index.md|g if $ARGV !~ /otel\/specification\/protocol\/_index.md/;
+  s|\bREADME.md\b|_index.md|g if $ARGV !~ /otel\/specification\/protocol\/_index.md/
+    # TODO drop once semconv PR is merged and module is updated in this repo
+    && $ARGV !~ /semconv\/docs\/non-normative\/code-generation.md/;
 
   # Rewrite paths that are outside of the main spec folder as external links
   s|(\.\.\/)+(experimental\/[^)]+)|$otelSpecRepoUrl/tree/v$otelSpecVers/$2|g;

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -6283,6 +6283,14 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:14:19.178532-05:00"
   },
+  "https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/README.md#code-generator": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:17:37.931186-05:00"
+  },
+  "https://github.com/open-telemetry/build-tools/tree/main/semantic-conventions#code-generator": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:07:16.214406-05:00"
+  },
   "https://github.com/open-telemetry/community": {
     "StatusCode": 206,
     "LastSeen": "2025-01-13T12:11:03.156031-05:00"

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -8747,6 +8747,22 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:14:36.015951-05:00"
   },
+  "https://github.com/open-telemetry/weaver/blob/main/crates/weaver_forge/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:20:32.148949-05:00"
+  },
+  "https://github.com/open-telemetry/weaver/blob/main/crates/weaver_forge/README.md#comment-filter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:20:34.09465-05:00"
+  },
+  "https://github.com/open-telemetry/weaver/blob/main/crates/weaver_forge/README.md#configuration-file---weaveryaml": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:20:33.672615-05:00"
+  },
+  "https://github.com/open-telemetry/weaver/blob/main/schemas/semconv-syntax.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:20:31.233996-05:00"
+  },
   "https://github.com/openclarity/apiclarity/tree/master/plugins/otel-collector": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:37:45.041259-05:00"

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -6311,10 +6311,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:23:07.447782-05:00"
   },
-  "https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md": {
-    "StatusCode": 404,
-    "LastSeen": "2025-01-16T14:23:26.32315-05:00"
-  },
   "https://github.com/open-telemetry/community/blob/main/README.md#special-interest-groups": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:23:22.158453-05:00"
@@ -6511,6 +6507,126 @@
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:14:54.058976-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/9b28f76c02c18f7479d10e4b6a95a21467fd85d6/processor/transformprocessor/testdata/config.yaml": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:12.970839-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:33:59.421324-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:48.902535-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/kafkaexporter/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:36:00.479836-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/lokiexporter/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:33.670548-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/otelarrowexporter/README.md#batching-configuration": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:32.344119-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/prometheusexporter/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:32.684942-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/prometheusremotewriteexporter/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:31.265625-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/basicauthextension/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:51.578896-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/bearertokenauthextension/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:52.547433-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/healthcheckextension/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:50.347077-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/oauth2clientauthextension/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:53.601334-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/pprofextension/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:01.938179-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:06.425038-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/stanza/docs/operators/container.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:31.436616-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/attributesprocessor/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:39.234992-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/filterprocessor/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:40.312743-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/k8sattributesprocessor/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:42.083244-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/resourcedetectionprocessor/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:11.332376-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/routingprocessor/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:46.89984-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/hostmetricsreceiver/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:35.525335-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/k8sclusterreceiver/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:37.169684-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/k8sclusterreceiver/documentation.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:07.923411-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/kubeletstatsreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:06.754709-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/kubeletstatsreceiver/documentation.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:05.692272-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/prometheusreceiver/DESIGN.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:11.893917-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/prometheusreceiver/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:32.683494-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/prometheusreceiver/README.md#%EF%B8%8F-warning": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:28.211515-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/receivercreator/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:02.842675-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.100.0/receiver/filelogreceiver/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:28.863197-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/issues": {
     "StatusCode": 200,
     "LastSeen": "2024-10-24T15:10:27.834953+02:00"
@@ -6558,6 +6674,898 @@
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.88.0": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:15:04.100016-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/cmd/telemetrygen": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:01.580787-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/otlpjsonconnector": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:34.16915-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:08.131057-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:00.98671-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/alertmanagerexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:07.543175-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/alibabacloudlogserviceexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:09.303084-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awscloudwatchlogsexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:12.605509-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awsemfexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:16.179897-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awskinesisexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:16.81682-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awss3exporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:18.078393-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awsxrayexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:10.058165-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/azuredataexplorerexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:23.037818-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/azuremonitorexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:19.999922-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/carbonexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:23.638421-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/cassandraexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:24.569975-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/clickhouseexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:01.079367-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/coralogixexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:25.669038-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:27.410266-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datasetexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:28.322342-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/dorisexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:30.121802-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/elasticsearchexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:30.806697-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/fileexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:31.623458-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:05.546382-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudpubsubexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:32.345198-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlemanagedprometheusexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:33.507391-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/honeycombmarkerexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:35.271518-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/influxdbexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:36.444022-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/kafkaexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:37.932018-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/kineticaexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:39.967534-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/loadbalancingexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:03.979971-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/loadbalancingexporter#metrics": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:01.593316-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/logicmonitorexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:43.203997-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/logzioexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:45.177457-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/lokiexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:46.696032-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/mezmoexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:49.038174-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/opencensusexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:50.347161-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/opensearchexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:52.045813-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/otelarrowexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:30.421853-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:32.684739-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusexporter#prometheus-exporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:30.277018-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusremotewriteexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:30.380949-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/pulsarexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:53.93854-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/rabbitmqexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:54.424106-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/sapmexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:54.851424-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/sentryexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:55.356383-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/signalfxexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:55.799752-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/splunkhecexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:56.27003-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/sumologicexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:56.679749-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/syslogexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:57.570243-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/tencentcloudlogserviceexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:58.010643-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/zipkinexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:58.574276-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/ackextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:58.989744-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/asapauthextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:59.393853-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/awsproxy#aws-proxy": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:45.350766-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/basicauthextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:59.94699-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/bearertokenauthextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:00.350319-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:00.785705-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/googleclientauthextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:01.185943-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/headerssetterextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:01.711848-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:01.887932-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckextension#health-check": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:47.798787-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckv2extension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:02.367929-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/httpforwarderextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:02.82966-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/jaegerremotesampling": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:03.025104-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/jaegerremotesampling#jaegers-remote-sampling-extension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:48.817937-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/oauth2clientauthextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:03.473243-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:03.986491-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/k8sobserver#setting-up-rbac-permissions": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:03.553006-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/oidcauthextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:04.409131-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/opampextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:04.978071-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/pprofextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:05.457394-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/remotetapextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:05.937357-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/sigv4authextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:06.51588-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/solarwindsapmsettingsextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:07.027685-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/sumologicextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:07.473453-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:13.579548-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/stanza": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:29.941516-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:02.074459-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/attributesprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:07.886086-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/coralogixprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:08.051761-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/cumulativetodeltaprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:08.597035-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/deltatocumulativeprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:09.054548-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/deltatorateprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:09.612589-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:02.693456-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/geoipprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:10.041348-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/groupbyattrsprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:10.98921-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/groupbytraceprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:10.497248-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/intervalprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:11.401643-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:03.495334-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor#deployment-scenarios": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:04.425417-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/logdedupprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:12.037687-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/logstransformprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:12.541966-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricsgenerationprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:13.01828-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:10.537389-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/probabilisticsamplerprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:06.287782-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/redactionprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:04.270609-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/remotetapprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:13.581173-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/remotetapprocessor#remote-tap-processor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:50.171254-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:09.666798-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourceprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:09.521979-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/routingprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:14.210211-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/schemaprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:14.638754-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/spanprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:15.069897-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/sumologicprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:15.525413-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:06.771228-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:12.144171-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:08.529327-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/activedirectorydsreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:16.005665-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/aerospikereceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:16.492577-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/apachereceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:16.949548-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/apachesparkreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:17.406702-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awscloudwatchmetricsreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:19.249178-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awscloudwatchreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:18.882065-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awscontainerinsightreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:19.724819-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awsecscontainermetricsreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:17.873323-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awsfirehosereceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:20.236654-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awsfirehosereceiver#aws-kinesis-data-firehose-receiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:29.718205-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awss3receiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:20.748697-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awsxrayreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:18.302161-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awsxrayreceiver#aws-x-ray-receiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:30.374917-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/azureblobreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:21.181315-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/azureeventhubreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:21.601347-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/azuremonitorreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:22.101601-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/bigipreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:22.501488-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/carbonreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:23.002806-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/chronyreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:23.513479-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/cloudflarereceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:23.945771-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/cloudfoundryreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:24.409141-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/collectdreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:24.946876-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/couchdbreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:25.385296-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/datadogreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:25.809479-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/dockerstatsreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:26.269206-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/elasticsearchreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:26.732746-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/expvarreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:27.261154-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:07.092157-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver#operators": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:27.407076-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filestatsreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:27.688929-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/flinkmetricsreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:28.071255-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/fluentforwardreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:28.517168-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/githubreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:29.040488-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/googlecloudmonitoringreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:29.540978-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/googlecloudpubsubreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:29.90399-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/googlecloudspannerreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:30.336711-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/haproxyreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:30.836531-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:09.090757-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver#collecting-host-metrics-from-inside-a-container-linux-only": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:15.419134-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/httpcheckreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:31.268516-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/iisreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:31.741142-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/influxdbreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:32.216015-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/influxdbreceiver#influxdb-receiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:31.66987-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/jaegerreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:33.311392-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/jaegerreceiver#jaeger-receiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:32.344077-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/jmxreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:33.735551-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/journaldreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:34.239933-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sclusterreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:08.755508-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8seventsreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:34.584489-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:09.27761-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kafkametricsreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:35.595969-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kafkareceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:35.1095-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:36.195619-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/lokireceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:36.025234-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/lokireceiver#loki-receiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:34.173623-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/memcachedreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:36.40747-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/mongodbatlasreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:37.392381-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/mongodbreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:36.848203-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/mysqlreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:37.751952-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/namedpipereceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:38.431627-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/nginxreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:39.095426-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/nsxtreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:39.61127-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/ntpreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:40.064363-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/opencensusreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:40.547763-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/opencensusreceiver#opencensus-receiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:35.183164-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/oracledbreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:40.9723-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/osqueryreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:41.408323-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/otelarrowreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:31.310709-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/otlpjsonfilereceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:41.958324-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/podmanreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:42.441468-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/postgresqlreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:43.070963-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:10.057491-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusremotewritereceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:43.510113-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/pulsarreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:43.970874-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/purefareceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:44.504014-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/purefbreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:44.97313-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/rabbitmqreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:45.329307-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/receivercreator": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:45.84633-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/redisreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:46.305883-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/riakreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:46.825494-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/saphanareceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:47.208735-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sapmreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:47.746236-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sapmreceiver#sapm-receiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:36.320143-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/signalfxreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:48.278363-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/signalfxreceiver#signalfx-receiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:37.538448-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/simpleprometheusreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:48.73275-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/skywalkingreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:49.157151-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/skywalkingreceiver#skywalking-receiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:38.608888-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/snmpreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:49.559529-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/snowflakereceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:50.033722-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/solacereceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:50.436859-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/splunkenterprisereceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:51.415235-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/splunkhecreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:50.820796-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/splunkhecreceiver#splunk-hec-receiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:40.319656-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sqlqueryreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:51.887084-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sqlserverreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:52.372698-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sshcheckreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:52.888815-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/statsdreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:53.36064-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/syslogreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:53.717535-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/systemdreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:54.197701-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/tcplogreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:54.604497-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/tlscheckreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:55.04078-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/udplogreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:55.513421-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/vcenterreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:55.944596-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/wavefrontreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:56.416525-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/webhookeventreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:56.894049-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/windowseventlogreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:57.918004-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/windowsperfcountersreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:57.500066-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/zipkinreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:58.364327-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/zipkinreceiver#zipkin-receiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:41.465055-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/zookeeperreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:35:58.912119-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/zookeeperreceiver#zookeeper-receiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:43.336423-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/testbed#opentelemetry-collector-testbed": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:03.747465-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/processor/resourcedetectionprocessor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:23.658479-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/receiver/fluentforwardreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:25.853743-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.61.0/exporter/prometheusexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:34:03.854505-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-releases": {
     "StatusCode": 200,

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -6307,6 +6307,110 @@
     "StatusCode": 200,
     "LastSeen": "2024-05-10T13:05:22.581509+02:00"
   },
+  "https://github.com/open-telemetry/community/blob/47813530864b9fe5a5146f466a58bd2bb94edc72/maturity-matrix.yaml#L57": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:23:07.447782-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md": {
+    "StatusCode": 404,
+    "LastSeen": "2025-01-16T14:23:26.32315-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/main/README.md#special-interest-groups": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:23:22.158453-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/main/code-of-conduct.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:22:47.823443-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/main/community-members.md#governance-committee": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:23:16.617649-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/main/community-members.md#technical-committee": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:23:17.045641-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/main/community-membership.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:22:47.59214-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/main/community-membership.md#requirements": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:23:20.244723-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/main/elections/2024/governance-committee-candidates.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:23:17.251564-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/main/elections/2024/governance-committee-election.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:23:15.075273-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/main/elections/2024/governance-committee-election.md#voter-eligibility": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:23:15.495178-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/main/gc-check-ins.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:23:24.518882-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/main/governance-charter.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:23:18.793405-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/main/governance-charter.md#elections": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:23:38.941975-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/main/governance-charter.md#members-of-standing": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:23:17.285485-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/main/guides/contributor": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:23:11.13075-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/main/guides/contributor/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:22:47.811861-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:22:47.985212-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/main/marketing-guidelines.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:22:52.070486-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/main/mission-vision-values.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:23:20.248736-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/main/project-management.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:23:21.722726-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/main/projects/gen-ai.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:23:17.554218-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/main/reports/ADA_Logics-collector-fuzzing-audit-2024.pdf": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:23:17.415384-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/main/social-media-guide.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:22:46.709042-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/main/tech-committee-charter.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:22:46.040248-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/master/governance-charter.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:23:19.568578-05:00"
+  },
   "https://github.com/open-telemetry/community/issues": {
     "StatusCode": 206,
     "LastSeen": "2025-01-13T12:11:00.776323-05:00"
@@ -6354,6 +6458,14 @@
   "https://github.com/open-telemetry/community/pull/2427": {
     "StatusCode": 200,
     "LastSeen": "2024-12-16T14:23:06.692223-05:00"
+  },
+  "https://github.com/open-telemetry/community/tree/main/mission-vision-values.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:23:39.08002-05:00"
+  },
+  "https://github.com/open-telemetry/community/tree/main/roadmap.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-16T14:23:39.490684-05:00"
   },
   "https://github.com/open-telemetry/opamp-go": {
     "StatusCode": 206,


### PR DESCRIPTION
- Contributes to #5951
- Notes:
  - @svrnm added the Micrometer link via https://github.com/open-telemetry/opentelemetry.io/pull/2201. This PR adjusts the link
  - f5 exporter is gone since https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31186, and so is dropped in this PR