### PR TITLE
[chore] Accessible links 5

### DIFF
--- a/content/en/blog/2022/announcing-opentelemetry-demo-release/index.md
+++ b/content/en/blog/2022/announcing-opentelemetry-demo-release/index.md
@@ -45,8 +45,8 @@ Another goal of this demo is to streamline the ability of vendors and commercial
 implementers of OpenTelemetry to have a standardized target for building demos
 around. We’ve already seen quite a bit of adoption, with five companies
 including Datadog, Dynatrace, Honeycomb, Lightstep, and New Relic integrating
-the community demo application into their product demos (you can find a list
-[here](https://github.com/open-telemetry/opentelemetry-demo#demos-featuring-the-astronomy-shop)).
+the community demo application into their
+[product demos](https://github.com/open-telemetry/opentelemetry-demo#demos-featuring-the-astronomy-shop).
 We hope to encourage further contributions and collaboration along these lines.
 
 However, just because we reached 1.0, that doesn’t mean we’re stopping -- this

--- a/content/en/blog/2022/instrument-kafka-clients/index.md
+++ b/content/en/blog/2022/instrument-kafka-clients/index.md
@@ -65,7 +65,7 @@ The simpler and automatic approach is by adding tracing to your application with
 no changes or additions into your application code. You also don't need to add
 any dependencies to OpenTelemetry specific libraries. It is possible by using
 the OpenTelemetry agent you can download from
-[here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases).
+[opentelemetry-java-instrumentation/releases](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases).
 This agent has to run alongside your application in order to inject the logic
 for tracing messages sent and received to/from a Kafka cluster.
 

--- a/content/en/blog/2022/tail-sampling/index.md
+++ b/content/en/blog/2022/tail-sampling/index.md
@@ -222,8 +222,8 @@ separate processors to do tail sampling will be more performant than just the
 tail sampling processor. It's important to note that nothing will be released
 without a backward-compatible solution. For the collector, there are limited
 options to monitor the collector, which is critical for troubleshooting. See
-[here](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/troubleshooting.md#observability)
-for more information.
+[Collector Troubleshooting](/docs/collector/troubleshooting/) for more
+information.
 
 _A version of this article was [originally posted][] on the New Relic blog._
 

--- a/content/en/blog/2023/end-user-discussions-01.md
+++ b/content/en/blog/2023/end-user-discussions-01.md
@@ -88,8 +88,8 @@ different backends, what’s the best way to go about it?
 [Connectors](https://github.com/open-telemetry/opentelemetry-collector/pull/6140)
 (a new Collector component that acts as an exporter/receiver pair to join
 pipelines together) can be used to solve this. Connectors will be launching
-soon. For more info, see the Connector PR
-[here](https://github.com/open-telemetry/opentelemetry-collector/pull/6372).
+soon. For more info, see the
+[Connector PR](https://github.com/open-telemetry/opentelemetry-collector/pull/6372).
 
 Another approach would be to use a
 [routing processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/routingprocessor).

--- a/content/en/blog/2023/end-user-discussions-02.md
+++ b/content/en/blog/2023/end-user-discussions-02.md
@@ -195,9 +195,8 @@ endpoints via the Kubernetes API.
 Azure to collect telemetry from Azure App Services and Azure functions?
 
 **A:** Usually, the community relies on folks from Microsoft to provide best
-practices. There is some issue with the latest version of OTel and Azure
-functions. You can track it
-[here](https://github.com/Azure/azure-functions-host/issues/8938).
+practices. There was an
+[issue with the 1.4 version of OTel and Azure functions 7](https://github.com/Azure/azure-functions-host/issues/8938).
 
 ## Meeting Notes & Recordings
 

--- a/content/en/blog/2023/end-user-discussions-02.md
+++ b/content/en/blog/2023/end-user-discussions-02.md
@@ -134,8 +134,8 @@ out metrics in Prometheus format, you can configure your OTel Collector to
 scrape Prometheus metrics. There is also a
 [statsd receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/statsdreceiver)
 that is available. If you have something that is already working, then you don’t
-need to change it. You can check the list of receivers
-[here](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver).
+need to change it. You can check the
+[list of receivers](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver).
 
 #### 2 - Emitting business metrics
 

--- a/content/en/blog/2023/end-user-q-and-a-02.md
+++ b/content/en/blog/2023/end-user-q-and-a-02.md
@@ -265,8 +265,9 @@ to Jaeger.
 
 ## What's next?
 
-If you’d like to see my conversation with Doug in full, you can check out the
-video [here](https://www.youtube.com/watch?v=ptYWBF-R1Fc).
+If you’d like to see my conversation with Doug in full, there is a
+[private video](https://www.youtube.com/watch?v=ptYWBF-R1Fc) -- you’ll have to
+ask someone for permission to be able to watch it.
 
 If anyone would like to continue the conversation with Doug, please reach out to
 him in the

--- a/content/en/blog/2023/jaeger-exporter-collector-migration.md
+++ b/content/en/blog/2023/jaeger-exporter-collector-migration.md
@@ -50,9 +50,9 @@ Versions of Jaeger until v1.46.0, need the following environment variable set
 ## Build a custom Collector
 
 If switching to the OTLP exporter isn't an option, an alternative is to build a
-custom Collector that includes the Jaeger exporter. The process to build is
-documented [here](/docs/collector/custom-collector/). Your manifest file will
-need to include the following line to add the Jaeger exporter:
+custom Collector that includes the Jaeger exporter. See
+[Building a custom collector](/docs/collector/custom-collector/). Your manifest
+file will need to include the following line to add the Jaeger exporter:
 
 ```yaml
 exporters:

--- a/content/en/docs/concepts/glossary.md
+++ b/content/en/docs/concepts/glossary.md
@@ -127,8 +127,8 @@ severity and trace information. See the [field spec][field].
 
 ### **gRPC**
 
-A high-performance, open source universal [RPC](#rpc) framework. More on gRPC
-[here](https://grpc.io).
+A high-performance, open source universal [RPC](#rpc) framework. See
+[gRPC](https://grpc.io).
 
 ### **HTTP**
 

--- a/content/en/docs/concepts/signals/traces.md
+++ b/content/en/docs/concepts/signals/traces.md
@@ -312,8 +312,7 @@ trace. Now, they are causally associated with one another.
 Links are optional but serve as a good way to associate trace spans with one
 another.
 
-For more information regarding Span Links, see
-[Link](/docs/specs/otel/trace/api/#link).
+For more information see [Span Links](/docs/specs/otel/trace/api/#link).
 
 ### Span Status
 

--- a/content/en/docs/demo/_index.md
+++ b/content/en/docs/demo/_index.md
@@ -67,8 +67,7 @@ We'll be adding more scenarios over time.
 
 - Generate a [Product Catalog error](feature-flags) for `GetProduct` requests
   with product ID: `OLJCESPC7Z` using the Feature Flag service
-- Discover a memory leak and diagnose it using metrics and traces.
-  [Read more](scenarios/recommendation-cache/)
+- [Using Metrics and Traces to diagnose a memory leak](scenarios/recommendation-cache/)
 
 ## Reference
 


### PR DESCRIPTION
The web isn't limited to people who read content with their eyes. Some users use screen readers and other accessibility agents and some people have other reasons for appreciating descriptive links. To that end, [check-spelling/spell-check-this](https://github.com/check-spelling/spell-check-this) includes a rule:

#### [Do not use `(click) here` links](https://github.com/check-spelling/spell-check-this/blob/4a57c3641b1c1603e70804208eb1bc644294bdf6/.github/actions/spelling/line_forbidden.patterns#L57-L63)

For more information, see:
* https://www.w3.org/QA/Tips/noClickHere
* https://webaim.org/techniques/hypertext/link_text
* https://granicus.com/blog/why-click-here-links-are-bad/
* https://heyoka.medium.com/dont-use-click-here-f32f445d1021
```
(?i)(?:>|\[)(?:(?:click |)here|link|(?:read |)more)(?:</|\]\()
```

The changes included here are designed to help users who benefit from descriptive links