### PR TITLE
[chore] Spelling `a`...`container.id`

### DIFF
--- a/.github/workflows/auto-update-community-members.yml
+++ b/.github/workflows/auto-update-community-members.yml
@@ -10,7 +10,7 @@ jobs:
   auto-update-versions:
     name: Auto-update community members page
     runs-on: ubuntu-24.04
-    # Remove the if statement below when testing againt a fork
+    # Remove the if statement below when testing against a fork
     if: github.repository == 'open-telemetry/opentelemetry.io'
     steps:
       - name: Checkout

--- a/.github/workflows/auto-update-registry.yml
+++ b/.github/workflows/auto-update-registry.yml
@@ -10,7 +10,7 @@ jobs:
   auto-update-versions:
     name: Auto-update registry versions
     runs-on: ubuntu-20.04
-    # Remove the if statement below when testing againt a fork
+    # Remove the if statement below when testing against a fork
     if: github.repository == 'open-telemetry/opentelemetry.io'
     steps:
       - name: Checkout

--- a/content/en/blog/2023/histograms-vs-summaries/index.md
+++ b/content/en/blog/2023/histograms-vs-summaries/index.md
@@ -3,7 +3,7 @@ title: Histograms vs Summaries
 date: 2023-05-15
 author: '[Daniel Dyla](https://github.com/dyladan)'
 canonical_url: https://dyladan.me/histograms/2023/05/03/histograms-vs-summaries/
-cSpell:ignore: aggregatable Björn Ganesh Kovalov Rabenstein Ruslan Vernekar
+cSpell:ignore: aggregable Björn Ganesh Kovalov Rabenstein Ruslan Vernekar
 ---
 
 In many ways, histograms and summaries appear quite similar. They both roll up
@@ -34,9 +34,9 @@ could be off by as much as 60ms (`360 - 300`), a relative error of 17%
 (`60 / 360`). This error can be mitigated by configuring more and smaller
 buckets around your SLO values, but never eliminated.
 
-One important property of histograms is that they are _aggregatable_, meaning
-that as long as the bucket boundaries line up, an arbitrary number of histograms
-can be combined into a single histogram with no loss of data or precision. This
+One important property of histograms is that they are _aggregable_, meaning that
+as long as the bucket boundaries line up, an arbitrary number of histograms can
+be combined into a single histogram with no loss of data or precision. This
 means that an arbitrary number of hosts can report histogram data structures to
 a server, which can aggregate and compute quantiles from all of them as if they
 were reported by a single host. By collecting histograms from 1 or more hosts

--- a/content/en/blog/2024/prometheus-compatibility-survey/index.md
+++ b/content/en/blog/2024/prometheus-compatibility-survey/index.md
@@ -175,10 +175,10 @@ existing conventions.
 
 For the most part, this feedback aligns with the future plans in the
 OpenTelemetry and Prometheus communities. The OpenTelemetry semantic conventions
