### PR TITLE
Fix example yaml file indent

### DIFF
--- a/content/en/docs/kubernetes/getting-started.md
+++ b/content/en/docs/kubernetes/getting-started.md
@@ -173,17 +173,17 @@ presets:
 ## If you want to send your data somewhere you need to
 ## configure an exporter, such as the otlpexporter
 # config:
-# exporters:
-#   otlp:
-#     endpoint: "<SOME BACKEND>"
-# service:
-#   pipelines:
-#     traces:
-#       exporters: [ otlp ]
-#     metrics:
-#       exporters: [ otlp ]
-#     logs:
-#       exporters: [ otlp ]
+#   exporters:
+#     otlp:
+#       endpoint: "<SOME BACKEND>"
+#   service:
+#     pipelines:
+#       traces:
+#         exporters: [ otlp ]
+#       metrics:
+#         exporters: [ otlp ]
+#       logs:
+#         exporters: [ otlp ]
 ```
 
 To use this `values.yaml` with the chart, save it to your preferred file


### PR DESCRIPTION
Fixes indent in example yaml config file for "Kubernetes Objects Receiver". `config` is root level, while `exporters` and `service` are its children.

<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->
