### PR TITLE
Glossary: add terms from style guide, and some rework

### DIFF
--- a/content/en/docs/collector/management.md
+++ b/content/en/docs/collector/management.md
@@ -13,8 +13,8 @@ the collector. These topics are covered elsewhere:
 
 - [Quick Start](/docs/collector/quick-start/) to understand how to install the
   OpenTelemetry Collector.
-- [Configuration][otel-collector-configuration] for how to configure the
-  OpenTelemetry Collector, setting up telemetry pipelines.
+- [Configuration] for how to configure the OpenTelemetry Collector, setting up
+  telemetry pipelines.
 
 ## Basics
 
@@ -24,8 +24,7 @@ Typical agent management tasks include:
 1. Querying the agent information and configuration. The agent information can
    include its version, operating system related information, or capabilities.
    The configuration of the agent refers to its telemetry collection setup, for
-   example, the OpenTelemetry Collector
-   [configuration][otel-collector-configuration].
+   example, the OpenTelemetry Collector [configuration].
 1. Upgrading/downgrading agents and management of agent-specific packages,
    including the base agent functionality and plugins.
 1. Applying new configurations to agents. This might be required because of
@@ -44,12 +43,12 @@ ideally done using OpenTelemetry.
 
 Observability vendors and cloud providers offer proprietary solutions for agent
 management. In the open source observability space, there is an emerging
-standard that you can use for agent management: Open Agent Management Protocol
+standard that you can use for agent management: [Open Agent Management Protocol]
 (OpAMP).
 
-The [OpAMP specification][opamp-spec] defines how to manage a fleet of telemetry
-data agents. These agents can be [OpenTelemetry collectors][otel-collector],
-Fluent Bit or other agents in any arbitrary combination.
+The [OpAMP specification] defines how to manage a fleet of telemetry data
+agents. These agents can be [OpenTelemetry collectors](/docs/collector/), Fluent
+Bit or other agents in any arbitrary combination.
 
 > **Note** The term "agent" is used here as a catch-all term for OpenTelemetry
 > components that respond to OpAMP, this could be the collector but also SDK
@@ -216,9 +215,9 @@ otelcol_receiver_refused_metric_points{receiver="prometheus/own_metrics",service
     Protocol][opamp-lt]
   - [What is OpAMP & What is BindPlane][opamp-bindplane]
 
-[otel-collector]: /docs/collector/
-[otel-collector-configuration]: /docs/collector/configuration/
-[opamp-spec]:
+[configuration]: /docs/collector/configuration/
+[Open Agent Management Protocol]: https://github.com/open-telemetry/opamp-spec/
+[OpAMP specification]:
   https://github.com/open-telemetry/opamp-spec/blob/main/specification.md
 [opamp-in-otel-collector]:
   https://docs.google.com/document/d/1KtH5atZQUs9Achbce6LiOaJxLbksNJenvgvyKLsJrkc/edit#heading=h.ioikt02qpy5f

--- a/content/en/docs/collector/management.md
+++ b/content/en/docs/collector/management.md
@@ -47,7 +47,7 @@ standard that you can use for agent management: [Open Agent Management Protocol]
 (OpAMP).
 
 The [OpAMP specification] defines how to manage a fleet of telemetry data
-agents. These agents can be [OpenTelemetry collectors](/docs/collector/), Fluent
+agents. These agents can be [OpenTelemetry Collectors](/docs/collector/), Fluent
 Bit or other agents in any arbitrary combination.
 
 > **Note** The term "agent" is used here as a catch-all term for OpenTelemetry

--- a/content/en/docs/concepts/glossary.md
+++ b/content/en/docs/concepts/glossary.md
@@ -370,7 +370,6 @@ on web pages when requested. See [more][zpages].
 
 [baggage]: /docs/specs/otel/baggage/api/
 [attribute]: /docs/specs/otel/common/#attributes
-[collector]: /docs/collector/
 [context propagation]: /docs/specs/otel/overview#context-propagation
 [dag]: https://en.wikipedia.org/wiki/Directed_acyclic_graph
 [distributed tracing]: /docs/concepts/signals/traces/
