### PR TITLE
[infra] Add textlint rules for work-around and walk-through

### DIFF
--- a/.textlintrc.yml
+++ b/.textlintrc.yml
@@ -159,6 +159,8 @@ rules:
       - ['screen[- ]shot(s)?', screenshot$1]
       - ['time[- ]stamp(s)?', timestamp$1]
       - ["uid['’]?(s)?", UID$1]
+      - ['(walk)-(throughs?)', $1$2] # cSpell:disable-line
+      - ['(work)-(arounds?)', $1$2]
       # Enable the following to find and replace "instrumentation module/package" with "instrumentation library":
       # - ["(auto(matic)?[- ])?instrumentation (module|package)", "instrumentation library"]
       # - ["(auto(matic)?[- ])?instrumentation (modules|packages)", "instrumentation libraries"]

--- a/content/en/blog/2023/end-user-discussions-01.md
+++ b/content/en/blog/2023/end-user-discussions-01.md
@@ -196,7 +196,7 @@ Please also check out
 **A:** Implementing correlation takes time and is a work in progress.
 Correlation work is more mature for some languages (e.g. Java, Go) than for
 others. The best approach is to raise this issue in one of the language-specific
-repositories that pertains to your situation. A possible work-around is to start
+repositories that pertains to your situation. A possible workaround is to start
 traces at the log level, whereby every log will have its own associated trace.
 
 #### 3- Profiling

--- a/content/en/docs/collector/building/connector/index.md
+++ b/content/en/docs/collector/building/connector/index.md
@@ -43,9 +43,9 @@ data, it is necessary to convert the trace data from the processor in the traces
 pipeline and send it to the metrics pipeline. Historically, some processors
 transmitted data by making use of a workaround that follows a bad practice where
 a processor directly exports data after processing. The connector component
-solves the need for this work-around and the processors that used the work
-around have been deprecated. On the same line, above mentioned processors are
-also now deprecated in recent releases and are replaced by the connectors.
+solves the need for this workaround and the processors that used the workaround
+have been deprecated. On the same line, above mentioned processors are also now
+deprecated in recent releases and are replaced by the connectors.
 
 Additional details about the connector's full capabilities can be found at the
 following links:


### PR DESCRIPTION
- Inspired by #6021
- Adds textlint rewrite rules for `walk-through` and `work-around`, to encode use without the hyphen.
- Runs textlint over pages to fix words
- Manually adjusts one more spelling
- ~Closes #6021 by superseding it~

/cc @jsoref @reyang 