### PR TITLE
[infra] Better support for RSS and blog pages

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -5,7 +5,9 @@ description: >-
   observability
 outputs:
   - HTML
-  - REDIRECTS # Include this `content/en` ONLY
+  # Include the following for `content/en` ONLY
+  - REDIRECTS
+  - RSS
 developer_note:
   The blocks/cover shortcode (used below) will use as a background image any
   image file containing "background" in its name.

--- a/content/en/blog/2024/_index.md
+++ b/content/en/blog/2024/_index.md
@@ -1,5 +1,4 @@
 ---
 title: 2024
 weight: -2024
-outputs: [HTML, RSS]
 ---

--- a/content/en/blog/2025/_index.md
+++ b/content/en/blog/2025/_index.md
@@ -1,7 +1,6 @@
 ---
 title: 2025
 weight: -2025
-outputs: [HTML, RSS]
 ---
 
 ## Happy New Year!

--- a/content/en/blog/_index.md
+++ b/content/en/blog/_index.md
@@ -1,11 +1,6 @@
 ---
 title: Blog
 menu: { main: { weight: 50 } }
-redirects:
-  # Every January, update the year number in the paths below
-  - { from: '', to: '2024/ 302!' }
-  # Workaround to https://github.com/open-telemetry/opentelemetry.io/issues/4440:
-  - { from: 'index.xml', to: '2024/index.xml 302!' }
 outputs: [HTML, RSS]
 htmltest:
   # 2024-11-07 DO NOT COPY the following IgnoreDirs to non-en pages because it handles all locales.
@@ -14,4 +9,16 @@ htmltest:
     - ^(../)?blog/(\d+/)?page/\d+
     # Ignore old blog posts
     - ^(../)?blog/20(19|21|22|23)/
+description: OpenTelemetry blog
 ---
+
+<script>
+    document.addEventListener("DOMContentLoaded", function () {
+        if (window.location.pathname.includes('/page/')) return;
+
+        var checkbox = document.getElementById("m-blog2025-check");
+        if (checkbox) checkbox.checked = true;
+        checkbox = document.getElementById("m-blog2024-check");
+        if (checkbox) checkbox.checked = true;
+    });
+</script>

--- a/content/es/_index.md
+++ b/content/es/_index.md
@@ -2,8 +2,6 @@
 title: OpenTelemetry
 description: >-
   Telemetría portable, ubicua, y de alta calidad para una observabilidad eficaz
-outputs:
-  - HTML
 developer_note:
   La macro para los bloques/portada usa como imagen de fondo cualquier archivo
   de imagen que contenga la palabra "background" en su nombre.

--- a/content/fr/_index.md
+++ b/content/fr/_index.md
@@ -3,9 +3,6 @@ title: OpenTelemetry
 description: >-
   Une télémétrie de qualité, universelle et portable pour une observabilité
   efficace
-outputs:
-  - HTML
-  - REDIRECTS # Include this `content/fr` ONLY
 developer_note:
   La macro "blocks/cover" définie ci-dessous permet d'utiliser comme image de
   fond tout visuel contenant "background" dans son nom.

--- a/content/ja/blog/2024/_index.md
+++ b/content/ja/blog/2024/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 2024
 weight: -2024
-outputs: [HTML, RSS]
 default_lang_commit: 48eac183a4dd74946d5a45fa436cfc6052f30532
 ---

--- a/content/ja/blog/_index.md
+++ b/content/ja/blog/_index.md
@@ -2,7 +2,5 @@
 title: ブログ
 menu:
   main: { weight: 50 }
-redirects: [{ from: '', to: '2024/ 301!' }]
-outputs: [HTML, RSS]
 default_lang_commit: 48eac183a4dd74946d5a45fa436cfc6052f30532
 ---

--- a/content/ja/blog/_index.md
+++ b/content/ja/blog/_index.md
@@ -1,6 +1,6 @@
 ---
 title: ブログ
-menu:
-  main: { weight: 50 }
+menu: { main: { weight: 50 } }
+outputs: [HTML, RSS]
 default_lang_commit: 48eac183a4dd74946d5a45fa436cfc6052f30532
 ---

--- a/content/pt/blog/2024/_index.md
+++ b/content/pt/blog/2024/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 2024
 weight: -2024
-outputs: [HTML, RSS]
 default_lang_commit: 48eac183a4dd74946d5a45fa436cfc6052f30532
 ---

--- a/content/pt/blog/_index.md
+++ b/content/pt/blog/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Blog
-menu:
-  main: { weight: 50 }
+menu: { main: { weight: 50 } }
+outputs: [HTML, RSS]
 default_lang_commit: 48eac183a4dd74946d5a45fa436cfc6052f30532
 ---

--- a/content/pt/blog/_index.md
+++ b/content/pt/blog/_index.md
@@ -2,7 +2,5 @@
 title: Blog
 menu:
   main: { weight: 50 }
