### PR TITLE
[i18n] Display page-outdated banner for non-en pages that have drifted

### DIFF
--- a/content/ja/docs/collector/_index.md
+++ b/content/ja/docs/collector/_index.md
@@ -5,6 +5,7 @@ cascade:
   vers: 0.120.0
 weight: 270
 default_lang_commit: cd90ab77550fb2e92ca37cb3c753ec2d8bb7d8dc
+drifted_from_default: true
 ---
 
 ![Jaeger、OTLP、Prometheusを統合したOpenTelemetryコレクターのダイアグラム](img/otel-collector.svg)

--- a/content/ja/docs/demo/architecture.md
+++ b/content/ja/docs/demo/architecture.md
@@ -4,6 +4,7 @@ linkTitle: アーキテクチャ
 aliases: [current_architecture]
 body_class: otel-mermaid-max-width
 default_lang_commit: fd7da211d5bc37ca93112a494aaf6a94445e2e28
+drifted_from_default: true
 ---
 
 **OpenTelemetryデモ** は、異なるプログラミング言語で書かれた複数のマイクロサービスから構成されており、gRPCとHTTPを使って相互に通信を行います。

--- a/content/ja/docs/demo/feature-flags.md
+++ b/content/ja/docs/demo/feature-flags.md
@@ -5,6 +5,7 @@ aliases:
   - services/feature-flag
   - services/featureflagservice
 default_lang_commit: 24146bd1368e4c6082c7d6077efd29dba0d51055
+drifted_from_default: true
 cSpell:ignore: loadgenerator OLJCESPC7Z
 ---
 

--- a/layouts/docs/td-content-after-header.html
+++ b/layouts/docs/td-content-after-header.html
@@ -43,7 +43,7 @@
               To see the changes to the English page since this page was last updated: visit
               {{ $compareUrl := printf "%s/compare/%s..%s"
                   .Site.Params.github_repo .Params.default_lang_commit $defaultLangPage.GitInfo.Hash -}}
-              <a href="{{ $compareUrl }}" class="external-link" target="_blank" rel="noopener">
+              <a href="{{ $compareUrl }}" class="external-link" target="_blank" rel="noopener" data-proofer-ignore>
                 GitHub compare
                 {{ substr .Params.default_lang_commit 0 8 }}..{{ $defaultLangPage.GitInfo.AbbreviatedHash -}}
               </a>

--- a/layouts/docs/td-content-after-header.html
+++ b/layouts/docs/td-content-after-header.html
@@ -1,28 +1,65 @@
 {{ $pageProseLang := partial "i18n/lang.html" . -}}
 {{ $siteLang := .Site.Language -}}
 
-{{/*
-
-The disable_translation_not_found_msg param isn't currently used and I suspect
-that we won't need it, but I'll wait until the following feature is implemented
-before removing the code:
-
-https://github.com/open-telemetry/opentelemetry.io/issues/6340
-
-*/ -}}
-
-{{ if and
-    (ne $siteLang $pageProseLang)
-    (not (.Param "disable_translation_not_found_msg"))
--}}
-  {{ with partial "_inline/ot-page-not-found-banner.html" . -}}
-  <div class="pageinfo pageinfo-secondary">
-    <div class="ps-4">
-      {{ . }}
+{{ if ne .Language.Lang "en" -}}
+  {{ if .Params.drifted_from_default -}}
+    {{ with partial "_inline/ot-page-drifted-banner.html" . -}}
+      {{ . -}}
+    {{ end -}}
+  {{ else if ne $siteLang $pageProseLang -}}
+    {{ with partial "_inline/ot-page-not-found-banner.html" . -}}
+    <div class="pageinfo pageinfo-secondary">
+      <div class="ps-4">
+        {{ . }}
+      </div>
     </div>
-  </div>
+    {{ end -}}
+  {{ else if false -}}
+    {{ with partial "_inline/ot-page-drifted-banner.html" . -}}
+      {{ . -}}
+    {{ end -}}
   {{ end -}}
 {{ end -}}
