### PR TITLE
Fix daily semconv build workflow

### DIFF
--- a/.github/workflows/build-semconv-daily.yml
+++ b/.github/workflows/build-semconv-daily.yml
@@ -21,4 +21,5 @@ jobs:
       success: ${{ needs.build-dev.result == 'success' }}
       repo: open-telemetry/semantic-conventions
     secrets:
-      opentelemetrybot_github_token: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+      opentelemetrybot_github_token:
+        ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}

--- a/.github/workflows/build-semconv-daily.yml
+++ b/.github/workflows/build-semconv-daily.yml
@@ -20,3 +20,5 @@ jobs:
     with:
       success: ${{ needs.build-dev.result == 'success' }}
       repo: open-telemetry/semantic-conventions
+    secrets:
+      opentelemetrybot_github_token: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}

--- a/.github/workflows/reusable-workflow-notification.yml
+++ b/.github/workflows/reusable-workflow-notification.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Open issue or add comment if issue already open
         env:
           # need to use opentelemetrybot token when opening issues in other repos
-          GH_TOKEN: ${{ secrets.opentelemetrybot_github_token || secrets.GITHUB_TOKEN }}
+          GH_TOKEN:
+            ${{ secrets.opentelemetrybot_github_token || secrets.GITHUB_TOKEN }}
         run: |
           if [ -z "${{ inputs.repo }}" ]; then
             repo="$GITHUB_REPOSITORY"

--- a/.github/workflows/reusable-workflow-notification.yml
+++ b/.github/workflows/reusable-workflow-notification.yml
@@ -11,6 +11,10 @@ on:
       repo:
         type: string
         required: false
+    secrets:
+      opentelemetrybot_github_token:
+        type: string
+        required: false
 
 jobs:
   workflow-notification:
@@ -20,10 +24,8 @@ jobs:
 
       - name: Open issue or add comment if issue already open
         env:
-          # need to use opentelemetrybot for opening issues in other repos
-          GH_TOKEN:
-            ${{ inputs.repo && secrets.OPENTELEMETRYBOT_GITHUB_TOKEN ||
-            secrets.GITHUB_TOKEN }}
+          # need to use opentelemetrybot token when opening issues in other repos
+          GH_TOKEN: ${{ secrets.opentelemetrybot_github_token || secrets.GITHUB_TOKEN }}
         run: |
           if [ -z "${{ inputs.repo }}" ]; then
             repo="$GITHUB_REPOSITORY"


### PR DESCRIPTION
[Secrets are not automatically passed to reusable workflows](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow)

cc @open-telemetry/specs-semconv-maintainers 