### PR TITLE
Add fix cmd desc to contrib docs, and other edits

### DIFF
--- a/content/en/docs/contributing/pr-checks.md
+++ b/content/en/docs/contributing/pr-checks.md
@@ -19,8 +19,8 @@ a set of checks are executed. The PR checks verify that...
 {{% alert title="Note" color="primary" %}}
 
 If any of the PR checks fails, try to
-[fix content issues automatically](../pull-requests/#fix-content-issues-automatically)
-first by running `npm run fix:all` on your machine.
+[fix content issues automatically](../pull-requests/#fix-issues) first by
+running `npm run fix:all` on your machine.
 
 Additionally, you can comment `/fix:all` on your Pull Request. This will make
 the OpenTelemetry Bot run those commands on your behalf and update the PR. Make

--- a/content/en/docs/contributing/pull-requests.md
+++ b/content/en/docs/contributing/pull-requests.md
@@ -1,19 +1,28 @@
 ---
 title: Submitting content
 description:
-  Learn how to submit new or changed content using the GitHub UI or a local
+  Learn how to submit new or changed content using the GitHub UI or from a local
   fork.
 aliases: [new-content]
 weight: 15
 ---
 
-To contribute new or improve existing documentation content, submit a [pull
-request][PR] (PR):
+To contribute new or improve existing documentation, submit a [pull request][PR]
+(PR):
 
-- If your change is small, or you're unfamiliar with Git, see
-  [Changes using GitHub](#changes-using-github) to learn how to edit a page.
-- If your changes are large, see [Work from a local fork](#fork-the-repo) to
-  learn how to make changes locally on your computer.
+- If your change is small, or you're unfamiliar with [Git], see
+  [Using GitHub](#changes-using-github) to learn how to edit a page.
+- Otherwise, see [Work from a local fork](#fork-the-repo) to learn how to make
+  changes in your own local development environment.
+
+{{% alert title="Contributor License Agreement (CLA)" color=warning %}}
+
+All contributors are required to [sign a Contributor License Agreement
+(CLA)][CLA] before changes can be reviewed and merged.
+
+[CLA]: ../prerequisites/#cla
+
+{{% /alert %}}
 
 {{% alert title="Tip: Draft status" %}}
 
@@ -47,20 +56,13 @@ class first,second white
 
 _Figure 1. Contributing new content._
 
-## Changes using GitHub {#changes-using-github}
+## Using GitHub {#changes-using-github}
+
+### Edit and submit changes from your browser {#page-edit-from-browser}
 
 If you're less experienced with Git workflows, here's an easier method of
-creating and submitting a pull request. Figure 2 outlines the steps and the
-details follow.
-
-{{% alert title="Contributor License Agreement (CLA)" color=warning %}}
-
-All contributors are required to [sign a Contributor License Agreement
-(CLA)][CLA] before changes can be approved and merged.
-
-[CLA]: ../prerequisites/#cla
-
-{{% /alert %}}
+preparing and opening a new pull request (PR). Figure 2 outlines the steps and
+the details follow.
 
 ```mermaid
 flowchart LR
@@ -124,21 +126,47 @@ If a reviewer asks you to make changes:
 When your review is complete, a reviewer merges your PR and your changes goes
 live a few minutes later.
 
-{{% alert title="Tip" %}}
+### Fixing PR check failures {#fixing-prs-in-github}
 
-Comment `/fix:format` on your pull request to trigger an automated check for
-formatting issues.
+After you've submitted a PR, GitHub runs some build checks. Certain check
+failures, like formatting issues, can be fixed automatically.
+
+Add the following comment to your PR:
+
+```text
+/fix:all
+```
+
+This will trigger the OpenTelemetry bot to try to fix build issues. Or you can
+issue one of the following fix commands to address a specific failure:
+
+```text
+fix:dict
+fix:expired
+fix:filenames
+fix:format
+fix:htmltest-config
+fix:i18n
+fix:markdown
+fix:refcache
+fix:submodule
+fix:text
+```
+
+{{% alert title="Pro tip" %}}
+
+You can also run the `fix` commands locally. For the complete list of fix
+commands, run `npm run -s '_list:fix:*'`.
 
 {{% /alert %}}
 
-## Work from a local fork {#fork-the-repo}
+## Working locally {#fork-the-repo}
 
 If you're more experienced with Git, or if your changes are larger than a few
 lines, work from a local fork.
 
-Make sure you have
-[git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) installed
-on your computer. You can also use a user interface for Git.
+Make sure you have [`git` installed] on your computer. You can also use a user
+interface for Git.
 
 Figure 3 shows the steps to follow when you work from a local fork. The details
 for each step follow.
@@ -170,14 +198,14 @@ class changes,changes2 white
 
 _Figure 3. Working from a local fork to make your changes._
 
-### Fork the opentelemetry.io repository
+### Fork the repository
 
 1. Navigate to the
    [`opentelemetry.io`](https://github.com/open-telemetry/opentelemetry.io/)
    repository.
 1. Select **Fork**.
 
-### Create a local clone and set the upstream
+### Clone and set upstream
 
 1. In a terminal window, clone your fork and install the requirements:
 
@@ -280,7 +308,7 @@ When you are ready to submit a pull request, commit your changes.
 
 1. Once the changes are pushed, GitHub lets you know that you can create a PR.
 
-### Open a pull request from your fork {#open-a-pr}
+### Open a new PR {#open-a-pr}
 
 Figure 4 shows the steps to open a PR from your fork to
 [opentelemetry.io](https://github.com/open-telemetry/opentelemetry.io).
@@ -346,7 +374,7 @@ using [Netlify](https://www.netlify.com/).
 
 Other checks might also fail. See the [list of all PR checks](../pr-checks).
 
-### Fix content issues automatically
+### Fix issues {#fix-issues}
 
 Before submitting a change to the repository, run the following command and (i)
 address any reported issues, (ii) commit any files changed by the script:
@@ -365,7 +393,7 @@ npm run fix:all # May update files
 To list available NPM scripts, run `npm run`. See [PR checks](../pr-checks) for
 more information on pull request checks and how to fix errors automatically.
 
-### Preview your changes locally {#preview-locally}
+### Preview your changes {#preview-locally}
 
 Preview your changes locally before pushing them or opening a pull request. A
 preview lets you catch build errors or markdown formatting problems.
@@ -376,7 +404,7 @@ To build and serve the site locally with Hugo, run the following command:
 npm run serve
 ```
 
-Navigate to `http://localhost:1313` in your web browser to see the local
+Navigate to <http://localhost:1313> in your web browser to see the local
 preview. Hugo watches for changes and rebuilds the site as needed.
 
 To stop the local Hugo instance, go back to the terminal and type `Ctrl+C`, or
@@ -513,4 +541,6 @@ Pull requests are merged when they comply with the following criteria:
 [dashboard]: https://app.netlify.com/sites/opentelemetry/overview
 [deploy preview]:
   https://www.netlify.com/blog/2016/07/20/introducing-deploy-previews-in-netlify/
+[Git]: https://docs.github.com/en/get-started/using-git/about-git
+[`git` installed]: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
 [PR]: https://docs.github.com/en/pull-requests

--- a/content/es/docs/contributing/pull-requests.md
+++ b/content/es/docs/contributing/pull-requests.md
@@ -4,7 +4,7 @@ description:
   Aprende a agregar contenido nuevo utilizando la interfaz de GitHub o desde tu
   editor de código.
 weight: 2
-default_lang_commit: f724c15be360e5059fb89e696d9a5cc8d00496f6
+default_lang_commit: f724c15be360e5059fb89e696d9a5cc8d00496f6 # patched
 cSpell:ignore: aplícala solucionándolas vincúlalos
 ---
 
@@ -345,7 +345,7 @@ implementar una vista previa usando [Netlify](https://www.netlify.com/).
 También pueden fallar otras comprobaciones. Consulta la
 [lista de todas las comprobaciones de PR](/docs/contributing/pr-checks).
 
-### Soluciona problemas de contenido automáticamente {#fix-content-issues-automatically}
+### Soluciona problemas de contenido automáticamente {#fix-issues}
 
 Antes de enviar un cambio al repositorio, ejecuta el siguiente comando y (i)
 aborda los problemas informados, (ii) confirma los archivos modificados por el

--- a/content/ja/docs/contributing/pull-requests.md
+++ b/content/ja/docs/contributing/pull-requests.md
@@ -3,7 +3,7 @@ title: コンテンツの提出
 description: GitHub UI またはローカルのフォークを利用して、新しいコンテンツまたはコンテンツの変更を提出する方法を学びます
 aliases: [new-content]
 weight: 15
-default_lang_commit: 99f0ae5760038d51f9e9eb376bb428a2caca8167
+default_lang_commit: 99f0ae5760038d51f9e9eb376bb428a2caca8167 # patched
 ---
 
 新しいドキュメントの内容を追加したり、既存のコンテンツの改善をするには、[プルリクエスト][PR] （PR）を提出してください。
@@ -313,7 +313,7 @@ PR を公開した後に、自動テストの実行と [Netlify](https://www.net
 
 他のチェックも同様に失敗している可能性があります。[すべての PR チェック](../pr-checks) を参照してください。
 
-### 内容の問題を自動的に修正する {#fix-content-issues-automatically}
+### 内容の問題を自動的に修正する {#fix-issues}
 
 リポジトリに変更を提出するまえに、以下のコマンドを実行して (i) 報告された問題の対応し、(ii) スクリプトによって変更されたファイルのコミットをしてください。
 

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -1139,6 +1139,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-02-01T07:12:03.67448-05:00"
   },
+  "https://docs.github.com/en/get-started/using-git/about-git": {
+    "StatusCode": 206,
+    "LastSeen": "2025-02-11T08:05:07.564567-05:00"
+  },
   "https://docs.github.com/en/pull-requests": {
     "StatusCode": 206,
     "LastSeen": "2024-09-28T12:02:48.071874-04:00"
@@ -6344,8 +6348,8 @@
     "LastSeen": "2025-02-10T19:31:48.400126029Z"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.119.0/component/config.go#L50": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-10T19:31:46.199745702Z"
+    "StatusCode": 200,
+    "LastSeen": "2025-02-11T11:40:12.345Z"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.119.0/pdata/internal/data/protogen/trace/v1/trace.pb.go": {
     "StatusCode": 206,
@@ -6360,8 +6364,8 @@
     "LastSeen": "2025-02-10T19:31:58.756540779Z"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.119.0/receiver/receiver.go#L58": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-10T19:31:53.421771005Z"
+    "StatusCode": 200,
+    "LastSeen": "2025-02-11T11:40:12.345Z"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.119.0/semconv/v1.9.0/generated_resource.go": {
     "StatusCode": 206,


### PR DESCRIPTION
Changes to contributing PR page:

- Adds a section covering the `/fix:*` commands
- Moves CLA-requirement alert to the top of the page
- Copyedits

**Preview**: https://deploy-preview-6286--opentelemetry.netlify.app/docs/contributing/pull-requests/#fixing-prs-in-github