### PR TITLE
fix: update an outdated word of Create Issue in contributing/issues page

### DIFF
--- a/content/en/docs/contributing/issues.md
+++ b/content/en/docs/contributing/issues.md
@@ -57,7 +57,7 @@ an issue.
    you to a GitHub issue page prepopulated with some headers.
 2. Describe the issue or suggestion for improvement. Provide as many details as
    you can.
-3. Click **Submit new issue**.
+3. Click **Create**.
 
 After submitting, check in on your issue occasionally or turn on GitHub
 notifications. It might take a few days until maintainers and approvers respond.


### PR DESCRIPTION
<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->

I fixed the outdated the word of Create Issue button in contributing/issues page.

issue: https://github.com/open-telemetry/opentelemetry.io/issues/6198
