### PR TITLE
[CI] Improve spec adjust-pages to handle README.md paths to spec-external resources

### DIFF
--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -26,6 +26,7 @@ my $otelSpecVers = $versions{'spec:'};
 my $otlpSpecVers = $versions{'otlp:'};
 my $semconvVers = $versions{'semconv:'};
 my %patchMsgCount;
+my $openRelref = '{{% relref';
 
 sub printTitleAndFrontMatter() {
   print "---\n";
@@ -152,26 +153,83 @@ while(<>) {
   s|(\]\()([^)]+\.png\))|$1../$2|g if $ARGV =~ /\btmp\/semconv\/docs\/general\/attributes/;
   s|(\]\()([^)]+\.png\))|$1../$2|g if $ARGV =~ /\btmp\/semconv\/docs\/http\/http-spans/;
 
-  s|\.\.\/README.md\b|$otelSpecRepoUrl/|g if $ARGV =~ /specification._index/;
-  s|\.\.\/README.md\b|..| if $ARGV =~ /specification.library-guidelines.md/;
+  # Handle links containing `README.md`
 
-  s|\.\./(opentelemetry/proto/?.*)|$otlpSpecRepoUrl/tree/v$otlpSpecVers/$1|g if $ARGV =~ /\btmp\/otlp/;
-  s|\.\./README.md\b|$otlpSpecRepoUrl/|g if $ARGV =~ /\btmp\/otlp/;
-  s|\.\./examples/README.md\b|$otlpSpecRepoUrl/tree/v$otlpSpecVers/examples/|g if $ARGV =~ /\btmp\/otlp/;
+  # Rewrite paths that are outside of the spec folders as external links:
 
-  s|\bREADME.md\b|_index.md|g if $ARGV !~ /otel\/specification\/protocol\/_index.md/
-    # TODO drop once semconv PR is merged and module is updated in this repo
-    && $ARGV !~ /semconv\/docs\/non-normative\/code-generation.md/;
+  s|\.\.\/README.md|$otelSpecRepoUrl/|g if $ARGV =~ /specification._index/;
+  s|\.\.\/README.md|..| if $ARGV =~ /specification\/library-guidelines.md/;
 
-  # Rewrite paths that are outside of the main spec folder as external links
   s|(\.\.\/)+(experimental\/[^)]+)|$otelSpecRepoUrl/tree/v$otelSpecVers/$2|g;
   s|(\.\.\/)+(supplementary-guidelines\/compatibility\/[^)]+)|$otelSpecRepoUrl/tree/v$otelSpecVers/$2|g;
+
+  s|\.\./((?:examples/)?README\.md)|$otlpSpecRepoUrl/tree/v$otlpSpecVers/$1|g if $ARGV =~ /^tmp\/otlp/;
+
+  # Replace `README.md` by `_index.md` in markdown links:
+  s{
+      # An inline markdown link, just before the URL: `](` like in `[docs](/docs)`
+      (
+        \]\(
+      )
+
+      # Match any local path. In the `[^...]` exclude group we have:
+      # - `:` so as to exclude external links, which use `:` after a protocol specifier
+      # - `)` prevents us from gobbling up past the end of the inline link
+
+      ([^:\)]*)
+      README\.md
+      ([^)]*)  # Any anchor specifier
+      (\))     # The end of the inline link
+  }{$1$openRelref "$2_index.md$3" \%\}\}$4}gx;
+
+  # Replace `README.md` by `_index.md` in markdown link definitions:
+  s{
+      # A markdown link definition, just before the URL: `]:`, like in `[docs]: /docs`
+      (
+        \]:\s*
+      )
+
+      # Match any local path. In the `[^...]` exclude group we have:
+      # - `:` so as to exclude external links, which use `:` after a protocol specifier
+      # - A space should prevent us from gobbling up beyond the end of a link def
+
+      ([^: ]*)
+      README\.md
+      ([^)]*) # Any anchor specifier
+      (\n)$   # End of the link definition
+  }{$1$openRelref "$2_index.md$3" \%\}\}$4}gx;
 
   # Rewrite inline links
   if ($ARGV =~ /\btmp\/opamp/) {
     s|\]\(([^:\)]*?)\.md((#.*?)?)\)|]($1/$2)|g;
   } else {
-    s|\]\(([^:\)]*?\.md(#.*?)?)\)|]({{% relref "$1" %}})|g;
+    # Generally rewrite markdown links as {{% relref "..." %}} expressions,
+    # since that gets Hugo to resolve the links. We can't use the raw path since
+    # some need a `../` prefix to resolve. We let Hugo handle that.
+    s{
+        # Match markdown link `](` just before the URL
+        (\]\()
+
+        # Match the link path:
+        (
+          # Match paths upto but excluding `.md`. The character exclusions are as follows:
+          #
+          # - `:` ensures the URL is a path, not an external link, which has a protocol followe by `:`
+          # - `)` so we don't overrun the end of the markdown link, which ends with `)`
+          # - `{` or `}` so that the path doesn't contain Hugo {{...}}
+
+          [^:\)\{\}]*?
+
+          \.md
+
+          # Match optional anchor of the form `#some-id`
+          (?:
+            \#.*?
+          )?
+        )
+        # Closing parenthesis of markdown link
+        \)
+    }{$1$openRelref "$2" \%\}\}\)}gx;
   }
 
   # Rewrite link defs to local pages such as the following:
