### PR TITLE
[Collector] Slight rewording of distributions and release info

### DIFF
--- a/content/en/docs/collector/_index.md
+++ b/content/en/docs/collector/_index.md
@@ -57,7 +57,7 @@ you launch a collector it will automatically start receiving telemetry.
 Follow best practices to make sure your collectors are [hosted] and [configured]
 securely.
 
-## Status and releases
+## Status
 
 The **Collector** status is: [mixed][], since core Collector components
 currently have mixed [stability levels][].
@@ -72,11 +72,16 @@ fixes for critical bugs and security issues. See the
 [support policies](https://github.com/open-telemetry/opentelemetry-collector/blob/main/VERSIONING.md)
 for more details.
 
-{{% docs/latest-release collector-releases /%}}
+## Distributions and releases {#releases}
 
-[registry]: /ecosystem/registry/?language=collector
-[hosted]: /docs/security/hosting-best-practices/
+For information about Collector distributions and releases, including the
+[latest release][], see [Distributions](distributions/).
+
 [configured]: /docs/security/config-best-practices/
+[hosted]: /docs/security/hosting-best-practices/
+[latest release]:
+  https://github.com/open-telemetry/opentelemetry-collector-releases/releases/latest
 [mixed]: /docs/specs/otel/document-status/#mixed
+[registry]: /ecosystem/registry/?language=collector
 [stability levels]:
   https://github.com/open-telemetry/opentelemetry-collector#stability-levels

--- a/content/en/docs/collector/distributions.md
+++ b/content/en/docs/collector/distributions.md
@@ -12,13 +12,11 @@ the `manifest.yaml` of each distribution.
 [distributions]:
   https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions
 
-{{% docs/latest-release collector-releases /%}}
-
 ## Custom Distributions
 
-For various reasons the existing distributions provided by the OpenTelemetry
-project may not meet your needs. Whether you want a smaller version, or have the
-need to implement custom functionality like
+Existing distributions provided by the OpenTelemetry project may not meet your
+needs. For example, you may want a smaller package, or have the need to
+implement custom functionality like
 [authenticator extensions](../building/authenticator-extension),
 [receivers](../building/receiver), processors, exporters or
 [connectors](../building/connector). The tool used to build distributions

--- a/content/en/docs/collector/distributions.md
+++ b/content/en/docs/collector/distributions.md
@@ -15,7 +15,7 @@ the `manifest.yaml` of each distribution.
 ## Custom Distributions
 
 Existing distributions provided by the OpenTelemetry project may not meet your
-needs. For example, you may want a smaller package or need to implement custom
+needs. For example, you may want a smaller binary or need to implement custom
 functionality like
 [authenticator extensions](../building/authenticator-extension),
 [receivers](../building/receiver), processors, exporters or

--- a/content/en/docs/collector/distributions.md
+++ b/content/en/docs/collector/distributions.md
@@ -15,7 +15,7 @@ the `manifest.yaml` of each distribution.
 ## Custom Distributions
 
 Existing distributions provided by the OpenTelemetry project may not meet your
-needs. For example, you may want a smaller package, or have the need to
+needs. For example, you may want a smaller package or need to
 implement custom functionality like
 [authenticator extensions](../building/authenticator-extension),
 [receivers](../building/receiver), processors, exporters or

--- a/content/en/docs/collector/distributions.md
+++ b/content/en/docs/collector/distributions.md
@@ -15,8 +15,8 @@ the `manifest.yaml` of each distribution.
 ## Custom Distributions
 
 Existing distributions provided by the OpenTelemetry project may not meet your
-needs. For example, you may want a smaller package or need to
-implement custom functionality like
+needs. For example, you may want a smaller package or need to implement custom
+functionality like
 [authenticator extensions](../building/authenticator-extension),
 [receivers](../building/receiver), processors, exporters or
 [connectors](../building/connector). The tool used to build distributions


### PR DESCRIPTION
- Reworks the Collector index page:
  - Splits "Status and releases" into separate sections
  - For releases, uses the title "Distributions and releases" and adds a link to the Distributions page
- Contributes to #6460 indirectly by eliminating the use of the shortcode in the Collector pages

**Preview**:

- https://deploy-preview-6476--opentelemetry.netlify.app/docs/collector/#status
- https://deploy-preview-6476--opentelemetry.netlify.app/docs/collector/distributions/
