### PR TITLE
[CI/i18n] Streamline includes and fix pt Aviso

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,6 @@
 {
   "emphasis-style": false,
+  "first-line-h1": false,
   "line-length": false,
   "link-fragments": false,
   "list-marker-space": false,

--- a/content/en/_includes/_index.md
+++ b/content/en/_includes/_index.md
@@ -1,5 +1,0 @@
----
-title: # bogus for markdownlint
-cascade:
-  build: { list: never, render: never }
----

--- a/content/en/_includes/page-not-translated-msg.md
+++ b/content/en/_includes/page-not-translated-msg.md
@@ -1,5 +1,4 @@
 ---
-title: # bogus entry for markdownlint
 ---
 
 <i class="fa-solid fa-circle-info" style="margin-left: -1.5rem"></i> You are

--- a/content/en/docs/languages/_includes/_index.md
+++ b/content/en/docs/languages/_includes/_index.md
@@ -1,5 +1,0 @@
----
-title: # bogus for markdownlint
-cascade:
-  build: { list: never, render: never }
----

--- a/content/en/docs/languages/_includes/instrumentation-intro.md
+++ b/content/en/docs/languages/_includes/instrumentation-intro.md
@@ -1,5 +1,4 @@
 ---
-title: # bogus for markdownlint
 ---
 
 [Instrumentation](/docs/concepts/instrumentation/) is the act of adding

--- a/content/en/docs/languages/js/_includes/browser-instrumentation-warning.md
+++ b/content/en/docs/languages/js/_includes/browser-instrumentation-warning.md
@@ -1,6 +1,4 @@
 ---
-title: # Bogus entry for markdownlint
-_build: { list: never, render: never }
 ---
 
 {{% alert title=Warning color=warning %}}

--- a/content/en/docs/languages/js/_index.md
+++ b/content/en/docs/languages/js/_index.md
@@ -10,7 +10,7 @@ weight: 20
 
 {{% docs/languages/index-intro js /%}}
 
-{{% include "./_browser-instrumentation-warning.md" %}}
+{{% include browser-instrumentation-warning.md %}}
 
 ## Version Support
 

--- a/content/en/docs/languages/js/getting-started/browser.md
+++ b/content/en/docs/languages/js/getting-started/browser.md
@@ -5,7 +5,7 @@ description: Learn how to add OpenTelemetry to your browser app
 weight: 20
 ---
 
-{{% include "./_browser-instrumentation-warning.md" %}}
+{{% include browser-instrumentation-warning.md %}}
 
 While this guide uses the example application presented below, the steps to
 instrument your own application should be similar.

--- a/content/en/docs/languages/js/instrumentation.md
+++ b/content/en/docs/languages/js/instrumentation.md
@@ -335,7 +335,7 @@ above, you have a `TracerProvider` setup for you already. You can continue with
 
 #### Browser
 
-{{% include "./_browser-instrumentation-warning.md" %}}
+{{% include browser-instrumentation-warning.md %}}
 
 First, ensure you've got the right packages:
 

--- a/content/en/ecosystem/_includes/_index.md
+++ b/content/en/ecosystem/_includes/_index.md
@@ -1,5 +1,0 @@
----
-title: # bogus for markdownlint
-cascade:
-  build: { list: never, render: never }
----

--- a/content/en/ecosystem/_includes/keep-up-to-date.md
+++ b/content/en/ecosystem/_includes/keep-up-to-date.md
@@ -1,5 +1,4 @@
 ---
-title: # bogus entry for markdownlint
 ---
 
 ## Keeping {{ $1 }} information current

--- a/content/pt/_includes/_index.md
+++ b/content/pt/_includes/_index.md
@@ -1,6 +1,0 @@
----
-title: # bogus for markdownlint
-cascade:
-  build: { list: never, render: never }
-default_lang_commit: 7811e854ba3b31c56ce681f1d60cf19e8a5c4358
----

--- a/content/pt/_includes/page-not-translated-msg.md
+++ b/content/pt/_includes/page-not-translated-msg.md
@@ -1,5 +1,4 @@
 ---
-title: # Bogus entry for markdownlint
 default_lang_commit: 8d115a9df96c52dbbb3f96c05a843390d90a9800
 ---
 

--- a/content/pt/docs/languages/_includes/_index.md
+++ b/content/pt/docs/languages/_includes/_index.md
@@ -1,6 +1,0 @@
----
-title: # bogus for markdownlint
-cascade:
-  build: { list: never, render: never }
-default_lang_commit: 7811e854ba3b31c56ce681f1d60cf19e8a5c4358
----

--- a/content/pt/docs/languages/_includes/instrumentation-intro.md
+++ b/content/pt/docs/languages/_includes/instrumentation-intro.md
@@ -1,6 +1,5 @@
 ---
-title: # bogus for markdownlint
-default_lang_commit: 080527543eae90112f01c89342891aabd6258173
+default_lang_commit: 080527543eae90112f01c89342891aabd6258173 # patched
 ---
 
 [Instrumentação](/docs/concepts/instrumentation/) é o ato de adicionar código de

--- a/content/pt/docs/languages/js/_includes/browser-instrumentation-warning.md
+++ b/content/pt/docs/languages/js/_includes/browser-instrumentation-warning.md
@@ -1,10 +1,8 @@
 ---
-title: # Bogus entry for markdownlint
-_build: { list: never, render: never }
-default_lang_commit: 0dac041dedfe5877f45e36065c1c6fb07490b243
+default_lang_commit: 0dac041dedfe5877f45e36065c1c6fb07490b243 # patched
 ---
 
-{{% alert-md title=Aviso color=warning %}}
+{{% alert title=Aviso color=warning %}}
 
 A instrumentação do cliente para o navegador é **experimental** e, em grande
 parte, **não está especificada**. Caso possua interesse em auxiliar, entre em
@@ -13,4 +11,4 @@ contato com o [SIG de Instrumentação do Cliente][sig].
 [sig]:
   https://docs.google.com/document/d/16Vsdh-DM72AfMg_FIt9yT9ExEWF4A_vRbQ3jRNBe09w
 
-{{% /alert-md %}}
+{{% /alert %}}

--- a/content/pt/docs/languages/js/getting-started/browser.md
+++ b/content/pt/docs/languages/js/getting-started/browser.md
@@ -6,7 +6,7 @@ weight: 20
 default_lang_commit: 7cb1bd39726fc03698164ee17fe9087afdac054c
 ---
 
-{{% include "./_browser-instrumentation-warning.md" %}}
+{{% include browser-instrumentation-warning.md %}}
 
 Embora este guia utilize o exemplo de aplicação apresentada abaixo, as etapas
 para instrumentar a sua própria aplicação devem ser similares.

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -80,6 +80,10 @@ outputs:
 services:
   rss: { limit: 20 }
 
+cascade:
+  build: { list: never, publishResources: false, render: never }
+  _target: { path: '{,/**}/_includes{,/**}' }
+
 params:
   copyright:
     authors: >-


### PR DESCRIPTION
- Contributes to #4467
- Drops markdownlint check for a title so that we don't need to include one in included files. I doubt we've every had someone include a regular doc page without a title. (In any case, I'll look into creating a custom rule later if ever this becomes an issue).
- Greatly streamlines the "includes" features by making use of targeted cascades across (multilingual) sites
  - Deletes all `**/_includes/_index.md` files since we no longer need them
  - Drops bogus titles from all includes files
- Moves `content/en/docs/languages/js/_browser-instrumentation-warning.md` back into an includes folder since this will be required moving forward.
- Because of recent past changes to the includes, the `pt` aviso for JS pages wasn't being picked up, instead the English version was displayed, this is now fixed.

**Previews**:

- https://deploy-preview-6398--opentelemetry.netlify.app/fr/docs/
- https://deploy-preview-6398--opentelemetry.netlify.app/pt/docs/languages/js/getting-started/browser/ as an example of the fixed browser Aviso
- https://deploy-preview-6398--opentelemetry.netlify.app/docs/languages/js/getting-started/browser/

Proof that no `_includes` resources/pages are getting generated:

```console
$ find public -name "_includes*" | wc -l
       0
```

Also, https://deploy-preview-6398--opentelemetry.netlify.app/_includes/ is a 404.