### PR TITLE
[i18n] Add `drifted_from_default` status to drifted pages, adjust script, add "Drift status" section to l10n page

### DIFF
--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -225,6 +225,13 @@ if you want HEAD to correspond to `main` in GitHub.
 
 {{% /alert %}}
 
+### Drift status
+
+Run `npm run fix:i18n:status` to add a front-matter field `drifted_from_default`
+to those target localization pages that have drifted. This field will soon be
+used to display a banner at the top of pages that have drifted relative to their
+English counterparts.
+
 ### Script help
 
 For more details about the script, run `npm run check:i18n -- -h`.

--- a/content/es/_index.md
+++ b/content/es/_index.md
@@ -7,6 +7,7 @@ developer_note:
   de imagen que contenga la palabra "background" en su nombre.
 show_banner: true
 default_lang_commit: 7ac35d6b429165bbe6c28bdd91feeae83fd35142
+drifted_from_default: true
 ---
 
 <div class="d-none"><a rel="me" href="https://fosstodon.org/@opentelemetry"></a></div>

--- a/content/es/docs/concepts/components.md
+++ b/content/es/docs/concepts/components.md
@@ -4,6 +4,7 @@ description: Componentes que forman OpenTelemetry
 aliases: [data-collection]
 weight: 20
 default_lang_commit: 9b7da35fd7abd77d867177902b36d95e5f322182
+drifted_from_default: true
 ---
 
 OpenTelemetry está compuesto por varios componentes principales:

--- a/content/es/docs/concepts/context-propagation.md
+++ b/content/es/docs/concepts/context-propagation.md
@@ -3,6 +3,7 @@ title: Propagación de contexto
 weight: 10
 description: Aprende sobre el concepto que habilita el trazado distribuido.
 default_lang_commit: 4966f752eb35f97c095ed1c813972c2ab38f0b1a
+drifted_from_default: true
 ---
 
 Con la propagación de contexto, [Señales](/docs/concepts/signals) pueden

--- a/content/es/docs/contributing/_index.md
+++ b/content/es/docs/contributing/_index.md
@@ -3,6 +3,7 @@ title: Contribuir
 description: Aprende cómo contribuir a la documentación de OpenTelemetry.
 weight: 980
 default_lang_commit: 30783526402b69a3ac44eeb0f6cf066732f0bdca
+drifted_from_default: true
 ---
 
 Quienes colaboran para documentar OpenTelemetry:

--- a/content/es/docs/contributing/issues.md
+++ b/content/es/docs/contributing/issues.md
@@ -7,6 +7,7 @@ weight: 10
 _issues: https://github.com/open-telemetry/opentelemetry.io/issues
 _issue: https://github.com/open-telemetry/opentelemetry.io/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A
 default_lang_commit: 99f0ae5760038d51f9e9eb376bb428a2caca8167 # patched
+drifted_from_default: true
 ---
 
 ## Solucionando una propuesta existente

--- a/content/es/docs/contributing/pull-requests.md
+++ b/content/es/docs/contributing/pull-requests.md
@@ -5,6 +5,7 @@ description:
   editor de código.
 weight: 2
 default_lang_commit: f724c15be360e5059fb89e696d9a5cc8d00496f6 # patched
+drifted_from_default: true
 cSpell:ignore: aplícala solucionándolas vincúlalos
 ---
 

--- a/content/es/docs/demo/_index.md
+++ b/content/es/docs/demo/_index.md
@@ -5,6 +5,7 @@ cascade:
   repo: https://github.com/open-telemetry/opentelemetry-demo
 weight: 180
 default_lang_commit: 9b5e318036fb92e4a1896259cc3bbdad2843e1de
+drifted_from_default: true
 cSpell:ignore: diagnostícala OLJCESPC preconfigurados
 ---
 

--- a/content/es/docs/getting-started/ops.md
+++ b/content/es/docs/getting-started/ops.md
@@ -2,6 +2,7 @@
 title: Introducción para Operaciones
 linkTitle: Ops
 default_lang_commit: ede5b715791550eccf1c0dc3d57e2713ca6350ab
+drifted_from_default: true
 ---
 
 Esta es tu página de [introducción](..) si:

