### PR TITLE
Demo repo links: fix & check them all, update refcache

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -73,9 +73,6 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   # FIXME: same issue as for the OTel spec mentioned above:
   - ^https://github.com/open-telemetry/semantic-conventions/tree/main
 
-  # Ignore some links to GH repo content for now, most 4XX
-  - ^https?://github\.com/open-telemetry/opentelemetry-demo/blob/main/src/(imageprovider|loadgenerator|otelcollector|.*service)
-
   # Too many redirects as the server tries to figure out the country and language,
   # e.g.: https://www.microsoft.com/en-ca/sql-server.
   - ^https://www.microsoft.com/sql-server$

--- a/content/en/blog/2023/testing-otel-demo/index.md
+++ b/content/en/blog/2023/testing-otel-demo/index.md
@@ -211,7 +211,7 @@ screenshot of a trace for this operation:
 In this operation, we can see inner calls to multiple services, like
 [Frontend](https://github.com/open-telemetry/opentelemetry-demo/tree/main/src/frontend),
 [CheckoutService](https://github.com/open-telemetry/opentelemetry-demo/tree/main/src/checkoutservice),
-[CartService](https://github.com/open-telemetry/opentelemetry-demo/tree/main/src/cartservice),
+[CartService](https://github.com/open-telemetry/opentelemetry-demo/tree/main/src/cart/),
 [ProductCatalogService](https://github.com/open-telemetry/opentelemetry-demo/tree/main/src/productcatalogservice),
 [CurrencyService](https://github.com/open-telemetry/opentelemetry-demo/tree/main/src/currencyservice),
 and others.
@@ -233,7 +233,7 @@ triggered during the checkout:
   [ShippingService](https://github.com/open-telemetry/opentelemetry-demo/tree/main/src/shippingservice)
   was called and emitted spans correctly;
 - _“The cart was emptied”_, checking if the
-  [CartService](https://github.com/open-telemetry/opentelemetry-demo/tree/main/src/cartservice)
+  [CartService](https://github.com/open-telemetry/opentelemetry-demo/tree/main/src/cart/)
   was called and emitted spans correctly.
 
 The final result was the following test YAML, which triggers the Checkout

--- a/content/en/docs/demo/_index.md
+++ b/content/en/docs/demo/_index.md
@@ -54,7 +54,7 @@ found here:
 - [Quote Service](services/quote/)
 - [Recommendation Service](services/recommendation/)
 - [Shipping Service](services/shipping/)
-- [Image Provider Service](services/imageprovider/)
+- [Image Provider Service](services/image-provider/)
 - [React Native App](services/react-native-app/)
 
 ## Scenarios

--- a/content/en/docs/demo/docker-deployment.md
+++ b/content/en/docs/demo/docker-deployment.md
@@ -109,7 +109,7 @@ configuration from two files:
 - `otelcol-config-extras.yml`
 
 To add your backend, open the file
-[src/otelcollector/otelcol-config-extras.yml](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/otelcollector/otelcol-config-extras.yml)
+[src/otel-collector/otelcol-config-extras.yml](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/otel-collector/otelcol-config-extras.yml)
 with an editor.
 
 - Start by adding a new exporter. For example, if your backend supports OTLP

--- a/content/en/docs/demo/services/cart/index.md
+++ b/content/en/docs/demo/services/cart/index.md
@@ -7,7 +7,7 @@ aliases: [cartservice]
 This service maintains items placed in the shopping cart by users. It interacts
 with a Redis caching service for fast access to shopping cart data.
 
-[Cart service source](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/cartservice/)
+[Cart service source](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/cart/)
 
 > **Note** OpenTelemetry for .NET uses the `System.Diagnostic.DiagnosticSource`
 > library as its API instead of the standard OpenTelemetry API for Traces and

--- a/content/en/docs/demo/services/image-provider.md
+++ b/content/en/docs/demo/services/image-provider.md
@@ -1,10 +1,12 @@
 ---
 title: Image Provider Service
 linkTitle: Image Provider
+aliases: [imageprovider] # cSpell:disable-line
 ---
 
 This service provides the images which are used in the frontend. The images are
 statically hosted on a NGINX instance. The NGINX server is instrumented with the
 [nginx-otel module](https://github.com/nginxinc/nginx-otel/tree/main).
 
-[Image Provider service source](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/imageprovider/)
+For details, see the
+[image provider service source](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/image-provider/).

--- a/content/es/docs/demo/_index.md
+++ b/content/es/docs/demo/_index.md
@@ -54,7 +54,7 @@ en cada servicio aquí:
 - [Servicio de Cotizaciones](services/quote/)
 - [Servicio de Recomendaciones](services/recommendation/)
 - [Servicio de Envío](services/shipping/)
-- [Servicio Proveedor de Imágenes](services/imageprovider/)
+- [Servicio Proveedor de Imágenes](services/image-provider/?i18n-patch)
 
 ## Escenarios
 

--- a/content/ja/docs/demo/_index.md
+++ b/content/ja/docs/demo/_index.md
@@ -51,7 +51,7 @@ default_lang_commit: 1e69c8f94a605ce5624c6b6657080d98f633ac7b
 - [見積サービス](services/quote/)
 - [レコメンデーションサービス](services/recommendation/)
 - [配送サービス](services/shipping/)
-- [画像プロバイダーサービス](services/imageprovider/)
+- [画像プロバイダーサービス](services/image-provider/?i18n-patch)
 
 ## シナリオ {#scenarios}
 

--- a/content/ja/docs/demo/architecture.md
+++ b/content/ja/docs/demo/architecture.md
@@ -119,7 +119,7 @@ classDef typescript fill:#e98516,color:black;
 
 デモアプリケーションの[メトリック](/docs/demo/telemetry-features/metric-coverage/) と [トレース](/docs/demo/telemetry-features/trace-coverage/) の計装の現状については、リンクをご確認ください。
 
-コレクターの設定は [otelcol-config.yml](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/otelcollector/otelcol-config.yml) で行われており、代替のエクスポーターをここで設定することができます。
+コレクターの設定は [otelcol-config.yml](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/otel-collector/otelcol-config.yml?i18n-patch) で行われており、代替のエクスポーターをここで設定することができます。
 
 ```mermaid
 graph TB

--- a/content/zh/docs/demo/_index.md
+++ b/content/zh/docs/demo/_index.md
@@ -50,7 +50,7 @@ default_lang_commit: c2cd5b14
 - [报价服务](services/quote/)
 - [推荐服务](services/recommendation/)
 - [发货服务](services/shipping/)
-- [图片提供商服务](services/imageprovider/)
+- [图片提供商服务](services/image-provider/?i18n-patch)
 
 ## 应用场景
 

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -8399,6 +8399,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:53:03.08475-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/cart/": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-30T10:52:29.52797-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/checkout/": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T18:15:55.588406336Z"
@@ -8415,6 +8419,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:53:00.941653-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/image-provider/": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-30T10:37:57.975407-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/kafka/": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:53:01.328807-05:00"
@@ -8422,6 +8430,10 @@
   "https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/load-generator/": {
     "StatusCode": 206,
     "LastSeen": "2025-01-21T15:24:31.221226625Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/otel-collector/otelcol-config-extras.yml": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-30T10:37:57.941533-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/otel-collector/otelcol-config.yml": {
     "StatusCode": 206,


### PR DESCRIPTION
- Contributes to #5017
- Removes temporary rule that had some external links into the demo repo igored
- Updates links to services etc that were recently renamed.
- Updates the refcache
- I decided to fix the broken links in non-`en` pages, and to tag the links with a `?i18n-patch` query parameter as an indicator for humans and tools that this is a link patch, but otherwise the rest of the page still matches it's `default_lang_commit`