### PR TITLE
[pt] Create index-intro.md include and drop shortcodes

### DIFF
--- a/content/pt/docs/languages/_includes/index-intro.md
+++ b/content/pt/docs/languages/_includes/index-intro.md
@@ -1,16 +1,6 @@
-{{/*
-default_lang_commit: 2e21274a01a24a62c67595591d8f4255bef640fc
-*/ -}} {{ $prettier_ignore := `
-
-<!-- prettier-ignore -->
-` -}}
-{{ $lang := .Get 0 -}}
-{{ $data := index $.Site.Data.instrumentation $lang }}
-{{ $name := $data.name -}}
-
-{{ $tracesStatus := partial "docs/get-signal-status.html" (dict "lang" $lang "signal" "traces") -}}
-{{ $metricsStatus := partial "docs/get-signal-status.html" (dict "lang" $lang "signal" "metrics") -}}
-{{ $logsStatus := partial "docs/get-signal-status.html" (dict "lang" $lang "signal" "logs") -}}
+---
+default_lang_commit: 3c38c3392fc74f8f071a7a0179fbd141faa7dc40
+---
 
 Esta é a documentação do OpenTelemetry para a linguagem {{ $name }}. O
 OpenTelemetry é um framework de observabilidade -- API, SDKs, e ferramentas que
@@ -27,4 +17,10 @@ O estado atual dos principais componentes funcionais do OpenTelemetry para
 | ------------------- | -------------------- | ----------------- |
 | {{ $tracesStatus }} | {{ $metricsStatus }} | {{ $logsStatus }} |
 
-{{ partial "pt/docs/latest-release.md" (dict "lang" $lang "Inner" .Inner) -}}
+Para lançamentos, incluindo a [última versão][latest release], consulte a página
+de [Lançamentos][Releases]. {{ $.Inner }}
+
+[latest release]:
+  <https://github.com/open-telemetry/opentelemetry-{{ $lang }}/releases/latest>
+[Releases]:
+  <https://github.com/open-telemetry/opentelemetry-{{ $lang }}/releases>

--- a/content/pt/docs/languages/_includes/instrumentation-intro.md
+++ b/content/pt/docs/languages/_includes/instrumentation-intro.md
@@ -1,6 +1,5 @@
 ---
 default_lang_commit: 1ececa0615b64c5dfd93fd6393f3e4052e0cc496 # patched
-drifted_from_default: true
 ---
 
 [Instrumentação](/docs/concepts/instrumentation/) é o ato de adicionar código de

--- a/content/pt/docs/languages/go/_index.md
+++ b/content/pt/docs/languages/go/_index.md
@@ -5,10 +5,10 @@ description: >-
   alt="Go"> A language-specific implementation of OpenTelemetry in Go.
 aliases: [/golang, /golang/metrics, /golang/tracing]
 weight: 16
-default_lang_commit: 06837fe15457a584f6a9e09579be0f0400593d57
+default_lang_commit: 06837fe15457a584f6a9e09579be0f0400593d57 # patched
 ---
 
-{{% pt/docs/languages/index-intro go /%}}
+{{% docs/languages/index-intro go /%}}
 
 ## Mais
 

--- a/content/pt/docs/languages/python/_index.md
+++ b/content/pt/docs/languages/python/_index.md
@@ -5,10 +5,10 @@ description: >-
   alt="Python"> Uma implementação específica de linguagem do OpenTelemetry em
   Python.
 weight: 22
-default_lang_commit: 3fd0bb513e5d3fa6f178a73584322bcc469f15e0
+default_lang_commit: 3fd0bb513e5d3fa6f178a73584322bcc469f15e0 # patched
 ---
 
-{{% pt/docs/languages/index-intro python /%}}
+{{% docs/languages/index-intro python /%}}
 
 ## Suporte de Versão {#status-and-releases}
 

--- a/layouts/partials/pt/docs/latest-release.md
+++ b/layouts/partials/pt/docs/latest-release.md
@@ -1,7 +1,0 @@
-{{ $relUrl := printf "https://github.com/open-telemetry/opentelemetry-%s/releases" .lang -}}
-
-Para lançamentos, incluindo a [última versão][latest release], consulte a página de [Lançamentos][Releases].
-{{- .Inner }}
-
-[latest release]: {{ $relUrl }}/latest
-[Releases]: {{ $relUrl }}


### PR DESCRIPTION
- Contributes to #6460 for `pt` pages
- Continues work started in #6750
- Moves the content of `shortcodes/pt/docs/languages/index-intro.md` into the drift-trackable `content/pt/docs/languages/_includes/index-intro.md` file
- Drop the two partials under `layouts/partials/pt/docs/` that are no longer necessary under this new scheme.

### Previews

- https://deploy-preview-6751--opentelemetry.netlify.app/pt/docs/languages/python/ - is the [same as before](https://opentelemetry.io/pt/docs/languages/python/)
- https://deploy-preview-6751--opentelemetry.netlify.app/pt/docs/languages/cpp/ now pickup the `pt` include even if the rest of the page is still in `en` :)

/cc @open-telemetry/docs-pt-approvers 