### PR TITLE
[pt] Update outdated pages under /pt/ecosystem

### DIFF
--- a/content/pt/ecosystem/distributions.md
+++ b/content/pt/ecosystem/distributions.md
@@ -3,7 +3,7 @@ title: Distribuições
 description:
   Lista de distribuições de código aberto do OpenTelemetry mantidas por
   terceiros.
-default_lang_commit: 8a15d0d668c516ccb255cd0a92e0bcd442e83b4d
+default_lang_commit: b6ddba1118d07bc3c8d1d07b293f227686d0290e
 drifted_from_default: true
 ---
 


### PR DESCRIPTION
Tracked on #6662 

Updates the `default_lang_commit` value for the following pages under `/pt/ecosystem`, that were marked as out-of-date:

- content/pt/ecosystem/distributions.md
- content/pt/ecosystem/integrations.md
- content/pt/ecosystem/vendors.md
- content/pt/ecosystem/adopters.md