### PR TITLE
[javascript] discontinue use of deprecated APIs

### DIFF
--- a/content/en/docs/demo/services/frontend.md
+++ b/content/en/docs/demo/services/frontend.md
@@ -178,9 +178,8 @@ const FrontendTracer = async () => {
     resource: new Resource({
       [SEMRESATTRS_SERVICE_NAME]: process.env.NEXT_PUBLIC_OTEL_SERVICE_NAME,
     }),
+    spanProcessors: [new SimpleSpanProcessor(new OTLPTraceExporter())],
   });
-
-  provider.addSpanProcessor(new SimpleSpanProcessor(new OTLPTraceExporter()));
 
   const contextManager = new ZoneContextManager();
 

--- a/content/en/docs/languages/js/exporters.md
+++ b/content/en/docs/languages/js/exporters.md
@@ -355,7 +355,7 @@ import * as opentelemetry from '@opentelemetry/sdk-node';
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
 
 const sdk = new NodeSDK({
-  spanProcessor: new SimpleSpanProcessor(exporter),
+  spanProcessors: [new SimpleSpanProcessor(exporter)],
   instrumentations: [getNodeAutoInstrumentations()],
 });
 sdk.start();
@@ -371,7 +371,7 @@ const {
 } = require('@opentelemetry/auto-instrumentations-node');
 
 const sdk = new opentelemetry.NodeSDK({
-  spanProcessor: new SimpleSpanProcessor(exporter)
+  spanProcessors: [new SimpleSpanProcessor(exporter)],
   instrumentations: [getNodeAutoInstrumentations()],
 });
 sdk.start();

--- a/content/en/docs/languages/js/instrumentation.md
+++ b/content/en/docs/languages/js/instrumentation.md
@@ -367,12 +367,13 @@ const resource = Resource.default().merge(
   }),
 );
 
-const provider = new WebTracerProvider({
-  resource: resource,
-});
 const exporter = new ConsoleSpanExporter();
 const processor = new BatchSpanProcessor(exporter);
-provider.addSpanProcessor(processor);
+
+const provider = new WebTracerProvider({
+  resource: resource,
+  spanProcessors: [processor],
+});
 
 provider.register();
 ```
@@ -399,12 +400,13 @@ const resource = Resource.default().merge(
   }),
 );
 
-const provider = new WebTracerProvider({
-  resource: resource,
-});
 const exporter = new ConsoleSpanExporter();
 const processor = new BatchSpanProcessor(exporter);
-provider.addSpanProcessor(processor);
+
+const provider = new WebTracerProvider({
+  resource: resource,
+  spanProcessors: [processor],
+});
 
 provider.register();
 ```
@@ -1126,16 +1128,28 @@ Initializing tracing is similar to how you'd do it with Node.js or the Web SDK.
 ```ts
 import opentelemetry from '@opentelemetry/api';
 import {
+  CompositePropagator,
+  W3CTraceContextPropagator,
+  W3CBaggagePropagator,
+} from '@opentelemetry/core';
+import {
   BasicTracerProvider,
   BatchSpanProcessor,
   ConsoleSpanExporter,
 } from '@opentelemetry/sdk-trace-base';
 
-const provider = new BasicTracerProvider();
+opentelemetry.trace.setGlobalTracerProvider(
+  new BasicTracerProvider({
+    // Configure span processor to send spans to the exporter
+    spanProcessors: [new BatchSpanProcessor(new ConsoleSpanExporter())],
+  }),
+);
 
-// Configure span processor to send spans to the exporter
-provider.addSpanProcessor(new BatchSpanProcessor(new ConsoleSpanExporter()));
-provider.register();
+opentelemetry.propagation.setGlobalPropagator(
+  new CompositePropagator({
+    propagators: [new W3CTraceContextPropagator(), new W3CBaggagePropagator()],
+  }),
+);
 
 // This is what we'll access in all instrumentation code
 const tracer = opentelemetry.trace.getTracer('example-basic-tracer-node');
@@ -1146,16 +1160,28 @@ const tracer = opentelemetry.trace.getTracer('example-basic-tracer-node');
 ```js
 const opentelemetry = require('@opentelemetry/api');
 const {
+  CompositePropagator,
+  W3CTraceContextPropagator,
+  W3CBaggagePropagator,
+} = require('@opentelemetry/core');
+const {
   BasicTracerProvider,
   ConsoleSpanExporter,
   BatchSpanProcessor,
 } = require('@opentelemetry/sdk-trace-base');
 
-const provider = new BasicTracerProvider();
+opentelemetry.trace.setGlobalTracerProvider(
+  new BasicTracerProvider({
+    // Configure span processor to send spans to the exporter
+    spanProcessors: [new BatchSpanProcessor(new ConsoleSpanExporter())],
+  }),
+);
 
