### PR TITLE
Upgrade Docsy and sync layout

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,7 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/google/docsy.git
-	docsy-pin = v0.11.0-34-gef59ee75
+	docsy-pin = v0.11.0-37-ga854cb31
 	docsy-note = "2024-04-01 Switching to google/docsy.git from cncf/docsy.git since we don't have any CNCF customizations."
 	docsy-reminder = "Ensure that any tag referenced by `docsy-pin` is present in the remote repo (url), otherwise add (push) the tags to the repo."
 [submodule "content-modules/opentelemetry-specification"]

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -2,7 +2,10 @@
 {{ $lang := partial "i18n/lang.html" . -}}
 
 <!doctype html>
-<html itemscope itemtype="http://schema.org/WebPage" lang="{{ $lang }}" class="no-js">
+<html itemscope itemtype="http://schema.org/WebPage"
+    {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
+    {{ with .Site.Language.Lang }} lang="{{ $lang }}" {{- end }} {{/**/ -}}
+    class="no-js">
   <head>
     {{ partial "head.html" . }}
   </head>
@@ -23,7 +26,9 @@
           </aside>
           <main class="col-12 col-md-9 col-xl-8 ps-md-5" role="main">
             {{ partial "version-banner.html" . }}
-            {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
+            {{ if not (.Param "ui.breadcrumb_disable") -}}
+              {{ partial "breadcrumb.html" . -}}
+            {{ end -}}
             {{ block "main" . }}{{ end }}
           </main>
         </div>


### PR DESCRIPTION
- Upgrades to Docsy v0.11.0-37-ga854cb31
- Sync's (minimizes differences) between Docsy's and our `layouts/docs/baseof.html`, in prep of further changes.