### PR TITLE
[pt] Update localized content under content/pt/docs/concepts/signals

### DIFF
--- a/content/pt/docs/concepts/signals/_index.md
+++ b/content/pt/docs/concepts/signals/_index.md
@@ -3,23 +3,33 @@ title: Sinais
 description:
   Aprenda sobre as categorias de telemetria suportadas pelo OpenTelemetry
 weight: 11
-default_lang_commit: 08e13eb62f2869300301670675969be705db59ae
+default_lang_commit: 7c0e4db0b6c39b0ca0e7efb17df5610d1b77b8a3
 ---
 
-O propósito do OpenTelemetry é coletar, processar e exportar **[sinais][]**.
-Sinais são dados emitidos que descrevem a atividade subjacente do sistema
-operacional e das aplicações que estão sendo executadas em uma plataforma. Um
-sinal pode ser algo que você deseja medir em um momento específico, como a
-temperatura ou o uso de memória, ou um evento que passa pelos componentes do seu
-sistema distribuído e que você gostaria de rastrear. Você pode agrupar
-diferentes sinais para observar o funcionamento interno de uma mesma tecnologia
-sob diferentes ângulos.
+O propósito do OpenTelemetry é coletar, processar e exportar [sinais]. Sinais
+são dados emitidos que descrevem a atividade subjacente do sistema operacional e
+das aplicações que estão sendo executadas em uma plataforma. Um sinal pode ser
+algo que você deseja medir em um momento específico, como a temperatura ou o uso
+de memória, ou um evento que passa pelos componentes do seu sistema distribuído
+e que você gostaria de rastrear. Você pode agrupar diferentes sinais para
+observar o funcionamento interno de uma mesma tecnologia sob diferentes ângulos.
 
-O OpenTelemetry atualmente suporta [rastros](/docs/concepts/signals/traces),
-[métricas](/docs/concepts/signals/metrics), [logs](/docs/concepts/signals/logs)
-e [bagagem](/docs/concepts/signals/baggage). Eventos são um tipo específico de
-log, e o
-[perfilamento está sendo trabalhado](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/profiles/0212-profiling-vision.md)
-pelo Grupo de Trabalho de Perfilamento _(Profiling Working Group)_.
+O OpenTelemetry atualmente suporta:
 
+- [Rastros](traces)
+- [Métricas](metrics)
+- [Logs](logs)
+- [Bagagem](baggage)
+
+Também em desenvolvimento ou na fase de [proposta]:
+
+- [Eventos], um tipo específico de [log](logs)
+- [Perfilamento] está sendo trabalhado pelo Grupo de Trabalho de Perfilamento
+  _(Profiling Working Group)_.
+
+[Eventos]: /docs/specs/otel/logs/data-model/#events
+[Perfilamento]:
+  https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/profiles/0212-profiling-vision.md
+[proposta]:
+  https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/#readme
 [sinais]: /docs/specs/otel/glossary/#signals

--- a/content/pt/docs/concepts/signals/baggage.md
+++ b/content/pt/docs/concepts/signals/baggage.md
@@ -2,21 +2,19 @@
 title: Bagagem
 weight: 4
 description: Informações contextuais que são propagadas entre sinais
-default_lang_commit: 896255cae4fea454ffc4c559ea29b08ccebbfcb2
+default_lang_commit: 7c0e4db0b6c39b0ca0e7efb17df5610d1b77b8a3
 ---
 
 No OpenTelemetry, Bagagem é uma informação contextual que acompanha o contexto.
 Bagagem é uma estrutura de armazenamento chave-valor, que te permite
