### PR TITLE
Add Otel demo link to Getting Started Dev

### DIFF
--- a/content/en/docs/getting-started/dev.md
+++ b/content/en/docs/getting-started/dev.md
@@ -22,6 +22,9 @@ natively:
 
 - [How can I add native instrumentation to my library?](../../concepts/instrumentation/libraries/)
 
+If you are looking for a set of applications to try things out, you will find
+our official [OpenTelemetry demo](/ecosystem/demo/) useful.
+
 Next, you can deep dive into the documentations for the
 [language](../../languages/) you are using:
 


### PR DESCRIPTION
<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->

## Goal 
Goal is to align the two Getting Started guides : 

https://opentelemetry.io/docs/getting-started/dev/
https://opentelemetry.io/docs/getting-started/ops/

The Getting Started Ops page have a link to the Otel demo but the Dev page doesn't have one. This should fix it. 

## Additional Notes

Also, I saw that the link goes to this page : 
https://opentelemetry.io/ecosystem/demo/
Which is not the demo page is this supposed to be this way ? 

Here is the direct demo page : 
https://opentelemetry.io/docs/demo/

