### PR TITLE
Point to Configure the SDK

### DIFF
--- a/content/en/docs/zero-code/java/agent/configuration.md
+++ b/content/en/docs/zero-code/java/agent/configuration.md
@@ -5,6 +5,12 @@ aliases: [agent-config]
 cSpell:ignore: classloaders customizer logback
 ---
 
+{{% alert title="For more information" %}}
+This page describes the various ways in which configuration can be supplied to the java agent.
+For information on the configuration options themselves,
+see [Configure the SDK](/docs/languages/java/configuration).
+{{% /alert %}}
+
 ## Agent Configuration
 
 The agent can consume configuration from one or more of the following sources

--- a/content/en/docs/zero-code/java/agent/configuration.md
+++ b/content/en/docs/zero-code/java/agent/configuration.md
@@ -5,11 +5,10 @@ aliases: [agent-config]
 cSpell:ignore: classloaders customizer logback
 ---
 
-{{% alert title="For more information" %}}
-This page describes the various ways in which configuration can be supplied to the java agent.
-For information on the configuration options themselves,
-see [Configure the SDK](/docs/languages/java/configuration).
-{{% /alert %}}
+{{% alert title="For more information" %}} This page describes the various ways
+in which configuration can be supplied to the java agent. For information on the
+configuration options themselves, see
+[Configure the SDK](/docs/languages/java/configuration). {{% /alert %}}
 
 ## Agent Configuration
 

--- a/content/en/docs/zero-code/java/agent/configuration.md
+++ b/content/en/docs/zero-code/java/agent/configuration.md
@@ -6,7 +6,7 @@ cSpell:ignore: classloaders customizer logback
 ---
 
 {{% alert title="For more information" %}} This page describes the various ways
-in which configuration can be supplied to the java agent. For information on the
+in which configuration can be supplied to the Java agent. For information on the
 configuration options themselves, see
 [Configure the SDK](/docs/languages/java/configuration). {{% /alert %}}
 


### PR DESCRIPTION
This page is meta-level information about how to supply configuration options, but users might land here searching for what the options actually are.

I've added an alert at the top of the page pointing users to this information if they want it.

Fixes #6622.