-redirects: [{ from: '', to: '2024/ 301!' }]
-outputs: [HTML, RSS]
 default_lang_commit: 48eac183a4dd74946d5a45fa436cfc6052f30532
 ---

--- a/content/zh/blog/2024/_index.md
+++ b/content/zh/blog/2024/_index.md
@@ -1,6 +1,5 @@
 ---
 title: 2024
 weight: -2024
-outputs: [HTML, RSS]
 default_lang_commit: aca2e07f0d3a6
 ---

--- a/content/zh/blog/_index.md
+++ b/content/zh/blog/_index.md
@@ -1,5 +1,6 @@
 ---
 title: 博客
 menu: { main: { weight: 50 } }
+outputs: [HTML, RSS]
 default_lang_commit: 4c5468f8d16434f25f335e1b45922ca0f4cec18f
 ---

--- a/content/zh/blog/_index.md
+++ b/content/zh/blog/_index.md
@@ -1,7 +1,5 @@
 ---
 title: 博客
 menu: { main: { weight: 50 } }
-redirects: [{ from: '', to: '2024/ 301!' }]
-outputs: [HTML, RSS]
 default_lang_commit: 4c5468f8d16434f25f335e1b45922ca0f4cec18f
 ---

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -70,8 +70,11 @@ outputFormats:
     notAlternative: true
 
 outputs:
-  home: [HTML]
+  home: [HTML, RSS]
   section: [HTML]
+
+services:
+  rss: { limit: 20 }
 
 params:
   copyright:

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,0 +1,62 @@
+{{/* Delta of https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/_default/rss.xml */}}
+
+{{- $authorEmail := "" }}
+{{- with site.Params.author }}
+  {{- if reflect.IsMap . }}
+    {{- with .email }}
+      {{- $authorEmail = . }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- $authorName := "" }}
+{{- with site.Params.author }}
+  {{- if reflect.IsMap . }}
+    {{- with .name }}
+      {{- $authorName = . }}
+    {{- end }}
+  {{- else }}
+    {{- $authorName  = . }}
+  {{- end }}
+{{- end }}
+
+{{- $pctx := . }}
+{{- if .IsHome }}{{ $pctx = .Site }}{{ end }}
+{{- $pages := slice }}
+{{- if or $.IsHome $.IsSection }}
+{{- $pages = $pctx.RegularPages }}
+{{- else }}
+{{- $pages = $pctx.Pages }}
+{{- end }}
+{{- $pages = .RegularPagesRecursive }} {{- /* OTel: always use all pages, recursively. */}}
+{{- $limit := .Site.Config.Services.RSS.Limit }}
+{{- if ge $limit 1 }}
+{{- $pages = $pages | first $limit }}
+{{- end }}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ if eq .Title .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>Recent content {{ if ne .Title .Site.Title }}{{ with .Title }}in {{ . }} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+    <generator>Hugo</generator>
+    <language>{{ site.Language.LanguageCode }}</language>{{ with $authorEmail }}
+    <managingEditor>{{.}}{{ with $authorName }} ({{ . }}){{ end }}</managingEditor>{{ end }}{{ with $authorEmail }}
+    <webMaster>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</webMaster>{{ end }}{{ with .Site.Copyright }}
+    <copyright>{{ . }}</copyright>{{ end }}{{ if not .Date.IsZero }}
+    <lastBuildDate>{{ (index $pages.ByLastmod.Reverse 0).Lastmod.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    {{- with .OutputFormats.Get "RSS" }}
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{- end }}
+    {{- range $pages.ByLastmod.Reverse }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Lastmod.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{- with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
+      <guid>{{ .Permalink }}</guid>
+      <description>{{ .Summary | transform.XMLEscape | safeHTML }}</description>
+    </item>
+    {{- end }}
+  </channel>
+</rss>


### PR DESCRIPTION
- Contributes to #5902
- Fixes #5873. (Re)fixes:
  - #3740
  - #4440
- Supports RSS feeds for the homepage of each locale, and the blog landing page. Each RSS feed is for the entire site or section, as appropriate.
- Limits the number of entries to 20, which seems typical.
- Fixes the config for all locales
- Eliminates the need for blog redirects, which needed to be updated each year. Replaces the redirect hack by a JS solution that will open the 2025 and 2024 blog subsections in the left nav. I'll adjust the code later so that we don't have to update this each year.

**Preview**:

- https://deploy-preview-6002--opentelemetry.netlify.app
- https://deploy-preview-6002--opentelemetry.netlify.app/blog
- https://deploy-preview-6002--opentelemetry.netlify.app/blog/2024

RSS feeds:

- https://deploy-preview-6002--opentelemetry.netlify.app/index.xml
- https://deploy-preview-6002--opentelemetry.netlify.app/fr/index.xml
- https://deploy-preview-6002--opentelemetry.netlify.app/blog/index.xml
- https://deploy-preview-6002--opentelemetry.netlify.app/pt/blog/index.xml

/cc @dmathieu 