### PR TITLE
[i18n] Update what-is-opentelemetry.md to use absolute path to spec pages

### DIFF
--- a/content/en/docs/what-is-opentelemetry.md
+++ b/content/en/docs/what-is-opentelemetry.md
@@ -68,10 +68,11 @@ If you want to learn more, take a look at OpenTelemetry's
 
 OpenTelemetry consists of the following major components:
 
-- A [specification](../specs/otel) for all components
-- A standard [protocol](../specs/otlp/) that defines the shape of telemetry data
-- [Semantic conventions](../specs/semconv/) that define a standard naming scheme
-  for common telemetry data types
+- A [specification](/docs/specs/otel) for all components
+- A standard [protocol](/docs/specs/otlp/) that defines the shape of telemetry
+  data
+- [Semantic conventions](/docs/specs/semconv/) that define a standard naming
+  scheme for common telemetry data types
 - APIs that define how to generate telemetry data
 - [Language SDKs](../languages) that implement the specification, APIs, and
   export of telemetry data


### PR DESCRIPTION
- Contributes to #4876
- Resolves issues raised in https://github.com/open-telemetry/opentelemetry.io/pull/6698#issuecomment-2802590264
- I'll later document that it is a requirement that links to spec pages (from outside the specs section), need to be absolute so that the render-link hook can ensure that the references point to the English spec section.