### PR TITLE
Fix Java native instrumentation entries

### DIFF
--- a/data/registry/instrumentation-java-elasticsearch-client.yml
+++ b/data/registry/instrumentation-java-elasticsearch-client.yml
@@ -15,6 +15,6 @@ authors:
     url: https://github.com/elastic
 urls:
   website: https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/index.html
-  docs: https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/opentelemetry.html
+  docs: https://www.elastic.co/docs/reference/elasticsearch/clients/java/setup/opentelemetry
 createdAt: '2024-08-06'
 isNative: true

--- a/data/registry/instrumentation-java-micrometer-tracing.yml
+++ b/data/registry/instrumentation-java-micrometer-tracing.yml
@@ -11,6 +11,7 @@ authors:
     url: https://github.com/micrometer-metrics
 urls:
   website: https://micrometer.io/
-  docs: https://docs.micrometer.io/micrometer/reference/implementations/otlp.html
+  docs: https://docs.micrometer.io/tracing/reference/api.html#_micrometer_tracing_opentelemetry_setup
+  repo: https://github.com/micrometer-metrics/tracing/tree/main/micrometer-tracing-bridges/micrometer-tracing-bridge-otel
 createdAt: 2024-08-06
-isNative: true
+isNative: false

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -1423,6 +1423,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-02-01T07:12:05.346585-05:00"
   },
+  "https://docs.micrometer.io/tracing/reference/api.html#_micrometer_tracing_opentelemetry_setup": {
+    "StatusCode": 206,
+    "LastSeen": "2025-04-24T05:50:04.173252398-07:00"
+  },
   "https://docs.microsoft.com/aspnet/core": {
     "StatusCode": 200,
     "LastSeen": "2025-02-02T10:58:41.536648-05:00"
@@ -4858,6 +4862,10 @@
   "https://github.com/micrometer-metrics": {
     "StatusCode": 200,
     "LastSeen": "2025-02-02T15:45:53.024Z"
+  },
+  "https://github.com/micrometer-metrics/tracing/tree/main/micrometer-tracing-bridges/micrometer-tracing-bridge-otel": {
+    "StatusCode": 206,
+    "LastSeen": "2025-04-24T05:50:03.356710098-07:00"
   },
   "https://github.com/microsft": {
     "StatusCode": 206,
@@ -18550,6 +18558,10 @@
   "https://www.elastic.co/": {
     "StatusCode": 206,
     "LastSeen": "2025-01-13T12:10:40.954551-05:00"
+  },
+  "https://www.elastic.co/docs/reference/elasticsearch/clients/java/setup/opentelemetry": {
+    "StatusCode": 206,
+    "LastSeen": "2025-04-24T05:49:17.499365942-07:00"
   },
   "https://www.elastic.co/elasticsearch": {
     "StatusCode": 206,


### PR DESCRIPTION
<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->

Addresses issues discussed briefly in https://github.com/open-telemetry/opentelemetry.io/issues/6741

In particular:
- Updates the link for the Elasticsearch Java client
- Adjusts the entry fro Micrometer Tracing by 1) correcting the entry (change value of `isNative` to false, since it's not actually a native instrumentation, but rather a bridging component); 2) correcting and updating the URLs (previously the documentation link lead to the Micrometer->OTLP documentation)
