### PR TITLE
Don't require locales to have Ask-AI i18n entries yet, fall back to en

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -7,8 +7,13 @@ disableAliases: true # We do redirects via Netlify's _redirects file
 enableGitInfo: true
 
 # Language settings
-enableMissingTranslationPlaceholders: true
 defaultContentLanguage: en
+#
+# TODO: Disabling the following for the duration of the Ask AI trial. If we
+# decide to keep Ask AI, then locales should provide Ask-AI i18n key entries
+# and the following should be re-enabled / uncommented.
+#
+# enableMissingTranslationPlaceholders: true
 
 languages:
   en:


### PR DESCRIPTION
- Contributes to #6658
- Followup to #6769
- Changes Hugo's config so that i18n key entries fall back to `en` values when they are missing from other locales. This seems better atm while we're in the trial period for the Ask AI feature. That is, it's way more usable than the screenshot below. Of course it means we might miss other missing translations, but we could use `--printI18nWarnings` on the build if/when that becomes an issue.

### Screenshots

Before:

> <img width="777" alt="image" src="https://github.com/user-attachments/assets/b587b664-a243-4b8b-8fdc-38c6767ea062" />

After:

> <img width="795" alt="image" src="https://github.com/user-attachments/assets/c42812dd-fa3a-4572-a89f-a9af82c12e71" />