--- a/content/es/docs/kubernetes/_index.md
+++ b/content/es/docs/kubernetes/_index.md
@@ -4,6 +4,7 @@ linkTitle: Kubernetes
 weight: 350
 description: Usando OpenTelemetry con Kubernetes
 default_lang_commit: d638c386ae327328ff35604df54fa6ddd8b51b65
+drifted_from_default: file not found
 ---
 
 ## Introducción

--- a/content/es/docs/kubernetes/collector/_index.md
+++ b/content/es/docs/kubernetes/collector/_index.md
@@ -2,6 +2,7 @@
 title: OpenTelemetry Collector y Kubernetes
 linkTitle: Colector
 default_lang_commit: f7cb8b65a478450d80d703b34c8473c579702108
+drifted_from_default: file not found
 ---
 
 El [OpenTelemetry Collector](/docs/collector/) es una forma de recibir, procesar

--- a/content/es/docs/kubernetes/collector/components.md
+++ b/content/es/docs/kubernetes/collector/components.md
@@ -2,6 +2,7 @@
 title: Componentes clave para Kubernetes
 linkTitle: Componentes
 default_lang_commit: 3815d1481fe753df10ea3dc26cbe64dba0230579 # with patched links
+drifted_from_default: file not found
 # prettier-ignore
 cSpell:ignore: alertmanagers asignador containerd crio filelog gotime horizontalpodautoscalers hostfs hostmetrics iostream k8sattributes kubelet kubeletstats logtag paginación replicasets replicationcontrollers resourcequotas statefulsets varlibdockercontainers varlogpods
 ---

--- a/content/es/docs/languages/_includes/_index.md
+++ b/content/es/docs/languages/_includes/_index.md
@@ -3,4 +3,5 @@ title: # bogus for markdownlint
 cascade:
   build: { list: never, render: never }
 default_lang_commit: 7811e854ba3b31c56ce681f1d60cf19e8a5c4358
+drifted_from_default: file not found
 ---

--- a/content/es/docs/languages/_includes/instrumentation-intro.md
+++ b/content/es/docs/languages/_includes/instrumentation-intro.md
@@ -1,6 +1,7 @@
 ---
 title: # bogus for markdownlint
 default_lang_commit: 7811e854ba3b31c56ce681f1d60cf19e8a5c4358
+drifted_from_default: true
 ---
 
 [Instrumentar](/docs/concepts/instrumentation/) consiste en añadir el código de

--- a/content/es/docs/languages/_index.md
+++ b/content/es/docs/languages/_index.md
@@ -5,6 +5,7 @@ description:
   lenguajes de programación populares.
 weight: 250
 default_lang_commit: 3815d1481fe753df10ea3dc26cbe64dba0230579
+drifted_from_default: true
 ---
 
 La [instrumentación][] de código de OpenTelemetry es compatible con los

--- a/content/es/docs/languages/python/instrumentation.md
+++ b/content/es/docs/languages/python/instrumentation.md
@@ -4,6 +4,7 @@ aliases: [manual]
 weight: 20
 description: Instrumentación manual para OpenTelemetry Python
 default_lang_commit: 9b53527853049b249f60f12a000c0d85b9e5f5dc
+drifted_from_default: true
 cSpell:ignore: millis ottrace textmap
 ---
 

--- a/content/es/docs/what-is-opentelemetry.md
+++ b/content/es/docs/what-is-opentelemetry.md
@@ -3,6 +3,7 @@ title: ¿Qué es OpenTelemetry?
 description: Qué es y qué no es OpenTelemetry, una breve explicación
 weight: 150
 default_lang_commit: 13c2d415e935fac3014344e67c6c61556779fd6f
+drifted_from_default: true
 cSpell:ignore: extensibilidad microservicios
 ---
 

--- a/content/fr/docs/concepts/context-propagation.md
+++ b/content/fr/docs/concepts/context-propagation.md
@@ -3,6 +3,7 @@ title: Propagation du contexte
 weight: 10
 description: Présentation du concept permettant le traçage distribué.
 default_lang_commit: 71833a5f8b84110dadf1e98604b87a900724ac33
+drifted_from_default: true
 ---
 
 La propagation du contexte permet de mettre en corrélation les

