### PR TITLE
Improve Status and Training page layout, some copyedits

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -25,7 +25,7 @@ IgnoreDirs:
 IgnoreInternalURLs: # list of paths
 IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - /index.xml$ # Ignore rel="alternative" links to RSS feeds
-  - ^/api$
+  - ^/api/?$
   - ^((/..)?/docs/languages/\w+|\.\.)/(api|examples|registry)/$
   - ^(/..)?/docs/collector/registry/$
   - ^(/..)?/docs/languages/net/(metrics-api|traces-api)/

--- a/assets/scss/_page_no_left_sidebar.scss
+++ b/assets/scss/_page_no_left_sidebar.scss
@@ -1,0 +1,53 @@
+// Styles for docs-like pages without left sidebar
+
+.td-no-left-sidebar .td-main {
+  // Hide left sidebar
+  .td-sidebar {
+    display: none !important;
+  }
+
+  // Adjust ToC sidebar, e.g., to fill Bootstrap columns that the left sidebar
+  // would have taken was using.
+  .td-sidebar-toc {
+    @include media-breakpoint-up(md) {
+      display: block !important;
+    }
+
+    // Always 2 col wide (unless hidden)
+    @extend .col-md-2;
+
+    // Don't scroll with the page (otherwise, for short pages, the ToC hides
+    // behind the top navbar).
+    position: fixed;
+    right: 0;
+
+    // Ensure ToC doesn't overlap with the footer
+    z-index: -1;
+  }
+
+  // The <main> element sibling of the ToC sidebar
+  > div > main {
+    // Always 10 col wide (unless the ToC sidebar is hidden)
+    @extend .col-md-10;
+    @extend .col-xl-10;
+
+    @include media-breakpoint-up(md) {
+      padding-right: 3rem;
+    }
+
+    @include media-breakpoint-up(lg) {
+      // Center content on larger screens
+
+      .td-content {
+        max-width: 80%;
+        margin-left: auto;
+        margin-right: auto;
+
+        // Cancel .td-max-width-on-larger-screens
+        > * {
+          max-width: 100%;
+        }
+      }
+    }
+  }
+}

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1,10 +1,11 @@
 /* Docsy-delta full file override: we're not tracking changes to the Docsy file of the same name. */
-// cSpell:ignore cncf docsy
+// cSpell:ignore cncf docsy otca
 
 @import 'registry';
 @import 'tabs';
 @import 'external_link';
 @import 'td/code-dark';
+@import '_page_no_left_sidebar';
 
 .td-home {
   .otel-logo {
@@ -333,5 +334,23 @@ details {
 
   @include media-breakpoint-up(md) {
     padding-left: 0.6rem;
+  }
+}
+
+.ot-training {
+  @extend .td-no-left-sidebar;
+
+  .otca img {
+    border-style: none !important;
+    max-width: 244px;
+    margin: auto;
+  }
+}
+
+// TODO: upstream to Docsy
+
+.hk-no-external-icon {
+  a.external-link:after {
+    display: none !important;
   }
 }

--- a/content/en/status.md
+++ b/content/en/status.md
@@ -3,11 +3,9 @@ title: Status
 menu: { main: { weight: 30 } }
 aliases: [/project-status, /releases]
 description: Maturity-level of the main OpenTelemetry components
+type: docs
+body_class: td-no-left-sidebar
 ---
-
-{{% blocks/section color="white" %}}
-
-## {{% param title %}}
 
 OpenTelemetry is made up of [several components](/docs/concepts/components/),
 some language-specific and others language-agnostic. When looking for a
@@ -50,5 +48,3 @@ state with components in `v1alpha1` and `v1beta1` states.
 For the development status, or maturity level, of the
 [specification](/docs/specs/otel/), see the following:
 [Specification Status Summary](/docs/specs/status/).
-
-{{% /blocks/section %}}

--- a/content/en/training/_index.md
+++ b/content/en/training/_index.md
@@ -1,13 +1,12 @@
 ---
 title: Training
 menu: { main: { weight: 45 } }
-description: Training programs and certifications for OpenTelemetry
+description: OpenTelemetry certifications and courses
+type: docs
+body_class: ot-training
+hide_feedback: true
 cSpell:ignore: otca
 ---
-
-{{% blocks/section color="white" %}}
-
-## {{% param title %}}
 
 This page showcases training resources for the OpenTelemetry project. Check back
 often for updates!
@@ -17,12 +16,13 @@ often for updates!
 Demonstrate your expertise in OpenTelemetry by becoming an OpenTelemetry
 Certified Associate.
 
-<a href="https://www.cncf.io/training/certification/otca/">
-  <img src="lft-badge-opentelemetry-associate2.svg" style="width: 250px; height: auto;" alt="OTCA Badge">
-</a>
+<!-- prettier-ignore -->
+[![OTCA badge]][OTCA URL]
+{.otca .hk-no-external-icon}
 
-### Training programs
+[OTCA badge]: lft-badge-opentelemetry-associate2.svg
+[OTCA URL]: https://www.cncf.io/training/certification/otca/
+
+### Courses
 
 Coming soon!
-
-{{% /blocks/section %}}


### PR DESCRIPTION
- Contributes to #3463
- Displays the Status and Training page layout by displaying:
  - Proper title and description, in the same manner as (most) other pages
  - Table of contents with repo links (view page source, etc)
  - Essentially, these are not displayed like docs pages, but without a left sidebar/nav
- Copyedits to the Training page
- **Preview**:
  - https://deploy-preview-6296--opentelemetry.netlify.app/status/
  - https://deploy-preview-6296--opentelemetry.netlify.app/training/

### Screenshots

Status page shown. Similar changes were made to the Training page.

Before:

> <img width="1184" alt="image" src="https://github.com/user-attachments/assets/d1fd7490-c6ec-48e2-823c-75dc2c49a719" />

After:

> <img width="1186" alt="image" src="https://github.com/user-attachments/assets/41f37d72-2b22-44e0-9a40-54ca73bc432b" />



/cc @tiffany76 