### PR TITLE
Update internal telemetry docs

### DIFF
--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -238,52 +238,50 @@ files in the repository.
 
 #### `basic`-level metrics
 
-| Metric name                                             | Description                                                                             | Type      |
-| ------------------------------------------------------- | --------------------------------------------------------------------------------------- | --------- |
-| `otelcol_exporter_enqueue_failed_`<br>`log_records`     | Number of logs that exporter(s) failed to enqueue.                                      | Counter   |
-| `otelcol_exporter_enqueue_failed_`<br>`metric_points`   | Number of metric points that exporter(s) failed to enqueue.                             | Counter   |
-| `otelcol_exporter_enqueue_failed_`<br>`spans`           | Number of spans that exporter(s) failed to enqueue.                                     | Counter   |
-| `otelcol_exporter_queue_capacity`                       | Fixed capacity of the sending queue, in batches.                                        | Gauge     |
-| `otelcol_exporter_queue_size`                           | Current size of the sending queue, in batches.                                          | Gauge     |
-| `otelcol_exporter_send_failed_`<br>`log_records`        | Number of logs that exporter(s) failed to send to destination.                          | Counter   |
-| `otelcol_exporter_send_failed_`<br>`metric_points`      | Number of metric points that exporter(s) failed to send to destination.                 | Counter   |
-| `otelcol_exporter_send_failed_`<br>`spans`              | Number of spans that exporter(s) failed to send to destination.                         | Counter   |
-| `otelcol_exporter_sent_log_records`                     | Number of logs successfully sent to destination.                                        | Counter   |
-| `otelcol_exporter_sent_metric_points`                   | Number of metric points successfully sent to destination.                               | Counter   |
-| `otelcol_exporter_sent_spans`                           | Number of spans successfully sent to destination.                                       | Counter   |
-| `otelcol_process_cpu_seconds`                           | Total CPU user and system time in seconds.                                              | Counter   |
-| `otelcol_process_memory_rss`                            | Total physical memory (resident set size) in bytes.                                     | Gauge     |
-| `otelcol_process_runtime_heap_`<br>`alloc_bytes`        | Bytes of allocated heap objects (see 'go doc runtime.MemStats.HeapAlloc').              | Gauge     |
-| `otelcol_process_runtime_total_`<br>`alloc_bytes`       | Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc'). | Counter   |
-| `otelcol_process_runtime_total_`<br>`sys_memory_bytes`  | Total bytes of memory obtained from the OS (see 'go doc runtime.MemStats.Sys').         | Gauge     |
-| `otelcol_process_uptime`                                | Uptime of the process in seconds.                                                       | Counter   |
-| `otelcol_processor_incoming_items`                      | Number of items passed to the processor.                                                | Counter   |
-| `otelcol_processor_outgoing_items`                      | Number of items emitted from the processor.                                             | Counter   |
-| `otelcol_receiver_accepted_`<br>`log_records`           | Number of logs successfully ingested and pushed into the pipeline.                      | Counter   |
-| `otelcol_receiver_accepted_`<br>`metric_points`         | Number of metric points successfully ingested and pushed into the pipeline.             | Counter   |
-| `otelcol_receiver_accepted_spans`                       | Number of spans successfully ingested and pushed into the pipeline.                     | Counter   |
-| `otelcol_receiver_refused_`<br>`log_records`            | Number of logs that could not be pushed into the pipeline.                              | Counter   |
-| `otelcol_receiver_refused_`<br>`metric_points`          | Number of metric points that could not be pushed into the pipeline.                     | Counter   |
-| `otelcol_receiver_refused_spans`                        | Number of spans that could not be pushed into the pipeline.                             | Counter   |
-| `otelcol_scraper_errored_`<br>`metric_points`           | Number of metric points the Collector failed to scrape.                                 | Counter   |
-| `otelcol_scraper_scraped_`<br>`metric_points`           | Number of metric points scraped by the Collector.                                       | Counter   |
+| Metric name                                            | Description                                                                             | Type    |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------- | ------- |
+| `otelcol_exporter_enqueue_failed_`<br>`log_records`    | Number of logs that exporter(s) failed to enqueue.                                      | Counter |
+| `otelcol_exporter_enqueue_failed_`<br>`metric_points`  | Number of metric points that exporter(s) failed to enqueue.                             | Counter |
+| `otelcol_exporter_enqueue_failed_`<br>`spans`          | Number of spans that exporter(s) failed to enqueue.                                     | Counter |
+| `otelcol_exporter_queue_capacity`                      | Fixed capacity of the sending queue, in batches.                                        | Gauge   |
+| `otelcol_exporter_queue_size`                          | Current size of the sending queue, in batches.                                          | Gauge   |
+| `otelcol_exporter_send_failed_`<br>`log_records`       | Number of logs that exporter(s) failed to send to destination.                          | Counter |
+| `otelcol_exporter_send_failed_`<br>`metric_points`     | Number of metric points that exporter(s) failed to send to destination.                 | Counter |
+| `otelcol_exporter_send_failed_`<br>`spans`             | Number of spans that exporter(s) failed to send to destination.                         | Counter |
+| `otelcol_exporter_sent_log_records`                    | Number of logs successfully sent to destination.                                        | Counter |
+| `otelcol_exporter_sent_metric_points`                  | Number of metric points successfully sent to destination.                               | Counter |
+| `otelcol_exporter_sent_spans`                          | Number of spans successfully sent to destination.                                       | Counter |
+| `otelcol_process_cpu_seconds`                          | Total CPU user and system time in seconds.                                              | Counter |
+| `otelcol_process_memory_rss`                           | Total physical memory (resident set size) in bytes.                                     | Gauge   |
+| `otelcol_process_runtime_heap_`<br>`alloc_bytes`       | Bytes of allocated heap objects (see 'go doc runtime.MemStats.HeapAlloc').              | Gauge   |
+| `otelcol_process_runtime_total_`<br>`alloc_bytes`      | Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc'). | Counter |
+| `otelcol_process_runtime_total_`<br>`sys_memory_bytes` | Total bytes of memory obtained from the OS (see 'go doc runtime.MemStats.Sys').         | Gauge   |
+| `otelcol_process_uptime`                               | Uptime of the process in seconds.                                                       | Counter |
+| `otelcol_processor_incoming_items`                     | Number of items passed to the processor.                                                | Counter |
+| `otelcol_processor_outgoing_items`                     | Number of items emitted from the processor.                                             | Counter |
+| `otelcol_receiver_accepted_`<br>`log_records`          | Number of logs successfully ingested and pushed into the pipeline.                      | Counter |
+| `otelcol_receiver_accepted_`<br>`metric_points`        | Number of metric points successfully ingested and pushed into the pipeline.             | Counter |
+| `otelcol_receiver_accepted_spans`                      | Number of spans successfully ingested and pushed into the pipeline.                     | Counter |
+| `otelcol_receiver_refused_`<br>`log_records`           | Number of logs that could not be pushed into the pipeline.                              | Counter |
+| `otelcol_receiver_refused_`<br>`metric_points`         | Number of metric points that could not be pushed into the pipeline.                     | Counter |
+| `otelcol_receiver_refused_spans`                       | Number of spans that could not be pushed into the pipeline.                             | Counter |
+| `otelcol_scraper_errored_`<br>`metric_points`          | Number of metric points the Collector failed to scrape.                                 | Counter |
+| `otelcol_scraper_scraped_`<br>`metric_points`          | Number of metric points scraped by the Collector.                                       | Counter |
 
 #### Additional `normal`-level metrics
 
