### PR TITLE
Add blog post about the mainframe priorities survey

### DIFF
--- a/content/en/blog/2025/otel-mainframe-priorities-survey.md
+++ b/content/en/blog/2025/otel-mainframe-priorities-survey.md
@@ -62,3 +62,10 @@ learn more about the work of the OpenTelemetry on Mainframe SIG, join the
 conversation at
 [#otel-mainframes](https://cloud-native.slack.com/archives/C05PXDFTCPJ) on
 [CNCF Slack](https://slack.cncf.io/).
+
+_A version of this article was [originally posted] on the Open Mainframe Project blog.
+
+[originally posted]: {{% param canonical_url %}}
+
+[survey]: https://www.surveymonkey.com/r/HGTD2KJ
+

--- a/content/en/blog/2025/otel-mainframe-priorities-survey.md
+++ b/content/en/blog/2025/otel-mainframe-priorities-survey.md
@@ -19,8 +19,7 @@ in hybrid cloud applications. **The SIG launched a new
 [survey](https://www.surveymonkey.com/r/HGTD2KJ) that calls for your
 participation.**
 
-Background
-----------
+## Background
 
 While there are many definitions of observability, we will refer here to the
 ability to receive actionable insight about the behavior of hybrid applications

--- a/content/en/blog/2025/otel-mainframe-priorities-survey.md
+++ b/content/en/blog/2025/otel-mainframe-priorities-survey.md
@@ -1,16 +1,17 @@
 --
 title: OpenTelemetry on Mainframe Priorities Survey
 linkTitle: Mainframe Priorities Survey # Mandatory, make sure that your short title.
-date: 2025-01-23 
-author: >- 
+date: 2025-01-23
+author: >-
 [Ruediger Schulze](https://github.com/rrschulze) (IBM)
-canonical_url: https://openmainframeproject.org/blog/opentelemetry-on-mainframe-priorities-survey/?utm_content=322043016&utm_medium=social&utm_source=linkedin&hss_channel=lcp-35545633
+canonical_url: <https://openmainframeproject.org/blog/opentelemetry-on-mainframe-priorities-survey/?utm_content=322043016&utm_medium=social&utm_source=linkedin&hss_channel=lcp-35545633>
 issue: [#6045](https://github.com/open-telemetry/opentelemetry.io/issues/6045)
-sig: SIG OpenTelemetry on Mainframe 
+sig: SIG OpenTelemetry on Mainframe
 cSpell:ignore: Ruediger Schulze
 ---
 
-## OpenTelemetry on Mainframe Priorities Survey
+OpenTelemetry on Mainframe Priorities Survey
+============================================
 
 The [OpenTelemetry](https://opentelemetry.io/) project and
 [The Open Mainframe Project](https://openmainframeproject.org/) established the
@@ -21,7 +22,8 @@ in hybrid cloud applications. **The SIG launched a new
 [survey](https://www.surveymonkey.com/r/HGTD2KJ) that calls for your
 participation.**
 
-### Background
+Background
+----------
 
 While there are many definitions of observability, we will refer here to the
 ability to receive actionable insight about the behavior of hybrid applications
@@ -51,7 +53,8 @@ Semantic Conventions for specific aspects of the platform. Once the survey is
 complete, we will publish the results and a prioritized list of activities on
 the websites of the OpenTelemetry project and The Open Mainframe Project.
 
-### Taking the survey
+Taking the survey
+-----------------
 
 The [survey](https://www.surveymonkey.com/r/HGTD2KJ) is structured in two
 sections. The first section gathers input about your role and background. The

--- a/content/en/blog/2025/otel-mainframe-priorities-survey.md
+++ b/content/en/blog/2025/otel-mainframe-priorities-survey.md
@@ -27,11 +27,11 @@ spanning multiple landing zones such as public and private cloud and
 mainframe environments.
 
 OpenTelemetry is a well-adopted open source framework for observability that
-aims to make high quality telemetry data such as traces, metrics and logs
+aims to make high quality telemetry data such as traces, metrics, and logs
 available from any source to any target. OpenTelemetry remains the second most
 active project under the Cloud Native Computing Foundation (CNCF). The community
 of the OpenTelemetry project has made major efforts to provide specifications
-and implementations that unify the collection, processing and distribution of
+and implementations that unify the collection, processing, and distribution of
 telemetry.
 
 Given the breadth of the OpenTelemetry project and sophisticated capabilities of

--- a/content/en/blog/2025/otel-mainframe-priorities-survey.md
+++ b/content/en/blog/2025/otel-mainframe-priorities-survey.md
@@ -9,8 +9,6 @@ sig: SIG OpenTelemetry on Mainframe
 cSpell:ignore: Ruediger Schulze
 ---
 
-OpenTelemetry on Mainframe Priorities Survey
-============================================
 
 The [OpenTelemetry](https://opentelemetry.io/) project and
 [The Open Mainframe Project](https://openmainframeproject.org/) established the

--- a/content/en/blog/2025/otel-mainframe-priorities-survey.md
+++ b/content/en/blog/2025/otel-mainframe-priorities-survey.md
@@ -1,0 +1,63 @@
+--
+title: OpenTelemetry on Mainframe Priorities Survey
+linkTitle: Mainframe Priorities Survey # Mandatory, make sure that your short title.
+date: 2025-01-23 
+author: >- 
+[Ruediger Schulze](https://github.com/rrschulze) (IBM)
+canonical_url: https://openmainframeproject.org/blog/opentelemetry-on-mainframe-priorities-survey/?utm_content=322043016&utm_medium=social&utm_source=linkedin&hss_channel=lcp-35545633
+issue: [#6045](https://github.com/open-telemetry/opentelemetry.io/issues/6045)
+sig: SIG OpenTelemetry on Mainframe 
+---
+
+## OpenTelemetry on Mainframe Priorities Survey
+
+The [OpenTelemetry](https://opentelemetry.io/) project and
+[The Open Mainframe Project](https://openmainframeproject.org/) established the
+[SIG “OpenTelemetry on Mainframe”](https://github.com/open-telemetry/sig-mainframe)
+at the beginning of 2024. Our focus is to enable OpenTelemetry on the Mainframe
+for an improved end-to-end observability and to support mainframe participation
+in hybrid cloud applications. **The SIG launched a new
+[survey](https://www.surveymonkey.com/r/HGTD2KJ) that calls for your
+participation.**
+
+### Background
+
+While there are many definitions of observability, we will refer here to the
+ability to receive actionable insight about the behavior of hybrid applications
+spanning across multiple landing zones such as public and private cloud and
+mainframe environments.
+
+OpenTelemetry is a well-adopted open-source framework for observability that
+aims to make high quality telemetry data such as traces, metrics and logs
+available from any source to any target. OpenTelemetry remains the second most
+active project under the Cloud Native Computing Foundation (CNCF). The community
+of the OpenTelemetry project has made major efforts to provide specifications
+and implementations that unify the collection, processing and distribution of
+telemetry.
+
+Given the breadth of the OpenTelemetry project and sophisticated capabilities of
+the mainframe, we as contributors to the SIG want to better understand the
+priorities for making the best use of OpenTelemetry on the mainframes. We seek
+feedback from a broad range of mainframe users and users of observability
+solutions, developers, site reliability engineers, application owners,
+architects, DevOps engineers and all other experts in the field.
+
+The results of the [survey](https://www.surveymonkey.com/r/HGTD2KJ) will help us
+prioritize and implement targeted activities to accelerate the adoption of
+OpenTelemetry on the mainframe platform. Such activities could be the expedited
+porting of selected SDKs for code instrumentation to z/OS or the definition of
+Semantic Conventions for specific aspects of the platform. Once the survey is
+complete, we will publish the results and a prioritized list of activities on
+the websites of the OpenTelemetry project and The Open Mainframe Project.
+
+### Taking the survey
+
+The [survey](https://www.surveymonkey.com/r/HGTD2KJ) is structured in two
+sections. The first section gathers input about your role and background. The
+second section gathers the priorities of your organization for enabling
+OpenTelemetry on mainframes. Responding to the 20 questions will take
+approximately 15 minutes. We appreciate your time spent on the survey and look
+forward to receiving your feedback! **Take the survey
+[here](https://www.surveymonkey.com/r/HGTD2KJ)!** Learn more about the work of
+the OpenTelemetry on Mainframe SIG by joining the conversation on Slack
+[here](https://cloud-native.slack.com/archives/C05PXDFTCPJ).

--- a/content/en/blog/2025/otel-mainframe-priorities-survey.md
+++ b/content/en/blog/2025/otel-mainframe-priorities-survey.md
@@ -49,7 +49,7 @@ the websites of the OpenTelemetry project and The Open Mainframe Project.
 
 ## Taking the survey
 
-The [survey](https://www.surveymonkey.com/r/HGTD2KJ) is structured in two
+The [survey] is structured in two
 sections. The first section gathers input about your role and background. The
 second section gathers the priorities of your organization for enabling
 OpenTelemetry on mainframes. Responding to the 20 questions will take

--- a/content/en/blog/2025/otel-mainframe-priorities-survey.md
+++ b/content/en/blog/2025/otel-mainframe-priorities-survey.md
@@ -1,4 +1,4 @@
---
+---
 title: OpenTelemetry on Mainframe Priorities Survey
 linkTitle: Mainframe Priorities Survey 
 date: 2025-01-24

--- a/content/en/blog/2025/otel-mainframe-priorities-survey.md
+++ b/content/en/blog/2025/otel-mainframe-priorities-survey.md
@@ -39,7 +39,7 @@ the mainframe, we as contributors to the SIG want to better understand the
 priorities for making the best use of OpenTelemetry on the mainframes. We seek
 feedback from a broad range of mainframe users and users of observability
 solutions, developers, site reliability engineers, application owners,
-architects, DevOps engineers and all other experts in the field.
+architects, DevOps engineers, and all other experts in the field.
 
 The results of the [survey](https://www.surveymonkey.com/r/HGTD2KJ) will help us
 prioritize and implement targeted activities to accelerate the adoption of

--- a/content/en/blog/2025/otel-mainframe-priorities-survey.md
+++ b/content/en/blog/2025/otel-mainframe-priorities-survey.md
@@ -9,7 +9,7 @@ sig: SIG OpenTelemetry on Mainframe
 cSpell:ignore: Ruediger Schulze
 ---
 
-The [OpenTelemetry](https://opentelemetry.io/) project and
+The [OpenTelemetry](/) project and
 [The Open Mainframe Project](https://openmainframeproject.org/) established the
 [SIG “OpenTelemetry on Mainframe”](https://github.com/open-telemetry/sig-mainframe)
 at the beginning of 2024. Our focus is to enable OpenTelemetry on the mainframe

--- a/content/en/blog/2025/otel-mainframe-priorities-survey.md
+++ b/content/en/blog/2025/otel-mainframe-priorities-survey.md
@@ -56,7 +56,7 @@ OpenTelemetry on mainframes. Responding to the 20 questions will take
 approximately 15 minutes. We appreciate your time spent on the survey and look
 forward to receiving your feedback!
 
-We invite you to take the [survey](https://www.surveymonkey.com/r/HGTD2KJ)! To
+We invite you to take the [survey]. To
 learn more about the work of the OpenTelemetry on Mainframe SIG, join the
 conversation at
 [#otel-mainframes](https://cloud-native.slack.com/archives/C05PXDFTCPJ) on

--- a/content/en/blog/2025/otel-mainframe-priorities-survey.md
+++ b/content/en/blog/2025/otel-mainframe-priorities-survey.md
@@ -56,7 +56,6 @@ sections. The first section gathers input about your role and background. The
 second section gathers the priorities of your organization for enabling
 OpenTelemetry on mainframes. Responding to the 20 questions will take
 approximately 15 minutes. We appreciate your time spent on the survey and look
-forward to receiving your feedback! **Take the survey
-[here](https://www.surveymonkey.com/r/HGTD2KJ)!** Learn more about the work of
-the OpenTelemetry on Mainframe SIG by joining the conversation on Slack
-[here](https://cloud-native.slack.com/archives/C05PXDFTCPJ).
+forward to receiving your feedback! 
+
+We invite you to take the [survey](https://www.surveymonkey.com/r/HGTD2KJ)! To learn more about the work of the OpenTelemetry on Mainframe SIG, join the conversation at [#otel-mainframes](https://cloud-native.slack.com/archives/C05PXDFTCPJ) on [CNCF Slack](https://slack.cncf.io/).

--- a/content/en/blog/2025/otel-mainframe-priorities-survey.md
+++ b/content/en/blog/2025/otel-mainframe-priorities-survey.md
@@ -1,11 +1,10 @@
 --
 title: OpenTelemetry on Mainframe Priorities Survey
-linkTitle: Mainframe Priorities Survey # Mandatory, make sure that your short title.
-date: 2025-01-23
-author: >-
-[Ruediger Schulze](https://github.com/rrschulze) (IBM)
-canonical_url: <https://openmainframeproject.org/blog/opentelemetry-on-mainframe-priorities-survey/?utm_content=322043016&utm_medium=social&utm_source=linkedin&hss_channel=lcp-35545633>
-issue: [#6045](https://github.com/open-telemetry/opentelemetry.io/issues/6045)
+linkTitle: Mainframe Priorities Survey 
+date: 2025-01-24
+author: '[Ruediger Schulze](https://github.com/rrschulze) (IBM)'
+canonical_url: https://openmainframeproject.org/blog/opentelemetry-on-mainframe-priorities-survey/
+issue: https://github.com/open-telemetry/opentelemetry.io/issues/6045
 sig: SIG OpenTelemetry on Mainframe
 cSpell:ignore: Ruediger Schulze
 ---

--- a/content/en/blog/2025/otel-mainframe-priorities-survey.md
+++ b/content/en/blog/2025/otel-mainframe-priorities-survey.md
@@ -24,7 +24,7 @@ Background
 
 While there are many definitions of observability, we will refer here to the
 ability to receive actionable insight about the behavior of hybrid applications
-spanning across multiple landing zones such as public and private cloud and
+spanning multiple landing zones such as public and private cloud and
 mainframe environments.
 
 OpenTelemetry is a well-adopted open source framework for observability that

--- a/content/en/blog/2025/otel-mainframe-priorities-survey.md
+++ b/content/en/blog/2025/otel-mainframe-priorities-survey.md
@@ -14,8 +14,8 @@ The [OpenTelemetry](/) project and
 [SIG “OpenTelemetry on Mainframe”](https://github.com/open-telemetry/sig-mainframe)
 at the beginning of 2024. Our focus is to enable OpenTelemetry on the mainframe
 for improved end-to-end observability and to support mainframe participation in
-hybrid cloud applications. **The SIG launched a new
-[survey] that calls for your participation.**
+hybrid cloud applications. **The SIG launched a new [survey] that calls for your
+participation.**
 
 ## Background
 
@@ -39,32 +39,30 @@ feedback from a broad range of mainframe users and users of observability
 solutions, developers, site reliability engineers, application owners,
 architects, DevOps engineers, and all other experts in the field.
 
-The results of the [survey] will help us
-prioritize and implement targeted activities to accelerate the adoption of
-OpenTelemetry on the mainframe platform. Such activities could be the expedited
-porting of selected SDKs for code instrumentation to z/OS or the definition of
-Semantic Conventions for specific aspects of the platform. Once the survey is
-complete, we will publish the results and a prioritized list of activities on
-the websites of the OpenTelemetry project and The Open Mainframe Project.
+The results of the [survey] will help us prioritize and implement targeted
+activities to accelerate the adoption of OpenTelemetry on the mainframe
+platform. Such activities could be the expedited porting of selected SDKs for
+code instrumentation to z/OS or the definition of Semantic Conventions for
+specific aspects of the platform. Once the survey is complete, we will publish
+the results and a prioritized list of activities on the websites of the
+OpenTelemetry project and The Open Mainframe Project.
 
 ## Taking the survey
 
-The [survey] is structured in two
-sections. The first section gathers input about your role and background. The
-second section gathers the priorities of your organization for enabling
-OpenTelemetry on mainframes. Responding to the 20 questions will take
-approximately 15 minutes. We appreciate your time spent on the survey and look
-forward to receiving your feedback!
+The [survey] is structured in two sections. The first section gathers input
+about your role and background. The second section gathers the priorities of
+your organization for enabling OpenTelemetry on mainframes. Responding to the 20
+questions will take approximately 15 minutes. We appreciate your time spent on
+the survey and look forward to receiving your feedback!
 
-We invite you to take the [survey]. To
-learn more about the work of the OpenTelemetry on Mainframe SIG, join the
-conversation at
+We invite you to take the [survey]. To learn more about the work of the
+OpenTelemetry on Mainframe SIG, join the conversation at
 [#otel-mainframes](https://cloud-native.slack.com/archives/C05PXDFTCPJ) on
 [CNCF Slack](https://slack.cncf.io/).
 
-_A version of this article was [originally posted] on the Open Mainframe Project blog.
+\_A version of this article was [originally posted] on the Open Mainframe
+Project blog.
 
 [originally posted]: {{% param canonical_url %}}
 
 [survey]: https://www.surveymonkey.com/r/HGTD2KJ
-

--- a/content/en/blog/2025/otel-mainframe-priorities-survey.md
+++ b/content/en/blog/2025/otel-mainframe-priorities-survey.md
@@ -39,7 +39,7 @@ feedback from a broad range of mainframe users and users of observability
 solutions, developers, site reliability engineers, application owners,
 architects, DevOps engineers, and all other experts in the field.
 
-The results of the [survey](https://www.surveymonkey.com/r/HGTD2KJ) will help us
+The results of the [survey] will help us
 prioritize and implement targeted activities to accelerate the adoption of
 OpenTelemetry on the mainframe platform. Such activities could be the expedited
 porting of selected SDKs for code instrumentation to z/OS or the definition of

--- a/content/en/blog/2025/otel-mainframe-priorities-survey.md
+++ b/content/en/blog/2025/otel-mainframe-priorities-survey.md
@@ -7,6 +7,7 @@ author: >-
 canonical_url: https://openmainframeproject.org/blog/opentelemetry-on-mainframe-priorities-survey/?utm_content=322043016&utm_medium=social&utm_source=linkedin&hss_channel=lcp-35545633
 issue: [#6045](https://github.com/open-telemetry/opentelemetry.io/issues/6045)
 sig: SIG OpenTelemetry on Mainframe 
+cSpell:ignore: Ruediger Schulze
 ---
 
 ## OpenTelemetry on Mainframe Priorities Survey
@@ -27,7 +28,7 @@ ability to receive actionable insight about the behavior of hybrid applications
 spanning across multiple landing zones such as public and private cloud and
 mainframe environments.
 
-OpenTelemetry is a well-adopted open-source framework for observability that
+OpenTelemetry is a well-adopted open source framework for observability that
 aims to make high quality telemetry data such as traces, metrics and logs
 available from any source to any target. OpenTelemetry remains the second most
 active project under the Cloud Native Computing Foundation (CNCF). The community

--- a/content/en/blog/2025/otel-mainframe-priorities-survey.md
+++ b/content/en/blog/2025/otel-mainframe-priorities-survey.md
@@ -1,7 +1,7 @@
 ---
 title: OpenTelemetry on Mainframe Priorities Survey
 linkTitle: Mainframe Priorities Survey
-date: 2025-01-24
+date: 2025-01-30
 author: '[Ruediger Schulze](https://github.com/rrschulze) (IBM)'
 canonical_url: https://openmainframeproject.org/blog/opentelemetry-on-mainframe-priorities-survey/
 issue: https://github.com/open-telemetry/opentelemetry.io/issues/6045

--- a/content/en/blog/2025/otel-mainframe-priorities-survey.md
+++ b/content/en/blog/2025/otel-mainframe-priorities-survey.md
@@ -13,8 +13,8 @@ cSpell:ignore: Ruediger Schulze
 The [OpenTelemetry](https://opentelemetry.io/) project and
 [The Open Mainframe Project](https://openmainframeproject.org/) established the
 [SIG “OpenTelemetry on Mainframe”](https://github.com/open-telemetry/sig-mainframe)
-at the beginning of 2024. Our focus is to enable OpenTelemetry on the Mainframe
-for an improved end-to-end observability and to support mainframe participation
+at the beginning of 2024. Our focus is to enable OpenTelemetry on the mainframe
+for improved end-to-end observability and to support mainframe participation
 in hybrid cloud applications. **The SIG launched a new
 [survey](https://www.surveymonkey.com/r/HGTD2KJ) that calls for your
 participation.**

--- a/content/en/blog/2025/otel-mainframe-priorities-survey.md
+++ b/content/en/blog/2025/otel-mainframe-priorities-survey.md
@@ -15,8 +15,7 @@ The [OpenTelemetry](/) project and
 at the beginning of 2024. Our focus is to enable OpenTelemetry on the mainframe
 for improved end-to-end observability and to support mainframe participation in
 hybrid cloud applications. **The SIG launched a new
-[survey](https://www.surveymonkey.com/r/HGTD2KJ) that calls for your
-participation.**
+[survey] that calls for your participation.**
 
 ## Background
 

--- a/content/en/blog/2025/otel-mainframe-priorities-survey.md
+++ b/content/en/blog/2025/otel-mainframe-priorities-survey.md
@@ -49,8 +49,7 @@ Semantic Conventions for specific aspects of the platform. Once the survey is
 complete, we will publish the results and a prioritized list of activities on
 the websites of the OpenTelemetry project and The Open Mainframe Project.
 
-Taking the survey
------------------
+## Taking the survey
 
 The [survey](https://www.surveymonkey.com/r/HGTD2KJ) is structured in two
 sections. The first section gathers input about your role and background. The

--- a/content/en/blog/2025/otel-mainframe-priorities-survey.md
+++ b/content/en/blog/2025/otel-mainframe-priorities-survey.md
@@ -1,6 +1,6 @@
 ---
 title: OpenTelemetry on Mainframe Priorities Survey
-linkTitle: Mainframe Priorities Survey 
+linkTitle: Mainframe Priorities Survey
 date: 2025-01-24
 author: '[Ruediger Schulze](https://github.com/rrschulze) (IBM)'
 canonical_url: https://openmainframeproject.org/blog/opentelemetry-on-mainframe-priorities-survey/
@@ -9,13 +9,12 @@ sig: SIG OpenTelemetry on Mainframe
 cSpell:ignore: Ruediger Schulze
 ---
 
-
 The [OpenTelemetry](https://opentelemetry.io/) project and
 [The Open Mainframe Project](https://openmainframeproject.org/) established the
 [SIG “OpenTelemetry on Mainframe”](https://github.com/open-telemetry/sig-mainframe)
 at the beginning of 2024. Our focus is to enable OpenTelemetry on the mainframe
-for improved end-to-end observability and to support mainframe participation
-in hybrid cloud applications. **The SIG launched a new
+for improved end-to-end observability and to support mainframe participation in
+hybrid cloud applications. **The SIG launched a new
 [survey](https://www.surveymonkey.com/r/HGTD2KJ) that calls for your
 participation.**
 
@@ -23,8 +22,8 @@ participation.**
 
 While there are many definitions of observability, we will refer here to the
 ability to receive actionable insight about the behavior of hybrid applications
-spanning multiple landing zones such as public and private cloud and
-mainframe environments.
+spanning multiple landing zones such as public and private cloud and mainframe
+environments.
 
 OpenTelemetry is a well-adopted open source framework for observability that
 aims to make high quality telemetry data such as traces, metrics, and logs
@@ -58,4 +57,8 @@ OpenTelemetry on mainframes. Responding to the 20 questions will take
 approximately 15 minutes. We appreciate your time spent on the survey and look
 forward to receiving your feedback!
 
-We invite you to take the [survey](https://www.surveymonkey.com/r/HGTD2KJ)! To learn more about the work of the OpenTelemetry on Mainframe SIG, join the conversation at [#otel-mainframes](https://cloud-native.slack.com/archives/C05PXDFTCPJ) on [CNCF Slack](https://slack.cncf.io/).
+We invite you to take the [survey](https://www.surveymonkey.com/r/HGTD2KJ)! To
+learn more about the work of the OpenTelemetry on Mainframe SIG, join the
+conversation at
+[#otel-mainframes](https://cloud-native.slack.com/archives/C05PXDFTCPJ) on
+[CNCF Slack](https://slack.cncf.io/).

--- a/content/en/blog/2025/otel-mainframe-priorities-survey.md
+++ b/content/en/blog/2025/otel-mainframe-priorities-survey.md
@@ -1,7 +1,7 @@
 ---
 title: OpenTelemetry on Mainframe Priorities Survey
 linkTitle: Mainframe Priorities Survey
-date: 2025-01-30
+date: 2025-01-31
 author: '[Ruediger Schulze](https://github.com/rrschulze) (IBM)'
 canonical_url: https://openmainframeproject.org/blog/opentelemetry-on-mainframe-priorities-survey/
 issue: https://github.com/open-telemetry/opentelemetry.io/issues/6045

--- a/content/en/blog/2025/otel-mainframe-priorities-survey.md
+++ b/content/en/blog/2025/otel-mainframe-priorities-survey.md
@@ -60,8 +60,8 @@ OpenTelemetry on Mainframe SIG, join the conversation at
 [#otel-mainframes](https://cloud-native.slack.com/archives/C05PXDFTCPJ) on
 [CNCF Slack](https://slack.cncf.io/).
 
-\_A version of this article was [originally posted] on the Open Mainframe
-Project blog.
+_A version of this article was [originally posted] on the Open Mainframe
+Project blog._
 
 [originally posted]: {{% param canonical_url %}}
 

--- a/content/en/blog/2025/otel-mainframe-priorities-survey.md
+++ b/content/en/blog/2025/otel-mainframe-priorities-survey.md
@@ -56,6 +56,6 @@ sections. The first section gathers input about your role and background. The
 second section gathers the priorities of your organization for enabling
 OpenTelemetry on mainframes. Responding to the 20 questions will take
 approximately 15 minutes. We appreciate your time spent on the survey and look
-forward to receiving your feedback! 
+forward to receiving your feedback!
 
 We invite you to take the [survey](https://www.surveymonkey.com/r/HGTD2KJ)! To learn more about the work of the OpenTelemetry on Mainframe SIG, join the conversation at [#otel-mainframes](https://cloud-native.slack.com/archives/C05PXDFTCPJ) on [CNCF Slack](https://slack.cncf.io/).

--- a/content/en/blog/2025/otel-mainframe-priorities-survey.md
+++ b/content/en/blog/2025/otel-mainframe-priorities-survey.md
@@ -60,8 +60,8 @@ OpenTelemetry on Mainframe SIG, join the conversation at
 [#otel-mainframes](https://cloud-native.slack.com/archives/C05PXDFTCPJ) on
 [CNCF Slack](https://slack.cncf.io/).
 
-_A version of this article was [originally posted] on the Open Mainframe
-Project blog._
+_A version of this article was [originally posted] on the Open Mainframe Project
+blog._
 
 [originally posted]: {{% param canonical_url %}}
 

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -1835,6 +1835,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-09T10:45:38.976435-04:00"
   },
+  "https://cloud-native.slack.com/archives/C05PXDFTCPJ": {
+    "StatusCode": 200,
+    "LastSeen": "2025-01-29T09:52:40.815112084Z"
+  },
   "https://cloud-native.slack.com/archives/C076RUAGP37": {
     "StatusCode": 200,
     "LastSeen": "2024-08-20T08:40:41.563366481Z"
@@ -13247,6 +13251,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-17T17:02:00.591524-05:00"
   },
+  "https://github.com/open-telemetry/sig-mainframe": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-29T09:52:33.855728393Z"
+  },
   "https://github.com/open-telemetry/sig-security": {
     "StatusCode": 200,
     "LastSeen": "2024-01-30T16:14:36.015951-05:00"
@@ -16035,6 +16043,14 @@
     "StatusCode": 200,
     "LastSeen": "2024-12-05T10:36:14.926178+01:00"
   },
+  "https://openmainframeproject.org/": {
+    "StatusCode": 200,
+    "LastSeen": "2025-01-29T09:52:30.138817065Z"
+  },
+  "https://openmainframeproject.org/blog/opentelemetry-on-mainframe-priorities-survey/": {
+    "StatusCode": 200,
+    "LastSeen": "2025-01-29T09:52:21.483732385Z"
+  },
   "https://openobserve.ai/docs/ingestion/logs/otlp/": {
     "StatusCode": 206,
     "LastSeen": "2024-08-09T10:45:10.679425-04:00"
@@ -16118,6 +16134,10 @@
   "https://opentelemetry.devstats.cncf.io/d/8/dashboards": {
     "StatusCode": 200,
     "LastSeen": "2025-01-06T11:32:22.440332-05:00"
+  },
+  "https://opentelemetry.io/": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-29T09:52:27.040323325Z"
   },
   "https://opentracing.io": {
     "StatusCode": 206,
@@ -20130,6 +20150,10 @@
   "https://www.sqlite.org/rescode.html": {
     "StatusCode": 200,
     "LastSeen": "2024-10-09T10:19:40.728167+02:00"
+  },
+  "https://www.surveymonkey.com/r/HGTD2KJ": {
+    "StatusCode": 200,
+    "LastSeen": "2025-01-29T09:52:38.143149632Z"
   },
   "https://www.swift.org/": {
     "StatusCode": 206,

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -16135,10 +16135,6 @@
     "StatusCode": 200,
     "LastSeen": "2025-01-06T11:32:22.440332-05:00"
   },
-  "https://opentelemetry.io/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-29T09:52:27.040323325Z"
-  },
   "https://opentracing.io": {
     "StatusCode": 206,
     "LastSeen": "2024-12-18T06:36:29.862015-05:00"


### PR DESCRIPTION
Fixes #6045

Adds a blog post to promote the OpenTelemetry on Mainframe Priorities Survey created by the Mainframe SIG. The blog has been previously published by the Open Mainframe Project [here](https://openmainframeproject.org/blog/opentelemetry-on-mainframe-priorities-survey/).