+
+
+{{ define "partials/_inline/ot-page-drifted-banner.html" }}
+  {{/* Assumption: .Params.drifted_from_default */ -}}
+
+  {{ $resultsArray := where .Translations "Lang" "en" -}}
+  {{ $defaultLangPage := index $resultsArray 0 -}}
+
+  <div class="pageinfo pageinfo-secondary">
+    <div class="ps-4">
+      <p>
+        <i class="fa-solid fa-triangle-exclamation" style="margin-left: -1.9rem; padding-right: 0.5rem;"></i>
+        The content of this page may be <b>outdated</b> and some links may be invalid.
+
+        {{- if and $defaultLangPage .Params.default_lang_commit }}
+          A <strong>newer version</strong> of this page exists in
+          <a href="{{ $defaultLangPage.RelPermalink }}">English</a>.
+          <details class="mt-2">
+            <summary>More information ...</summary>
+            <p>
+              To see the changes to the English page since this page was last updated: visit
+              {{ $compareUrl := printf "%s/compare/%s..%s"
+                  .Site.Params.github_repo .Params.default_lang_commit $defaultLangPage.GitInfo.Hash -}}
+              <a href="{{ $compareUrl }}" class="external-link" target="_blank" rel="noopener">
+                GitHub compare
+                {{ substr .Params.default_lang_commit 0 8 }}..{{ $defaultLangPage.GitInfo.AbbreviatedHash -}}
+              </a>
+              and search for
+              {{ $defLangPath := strings.TrimPrefix (add hugo.WorkingDir "/") $defaultLangPage.File.Filename -}}
+              <code>{{ $defLangPath }}</code>.
+            </p>
+          </details>
+        {{ else if not $defaultLangPage }}
+          This page no longer has a corresponding English page.
+        {{ end -}}
+      </p>
+    </div>
+</div>
+{{ end -}}
+
 
 {{ define "partials/_inline/ot-page-not-found-banner.html" }}
   {{ $path := "page-not-translated-msg.md" -}}
@@ -37,4 +74,3 @@ https://github.com/open-telemetry/opentelemetry.io/issues/6340
     {{ warnf "_inline/ot-page-not-found-banner: '%s' not found from page %s (%s)" $path .Page.Path $lang -}}
   {{ end -}}
 {{ end -}}
-

--- a/layouts/partials/i18n/fallback-page.html
+++ b/layouts/partials/i18n/fallback-page.html
@@ -2,7 +2,7 @@
 
   Returns the fallback page of this page, if it has one. A fallback page is a
   page in the default site language that has been mounted under this locale as a
-  fallback when this locale is missing a translation.
+  fallback when this locale is missing a page translation.
 
 */ -}}
 

--- a/scripts/check-i18n.sh
+++ b/scripts/check-i18n.sh
@@ -317,7 +317,7 @@ function main() {
     if [[ ! -e "$EN_VERSION" ]]; then
       ((FILE_PROCESSED_COUNT++))
       if [[ -z $FLAG_QUIET ]]; then
-        echo -e "File not found:\t$EN_VERSION - $f - $DEFAULT_LANG was removed or renamed"
+        echo -e "File not found:\t$f - $DEFAULT_LANG page was removed or renamed"
       fi
       set_file_drifted_status "$f" "file not found"
       continue


### PR DESCRIPTION
- Contributes to #6443
- Adds support for a "this page is outdated" banner for pages that have `drifted_from_default` set to a value other than false.
- I've not yet setup the banner so that it can be easily localized. That will come later.

### Previews

- https://deploy-preview-6475--opentelemetry.netlify.app/fr/docs/what-is-opentelemetry/ - page outdated because the English page has changed
- https://deploy-preview-6475--opentelemetry.netlify.app/es/docs/kubernetes/ - page outdated because the English page has moved

### Screenshots (corresponding to the pages above)

> [!NOTE]
> The banner illustrated next has a [`<details>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) element, which is show in its **expanded** form.

> <img width="600" alt="image" src="https://github.com/user-attachments/assets/ebe396ea-c774-4882-b452-35506eb6c18b" />

> <img width="600" alt="image" src="https://github.com/user-attachments/assets/15f79748-6b49-44fa-9e2f-819673b3274f" />
