### PR TITLE
[PHP] Replace deprecated constants `DEPLOYMENT_ENVIRONMENT` to `DEPLOYMENT_ENVIRONMENT_NAME`

### DIFF
--- a/content/en/docs/languages/php/instrumentation.md
+++ b/content/en/docs/languages/php/instrumentation.md
@@ -186,7 +186,7 @@ $resource = ResourceInfoFactory::emptyResource()->merge(ResourceInfo::create(Att
     ResourceAttributes::SERVICE_NAMESPACE => 'demo',
     ResourceAttributes::SERVICE_NAME => 'test-application',
     ResourceAttributes::SERVICE_VERSION => '0.1',
-    ResourceAttributes::DEPLOYMENT_ENVIRONMENT => 'development',
+    ResourceAttributes::DEPLOYMENT_ENVIRONMENT_NAME => 'development',
 ])));
 $spanExporter = new SpanExporter(
     (new StreamTransportFactory())->create('php://stdout', 'application/json')

--- a/content/en/docs/languages/php/resources.md
+++ b/content/en/docs/languages/php/resources.md
@@ -80,7 +80,7 @@ $resource = ResourceInfoFactory::defaultResource()->merge(ResourceInfo::create(A
     ResourceAttributes::SERVICE_NAME => 'bar',
     ResourceAttributes::SERVICE_INSTANCE_ID => 1,
     ResourceAttributes::SERVICE_VERSION => '0.1',
-    ResourceAttributes::DEPLOYMENT_ENVIRONMENT => 'development',
+    ResourceAttributes::DEPLOYMENT_ENVIRONMENT_NAME => 'development',
 ])));
 
 $tracerProvider =  new TracerProvider(


### PR DESCRIPTION
`ResourceAttributes::DEPLOYMENT_ENVIRONMENT` is no longer supported.

https://github.com/open-telemetry/opentelemetry-php/commit/d2b15077df5e3e13b5c62c87effb99abf70d7e9d#diff-e9c5d40b11db32802d0ca95fbd8b82016f75d1f7a1ac8e5952e3fbcc0c9c13dbL1057