### PR TITLE
Use render-link hook to resolve references in specs

### DIFF
--- a/content/en/docs/specs/status.md
+++ b/content/en/docs/specs/status.md
@@ -59,7 +59,7 @@ same as the **Protocol** status.
 - [Specification][tracing]
 - {{% spec_status "API" "otel/trace/api" "Status" %}}
 - {{% spec_status "SDK" "otel/trace/sdk" "Status" %}}
-- {{% spec_status "Protocol" "otlp" "/document-status/.*for.*trace" %}}
+- {{% spec_status "Protocol" "otlp" "/document-status.*for.*trace" %}}
 - Notes:
   - The tracing specification is now completely stable, and covered by long term
     support.
@@ -73,7 +73,7 @@ same as the **Protocol** status.
 - [Specification][metrics]
 - {{% spec_status "API" "otel/metrics/api" "Status" %}}
 - {{% spec_status "SDK" "otel/metrics/sdk" "Status" %}}
-- {{% spec_status "Protocol" "otlp" "/document-status/.*for.*metric" %}}
+- {{% spec_status "Protocol" "otlp" "/document-status.*for.*metric" %}}
 - Notes:
   - OpenTelemetry Metrics is currently under active development.
   - The data model is stable and released as part of the OTLP protocol.
@@ -98,7 +98,7 @@ same as the **Protocol** status.
 - [Specification][logging]
 - {{% spec_status "Bridge API" "otel/logs/api" "Status" %}}
 - {{% spec_status "SDK" "otel/logs/sdk" "Status" %}}
-- {{% spec_status "Protocol" "otlp" "/document-status/.*for.*log" %}}
+- {{% spec_status "Protocol" "otlp" "/document-status.*for.*log" %}}
 - Notes:
   - The [logs data model][] is released as part of the OpenTelemetry Protocol.
   - Log processing for many data formats has been added to the Collector, thanks
@@ -116,7 +116,7 @@ same as the **Protocol** status.
 ### Profiles
 
 - [Specification][profiles]
-- {{% spec_status "Protocol" "otlp" "/document-status/.*for.*profiles" %}}
+- {{% spec_status "Protocol" "otlp" "/document-status.*for.*profiles" %}}
 
 [baggage]: /docs/specs/otel/baggage/
 [event semantic conventions]: /docs/specs/semconv/general/events/

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,4 +1,5 @@
-{{ $url := .Destination -}}
+{{ $url := .Destination -}} {{/* TODO: rename to $dest */ -}}
+{{ $u := urls.Parse $url -}}
 
 {{/*
 
@@ -10,9 +11,32 @@
   - $url is an absolute path -- that is, it starts with /
   - The $url target page exists in this locale
 
+  Reference to Hugo's default:
+  https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/_default/_markup/render-link.html
+
   */ -}}
 
-{{ if hasPrefix $url "/" -}}
+
+{{ if and
+    (strings.HasPrefix $.PageInner.RelPermalink "/docs/specs")
+    (not $u.IsAbs)
+    (not (strings.HasPrefix $url "#"))
+-}}
+  {{ $path := replaceRE `\bREADME\.md\b` "_index.md" $u.Path -}}
+  {{ $href := $url -}}
+  {{ with or
+    ($.PageInner.GetPage $path)
+    ($.PageInner.Resources.Get $path)
+    (resources.Get $path)
+  -}}
+    {{ $href = .RelPermalink -}}
+    {{ with $u.RawQuery -}}{{ $href = printf "%s?%s" $href . -}}{{ end -}}
+    {{ with $u.Fragment -}}{{ $href = printf "%s#%s" $href . -}}{{ end -}}
+  {{ else -}}
+    {{ warnf "File %s: cannot resolve spec link reference '%s'" .Page.File.Filename $url -}}
+  {{ end -}}
+  {{ $url = $href -}}
+{{ else if hasPrefix $url "/" -}}
   {{/* Hard-coded default lang since it's what's most efficient and won't change :) */ -}}
   {{ $defaultLang := "en" -}}
   {{ $lang := .Page.Language.Lang -}}
@@ -22,7 +46,6 @@
       {{ warnf "File %s: drop unnecessary '%s' prefix from %s"
               .Page.File.Filename $langPathPrefix $url -}}
     {{ else -}}
-      {{ $u := urls.Parse $url -}}
       {{ $localizedPagePath := add $langPathPrefix (strings.TrimPrefix "/" $url) -}}
       {{/*
         Look for the page (referenced by $url) in this page's locale's site.


### PR DESCRIPTION
- Fixes #6025
- Adds code to the render-link hook to resolve intra-spec references in a manner that was previously done using `relref`. The `relref` function is no longer used / emitted.
- Greatly simplifies `scripts/content-modules/adjust-pages.pl` by removing link-transformation code that was previously used to insert `relref` function calls, and rename `README.md`. We might eventually be able to move more of the `adjust-pages.pl` functionality into the render-link hook.

The only change to the generated site files is the addition of trailing `/` at the end of `/docs/specs/otel/document-status` links in semconv pages:

```console
$ (cd public && git diff -bw --ignore-blank-lines -I '/docs/specs/otel/document-status' -I 'modified_time|Last modified|dateModified' -- . ':(exclude)*.xml') | grep ^diff
diff --git a/site/index.html b/site/index.html
```

**Preview**: https://deploy-preview-6032--opentelemetry.netlify.app/docs/specs/