### PR TITLE
[i18n] Add page-not-yet-translated banner, ask for help

### DIFF
--- a/layouts/docs/td-content-after-header.html
+++ b/layouts/docs/td-content-after-header.html
@@ -1,0 +1,15 @@
+{{ $pageProseLang := partial "i18n/lang.html" . -}}
+{{ $siteLang := .Site.Language -}}
+
+{{ if ne $siteLang $pageProseLang -}}
+
+<div class="pageinfo pageinfo-secondary">
+  <p class="ps-4">
+    <i class="fa-solid fa-circle-info" style="margin-left: -1.5rem"></i>
+    You are viewing the <strong>English version</strong> of this page because it
+    has not yet been translated. Interested in helping out? See
+    <a href="/docs/contributing/">Contributing</a>.
+  </p>
+</div>
+
+{{- end -}}


### PR DESCRIPTION
- Contributes to #4467
- Adds a banner at the top of fallback pages, informing readers of the obvious (that the page is in English), explaining why (page hasn't been translated), and asks for help.

### Preview

- E.g., see https://deploy-preview-6287--opentelemetry.netlify.app/fr/docs/

### Screenshot

> <img width="780" alt="image" src="https://github.com/user-attachments/assets/03d44f59-8464-49ef-8183-73a7792e509e" />

