### PR TITLE
[pt] Update localized content on content/pt/docs/concepts/instrumentation/_index.md

### DIFF
--- a/content/pt/docs/concepts/instrumentation/_index.md
+++ b/content/pt/docs/concepts/instrumentation/_index.md
@@ -2,21 +2,18 @@
 title: Instrumentação
 description: Como o OpenTelemetry facilita a instrumentação
 weight: 15
-default_lang_commit: 82bd738d51426acb34e126b230a8a1281f193e3e
+default_lang_commit: efeda2d8ded2471211697c3993f6d475a3a8b06e
 drifted_from_default: true
 ---
 
-Para que um sistema seja observável, ele deve ser **instrumentado**: ou seja, o
-código dos componentes do sistema deve emitir
-[rastros](/docs/concepts/signals/traces/),
-[métricas](/docs/concepts/signals/metrics/) e
-[logs](/docs/concepts/signals/logs/).
+Para que um sistema seja [observável], ele deve ser **instrumentado**: ou seja,
+o código dos componentes do sistema deve emitir [rastros], [métricas] e [logs].
 
 Com o OpenTelemetry, você pode instrumentar seu código de duas maneiras:
 
-1. [Soluções manuais](/docs/concepts/instrumentation/code-based) por meio das
+1. [Soluções manuais](code-based/) por meio das
    [APIs e SDKs oficiais para a maioria das linguagens](/docs/languages/)
-2. [Soluções sem código](/docs/concepts/instrumentation/zero-code/)
+2. [Soluções sem código](zero-code/)
 
 As **soluções manuais** permitem obter uma visão mais aprofundada e telemetria
 rica diretamente da sua aplicação. Possibilitando o uso da API OpenTelemetry
@@ -39,19 +36,26 @@ código. Os seguintes recursos também fazem parte do OpenTelemetry:
 - Bibliotecas podem utilizar a API OpenTelemetry como dependência, sem impactar
   as aplicações que usam essa biblioteca, a menos que o SDK do OpenTelemetry
   seja importado.
-- Para cada [sinal](/docs/concepts/signals) (rastros, métricas, logs), você tem
-  à disposição diversos métodos para criá-los, processá-los e exportá-los.
-- Com a [propagação de contexto](/docs/concepts/context-propagation) integrada
-  nas implementações, você pode correlacionar sinais, independentemente de onde
-  eles são gerados.
-- [Recursos](/docs/concepts/resources) e
+- Para cada um dos sinais [sinais], você tem à disposição diversos métodos para
+  criá-los, processá-los e exportá-los.
+- Com a [propagação de contexto](../context-propagation/) integrada nas
+  implementações, você pode correlacionar sinais independentemente de onde eles
+  são gerados.
+- [Recursos](../resources/) e
   [Escopo de instrumentação](/docs/concepts/instrumentation-scope) permitem
   agrupar sinais por diferentes entidades, como
