### PR TITLE
.NET - getting started bump to .NET8

### DIFF
--- a/content/en/docs/languages/net/getting-started.md
+++ b/content/en/docs/languages/net/getting-started.md
@@ -17,7 +17,7 @@ that [traces][], [metrics][] and [logs][] are emitted to the console.
 
 Ensure that you have the following installed locally:
 
-- [.NET SDK](https://dotnet.microsoft.com/download/dotnet) 6+
+- [.NET SDK](https://dotnet.microsoft.com/download/dotnet) 8+
 
 ## Example Application
 


### PR DESCRIPTION
Bump minimal .NET SDK to 8. Older versions are no longer supported.