### PR TITLE
Add Tranzzo to OpenTelemetry adopters

### DIFF
--- a/data/ecosystem/adopters.yaml
+++ b/data/ecosystem/adopters.yaml
@@ -1,4 +1,4 @@
-# cSpell:ignore Dyte Farfetch Globale Datenrettungsdienste Uplight Wandera Zocdoc Sicredi Skyscanner VTEX
+# cSpell:ignore Dyte Farfetch Globale Datenrettungsdienste Uplight Wandera Zocdoc Sicredi Skyscanner Tranzzo VTEX
 - name: AppDirect
   url: https://www.appdirect.com/
   components: [Collector]
@@ -124,6 +124,11 @@
   components: []
   reference: ''
   contact: ''
+- name: Tranzzo
+  url: https://tranzzo.com/
+  components: [Collector, Java]
+  reference: ''
+  contact: https://github.com/illenko
 - name: Uplight
   url: https://uplight.com/
   components: [Collector, Ruby, Java, Python, .NET]


### PR DESCRIPTION
Tranzzo adopted OpenTelemetry ~ 1 year ago and actively uses it to collect traces and metrics.

OpenTelemetry Collector is a core component where all signals are sent, then data is processed by Prometheus (or VictoriaMetrics for other environment) and Jaeger.

We have 2 main stacks for our backend: Java + Spring and Scala + Play.

For Java + Spring services, we use Micrometer as a Vendor-neutral application observability facade with OTLP exporter.
Scala + Play services instrumented using Java OpenTelemetry SDK.

The metrics and traces gathered through OpenTelemetry play a crucial role in Tranzzo's release processes, ongoing monitoring efforts, and performance optimization initiatives.

We are happy with OpenTelemetry, which allows us to switch between observability backends easily.

For now we do not have blog post or something to add as a reference, but after we create it - I will add it ASAP.