### PR TITLE
[chore] Add links into CNCF blog of crossposted articles

### DIFF
--- a/content/en/blog/2024/otel-generative-ai/index.md
+++ b/content/en/blog/2024/otel-generative-ai/index.md
@@ -7,6 +7,7 @@ author: >-
   Molkova](https://github.com/lmolkova) (Microsoft)
 issue: https://github.com/open-telemetry/opentelemetry.io/issues/5581
 sig: SIG GenAI Observability
+crosspost_url: https://www.cncf.io/blog/2025/01/20/opentelemetry-for-generative-ai/
 cSpell:ignore: genai liudmila molkova
 ---
 
@@ -227,3 +228,7 @@ and more!
 
 You are welcome to join the community! More information can be found at the
 [Generative AI Observability project page](https://github.com/open-telemetry/community/blob/main/projects/gen-ai.md).
+
+_A version of this article also [appears on the CNCF blog][]._
+
+[appears on the CNCF blog]: <{{% param crosspost_url %}}>

--- a/content/en/blog/2024/prom-and-otel/index.md
+++ b/content/en/blog/2024/prom-and-otel/index.md
@@ -678,6 +678,6 @@ Whether or not you choose to implement these solutions in your organization,
 it’s nice to know that there are additional options out there to lead you to
 observability greatness with OTel and Prometheus.
 
-_A version of this article was
-[originally posted](https://newrelic.com/blog/how-to-relic/prometheus-and-opentelemetry-better-together)
-on the New Relic blog._
+_A version of this article was [originally posted][] to the New Relic blog._
+
+[originally posted]: <{{% param canonical_url %}}>

--- a/content/en/blog/2024/year-in-review.md
+++ b/content/en/blog/2024/year-in-review.md
@@ -7,6 +7,7 @@ author: >-
   Chalin](https://github.com/chalin/) (CNCF), [Tiffany
   Hrabusa](https://github.com/tiffany76) (Grafana Labs)
 sig: Comms
+crosspost_url: https://www.cncf.io/blog/2024/12/20/opentelemetry-io-2024-review/
 cSpell:ignore: Chalin Hrabusa opentelemetrybot
 ---
 
@@ -217,13 +218,11 @@ You can also join us:
 
 Together, we can make 2025 another amazing year for [opentelemetry.io](/)!
 
-_[Cross-posted] to the [CNCF blog]._
+_A version of this article also [appears on the CNCF blog][]._
 
-[CNCF blog]: https://www.cncf.io/blog/
+[appears on the CNCF blog]: <{{% param crosspost_url %}}>
 [Comms meetings]:
   https://docs.google.com/document/d/1wW0jLldwXN8Nptq2xmgETGbGn9eWP8fitvD5njM-xZY
-[Cross-posted]:
-  https://www.cncf.io/blog/2024/12/20/opentelemetry-io-2024-review/
 [discussions]: https://github.com/open-telemetry/opentelemetry.io/discussions
 [get involved]: /docs/contributing/
 [issues]: https://github.com/open-telemetry/opentelemetry.io/issues

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -16747,6 +16747,10 @@
     "StatusCode": 200,
     "LastSeen": "2025-01-04T17:12:03.120768-05:00"
   },
+  "https://www.cncf.io/blog/2025/01/20/opentelemetry-for-generative-ai/": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-14T12:23:38.590496-05:00"
+  },
   "https://www.cncf.io/enduser/": {
     "StatusCode": 200,
     "LastSeen": "2025-01-15T13:49:20.913378-05:00"


### PR DESCRIPTION
- ... this make is easier to keep track of which articles have been cross posted. /cc @svrnm 
- Contributes to #6329
