### PR TITLE
[pt] Update localized content under content/pt/docs/languages/go

### DIFF
--- a/content/pt/docs/languages/go/examples.md
+++ b/content/pt/docs/languages/go/examples.md
@@ -1,8 +1,8 @@
 ---
 title: Exemplos
-redirect: https://github.com/open-telemetry/opentelemetry-go/tree/main/example
+redirect: https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/examples
 manualLinkTarget: _blank
 _build: { render: link }
 weight: 220
-default_lang_commit: 06837fe15457a584f6a9e09579be0f0400593d57
+default_lang_commit: 5e2a0b43c1f9f42824a024206e797cf7041ed9db
 ---

--- a/content/pt/docs/languages/go/exporters.md
+++ b/content/pt/docs/languages/go/exporters.md
@@ -2,7 +2,7 @@
 title: Exporters
 aliases: [exporting_data]
 weight: 50
-default_lang_commit: 5e2a0b43c1f9f42824a024206e797cf7041ed9db
+default_lang_commit: 07431d6e22a33faa6775f2c1f40aa122990dc214
 # prettier-ignore
 cSpell:ignore: otlplog otlploggrpc otlploghttp otlpmetric otlpmetricgrpc otlpmetrichttp otlptrace otlptracegrpc otlptracehttp promhttp stdoutlog stdouttrace
 ---
@@ -92,7 +92,7 @@ padrão:
 
 ```go
 import (
-  "context"
+	"context"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/sdk/trace"
@@ -115,7 +115,7 @@ padrão:
 
 ```go
 import (
-  "context"
+ 	"context"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/sdk/trace"
@@ -153,7 +153,7 @@ padrão:
 
 ```go
 import (
-  "context"
+ 	"context"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/sdk/metric"
@@ -176,7 +176,7 @@ padrão:
 
 ```go
 import (
-  "context"
+ 	"context"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/sdk/metric"
@@ -201,7 +201,7 @@ de métricas) com as configurações padrão:
 
 ```go
 import (
-  "context"
+ 	"context"
 
 	"go.opentelemetry.io/otel/exporters/prometheus"
 	"go.opentelemetry.io/otel/sdk/metric"
@@ -229,7 +229,7 @@ padrão:
 
 ```go
 import (
-  "context"
+ 	"context"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
 	"go.opentelemetry.io/otel/sdk/log"

--- a/content/pt/docs/languages/go/getting-started.md
+++ b/content/pt/docs/languages/go/getting-started.md
@@ -1,7 +1,7 @@
 ---
 title: Primeiros Passos
 weight: 10
-default_lang_commit: 7fd0d2a6b87d6bbf2d5a35340c7afbd2bb33ca1c
+default_lang_commit: a025c25aaf1aef653caa34e49e8714472cbeddbd
 # prettier-ignore
 cSpell:ignore: chan fatalln funcs intn itoa khtml otelhttp rolldice stdouttrace strconv
 ---
@@ -141,7 +141,7 @@ qualquer aplicação que exporte telemetria.
 Crie um arquivo `otel.go` com o código de inicialização do SDK OpenTelemetry:
 
 <!-- prettier-ignore-start -->
-<?code-excerpt "otel.go" from="package main"?>
+<!-- code-excerpt "otel.go" from="package main"?-->
 ```go
 package main
 
@@ -280,7 +280,7 @@ OpenTelemetry e instrumenta o servidor HTTP utilizando a biblioteca de
 instrumentação `otelhttp`:
 
 <!-- prettier-ignore-start -->
-<?code-excerpt "main.go" from="package main"?>
+<--?code-excerpt "main.go" from="package main"?-->
 ```go
 package main
 
@@ -381,7 +381,7 @@ Modifique o arquivo `rolldice.go` para incluir instrumentação personalizada
 usando a API do OpenTelemetry:
 
 <!-- prettier-ignore-start -->
-<?code-excerpt "rolldice.go" from="package main"?>
+<!--?code-excerpt "rolldice.go" from="package main"?-->
 ```go
 package main
 

--- a/content/pt/docs/languages/go/instrumentation.md
+++ b/content/pt/docs/languages/go/instrumentation.md
@@ -5,7 +5,7 @@ aliases:
   - manual_instrumentation
 weight: 30
 description: Instrumentação manual para OpenTelemetry Go
-default_lang_commit: 1c6697de9c4d67fb72231354d5d9c6cdcfdfa64b
+default_lang_commit: a025c25aaf1aef653caa34e49e8714472cbeddbd
 # prettier-ignore
 cSpell:ignore: fatalf logr logrus otelslog otlplog otlploghttp sdktrace sighup updown
 ---
@@ -1127,7 +1127,7 @@ mais backends de telemetria.
 [instrumentation library]: ../libraries/
 [opentelemetry collector]:
   https://github.com/open-telemetry/opentelemetry-collector
-[logs bridge API]: /docs/specs/otel/logs/api
+[logs bridge API]: /docs/specs/otel/logs/api/
 [log data model]: /docs/specs/otel/logs/data-model
 [`go.opentelemetry.io/otel`]: https://pkg.go.dev/go.opentelemetry.io/otel
 [`go.opentelemetry.io/otel/exporters/stdout/stdoutmetric`]:


### PR DESCRIPTION
Tracked on #6144

Updates the Portuguese localized content for the following files:
- content/pt/docs/languages/go/getting-started.md
- content/pt/docs/languages/go/instrumentation.md
- content/pt/docs/languages/go/exporters.md
- content/pt/docs/languages/go/examples.md


