### PR TITLE
[bn] Translate Landing Page for Bengali localization kickoff

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1,17 +1,14 @@
 ---
 title: OpenTelemetry
 description: >-
-  High-quality, ubiquitous, and portable telemetry to enable effective
-  observability
+  কার্যকর অবজারভেবিলিটির জন্য উচ্চ-মানের, সর্বজনীন ও পোর্টেবল টেলিমেট্রি প্রদান
 outputs:
   - HTML
-  # Include the following for `content/en` ONLY
-  - REDIRECTS
-  - RSS
 developer_note:
   The blocks/cover shortcode (used below) will use as a background image any
   image file containing "background" in its name.
 show_banner: true
+default_lang_commit: c0a5eea5d720b0e075efa87f99dcf58c89106268
 ---
 
 <div class="d-none"><a rel="me" href="https://fosstodon.org/@opentelemetry"></a></div>
@@ -28,13 +25,13 @@ show_banner: true
 
 <div class="l-primary-buttons mt-5">
 
-- [Learn more](docs/what-is-opentelemetry/)
-- [Try the demo](docs/demo/)
+- [আরও জানুন](docs/what-is-opentelemetry/)
+- [Demo ট্রাই করুন](docs/demo/)
 
 </div>
 
 <div class="h3 mt-4">
-<a class="text-secondary" href="docs/getting-started/">Get started</a> based on your role
+আপনার কাজের উপর ভিত্তি করে <a class="text-secondary" href="docs/getting-started/"> শুরু করুন </a>
 </div>
 <div class="l-get-started-buttons">
 
@@ -46,41 +43,37 @@ show_banner: true
 
 {{% blocks/lead color="white" %}}
 
-OpenTelemetry is a collection of APIs, SDKs, and tools. Use it to instrument,
-generate, collect, and export telemetry data (metrics, logs, and traces) to help
-you analyze your software's performance and behavior.
+OpenTelemetry একটি API, SDK এবং টুলের সংগ্রহ। এটি ব্যবহার করে আপনি টেলিমেট্রি ডেটা (মেট্রিকস, লগ এবং ট্রেস) ইনস্ট্রুমেন্ট, তৈরি, সংগ্রহ এবং রপ্তানি করতে পারেন, যা আপনার সফটওয়্যারের পারফরম্যান্স এবং আচরণ বিশ্লেষণে সহায়তা করে।
 
-> OpenTelemetry is [generally available](/status/) across
-> [several languages](docs/languages/) and is suitable for production use.
+> OpenTelemetry [সাধারণভাবে উপলভ্য](/status/)
+> অনেক [ভাষায়](docs/languages/) এবং প্রোডাকশনে ব্যবহারের জন্য উপযোগী।
 
 {{% /blocks/lead %}}
 
 {{% blocks/section color="dark" type="row" %}}
 
-{{% blocks/feature icon="fas fa-chart-line" title="Traces, Metrics, Logs" url="docs/concepts/observability-primer/" %}}
+{{% blocks/feature icon="fas fa-chart-line" title="ট্রেসেস, মেট্রিকস, লগস" url="docs/concepts/observability-primer/" %}}
 
-Create and collect telemetry from your services and software, then forward it to
-a variety of analysis tools.
-
-{{% /blocks/feature %}}
-
-{{% blocks/feature icon="fas fa-magic" title="Drop-in Instrumentation & Integrations" %}}
-
-OpenTelemetry [integrates] with many popular libraries and frameworks, and
-supports _code-based and zero-code_ [instrumentation].
-
-[instrumentation]: /docs/concepts/instrumentation/
-[integrates]: /ecosystem/integrations/
+আপনার সার্ভিস এবং সফটওয়্যার থেকে টেলিমেট্রি তৈরি ও সংগ্রহ করুন, এবং এটি বিশ্লেষণ টুলে পাঠান।
 
 {{% /blocks/feature %}}
 
-{{% blocks/feature icon="fab fa-github" title="Open Source, Vendor Neutral" %}}
+{{% blocks/feature icon="fas fa-magic" title="সহজ ইন্টিগ্রেশন ও ইন্সট্রুমেন্টেশন" %}}
 
-100% free and open source, OpenTelemetry is [adopted] and supported by [industry
-leaders] in the observability space.
+OpenTelemetry অনেক জনপ্রিয় লাইব্রেরি ও ফ্রেমওয়ার্কের সাথে [ইন্টিগ্রেট] করে এবং
+_কোড-ভিত্তিক ও জিরো-কোড_ [ইন্সট্রুমেন্টেশন] সাপোর্ট করে।
 
-[adopted]: /ecosystem/adopters/
-[industry leaders]: /ecosystem/vendors/
+[ইন্সট্রুমেন্টেশন]: /docs/concepts/instrumentation/
+[ইন্টিগ্রেট]: /ecosystem/integrations/
+
+{{% /blocks/feature %}}
+
+{{% blocks/feature icon="fab fa-github" title="ওপেন সোর্স, ভেন্ডর নিরপেক্ষ" %}}
+
+OpenTelemetry ১০০% ফ্রি ও ওপেন সোর্স, [শিল্প নেতারা] এটিকে [গ্রহণ করেছে] এবং সমর্থন করছে যারা অবজারভেবিলিটি ক্ষেত্রে কাজ করছে।
+
+[গ্রহণ করেছে]: /ecosystem/adopters/
+[শিল্প নেতারা]: /ecosystem/vendors/
 
 {{% /blocks/feature %}}
 
@@ -88,13 +81,12 @@ leaders] in the observability space.
 
 {{% blocks/section color="secondary" type="cncf" %}}
 
-**OpenTelemetry is a [CNCF][] [incubating][] project**.<br> Formed through a
-merger of the OpenTracing and OpenCensus projects.
+**OpenTelemetry একটি [CNCF][] [ইনকিউবেটিং][] প্রজেক্ট**।<br> এটি OpenTracing এবং OpenCensus প্রজেক্টগুলোর একত্রীকরণের মাধ্যমে গঠিত।
 
 [![CNCF logo][]][cncf]
 
 [cncf]: https://cncf.io
 [cncf logo]: /img/logos/cncf-white.svg
-[incubating]: https://www.cncf.io/projects/
+[ইনকিউবেটিং]: https://www.cncf.io/projects/
 
 {{% /blocks/section %}}


### PR DESCRIPTION
This PR translates the Landing Page (`content/en/_index.md`) into Bengali (bn) as part of the initial localization effort

- Only the Landing Page is translated, as per instructions.
- Metadata (frontmatter) is preserved.
- Links and structure are kept intact.
- Translation follows the contribution and style guidelines.

Fixes: #6765
Please let me know if any further adjustments are needed.