### PR TITLE
Docsy upgrade to bring in new heading render hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,10 @@ assets/jsconfig.json
 # VS Code
 /.vscode/**
 
-# Webstorm
+# WebStorm
 /.idea/**
 
 .dart_tool
 pubspec.lock
+
+# cSpell:ignore pubspec

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,7 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/google/docsy.git
-	docsy-pin = v0.11.0-44-gcbc714be
+	docsy-pin = v0.11.0-48-g3b848255
 	docsy-note = "2024-04-01 Switching to google/docsy.git from cncf/docsy.git since we don't have any CNCF customizations."
 	docsy-reminder = "Ensure that any tag referenced by `docsy-pin` is present in the remote repo (url), otherwise add (push) the tags to the repo."
 [submodule "content-modules/opentelemetry-specification"]


### PR DESCRIPTION
- Upgrades Docsy to bring in new heading-render-hook functionality, in support of #6595 and use of `lang="en"` attributes
- Spell-check fixes