### PR TITLE
[CI] Fix fix:dict and run it

### DIFF
--- a/content/en/blog/2025/go-auto-instrumentation-beta.md
+++ b/content/en/blog/2025/go-auto-instrumentation-beta.md
@@ -1,12 +1,14 @@
 ---
-title: Announcing the Beta Release of OpenTelemetry Go Auto-Instrumentation using eBPF
+title: >-
+  Announcing the Beta Release of OpenTelemetry Go Auto-Instrumentation using
+  eBPF
 linkTitle: Go Auto-Instrumentation Beta
 date: 2025-01-30
 author: >-
-  [Tyler Yahn](https://github.com/MrAlias) (Splunk)
-  [Mike Dame](https://github.com/damemi) (Odigos)
+  [Tyler Yahn](https://github.com/MrAlias) (Splunk), [Mike
+  Dame](https://github.com/damemi) (Odigos)
 sig: SIG Go Auto-Instrumentation
-cSpell:ignore: Beyla Beyla's Odigos rolldice Yahn
+cSpell:ignore: Beyla Odigos rolldice Yahn
 ---
 
 The OpenTelemetry community is excited to announce the beta release of the

--- a/content/en/blog/2025/go-auto-instrumentation-beta.md
+++ b/content/en/blog/2025/go-auto-instrumentation-beta.md
@@ -1,15 +1,12 @@
 ---
-# prettier-ignore
 title: Announcing the Beta Release of OpenTelemetry Go Auto-Instrumentation using eBPF
 linkTitle: Go Auto-Instrumentation Beta
 date: 2025-01-30
-# prettier-ignore
 author: >-
   [Tyler Yahn](https://github.com/MrAlias) (Splunk)
   [Mike Dame](https://github.com/damemi) (Odigos)
 sig: SIG Go Auto-Instrumentation
-# prettier-ignore
-cSpell:ignore: Yahn Odigos rolldice Beyla's Beyla
+cSpell:ignore: Beyla Beyla's Odigos rolldice Yahn
 ---
 
 The OpenTelemetry community is excited to announce the beta release of the

--- a/content/en/blog/2025/otel-collector-k8s-discovery.md
+++ b/content/en/blog/2025/otel-collector-k8s-discovery.md
@@ -7,7 +7,7 @@ author: >
   Markou](https://github.com/ChrsMark) (Elastic)
 sig: Collector
 issue: opentelemetry-collector-contrib#34427
-cSpell:ignore: Dmitrii Anoshin Markou
+cSpell:ignore: Anoshin Dmitrii Markou
 ---
 
 In the world of containers and [Kubernetes](https://kubernetes.io/),

--- a/content/ja/docs/collector/installation.md
+++ b/content/ja/docs/collector/installation.md
@@ -1,9 +1,9 @@
 ---
 title: コレクターのインストール
-# prettier-ignore
-cSpell:ignore: darwin dpkg GOARCH journalctl kubectl otelcorecol pprof tlsv zpages
 weight: 2
 default_lang_commit: a570a00
+# prettier-ignore
+cSpell:ignore: darwin dpkg GOARCH journalctl kubectl otelcorecol pprof tlsv zpages
 ---
 
 OpenTelemetryコレクターはさまざまなオペレーティングシステムやアーキテクチャにデプロイできます。

--- a/content/ja/docs/concepts/instrumentation/code-based.md
+++ b/content/ja/docs/concepts/instrumentation/code-based.md
@@ -2,8 +2,8 @@
 title: コードベース
 description: コードベース計装のセットアップに不可欠なステップを学ぶ
 weight: 20
-cSpell:ignore: proxying
 default_lang_commit: d8c5612
+cSpell:ignore: proxying
 ---
 
 ## OpenTelemetry APIとSDKをインポートする {#import-the-opentelemetry-api-and-sdk}

--- a/content/ja/docs/concepts/observability-primer.md
+++ b/content/ja/docs/concepts/observability-primer.md
@@ -2,8 +2,8 @@
 title: Observability入門
 description: 重要なオブザーバビリティに関する概念
 weight: 9
-cSpell:ignore: webshop
 default_lang_commit: ebd92bb
+cSpell:ignore: webshop
 ---
 
 ## オブザーバビリティとは何か {#what-is-observability}

--- a/content/ja/docs/concepts/signals/traces.md
+++ b/content/ja/docs/concepts/signals/traces.md
@@ -1,9 +1,9 @@
 ---
 title: トレース
 weight: 1
-cSpell:ignore: Guten
 description: アプリケーションを通過するリクエストの経路
 default_lang_commit: 9b5e318
+cSpell:ignore: Guten
 ---
 
 **トレース** は、リクエストがアプリケーションに投げられたときに何が起こるかの全体像を教えてくれます。

--- a/content/ja/docs/demo/_index.md
+++ b/content/ja/docs/demo/_index.md
@@ -4,8 +4,8 @@ linkTitle: デモ
 cascade:
   repo: https://github.com/open-telemetry/opentelemetry-demo
 weight: 180
-cSpell:ignore: OLJCESPC
 default_lang_commit: 1e69c8f94a605ce5624c6b6657080d98f633ac7b
+cSpell:ignore: OLJCESPC
 ---
 
 [OpenTelemetryデモ](/ecosystem/demo/)のドキュメンテーションへようこそ。

--- a/content/ja/docs/demo/development.md
+++ b/content/ja/docs/demo/development.md
@@ -1,8 +1,8 @@
 ---
 title: 開発環境
+default_lang_commit: a6efef05af7f854d2fcc9ec4b7433cc4ae799a40
 # prettier-ignore
 cSpell:ignore: grpcio intellij libcurl libprotobuf nlohmann openssl protoc rebar
-default_lang_commit: a6efef05af7f854d2fcc9ec4b7433cc4ae799a40
 ---
 
 [OpenTelemetry デモ GitHub リポジトリ](https://github.com/open-telemetry/opentelemetry-demo)

--- a/content/pt/docs/languages/js/getting-started/nodejs.md
+++ b/content/pt/docs/languages/js/getting-started/nodejs.md
@@ -3,8 +3,8 @@ title: Node.js
 description: Obtenha telemetria para sua aplicação em menos de 5 minutos!
 aliases: [/docs/js/getting_started/nodejs]
 weight: 10
-cSpell:ignore: autoinstrumentations KHTML rolldice
 default_lang_commit: 1f6a173c26d1e194696ba77e95b6c3af40234952
+cSpell:ignore: autoinstrumentations KHTML rolldice
 ---
 
 Esta página mostrará como começar a usar o OpenTelemetry no Node.js.

--- a/content/pt/docs/languages/sdk-configuration/general.md
+++ b/content/pt/docs/languages/sdk-configuration/general.md
@@ -2,8 +2,8 @@
 title: Configurações gerais de SDK
 linkTitle: Geral
 aliases: [general-sdk-configuration]
-cSpell:ignore: ottrace
 default_lang_commit: 1e4970e9193c8af1d1f9b86901b13492071aecc7
+cSpell:ignore: ottrace
 ---
 
 {{% alert title="Nota" color="info" %}}

--- a/content/zh/docs/concepts/observability-primer.md
+++ b/content/zh/docs/concepts/observability-primer.md
@@ -2,8 +2,8 @@
 title: 可观测性入门
 description: 可观测性的核心概念
 weight: 9
-cSpell:ignore: webshop
 default_lang_commit: e771c886739c4847b332b74f24b09d2769aab875
+cSpell:ignore: webshop
 ---
 
 ## 什么是可观测性？ {#what-is-observability}

--- a/content/zh/docs/contributing/style-guide.md
+++ b/content/zh/docs/contributing/style-guide.md
@@ -3,8 +3,8 @@ title: 文档风格指南
 description: 编写 OpenTelemetry 文档时的术语和风格指南。
 linkTitle: 风格指南
 weight: 20
-cSpell:ignore: open-telemetry postgre style-guide textlintrc
 default_lang_commit: 2394fa1f1c693e547093e46e83a6819d3c26e9d5
+cSpell:ignore: open-telemetry postgre style-guide textlintrc
 ---
 
 OpenTelemetry 还没有官方的风格指南，当前版本的 OpenTelemetry 文档风格受到以下风格指南的启发：

--- a/content/zh/docs/demo/_index.md
+++ b/content/zh/docs/demo/_index.md
@@ -4,8 +4,8 @@ linkTitle: 演示
 cascade:
   repo: https://github.com/open-telemetry/opentelemetry-demo
 weight: 180
-cSpell:ignore: OLJCESPC
 default_lang_commit: c2cd5b14
+cSpell:ignore: OLJCESPC
 ---
 
 欢迎使用 [OpenTelemetry 演示](/ecosystem/demo/)文档，

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "diff:check": "npm run _diff:check || (echo; echo 'WARNING: the files above have not been committed'; echo)",
     "diff:fail": "npm run _diff:check || (echo; echo 'ERROR: the files above have changed. Locally rerun `npm run test-and-fix` and commit changes'; echo; exit 1)",
     "fix:all": "npm run all -- $(npm -s run _list:fix:*)",
-    "fix:dict": "find content/{en,es,fr,pt} layouts -name \"*.md\" -print0 | xargs -0 scripts/normalize-cspell-front-matter.pl",
+    "fix:dict": "find content layouts -name \"*.md\" -print0 | xargs -0 scripts/normalize-cspell-front-matter.pl",
     "fix:expired": "npm run -s check:expired -- -q | xargs -r -I {} sh -c 'echo \"Deleting expired file: {}\" && rm {}'",
     "fix:filenames": "npm run _rename-to-kebab-case",
     "fix:format": "npm run format",


### PR DESCRIPTION
- Fixes #6142
  - For some reason the shell used by NPM was a barebones one, not `bash`. Anyhow, fixed this by avoiding path expansion using the `{...}` syntax.
- Runs `fix:dict` on all locales now
- Includes the results of running `fix:dict`