### PR TITLE
[pt] feat: add languages python index localization

### DIFF
--- a/content/pt/docs/languages/python/_index.md
+++ b/content/pt/docs/languages/python/_index.md
@@ -45,8 +45,8 @@ diretórios.
 ## Extensões {#extensions}
 
 Para encontrar projetos relacionados como exporters, bibliotecas de
-instrumentação, implementações de rastros, etc., visite
-o [Registro](/ecosystem/registry/?s=python).
+instrumentação, implementações de rastros, etc., visite o
+[Registro](/ecosystem/registry/?s=python).
 
 ### Instalando Pacotes de Ponta (#installing-cutting-edge-packages)
 

--- a/content/pt/docs/languages/python/_index.md
+++ b/content/pt/docs/languages/python/_index.md
@@ -4,7 +4,6 @@ description: >-
   <img width="35" class="img-initial" src="/img/logos/32x32/Python_SDK.svg"
   alt="Python"> Uma implementação específica de linguagem do OpenTelemetry em
   Python.
-aliases: [/python, /python/metrics, /python/tracing]
 weight: 22
 default_lang_commit: 3fd0bb513e5d3fa6f178a73584322bcc469f15e0
 ---

--- a/content/pt/docs/languages/python/_index.md
+++ b/content/pt/docs/languages/python/_index.md
@@ -13,7 +13,7 @@ default_lang_commit: 3fd0bb513e5d3fa6f178a73584322bcc469f15e0
 
 ## Suporte de Versão {#status-and-releases}
 
-O OpenTelemetry suporta Python 3.8 e superior.
+O OpenTelemetry suporta a versão Python 3.8 e superiores.
 
 ## Instalação {#installation}
 

--- a/content/pt/docs/languages/python/_index.md
+++ b/content/pt/docs/languages/python/_index.md
@@ -1,0 +1,72 @@
+---
+title: Python
+description: >-
+  <img width="35" class="img-initial" src="/img/logos/32x32/Python_SDK.svg"
+  alt="Python"> Uma implementação específica de linguagem do OpenTelemetry em
+  Python.
+aliases: [/python, /python/metrics, /python/tracing]
+weight: 22
+default_lang_commit: 3fd0bb513e5d3fa6f178a73584322bcc469f15e0
+---
+
+{{% docs/languages/index-intro python /%}}
+
+## Suporte de Versão {#status-and-releases}
+
+O OpenTelemetry suporta Python 3.8 e superior.
+
+## Instalação {#installation}
+
+Os pacotes API e SDK estão disponíveis no PyPI e podem ser instalados via pip:
+
+```sh
+pip install opentelemetry-api
+pip install opentelemetry-sdk
+```
+
+Além disso, existem vários pacotes de extensão que podem ser instalados
+separadamente como:
+
+```sh
+pip install opentelemetry-exporter-{exporter}
+pip install opentelemetry-instrumentation-{instrumentation}
+```
+
+Essas são as bibliotecas de exporters e instrumentação, respectivamente. Os
+exporters Jaeger, Zipkin, Prometheus, OTLP e OpenCensus podem ser encontrados no
+diretório de
+[exporters](https://github.com/open-telemetry/opentelemetry-python/blob/main/exporter/)
+do repositório. Instrumentações e exporters adicionais podem ser encontrados no
+repositório contrib
+[instrumentação](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation)
+e
+[exporter](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/exporter)
+diretórios.
+
+## Extensões {#extensions}
+
+Para encontrar projetos relacionados como exporters, bibliotecas de
+instrumentação, implementações de rastros, etc., visite
+o[Registro](/ecosystem/registry/?s=python).
+
+### Instalando Pacotes de Ponta (#installing-cutting-edge-packages)
+
+Há algumas funcionalidades que ainda não foram lançadas no PyPI. Nessa situação,
+você pode querer instalar os pacotes diretamente do repositório. Isso pode ser
+feito clonando o repositório e fazendo uma
+[instalação editável](https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs):
+
+```sh
+git clone https://github.com/open-telemetry/opentelemetry-python.git
+cd opentelemetry-python
+pip install -e ./opentelemetry-api -e ./opentelemetry-sdk -e ./opentelemetry-semantic-conventions
+```
+
+## Repositórios e _benchmarks_
+
+- Repositório Principal: [opentelemetry-python][]
+- Repositório Contrib: [opentelemetry-python-contrib][]
+
+[opentelemetry-python]: https://github.com/open-telemetry/opentelemetry-python
+[opentelemetry-python-contrib]:
+  https://github.com/open-telemetry/opentelemetry-python-contrib

--- a/content/pt/docs/languages/python/_index.md
+++ b/content/pt/docs/languages/python/_index.md
@@ -8,7 +8,7 @@ weight: 22
 default_lang_commit: 3fd0bb513e5d3fa6f178a73584322bcc469f15e0
 ---
 
-{{% docs/languages/index-intro python /%}}
+{{% pt/docs/languages/index-intro python /%}}
 
 ## Suporte de Versão {#status-and-releases}
 
@@ -46,7 +46,7 @@ diretórios.
 
 Para encontrar projetos relacionados como exporters, bibliotecas de
 instrumentação, implementações de rastros, etc., visite
-o[Registro](/ecosystem/registry/?s=python).
+o [Registro](/ecosystem/registry/?s=python).
 
 ### Instalando Pacotes de Ponta (#installing-cutting-edge-packages)
 


### PR DESCRIPTION
This pull request adds a comprehensive documentation page for Python in the OpenTelemetry project. The most important changes include the addition of installation instructions, version support details, and links to related repositories and packages.

Documentation updates:

* [`content/pt/docs/languages/python/_index.md`](diffhunk://#diff-2e8373a87d316f754b709f81fb25da44d6cbad49324e57689a7ea9ec45785fa3R1-R72): Added a new documentation page for Python, including sections on version support, installation instructions, extensions, and links to related repositories and packages.

*Issue*: #5963 