-| Metric name                                             | Description                                                                             | Type      |
-| ------------------------------------------------------- | --------------------------------------------------------------------------------------- | --------- |
-| `otelcol_processor_batch_batch_`<br>`send_size`         | Number of units in the batch that was sent.                                             | Histogram |
-| `otelcol_processor_batch_batch_size_`<br>`trigger_send` | Number of times the batch was sent due to a size trigger.                               | Counter   |
-| `otelcol_processor_batch_metadata_`<br>`cardinality`    | Number of distinct metadata value combinations being processed.                         | Counter   |
-| `otelcol_processor_batch_timeout_`<br>`trigger_send`    | Number of times the batch was sent due to a timeout trigger.                            | Counter   |
+| Metric name                                             | Description                                                     | Type      |
+| ------------------------------------------------------- | --------------------------------------------------------------- | --------- |
+| `otelcol_processor_batch_batch_`<br>`send_size`         | Number of units in the batch that was sent.                     | Histogram |
+| `otelcol_processor_batch_batch_size_`<br>`trigger_send` | Number of times the batch was sent due to a size trigger.       | Counter   |
+| `otelcol_processor_batch_metadata_`<br>`cardinality`    | Number of distinct metadata value combinations being processed. | Counter   |
+| `otelcol_processor_batch_timeout_`<br>`trigger_send`    | Number of times the batch was sent due to a timeout trigger.    | Counter   |
 
