### PR TITLE
chore(ci): Make linter tolerate org/repo references

### DIFF
--- a/.textlintrc.yml
+++ b/.textlintrc.yml
@@ -146,8 +146,9 @@ rules:
         # - Compound names: go.opentelemetry.io
         # - Paths: medium.com/opentelemetry
         # - Repo names: opentelemetry-cpp or ocaml-opentelemetry
+        # - Repo names: open-telemetry/opentelemetry-cpp
         # - Slack or social media anchors: #opentelemetry or @opentelemetry
-        - '(?<![-#@./])\bopen[- ]?telemetry\b(?![.-])'
+        - '(?<![-#@./])\bopen[- ]?telemetry\b(?![-./])'
         - OpenTelemetry
       - [os x, macOS]
       - [postgres, PostgreSQL]


### PR DESCRIPTION
- https://github.com/open-telemetry/opentelemetry.io/pull/6054 has a failure that isn't particularly reasonable... It shouldn't be a problem to link to `open-telemetry/<repo name>` nor to describe such a link by that name.
https://github.com/open-telemetry/opentelemetry.io/actions/runs/12932842042/job/36070036852