### PR TITLE
[blog] Announce JS SDK 2.0

### DIFF
--- a/content/en/blog/2025/otel-js-sdk-2-0.md
+++ b/content/en/blog/2025/otel-js-sdk-2-0.md
@@ -59,8 +59,6 @@ Details:
 
 ## Why was this done?
 
-Some of the details for why this 2.0 was done can be found
-[in this issue](https://github.com/open-telemetry/opentelemetry-js/issues/4083).
 We knew we would gain the greatest benefit by allowing breaking changes to
 improve things related to:
 
@@ -72,6 +70,10 @@ improve things related to:
   feature and maintenance work.
 
 This also begins our goal of releasing a new major release every year.
+
+For a more detailed explanation of why 2.0, see issue [#4083].
+
+[#4083]: https://github.com/open-telemetry/opentelemetry-js/issues/4083
 
 ## How can I get involved?
 

--- a/content/en/blog/2025/otel-js-sdk-2-0.md
+++ b/content/en/blog/2025/otel-js-sdk-2-0.md
@@ -8,8 +8,10 @@ sig: OpenTelemetry JS
 cSpell:ignore: Danielson
 ---
 
-Exciting news: [OpenTelemetry JavaScript](/docs/languages/js/) has released
-[SDK 2.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v2.0.0)!
+Exciting news: [OpenTelemetry JavaScript](/docs/languages/js/) has released [SDK
+2.0][v2.0.0]!
+
+[v2.0.0]: https://github.com/open-telemetry/opentelemetry-js/releases/tag/v2.0.0
 
 {{% alert-md title="Migration guide" color="info" %}}
 
@@ -77,11 +79,10 @@ For a more detailed explanation of why 2.0, see issue [#4083].
 
 ## How can I get involved?
 
-- Try out the
-  [v2.0.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v2.0.0)
-  and
-  [v0.200.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental%2Fv0.200.0)
-  releases and provide feedback
+[v0.200.0]:
+  https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental%2Fv0.200.0
+
+- Try out the [v2.0.0] and [v0.200.0] releases and provide feedback
 - Review our
   [contributing guide](https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md)
   for details on contributing

--- a/content/en/blog/2025/otel-js-sdk-2-0.md
+++ b/content/en/blog/2025/otel-js-sdk-2-0.md
@@ -33,7 +33,7 @@ guide][].
 
 ## What has changed?
 
-### Summary
+In summary:
 
 - The **minimum supported Node.js has been raised to `^18.19.0 || >=20.6.0`**.
   This means that support for Node.js 14 and 16 has been dropped.
@@ -44,7 +44,7 @@ guide][].
   - for notes on migrating to 2.x / 0.200.x see
     [the upgrade guide](https://github.com/open-telemetry/opentelemetry-js/tree/main/doc/upgrade-to-2.x.md)
 
-### Details
+Details:
 
 - [Node.js supported versions](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-nodejs-supported-versions)
 - [TypeScript supported versions](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-typescript-supported-versions)

--- a/content/en/blog/2025/otel-js-sdk-2-0.md
+++ b/content/en/blog/2025/otel-js-sdk-2-0.md
@@ -1,0 +1,56 @@
+---
+title: Announcing the OpenTelemetry JavaScript SDK 2.0
+linkTitle: OTel JS SDK 2.0
+date: 2025-02-21
+author: >
+  [Jamie Danielson](https://github.com/JamieDanielson) (Honeycomb)
+sig: OpenTelemetry JS
+---
+
+Exciting news! [OpenTelemetry JavaScript](https://github.com/open-telemetry/opentelemetry-js) has released [SDK 2.0](https://github.com/open-telemetry/opentelemetry-js/releases)!
+
+There is a [migration guide](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md) in the repo detailing breaking changes and steps for users to take to upgrade to the latest versions.
+
+## What is JS SDK 2.x?
+
+"JS SDK 2.x" encompasses new releases of the `@opentelemetry/*` JavaScript packages published from the [`opentelemetry-js` repository](https://github.com/open-telemetry/opentelemetry-js), except the API and semantic-conventions packages. The package versions for this new major will be `>=2.0.0` for the stable and `>=0.200.0` for the unstable packages. Details on the full list of packages can be found in the [migration guide](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#what-is-js-sdk-2x).
+
+## What has changed?
+
+### Summary
+
+- The **minimum supported Node.js has been raised to `^18.19.0 || >=20.6.0`**. This means that support for Node.js 14 and 16 has been dropped.
+- The **minimum supported TypeScript version has been raised to 5.0.4**.
+- The **compilation target for transpiled TypeScript has been raised to ES2022** (from ES2017).
+- The **public interface has changed**
+  - for notes on migrating to 2.x / 0.200.x see [the upgrade guide](https://github.com/open-telemetry/opentelemetry-js/tree/main/doc/upgrade-to-2.x.md)
+
+### Details
+
+- [Node.js supported versions](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-nodejs-supported-versions)
+- [TypeScript supported versions](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-typescript-supported-versions)
+- [ES2022 compilation target](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-es2022-compilation-target)
+- [Drop `window.OTEL_*` support in browsers](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-drop-windowotel_-support-in-browsers)
+- [`@opentelemetry/resources` API changes](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-opentelemetryresources-api-changes)
+- [`@opentelemetry/core` API changes](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-opentelemetrycore-api-changes)
+- [Tracing SDK API changes](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-tracing-sdk-api-changes)
+- [`@opentelemetry/sdk-metrics` API changes](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-opentelemetrysdk-metrics-api-changes)
+- [`@opentelemetry/resources` changes for *implementors* of Resource Detectors](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-opentelemetryresources-changes-for-implementors-of-resource-detectors)
+- [Other changes](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-other-changes)
+
+## Why was this done?
+
+Some of the details for why this 2.0 was done can be found [in this issue](https://github.com/open-telemetry/opentelemetry-js/issues/4083). We knew we would gain the greatest benefit by allowing breaking changes to improve things related to:
+
+- Optimization: removing classes and namespaces to allow better minification and tree-shaking.
+- Better Tooling and Support: dropping old runtimes and tool versions to take advantage of enhanced ESM support and simplify documentation.
+- Velocity: reducing code complexity and removing deprecated fields for faster feature and maintenance work.
+
+This also begins our goal of releasing a new major release every year.
+
+## How can I get involved?
+
+- Try out the [v2.0.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v2.0.0) and [v0.200.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental%2Fv0.200.0) releases and provide feedback
+- Review our [contributing guide](https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md) for details on contributing
+- Attend our [SIG meetings](https://groups.google.com/a/opentelemetry.io/g/calendar-js)
+- Collaborate on [Slack](https://cloud-native.slack.com/archives/C01NL1GRPQR)

--- a/content/en/blog/2025/otel-js-sdk-2-0.md
+++ b/content/en/blog/2025/otel-js-sdk-2-0.md
@@ -15,7 +15,7 @@ Exciting news: [OpenTelemetry JavaScript](/docs/languages/js/) has released [SDK
 
 {{% alert-md title="Migration guide" color="info" %}}
 
-For a detailed description of breaking changes, see the **migration guide**
+For a detailed description of breaking changes, see the **migration guide**:
 [Upgrade to OpenTelemetry JS SDK 2.x][migration guide].
 
 [migration guide]:
@@ -42,9 +42,9 @@ In summary:
 - The **minimum supported TypeScript version has been raised to 5.0.4**.
 - The **compilation target for transpiled TypeScript has been raised to ES2022**
   (from ES2017).
-- The **public interface has changed**
-  - for notes on migrating to 2.x / 0.200.x see
-    [the upgrade guide](https://github.com/open-telemetry/opentelemetry-js/tree/main/doc/upgrade-to-2.x.md)
+- The **public interface has changed**.
+  - For notes on migrating to 2.x / 0.200.x, see
+    [the upgrade guide](https://github.com/open-telemetry/opentelemetry-js/tree/main/doc/upgrade-to-2.x.md).
 
 Details:
 
@@ -66,7 +66,7 @@ improve things related to:
 
 - Optimization: removing classes and namespaces to allow better minification and
   tree-shaking.
-- Better Tooling and Support: dropping old runtimes and tool versions to take
+- Better tooling and support: dropping old runtimes and tool versions to take
   advantage of enhanced ESM support and simplify documentation.
 - Velocity: reducing code complexity and removing deprecated fields for faster
   feature and maintenance work.
@@ -82,10 +82,10 @@ For a more detailed explanation of why 2.0, see issue [#4083].
 [v0.200.0]:
   https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental%2Fv0.200.0
 
-- Try out the [v2.0.0] and [v0.200.0] releases and provide feedback
+- Try out the [v2.0.0] and [v0.200.0] releases and provide feedback.
 - Review our
   [contributing guide](https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md)
-  for details on contributing
+  for details on contributing.
 - Attend our
-  [SIG meetings](https://groups.google.com/a/opentelemetry.io/g/calendar-js)
-- Collaborate on [Slack](https://cloud-native.slack.com/archives/C01NL1GRPQR)
+  [SIG meetings](https://groups.google.com/a/opentelemetry.io/g/calendar-js).
+- Collaborate on [Slack](https://cloud-native.slack.com/archives/C01NL1GRPQR).

--- a/content/en/blog/2025/otel-js-sdk-2-0.md
+++ b/content/en/blog/2025/otel-js-sdk-2-0.md
@@ -1,7 +1,7 @@
 ---
 title: Announcing the OpenTelemetry JavaScript SDK 2.0
 linkTitle: OTel JS SDK 2.0
-date: 2025-03-21
+date: 2025-03-26
 author: >
   [Jamie Danielson](https://github.com/JamieDanielson) (Honeycomb)
 sig: OpenTelemetry JS

--- a/content/en/blog/2025/otel-js-sdk-2-0.md
+++ b/content/en/blog/2025/otel-js-sdk-2-0.md
@@ -2,6 +2,7 @@
 title: Announcing the OpenTelemetry JavaScript SDK 2.0
 linkTitle: OTel JS SDK 2.0
 date: 2025-02-21
+draft: true
 author: >
   [Jamie Danielson](https://github.com/JamieDanielson) (Honeycomb)
 sig: OpenTelemetry JS

--- a/content/en/blog/2025/otel-js-sdk-2-0.md
+++ b/content/en/blog/2025/otel-js-sdk-2-0.md
@@ -8,25 +8,30 @@ sig: OpenTelemetry JS
 cSpell:ignore: Danielson
 ---
 
-Exciting news!
-[OpenTelemetry JavaScript](https://github.com/open-telemetry/opentelemetry-js)
+Exciting news:
+[OpenTelemetry JavaScript](/docs/languages/js/)
 has released
-[SDK 2.0](https://github.com/open-telemetry/opentelemetry-js/releases)!
+[SDK 2.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v2.0.0)!
 
-There is a
-[migration guide](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md)
-in the repository detailing breaking changes and steps for users to take to
-upgrade to the latest versions.
+{{% alert-md title="Migration guide" color="info" %}}
+
+For a detailed description of breaking changes, see the **migration guide**
+[Upgrade to OpenTelemetry JS SDK 2.x][migration guide].
+
+[migration guide]:
+  https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md
+
+{{% /alert-md %}}
 
 ## What is JS SDK 2.x?
 
-"JS SDK 2.x" encompasses new releases of the `@opentelemetry/*` JavaScript
+JS SDK 2.x encompasses new releases of the `@opentelemetry/*` JavaScript
 packages published from the
 [`opentelemetry-js` repository](https://github.com/open-telemetry/opentelemetry-js),
 except the API and semantic-conventions packages. The package versions for this
 new major will be `>=2.0.0` for the stable and `>=0.200.0` for the unstable
 packages. Details on the full list of packages can be found in the
-[migration guide](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#what-is-js-sdk-2x).
+[migration guide][].
 
 ## What has changed?
 

--- a/content/en/blog/2025/otel-js-sdk-2-0.md
+++ b/content/en/blog/2025/otel-js-sdk-2-0.md
@@ -8,9 +8,7 @@ sig: OpenTelemetry JS
 cSpell:ignore: Danielson
 ---
 
-Exciting news:
-[OpenTelemetry JavaScript](/docs/languages/js/)
-has released
+Exciting news: [OpenTelemetry JavaScript](/docs/languages/js/) has released
 [SDK 2.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v2.0.0)!
 
 {{% alert-md title="Migration guide" color="info" %}}
@@ -30,8 +28,8 @@ packages published from the
 [`opentelemetry-js` repository](https://github.com/open-telemetry/opentelemetry-js),
 except the API and semantic-conventions packages. The package versions for this
 new major will be `>=2.0.0` for the stable and `>=0.200.0` for the unstable
-packages. Details on the full list of packages can be found in the
-[migration guide][].
+packages. Details on the full list of packages can be found in the [migration
+guide][].
 
 ## What has changed?
 

--- a/content/en/blog/2025/otel-js-sdk-2-0.md
+++ b/content/en/blog/2025/otel-js-sdk-2-0.md
@@ -7,23 +7,38 @@ author: >
 sig: OpenTelemetry JS
 ---
 
-Exciting news! [OpenTelemetry JavaScript](https://github.com/open-telemetry/opentelemetry-js) has released [SDK 2.0](https://github.com/open-telemetry/opentelemetry-js/releases)!
+Exciting news!
+[OpenTelemetry JavaScript](https://github.com/open-telemetry/opentelemetry-js)
+has released
+[SDK 2.0](https://github.com/open-telemetry/opentelemetry-js/releases)!
 
-There is a [migration guide](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md) in the repo detailing breaking changes and steps for users to take to upgrade to the latest versions.
+There is a
+[migration guide](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md)
+in the repository detailing breaking changes and steps for users to take to upgrade to
+the latest versions.
 
 ## What is JS SDK 2.x?
 
-"JS SDK 2.x" encompasses new releases of the `@opentelemetry/*` JavaScript packages published from the [`opentelemetry-js` repository](https://github.com/open-telemetry/opentelemetry-js), except the API and semantic-conventions packages. The package versions for this new major will be `>=2.0.0` for the stable and `>=0.200.0` for the unstable packages. Details on the full list of packages can be found in the [migration guide](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#what-is-js-sdk-2x).
+"JS SDK 2.x" encompasses new releases of the `@opentelemetry/*` JavaScript
+packages published from the
+[`opentelemetry-js` repository](https://github.com/open-telemetry/opentelemetry-js),
+except the API and semantic-conventions packages. The package versions for this
+new major will be `>=2.0.0` for the stable and `>=0.200.0` for the unstable
+packages. Details on the full list of packages can be found in the
+[migration guide](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#what-is-js-sdk-2x).
 
 ## What has changed?
 
 ### Summary
 
-- The **minimum supported Node.js has been raised to `^18.19.0 || >=20.6.0`**. This means that support for Node.js 14 and 16 has been dropped.
+- The **minimum supported Node.js has been raised to `^18.19.0 || >=20.6.0`**.
+  This means that support for Node.js 14 and 16 has been dropped.
 - The **minimum supported TypeScript version has been raised to 5.0.4**.
-- The **compilation target for transpiled TypeScript has been raised to ES2022** (from ES2017).
+- The **compilation target for transpiled TypeScript has been raised to ES2022**
+  (from ES2017).
 - The **public interface has changed**
-  - for notes on migrating to 2.x / 0.200.x see [the upgrade guide](https://github.com/open-telemetry/opentelemetry-js/tree/main/doc/upgrade-to-2.x.md)
+  - for notes on migrating to 2.x / 0.200.x see
+    [the upgrade guide](https://github.com/open-telemetry/opentelemetry-js/tree/main/doc/upgrade-to-2.x.md)
 
 ### Details
 
@@ -35,22 +50,35 @@ There is a [migration guide](https://github.com/open-telemetry/opentelemetry-js/
 - [`@opentelemetry/core` API changes](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-opentelemetrycore-api-changes)
 - [Tracing SDK API changes](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-tracing-sdk-api-changes)
 - [`@opentelemetry/sdk-metrics` API changes](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-opentelemetrysdk-metrics-api-changes)
-- [`@opentelemetry/resources` changes for *implementors* of Resource Detectors](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-opentelemetryresources-changes-for-implementors-of-resource-detectors)
+- [`@opentelemetry/resources` changes for _implementors_ of Resource Detectors](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-opentelemetryresources-changes-for-implementors-of-resource-detectors)
 - [Other changes](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-other-changes)
 
 ## Why was this done?
 
-Some of the details for why this 2.0 was done can be found [in this issue](https://github.com/open-telemetry/opentelemetry-js/issues/4083). We knew we would gain the greatest benefit by allowing breaking changes to improve things related to:
+Some of the details for why this 2.0 was done can be found
+[in this issue](https://github.com/open-telemetry/opentelemetry-js/issues/4083).
+We knew we would gain the greatest benefit by allowing breaking changes to
+improve things related to:
 
-- Optimization: removing classes and namespaces to allow better minification and tree-shaking.
-- Better Tooling and Support: dropping old runtimes and tool versions to take advantage of enhanced ESM support and simplify documentation.
-- Velocity: reducing code complexity and removing deprecated fields for faster feature and maintenance work.
+- Optimization: removing classes and namespaces to allow better minification and
+  tree-shaking.
+- Better Tooling and Support: dropping old runtimes and tool versions to take
+  advantage of enhanced ESM support and simplify documentation.
+- Velocity: reducing code complexity and removing deprecated fields for faster
+  feature and maintenance work.
 
 This also begins our goal of releasing a new major release every year.
 
 ## How can I get involved?
 
-- Try out the [v2.0.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v2.0.0) and [v0.200.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental%2Fv0.200.0) releases and provide feedback
-- Review our [contributing guide](https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md) for details on contributing
-- Attend our [SIG meetings](https://groups.google.com/a/opentelemetry.io/g/calendar-js)
+- Try out the
+  [v2.0.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v2.0.0)
+  and
+  [v0.200.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental%2Fv0.200.0)
+  releases and provide feedback
+- Review our
+  [contributing guide](https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md)
+  for details on contributing
+- Attend our
+  [SIG meetings](https://groups.google.com/a/opentelemetry.io/g/calendar-js)
 - Collaborate on [Slack](https://cloud-native.slack.com/archives/C01NL1GRPQR)

--- a/content/en/blog/2025/otel-js-sdk-2-0.md
+++ b/content/en/blog/2025/otel-js-sdk-2-0.md
@@ -71,7 +71,7 @@ improve things related to:
 - Velocity: reducing code complexity and removing deprecated fields for faster
   feature and maintenance work.
 
-This also begins our goal of releasing a new major release every year.
+This also begins our goal of releasing a new SDK major release every year.
 
 For a more detailed explanation of why 2.0, see issue [#4083].
 

--- a/content/en/blog/2025/otel-js-sdk-2-0.md
+++ b/content/en/blog/2025/otel-js-sdk-2-0.md
@@ -1,8 +1,7 @@
 ---
 title: Announcing the OpenTelemetry JavaScript SDK 2.0
 linkTitle: OTel JS SDK 2.0
-date: 2025-02-21
-draft: true
+date: 2025-03-21
 author: >
   [Jamie Danielson](https://github.com/JamieDanielson) (Honeycomb)
 sig: OpenTelemetry JS

--- a/content/en/blog/2025/otel-js-sdk-2-0.md
+++ b/content/en/blog/2025/otel-js-sdk-2-0.md
@@ -5,6 +5,7 @@ date: 2025-02-21
 author: >
   [Jamie Danielson](https://github.com/JamieDanielson) (Honeycomb)
 sig: OpenTelemetry JS
+cSpell:ignore: Danielson
 ---
 
 Exciting news!

--- a/content/en/blog/2025/otel-js-sdk-2-0.md
+++ b/content/en/blog/2025/otel-js-sdk-2-0.md
@@ -15,8 +15,8 @@ has released
 
 There is a
 [migration guide](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md)
-in the repository detailing breaking changes and steps for users to take to upgrade to
-the latest versions.
+in the repository detailing breaking changes and steps for users to take to
+upgrade to the latest versions.
 
 ## What is JS SDK 2.x?
 

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -303,6 +303,10 @@
     "StatusCode": 200,
     "LastSeen": "2025-02-02T10:59:14.907548-05:00"
   },
+  "https://cloud-native.slack.com/archives/C01NL1GRPQR": {
+    "StatusCode": 200,
+    "LastSeen": "2025-03-20T10:14:45.444428061Z"
+  },
   "https://cloud-native.slack.com/archives/C01NP3BV26R": {
     "StatusCode": 200,
     "LastSeen": "2024-12-18T05:52:49.606187-05:00"
@@ -8683,9 +8687,61 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:37:42.172729-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-03-20T10:13:41.886468706Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-drop-windowotel_-support-in-browsers": {
+    "StatusCode": 206,
+    "LastSeen": "2025-03-20T10:14:05.826276468Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-es2022-compilation-target": {
+    "StatusCode": 206,
+    "LastSeen": "2025-03-20T10:14:01.473606522Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-nodejs-supported-versions": {
+    "StatusCode": 206,
+    "LastSeen": "2025-03-20T10:13:54.514932507Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-opentelemetrycore-api-changes": {
+    "StatusCode": 206,
+    "LastSeen": "2025-03-20T10:14:11.949279247Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-opentelemetryresources-api-changes": {
+    "StatusCode": 206,
+    "LastSeen": "2025-03-20T10:14:09.243229009Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-opentelemetryresources-changes-for-implementors-of-resource-detectors": {
+    "StatusCode": 206,
+    "LastSeen": "2025-03-20T10:14:23.176428015Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-opentelemetrysdk-metrics-api-changes": {
+    "StatusCode": 206,
+    "LastSeen": "2025-03-20T10:14:19.596391096Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-other-changes": {
+    "StatusCode": 206,
+    "LastSeen": "2025-03-20T10:14:25.673601051Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-tracing-sdk-api-changes": {
+    "StatusCode": 206,
+    "LastSeen": "2025-03-20T10:14:16.442116351Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-typescript-supported-versions": {
+    "StatusCode": 206,
+    "LastSeen": "2025-03-20T10:13:58.466804234Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#what-is-js-sdk-2x": {
+    "StatusCode": 206,
+    "LastSeen": "2025-03-20T10:13:44.541686095Z"
+  },
   "https://github.com/open-telemetry/opentelemetry-js/discussions": {
     "StatusCode": 206,
     "LastSeen": "2025-01-13T12:10:34.858443-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/issues/4083": {
+    "StatusCode": 206,
+    "LastSeen": "2025-03-20T10:14:29.294035439Z"
   },
   "https://github.com/open-telemetry/opentelemetry-js/issues/4551": {
     "StatusCode": 206,
@@ -8702,6 +8758,18 @@
   "https://github.com/open-telemetry/opentelemetry-js/releases/latest": {
     "StatusCode": 206,
     "LastSeen": "2025-01-07T10:31:44.055855-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental%2Fv0.200.0": {
+    "StatusCode": 206,
+    "LastSeen": "2025-03-20T10:14:38.07150847Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/releases/tag/v2.0.0": {
+    "StatusCode": 206,
+    "LastSeen": "2025-03-20T10:14:33.420944891Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/tree/main/doc/upgrade-to-2.x.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-03-20T10:13:48.375113273Z"
   },
   "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/opentelemetry-web": {
     "StatusCode": 206,
@@ -13474,6 +13542,10 @@
   "https://groups.google.com/a/opentelemetry.io/g/calendar-go": {
     "StatusCode": 200,
     "LastSeen": "2025-01-17T12:58:38.699931Z"
+  },
+  "https://groups.google.com/a/opentelemetry.io/g/calendar-js": {
+    "StatusCode": 200,
+    "LastSeen": "2025-03-20T10:14:41.765468714Z"
   },
   "https://groups.google.com/a/opentelemetry.io/g/calendar-maintainer-meeting": {
     "StatusCode": 200,


### PR DESCRIPTION
OpenTelemetry JavaScript recently released SDK 2.0. There have been many improvements and breaking changes and we want to make this easily findable.

---

**Preview**: https://deploy-preview-6574--opentelemetry.netlify.app/blog/2025/otel-js-sdk-2-0/
