### PR TITLE
Remove text duplication in dotnet instrumentation

### DIFF
--- a/content/en/docs/languages/dotnet/instrumentation.md
+++ b/content/en/docs/languages/dotnet/instrumentation.md
@@ -636,8 +636,6 @@ var activity = MyActivitySource.StartActivity(
 
 {{% docs/languages/span-status-preamble %}}
 
-The status can be set at any time before the span is finished.
-
 It can be a good idea to record exceptions when they happen. It's recommended to
 do this in conjunction with
 [setting span status](/docs/specs/otel/trace/api/#set-status).


### PR DESCRIPTION
The sentence being removed already exists in the layouts/shortcodes/docs/languages/span-status-preamble.md file, so it appears as duplicate in the output docs: https://opentelemetry.io/docs/languages/dotnet/instrumentation/#set-activity-status