--- a/content/fr/docs/concepts/signals/_index.md
+++ b/content/fr/docs/concepts/signals/_index.md
@@ -3,6 +3,7 @@ title: Les signaux
 description: Catégories de télémétrie supportées par OpenTelemetry
 weight: 11
 default_lang_commit: 71833a5f8b84110dadf1e98604b87a900724ac33
+drifted_from_default: true
 ---
 
 L'objectif d'OpenTelemetry est de collecter, traiter et exporter des

--- a/content/fr/docs/what-is-opentelemetry.md
+++ b/content/fr/docs/what-is-opentelemetry.md
@@ -4,6 +4,7 @@ description:
   Une brève explication de ce qu'est OpenTelemetry, et de ce qu'il n'est pas.
 weight: 150
 default_lang_commit: 71833a5f8b84110dadf1e98604b87a900724ac33
+drifted_from_default: true
 ---
 
 OpenTelemetry, c'est :

--- a/content/ja/docs/collector/_index.md
+++ b/content/ja/docs/collector/_index.md
@@ -5,6 +5,7 @@ cascade:
   vers: 0.119.0
 weight: 270
 default_lang_commit: fd7da211d5bc37ca93112a494aaf6a94445e2e28
+drifted_from_default: true
 ---
 
 ![Jaeger、OTLP、Prometheusを統合したOpenTelemetryコレクターのダイアグラム](img/otel-collector.svg)

--- a/content/ja/docs/concepts/glossary.md
+++ b/content/ja/docs/concepts/glossary.md
@@ -3,6 +3,7 @@ title: 用語集
 description: OpenTelemetryプロジェクトで使用されている用語に馴染みがあるものもないものもあるでしょう。
 weight: 200
 default_lang_commit: 21d6bf0
+drifted_from_default: true
 ---
 
 OpenTelemetryプロジェクトは、あなたが馴染みのない用語を使っているかもしれません。

--- a/content/ja/docs/concepts/resources/index.md
+++ b/content/ja/docs/concepts/resources/index.md
@@ -2,6 +2,7 @@
 title: リソース
 weight: 70
 default_lang_commit: 8d115a9df96c52dbbb3f96c05a843390d90a9800
+drifted_from_default: true
 ---
 
 ## はじめに

--- a/content/ja/docs/contributing/issues.md
+++ b/content/ja/docs/contributing/issues.md
@@ -5,6 +5,7 @@ weight: 10
 _issues: https://github.com/open-telemetry/opentelemetry.io/issues
 _issue: https://github.com/open-telemetry/opentelemetry.io/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A
 default_lang_commit: 24146bd1368e4c6082c7d6077efd29dba0d51055 # patched
+drifted_from_default: true
 ---
 
 ## 既存のイシューの修正 {#fixing-an-existing-issue}

--- a/content/ja/docs/contributing/localization.md
+++ b/content/ja/docs/contributing/localization.md
@@ -4,6 +4,7 @@ description: 非英語ローカリゼーションのサイトページの作成�
 linkTitle: ローカリゼーション
 weight: 25
 default_lang_commit: b7e40731390448f604897ded62cff8abd3505430
+drifted_from_default: true
 cSpell:ignore: shortcodes
 ---
 

--- a/content/ja/docs/contributing/pull-requests.md
+++ b/content/ja/docs/contributing/pull-requests.md
@@ -4,6 +4,7 @@ description: GitHub UI またはローカルのフォークを利用して、新
 aliases: [new-content]
 weight: 15
 default_lang_commit: 99f0ae5760038d51f9e9eb376bb428a2caca8167 # patched
+drifted_from_default: true
 ---
 
 新しいドキュメントの内容を追加したり、既存のコンテンツの改善をするには、[プルリクエスト][PR] （PR）を提出してください。

--- a/content/ja/docs/demo/_index.md
+++ b/content/ja/docs/demo/_index.md
@@ -5,6 +5,7 @@ cascade:
   repo: https://github.com/open-telemetry/opentelemetry-demo
 weight: 180
 default_lang_commit: fd7da211d5bc37ca93112a494aaf6a94445e2e28
+drifted_from_default: true
 cSpell:ignore: OLJCESPC
 ---
 

--- a/content/ja/docs/demo/development.md
+++ b/content/ja/docs/demo/development.md
@@ -1,6 +1,7 @@
 ---
 title: 開発環境
 default_lang_commit: fd7da211d5bc37ca93112a494aaf6a94445e2e28
