### PR TITLE
[pt] Update default_lang_commit for drifted pages

### DIFF
--- a/content/pt/_includes/page-not-translated-msg.md
+++ b/content/pt/_includes/page-not-translated-msg.md
@@ -1,5 +1,5 @@
 ---
-default_lang_commit: 8d115a9df96c52dbbb3f96c05a843390d90a9800
+default_lang_commit: 1ececa0615b64c5dfd93fd6393f3e4052e0cc496
 drifted_from_default: true
 ---
 

--- a/content/pt/docs/concepts/components.md
+++ b/content/pt/docs/concepts/components.md
@@ -2,7 +2,7 @@
 title: Componentes
 description: Os principais componentes que compõem o OpenTelemetry
 weight: 20
-default_lang_commit: f5c228e5d03deaabc00d5920c5757bf7bd23e3f3
+default_lang_commit: 99a39c5e4e51daba968bfbb3eb078be4a14ad363
 drifted_from_default: true
 ---
 

--- a/content/pt/docs/concepts/instrumentation/libraries.md
+++ b/content/pt/docs/concepts/instrumentation/libraries.md
@@ -2,7 +2,7 @@
 title: Bibliotecas
 description: Aprenda como adicionar instrumentação nativa à sua biblioteca.
 weight: 40
-default_lang_commit: e09adae2c06b71a08cafb2b1c42e3e7b9e48997b
+default_lang_commit: d8e58463c6e7c324b01115ab4f88d1f2bcf802c2
 drifted_from_default: true
 ---
 

--- a/content/pt/docs/concepts/instrumentation/zero-code/index.md
+++ b/content/pt/docs/concepts/instrumentation/zero-code/index.md
@@ -4,7 +4,7 @@ description: >-
   Aprenda como adicionar observabilidade a uma aplicação sem precisar escrever
   código
 weight: 10
-default_lang_commit: 2127d75cef0be2f2554f5b47520a108ba381b790
+default_lang_commit: d1ef521ee4a777881fb99c3ec2b506e068cdec4c
 ---
 
 Como [operações](/docs/getting-started/ops/), você pode querer adicionar

--- a/content/pt/docs/concepts/resources/index.md
+++ b/content/pt/docs/concepts/resources/index.md
@@ -1,7 +1,7 @@
 ---
 title: Recursos
 weight: 70
-default_lang_commit: 17c3b8eb53b8abc56213abb736c0f850eab752df
+default_lang_commit: 86d2fbde246b9e56665146db78d4fc1d34d00ddf
 drifted_from_default: true
 ---
 
@@ -14,7 +14,7 @@ observabilidade, os atributos do recurso são agrupados na guia **Process**:
 
 ![Uma captura de tela do Jaeger mostrando um exemplo de saída de atributos do recurso associados a um rastro.](screenshot-jaeger-resources.png)
 
-Um recurso é adicionado ao `TraceProvider` ou `MetricProvider` quando eles são
+Um recurso é adicionado ao `TracerProvider` ou `MetricProvider` quando eles são
 criados durante a inicialização. Esta associação não pode ser alterada
 posteriormente. Após um recurso ser adicionado, todos os trechos e métricas
 produzidos a partir de um `Tracer` ou `Meter` do _provider_ terão o recurso

--- a/content/pt/docs/getting-started/ops.md
+++ b/content/pt/docs/getting-started/ops.md
@@ -1,7 +1,7 @@
 ---
 title: Primeiros passos para Operações
 linkTitle: Ops
-default_lang_commit: 6a828d6dd3a3a8ef3cbf1b7d283f335b4626ae62
+default_lang_commit: 99a39c5e4e51daba968bfbb3eb078be4a14ad363
 drifted_from_default: true
 ---
 

--- a/content/pt/docs/languages/_includes/instrumentation-intro.md
+++ b/content/pt/docs/languages/_includes/instrumentation-intro.md
@@ -1,5 +1,5 @@
 ---
-default_lang_commit: 080527543eae90112f01c89342891aabd6258173 # patched
+default_lang_commit: 1ececa0615b64c5dfd93fd6393f3e4052e0cc496 # patched
 drifted_from_default: true
 ---
 

--- a/content/pt/docs/languages/_index.md
+++ b/content/pt/docs/languages/_index.md
@@ -4,7 +4,7 @@ description:
   A instrumentação de código do OpenTelemetry é suportada para muitas linguagens
   populares de programação.
 weight: 250
