### PR TITLE
Add username to survey message

### DIFF
--- a/.github/workflows/survey-on-merged-pr.yml
+++ b/.github/workflows/survey-on-merged-pr.yml
@@ -36,6 +36,6 @@ jobs:
         if: env.MEMBER_FOUND == 'false'
         run: |
           USERNAME=$(jq -r '.pull_request.user.login' "$GITHUB_EVENT_PATH")
-          gh pr comment ${PR_NUM} --repo open-telemetry/opentelemetry.io --body "Thank you for your contribution! 🎉 We would like to hear from you about your experience contributing to OpenTelemetry by taking a few minutes to fill out this [survey](${SURVEY_URL})"
+          gh pr comment ${PR_NUM} --repo open-telemetry/opentelemetry-js --body "Thank you for your contribution @${USERNAME}! 🎉 We would like to hear from you about your experience contributing to OpenTelemetry by taking a few minutes to fill out this [survey](${SURVEY_URL})."
         env:
           GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}

--- a/.github/workflows/survey-on-merged-pr.yml
+++ b/.github/workflows/survey-on-merged-pr.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Add comment to PR if author is not a member
         if: env.MEMBER_FOUND == 'false'
         run: |
+          USERNAME=$(jq -r '.pull_request.user.login' "$GITHUB_EVENT_PATH")
           gh pr comment ${PR_NUM} --repo open-telemetry/opentelemetry.io --body "Thank you for your contribution! 🎉 We would like to hear from you about your experience contributing to OpenTelemetry by taking a few minutes to fill out this [survey](${SURVEY_URL})"
         env:
           GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}

--- a/.github/workflows/survey-on-merged-pr.yml
+++ b/.github/workflows/survey-on-merged-pr.yml
@@ -36,6 +36,6 @@ jobs:
         if: env.MEMBER_FOUND == 'false'
         run: |
           USERNAME=$(jq -r '.pull_request.user.login' "$GITHUB_EVENT_PATH")
-          gh pr comment ${PR_NUM} --repo open-telemetry/opentelemetry-js --body "Thank you for your contribution @${USERNAME}! 🎉 We would like to hear from you about your experience contributing to OpenTelemetry by taking a few minutes to fill out this [survey](${SURVEY_URL})."
+          gh pr comment ${PR_NUM} --repo open-telemetry/opentelemetry.io --body "Thank you for your contribution @${USERNAME}! 🎉 We would like to hear from you about your experience contributing to OpenTelemetry by taking a few minutes to fill out this [survey](${SURVEY_URL})."
         env:
           GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
While sending the same message on the JS sdk repo, we got the feedback that we should add the username to the message, so they get properly pinged, otherwise people can miss it.
Adding the same change here after being tested on the other repo for awhile.