### PR TITLE
fix: update links to OpenTelemetry Operator API documentation

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -93,6 +93,3 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - ^https://pkg.go.dev/go.opentelemetry.io/collector/config/configauth#client-authenticators
   - ^https://pkg.go.dev/go.opentelemetry.io/collector/config/configauth#server-authenticators
 
-  # Temporary until
-  # https://github.com/open-telemetry/opentelemetry.io/issues/6237 is resolved
-  - ^https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md#

--- a/content/en/blog/2023/end-user-q-and-a-04.md
+++ b/content/en/blog/2023/end-user-q-and-a-04.md
@@ -61,13 +61,13 @@ monorepo, but that would have risked a bug being pushed up.
 
 Jacob says, "This is app data which we use for alerting to understand how our
 workloads are functioning in all of our environments, so it's important to not
-take that down since it’d be disastrous. Same story for users, they want to know
-if they move to OTel they won’t lose their alerting capabilities. You want a
+take that down since it'd be disastrous. Same story for users, they want to know
+if they move to OTel they won't lose their alerting capabilities. You want a
 safe and easy migration."
 
 His team did the feature flag-based part of the configuration in Kubernetes. He
 says, "It would disable the sidecar and enable some code that would then swap
-the OTel for metrics and forward it to where it’s supposed to go. So that was
+the OTel for metrics and forward it to where it's supposed to go. So that was
 the path there."
 
 However, along the way, he noticed some "pretty large performance issues" as he
@@ -76,7 +76,7 @@ worked with the OTel team to alleviate some of these concerns, and found that
 one of the big blockers was their heavy use of attributes on metrics.
 
 "It was tedious to go in and figure out which metrics are using them and getting
-rid of them. I had a theory that one codepath was the problem, where we’re doing
+rid of them. I had a theory that one codepath was the problem, where we're doing
 the conversion from our internal tagging implementation to OTel tags, which came
 with a lot of other logic and [is] expensive to do, and it was on almost every
 call," he says. "No better time than now to begin another migration from
@@ -84,7 +84,7 @@ OpenCensus to OTel."
 
 He saw this as another opportunity: "While we wait for the OTel folks on the
 metrics side to push out more performant code and implementations, we could also
-test out the theory of, if we migrate to OTel entirely, we’re going to see more
+test out the theory of, if we migrate to OTel entirely, we're going to see more
 performance benefits." Thus, they paused the metrics work and began on migrating
 their tracing.
 
@@ -111,7 +111,7 @@ code and some dangerous hacks, so that was a really good thing."
 enough for it to be constant," Jacob says. "The reason you want to pick a
 service like this is that if it's too low traffic, like one request every 10
 minutes, you have to worry about sample rates, [and] you may not have a lot of
-data to compare against – that’s the big thing: you need to have some data to
+data to compare against – that's the big thing: you need to have some data to
 compare against."
 
 He had written a script early on for their metrics migration that queried
@@ -131,12 +131,12 @@ different types of instrumentation, so from Envoy to OTel to OpenTracing."
 He explains, "What you want to see is that the trace before has the same
 structure as the trace after. So I made another script that checked that those
 structures were relatively the same and that they all had the same attributes as
-well... That’s the point of the tracing migration – what matters is that all the
+well... That's the point of the tracing migration – what matters is that all the
 attributes stayed the same."
 
 ### When data goes missing
 
-"The ‘why it’s missing’ stories are the really complicated ones," says Jacob.
+"The 'why it's missing' stories are the really complicated ones," says Jacob.
 Sometimes, it's as simple as forgetting "to add something somewhere," but other
 times, there could be an upstream library that doesn't emit what you expected
 for OTel.
@@ -144,10 +144,10 @@ for OTel.
 He tells a story about the time he migrated their gRPC util package (which is
 now in Go contrib) and found an issue with propagation.
 
-"I was trying to understand what’s going wrong here. When I looked at the code –
+"I was trying to understand what's going wrong here. When I looked at the code –
 this tells you how early I was doing this migration – where there was supposed
 to be a propagator, there was just a 'TODO'," he shares. "It just took down our
-entire services’ traces in staging."
+entire services' traces in staging."
 
 He spent some time working on it, but they in turn were waiting on something
 else, and so on and so forth -- Jacob says there are "endless cycles of that
