### PR TITLE
Update Footer with Bluesky Link

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -141,8 +141,9 @@ params:
       - name: Bluesky
         url: https://bsky.app/profile/opentelemetry.io
         icon: fab fa-bluesky
-        desc: Follow us on Bluesky to get the latest news!
-          Follow us on X, previously known as Twitter, to get the latest news!
+        desc:
+          Follow us on Bluesky to get the latest news! Follow us on X,
+          previously known as Twitter, to get the latest news!
       - name: Stack Overflow
         url: https://stackoverflow.com/questions/tagged/open-telemetry
         icon: fab fa-stack-overflow

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -138,10 +138,10 @@ params:
         url: https://fosstodon.org/@opentelemetry
         icon: fab fa-mastodon
         desc: Follow us on Mastodon to get the latest news!
-      - name: X
-        url: https://x.com/opentelemetry
-        icon: fab fa-x-twitter
-        desc:
+      - name: Bluesky
+        url: https://bsky.app/profile/opentelemetry.io
+        icon: fab fa-bluesky
+        desc: Follow us on Bluesky to get the latest news!
           Follow us on X, previously known as Twitter, to get the latest news!
       - name: Stack Overflow
         url: https://stackoverflow.com/questions/tagged/open-telemetry

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -134,16 +134,14 @@ params:
         url: https://github.com/open-telemetry/community#mailing-lists
         icon: fa fa-envelope
         desc: List of mailing lists that the project uses.
+      - name: Bluesky
+        url: https://bsky.app/profile/opentelemetry.io
+        icon: fab fa-bluesky
+        desc: Follow us on Bluesky to get the latest news!
       - name: Mastodon
         url: https://fosstodon.org/@opentelemetry
         icon: fab fa-mastodon
         desc: Follow us on Mastodon to get the latest news!
-      - name: Bluesky
-        url: https://bsky.app/profile/opentelemetry.io
-        icon: fab fa-bluesky
-        desc:
-          Follow us on Bluesky to get the latest news! Follow us on X,
-          previously known as Twitter, to get the latest news!
       - name: Stack Overflow
         url: https://stackoverflow.com/questions/tagged/open-telemetry
         icon: fab fa-stack-overflow


### PR DESCRIPTION
Per https://github.com/open-telemetry/community/issues/2444, this updates the footer to remove the link to Twitter.