### PR TITLE
Nit fix to collector doc

### DIFF
--- a/content/en/docs/collector/_index.md
+++ b/content/en/docs/collector/_index.md
@@ -15,9 +15,7 @@ The OpenTelemetry Collector offers a vendor-agnostic implementation of how to
 receive, process and export telemetry data. It removes the need to run, operate,
 and maintain multiple agents/collectors. This works with improved scalability
 and supports open source observability data formats (e.g. Jaeger, Prometheus,
-Fluent Bit, etc.) sending to one or more open source or commercial backends. The
-local Collector agent is the default location to which instrumentation libraries
-export their telemetry data.
+Fluent Bit, etc.) sending to one or more open source or commercial backends.
 
 ## Objectives
 


### PR DESCRIPTION
Removed a technically incorrect statement about "instrumentation libraries" exporting telemetry.  It is OTLP Exporter that exports telemetry. I did not replace the statement with OTLP Exporter, because just few lines below (line 50) such a statement already exists.
