### PR TITLE
[i18n] Update drift status of non-English pages

### DIFF
--- a/content/es/docs/concepts/distributions.md
+++ b/content/es/docs/concepts/distributions.md
@@ -5,6 +5,7 @@ description: >-
   personalizada de un componente de OpenTelemetry.
 weight: 190
 default_lang_commit: 4966f752eb35f97c095ed1c813972c2ab38f0b1a
+drifted_from_default: true
 ---
 
 Los proyectos de OpenTelemetry consisten en múltiples

--- a/content/es/docs/getting-started/dev.md
+++ b/content/es/docs/getting-started/dev.md
@@ -2,6 +2,7 @@
 title: Introducción para desarrolladores
 linkTitle: Dev
 default_lang_commit: ede5b715791550eccf1c0dc3d57e2713ca6350ab
+drifted_from_default: true
 ---
 
 Esta es tu página de [introducción](..) si:

--- a/content/ja/docs/concepts/distributions.md
+++ b/content/ja/docs/concepts/distributions.md
@@ -3,6 +3,7 @@ title: ディストリビューション
 description: フォークと混同されがちですが、ディストリビューションは、OpenTelemetryコンポーネントのカスタマイズバージョンです。
 weight: 190
 default_lang_commit: 21d6bf0
+drifted_from_default: true
 ---
 
 OpenTelemetryプロジェクトは、複数の[シグナル](../signals)をサポートする複数の[コンポーネント](../components)から構成されています。

--- a/content/ja/docs/concepts/instrumentation/zero-code/index.md
+++ b/content/ja/docs/concepts/instrumentation/zero-code/index.md
@@ -4,6 +4,7 @@ description: >-
   コードを書かずにアプリケーションにオブザーバビリティを追加する方法を学ぶ
 weight: 10
 default_lang_commit: 35fde3d
+drifted_from_default: true
 ---
 
 [運用担当者](/docs/getting-started/ops/)として、ソースを編集することなく、1つ以上のアプリケーションにオブザーバビリティを追加したいと思うかもしれません。

--- a/content/ja/docs/contributing/localization.md
+++ b/content/ja/docs/contributing/localization.md
@@ -4,6 +4,7 @@ description: 非英語ローカリゼーションのサイトページの作成�
 linkTitle: ローカリゼーション
 weight: 25
 default_lang_commit: f2a520b85d72db706bff91d879f5bb10fd2e7367
+drifted_from_default: true
 cSpell:ignore: shortcodes
 ---
 

--- a/content/ja/docs/contributing/pr-checks.md
+++ b/content/ja/docs/contributing/pr-checks.md
@@ -3,6 +3,7 @@ title: プルリクエストのチェック
 description: プルリクエストがすべてのチェックをパスする方法学ぶ
 weight: 40
 default_lang_commit: 9ba98f4fded66ec78bfafa189ab2d15d66df2309
+drifted_from_default: true
 cSpell:ignore: REFCACHE
 ---
 

--- a/content/ja/docs/getting-started/dev.md
+++ b/content/ja/docs/getting-started/dev.md
@@ -2,6 +2,7 @@
 title: 開発者のための入門
 linkTitle: Dev
 default_lang_commit: e7a6289
+drifted_from_default: true
 ---
 
 あなたが以下のいずれかに当てはまれば、このページはあなたのための[入門](..)ページです。

--- a/content/ja/docs/languages/_index.md
+++ b/content/ja/docs/languages/_index.md
@@ -4,6 +4,7 @@ description: OpenTelemetryのコード計装は、多くの一般的なプログ
 weight: 250
 aliases: [/docs/instrumentation]
 default_lang_commit: 1ececa0615b64c5dfd93fd6393f3e4052e0cc496
