### PR TITLE
Add Dynatrace OTel collector to distribution list

### DIFF
--- a/data/ecosystem/distributions.yaml
+++ b/data/ecosystem/distributions.yaml
@@ -123,3 +123,7 @@
   url: https://github.com/embrace-io/embrace-react-native-sdk
   docsUrl: https://embrace.io/docs/open-telemetry/integration/#react-native
   components: [React Native, Javascript]
+- name: Dynatrace Distribution of the OpenTelemetry Collector
+  url: https://github.com/Dynatrace/dynatrace-otel-collector
+  docsUrl: https://docs.dynatrace.com/docs/shortlink/opentelemetry-collector
+  components: [Collector]

--- a/data/ecosystem/distributions.yaml
+++ b/data/ecosystem/distributions.yaml
@@ -1,4 +1,4 @@
-# cSpell:ignore Splunk AWS ADOT Grafana observIQ BindPlane RHOSDT RedHat Sumo Liatrio Lumigo Distro
+# cSpell:ignore Splunk AWS ADOT Grafana observIQ BindPlane RHOSDT RedHat Sumo Liatrio Lumigo Distro Dynatrace
 - name: Splunk Distribution of OpenTelemetry Collector
   url: https://github.com/signalfx/splunk-otel-collector
   docsUrl: https://docs.splunk.com/observability/en/gdi/opentelemetry/opentelemetry.html

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -1159,6 +1159,10 @@
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:05:12.345Z"
   },
+  "https://docs.dynatrace.com/docs/shortlink/opentelemetry-collector": {
+    "StatusCode": 206,
+    "LastSeen": "2025-03-28T08:01:17.634111921Z"
+  },
   "https://docs.expo.dev/get-started/introduction/": {
     "StatusCode": 206,
     "LastSeen": "2025-01-07T10:55:21.674477-05:00"
@@ -2366,6 +2370,10 @@
   "https://github.com/DoubleTK": {
     "StatusCode": 200,
     "LastSeen": "2024-11-18T07:27:46.234973166Z"
+  },
+  "https://github.com/Dynatrace/dynatrace-otel-collector": {
+    "StatusCode": 206,
+    "LastSeen": "2025-03-28T08:01:13.396025675Z"
   },
   "https://github.com/EzzioMoreira": {
     "StatusCode": 200,


### PR DESCRIPTION
This PR adds the [Dynatrace OpenTelemetry Collector](https://github.com/Dynatrace/dynatrace-otel-collector) distribution to the distribution list
