### PR TITLE
Update survey URL

### DIFF
--- a/.github/workflows/survey-on-merged-pr.yml
+++ b/.github/workflows/survey-on-merged-pr.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   PR_NUM: ${{ github.event.pull_request.number }}
-  SURVEY_URL: https://forms.gle/WV58koUBGSG9HBY66
+  SURVEY_URL: https://docs.google.com/forms/d/e/1FAIpQLSf2FfCsW-DimeWzdQgfl0KDzT2UEAqu69_f7F2BVPSxVae1cQ/viewform?entry.1540511742=open-telemetry/opentelemetry.io
 
 jobs:
   comment-on-pr:
@@ -35,6 +35,6 @@ jobs:
       - name: Add comment to PR if author is not a member
         if: env.MEMBER_FOUND == 'false'
         run: |
-          gh pr comment ${PR_NUM} --repo open-telemetry/opentelemetry.io --body "Thank you for your contribution! 🎉 We would like to hear from you about your experience contributing to OpenTelemetry by taking a few minutes to fill out this survey: ${SURVEY_URL}"
+          gh pr comment ${PR_NUM} --repo open-telemetry/opentelemetry.io --body "Thank you for your contribution! 🎉 We would like to hear from you about your experience contributing to OpenTelemetry by taking a few minutes to fill out this [survey](${SURVEY_URL})"
         env:
           GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Update the server url to have the pre-selected value for repo.
The prior form didn't have a repo field, now with the new field, we want to have the value already pre-selected to help the user.