-SIG is working on stabilizing conventions for a a wide variety of
-instrumentation. The OpenTelemetry Prometheus interoperability SIG is working on
-incorporating the results of this survey into the compatibility specification.
-The Prometheus community has
+SIG is working on stabilizing conventions for a wide variety of instrumentation.
+The OpenTelemetry Prometheus interoperability SIG is working on incorporating
+the results of this survey into the compatibility specification. The Prometheus
+community has
 [ambitious plans](https://prometheus.io/blog/2024/03/14/commitment-to-opentelemetry/)
 to add support for OpenTelemetry concepts.
 

--- a/content/en/docs/concepts/resources/index.md
+++ b/content/en/docs/concepts/resources/index.md
@@ -13,8 +13,8 @@ backend, resource attributes are grouped under the **Process** tab:
 ![A screenshot from Jaeger showing an example output of resource attributes associated to a trace](screenshot-jaeger-resources.png)
 
 A resource is added to the `TraceProvider` or `MetricProvider` when they are
-created during initialization. This association can not be changed later. After
-a resource is added, all spans and metrics produced from a `Tracer` or `Meter`
+created during initialization. This association cannot be changed later. After a
+resource is added, all spans and metrics produced from a `Tracer` or `Meter`
 from the provider will have the resource associated with them.
 
 ## Semantic Attributes with SDK-provided Default Value

--- a/content/en/docs/contributing/blog.md
+++ b/content/en/docs/contributing/blog.md
@@ -55,7 +55,7 @@ with the following details:
   review that PR. That sponsor should ideally be from a different company.
 
 Maintainers of SIG Communication will verify, that your blog post satisfies all
-the requirements for being accepted. If you can not name a SIG/sponsor in your
+the requirements for being accepted. If you cannot name a SIG/sponsor in your
 initial issue details, they will also point you to an appropriate SIG, you can
 reach out to for sponsorship. Having a sponsor is optional, but having one
 increases the chance of having your blog post reviewed and approved more

--- a/content/en/docs/demo/services/payment.md
+++ b/content/en/docs/demo/services/payment.md
@@ -6,7 +6,7 @@ cSpell:ignore: nanos
 ---
 
 This service is responsible to process credit card payments for orders. It will
-return an error if the credit card is invalid or the payment can not be
+return an error if the credit card is invalid or the payment cannot be
 processed.
 
 [Payment service source](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/payment/)

--- a/content/en/docs/languages/java/sdk.md
+++ b/content/en/docs/languages/java/sdk.md
@@ -1513,7 +1513,7 @@ public class OtlpAuthenticationConfig {
   }
 
   private static String refreshToken(String username, String password) {
-    // For a production scenario, this would be replaced with out-of-band request to exchange
+    // For a production scenario, this would be replaced with an out-of-band request to exchange
     // username / password for bearer token.
     return "abc123";
   }

--- a/content/en/docs/languages/js/resources.md
+++ b/content/en/docs/languages/js/resources.md
@@ -184,7 +184,7 @@ $ docker run --rm -p 8080:8080 nodejs-otel-getting-started
 Listening for requests on http://localhost:8080
 DockerCGroupV1Detector found resource. Resource {
   attributes: {
-    'container.id': 'fffbeaf682f32ef86916f306ff9a7f88cc58048ab78f7de464da3c320ldb5c54'
+    'container.id': 'fffbeaf682f32ef86916f306ff9a7f88cc58048ab78f7de464da3c3201db5c54'
   }
 }
 ```

--- a/data/registry-schema.json
+++ b/data/registry-schema.json
@@ -9,7 +9,7 @@
     "title": {
       "type": "string",
       "description": "The title of the entry",
-      "errorMessage": "The title of the entry must be a string and can not be empty",
+      "errorMessage": "The title of the entry must be a string and cannot be empty",
       "minLength": 1
     },
     "registryType": {
@@ -64,7 +64,7 @@
     "description": {
       "type": "string",
       "description": "A description of the entry",
-      "errorMessage": "The description of the entry must be a string and can not be empty"
+      "errorMessage": "The description of the entry must be a string and cannot be empty"
     },
     "license": {
       "type": "string",
@@ -94,7 +94,7 @@
             "oneOf": [
               {
                 "pattern": "OpenTelemetry Authors",
-                "errorMessage": "The name of the author can not contain 'OpenTelemetry' except for 'OpenTelemetry Authors'"
+                "errorMessage": "The name of the author cannot contain 'OpenTelemetry' except for 'OpenTelemetry Authors'"
               },
               {
                 "pattern": "^(?!.*OpenTelemetry).*$"
@@ -213,7 +213,7 @@
         "reason": {
           "type": "string",
           "description": "The reason for deprecation",
-          "errorMessage": "The reason for deprecation must be a string and can not be empty"
+          "errorMessage": "The reason for deprecation must be a string and cannot be empty"
         }
       },
       "required": ["reason"],


### PR DESCRIPTION
Per https://github.com/open-telemetry/opentelemetry.io/pull/6009#issuecomment-2605506429