+drifted_from_default: true
 cSpell:ignore: grpcio intellij libcurl libprotobuf nlohmann openssl protoc
 ---
 

--- a/content/pt/_includes/page-not-translated-msg.md
+++ b/content/pt/_includes/page-not-translated-msg.md
@@ -1,5 +1,6 @@
 ---
 default_lang_commit: 8d115a9df96c52dbbb3f96c05a843390d90a9800
+drifted_from_default: true
 ---
 
 <i class="fa-solid fa-circle-info" style="margin-left: -1.5rem"></i> Você está

--- a/content/pt/docs/concepts/components.md
+++ b/content/pt/docs/concepts/components.md
@@ -3,6 +3,7 @@ title: Componentes
 description: Os principais componentes que compõem o OpenTelemetry
 weight: 20
 default_lang_commit: f5c228e5d03deaabc00d5920c5757bf7bd23e3f3
+drifted_from_default: true
 ---
 
 O OpenTelemetry é atualmente composto por vários componentes principais:

--- a/content/pt/docs/concepts/glossary.md
+++ b/content/pt/docs/concepts/glossary.md
@@ -5,6 +5,7 @@ description: >-
   OpenTelemetry.
 weight: 200
 default_lang_commit: f37118d8489a60d73dd881645f317d866b53b418
+drifted_from_default: true
 ---
 
 Esse glossário define termos e [conceitos](/docs/concepts/) que são novos no

--- a/content/pt/docs/concepts/instrumentation/libraries.md
+++ b/content/pt/docs/concepts/instrumentation/libraries.md
@@ -3,6 +3,7 @@ title: Bibliotecas
 description: Aprenda como adicionar instrumentação nativa à sua biblioteca.
 weight: 40
 default_lang_commit: e09adae2c06b71a08cafb2b1c42e3e7b9e48997b
+drifted_from_default: true
 ---
 
 O OpenTelemetry fornece [bibliotecas de instrumentação][] para várias

--- a/content/pt/docs/concepts/resources/index.md
+++ b/content/pt/docs/concepts/resources/index.md
@@ -2,6 +2,7 @@
 title: Recursos
 weight: 70
 default_lang_commit: 17c3b8eb53b8abc56213abb736c0f850eab752df
+drifted_from_default: true
 ---
 
 ## Introdução {#introduction}

--- a/content/pt/docs/getting-started/ops.md
+++ b/content/pt/docs/getting-started/ops.md
@@ -2,6 +2,7 @@
 title: Primeiros passos para Operações
 linkTitle: Ops
 default_lang_commit: 6a828d6dd3a3a8ef3cbf1b7d283f335b4626ae62
+drifted_from_default: true
 ---
 
 A página [primeiros-passos](..) é para você se:

--- a/content/pt/docs/languages/_includes/instrumentation-intro.md
+++ b/content/pt/docs/languages/_includes/instrumentation-intro.md
@@ -1,5 +1,6 @@
 ---
 default_lang_commit: 080527543eae90112f01c89342891aabd6258173 # patched
+drifted_from_default: true
 ---
 
 [Instrumentação](/docs/concepts/instrumentation/) é o ato de adicionar código de

--- a/content/pt/docs/languages/_index.md
+++ b/content/pt/docs/languages/_index.md
@@ -5,6 +5,7 @@ description:
   populares de programação.
 weight: 250
 default_lang_commit: e6aed25fb78cbd1c1934c70f4f7c11f411f4c24e
+drifted_from_default: true
 ---
 
 A [instrumentação][] de código do OpenTelemetry é suportada para as linguagens

--- a/content/pt/docs/languages/go/exporters.md
+++ b/content/pt/docs/languages/go/exporters.md
@@ -3,6 +3,7 @@ title: Exporters
 aliases: [exporting_data]
 weight: 50
 default_lang_commit: 07431d6e22a33faa6775f2c1f40aa122990dc214
+drifted_from_default: true
 # prettier-ignore
 cSpell:ignore: otlplog otlploggrpc otlploghttp otlpmetric otlpmetricgrpc otlpmetrichttp otlptrace otlptracegrpc otlptracehttp promhttp stdoutlog stdouttrace
 ---

