### PR TITLE
Fix the missing parent span

### DIFF
--- a/content/en/docs/languages/python/getting-started.md
+++ b/content/en/docs/languages/python/getting-started.md
@@ -313,7 +313,8 @@ app = Flask(__name__)
 
 @app.route("/rolldice")
 def roll_dice():
-    return str(roll())
+    with tracer.start_as_current_span("/rolldice") as main_span:
+        return str(roll())
 
 def roll():
     # This creates a new span that's the child of the current one


### PR DESCRIPTION
# Why
The parent span is missing in the examples for the Flask example
- this means the child span has a NULL parent_id

# What
I match the name of the parent span with the docs here: https://opentelemetry.io/docs/languages/python/getting-started/

<img width="1011" alt="Screenshot 2025-01-31 at 4 53 59 PM" src="https://github.com/user-attachments/assets/85ebfcaf-a8c7-417c-9ee0-0cbc80c536de" />

<img width="868" alt="Screenshot 2025-01-31 at 4 51 59 PM" src="https://github.com/user-attachments/assets/c44ffc76-2896-45c6-a7ce-542f072b5748" />
