### PR TITLE
Docsy upgrade to use new render-heading partial

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,7 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/google/docsy.git
-	docsy-pin = v0.11.0-52-g9b1fda96
+	docsy-pin = v0.11.0-53-g343cdec1
 	docsy-note = "2024-04-01 Switching to google/docsy.git from cncf/docsy.git since we don't have any CNCF customizations."
 	docsy-reminder = "Ensure that any tag referenced by `docsy-pin` is present in the remote repo (url), otherwise add (push) the tags to the repo."
 [submodule "content-modules/opentelemetry-specification"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,7 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/google/docsy.git
-	docsy-pin = v0.11.0-48-g3b848255
+	docsy-pin = v0.11.0-52-g9b1fda96
 	docsy-note = "2024-04-01 Switching to google/docsy.git from cncf/docsy.git since we don't have any CNCF customizations."
 	docsy-reminder = "Ensure that any tag referenced by `docsy-pin` is present in the remote repo (url), otherwise add (push) the tags to the repo."
 [submodule "content-modules/opentelemetry-specification"]

--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,1 +1,1 @@
-{{ template "_default/_markup/td-render-heading.html" . }}
+{{ partial "td/render-heading.html" . }}


### PR DESCRIPTION
- In prep for Hugo upgrade.
- Followup to #6743
- Upgrades Docsy to use new render-heading hook partial
- No change to generated site files other than CSS file updates due to Bootstrap upgrade