### PR TITLE
Ensure that spec front matter redirect path gets patched too

### DIFF
--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -72,6 +72,17 @@ sub printPatchInfoIf($$) {
     if $specVersTest && !$patchMsgCount{$patchID}++;
 }
 
+sub patchAttrNaming($$) {
+  my ($ARGV, $__) = @_;
+  $_ = $__;
+  my $semconv_attr_naming = '(/docs/specs/semconv/general)/naming/';
+  if ($ARGV =~ /^tmp\/otel\/specification/ && /$semconv_attr_naming/) {
+    s|$semconv_attr_naming|$1/attribute-naming/|g;
+    printPatchInfoIf("2025-01-22-attribute-naming", $semconvVers ne "1.29.0");
+  }
+  return $_;
+}
+
 # main
 
 while(<>) {
@@ -84,6 +95,7 @@ while(<>) {
     if (/^<!---? Hugo/) {
         while(<>) {
           last if /^-?-->/;
+          $_ = patchAttrNaming($ARGV, $_); # TEMPORARY patch
           $frontMatterFromFile .= $_;
         }
         next;
@@ -137,11 +149,7 @@ while(<>) {
     printPatchInfoIf("2025-01-22-attribute-naming.md", $semconvVers ne "1.29.0");
   }
 
-  my $semconv_attr_naming = '(/docs/specs/semconv/general)/naming/';
-  if ($ARGV =~ /^tmp\/otel\/specification/ && /$semconv_attr_naming/) {
-    s|$semconv_attr_naming|$1/attribute-naming/|g;
-    printPatchInfoIf("2025-01-22-attribute-naming", $semconvVers ne "1.29.0");
-  }
+  $_ = patchAttrNaming($ARGV, $_); # TEMPORARY patch
 
   s|\(https://github.com/open-telemetry/opentelemetry-specification\)|($specBasePath/otel/)|;
   s|(\]\()/specification/|$1$specBasePath/otel/)|;


### PR DESCRIPTION
- Followup to #6022
- Ensures that path patch gets applied to path in  front matter too. Currently we get a 404:
  ```console
  $ curl -sIL https://opentelemetry.io/docs/specs/otel/common/attribute-naming/ | grep -E 'HTTP|^date|loc'
  HTTP/2 301 
  date: Wed, 22 Jan 2025 13:51:50 GMT
  location: /docs/specs/semconv/general/naming/
  HTTP/2 404 
  date: Wed, 22 Jan 2025 13:51:50 GMT
  ```

This PR also patches the redirect path:

```console
$ curl -sIL https://deploy-preview-6027--opentelemetry.netlify.app/docs/specs/otel/common/attribute-naming/ | grep -E 'HTTP|^date|loc' 
HTTP/2 301 
date: Wed, 22 Jan 2025 13:53:43 GMT
location: /docs/specs/semconv/general/attribute-naming/
HTTP/2 200 
date: Wed, 22 Jan 2025 13:53:43 GMT
```

**Preview**: https://deploy-preview-6027--opentelemetry.netlify.app/docs/specs/otel/common/attribute-naming/