### PR TITLE
Fix typo traceProvider -> tracerProvider

### DIFF
--- a/content/en/blog/2022/go-web-app-instrumentation/index.md
+++ b/content/en/blog/2022/go-web-app-instrumentation/index.md
@@ -183,7 +183,7 @@ Here’s what the setup looks like:
        semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
    )
 
-   func JaegerTraceProvider()(*sdktrace.TracerProvider, error) {
+   func JaegerTracerProvider()(*sdktrace.TracerProvider, error) {
        exp, err: = jaeger.New(jaeger.WithCollectorEndpoint(jaeger.WithEndpoint("http://localhost:14268/api/traces")))
        if err != nil {
            return nil, err
@@ -201,11 +201,11 @@ Here’s what the setup looks like:
    ```
 
 4. Go back to the main.go file and modify our code to use the
-   JaegerTraceProvider function we just created
+   JaegerTracerProvider function we just created
 
    ```go
    func main() {
-       tp, tpErr: = tracing.JaegerTraceProvider()
+       tp, tpErr: = tracing.JaegerTracerProvider()
        if tpErr != nil {
            log.Fatal(tpErr)
        }
@@ -322,7 +322,7 @@ Here’s what the setup looks like:
 
    func main() {
        //Export traces to Jaeger
-       tp, tpErr: = tracing.JaegerTraceProvider()
+       tp, tpErr: = tracing.JaegerTracerProvider()
        if tpErr != nil {
            log.Fatal(tpErr)
        }

--- a/content/en/docs/concepts/resources/index.md
+++ b/content/en/docs/concepts/resources/index.md
@@ -12,7 +12,7 @@ backend, resource attributes are grouped under the **Process** tab:
 
 ![A screenshot from Jaeger showing an example output of resource attributes associated to a trace](screenshot-jaeger-resources.png)
 
-A resource is added to the `TraceProvider` or `MetricProvider` when they are
+A resource is added to the `TracerProvider` or `MetricProvider` when they are
 created during initialization. This association cannot be changed later. After a
 resource is added, all spans and metrics produced from a `Tracer` or `Meter`
 from the provider will have the resource associated with them.

--- a/content/en/docs/languages/go/getting-started.md
+++ b/content/en/docs/languages/go/getting-started.md
@@ -182,7 +182,7 @@ func setupOTelSDK(ctx context.Context) (shutdown func(context.Context) error, er
 	otel.SetTextMapPropagator(prop)
 
 	// Set up trace provider.
-	tracerProvider, err := newTraceProvider()
+	tracerProvider, err := newTracerProvider()
 	if err != nil {
 		handleErr(err)
 		return
@@ -218,19 +218,19 @@ func newPropagator() propagation.TextMapPropagator {
 	)
 }
 
-func newTraceProvider() (*trace.TracerProvider, error) {
+func newTracerProvider() (*trace.TracerProvider, error) {
 	traceExporter, err := stdouttrace.New(
 		stdouttrace.WithPrettyPrint())
 	if err != nil {
 		return nil, err
 	}
 
-	traceProvider := trace.NewTracerProvider(
+	tracerProvider := trace.NewTracerProvider(
 		trace.WithBatcher(traceExporter,
 			// Default is 5s. Set to 1s for demonstrative purposes.
 			trace.WithBatchTimeout(time.Second)),
 	)
-	return traceProvider, nil
+	return tracerProvider, nil
 }
 
 func newMeterProvider() (*metric.MeterProvider, error) {

--- a/content/en/docs/languages/go/instrumentation.md
+++ b/content/en/docs/languages/go/instrumentation.md
@@ -49,7 +49,7 @@ func newExporter(ctx context.Context)  /* (someExporter.Exporter, error) */ {
 	// Your preferred exporter: console, jaeger, zipkin, OTLP, etc.
 }
 
-func newTraceProvider(exp sdktrace.SpanExporter) *sdktrace.TracerProvider {
+func newTracerProvider(exp sdktrace.SpanExporter) *sdktrace.TracerProvider {
 	// Ensure default SDK resources and the required service name are set.
 	r, err := resource.Merge(
 		resource.Default(),
@@ -78,7 +78,7 @@ func main() {
 	}
 
 	// Create a new tracer provider with a batch span processor and the given exporter.
-	tp := newTraceProvider(exp)
+	tp := newTracerProvider(exp)
 
 	// Handle shutdown properly so nothing leaks.
 	defer func() { _ = tp.Shutdown(ctx) }()

--- a/content/en/docs/languages/net/instrumentation.md
+++ b/content/en/docs/languages/net/instrumentation.md
@@ -329,7 +329,7 @@ dotnet run
 ### Initialize Tracing
 
 {{% alert title="Note" color="info" %}} If you’re instrumenting a library, you
-don't need to initialize a TraceProvider. {{% /alert %}}
+don't need to initialize a TracerProvider. {{% /alert %}}
 
 To enable [tracing](/docs/concepts/signals/traces/) in your app, you'll need to
 have an initialized

--- a/content/en/docs/languages/python/exporters.md
+++ b/content/en/docs/languages/python/exporters.md
@@ -60,10 +60,10 @@ resource = Resource(attributes={
     SERVICE_NAME: "your-service-name"
 })
 
-traceProvider = TracerProvider(resource=resource)
+tracerProvider = TracerProvider(resource=resource)
 processor = BatchSpanProcessor(OTLPSpanExporter(endpoint="<traces-endpoint>/v1/traces"))
-traceProvider.add_span_processor(processor)
-trace.set_tracer_provider(traceProvider)
+tracerProvider.add_span_processor(processor)
+trace.set_tracer_provider(tracerProvider)
 
 reader = PeriodicExportingMetricReader(
     OTLPMetricExporter(endpoint="<traces-endpoint>/v1/metrics")
@@ -92,10 +92,10 @@ resource = Resource(attributes={
     SERVICE_NAME: "your-service-name"
 })
 
-traceProvider = TracerProvider(resource=resource)
+tracerProvider = TracerProvider(resource=resource)
 processor = BatchSpanProcessor(OTLPSpanExporter(endpoint="your-endpoint-here"))
-traceProvider.add_span_processor(processor)
-trace.set_tracer_provider(traceProvider)
+tracerProvider.add_span_processor(processor)
+trace.set_tracer_provider(tracerProvider)
 
 reader = PeriodicExportingMetricReader(
     OTLPMetricExporter(endpoint="localhost:5555")
@@ -132,10 +132,10 @@ resource = Resource(attributes={
     SERVICE_NAME: "your-service-name"
 })
 
-traceProvider = TracerProvider(resource=resource)
+tracerProvider = TracerProvider(resource=resource)
 processor = BatchSpanProcessor(ConsoleSpanExporter())
-traceProvider.add_span_processor(processor)
-trace.set_tracer_provider(traceProvider)
+tracerProvider.add_span_processor(processor)
+trace.set_tracer_provider(tracerProvider)
 
 reader = PeriodicExportingMetricReader(ConsoleMetricExporter())
 meterProvider = MeterProvider(resource=resource, metric_readers=[reader])

--- a/content/en/docs/languages/swift/libraries.md
+++ b/content/en/docs/languages/swift/libraries.md
@@ -35,7 +35,7 @@ Use `DefaultResource.get()` to generate an all-in-one resource object. This
 resource can be added to a `TracerProvider` or `MetricProvider`.
 
 ```swift
-OpenTelemetry.registerTracerProvider(traceProvider: TracerProviderBuilder()
+OpenTelemetry.registerTracerProvider(tracerProvider: TracerProviderBuilder()
             .with(resource: DefaultResource.get())
             .build())
 ```


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-go-contrib/issues/6802

I guess for Swift it might have even been a bug: https://github.com/search?q=repo%3Aopen-telemetry%2Fopentelemetry-swift+registerTracerProvider&type=code