### PR TITLE
[ja] update default_lang_commit in content/ja/docs/getting-started page

### DIFF
--- a/content/ja/docs/getting-started/ops.md
+++ b/content/ja/docs/getting-started/ops.md
@@ -1,7 +1,7 @@
 ---
 title: 運用担当者のための入門
 linkTitle: Ops
-default_lang_commit: e7a6289
+default_lang_commit: d2368c7e90e6abeb4580193aa305dfabd21ed4f7
 ---
 
 あなたが以下のいずれかに当てはまれば、このページはあなたのための[入門](..)ページです。


### PR DESCRIPTION
<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->

The diff happened by `npm run check:i18n -- content/ja`, so I updated `default_lang_commit`. I think that there are no other outdated words.

I also guessed that this diff is caused due to a bellow PR but it forgot to update `default_lang_commit` in ja page.

- https://github.com/open-telemetry/opentelemetry.io/pull/6232
- https://github.com/open-telemetry/opentelemetry.io/pull/6232/files#diff-140c308473d8cad8d40d0982bc9510e96f383b39811dc992f3f959ebb154eaf9