-  [host](/docs/specs/semconv/resource/host/),
+  [Escopo de instrumentação](../instrumentation-scope/) permitem agrupar sinais
+  por diferentes entidades, como [host](/docs/specs/semconv/resource/host/),
   [sistema operacional](/docs/specs/semconv/resource/os/) ou
   [cluster K8s](/docs/specs/semconv/resource/k8s/#cluster).
 - Cada implementação específica de linguagem da API e SDK segue os requisitos e
   expectativas da [especificação OpenTelemetry](/docs/specs/otel/).
-- As [Convenções Semânticas](/docs/concepts/semantic-conventions) fornecem um
-  esquema de nomenclatura comum que pode ser usado para padronização em
-  diferentes bases de código e plataformas.
+- As [Convenções Semânticas](../semantic-conventions/) fornecem um esquema de
+  nomenclatura comum que pode ser usado para padronização em diferentes bases de
+  código e plataformas.
+
+[logs]: ../signals/logs/
+[métricas]: ../signals/metrics/
+[observável]: ../observability-primer/#what-is-observability
+[sinais]: ../signals/
+[rastros]: ../signals/traces/

--- a/content/pt/docs/concepts/instrumentation/_index.md
+++ b/content/pt/docs/concepts/instrumentation/_index.md
@@ -36,14 +36,12 @@ código. Os seguintes recursos também fazem parte do OpenTelemetry:
 - Bibliotecas podem utilizar a API OpenTelemetry como dependência, sem impactar
   as aplicações que usam essa biblioteca, a menos que o SDK do OpenTelemetry
   seja importado.
-- Para cada um dos sinais [sinais], você tem à disposição diversos métodos para
+- Para cada um dos [sinais], você tem à disposição diversos métodos para
   criá-los, processá-los e exportá-los.
 - Com a [propagação de contexto](../context-propagation/) integrada nas
   implementações, você pode correlacionar sinais independentemente de onde eles
   são gerados.
 - [Recursos](../resources/) e
-  [Escopo de instrumentação](/docs/concepts/instrumentation-scope) permitem
-  agrupar sinais por diferentes entidades, como
   [Escopo de instrumentação](../instrumentation-scope/) permitem agrupar sinais
   por diferentes entidades, como [host](/docs/specs/semconv/resource/host/),
   [sistema operacional](/docs/specs/semconv/resource/os/) ou


### PR DESCRIPTION
## Description

Tracked on #6662 

Updates the drifted content for `content/pt/docs/concepts/instrumentation/_index.md`.

```diff
❯ npm run check:i18n -- -d content/pt/docs/concepts/instrumentation/_index.md

> check:i18n
> scripts/check-i18n.sh -d content/pt/docs/concepts/instrumentation/_index.md

Processing paths: content/pt/docs/concepts/instrumentation/_index.md
diff --git a/content/en/docs/concepts/instrumentation/_index.md b/content/en/docs/concepts/instrumentation/_index.md
index 39ae1d73..665b3a81 100644
--- a/content/en/docs/concepts/instrumentation/_index.md
+++ b/content/en/docs/concepts/instrumentation/_index.md
@@ -5,16 +5,15 @@ aliases: [instrumenting]
 weight: 15
 ---
 
-In order to make a system observable, it must be **instrumented**: That is, code
-from the system's components must emit [traces](/docs/concepts/signals/traces/),
-[metrics](/docs/concepts/signals/metrics/), and
-[logs](/docs/concepts/signals/logs/).
+For a system to be [observable], it must be **instrumented**: that is, code from
+the system's components must emit [signals], such as [traces], [metrics], and
+[logs].
 
 Using OpenTelemetry, you can instrument your code in two primary ways:
 
-1. [Code-based solutions](/docs/concepts/instrumentation/code-based) via
-   official [APIs and SDKs for most languages](/docs/languages/)
-2. [Zero-code solutions](/docs/concepts/instrumentation/zero-code/)
+1. [Code-based solutions](code-based/) via official
+   [APIs and SDKs for most languages](/docs/languages/)
+2. [Zero-code solutions](zero-code/)
 
 **Code-based** solutions allow you to get deeper insight and rich telemetry from
 your application itself. They let you use the OpenTelemetry API to generate
@@ -37,20 +36,24 @@ solutions. The following things are also a part of OpenTelemetry:
 - Libraries can leverage the OpenTelemetry API as a dependency, which will have
   no impact on applications using that library, unless the OpenTelemetry SDK is
   imported.
-- For each [signal](/docs/concepts/signals) (traces, metrics, logs) you have
-  several methods at your disposals to create, process, and export them.
-- With [context propagation](/docs/concepts/context-propagation) built into the
+- For each of the [signals] you have several methods at your disposal to create,
+  process, and export them.
+- With [context propagation](../context-propagation/) built into the
   implementations, you can correlate signals regardless of where they are
   generated.
-- [Resources](/docs/concepts/resources) and
-  [Instrumentation Scopes](/docs/concepts/instrumentation-scope) allow grouping
-  of signals, by different entities, like, the
-  [host](/docs/specs/semconv/resource/host/),
+- [Resources](../resources/) and
+  [Instrumentation Scopes](../instrumentation-scope/) allow grouping of signals,
+  by different entities, like, the [host](/docs/specs/semconv/resource/host/),
   [operating system](/docs/specs/semconv/resource/os/) or
   [K8s cluster](/docs/specs/semconv/resource/k8s/#cluster)
 - Each language-specific implementation of the API and SDK follows the
   requirements and expectations of the
   [OpenTelemetry specification](/docs/specs/otel/).
-- [Semantic Conventions](/docs/concepts/semantic-conventions) provide a common
-  naming schema that can be used for standardization across code bases and
-  platforms.
+- [Semantic Conventions](../semantic-conventions/) provide a common naming
+  schema that can be used for standardization across code bases and platforms.
+
+[logs]: ../signals/logs/
+[metrics]: ../signals/metrics/
+[observable]: ../observability-primer/#what-is-observability
+[signals]: ../signals/
+[traces]: ../signals/traces/
DRIFTED files: 1 out of 1
```