### PR TITLE
Reset survey-on-merged-pr `on` to `pull_request`

### DIFF
--- a/.github/workflows/survey-on-merged-pr.yml
+++ b/.github/workflows/survey-on-merged-pr.yml
@@ -1,7 +1,7 @@
 name: Survey on Merged PR by Non-Member
 
 on:
-  pull_request_target:
+  pull_request:
     types: [closed]
 
 env:


### PR DESCRIPTION
if `pull_request_target` is used it seems that the `gh comment` is looking for the PR in the fork that's why this is breaking