### PR TITLE
Add OTel Observatory calendar link to KubeCon EU 25 blog post

### DIFF
--- a/content/en/blog/2025/kubecon-eu.md
+++ b/content/en/blog/2025/kubecon-eu.md
@@ -167,17 +167,16 @@ Drop by and say _"Hi!"_ at OpenTelemetry Observatory presented by Splunk in the
 Expo Hall. This will be a place for informal chats, meetups, and other
 discussions led by OpenTelemetry community members and maintainers.
 
-<!-- For the activity schedule, see the [OTel Observatory Calendar](https://shorturl.at/qEUX1). -->
+For the activity schedule, see the
+[OTel Observatory Calendar](https://calendar.google.com/calendar/u/0/embed?src=c_6b6b343737cc9bbf0393ba40c101d6b017514751e66951c9890d089eedd78a37@group.calendar.google.com).
 
 Note that the Observatory might show up as "Splunk Activation Booth" on the
 event map.
 
-Activity schedule coming soon. Check back in the coming weeks for updates!
-
-<!-- If you’d like to participate and lead a discussion or short presentation, reach
+If you’d like to participate and lead a discussion or short presentation, reach
 out to the
 [OpenTelemetry End User Working Group](https://cloud-native.slack.com/archives/C01RT3MSWGZ)
-to indicate your interest. -->
+to indicate your interest.
 
 You can help us improve the project by sharing your thoughts and feedback about
 your OpenTelemetry adoption, implementation, and usage.

--- a/content/en/blog/2025/kubecon-eu.md
+++ b/content/en/blog/2025/kubecon-eu.md
@@ -168,7 +168,7 @@ Expo Hall. This will be a place for informal chats, meetups, and other
 discussions led by OpenTelemetry community members and maintainers.
 
 For the activity schedule, see the
-[OTel Observatory Calendar](https://calendar.google.com/calendar/u/0/embed?src=c_6b6b343737cc9bbf0393ba40c101d6b017514751e66951c9890d089eedd78a37@group.calendar.google.com&mode=WEEK&dates=20250331/20250406).
+[OTel Observatory Calendar](https://calendar.google.com/calendar/embed?src=c_6b6b343737cc9bbf0393ba40c101d6b017514751e66951c9890d089eedd78a37@group.calendar.google.com&mode=WEEK&dates=20250331/20250406).
 
 Note that the Observatory might show up as "Splunk Activation Booth" on the
 event map.

--- a/content/en/blog/2025/kubecon-eu.md
+++ b/content/en/blog/2025/kubecon-eu.md
@@ -168,7 +168,7 @@ Expo Hall. This will be a place for informal chats, meetups, and other
 discussions led by OpenTelemetry community members and maintainers.
 
 For the activity schedule, see the
-[OTel Observatory Calendar](https://calendar.google.com/calendar/u/0/embed?src=c_6b6b343737cc9bbf0393ba40c101d6b017514751e66951c9890d089eedd78a37@group.calendar.google.com).
+[OTel Observatory Calendar](https://calendar.google.com/calendar/u/0/embed?src=c_6b6b343737cc9bbf0393ba40c101d6b017514751e66951c9890d089eedd78a37@group.calendar.google.com&mode=WEEK&dates=20250331/20250406).
 
 Note that the Observatory might show up as "Splunk Activation Booth" on the
 event map.

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -203,6 +203,10 @@
     "StatusCode": 200,
     "LastSeen": "2025-02-24T16:02:34.66521577Z"
   },
+  "https://calendar.google.com/calendar/u/0/embed": {
+    "StatusCode": 401,
+    "LastSeen": "2025-03-13T10:27:01.731212Z"
+  },
   "https://calendly.com/euwg-user-feedback-session/end-user-feedback-session": {
     "StatusCode": 200,
     "LastSeen": "2025-02-01T06:39:29.009216-05:00"

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -204,8 +204,8 @@
     "LastSeen": "2025-02-24T16:02:34.66521577Z"
   },
   "https://calendar.google.com/calendar/embed": {
-    "StatusCode": 401,
-    "LastSeen": "2025-03-14T16:52:06.624588Z"
+    "StatusCode": 200,
+    "LastSeen": "2025-03-14T17:34:13.352Z"
   },
   "https://calendly.com/euwg-user-feedback-session/end-user-feedback-session": {
     "StatusCode": 200,

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -203,9 +203,9 @@
     "StatusCode": 200,
     "LastSeen": "2025-02-24T16:02:34.66521577Z"
   },
-  "https://calendar.google.com/calendar/u/0/embed": {
+  "https://calendar.google.com/calendar/embed": {
     "StatusCode": 401,
-    "LastSeen": "2025-03-13T10:27:01.731212Z"
+    "LastSeen": "2025-03-14T16:52:06.624588Z"
   },
   "https://calendly.com/euwg-user-feedback-session/end-user-feedback-session": {
     "StatusCode": 200,


### PR DESCRIPTION
Add link to Google Calendar containing events at the OTel Observatory. Although there are still some slots available, I think we have enough there already to share more widely.

**Preview**: https://deploy-preview-6542--opentelemetry.netlify.app/blog/2025/kubecon-eu/