### PR TITLE
[pt] Updated localized content on content/pt/docs/what-is-opentelemetry.md

### DIFF
--- a/content/pt/docs/what-is-opentelemetry.md
+++ b/content/pt/docs/what-is-opentelemetry.md
@@ -71,10 +71,10 @@ Se você quiser saber mais, dê uma olhada na
 
 O OpenTelemetry consiste dos seguintes componentes:
 
-- Uma [especificação](../specs/otel) para todos os componentes
-- Um [protocolo](../specs/otlp/) padrão que define o formato dos dados de
+- Uma [especificação](/docs/specs/otel) para todos os componentes
+- Um [protocolo](/docs/specs/otlp/) padrão que define o formato dos dados de
   telemetria
-- [Convenções semânticas](../specs/semconv/) que estabelecem um padrão de
+- [Convenções semânticas](/docs/specs/semconv/) que estabelecem um padrão de
   nomenclatura para tipos comuns de dados de telemetria
 - APIs que definem como gerar dados de telemetria
 - [SDKs para linguagens de programação](../languages) que implementam a

--- a/content/pt/docs/what-is-opentelemetry.md
+++ b/content/pt/docs/what-is-opentelemetry.md
@@ -2,51 +2,56 @@
 title: O que é o OpenTelemetry?
 description: Uma breve explicação sobre o que o OpenTelemetry é e não é.
 weight: 150
-default_lang_commit: f37118d8489a60d73dd881645f317d866b53b418
+default_lang_commit: 44d2ea2545c36610dc64be455cef7e7b8491cfe5
 drifted_from_default: true
 ---
 
 O OpenTelemetry é:
 
