### PR TITLE
Fix flowchart syntax

### DIFF
--- a/content/en/blog/2024/prom-and-otel/index.md
+++ b/content/en/blog/2024/prom-and-otel/index.md
@@ -271,9 +271,9 @@ flowchart RL
   oc1 --> ta
   oc2 --> ta
   oc3 --> ta
-  sm ~~~|"1. Discover Prometheus Operator CRs"| sm
-  ta ~~~|"2. Add job to TA scrape configuration"| ta
-  oc3 ~~~|"3. Add job to OTel Collector scrape configuration"| oc3
+  sm ~~~|1#46; Discover Prometheus Operator CRs| sm
+  ta ~~~|2#46; Add job to TA scrape configuration| ta
+  oc3 ~~~|3#46; Add job to OTel Collector scrape configuration| oc3
 ```
 
 Even though Prometheus is not required to be installed in your Kubernetes


### PR DESCRIPTION
The Mermaid chart under *Discovery* currently renders with an error:
```
Unsupported markdown: list
```

Quotation marks are used to escape [characters that break Mermaid's own syntax](https://mermaid.js.org/syntax/flowchart.html#special-characters-that-break-syntax).  For Markdown escaping, [entity codes](https://mermaid.js.org/syntax/flowchart.html#entity-codes-to-escape-characters) have to be used.