### PR TITLE
[Go] Remove redunant snippets from exporters docs

### DIFF
--- a/content/en/docs/languages/go/exporters.md
+++ b/content/en/docs/languages/go/exporters.md
@@ -19,56 +19,17 @@ The
 [`go.opentelemetry.io/otel/exporters/stdout/stdouttrace`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/stdout/stdouttrace)
 package contains an implementation of the console trace exporter.
 
-Here's how you can create an exporter with default configuration:
-
-```go
-import (
-	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
-	"go.opentelemetry.io/otel/sdk/trace"
-)
-
-func newExporter() (trace.SpanExporter, error) {
-	return stdouttrace.New()
-}
-```
-
 ### Console metrics
 
 The
 [`go.opentelemetry.io/otel/exporters/stdout/stdoutmetric`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/stdout/stdoutmetric)
 package contains an implementation of the console metrics exporter.
 
-Here's how you can create an exporter with default configuration:
-
-```go
-import (
-	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
-	"go.opentelemetry.io/otel/sdk/metric"
-)
-
-func newExporter() (metric.Exporter, error) {
-	return stdoutmetric.New()
-}
-```
-
 ### Console logs (Experimental) {#console-logs}
 
 The
 [`go.opentelemetry.io/otel/exporters/stdout/stdoutlog`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/stdout/stdoutlog)
 package contains an implementation of the console log exporter.
-
-Here's how you can create an exporter with default configuration:
-
-```go
-import (
-	"go.opentelemetry.io/otel/exporters/stdout/stdoutlog"
-	"go.opentelemetry.io/otel/sdk/log"
-)
-
-func newExporter() (log.Exporter, error) {
-	return stdoutlog.New()
-}
-```
 
 ## OTLP
 
@@ -82,40 +43,10 @@ endpoint.
 contains an implementation of the OTLP trace exporter using HTTP with binary
 protobuf payloads.
 
-Here's how you can create an exporter with default configuration:
-
-```go
-import (
-	"context"
-
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
-	"go.opentelemetry.io/otel/sdk/trace"
-)
-
-func newExporter(ctx context.Context) (trace.SpanExporter, error) {
-	return otlptracehttp.New(ctx)
-}
-```
-
 ### OTLP traces over gRPC
 
 [`go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc)
 contains an implementation of OTLP trace exporter using gRPC.
-
-Here's how you can create an exporter with default configuration:
-
-```go
-import (
-	"context"
-
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
-	"go.opentelemetry.io/otel/sdk/trace"
-)
-
-func newExporter(ctx context.Context) (trace.SpanExporter, error) {
-	return otlptracegrpc.New(ctx)
-}
-```
 
 ### Jaeger
 
@@ -138,40 +69,10 @@ docker run -d --name jaeger \
 contains an implementation of OTLP metrics exporter using HTTP with binary
 protobuf payloads.
 
-Here's how you can create an exporter with default configuration:
-
-```go
-import (
-	"context"
-
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
-	"go.opentelemetry.io/otel/sdk/metric"
-)
-
-func newExporter(ctx context.Context) (metric.Exporter, error) {
-	return otlpmetrichttp.New(ctx)
-}
-```
-
 ### OTLP metrics over gRPC
 
 [`go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc)
 contains an implementation of OTLP metrics exporter using gRPC.
-
-Here's how you can create an exporter with default configuration:
-
-```go
-import (
-	"context"
-
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
-	"go.opentelemetry.io/otel/sdk/metric"
-)
-
-func newExporter(ctx context.Context) (metric.Exporter, error) {
-	return otlpmetricgrpc.New(ctx)
-}
-```
 
 ## Prometheus (Experimental)
 
@@ -184,21 +85,6 @@ contains an implementation of Prometheus metrics exporter.
 Here's how you can create an exporter (which is also a metric reader) with
 default configuration:
 
-```go
-import (
-	"context"
-
-	"go.opentelemetry.io/otel/exporters/prometheus"
-	"go.opentelemetry.io/otel/sdk/metric"
-)
-
-func newExporter(ctx context.Context) (metric.Reader, error) {
-	// prometheus.DefaultRegisterer is used by default
-	// so that metrics are available via promhttp.Handler.
-	return prometheus.New()
-}
-```
-
 To learn more on how to use the Prometheus exporter, try the
 [prometheus example](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/examples/prometheus)
 
@@ -208,37 +94,7 @@ To learn more on how to use the Prometheus exporter, try the
 contains an implementation of OTLP logs exporter using HTTP with binary protobuf
 payloads.
 
-Here's how you can create an exporter with default configuration:
-
-```go
-import (
-	"context"
-
-	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
-	"go.opentelemetry.io/otel/sdk/log"
-)
-
-func newExporter(ctx context.Context) (log.Exporter, error) {
-	return otlploghttp.New(ctx)
-}
-```
-
 ### OTLP logs over gRPC (Experimental)
 
 [`go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc)
 contains an implementation of OTLP logs exporter using gRPC.
-
-Here's how you can create an exporter with default configuration:
-
-```go
-import (
-	"context"
-
-	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
-	"go.opentelemetry.io/otel/sdk/log"
-)
-
-func newExporter(ctx context.Context) (log.Exporter, error) {
-	return otlploggrpc.New(ctx)
-}
-```

--- a/content/en/docs/languages/go/exporters.md
+++ b/content/en/docs/languages/go/exporters.md
@@ -3,7 +3,7 @@ title: Exporters
 aliases: [exporting_data]
 weight: 50
 # prettier-ignore
-cSpell:ignore: otlplog otlploggrpc otlploghttp otlpmetric otlpmetricgrpc otlpmetrichttp otlptrace otlptracegrpc otlptracehttp promhttp stdoutlog stdouttrace
+cSpell:ignore: otlplog otlploggrpc otlploghttp otlpmetric otlpmetricgrpc otlpmetrichttp otlptrace otlptracegrpc otlptracehttp stdoutlog stdouttrace
 ---
 
 {{% docs/languages/exporters/intro go %}}

--- a/content/en/docs/languages/go/exporters.md
+++ b/content/en/docs/languages/go/exporters.md
@@ -74,6 +74,17 @@ protobuf payloads.
 [`go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc)
 contains an implementation of OTLP metrics exporter using gRPC.
 
+### OTLP logs over HTTP (Experimental)
+
+[`go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp)
+contains an implementation of OTLP logs exporter using HTTP with binary protobuf
+payloads.
+
+### OTLP logs over gRPC (Experimental)
+
+[`go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc)
+contains an implementation of OTLP logs exporter using gRPC.
+
 ## Prometheus (Experimental)
 
 A Prometheus exporter is used to report metrics via Prometheus scrape HTTP
@@ -87,14 +98,3 @@ default configuration:
 
 To learn more on how to use the Prometheus exporter, try the
 [prometheus example](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/examples/prometheus)
-
-### OTLP logs over HTTP (Experimental)
-
-[`go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp)
-contains an implementation of OTLP logs exporter using HTTP with binary protobuf
-payloads.
-
-### OTLP logs over gRPC (Experimental)
-
-[`go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc)
-contains an implementation of OTLP logs exporter using gRPC.


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry.io/issues/5847

Better code example showing how to use an exporter are help in package documentation. E.g. https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp#example-package

I also fixed the location of the OTLP logs exporters (there were under Prometheus :sweat_smile: )

---

**Preview**: https://deploy-preview-6319--opentelemetry.netlify.app/docs/languages/go/exporters/