### PR TITLE
add missing provider.register() in serverless

### DIFF
--- a/content/en/docs/languages/js/serverless.md
+++ b/content/en/docs/languages/js/serverless.md
@@ -74,6 +74,8 @@ const provider = new NodeTracerProvider({
   spanProcessors: [spanProcessor],
 });
 
+provider.register();
+
 registerInstrumentations({
   instrumentations: [
     getNodeAutoInstrumentations({


### PR DESCRIPTION
add missing provider.register() in serverless example with aws lambda

<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->