@@ -184,6 +242,9 @@ while(<>) {
 
   # Make website-local page references local:
   s|https://opentelemetry.io/|/|g;
+
+  ## OTLP proto files: link into the repo:
+  s|\.\./(opentelemetry/proto/?.*)|$otlpSpecRepoUrl/tree/v$otlpSpecVers/$1|g if $ARGV =~ /\btmp\/otlp/;
 
   ## OpAMP
 


### PR DESCRIPTION
- Improves adjust-pages processing of links to `README.md` pages
- This is in preparation for fixing of `opentelemetry-collector-contrib` links of #5951.

These are the site-generated files affected by this PR's script adjustment:

```console
$ npm run cd:public -- git diff | grep ^diff
diff --git a/docs/specs/otlp/index.html b/docs/specs/otlp/index.html
diff --git a/docs/specs/semconv/attributes-registry/artifact/index.html b/docs/specs/semconv/attributes-registry/artifact/index.html
diff --git a/docs/specs/semconv/non-normative/db-migration/index.html b/docs/specs/semconv/non-normative/db-migration/index.html
diff --git a/docs/specs/semconv/non-normative/http-migration/index.html b/docs/specs/semconv/non-normative/http-migration/index.html
diff --git a/docs/specs/semconv/system/hardware-metrics/index.html b/docs/specs/semconv/system/hardware-metrics/index.html
```

The last file listed in the diff above is handled by https://github.com/open-telemetry/semantic-conventions/pull/1759, so we can ignore it in our review.

As for `specs/otlp/index.html`, we now link to a specific anchored version of the spec README, including in the `examples` folder:

```diff
diff --git a/docs/specs/otlp/index.html b/docs/specs/otlp/index.html
index 55189c6b..fedd722a 100644
--- a/docs/specs/otlp/index.html
+++ b/docs/specs/otlp/index.html
@@ -3106,7 +3106,7 @@ data while being throttled.</p>
 <h4 id="otlpgrpc-service-and-protobuf-definitions">OTLP/gRPC Service and Protobuf Definitions<a class="td-heading-self-link" href="#otlpgrpc-service-and-protobuf-definitions" aria-label="Heading self-link"></a></h4>
 <p>gRPC service definitions <a href="https://github.com/open-telemetry/opentelemetry-proto/tree/v1.5.0/opentelemetry/proto/collector" target="_blank" rel="noopener" class="external-link">are here</a>.</p>
 <p>Protobuf definitions for requests and responses <a href="https://github.com/open-telemetry/opentelemetry-proto/tree/v1.5.0/opentelemetry/proto" target="_blank" rel="noopener" class="external-link">are here</a>.</p>
-<p>Please make sure to check the proto version and <a href="https://github.com/open-telemetry/opentelemetry-proto/#maturity-level" target="_blank" rel="noopener" class="external-link">maturity level</a>.
+<p>Please make sure to check the proto version and <a href="https://github.com/open-telemetry/opentelemetry-proto/tree/v1.5.0/README.md#maturity-level" target="_blank" rel="noopener" class="external-link">maturity level</a>.
 Schemas for different signals may be at different maturity level - some stable,
 some in beta.</p>
 <h4 id="otlpgrpc-default-port">OTLP/gRPC Default Port<a class="td-heading-self-link" href="#otlpgrpc-default-port" aria-label="Heading self-link"></a></h4>
@@ -3169,7 +3169,7 @@ numbers in JSON-encoded payloads are encoded as decimal strings, and either
 numbers or strings are accepted when decoding.</p>
 <p>The client and the server MUST set &ldquo;Content-Type: application/json&rdquo; request and
 response headers when sending JSON Protobuf encoded payload.</p>
-<p>For JSON payload examples see: <a href="https://github.com/open-telemetry/opentelemetry-proto/tree/v1.5.0/examples/" target="_blank" rel="noopener" class="external-link">OTLP JSON request examples</a></p>
+<p>For JSON payload examples see: <a href="https://github.com/open-telemetry/opentelemetry-proto/tree/v1.5.0/examples/README.md" target="_blank" rel="noopener" class="external-link">OTLP JSON request examples</a></p>
 <h4 id="otlphttp-request">OTLP/HTTP Request<a class="td-heading-self-link" href="#otlphttp-request" aria-label="Heading self-link"></a></h4>
 <p>Telemetry data is sent via HTTP POST request. The body of the POST request is a
 payload either in binary-encoded Protobuf format or in JSON-encoded Protobuf
```

As for the other three files, the `adjust-pages.pl` script used to incorrectly replace `README.md` by `_index.md` in _external links_. We used to avoid this on a case-by-case basis. That's too brittle so I rewrote the script to only do the rewrite for local paths, not external links. Here's an example of the fix:

```diff
--- a/docs/specs/semconv/non-normative/db-migration/index.html
+++ b/docs/specs/semconv/non-normative/db-migration/index.html
@@ -2789,9 +2789,9 @@ the stable database conventions.</li>
 <h2 id="summary-of-changes">Summary of changes<a class="td-heading-self-link" href="#summary-of-changes" aria-label="Heading self-link"></a></h2>
 <p>This section summarizes the changes made to the HTTP semantic conventions
 from
-<a href="https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/database/_index.md" target="_blank" rel="noopener" class="external-link">v1.24.0</a>.
+<a href="https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/database/README.md" target="_blank" rel="noopener" class="external-link">v1.24.0</a>.
 to
-<a href="https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/_index.md" target="_blank" rel="noopener" class="external-link">v1.28.0 (RC)</a>.</p>
+<a href="https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/README.md" target="_blank" rel="noopener" class="external-link">v1.28.0 (RC)</a>.</p>
 <h3 id="database-client-span-attributes">Database client span attributes<a class="td-heading-self-link" href="#database-client-span-attributes" aria-label="Heading self-link"></a></h3>
 <!-- prettier-ignore-start -->
 <table>
```

We need this fix before we can address the `opentelemetry-collector-contrib` links of #5951.