+drifted_from_default: true
 ---
 
 OpenTelemetryのコード[計装][instrumentation]は、以下の[ステータスとリリース](#status-and-releases)の表に記載されている言語でサポートされています。

--- a/content/pt/_includes/page-not-translated-msg.md
+++ b/content/pt/_includes/page-not-translated-msg.md
@@ -1,6 +1,5 @@
 ---
 default_lang_commit: 1ececa0615b64c5dfd93fd6393f3e4052e0cc496
-drifted_from_default: true
 ---
 
 <i class="fa-solid fa-circle-info" style="margin-left: -1.5rem"></i> Você está

--- a/content/pt/docs/concepts/components.md
+++ b/content/pt/docs/concepts/components.md
@@ -3,7 +3,6 @@ title: Componentes
 description: Os principais componentes que compõem o OpenTelemetry
 weight: 20
 default_lang_commit: 99a39c5e4e51daba968bfbb3eb078be4a14ad363
-drifted_from_default: true
 ---
 
 O OpenTelemetry é atualmente composto por vários componentes principais:

--- a/content/pt/docs/concepts/distributions.md
+++ b/content/pt/docs/concepts/distributions.md
@@ -5,6 +5,7 @@ description: >-
   customizada de um componente do OpenTelemetry.
 weight: 190
 default_lang_commit: 2f34c456ab38b4d3502cd07bc36fa1455d4ef875
+drifted_from_default: true
 ---
 
 Os projetos do OpenTelemetry consistem de múltiplos [componentes](../components)

--- a/content/pt/docs/concepts/glossary.md
+++ b/content/pt/docs/concepts/glossary.md
@@ -5,7 +5,6 @@ description: >-
   OpenTelemetry.
 weight: 200
 default_lang_commit: 389e023192e051a3a835bfc6a71089c98af3b8a8
-drifted_from_default: true
 ---
 
 Esse glossário define termos e [conceitos](/docs/concepts/) que são novos no

--- a/content/pt/docs/concepts/instrumentation/_index.md
+++ b/content/pt/docs/concepts/instrumentation/_index.md
@@ -3,7 +3,6 @@ title: Instrumentação
 description: Como o OpenTelemetry facilita a instrumentação
 weight: 15
 default_lang_commit: efeda2d8ded2471211697c3993f6d475a3a8b06e
-drifted_from_default: true
 ---
 
 Para que um sistema seja [observável], ele deve ser **instrumentado**: ou seja,

--- a/content/pt/docs/concepts/instrumentation/libraries.md
+++ b/content/pt/docs/concepts/instrumentation/libraries.md
@@ -3,7 +3,6 @@ title: Bibliotecas
 description: Aprenda como adicionar instrumentação nativa à sua biblioteca.
 weight: 40
 default_lang_commit: d8e58463c6e7c324b01115ab4f88d1f2bcf802c2
-drifted_from_default: true
 ---
 
 O OpenTelemetry fornece [bibliotecas de instrumentação][] para várias

--- a/content/pt/docs/concepts/resources/index.md
+++ b/content/pt/docs/concepts/resources/index.md
@@ -2,7 +2,6 @@
 title: Recursos
 weight: 70
 default_lang_commit: 86d2fbde246b9e56665146db78d4fc1d34d00ddf
-drifted_from_default: true
 ---
 
 ## Introdução {#introduction}

--- a/content/pt/docs/getting-started/ops.md
+++ b/content/pt/docs/getting-started/ops.md
@@ -2,7 +2,6 @@
 title: Primeiros passos para Operações
 linkTitle: Ops
 default_lang_commit: 99a39c5e4e51daba968bfbb3eb078be4a14ad363
-drifted_from_default: true
 ---
 
 A página [primeiros-passos](..) é para você se:

--- a/content/pt/docs/languages/_index.md
+++ b/content/pt/docs/languages/_index.md
@@ -5,7 +5,6 @@ description:
   populares de programação.
 weight: 250
 default_lang_commit: d1ef521ee4a777881fb99c3ec2b506e068cdec4c
-drifted_from_default: true
 ---
 
 A [instrumentação][] de código do OpenTelemetry é suportada para as linguagens

--- a/content/pt/docs/languages/js/_includes/browser-instrumentation-warning.md
+++ b/content/pt/docs/languages/js/_includes/browser-instrumentation-warning.md
@@ -1,6 +1,5 @@
 ---
 default_lang_commit: 1ececa0615b64c5dfd93fd6393f3e4052e0cc496 # patched
-drifted_from_default: true
 ---
 
 {{% alert title=Aviso color=warning %}}

--- a/content/pt/docs/languages/js/getting-started/browser.md
+++ b/content/pt/docs/languages/js/getting-started/browser.md
@@ -4,7 +4,6 @@ aliases: [/docs/js/getting_started/browser]
 description: Aprenda como adicionar o OpenTelemetry à sua aplicação de navegador
 weight: 20
 default_lang_commit: 1ececa0615b64c5dfd93fd6393f3e4052e0cc496
-drifted_from_default: true
 ---
 
 {{% include browser-instrumentation-warning.md %}}

--- a/content/pt/ecosystem/adopters.md
+++ b/content/pt/ecosystem/adopters.md
@@ -2,7 +2,6 @@
 title: Adotantes
 description: Organizações que usam OpenTelemetry
 default_lang_commit: b6ddba1118d07bc3c8d1d07b293f227686d0290e
-drifted_from_default: true
 ---
 
 A missão do OpenTelemetry é possibilitar uma observabilidade eficaz para todos

--- a/content/pt/ecosystem/distributions.md
+++ b/content/pt/ecosystem/distributions.md
@@ -4,7 +4,6 @@ description:
   Lista de distribuições de código aberto do OpenTelemetry mantidas por
   terceiros.
 default_lang_commit: b6ddba1118d07bc3c8d1d07b293f227686d0290e
-drifted_from_default: true
 ---
 
 As [distribuições](/docs/concepts/distributions/) do OpenTelemetry são uma forma

--- a/content/pt/ecosystem/integrations.md
+++ b/content/pt/ecosystem/integrations.md
@@ -4,7 +4,6 @@ description:
   Bibliotecas, serviços e aplicações com suporte nativo para o OpenTelemetry.
 aliases: [/integrations]
 default_lang_commit: b6ddba1118d07bc3c8d1d07b293f227686d0290e
-drifted_from_default: true
 ---
 
 A missão do OpenTelemetry é

--- a/content/pt/ecosystem/vendors.md
+++ b/content/pt/ecosystem/vendors.md
@@ -3,7 +3,6 @@ title: Fornecedores
 description: Fornecedores que oferecem suporte nativo ao OpenTelemetry
 aliases: [/vendors]
 default_lang_commit: b6ddba1118d07bc3c8d1d07b293f227686d0290e
-drifted_from_default: true
 ---
 
 Uma lista não exaustiva de organizações que oferecem soluções que consomem o

--- a/content/pt/status.md
+++ b/content/pt/status.md
@@ -6,7 +6,6 @@ description: Nível de maturidade dos principais componentes do OpenTelemetry
 type: docs
 body_class: td-no-left-sidebar
 default_lang_commit: 1f83b9ffa3ecdd5e2b507379cc259e5678596c7f
-drifted_from_default: true
 ---
 
 O OpenTelemetry é composto de

--- a/content/zh/docs/getting-started/dev.md
+++ b/content/zh/docs/getting-started/dev.md
@@ -2,6 +2,7 @@
 title: 开发人员入门
 linkTitle: Dev
 default_lang_commit: e771c886739c4847b332b74f24b09d2769aab875
+drifted_from_default: true
 ---
 
 如果你符合以下条件，那么这个[入门指南](..)就是为你准备的：


### PR DESCRIPTION
Changes from running:

```console
$ npm run check:i18n -- -D                                    

> check:i18n
> scripts/check-i18n.sh -D

Processing paths: content
> Drifted file: content/ja/docs/contributing/localization.md
...
```