### PR TITLE
[infra] Factor out include partial from shortcode

### DIFF
--- a/content/en/docs/languages/_includes/index-intro.md
+++ b/content/en/docs/languages/_includes/index-intro.md
@@ -1,0 +1,24 @@
+---
+---
+
+This is the OpenTelemetry {{ $name }} documentation. OpenTelemetry is an
+observability framework -- an API, SDK, and tools that are designed to aid in
+the generation and collection of application telemetry data such as metrics,
+logs, and traces. This documentation is designed to help you understand how to
+get started using OpenTelemetry {{ $name }}.
+
+## Status and Releases
+
+The current status of the major functional components for OpenTelemetry
+{{ $name }} is as follows:
+
+| Traces              | Metrics              | Logs              |
+| ------------------- | -------------------- | ----------------- |
+| {{ $tracesStatus }} | {{ $metricsStatus }} | {{ $logsStatus }} |
+
+For releases, including the [latest release][], see [Releases]. {{ $.Inner }}
+
+[latest release]:
+  <https://github.com/open-telemetry/opentelemetry-{{ $lang }}/releases/latest>
+[Releases]:
+  <https://github.com/open-telemetry/opentelemetry-{{ $lang }}/releases>

--- a/layouts/partials/include.md
+++ b/layouts/partials/include.md
@@ -1,0 +1,37 @@
+{{/*
+
+This partial implements the core functionality of the 'include.html' shortcode,
+allowing reuse across other shortcodes and partials.
+
+This partial expects the following arguments -- beyond those used for the
+include functionality:
+
+- `_dot`: the '.' context of the page or shortcode invoking this partial
+- `_path`: the path to the file to be included
+
+*/ -}}
+
+{{ $path := ._path -}}
+{{ $args := . -}}
+{{ $page := partial "func/find-include.html"  (dict "path" $path "page" ._dot.Page) -}}
+{{ with $page -}}
+  {{ $content := .RenderShortcodes -}}
+  {{ range $_k, $v := $args -}}
+    {{ $k := string $_k -}}
+    {{ if not (hasPrefix $k "_") -}}
+      {{ $regex := printf "\\{\\{\\s*\\$%s\\s*\\}\\}" $k -}}
+      {{ $content = replaceRE $regex $v $content -}}
+    {{ end -}}
+  {{ end -}}
+  {{ $content -}}
+{{ else -}}
+  {{ $msg := printf
+      "Can't include '%s': file not found in page or ancestor contexts of page %s."
+      $path .Page.Path -}}
+  {{ warnf $msg -}}
+
+  <div class="alert alert-warning">
+  <div class="h4 alert-heading">INTERNAL SITE ERROR</div>
+  {{ $msg }}
+  </div>
+{{ end -}}

--- a/layouts/shortcodes/docs/languages/index-intro2.md
+++ b/layouts/shortcodes/docs/languages/index-intro2.md
@@ -1,0 +1,24 @@
+{{ $prettier_ignore := `
+
+<!-- prettier-ignore -->
+` -}}
+{{ $lang := .Get 0 -}}
+{{ $data := index $.Site.Data.instrumentation $lang }}
+{{ $name := $data.name -}}
+
+{{ $tracesStatus := partial "docs/get-signal-status.html" (dict "lang" $lang "signal" "traces") -}}
+{{ $metricsStatus := partial "docs/get-signal-status.html" (dict "lang" $lang "signal" "metrics") -}}
+{{ $logsStatus := partial "docs/get-signal-status.html" (dict "lang" $lang "signal" "logs") -}}
+
+{{ $args := dict
+    "_dot" .
+    "_path" "index-intro.md"
+    "name" $name
+    "lang" $lang
+    "tracesStatus" $tracesStatus
+    "metricsStatus" $metricsStatus
+    "logsStatus" $logsStatus
+    ".Inner" .Inner
+-}}
+
+{{ partial "include.md" $args -}}

--- a/layouts/shortcodes/include.html
+++ b/layouts/shortcodes/include.html
@@ -1,24 +1,22 @@
-{{/* Use to include Markdown snippets. Note that the included content can have
-calls to shortcodes. */ -}}
+{{/*
+
+Use to include markdown snippets. Note that the included content can have calls
+to shortcodes. Arguments to this shortcode can be named or positional.
+
+The first argument (optionally named "file") is mandatory, it is the path to the
+file to include. The path is relative to the content directory. Search will be
+done in '_includes' folders unless the argument starts with a dot or slash.
+
+The value of other positional or named arguments will be used to replace
+occurrences of '{{ $key }}' in the included content, where 'key' is the name of
+the argument or its position in the list of positional arguments.
+
+*/ -}}
 
 {{ $path := .Get (cond .IsNamedParams "file" 0) -}}
-{{ $args := .Params -}}
-{{ $page := partial "func/find-include.html"  (dict "path" $path "page" .Page) -}}
-{{ with $page -}}
-  {{ $content := .RenderShortcodes -}}
-  {{ range $k, $v := $args -}}
-    {{ $regex := printf "\\{\\{\\s*\\$%s\\s*\\}\\}" (string $k) -}}
-    {{ $content = replaceRE $regex $v $content -}}
-  {{ end -}}
-  {{ $content -}}
-{{ else -}}
-  {{ $msg := printf
-      "Can't include '%s': file not found in page or ancestor contexts of page %s."
-      $path .Page.Path -}}
-  {{ warnf $msg -}}
-
-  <div class="alert alert-warning">
-  <div class="h4 alert-heading">INTERNAL SITE ERROR</div>
-  {{ $msg }}
-  </div>
+{{ $args := dict "_dot" . "_path" $path -}}
+{{/* Add the positional and named params to our $args map. */ -}}
+{{ range $i, $v := .Params -}}
+  {{ $args = merge $args (dict (string $i) $v) -}}
 {{ end -}}
+{{ partial "include.md" $args -}}


### PR DESCRIPTION
- Refactoring in prep for #6460 and other work
- Why this change: we can't call shortcodes from other shortcodes or partials (without resorting to `.RenderString` magic, which doesn't work when we're trying to keep things all in markdown).
- Factors out the core functionality of the `includes.html` shortcode and makes it available as a partial of the same name
- In prep for 6460, this refactors the `docs/languages/index-intro.md` shortcode for better **separate concerns**: have the natural language part in an include file, while keeping the code in a shortcode
  - An include-file version of the `docs/languages/index-intro.md` shortcode
  - A new version of the shortcode (suffixed with "2"), which isn't currently used

The only change in the generated site files are for pages with includes. Any included text with an apostrophe (`'`) is now encoded as `&rsquo;`:

```console
$ (cd public && g diff -bw --ignore-blank-lines -I "'|&rsquo;") | grep ^diff | head
diff --git a/site/index.html b/site/index.html
diff --git a/sitemap.xml b/sitemap.xml
```

**Preview**: https://deploy-preview-6494--opentelemetry.netlify.app/docs/languages/cpp/instrumentation/

Here's what the diff looks like:

> <img width="699" alt="image" src="https://github.com/user-attachments/assets/14396a87-a950-4f0e-970c-0b231ec4047c" />
