### PR TITLE
[CI] Warn about spec pages without level 1 headings

### DIFF
--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -155,6 +155,9 @@ while(<>) {
   # printf STDOUT "$ARGV Got:$lineNum: $_" if $gD;
 
   if ($file ne $ARGV) {
+    # Did the previous file not have a title?
+    warn "WARN: $file: no level 1 heading found, so no page will be generated"
+      if $file && $lineNum && ! $title;
     $file = $ARGV;
     $frontMatterFromFile = '';
     $title = '';


### PR DESCRIPTION
- Adjusts the `adjust-pages.pl` script to emit a warning when a spec page doesn't have a level-1 heading, as was the case for https://github.com/open-telemetry/semantic-conventions/issues/1971
