### PR TITLE
[CI] Upgrade tracing code by following JS SDK migration guide

### DIFF
--- a/assets/js/tracing.js
+++ b/assets/js/tracing.js
@@ -6,7 +6,7 @@ import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
 import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
-import { Resource } from '@opentelemetry/resources';
+import { resourceFromAttributes } from '@opentelemetry/resources';
 import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 import { ZoneContextManager } from '@opentelemetry/context-zone-peer-dep';
 
@@ -15,7 +15,7 @@ const collectorOptions = {
 };
 const exporter = new OTLPTraceExporter(collectorOptions);
 
-const resources = new Resource({
+const resources = resourceFromAttributes({
   [ATTR_SERVICE_NAME]: 'opentelemetry.io',
   'browser.language': navigator.language,
 });


### PR DESCRIPTION
- Fixes #6632.
  - We should probably be more careful when there are major version upgrades of OTel packages. /cc @cartermp 
- Local production build shows traces exported to the browser console ✅ 

**Preview**: https://deploy-preview-6633--opentelemetry.netlify.app/