### PR TITLE
[CI] Upgrade Docsy, and Hugo to 0.143.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,7 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/google/docsy.git
-	docsy-pin = v0.11.0-38-g77da7e49
+	docsy-pin = v0.11.0-39-g9e685592
 	docsy-note = "2024-04-01 Switching to google/docsy.git from cncf/docsy.git since we don't have any CNCF customizations."
 	docsy-reminder = "Ensure that any tag referenced by `docsy-pin` is present in the remote repo (url), otherwise add (push) the tags to the repo."
 [submodule "content-modules/opentelemetry-specification"]

--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -209,7 +209,7 @@ Prometheus exporter, regardless of their origin, are prefixed with `otelcol_`.
 This includes metrics from both Collector components and instrumentation
 libraries. {{% /alert %}}
 
-{{% comment %}}
+{{< comment >}}
 
 To compile this list, configure a Collector instance to emit its own metrics to
 the localhost:8888/metrics endpoint. Select a metric and grep for it in the
@@ -222,7 +222,7 @@ the .go file that contains the list of metrics. In the case of
 Note that the Collector's internal metrics are defined in several different
 files in the repository.
 
-{{% /comment %}}
+{{< /comment >}}
 
 #### `basic`-level metrics
 

--- a/package.json
+++ b/package.json
@@ -120,9 +120,9 @@
     "ajv-formats": "^3.0.1",
     "ajv": "^8.17.1",
     "autoprefixer": "^10.4.20",
-    "cspell": "^8.17.2",
+    "cspell": "^8.17.3",
     "gulp": "^5.0.0",
-    "hugo-extended": "0.142.0",
+    "hugo-extended": "0.143.0",
     "js-yaml": "^4.1.0",
     "markdown-link-check": "^3.13.6",
     "markdownlint": "^0.37.4",
@@ -151,7 +151,7 @@
     "path": "^0.12.7"
   },
   "optionalDependencies": {
-    "netlify-cli": "^18.0.2",
+    "netlify-cli": "^18.0.3",
     "npm-check-updates": "^17.1.14"
   },
   "enginesComment": "Ensure that engines.node value stays consistent with the project's .nvmrc",


### PR DESCRIPTION
- Upgrades to Hugo 0.143.0
- Upgrades Docsy, bringing with it the `comment` shortcode that Hugo has deprecated