-default_lang_commit: e6aed25fb78cbd1c1934c70f4f7c11f411f4c24e
+default_lang_commit: d1ef521ee4a777881fb99c3ec2b506e068cdec4c
 drifted_from_default: true
 ---
 

--- a/content/pt/docs/languages/js/_includes/browser-instrumentation-warning.md
+++ b/content/pt/docs/languages/js/_includes/browser-instrumentation-warning.md
@@ -1,5 +1,5 @@
 ---
-default_lang_commit: 0dac041dedfe5877f45e36065c1c6fb07490b243 # patched
+default_lang_commit: 1ececa0615b64c5dfd93fd6393f3e4052e0cc496 # patched
 drifted_from_default: true
 ---
 

--- a/content/pt/docs/languages/js/getting-started/browser.md
+++ b/content/pt/docs/languages/js/getting-started/browser.md
@@ -3,7 +3,7 @@ title: Navegador
 aliases: [/docs/js/getting_started/browser]
 description: Aprenda como adicionar o OpenTelemetry à sua aplicação de navegador
 weight: 20
-default_lang_commit: 7cb1bd39726fc03698164ee17fe9087afdac054c
+default_lang_commit: 1ececa0615b64c5dfd93fd6393f3e4052e0cc496
 drifted_from_default: true
 ---
 

--- a/content/pt/ecosystem/adopters.md
+++ b/content/pt/ecosystem/adopters.md
@@ -1,7 +1,7 @@
 ---
 title: Adotantes
 description: Organizações que usam OpenTelemetry
-default_lang_commit: 748555c22f43476291ae0c7974ca4a2577da0472
+default_lang_commit: b6ddba1118d07bc3c8d1d07b293f227686d0290e
 drifted_from_default: true
 ---
 

--- a/content/pt/ecosystem/distributions.md
+++ b/content/pt/ecosystem/distributions.md
@@ -3,7 +3,7 @@ title: Distribuições
 description:
   Lista de distribuições de código aberto do OpenTelemetry mantidas por
   terceiros.
-default_lang_commit: 8a15d0d668c516ccb255cd0a92e0bcd442e83b4d
+default_lang_commit: b6ddba1118d07bc3c8d1d07b293f227686d0290e
 drifted_from_default: true
 ---
 

--- a/content/pt/ecosystem/integrations.md
+++ b/content/pt/ecosystem/integrations.md
@@ -3,7 +3,7 @@ title: Integrações
 description:
   Bibliotecas, serviços e aplicações com suporte nativo para o OpenTelemetry.
 aliases: [/integrations]
-default_lang_commit: 8a15d0d668c516ccb255cd0a92e0bcd442e83b4d
+default_lang_commit: b6ddba1118d07bc3c8d1d07b293f227686d0290e
 drifted_from_default: true
 ---
 

--- a/content/pt/ecosystem/vendors.md
+++ b/content/pt/ecosystem/vendors.md
@@ -2,7 +2,7 @@
 title: Fornecedores
 description: Fornecedores que oferecem suporte nativo ao OpenTelemetry
 aliases: [/vendors]
-default_lang_commit: 8a15d0d668c516ccb255cd0a92e0bcd442e83b4d
+default_lang_commit: b6ddba1118d07bc3c8d1d07b293f227686d0290e
 drifted_from_default: true
 ---
 


### PR DESCRIPTION
## Description

Tracked on #6662 

The following pages are marked as drifted, however, their content remains the same since the last commit. Ths PR only updates the `default_lang_commit` value for them. 

## Pages