-{{% alert title="Note" color="info" %}}
-Aside from `otelcol_processor_batch_batch_send_size_bytes` which has been
-`detailed` since its introduction, the other batch processor metrics were
-`basic` until they were switched to `normal` in Collector version 0.99.0.
-They were later switched back to `basic` by mistake in versions [0.109.0,
-0.121.0].
-{{% /alert %}}
+{{% alert title="Note" color="info" %}} Aside from
+`otelcol_processor_batch_batch_send_size_bytes` which has been `detailed` since
+its introduction, the other batch processor metrics were `basic` until they were
+switched to `normal` in Collector version 0.99. They were later switched back to
+`basic` by mistake in versions [0.109, 0.121]. {{% /alert %}}
 
 #### Additional `detailed`-level metrics
 

--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -257,10 +257,6 @@ files in the repository.
 | `otelcol_process_runtime_total_`<br>`alloc_bytes`       | Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc'). | Counter   |
 | `otelcol_process_runtime_total_`<br>`sys_memory_bytes`  | Total bytes of memory obtained from the OS (see 'go doc runtime.MemStats.Sys').         | Gauge     |
 | `otelcol_process_uptime`                                | Uptime of the process in seconds.                                                       | Counter   |
-| `otelcol_processor_batch_batch_`<br>`send_size`         | Number of units in the batch that was sent.                                             | Histogram |
-| `otelcol_processor_batch_batch_size_`<br>`trigger_send` | Number of times the batch was sent due to a size trigger.                               | Counter   |
-| `otelcol_processor_batch_metadata_`<br>`cardinality`    | Number of distinct metadata value combinations being processed.                         | Counter   |
-| `otelcol_processor_batch_timeout_`<br>`trigger_send`    | Number of times the batch was sent due to a timeout trigger.                            | Counter   |
 | `otelcol_processor_incoming_items`                      | Number of items passed to the processor.                                                | Counter   |
 | `otelcol_processor_outgoing_items`                      | Number of items emitted from the processor.                                             | Counter   |
 | `otelcol_receiver_accepted_`<br>`log_records`           | Number of logs successfully ingested and pushed into the pipeline.                      | Counter   |
@@ -274,7 +270,20 @@ files in the repository.
 
 #### Additional `normal`-level metrics
 
-There are currently no metrics specific to `normal` verbosity.
+| Metric name                                             | Description                                                                             | Type      |
+| ------------------------------------------------------- | --------------------------------------------------------------------------------------- | --------- |
+| `otelcol_processor_batch_batch_`<br>`send_size`         | Number of units in the batch that was sent.                                             | Histogram |
+| `otelcol_processor_batch_batch_size_`<br>`trigger_send` | Number of times the batch was sent due to a size trigger.                               | Counter   |
+| `otelcol_processor_batch_metadata_`<br>`cardinality`    | Number of distinct metadata value combinations being processed.                         | Counter   |
+| `otelcol_processor_batch_timeout_`<br>`trigger_send`    | Number of times the batch was sent due to a timeout trigger.                            | Counter   |
+
+{{% alert title="Note" color="info" %}}
+Aside from `otelcol_processor_batch_batch_send_size_bytes` which has been
+`detailed` since its introduction, the other batch processor metrics were
+`basic` until they were switched to `normal` in Collector version 0.99.0.
+They were later switched back to `basic` by mistake in versions [0.109.0,
+0.121.0].
+{{% /alert %}}
 
 #### Additional `detailed`-level metrics
 


### PR DESCRIPTION
[This PR in the Collector](https://github.com/open-telemetry/opentelemetry-collector/pull/12525), which moves some internal Collector metrics from the `basic` level to `normal`, was recently merged and should be part of the next release (v0.122.0). This PR updates the docs related to internal telemetry to reflect this change, and should probably wait until the release of 0.122.0 on March 17 before being merged.

This PR also adds a note detailing the history of changes to these metrics' level. ([This](https://github.com/open-telemetry/opentelemetry-collector/pull/9767) is the PR that initially restricted them to `normal`, and I believe [this](https://github.com/open-telemetry/opentelemetry-collector/pull/10912) is the PR that accidentally moved them back to `basic`.)