### PR TITLE
Automated GitHub Action to Prevent PRs from Main Branch

### DIFF
--- a/.github/workflows/check-branch.yml
+++ b/.github/workflows/check-branch.yml
@@ -1,0 +1,19 @@
+name: Enforce PR Branch Naming
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  check-branch-name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if PR is from 'main' branch
+        run: |
+          if [[ "${{ github.head_ref }}" == "main" ]]; then
+            echo "❌ Pull requests must not be created from the 'main' branch."
+            echo "❗ Please create a new branch and submit your PR again."
+            exit 1
+          else
+            echo "✅ Branch name is valid."
+          fi


### PR DESCRIPTION
**Problem:** Sometimes, contributors accidentally submit PRs from the main branch instead of a separate branch.
### Why is this a problem?
If a PR is created from main, maintainers can't easily make edits or use automated /fix commands.
It can cause conflicts if multiple PRs are based on the same main branch.
It can lead to issues when merging, since main is usually the production or stable branch.
**Proposed Solution:**
I implemented a GitHub Actions check that automatically fails a PR if it originates from the main branch. This ensures contributors receive an immediate warning, preventing maintainers from discovering the issue later in the review process. 🚀
