### PR TITLE
fix: content/en/docs/languages/python/exporters.md

### DIFF
--- a/content/en/docs/languages/python/exporters.md
+++ b/content/en/docs/languages/python/exporters.md
@@ -237,7 +237,7 @@ the metrics from this endpoint.
 
 ### Dependencies {#zipkin-dependencies}
 
-To send your trace data to [Zipkin](https://zipkin.io/), , you can choose
+To send your trace data to [Zipkin](https://zipkin.io/), you can choose
 between two different protocols to transport your data:
 
 - [HTTP/protobuf](https://pypi.org/project/opentelemetry-exporter-zipkin-proto-http/)

--- a/content/en/docs/languages/python/exporters.md
+++ b/content/en/docs/languages/python/exporters.md
@@ -237,8 +237,8 @@ the metrics from this endpoint.
 
 ### Dependencies {#zipkin-dependencies}
 
-To send your trace data to [Zipkin](https://zipkin.io/), you can choose
-between two different protocols to transport your data:
+To send your trace data to [Zipkin](https://zipkin.io/), you can choose between
+two different protocols to transport your data:
 
 - [HTTP/protobuf](https://pypi.org/project/opentelemetry-exporter-zipkin-proto-http/)
 - [Thrift](https://pypi.org/project/opentelemetry-exporter-zipkin-json/)


### PR DESCRIPTION
This pull request includes a minor correction to the `content/en/docs/languages/python/exporters.md` file. The change removes an extra comma in the sentence describing how to send trace data to Zipkin.

Documentation improvement:

* [`content/en/docs/languages/python/exporters.md`](diffhunk://#diff-332118e78b0825892438757cd0b61990b37fcde4bca77fbd0b1327baf59cc3d4L240-R240): Removed an unnecessary comma in the sentence explaining the protocols for sending trace data to Zipkin.

Issue: #6564 