--- a/content/pt/docs/languages/go/getting-started.md
+++ b/content/pt/docs/languages/go/getting-started.md
@@ -2,6 +2,7 @@
 title: Primeiros Passos
 weight: 10
 default_lang_commit: a025c25aaf1aef653caa34e49e8714472cbeddbd
+drifted_from_default: true
 # prettier-ignore
 cSpell:ignore: chan fatalln funcs intn itoa khtml otelhttp rolldice stdouttrace strconv
 ---

--- a/content/pt/docs/languages/go/instrumentation.md
+++ b/content/pt/docs/languages/go/instrumentation.md
@@ -6,6 +6,7 @@ aliases:
 weight: 30
 description: Instrumentação manual para OpenTelemetry Go
 default_lang_commit: 748555c22f43476291ae0c7974ca4a2577da0472
+drifted_from_default: true
 cSpell:ignore: fatalf logr logrus otlplog otlploghttp sdktrace sighup updown
 ---
 

--- a/content/pt/docs/languages/java/instrumentation.md
+++ b/content/pt/docs/languages/java/instrumentation.md
@@ -9,6 +9,7 @@ aliases:
 weight: 10
 description: Ecossistema de Instrumentação no OpenTelemetry Java
 default_lang_commit: 748555c22f43476291ae0c7974ca4a2577da0472
+drifted_from_default: true
 cSpell:ignore: logback
 ---
 

--- a/content/pt/docs/languages/js/_includes/browser-instrumentation-warning.md
+++ b/content/pt/docs/languages/js/_includes/browser-instrumentation-warning.md
@@ -1,5 +1,6 @@
 ---
 default_lang_commit: 0dac041dedfe5877f45e36065c1c6fb07490b243 # patched
+drifted_from_default: true
 ---
 
 {{% alert title=Aviso color=warning %}}

--- a/content/pt/docs/languages/js/getting-started/browser.md
+++ b/content/pt/docs/languages/js/getting-started/browser.md
@@ -4,6 +4,7 @@ aliases: [/docs/js/getting_started/browser]
 description: Aprenda como adicionar o OpenTelemetry à sua aplicação de navegador
 weight: 20
 default_lang_commit: 7cb1bd39726fc03698164ee17fe9087afdac054c
+drifted_from_default: true
 ---
 
 {{% include browser-instrumentation-warning.md %}}

--- a/content/pt/docs/what-is-opentelemetry.md
+++ b/content/pt/docs/what-is-opentelemetry.md
@@ -3,6 +3,7 @@ title: O que é o OpenTelemetry?
 description: Uma breve explicação sobre o que o OpenTelemetry é e não é.
 weight: 150
 default_lang_commit: f37118d8489a60d73dd881645f317d866b53b418
+drifted_from_default: true
 ---
 
 O OpenTelemetry é:

--- a/content/pt/ecosystem/adopters.md
+++ b/content/pt/ecosystem/adopters.md
@@ -2,6 +2,7 @@
 title: Adotantes
 description: Organizações que usam OpenTelemetry
 default_lang_commit: 748555c22f43476291ae0c7974ca4a2577da0472
+drifted_from_default: true
 ---
 
 A missão do OpenTelemetry é possibilitar uma observabilidade eficaz para todos

--- a/content/pt/ecosystem/distributions.md
+++ b/content/pt/ecosystem/distributions.md
@@ -4,6 +4,7 @@ description:
   Lista de distribuições de código aberto do OpenTelemetry mantidas por
   terceiros.
 default_lang_commit: 8a15d0d668c516ccb255cd0a92e0bcd442e83b4d
+drifted_from_default: true
 ---
 
 As [distribuições](/docs/concepts/distributions/) do OpenTelemetry são uma forma

--- a/content/pt/ecosystem/integrations.md
+++ b/content/pt/ecosystem/integrations.md
@@ -4,6 +4,7 @@ description:
   Bibliotecas, serviços e aplicações com suporte nativo para o OpenTelemetry.
 aliases: [/integrations]
 default_lang_commit: 8a15d0d668c516ccb255cd0a92e0bcd442e83b4d
+drifted_from_default: true
 ---
 
 A missão do OpenTelemetry é

