### PR TITLE
[CI] Enable markdownlint2 checks, and fix issues

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -59,4 +59,5 @@ words: # Valid words across all locales
   - Docsy
   - htmltest
   # Hugo
+  - jsonify
   - warnf

--- a/.github/workflows/check-text.yml
+++ b/.github/workflows/check-text.yml
@@ -46,3 +46,4 @@ jobs:
           cache-dependency-path: tmp/package-ci.json
       - run: npm install --ignore-scripts --omit=optional
       - run: npm run check:markdown
+      - run: npm run check:markdown2

--- a/content/es/docs/contributing/issues.md
+++ b/content/es/docs/contributing/issues.md
@@ -6,7 +6,7 @@ description:
 weight: 10
 _issues: https://github.com/open-telemetry/opentelemetry.io/issues
 _issue: https://github.com/open-telemetry/opentelemetry.io/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A
-default_lang_commit: 99f0ae5760038d51f9e9eb376bb428a2caca8167
+default_lang_commit: 99f0ae5760038d51f9e9eb376bb428a2caca8167 # patched
 ---
 
 ## Solucionando una propuesta existente
@@ -33,8 +33,8 @@ OpenTelemetry (OTel) es solucionando un problema ya identificado.
    {.mt-3}
 
    <!-- prettier-ignore -->
-   [good first issue]: {{% param _issue %}}%22good+first+issue%22
-   [help wanted]: {{% param _issue %}}%3A%22help+wanted%22
+   [good first issue]: <{{% param _issue %}}%22good+first+issue%22>
+   [help wanted]: <{{% param _issue %}}%3A%22help+wanted%22>
    [org]: https://github.com/open-telemetry
 
    {{% /alert %}}

--- a/content/es/docs/contributing/issues.md
+++ b/content/es/docs/contributing/issues.md
@@ -28,8 +28,9 @@ OpenTelemetry (OTel) es solucionando un problema ya identificado.
    - [Help wanted]
 
    <!-- prettier-ignore -->
-   > **NOTA**: **_No_ asignamos propuestas** a aquellos que aún no hayan contribuido a la organización [OpenTelemetry
-   > organization][org], a menos que sean parte de un proceso de tutoria o onboarding.
+   > **NOTA**: **_No_ asignamos propuestas** a aquellos que aún no hayan
+   > contribuido a la organización [OpenTelemetry organization][org], a menos
+   > que sean parte de un proceso de tutoria o onboarding.
    {.mt-3}
 
    <!-- prettier-ignore -->


### PR DESCRIPTION
- Enables mdl2 checks, which seem to be catching more issues
- Fixes the issues in es issues page
- Copyedits that were forgotten during reivew, see https://github.com/open-telemetry/opentelemetry.io/pull/6088#discussion_r1952837501