### PR TITLE
[CI] Report `http` scheme in URL unless localhost, fix links

### DIFF
--- a/content/en/blog/2023/end-user-discussions-01.md
+++ b/content/en/blog/2023/end-user-discussions-01.md
@@ -20,7 +20,7 @@ they use OpenTelemetry in real life. Sessions are held for users in the Americas
 discussions take place using a
 [Lean Coffee format](https://agilecoffee.com/leancoffee/), whereby folks are
 invited to post their topics to the
-[Agile Coffee board like this one](http://agile.coffee/#b3b37364-d40e-4029-847c-8ee059d60855),
+[Agile Coffee board like this one](http://agile.coffee/?disable_http_check#b3b37364-d40e-4029-847c-8ee059d60855),
 and everyone in attendance votes on what they want to talk about.
 
 This is a great way to meet other users in the OpenTelemetry community, and to

--- a/content/en/blog/2023/end-user-discussions-02.md
+++ b/content/en/blog/2023/end-user-discussions-02.md
@@ -18,7 +18,7 @@ Americas (AMER), Europe Middle-East & Africa (EMEA), and Asia-Pacific (APAC).
 The discussions take place using a
 [Lean Coffee format](https://agilecoffee.com/leancoffee/), whereby folks are
 invited to post their topics to the
-[Agile Coffee board like this one](http://agile.coffee/#3716060f-183a-4966-8da4-60daab2842c4),
+[Agile Coffee board like this one](http://agile.coffee/?disable_http_check#3716060f-183a-4966-8da4-60daab2842c4),
 and everyone in attendance votes on what they want to talk about.
 
 ## What we talked about

--- a/content/en/blog/2023/end-user-discussions-03.md
+++ b/content/en/blog/2023/end-user-discussions-03.md
@@ -19,7 +19,7 @@ Americas (AMER), Europe Middle-East & Africa (EMEA), and Asia-Pacific (APAC).
 The discussions take place using a
 [Lean Coffee format](https://agilecoffee.com/leancoffee/), whereby folks are
 invited to post their topics to the
-[Agile Coffee board like this one](http://agile.coffee/#3716060f-183a-4966-8da4-60daab2842c4),
+[Agile Coffee board like this one](http://agile.coffee/?disable_http_check#3716060f-183a-4966-8da4-60daab2842c4),
 and everyone in attendance votes on what they want to talk about.
 
 ## What we talked about

--- a/content/en/blog/2023/end-user-discussions-04.md
+++ b/content/en/blog/2023/end-user-discussions-04.md
@@ -13,7 +13,7 @@ regions again in May.
 The discussions take place using a
 [Lean Coffee format](https://agilecoffee.com/leancoffee/), whereby folks are
 invited to post their topics to the
-[Agile Coffee board like this one](http://agile.coffee/#2f83c1c1-918c-4c78-8671-194b2e9d8e54),
+[Agile Coffee board like this one](http://agile.coffee/?disable_http_check#2f83c1c1-918c-4c78-8671-194b2e9d8e54),
 and everyone in attendance votes on what they want to talk about.
 
 ## What we talked about

--- a/content/en/blog/2023/end-user-q-and-a-02.md
+++ b/content/en/blog/2023/end-user-q-and-a-02.md
@@ -274,7 +274,7 @@ him in the
 channel!
 
 Also, be sure to check out more of Doug's OTel adventures at this month's
-[OTel in Practice series, on March 27th, 09:00 PT/11:00 ET](http://surl.li/fqdox).
+[OTel in Practice series, on March 27th, 09:00 PT/11:00 ET](https://surl.li/fqdox).
 
 ## Final Thoughts
 

--- a/content/en/blog/2023/otel-arrow/index.md
+++ b/content/en/blog/2023/otel-arrow/index.md
@@ -15,10 +15,11 @@ which is based on [Apache Arrow](https://arrow.apache.org/), a columnar-oriented
 memory format used for developing analytics applications. This integration
 facilitates a reduction in telemetry data traffic by a factor of 10 after
 compression, offering a 40% improvement over the best existing OpenTelemetry
-Protocol (OTLP) configurations with [Zstandard (zstd)](http://www.zstd.net/)
-compression enabled. As a result, this new protocol emerges as an optimal choice
-for transporting telemetry data over the internet. We are also excited to
-announce the release of a new pair of receiver/exporter in the
+Protocol (OTLP) configurations with
+[Zstandard (zstd)](https://facebook.github.io/zstd/) compression enabled. As a
+result, this new protocol emerges as an optimal choice for transporting
+telemetry data over the internet. We are also excited to announce the release of
+a new pair of receiver/exporter in the
 [opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/)
 repository that supports this protocol. This protocol, designed to complement
 the OTLP protocol in situations with substantial telemetry data volumes, has

--- a/content/en/blog/2024/cve-2024-36129.md
+++ b/content/en/blog/2024/cve-2024-36129.md
@@ -100,10 +100,11 @@ If you are using a custom distribution and building it with the
 can add a
 [“replaces”](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder#configuration)
 entry pointing to the latest version of the
-[confighttp](http://go.opentelemetry.io/collector/config/confighttp) and
-[configgrpc](http://go.opentelemetry.io/collector/config/configgrpc) Go module.
-If your base Collector version is at v0.96.0 or higher, we do not expect any
-compatibility issues by just bumping to the latest version.
+[confighttp](https://pkg.go.dev/go.opentelemetry.io/collector/config/confighttp)
+and
+[configgrpc](https://pkg.go.dev/go.opentelemetry.io/collector/config/configgrpc)
+Go module. If your base Collector version is at v0.96.0 or higher, we do not
+expect any compatibility issues by just bumping to the latest version.
 
 ## Lessons learned
 

--- a/content/en/docs/languages/python/mypy.md
+++ b/content/en/docs/languages/python/mypy.md
@@ -4,7 +4,7 @@ weight: 120
 cSpell:ignore: mypy
 ---
 
-If you're using [mypy](http://mypy-lang.org/), you'll need to turn on
+If you're using [mypy](https://mypy-lang.org/), you'll need to turn on
 [namespace packages](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-namespace-packages),
 otherwise `mypy` won't be able to run correctly.
 

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -18,9 +18,9 @@
 
 
 {{ if and
-    (strings.HasPrefix $.PageInner.RelPermalink "/docs/specs")
+    (hasPrefix $.PageInner.RelPermalink "/docs/specs")
     (not $u.IsAbs)
-    (not (strings.HasPrefix $url "#"))
+    (not (hasPrefix $url "#"))
 -}}
   {{ $path := replaceRE `\bREADME\.md\b` "_index.md" $u.Path -}}
   {{ $href := $url -}}
@@ -60,6 +60,20 @@
         {{/* warnf "Render-link: locale %s doesn't have the page %s (%s)" $lang $url $localizedPagePath */ -}}
       {{ end -}}
     {{ end -}}
+  {{ end -}}
+{{ else if and $u.IsAbs (eq $u.Scheme "http")
+    (not ($u.Query.Has "disable_http_check"))
+    (not (findRE `\blocalhost\b|^127\.0` $u.Host))
+-}}
+  {{/*
+    TODO: drop the temporary allowance of various hosts such as publicsuffix.org once
+    https://github.com/open-telemetry/opentelemetry.io/issues/6409
+    is fully resolved.
+  */ -}}
+  {{ if findRE `^(publicsuffix.org|docs.oasis|unitsofmeasure|connect.build)` $u.Host -}}
+    {{/* Do nothing until semconv fixes land. */ -}}
+  {{ else -}}
+    {{ warnf "%s: use 'https' for external URL '%s', or add query parameter '?disable_http_check'" .Page.File.Path $url -}}
   {{ end -}}
 {{ end -}}
 

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -4,20 +4,8 @@
     "LastSeen": "2025-02-06T01:30:18.284Z"
   },
   "http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T01:30:20.159Z"
-  },
-  "http://go.opentelemetry.io/collector/config/configgrpc": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-01T07:10:49.949312-05:00"
-  },
-  "http://go.opentelemetry.io/collector/config/confighttp": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-01T07:10:49.659547-05:00"
-  },
-  "http://mypy-lang.org/": {
     "StatusCode": 206,
-    "LastSeen": "2025-01-06T11:23:22.730585-05:00"
+    "LastSeen": "2025-02-24T14:46:01.790558-05:00"
   },
   "http://publicsuffix.org": {
     "StatusCode": 206,
@@ -4828,8 +4816,8 @@
     "LastSeen": "2025-01-13T12:11:03.156031-05:00"
   },
   "https://github.com/open-telemetry/community#calendar": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-10T23:17:06.259092229Z"
+    "StatusCode": 200,
+    "LastSeen": "2025-02-24T18:45:12.345Z"
   },
   "https://github.com/open-telemetry/community#mailing-lists": {
     "StatusCode": 200,
@@ -5148,20 +5136,20 @@
     "LastSeen": "2025-02-11T17:52:52.423025+01:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/transformprocessor/README.md#advanced-config": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-17T11:19:09.111297+01:00"
+    "StatusCode": 200,
+    "LastSeen": "2025-02-24T18:45:12.345Z"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/transformprocessor/README.md#basic-config": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-17T11:19:06.75063+01:00"
+    "StatusCode": 200,
+    "LastSeen": "2025-02-24T18:45:12.345Z"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/transformprocessor/README.md#context-inference": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-11T15:13:04.026653+01:00"
+    "StatusCode": 200,
+    "LastSeen": "2025-02-24T18:45:12.345Z"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/transformprocessor/README.md#context-inferred-configurations": {
     "StatusCode": 206,
-    "LastSeen": "2025-02-11T15:13:06.05203+01:00"
+    "LastSeen": "2025-02-24T18:45:59.999Z"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/hostmetricsreceiver/README.md": {
     "StatusCode": 206,
@@ -5752,12 +5740,12 @@
     "LastSeen": "2025-01-16T14:34:12.144171-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor#advanced-config": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-17T11:19:16.683343+01:00"
+    "StatusCode": 200,
+    "LastSeen": "2025-02-24T18:46:12.345Z"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor#context-inference": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-13T16:50:41.935955+01:00"
+    "StatusCode": 200,
+    "LastSeen": "2025-02-24T18:46:12.345Z"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver": {
     "StatusCode": 206,
@@ -6496,8 +6484,8 @@
     "LastSeen": "2025-02-19T19:17:45.009325266Z"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.120.0/component/config.go#L50": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-19T19:17:42.775563833Z"
+    "StatusCode": 200,
+    "LastSeen": "2025-02-24T18:46:12.345Z"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.120.0/pdata/internal/data/protogen/trace/v1/trace.pb.go": {
     "StatusCode": 206,
@@ -6512,8 +6500,8 @@
     "LastSeen": "2025-02-19T19:17:50.788198899Z"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.120.0/receiver/receiver.go#L58": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-19T19:17:50.094394779Z"
+    "StatusCode": 200,
+    "LastSeen": "2025-02-24T18:46:12.345Z"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.120.0/semconv/v1.9.0/generated_resource.go": {
     "StatusCode": 206,
@@ -13943,6 +13931,10 @@
     "StatusCode": 200,
     "LastSeen": "2025-01-30T22:19:22.414Z"
   },
+  "https://mypy-lang.org/": {
+    "StatusCode": 206,
+    "LastSeen": "2025-02-24T16:11:00.392872-05:00"
+  },
   "https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-namespace-packages": {
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:26:59.999Z"
@@ -15519,6 +15511,14 @@
     "StatusCode": 200,
     "LastSeen": "2025-01-06T11:32:23.675071-05:00"
   },
+  "https://pkg.go.dev/go.opentelemetry.io/collector/config/configgrpc": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-24T15:00:02.897452-05:00"
+  },
+  "https://pkg.go.dev/go.opentelemetry.io/collector/config/confighttp": {
+    "StatusCode": 200,
+    "LastSeen": "2025-02-24T15:00:01.821356-05:00"
+  },
   "https://pkg.go.dev/go.opentelemetry.io/collector/confmap/provider/envprovider": {
     "StatusCode": 200,
     "LastSeen": "2024-11-19T13:34:41.905691-05:00"
@@ -16000,8 +16000,8 @@
     "LastSeen": "2025-01-06T11:32:19.346196-05:00"
   },
   "https://quarkus.io/guides/opentelemetry#configuration-reference": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-05T16:11:20.963349Z"
+    "StatusCode": 200,
+    "LastSeen": "2025-02-24T19:45:12.345Z"
   },
   "https://quarkus.io/guides/opentelemetry-logging": {
     "StatusCode": 206,


### PR DESCRIPTION
- Contributes to #6409
- Adds a check to the render-link hook, ensuring that non-localhost URLs use `https` rather than `http` (since doing so if often a typo)
- Fixes various `http` links