### PR TITLE
docs: Update links for metrics and logs in _index.md

### DIFF
--- a/content/en/docs/concepts/instrumentation/_index.md
+++ b/content/en/docs/concepts/instrumentation/_index.md
@@ -52,8 +52,8 @@ solutions. The following things are also a part of OpenTelemetry:
 - [Semantic Conventions](../semantic-conventions/) provide a common naming
   schema that can be used for standardization across code bases and platforms.
 
-[logs]: ../signals/traces/
-[metrics]: ../signals/traces/
+[logs]: ../signals/logs/
+[metrics]: ../signals/metrics/
 [observable]: ../observability-primer/#what-is-observability
 [signals]: ../signals/
 [traces]: ../signals/traces/


### PR DESCRIPTION
<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->

Fixing links for `logs` and `metrics` to point at their respective pages as they currently point at traces documentation.

Current link for logs and metrics: https://opentelemetry.io/docs/concepts/signals/traces/

New logs link: https://opentelemetry.io/docs/concepts/signals/logs/

New metrics link: https://opentelemetry.io/docs/concepts/signals/metrics/
