### PR TITLE
Update rust documentation: `exporters`

### DIFF
--- a/content/en/docs/languages/rust/exporters.md
+++ b/content/en/docs/languages/rust/exporters.md
@@ -11,28 +11,43 @@ To send trace data to a OTLP endpoint (like the [collector](/docs/collector) or
 Jaeger) you'll want to use an exporter crate, such as
 [opentelemetry-otlp](https://crates.io/crates/opentelemetry-otlp):
 
+For example, you can update the [Getting Started](../getting-started/) dice server by adding the new dependency:
+
 ```toml
 [dependencies]
-opentelemetry-otlp = { version = "{{% version-from-registry exporter-rust-otlp %}}", features = ["default"] }
+opentelemetry-otlp = { version = "{{% version-from-registry exporter-rust-otlp %}}", features = ["grpc-tonic"] }
 ```
 
-Next, configure the exporter to point at an OTLP endpoint. For example you can
-update `init_tracer` in `dice_server.rs` from the
-[Getting Started](../getting-started/) like the following:
+Next, update `init_tracer_provider` in `dice_server.rs` to configure the exporter to point at an OTLP endpoint:
 
 ```rust
-fn init_tracer() {
-    match SpanExporter::new_tonic(ExportConfig::default(), TonicConfig::default()) {
-        Ok(exporter) => {
-            global::set_text_map_propagator(TraceContextPropagator::new());
-            let provider = TracerProvider::builder()
-                .with_simple_exporter(exporter)
-                .build();
-            global::set_tracer_provider(provider);
-        },
-        Err(why) => panic!("{:?}", why)
-    }
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use std::sync::OnceLock;
 
+use http_body_util::Full;
+use hyper::{Method, Request, Response, body::Bytes, server::conn::http1, service::service_fn};
+use hyper_util::rt::TokioIo;
+use opentelemetry::global::{self, BoxedTracer};
+use opentelemetry::trace::{Span, SpanKind, Status, Tracer};
+use opentelemetry_otlp::SpanExporter;
+use opentelemetry_sdk::{Resource, propagation::TraceContextPropagator, trace::SdkTracerProvider};
+use rand::Rng;
+use tokio::net::TcpListener;
+
+// ...
+
+fn init_tracer_provider() {
+    let exporter = SpanExporter::builder()
+        .with_tonic()
+        .build()
+        .expect("Failed to create span exporter");
+    let provider = SdkTracerProvider::builder()
+        .with_resource(Resource::builder().with_service_name("dice_server").build())
+        .with_batch_exporter(exporter)
+        .build();
+    global::set_text_map_propagator(TraceContextPropagator::new());
+    global::set_tracer_provider(provider);
 }
 ```
 
@@ -55,3 +70,5 @@ docker run -d --name jaeger \
   -p 9411:9411 \
   jaegertracing/all-in-one:latest
 ```
+
+Make requests on [http://localhost:8080/rolldice](http://localhost:8080/rolldice) and check the traces on Jaeger on [http://localhost:16686](http://localhost:16686)

--- a/data/registry/exporter-rust-otlp.yml
+++ b/data/registry/exporter-rust-otlp.yml
@@ -17,4 +17,4 @@ createdAt: 2020-08-28
 package:
   registry: crates
   name: opentelemetry-otlp
-  version: 0.14.0
+  version: 0.28.0


### PR DESCRIPTION
- Fixes #5947 and #5473

### Changes:

- Update `opentelemetry-otlp` from `0.14` to `0.28` in the registry to be on par with the other rust otel dependencies
- Update  the `exporters` page & code samples to use the updated `opentelemetry-otlp` version and list the modified imports.

I updated to 0.28 instead of the latest 0.29 as all the other examples and crates are still on 0.28.