--- a/content/pt/ecosystem/vendors.md
+++ b/content/pt/ecosystem/vendors.md
@@ -3,6 +3,7 @@ title: Fornecedores
 description: Fornecedores que oferecem suporte nativo ao OpenTelemetry
 aliases: [/vendors]
 default_lang_commit: 8a15d0d668c516ccb255cd0a92e0bcd442e83b4d
+drifted_from_default: true
 ---
 
 Uma lista não exaustiva de organizações que oferecem soluções que consomem o

--- a/content/pt/status.md
+++ b/content/pt/status.md
@@ -4,6 +4,7 @@ menu: { main: { weight: 30 } }
 aliases: [/project-status, /releases]
 description: Nível de maturidade dos principais componentes do OpenTelemetry
 default_lang_commit: a6e46dac8b73165a904e9fee4c1ee46305a8b968
+drifted_from_default: true
 ---
 
 {{% blocks/section color="white" %}}

--- a/content/zh/_index.md
+++ b/content/zh/_index.md
@@ -8,6 +8,7 @@ developer_note:
   的图像文件作为背景图。
 show_banner: true
 default_lang_commit: c2cd5b14
+drifted_from_default: true
 ---
 
 <div class="d-none"><a rel="me" href="https://fosstodon.org/@opentelemetry"></a></div>

--- a/content/zh/docs/_index.md
+++ b/content/zh/docs/_index.md
@@ -7,6 +7,7 @@ htmltest:
     - ^zh/docs/concepts/signals/baggage/
     - ^zh/docs/zero-code/php/
 default_lang_commit: 6e35a949
