### PR TITLE
fix: removing deplulicated words of `file file`

### DIFF
--- a/content/en/docs/contributing/style-guide.md
+++ b/content/en/docs/contributing/style-guide.md
@@ -94,8 +94,8 @@ cSpell:ignore: <word>
 ```
 
 For any other file, add `cSpell:ignore <word>` in a comment line appropriate for
-the file's context. For a [registry](/ecosystem/registry/) entry YAML file file,
-it might look like this:
+the file's context. For a [registry](/ecosystem/registry/) entry YAML file, it
+might look like this:
 
 ```yaml
 # cSpell:ignore <word>


### PR DESCRIPTION
<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->

I found the a duplicated words in contributing/style-guide page.
I fixed it because  I think that it is a mistake.
