### PR TITLE
[spelling] Write "cloud native" without a hyphen

### DIFF
--- a/.textlintrc.yml
+++ b/.textlintrc.yml
@@ -113,10 +113,11 @@ rules:
       # https://github.com/sapegin/textlint-rule-terminology/blob/ca36a645c56d21f27cb9d902b5fb9584030c59e3/index.js#L137-L142.
       #
       - ['3rd[- ]party', third-party]
-      - ['auto[- ]c(onfigur)(es?|ations?)', 'autoc$1$2'] # cspell:ignore autoc ations onfigur
+      - ['auto[- ]c(onfigur)(es?|ations?)', 'autoc$1$2'] # cSpell:disable-line
       - ['back[- ]end(s)?', 'backend$1']
       - [bugfix, bug fix]
       - [byte code, bytecode]
+      - ['(cloud)-(native)', '$1 $2']
       - [cpp, C++]
       - # dotnet|.net -> .NET, but NOT for strings like:
         # - File extension: file.net

--- a/content/en/blog/2019/opentelemetry-governance-committee-explained/index.md
+++ b/content/en/blog/2019/opentelemetry-governance-committee-explained/index.md
@@ -17,7 +17,7 @@ community by establishing processes. Let me explain.
 ![Watering can](watering-can.jpeg)
 
 The main objective of the OpenTelemetry project is to make robust, portable
-telemetry a built-in feature of cloud-native software. The most effective way to
+telemetry a built-in feature of cloud native software. The most effective way to
 do it is to build a community of passionate people, from existing ecosystem with
 the diverse expertise and experience. This community will build a project that
 is attractive to users, who will use it to instrument their software, as well as

