### PR TITLE
fix: remove duplucated `)`in content/en/docs/concepts/instrumentation/libraries page

### DIFF
--- a/content/en/docs/concepts/instrumentation/libraries.md
+++ b/content/en/docs/concepts/instrumentation/libraries.md
@@ -75,7 +75,7 @@ Follow the semantic conventions when setting span attributes.
 
 Some libraries are thin clients wrapping network calls. Chances are that
 OpenTelemetry has an instrumentation library for the underlying RPC client.
-Check out the [registry](/ecosystem/registry/)) to find existing libraries. If a
+Check out the [registry](/ecosystem/registry/) to find existing libraries. If a
 library exists, instrumenting the wrapper library might not be necessary.
 
 As a general guideline, only instrument your library at its own level. Don't


### PR DESCRIPTION
<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->

I fixed a tidy mistake in content/en/docs/concepts/instrumentation/libraries page.