- [content/pt/ecosystem/distributions.md](https://github.com/open-telemetry/opentelemetry.io/compare/8a15d0d668c516ccb255cd0a92e0bcd442e83b4d...b6ddba1118d07bc3c8d1d07b293f227686d0290e#diff-9c846049966b6c82c5895b32af85022d16ac9299d3eccf93bd4ba858461f0177)
- [content/pt/ecosystem/integrations.md](https://github.com/open-telemetry/opentelemetry.io/compare/8a15d0d668c516ccb255cd0a92e0bcd442e83b4d...HEAD#diff-d3131193abe43d44e1b8a1614a6cb79da9eb8a33267267c0f9be8fafb52d1f12)
- [content/pt/ecosystem/vendors.md](https://github.com/open-telemetry/opentelemetry.io/compare/8a15d0d668c516ccb255cd0a92e0bcd442e83b4d...b6ddba1118d07bc3c8d1d07b293f227686d0290e#diff-57eeae6db393d84762f18f855096080d034af34091eae5fb6f6163a225845717)
- [content/pt/ecosystem/adopters.md](https://github.com/open-telemetry/opentelemetry.io/compare/8a15d0d668c516ccb255cd0a92e0bcd442e83b4d...b6ddba1118d07bc3c8d1d07b293f227686d0290e#diff-5cd505be5b98e80944c45992f9433878021b119eeca38290778e64adc4cf92dc)
- [content/pt/_includes/page-not-translated-msg.md](https://github.com/open-telemetry/opentelemetry.io/compare/8d115a9df96c52dbbb3f96c05a843390d90a9800...1ececa0615b64c5dfd93fd6393f3e4052e0cc496#diff-049244012cd040b4df2b4dc4b5ab09b6629c868fc9777d3fd81e672aaadcc870)
- [content/pt/docs/languages/_includes/instrumentation-intro.md](https://github.com/open-telemetry/opentelemetry.io/compare/080527543eae90112f01c89342891aabd6258173...1ececa0615b64c5dfd93fd6393f3e4052e0cc496#diff-703e8ccbbd06fde050ac1d7b5d2b30c7bf55082eafe7dfbcc7c2763fc8bfcaaa)
- [content/pt/docs/languages/js/_includes/browser-instrumentation-warning.md](https://github.com/open-telemetry/opentelemetry.io/compare/0dac041dedfe5877f45e36065c1c6fb07490b243...1ececa0615b64c5dfd93fd6393f3e4052e0cc496#diff-2691d1ffb245a9c6d758fafa1668800f645aa3d68490023e615f5c981baac56d)
- [content/pt/docs/languages/js/getting-started/browser.md](https://github.com/open-telemetry/opentelemetry.io/compare/7cb1bd39726fc03698164ee17fe9087afdac054c...1ececa0615b64c5dfd93fd6393f3e4052e0cc496#diff-9d470e2e0faff0c81f5484dec77f89980346001b54f1db7b421404e22aa071dc)
- [content/pt/docs/languages/_index.md](https://github.com/open-telemetry/opentelemetry.io/compare/e6aed25fb78cbd1c1934c70f4f7c11f411f4c24e...d1ef521ee4a777881fb99c3ec2b506e068cdec4c#diff-097c0299e37591d8eea65628e18433976c197298adf3874aa4fdb2d85e0fbc06)
- [content/pt/docs/getting-started/ops.md](https://github.com/open-telemetry/opentelemetry.io/compare/6a828d6dd3a3a8ef3cbf1b7d283f335b4626ae62...99a39c5e4e51daba968bfbb3eb078be4a14ad363#diff-6bab07f79580ddcfc5e4a7db33e0073458a59598a40e4849ea48204459305453)
- [content/pt/docs/concepts/resources/index.md](https://github.com/open-telemetry/opentelemetry.io/compare/17c3b8eb53b8abc56213abb736c0f850eab752df...86d2fbde246b9e56665146db78d4fc1d34d00ddf#diff-c05fa8e307af70c1bbd93ddf719b475a67b158a7f5d0df2a2b011ca0c0bc0eee)
- [content/pt/docs/concepts/components.md](https://github.com/open-telemetry/opentelemetry.io/compare/f5c228e5d03deaabc00d5920c5757bf7bd23e3f3...99a39c5e4e51daba968bfbb3eb078be4a14ad363#diff-8a80d3f2bb6219e3aa2380de5b72d72f826d7249a6a28468a7de48c1e9f887b1)
- [content/pt/docs/concepts/instrumentation/zero-code/index.md](https://github.com/open-telemetry/opentelemetry.io/compare/2127d75cef0be2f2554f5b47520a108ba381b790...d1ef521ee4a777881fb99c3ec2b506e068cdec4c)
- [content/pt/docs/concepts/instrumentation/libraries.md](https://github.com/open-telemetry/opentelemetry.io/compare/e09adae2c06b71a08cafb2b1c42e3e7b9e48997b...d8e58463c6e7c324b01115ab4f88d1f2bcf802c2#diff-dfb606bc16f5604c91f7eecf4e1dc4170dd26b3dcbf06f5083f8e97ab44fbb24)