### PR TITLE
[ja] Create index-intro.md include and drop shortcodes

### DIFF
--- a/content/ja/docs/languages/_includes/index-intro.md
+++ b/content/ja/docs/languages/_includes/index-intro.md
@@ -1,14 +1,6 @@
-{{ $prettier_ignore := `
-
-<!-- prettier-ignore -->
-` -}}
-{{ $lang := .Get 0 -}}
-{{ $data := index $.Site.Data.instrumentation $lang }}
-{{ $name := $data.name -}}
-
-{{ $tracesStatus := partial "docs/get-signal-status.html" (dict "lang" $lang "signal" "traces") -}}
-{{ $metricsStatus := partial "docs/get-signal-status.html" (dict "lang" $lang "signal" "metrics") -}}
-{{ $logsStatus := partial "docs/get-signal-status.html" (dict "lang" $lang "signal" "logs") -}}
+---
+default_lang_commit: 3c38c3392fc74f8f071a7a0179fbd141faa7dc40
+---
 
 これはOpenTelemetry{{ $name }}のドキュメントです。
 OpenTelemetryはオブザーバビリティのためのフレームワークであり、メトリクス、ログ、トレースといったアプリケーションのテレメトリーデータの生成および収集を支援するように設計された API、SDK、およびツール群で構成されています。
@@ -22,4 +14,10 @@ OpenTelemetry {{ $name }}の主要な機能コンポーネントの現在のス�
 | ------------------- | -------------------- | ----------------- |
 | {{ $tracesStatus }} | {{ $metricsStatus }} | {{ $logsStatus }} |
 
-{{ partial "ja/docs/latest-release.md" (dict "lang" $lang "Inner" .Inner) -}}
+[最新のリリース][latest release]を含むリリース情報については、[リリース][Releases]をご覧ください。
+{{ $.Inner }}
+
+[latest release]:
+  <https://github.com/open-telemetry/opentelemetry-{{ $lang }}/releases/latest>
+[Releases]:
+  <https://github.com/open-telemetry/opentelemetry-{{ $lang }}/releases>

--- a/content/ja/docs/languages/go/_index.md
+++ b/content/ja/docs/languages/go/_index.md
@@ -8,7 +8,7 @@ weight: 16
 default_lang_commit: dc174c212e81fadbf8382bb54c54cff294954b1b
 ---
 
-{{% ja/docs/languages/index-intro go /%}}
+{{% docs/languages/index-intro go /%}}
 
 ## 関連情報 {#more}
 

--- a/layouts/partials/ja/docs/latest-release.md
+++ b/layouts/partials/ja/docs/latest-release.md
@@ -1,7 +1,0 @@
-{{ $relUrl := printf "https://github.com/open-telemetry/opentelemetry-%s/releases" .lang -}}
-
-[最新のリリース][latest release]を含むリリース情報については、[リリース][Releases]をご覧ください。
-{{- .Inner }}
-
-[latest release]: {{ $relUrl }}/latest
-[Releases]: {{ $relUrl }}


### PR DESCRIPTION
- Contributes to #6460 for `pt` pages
- Continues work started in #6750, then #6751
- Moves the content of `shortcodes/ja/docs/languages/index-intro.md` into the drift-trackable `content/ja/docs/languages/_includes/index-intro.md` file
- Drops the ja-specific partial and shortcode that are no longer necessary under this new scheme.

### Previews

- https://deploy-preview-6751--opentelemetry.netlify.app/ja/docs/languages/go/ - is the [same as before](https://opentelemetry.io/ja/docs/languages/go/)
- https://deploy-preview-6751--opentelemetry.netlify.app/pt/docs/languages/cpp/ now picks up the `ja` include even if the rest of the page is still in `en` :)

/cc @open-telemetry/docs-ja-approvers 