### PR TITLE
[CI] Get markdownlint func from proper module, update Hugo etc

### DIFF
--- a/gulp-src/lint-md.js
+++ b/gulp-src/lint-md.js
@@ -2,7 +2,7 @@ const tcb_rule_name = 'trim-code-block-and-unindent';
 const trimCodeBlockRule = require('./_md-rules/' + tcb_rule_name);
 const gulp = require('gulp');
 const through2 = require('through2');
-const markdownlint = require('markdownlint');
+const markdownlint = require('markdownlint/async').lint;
 const { taskArgs, trimBlankLinesFromArray } = require('./_util');
 const fs = require('fs');
 

--- a/package.json
+++ b/package.json
@@ -121,10 +121,10 @@
     "autoprefixer": "^10.4.20",
     "cspell": "^8.17.2",
     "gulp": "^5.0.0",
-    "hugo-extended": "0.141.0",
+    "hugo-extended": "0.142.0",
     "js-yaml": "^4.1.0",
     "markdown-link-check": "^3.13.6",
-    "markdownlint": "^0.36.1",
+    "markdownlint": "^0.37.4",
     "postcss-cli": "^11.0.0",
     "prettier": "3.4.2",
     "require-dir": "^1.2.0",
@@ -149,7 +149,7 @@
     "path": "^0.12.7"
   },
   "optionalDependencies": {
-    "netlify-cli": "^18.0.1",
+    "netlify-cli": "^18.0.2",
     "npm-check-updates": "^17.1.14"
   },
   "enginesComment": "Ensure that engines.node value stays consistent with the project's .nvmrc",


### PR DESCRIPTION
- Fixes #5767. The fix was rather simple, as you can see.

---

Diff in generated site files:

```console
$ (cd public && git diff -bw --ignore-blank-lines -I 'background-image|hero-as-background' -I 'Hugo 0.14' -- . ':(exclude)*.xml') | grep ^diff
diff --git a/blog/2024/otel-operator-q-and-a/index.html b/blog/2024/otel-operator-q-and-a/index.html
diff --git a/fr/docs/zero-code/python/logs-example/index.html b/fr/docs/zero-code/python/logs-example/index.html
diff --git a/homepage-hero-as-background_hu13043826424429285166.jpg b/homepage-hero-as-background_hu13043826424429285166.jpg
diff --git a/homepage-hero-as-background_hu89650641306215219.jpg b/homepage-hero-as-background_hu89650641306215219.jpg
diff --git a/site/index.html b/site/index.html
```

Details (the first is the fix for https://github.com/gohugoio/hugo/issues/13286):

```diff
diff --git a/blog/2024/otel-operator-q-and-a/index.html b/blog/2024/otel-operator-q-and-a/index.html
index 81574d959c..1da4ebb5b5 100644
--- a/blog/2024/otel-operator-q-and-a/index.html
+++ b/blog/2024/otel-operator-q-and-a/index.html
@@ -886,7 +886,7 @@ Manages deployment of the OpenTelemetry Collector, supported by the OpenTelemetr
   <header class="article-meta">
                
 </header>
-  <img src="/blog/2024/otel-operator-q-and-a/mount-rainier.jpg" alt="Seattles Mount Rainier rising about the clouds, as seen from an airplane. Photo by Adriana Villela"><p>The
+  <img src="/blog/2024/otel-operator-q-and-a/mount-rainier.jpg" alt="Seattle’s Mount Rainier rising about the clouds, as seen from an airplane. Photo by Adriana Villela"><p>The
 <a href="https://github.com/open-telemetry/opentelemetry-operator" target="_blank" rel="noopener" class="external-link">OpenTelemetry (OTel) Operator</a>
 is a
 <a href="https://kubernetes.io/docs/concepts/extend-kubernetes/operator/" target="_blank" rel="noopener" class="external-link">Kubernetes Operator</a>
diff --git a/fr/docs/zero-code/python/logs-example/index.html b/fr/docs/zero-code/python/logs-example/index.html
index 128028c4de..e04f3befa7 100644
--- a/fr/docs/zero-code/python/logs-example/index.html
+++ b/fr/docs/zero-code/python/logs-example/index.html
@@ -1550,7 +1550,7 @@ instrumented logs.</p>
 </span></span><span class="line"><span class="cl">
 </span></span><span class="line"><span class="cl"><span class="nb">export</span> <span class="nv">OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED</span><span class="o">=</span><span class="nb">true</span>
 </span></span><span class="line"><span class="cl">opentelemetry-instrument <span class="se">\
-</span></span></span><span class="line"><span class="cl"><span class="se"></span>  --traces_exporter console,otlp <span class="se">\
+</span></span></span><span class="line"><span class="cl"><span class="se"></span><span class="err"> </span> --traces_exporter console,otlp <span class="se">\
 </span></span></span><span class="line"><span class="cl"><span class="se"></span>  --metrics_exporter console,otlp <span class="se">\
 </span></span></span><span class="line"><span class="cl"><span class="se"></span>  --logs_exporter console,otlp <span class="se">\
 </span></span></span><span class="line"><span class="cl"><span class="se"></span>  --service_name python-logs-example <span class="se">\
diff --git a/homepage-hero-as-background_hu13043826424429285166.jpg b/homepage-hero-as-background_hu13043826424429285166.jpg
deleted file mode 100644
index f934adb1d4..0000000000
Binary files a/homepage-hero-as-background_hu13043826424429285166.jpg and /dev/null differ
diff --git a/homepage-hero-as-background_hu89650641306215219.jpg b/homepage-hero-as-background_hu89650641306215219.jpg
deleted file mode 100644
index c4058f7102..0000000000
Binary files a/homepage-hero-as-background_hu89650641306215219.jpg and /dev/null differ
diff --git a/site/index.html b/site/index.html
index a3008f029e..eec11f72f8 100644
--- a/site/index.html
+++ b/site/index.html
@@ -229,7 +229,7 @@ Attribute Value Netlify built false Deploy context local">
 <script>
 document.addEventListener("DOMContentLoaded", function() {
   var options = { hour: '2-digit', hour12: false, minute: '2-digit', timeZoneName: 'short' };
-  var buildDate = new Date("2025-01-23T17:17:08-05:00");
+  var buildDate = new Date("2025-01-23T18:54:11-05:00");
   document.getElementById("local-time").innerText = buildDate.toLocaleString(undefined, options);
 });
 </script>
```