### PR TITLE
Link fix of Spring Boot Starter other-spring-autoconfig.md

### DIFF
--- a/content/en/docs/zero-code/java/spring-boot-starter/other-spring-autoconfig.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/other-spring-autoconfig.md
@@ -18,9 +18,7 @@ OpenTelemetry Zipkin Exporter Starter is a starter package that includes the
 and spring framework starters required to setup distributed tracing. It also
 provides the
 [opentelemetry-exporters-zipkin](https://github.com/open-telemetry/opentelemetry-java/tree/main/exporters/zipkin)
-artifact and corresponding exporter autoconfiguration. Check out
-[opentelemetry-spring-boot-autoconfigure](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/spring/spring-boot-autoconfigure/README.md#features?FIXME)
-for the list of supported libraries and features.
+artifact and corresponding exporter autoconfiguration.
 
 If an exporter is present in the classpath during runtime and a spring bean of
 the exporter is missing from the spring application context, an exporter bean is

--- a/content/en/docs/zero-code/java/spring-boot-starter/other-spring-autoconfig.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/other-spring-autoconfig.md
@@ -19,7 +19,7 @@ and spring framework starters required to setup distributed tracing. It also
 provides the
 [opentelemetry-exporters-zipkin](https://github.com/open-telemetry/opentelemetry-java/tree/main/exporters/zipkin)
 artifact and corresponding exporter autoconfiguration. Check out
-[opentelemetry-spring-boot-autoconfigure](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/spring/spring-boot-autoconfigure/README.md#features)
+[opentelemetry-spring-boot-autoconfigure](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/spring/spring-boot-autoconfigure/README.md#features?FIXME)
 for the list of supported libraries and features.
 
 If an exporter is present in the classpath during runtime and a spring bean of


### PR DESCRIPTION
The folder/package `opentelemetry-spring-boot-autoconfigure` doesn't seem to exist anymore. Also, the following link has an invalid hash, but in any case it points back to this website, so we should just refer directly to this website. WDYT @trask @open-telemetry/java-instrumentation-approvers?

```markdown
[opentelemetry-spring-boot-autoconfigure](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/spring/spring-boot-autoconfigure/README.md#features?FIXME)
```

This work is in support of:

- #6196

Related:

- #6205

