### PR TITLE
Upgrade to Docsy v0.11.0-34-gef59ee75, and more

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,7 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/google/docsy.git
-	docsy-pin = v0.11.0-32-ge6d94771
+	docsy-pin = v0.11.0-34-gef59ee75
 	docsy-note = "2024-04-01 Switching to google/docsy.git from cncf/docsy.git since we don't have any CNCF customizations."
 	docsy-reminder = "Ensure that any tag referenced by `docsy-pin` is present in the remote repo (url), otherwise add (push) the tags to the repo."
 [submodule "content-modules/opentelemetry-specification"]

--- a/content/en/blog/2024/otel-operator-q-and-a/index.md
+++ b/content/en/blog/2024/otel-operator-q-and-a/index.md
@@ -4,9 +4,7 @@ title:
   Operator Q&A
 linkTitle: OTel Operator Q&A
 date: 2024-05-13
-author: >-
-  [Adriana Villela](https://github.com/avillela) (ServiceNow),
-
+author: '[Adriana Villela](https://github.com/avillela) (ServiceNow)'
 canonical_url: https://adri-v.medium.com/81d63addbf92?
 cSpell:ignore: automagically mycollector
 ---

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "autoprefixer": "^10.4.20",
     "cspell": "^8.17.2",
     "gulp": "^5.0.0",
-    "hugo-extended": "0.140.2",
+    "hugo-extended": "0.141.0",
     "js-yaml": "^4.1.0",
     "markdown-link-check": "^3.13.6",
     "markdownlint": "^0.36.1",
@@ -150,7 +150,7 @@
   },
   "optionalDependencies": {
     "netlify-cli": "^18.0.1",
-    "npm-check-updates": "^17.1.13"
+    "npm-check-updates": "^17.1.14"
   },
   "enginesComment": "Ensure that engines.node value stays consistent with the project's .nvmrc",
   "engines": {


### PR DESCRIPTION
- Upgrades Docsy
- Upgrades to Hugo v0.141.0
  - We'll address https://github.com/gohugoio/hugo/issues/13286 if/when it gets fixed.
- Copyedit to author name of a 2024 blog that had an excess comma at the end
- For an example of how generated HTML for code-blocks have changes, see the opening comment of https://github.com/google/docsy/pull/2177