--- a/content/en/blog/2022/demo-announcement/index.md
+++ b/content/en/blog/2022/demo-announcement/index.md
@@ -126,7 +126,7 @@ ourselves to just the items listed here.
 - Demonstrations of the ability to add
   [Baggage](https://github.com/open-telemetry/opentelemetry-demo/issues/100) and
   other custom tags
-- Continue to build on other cloud-native technologies like:
+- Continue to build on other cloud native technologies like:
   - Kubernetes
   - gRPC
   - [OpenFeature](https://github.com/open-feature)

--- a/content/en/blog/2022/instrument-kafka-clients/index.md
+++ b/content/en/blog/2022/instrument-kafka-clients/index.md
@@ -11,7 +11,7 @@ system in a distributed environment. Different services communicate with each
 other by using Apache Kafka as a messaging system but even more as en event or
 data streaming platform.
 
-Taking into account the cloud-native approach for developing microservices,
+Taking into account the cloud native approach for developing microservices,
 quite often [Kubernetes](https://kubernetes.io/) is also used to run the
 workloads. In this scenario, you can also easily deploy and manage an Apache
 Kafka cluster on top of it, by using a project like

--- a/content/en/blog/2022/why-and-how-ebay-pivoted-to-opentelemetry/index.md
+++ b/content/en/blog/2022/why-and-how-ebay-pivoted-to-opentelemetry/index.md
@@ -22,7 +22,7 @@ experience. The Observability landscape is an ever-changing one and recent
 developments in the OpenTelemetry world forced us to rethink our strategy in
 order to pivot to using it. eBay’s observability platform Sherlock.io provides
 developers and Site Reliability Engineers (SREs) with a robust set of
-cloud-native offerings to observe the various applications that power the eBay
+cloud native offerings to observe the various applications that power the eBay
 ecosystem. Sherlock.io supports the three pillars of observability — metrics,
 logs and traces. The platform’s metric store is a clustered and sharded
 implementation of the Prometheus storage engine. We use the Metricbeat agent to

--- a/content/en/blog/2023/end-user-q-and-a-03.md
+++ b/content/en/blog/2023/end-user-q-and-a-03.md
@@ -69,7 +69,7 @@ at the chance to work with it.
 ### What is the architecture at Farfetch like? How has OpenTelemetry helped?
 
 Farfetch currently has 2000 engineers, with a complex and varied architecture
-which includes cloud-native, Kubernetes, and virtual machines running on three
+which includes cloud native, Kubernetes, and virtual machines running on three
 different cloud providers. There is a lot of information coming from everywhere,
 with a lack of standardization on how to collect this information. For example,
 Prometheus is used mostly as a standard for collecting metrics; however, in some

--- a/content/en/blog/2023/kubecon-eu.md
+++ b/content/en/blog/2023/kubecon-eu.md
@@ -42,7 +42,7 @@ Come network with OpenTelemetry maintainers and core contributors during the
 2023 from 16:00 - 17:00. You can attend with a _standard in-person pass_.
 
 [Observability Day][] _fosters collaboration, discussion, and knowledge sharing
-of cloud-native observability projects_. This event will be held on April 18,
+of cloud native observability projects_. This event will be held on April 18,
 2023 from 9:00 - 17:00. There will be several sessions on OpenTelemetry as well.
 
 > <i class="far fa-exclamation-triangle"></i> **IMPORTANT access note**: You

--- a/content/en/blog/2023/kubecon-na.md
+++ b/content/en/blog/2023/kubecon-na.md
@@ -79,7 +79,7 @@ OpenTelemetry maintainers in making OpenTelemetry better for everyone during the
 ## Co-located Events
 
 [Observability Day][] _fosters collaboration, discussion, and knowledge sharing
-of cloud-native observability projects_. This event will be held on November 6,
+of cloud native observability projects_. This event will be held on November 6,
 2023 from 9am - 5pm. There will be several sessions on OpenTelemetry as well.
 
 > <i class="far fa-exclamation-triangle"></i> **IMPORTANT access note**: You

--- a/content/en/blog/2023/otel-in-focus-04.md
+++ b/content/en/blog/2023/otel-in-focus-04.md
@@ -81,7 +81,7 @@ There's much more -- be sure to check out the release notes!
 
 ## Project Updates
 
-KubeCon EU saw over ten thousand cloud-native developers gather in Amsterdam,
+KubeCon EU saw over ten thousand cloud native developers gather in Amsterdam,
 and a lot of you stopped by the OpenTelemetry booth to say hi! Hopefully some of
 you got your hands on our limited-edition KubeCon stickers... if not, well,
 there'll be more limited edition stickers. Just not for KubeCon, because it's

--- a/content/en/blog/2024/kubecon-eu.md
+++ b/content/en/blog/2024/kubecon-eu.md
@@ -10,8 +10,8 @@ cSpell:ignore: Aiven Alexandre Anusha Arbiv Beemer Benedikt Blanco Bongartz Chek
 ---
 
 The OpenTelemetry project maintainers, members of the governance committee, and
-technical committee are thrilled to be at [KubeCon + CloudNativeCon Europe][]
-and at the co-located
+technical committee are thrilled to be at [KubeCon + CloudNativeCon Europe] and
+at the co-located
 [Observability Day](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/co-located-events/observability-day/)
 in Paris from March 19 - 22, 2024.
 
@@ -46,9 +46,9 @@ it again right before KubeCon!
 
 ## Observability Day
 
-_[Observability Day][] fosters collaboration, discussion, and knowledge sharing
-of cloud-native observability projects_. This event will be held on March 19,
-2024 from 9:00 - 17:35. There will be several sessions on OpenTelemetry as well:
+_[Observability Day] fosters collaboration, discussion, and knowledge sharing of
+cloud native observability projects_. This event will be held on March 19, 2024
+from 9:00 - 17:35. There will be several sessions on OpenTelemetry as well:
 
 - **[Welcome + Project Updates](https://sched.co/1YGT9)**<br> by Eduardo Silva,
   FluentBit & Austin Parker, honeycomb.io<br> Tuesday, March 19th • 09:00 -
@@ -90,7 +90,7 @@ of cloud-native observability projects_. This event will be held on March 19,
 {{% alert title="Important access note" color="danger" %}}
 
 You need an _in-person all-access_ pass for on-site access to **Observability
-Day**. For details, see [KubeCon registration][]. If you have a virtual ticket,
+Day**. For details, see [KubeCon registration]. If you have a virtual ticket,
 you will be able to follow **Observability Day** through a live stream.
 
 [kubecon registration]:
@@ -135,7 +135,7 @@ that SIG. Sessions will be recorded and posted on the
 [OTel YouTube channel](https://youtube.com/@otel-official).
 
 We will create action items from your comments as appropriate. Check
-[#otel-user-research][] in CNCF's Slack instance for results and action item
+[#otel-user-research] in CNCF's Slack instance for results and action item
 updates to come after KubeCon EU.
 
 Back by popular demand! We'll be recording

--- a/content/en/blog/2024/kubecon-na.md
+++ b/content/en/blog/2024/kubecon-na.md
@@ -8,7 +8,7 @@ cSpell:ignore: Arnell Ashok Chandrasekar Clario Contribfest Ekansh Grabner Haeus
 ---
 
 The OpenTelemetry project maintainers, members of the governance committee, and
-technical committee are thrilled to be at [KubeCon NA][] in Salt Lake City from
+technical committee are thrilled to be at [KubeCon NA] in Salt Lake City from
 November 12 - 15, 2024.
 
 Read on to learn about all the things related OpenTelemetry during KubeCon.
@@ -78,17 +78,16 @@ first steps: documentation, Collector, Java, JS, Ruby, Python, .NET, and more.
 
 ## Observability Day
 
-_[Observability Day][] fosters collaboration, discussion, and knowledge sharing
-of cloud-native observability projects_. This event will be held on November 12,
+_[Observability Day] fosters collaboration, discussion, and knowledge sharing of
+cloud native observability projects_. This event will be held on November 12,
 2024 from 9am to 6pm.
 [Check the full schedule](https://colocatedeventsna2024.sched.com/overview/type/Observability+Day)
 to find your favorite talks about Observability and OpenTelemetry.
 
 > <i class="far fa-exclamation-triangle"></i> **IMPORTANT access note**: You
 > need an _in-person all-access_ pass for on-site access to **Observability
-> Day**. For details, see [KubeCon registration][]. If you have a virtual
-> ticket, you will be able to follow **Observability Day** through a live
-> stream.
+> Day**. For details, see [KubeCon registration]. If you have a virtual ticket,
+> you will be able to follow **Observability Day** through a live stream.
 
 ## OpenTelemetry Observatory
 
@@ -120,7 +119,7 @@ You can help us improve the project by sharing your thoughts and feedback about
 your OpenTelemetry adoption, implementation, and usage.
 
 We will create action items from your comments as appropriate. Check
-[#otel-sig-end-user][] in CNCF's Slack instance for results and action item
+[#otel-sig-end-user] in CNCF's Slack instance for results and action item
 updates to come after KubeCon EU.
 
 Come join us to listen, learn, and get involved in OpenTelemetry.

--- a/content/en/blog/2024/new-otel-features-envoy-istio/index.md
+++ b/content/en/blog/2024/new-otel-features-envoy-istio/index.md
@@ -8,7 +8,7 @@ sig: OpenTelemetry Specification
 cSpell:ignore: bookinfo Grassi istioctl Joao productpage
 ---
 
-In the dynamic world of cloud-native and distributed applications, managing
+In the dynamic world of cloud native and distributed applications, managing
 microservices effectively is critical. [Kubernetes](https://kubernetes.io/) has
 become the de facto standard for container orchestration, enabling seamless
 deployment, scaling, and management of containerized applications.

--- a/content/en/docs/demo/requirements/architecture.md
+++ b/content/en/docs/demo/requirements/architecture.md
@@ -7,7 +7,7 @@ cSpell:ignore: dockerstatsreceiver
 
 ## Summary
 
-The OpenTelemetry Community Demo application is intended to be a 'showcase' for
+The OpenTelemetry Community Demo application is intended to be a showcase for
 OpenTelemetry API, SDK, and tools in a production-lite cloud native application.
 The overall goal of this application is not only to provide a canonical 'demo'
 of OpenTelemetry components, but also to act as a framework for further

--- a/content/en/docs/faas/_index.md
+++ b/content/en/docs/faas/_index.md
@@ -8,9 +8,9 @@ weight: 360
 ---
 
 Functions as a Service (FaaS) is an important serverless compute platform for
-cloud native applications. However, platform quirks usually mean these
-applications have slightly different monitoring guidance and requirements than
-applications running on Kubernetes or Virtual Machines.
+[cloud native apps]. However, platform quirks usually mean these applications
+have slightly different monitoring guidance and requirements than applications
+running on Kubernetes or Virtual Machines.
 
 The initial vendor scope of the FaaS documentation is around Microsoft Azure,
 Google Cloud Platform (GCP), and Amazon Web Services (AWS). AWS functions are
@@ -25,3 +25,5 @@ automatically.
 
 The release status can be tracked in the
 [OpenTelemetry-Lambda repository](https://github.com/open-telemetry/opentelemetry-lambda).
+
+[cloud native apps]: https://glossary.cncf.io/cloud-native-apps/

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -12311,6 +12311,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-02-01T07:12:05.193348-05:00"
   },
+  "https://glossary.cncf.io/cloud-native-apps/": {
+    "StatusCode": 206,
+    "LastSeen": "2025-02-03T05:30:54.785412-05:00"
+  },
   "https://go.dev/": {
     "StatusCode": 200,
     "LastSeen": "2025-01-30T14:41:02.735818-05:00"


### PR DESCRIPTION
- Adds a 'textlint' rule for "cloud native", without a hyphen, per:
  - CNCF usage, see https://cncf.io and https://glossary.cncf.io
  - https://developers.google.com/style/hyphens
- Fixes occurrences in doc pages
- Adds link to "cloud native apps" glossary entry from the FaaS page