### PR TITLE
Markdown cleanup: Replace {{< >}} with {{% %}}

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -16,7 +16,7 @@ show_banner: true
 
 <div class="d-none"><a rel="me" href="https://fosstodon.org/@opentelemetry"></a></div>
 
-{{< blocks/cover image_anchor="top" height="max" color="primary" >}}
+{{% blocks/cover image_anchor="top" height="max" color="primary" %}}
 
 <!-- prettier-ignore -->
 ![OpenTelemetry](/img/logos/opentelemetry-horizontal-color.svg)
@@ -42,7 +42,7 @@ show_banner: true
 - [Ops](docs/getting-started/ops/)
 
 </div>
-{{< /blocks/cover >}}
+{{% /blocks/cover %}}
 
 {{% blocks/lead color="white" %}}
 

--- a/content/en/blog/2023/cloud-foundry.md
+++ b/content/en/blog/2023/cloud-foundry.md
@@ -8,7 +8,7 @@ author: >-
 cSpell:ignore: Kocher unscalable
 ---
 
-{{< blog/integration-badge >}}
+{{% blog/integration-badge %}}
 
 [Cloud Foundry](https://www.cloudfoundry.org/) recently integrated the
 [OpenTelemetry Collector](/docs/collector/) for metrics egress and we learned a

--- a/content/en/blog/2023/euwg-future-of-observability-panel.md
+++ b/content/en/blog/2023/euwg-future-of-observability-panel.md
@@ -25,7 +25,7 @@ Observability practices, in this panel hosted by the
 centered around their journey with OpenTelemetry and how it has shaped their
 Observability practices. Watch the full recording:
 
-{{<youtube zSeKL2-_sVg>}}
+{{%youtube zSeKL2-_sVg%}}
 
 <br/>For a quick summary, check out some of the key discussion takeaways below.
 

--- a/content/en/blog/2023/humans-of-otel.md
+++ b/content/en/blog/2023/humans-of-otel.md
@@ -41,7 +41,7 @@ Special thanks to [Reese Lee](https://github.com/reese-lee) for the camera work!
 
 You can watch the full recording here:
 
-{{<youtube coPrhP_7lVU>}}
+{{%youtube coPrhP_7lVU%}}
 
 <br/>Thanks to everyone who has contributed to OpenTelemetry to date, and we
 look forward to your contributions in 2024! 🎉

--- a/content/en/blog/2023/integrations.md
+++ b/content/en/blog/2023/integrations.md
@@ -4,7 +4,7 @@ linkTitle: Integrations Welcome!
 date: 2023-11-06
 ---
 
-{{< blog/integration-badge >}}
+{{% blog/integration-badge %}}
 
 Embracing OpenTelemetry's [vision], we are committed to enabling high-quality
 telemetry throughout the entire software stack!

--- a/content/en/blog/2023/otterize-otel/index.md
+++ b/content/en/blog/2023/otterize-otel/index.md
@@ -8,7 +8,7 @@ author: >-
 cSpell:ignore: brainer Otterize Shoshan
 ---
 
-{{< blog/integration-badge >}}
+{{% blog/integration-badge %}}
 
 ## A no-brainer integration: Adding OpenTelemetry support to the Otterize network mapper
 

--- a/content/en/blog/2023/tyk-api-gateway/index.md
+++ b/content/en/blog/2023/tyk-api-gateway/index.md
@@ -6,7 +6,7 @@ author: >-
   [Sonja Chevre](https://github.com/SonjaChevre) (Tyk Technologies)
 ---
 
-{{< blog/integration-badge >}}
+{{% blog/integration-badge %}}
 
 We're excited to announce that
 [Tyk API Gateway](https://github.com/TykTechnologies/tyk) has first-class

--- a/content/en/blog/2024/collecting-otel-compliant-java-logs-from-files/index.md
+++ b/content/en/blog/2024/collecting-otel-compliant-java-logs-from-files/index.md
@@ -205,7 +205,7 @@ OTLP/JSON format, with a JSON object per line. The log records are nested in the
 
 ## Configure the Collector to ingest the OTLP/JSON logs
 
-{{< figure class="figure" src="otel-collector-otlpjson-pipeline.png" attr="View OTel Collector pipeline with OTelBin" attrlink=`https://www.otelbin.io/s/69739d790cf279c203fc8efc86ad1a876a2fc01a` >}}
+{{% figure class="figure" src="otel-collector-otlpjson-pipeline.png" attr="View OTel Collector pipeline with OTelBin" attrlink=`https://www.otelbin.io/s/69739d790cf279c203fc8efc86ad1a876a2fc01a` %}}
 
 ```yaml
 # tested with otelcol-contrib v0.112.0

--- a/content/en/blog/2024/humans-of-otel-eu-2024.md
+++ b/content/en/blog/2024/humans-of-otel-eu-2024.md
@@ -36,7 +36,7 @@ Also, special thanks to:
 
 You can watch the full recording here:
 
-{{<youtube bsfMECwmsm0>}}
+{{%youtube bsfMECwmsm0%}}
 
 <br/>Thanks to everyone who has contributed to OpenTelemetry to date, and we
 look forward to your continued contributions in 2024 and beyond! 🎉

--- a/content/en/blog/2024/humans-of-otel-na-2024.md
+++ b/content/en/blog/2024/humans-of-otel-na-2024.md
@@ -38,7 +38,7 @@ Also, special thanks to:
 
 You can watch the full recording here:
 
-{{<youtube TIMgKXCeiyQ>}}
+{{%youtube TIMgKXCeiyQ%}}
 
 <br/>Thanks to everyone who has contributed to OpenTelemetry to date, and we
 look forward to your continued contributions in 2025 and beyond! 🎉

--- a/content/en/blog/2025/observing-lambdas/index.md
+++ b/content/en/blog/2025/observing-lambdas/index.md
@@ -57,7 +57,7 @@ Lambda to return, even if not all data has been sent. At the next invocation (or
 on shutdown) the Collector continues exporting the data while your function does
 its thing.
 
-{{< figure src="diagram-execution-timing.svg" caption="Diagram showcasing how execution timing differs with and without a Collector">}}
+{{% figure src="diagram-execution-timing.svg" caption="Diagram showcasing how execution timing differs with and without a Collector"%}}
 
 ## How can I use it?
 

--- a/content/en/blog/2025/otel-cicd-sig/index.md
+++ b/content/en/blog/2025/otel-cicd-sig/index.md
@@ -163,7 +163,7 @@ that closely align with the [SLSA](https://slsa.dev/spec/v1.0/about) model. This
 is really the first time a direct connection is being made between observability
 and software supply chain security. Consider the following
 [supply chain threat model](https://slsa.dev/spec/v1.0/threats) defined by SLSA:
-{{< figure class="figure" src="SLSA-supply-chain-model.png" attr="SLSA Community Specification License 1.0" attrlink=`https://github.com/slsa-framework/slsa?tab=License-1-ov-file` >}}
+{{% figure class="figure" src="SLSA-supply-chain-model.png" attr="SLSA Community Specification License 1.0" attrlink=`https://github.com/slsa-framework/slsa?tab=License-1-ov-file` %}}
 
 These new attributes for artifacts and attestations help observe the sequence of
 events modeled in the above diagram in real time. Really, the conventions that

--- a/content/en/docs/collector/custom-collector.md
+++ b/content/en/docs/collector/custom-collector.md
@@ -31,7 +31,7 @@ Collector [releases with `cmd/builder` tags][tags]. You will find a list of
 assets named based on OS and chipset, so download the one that fits your
 configuration:
 
-{{< tabpane text=true >}}
+{{% tabpane text=true %}}
 
 {{% tab "Linux (AMD 64)" %}}
 
@@ -80,7 +80,7 @@ Invoke-WebRequest -Uri "https://github.com/open-telemetry/opentelemetry-collecto
 Unblock-File -Path "ocb.exe"
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 To make sure the `ocb` is ready to be used, go to your terminal and type
 `./ocb help`, and once you hit enter you should have the output of the `help`

--- a/content/en/docs/collector/deployment/agent.md
+++ b/content/en/docs/collector/deployment/agent.md
@@ -36,7 +36,7 @@ export OTEL_EXPORTER_OTLP_ENDPOINT=http://collector.example.com:4318
 The collector serving at `collector.example.com:4318` would then be configured
 like so:
 
-{{< tabpane text=true >}} {{% tab Traces %}}
+{{% tabpane text=true %}} {{% tab Traces %}}
 
 ```yaml
 receivers:
@@ -109,7 +109,7 @@ service:
       exporters: [file]
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 If you want to try it out for yourself, you can have a look at the end-to-end
 [Java][java-otlp-example] or [Python][py-otlp-example] examples.

--- a/content/en/docs/collector/deployment/gateway/index.md
+++ b/content/en/docs/collector/deployment/gateway/index.md
@@ -111,7 +111,7 @@ configuration fields:
 The first-tier collector servicing the OTLP endpoint would be configured as
 shown below:
 
-{{< tabpane text=true >}} {{% tab Static %}}
+{{% tabpane text=true %}} {{% tab Static %}}
 
 ```yaml
 receivers:
@@ -194,7 +194,7 @@ service:
       exporters: [loadbalancing]
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 The load-balancing exporter emits metrics including
 `otelcol_loadbalancer_num_backends` and `otelcol_loadbalancer_backend_latency`

--- a/content/en/docs/collector/installation.md
+++ b/content/en/docs/collector/installation.md
@@ -17,7 +17,7 @@ and [Deployment Methods][] page.
 The following commands pull a Docker image and run the Collector in a container.
 Replace `{{% param vers %}}` with the version of the Collector you want to run.
 
-{{< tabpane text=true >}} {{% tab DockerHub %}}
+{{% tabpane text=true %}} {{% tab DockerHub %}}
 
 ```sh
 docker pull otel/opentelemetry-collector-contrib:{{% param vers %}}
@@ -31,12 +31,12 @@ docker pull ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetr
 docker run ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{% param vers %}}
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 To load a custom configuration file from your working directory, mount that file
 as a volume:
 
-{{< tabpane text=true >}} {{% tab DockerHub %}}
+{{% tabpane text=true %}} {{% tab DockerHub %}}
 
 ```sh
 docker run -v $(pwd)/config.yaml:/etc/otelcol-contrib/config.yaml otel/opentelemetry-collector-contrib:{{% param vers %}}
@@ -48,7 +48,7 @@ docker run -v $(pwd)/config.yaml:/etc/otelcol-contrib/config.yaml otel/opentelem
 docker run -v $(pwd)/config.yaml:/etc/otelcol-contrib/config.yaml ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{% param vers %}}
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ## Docker Compose
 
@@ -108,7 +108,7 @@ amd64/arm64/i386 systems. You can find the default configuration in
 
 To get started on Debian systems run the following commands:
 
-{{< tabpane text=true >}} {{% tab AMD64 %}}
+{{% tabpane text=true %}} {{% tab AMD64 %}}
 
 ```sh
 sudo apt-get update
@@ -135,13 +135,13 @@ wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases
 sudo dpkg -i otelcol_{{% param vers %}}_linux_386.deb
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### RPM Installation
 
 To get started on Red Hat systems run the following commands:
 
-{{< tabpane text=true >}} {{% tab AMD64 %}}
+{{% tabpane text=true %}} {{% tab AMD64 %}}
 
 ```sh
 sudo yum update
@@ -168,14 +168,14 @@ wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases
 sudo rpm -ivh otelcol_{{% param vers %}}_linux_386.rpm
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### Manual Linux installation
 
 Linux [releases][] are available for various architectures. You can download the
 file containing the binary and install it on your machine manually:
 
-{{< tabpane text=true >}} {{% tab AMD64 %}}
+{{% tabpane text=true %}} {{% tab AMD64 %}}
 
 ```sh
 curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_linux_amd64.tar.gz
@@ -203,7 +203,7 @@ curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelem
 tar -xvf otelcol_{{% param vers %}}_linux_ppc64le.tar.gz
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### Automatic service configuration
 
@@ -235,7 +235,7 @@ macOS [releases][] are available for Intel and ARM systems. The releases are
 packaged as gzipped tarballs (`.tar.gz`). To unpack them, run the following
 commands:
 
-{{< tabpane text=true >}} {{% tab Intel %}}
+{{% tabpane text=true %}} {{% tab Intel %}}
 
 ```sh
 curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_darwin_amd64.tar.gz
@@ -249,7 +249,7 @@ curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelem
 tar -xvf otelcol_{{% param vers %}}_darwin_arm64.tar.gz
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 Every Collector release includes an `otelcol` executable that you can run after
 unpacking.

--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -118,7 +118,7 @@ are:
 You can also see logs for the Collector on a Linux systemd system using
 `journalctl`:
 
-{{< tabpane text=true >}} {{% tab "All logs" %}}
+{{% tabpane text=true %}} {{% tab "All logs" %}}
 
 ```sh
 journalctl | grep otelcol
@@ -130,7 +130,7 @@ journalctl | grep otelcol
 journalctl | grep otelcol | grep Error
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 The following configuration can be used to emit internal logs from the Collector
 to an OTLP/HTTP backend:
@@ -221,7 +221,7 @@ Prometheus exporter, regardless of their origin, are prefixed with `otelcol_`.
 This includes metrics from both Collector components and instrumentation
 libraries. {{% /alert %}}
 
-{{< comment >}}
+{{% comment %}}
 
 To compile this list, configure a Collector instance to emit its own metrics to
 the localhost:8888/metrics endpoint. Select a metric and grep for it in the
@@ -234,7 +234,7 @@ the .go file that contains the list of metrics. In the case of
 Note that the Collector's internal metrics are defined in several different
 files in the repository.
 
-{{< /comment >}}
+{{% /comment %}}
 
 #### `basic`-level metrics
 

--- a/content/en/docs/demo/docker-deployment.md
+++ b/content/en/docs/demo/docker-deployment.md
@@ -30,7 +30,7 @@ cSpell:ignore: otlphttp spanmetrics tracetest tracetesting
 
 3.  Start the demo[^1]:
 
-    {{< tabpane text=true >}} {{% tab Make %}}
+    {{% tabpane text=true %}} {{% tab Make %}}
 
 ```shell
 make start
@@ -42,11 +42,11 @@ make start
 docker compose up --force-recreate --remove-orphans --detach
 ```
 
-    {{% /tab %}} {{< /tabpane >}}
+    {{% /tab %}} {{% /tabpane %}}
 
 4.  (Optional) Enable API observability-driven testing[^1]:
 
-    {{< tabpane text=true >}} {{% tab Make %}}
+    {{% tabpane text=true %}} {{% tab Make %}}
 
 ```shell
 make run-tracetesting
@@ -58,7 +58,7 @@ make run-tracetesting
 docker compose -f docker-compose-tests.yml run traceBasedTests
 ```
 
-    {{% /tab %}} {{< /tabpane >}}
+    {{% /tab %}} {{% /tabpane %}}
 
 ## Verify the web store and Telemetry
 
@@ -80,7 +80,7 @@ variable before starting the demo.
 
 - For example, to use port 8081[^1]:
 
-  {{< tabpane text=true >}} {{% tab Make %}}
+  {{% tabpane text=true %}} {{% tab Make %}}
 
 ```shell
 ENVOY_PORT=8081 make start
@@ -92,7 +92,7 @@ ENVOY_PORT=8081 make start
 ENVOY_PORT=8081 docker compose up --force-recreate --remove-orphans --detach
 ```
 
-    {{% /tab %}} {{< /tabpane >}}
+    {{% /tab %}} {{% /tabpane %}}
 
 ## Bring your own backend
 

--- a/content/en/docs/languages/cpp/exporters.md
+++ b/content/en/docs/languages/cpp/exporters.md
@@ -28,7 +28,7 @@ Make sure that you have set the right cmake build variables while
 
 Next, configure the exporter to point at an OTLP endpoint in your code.
 
-{{< tabpane text=true >}} {{% tab "HTTP/Proto" %}}
+{{% tabpane text=true %}} {{% tab "HTTP/Proto" %}}
 
 ```cpp
 #include "opentelemetry/exporters/otlp/otlp_http_exporter_factory.h"
@@ -195,7 +195,7 @@ void InitLogger()
 }
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### Console
 
@@ -355,7 +355,7 @@ void InitTracer()
 
 {{% docs/languages/exporters/outro python `https://opentelemetry-cpp.readthedocs.io/en/latest/otel_docs/classopentelemetry_1_1sdk_1_1trace_1_1SpanExporter.html` %}}
 
-{{< tabpane text=true >}} {{% tab Batch %}}
+{{% tabpane text=true %}} {{% tab Batch %}}
 
 ```cpp
 #include "opentelemetry/exporters/otlp/otlp_http_exporter_factory.h"
@@ -382,6 +382,6 @@ auto exporter  = opentelemetry::exporter::otlp::OtlpHttpExporterFactory::Create(
 auto processor = opentelemetry::sdk::trace::SimpleSpanProcessorFactory::Create(std::move(exporter));
 ```
 
-{{< /tab >}} {{< /tabpane>}}
+{{% /tab %}} {{% /tabpane%}}
 
 {{% /docs/languages/exporters/outro %}}

--- a/content/en/docs/languages/erlang/exporters.md
+++ b/content/en/docs/languages/erlang/exporters.md
@@ -89,7 +89,7 @@ Zipkin also run by [docker-compose](https://docs.docker.com/compose/).
 To export to the running Collector the `opentelemetry_exporter` package must be
 added to the project's dependencies:
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 {deps, [{opentelemetry_api, "~> {{% param versions.otelApi %}}"},
@@ -109,7 +109,7 @@ def deps do
 end
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 It should then be added to the configuration of the Release before the SDK
 Application to ensure the exporter's dependencies are started before the SDK
@@ -118,7 +118,7 @@ attempts to initialize and use the exporter.
 Example of Release configuration in `rebar.config` and for
 [mix's Release task](https://hexdocs.pm/mix/Mix.Tasks.Release.html):
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 %% rebar.config
@@ -147,7 +147,7 @@ def project do
 end
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 Finally, the runtime configuration of the `opentelemetry` and
 `opentelemetry_exporter` Applications are set to export to the Collector. The
@@ -159,7 +159,7 @@ the HTTP protocol with endpoint of `localhost` on port `4318`. Note:
 - If you're using the docker compose file from above, you should replace
   `localhost` with `otel`.
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 %% config/sys.config.src
@@ -189,7 +189,7 @@ config :opentelemetry_exporter,
   # otlp_endpoint: "http://otel:4318" if using docker compose file
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 You can see your traces by running `docker compose up` in one terminal, then
 `mix phx.server` in another. After sending some requests through the app, go to

--- a/content/en/docs/languages/erlang/getting-started.md
+++ b/content/en/docs/languages/erlang/getting-started.md
@@ -353,7 +353,7 @@ telemetry backends.
 
 To get started with this guide, create a new project with `rebar3` or `mix`:
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 rebar3 new release otel_getting_started
@@ -365,13 +365,13 @@ rebar3 new release otel_getting_started
 mix new --sup otel_getting_started
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 Then, in the project you just created, add both `opentelemetry_api` and
 `opentelemetry` as dependencies. We add both because this is a project we will
 run as a Release and export spans from.
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 {deps, [{opentelemetry_api, "~> {{% param versions.otelApi %}}"},
@@ -389,13 +389,13 @@ def deps do
 end
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 In the case of Erlang, the API Application will also need to be added to
 `src/otel_getting_started.app.src` and a `relx` section to `rebar.config`. In an
 Elixir project, a `releases` section needs to be added to `mix.exs`:
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 %% src/otel_getting_started.app.src
@@ -425,7 +425,7 @@ releases: [
 ]
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 The SDK `opentelemetry` should be added as early as possible in the Release boot
 process to ensure it is available before any telemetry is produced. Here it is
@@ -462,7 +462,7 @@ To configure OpenTelemetry to use a particular exporter, in this case
 set the `exporter` for the span processor `otel_batch_processor`, a type of span
 processor that batches up multiple spans over a period of time:
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 %% config/sys.config.src
@@ -482,14 +482,14 @@ config :opentelemetry,
   traces_exporter: {:otel_exporter_stdout, []}
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ## Working with Spans
 
 Now that the dependencies and configuration are set up, we can create a module
 with a function `hello/0` that starts some spans:
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 %% apps/otel_getting_started/src/otel_getting_started.erl
@@ -536,7 +536,7 @@ defmodule OtelGettingStarted do
 end
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 In this example, we're using macros that use the process dictionary for context
 propagation and for getting the tracer.
@@ -561,7 +561,7 @@ To test out this project and see the spans created, you can run with
 `rebar3 shell` or `iex -S mix`, each will pick up the corresponding
 configuration for the release, resulting in the tracer and exporter to started.
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```console
 $ rebar3 shell
@@ -613,7 +613,7 @@ iex(2)>
       [],undefined,1,false,undefined}
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ## Next Steps
 

--- a/content/en/docs/languages/erlang/instrumentation.md
+++ b/content/en/docs/languages/erlang/instrumentation.md
@@ -53,7 +53,7 @@ interactive shell, a `Tracer` with a blank name and version is used.
 The created `Tracer`'s record can be looked up by the name of a module in the
 OTP Application:
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 opentelemetry:get_application_tracer(?MODULE)
@@ -65,7 +65,7 @@ opentelemetry:get_application_tracer(?MODULE)
 :opentelemetry.get_application_tracer(__MODULE__)
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 This is how the Erlang and Elixir macros for starting and updating `Spans` get a
 `Tracer` automatically without need for you to pass the variable in each call.
@@ -75,7 +75,7 @@ This is how the Erlang and Elixir macros for starting and updating `Spans` get a
 Now that you have [Tracer](/docs/concepts/signals/traces/#tracer)s initialized,
 you can create [Spans](/docs/concepts/signals/traces/#spans).
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 ?with_span(main, #{}, fun() ->
@@ -97,14 +97,14 @@ OpenTelemetry.Tracer.with_span :main do
 end
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 The above code sample shows how to create an active Span, which is the most
 common kind of Span to create.
 
 ### Create Nested Spans
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 parent_function() ->
@@ -139,7 +139,7 @@ def child_function() do
 end
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### Spans in Separate Processes
 
@@ -160,7 +160,7 @@ attaching the context and setting the new span as currently active in the
 process. The whole context should be attached in order to not lose other
 telemetry data like [baggage](/docs/specs/otel/baggage/api/).
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 SpanCtx = ?start_span(child),
@@ -195,7 +195,7 @@ task = Task.async(fn ->
 _ = Task.await(task)
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### Linking the New Span
 
@@ -204,7 +204,7 @@ Span Links that causally link it to another Span. A
 [Link](/docs/concepts/signals/traces/#span-links) needs a Span context to be
 created.
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 Parent = ?current_span_ctx,
@@ -231,7 +231,7 @@ task = Task.async(fn ->
                  end)
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### Adding Attributes to a Span
 
@@ -243,7 +243,7 @@ The following example shows the two ways of setting attributes on a span by both
 setting an attribute in the start options and then again with `set_attributes`
 in the body of the span operation:
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 ?with_span(my_span, #{attributes => [{'start-opts-attr', <<"start-opts-value">>}]},
@@ -262,7 +262,7 @@ Tracer.with_span :span_1, %{attributes: [{:"start-opts-attr", <<"start-opts-valu
 end
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### Semantic Attributes
 
@@ -276,7 +276,7 @@ from the specification and provided in
 For example, an instrumentation for an HTTP client or server would need to
 include semantic attributes like the scheme of the URL:
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 -include_lib("opentelemetry_semantic_conventions/include/trace.hrl").
@@ -297,7 +297,7 @@ Tracer.with_span :span_1, %{attributes: [{Trace.http_scheme(), <<"https">>}]} do
 end
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### Adding Events
 
@@ -306,7 +306,7 @@ message on an [Span](/docs/concepts/signals/traces/#spans) that represents a
 discrete event with no duration that can be tracked by a single timestamp. You
 can think of it like a primitive log.
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 ?add_event(<<"Gonna try it">>),
@@ -326,11 +326,11 @@ Tracer.add_event("Gonna try it")
 Tracer.add_event("Did it!")
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 Events can also have attributes of their own:
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 ?add_event(<<"Process exited with reason">>, [{pid, Pid)}, {reason, Reason}]))
@@ -342,7 +342,7 @@ Events can also have attributes of their own:
 Tracer.add_event("Process exited with reason", pid: pid, reason: Reason)
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### Set Span Status
 
@@ -354,7 +354,7 @@ could override the Error status with `StatusCode.OK`, but don’t set
 
 The status can be set at any time before the span is finished:
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 -include_lib("opentelemetry_api/include/opentelemetry.hrl").
@@ -368,7 +368,7 @@ The status can be set at any time before the span is finished:
 Tracer.set_status(:error, "this is not ok")
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ## Metrics
 

--- a/content/en/docs/languages/erlang/propagation.md
+++ b/content/en/docs/languages/erlang/propagation.md
@@ -28,7 +28,7 @@ propagators. By default the global propagators used are the W3C
 You can configure global propagators using the OTP application environment
 variable `text_map_propagators`:
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 %% sys.config
@@ -47,7 +47,7 @@ text_map_propagators: [:baggage, :trace_context],
 ...
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 You can also pass a comma separated list using the environment variable
 `OTEL_PROPAGATORS`. Both forms of configuration accept the values
@@ -59,7 +59,7 @@ and `b3multi`.
 To manually inject or extract context, you can use the
 `otel_propagator_text_map` module:
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 %% uses the context from the process dictionary to add to an empty list of headers
@@ -79,7 +79,7 @@ headers = :otel_propagator_text_map.inject([])
 :otel_propagator_text_map.extract(headers)
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 `otel_propagator_text_map:inject/1` and `otel_propagator_text_map:extract/1` use
 globally registered propagators. To use a specific propagator

--- a/content/en/docs/languages/erlang/resources.md
+++ b/content/en/docs/languages/erlang/resources.md
@@ -20,7 +20,7 @@ detectors use the OS environment variable `OTEL_RESOURCE_ATTRIBUTES` and the
 The detectors to use is a list of module names and can be configured in the
 Application configuration:
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 %% sys.config
@@ -34,7 +34,7 @@ Application configuration:
 config :opentelemetry, resource_detectors: [:otel_resource_env_var, :otel_resource_app_env]
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 Or through the environment variable `OTEL_RESOURCE_DETECTORS`:
 
@@ -61,11 +61,11 @@ OTEL_RESOURCE_ATTRIBUTES="deployment.environment=development"
 Alternatively, use the `resource` OTP application environment under the
 `opentelemetry` Application configuration of `sys.config` or `runtime.exs`:
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 %% sys.config
-{opentelemetry, {resource, #{deployment => #{environment => <<"development">>}}}}
+{opentelemetry, {resource, #{deployment => #{environment => <<"development">%}}}}
 ```
 
 {{% /tab %}} {{% tab Elixir %}}
@@ -75,7 +75,7 @@ Alternatively, use the `resource` OTP application environment under the
 config :opentelemetry, resource: %{deployment: %{environment: "development" }}
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 Resource attributes in the `resource` OTP application environment variable are
 flattened and combined with `.`, so

--- a/content/en/docs/languages/erlang/sampling.md
+++ b/content/en/docs/languages/erlang/sampling.md
@@ -58,7 +58,7 @@ This tells the SDK to sample spans such that only 10% of Traces get created.
 Example in the Application configuration with a root sampler for sampling 10% of
 Traces and using the parent decision in the other cases:
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 %% config/sys.config.src
@@ -80,7 +80,7 @@ config :opentelemetry, sampler: {:parent_based, %{root: {:trace_id_ratio_based, 
                                                   local_parent_not_sampled: :always_off}}
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### AlwaysOn and AlwaysOff Sampler
 
@@ -107,7 +107,7 @@ export OTEL_TRACES_SAMPLER="parentbased_always_off"
 Here's an example in the Application configuration with a root sampler that
 always samples and using the parent decision in the other cases:
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 %% config/sys.config.src
@@ -129,7 +129,7 @@ config :opentelemetry, sampler: {:parent_based, %{root: :always_on,
                                                   local_parent_not_sampled: :always_off}}
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ## Custom Sampler
 
@@ -137,7 +137,7 @@ Custom samplers can be created by implementing the
 [`otel_sampler` behaviour](https://hexdocs.pm/opentelemetry/1.3.0/otel_sampler.html#callbacks).
 This example sampler:
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 -module(attribute_sampler).
@@ -193,7 +193,7 @@ defmodule AttributesSampler do
 end
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 Will sample Spans that do not have any attributes that match the attributes
 passed as the sampler's configuration.
@@ -201,10 +201,10 @@ passed as the sampler's configuration.
 Example configuration to not sample any Span with an attribute specifying the
 URL requested is `/healthcheck`:
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
-{opentelemetry, {sampler, {attributes_sampler, #{'http.target' => <<"/healthcheck">>}}}}
+{opentelemetry, {sampler, {attributes_sampler, #{'http.target' => <<"/healthcheck">%}}}}
 ```
 
 {{% /tab %}} {{% tab Elixir %}}
@@ -213,4 +213,4 @@ URL requested is `/healthcheck`:
 config :opentelemetry, sampler: {AttributesSampler, %{"http.target": "/healthcheck"}}
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}

--- a/content/en/docs/languages/erlang/testing.md
+++ b/content/en/docs/languages/erlang/testing.md
@@ -15,7 +15,7 @@ validation.
 Only the `opentelemetry` and `opentelemetry_api` libraries are required for
 testing in Elixir/Erlang:
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 {deps, [{opentelemetry_api, "~> {{% param versions.otelApi %}}"},
@@ -33,13 +33,13 @@ def deps do
 end
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 Set your `exporter` to `:none` and the span processor to
 `:otel_simple_processor`. This ensure that your tests don't actually export data
 to a destination, and that spans can be analyzed after they are processed.
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 %% config/sys.config.src
@@ -63,13 +63,13 @@ config :opentelemetry, :processors, [
 ]
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 A modified version of the `hello` function from the
 [Getting Started](/docs/languages/erlang/getting-started/) guide will serve as
 our test case:
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 %% apps/otel_getting_started/src/otel_getting_started.erl
@@ -104,11 +104,11 @@ defmodule OtelGettingStarted do
 end
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ## Testing
 
-{{< tabpane text=true >}} {{% tab Erlang %}}
+{{% tabpane text=true %}} {{% tab Erlang %}}
 
 ```erlang
 -module(otel_getting_started_SUITE).
@@ -198,4 +198,4 @@ defmodule OtelGettingStartedTest do
 end
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}

--- a/content/en/docs/languages/java/intro.md
+++ b/content/en/docs/languages/java/intro.md
@@ -130,7 +130,7 @@ The following code snippet demonstrates adding a BOM dependency,
 with`{{bomGroupId}}`, `{{bomArtifactId}}`, and `{{bomVersion}}` referring to the
 "Group ID", "Artifact ID", and "Current Version" table columns, respectively.
 
-{{< tabpane text=true >}} {{% tab "Gradle" %}}
+{{% tabpane text=true %}} {{% tab "Gradle" %}}
 
 ```kotlin
 dependencies {
@@ -165,7 +165,7 @@ dependencies {
 </project>
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 [opentelemetry-bom]:
   <https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom/{{% param vers.otel %}}/opentelemetry-bom-{{% param vers.otel %}}.pom>

--- a/content/en/docs/languages/js/exporters.md
+++ b/content/en/docs/languages/js/exporters.md
@@ -20,7 +20,7 @@ transport your data:
 Start by installing the respective exporter packages as a dependency for your
 project:
 
-{{< tabpane text=true >}} {{% tab "HTTP/Proto" %}}
+{{% tabpane text=true %}} {{% tab "HTTP/Proto" %}}
 
 ```shell
 npm install --save @opentelemetry/exporter-trace-otlp-proto \
@@ -41,7 +41,7 @@ npm install --save @opentelemetry/exporter-trace-otlp-grpc \
   @opentelemetry/exporter-metrics-otlp-grpc
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### Usage with Node.js
 
@@ -51,7 +51,7 @@ JavaScript) from the
 [Getting Started](/docs/languages/js/getting-started/nodejs/) like the following
 to export traces and metrics via OTLP (`http/protobuf`) :
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 /*instrumentation.ts*/
@@ -114,7 +114,7 @@ const sdk = new opentelemetry.NodeSDK({
 sdk.start();
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### Usage in the Browser
 
@@ -256,7 +256,7 @@ npm install --save @opentelemetry/exporter-prometheus
 Update your OpenTelemetry configuration to use the exporter and to send data to
 your Prometheus backend:
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 import * as opentelemetry from '@opentelemetry/sdk-node';
@@ -290,7 +290,7 @@ const sdk = new opentelemetry.NodeSDK({
 sdk.start();
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 With the above you can access your metrics at <http://localhost:9464/metrics>.
 Prometheus or an OpenTelemetry Collector with the Prometheus receiver can scrape
@@ -314,7 +314,7 @@ npm install --save @opentelemetry/exporter-zipkin
 Update your OpenTelemetry configuration to use the exporter and to send data to
 your Zipkin backend:
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 import * as opentelemetry from '@opentelemetry/sdk-node';
@@ -343,11 +343,11 @@ const sdk = new opentelemetry.NodeSDK({
 });
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 {{% docs/languages/exporters/outro js `https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_sdk_trace_base.SpanExporter.html` %}}
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 /*instrumentation.ts*/
@@ -377,7 +377,7 @@ const sdk = new opentelemetry.NodeSDK({
 sdk.start();
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 {{% /docs/languages/exporters/outro %}}
 

--- a/content/en/docs/languages/js/getting-started/browser.md
+++ b/content/en/docs/languages/js/getting-started/browser.md
@@ -86,7 +86,7 @@ Create an empty code file named `document-load` with a `.ts` or `.js` extension,
 as appropriate, based on the language you've chosen to write your app in. Add
 the following code to your HTML right before the `</body>` closing tag:
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```html
 <script type="module" src="document-load.ts"></script>
@@ -98,7 +98,7 @@ the following code to your HTML right before the `</body>` closing tag:
 <script type="module" src="document-load.js"></script>
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 We will add some code that will trace the document load timings and output those
 as OpenTelemetry Spans.

--- a/content/en/docs/languages/js/getting-started/nodejs.md
+++ b/content/en/docs/languages/js/getting-started/nodejs.md
@@ -44,7 +44,7 @@ npm init -y
 
 Next, install Express dependencies.
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```sh
 npm install typescript \
@@ -63,7 +63,7 @@ npx tsc --init
 npm install express
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### Create and launch an HTTP Server
 
@@ -119,7 +119,7 @@ app.listen(PORT, () => {
 Run the application with the following command and open
 <http://localhost:8080/rolldice> in your web browser to ensure it is working.
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```console
 $ npx ts-node app.ts
@@ -133,7 +133,7 @@ $ node app.js
 Listening for requests on http://localhost:8080
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ## Instrumentation
 
@@ -172,7 +172,7 @@ application code. One tool commonly used for this task is the
 Create a file named `instrumentation.ts` (or `instrumentation.js` if not using
 TypeScript) , which will contain your instrumentation setup code.
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 /*instrumentation.ts*/
@@ -221,7 +221,7 @@ const sdk = new NodeSDK({
 sdk.start();
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ## Run the instrumented app
 
@@ -231,7 +231,7 @@ sure you don't have other conflicting `--require` flags such as
 `--require @opentelemetry/auto-instrumentations-node/register` on your
 `NODE_OPTIONS` environment variable.
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```console
 $ npx ts-node --require ./instrumentation.ts app.ts
@@ -245,7 +245,7 @@ $ node --require ./instrumentation.js app.js
 Listening for requests on http://localhost:8080
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 Open <http://localhost:8080/rolldice> in your web browser and reload the page a
 few times. After a while you should see the spans printed in the console by the
@@ -488,7 +488,7 @@ If you'd like to explore a more complex example, take a look at the
 Did something go wrong? You can enable diagnostic logging to validate that
 OpenTelemetry is initialized correctly:
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 /*instrumentation.ts*/
@@ -513,7 +513,7 @@ diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
 // const sdk = new NodeSDK({...
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 [traces]: /docs/concepts/signals/traces/
 [metrics]: /docs/concepts/signals/metrics/

--- a/content/en/docs/languages/js/instrumentation.md
+++ b/content/en/docs/languages/js/instrumentation.md
@@ -43,7 +43,7 @@ npm init -y
 
 Next, install Express dependencies.
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```sh
 npm install typescript \
@@ -59,7 +59,7 @@ npm install typescript \
 npm install express
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### Create and launch an HTTP Server
 
@@ -70,7 +70,7 @@ imported as a dependency by the _app file_.
 Create the _library file_ named `dice.ts` (or `dice.js` if you are not using
 TypeScript) and add the following code to it:
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 /*dice.ts*/
@@ -106,12 +106,12 @@ function rollTheDice(rolls, min, max) {
 module.exports = { rollTheDice };
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 Create the _app file_ named `app.ts` (or `app.js` if not using TypeScript) and
 add the following code to it:
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 /*app.ts*/
@@ -163,12 +163,12 @@ app.listen(PORT, () => {
 });
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 To ensure that it is working, run the application with the following command and
 open <http://localhost:8080/rolldice?rolls=12> in your web browser.
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```console
 $ npx ts-node app.ts
@@ -182,7 +182,7 @@ $ node app.js
 Listening for requests on http://localhost:8080
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ## Manual instrumentation setup
 
@@ -211,7 +211,7 @@ SDK. If you fail to initialize the SDK or initialize it too late, no-op
 implementations will be provided to any library that acquires a tracer or meter
 from the API.
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 /*instrumentation.ts*/
@@ -271,7 +271,7 @@ const sdk = new NodeSDK({
 sdk.start();
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 For debugging and local development purposes, the following example exports
 telemetry to the console. After you have finished setting up manual
@@ -289,7 +289,7 @@ information, see [Resources](/docs/languages/js/resources/).
 
 To verify your code, run the app by requiring the library:
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```sh
 npx ts-node --require ./instrumentation.ts app.ts
@@ -301,7 +301,7 @@ npx ts-node --require ./instrumentation.ts app.ts
 node --require ./instrumentation.js app.js
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 This basic setup has no effect on your app yet. You need to add code for
 [traces](#traces), [metrics](#metrics), and/or [logs](#logs).
@@ -346,7 +346,7 @@ npm install @opentelemetry/sdk-trace-web
 Next, update `instrumentation.ts` (or `instrumentation.js`) to contain all the
 SDK initialization code in it:
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 import { Resource } from '@opentelemetry/resources';
@@ -411,7 +411,7 @@ const provider = new WebTracerProvider({
 provider.register();
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 You'll need to bundle this file with your web application to be able to use
 tracing throughout the rest of your web application.
@@ -442,7 +442,7 @@ In most cases, stick with `BatchSpanProcessor` over `SimpleSpanProcessor`.
 Anywhere in your application where you write manual tracing code should call
 `getTracer` to acquire a tracer. For example:
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 import opentelemetry from '@opentelemetry/api';
@@ -470,7 +470,7 @@ const tracer = opentelemetry.trace.getTracer(
 // You can now use a 'tracer' to do tracing!
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 The values of `instrumentation-scope-name` and `instrumentation-scope-version`
 should uniquely identify the
@@ -488,7 +488,7 @@ tracer may be acquired with an appropriate Instrumentation Scope:
 
 First, in the _application file_ `app.ts` (or `app.js`):
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 /*app.ts*/
@@ -546,11 +546,11 @@ app.listen(PORT, () => {
 });
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 And second, in the _library file_ `dice.ts` (or `dice.js`):
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 /*dice.ts*/
@@ -594,7 +594,7 @@ function rollTheDice(rolls, min, max) {
 module.exports = { rollTheDice };
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### Create spans
 
@@ -616,7 +616,7 @@ care of setting the span and its context active.
 
 The code below illustrates how to create an active span.
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 import { trace, Span } from '@opentelemetry/api';
@@ -654,7 +654,7 @@ function rollTheDice(rolls, min, max) {
 }
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 If you followed the instructions using the [example app](#example-app) up to
 this point, you can copy the code above in your library file `dice.ts` (or
@@ -663,7 +663,7 @@ this point, you can copy the code above in your library file `dice.ts` (or
 Start your app as follows, and then send it requests by visiting
 <http://localhost:8080/rolldice?rolls=12> with your browser or `curl`.
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```sh
 ts-node --require ./instrumentation.ts app.ts
@@ -675,7 +675,7 @@ ts-node --require ./instrumentation.ts app.ts
 node --require ./instrumentation.js app.js
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 After a while, you should see the spans printed in the console by the
 `ConsoleSpanExporter`, something like this:
@@ -703,7 +703,7 @@ nested in nature. For example, the `rollOnce()` function below represents a
 nested operation. The following sample creates a nested span that tracks
 `rollOnce()`:
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 function rollOnce(i: number, min: number, max: number) {
@@ -753,7 +753,7 @@ function rollTheDice(rolls, min, max) {
 }
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 This code creates a child span for each _roll_ that has `parentSpan`'s ID as
 their parent ID:
@@ -845,7 +845,7 @@ const span = opentelemetry.trace.getSpan(ctx);
 pairs to a [`Span`](/docs/concepts/signals/traces/#spans) so it carries more
 information about the current operation that it's tracking.
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 function rollOnce(i: number, min: number, max: number) {
@@ -877,7 +877,7 @@ function rollOnce(i, min, max) {
 }
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 You can also add attributes to a span as it's created:
 
@@ -893,7 +893,7 @@ tracer.startActiveSpan(
 );
 ```
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 function rollTheDice(rolls: number, min: number, max: number) {
@@ -921,7 +921,7 @@ function rollTheDice(rolls, min, max) {
 }
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 #### Semantic Attributes
 
@@ -939,7 +939,7 @@ npm install --save @opentelemetry/semantic-conventions
 
 Add the following to the top of your application file:
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 import {
@@ -957,7 +957,7 @@ const {
 } = require('@opentelemetry/semantic-conventions');
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 Finally, you can update your file to include semantic attributes:
 
@@ -1027,7 +1027,7 @@ const someFunction = (spanToLinkFrom) => {
 
 {{% docs/languages/span-status-preamble %}}
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 import opentelemetry, { SpanStatusCode } from '@opentelemetry/api';
@@ -1069,14 +1069,14 @@ tracer.startActiveSpan('app.doWork', (span) => {
 });
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### Recording exceptions
 
 It can be a good idea to record exceptions when they happen. It's recommended to
 do this in conjunction with setting [span status](#span-status).
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 import opentelemetry, { SpanStatusCode } from '@opentelemetry/api';
@@ -1110,7 +1110,7 @@ try {
 }
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### Using `sdk-trace-base` and manually propagating span context
 
@@ -1123,7 +1123,7 @@ nested spans.
 
 Initializing tracing is similar to how you'd do it with Node.js or the Web SDK.
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 import opentelemetry from '@opentelemetry/api';
@@ -1187,7 +1187,7 @@ opentelemetry.propagation.setGlobalPropagator(
 const tracer = opentelemetry.trace.getTracer('example-basic-tracer-node');
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 Like the other examples in this document, this exports a tracer you can use
 throughout the app.
@@ -1277,7 +1277,7 @@ If you have not created it for tracing already, create a separate
 `instrumentation.ts` (or `instrumentation.js`) file that has all the SDK
 initialization code in it:
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 import opentelemetry from '@opentelemetry/api';
@@ -1352,11 +1352,11 @@ const myServiceMeterProvider = new MeterProvider({
 opentelemetry.metrics.setGlobalMeterProvider(myServiceMeterProvider);
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 You'll need to `--require` this file when you run your app, such as:
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```sh
 ts-node --require ./instrumentation.ts app.ts
@@ -1368,7 +1368,7 @@ ts-node --require ./instrumentation.ts app.ts
 node --require ./instrumentation.js app.js
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 Now that a `MeterProvider` is configured, you can acquire a `Meter`.
 
@@ -1377,7 +1377,7 @@ Now that a `MeterProvider` is configured, you can acquire a `Meter`.
 Anywhere in your application where you have manually instrumented code you can
 call `getMeter` to acquire a meter. For example:
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 import opentelemetry from '@opentelemetry/api';
@@ -1403,7 +1403,7 @@ const myMeter = opentelemetry.metrics.getMeter(
 // You can now use a 'meter' to create instruments!
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 The values of `instrumentation-scope-name` and `instrumentation-scope-version`
 should uniquely identify the
@@ -1421,7 +1421,7 @@ tracer may be acquired with an appropriate Instrumentation Scope:
 
 First, in the _application file_ `app.ts` (or `app.js`):
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 /*app.ts*/
@@ -1481,11 +1481,11 @@ app.listen(PORT, () => {
 });
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 And second, in the _library file_ `dice.ts` (or `dice.js`):
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 /*dice.ts*/
@@ -1531,7 +1531,7 @@ function rollTheDice(rolls, min, max) {
 module.exports = { rollTheDice };
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 Now that you have [meters](/docs/concepts/signals/metrics/#meter) initialized.
 you can create
@@ -1544,7 +1544,7 @@ Counters can be used to measure a non-negative, increasing value.
 In the case of our [example app](#example-app) we can use this to count how
 often the dice has been rolled:
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 /*dice.ts*/
@@ -1568,7 +1568,7 @@ function rollOnce(min, max) {
 }
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### Using UpDown Counters
 
@@ -1594,7 +1594,7 @@ Histograms are used to measure a distribution of values over time.
 For example, here's how you report a distribution of response times for an API
 route with Express:
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 import express from 'express';
@@ -1636,7 +1636,7 @@ app.get('/', (_req, _res) => {
 });
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### Using Observable (Async) Counters
 

--- a/content/en/docs/languages/js/libraries.md
+++ b/content/en/docs/languages/js/libraries.md
@@ -40,7 +40,7 @@ that bundle all Node.js- or web-based instrumentation libraries into a single
 package. It’s a convenient way to add automatically-generated telemetry for all
 your libraries with minimal effort:
 
-{{< tabpane text=true >}}
+{{% tabpane text=true %}}
 
 {{% tab Node.js %}}
 
@@ -56,7 +56,7 @@ npm install --save @opentelemetry/auto-instrumentations-node
 npm install --save @opentelemetry/auto-instrumentations-web
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 Note, that using those metapackages increases your dependency graph size. Use
 individual instrumentation libraries if you know exactly which ones you need.
@@ -70,7 +70,7 @@ the metapackages. If you followed the instructions
 [to initialize the SDK for manual instrumentation](/docs/languages/js/instrumentation/#initialize-tracing),
 update your `instrumentation.ts` (or `instrumentation.js`) as follows:
 
-{{< tabpane text=true >}}
+{{% tabpane text=true %}}
 
 {{% tab TypeScript %}}
 
@@ -105,12 +105,12 @@ const sdk = new NodeSDK({
 
 {{% /tab %}}
 
-{{< /tabpane >}}
+{{% /tabpane %}}
 
 To disable individual instrumentation libraries you can apply the following
 change:
 
-{{< tabpane text=true >}}
+{{% tabpane text=true %}}
 
 {{% tab TypeScript %}}
 
@@ -157,12 +157,12 @@ const sdk = new NodeSDK({
 
 {{% /tab %}}
 
-{{< /tabpane >}}
+{{% /tabpane %}}
 
 To only load individual instrumentation libraries, replace
 `[getNodeAutoInstrumentations()]` with the list of those you need:
 
-{{< tabpane text=true >}}
+{{% tabpane text=true %}}
 
 {{% tab TypeScript %}}
 
@@ -203,7 +203,7 @@ const sdk = new NodeSDK({
 
 {{% /tab %}}
 
-{{< /tabpane >}}
+{{% /tabpane %}}
 
 ### Configuration
 
@@ -214,7 +214,7 @@ For example,
 offers ways to ignore specified middleware or enrich spans created automatically
 with a request hook:
 
-{{< tabpane text=true >}}
+{{% tabpane text=true %}}
 
 {{% tab TypeScript %}}
 
@@ -267,7 +267,7 @@ const expressInstrumentation = new ExpressInstrumentation({
 
 {{% /tab %}}
 
-{{< /tabpane >}}
+{{% /tabpane %}}
 
 You'll need to refer to each instrumentation library's documentation for
 advanced configuration.

--- a/content/en/docs/languages/js/propagation.md
+++ b/content/en/docs/languages/js/propagation.md
@@ -29,7 +29,7 @@ applications written in different languages without any differences.
 Start by creating a new folder called `dice-client` and install the required
 dependencies:
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```sh
 npm init -y
@@ -53,12 +53,12 @@ npm install undici \
   @opentelemetry/sdk-node
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 Next, create a new file called `client.ts` (or client.js) with the following
 content:
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 import { NodeSDK } from '@opentelemetry/sdk-node';
@@ -111,7 +111,7 @@ request('http://localhost:8080/rolldice').then((response) => {
 Make sure that you have the instrumented version of `app.ts` (or `app.js`) from
 the [Getting Started](../getting-started/nodejs) running in one shell:
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```console
 $ npx ts-node --require ./instrumentation.ts app.ts
@@ -125,11 +125,11 @@ $ node --require ./instrumentation.js app.js
 Listening for requests on http://localhost:8080
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 Start a second shell and run the `client.ts` (or `client.js`):
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```shell
 npx ts-node client.ts
@@ -141,7 +141,7 @@ npx ts-node client.ts
 node client.js
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 Both shells should emit span details to the console. The client output looks
 similar to the following:
@@ -219,7 +219,7 @@ manually.
 
 First, on the sending service, you'll need to inject the current `context`:
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```typescript
 // Sending service
@@ -269,12 +269,12 @@ const { traceparent, tracestate } = output;
 // across services.
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 On the receiving service, you'll need to extract `context` (for example, from
 parsed HTTP headers) and then set them as the current trace context.
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```typescript
 // Receiving service
@@ -344,7 +344,7 @@ let span = tracer.startSpan(
 trace.setSpan(activeContext, span);
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 From there, when you have a deserialized active context, you can create spans
 that will be a part of the same trace from the other service.

--- a/content/en/docs/languages/js/sampling.md
+++ b/content/en/docs/languages/js/sampling.md
@@ -35,7 +35,7 @@ This tells the SDK to sample spans such that only 10% of traces get created.
 You can also configure the TraceIdRatioBasedSampler in code. Here's an example
 for Node.js:
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 import { TraceIdRatioBasedSampler } from '@opentelemetry/sdk-trace-node';
@@ -61,14 +61,14 @@ const sdk = new NodeSDK({
 });
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### Browser
 
 You can also configure the TraceIdRatioBasedSampler in code. Here's an example
 for browser apps:
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 import {
@@ -98,4 +98,4 @@ const provider = new WebTracerProvider({
 });
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}

--- a/content/en/docs/languages/php/exporters.md
+++ b/content/en/docs/languages/php/exporters.md
@@ -36,7 +36,7 @@ composer require open-telemetry/transport-grpc
 
 Next, configure an exporter with an OTLP endpoint. For example:
 
-{{< tabpane text=true >}} {{% tab gRPC %}}
+{{% tabpane text=true %}} {{% tab gRPC %}}
 
 ```php
 <?php
@@ -122,7 +122,7 @@ $tracer = $tracerProvider->getTracer('io.opentelemetry.contrib.php');
 $tracer->spanBuilder('example')->startSpan()->end();
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 Then, append the following code to generate a span:
 

--- a/content/en/docs/languages/php/getting-started.md
+++ b/content/en/docs/languages/php/getting-started.md
@@ -94,7 +94,7 @@ Next, you’ll use the OpenTelemetry PHP extension to
 1. Since the extension is built from source, you need to install some build
    tools
 
-   {{< tabpane text=true >}} {{% tab "Linux (apt)" %}}
+   {{% tabpane text=true %}} {{% tab "Linux (apt)" %}}
 
    ```sh
    sudo apt-get install gcc make autoconf
@@ -106,7 +106,7 @@ Next, you’ll use the OpenTelemetry PHP extension to
    brew install gcc make autoconf
    ```
 
-   {{% /tab %}} {{< /tabpane >}}
+   {{% /tab %}} {{% /tabpane %}}
 
 2. Build the extension with `PECL`:
 

--- a/content/en/docs/languages/python/exporters.md
+++ b/content/en/docs/languages/python/exporters.md
@@ -22,7 +22,7 @@ transport your data:
 Start by installing the respective exporter packages as a dependency for your
 project:
 
-{{< tabpane text=true >}} {{% tab "HTTP/Proto" %}}
+{{% tabpane text=true %}} {{% tab "HTTP/Proto" %}}
 
 ```shell
 pip install opentelemetry-exporter-otlp-proto-http
@@ -34,13 +34,13 @@ pip install opentelemetry-exporter-otlp-proto-http
 pip install opentelemetry-exporter-otlp-proto-grpc
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### Usage
 
 Next, configure the exporter to point at an OTLP endpoint in your code.
 
-{{< tabpane text=true >}} {{% tab "HTTP/Proto" %}}
+{{% tabpane text=true %}} {{% tab "HTTP/Proto" %}}
 
 ```python
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
@@ -104,7 +104,7 @@ meterProvider = MeterProvider(resource=resource, metric_readers=[reader])
 metrics.set_meter_provider(meterProvider)
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ## Console
 
@@ -245,7 +245,7 @@ between two different protocols to transport your data:
 
 Install the exporter package as a dependency for your application:
 
-{{< tabpane text=true >}} {{% tab "HTTP/Proto" %}}
+{{% tabpane text=true %}} {{% tab "HTTP/Proto" %}}
 
 ```shell
 pip install opentelemetry-exporter-zipkin-proto-http
@@ -257,12 +257,12 @@ pip install opentelemetry-exporter-zipkin-proto-http
 pip install opentelemetry-exporter-zipkin-json
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 Update your OpenTelemetry configuration to use the exporter and to send data to
 your Zipkin backend:
 
-{{< tabpane text=true >}} {{% tab "HTTP/Proto" %}}
+{{% tabpane text=true %}} {{% tab "HTTP/Proto" %}}
 
 ```python
 from opentelemetry import trace
@@ -304,7 +304,7 @@ provider.add_span_processor(processor)
 trace.set_tracer_provider(provider)
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 {{% docs/languages/exporters/outro python `https://opentelemetry-python.readthedocs.io/en/latest/sdk/trace.export.html#opentelemetry.sdk.trace.export.SpanExporter` %}}
 

--- a/content/en/docs/languages/ruby/exporters.md
+++ b/content/en/docs/languages/ruby/exporters.md
@@ -11,7 +11,7 @@ To send trace data to a OTLP endpoint (like the [collector](/docs/collector) or
 Jaeger) you'll want to use an exporter package, such as
 `opentelemetry-exporter-otlp`:
 
-{{< tabpane text=true >}} {{% tab bundler %}}
+{{% tabpane text=true %}} {{% tab bundler %}}
 
 ```sh
 bundle add opentelemetry-exporter-otlp
@@ -23,7 +23,7 @@ bundle add opentelemetry-exporter-otlp
 gem install opentelemetry-exporter-otlp
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 Next, configure the exporter to point at an OTLP endpoint. For example you can
 update `config/initializers/opentelemetry.rb` from the
@@ -85,7 +85,7 @@ docker run --rm -d -p 9411:9411 --name zipkin openzipkin/zipkin
 
 Install the exporter package as a dependency for your application:
 
-{{< tabpane text=true >}} {{% tab bundle %}}
+{{% tabpane text=true %}} {{% tab bundle %}}
 
 ```sh
 bundle add opentelemetry-exporter-zipkin
@@ -97,7 +97,7 @@ bundle add opentelemetry-exporter-zipkin
 gem install opentelemetry-exporter-zipkin
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 Update your OpenTelemetry configuration to use the exporter and to send data to
 your Zipkin backend:

--- a/content/en/docs/platforms/faas/lambda-auto-instrument.md
+++ b/content/en/docs/platforms/faas/lambda-auto-instrument.md
@@ -26,7 +26,7 @@ first.
 
 ### Language Requirements
 
-{{< tabpane text=true >}} {{% tab Java %}}
+{{% tabpane text=true %}} {{% tab Java %}}
 
 The Lambda layer supports the Java 8, 11, and 17 (Corretto) Lambda runtimes. For
 more information about supported Java versions, see the
@@ -88,7 +88,7 @@ about supported OpenTelemetry Ruby SDK and API versions, see the
 [OpenTelemetry Ruby documentation](https://github.com/open-telemetry/opentelemetry-ruby/blob/main/README.md#compatibility)
 and the package on [RubyGem](https://rubygems.org/search?query=opentelemetry).
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### Configure `AWS_LAMBDA_EXEC_WRAPPER`
 
@@ -123,7 +123,7 @@ there is an embedded Collector with gRPC / HTTP receivers. The environment
 variables do not need to be updated. However, there are varying levels of
 protocol support and default values by language which are documented below.
 
-{{< tabpane text=true >}} {{% tab Java %}}
+{{% tabpane text=true %}} {{% tab Java %}}
 
 `OTEL_EXPORTER_OTLP_PROTOCOL=grpc` supports: `grpc`, `http/protobuf` and
 `http/json` `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317`
@@ -144,7 +144,7 @@ uses the protocol `http/protobuf`
 `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` supports: `http/protobuf`
 `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318`
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### Publish your Lambda
 

--- a/content/en/docs/zero-code/java/agent/annotations.md
+++ b/content/en/docs/zero-code/java/agent/annotations.md
@@ -18,7 +18,7 @@ You'll need to add a dependency on the
 `opentelemetry-instrumentation-annotations` library to use the `@WithSpan`
 annotation.
 
-{{< tabpane text=true >}} {{% tab "Maven" %}}
+{{% tabpane text=true %}} {{% tab "Maven" %}}
 
 ```xml
 <dependencies>
@@ -40,7 +40,7 @@ dependencies {
 }
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ## Creating spans around methods with `@WithSpan`
 

--- a/content/en/docs/zero-code/java/agent/server-config.md
+++ b/content/en/docs/zero-code/java/agent/server-config.md
@@ -15,7 +15,7 @@ this differs from server to server.
 You can add the `javaagent` argument at the end of the standalone configuration
 file:
 
-{{< tabpane text=true persist=lang >}}
+{{% tabpane text=true persist=lang %}}
 
 {{% tab header="Linux" lang=Linux %}}
 
@@ -31,7 +31,7 @@ rem Add to standalone.conf.bat
 set "JAVA_OPTS=%JAVA_OPTS% -javaagent:<Drive>:\path\to\opentelemetry-javaagent.jar"
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ## Jetty
 
@@ -63,7 +63,7 @@ argument after the `--exec` option:
 
 Add the path to the Java agent using the `asadmin` tool:
 
-{{< tabpane text=true >}} {{% tab Linux %}}
+{{% tabpane text=true %}} {{% tab Linux %}}
 
 ```sh
 <server_install_dir>/bin/asadmin create-jvm-options "-javaagent\:/path/to/opentelemetry-javaagent.jar"
@@ -75,7 +75,7 @@ Add the path to the Java agent using the `asadmin` tool:
 <server_install_dir>\bin\asadmin.bat create-jvm-options '-javaagent\:<Drive>\:\\path\\to\\opentelemetry-javaagent.jar'
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 You can also add the `-javaagent` argument from the Admin Console. For example:
 
@@ -93,7 +93,7 @@ Make sure that the domain.xml file in your domain directory contains a
 
 Add the path to the Java agent to your startup script:
 
-{{< tabpane text=true persist=lang >}}
+{{% tabpane text=true persist=lang %}}
 
 {{% tab header="Linux" lang=Linux %}}
 
@@ -109,13 +109,13 @@ rem Add to <tomcat_home>\bin\setenv.bat
 set CATALINA_OPTS=%CATALINA_OPTS% -javaagent:"<Drive>:\path\to\opentelemetry-javaagent.jar"
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ## WebLogic
 
 Add the path to the Java agent to your domain startup script:
 
-{{< tabpane text=true persist=lang >}}
+{{% tabpane text=true persist=lang %}}
 
 {{% tab header="Linux" lang=Linux %}}
 
@@ -131,7 +131,7 @@ rem Add to <domain_home>\bin\startWebLogic.cmd
 set JAVA_OPTIONS=%JAVA_OPTIONS% -javaagent:"<Drive>:\path\to\opentelemetry-javaagent.jar"
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 For managed server instances, add the `-javaagent` argument using the admin
 console.

--- a/content/en/docs/zero-code/java/quarkus.md
+++ b/content/en/docs/zero-code/java/quarkus.md
@@ -34,7 +34,7 @@ if you are not running a native image application.
 To enable OpenTelemetry in your Quarkus application, add the
 `quarkus-opentelemetry` extension dependency to your project.
 
-{{< tabpane text=true >}} {{% tab header="Maven (`pom.xml`)" lang=Maven %}}
+{{% tabpane text=true %}} {{% tab header="Maven (`pom.xml`)" lang=Maven %}}
 
 ```xml
 <dependency>
@@ -49,7 +49,7 @@ To enable OpenTelemetry in your Quarkus application, add the
 implementation("io.quarkus:quarkus-opentelemetry")
 ```
 
-{{% /tab %}} {{< /tabpane>}}
+{{% /tab %}} {{% /tabpane%}}
 
 Only the **tracing** signal is enabled by default. To enable **metrics** and
 **logs**, add the following configuration to your `application.properties` file:

--- a/content/en/docs/zero-code/java/spring-boot-starter/annotations.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/annotations.md
@@ -80,7 +80,7 @@ public class MyControllerManagedBySpring {
 To be able to use the OpenTelemetry annotations, you have to add the Spring Boot
 Starter AOP dependency to your project:
 
-{{< tabpane text=true >}} {{% tab header="Maven (`pom.xml`)" lang=Maven %}}
+{{% tabpane text=true %}} {{% tab header="Maven (`pom.xml`)" lang=Maven %}}
 
 ```xml
 <dependencies>
@@ -99,7 +99,7 @@ dependencies {
 }
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 {{% /alert %}}
 

--- a/content/en/docs/zero-code/java/spring-boot-starter/getting-started.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/getting-started.md
@@ -108,7 +108,7 @@ Add the dependency given below to enable the OpenTelemetry starter.
 The OpenTelemetry starter uses OpenTelemetry Spring Boot
 [autoconfiguration](https://docs.spring.io/spring-boot/reference/using/auto-configuration.html).
 
-{{< tabpane text=true >}} {{% tab header="Maven (`pom.xml`)" lang=Maven %}}
+{{% tabpane text=true %}} {{% tab header="Maven (`pom.xml`)" lang=Maven %}}
 
 ```xml
 <dependency>
@@ -123,4 +123,4 @@ The OpenTelemetry starter uses OpenTelemetry Spring Boot
 implementation("io.opentelemetry.instrumentation:opentelemetry-spring-boot-starter")
 ```
 
-{{% /tab %}} {{< /tabpane>}}
+{{% /tab %}} {{% /tabpane%}}

--- a/content/en/docs/zero-code/java/spring-boot-starter/other-spring-autoconfig.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/other-spring-autoconfig.md
@@ -26,7 +26,7 @@ initialized and added to a simple span processor in the active tracer provider.
 Check out the implementation
 [here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/OpenTelemetryAutoConfiguration.java).
 
-{{< tabpane text=true >}} {{% tab header="Maven (`pom.xml`)" lang=Maven %}}
+{{% tabpane text=true %}} {{% tab header="Maven (`pom.xml`)" lang=Maven %}}
 
 ```xml
 <dependencies>
@@ -46,7 +46,7 @@ dependencies {
 }
 ```
 
-{{% /tab %}} {{< /tabpane>}}
+{{% /tab %}} {{% /tabpane%}}
 
 ### Configurations
 

--- a/content/en/docs/zero-code/java/spring-boot-starter/sdk-configuration.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/sdk-configuration.md
@@ -100,7 +100,7 @@ which are not configurable using properties.
 As an example, you can customize the sampler to exclude health check endpoints
 from tracing:
 
-{{< tabpane text=true >}} {{% tab header="Maven (`pom.xml`)" lang=Maven %}}
+{{% tabpane text=true %}} {{% tab header="Maven (`pom.xml`)" lang=Maven %}}
 
 ```xml
 <dependencies>
@@ -120,7 +120,7 @@ dependencies {
 }
 ```
 
-{{% /tab %}} {{< /tabpane>}}
+{{% /tab %}} {{% /tabpane%}}
 
 <!-- prettier-ignore-start -->
 <?code-excerpt "src/main/java/otel/FilterPaths.java"?>
@@ -243,7 +243,7 @@ precedence rules, in accordance with the OpenTelemetry
 Use the following snippet in your pom.xml file to generate the
 `build-info.properties` file:
 
-{{< tabpane text=true >}} {{% tab header="Maven (`pom.xml`)" lang=Maven %}}
+{{% tabpane text=true %}} {{% tab header="Maven (`pom.xml`)" lang=Maven %}}
 
 ```xml
 <build>
@@ -274,4 +274,4 @@ springBoot {
 }
 ```
 
-{{% /tab %}} {{< /tabpane>}}
+{{% /tab %}} {{% /tabpane%}}

--- a/content/en/docs/zero-code/net/getting-started.md
+++ b/content/en/docs/zero-code/net/getting-started.md
@@ -116,7 +116,7 @@ or PowerShell scripts.
 1. Download installation scripts from [Releases][] of the
    `opentelemetry-dotnet-instrumentation` repository:
 
-   {{< tabpane text=true >}} {{% tab Unix-shell %}}
+   {{% tabpane text=true %}} {{% tab Unix-shell %}}
 
    ```sh
    curl -L -O https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/latest/download/otel-dotnet-auto-install.sh
@@ -130,12 +130,12 @@ or PowerShell scripts.
    Invoke-WebRequest -Uri $module_url -OutFile $download_path -UseBasicParsing
    ```
 
-   {{% /tab %}} {{< /tabpane >}}
+   {{% /tab %}} {{% /tabpane %}}
 
 2. Execute following script to download automatic instrumentation for your
    development environment:
 
-   {{< tabpane text=true >}} {{% tab Unix-shell %}}
+   {{% tabpane text=true %}} {{% tab Unix-shell %}}
 
    ```sh
    ./otel-dotnet-auto-install.sh
@@ -148,14 +148,14 @@ or PowerShell scripts.
    Install-OpenTelemetryCore
    ```
 
-   {{% /tab %}} {{< /tabpane >}}
+   {{% /tab %}} {{% /tabpane %}}
 
 3. Set and export variables that specify a [console exporter][], then execute
    script configuring other necessary environment variables using a notation
    suitable for your shell/terminal environment &mdash; we illustrate a notation
    for bash-like shells and PowerShell:
 
-   {{< tabpane text=true >}} {{% tab Unix-shell %}}
+   {{% tabpane text=true %}} {{% tab Unix-shell %}}
 
    ```sh
    export OTEL_TRACES_EXPORTER=console \
@@ -174,7 +174,7 @@ or PowerShell scripts.
    Register-OpenTelemetryForCurrentSession -OTelServiceName "RollDiceService"
    ```
 
-   {{% /tab %}} {{< /tabpane >}}
+   {{% /tab %}} {{% /tabpane %}}
 
 4. Run your **application** once again:
 

--- a/content/en/docs/zero-code/php.md
+++ b/content/en/docs/zero-code/php.md
@@ -39,7 +39,7 @@ RPM and APK packages are provided by the following:
   APK (currently in the
   [_testing_ branch](https://wiki.alpinelinux.org/wiki/Repositories#Testing))
 
-{{< tabpane text=true >}} {{% tab "RPM" %}}
+{{% tabpane text=true %}} {{% tab "RPM" %}}
 
 ```sh
 #this example is for CentOS 7. The PHP version can be changed by
@@ -64,14 +64,14 @@ apk add php php81-pecl-opentelemetry@testing
 php --ri opentelemetry
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### PECL
 
 1. Setup development environment. Installing from source requires proper
    development environment and some dependencies:
 
-   {{< tabpane text=true >}} {{% tab "Linux (apt)" %}}
+   {{% tabpane text=true %}} {{% tab "Linux (apt)" %}}
 
    ```sh
    sudo apt-get install gcc make autoconf
@@ -83,12 +83,12 @@ php --ri opentelemetry
    brew install gcc make autoconf
    ```
 
-   {{% /tab %}} {{< /tabpane >}}
+   {{% /tab %}} {{% /tabpane %}}
 
 2. Build/install the extension. With your environment set up you can install the
    extension:
 
-   {{< tabpane text=true >}} {{% tab pecl %}}
+   {{% tabpane text=true %}} {{% tab pecl %}}
 
    ```sh
    pecl install opentelemetry
@@ -106,7 +106,7 @@ php --ri opentelemetry
    install-php-extensions opentelemetry
    ```
 
-   {{% /tab %}} {{< /tabpane >}}
+   {{% /tab %}} {{% /tabpane %}}
 
 3. Add the extension to your `php.ini` file:
 

--- a/content/en/ecosystem/registry/_index.md
+++ b/content/en/ecosystem/registry/_index.md
@@ -37,7 +37,7 @@ redirects: [{ from: /ecosystem/registry*, to: '/ecosystem/registry?' }]
 
 {{% /blocks/lead %}}
 
-{{< blocks/section color="white" type="container-lg" >}}
+{{% blocks/section color="white" type="container-lg" %}}
 
 {{% alert color="info" %}}
 
@@ -48,6 +48,6 @@ ecosystem. If you are a project maintainer, you can
 
 {{% /alert %}}
 
-{{< ecosystem/registry/search-form >}}
+{{% ecosystem/registry/search-form %}}
 
-{{< /blocks/section >}}
+{{% /blocks/section %}}

--- a/content/es/_index.md
+++ b/content/es/_index.md
@@ -11,7 +11,7 @@ default_lang_commit: 7ac35d6b429165bbe6c28bdd91feeae83fd35142
 
 <div class="d-none"><a rel="me" href="https://fosstodon.org/@opentelemetry"></a></div>
 
-{{< blocks/cover image_anchor="top" height="max" color="primary" >}}
+{{% blocks/cover image_anchor="top" height="max" color="primary" %}}
 
 <!-- prettier-ignore -->
 ![OpenTelemetry](/img/logos/opentelemetry-horizontal-color.svg)
@@ -38,7 +38,7 @@ default_lang_commit: 7ac35d6b429165bbe6c28bdd91feeae83fd35142
 - [Ops](docs/getting-started/ops/)
 
 </div>
-{{< /blocks/cover >}}
+{{% /blocks/cover %}}
 
 {{% blocks/lead color="white" %}}
 

--- a/content/fr/_index.md
+++ b/content/fr/_index.md
@@ -12,7 +12,7 @@ default_lang_commit: c0a5eea5d720b0e075efa87f99dcf58c89106268
 
 <div class="d-none"><a rel="me" href="https://fosstodon.org/@opentelemetry"></a></div>
 
-{{< blocks/cover image_anchor="top" height="max" color="primary" >}}
+{{% blocks/cover image_anchor="top" height="max" color="primary" %}}
 
 <!-- prettier-ignore -->
 ![OpenTelemetry](/img/logos/opentelemetry-horizontal-color.svg)
@@ -38,7 +38,7 @@ default_lang_commit: c0a5eea5d720b0e075efa87f99dcf58c89106268
 - [Ops](docs/getting-started/ops/)
 
 </div>
-{{< /blocks/cover >}}
+{{% /blocks/cover %}}
 
 {{% blocks/lead color="white" %}}
 

--- a/content/ja/_index.md
+++ b/content/ja/_index.md
@@ -9,7 +9,7 @@ default_lang_commit: fd7da211d5bc37ca93112a494aaf6a94445e2e28
 
 <div class="d-none"><a rel="me" href="https://fosstodon.org/@opentelemetry"></a></div>
 
-{{< blocks/cover image_anchor="top" height="max" color="primary" >}}
+{{% blocks/cover image_anchor="top" height="max" color="primary" %}}
 
 <!-- prettier-ignore -->
 ![OpenTelemetry](/img/logos/opentelemetry-horizontal-color.svg)
@@ -35,7 +35,7 @@ default_lang_commit: fd7da211d5bc37ca93112a494aaf6a94445e2e28
 - [運用担当者（Ops）](docs/getting-started/ops/)
 
 </div>
-{{< /blocks/cover >}}
+{{% /blocks/cover %}}
 
 {{% blocks/lead color="white" %}}
 

--- a/content/ja/docs/collector/installation.md
+++ b/content/ja/docs/collector/installation.md
@@ -15,7 +15,7 @@ OpenTelemetryコレクターに適用可能なデプロイメントモデル、�
 以下のコマンドはDockerイメージをプルし、コレクターをコンテナ内で実行します。
 `{{% param vers %}}` を実行したいコレクターのバージョンに置き換えてください。
 
-{{< tabpane text=true >}} {{% tab DockerHub %}}
+{{% tabpane text=true %}} {{% tab DockerHub %}}
 
 ```sh
 docker pull otel/opentelemetry-collector-contrib:{{% param vers %}}
@@ -29,11 +29,11 @@ docker pull ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetr
 docker run ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{% param vers %}}
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 作業ディレクトリからカスタム設定ファイルを読み込むには、そのファイルをボリュームとしてマウントします。
 
-{{< tabpane text=true >}} {{% tab DockerHub %}}
+{{% tabpane text=true %}} {{% tab DockerHub %}}
 
 ```sh
 docker run -v $(pwd)/config.yaml:/etc/otelcol-contrib/config.yaml otel/opentelemetry-collector-contrib:{{% param vers %}}
@@ -45,7 +45,7 @@ docker run -v $(pwd)/config.yaml:/etc/otelcol-contrib/config.yaml otel/opentelem
 docker run -v $(pwd)/config.yaml:/etc/otelcol-contrib/config.yaml ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:{{% param vers %}}
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ## Docker Compose
 
@@ -97,7 +97,7 @@ Kubernetesでコレクターを使用する方法については、[Kubernetes�
 
 Debian系のシステムで使い始めるには、以下のコマンドを実行します。
 
-{{< tabpane text=true >}} {{% tab AMD64 %}}
+{{% tabpane text=true %}} {{% tab AMD64 %}}
 
 ```sh
 sudo apt-get update
@@ -124,13 +124,13 @@ wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases
 sudo dpkg -i otelcol_{{% param vers %}}_linux_386.deb
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### RPMのインストール
 
 Red Hat系のシステムで使い始めるには、以下のコマンドを実行します。
 
-{{< tabpane text=true >}} {{% tab AMD64 %}}
+{{% tabpane text=true %}} {{% tab AMD64 %}}
 
 ```sh
 sudo yum update
@@ -157,14 +157,14 @@ wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases
 sudo rpm -ivh otelcol_{{% param vers %}}_linux_386.rpm
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### 手動でのLinuxへのインストール
 
 Linux向けの[リリース][releases]は、さまざまなアーキテクチャに対応しています。
 バイナリを含むファイルをダウンロードし、あなたのマシンに手動でインストールしてください。
 
-{{< tabpane text=true >}} {{% tab AMD64 %}}
+{{% tabpane text=true %}} {{% tab AMD64 %}}
 
 ```sh
 curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_linux_amd64.tar.gz
@@ -192,7 +192,7 @@ curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelem
 tar -xvf otelcol_{{% param vers %}}_linux_ppc64le.tar.gz
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### 自動サービスコンフィギュレーション
 
@@ -220,7 +220,7 @@ macOS向けの [リリース][releases] は Intel および ARM システムで�
 リリースはgzip圧縮されたtarball (`.tar.gz`) としてパッケージ化されています。
 解凍するには、以下のコマンドを実行してください。
 
-{{< tabpane text=true >}} {{% tab Intel %}}
+{{% tabpane text=true %}} {{% tab Intel %}}
 
 ```sh
 curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v{{% param vers %}}/otelcol_{{% param vers %}}_darwin_amd64.tar.gz
@@ -234,7 +234,7 @@ curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelem
 tar -xvf otelcol_{{% param vers %}}_darwin_arm64.tar.gz
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 すべてのコレクターのリリースには、解凍後に実行できる `otelcol` 実行ファイルが含まれています。
 

--- a/content/ja/docs/demo/docker-deployment.md
+++ b/content/ja/docs/demo/docker-deployment.md
@@ -32,7 +32,7 @@ cSpell:ignore: otlphttp spanmetrics tracetest tracetesting
 
 3. デモを起動[^1]します。
 
-   {{< tabpane text=true >}} {{% tab Make %}}
+   {{% tabpane text=true %}} {{% tab Make %}}
 
 ```shell
 make start
@@ -44,11 +44,11 @@ make start
 docker compose up --force-recreate --remove-orphans --detach
 ```
 
-    {{% /tab %}} {{< /tabpane >}}
+    {{% /tab %}} {{% /tabpane %}}
 
 4. (オプション) API オブザーバビリティ駆動テストの有効化[^1]します。
 
-   {{< tabpane text=true >}} {{% tab Make %}}
+   {{% tabpane text=true %}} {{% tab Make %}}
 
 ```shell
 make run-tracetesting
@@ -60,7 +60,7 @@ make run-tracetesting
 docker compose -f docker-compose-tests.yml run traceBasedTests
 ```
 
-    {{% /tab %}} {{< /tabpane >}}
+    {{% /tab %}} {{% /tabpane %}}
 
 ## ウェブストアとテレメトリーの確認 {#verify-the-web-store-and-telemetry}
 
@@ -80,7 +80,7 @@ docker compose -f docker-compose-tests.yml run traceBasedTests
 
 - 次の設定は 8081 ポートを利用する場合の例です[^1]。
 
-  {{< tabpane text=true >}} {{% tab Make %}}
+  {{% tabpane text=true %}} {{% tab Make %}}
 
 ```shell
 ENVOY_PORT=8081 make start
@@ -92,7 +92,7 @@ ENVOY_PORT=8081 make start
 ENVOY_PORT=8081 docker compose up --force-recreate --remove-orphans --detach
 ```
 
-    {{% /tab %}} {{< /tabpane >}}
+    {{% /tab %}} {{% /tabpane %}}
 
 ## 独自のバックエンドを導入する {#bring-your-own-backend}
 

--- a/content/pt/_index.md
+++ b/content/pt/_index.md
@@ -12,7 +12,7 @@ default_lang_commit: c0a5eea5d720b0e075efa87f99dcf58c89106268
 
 <div class="d-none"><a rel="me" href="https://fosstodon.org/@opentelemetry"></a></div>
 
-{{< blocks/cover image_anchor="top" height="max" color="primary" >}}
+{{% blocks/cover image_anchor="top" height="max" color="primary" %}}
 
 <!-- prettier-ignore -->
 ![OpenTelemetry](/img/logos/opentelemetry-horizontal-color.svg)
@@ -38,7 +38,7 @@ default_lang_commit: c0a5eea5d720b0e075efa87f99dcf58c89106268
 - [Ops](docs/getting-started/ops/)
 
 </div>
-{{< /blocks/cover >}}
+{{% /blocks/cover %}}
 
 {{% blocks/lead color="white" %}}
 

--- a/content/pt/docs/languages/js/getting-started/browser.md
+++ b/content/pt/docs/languages/js/getting-started/browser.md
@@ -91,7 +91,7 @@ Crie um arquivo de código vazio chamado `document-load` com a extensão `.ts` o
 escrever sua aplicação. Adicione o seguinte código ao seu HTML, logo antes da
 tag de fechamento `</body>`:
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```html
 <script type="module" src="document-load.ts"></script>
@@ -103,7 +103,7 @@ tag de fechamento `</body>`:
 <script type="module" src="document-load.js"></script>
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 Adicionaremos o código para rastrear os tempos de carregamento do documento e
 relatar esses dados como trechos OpenTelemetry.

--- a/content/pt/docs/languages/js/getting-started/nodejs.md
+++ b/content/pt/docs/languages/js/getting-started/nodejs.md
@@ -47,7 +47,7 @@ npm init -y
 
 Em seguida, instale as dependências do Express.
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```sh
 npm install typescript \
@@ -66,7 +66,7 @@ npx tsc --init
 npm install express
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ### Crie e inicie um servidor HTTP {#create-and-launch-an-http-server}
 
@@ -123,7 +123,7 @@ Execute a aplicação utilizando o comando abaixo e acesse
 <http://localhost:8080/rolldice> no seu navegador para garantir que esteja
 funcionando.
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```console
 $ npx ts-node app.ts
@@ -137,7 +137,7 @@ $ node app.js
 Aguardando requisições em http://localhost:8080
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ## Instrumentação {#instrumentation}
 
@@ -179,7 +179,7 @@ Crie um arquivo chamado `instrumentation.ts` (ou `instrumentation.js`, caso não
 esteja utilizando TypeScript), que deverá conter o código de configuração de
 instrumentação.
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 /*instrumentation.ts*/
@@ -228,7 +228,7 @@ const sdk = new NodeSDK({
 sdk.start();
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 ## Execute a aplicação instrumentada {#run-the-instrumented-app}
 
@@ -238,7 +238,7 @@ Certifique-se de que não haja conflitos na utilização da _flag_ `--require`,
 como, por exemplo, a variável de ambiente `NODE_OPTIONS` já possuir algo como
 `--require @opentelemetry/auto-instrumentations-node/register`.
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```console
 $ npx ts-node --require ./instrumentation.ts app.ts
@@ -252,7 +252,7 @@ $ node --require ./instrumentation.js app.js
 Aguardando requisições em http://localhost:8080
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 Acesse <http://localhost:8080/rolldice> no seu navegador e recarregue a página
 algumas vezes. Depois de um tempo, você deverá ver os trechos exibidos no
@@ -496,7 +496,7 @@ Caso queira explorar um exemplo mais complexo, dê uma olhada no
 Algo deu errado? Você pode habilitar o _logging_ de diagnóstico para validar se
 o OpenTelemetry está inicializado corretamente:
 
-{{< tabpane text=true >}} {{% tab TypeScript %}}
+{{% tabpane text=true %}} {{% tab TypeScript %}}
 
 ```ts
 /*instrumentation.ts*/
@@ -521,7 +521,7 @@ diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
 // const sdk = new NodeSDK({...
 ```
 
-{{% /tab %}} {{< /tabpane >}}
+{{% /tab %}} {{% /tabpane %}}
 
 [rastros]: /docs/concepts/signals/traces/
 [métricas]: /docs/concepts/signals/metrics/

--- a/content/pt/ecosystem/registry/_index.md
+++ b/content/pt/ecosystem/registry/_index.md
@@ -20,7 +20,7 @@ default_lang_commit: fd873ed11bfa9920c2e8b0726784f482368e85c2
 
 {{% /blocks/lead %}}
 
-{{< blocks/section color="white" type="container-lg" >}}
+{{% blocks/section color="white" type="container-lg" %}}
 
 {{% alert color="info" %}}
 
@@ -31,6 +31,6 @@ ecossistema. Caso você seja mantenedor de um projeto, é possível
 
 {{% /alert %}}
 
-{{< ecosystem/registry/search-form >}}
+{{% ecosystem/registry/search-form %}}
 
-{{< /blocks/section >}}
+{{% /blocks/section %}}

--- a/content/zh/_index.md
+++ b/content/zh/_index.md
@@ -12,7 +12,7 @@ default_lang_commit: c2cd5b14
 
 <div class="d-none"><a rel="me" href="https://fosstodon.org/@opentelemetry"></a></div>
 
-{{< blocks/cover image_anchor="top" height="max" color="primary" >}}
+{{% blocks/cover image_anchor="top" height="max" color="primary" %}}
 
 <!-- prettier-ignore -->
 ![OpenTelemetry](/img/logos/opentelemetry-horizontal-color.svg)
@@ -39,7 +39,7 @@ default_lang_commit: c2cd5b14
 - [运维人员](docs/getting-started/ops/)
 
 </div>
-{{< /blocks/cover >}}
+{{% /blocks/cover %}}
 
 {{% blocks/lead color="white" %}}
 


### PR DESCRIPTION
This pull request addresses the markdown syntax cleanup issue by replacing `{{< >}}` with `{{% %}}`, as per the request in the issue.

- Replaced all instances of `{{< >}}` with `{{% %}}` in the markdown files.
- Ensured consistency and readability across the documentation.

I am not a member of the organization, but I believe this change will help improve the project's documentation. Please let me know if any further modifications are needed.
