### PR TITLE
update protocol to http for internal collector metrics config

### DIFF
--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -49,8 +49,8 @@ service:
         - periodic:
             exporter:
               otlp:
-                protocol: grpc
-                endpoint: http://localhost:14317
+                protocol: http/protobuf
+                endpoint: https://backend:4318
 ```
 
 Alternatively, you can expose the Prometheus endpoint to one specific or all
@@ -169,8 +169,8 @@ service:
         - batch:
             exporter:
               otlp:
-                protocol: grpc
-                endpoint: https://backend:4317
+                protocol: http/protobuf
+                endpoint: https://backend:4318
 ```
 
 See the [example configuration][kitchen-sink-config] for additional options.

--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -159,7 +159,7 @@ the stability of the emitted span names and attributes.
 {{% /alert %}}
 
 The following configuration can be used to emit internal traces from the
-Collector to an OTLP/gRPC backend:
+Collector to an OTLP backend:
 
 ```yaml
 service:


### PR DESCRIPTION
This follows the project's recommendation of using http/protobuf instead of grpc.
