### PR TITLE
Update example config for handling tail-sampling and span metric generation when horizontally scaling collectors

### DIFF
--- a/content/en/docs/collector/scaling.md
+++ b/content/en/docs/collector/scaling.md
@@ -340,7 +340,7 @@ A similar situation happens when using the
 to generate service metrics. When different collectors receive data related to
 the same service, aggregations based on the service name will be inaccurate due
 to violating the
-[single-writer assumption](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#single-writer).
+[single-writer assumption](/docs/specs/otel/metrics/data-model/#single-writer).
 
 To overcome this, the
 [load-balancing exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/loadbalancingexporter/README.md)

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -4971,6 +4971,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:33:59.421324-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-02-09T14:36:41.344544-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/README.md": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:34:48.902535-05:00"
@@ -4978,6 +4982,10 @@
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/kafkaexporter/README.md": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:36:00.479836-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/loadbalancingexporter/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-02-09T14:36:47.129387-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/lokiexporter/README.md": {
     "StatusCode": 206,
@@ -5042,6 +5050,10 @@
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/routingprocessor/README.md": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:34:46.89984-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/tailsamplingprocessor/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-02-09T14:36:38.940351-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/hostmetricsreceiver/README.md": {
     "StatusCode": 206,


### PR DESCRIPTION
Hello, we used this page's documentation when setting-up tail-sampling and span metric generation. The guide was helpful but there were a couple things it could've mentioned to make our implementation smoother:
1. The guide currently suggests having two separate deployments of collectors. One just for load-balancing spans and another for processing the load-balanced spans. We started with the two deployments but then found it easier to maintain a single deployment of collectors responsible for both tasks. However, it wasn't obvious (to us at least) that this was possible and I'm guessing others would prefer this approach too.
2. There wasn't any example configuration of how the load-balancing exporter, span metric connector, and tail sampling processor all fit together, so it took some jumping between READMEs and unintentional violations of single-writer assumption (which we weren't aware of) to get it right.

So this documentation suggestion shows how all the components work together in a single collector deployment.