### PR TITLE
Add registry entry for tracesimulationreceiver

### DIFF
--- a/data/registry/collector-receiver-tracesimulation.yml
+++ b/data/registry/collector-receiver-tracesimulation.yml
@@ -1,0 +1,21 @@
+# cSpell:ignore tracesimulationreceiver k4ji
+title: Trace Simulation Receiver
+registryType: receiver
+language: collector
+tags:
+  - go
+  - receiver
+  - synthetic
+  - trace
+  - simulation
+license: Apache 2.0
+description: A receiver that generates synthetic traces based on a declarative blueprint for testing and demonstration purposes.
+authors:
+  - name: Takuya Kajiwara
+    url: https://github.com/k4ji
+urls:
+  repo: https://github.com/k4ji/tracesimulationreceiver
+createdAt: 2025-05-01
+isNative: false
+isFirstParty: false
+

--- a/data/registry/collector-receiver-tracesimulation.yml
+++ b/data/registry/collector-receiver-tracesimulation.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore tracesimulationreceiver k4ji
+# cSpell:ignore k4ji Kajiwara tracesimulationreceiver
 title: Trace Simulation Receiver
 registryType: receiver
 language: collector
@@ -9,7 +9,9 @@ tags:
   - trace
   - simulation
 license: Apache 2.0
-description: A receiver that generates synthetic traces based on a declarative blueprint for testing and demonstration purposes.
+description:
+  A receiver that generates synthetic traces based on a declarative blueprint
+  for testing and demonstration purposes.
 authors:
   - name: Takuya Kajiwara
     url: https://github.com/k4ji
@@ -18,4 +20,3 @@ urls:
 createdAt: 2025-05-01
 isNative: false
 isFirstParty: false
-

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -4555,6 +4555,14 @@
     "StatusCode": 206,
     "LastSeen": "2025-04-19T04:42:33.648860127-07:00"
   },
+  "https://github.com/k4ji": {
+    "StatusCode": 206,
+    "LastSeen": "2025-04-30T13:03:26.186581121-07:00"
+  },
+  "https://github.com/k4ji/tracesimulationreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-04-30T13:03:25.069025604-07:00"
+  },
   "https://github.com/kamphaus": {
     "StatusCode": 206,
     "LastSeen": "2025-02-21T14:47:49.820203164Z"


### PR DESCRIPTION
<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->
This PR adds a new receiver entry for the [Trace Simulation Receiver](https://github.com/k4ji/tracesimulationreceiver) to the OpenTelemetry Collector registry.

The Trace Simulation Receiver is a custom OpenTelemetry receiver that generates synthetic traces based on a declarative blueprint. It's designed for testing telemetry pipelines, validating backend behavior, and demonstrating observability features.

Please let me know if any additional changes are needed, Thank you!