### PR TITLE
Registry support for i18n

### DIFF
--- a/content/en/ecosystem/registry/_index.md
+++ b/content/en/ecosystem/registry/_index.md
@@ -3,6 +3,20 @@ title: Registry
 description: >-
   Find libraries, plugins, integrations, and other useful tools for using and
   extending OpenTelemetry.
+type: default
+layout: registry
+body_class: registry td-content
+weight: 20
+
+# =============================================================================
+# IMPORTANT:
+# IMPORTANT: Non-English locales: DO NOT include the front matter entries below
+# IMPORTANT:
+# =============================================================================
+
+aliases: [/registry/*]
+outputs: [html, json]
+
 # The redirects and aliases implement catch-all rules for old registry entries;
 # we don't publish individual entry pages anymore.
 #
@@ -11,19 +25,13 @@ description: >-
 # redirect rule to avoid the loop, as suggested by Netlify support
 # (email support ID 159489):
 redirects: [{ from: /ecosystem/registry*, to: '/ecosystem/registry?' }]
-aliases: [/registry/*]
-type: default
-layout: registry
-outputs: [html, json]
-body_class: registry td-content
-weight: 20
 ---
 
 {{% blocks/lead color="dark" %}}
 
 <!-- markdownlint-disable single-h1 -->
 
-# {{% param title %}}
+<h1>{{% param title %}}</h1>
 
 {{% param description %}}
 

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -380,6 +380,9 @@ module:
       source: content/en/docs
       target: content/docs
       lang: pt
+    - source: content/en/ecosystem
+      target: content/ecosystem
+      lang: pt
 
     ## static
     - source: static

--- a/layouts/partials/ecosystem/registry/entry.html
+++ b/layouts/partials/ecosystem/registry/entry.html
@@ -1,4 +1,5 @@
 {{ $languageNames := .languageNames -}}
+{{ $registryUrl := .registryUrl -}}
 
 {{ with .value -}}
     {{
@@ -116,18 +117,18 @@
             <span class="badge rounded-pill text-bg-info"><i class="fa-regular fa-star"></i> new</span>
             {{ end -}}
             {{ if $isNative -}}
-            <a href="/ecosystem/registry?flag=native" class="badge rounded-pill text-bg-success text-white" title="Click to filter by native flag">
+            <a href="{{ $registryUrl }}/?flag=native" class="badge rounded-pill text-bg-success text-white" title="Click to filter by native flag">
             <i class="fa-solid fa-puzzle-piece"></i> native</a>
             {{ end -}}
             {{ if $isFirstParty -}}
-            <a href="/ecosystem/registry?flag=first_party" class="badge rounded-pill text-bg-success text-white" title="Click to filter by first party flag">
+            <a href="{{ $registryUrl }}/?flag=first_party" class="badge rounded-pill text-bg-success text-white" title="Click to filter by first party flag">
             <i class="fa-solid fa-heart"></i> first party integration</a>
             {{ end -}}
             {{ if $usedInDemo -}}
             <span class="badge rounded-pill text-bg-secondary text-white" title="This package is used in the OpenTelemetry Demo!"><i class="fa-solid fa-shapes"></i> OTel Demo</span>
             {{ end -}}
             {{ if $deprecated -}}
-            <a href="/ecosystem/registry?flag=deprecated" class="badge rounded-pill text-bg-danger text-white" title="Click to filter by deprecated flag">
+            <a href="{{ $registryUrl }}/?flag=deprecated" class="badge rounded-pill text-bg-danger text-white" title="Click to filter by deprecated flag">
             <i class="fa-solid fa-ban"></i> deprecated</a>
             {{ end -}}
             {{ if .cncfProjectLevel -}}
@@ -171,7 +172,7 @@
                         <div>
                             {{ range .tags }}
                                 {{ $tag := . }} <!-- Store the tag in a variable -->
-                                <a href="/ecosystem/registry/?s={{ $tag | urlize }}" class="badge bg-light me-1">{{ $tag }}</a>
+                                <a href="{{ $registryUrl }}/?s={{ $tag | urlize }}" class="badge bg-light me-1">{{ $tag }}</a>
                             {{ end }}
                         </div>
                     {{ end }}

--- a/layouts/shortcodes/ecosystem/registry/search-form.html
+++ b/layouts/shortcodes/ecosystem/registry/search-form.html
@@ -1,4 +1,5 @@
 {{ $registry := .Site.Data.registry -}}
+{{ $registryUrl := .Page.RelPermalink -}}
 
 {{ $languageNames := newScratch -}}
 {{ $languageNames.Set "cpp" "C++" -}}
@@ -15,7 +16,7 @@
   {{- $val := (dict
     "name" .language
     "isOfficial" (in $officialLanguages .language)
-    ) 
+    )
   -}}
   {{ $langs = $langs | append $val -}}
   {{ if ne $language (lower $language) -}}
@@ -69,11 +70,12 @@
 <div class="alert alert-info">
 The OpenTelemetry Registry allows you to search for instrumentation libraries,
 collector components, utilities, and other useful projects in the OpenTelemetry
-ecosystem. If you are a project maintainer, you can <a href="/ecosystem/registry/adding/">add your project to the OpenTelemetry Registry</a>
+ecosystem. If you are a project maintainer, you can
+<a href="{{ $registryUrl }}adding/">add your project to the OpenTelemetry Registry</a>
 </div>
 
 <div class="pb-4">
-  <form action="/ecosystem/registry" id="searchForm">
+  <form action="{{ $registryUrl }}" id="searchForm">
     <div class="input-group">
       <span class="input-group-text" id="basic-addon1" title="{{ len $registry }} entries">Search {{ len $registry }} entries</span>
       <input class="form-control w-auto" list="search-suggestions" id="input-s" type="text" name="s" placeholder="Type to search…"
@@ -123,7 +125,7 @@ ecosystem. If you are a project maintainer, you can <a href="/ecosystem/registry
       </div>
 
       <!-- Flags Filter Dropdown -->
-    <button class="btn btn-outline-secondary dropdown-toggle" id="flagsDropdown" type="button" 
+    <button class="btn btn-outline-secondary dropdown-toggle" id="flagsDropdown" type="button"
     data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Flags</button>
     <div class="dropdown-menu" id="flagsFilter">
     <a value="all" class="dropdown-item">Any Flag</a>
@@ -145,7 +147,12 @@ ecosystem. If you are a project maintainer, you can <a href="/ecosystem/registry
   <ul class="list-unstyled" id="default-body">
     {{ range $key, $value := $registry -}}
       {{ $value = merge $value (dict "_key" $key) -}}
-      {{ partial "ecosystem/registry/entry" (dict "value" $value "languageNames" $languageNames) }}
+      {{ partial "ecosystem/registry/entry"
+          (dict
+            "registryUrl" $registryUrl
+            "value" $value
+            "languageNames" $languageNames
+          ) -}}
     {{ end -}}
   </ul>
 </div>


### PR DESCRIPTION
- Contributes to #4467
- Enables `ecosystem` fallback pages for `pt`, in support of #6263
- Ensures that non-en registry links stay within their site locale

**Preview**: https://deploy-preview-6320--opentelemetry.netlify.app/ecosystem/registry/