### PR TITLE
Skip refcache check for daily semconv build

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -12,6 +12,9 @@ on:
       submodule_path_regex:
         type: string
         required: true
+      skip_ref_cache_check:
+        type: boolean
+        default: false
 
 jobs:
   build-and-test:
@@ -57,6 +60,7 @@ jobs:
     name: REFCACHE updates?
     needs: build-and-test
     runs-on: ubuntu-latest
+    if: ${{ !inputs.skip_ref_cache_check }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4

--- a/.github/workflows/build-semconv-daily.yml
+++ b/.github/workflows/build-semconv-daily.yml
@@ -11,6 +11,7 @@ jobs:
     uses: ./.github/workflows/build-dev.yml
     with:
       submodule_path_regex: semantic-conventions
+      skip_ref_cache_check: true
 
   workflow-notification:
     needs:


### PR DESCRIPTION
From @chalin's https://github.com/open-telemetry/opentelemetry.io/pull/6034#pullrequestreview-2568562436

> we might want to see how we can tweak this so that it doesn't fail if the refcache is updated, only if there are broken links.