@@ -163,9 +163,9 @@ Views and the use of Views is something we used heavily early in the migration."
 
 "A Metrics View is something that is run inside of your Meter Provider in OTel,"
 Jacob explains. There are many configuration options, such as dropping
-attributes, which is one of the most common use cases. "For example, you’re a
+attributes, which is one of the most common use cases. "For example, you're a
 centralized SRE and you don't want anyone to instrument code with any user ID
-attribute, because that’s a high cardinality thing and it’s going to explode
+attribute, because that's a high cardinality thing and it's going to explode
 your metrics cost. You can make a View that gets added to your instrumentation
 and tell it to not record it, to deny it."
 
@@ -174,19 +174,19 @@ temporality or aggregation of your metrics. Temporality refers to whether a
 metric incorporates the previous measurement or not (cumulative and delta), and
 aggregation refers to how you send off the metrics.
 
-"It’s most useful for [our] histograms," says Jacob. "When you record
+"It's most useful for [our] histograms," says Jacob. "When you record
 histograms, there are a few different kinds – DataDog and Statsd histograms are
-not true histograms because what they’re recording is like aggregation samples.
+not true histograms because what they're recording is like aggregation samples.
 They give you a min, max, count, average, and P95 or something. The problem with
 that is, in distributed computing, if you have multiple applications that are
-reporting a P95, there’s no way you can get a true P95 from that observation
+reporting a P95, there's no way you can get a true P95 from that observation
 with that aggregation," he continues.
 
-"The reason for that is, if you have five P95 observations, there’s not an
+"The reason for that is, if you have five P95 observations, there's not an
 aggregation to say, give me the overall P95 from that. You need to have
 something about the original data to recalculate it. You can get the average of
-the P95s but it’s not a great metric, it doesn't really tell you much. It's not
-really accurate. If you’re going to alert on something and page someone at
+the P95s but it's not a great metric, it doesn't really tell you much. It's not
+really accurate. If you're going to alert on something and page someone at
 night, you should be paging on accurate measurements."
 
 Initially, they did have a few people who relied on the min, max, sum, count
@@ -207,13 +207,13 @@ other components, which was really neat."
 
 When Jacob started the OTel migration, it was still too early for logs. "The
 thing we would change," he says, "is how we collect those logs, potentially; we
