### PR TITLE
Demo - update required .NET version to .NET8

### DIFF
--- a/content/en/docs/demo/development.md
+++ b/content/en/docs/demo/development.md
@@ -22,7 +22,7 @@ receive hints from IDEs such as IntelliJ or VS Code. It may be necessary to run
 
 ### .NET
 
-- .NET 6.0+
+- .NET 8.0+
 
 ### C++
 


### PR DESCRIPTION
.NET6 is no longer supported. What is more, demo was already updated to .NET8.