### PR TITLE
Change wording of "size" to "number of spans".

### DIFF
--- a/content/en/docs/languages/java/configuration.md
+++ b/content/en/docs/languages/java/configuration.md
@@ -193,12 +193,12 @@ artifact coordinates.
 Properties for [batch span processor(s)](../sdk/#spanprocessor) paired with
 exporters specified via `otel.traces.exporter`:
 
-| System property                  | Description                                                      | Default |
-| -------------------------------- |------------------------------------------------------------------| ------- |
-| `otel.bsp.schedule.delay`        | The interval, in milliseconds, between two consecutive exports.  | `5000`  |
-| `otel.bsp.max.queue.size`        | The maximum number of spans that can be queued before batching.  | `2048`  |
-| `otel.bsp.max.export.batch.size` | The maximum number of spans to export in a single batch.         | `512`   |
-| `otel.bsp.export.timeout`        | The maximum allowed time, in milliseconds, to export data.       | `30000` |
+| System property                  | Description                                                     | Default |
+| -------------------------------- | --------------------------------------------------------------- | ------- |
+| `otel.bsp.schedule.delay`        | The interval, in milliseconds, between two consecutive exports. | `5000`  |
+| `otel.bsp.max.queue.size`        | The maximum number of spans that can be queued before batching. | `2048`  |
+| `otel.bsp.max.export.batch.size` | The maximum number of spans to export in a single batch.        | `512`   |
+| `otel.bsp.export.timeout`        | The maximum allowed time, in milliseconds, to export data.      | `30000` |
 
 Properties for [sampler](../sdk/#sampler):
 

--- a/content/en/docs/languages/java/configuration.md
+++ b/content/en/docs/languages/java/configuration.md
@@ -193,12 +193,12 @@ artifact coordinates.
 Properties for [batch span processor(s)](../sdk/#spanprocessor) paired with
 exporters specified via `otel.traces.exporter`:
 
-| System property                  | Description                                                     | Default |
-| -------------------------------- | --------------------------------------------------------------- | ------- |
-| `otel.bsp.schedule.delay`        | The interval, in milliseconds, between two consecutive exports. | `5000`  |
-| `otel.bsp.max.queue.size`        | The maximum queue size.                                         | `2048`  |
-| `otel.bsp.max.export.batch.size` | The maximum batch size.                                         | `512`   |
-| `otel.bsp.export.timeout`        | The maximum allowed time, in milliseconds, to export data.      | `30000` |
+| System property                  | Description                                                      | Default |
+| -------------------------------- |------------------------------------------------------------------| ------- |
+| `otel.bsp.schedule.delay`        | The interval, in milliseconds, between two consecutive exports.  | `5000`  |
+| `otel.bsp.max.queue.size`        | The maximum number of spans that can be queued before batching.  | `2048`  |
+| `otel.bsp.max.export.batch.size` | The maximum number of spans to export in a single batch.         | `512`   |
+| `otel.bsp.export.timeout`        | The maximum allowed time, in milliseconds, to export data.       | `30000` |
 
 Properties for [sampler](../sdk/#sampler):
 

--- a/content/en/docs/languages/java/configuration.md
+++ b/content/en/docs/languages/java/configuration.md
@@ -256,12 +256,12 @@ Properties for cardinality limits:
 Properties for [log record processor(s)](../sdk/#logrecordprocessor) pared with
 exporters via `otel.logs.exporter`:
 
-| System property                   | Description                                                     | Default |
-| --------------------------------- | --------------------------------------------------------------- | ------- |
-| `otel.blrp.schedule.delay`        | The interval, in milliseconds, between two consecutive exports. | `1000`  |
-| `otel.blrp.max.queue.size`        | The maximum queue size.                                         | `2048`  |
-| `otel.blrp.max.export.batch.size` | The maximum batch size.                                         | `512`   |
-| `otel.blrp.export.timeout`        | The maximum allowed time, in milliseconds, to export data.      | `30000` |
+| System property                   | Description                                                           | Default |
+| --------------------------------- | --------------------------------------------------------------------- | ------- |
+| `otel.blrp.schedule.delay`        | The interval, in milliseconds, between two consecutive exports.       | `1000`  |
+| `otel.blrp.max.queue.size`        | The maximum number of log records that can be queued before batching. | `2048`  |
+| `otel.blrp.max.export.batch.size` | The maximum number of log records to export in a single batch.        | `512`   |
+| `otel.blrp.export.timeout`        | The maximum allowed time, in milliseconds, to export data.            | `30000` |
 
 #### Properties: exporters
 


### PR DESCRIPTION
The current wording around 2 config settings in the Java BatchSpanProcessor leaves room for misinterpretation. The use of "size" could suggest bytes or some other data unit, but the actual implementation is in "number of spans"...so this change clarifies that. 

Hopefully this makes things clearer for readers.