### PR TITLE
fix: incorrect check:i18n option in a localization page

### DIFF
--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -210,7 +210,7 @@ at `HEAD`, then erase the commit hash value in the front matter, and run the
 {{% /alert %}}
 
 If you have batch updated all of your localization pages that had drifted, you
-can update the commit hash of these files using the `-u` flag followed by a
+can update the commit hash of these files using the `-c` flag followed by a
 commit hash or 'HEAD' to use `main@HEAD`.
 
 ```sh


### PR DESCRIPTION
<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->

I found the a mistake in contributing/localization page.
There is no `-u` option in `scripts/check-i18n.sh`.

I think that `-c` is correct.

https://github.com/open-telemetry/opentelemetry.io/blob/44059882dcc7aaeab26911ebccc4e09c2a0ba26a/scripts/check-i18n.sh#L39-L57




