### PR TITLE
fix: missing `to` in demo/tests page

### DIFF
--- a/content/en/docs/demo/tests.md
+++ b/content/en/docs/demo/tests.md
@@ -4,7 +4,7 @@ cSpell:ignore: Tracetest
 ---
 
 Currently, the repository includes E2E tests for both the frontend and backend
-services. For the Frontend we are using [Cypress](https://www.cypress.io/)
+services. For the Frontend we are using [Cypress](https://www.cypress.io/) to
 execute the different flows in the web store. While the backend services use
 [AVA](https://avajs.dev) as the main testing framework for integration tests and
 [Tracetest](https://tracetest.io/) for trace-based tests.


### PR DESCRIPTION
- fix grammatical error in demo/tests page.
- fixes #6171
