### PR TITLE
[pt] Update localized content on content/pt/docs/concepts/glossary.md

### DIFF
--- a/content/pt/docs/concepts/glossary.md
+++ b/content/pt/docs/concepts/glossary.md
@@ -149,7 +149,7 @@ linguagens. Consulte [mais informações][specification].
 ### Evento {#event}
 
 Um Evento é um [Registro de Log](#log-record) com um nome de evento e uma
-estrutura bem definida. Por exemplo, eventos de navegador no OpenTelemetry
+estrutura bem conhecida. Por exemplo, eventos de navegador no OpenTelemetry
 seguem uma convenção de nomenclatura particular e carregam dados específicos em
 uma estrutura comum.
 

--- a/content/pt/docs/concepts/glossary.md
+++ b/content/pt/docs/concepts/glossary.md
@@ -4,7 +4,7 @@ description: >-
   Definições e convenções para termos de telemetria conforme usados no
   OpenTelemetry.
 weight: 200
-default_lang_commit: f37118d8489a60d73dd881645f317d866b53b418
+default_lang_commit: 389e023192e051a3a835bfc6a71089c98af3b8a8
 drifted_from_default: true
 ---
 
@@ -148,8 +148,10 @@ linguagens. Consulte [mais informações][specification].
 
 ### Evento {#event}
 
-Algo que aconteceu cuja representação depende da [Fonte de dados](#data-source).
-Por exemplo, [Trecho](#span).
+Um Evento é um [Registro de Log](#log-record) com um nome de evento e uma
+estrutura bem definida. Por exemplo, eventos de navegador no OpenTelemetry
+seguem uma convenção de nomenclatura particular e carregam dados específicos em
+uma estrutura comum.
 
 ### Exporter
 
@@ -325,10 +327,9 @@ atributos podem ser incluídos no `Recurso`.
 
 ### Registro de log {#log-record}
 
-Uma gravação de um [Evento](#event). Normalmente, o registro inclui um carimbo
-de data/hora indicando quando o [Evento](#event) ocorreu, além de outros dados
-que descrevem o que aconteceu, onde aconteceu, e assim por diante. Consulte
-[mais informações][log record].
+Uma gravação de dados com o carimbo de data/hora e uma severidade. Também pode
+possuir um [ID de Rastro](#trace) e um [ID de Trecho](#span), quando
+correlacionado com um rastro. Consulte [mais informações][log record].
 
 ### REST
 


### PR DESCRIPTION
## Description

Tracked on #6662 

Updates the drifted content for `content/pt/docs/concepts/glossary.md`.

```diff
❯ npm run check:i18n -- -d content/pt/docs/concepts/glossary.md

> check:i18n
> scripts/check-i18n.sh -d content/pt/docs/concepts/glossary.md

Processing paths: content/pt/docs/concepts/glossary.md
diff --git a/content/en/docs/concepts/glossary.md b/content/en/docs/concepts/glossary.md
index e393a25e..89b2b68c 100644
--- a/content/en/docs/concepts/glossary.md
+++ b/content/en/docs/concepts/glossary.md
@@ -116,8 +116,9 @@ some customizations. See [more][distribution].
 
 ### Event
 
-Something that happened where representation depends on the
-[Data source](#data-source). For example, [Spans](#span).
+An Event is a [Log Record](#log-record) with an event name and a well-known
+structure. For example, browser events in OpenTelemetry follow a particular
+naming convention and carry particular data in a common structure.
 
 ### Exporter
 
@@ -180,9 +181,9 @@ qualifiers, for example, `Log record`. See [more][log]
 
 ### Log record
 
-A recording of an [Event](#event). Typically, the record includes a timestamp
-indicating when the [Event](#event) happened as well as other data that
-describes what happened, where it happened, and so on. See [more][log record].
+A recording of data with a timestamp and a severity. May also have a
+[Trace ID](#trace) and [Span ID](#span) when correlated with a trace. See
+[more][log record].
 
 ### Metadata
 
DRIFTED files: 1 out of 1
```