### PR TITLE
[chore] Accessible links 1

### DIFF
--- a/content/en/blog/2022/gc-elections.md
+++ b/content/en/blog/2022/gc-elections.md
@@ -48,9 +48,9 @@ refer to the
 [charter document](https://github.com/open-telemetry/community/blob/main/governance-charter.md).
 You may nominate yourself (or others!) by submitting a Pull Request against the
 [list of candidates](https://github.com/open-telemetry/community/blob/main/elections/2022/governance-committee-candidates.md)
-by 7 October 2022 23:59 UTC — more detailed requirements about the nomination
-and ratification process can be found
-[here](https://github.com/open-telemetry/community/blob/main/elections/2022/governance-committee-election.md).
+by 7 October 2022 23:59 UTC — see the detailed requirements under
+[nominations](https://github.com/open-telemetry/community/blob/main/elections/2022/governance-committee-election.md#nominations)
+for the Governance Committee election.
 
 We would like to thank the GC members who have helped grow OpenTelemetry, and
 invite them to run for re-election if they so choose: Alolita Sharma, Daniel

--- a/content/en/blog/2022/otel-demo-app-nomad/index.md
+++ b/content/en/blog/2022/otel-demo-app-nomad/index.md
@@ -48,8 +48,8 @@ Below are the repositories that we’ll be using for today’s tutorial:
 
 - My modified [HashiQube Repository](https://github.com/avillela/hashiqube)
   (fork of [servian/hashiqube](https://github.com/servian/hashiqube)). If you’re
-  curious, you can see what modifications I’ve made
-  [here](https://github.com/avillela/hashiqube).
+  curious, you can see
+  [the modifications I’ve made to hashiqube](https://github.com/avillela/hashiqube/commits).
 - My [Nomad Conversions](https://github.com/avillela/nomad-conversions)
   repository
 

--- a/content/en/blog/2023/contributing-to-otel/index.md
+++ b/content/en/blog/2023/contributing-to-otel/index.md
@@ -133,7 +133,7 @@ greatest versions of things like the [OTel Collector](/docs/collector/) and
 language-specific instrumentation. In short, there's always work to be done!
 
 You can check out an example of one of my contributions
-[here](https://github.com/open-telemetry/opentelemetry-demo/pull/432).
+[Integrate with existing metrics code](https://github.com/open-telemetry/opentelemetry-demo/pull/432).
 
 Learn more about how to contribute to the OTel Demo
 [here](https://github.com/open-telemetry/opentelemetry-demo/blob/main/CONTRIBUTING.md).

--- a/content/en/blog/2023/contributing-to-otel/index.md
+++ b/content/en/blog/2023/contributing-to-otel/index.md
@@ -138,8 +138,8 @@ language-specific instrumentation. In short, there's always work to be done!
 You can check out an example of one of my contributions
 [Integrate with existing metrics code](https://github.com/open-telemetry/opentelemetry-demo/pull/432).
 
-Learn more about how to contribute to the OTel Demo
-[here](https://github.com/open-telemetry/opentelemetry-demo/blob/main/CONTRIBUTING.md).
+Learn more about how to
+[contribute to the OTel Demo](https://github.com/open-telemetry/opentelemetry-demo/blob/main/CONTRIBUTING.md).
 
 ### Join a Special Interest Group
 

--- a/content/en/blog/2023/contributing-to-otel/index.md
+++ b/content/en/blog/2023/contributing-to-otel/index.md
@@ -173,7 +173,7 @@ within OTel to be nothing but helpful and welcoming.
 You can check out an example of one of my contributions
 [here](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/531).
 
-Learn more about the OTel SIGs [here](/community/#special-interest-groups).
+Learn more about the [OTel SIGs](/community/#special-interest-groups).
 
 ### Final thoughts
 

--- a/content/en/blog/2023/contributing-to-otel/index.md
+++ b/content/en/blog/2023/contributing-to-otel/index.md
@@ -53,7 +53,8 @@ don't. This usually means that I have to do a bit more digging beyond the docs,
 by seeking out external blog posts, bugging techie friends, etc. Once I'm able
 to fill that knowledge gap, I do two things:
 
-1. I blog about it. See examples [here](https://shorturl.at/vLYZ0) and [here](https://shorturl.at/czHST).
+1. I blog about it. See examples [here](https://shorturl.at/vLYZ0) and
+   [Let’s Learn About the OTel Operator’s Target Allocator!](https://adri-v.medium.com/lets-learn-about-the-otel-operator-s-target-allocator-47a2b1f07562).
 2. I contribute to the OTel docs. See examples
    [Include docs about Python logs auto-instrumentation](https://github.com/open-telemetry/opentelemetry.io/pull/3195),
    [Add troubleshooting guidance to OTel Operator auto-instrumentation docs](https://github.com/open-telemetry/opentelemetry.io/pull/3098),

--- a/content/en/blog/2023/contributing-to-otel/index.md
+++ b/content/en/blog/2023/contributing-to-otel/index.md
@@ -56,7 +56,8 @@ to fill that knowledge gap, I do two things:
 1. I blog about it. See examples [here](https://shorturl.at/vLYZ0) and [here](https://shorturl.at/czHST).
 2. I contribute to the OTel docs. See examples
    [here](https://github.com/open-telemetry/opentelemetry.io/pull/3195),
-   [here](https://github.com/open-telemetry/opentelemetry.io/pull/3098), and
+   [Add troubleshooting guidance to OTel Operator auto-instrumentation docs](https://github.com/open-telemetry/opentelemetry.io/pull/3098),
+   and
    [here](https://github.com/open-telemetry/opentelemetry.io/pull/2130).
 
 > ✨ **NOTE:** ✨ Number two is _especially_ important, because the best way for

--- a/content/en/blog/2023/contributing-to-otel/index.md
+++ b/content/en/blog/2023/contributing-to-otel/index.md
@@ -53,8 +53,7 @@ don't. This usually means that I have to do a bit more digging beyond the docs,
 by seeking out external blog posts, bugging techie friends, etc. Once I'm able
 to fill that knowledge gap, I do two things:
 
-1. I blog about it. See examples [here](https://shorturl.at/vLYZ0),
-   [here](https://shorturl.at/hlqtE), and [here](https://shorturl.at/czHST).
+1. I blog about it. See examples [here](https://shorturl.at/vLYZ0) and [here](https://shorturl.at/czHST).
 2. I contribute to the OTel docs. See examples
    [here](https://github.com/open-telemetry/opentelemetry.io/pull/3195),
    [here](https://github.com/open-telemetry/opentelemetry.io/pull/3098), and

--- a/content/en/blog/2023/contributing-to-otel/index.md
+++ b/content/en/blog/2023/contributing-to-otel/index.md
@@ -106,7 +106,7 @@ OpenTelemetry practitioners who come together a few times a month to:
 
 As an added bonus, I'm one of the co-chairs. Just sayin'… 😉
 
-Learn more about the OTel EUWG [here](/community/end-user/).
+Learn more about the [OTel EUWG](/community/end-user/).
 
 ### Contribute to the OpenTelemetry Demo
 

--- a/content/en/blog/2023/contributing-to-otel/index.md
+++ b/content/en/blog/2023/contributing-to-otel/index.md
@@ -67,8 +67,7 @@ to fill that knowledge gap, I do two things:
 > the OTel docs to be the Source of Truth for All Things OTel<sup>TM</sup> is to
 > have folks like us contributing to the docs whenever we see a gap.
 
-Learn more about contributing to the OTel docs
-[here](https://github.com/open-telemetry/opentelemetry.io/blob/main/CONTRIBUTING.md).
+Learn more about [contributing to the OTel docs](/docs/contributing/).
 
 > ✨ **NOTE:** ✨ If you find the contribution guidelines for the OTel Docs to
 > be confusing or have a mistake, improving them is a great way to contribute!

--- a/content/en/blog/2023/contributing-to-otel/index.md
+++ b/content/en/blog/2023/contributing-to-otel/index.md
@@ -84,8 +84,8 @@ community at large. As long as your work isn't promoting a product you're
 selling or requires readers to make a purchase in order to replicate your work,
 your blog post is most welcome!
 
-You can check out an example of one of my previous blog posts
-[here](/blog/2022/otel-demo-app-nomad/).
+You can check out an example of one of my previous blog posts:
+[Running the OpenTelemetry Demo App on HashiCorp Nomad](/blog/2022/otel-demo-app-nomad/).
 
 Learn more about submitting a post to the OTel blog
 [here](https://github.com/open-telemetry/opentelemetry.io#submitting-a-blog-post).

--- a/content/en/blog/2023/contributing-to-otel/index.md
+++ b/content/en/blog/2023/contributing-to-otel/index.md
@@ -171,7 +171,7 @@ community member to implement these types of code changes. I've found folks
 within OTel to be nothing but helpful and welcoming.
 
 You can check out an example of one of my contributions
-[here](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/531).
+[Specify gRPC endpoint in otlp receiver config](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/531).
 
 Learn more about the [OTel SIGs](/community/#special-interest-groups).
 

--- a/content/en/blog/2023/contributing-to-otel/index.md
+++ b/content/en/blog/2023/contributing-to-otel/index.md
@@ -61,7 +61,7 @@ to fill that knowledge gap, I do two things:
    [Include docs about Python logs auto-instrumentation](https://github.com/open-telemetry/opentelemetry.io/pull/3195),
    [Add troubleshooting guidance to OTel Operator auto-instrumentation docs](https://github.com/open-telemetry/opentelemetry.io/pull/3098),
    and
-   [here](https://github.com/open-telemetry/opentelemetry.io/pull/2130).
+   [Update Python auto-instrumentation docs](https://github.com/open-telemetry/opentelemetry.io/pull/2130).
 
 > ✨ **NOTE:** ✨ Number two is _especially_ important, because the best way for
 > the OTel docs to be the Source of Truth for All Things OTel<sup>TM</sup> is to

--- a/content/en/blog/2023/contributing-to-otel/index.md
+++ b/content/en/blog/2023/contributing-to-otel/index.md
@@ -86,8 +86,7 @@ your blog post is most welcome!
 You can check out an example of one of my previous blog posts:
 [Running the OpenTelemetry Demo App on HashiCorp Nomad](/blog/2022/otel-demo-app-nomad/).
 
-Learn more about submitting a post to the OTel blog
-[here](https://github.com/open-telemetry/opentelemetry.io#submitting-a-blog-post).
+Learn more about [submitting a post to the OTel blog](/docs/contributing/blog/).
 
 ### Join the OTel End User Working Group
 

--- a/content/en/blog/2023/contributing-to-otel/index.md
+++ b/content/en/blog/2023/contributing-to-otel/index.md
@@ -55,7 +55,7 @@ to fill that knowledge gap, I do two things:
 
 1. I blog about it. See examples [here](https://shorturl.at/vLYZ0) and [here](https://shorturl.at/czHST).
 2. I contribute to the OTel docs. See examples
-   [here](https://github.com/open-telemetry/opentelemetry.io/pull/3195),
+   [Include docs about Python logs auto-instrumentation](https://github.com/open-telemetry/opentelemetry.io/pull/3195),
    [Add troubleshooting guidance to OTel Operator auto-instrumentation docs](https://github.com/open-telemetry/opentelemetry.io/pull/3098),
    and
    [here](https://github.com/open-telemetry/opentelemetry.io/pull/2130).

--- a/content/en/blog/2023/contributing-to-otel/index.md
+++ b/content/en/blog/2023/contributing-to-otel/index.md
@@ -53,7 +53,9 @@ don't. This usually means that I have to do a bit more digging beyond the docs,
 by seeking out external blog posts, bugging techie friends, etc. Once I'm able
 to fill that knowledge gap, I do two things:
 
-1. I blog about it. See examples [here](https://shorturl.at/vLYZ0) and
+1. I blog about it. See examples
+   [OTel Python Logging Auto-Instrumentation with the OTel Operator](https://medium.com/cloud-native-daily/lets-learn-about-otel-python-logging-auto-instrumentation-with-the-otel-operator-663247666570)
+   and
    [Let’s Learn About the OTel Operator’s Target Allocator!](https://adri-v.medium.com/lets-learn-about-the-otel-operator-s-target-allocator-47a2b1f07562).
 2. I contribute to the OTel docs. See examples
    [Include docs about Python logs auto-instrumentation](https://github.com/open-telemetry/opentelemetry.io/pull/3195),

--- a/content/en/blog/2023/end-user-q-and-a-04.md
+++ b/content/en/blog/2023/end-user-q-and-a-04.md
@@ -331,7 +331,7 @@ for the OTel Collector in Kubernetes:
 
 - [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) -
   see example
-  [here](https://github.com/open-telemetry/opentelemetry-operator/blob/main/tests/e2e/ingress/00-install.yaml)
+  [ingress/00-install.yaml](https://github.com/open-telemetry/opentelemetry-operator/blob/main/tests/e2e/ingress/00-install.yaml)
 - [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) -
   see example
   [daemonset-features/01-install.yaml](https://github.com/open-telemetry/opentelemetry-operator/blob/main/tests/e2e/daemonset-features/01-install.yaml)

--- a/content/en/blog/2023/end-user-q-and-a-04.md
+++ b/content/en/blog/2023/end-user-q-and-a-04.md
@@ -334,7 +334,7 @@ for the OTel Collector in Kubernetes:
   [here](https://github.com/open-telemetry/opentelemetry-operator/blob/main/tests/e2e/ingress/00-install.yaml)
 - [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) -
   see example
-  [here](https://github.com/open-telemetry/opentelemetry-operator/blob/main/tests/e2e/daemonset-features/01-install.yaml)
+  [daemonset-features/01-install.yaml](https://github.com/open-telemetry/opentelemetry-operator/blob/main/tests/e2e/daemonset-features/01-install.yaml)
 - [StatefulSet](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) -
   see example
   [here](https://github.com/open-telemetry/opentelemetry-operator/blob/main/tests/e2e/smoke-statefulset/00-install.yaml)

--- a/content/en/blog/2023/end-user-q-and-a-04.md
+++ b/content/en/blog/2023/end-user-q-and-a-04.md
@@ -340,7 +340,7 @@ for the OTel Collector in Kubernetes:
   [here](https://github.com/open-telemetry/opentelemetry-operator/blob/main/tests/e2e/smoke-statefulset/00-install.yaml)
 - [Sidecar](https://www.techtarget.com/searchapparchitecture/tip/The-reasons-to-use-or-not-use-sidecars-in-Kubernetes) -
   see example
-  [here](https://github.com/open-telemetry/opentelemetry-operator/blob/main/tests/e2e/instrumentation-python/00-install-collector.yaml)
+  [instrumentation-python/00-install-collector.yaml](https://github.com/open-telemetry/opentelemetry-operator/blob/cd1d136a539820a87bbc26fa2d8ff1fb821bbcf1/tests/e2e/instrumentation-python/00-install-collector.yaml)
 
 Which ones you should use depends on what you need to do, such as how you like
 to run applications for reliability.

--- a/content/en/blog/2023/end-user-q-and-a-04.md
+++ b/content/en/blog/2023/end-user-q-and-a-04.md
@@ -5,7 +5,7 @@ date: 2023-07-24
 author: '[Reese Lee](https://github.com/reese-lee) (New Relic)'
 body_class: otel-with-contributions-from
 # prettier-ignore
-cSpell:ignore: Aronoff autoscaler Boten codepath fluentbit k8sattributesprocessor kubelet spanmetrics
+cSpell:ignore: Aronoff autoscaler Boten codepath fluentbit k8sattributesprocessor kubelet spanmetrics statefulset
 ---
 
 With contributions from [Adriana Villela](https://github.com/avillela)
@@ -337,7 +337,7 @@ for the OTel Collector in Kubernetes:
   [daemonset-features/01-install.yaml](https://github.com/open-telemetry/opentelemetry-operator/blob/main/tests/e2e/daemonset-features/01-install.yaml)
 - [StatefulSet](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) -
   see example
-  [here](https://github.com/open-telemetry/opentelemetry-operator/blob/main/tests/e2e/smoke-statefulset/00-install.yaml)
+  [smoke-statefulset/00-install.yaml](https://github.com/open-telemetry/opentelemetry-operator/blob/main/tests/e2e/smoke-statefulset/00-install.yaml)
 - [Sidecar](https://www.techtarget.com/searchapparchitecture/tip/The-reasons-to-use-or-not-use-sidecars-in-Kubernetes) -
   see example
   [instrumentation-python/00-install-collector.yaml](https://github.com/open-telemetry/opentelemetry-operator/blob/cd1d136a539820a87bbc26fa2d8ff1fb821bbcf1/tests/e2e/instrumentation-python/00-install-collector.yaml)

--- a/content/en/blog/2023/gc-elections.md
+++ b/content/en/blog/2023/gc-elections.md
@@ -46,9 +46,9 @@ refer to the
 [charter document](https://github.com/open-telemetry/community/blob/master/governance-charter.md).
 You may nominate yourself (or others!) by submitting a Pull Request against the
 [list of candidates](https://github.com/open-telemetry/community/blob/main/elections/2023/governance-committee-candidates.md)
-by 13 October 2023 23:59 UTC — more detailed requirements about the nomination
-and ratification process can be found
-[here](https://github.com/open-telemetry/community/blob/main/elections/2023/governance-committee-election.md).
+by 13 October 2023 23:59 UTC — see the detailed requirements under
+[nominations](https://github.com/open-telemetry/community/blob/main/elections/2023/governance-committee-election.md#nominations)
+for the Governance Committee election.
 
 We would like to thank the GC members who have helped grow OpenTelemetry, and
 invite them to run for re-election if they so choose: Ben Sigelman, Bogdan

--- a/content/en/blog/2023/jmx-metric-insight/index.md
+++ b/content/en/blog/2023/jmx-metric-insight/index.md
@@ -149,8 +149,8 @@ viewing the metric `kafka_request_count_total` on Prometheus.
 
 ![A sample Kafka Broker metric shown on Prometheus](prometheus.png)
 
-More installation options for Prometheus can be found
-[here](https://prometheus.io/docs/prometheus/latest/installation/).
+See
+[installation options for Prometheus](https://prometheus.io/docs/prometheus/latest/installation/).
 
 ### View the metrics on a Grafana Dashboard
 

--- a/content/en/blog/2023/jmx-metric-insight/index.md
+++ b/content/en/blog/2023/jmx-metric-insight/index.md
@@ -38,8 +38,8 @@ servers or frameworks, such as:
 - [WildFly](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/javaagent/wildfly.md)
 
 You can also provide your own metric definitions, through one or more YAML
-files. The YAML file syntax documentation is available
-[here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/jmx-metrics/javaagent#configuration-files).
+files. For more information, see the
+[YAML file syntax documentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/jmx-metrics/javaagent#configuration-files).
 
 ## Observe Kafka Broker metrics
 

--- a/content/en/blog/2023/jmx-metric-insight/index.md
+++ b/content/en/blog/2023/jmx-metric-insight/index.md
@@ -111,9 +111,8 @@ that our Kafka installation is working as expected.
 ### Export metrics to Prometheus
 
 The metrics can be exported by any of the supported metric exporters, to a
-backend of your choice. The full list of exporters and their configuration
-options can be found
-[here](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#exporters).
+backend of your choice. See the
+[list of exporters and their configuration options](/docs/languages/java/configuration/#properties-exporters).
 For instance, you can export the metrics to an OTel collector using the OTLP
 exporter, perform some processing and then consume the metrics on a backend of
 your choice. In this example for the sake of simplicity, we are directly

--- a/content/en/blog/2023/jmx-metric-insight/index.md
+++ b/content/en/blog/2023/jmx-metric-insight/index.md
@@ -62,8 +62,8 @@ zookeeper-server-start /usr/local/etc/kafka/zookeeper.properties
 
 Before starting the Kafka broker, attach the OpenTelemetry Java instrumentation
 agent to Kafka Broker by providing options in the KAFKA_OPTS environment
-variable. You can download the latest release of the agent from
-[here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases).
+variable. You can
+[download the latest release of the agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases).
 
 ```shell
 export KAFKA_OPTS="-Dapplication.name=my-kafka-app

--- a/content/en/blog/2024/gc-elections.md
+++ b/content/en/blog/2024/gc-elections.md
@@ -45,9 +45,9 @@ refer to the
 [charter document](https://github.com/open-telemetry/community/blob/master/governance-charter.md).
 You may nominate yourself (or others!) by submitting a Pull Request against the
 [list of candidates](https://github.com/open-telemetry/community/blob/main/elections/2024/governance-committee-candidates.md)
-by 11 October 2024 23:59 UTC — more detailed requirements about the nomination
-and ratification process can be found
-[here](https://github.com/open-telemetry/community/blob/main/elections/2024/governance-committee-election.md).
+by 11 October 2024 23:59 UTC — see the detailed requirements under
+[nominations](https://github.com/open-telemetry/community/blob/main/elections/2024/governance-committee-election.md#nominations)
+for the Governance Committee election.
 
 We would like to thank the GC members who have helped grow OpenTelemetry, and
 invite them to run for re-election if they so choose: Alolita Sharma, Daniel

--- a/content/en/docs/collector/transforming-telemetry.md
+++ b/content/en/docs/collector/transforming-telemetry.md
@@ -156,9 +156,8 @@ processors:
 
 Similarly, the K8s processor enriches telemetry with relevant Kubernetes
 metadata like pod name, node name, or workload name. The collector pod must be
-configured to have read access to certain Kubernetes RBAC APIs, which is
-documented
-[here](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor#hdr-RBAC).
+configured to have
+[read access to certain Kubernetes RBAC APIs](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor#readme-role-based-access-control).
 To use the default options, it can be configured with an empty block:
 
 ```yaml

--- a/content/en/docs/languages/erlang/getting-started.md
+++ b/content/en/docs/languages/erlang/getting-started.md
@@ -32,7 +32,8 @@ it with OpenTelemetry. For reference, a complete example of the code you will
 build can be found here:
 [opentelemetry-erlang-contrib/examples/roll_dice](https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/examples/roll_dice).
 
-Additional examples can be found [here](/docs/languages/erlang/examples/).
+Additional examples can be found in
+[opentelemetry-erlang-contrib examples](https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/examples).
 
 ### Initial Setup
 

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -16271,6 +16271,10 @@
     "StatusCode": 200,
     "LastSeen": "2025-01-06T11:32:21.365098-05:00"
   },
+  "https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor#readme-role-based-access-control": {
+    "StatusCode": 200,
+    "LastSeen": "2025-01-21T12:21:51.779082249Z"
+  },
   "https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sprocessor": {
     "StatusCode": 200,
     "LastSeen": "2025-01-06T11:32:47.414799-05:00"

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -4431,6 +4431,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-13T12:11:02.685168-05:00"
   },
+  "https://github.com/avillela/hashiqube/commits": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-21T12:24:19.718458532Z"
+  },
   "https://github.com/avillela/otel-errors-talk": {
     "StatusCode": 200,
     "LastSeen": "2024-03-27T00:26:43.376792984Z"

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -8679,6 +8679,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-13T11:43:31.702442-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/examples": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-21T14:28:34.626770908Z"
+  },
   "https://github.com/open-telemetry/opentelemetry-erlang-contrib/tree/main/examples/roll_dice": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:37:41.082551-05:00"

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -6367,6 +6367,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:23:15.075273-05:00"
   },
+  "https://github.com/open-telemetry/community/blob/main/elections/2024/governance-committee-election.md#nominations": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-21T14:30:53.283875975Z"
+  },
   "https://github.com/open-telemetry/community/blob/main/elections/2024/governance-committee-election.md#voter-eligibility": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:23:15.495178-05:00"

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -59,6 +59,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-04-25T00:01:01.348993-04:00"
   },
+  "https://adri-v.medium.com/lets-learn-about-the-otel-operator-s-target-allocator-47a2b1f07562": {
+    "StatusCode": 200,
+    "LastSeen": "2025-01-21T12:24:18.472460168Z"
+  },
   "https://adri-v.medium.com/prometheus-opentelemetry-better-together-41dc637f2292": {
     "StatusCode": 200,
     "LastSeen": "2024-04-25T00:01:03.277893-04:00"


### PR DESCRIPTION
The web isn't limited to people who read content with their eyes. Some users use screen readers and other accessibility agents and some people have other reasons for appreciating descriptive links. To that end, [check-spelling/spell-check-this](https://github.com/check-spelling/spell-check-this) includes a rule:

#### [Do not use `(click) here` links](https://github.com/check-spelling/spell-check-this/blob/4a57c3641b1c1603e70804208eb1bc644294bdf6/.github/actions/spelling/line_forbidden.patterns#L57-L63)

For more information, see:
* https://www.w3.org/QA/Tips/noClickHere
* https://webaim.org/techniques/hypertext/link_text
* https://granicus.com/blog/why-click-here-links-are-bad/
* https://heyoka.medium.com/dont-use-click-here-f32f445d1021
```
(?i)(?:>|\[)(?:(?:click |)here|link|(?:read |)more)(?:</|\]\()
```

The changes included here are designed to help users who benefit from descriptive links