+drifted_from_default: true
 ---
 
 OpenTelemetry 也被称为 OTel，是一个供应商中立的、开源的[可观测性](concepts/observability-primer/#what-is-observability)框架，

--- a/content/zh/docs/concepts/components.md
+++ b/content/zh/docs/concepts/components.md
@@ -4,6 +4,7 @@ description: 构成 OpenTelemetry 的主要组件
 aliases: [data-collection]
 weight: 20
 default_lang_commit: 1ca30b4d
+drifted_from_default: true
 ---
 
 OpenTelemetry 项目目前由以下几个主要部分构成：

--- a/content/zh/docs/concepts/context-propagation.md
+++ b/content/zh/docs/concepts/context-propagation.md
@@ -3,6 +3,7 @@ title: 上下文传播
 weight: 10
 description: 了解实现分布式追踪的概念。
 default_lang_commit: 7bb7dbb6
+drifted_from_default: true
 ---
 
 通过上下文传播，[信号](/docs/concepts/signals)可以相互关联，

--- a/content/zh/docs/concepts/signals/_index.md
+++ b/content/zh/docs/concepts/signals/_index.md
@@ -6,6 +6,7 @@ aliases:
   - /docs/concepts/otel-concepts
 weight: 11
 default_lang_commit: e7c30e9
+drifted_from_default: true
 ---
 
 OpenTelemetry 的目的是收集、处理和导出 **[信号][]** 。

--- a/content/zh/docs/contributing/_index.md
+++ b/content/zh/docs/contributing/_index.md
@@ -10,6 +10,7 @@ htmltest:
     #     Non-OK status: 404 --> https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md
     - ^zh/docs/contributing/
 default_lang_commit: 8603bc8
+drifted_from_default: true
 ---
 
 下面的指引描述了如何为 OpenTelemetry 文档做贡献。关于如何为 OpenTelemetry 项目作出贡献，请参阅[OpenTelemetry 贡献者指南](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md)，其中提供了有关贡献者许可协议和行为准则的详细信息。从某种程度上讲，每种语言实现、收集器和约定 [仓库](https://github.com/open-telemetry/) 都有自己特定的贡献指南。

--- a/content/zh/docs/contributing/style-guide.md
+++ b/content/zh/docs/contributing/style-guide.md
@@ -4,6 +4,7 @@ description: 编写 OpenTelemetry 文档时的术语和风格指南。
 linkTitle: 风格指南
 weight: 20
 default_lang_commit: 2394fa1f1c693e547093e46e83a6819d3c26e9d5
+drifted_from_default: true
 cSpell:ignore: open-telemetry postgre style-guide textlintrc
 ---
 

--- a/content/zh/docs/demo/_index.md
+++ b/content/zh/docs/demo/_index.md
@@ -5,6 +5,7 @@ cascade:
   repo: https://github.com/open-telemetry/opentelemetry-demo
 weight: 180
 default_lang_commit: c2cd5b14
+drifted_from_default: true
 cSpell:ignore: OLJCESPC
 ---
 

--- a/content/zh/docs/faas/_index.md
+++ b/content/zh/docs/faas/_index.md
@@ -5,6 +5,7 @@ description: >-
   OpenTelemetry 支持不同云供应商提供的各种功能即服务（FaaS）的监控方法
 weight: 360
 default_lang_commit: c2cd5b14a73e051acacb6914740fb3e20536f8ba
+drifted_from_default: file not found
 ---
 
 功能即服务（FaaS）是云原生应用的重要无服务（Serverless）计算平台。

--- a/content/zh/docs/faas/lambda-manual-instrument.md
+++ b/content/zh/docs/faas/lambda-manual-instrument.md
@@ -3,6 +3,7 @@ title: Lambda 手动插桩
 weight: 11
 description: 使用 OpenTelemetry 手动插桩 Lambda
 default_lang_commit: 06837fe15457a584f6a9e09579be0f0400593d57 # with links patched
+drifted_from_default: file not found
 ---
 
 对于在 Lambda 自动插桩文档中未涵盖的语言，社区尚未提供独立的插桩器。

--- a/content/zh/docs/getting-started/ops.md
+++ b/content/zh/docs/getting-started/ops.md
@@ -2,6 +2,7 @@
 title: 运维人员入门
 linkTitle: Ops
 default_lang_commit: e771c886739c4847b332b74f24b09d2769aab875
+drifted_from_default: true
 ---
 
 如果你符合以下条件，那么这个[入门指南](..)就是为你准备的：

--- a/content/zh/docs/kubernetes/_index.md
+++ b/content/zh/docs/kubernetes/_index.md
@@ -4,6 +4,7 @@ linkTitle: Kubernetes
 weight: 350
 description: Using OpenTelemetry with Kubernetes
 default_lang_commit: c2cd5b14
+drifted_from_default: file not found
 ---
 
 ## 介绍

--- a/content/zh/docs/languages/java/_index.md
+++ b/content/zh/docs/languages/java/_index.md
@@ -12,6 +12,7 @@ cascade:
     semconv: 1.27.0
 weight: 18
 default_lang_commit: 20c51c53
+drifted_from_default: true
 ---
 
 {{% docs/languages/index-intro java /%}}

--- a/content/zh/docs/migration/_index.md
+++ b/content/zh/docs/migration/_index.md
@@ -3,6 +3,7 @@ title: 迁移
 description: 如何迁移到 OpenTelemetry
 weight: 950
 default_lang_commit: 4b1f5e382758278e1e56e7b197bd349c17fdf9cb
+drifted_from_default: true
 ---
 
 ## OpenTracing 和 OpenCensus

--- a/content/zh/docs/what-is-opentelemetry.md
+++ b/content/zh/docs/what-is-opentelemetry.md
@@ -3,6 +3,7 @@ title: 什么是 OpenTelemetry？
 description: 简短说明 OpenTelemetry 是什么，不是什么。
 weight: 150
 default_lang_commit: d638c386
+drifted_from_default: true
 ---
 
 OpenTelemetry

--- a/scripts/check-i18n.sh
+++ b/scripts/check-i18n.sh
@@ -239,7 +239,7 @@ function set_file_drifted_status() {
   local post_msg="${4:-$I18N_DLD_KEY key}" # Not used atm
 
   if [[ $status == "false" ]]; then
-    perl -i -pe "s/(^$I18N_DLD_KEY):.*$//g" "$f"
+    perl -i -pe "s/(^$I18N_DLD_KEY):.*\n$//g" "$f"
   elif grep -q "^$I18N_DLD_KEY:" "$f"; then
     perl -i -pe "s/(^$I18N_DLD_KEY):.*$/\$1: $status/" "$f"
     post_msg="$post_msg UPDATED"


### PR DESCRIPTION
- Followup to #6444
- Contributes to #6443
- Adds a section about page "Drift status" to the Localization page
- Adds `drifted_from_default: (true|file not found)` to non-English pages that are currently out-of-date
