### PR TITLE
Cleanup 2023 blog post's in-page CSS

### DIFF
--- a/content/en/blog/2023/http-conventions-declared-stable.md
+++ b/content/en/blog/2023/http-conventions-declared-stable.md
@@ -3,8 +3,10 @@ title: HTTP semantic conventions declared stable
 linkTitle: HTTP semconv are stable
 date: 2023-11-06
 author: '[Trask Stalnaker](https://github.com/trask) (Microsoft)'
-cSpell:ignore: chalin Liudmila Molkova
+cSpell:ignore: Liudmila Molkova
 ---
+
+<!-- markdownlint-disable table-pipe-style table-column-count -->
 
 Early this year, we launched an effort to stabilize HTTP semantic conventions.
 Today, we proudly announce that the HTTP semantic conventions are the _first_
@@ -95,8 +97,6 @@ to
 | `net.sock.peer.name` | Removed |
 | New: `http.request.method_original` | Only captured when `http.request.method` is `_OTHER` |
 | New: `error.type` | New |
-
-{.td-initial .table .table-responsive}
 <!-- prettier-ignore-end -->
 
 References:
@@ -106,10 +106,8 @@ References:
 
 ### HTTP client span attributes
 
-<!-- TODO(@chalin): I'll move this embedded style elsewhere in a followup PR -->
 <style>
-.ot-table-first-row-50 td:first-child { width: 50%; }
-.ot-table-first-row-60 td:first-child { width: 60%; }
+.ot-table-first-col-50 th:first-child { width: 50%; }
 </style>
 
 <!-- prettier-ignore-start -->
@@ -119,8 +117,6 @@ References:
 | `http.resend_count` &rarr; `http.request.resend_count` | |
 | `net.peer.name` &rarr; `server.address` | |
 | `net.peer.port` &rarr; `server.port` | Now captured even when same as default port for scheme |
-
-{.td-initial .table .table-responsive .ot-table-first-row-60}
 <!-- prettier-ignore-end -->
 
 References:
@@ -139,8 +135,7 @@ References:
 | `http.client_ip` &rarr; `client.address` | If `http.client_ip` was unknown (i.e., no [X-Forwarded-For][], [Forwarded#for][] headers), then `net.sock.peer.addr` &rarr; `client.address`; now must be provided to sampler |
 | `net.host.name` &rarr; `server.address` | Now based only on [Host][Host header], [:authority][HTTP/2 authority], [X-Forwarded-Host][], [Forwarded#host][] headers |
 | `net.host.port` &rarr; `server.port` | Now based only on [Host][Host header], [:authority][HTTP/2 authority], [X-Forwarded-Host][X-Forwarded-Host], [Forwarded#host][] headers |
-
-{.td-initial .table .table-responsive .ot-table-first-row-50}
+{.ot-table-first-col-50}
 <!-- prettier-ignore-end -->
 
 References:
@@ -183,8 +178,6 @@ Metric changes:
 | `net.protocol.name` &rarr; `network.protocol.name` | Recommended &rarr; Conditionally required if not `http` and `network.protocol.version` is set |
 | `net.protocol.version` &rarr; `network.protocol.version` | Examples fixed: `2.0` &rarr; `2` and `3.0` &rarr; `3`; see note if [migrating from `<= v1.19.0`](#migrating-from--v1190) |
 | New: `error.type` | New |
-
-{.td-initial .table .table-responsive}
 <!-- prettier-ignore-end -->
 
 References:
@@ -216,8 +209,7 @@ Metric changes:
 | `net.host.name` → `server.address` | &bullet; Recommended → Opt-In (due to high-cardinality vulnerability since based on HTTP headers)<br>&bullet; Now based only on [`Host` span][Host header], [`:authority` span][HTTP/2 authority], [`X-Forwarded-Host` span][X-Forwarded-Host], [`Forwarded#host` span][Forwarded#host] headers |
 | `net.host.port` → `server.port` | &bullet; Recommended → Opt-In (due to high-cardinality vulnerability since based on HTTP headers)<br>&bullet; Now based only on [`Host` span][Host header], [`:authority` span][HTTP/2 authority], [`X-Forwarded-Host` span][X-Forwarded-Host], [`Forwarded#host` span][Forwarded#host] headers |
 | New: `error.type` | New |
-
-{.td-initial .table .table-responsive .ot-table-first-row-50}
+{.ot-table-first-col-50}
 <!-- prettier-ignore-end -->
 
 References:


### PR DESCRIPTION
- Cleans up in-page styles of a 2023 blog. While we don't generally update old blog posts, they sometimes end up being used as templates or examples.
- Removes unused table-specific styling. For some reason the styles were inactive, maybe because an early run of Prettier put a space between the table and the markdown class attributes (which renders the attributes inactive).

**Preview**, e.g.: https://deploy-preview-6303--opentelemetry.netlify.app/blog/2023/http-conventions-declared-stable/#summary-of-changes