### PR TITLE
[en]chore: refine Metric Gauges usage in Go SDK

### DIFF
--- a/content/en/docs/languages/go/instrumentation.md
+++ b/content/en/docs/languages/go/instrumentation.md
@@ -551,6 +551,8 @@ import (
 
 var fanSpeedSubscription chan int64
 
+var speedGauge metric.Int64Gauge
+
 func init() {
 	speedGauge, err := meter.Int64Gauge(
 		"cpu.fan.speed",

--- a/content/en/docs/languages/go/instrumentation.md
+++ b/content/en/docs/languages/go/instrumentation.md
@@ -512,7 +512,8 @@ import (
 var itemsCounter metric.Int64UpDownCounter
 
 func init() {
-	itemsCounter, err := meter.Int64UpDownCounter(
+	var err error
+	itemsCounter, err = meter.Int64UpDownCounter(
 		"items.counter",
 		metric.WithDescription("Number of items."),
 		metric.WithUnit("{item}"),
@@ -554,7 +555,8 @@ var (
 )
 
 func init() {
-	speedGauge, err := meter.Int64Gauge(
+	var err error
+	speedGauge, err = meter.Int64Gauge(
 		"cpu.fan.speed",
 		metric.WithDescription("Speed of CPU fan"),
 		metric.WithUnit("RPM"),

--- a/content/en/docs/languages/go/instrumentation.md
+++ b/content/en/docs/languages/go/instrumentation.md
@@ -512,8 +512,7 @@ import (
 var itemsCounter metric.Int64UpDownCounter
 
 func init() {
-	var err error
-	itemsCounter, err = meter.Int64UpDownCounter(
+	itemsCounter, err := meter.Int64UpDownCounter(
 		"items.counter",
 		metric.WithDescription("Number of items."),
 		metric.WithUnit("{item}"),
@@ -549,9 +548,10 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
-var fanSpeedSubscription chan int64
-
-var speedGauge metric.Int64Gauge
+var (
+  fanSpeedSubscription chan int64
+  speedGauge metric.Int64Gauge
+)
 
 func init() {
 	speedGauge, err := meter.Int64Gauge(


### PR DESCRIPTION
We cannot directly compile the content at https://opentelemetry.io/docs/languages/go/instrumentation/#using-gauges, the issue is that the speedGauge is not declared before using
