### PR TITLE
Change the status of AWS' native OTLP support

### DIFF
--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -25,7 +25,7 @@
 - name: AWS
   nativeOTLP: true
   url: https://aws-otel.github.io
-  contact:
+  contact: opentelemetry@amazon.com
   oss: false
   commercial: true
 - name: OpenSearch

--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -23,7 +23,7 @@
   oss: false
   commercial: true
 - name: AWS
-  nativeOTLP: false
+  nativeOTLP: true
   url: https://aws-otel.github.io
   contact:
   oss: false


### PR DESCRIPTION
Because AWS now supports native OTLP at AWS X-Ray and Amazon CloudWatch Logs, [the vendor list table](https://opentelemetry.io/ecosystem/vendors/) is not up-to-date. This PR updates the status of AWS.

ref: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-OTLPEndpoint.html