### PR TITLE
[i18n] Make `instrumentation-intro` shortcode a simple include

### DIFF
--- a/content/en/_includes/_index.md
+++ b/content/en/_includes/_index.md
@@ -1,0 +1,5 @@
+---
+title: # bogus for markdownlint
+cascade:
+  build: { list: never, render: never }
+---

--- a/content/en/_includes/page-not-translated-msg.md
+++ b/content/en/_includes/page-not-translated-msg.md
@@ -3,5 +3,5 @@ title: # bogus entry for markdownlint
 ---
 
 <i class="fa-solid fa-circle-info" style="margin-left: -1.5rem"></i> You are
-viewing the **English version** of this page because it has not yet been
+viewing the **English version** of this page because it has not yet been fully
 translated. Interested in helping out? See [Contributing](/docs/contributing/).

--- a/content/en/_includes/page-not-translated-msg.md
+++ b/content/en/_includes/page-not-translated-msg.md
@@ -1,6 +1,5 @@
 ---
-title: # Bogus entry for markdownlint
-_build: { list: never, render: never }
+title: # bogus entry for markdownlint
 ---
 
 <i class="fa-solid fa-circle-info" style="margin-left: -1.5rem"></i> You are

--- a/content/en/docs/languages/_includes/_index.md
+++ b/content/en/docs/languages/_includes/_index.md
@@ -1,0 +1,5 @@
+---
+title: # bogus for markdownlint
+cascade:
+  build: { list: never, render: never }
+---

--- a/content/en/docs/languages/_includes/instrumentation-intro.md
+++ b/content/en/docs/languages/_includes/instrumentation-intro.md
@@ -1,3 +1,7 @@
+---
+title: # bogus for markdownlint
+---
+
 [Instrumentation](/docs/concepts/instrumentation/) is the act of adding
 observability code to an app yourself.
 

--- a/content/en/docs/languages/cpp/instrumentation.md
+++ b/content/en/docs/languages/cpp/instrumentation.md
@@ -9,7 +9,7 @@ cSpell:ignore: decltype labelkv nostd nullptr
 
 <!-- markdownlint-disable no-duplicate-heading -->
 
-{{% docs/languages/instrumentation-intro %}}
+{{% include instrumentation-intro.md %}}
 
 {{% alert title="Note" color="primary" %}}
 

--- a/content/en/docs/languages/erlang/instrumentation.md
+++ b/content/en/docs/languages/erlang/instrumentation.md
@@ -5,7 +5,7 @@ weight: 30
 description: Instrumentation for OpenTelemetry Erlang/Elixir
 ---
 
-{{% docs/languages/instrumentation-intro %}}
+{{% include instrumentation-intro.md %}}
 
 ## Setup
 

--- a/content/en/docs/languages/go/instrumentation.md
+++ b/content/en/docs/languages/go/instrumentation.md
@@ -8,7 +8,7 @@ description: Manual instrumentation for OpenTelemetry Go
 cSpell:ignore: fatalf logr logrus otlplog otlploghttp sdktrace sighup
 ---
 
-{{% docs/languages/instrumentation-intro %}}
+{{% include instrumentation-intro.md %}}
 
 ## Setup
 

--- a/content/en/docs/languages/js/instrumentation.md
+++ b/content/en/docs/languages/js/instrumentation.md
@@ -8,7 +8,7 @@ description: Instrumentation for OpenTelemetry JavaScript
 cSpell:ignore: dicelib Millis rolldice
 ---
 
-{{% docs/languages/instrumentation-intro %}}
+{{% include instrumentation-intro.md %}}
 
 {{% alert title="Note" color="info" %}}
 

--- a/content/en/docs/languages/net/instrumentation.md
+++ b/content/en/docs/languages/net/instrumentation.md
@@ -6,7 +6,7 @@ description: Instrumentation for OpenTelemetry .NET
 cSpell:ignore: dicelib rolldice
 ---
 
-{{% docs/languages/instrumentation-intro %}}
+{{% include instrumentation-intro.md %}}
 
 {{% alert title="Note" color="info" %}}
 

--- a/content/en/docs/languages/php/instrumentation.md
+++ b/content/en/docs/languages/php/instrumentation.md
@@ -8,7 +8,7 @@ cSpell:ignore: guzzlehttp myapp
 
 <!-- markdownlint-disable no-duplicate-heading -->
 
-{{% docs/languages/instrumentation-intro %}}
+{{% include instrumentation-intro.md %}}
 
 ## Example app preparation {#example-app}
 

--- a/content/en/docs/languages/python/instrumentation.md
+++ b/content/en/docs/languages/python/instrumentation.md
@@ -8,7 +8,7 @@ cSpell:ignore: millis ottrace textmap
 
 <!-- markdownlint-disable no-duplicate-heading -->
 
-{{% docs/languages/instrumentation-intro %}}
+{{% include instrumentation-intro.md %}}
 
 ## Setup
 

--- a/content/en/docs/languages/ruby/instrumentation.md
+++ b/content/en/docs/languages/ruby/instrumentation.md
@@ -10,7 +10,7 @@ description: Instrumentation for OpenTelemetry Ruby
 cSpell:ignore: SIGHUP
 ---
 
-{{% docs/languages/instrumentation-intro %}}
+{{% include instrumentation-intro.md %}}
 
 ## Setup
 

