### PR TITLE
[CI] Support relative links to oteps from OTel spec

### DIFF
--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -1,4 +1,6 @@
 #!/usr/bin/perl -w -i
+#
+# cSpell:ignore oteps
 
 $^W = 1;
 
@@ -169,7 +171,7 @@ while(<>) {
         next;
     }
   }
-  if(! $title) {
+  if (! $title) {
     ($title) = /^#\s+(.*)/;
     $linkTitle = '';
     printFrontMatter() if $title;
@@ -180,7 +182,7 @@ while(<>) {
     while(<>) { $lineNum++; last if /<\/details>/; }
     next;
   }
-  if(/<!-- toc -->/) {
+  if (/<!-- toc -->/) {
     my $tocstop = '<!-- tocstop -->';
     while(<>) {
       $lineNum++;
@@ -227,9 +229,13 @@ while(<>) {
   # Rewrite paths that are outside of the spec folders as external links:
   s|\.\.\/README.md|$otelSpecRepoUrl/|g if $ARGV =~ /specification._index/;
   s|\.\.\/README.md|/docs/specs/otel/| if $ARGV =~ /specification\/library-guidelines.md/;
-
-  s|(\.\.\/)+(experimental\/[^)]+)|$otelSpecRepoUrl/tree/v$otelSpecVers/$2|g;
-  s|(\.\.\/)+(supplementary-guidelines\/compatibility\/[^)]+)|$otelSpecRepoUrl/tree/v$otelSpecVers/$2|g;
+  s{
+    (\.\.\/)+
+    (
+      (?:oteps|supplementary-guidelines)\/
+      [^)]+
+    )
+  }{$otelSpecRepoUrl/tree/v$otelSpecVers/$2}gx;
 
   s|\.\./((?:examples/)?README\.md)|$otlpSpecRepoUrl/tree/v$otlpSpecVers/$1|g if $ARGV =~ /^tmp\/otlp/;
 


### PR DESCRIPTION
- In preparation for https://github.com/open-telemetry/opentelemetry-specification/pull/4410
- Ensures that path-relative links to OTEPS are translated into external links (into the spec repo)
- Other cleanup and rule consolidation
- There is no change to the generated site files, but it fixes https://github.com/open-telemetry/opentelemetry.io/actions/runs/13394526898/job/37410079743

/cc @carlosalberto 