-// Configure span processor to send spans to the exporter
-provider.addSpanProcessor(new BatchSpanProcessor(new ConsoleSpanExporter()));
-provider.register();
+opentelemetry.propagation.setGlobalPropagator(
+  new CompositePropagator({
+    propagators: [new W3CTraceContextPropagator(), new W3CBaggagePropagator()],
+  }),
+);
 
 // This is what we'll access in all instrumentation code
 const tracer = opentelemetry.trace.getTracer('example-basic-tracer-node');

--- a/content/en/docs/languages/js/serverless.md
+++ b/content/en/docs/languages/js/serverless.md
@@ -64,17 +64,15 @@ const {
 
 api.diag.setLogger(new api.DiagConsoleLogger(), api.DiagLogLevel.ALL);
 
-const provider = new NodeTracerProvider();
-const collectorOptions = {
-  url: '<backend_url>',
-};
-
 const spanProcessor = new BatchSpanProcessor(
-  new OTLPTraceExporter(collectorOptions),
+  new OTLPTraceExporter({
+    url: '<backend_url>',
+  }),
 );
 
-provider.addSpanProcessor(spanProcessor);
-provider.register();
+const provider = new NodeTracerProvider({
+  spanProcessors: [spanProcessor],
+});
 
 registerInstrumentations({
   instrumentations: [
@@ -241,24 +239,21 @@ const {
   getNodeAutoInstrumentations,
 } = require('@opentelemetry/auto-instrumentations-node');
 
-const providerConfig = {
-  resource: new Resource({
-    [SEMRESATTRS_SERVICE_NAME]: '<your function name>',
-  }),
-};
-
 api.diag.setLogger(new api.DiagConsoleLogger(), api.DiagLogLevel.ALL);
 
-const provider = new NodeTracerProvider(providerConfig);
 const collectorOptions = {
   url: '<address for your backend>',
 };
 
-const spanProcessor = new BatchSpanProcessor(
-  new OTLPTraceExporter(collectorOptions),
-);
+const provider = new NodeTracerProvider({
+  resource: resourceFromAttributes({
+    [SEMRESATTRS_SERVICE_NAME]: '<your function name>',
+  }),
+  spanProcessors: [
+    new BatchSpanProcessor(new OTLPTraceExporter(collectorOptions)),
+  ],
+});
 
-provider.addSpanProcessor(spanProcessor);
 provider.register();
 
 registerInstrumentations({
@@ -274,15 +269,15 @@ Add the following to your `package.json`:
 {
   "dependencies": {
     "@google-cloud/functions-framework": "^3.0.0",
-    "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/auto-instrumentations-node": "^0.35.0",
-    "@opentelemetry/exporter-trace-otlp-http": "^0.34.0",
-    "@opentelemetry/instrumentation": "^0.34.0",
-    "@opentelemetry/sdk-node": "^0.34.0",
-    "@opentelemetry/sdk-trace-base": "^1.8.0",
-    "@opentelemetry/sdk-trace-node": "^1.8.0",
-    "@opentelemetry/resources": "^1.8.0",
-    "@opentelemetry/semantic-conventions": "^1.8.0"
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.56.1",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.57.2",
+    "@opentelemetry/instrumentation": "^0.57.2",
+    "@opentelemetry/sdk-node": "^0.57.2",
+    "@opentelemetry/sdk-trace-base": "^1.30.1",
+    "@opentelemetry/sdk-trace-node": "^1.30.1",
+    "@opentelemetry/resources": "^1.30.1",
+    "@opentelemetry/semantic-conventions": "^1.30.0"
   }
 }
 ```


### PR DESCRIPTION
Hi all - this PR contains updates to documentation discontinuing the use of deprecated APIs. As discussed in #6396 this is in preparation of the upcoming SDK `2.0.0` release, but uses only features that are available in the currently latest release `1.30.1`/`0.57.2` for now.

I will follow up with 2 other PRs for
- `assets/js/tracing.js` (edit: #6418) 
- actually lifting all JS docs to 2.0 

**Notable changes:**
- `BasicTracerProvider#register()` will be removed to allow for better tree-shaking
  - this was replaced in the docs by manually registering the propagator that would've been registered by `BasicTracerProvider#register()`
  - `NodeTracerProvider#register()` is still available in 2.0, therefore docs using it remain unchanged
  - `WebTracerProvider#register()` is still available in 2.0, therefore docs using it remain unchanged
- `*TracerProvider#addSpanProcessor()` was replaced by a `spanProcessors` constructor option, which is available since `1.28.0`
  - changing this required some re-ordering in the docs as exporters used to be instantiated later
- I updated dependencies in the serverless docs to ensure that all of these features are available.

Refs #6396 