### PR TITLE
Update capitalization for JRuby and TruffleRuby

### DIFF
--- a/content/en/docs/languages/ruby/getting-started.md
+++ b/content/en/docs/languages/ruby/getting-started.md
@@ -16,7 +16,7 @@ You will learn how you can instrument a simple application, in such a way that
 
 Ensure that you have the following installed locally:
 
-- CRuby >= `3.0`, jruby >= `9.3.2.0`, or truffleruby >= 22.1
+- CRuby >= `3.0`, JRuby >= `9.3.2.0`, or TruffleRuby >= 22.1
 - [Bundler](https://bundler.io/)
 
 {{% alert  title="Warning" color="warning" %}} While tested, support for `jruby`


### PR DESCRIPTION
Use capitalization consistent with the tool's website. 

Another test for @svrnm / the contributor experience SIG.