### PR TITLE
[chore] Clean up some UTF-8 encoded characters, fix links

### DIFF
--- a/.textlintrc.yml
+++ b/.textlintrc.yml
@@ -19,7 +19,7 @@ filters:
       # src attribute in figure Hugo template:
       - /src=".*?"/
       # Other:
-      - /<https?://.*?>/ # Raw URLs
+      - /<https?:\/\/.*?>/ # Raw URLs
 rules:
   terminology:
     defaultTerms: false

--- a/content/en/blog/2023/otterize-otel/index.md
+++ b/content/en/blog/2023/otterize-otel/index.md
@@ -47,7 +47,7 @@ with each other. You can then use that information for operational or security
 needs, such as determining the blast radius of a downtime or security incident.
 You can use the service graph to figure out where to start rolling out
 OpenTelemetry tracing, as that deployment tends to be more involved and requires
-the integration of the OpenTelemetry SDK into your source code.
+the integration of the OpenTelemetry SDK into your source code.
 
 While it was easy to use the OTel SDK for the network mapper, we can see why
 there's a bit of a chicken-and-egg problem here when you're looking into

--- a/content/en/docs/collector/building/receiver.md
+++ b/content/en/docs/collector/building/receiver.md
@@ -1137,14 +1137,14 @@ of now:
 ├── go.work.sum
 ├── ocb
 ├── otelcol-dev
-│   ├── components.go
-│   ├── components_test.go
-│   ├── go.mod
-│   ├── go.sum
-│   ├── main.go
-│   ├── main_others.go
-│   ├── main_windows.go
-│   └── otelcol-dev
+│   ├── components.go
+│   ├── components_test.go
+│   ├── go.mod
+│   ├── go.sum
+│   ├── main.go
+│   ├── main_others.go
+│   ├── main_windows.go
+│   └── otelcol-dev
 └── tailtracer
     ├── config.go
     ├── factory.go

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -246,11 +246,11 @@ least two potential contributors**, ideally three. Include the following task
 list in your issue as well:
 
 ```markdown
-- [ ] Contributors for the new language: @GITHUB_HANDLE1, @GITHUB_HANDLE2, ...
-- [ ] Localize site homepage to YOUR_LANGUAGE_NAME
-- [ ] Create an issue label for `lang:LANG_ID`
-- [ ] Create org-level group for `LANG_ID` approvers
-- [ ] Update components owners for `content/LANG_ID`
+- [ ] Contributors for the new language: @GITHUB_HANDLE1, @GITHUB_HANDLE2, ...
+- [ ] Localize site homepage to YOUR_LANGUAGE_NAME
+- [ ] Create an issue label for `lang:LANG_ID`
+- [ ] Create org-level group for `LANG_ID` approvers
+- [ ] Update components owners for `content/LANG_ID`
 - [ ] Set up spell checking, if a cSpell dictionary is available
 ```
 

--- a/content/en/docs/platforms/kubernetes/operator/troubleshooting/target-allocator.md
+++ b/content/en/docs/platforms/kubernetes/operator/troubleshooting/target-allocator.md
@@ -3,12 +3,12 @@ title: Target Allocator
 cSpell:ignore: bleh targetallocator
 ---
 
-If you’ve enabled
+If you've enabled
 [Target Allocator](/docs/platforms/kubernetes/operator/target-allocator/)
 service discovery on the
 [OpenTelemetry Operator](/docs/platforms/kubernetes/operator/), and the Target
 Allocator is failing to discover scrape targets, there are a few troubleshooting
-steps that you can take to help you understand what’s going on and restore
+steps that you can take to help you understand what's going on and restore
 normal operation.
 
 ## Troubleshooting steps
@@ -18,9 +18,9 @@ normal operation.
 As a first step, make sure that you have deployed all relevant resources to your
 Kubernetes cluster.
 
-### Do you know if metrics are actually being scraped?
+### Do you know if metrics are actually being scraped?
 