-- Um _framework_ de
-  [Observabilidade](/docs/concepts/observability-primer/#what-is-observability)
-  e um conjunto de ferramentas projetadas para criar e gerenciar dados de
-  telemetria como [rastros](/docs/concepts/signals/traces/),
-  [métricas](/docs/concepts/signals/metrics/) e
-  [logs](/docs/concepts/signals/logs/).
-- Agnóstico em relação a fornecedores e ferramentas, o que possibilita ser
-  utilizado com uma grande variedade de _backends_ de observabilidade, incluindo
-  ferramentas de código aberto como [Jaeger](https://www.jaegertracing.io/) e
-  [Prometheus](https://prometheus.io/), além de soluções comerciais.
-- Não é um _backend_ de observabilidade como Jaeger, Prometheus ou outras
-  soluções comerciais.
-- É focado na geração, coleta, gerenciamento e exportação de telemetria. Um dos
-  principais objetivos do OpenTelemetry é permitir que você possa instrumentar
-  suas aplicações ou sistemas de forma fácil, independentemente da linguagem,
-  infraestrutura ou ambiente de execução. O armazenamento e a visualização da
-  telemetria são intencionalmente deixados para outras ferramentas.
+- Um **_framework_ e conjunto de ferramentas** projetado para facilitar a
 
-## O que é observabilidade?
+  - [Geração][instr]
+  - Exportação
+  - [Coleta](../concepts/components/#collector)
 
-[Observabilidade](/docs/concepts/observability-primer/#what-is-observability) é
-a capacidade de entender o estado interno de um sistema ao examinar os dados que
-ele emite. No contexto de software, isso significa ser capaz de entender o
-estado interno do sistema analisando seus dados de telemetria, que incluem
-rastros, métricas e logs.
+  de [dados de telemetria][] como [rastros], [métricas] e [logs].
 
-Para tornar um sistema observável, ele deve ser
-[instrumentado](/docs/concepts/instrumentation). Ou seja, o código deve emitir
-[rastros](/docs/concepts/signals/traces/),
-[métricas](/docs/concepts/signals/metrics/) ou
-[logs](/docs/concepts/signals/logs/). Os dados instrumentados devem então ser
-enviados para um backend de observabilidade.
+- **Código aberto**, além de **agnóstico em relação a fornecedores e
+  ferramentas**, o que possibilita ser utilizado com uma grande variedade de
+  _backends_ de observabilidade, incluindo ferramentas de código aberto como
+  [Jaeger] e [Prometheus], além de soluções comerciais. O OpenTelemetry **não**
+  é um _backend_ de observabilidade.
 
-## Por que OpenTelemetry?
+Um dos principais objetivos do OpenTelemetry é permitir que você possa
+instrumentar suas aplicações ou sistemas de maneira fácil, independentemente da
+linguagem de programação, infraestrutura ou ambiente de execução.
+
+O _backend_ (armazenamento) e o _frontend_ (visualização) de dados de telemetria
+são intencionalmente deixados para outras ferramentas.
+
+<div class="td-max-width-on-larger-screens">
+{{< youtube iEEIabOha8U >}}
+</div>
+
+Para mais vídeos nesta série e mais recursos, consulte
+[Próximos passos](#what-next)
+
+## O que é observabilidade? {#what-is-observability}
+
+[Observabilidade] é a capacidade de entender o estado interno de um sistema ao
+examinar os dados que ele emite. No contexto de software, isso significa ser
+capaz de entender o estado interno do sistema analisando seus dados de
+telemetria, que incluem rastros, métricas e logs.
+
+Para tornar um sistema observável, ele deve ser [instrumentado][instr]. Ou seja,
+o código deve emitir [rastros], [métricas] ou [logs]. Os dados instrumentados
+devem então ser enviados para um backend de observabilidade.
+
+## Por que OpenTelemetry? {#why-opentelemetry}
 
 Com a ascensão da computação em nuvem, arquiteturas de microsserviços e
 requisitos de negócios cada vez mais complexos, a necessidade de
-[observabilidade](/docs/concepts/observability-primer/#what-is-observability) de
-software e infraestrutura é cada vez maior.
+[observabilidade] de software e infraestrutura é cada vez maior.
 
 O OpenTelemetry atende à necessidade de observabilidade seguindo dois
 princípios-chave:
@@ -61,28 +66,28 @@ precisam no mundo da computação moderna atual.
 Se você quiser saber mais, dê uma olhada na
 [missão, visão e valores](/community/mission/) do OpenTelemetry.
 
-## Os principais componentes do OpenTelemetry
+## Os principais componentes do OpenTelemetry {#main-opentelemetry-components}
 
 O OpenTelemetry consiste dos seguintes componentes:
 
-- Uma [especificação](/docs/specs/otel) para todos os componentes
-- Um [protocolo](/docs/specs/otlp/) padrão que define o formato dos dados de
+- Uma [especificação](../specs/otel) para todos os componentes
+- Um [protocolo](../specs/otlp/) padrão que define o formato dos dados de
   telemetria
-- [Convenções semânticas](/docs/specs/semconv/) que estabelecem um padrão de
+- [Convenções semânticas](../specs/semconv/) que estabelecem um padrão de
   nomenclatura para tipos comuns de dados de telemetria
 - APIs que definem como gerar dados de telemetria
-- [SDKs para linguagens de programação](/docs/languages) que implementam a
+- [SDKs para linguagens de programação](../languages) que implementam a
   especificação, APIs e exportação de dados de telemetria
 - Um [ecossistema de bibliotecas](/ecosystem/registry) que implementa
   instrumentação para bibliotecas e frameworks comuns
 - Componentes para instrumentação automática que geram dados de telemetria sem
   exigir alterações no código
-- O [OpenTelemetry Collector](/docs/collector), um _proxy_ intermediário que
+- O [OpenTelemetry Collector](../collector), um _proxy_ intermediário que
   recebe, processa e exporta dados de telemetria
 - Várias outras ferramentas, como o
-  [OpenTelemetry Operator para Kubernetes](/docs/platforms/kubernetes/operator/),
-  [OpenTelemetry Helm Charts](/docs/platforms/kubernetes/helm/), e
-  [recursos da comunidade para FaaS](/docs/platforms/faas/)
+  [OpenTelemetry Operator para Kubernetes](../platforms/kubernetes/operator/),
+  [OpenTelemetry Helm Charts](../platforms/kubernetes/helm/), e
+  [recursos da comunidade para FaaS](../platforms/faas/)
 
 O OpenTelemetry é utilizado por diversas
 [bibliotecas, serviços e aplicativos](/ecosystem/integrations/) que o integram
@@ -92,7 +97,7 @@ O OpenTelemetry é suportado por inúmeros [fornecedores](/ecosystem/vendors/),
 muitos dos quais oferecem suporte comercial para o OpenTelemetry e contribuem
 diretamente para o projeto.
 
-## Extensibilidade
+## Extensibilidade {#extensibility}
 
 O OpenTelemetry é projetado para ser extensível. Alguns exemplos de como ele
 pode ser estendido incluem:
@@ -100,8 +105,8 @@ pode ser estendido incluem:
 - Adicionar um _receiver_ ao OpenTelemetry Collector para suportar dados de
   telemetria de uma fonte personalizada
 - Carregar bibliotecas de instrumentação personalizadas em um SDK
-- Criar uma [distribuição](/docs/concepts/distributions/) de um SDK ou do
-  Collector adaptada a um caso de uso específico
+- Criar uma [distribuição](../concepts/distributions/) de um SDK ou do Collector
+  adaptada a um caso de uso específico
 - Criar um novo _exporter_ para um _backend_ personalizado que ainda não suporta
   o protocolo do OpenTelemetry (OTLP)
 - Criar um propagador personalizado para formatos de propagação de contexto não
@@ -112,23 +117,40 @@ projeto é projetado para tornar isso possível em quase todos os níveis.
 
 ## História {#history}
 
-O OpenTelemetry é um projeto da
-[Cloud Native Computing Foundation (CNCF)](https://www.cncf.io) que é resultado
-da [fusão] entre dois projetos anteriores, [OpenTracing](https://opentracing.io)
-e [OpenCensus](https://opencensus.io). Ambos os projetos foram criados para
-resolver o mesmo problema: a falta de um padrão de como instrumentar o código e
-enviar dados de telemetria para um _backend_ de Observabilidade. Como nenhum dos
-projetos conseguiu resolver o problema por completo de forma independente, eles
-se fundiram para formar o OpenTelemetry e combinar seus esforços para oferecer
-uma solução única.
+O OpenTelemetry é um projeto da [Cloud Native Computing Foundation][] (CNCF) que
+é resultado da [fusão] entre dois projetos anteriores,
+[OpenTracing](https://opentracing.io) e [OpenCensus](https://opencensus.io).
+Ambos os projetos foram criados para resolver o mesmo problema: a falta de um
+padrão de como instrumentar o código e enviar dados de telemetria para um
+_backend_ de Observabilidade. Como nenhum dos projetos conseguiu resolver o
+problema por completo de forma independente, eles se fundiram para formar o
+OpenTelemetry e combinar seus esforços para oferecer uma solução única.
 
 Se você está atualmente utilizando OpenTracing ou OpenCensus, pode aprender como
-migrar para o OpenTelemetry no [guia de migração](/docs/migration/).
+migrar para o OpenTelemetry no [guia de migração](../migration/).
 
 [fusão]:
   https://www.cncf.io/blog/2019/05/21/a-brief-history-of-opentelemetry-so-far/
 
-## Próximos passos
+## Próximos passos {#what-next}
 
-- [Começando](/docs/getting-started/) &mdash; mergulhe de cabeça!
-- Aprenda sobre os [conceitos do OpenTelemetry](/docs/concepts/).
+- [Começando](../getting-started/) &mdash; mergulhe de cabeça!
+- Aprenda sobre os [conceitos do OpenTelemetry](../concepts/).
+- [Assista vídeos][] da série [OTel para iniciantes][] ou outras [listas de
+  reprodução].
+- Registre-se nos [treinamentos](/training), incluindo o **treinamento
+  gratuito** _[Getting started with OpenTelemetry](/training/#courses)_.
+
+[Cloud Native Computing Foundation]: https://www.cncf.io
+[instr]: ../concepts/instrumentation
+[Jaeger]: https://www.jaegertracing.io/
+[logs]: ../concepts/signals/logs/
+[métricas]: ../concepts/signals/metrics/
+[observabilidade]: ../concepts/observability-primer/#what-is-observability
+[OTel para iniciantes]:
+  https://www.youtube.com/playlist?list=PLVYDBkQ1TdyyWjeWJSjXYUaJFVhplRtvN
+[listas de reprodução]: https://www.youtube.com/@otel-official/playlists
+[Prometheus]: https://prometheus.io/
+[dados de telemetria]: ../concepts/signals/
+[rastros]: ../concepts/signals/traces/
+[Assista vídeos]: https://www.youtube.com/@otel-official

--- a/content/pt/docs/what-is-opentelemetry.md
+++ b/content/pt/docs/what-is-opentelemetry.md
@@ -3,7 +3,6 @@ title: O que é o OpenTelemetry?
 description: Uma breve explicação sobre o que o OpenTelemetry é e não é.
 weight: 150
 default_lang_commit: 44d2ea2545c36610dc64be455cef7e7b8491cfe5
-drifted_from_default: true
 cSpell:ignore: youtube
 ---
 

--- a/content/pt/docs/what-is-opentelemetry.md
+++ b/content/pt/docs/what-is-opentelemetry.md
@@ -4,6 +4,7 @@ description: Uma breve explicação sobre o que o OpenTelemetry é e não é.
 weight: 150
 default_lang_commit: 44d2ea2545c36610dc64be455cef7e7b8491cfe5
 drifted_from_default: true
+cSpell:ignore: youtube
 ---
 
 O OpenTelemetry é:


### PR DESCRIPTION
## Description

Tracked on #6662 

Updates the drifted content for `content/pt/docs/what-is-opentelemetry.md`.

```diff
❯ npm run check:i18n -- -d content/pt/docs/what-is-opentelemetry.md


> check:i18n
> scripts/check-i18n.sh -d content/pt/docs/what-is-opentelemetry.md

Processing paths: content/pt/docs/what-is-opentelemetry.md
diff --git a/content/en/docs/what-is-opentelemetry.md b/content/en/docs/what-is-opentelemetry.md
index bcb28175..12d3c14c 100644
--- a/content/en/docs/what-is-opentelemetry.md
+++ b/content/en/docs/what-is-opentelemetry.md
@@ -1,50 +1,56 @@
 ---
 title: What is OpenTelemetry?
-description: A short explanation of what OpenTelemetry is and isn't.
+description: A brief explanation of what OpenTelemetry is and isn't.
 aliases: [/about, /docs/concepts/what-is-opentelemetry, /otel]
 weight: 150
+cSpell:ignore: youtube
 ---
 
 OpenTelemetry is:
 
-- An [Observability](/docs/concepts/observability-primer/#what-is-observability)
-  framework and toolkit designed to create and manage telemetry data such as
-  [traces](/docs/concepts/signals/traces/),
-  [metrics](/docs/concepts/signals/metrics/), and
-  [logs](/docs/concepts/signals/logs/).
-- Vendor- and tool-agnostic, meaning that it can be used with a broad variety of
-  Observability backends, including open source tools like
-  [Jaeger](https://www.jaegertracing.io/) and
-  [Prometheus](https://prometheus.io/), as well as commercial offerings.
-- Not an observability backend like Jaeger, Prometheus, or other commercial
-  vendors.
-- Focused on the generation, collection, management, and export of telemetry. A
-  major goal of OpenTelemetry is that you can easily instrument your
-  applications or systems, no matter their language, infrastructure, or runtime
-  environment. The storage and visualization of telemetry is intentionally left
-  to other tools.
+- An **[observability] framework and toolkit** designed to facilitate the
+
+  - [Generation][instr]
+  - Export
+  - [Collection](../concepts/components/#collector)
+
+  of [telemetry data][] such as [traces], [metrics], and [logs].
+
+- **Open source**, as well as **vendor- and tool-agnostic**, meaning that it can
+  be used with a broad variety of observability backends, including open source
+  tools like [Jaeger] and [Prometheus], as well as commercial offerings.
+  OpenTelemetry is **not** an observability backend itself.
+
+A major goal of OpenTelemetry is to enable easy instrumentation of your
+applications and systems, regardless of the programming language,
+infrastructure, and runtime environments used.
+
+The backend (storage) and the frontend (visualization) of telemetry data are
+intentionally left to other tools.
+
+<div class="td-max-width-on-larger-screens">
+{{< youtube iEEIabOha8U >}}
+</div>
+
+For more videos in this series and additional resources, see
+[What next?](#what-next)
 
 ## What is observability?
 
-[Observability](/docs/concepts/observability-primer/#what-is-observability) is
-the ability to understand the internal state of a system by examining its
-outputs. In the context of software, this means being able to understand the
-internal state of a system by examining its telemetry data, which includes
-traces, metrics, and logs.
+[Observability] is the ability to understand the internal state of a system by
+examining its outputs. In the context of software, this means being able to
+understand the internal state of a system by examining its telemetry data, which
+includes traces, metrics, and logs.
 
-To make a system observable, it must be
-[instrumented](/docs/concepts/instrumentation). That is, the code must emit
-[traces](/docs/concepts/signals/traces/),
-[metrics](/docs/concepts/signals/metrics/), or
-[logs](/docs/concepts/signals/logs/). The instrumented data must then be sent to
-an observability backend.
+To make a system observable, it must be [instrumented][instr]. That is, the code
+must emit [traces], [metrics], or [logs]. The instrumented data must then be
+sent to an observability backend.
 
 ## Why OpenTelemetry?
 
 With the rise of cloud computing, microservices architectures, and increasingly
 complex business requirements, the need for software and infrastructure
-[observability](/docs/concepts/observability-primer/#what-is-observability) is
-greater than ever.
+[observability] is greater than ever.
 
 OpenTelemetry satisfies the need for observability while following two key
 principles:
@@ -62,24 +68,23 @@ If you want to learn more, take a look at OpenTelemetry's
 
 OpenTelemetry consists of the following major components:
 
-- A [specification](/docs/specs/otel) for all components
-- A standard [protocol](/docs/specs/otlp/) that defines the shape of telemetry
-  data
-- [Semantic conventions](/docs/specs/semconv/) that define a standard naming
-  scheme for common telemetry data types
+- A [specification](../specs/otel) for all components
+- A standard [protocol](../specs/otlp/) that defines the shape of telemetry data
+- [Semantic conventions](../specs/semconv/) that define a standard naming scheme
+  for common telemetry data types
 - APIs that define how to generate telemetry data
-- [Language SDKs](/docs/languages) that implement the specification, APIs, and
+- [Language SDKs](../languages) that implement the specification, APIs, and
   export of telemetry data
 - A [library ecosystem](/ecosystem/registry) that implements instrumentation for
   common libraries and frameworks
 - Automatic instrumentation components that generate telemetry data without
   requiring code changes
-- The [OpenTelemetry Collector](/docs/collector), a proxy that receives,
-  processes, and exports telemetry data
+- The [OpenTelemetry Collector](../collector), a proxy that receives, processes,
+  and exports telemetry data
 - Various other tools, such as the
-  [OpenTelemetry Operator for Kubernetes](/docs/kubernetes/operator/),
-  [OpenTelemetry Helm Charts](/docs/kubernetes/helm/), and
-  [community assets for FaaS](/docs/faas/)
+  [OpenTelemetry Operator for Kubernetes](../platforms/kubernetes/operator/),
+  [OpenTelemetry Helm Charts](../platforms/kubernetes/helm/), and
+  [community assets for FaaS](../platforms/faas/)
 
 OpenTelemetry is used by a wide variety of
 [libraries, services and apps](/ecosystem/integrations/) that have OpenTelemetry
@@ -97,7 +102,7 @@ extended include:
 - Adding a receiver to the OpenTelemetry Collector to support telemetry data
   from a custom source
 - Loading custom instrumentation libraries into an SDK
-- Creating a [distribution](/docs/concepts/distributions/) of an SDK or the
+- Creating a [distribution](../concepts/distributions/) of an SDK or the
   Collector tailored to a specific use case
 - Creating a new exporter for a custom backend that doesn't yet support the
   OpenTelemetry protocol (OTLP)
@@ -108,8 +113,7 @@ designed to make it possible at nearly every level.
 
 ## History
 
-OpenTelemetry is a
-[Cloud Native Computing Foundation (CNCF)](https://www.cncf.io) project that is
+OpenTelemetry is a [Cloud Native Computing Foundation][] (CNCF) project that is
 the result of a [merger] between two prior projects,
 [OpenTracing](https://opentracing.io) and [OpenCensus](https://opencensus.io).
 Both of these projects were created to solve the same problem: the lack of a
@@ -119,12 +123,29 @@ they merged to form OpenTelemetry and combine their strengths while offering a
 single solution.
 
 If you are currently using OpenTracing or OpenCensus, you can learn how to
-migrate to OpenTelemetry in the [Migration guide](/docs/migration/).
+migrate to OpenTelemetry in the [Migration guide](../migration/).
 
 [merger]:
   https://www.cncf.io/blog/2019/05/21/a-brief-history-of-opentelemetry-so-far/
 
 ## What next?
 
-- [Getting started](/docs/getting-started/) &mdash; jump right in!
-- Learn about [OpenTelemetry concepts](/docs/concepts/).
+- [Getting started](../getting-started/) &mdash; jump right in!
+- Learn about [OpenTelemetry concepts](../concepts/).
+- [Watch videos][] from the [OTel for beginners][] or other [playlists].
+- Sign up for [training](/training), including the **free course**
+  [Getting started with OpenTelemetry](/training/#courses).
+
+[Cloud Native Computing Foundation]: https://www.cncf.io
+[instr]: ../concepts/instrumentation
+[Jaeger]: https://www.jaegertracing.io/
+[logs]: ../concepts/signals/logs/
+[metrics]: ../concepts/signals/metrics/
+[observability]: ../concepts/observability-primer/#what-is-observability
+[OTel for beginners]:
+  https://www.youtube.com/playlist?list=PLVYDBkQ1TdyyWjeWJSjXYUaJFVhplRtvN
+[playlists]: https://www.youtube.com/@otel-official/playlists
+[Prometheus]: https://prometheus.io/
+[telemetry data]: ../concepts/signals/
+[traces]: ../concepts/signals/traces/
+[Watch videos]: https://www.youtube.com/@otel-official
DRIFTED files: 1 out of 1
```