### PR TITLE
[ecosystem] Fix heading ID for included section

### DIFF
--- a/content/en/ecosystem/_includes/keep-up-to-date.md
+++ b/content/en/ecosystem/_includes/keep-up-to-date.md
@@ -1,7 +1,7 @@
 ---
 ---
 
-## Keeping {{ $1 }} information current
+## Keeping {{ $1 }} information current {#keeping-up-to-date}
 
 Ensure that you keep your {{ $1 }} information up-to-date, otherwise we might
 update or remove it from the registry or [ecosystem list]. For details, see


### PR DESCRIPTION
- Contributes to #4467
- Fixes the heading ID inside the `keep-up-to-date.md` include file so that it is the same across locales

**Preview**:

- https://deploy-preview-6419--opentelemetry.netlify.app/ecosystem/adopters/#keeping-up-to-date
- https://deploy-preview-6419--opentelemetry.netlify.app/pt/ecosystem/adopters/#keeping-up-to-date

Related:

- #6415, might be waiting on this PR