### PR TITLE
[ja] update content/ja/blog/2024/docs-localized

### DIFF
--- a/content/ja/blog/2024/docs-localized.md
+++ b/content/ja/blog/2024/docs-localized.md
@@ -6,7 +6,7 @@ author: >-
   [Severin Neumann](https://github.com/svrnm) (Cisco)
 issue: 4863
 sig: Comms
-default_lang_commit: 48eac183a4dd74946d5a45fa436cfc6052f30532
+default_lang_commit: fd7da211d5bc37ca93112a494aaf6a94445e2e28
 ---
 
 OpenTelemetry のウェブサイトが多言語で利用可能になったことをお知らせします！


### PR DESCRIPTION
<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->

I updated content/ja/blog/2024/docs-localized page.
ref: #6172.

When I checked the diff, I noticed that all contents was not recognized.
I confirm the ja localization is true. So then, I updated `default_lang_commit`.


```bash
> npm run check:i18n -- -d content/ja/blog/2024/docs-localized.md

> check:i18n
> scripts/check-i18n.sh -d content/ja/blog/2024/docs-localized.md

Processing paths: content/ja/blog/2024/docs-localized.md
diff --git a/content/en/blog/2024/docs-localized.md b/content/en/blog/2024/docs-localized.md
new file mode 100644
index 00000000..030b5252
--- /dev/null
+++ b/content/en/blog/2024/docs-localized.md
@@ -0,0 +1,36 @@
+---
+title: OpenTelemetry website goes multilingual!
+linkTitle: Multilingual website
+date: 2024-08-20
+author: >-
+  [Severin Neumann](https://github.com/svrnm) (Cisco)
+issue: 4863
+sig: Comms
+---
+
+We are happy to announce that the OpenTelemetry website is available in multiple
+languages! Localization teams have already started to translate website pages
+into [Chinese](/zh), [Japanese](/ja), [Portuguese](/pt), and [Spanish](/es).
+
+The OpenTelemetry project has grown to include contributors and users from all
+over the world. Making the website available in multiple languages is an
+important step for ensuring that everyone, regardless of their native language,
+can contribute to the project. We are also thrilled that this initiative gives
+end users access to multilingual documentation, making it easier to learn and
+understand OpenTelemetry.
+
+To access the website in your preferred language, use the language selector at
+the top right of the page.
+
+We invite you to contribute to this effort. You can find fellow localization
+contributors in the
+[#otel-docs-localization](https://cloud-native.slack.com/archives/C076RUAGP37)
+Slack channel. If you are fluent in a language that is supported already, you
+can help by authoring or reviewing translations. If your language is not yet
+supported and you'd like to help translate,
+[create an issue](<https://github.com/open-telemetry/opentelemetry.io/issues/new?title=Add+%3CYOUR%20LANGUAGE%3E+(%3CYOUR+CODE%3E)+version+of+website+pages&body=%3C!--+Provide+github+handles+of+at+least+2+people+that+will+work+on+this+translation+project%20--%3E>).
+
+Your contributions can make a meaningful impact!
+
+We thank all contributors for making this possible, and we look forward to
+seeing how these new language options improve the OpenTelemetry user experience.DRIFTED files: 1 out of 1

```