-[propagar](/docs/concepts/context-propagation/#propagation) quaisquer dados
-junto com o [contexto](/docs/concepts/context-propagation/#context).
+[propagar](../../context-propagation/#propagation) quaisquer dados junto com o
+[contexto](../../context-propagation/#context).
 
 A Bagagem permite a transferência de dados entre serviços e processos,
-tornando-os acessíveis para serem adicionados a
-[rastros](/docs/concepts/signals/traces/),
-[métricas](/docs/concepts/signals/metrics/) ou
-[logs](/docs/concepts/signals/logs/) ao longo desses serviços.
+tornando-os acessíveis para serem adicionados a [rastros](../traces/),
+[métricas](../metrics/) ou [logs](../logs/) ao longo desses serviços.
 
-## Exemplo
+## Exemplo {#example}
 
 Bagagem é frequentemente usada em rastreamento para propagar dados adicionais
 entre serviços.
@@ -27,14 +25,14 @@ algumas métricas de outro serviço, e em alguns logs ao longo do caminho. Como 
 rastro pode abranger vários serviços, você precisa de uma maneira de propagar
 esses dados sem copiar o `clientId` em diversos pontos do seu código.
 
-Usando a
-[Propagação de Contexto](/docs/concepts/signals/traces/#context-propagation)
-para passar a bagagem entre esses serviços, o `clientId` estará disponível para
-ser adicionado a quaisquer trechos, métricas ou logs. Além disso, as
-instrumentações automaticamente propagam a Bagagem para você.
+Usando a [Propagação de Contexto](../traces/#context-propagation) para passar a
+bagagem entre esses serviços, o `clientId` estará disponível para ser adicionado
+a quaisquer trechos, métricas ou logs. Além disso, as instrumentações
+automaticamente propagam a Bagagem para você.
+
 ![OTel Baggage](../otel-baggage.svg)
 
-## Para que a Bagagem do OTel deve ser usada?
+## Para que a Bagagem do OTel deve ser usada? {##what-should-otel-baggage-be-used-for}
 
 A Bagagem é mais adequada para incluir informações que normalmente estão
 disponíveis apenas no início de uma requisição e que precisam ser propagadas
@@ -51,7 +49,7 @@ usuário nos dados do log.
 
 ![OTel Baggage](../otel-baggage-2.svg)
 
-## Considerações de segurança da Bagagem
+## Considerações de segurança da Bagagem {#baggage-security-considerations}
 
 Itens sensíveis da Bagagem podem ser compartilhados com recursos não
 intencionais, como APIs de terceiros. Isso ocorre porque a instrumentação
@@ -65,7 +63,7 @@ podem propagar a Bagagem fora da sua rede.
 Além disso, não há verificações de integridade automáticas para garantir que os
 itens de Bagagem sejam legítimos, portanto, tenha cautela ao acessá-los.
 
-## Bagagem não é o mesmo que atributos
+## Bagagem não é o mesmo que atributos {#baggage-is-not-the-same-as-attributes}
 
 É importante destacar que a Bagagem é um armazenamento de chave-valor separado e
 não está ligada aos atributos de trechos, métricas ou logs sem que seja
@@ -76,10 +74,10 @@ explicitamente os dados da Bagagem e adicioná-los como atributos aos seus
 trechos, métricas ou logs.
 
 Como um dos casos de uso comum da Bagagem é adicionar dados aos
-[Atributos de Trecho](/docs/concepts/signals/traces/#attributes) ao longo de
-todo um rastro, várias linguagens possuem Processadores de Trecho de Bagagem que
-adicionam dados da Bagagem como atributos na criação de trechos.
+[Atributos de Trecho](../traces/#attributes) ao longo de todo um rastro, várias
+linguagens possuem Processadores de Trecho de Bagagem que adicionam dados da
+Bagagem como atributos na criação de trechos.
 
-Para mais informações, consulte a [especificação da Bagagem][].
+Para mais informações, consulte a [especificação da Bagagem].
 
 [especificação da Bagagem]: /docs/specs/otel/overview/#baggage-signal

--- a/content/pt/docs/concepts/signals/baggage.md
+++ b/content/pt/docs/concepts/signals/baggage.md
@@ -32,7 +32,7 @@ automaticamente propagam a Bagagem para você.
 
 ![OTel Baggage](../otel-baggage.svg)
 
-## Para que a Bagagem do OTel deve ser usada? {##what-should-otel-baggage-be-used-for}
+## Para que a Bagagem do OTel deve ser usada? {#what-should-otel-baggage-be-used-for}
 
 A Bagagem é mais adequada para incluir informações que normalmente estão
 disponíveis apenas no início de uma requisição e que precisam ser propagadas

--- a/content/pt/docs/concepts/signals/logs.md
+++ b/content/pt/docs/concepts/signals/logs.md
@@ -2,7 +2,7 @@
 title: Logs
 description: Um registro de um evento.
 weight: 3
-default_lang_commit: ebc9a3a9f07278110677f4f8f69291a02704746b
+default_lang_commit: 7c0e4db0b6c39b0ca0e7efb17df5610d1b77b8a3
 cSpell:ignore: filelogreceiver semistructured transformprocessor
 ---
 
@@ -18,7 +18,7 @@ O OpenTelemetry não possui uma especificação de API ou SDK própria para gera
 logs. Em vez disso, os logs no OpenTelemetry são os logs que você já possui, que
 foram gerados por um framework de _logging_ ou componente de infraestrutura. Os
 SDKs e a autoinstrumentação do OpenTelemetry utilizam vários componentes para
-correlacionar automaticamente logs com [rastros](/docs/concepts/signals/traces).
+correlacionar automaticamente logs com [rastros](../traces).
 
 O suporte do OpenTelemetry para logs é projetado para ser totalmente compatível
 com o que você já possui, oferecendo a capacidade de adicionar contextos a esses
@@ -27,7 +27,7 @@ comum, abrangendo diversas fontes.
 
 ### Logs do OpenTelemetry no OpenTelemetry Collector {#opentelemetry-logs-in-the-opentelemetry-collector}
 
-O [OpenTelemetry Collector](/docs/collector) fornece várias ferramentas para
+O [OpenTelemetry Collector](/docs/collector/) fornece várias ferramentas para
 trabalhar com logs:
 
 - Vários _receivers_ que analisam logs de fontes específicas e conhecidas de

--- a/content/pt/docs/concepts/signals/metrics.md
+++ b/content/pt/docs/concepts/signals/metrics.md
@@ -2,7 +2,7 @@
 title: Métricas
 weight: 2
 description: Uma medição capturada em tempo de execução.
-default_lang_commit: eb19d1dd5ab2f66343ec76adbfb31f81024da3a1
+default_lang_commit: 7c0e4db0b6c39b0ca0e7efb17df5610d1b77b8a3
 ---
 
 Uma métrica é uma medição de um serviço capturada em tempo de execução. O
@@ -94,11 +94,11 @@ para cada instrumento de medição, que podem ser sobrescritas com o uso de
 _Views_. Por padrão, o projeto OpenTelemetry visa fornecer agregações que sejam
 suportadas por diferentes visualizadores e backends de telemetria.
 
-Ao contrário dos [rastros](/docs/concepts/signals/traces/), que são destinados a
-capturar os ciclos de vida das requisições e fornecer o contexto para as partes
-individuais de uma requisição, as métricas são destinadas a fornecer informações
-estatísticas em forma de dados agregados. Alguns exemplos de caso de uso para as
-métricas incluem:
+Ao contrário dos [rastros](../traces/), que são destinados a capturar os ciclos
+de vida das requisições e fornecer o contexto para as partes individuais de uma
+requisição, as métricas são destinadas a fornecer informações estatísticas em
+forma de dados agregados. Alguns exemplos de caso de uso para as métricas
+incluem:
 
 - Reportar o número total de _bytes_ lidos por um serviço, por tipo de
   protocolo.

--- a/content/pt/docs/concepts/signals/metrics.md
+++ b/content/pt/docs/concepts/signals/metrics.md
@@ -71,7 +71,7 @@ O tipo de instrumento deve ser um dos seguintes:
   tenha acesso às mudanças contínuas, mas apenas ao valor agregado (ex., atual
   tamanho da fila).
 - **Gauge**: Mede o valor atual no momento da leitura. Um exemplo seria um
-  medidor de tanque de combustível de um veículo. Gauges são assíncronos.
+  medidor de tanque de combustível de um veículo. Gauges são síncronos.
 - **Asynchronous Gauge**: Assim como o **Gauge**, porém é coletado uma vez a
   cada exportação. Pode ser usado em casos onde você não tenha acesso às
   mudanças contínuas, mas apenas ao valor agregado.

--- a/content/pt/docs/concepts/signals/traces.md
+++ b/content/pt/docs/concepts/signals/traces.md
@@ -2,7 +2,7 @@
 title: Rastros
 weight: 1
 description: O caminho de uma solicitação através do seu aplicativo.
-default_lang_commit: 57cd4f78d61cc1642ce56089aeec7ae278544194
+default_lang_commit: 7c0e4db0b6c39b0ca0e7efb17df5610d1b77b8a3
 ---
 
 Os **rastros** nos fornecem uma visão geral do que acontece quando uma
@@ -27,8 +27,8 @@ trecho `olá`:
 {
   "name": "olá",
   "context": {
-    "trace_id": "0x5b8aa5a2d2c872e8321cf37308d69df2",
-    "span_id": "0x051581bf3cb55c13"
+    "trace_id": "5b8aa5a2d2c872e8321cf37308d69df2",
+    "span_id": "051581bf3cb55c13"
   },
   "parent_id": null,
   "start_time": "2022-04-29T18:52:58.114201Z",
@@ -58,10 +58,10 @@ O trecho `olá-cumprimentos`:
 {
   "name": "olá-cumprimentos",
   "context": {
-    "trace_id": "0x5b8aa5a2d2c872e8321cf37308d69df2",
+    "trace_id": "5b8aa5a2d2c872e8321cf37308d69df2",
     "span_id": "0x5fb397be34d26b51"
   },
-  "parent_id": "0x051581bf3cb55c13",
+  "parent_id": "051581bf3cb55c13",
   "start_time": "2022-04-29T18:52:58.114304Z",
   "end_time": "2022-04-29T22:52:58.114561Z",
   "attributes": {
@@ -97,10 +97,10 @@ O trecho `olá-saudações`:
 {
   "name": "olá-saudações",
   "context": {
-    "trace_id": "0x5b8aa5a2d2c872e8321cf37308d69df2",
-    "span_id": "0x93564f51e1abe1c2"
+    "trace_id": "5b8aa5a2d2c872e8321cf37308d69df2",
+    "span_id": "5fb397be34d26b51"
   },
-  "parent_id": "0x051581bf3cb55c13",
+  "parent_id": "051581bf3cb55c13",
   "start_time": "2022-04-29T18:52:58.114492Z",
   "end_time": "2022-04-29T18:52:58.114631Z",
   "attributes": {
@@ -163,7 +163,7 @@ A propagação de contexto é o conceito central que possibilita o rastreamento
 distribuído. Com a propagação de contexto, trechos podem ser correlacionados
 entre si e montados em um rastro, independentemente de onde os trechos são
 gerados. Para saber mais sobre este tópico, consulte a página de conceitos sobre
-[Propagação de Contexto](/docs/concepts/context-propagation).
+[Propagação de Contexto](../../context-propagation).
 
 ## Trechos {#spans}
 
@@ -234,8 +234,8 @@ O contexto do trecho é um objeto imutável em cada trecho que contém o seguint
   rastro específicos do fornecedor
 
 O contexto do trecho é a parte de um trecho que é serializada e propagada junto
-com a [propagação de contexto](#context-propagation) e
-[baggage](/docs/concepts/signals/baggage).
+com a [Propagação de Contexto](#context-propagation) e
+[Baggage](../baggage).
 
 Como o contexto do trecho contém o trace ID, o trace ID é usado ao criar
 [links de trechos](#span-links).
@@ -317,6 +317,8 @@ segundo rastro. Agora, eles estão causalmente associados entre si.
 
 Os links são opcionais, mas servem como uma boa maneira de associar trechos de
 rastro uns aos outros.
+
+Para mais informações sobre Links de Trechos, consulte [Link](/docs/specs/otel/trace/api/#link).
 
 ### O estado do Trecho {#span-status}
 

--- a/content/pt/docs/concepts/signals/traces.md
+++ b/content/pt/docs/concepts/signals/traces.md
@@ -234,8 +234,7 @@ O contexto do trecho é um objeto imutável em cada trecho que contém o seguint
   rastro específicos do fornecedor
 
 O contexto do trecho é a parte de um trecho que é serializada e propagada junto
-com a [Propagação de Contexto](#context-propagation) e
-[Baggage](../baggage).
+com a [Propagação de Contexto](#context-propagation) e [Baggage](../baggage).
 
 Como o contexto do trecho contém o trace ID, o trace ID é usado ao criar
 [links de trechos](#span-links).
@@ -318,7 +317,8 @@ segundo rastro. Agora, eles estão causalmente associados entre si.
 Os links são opcionais, mas servem como uma boa maneira de associar trechos de
 rastro uns aos outros.
 
-Para mais informações sobre Links de Trechos, consulte [Link](/docs/specs/otel/trace/api/#link).
+Para mais informações sobre Links de Trechos, consulte
+[Link](/docs/specs/otel/trace/api/#link).
 
 ### O estado do Trecho {#span-status}
 


### PR DESCRIPTION
Tracked on #6144

Updates the Portuguese localized content for the following files:
- content/pt/docs/concepts/signals/_index.md
- content/pt/docs/concepts/signals/baggage.md
- content/pt/docs/concepts/signals/logs.md
- content/pt/docs/concepts/signals/metrics.md
- content/pt/docs/concepts/signals/traces.md


