### PR TITLE
[pt] Updated localized content on content/pt/status.md

### DIFF
--- a/content/pt/status.md
+++ b/content/pt/status.md
@@ -4,7 +4,7 @@ menu: { main: { weight: 30 } }
 aliases: [/project-status, /releases]
 description: Nível de maturidade dos principais componentes do OpenTelemetry
 type: docs
-body_class: td-no-left-sidebar 
+body_class: td-no-left-sidebar
 default_lang_commit: 1f83b9ffa3ecdd5e2b507379cc259e5678596c7f
 drifted_from_default: true
 ---

--- a/content/pt/status.md
+++ b/content/pt/status.md
@@ -3,13 +3,11 @@ title: Status
 menu: { main: { weight: 30 } }
 aliases: [/project-status, /releases]
 description: Nível de maturidade dos principais componentes do OpenTelemetry
-default_lang_commit: a6e46dac8b73165a904e9fee4c1ee46305a8b968
+type: docs
+body_class: td-no-left-sidebar 
+default_lang_commit: 1f83b9ffa3ecdd5e2b507379cc259e5678596c7f
 drifted_from_default: true
 ---
-
-{{% blocks/section color="white" %}}
-
-## {{% param title %}}
 
 O OpenTelemetry é composto de
 [diversos componentes](/docs/concepts/components/), alguns específicos e outros
@@ -58,5 +56,3 @@ O Operator em si está em um _status_
 Para o _status_ de desenvolvimento ou nível de maturidade da
 [especificação](/docs/specs/otel/), consulte o seguinte:
 [Resumo do _Status_ da Especificação](/docs/specs/status/).
-
-{{% /blocks/section %}}


### PR DESCRIPTION
## Description

Tracked on #6662 

Updates the drifted content for `content/pt/status.md`.

```diff
❯ npm run check:i18n -- -d content/pt/status.md


> check:i18n
> scripts/check-i18n.sh -d content/pt/status.md

Processing paths: content/pt/status.md
diff --git a/content/en/status.md b/content/en/status.md
index 513cc8ea..a741c3d2 100644
--- a/content/en/status.md
+++ b/content/en/status.md
@@ -3,12 +3,10 @@ title: Status
 menu: { main: { weight: 30 } }
 aliases: [/project-status, /releases]
 description: Maturity-level of the main OpenTelemetry components
+type: docs
+body_class: td-no-left-sidebar
 ---
 
-{{% blocks/section color="white" %}}
-
-## {{% param title %}}
-
 OpenTelemetry is made up of [several components](/docs/concepts/components/),
 some language-specific and others language-agnostic. When looking for a
 [status](/docs/specs/otel/versioning-and-stability/), make sure to look for the
@@ -50,5 +48,3 @@ state with components in `v1alpha1` and `v1beta1` states.
 For the development status, or maturity level, of the
 [specification](/docs/specs/otel/), see the following:
 [Specification Status Summary](/docs/specs/status/).
-
-{{% /blocks/section %}}
DRIFTED files: 1 out of 1
```