### PR TITLE
Avoid 800+ blank lines in registry JSON file

### DIFF
--- a/layouts/ecosystem/registry.json.json
+++ b/layouts/ecosystem/registry.json.json
@@ -13,6 +13,6 @@
   {{ end -}}
   {{ $entry = merge $entry (dict "_key" $key "id" $counter "flags" $flags) -}}
   {{ $entries = $entries | append $entry -}}
-  {{ $counter = add $counter 1 }}
+  {{ $counter = add $counter 1 -}}
 {{ end -}}
 {{ jsonify (dict "indent" "  ") $entries -}}


### PR DESCRIPTION
Prior to this fix, the registry JSON file had 866 blank lines at the start of it :)

```console
$ grep -e '^\s*$' public/ecosystem/registry/index.json | wc -l
     866
```

With this fix:

```console
$ grep -e '^\s*$' public/ecosystem/registry/index.json | wc -l
     0
```
