### PR TITLE
fix description of log instrumentation

### DIFF
--- a/content/en/docs/languages/java/instrumentation.md
+++ b/content/en/docs/languages/java/instrumentation.md
@@ -23,13 +23,12 @@ instrumentation topics:
 - [Instrumentation categories](#instrumentation-categories): There are a variety
   of categories of instrumentation addressing different use cases and
   installation patterns.
-- [Context propagation](#context-propagation): Provides
-  correlation between traces, metrics, and logs, allowing the signals to
-  complement each other.
-- [Semantic conventions](#semantic-conventions): Define
-  how to produce telemetry for standard operations.
-- [Log instrumentation](#log-instrumentation): Can be used
-  to get logs from an existing Java logging framework into OpenTelemetry.
+- [Context propagation](#context-propagation): Provides correlation between
+  traces, metrics, and logs, allowing the signals to complement each other.
+- [Semantic conventions](#semantic-conventions): Define how to produce telemetry
+  for standard operations.
+- [Log instrumentation](#log-instrumentation): Can be used to get logs from an
+  existing Java logging framework into OpenTelemetry.
 
 {{% alert %}} While [instrumentation categories](#instrumentation-categories)
 enumerates several options for instrumenting an application, we recommend users

--- a/content/en/docs/languages/java/instrumentation.md
+++ b/content/en/docs/languages/java/instrumentation.md
@@ -23,12 +23,12 @@ instrumentation topics:
 - [Instrumentation categories](#instrumentation-categories): There are a variety
   of categories of instrumentation addressing different use cases and
   installation patterns.
-- [Context propagation](#context-propagation): Context propagation provides
+- [Context propagation](#context-propagation): Provides
   correlation between traces, metrics, and logs, allowing the signals to
   complement each other.
-- [Semantic conventions](#semantic-conventions): The semantic conventions define
+- [Semantic conventions](#semantic-conventions): Define
   how to produce telemetry for standard operations.
-- [Log instrumentation](#log-instrumentation): Log instrumentation can be used
+- [Log instrumentation](#log-instrumentation): Can be used
   to get logs from an existing Java logging framework into OpenTelemetry.
 
 {{% alert %}} While [instrumentation categories](#instrumentation-categories)

--- a/content/en/docs/languages/java/instrumentation.md
+++ b/content/en/docs/languages/java/instrumentation.md
@@ -28,8 +28,8 @@ instrumentation topics:
   complement each other.
 - [Semantic conventions](#semantic-conventions): The semantic conventions define
   how to produce telemetry for standard operations.
-- [Log instrumentation](#log-instrumentation): The semantic conventions define
-  how to produce telemetry for standard operations.
+- [Log instrumentation](#log-instrumentation): Log instrumentation can be used
+  to get logs from an existing Java logging framework into OpenTelemetry.
 
 {{% alert %}} While [instrumentation categories](#instrumentation-categories)
 enumerates several options for instrumenting an application, we recommend users

--- a/content/en/docs/languages/java/instrumentation.md
+++ b/content/en/docs/languages/java/instrumentation.md
@@ -20,14 +20,13 @@ instrumentation API calls. This page discusses the OpenTelemetry ecosystem in
 OpenTelemetry Java, including resources for end users and cross-cutting
 instrumentation topics:
 
-- [Instrumentation categories](#instrumentation-categories): There are a variety
-  of categories of instrumentation addressing different use cases and
-  installation patterns.
-- [Context propagation](#context-propagation): Provides correlation between
+- [Instrumentation categories](#instrumentation-categories) addressing different
+  use cases and installation patterns.
+- [Context propagation](#context-propagation) provides correlation between
   traces, metrics, and logs, allowing the signals to complement each other.
-- [Semantic conventions](#semantic-conventions): Define how to produce telemetry
+- [Semantic conventions](#semantic-conventions) define how to produce telemetry
   for standard operations.
-- [Log instrumentation](#log-instrumentation): Can be used to get logs from an
+- [Log instrumentation](#log-instrumentation), which is used to get logs from an
   existing Java logging framework into OpenTelemetry.
 
 {{% alert %}} While [instrumentation categories](#instrumentation-categories)


### PR DESCRIPTION
Fixes #6093 
Update to the correct description for `Log instrumentation`.