-previously did it using Google’s log agent, basically running
+previously did it using Google's log agent, basically running
 [fluentbit](https://fluentbit.io) on every node in a GKE cluster and then they
 send it off to GCP and we tail it there." He notes that there may have been
 recent changes to this that he's not aware of at this time.
 
-"For a long time, we’ve used span events and logs for a lot of things
-internally," he says. "I’m a big fan of them." He is not as big a fan of
+"For a long time, we've used span events and logs for a lot of things
+internally," he says. "I'm a big fan of them." He is not as big a fan of
 logging, sharing that he thinks they are "cumbersome and expensive." He suggests
 that users opt for tracing and trace logs whenever possible, although he does
 like logging for local development, and tracing for distributed development."
@@ -276,11 +276,11 @@ components that you'll need to monitor.
 "In OTel, we tack on this
 [Prometheus receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/prometheusreceiver/README.md)
 to get all this data, but because we want to be more efficient than Prometheus,
-because we don’t need to store the data, we have this component called the
+because we don't need to store the data, we have this component called the
 Target Allocator, which goes to do the service discovery from Prometheus," says
 Jacob. "It says give me all the targets I need to scrape. Then the Target
 Allocator says: with these targets, distribute them evenly among the set of
-collectors that’s running."
+collectors that's running."
 
 That's the main thing this component does, and it also helps with job discovery.
 If you're using Prometheus service monitors, which is part of the
@@ -303,31 +303,29 @@ to run this."
 ### The Collector setup
 
 Jacob's team runs a lot of different types of Collectors over at Lightstep. "We
-run metrics things, tracing things, internal ones, external ones – there’s a lot
+run metrics things, tracing things, internal ones, external ones – there's a lot
 of different collectors that are running at all times", he shares.
 
-"It’s all very in-flux." They're changing things around a lot to run
+"It's all very in-flux." They're changing things around a lot to run
 experiments, since the best way for them to create features for customers and
 end users is to make sure they work internally first.
 
 "We're running in a single path where there could be two collectors in two
 environments that could be running two different images and two different
 versions. It gets really meta and really confusing to talk about," he says. "And
-then, if you’re sending Collector A across an environment to Collector B,
+then, if you're sending Collector A across an environment to Collector B,
 Collector B also emits telemetry about itself, which is then collected by
 Collector C, so it just chains."
 
 In a nutshell, you need to make sure that the collector is actually working.
-"That’s like the problem when we’re debugging this stuff. When there’s a problem
+"That's like the problem when we're debugging this stuff. When there's a problem
 you have to think up where the problem actually is -- is it in how we collect
 the data, is it in how we emit the data, is it in the source of how the data was
 generated? One of a bunch of things."
 
 ### Kubernetes modes on OTel
 
-The OTel Operator supports four
-[deployment modes](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md#opentelemetrycollectorspec)
-for the OTel Collector in Kubernetes:
+The OTel Operator supports [four deployment modes](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/opentelemetrycollectors.md) in Kubernetes.
 
 - [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) -
   see example
@@ -346,19 +344,18 @@ Which ones you should use depends on what you need to do, such as how you like
 to run applications for reliability.
 
 "Sidecar is the one we use the least and is probably used the least across the
-industry if I had to make a bet," Jacob says. "They’re expensive. If you don’t
-really need them, then you shouldn’t use them." An example of something run as a
+industry if I had to make a bet," Jacob says. "They're expensive. If you don't
+really need them, then you shouldn't use them." An example of something run as a
 sidecar is Istio, "which makes a lot of sense to run as a sidecar because it
 does proxy traffic and it hooks into your container network to change how it all
 does its thing."
 
 You will get a cost hit if you sidecar your Collectors for all your services,
-and you also have limited capabilities. He says, "If you’re making Kubernetes
-APIs calls or attribute enrichment, that’s the thing that would get
-exponentially expensive if you’re running as a sidecar." He shares an example:
-"...if you have sidecar [Collector using the
+and you also have limited capabilities. He says, "If you're making Kubernetes
+APIs calls or attribute enrichment, that's the thing that would get
+exponentially expensive if you're running as a sidecar." He shares an example: "...if you have sidecar [Collector using the
 [k8sattributesprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor)]
-on 10k pods, then that’s 10k API calls made to the K8s API. That's expensive."
+on 10k pods, then that's 10k API calls made to the K8s API. That's expensive."
 
 On the other hand, if you have five pods deployed on StatefulSets, "that's not
 that expensive." When you run in StatefulSet mode, you get an exact number of
@@ -370,7 +367,7 @@ which is why it's required. Another thing that StatefulSets guarantee is
 something called in-place deployment, which is also available with DaemonSets;
 this is where you take the pod down before you create a new one.
 
-"In a deployment you usually do a 1-up, 1-down, or what’s called a
+"In a deployment you usually do a 1-up, 1-down, or what's called a
 [rolling deployment](https://www.techtarget.com/searchitoperations/definition/rolling-deployment),
 or rolling update," Jacob says. If you were doing this with the Target
 Allocator, you are likely to get much more unreliable scrapes. This is because
@@ -380,30 +377,30 @@ the hashes you've assigned.
 
 Whereas with StatefulSets, this isn't necessary, since you get a consistent ID
 range. "So when you do 1-down 1 up, it keeps the same targets each time. So like
-a placeholder for it – you don’t have to recalculate the ring," he explains.
+a placeholder for it – you don't have to recalculate the ring," he explains.
 
 He notes that this is really only useful as a metrics use case, where you're
 scraping Prometheus. He notes that they'd probably run it as a Deployment for
 anything else, since that mode gives you most everything you would need.
 Collectors are usually stateless, so there is no need for them to hold on to
 anything, and Deployments are leaner as a result. "You can just run and roll out
-and everyone’s happy," he says. "That’s how we run most of our collectors, is
+and everyone's happy," he says. "That's how we run most of our collectors, is
 just as a Deployment."
 
 For per-node scraping, DaemonSets come in handy. "This allows you to scrape the
-kubelet that’s run on every node, it allows you to scrape the node exporter
-that’s also run on every node, which is another Prometheus daemonset that most
+kubelet that's run on every node, it allows you to scrape the node exporter
+that's also run on every node, which is another Prometheus daemonset that most
 people run," he explains.
 
 DaemonSets are useful for scaling out, since they guarantee that you've got pods
 running on every node that matches its selector. "If you have a cluster of 800+
-nodes, it’s more reliable to run a bunch of little collectors that get those
+nodes, it's more reliable to run a bunch of little collectors that get those
 tiny metrics, rather than a few bigger stateful set pods because your blast
 radius is much lower," he says.
 
 "If one pod goes down, you lose just a tiny bit of data, but remember, with all
-this cardinality stuff, that’s a lot of memory. So if you’re doing a
-StatefulSet, scraping all these nodes, that’s a lot of targets, that’s a lot of
+this cardinality stuff, that's a lot of memory. So if you're doing a
+StatefulSet, scraping all these nodes, that's a lot of targets, that's a lot of
 memory, it can go down much more easily and you can lose more data."
 
 If a Collector goes down, it comes back up quickly, since it is usually
@@ -418,10 +415,10 @@ scale on, and you can distribute targets and load-balance.
 
 "Pull-based is like the reason that Prometheus is so ubiquitous... because it
 makes local development really easy, where you can just scrape your local
-endpoint, that’s what most backend development is anyway," he says. "You can hit
+endpoint, that's what most backend development is anyway," he says. "You can hit
 endpoint A and then hit your metrics endpoint. Then hit endpoint A again and
-then metrics endpoint, and check that, so it’s an easy developer loop. It also
-means you don’t have to reach outside of the network so if you have really
+then metrics endpoint, and check that, so it's an easy developer loop. It also
+means you don't have to reach outside of the network so if you have really
 strict proxy requirements to send data, local dev is much easier for that.
 That's why OTel now has a really good Prometheus exporter, so it can do both."
 
@@ -451,8 +448,8 @@ He recommends using Dependabot, which they use in OTel. OTel packages update in
 lockstep, which means you have to update "a fair amount of packages at once, but
 it does do it all for you, which is nice," he says. However, you should be doing
 this with all your dependencies, as "CVEs happen in the industry constantly. If
-you're not staying up to date with vulnerability fixes then you’re opening
-yourself up to security attacks, which you don’t want. 'Do something about it'
+you're not staying up to date with vulnerability fixes then you're opening
+yourself up to security attacks, which you don't want. 'Do something about it'
 is my recommendation."
 
 ## Additional Resources
@@ -469,7 +466,7 @@ is my recommendation."
 
 ## Final Thoughts
 
-OpenTelemetry is all about community, and we wouldn’t be where we are without
+OpenTelemetry is all about community, and we wouldn't be where we are without
 our contributors, maintainers, and users. We value user feedback -- please share
 your experiences and help us improve OpenTelemetry.
 

--- a/content/en/blog/2024/otel-operator-q-and-a/index.md
+++ b/content/en/blog/2024/otel-operator-q-and-a/index.md
@@ -36,7 +36,7 @@ easier. It does the following:
 
 I've had a chance to use the Operator in the last year, and learned some pretty
 cool things, so I thought it might be helpful to share some little OTel Operator
-goodies that I’ve picked up along the way, in the form of a Q&A.
+goodies that I've picked up along the way, in the form of a Q&A.
 
 Please note that this post assumes that you have some familiarity with
 OpenTelemetry, the [OpenTelemetry Collector](/docs/collector/), the
@@ -55,7 +55,7 @@ Longer answer: OTel Collector can be fed more than one Collector config YAML
 file. That way, you can keep your base configurations in, say,
 `otelcol-config.yaml`, and overrides or additions to the base configuration can
 go in, for example, `otelcol-config-extras.yaml`. See an example of this in the
-[OTel Demo’s Docker compose file](https://github.com/open-telemetry/opentelemetry-demo/blob/06f020c97f78ae9625d3a4a5d1107c55045c567f/docker-compose.yml#L665-L668).
+[OTel Demo's Docker compose file](https://github.com/open-telemetry/opentelemetry-demo/blob/06f020c97f78ae9625d3a4a5d1107c55045c567f/docker-compose.yml#L665-L668).
 
 Unfortunately, while the OTel Collector supports multiple Collector
 configuration files, the Collector managed by the OTel Operator does not.
@@ -86,18 +86,18 @@ data to a vendor backend.
 When using the OpenTelemetry Operator to manage the OTel Collector, the OTel
 Collector config YAML is defined in the
 [OpenTelemetryCollector](https://github.com/open-telemetry/opentelemetry-operator?tab=readme-ov-file#getting-started)
-CR. This file should be version-controlled and therefore shouldn’t contain any
+CR. This file should be version-controlled and therefore shouldn't contain any
 sensitive data, including access tokens stored as plain text.
 
 Fortunately, the `OpenTelemetryCollector` CR gives us a way to reference that
-value as a secret. Here’s how you do it:
+value as a secret. Here's how you do it:
 
 1- Create a Kubernetes secret for your access token. Remember to
 [base-64 encode](https://www.base64encode.org/) the secret.
 
 2-
 [Expose the secret as an environment variable](https://kubernetes.io/docs/concepts/configuration/secret/#using-a-secret)
-by adding it to the `OpenTelemetryCollector` CR’s
+by adding it to the `OpenTelemetryCollector` CR's
 [`env` section](https://github.com/avillela/otel-target-allocator-talk/blob/21e9643e28165e39bd79f3beec7f2b1f989d87e9/src/resources/02-otel-collector-ls.yml#L16-L21).
 For example:
 
@@ -201,8 +201,7 @@ to authenticate against that private registry. For more info on how to use
 `imagePullSecrets` for your Collector image, see
 [the instructions](https://github.com/open-telemetry/opentelemetry-operator?tab=readme-ov-file#using-imagepullsecrets).
 
-For more info, check out the
-[OpenTelemetryCollector CR API docs](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md#opentelemetrycollector).
+You can use `imagePullSecrets` for the Collector image. See the [OpenTelemetry Collector CR API documentation](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/opentelemetrycollectors.md) for more details.
 
 ### Q5: Does the Target Allocator work for all deployment types?
 
@@ -218,7 +217,7 @@ For more info, see
 
 Yes, you do. These CRs are bundled with the
 [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator);
-however, they can be installed standalone, which means that you don’t need to
+however, they can be installed standalone, which means that you don't need to
 install the Prometheus Operator just to use these two CRs with the Target
 Allocator.
 
@@ -240,23 +239,23 @@ kubectl --context kind-otel-target-allocator-talk apply -f https://raw.githubuse
 ```
 
 See my
-[example of the OpenTelemetry Operator’s Target Allocator with `ServiceMonitor`](https://github.com/avillela/otel-target-allocator-talk/tree/main?tab=readme-ov-file#3b--kubernetes-deployment-servicenow-cloud-observability-backend).
+[example of the OpenTelemetry Operator's Target Allocator with `ServiceMonitor`](https://github.com/avillela/otel-target-allocator-talk/tree/main?tab=readme-ov-file#3b--kubernetes-deployment-servicenow-cloud-observability-backend).
 
 ### Q7: Do I need to create a service account to use the Target Allocator?
 
-No, but you do need to do a bit of extra work. So, here’s the deal…although you
+No, but you do need to do a bit of extra work. So, here's the deal...although you
 need a
 [service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/)
-to use the Target Allocator, you don’t have to create your own.
+to use the Target Allocator, you don't have to create your own.
 
-If you enable the Target Allocator and don’t create a service account, one is
-automagically created for you. This service account’s default name is a
+If you enable the Target Allocator and don't create a service account, one is
+automagically created for you. This service account's default name is a
 concatenation of the Collector name (`metadata.name` in the
 `OpenTelemetryCollector` CR) and `-collector`. For example, if your Collector is
 called `mycollector`, then your service account would be called
 `mycollector-collector`.
 
-By default, this service account has no defined policy. This means that you’ll
+By default, this service account has no defined policy. This means that you'll
 still need to create your own
 [`ClusterRole`](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole)
 and
@@ -272,6 +271,8 @@ for more on Target Allocator RBAC configuration.
 > [PR](https://github.com/open-telemetry/opentelemetry-operator/pull/2787)), as
 > part of version `0.100.0`.
 
+The Operator automatically creates a service account for the Target Allocator. See the [Target Allocator API documentation](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/targetallocators.md) for more details.
+
 ### Q8: Can I override the Target Allocator base image?
 
 Just like you can override the Collector base image in the
@@ -279,9 +280,9 @@ Just like you can override the Collector base image in the
 image.
 
 Please keep in mind that
-[it’s usually best to keep the Target Allocator and OTel operator versions the same](https://cloud-native.slack.com/archives/C033BJ8BASU/p1709128862949249?thread_ts=1709081221.484429&cid=C033BJ8BASU),
+[it's usually best to keep the Target Allocator and OTel operator versions the same](https://cloud-native.slack.com/archives/C033BJ8BASU/p1709128862949249?thread_ts=1709081221.484429&cid=C033BJ8BASU),
 to avoid any compatibility issues. If do you choose to override the Target
-Allocator’s base image, you can do so by adding `spec.targetAllocator.image` in
+Allocator's base image, you can do so by adding `spec.targetAllocator.image` in
 the `OpenTelemetryCollector` CR. You can also specify the number of replicas by
 adding `spec.targetAllocator.replicas`. This is totally independent of whether
 or not you override the TA image.
@@ -308,21 +309,21 @@ Where:
 - `<number_of_replicas>` is the number of pod instances for the underlying
   Target Allocator
 
-### Q9: If it’s not recommended that you override the Target Allocator base image, then why would you want to?
+### Q9: If it's not recommended that you override the Target Allocator base image, then why would you want to?
 
 One use case might be
 [if you need to host a mirror of the Target Allocator image in your own private container registry for security purposes](https://cloud-native.slack.com/archives/C033BJ8BASU/p1713894678225579).
 
 If you do need to reference a Target Allocator image from a private registry,
-you’ll need to use `imagePullSecrets`. For details, see
+you'll need to use `imagePullSecrets`. For details, see
 [the instructions](https://github.com/open-telemetry/opentelemetry-operator?tab=readme-ov-file#using-imagepullsecrets).
-Note that you don’t need to create a `serviceAccount` for the Target Allocator,
-since once is already created for you automagically if you don’t create one
+Note that you don't need to create a `serviceAccount` for the Target Allocator,
+since once is already created for you automagically if you don't create one
 yourself (see
 [Q7](#q7-do-i-need-to-create-a-service-account-to-use-the-target-allocator)).
 
 For more info, check out the
-[Target Allocator API docs](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md#opentelemetrycollectorspectargetallocator).
+[Target Allocator API docs](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/targetallocators.md).
 
 ### Q10: Is there a version lag between the OTel Operator auto-instrumentation and auto-instrumentation of supported languages?
 
@@ -334,7 +335,7 @@ details, see this
 
 ## Final thoughts
 
-Hopefully this has helped to demystify the OTel Operator a bit more. There’s
+Hopefully this has helped to demystify the OTel Operator a bit more. There's
 definitely a lot going on, and the OTel Operator can certainly be a bit scary at
 first, but understanding some of the basics will get you well on your way to
 mastering this powerful tool.

--- a/content/en/docs/platforms/kubernetes/operator/automatic.md
+++ b/content/en/docs/platforms/kubernetes/operator/automatic.md
@@ -44,7 +44,7 @@ component. If you chose not to use a Collector, you can skip to the next
 section.
 
 The Operator provides a
-[Custom Resource Definition (CRD) for the OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md#opentelemetrycollector)
+[Custom Resource Definition (CRD) for the OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/opentelemetrycollectors.md)
 which is used to create an instance of the Collector that the Operator manages.
 The following example deploys the Collector as a deployment (the default), but
 there are other
@@ -109,7 +109,7 @@ an endpoint for auto-instrumentation in your pods.
 To be able to manage automatic instrumentation, the Operator needs to be
 configured to know what pods to instrument and which automatic instrumentation
 to use for those pods. This is done via the
-[Instrumentation CRD](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md#instrumentation).
+[Instrumentation CRD](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/instrumentations.md).
 
 Creating the Instrumentation resource correctly is paramount to getting
 auto-instrumentation working. Making sure all endpoints and env vars are correct
@@ -546,7 +546,7 @@ your deployment.
 ## Add annotations to existing deployments
 
 The final step is to opt in your services to automatic instrumentation. This is
-done by updating your service’s `spec.template.metadata.annotations` to include
+done by updating your service's `spec.template.metadata.annotations` to include
 a language-specific annotation:
 
 - .NET: `instrumentation.opentelemetry.io/inject-dotnet: "true"`
@@ -689,7 +689,7 @@ kubectl logs -l app.kubernetes.io/name=opentelemetry-operator --container manage
 ### Were the resources deployed in the right order?
 
 Order matters! The `Instrumentation` resource needs to be deployed before
-deploying the application, otherwise the auto-instrumentation won’t work.
+deploying the application, otherwise the auto-instrumentation won't work.
 
 Recall the auto-instrumentation annotation:
 
@@ -699,18 +699,18 @@ annotations:
 ```
 
 The annotation above tells the OTel Operator to look for an `Instrumentation`
-object in the pod’s namespace. It also tells the Operator to inject Python
+object in the pod's namespace. It also tells the Operator to inject Python
 auto-instrumentation into the pod.
 
 When the pod starts up, the annotation tells the Operator to look for an
-Instrumentation object in the pod’s namespace, and to inject
+Instrumentation object in the pod's namespace, and to inject
 auto-instrumentation into the pod. It adds an
 [init-container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)
 to the application's pod, called `opentelemetry-auto-instrumentation`, which is
 then used to injects the auto-instrumentation into the app container.
 
-If the `Instrumentation` resource isn’t present by the time the application is
-deployed, however, the init-container can’t be created. Therefore, if the
+If the `Instrumentation` resource isn't present by the time the application is
+deployed, however, the init-container can't be created. Therefore, if the
 application is deployed _before_ deploying the `Instrumentation` resource, the
 auto-instrumentation will fail.
 
@@ -732,11 +732,11 @@ If the output is missing `Created` and/or `Started` entries for
 `opentelemetry-auto-instrumentation`, then it means that there is an issue with
 your auto-instrumentation. This can be the result of any of the following:
 
-- The `Instrumentation` resource wasn’t installed (or wasn’t installed
+- The `Instrumentation` resource wasn't installed (or wasn't installed
   properly).
 - The `Instrumentation` resource was installed _after_ the application was
   deployed.
-- There’s an error in the auto-instrumentation annotation, or the annotation in
+- There's an error in the auto-instrumentation annotation, or the annotation in
   the wrong spot — see #4 below.
 
 Be sure to check the output of `kubectl get events` for any errors, as these
@@ -760,7 +760,7 @@ Here are a few things to check for:
   defining a `Deployment`, annotations can be added in one of two locations:
   `spec.metadata.annotations`, and `spec.template.metadata.annotations`. The
   auto-instrumentation annotation needs to be added to
-  `spec.template.metadata.annotations`, otherwise it won’t work.
+  `spec.template.metadata.annotations`, otherwise it won't work.
 
 ### Was the auto-instrumentation endpoint configured correctly?
 
@@ -787,5 +787,5 @@ Here, the Collector endpoint is set to
 `demo-collector` is the name of the OTel Collector Kubernetes `Service`. In the
 above example, the Collector is running in a different namespace from the
 application, which means that `opentelemetry.svc.cluster.local` must be appended
-to the Collector’s service name, where `opentelemetry` is the namespace in which
+to the Collector's service name, where `opentelemetry` is the namespace in which
 the Collector resides.

--- a/content/en/docs/platforms/kubernetes/operator/troubleshooting/target-allocator.md
+++ b/content/en/docs/platforms/kubernetes/operator/troubleshooting/target-allocator.md
@@ -3,12 +3,12 @@ title: Target Allocator
 cSpell:ignore: bleh targetallocator
 ---
 
-If you’ve enabled
+If you've enabled
 [Target Allocator](/docs/platforms/kubernetes/operator/target-allocator/)
 service discovery on the
 [OpenTelemetry Operator](/docs/platforms/kubernetes/operator/), and the Target
 Allocator is failing to discover scrape targets, there are a few troubleshooting
-steps that you can take to help you understand what’s going on and restore
+steps that you can take to help you understand what's going on and restore
 normal operation.
 
 ## Troubleshooting steps
@@ -18,9 +18,9 @@ normal operation.
 As a first step, make sure that you have deployed all relevant resources to your
 Kubernetes cluster.
 
-### Do you know if metrics are actually being scraped?
+### Do you know if metrics are actually being scraped?
 
-After you’ve deployed all of your resources to Kubernetes, make sure that the
+After you've deployed all of your resources to Kubernetes, make sure that the
 Target Allocator is discovering scrape targets from your
 [`ServiceMonitor`](https://prometheus-operator.dev/docs/getting-started/design/#servicemonitor)(s)
 or [PodMonitor]s.
@@ -294,12 +294,12 @@ for more information on the `/jobs` endpoint.
 
 ### Is the Target Allocator enabled? Is Prometheus service discovery enabled?
 
-If the `curl` commands above don’t show a list of expected `ServiceMonitor`s and
+If the `curl` commands above don't show a list of expected `ServiceMonitor`s and
 `PodMonitor`s, you need to check whether the features that populate those values
 are turned on.
 
 One thing to remember is that just because you include the `targetAllocator`
-section in the `OpenTelemetryCollector` CR doesn’t mean that it’s enabled. You
+section in the `OpenTelemetryCollector` CR doesn't mean that it's enabled. You
 need to explicitly enable it. Furthermore, if you want to use
 [Prometheus service discovery](https://github.com/open-telemetry/opentelemetry-operator/blob/main/cmd/otel-allocator/README.md#discovery-of-prometheus-custom-resources),
 you must explicitly enable it:
@@ -333,10 +333,10 @@ If you configured a
 [`ServiceMonitor`](https://observability.thomasriley.co.uk/prometheus/configuring-prometheus/using-service-monitors/)
 selector, it means that the Target Allocator only looks for `ServiceMonitors`
 having a `metadata.label` that matches the value in
-[`serviceMonitorSelector`](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md#opentelemetrycollectorspectargetallocatorprometheuscr-1).
+[`serviceMonitorSelector`](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/targetallocators.md#prometheuscr).
 
 Suppose that you configured a
-[`serviceMonitorSelector`](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md#opentelemetrycollectorspectargetallocatorprometheuscr-1)
+[`serviceMonitorSelector`](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/targetallocators.md#prometheuscr)
 for your Target Allocator, like in the following example:
 
 ```yaml
@@ -386,8 +386,8 @@ Allocator will fail to discover scrape targets from that `ServiceMonitor`.
 
 {{% alert title="Tip" %}}
 
-The same applies if you’re using a [PodMonitor]. In that case, you would use a
-[`podMonitorSelector`](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md#opentelemetrycollectorspectargetallocatorprometheuscr)
+The same applies if you're using a [PodMonitor]. In that case, you would use a
+[`podMonitorSelector`](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/targetallocators.md#prometheuscr)
 instead of a `serviceMonitorSelector`.
 
 {{% /alert %}}
@@ -401,13 +401,13 @@ results in the Target Allocator failing to discover scrape targets from your
 `ServiceMonitors` and `PodMonitors`, respectively.
 
 Similarly, in
-[`v1beta1`](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md#opentelemetrycollector-1)
+[`v1beta1`](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/opentelemetrycollectors.md)
 of the `OpenTelemetryCollector` CR, leaving out this configuration altogether
 also results in the Target Allocator failing to discover scrape targets from
 your `ServiceMonitors` and `PodMonitors`.
 
 As of `v1beta1` of the `OpenTelemetryOperator`, a `serviceMonitorSelector` and
-`podMonitorSelector` must be included, even if you don’t intend to use it, like
+`podMonitorSelector` must be included, even if you don't intend to use it, like
 this:
 
 ```yaml
@@ -485,7 +485,7 @@ spec:
 
 The following `Service` resource would not be picked up, because the
 `ServiceMonitor` is looking for ports named `prom`, `py-client-port`, _or_
-`py-server-port`, and this service’s port is called `bleh`.
+`py-server-port`, and this service's port is called `bleh`.
 
 ```yaml
 apiVersion: v1
@@ -507,7 +507,7 @@ spec:
 
 {{% alert title="Tip" %}}
 
-If you’re using `PodMonitor`, the same applies, except that it picks up
+If you're using `PodMonitor`, the same applies, except that it picks up
 Kubernetes pods that match on labels, namespaces, and named ports.
 
 {{% /alert %}}


### PR DESCRIPTION
The OpenTelemetry Operator repository recently refactored its API documentation structure, moving content from the single `docs/api.md` file to a directory-based structure with separate files for each component (`docs/api/opentelemetrycollectors.md`, `docs/api/instrumentations.md`, `docs/api/targetallocators.md`, etc.).

This PR updates all references to the old API documentation structure across our documentation files to point to the new locations:
- Updated links in `content/en/docs/platforms/kubernetes/operator/automatic.md`
- Updated links in `content/en/docs/platforms/kubernetes/operator/troubleshooting/target-allocator.md`
- Updated links in `content/en/blog/2023/end-user-q-and-a-04.md`
- Updated links in `content/en/blog/2024/otel-operator-q-and-a/index.md`
- Removed the temporary exclusion in `.htmltest.yml` since the links are now fixed

These changes ensure that users are directed to the correct, up-to-date API documentation when following links in our documentation.

Helps Fix #6237

I'm a relatively new contributor, so please let me know if I've missed anything or if there are any improvements I should make to this PR.