### PR TITLE
[pt] Update content/pt/ecosystem/registry/_index.md - Fix duplicate redirect

### DIFF
--- a/content/pt/ecosystem/registry/_index.md
+++ b/content/pt/ecosystem/registry/_index.md
@@ -1,23 +1,20 @@
 ---
-title: Registry
+title: Registro
 description: >-
   Encontre bibliotecas, plugins, integrações e outras ferramentas úteis para
   usar e expandir o OpenTelemetry.
-redirects: [{ from: /ecosystem/registry*, to: '/ecosystem/registry?' }]
-aliases: [/registry/*]
 type: default
 layout: registry
-outputs: [html, json]
 body_class: registry td-content
 weight: 20
-default_lang_commit: e6aa6923419a45ee9c36208eb74da760e7e9abaa
+default_lang_commit: f235aa0d4e059bb085ba8040960bb49c8f90a1fe
 ---
 
 {{% blocks/lead color="dark" %}}
 
 <!-- markdownlint-disable single-h1 -->
 
-# {{% param title %}}
+<h1>{{% param title %}}</h1>
 
 {{% param description %}}
 

--- a/content/pt/ecosystem/registry/_index.md
+++ b/content/pt/ecosystem/registry/_index.md
@@ -7,7 +7,7 @@ type: default
 layout: registry
 body_class: registry td-content
 weight: 20
-default_lang_commit: f235aa0d4e059bb085ba8040960bb49c8f90a1fe
+default_lang_commit: 1304e92e609273a3638b8a50ba82dca3b47ef609
 ---
 
 {{% blocks/lead color="dark" %}}
@@ -21,6 +21,13 @@ default_lang_commit: f235aa0d4e059bb085ba8040960bb49c8f90a1fe
 {{% /blocks/lead %}}
 
 {{< blocks/section color="white" type="container-lg" >}}
+
+
+{{% alert color="info" %}}
+
+O Registro do OpenTelemetry permite a busca por bibliotecas de instrumentação, compoenntes do Collector, utilitários e outros projetos úteis dentro do ecossistema. Caso você seja mantenedor de um projeto, é possível [adicionar seu projeto ao Registro do OpenTelemetry](adding/).
+
+{{% /alert %}}
 
 {{< ecosystem/registry/search-form >}}
 

--- a/content/pt/ecosystem/registry/_index.md
+++ b/content/pt/ecosystem/registry/_index.md
@@ -22,10 +22,12 @@ default_lang_commit: 1304e92e609273a3638b8a50ba82dca3b47ef609
 
 {{< blocks/section color="white" type="container-lg" >}}
 
-
 {{% alert color="info" %}}
 
-O Registro do OpenTelemetry permite a busca por bibliotecas de instrumentação, compoenntes do Collector, utilitários e outros projetos úteis dentro do ecossistema. Caso você seja mantenedor de um projeto, é possível [adicionar seu projeto ao Registro do OpenTelemetry](adding/).
+O Registro do OpenTelemetry permite a busca por bibliotecas de instrumentação,
+compoenntes do Collector, utilitários e outros projetos úteis dentro do
+ecossistema. Caso você seja mantenedor de um projeto, é possível
+[adicionar seu projeto ao Registro do OpenTelemetry](adding/).
 
 {{% /alert %}}
 

--- a/content/pt/ecosystem/registry/_index.md
+++ b/content/pt/ecosystem/registry/_index.md
@@ -25,7 +25,7 @@ default_lang_commit: 1304e92e609273a3638b8a50ba82dca3b47ef609
 {{% alert color="info" %}}
 
 O Registro do OpenTelemetry permite a busca por bibliotecas de instrumentação,
-compoenntes do Collector, utilitários e outros projetos úteis dentro do
+componentes do Collector, utilitários e outros projetos úteis dentro do
 ecossistema. Caso você seja mantenedor de um projeto, é possível
 [adicionar seu projeto ao Registro do OpenTelemetry](adding/).
 

--- a/content/pt/ecosystem/registry/_index.md
+++ b/content/pt/ecosystem/registry/_index.md
@@ -7,7 +7,7 @@ type: default
 layout: registry
 body_class: registry td-content
 weight: 20
-default_lang_commit: 1304e92e609273a3638b8a50ba82dca3b47ef609
+default_lang_commit: fd873ed11bfa9920c2e8b0726784f482368e85c2
 ---
 
 {{% blocks/lead color="dark" %}}


### PR DESCRIPTION
Removes the Fixes the redirects, aliases and outputs properties so it doesn't duplicate the redirect rules, as mentioned on https://github.com/open-telemetry/opentelemetry.io/issues/6330.

Also, updates the header definition to match the original content.