### PR TITLE
Fix load generator source link

### DIFF
--- a/content/en/docs/demo/services/load-generator.md
+++ b/content/en/docs/demo/services/load-generator.md
@@ -8,7 +8,7 @@ The load generator is based on the Python load testing framework
 [Locust](https://locust.io). By default it will simulate users requesting
 several different routes from the frontend.
 
-[Load generator source](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/loadgenerator/)
+[Load generator source](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/load-generator/)
 
 ## Traces
 

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -8223,6 +8223,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:53:01.328807-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/load-generator/": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-21T15:24:31.221226625Z"
+  },
   "https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/otel-collector/otelcol-config.yml": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:53:13.345763-05:00"


### PR DESCRIPTION
It appears the folder name for the load generator changed, or there was a typo in this link.