### PR TITLE
[Go] fix: remove extra text on content/en/docs/languages/go/exporters.md

### DIFF
--- a/content/en/docs/languages/go/exporters.md
+++ b/content/en/docs/languages/go/exporters.md
@@ -93,8 +93,5 @@ endpoint.
 [`go.opentelemetry.io/otel/exporters/prometheus`](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/prometheus)
 contains an implementation of Prometheus metrics exporter.
 
-Here's how you can create an exporter (which is also a metric reader) with
-default configuration:
-
 To learn more on how to use the Prometheus exporter, try the
 [prometheus example](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/examples/prometheus)


### PR DESCRIPTION
As mentioned on https://github.com/open-telemetry/opentelemetry.io/issues/6781, I assume that this section has an extra paragraph that should've been removed on https://github.com/open-telemetry/opentelemetry.io/pull/6319.
 