### PR TITLE
[i18n] Move registry search-form alert into registry page

### DIFF
--- a/content/en/ecosystem/registry/_index.md
+++ b/content/en/ecosystem/registry/_index.md
@@ -39,6 +39,15 @@ redirects: [{ from: /ecosystem/registry*, to: '/ecosystem/registry?' }]
 
 {{< blocks/section color="white" type="container-lg" >}}
 
+{{% alert color="info" %}}
+
+The OpenTelemetry Registry allows you to search for instrumentation libraries,
+collector components, utilities, and other useful projects in the OpenTelemetry
+ecosystem. If you are a project maintainer, you can
+[add your project to the OpenTelemetry Registry](adding/).
+
+{{% /alert %}}
+
 {{< ecosystem/registry/search-form >}}
 
 {{< /blocks/section >}}

--- a/layouts/shortcodes/ecosystem/registry/search-form.html
+++ b/layouts/shortcodes/ecosystem/registry/search-form.html
@@ -9,7 +9,6 @@
 
 {{ $officialLanguages := slice "collector" "cpp" "erlang" "elixir" "dotnet" "go" "java" "js" "php" "python" "ruby" "rust" "swift" -}}
 
-
 {{ $langs := slice -}}
 {{ range $registry -}}
   {{ $language := .language -}}
@@ -66,13 +65,6 @@
   {{ end -}}
 {{ end -}}
 {{ $uniqueFlags := $allFlags | uniq | sort }}
-
-<div class="alert alert-info">
-The OpenTelemetry Registry allows you to search for instrumentation libraries,
-collector components, utilities, and other useful projects in the OpenTelemetry
-ecosystem. If you are a project maintainer, you can
-<a href="{{ $registryUrl }}adding/">add your project to the OpenTelemetry Registry</a>
-</div>
 
 <div class="pb-4">
   <form action="{{ $registryUrl }}" id="searchForm">


### PR DESCRIPTION
- Contributes to #4467
- Moves the alert from the registry search-form shortcode into the page where it is used. This will make it possible for the alert text to be localized more easily.
- There is no change to the generated site files.

/cc @vitorvasc 