### PR TITLE
[CI] Check links to crates.io, and link fix

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -70,8 +70,6 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   # e.g.: https://www.microsoft.com/en-ca/sql-server.
   - ^https://www.microsoft.com/sql-server$
 
-  # TODO: drop after fix to https://github.com/rust-lang/crates.io/issues/788
-  - ^https://crates\.io/crates
   # TODO move into content/en/blog/2023/humans-of-otel.md once https://github.com/open-telemetry/opentelemetry.io/issues/3889 is implemented
   - ^https://shorturl.at/osHRX$
   # TODO move into content/en/blog/2023/contributing-to-otel/index.md once https://github.com/open-telemetry/opentelemetry.io/issues/3889 is implemented

--- a/data/registry/instrumentation-rust-trillium.yml
+++ b/data/registry/instrumentation-rust-trillium.yml
@@ -15,6 +15,6 @@ urls:
 createdAt: 2021-04-25
 package:
   registry: crates
-  name: opentelemetry-trillium-opentelemetry
+  name: trillium-opentelemetry
   version: 0.2.16
 isFirstParty: true

--- a/scripts/double-check-refcache-400s.mjs
+++ b/scripts/double-check-refcache-400s.mjs
@@ -4,6 +4,7 @@ import fs from 'fs/promises';
 import { getUrlStatus, isHttp2XX } from './get-url-status.mjs';
 
 const CACHE_FILE = 'static/refcache.json';
+const cratesIoURL = 'https://crates.io/crates/';
 
 async function readRefcache() {
   try {
@@ -28,13 +29,14 @@ async function retry400sAndUpdateCache() {
   for (const [url, details] of Object.entries(cache)) {
     const { StatusCode, LastSeen } = details;
     if (isHttp2XX(StatusCode)) continue;
-    if (StatusCode === 404) {
+    if (StatusCode === 404 && !url.startsWith(cratesIoURL)) {
       console.log(`Skipping 404: ${url} (last seen ${LastSeen}).`);
       continue;
     }
 
-    process.stdout.write(`Checking: ${url} (was ${StatusCode})... `);
-    const status = await getUrlStatus(url, true);
+    process.stdout.write(`Checking: ${url} (was ${StatusCode}) ... `);
+    const verbose = false;
+    const status = await getUrlStatus(url, verbose);
     console.log(`${status}.`);
 
     if (!isHttp2XX(status)) continue;

--- a/scripts/get-url-status.mjs
+++ b/scripts/get-url-status.mjs
@@ -58,7 +58,7 @@ async function getUrlHeadless(url) {
       const crateName = url.split('/').pop();
       // E.g. 'https://crates.io/crates/opentelemetry-sdk' -> 'opentelemetry-sdk'
       const crateNameRegex = new RegExp(crateName.replace(/-/g, '[-_]'));
-      // Crate found iff title starts with createName (in kebab or snake case)
+      // Crate found if title starts with createName (in kebab or snake case)
       if (!crateNameRegex.test(title)) status = 404;
     }
 

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -535,6 +535,106 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-13T12:41:25.904834-05:00"
   },
+  "https://crates.io/crates/actix-web-opentelemetry": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-02T17:57:45.084Z"
+  },
+  "https://crates.io/crates/axum-tracing-opentelemetry": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-02T17:57:47.339Z"
+  },
+  "https://crates.io/crates/opentelemetry": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-02T17:57:49.61Z"
+  },
+  "https://crates.io/crates/opentelemetry-api": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-02T18:05:36.945Z"
+  },
+  "https://crates.io/crates/opentelemetry-application-insights": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-02T17:57:54.019Z"
+  },
+  "https://crates.io/crates/opentelemetry-aws": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-02T17:57:56.112Z"
+  },
+  "https://crates.io/crates/opentelemetry-contrib": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-02T17:57:58.245Z"
+  },
+  "https://crates.io/crates/opentelemetry-datadog": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-02T17:58:00.377Z"
+  },
+  "https://crates.io/crates/opentelemetry-dynatrace": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-02T17:58:02.494Z"
+  },
+  "https://crates.io/crates/opentelemetry-http": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-02T17:58:04.819Z"
+  },
+  "https://crates.io/crates/opentelemetry-jaeger": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-02T17:58:07.016Z"
+  },
+  "https://crates.io/crates/opentelemetry-jaeger-propagator": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-02T17:58:09.226Z"
+  },
+  "https://crates.io/crates/opentelemetry-otlp": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-02T17:58:11.386Z"
+  },
+  "https://crates.io/crates/opentelemetry-prometheus": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-02T17:58:13.549Z"
+  },
+  "https://crates.io/crates/opentelemetry-sdk": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-02T18:05:39.108Z"
+  },
+  "https://crates.io/crates/opentelemetry-semantic-conventions": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-02T17:58:17.816Z"
+  },
+  "https://crates.io/crates/opentelemetry-stackdriver": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-02T17:58:19.861Z"
+  },
+  "https://crates.io/crates/opentelemetry-stdout": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-02T17:58:22.05Z"
+  },
+  "https://crates.io/crates/opentelemetry-tide": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-02T17:58:24.207Z"
+  },
+  "https://crates.io/crates/opentelemetry-user-events-logs": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-02T17:58:28.107Z"
+  },
+  "https://crates.io/crates/opentelemetry-user-events-metrics": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-02T17:58:30.247Z"
+  },
+  "https://crates.io/crates/opentelemetry-zipkin": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-02T17:58:32.438Z"
+  },
+  "https://crates.io/crates/opentelemetry_sdk": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-02T17:58:34.619Z"
+  },
+  "https://crates.io/crates/tracing-opentelemetry": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-02T17:58:36.89Z"
+  },
+  "https://crates.io/crates/trillium-opentelemetry": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-02T18:16:27.365Z"
+  },
   "https://creativecommons.org/licenses/by/4.0": {
     "StatusCode": 206,
     "LastSeen": "2025-02-01T06:38:25.294134-05:00"


### PR DESCRIPTION
- Fixes #6175
- Contributes to #5017
- Enables the checking of links to crates.io, despite https://github.com/rust-lang/crates.io/issues/788
- Fixes package name

/cc @open-telemetry/rust-approvers 