### PR TITLE
Add docs for @WithSpan params.

### DIFF
--- a/content/en/docs/zero-code/java/agent/annotations.md
+++ b/content/en/docs/zero-code/java/agent/annotations.md
@@ -87,7 +87,7 @@ customization of spans:
 
 | name             | type              | default    | description                                                                                                                                  |
 | ---------------- | ----------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `kind`           | `SpanKind` (enum) | `INTERNAL` | The [kind of span](/docs/specs/otel/trace/api/#spankind).             |
+| `kind`           | `SpanKind` (enum) | `INTERNAL` | The [kind of span](/docs/specs/otel/trace/api/#spankind).                                                                                    |
 | `inheritContext` | `boolean`         | `true`     | Since 2.14.0. Controls whether or not the new span will be parented in the existing (current) context. If `false`, a new context is created. |
 
 Example parameter usage:

--- a/content/en/docs/zero-code/java/agent/annotations.md
+++ b/content/en/docs/zero-code/java/agent/annotations.md
@@ -80,6 +80,25 @@ types listed below, then the span will not be ended until the future completes.
 - [io.reactivex.Flowable](https://reactivex.io/RxJava/2.x/javadoc/index.html?io/reactivex/Flowable.html)
 - [io.reactivex.parallel.ParallelFlowable](https://reactivex.io/RxJava/2.x/javadoc/index.html?io/reactivex/parallel/ParallelFlowable.html)
 
+### Parameters
+
+The `@WithSpan` attribute supports two optional parameters to allow
+customization of spans:
+
+| name             | type              | default    | description                                                                                                                                  |
+|------------------|-------------------|------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| `kind`           | `SpanKind` (enum) | `INTERNAL` | The [kind of span](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#spankind).             |
+| `inheritContext` | `boolean`         | `true`     | Since 2.14.0. Controls whether or not the new span will be parented in the existing (current) context. If `false`, a new context is created. |
+
+Example parameter usage:
+
+```java
+@WithSpan(kind = SpanKind.CLIENT, inheritContext = false)
+public void myMethod() {
+    <...>
+}
+```
+
 ## Adding attributes to the span with `@SpanAttribute`
 
 When a [span](/docs/concepts/signals/traces/#spans) is created for an annotated

--- a/content/en/docs/zero-code/java/agent/annotations.md
+++ b/content/en/docs/zero-code/java/agent/annotations.md
@@ -86,7 +86,7 @@ The `@WithSpan` attribute supports two optional parameters to allow
 customization of spans:
 
 | name             | type              | default    | description                                                                                                                                  |
-|------------------|-------------------|------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| ---------------- | ----------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `kind`           | `SpanKind` (enum) | `INTERNAL` | The [kind of span](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#spankind).             |
 | `inheritContext` | `boolean`         | `true`     | Since 2.14.0. Controls whether or not the new span will be parented in the existing (current) context. If `false`, a new context is created. |
 

--- a/content/en/docs/zero-code/java/agent/annotations.md
+++ b/content/en/docs/zero-code/java/agent/annotations.md
@@ -82,7 +82,7 @@ types listed below, then the span will not be ended until the future completes.
 
 ### Parameters
 
-The `@WithSpan` attribute supports two optional parameters to allow
+The `@WithSpan` attribute supports the following optional parameters to allow
 customization of spans:
 
 | name             | type              | default    | description                                                                                                                                  |

--- a/content/en/docs/zero-code/java/agent/annotations.md
+++ b/content/en/docs/zero-code/java/agent/annotations.md
@@ -87,7 +87,7 @@ customization of spans:
 
 | name             | type              | default    | description                                                                                                                                  |
 | ---------------- | ----------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `kind`           | `SpanKind` (enum) | `INTERNAL` | The [kind of span](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#spankind).             |
+| `kind`           | `SpanKind` (enum) | `INTERNAL` | The [kind of span](/docs/specs/otel/trace/api/#spankind).             |
 | `inheritContext` | `boolean`         | `true`     | Since 2.14.0. Controls whether or not the new span will be parented in the existing (current) context. If `false`, a new context is created. |
 
 Example parameter usage:

--- a/content/ja/blog/2025/ai-agent-observability/index.md
+++ b/content/ja/blog/2025/ai-agent-observability/index.md
@@ -8,6 +8,7 @@ issue: https://github.com/open-telemetry/opentelemetry.io/issues/6389
 sig: SIG GenAI Observability
 date: 2025-03-06
 default_lang_commit: f2a520b85d72db706bff91d879f5bb10fd2e7367
+drifted_from_default: true
 cSpell:ignore: genai Guangya PydanticAI Sujay
 ---
 

--- a/content/ja/docs/collector/deployment/agent.md
+++ b/content/ja/docs/collector/deployment/agent.md
@@ -3,6 +3,7 @@ title: エージェント
 description: コレクターにシグナルを送信し、そこからバックエンドに送信する理由と方法
 weight: 2
 default_lang_commit: b34ebe22b71962da96b898eb39a666ed57d447fe
+drifted_from_default: true
 cSpell:ignore: prometheusremotewrite
 ---
 

--- a/content/ja/docs/collector/deployment/gateway/index.md
+++ b/content/ja/docs/collector/deployment/gateway/index.md
@@ -3,6 +3,7 @@ title: ゲートウェイ
 description: シグナルを単一のOTLPエンドポイントに送信し、そこからバックエンドに送信する理由と方法
 weight: 3
 default_lang_commit: b34ebe22b71962da96b898eb39a666ed57d447fe
+drifted_from_default: true
 # prettier-ignore
 cSpell:ignore: filelogreceiver hostmetricsreceiver hostnames loadbalancer loadbalancing resourcedetectionprocessor
 ---

--- a/content/ja/docs/what-is-opentelemetry.md
+++ b/content/ja/docs/what-is-opentelemetry.md
@@ -3,6 +3,7 @@ title: OpenTelemetryとは
 description: OpenTelemetryが何であり、何でないかについての簡単な説明。
 weight: 150
 default_lang_commit: 44059882
+drifted_from_default: true
 ---
 
 - OpenTelemetryは、[オブザーバビリティ](/docs/concepts/observability-primer/#what-is-observability)フレームワークであり、[トレース](/docs/concepts/signals/traces/)、[メトリクス](/docs/concepts/signals/metrics/)、[ログ](/docs/concepts/signals/logs/)のようなテレメトリーデータを作成・管理するためにデザインされたツールキットです。

--- a/content/pt/docs/concepts/instrumentation/_index.md
+++ b/content/pt/docs/concepts/instrumentation/_index.md
@@ -3,6 +3,7 @@ title: Instrumentação
 description: Como o OpenTelemetry facilita a instrumentação
 weight: 15
 default_lang_commit: 82bd738d51426acb34e126b230a8a1281f193e3e
+drifted_from_default: true
 ---
 
 Para que um sistema seja observável, ele deve ser **instrumentado**: ou seja, o

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -9739,6 +9739,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-02-06T02:17:59.999Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#spankind": {
+    "StatusCode": 206,
+    "LastSeen": "2025-03-13T17:21:15.569829279Z"
+  },
   "https://github.com/open-telemetry/opentelemetry-specification/blob/v1.14.0/specification/sdk-environment-variables.md#general-sdk-configuration": {
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:17:12.345Z"


### PR DESCRIPTION
The documentation for Java's `@WithSpan` annotation currently omits the `kind` (SpanKind control) parameter. With the upcoming 2.14.0 release, we're also gaining another parameter (`inheritContext`)...so this seemed like a good opportunity to document them both.