### PR TITLE
Use alert component for java performance note

### DIFF
--- a/content/en/docs/zero-code/java/agent/performance.md
+++ b/content/en/docs/zero-code/java/agent/performance.md
@@ -92,9 +92,10 @@ increase agent overhead. For more information on how to turn off unnecessary
 instrumentations, see
 [Turn off specific instrumentations](#turn-off-specific-instrumentations).
 
-> [!NOTE] Experimental features of the Java agent might increase agent overhead
-> due to the experimental focus on functionality over performance. Stable
-> features are safer in terms of agent overhead.
+{{% alert title="Note" color="info" %}}Experimental features of the Java
+agent might increase agent overhead due to the experimental focus on
+functionality over performance. Stable features are safer in terms of agent
+overhead.{{% /alert %}}
 
 ## Troubleshooting agent overhead issues
 

--- a/content/en/docs/zero-code/java/agent/performance.md
+++ b/content/en/docs/zero-code/java/agent/performance.md
@@ -92,10 +92,13 @@ increase agent overhead. For more information on how to turn off unnecessary
 instrumentations, see
 [Turn off specific instrumentations](#turn-off-specific-instrumentations).
 
-{{% alert title="Note" color="info" %}}Experimental features of the Java agent
-might increase agent overhead due to the experimental focus on functionality
-over performance. Stable features are safer in terms of agent
-overhead.{{% /alert %}}
+{{% alert title="Note" color="info" %}}
+
+Experimental features of the Java agent might increase agent overhead due to
+the experimental focus on functionality over performance. Stable features are
+safer in terms of agent overhead.
+
+{{% /alert %}}
 
 ## Troubleshooting agent overhead issues
 

--- a/content/en/docs/zero-code/java/agent/performance.md
+++ b/content/en/docs/zero-code/java/agent/performance.md
@@ -92,9 +92,9 @@ increase agent overhead. For more information on how to turn off unnecessary
 instrumentations, see
 [Turn off specific instrumentations](#turn-off-specific-instrumentations).
 
-{{% alert title="Note" color="info" %}}Experimental features of the Java
-agent might increase agent overhead due to the experimental focus on
-functionality over performance. Stable features are safer in terms of agent
+{{% alert title="Note" color="info" %}}Experimental features of the Java agent
+might increase agent overhead due to the experimental focus on functionality
+over performance. Stable features are safer in terms of agent
 overhead.{{% /alert %}}
 
 ## Troubleshooting agent overhead issues

--- a/content/en/docs/zero-code/java/agent/performance.md
+++ b/content/en/docs/zero-code/java/agent/performance.md
@@ -94,9 +94,9 @@ instrumentations, see
 
 {{% alert title="Note" color="info" %}}
 
-Experimental features of the Java agent might increase agent overhead due to
-the experimental focus on functionality over performance. Stable features are
-safer in terms of agent overhead.
+Experimental features of the Java agent might increase agent overhead due to the
+experimental focus on functionality over performance. Stable features are safer
+in terms of agent overhead.
 
 {{% /alert %}}
 


### PR DESCRIPTION
Changing the format of this note to use an alert component instead of a quotation block for consistency with the way we handle these types of notes elsewhere.