--- a/content/en/docs/languages/swift/instrumentation.md
+++ b/content/en/docs/languages/swift/instrumentation.md
@@ -5,7 +5,7 @@ aliases: [manual]
 description: Instrumentation for OpenTelemetry Swift
 ---
 
-{{% docs/languages/instrumentation-intro %}}
+{{% include instrumentation-intro.md %}}
 
 ## Setup
 

--- a/content/es/docs/languages/_includes/_index.md
+++ b/content/es/docs/languages/_includes/_index.md
@@ -1,0 +1,6 @@
+---
+title: # bogus for markdownlint
+cascade:
+  build: { list: never, render: never }
+default_lang_commit: 7811e854ba3b31c56ce681f1d60cf19e8a5c4358
+---

--- a/content/es/docs/languages/_includes/instrumentation-intro.md
+++ b/content/es/docs/languages/_includes/instrumentation-intro.md
@@ -1,3 +1,8 @@
+---
+title: # bogus for markdownlint
+default_lang_commit: 7811e854ba3b31c56ce681f1d60cf19e8a5c4358
+---
+
 [Instrumentar](/docs/concepts/instrumentation/) consiste en añadir el código de
 observabilidad a una app.
 

--- a/content/es/docs/languages/python/instrumentation.md
+++ b/content/es/docs/languages/python/instrumentation.md
@@ -9,7 +9,7 @@ cSpell:ignore: millis ottrace textmap
 
 <!-- markdownlint-disable no-duplicate-heading -->
 
-{{% es/docs/languages/instrumentation-intro %}}
+{{% include instrumentation-intro.md %}}
 
 ## Configuración
 

--- a/content/pt/_includes/_index.md
+++ b/content/pt/_includes/_index.md
@@ -1,0 +1,6 @@
+---
+title: # bogus for markdownlint
+cascade:
+  build: { list: never, render: never }
+default_lang_commit: 7811e854ba3b31c56ce681f1d60cf19e8a5c4358
+---

--- a/content/pt/_includes/page-not-translated-msg.md
+++ b/content/pt/_includes/page-not-translated-msg.md
@@ -1,6 +1,5 @@
 ---
 title: # Bogus entry for markdownlint
-_build: { list: never, render: never }
 default_lang_commit: 8d115a9df96c52dbbb3f96c05a843390d90a9800
 ---
 

--- a/content/pt/docs/languages/_includes/_index.md
+++ b/content/pt/docs/languages/_includes/_index.md
@@ -1,0 +1,6 @@
+---
+title: # bogus for markdownlint
+cascade:
+  build: { list: never, render: never }
+default_lang_commit: 7811e854ba3b31c56ce681f1d60cf19e8a5c4358
+---

--- a/content/pt/docs/languages/_includes/instrumentation-intro.md
+++ b/content/pt/docs/languages/_includes/instrumentation-intro.md
@@ -1,6 +1,7 @@
-{{/*
+---
+title: # bogus for markdownlint
 default_lang_commit: 080527543eae90112f01c89342891aabd6258173
-*/ -}}
+---
 
 [Instrumentação](/docs/concepts/instrumentation/) é o ato de adicionar código de
 observabilidade a uma aplicação por conta própria.

--- a/content/pt/docs/languages/go/instrumentation.md
+++ b/content/pt/docs/languages/go/instrumentation.md
@@ -9,7 +9,7 @@ default_lang_commit: 748555c22f43476291ae0c7974ca4a2577da0472
 cSpell:ignore: fatalf logr logrus otlplog otlploghttp sdktrace sighup updown
 ---
 
-{{% docs/languages/instrumentation-intro %}}
+{{% include instrumentation-intro.md %}}
 
 ## Configuração {#setup}
 


### PR DESCRIPTION
- Contributes to #4467
- Converts the `instrumentation-intro.md` shortcode into a regular markdown file, included via the new includes shortcode. This way we can enable all the regular text, markdown, and i18n checks (for drift etc.). This is done for the following languages that had a `instrumentation-intro.md` shortcode:
  - `en`
  - `es`
  - `pt`
- There is no change in the generated site files where we switched to using `include` instead of a shortcode.
- We do have the interesting side-effect that English fallback pages with an `include` of `instrumentation-intro.md` will be populated with the locale's version of the include. Is this ok with you @open-telemetry/docs-es-approvers @open-telemetry/docs-pt-approvers? It might be a bit strange (and we might need to modify the page-not-translated banner text), but I think that this is be best way moving forward.
  - ~(If we agree to edit the page-not-translated text, I'll do that in a followup PR. I'd probably just add a qualifier like: "... not yet been _fully_ translated ...")~ (I've added the qualifier "fully" to the banner text in this PR.)
- Updates `/xx/_includes` with:
  - A section index so that we can ensure that no page is generated for any includes, including the section itself

**Preview**:

- https://deploy-preview-6364--opentelemetry.netlify.app/docs/languages/go/instrumentation/ - page where the shortcode was replaced by an include. No change in the page content.
- https://deploy-preview-6364--opentelemetry.netlify.app/es/docs/languages/go/instrumentation/ - page where the Spanish include is used in the English page 🤷🏼‍♂️ 
- https://deploy-preview-6364--opentelemetry.netlify.app/pt/docs/languages/go/instrumentation/ - page where the shortcode was replaced by an include. No change in the page content.