### PR TITLE
blog: fix slack channel name up-to-date

### DIFF
--- a/content/en/blog/2025/ai-agent-observability/index.md
+++ b/content/en/blog/2025/ai-agent-observability/index.md
@@ -255,5 +255,5 @@ transparent and effective AI ecosystem.
 
 Don’t miss this opportunity to help shape the future of industry standards for
 GenAI Observability! Join us on the [CNCF Slack](https://slack.cncf.io)
-`#otel-genai-instrumentation-wg` channel, or by attending a
+`#otel-genai-instrumentation` channel, or by attending a
 [GenAI SIG meeting](https://github.com/open-telemetry/community/blob/main/projects/gen-ai.md#meeting-times).


### PR DESCRIPTION
Very minor change to update the slack channel name mentioned in [the blog post](https://opentelemetry.io/blog/2025/ai-agent-observability/):

- before: `#otel-genai-instrumentation-wg`
- after: `#otel-genai-instrumentation`

Though Slack can suggest the new channel name in the UI, I though still it's good to provide precise information for readers.