### PR TITLE
[CI] Address semconv link to in-toto

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -74,8 +74,6 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
 
   # Ignore some links to GH repo content for now, most 4XX
   - ^https?://github\.com/open-telemetry/opentelemetry-demo/blob/main/src/(imageprovider|loadgenerator|otelcollector|.*service)
-  # TODO drop the following after https://github.com/open-telemetry/semantic-conventions/pull/1753 is merged and the submodule updated:
-  - ^https?://github\.com/in-toto/
 
   # Too many redirects as the server tries to figure out the country and language,
   # e.g.: https://www.microsoft.com/en-ca/sql-server.

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -5487,6 +5487,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-11-13T13:16:21.346606655Z"
   },
+  "https://github.com/in-toto/attestation/blob/main/spec/README.md#in-toto-attestation-framework-spec": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-17T17:24:29.99273-05:00"
+  },
   "https://github.com/instana": {
     "StatusCode": 200,
     "LastSeen": "2024-11-14T11:47:17.991776+01:00"


### PR DESCRIPTION
- Contributes to #5951
- We don't actually need to wait for the semconv update because the in-toto link issue was fixed via #5969