@@ -381,8 +380,6 @@ on web pages when requested. See [more][zpages].
 [log]: /docs/specs/otel/glossary#log
 [log record]: /docs/specs/otel/glossary#log-record
 [metric]: /docs/concepts/signals/metrics/
-[opencensus]: https://opencensus.io
-[opentracing]: https://opentracing.io
 [propagators]: /docs/languages/go/instrumentation/#propagators-and-context
 [proto]: https://github.com/open-telemetry/opentelemetry-proto
 [receiver]: /docs/collector/configuration/#receivers

--- a/content/en/docs/concepts/glossary.md
+++ b/content/en/docs/concepts/glossary.md
@@ -7,7 +7,7 @@ weight: 200
 
 This glossary defines terms and [concepts](/docs/concepts/) that are new to the
 OpenTelemetry project, and clarifies OpenTelemetry-specific uses of terms common
-in the telemetry field.
+in the observability field.
 
 We also comment on spelling and capitalization when helpful. For example, see
 [OpenTelemetry](#opentelemetry) and [OTel](#otel).

--- a/content/en/docs/concepts/glossary.md
+++ b/content/en/docs/concepts/glossary.md
@@ -1,100 +1,108 @@
 ---
 title: Glossary
-description: >-
-  Terminology you may or may not be familiar with used by the OpenTelemetry
-  project.
+description:
+  Definitions and conventions for telemetry terms as used in OpenTelemetry.
 weight: 200
 ---
 
-The OpenTelemetry project uses terminology you might not be familiar with. In
-addition, the project defines the terminology in a different way than others.
-This page captures terminology used in the project and what it means.
+This glossary defines terms and [concepts](/docs/concepts/) that are new to the
+OpenTelemetry project, and clarifies OpenTelemetry-specific uses of terms common
+in the telemetry field.
 
-## Generic terminology
+We also comment on spelling and capitalization when helpful. For example, see
+[OpenTelemetry](#opentelemetry) and [OTel](#otel).
 
-### **Aggregation**
+## Terms
+
+### Aggregation
 
 The process of combining multiple measurements into exact or estimated
 statistics about the measurements that took place during an interval of time,
 during program execution. Used by the [Metric](#metric)
 [Data source](#data-source).
 
-### **API**
+### API
 
 Application Programming Interface. In the OpenTelemetry project, used to define
 how telemetry data is generated per [Data source](#data-source).
 
-### **Application**
+### Application
 
 One or more [Services](#service) designed for end users or other applications.
 
-### **APM**
+### APM
 
 Application Performance Monitoring is about monitoring software applications,
 their performance (speed, reliability, availability, and so on) to detect
 issues, alerting and tooling for finding the root cause.
 
-### **Attribute**
+### Attribute
 
 OpenTelemetry term for [Metadata](#metadata). Adds key-value information to the
 entity producing telemetry. Used across [Signals](#signal) and
 [Resources](#resource). See [attribute spec][attribute].
 
-### **Automatic instrumentation**
+### Automatic instrumentation
 
 Refers to telemetry collection methods that do not require the end-user to
 modify application's source code. Methods vary by programming language, and
 examples include bytecode injection or monkey patching.
 
-### **Baggage**
+### Baggage
 
 A mechanism for propagating [Metadata](#metadata) to help establish a causal
 relationship between events and services. See [baggage spec][baggage].
 
-### **Client library**
+### Client library
 
 See [Instrumented library](#instrumented-library).
 
-### **Client-side app**
+### Client-side app
 
 A component of an [Application](#application) that is not running inside a
 private infrastructure and is typically used directly by end-users. Examples of
 client-side apps are browser apps, mobile apps, and apps running on IoT devices.
 
-### **Collector**
+### Collector
 
-A vendor-agnostic implementation on how to receive, process, and export
-telemetry data. A single binary that can be deployed as an agent or gateway.
+The [OpenTelemetry Collector], or Collector for short, is a vendor-agnostic
+implementation on how to receive, process, and export telemetry data. A single
+binary that can be deployed as an agent or gateway.
 
-Also known as the OpenTelemetry Collector. More on the Collector
-[here][collector].
+Also known as.
 
-### **Contrib**
+> **Spelling**: When referring to the [OpenTelemetry Collector], always
+> capitalize Collector. Use just "Collector" if you are using Collector as an
+> adjective &mdash; for example, "Collector configuration".
+
+[OpenTelemetry Collector]: /docs/collector/
+
+### Contrib
 
 Several [Instrumentation Libraries](#instrumentation-library) and the
 [Collector](#collector) offer a set of core capabilities as well as a dedicated
 contrib repository for non-core capabilities including vendor `Exporters`.
 
-### **Context propagation**
+### Context propagation
 
 Allows all [Data sources](#data-source) to share an underlying context mechanism
 for storing state and accessing data across the lifespan of a
 [Transaction](#transaction). See [context propagation
 spec][context propagation].
 
-### **DAG**
+### DAG
 
 [Directed Acyclic Graph][dag].
 
-### **Data source**
+### Data source
 
 See [Signal](#signal)
 
-### **Dimension**
+### Dimension
 
 A term used specifically by [Metrics](#metric). See [Attribute](#attribute).
 
-### **Distributed tracing**
+### Distributed tracing
 
 Tracks the progression of a single [Request](#request), called a
 [Trace](#trace), as it is handled by [Services](#service) that make up an
@@ -103,44 +111,44 @@ transverses process, network and security boundaries.
 
 See [Distributed tracing][distributed tracing].
 
-### **Distribution**
+### Distribution
 
 A distribution is a wrapper around an upstream OpenTelemetry repository with
 some customizations. See [more][distribution].
 
-### **Event**
+### Event
 
 Something that happened where representation depends on the
 [Data source](#data-source). For example, [Spans](#span).
 
-### **Exporter**
+### Exporter
 
 Provides functionality to emit telemetry to consumers. Exporters can be push- or
 pull-based.
 
-### **Field**
+### Field
 
 A term used specifically by [Log Records](#log-record). [Metadata](#metadata)
 can be added through defined fields, including [Attributes](#attribute) and
 [Resource](#resource). Other fields may also be considered `Metadata`, including
 severity and trace information. See the [field spec][field].
 
-### **gRPC**
+### gRPC
 
 A high-performance, open source universal [RPC](#rpc) framework. More on gRPC
 [here](https://grpc.io).
 
-### **HTTP**
+### HTTP
 
 Short for [Hypertext Transfer Protocol][http].
 
-### **Instrumented library**
+### Instrumented library
 
 Denotes the [Library](#library) for which the telemetry signals
 ([Traces](#trace), [Metrics](#metric), [Logs](#log)) are gathered. See
 [more][spec-instrumented-lib].
 
-### **Instrumentation library**
+### Instrumentation library
 
 Denotes the [Library](#library) that provides the instrumentation for a given
 [Instrumented library](#instrumented-library).
@@ -149,101 +157,133 @@ Denotes the [Library](#library) that provides the instrumentation for a given
 [Library](#library) if it has built-in OpenTelemetry instrumentation. See [the
 lib specification][spec-instrumentation-lib].
 
-### **JSON**
+### JSON
 
 Short for [JavaScript Object Notation][json].
 
-### **Label**
+### Label
 
 A term used specifically by [Metrics](#metric). See [Metadata](#metadata).
 
-### **Language**
+### Language
 
 Programming Language.
 
-### **Library**
+### Library
 
 A language-specific collection of behavior invoked by an interface.
 
-### **Log**
+### Log
 
 Sometimes used to refer to a collection of [Log records](#log-record). Can be
 ambiguous since people also sometimes use [Log](#log) to refer to a single
 [Log record](#log-record). Where ambiguity is possible, use additional
 qualifiers, for example, `Log record`. See [more][log]
 
-### **Log record**
+### Log record
 
 A recording of an [Event](#event). Typically, the record includes a timestamp
 indicating when the [Event](#event) happened as well as other data that
 describes what happened, where it happened, and so on. See [more][log record].
 
-### **Metadata**
+### Metadata
 
 A key-value pair, for example `foo="bar"`, added to an entity producing
 telemetry. OpenTelemetry calls these pairs [Attributes](#attribute). In
 addition, [Metrics](#metric) have [Dimensions](#dimension) an [Labels](#label),
 while [Logs](#log) have [Fields](#field).
 
-### **Metric**
+### Metric
 
 Records a data point, either raw measurements or predefined aggregation, as time
 series with [Metadata](#metadata). See [more][metric].
 
-### **OC**
+### OC
 
 Short form for [OpenCensus](#opencensus).
 
-### **OpenCensus**
+### OpAMP
 
-A set of libraries for various languages that allow you to collect application
-metrics and distributed traces, then transfer the data to a backend of your
-choice in real time.
-[Precursor to OpenTelemetry](/docs/what-is-opentelemetry/#history). See
-[more][opencensus].
+Abbreviation for the
+[Open Agent Management Protocol](/docs/collector/management/#opamp).
 
-### **OpenTracing**
+> **Spelling**: Write OpAMP, not `OPAMP` nor `opamp` in descriptions or
+> instructions.
 
-Vendor-neutral APIs and instrumentation for distributed tracing.
-[Precursor to OpenTelemetry](/docs/what-is-opentelemetry/#history). See
-[more][opentracing].
+### OpenCensus
 
-### **OT**
+Precursor to OpenTelemetry. For details, see
+[History](/docs/what-is-opentelemetry/#history).
+
+### OpenTelemetry
+
+Formed through a [merger] of the [OpenTracing](#opentracing) and
+[OpenCensus](#opencensus), OpenTelemetry &mdash; the subject of this website
+&mdash; is a collection of [APIs](#api), [SDKs](#sdk), and tools that you can
+use to [instrument](/docs/concepts/instrumentation/), generate,
+[collect](/docs/concepts/components/#collector), and
+[export](/docs/concepts/components/#exporters)
+[telemetry data](/docs/concepts/signals/) such as [metrics](#metric),
+[logs](#log), and [traces](#trace).
+
+> **Spelling**: OpenTelemetry should always be a single unhyphenated word and
+> capitalized as shown.
+
+[merger]: /docs/what-is-opentelemetry/#history
+
+### OpenTracing
+
+Precursor to OpenTelemetry. For details, see
+[History](/docs/what-is-opentelemetry/#history).
+
+### OT
 
 Short form for [OpenTracing](#opentracing).
 
-### **OTel**
+### OTel
 
 Short form for [OpenTelemetry](/docs/what-is-opentelemetry/).
 
-### **OTelCol**
+> **Spelling**: Write OTel, not `OTEL`.
+
+### OTelCol
 
 Short form for [OpenTelemetry Collector](#collector).
 
-### **OTLP**
+### OTEP
+
+An acronym for [OpenTelemetry Enhancement Proposal].
+
+> **Spelling**: Write "OTEPs" as plural form. Don't write `OTep` or `otep` in
+> descriptions.
+
+[OpenTelemetry Enhancement Proposal]:
+  https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/README.md
+
+### OTLP
 
 Short for [OpenTelemetry Protocol](/docs/specs/otlp/).
 
-### **Propagators**
+### Propagators
 
 Used to serialize and deserialize specific parts of telemetry data such as span
 context and [Baggage](#baggage) in [Spans](#span). See [more][propagators].
 
-### **Proto**
+### Proto
 
 Language independent interface types. See [more][proto].
 
-### **Receiver**
+### Receiver
 
 The term used by the [Collector](/docs/collector/configuration/#receivers) to
 define how telemetry data is received. Receivers can be push- or pull-based. See
 [more][receiver].
 
-### **Request**
+### Request
 
 See [Distributed Tracing](#distributed-tracing).
 
-### **Resource**
+### Resource
 
 Captures information about the entity producing telemetry as
 [Attributes](#attribute). For example, a process producing telemetry that is
@@ -251,78 +291,78 @@ running in a container on Kubernetes has a process name, a pod name, a
 namespace, and possibly a deployment name. All these attributes can be included
 in the `Resource`.
 
-### **REST**
+### REST
 
 Short for [Representational State Transfer][rest].
 
-### **RPC**
+### RPC
 
 Short for [Remote Procedure Call][rpc].
 
-### **Sampling**
+### Sampling
 
 A mechanism to control the amount of data exported. Most commonly used with the
 [Tracing](#trace) [Data Source](#data-source). See [more][sampling].
 
-### **SDK**
+### SDK
 
 Short for Software Development Kit. Refers to a telemetry SDK that denotes a
 [Library](#library) that implement the OpenTelemetry [API](#api).
 
-### **Semantic conventions**
+### Semantic conventions
 
 Defines standard names and values of [Metadata](#metadata) in order to provide
 vendor-agnostic telemetry data.
 
-### **Service**
+### Service
 
 A component of an [Application](#application). Multiple instances of a
 [Service](#service) are typically deployed for high availability and
 scalability. A [Service](#service) can be deployed in multiple locations.
 
-### **Signal**
+### Signal
 
 One of [Traces](#trace), [Metrics](#metric) or [Logs](#log). More on Signals
 [here][signals].
 
-### **Span**
+### Span
 
 Represents a single operation within a [Trace](#trace). See [more][span].
 
-### **Span link**
+### Span link
 
 A span link is a link between causally-related spans. For details see
 [Links between spans](/docs/specs/otel/overview#links-between-spans) and
 [Specifying Links](/docs/specs/otel/trace/api#specifying-links).
 
-### **Specification**
+### Specification
 
 Describes the cross-language requirements and expectations for all
 implementations. See [more][specification].
 
-### **Status**
+### Status
 
 The result of the operation. Typically used to indicate whether an error
 occurred. See [more][status].
 
-### **Tag**
+### Tag
 
 See [Metadata](#metadata).
 
-### **Trace**
+### Trace
 
 A [DAG](#dag) of [Spans](#span), where the edges between [Spans](#span) are
 defined as parent-child relationship. See [more][trace].
 
-### **Tracer**
+### Tracer
 
 Responsible for creating [Spans](#span). See [more][tracer].
 
-### **Transaction**
+### Transaction
 
 See [Distributed Tracing](#distributed-tracing).
 
-### **zPages**
+### zPages
 
 An in-process alternative to external exporters. When included, they collect and
 aggregate tracing and metrics information in the background; this data is served
@@ -330,7 +370,7 @@ on web pages when requested. See [more][zpages].
 
 [baggage]: /docs/specs/otel/baggage/api/
 [attribute]: /docs/specs/otel/common/#attributes
-[collector]: /docs/collector
+[collector]: /docs/collector/
 [context propagation]: /docs/specs/otel/overview#context-propagation
 [dag]: https://en.wikipedia.org/wiki/Directed_acyclic_graph
 [distributed tracing]: /docs/concepts/signals/traces/

--- a/content/en/docs/concepts/glossary.md
+++ b/content/en/docs/concepts/glossary.md
@@ -69,7 +69,6 @@ The [OpenTelemetry Collector], or Collector for short, is a vendor-agnostic
 implementation on how to receive, process, and export telemetry data. A single
 binary that can be deployed as an agent or gateway.
 
-
 > **Spelling**: When referring to the [OpenTelemetry Collector], always
 > capitalize Collector. Use just "Collector" if you are using Collector as an
 > adjective &mdash; for example, "Collector configuration".
@@ -217,9 +216,9 @@ Precursor to OpenTelemetry. For details, see
 ### OpenTelemetry
 
 Formed through a [merger] of the [OpenTracing](#opentracing) and
-[OpenCensus](#opencensus) projects, OpenTelemetry &mdash; the subject of this website
-&mdash; is a collection of [APIs](#api), [SDKs](#sdk), and tools that you can
-use to [instrument](/docs/concepts/instrumentation/), generate,
+[OpenCensus](#opencensus) projects, OpenTelemetry &mdash; the subject of this
+website &mdash; is a collection of [APIs](#api), [SDKs](#sdk), and tools that
+you can use to [instrument](/docs/concepts/instrumentation/), generate,
 [collect](/docs/concepts/components/#collector), and
 [export](/docs/concepts/components/#exporters)
 [telemetry data](/docs/concepts/signals/) such as [metrics](#metric),

--- a/content/en/docs/concepts/glossary.md
+++ b/content/en/docs/concepts/glossary.md
@@ -69,7 +69,6 @@ The [OpenTelemetry Collector], or Collector for short, is a vendor-agnostic
 implementation on how to receive, process, and export telemetry data. A single
 binary that can be deployed as an agent or gateway.
 
-Also known as.
 
 > **Spelling**: When referring to the [OpenTelemetry Collector], always
 > capitalize Collector. Use just "Collector" if you are using Collector as an
@@ -218,7 +217,7 @@ Precursor to OpenTelemetry. For details, see
 ### OpenTelemetry
 
 Formed through a [merger] of the [OpenTracing](#opentracing) and
-[OpenCensus](#opencensus), OpenTelemetry &mdash; the subject of this website
+[OpenCensus](#opencensus) projects, OpenTelemetry &mdash; the subject of this website
 &mdash; is a collection of [APIs](#api), [SDKs](#sdk), and tools that you can
 use to [instrument](/docs/concepts/instrumentation/), generate,
 [collect](/docs/concepts/components/#collector), and

--- a/content/en/docs/contributing/style-guide.md
+++ b/content/en/docs/contributing/style-guide.md
@@ -30,17 +30,16 @@ guide and learn what you can do to fix certain common issues.
 ## OpenTelemetry.io word list
 
 A list of OpenTelemetry-specific terms and words to be used consistently across
-the site.
+the site:
 
-<!-- prettier-ignore-start -->
-| Term | Usage |
-| --- | --- |
-| OpenTelemetry | OpenTelemetry should always be capitalized. Don't use Open-Telemetry. |
-| OTel | OTel is the accepted short form of OpenTelemetry. Don't use OTEL. |
-| Collector | When referring to the OpenTelemetry Collector, always capitalize Collector. Write "The Collector" or "The Opentelemetry Collector" if you're starting a sentence. Write "the Collector" or "the OpenTelemetry Collector" in the middle or end of a sentence. Use just "Collector" if you are using Collector as an adjective (for example, "Collector configuration").|
-| OTEP | [OpenTelemetry Enhancement Proposal]. Write "OTEPs" as plural form. Don't write "OTep" or "otep". |
-| OpAMP | Open Agent Management Protocol. Don't write "OPAMP" or "opamp" in descriptions or instructions. |
-<!-- prettier-ignore-end -->
+- [OpenTelemetry](/docs/concepts/glossary/#opentelemetry) and
+  [OTel](/docs/concepts/glossary/#otel)
+- [Collector](/docs/concepts/glossary/#collector)
+- [OTEP](/docs/concepts/glossary/#otep)
+- [OpAMP](/docs/concepts/glossary/#opamp)
+
+For a complete list of OpenTelemetry terms and their definition, see
+[Glossary](/docs/concepts/glossary/).
 
 Make sure that proper nouns, such as other CNCF projects or third-party tools,
 are properly written and use the original capitalization. For example, write
@@ -48,14 +47,15 @@ are properly written and use the original capitalization. For example, write
 [`.textlintrc.yml`](https://github.com/open-telemetry/opentelemetry.io/blob/main/.textlintrc.yml)
 file.
 
-See also the [Glossary](/docs/concepts/glossary/) for a list of OpenTelemetry
-terms and their definition.
+{{% alert title="Tip" %}}
 
 Run `npm run check:text` to verify that all terms and words are written
 properly.
 
 Run `npm run check:text -- --fix` to fix terms and words that are not written
 properly.
+
+{{% /alert %}}
 
 ## Markdown standards
 

--- a/content/en/docs/contributing/style-guide.md
+++ b/content/en/docs/contributing/style-guide.md
@@ -116,6 +116,3 @@ submitting a PR, or run it afterwards and push an additional commit.
 All file names should be in
 [kebab case](https://en.wikipedia.org/wiki/Letter_case#Kebab_case). Run
 `npm run fix:filenames` to automatically rename your files.
-
-[OpenTelemetry Enhancement Proposal]:
-  https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/README.md

--- a/content/en/docs/what-is-opentelemetry.md
+++ b/content/en/docs/what-is-opentelemetry.md
@@ -110,7 +110,7 @@ designed to make it possible at nearly every level.
 
 OpenTelemetry is a
 [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io) project that is
-the result of a merger between two prior projects,
+the result of a [merger] between two prior projects,
 [OpenTracing](https://opentracing.io) and [OpenCensus](https://opencensus.io).
 Both of these projects were created to solve the same problem: the lack of a
 standard for how to instrument code and send telemetry data to an Observability
@@ -120,6 +120,9 @@ single solution.
 
 If you are currently using OpenTracing or OpenCensus, you can learn how to
 migrate to OpenTelemetry in the [Migration guide](/docs/migration/).
+
+[merger]:
+  https://www.cncf.io/blog/2019/05/21/a-brief-history-of-opentelemetry-so-far/
 
 ## What next?
 

--- a/content/ja/docs/concepts/glossary.md
+++ b/content/ja/docs/concepts/glossary.md
@@ -177,11 +177,19 @@ OpenTelemetryはこれらのペアを[属性](#attribute)と呼びます。
 
 [OpenCensus](#opencensus)の略称。
 
+### OpAMP
+
+[コンテンツは後日追加されます]
+
 ### **OpenCensus**
 
 アプリケーションのメトリクスと分散トレースを収集し、リアルタイムで任意のバックエンドにデータを転送することを可能にする、さまざまな言語用のライブラリのセットです。
 [OpenTelemetryの前身](/docs/what-is-opentelemetry/#history)プロジェクトです。
 詳細は[このサイト][opencensus]を参照のこと。
+
+### OpenTelemetry
+
+[コンテンツは後日追加されます]
 
 ### **OpenTracing**
 
@@ -200,6 +208,10 @@ OpenTelemetryはこれらのペアを[属性](#attribute)と呼びます。
 ### **OTelCol**
 
 [OpenTelemetryコレクター](#collector)の略称。
+
+### OTEP
+
+[コンテンツは後日追加されます]
 
 ### **OTLP**
 

--- a/content/pt/docs/concepts/glossary.md
+++ b/content/pt/docs/concepts/glossary.md
@@ -201,6 +201,10 @@ informações][metric].
 
 Abreviação para [OpenCensus](#opencensus).
 
+### OpAMP
+
+[Conteúdo será adicionado posteriormente]
+
 ### **OpenCensus**
 
 Um conjunto de bibliotecas para várias linguagens que permite coletar métricas
@@ -208,6 +212,10 @@ de aplicações e rastreamentos distribuídos, transferindo os dados para um
 backend de sua preferência em tempo real.
 [Precursor do OpenTelemetry](/docs/what-is-opentelemetry/#history). Consulte
 [mais informações][opencensus].
+
+### OpenTelemetry
+
+[Conteúdo será adicionado posteriormente]
 
 ### **OpenTracing**
 
@@ -226,6 +234,10 @@ Abreviação para [OpenTelemetry](/docs/what-is-opentelemetry/).
 ### **OTelCol**
 
 Abreviação para [OpenTelemetry Collector](#collector).
+
+### OTEP
+
+[Conteúdo será adicionado posteriormente]
 
 ### **OTLP**
 

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -6547,6 +6547,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-13T11:43:24.09422-05:00"
   },
+  "https://github.com/open-telemetry/opamp-spec/": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-24T10:00:32.770402-05:00"
+  },
   "https://github.com/open-telemetry/opamp-spec/blob/main/proto/opamp.proto": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:38:07.885812-05:00"


### PR DESCRIPTION
- Related / in prep for #6068
- Consolidates the "terms" in the style guide, by moving them into the glossary, and referring to the glossary. Moves spelling & capitalization recommendations along with them.
- Copyedits and style (markdown) cleanup of the glossary and a few pages it refers to

### Preview

For example, see:

- https://deploy-preview-6074--opentelemetry.netlify.app/docs/concepts/glossary/#opentelemetry
- https://deploy-preview-6074--opentelemetry.netlify.app/docs/contributing/style-guide/#opentelemetryio-word-list