-After you’ve deployed all of your resources to Kubernetes, make sure that the
+After you've deployed all of your resources to Kubernetes, make sure that the
 Target Allocator is discovering scrape targets from your
 [`ServiceMonitor`](https://prometheus-operator.dev/docs/getting-started/design/#servicemonitor)(s)
 or [PodMonitor]s.
@@ -294,12 +294,12 @@ for more information on the `/jobs` endpoint.
 
 ### Is the Target Allocator enabled? Is Prometheus service discovery enabled?
 
-If the `curl` commands above don’t show a list of expected `ServiceMonitor`s and
+If the `curl` commands above don't show a list of expected `ServiceMonitor`s and
 `PodMonitor`s, you need to check whether the features that populate those values
 are turned on.
 
 One thing to remember is that just because you include the `targetAllocator`
-section in the `OpenTelemetryCollector` CR doesn’t mean that it’s enabled. You
+section in the `OpenTelemetryCollector` CR doesn't mean that it's enabled. You
 need to explicitly enable it. Furthermore, if you want to use
 [Prometheus service discovery](https://github.com/open-telemetry/opentelemetry-operator/blob/main/cmd/otel-allocator/README.md#discovery-of-prometheus-custom-resources),
 you must explicitly enable it:
@@ -325,7 +325,7 @@ spec:
 ```
 
 See the full `OpenTelemetryCollector`
-[resource definition in "Do you know if metrics are actually being scraped?"](#do-you-know-if-metrics-are-actually-beingscraped).
+[resource definition in "Do you know if metrics are actually being scraped?"](#do-you-know-if-metrics-are-actually-being-scraped).
 
 ### Did you configure a ServiceMonitor (or PodMonitor) selector?
 
@@ -374,7 +374,7 @@ spec:
 ```
 
 See the full `ServiceMonitor`
-[resource definition in "Do you know if metrics are actually being scraped?"](#do-you-know-if-metrics-are-actually-beingscraped).
+[resource definition in "Do you know if metrics are actually being scraped?"](#do-you-know-if-metrics-are-actually-being-scraped).
 
 In this case, the `OpenTelemetryCollector` resource's
 `prometheusCR.serviceMonitorSelector.matchLabels` is looking only for
@@ -386,7 +386,7 @@ Allocator will fail to discover scrape targets from that `ServiceMonitor`.
 
 {{% alert title="Tip" %}}
 
-The same applies if you’re using a [PodMonitor]. In that case, you would use a
+The same applies if you're using a [PodMonitor]. In that case, you would use a
 [`podMonitorSelector`](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md#opentelemetrycollectorspectargetallocatorprometheuscr)
 instead of a `serviceMonitorSelector`.
 
@@ -407,7 +407,7 @@ also results in the Target Allocator failing to discover scrape targets from
 your `ServiceMonitors` and `PodMonitors`.
 
 As of `v1beta1` of the `OpenTelemetryOperator`, a `serviceMonitorSelector` and
-`podMonitorSelector` must be included, even if you don’t intend to use it, like
+`podMonitorSelector` must be included, even if you don't intend to use it, like
 this:
 
 ```yaml
@@ -419,7 +419,7 @@ prometheusCR:
 
 This configuration means that it will match on all `PodMonitor` and
 `ServiceMonitor` resources. See the
-[full OpenTelemetryCollector definition in "Do you know if metrics are actually being scraped?"](#do-you-know-if-metrics-are-actually-beingscraped).
+[full OpenTelemetryCollector definition in "Do you know if metrics are actually being scraped?"](#do-you-know-if-metrics-are-actually-being-scraped).
 
 ### Do your labels, namespaces, and ports match for your ServiceMonitor and your Service (or PodMonitor and your Pod)?
 
@@ -485,7 +485,7 @@ spec:
 
 The following `Service` resource would not be picked up, because the
 `ServiceMonitor` is looking for ports named `prom`, `py-client-port`, _or_
-`py-server-port`, and this service’s port is called `bleh`.
+`py-server-port`, and this service's port is called `bleh`.
 
 ```yaml
 apiVersion: v1
@@ -507,7 +507,7 @@ spec:
 
 {{% alert title="Tip" %}}
 
-If you’re using `PodMonitor`, the same applies, except that it picks up
+If you're using `PodMonitor`, the same applies, except that it picks up
 Kubernetes pods that match on labels, namespaces, and named ports.
 
 {{% /alert %}}

--- a/content/ja/docs/contributing/localization.md
+++ b/content/ja/docs/contributing/localization.md
@@ -199,11 +199,11 @@ OpenTelemetry ウェブサイトの新しい言語のローカリゼーション
 また、イシューに以下のタスクリストも含めてください。
 
 ```markdown
-- [ ] Contributors for the new language: @GITHUB_HANDLE1, @GITHUB_HANDLE2, ...
-- [ ] Localize site homepage to YOUR_LANGUAGE_NAME
-- [ ] Create an issue label for `lang:LANG_ID`
-- [ ] Create org-level group for `LANG_ID` approvers
-- [ ] Update components owners for `content/LANG_ID`
+- [ ] Contributors for the new language: @GITHUB_HANDLE1, @GITHUB_HANDLE2, ...
+- [ ] Localize site homepage to YOUR_LANGUAGE_NAME
+- [ ] Create an issue label for `lang:LANG_ID`
+- [ ] Create org-level group for `LANG_ID` approvers
+- [ ] Update components owners for `content/LANG_ID`
 - [ ] Set up spell checking, if a cSpell dictionary is available
 ```
 

--- a/content/pt/docs/concepts/signals/traces.md
+++ b/content/pt/docs/concepts/signals/traces.md
@@ -344,7 +344,7 @@ explicitamente definido por um usuário. Isso é útil em qualquer situação em
 um desenvolvedor deseje que não haja outra interpretação de um trecho além de
 "bem-sucedido".
 
-Para reiterar: `Unset` representa um trecho que foi concluído sem erro. `OK`
+Para reiterar: `Unset` representa um trecho que foi concluído sem erro. `OK`
 representa quando um desenvolvedor marca explicitamente um trecho como
 bem-sucedido. Na maioria dos casos, não é necessário marcar explicitamente um
 trecho como OK.

--- a/layouts/shortcodes/ecosystem/vendor-table.md
+++ b/layouts/shortcodes/ecosystem/vendor-table.md
@@ -18,8 +18,8 @@ cSpell:ignore: cial cond
   {{ .name }} |
   {{- cond .oss "Yes" "No" }} |
   {{- cond .commercial "Yes" "No" }} |
-  {{- cond .nativeOTLP "Yes" "No" }} |
-  {{- /* */}} [{{ $shortUrl }}]({{ .url }}) |
+  {{- cond .nativeOTLP "Yes" "No" }} |
+  {{- /* */}} [{{ $shortUrl }}]({{ .url }}) |
 {{- end }}
 
 [^org]: Organizations are grouped as follows based on their OTel support:


### PR DESCRIPTION
- Inspired by the GH action failures of #6448, namely the link-check issues reported by https://github.com/open-telemetry/opentelemetry.io/actions/runs/13605322132/job/38036110496
- Replaces UTF-8 encoded non-breaking spaces by regular spaces (I didn't see any use that justified using `&nbsp;` instead of a regular space).
- Replaced UTF-8 encoded apostrophes in one file (the one touched by #6448) by a "plain" `'`.