### PR TITLE
[pt] Update localized content on content/pt/docs/getting-started/dev.md

### DIFF
--- a/content/pt/docs/getting-started/dev.md
+++ b/content/pt/docs/getting-started/dev.md
@@ -1,7 +1,7 @@
 ---
 title: Primeiros passos para Desenvolvedores
 linkTitle: Dev
-default_lang_commit: 6a828d6dd3a3a8ef3cbf1b7d283f335b4626ae62
+default_lang_commit: f1ccafef4b5070f26ce63a3dc19fcafc8a00fb8f
 ---
 
 A página [primeiros-passos](..) é para você se:
@@ -23,6 +23,9 @@ dependência em outros softwares, recomendamos que você aprenda como pode
 fornecer telemetria nativamente:
 
 - [Como adicionar instrumentação nativa à minha biblioteca?](../../concepts/instrumentation/libraries/)
+
+Se você está procurando um conjunto de aplicações para testar coisas, a nossa
+[demonstração oficial do OpenTelemetry](/ecosystem/demo/) poderá ser útil.
 
 Em seguida, você pode se aprofundar na documentação da
 [linguagem](../../languages/) que você está usando:

--- a/content/pt/docs/getting-started/dev.md
+++ b/content/pt/docs/getting-started/dev.md
@@ -24,7 +24,7 @@ fornecer telemetria nativamente:
 
 - [Como adicionar instrumentação nativa à minha biblioteca?](../../concepts/instrumentation/libraries/)
 
-Se você está procurando um conjunto de aplicações para testar coisas, a nossa
+Se você está procurando um conjunto de aplicações para realizar testes, a nossa
 [demonstração oficial do OpenTelemetry](/ecosystem/demo/) poderá ser útil.
 
 Em seguida, você pode se aprofundar na documentação da


### PR DESCRIPTION
## Description

Tracked on #6662 

Updates the drifted content for `content/pt/docs/getting-started/dev.md`.

```diff
❯ npm run check:i18n -- -d content/pt/docs/getting-started/dev.md

> check:i18n
> scripts/check-i18n.sh -d content/pt/docs/getting-started/dev.md

Processing paths: content/pt/docs/getting-started/dev.md
diff --git a/content/en/docs/getting-started/dev.md b/content/en/docs/getting-started/dev.md
index 73c8175a..82f4a63f 100644
--- a/content/en/docs/getting-started/dev.md
+++ b/content/en/docs/getting-started/dev.md
@@ -22,11 +22,14 @@ natively:
 
 - [How can I add native instrumentation to my library?](../../concepts/instrumentation/libraries/)
 
+If you are looking for a set of applications to try things out, you will find
+our official [OpenTelemetry demo](/ecosystem/demo/) useful.
+
 Next, you can deep dive into the documentations for the
 [language](../../languages/) you are using:
 
 - [C++](../../languages/cpp/)
-- [.NET](../../languages/net/)
+- [.NET](../../languages/dotnet/)
 - [Erlang / Elixir](../../languages/erlang/)
 - [Go](../../languages/go/)
 - [Java](../../languages/java/)
DRIFTED files: 1 out of 1
```