### PR TITLE
Updated OpenTelemetryCollector demo manifest

### DIFF
--- a/content/en/docs/platforms/kubernetes/operator/automatic.md
+++ b/content/en/docs/platforms/kubernetes/operator/automatic.md
@@ -58,12 +58,12 @@ example that will be `demo-collector`.
 
 ```bash
 kubectl apply -f - <<EOF
-apiVersion: opentelemetry.io/v1alpha1
+apiVersion: opentelemetry.io/v1beta1
 kind: OpenTelemetryCollector
 metadata:
   name: demo
 spec:
-  config: |
+  config:
     receivers:
       otlp:
         protocols:
@@ -79,10 +79,9 @@ spec:
       batch:
         send_batch_size: 10000
         timeout: 10s
-
     exporters:
-      # NOTE: Prior to v0.86.0 use `logging` instead of `debug`.
       debug:
+        verbosity: basic
 
     service:
       pipelines:


### PR DESCRIPTION
I wanted to get started using open telemetry auto instrumentation. Following the docs on this site and applying the demo manifest I received a deprecation warning.

This PR replaces the demo manifest updating the apiVersion from `v1alpha1`  to `v1beta1`.

Note: I added `config.exporters.debug.verbosity: basic` because simply `config.exporters.debug` results in `invalid configuration: no exporter configuration specified in config`

