### PR TITLE
Highlight a gotcha when sending OTLP data to hostPort

### DIFF
--- a/content/en/docs/security/config-best-practices.md
+++ b/content/en/docs/security/config-best-practices.md
@@ -239,6 +239,15 @@ env:
         fieldPath: status.hostIP
 ```
 
+However when sending OTLP data to `hostPort` this way, the default configuration of 
+[`k8sattributes` processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor) 
+prevents enriching pod OTLP data with k8s metadata (i.e. will not attach k8s.pod.name, 
+k8s.namespace.name, etc.). If Pod association rules are not configured for `k8sattributes`
+processor, resources are associated with metadata only by connection's IP Address. 
+Unfortunatelly sending via `hostPort` means that the Collector sees this connection
+as coming from the node and is unable to associate the pod with incoming OTLP data
+in its default configuration.
+
 ### Scrub sensitive data
 
 [Processors](/docs/collector/configuration/#processors) are the Collector


### PR DESCRIPTION
<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->

As a newcomer to OTEL it took me quite a while to figure out the root cause why pod metrics were not enriched with k8s attributes (k8s.pod.name, k8s.namespace.name, etc.) after I followed the best practices for deploying otel. 

I installed otel in `mode: daemonset` via helm chart https://open-telemetry.github.io/opentelemetry-helm-charts and enabled multiple presets, in particular the kubernetesAttributes preset https://opentelemetry.io/docs/kubernetes/collector/components/#kubernetes-attributes-processor and followed the kubernetes best practices to use `hostPort` as written here - https://opentelemetry.io/docs/security/config-best-practices/#kubernetes

However sending to hostPort means that more configuration is necessary for the k8sattributes processor to discover the pod metadata, as connection info is lost (the node's ip address appears as ip source to the collector).  More configuration can be e.g. setting a resource attribute (k8s.pod.ip or k8s.pod.uid) on the pod via an ENV var https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_resource_attributes and then this attribute can be matched in the  k8sattributes processor config.

With this change I want to highlight this gotcha, so it does not waste so much time for others.

