### PR TITLE
Add blog post on Go Compile-Time Instrumentation SIG

### DIFF
--- a/content/en/blog/2025/go-compile-time-instrumentation.md
+++ b/content/en/blog/2025/go-compile-time-instrumentation.md
@@ -12,18 +12,18 @@ effective if the available tooling facilitates it. I imagine
 not have been too popular when they were introduced if you had to build your own
 scales to weigh things in Kilograms!
 
-If you use [OpenTelemetry in Go](https://opentelemetry.io/docs/languages/go/),
-you'll be familiar with the challenges of configuring instrumentation libraries
-to automatically generate telemetry from well-known open source components. Due
-to the compiled nature of the language, you currently have two options (unless
-you want to "build your own scales", or the OTel equivalent):
+If you use [OpenTelemetry in Go](/docs/languages/go/), you'll be familiar with
+the challenges of configuring instrumentation libraries to automatically
+generate telemetry from well-known open source components. Due to the compiled
+nature of the language, you currently have two options (unless you want to
+"build your own scales", or the OTel equivalent):
 
 - Use a separate binary that analyzes your Go process and attaches eBPF programs
   to hooks in your application (see
   [opentelemetry-go-instrumentation](https://github.com/open-telemetry/opentelemetry-go-instrumentation/)).
 - Manually configure instrumentation libraries in your code (see an
-  [example](https://opentelemetry.io/docs/languages/go/getting-started/#instrument-the-http-server)
-  to instrument `net/http`).
+  [example](/docs/languages/go/getting-started/#instrument-the-http-server) to
+  instrument `net/http`).
 
 For different reasons, it is possible that none of those options is viable, or
 optimal, in your environment. However, things are about to change!

--- a/content/en/blog/2025/go-compile-time-instrumentation.md
+++ b/content/en/blog/2025/go-compile-time-instrumentation.md
@@ -1,6 +1,6 @@
 ---
 title:
-  Alibaba, Datadog and Quesma Join Forces on Go Compile-Time Instrumentation
+  Alibaba, Datadog, and Quesma Join Forces on Go Compile-Time Instrumentation
 linkTitle: Go Compile-Time Instrumentation
 date: 2025-01-17
 author: OpenTelemetry Governance Committee

--- a/content/en/blog/2025/go-compile-time-instrumentation.md
+++ b/content/en/blog/2025/go-compile-time-instrumentation.md
@@ -2,7 +2,7 @@
 title:
   Alibaba, Datadog, and Quesma Join Forces on Go Compile-Time Instrumentation
 linkTitle: Go Compile-Time Instrumentation
-date: 2025-01-17
+date: 2025-01-24
 author: OpenTelemetry Governance Committee
 issue: https://github.com/open-telemetry/community/issues/2509
 sig: Governance Committee

--- a/content/en/blog/2025/go-compile-time-instrumentation.md
+++ b/content/en/blog/2025/go-compile-time-instrumentation.md
@@ -3,6 +3,8 @@ title: Alibaba and Datadog Join Forces on Go Compile-Time Instrumentation
 linkTitle: Go Compile-Time Instrumentation
 date: 2025-01-17
 author: OpenTelemetry Governance Committee
+issue: https://github.com/open-telemetry/community/issues/2509
+sig: Governance Committee
 cSpell:ignore: instrgen toolexec
 ---
 

--- a/content/en/blog/2025/go-compile-time-instrumentation.md
+++ b/content/en/blog/2025/go-compile-time-instrumentation.md
@@ -19,7 +19,7 @@ you want to "build your own scales", or the OTel equivalent):
 
 - Use a separate binary that analyzes your Go process and attaches eBPF programs
   to hooks in your application (see
-  https://github.com/open-telemetry/opentelemetry-go-instrumentation/).
+  [opentelemetry-go-instrumentation](https://github.com/open-telemetry/opentelemetry-go-instrumentation/)).
 - Manually configure instrumentation libraries in your code (see an
   [example](https://opentelemetry.io/docs/languages/go/getting-started/#instrument-the-http-server)
   to instrument `net/http`).

--- a/content/en/blog/2025/go-compile-time-instrumentation.md
+++ b/content/en/blog/2025/go-compile-time-instrumentation.md
@@ -55,7 +55,7 @@ the Go standard library).
 
 The most exciting part of this announcement is that it won't be Alibaba's or
 Datadog's solution that "wins". In the true spirit of open source collaboration,
-these two organisations have decided to join forces and commit the necessary
+these two organizations have decided to join forces and commit the necessary
 resources to bootstrap a new
 [Go Compile-Time Instrumentation SIG](https://github.com/open-telemetry/community/blob/main/projects/go-compile-instrumentation.md),
 with the intention of providing a unified, vendor-neutral approach that picks

--- a/content/en/blog/2025/go-compile-time-instrumentation.md
+++ b/content/en/blog/2025/go-compile-time-instrumentation.md
@@ -22,11 +22,10 @@ nature of the language, you currently have two options (unless you want to
 "build your own scales", or the OTel equivalent):
 
 - Use a separate binary that analyzes your Go process and attaches eBPF programs
-  to hooks in your application (see
-  [opentelemetry-go-instrumentation](https://github.com/open-telemetry/opentelemetry-go-instrumentation/)).
-- Manually configure instrumentation libraries in your code (see an
-  [example](/docs/languages/go/getting-started/#instrument-the-http-server) to
-  instrument `net/http`).
+  to hooks in your application &mdash; see
+  [opentelemetry-go-instrumentation](https://github.com/open-telemetry/opentelemetry-go-instrumentation/).
+- Manually configure instrumentation libraries in your code, for example see
+  [Instrument the HTTP server](/docs/languages/go/getting-started/#instrument-the-http-server).
 
 For different reasons, it is possible that none of those options is viable, or
 optimal, in your environment. However, things are about to change!
@@ -38,14 +37,11 @@ proposals from industry leaders to provide a solution to the problem described
 above, and enable the use of zero-code, vendor-neutral, compile-time
 instrumentation in Go applications. These are:
 
-- Alibaba's
+- Alibaba's [donation proposal](https://github.com/open-telemetry/community/issues/2344) of 
   [opentelemetry-go-auto-instrumentation](https://github.com/alibaba/opentelemetry-go-auto-instrumentation)
-  (see
-  [donation proposal](https://github.com/open-telemetry/community/issues/2344)).
-- Datadog's [Orchestrion](https://github.com/datadog/orchestrion) (see
-  [donation proposal](https://github.com/open-telemetry/community/issues/2497)).
+- Datadog's [donation proposal](https://github.com/open-telemetry/community/issues/2497) of [Orchestrion](https://github.com/datadog/orchestrion)
 
-We are really grateful to Alibaba and Datadog for these donation proposals. This
+We are very grateful to Alibaba and Datadog for these donation proposals. This
 continues to demonstrate the convergence of the wider industry towards the
 standards defined by OpenTelemetry.
 

--- a/content/en/blog/2025/go-compile-time-instrumentation.md
+++ b/content/en/blog/2025/go-compile-time-instrumentation.md
@@ -62,6 +62,7 @@ the best aspects of each solution and benefits the community as a whole.
 The initial output from this SIG will soon replace
 [instrgen](https://github.com/open-telemetry/opentelemetry-go-contrib/blob/dafdad14b7858c7f491c8cb72e4bc7deaf9378e3/instrgen/README.md),
 Go SIG's initial experimental approach to provide compile-time instrumentation.
+
 In the longer term, this SIG will focus on:
 
 - Developing compiler plugins or enhancements that inject instrumentation code

--- a/content/en/blog/2025/go-compile-time-instrumentation.md
+++ b/content/en/blog/2025/go-compile-time-instrumentation.md
@@ -18,8 +18,7 @@ scales to weigh things in Kilograms!
 If you use [OpenTelemetry in Go](/docs/languages/go/), you'll be familiar with
 the challenges of configuring instrumentation libraries to automatically
 generate telemetry from well-known open source components. Due to the compiled
-nature of the language, you currently have two options (unless you want to
-"build your own scales", or the OTel equivalent):
+nature of the language, you currently have two options[^1]:
 
 - Use a separate binary that analyzes your Go process and attaches eBPF programs
   to hooks in your application &mdash; see
@@ -37,9 +36,13 @@ proposals from industry leaders to provide a solution to the problem described
 above, and enable the use of zero-code, vendor-neutral, compile-time
 instrumentation in Go applications. These are:
 
-- Alibaba's [donation proposal](https://github.com/open-telemetry/community/issues/2344) of 
+- Alibaba's
+  [donation proposal](https://github.com/open-telemetry/community/issues/2344)
+  of
   [opentelemetry-go-auto-instrumentation](https://github.com/alibaba/opentelemetry-go-auto-instrumentation)
-- Datadog's [donation proposal](https://github.com/open-telemetry/community/issues/2497) of [Orchestrion](https://github.com/datadog/orchestrion)
+- Datadog's
+  [donation proposal](https://github.com/open-telemetry/community/issues/2497)
+  of [Orchestrion](https://github.com/datadog/orchestrion)
 
 We are very grateful to Alibaba and Datadog for these donation proposals. This
 continues to demonstrate the convergence of the wider industry towards the
@@ -86,3 +89,7 @@ here's some useful information about the SIG:
 
 We look forward to seeing this new SIG in operation, and cannot wait for the
 fruits of this awesome collaboration!
+
+[^1]:
+    Unless you want to "build your own scales", or the OTel equivalent, which is
+    manually instrumenting third-party libraries.

--- a/content/en/blog/2025/go-compile-time-instrumentation.md
+++ b/content/en/blog/2025/go-compile-time-instrumentation.md
@@ -61,7 +61,8 @@ the best aspects of each solution and benefits the community as a whole.
 
 The initial output from this SIG will soon replace
 [instrgen](https://github.com/open-telemetry/opentelemetry-go-contrib/blob/dafdad14b7858c7f491c8cb72e4bc7deaf9378e3/instrgen/README.md),
-Go SIG's initial experimental approach to provide compile-time instrumentation.
+OpenTelemetry's initial experimental approach to provide Go compile-time
+instrumentation based on `-toolexec`.
 
 In the longer term, this SIG will focus on:
 

--- a/content/en/blog/2025/go-compile-time-instrumentation.md
+++ b/content/en/blog/2025/go-compile-time-instrumentation.md
@@ -3,6 +3,7 @@ title: Alibaba and Datadog Join Forces on Go Compile-Time Instrumentation
 linkTitle: Go Compile-Time Instrumentation
 date: 2025-01-17
 author: OpenTelemetry Governance Committee
+cSpell:ignore: instrgen toolexec 
 ---
 
 Standards are only useful if they're widely adopted, and adoption is only

--- a/content/en/blog/2025/go-compile-time-instrumentation.md
+++ b/content/en/blog/2025/go-compile-time-instrumentation.md
@@ -1,5 +1,6 @@
 ---
-title: Alibaba and Datadog Join Forces on Go Compile-Time Instrumentation
+title:
+  Alibaba, Datadog and Quesma Join Forces on Go Compile-Time Instrumentation
 linkTitle: Go Compile-Time Instrumentation
 date: 2025-01-17
 author: OpenTelemetry Governance Committee
@@ -59,12 +60,13 @@ these two organisations have decided to join forces and commit the necessary
 resources to bootstrap a new
 [Go Compile-Time Instrumentation SIG](https://github.com/open-telemetry/community/blob/main/projects/go-compile-instrumentation.md),
 with the intention of providing a unified, vendor-neutral approach that picks
-the best aspects of each solution and benefits the community as a whole.
-
-The initial output from this SIG will soon replace
+the best aspects of each solution and benefits the community as a whole. They
+will be supported with further contributions from Quesma, bringing in experience
+on
 [instrgen](https://github.com/open-telemetry/opentelemetry-go-contrib/blob/dafdad14b7858c7f491c8cb72e4bc7deaf9378e3/instrgen/README.md),
 OpenTelemetry's initial experimental approach to provide Go compile-time
-instrumentation based on `-toolexec`.
+instrumentation based on `-toolexec` and which will be superseded as part of the
+initial efforts of this SIG.
 
 In the longer term, this SIG will focus on:
 

--- a/content/en/blog/2025/go-compile-time-instrumentation.md
+++ b/content/en/blog/2025/go-compile-time-instrumentation.md
@@ -3,7 +3,7 @@ title: Alibaba and Datadog Join Forces on Go Compile-Time Instrumentation
 linkTitle: Go Compile-Time Instrumentation
 date: 2025-01-17
 author: OpenTelemetry Governance Committee
-cSpell:ignore: instrgen toolexec 
+cSpell:ignore: instrgen toolexec
 ---
 
 Standards are only useful if they're widely adopted, and adoption is only
@@ -77,10 +77,10 @@ here's some useful information about the SIG:
   [opentelemetry-go-compile-instrumentation](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation)
 - CNCF Slack:
   [#otel-go-compt-instr-sig](https://cloud-native.slack.com/archives/C088D8GSSSF)
-- Meetings: Every other Thursday UTC: 08:00 – 09:00 (subscribe to this
-  [Google Group](https://groups.google.com/a/opentelemetry.io/g/calendar-go) for
-  calendar invites, or visit the
-  [OpenTelemetry Calendar](https://calendar.google.com/calendar/embed?src=c_2bf73e3b6b530da4babd444e72b76a6ad893a5c3f43cf40467abc7a9a897f977%40group.calendar.google.com))
+- Meetings: Every other Thursday UTC: 08:00 – 09:00 (subscribe to
+  [this Google Group](https://groups.google.com/a/opentelemetry.io/g/calendar-go)
+  for calendar invites, or read more about
+  [our community calendar](https://github.com/open-telemetry/community/?tab=readme-ov-file#calendar))
 
 We look forward to seeing this new SIG in operation, and cannot wait for the
 fruits of this awesome collaboration!

--- a/content/en/blog/2025/go-compile-time-instrumentation.md
+++ b/content/en/blog/2025/go-compile-time-instrumentation.md
@@ -6,7 +6,7 @@ date: 2025-01-17
 author: OpenTelemetry Governance Committee
 issue: https://github.com/open-telemetry/community/issues/2509
 sig: Governance Committee
-cSpell:ignore: instrgen toolexec
+cSpell:ignore: instrgen quesma toolexec
 ---
 
 Standards are only useful if they're widely adopted, and adoption is only

--- a/content/en/blog/2025/go-compile-time-instrumentation.md
+++ b/content/en/blog/2025/go-compile-time-instrumentation.md
@@ -1,0 +1,65 @@
+---
+title: Alibaba and Datadog Join Forces on Go Compile-Time Instrumentation
+linkTitle: Go Compile-Time Instrumentation
+date: 2025-01-17
+author: OpenTelemetry Governance Committee
+---
+
+Standards are only useful if they're widely adopted, and adoption is only
+effective if the available tooling facilitates it. I imagine
+[SI units](https://en.wikipedia.org/wiki/International_System_of_Units) would
+not have been too popular when they were introduced if you had to build your own
+scales to weigh things in Kilograms!
+
+If you use [OpenTelemetry in Go](https://opentelemetry.io/docs/languages/go/),
+you'll be familiar with the challenges of configuring instrumentation libraries
+to automatically generate telemetry from well-known open source components. Due
+to the compiled nature of the language, you currently have two options (unless
+you want to "build your own scales", or the OTel equivalent):
+
+- Use a separate binary that analyzes your Go process and attaches eBPF programs
+  to hooks in your application (see
+  https://github.com/open-telemetry/opentelemetry-go-instrumentation/).
+- Manually configure instrumentation libraries in your code (see an
+  [example](https://opentelemetry.io/docs/languages/go/getting-started/#instrument-the-http-server)
+  to instrument `net/http`).
+
+For different reasons, it is possible that none of those options is viable, or
+optimal, in your environment. However, things are about to change!
+
+## Industry collaboration at the heart of open standards
+
+Over the past few months, OpenTelemetry has received not one, but two donation
+proposals from industry leaders to provide a solution to the problem described
+above, and enable the use of zero-code, vendor-neutral, compile-time
+instrumentation in Go applications. These are:
+
+- Alibaba's
+  [opentelemetry-go-auto-instrumentation](https://github.com/alibaba/opentelemetry-go-auto-instrumentation)
+  (see
+  [donation proposal](https://github.com/open-telemetry/community/issues/2344)).
+- Datadog's [Orchestrion](https://github.com/datadog/orchestrion) (see
+  [donation proposal](https://github.com/open-telemetry/community/issues/2497)).
+
+We are really grateful to Alibaba and Datadog for these donation proposals. This
+continues to demonstrate the convergence of the wider industry towards the
+standards defined by OpenTelemetry.
+
+The most exciting part of this announcement is that it won't be Alibaba's or
+Datadog's solution that "wins". In the true spirit of open source collaboration,
+these two organisations have decided to join forces and commit the necessary
+resources to bootstrap a new
+[Go Compile-Time Instrumentation SIG](https://github.com/open-telemetry/community/blob/main/projects/go-compile-instrumentation.md),
+with the intention of providing a unified, vendor-neutral approach that picks
+the best aspects of each solution and benefits the community as a whole.
+
+This SIG will focus on:
+
+- Developing compiler plugins or enhancements that inject instrumentation code
+  automatically, ensuring minimal runtime performance overhead and compatibility
+  with existing Go projects.
+- Providing standardized instrumentation patterns aligned with OpenTelemetry and
+  other monitoring frameworks.
+
+We look forward to seeing this new SIG in operation, and cannot wait for the
+fruits of this awesome collaboration!

--- a/content/en/blog/2025/go-compile-time-instrumentation.md
+++ b/content/en/blog/2025/go-compile-time-instrumentation.md
@@ -45,6 +45,11 @@ We are really grateful to Alibaba and Datadog for these donation proposals. This
 continues to demonstrate the convergence of the wider industry towards the
 standards defined by OpenTelemetry.
 
+Compile-time instrumentation leverages the standard Go toolchain’s `-toolexec`
+mechanism to re-write Go source code before it is passed to the Go compiler,
+adding instrumentation in all relevant places (including dependencies as well as
+the Go standard library).
+
 The most exciting part of this announcement is that it won't be Alibaba's or
 Datadog's solution that "wins". In the true spirit of open source collaboration,
 these two organisations have decided to join forces and commit the necessary
@@ -53,13 +58,28 @@ resources to bootstrap a new
 with the intention of providing a unified, vendor-neutral approach that picks
 the best aspects of each solution and benefits the community as a whole.
 
-This SIG will focus on:
+The initial output from this SIG will soon replace
+[instrgen](https://github.com/open-telemetry/opentelemetry-go-contrib/blob/dafdad14b7858c7f491c8cb72e4bc7deaf9378e3/instrgen/README.md),
+Go SIG's initial experimental approach to provide compile-time instrumentation.
+In the longer term, this SIG will focus on:
 
 - Developing compiler plugins or enhancements that inject instrumentation code
   automatically, ensuring minimal runtime performance overhead and compatibility
   with existing Go projects.
 - Providing standardized instrumentation patterns aligned with OpenTelemetry and
   other monitoring frameworks.
+
+If you are interested in contributing, or you simply want to find out more,
+here's some useful information about the SIG:
+
+- GitHub repository:
+  [opentelemetry-go-compile-instrumentation](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation)
+- CNCF Slack:
+  [#otel-go-compt-instr-sig](https://cloud-native.slack.com/archives/C088D8GSSSF)
+- Meetings: Every other Thursday UTC: 08:00 – 09:00 (subscribe to this
+  [Google Group](https://groups.google.com/a/opentelemetry.io/g/calendar-go) for
+  calendar invites, or visit the
+  [OpenTelemetry Calendar](https://calendar.google.com/calendar/embed?src=c_2bf73e3b6b530da4babd444e72b76a6ad893a5c3f43cf40467abc7a9a897f977%40group.calendar.google.com))
 
 We look forward to seeing this new SIG in operation, and cannot wait for the
 fruits of this awesome collaboration!

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -1631,6 +1631,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-15T13:17:28.410343-05:00"
   },
+  "https://calendar.google.com/calendar/embed": {
+    "StatusCode": 401,
+    "LastSeen": "2025-01-17T13:21:32.505559Z"
+  },
   "https://calendly.com/euwg-user-feedback-session/end-user-feedback-session": {
     "StatusCode": 200,
     "LastSeen": "2024-03-12T07:55:41.183146657Z"
@@ -1822,6 +1826,10 @@
   "https://cloud-native.slack.com/archives/C076RUAGP37": {
     "StatusCode": 200,
     "LastSeen": "2024-08-20T08:40:41.563366481Z"
+  },
+  "https://cloud-native.slack.com/archives/C088D8GSSSF": {
+    "StatusCode": 200,
+    "LastSeen": "2025-01-17T12:58:36.720595Z"
   },
   "https://cloud-native.slack.com/archives/CJFCJHG4Q": {
     "StatusCode": 200,
@@ -3347,6 +3355,10 @@
     "StatusCode": 200,
     "LastSeen": "2025-01-06T11:23:54.720969-05:00"
   },
+  "https://en.wikipedia.org/wiki/International_System_of_Units": {
+    "StatusCode": 200,
+    "LastSeen": "2025-01-17T12:58:25.584113Z"
+  },
   "https://en.wikipedia.org/wiki/JSON": {
     "StatusCode": 200,
     "LastSeen": "2025-01-06T11:23:32.692041-05:00"
@@ -4295,6 +4307,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-06T15:18:42.027775+02:00"
   },
+  "https://github.com/alibaba/opentelemetry-go-auto-instrumentation": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-17T12:58:30.442533Z"
+  },
   "https://github.com/alolita": {
     "StatusCode": 206,
     "LastSeen": "2025-01-13T12:11:00.000033-05:00"
@@ -4846,6 +4862,10 @@
   "https://github.com/dashpole": {
     "StatusCode": 206,
     "LastSeen": "2025-01-13T12:41:52.17647-05:00"
+  },
+  "https://github.com/datadog/orchestrion": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-17T12:58:33.133351Z"
   },
   "https://github.com/dattto": {
     "StatusCode": 200,
@@ -8735,9 +8755,17 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-07T10:33:12.688711-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-17T12:58:34.746413Z"
+  },
   "https://github.com/open-telemetry/opentelemetry-go-contrib": {
     "StatusCode": 206,
     "LastSeen": "2025-01-07T10:31:43.730419-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-go-contrib/blob/dafdad14b7858c7f491c8cb72e4bc7deaf9378e3/instrgen/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-17T13:21:30.685258Z"
   },
   "https://github.com/open-telemetry/opentelemetry-go-contrib/blob/main/CONTRIBUTING.md#code-owners": {
     "StatusCode": 206,
@@ -14207,6 +14235,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-06-18T10:36:39.590318+02:00"
   },
+  "https://groups.google.com/a/opentelemetry.io/g/calendar-go": {
+    "StatusCode": 200,
+    "LastSeen": "2025-01-17T12:58:38.699931Z"
+  },
   "https://groups.google.com/a/opentelemetry.io/g/calendar-maintainer-meeting": {
     "StatusCode": 200,
     "LastSeen": "2024-06-18T10:36:41.220362+02:00"
@@ -15602,6 +15634,14 @@
   "https://opentelemetry.devstats.cncf.io/d/8/dashboards": {
     "StatusCode": 200,
     "LastSeen": "2025-01-06T11:32:22.440332-05:00"
+  },
+  "https://opentelemetry.io/docs/languages/go/": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-17T12:58:27.368618Z"
+  },
+  "https://opentelemetry.io/docs/languages/go/getting-started/#instrument-the-http-server": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-17T12:58:28.687325Z"
   },
   "https://opentracing.io": {
     "StatusCode": 206,

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -6423,6 +6423,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:23:17.554218-05:00"
   },
+  "https://github.com/open-telemetry/community/blob/main/projects/go-compile-instrumentation.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-18T20:45:35.792292Z"
+  },
   "https://github.com/open-telemetry/community/blob/main/reports/ADA_Logics-collector-fuzzing-audit-2024.pdf": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:23:17.415384-05:00"
@@ -6470,6 +6474,14 @@
   "https://github.com/open-telemetry/community/issues/2329": {
     "StatusCode": 200,
     "LastSeen": "2024-10-15T15:52:36.027937+01:00"
+  },
+  "https://github.com/open-telemetry/community/issues/2344": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-18T20:45:29.87596Z"
+  },
+  "https://github.com/open-telemetry/community/issues/2497": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-18T20:45:32.577654Z"
   },
   "https://github.com/open-telemetry/community/issues/828": {
     "StatusCode": 206,

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -1633,7 +1633,7 @@
   },
   "https://calendar.google.com/calendar/embed": {
     "StatusCode": 401,
-    "LastSeen": "2025-01-17T13:21:32.505559Z"
+    "LastSeen": "2025-01-17T14:06:45.293165Z"
   },
   "https://calendly.com/euwg-user-feedback-session/end-user-feedback-session": {
     "StatusCode": 200,

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -1631,10 +1631,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-15T13:17:28.410343-05:00"
   },
-  "https://calendar.google.com/calendar/embed": {
-    "StatusCode": 401,
-    "LastSeen": "2025-01-17T14:06:45.293165Z"
-  },
   "https://calendly.com/euwg-user-feedback-session/end-user-feedback-session": {
     "StatusCode": 200,
     "LastSeen": "2024-03-12T07:55:41.183146657Z"

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -15643,14 +15643,6 @@
     "StatusCode": 200,
     "LastSeen": "2025-01-06T11:32:22.440332-05:00"
   },
-  "https://opentelemetry.io/docs/languages/go/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T12:58:27.368618Z"
-  },
-  "https://opentelemetry.io/docs/languages/go/getting-started/#instrument-the-http-server": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T12:58:28.687325Z"
-  },
   "https://opentracing.io": {
     "StatusCode": 206,
     "LastSeen": "2024-12-18T06:36:29.862015-05:00"


### PR DESCRIPTION
Add blogpost after https://github.com/open-telemetry/community/pull/2490 was merged and the SIG has been created, announcing donations proposals and creation of new SIG.

cc @open-telemetry/governance-committee @open-telemetry/go-compile-instrumentation-approvers 

---

**Preview**: https://deploy-preview-5956--opentelemetry.netlify.app/blog/2025/go-compile-time-instrumentation/
