### PR TITLE
Update internal-telemetry.md

### DIFF
--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -232,8 +232,6 @@ However in the list of internal metrics within this document, this is listed as 
 This behavior can be disabled by setting without_type_suffix: false in the exporter's configuration. Any internal metrics exported through OTLP will not have this behavior.
 If you leave out service::telemetry::metrics::readers in the Collector config, the default Prometheus exporter set up by the Collector already has that option set. However, if you customize the readers and add a Prometheus exporter manually, you must set that option to return to the "raw" metric name.
 
-For more information, refer to [Collector v1.25.0/v0.119.0 release notes](https://github.com/codeboten/opentelemetry-collector/blob/313167505b44e5dc9a29c0b9242cc4547db11ec3/CHANGELOG.md#v1250v01190).
-
 #### Dot replaced with underscore
 
 `http_` and `rpc_` metrics come from instrumentation libraries. While the original metric name uses dots (`.`), when

--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -232,7 +232,7 @@ However in the list of internal metrics within this document, metrics are listed
 This behavior can be disabled by setting `without_type_suffix: false` in the exporter's configuration. Any internal metrics exported through OTLP do not have this behavior.
 If you leave out `service::telemetry::metrics::readers` in the Collector config, the default Prometheus exporter set up by the Collector already has `without_type_suffix` set to `false`. However, if you customize the readers and add a Prometheus exporter manually, you must set that option to return to the "raw" metric name. For more information, see the [Collector v1.25.0/v0.119.0 release notes](https://github.com/codeboten/opentelemetry-collector/blob/313167505b44e5dc9a29c0b9242cc4547db11ec3/CHANGELOG.md#v1250v01190).
 
-#### Dot replaced with underscore
+#### Prometheus escaped characters
 
 `http_` and `rpc_` metrics come from instrumentation libraries. While the original metric name uses dots (`.`), when
 exposing internal metrics with Prometheus, the dots change to underscores (`_`) to match Prometheus' naming constraints.

--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -229,7 +229,7 @@ Metrics names may be altered slightly with a suffix appended or by replacing a d
 By default and unique to Prometheus, the Prometheus exporter adds a `_total` suffix to summation metrics to follow Prometheus naming conventions. For example,  `otelcol_exporter_send_failed_spans_total`. 
 However in the list of internal metrics within this document, metrics are listed in OTLP format, such as `otelcol_exporter_send_failed_spans`. 
 
-This behavior can be disabled by setting without_type_suffix: false in the exporter's configuration. Any internal metrics exported through OTLP will not have this behavior.
+This behavior can be disabled by setting `without_type_suffix: false` in the exporter's configuration. Any internal metrics exported through OTLP do not have this behavior.
 If you leave out service::telemetry::metrics::readers in the Collector config, the default Prometheus exporter set up by the Collector already has that option set. However, if you customize the readers and add a Prometheus exporter manually, you must set that option to return to the "raw" metric name.
 
 #### Dot replaced with underscore

--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -350,27 +350,27 @@ its introduction. Note however that these metrics were inadvertently reverted to
 
 | Metric name                                           | Description                                                                               | Type      |
 | ----------------------------------------------------- | ----------------------------------------------------------------------------------------- | --------- |
-| `http_client_active_requests`                         | Number of active HTTP client requests.                                                    | Counter   |
-| `http_client_connection_duration`                     | Measures the duration of the successfully established outbound HTTP connections.          | Histogram |
-| `http_client_open_connections`                        | Number of outbound HTTP connections that are active or idle on the client.                | Counter   |
-| `http_client_request_size`                            | Measures the size of HTTP client request bodies.                                          | Counter   |
-| `http_client_duration`                                | Measures the duration of HTTP client requests.                                            | Histogram |
-| `http_client_response_size`                           | Measures the size of HTTP client response bodies.                                         | Counter   |
-| `http_server_active_requests`                         | Number of active HTTP server requests.                                                    | Counter   |
-| `http_server_request_size`                            | Measures the size of HTTP server request bodies.                                          | Counter   |
-| `http_server_duration`                                | Measures the duration of HTTP server requests.                                            | Histogram |
-| `http_server_response_size`                           | Measures the size of HTTP server response bodies.                                         | Counter   |
+| `http.client.active_requests`                         | Number of active HTTP client requests.                                                    | Counter   |
+| `http.client.connection.duration`                     | Measures the duration of the successfully established outbound HTTP connections.          | Histogram |
+| `http.client.open_connections`                        | Number of outbound HTTP connections that are active or idle on the client.                | Counter   |
+| `http.client.request.size`                            | Measures the size of HTTP client request bodies.                                          | Counter   |
+| `http.client.duration`                                | Measures the duration of HTTP client requests.                                            | Histogram |
+| `http.client.response.size`                           | Measures the size of HTTP client response bodies.                                         | Counter   |
+| `http.server.active_requests`                         | Number of active HTTP server requests.                                                    | Counter   |
+| `http.server.request.size`                            | Measures the size of HTTP server request bodies.                                          | Counter   |
+| `http.server.duration`                                | Measures the duration of HTTP server requests.                                            | Histogram |
+| `http.server.response.size`                           | Measures the size of HTTP server response bodies.                                         | Counter   |
 | `otelcol_processor_batch_batch_`<br>`send_size_bytes` | Number of bytes in the batch that was sent.                                               | Histogram |
-| `rpc_client_duration`                                 | Measures the duration of outbound RPC.                                                    | Histogram |
-| `rpc_client_request_size`                             | Measures the size of RPC request messages (uncompressed).                                 | Histogram |
-| `rpc_client_requests_per_rpc`                         | Measures the number of messages received per RPC. Should be 1 for all non-streaming RPCs. | Histogram |
-| `rpc_client_response_size`                            | Measures the size of RPC response messages (uncompressed).                                | Histogram |
-| `rpc_client_responses_per_rpc`                        | Measures the number of messages sent per RPC. Should be 1 for all non-streaming RPCs.     | Histogram |
-| `rpc_server_duration`                                 | Measures the duration of inbound RPC.                                                     | Histogram |
-| `rpc_server_request_size`                             | Measures the size of RPC request messages (uncompressed).                                 | Histogram |
-| `rpc_server_requests_per_rpc`                         | Measures the number of messages received per RPC. Should be 1 for all non-streaming RPCs. | Histogram |
-| `rpc_server_response_size`                            | Measures the size of RPC response messages (uncompressed).                                | Histogram |
-| `rpc_server_responses_per_rpc`                        | Measures the number of messages sent per RPC. Should be 1 for all non-streaming RPCs.     | Histogram |
+| `rpc.client.duration`                                 | Measures the duration of outbound RPC.                                                    | Histogram |
+| `rpc.client.request.size`                             | Measures the size of RPC request messages (uncompressed).                                 | Histogram |
+| `rpc.client.requests_per_rpc`                         | Measures the number of messages received per RPC. Should be 1 for all non-streaming RPCs. | Histogram |
+| `rpc.client.response.size`                            | Measures the size of RPC response messages (uncompressed).                                | Histogram |
+| `rpc.client.responses_per_rpc`                        | Measures the number of messages sent per RPC. Should be 1 for all non-streaming RPCs.     | Histogram |
+| `rpc.server.duration`                                 | Measures the duration of inbound RPC.                                                     | Histogram |
+| `rpc.server.request.size`                             | Measures the size of RPC request messages (uncompressed).                                 | Histogram |
+| `rpc.server.requests_per_rpc`                         | Measures the number of messages received per RPC. Should be 1 for all non-streaming RPCs. | Histogram |
+| `rpc.server.response.size`                            | Measures the size of RPC response messages (uncompressed).                                | Histogram |
+| `rpc.server.responses_per_rpc`                        | Measures the number of messages sent per RPC. Should be 1 for all non-streaming RPCs.     | Histogram |
 
 {{% alert title="Note" color="info" %}} The `http*` and `rpc*` metrics are not
 covered by the maturity levels below since they are not under the Collector SIG
@@ -380,7 +380,8 @@ The `otelcol_processor_batch_` metrics are unique to the `batchprocessor`.
 
 The `otelcol_receiver_`, `otelcol_scraper_`, `otelcol_processor_`, and
 `otelcol_exporter_` metrics come from their respective `helper` packages. As
-such, some components not using those packages may not emit them. {{% /alert %}}
+such, some components not using those packages might not emit them.
+{{% /alert %}}
 
 ### Events observable with internal logs
 

--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -230,7 +230,7 @@ By default and unique to Prometheus, the Prometheus exporter adds a `_total` suf
 However in the list of internal metrics within this document, metrics are listed in OTLP format, such as `otelcol_exporter_send_failed_spans`. 
 
 This behavior can be disabled by setting `without_type_suffix: false` in the exporter's configuration. Any internal metrics exported through OTLP do not have this behavior.
-If you leave out service::telemetry::metrics::readers in the Collector config, the default Prometheus exporter set up by the Collector already has that option set. However, if you customize the readers and add a Prometheus exporter manually, you must set that option to return to the "raw" metric name.
+If you leave out `service::telemetry::metrics::readers` in the Collector config, the default Prometheus exporter set up by the Collector already has `without_type_suffix` set to `false`. However, if you customize the readers and add a Prometheus exporter manually, you must set that option to return to the "raw" metric name. For more information, see the [Collector v1.25.0/v0.119.0 release notes](https://github.com/codeboten/opentelemetry-collector/blob/313167505b44e5dc9a29c0b9242cc4547db11ec3/CHANGELOG.md#v1250v01190).
 
 #### Dot replaced with underscore
 

--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -227,29 +227,8 @@ metrics.
 
 #### `otelcol_` prefix
 
-<<<<<<< Updated upstream
-By default and unique to Prometheus, the Prometheus exporter adds a `_total` suffix to summation metrics to follow Prometheus naming conventions. For example,  `otelcol_exporter_send_failed_spans_total`. 
-However in the list of internal metrics within this document, metrics are listed in OTLP format, such as `otelcol_exporter_send_failed_spans`. 
-
-This behavior can be disabled by setting `without_type_suffix: false` in the exporter's configuration. Any internal metrics exported through OTLP do not have this behavior.
-If you leave out `service::telemetry::metrics::readers` in the Collector config, the default Prometheus exporter set up by the Collector already has `without_type_suffix` set to `false`. However, if you customize the readers and add a Prometheus exporter manually, you must set that option to return to the "raw" metric name. For more information, see the [Collector v1.25.0/v0.119.0 release notes](https://github.com/codeboten/opentelemetry-collector/blob/313167505b44e5dc9a29c0b9242cc4547db11ec3/CHANGELOG.md#v1250v01190).
-
-#### Prometheus escaped characters
-
-`http_` and `rpc_` metrics come from instrumentation libraries. Prior to Collector v0.120.0, internal metrics exposed with Prometheus changed dots (`.`) to underscores (`_`) to match Prometheus naming constraints. Versions 0.120.0 and later of the Collector use Prometheus 3.0 scrapers, so the original 'http_` and `rpc_` metric names with dots are preserved. For more information, see the [Collector v0.120.0 release notes](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CHANGELOG.md#v01200).
-
-### Lists of internal metrics
-
-The following tables group each internal metric by level of verbosity: `basic`,
-`normal`, and `detailed`. Each metric is identified by name and description and
-categorized by instrumentation type.
-
-{{% alert title="Note" %}} As of Collector v0.106.1, internal metric names are
-handled differently based on their source:
-=======
 As of Collector v0.106.1, internal metric names are handled differently based on
 their source:
->>>>>>> Stashed changes
 
 - Metrics generated from Collector components are prefixed with `otelcol_`.
 - Metrics generated from instrumentation libraries do not use the `otelcol_`
@@ -393,14 +372,7 @@ its introduction. Note however that these metrics were inadvertently reverted to
 | `rpc_server_response_size`                            | Measures the size of RPC response messages (uncompressed).                                | Histogram |
 | `rpc_server_responses_per_rpc`                        | Measures the number of messages sent per RPC. Should be 1 for all non-streaming RPCs.     | Histogram |
 
-<<<<<<< Updated upstream
-{{% alert title="Note" %}} The `http_` and `rpc_` metrics come from
-instrumentation libraries. Their original names use dots (`.`), but when
-exposing internal metrics with Prometheus, they are translated to use
-underscores (`_`) to match Prometheus' naming constraints. These metrics are not
-=======
 {{% alert title="Note" color="info" %}} The `http*` and `rpc*` metrics are not
->>>>>>> Stashed changes
 covered by the maturity levels below since they are not under the Collector SIG
 control.
 

--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -226,7 +226,7 @@ Metrics names may be altered slightly with a suffix appended or by replacing a d
 
 #### `_total` suffix appended
 
-By default and unique to Prometheus, the Prometheus exporter adds a `_total` suffix to some metrics to follow Prometheus naming conventions. For example,  `otelcol_exporter_send_failed_spans_total`. 
+By default and unique to Prometheus, the Prometheus exporter adds a `_total` suffix to summation metrics to follow Prometheus naming conventions. For example,  `otelcol_exporter_send_failed_spans_total`. 
 However in the list of internal metrics within this document, this is listed as `otelcol_exporter_send_failed_spans`. 
 
 This behavior can be disabled by setting without_type_suffix: false in the exporter's configuration. Any internal metrics exported through OTLP will not have this behavior.

--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -234,8 +234,7 @@ If you leave out `service::telemetry::metrics::readers` in the Collector config,
 
 #### Prometheus escaped characters
 
-`http_` and `rpc_` metrics come from instrumentation libraries. While the original metric name uses dots (`.`), when
-exposing internal metrics with Prometheus, the dots change to underscores (`_`) to match Prometheus' naming constraints.
+`http_` and `rpc_` metrics come from instrumentation libraries. Prior to Collector v0.120.0, internal metrics exposed with Prometheus changed dots (`.`) to underscores (`_`) to match Prometheus naming constraints. Versions 0.120.0 and later of the Collector use Prometheus 3.0 scrapers, so the original 'http_` and `rpc_` metric names with dots are preserved. For more information, see the [Collector v0.120.0 release notes](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CHANGELOG.md#v01200).
 
 ### Lists of internal metrics
 

--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -220,7 +220,7 @@ The Collector emits internal metrics for at least the following values:
 
 A more detailed list is available in the following sections.
 
-### Metrics naming
+### Metric names
 
 Metrics names may be altered slightly with a suffix appended or by replacing a dot (`.`) with an underscore (`_`) .
 

--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -224,7 +224,7 @@ A more detailed list is available in the following sections.
 
 Metrics names may be altered slightly with a suffix appended or by replacing a dot (`.`) with an underscore (`_`) .
 
-#### Suffix appended
+#### `_total` suffix appended
 
 By default and unique to Prometheus, the Prometheus exporter adds a `_total` suffix to some metrics to follow Prometheus naming conventions. For example,  `otelcol_exporter_send_failed_spans_total`. 
 However in the list of internal metrics within this document, this is listed as `otelcol_exporter_send_failed_spans`. 

--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -222,10 +222,12 @@ A more detailed list is available in the following sections.
 
 ### Metric names
 
-Metrics names may be altered slightly with a suffix appended or by replacing a dot (`.`) with an underscore (`_`) .
+This section explains special naming conventions applied to some internal
+metrics.
 
-#### `_total` suffix appended
+#### `otelcol_` prefix
 
+<<<<<<< Updated upstream
 By default and unique to Prometheus, the Prometheus exporter adds a `_total` suffix to summation metrics to follow Prometheus naming conventions. For example,  `otelcol_exporter_send_failed_spans_total`. 
 However in the list of internal metrics within this document, metrics are listed in OTLP format, such as `otelcol_exporter_send_failed_spans`. 
 
@@ -244,6 +246,10 @@ categorized by instrumentation type.
 
 {{% alert title="Note" %}} As of Collector v0.106.1, internal metric names are
 handled differently based on their source:
+=======
+As of Collector v0.106.1, internal metric names are handled differently based on
+their source:
+>>>>>>> Stashed changes
 
 - Metrics generated from Collector components are prefixed with `otelcol_`.
 - Metrics generated from instrumentation libraries do not use the `otelcol_`
@@ -252,7 +258,45 @@ handled differently based on their source:
 For Collector versions prior to v0.106.1, all internal metrics emitted using the
 Prometheus exporter, regardless of their origin, are prefixed with `otelcol_`.
 This includes metrics from both Collector components and instrumentation
-libraries. {{% /alert %}}
+libraries.
+
+#### `_total` suffix
+
+By default and unique to Prometheus, the Prometheus exporter adds a `_total`
+suffix to summation metrics to follow Prometheus naming conventions, such as
+`otelcol_exporter_send_failed_spans_total`. This behavior can be disabled by
+setting `without_type_suffix: false` in the Prometheus exporter's configuration.
+
+If you leave out `service::telemetry::metrics::readers` in the Collector
+configuration, the default Prometheus exporter set up by the Collector already
+has `without_type_suffix` set to `false`. However, if you customize the readers
+and add a Prometheus exporter manually, you must set that option to return to
+the "raw" metric name. For more information, see the
+[Collector v1.25.0/v0.119.0 release notes](https://github.com/codeboten/opentelemetry-collector/blob/313167505b44e5dc9a29c0b9242cc4547db11ec3/CHANGELOG.md#v1250v01190).
+
+Internal metrics exported through OTLP do not have this behavior. The
+[internal metrics](#lists-of-internal-metrics) on this page are listed in OTLP
+format, such as `otelcol_exporter_send_failed_spans`.
+
+#### Dots (`.`) v. underscores (`_`)
+
+`http*` and `rpc*` metrics come from instrumentation libraries. Their original
+names used dots (`.`). Prior to Collector v0.120.0, internal metrics exposed
+with Prometheus changed dots (`.`) to underscores (`_`) to match Prometheus
+naming conventions, resulting in metric names that looked like
+`rpc_server_duration`.
+
+Versions 0.120.0 and later of the Collector use Prometheus 3.0 scrapers, so the
+original `http*` and `rpc*` metric names with dots are preserved. The
+[internal metrics](#lists-of-internal-metrics) on this page are listed in their
+original form, such as`rpc.server.duration`. For more information, see the
+[Collector v0.120.0 release notes](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CHANGELOG.md#v01200).
+
+### Lists of internal metrics
+
+The following tables group each internal metric by level of verbosity: `basic`,
+`normal`, and `detailed`. Each metric is identified by name and description and
+categorized by instrumentation type.
 
 {{< comment >}}
 
@@ -349,10 +393,14 @@ its introduction. Note however that these metrics were inadvertently reverted to
 | `rpc_server_response_size`                            | Measures the size of RPC response messages (uncompressed).                                | Histogram |
 | `rpc_server_responses_per_rpc`                        | Measures the number of messages sent per RPC. Should be 1 for all non-streaming RPCs.     | Histogram |
 
+<<<<<<< Updated upstream
 {{% alert title="Note" %}} The `http_` and `rpc_` metrics come from
 instrumentation libraries. Their original names use dots (`.`), but when
 exposing internal metrics with Prometheus, they are translated to use
 underscores (`_`) to match Prometheus' naming constraints. These metrics are not
+=======
+{{% alert title="Note" color="info" %}} The `http*` and `rpc*` metrics are not
+>>>>>>> Stashed changes
 covered by the maturity levels below since they are not under the Collector SIG
 control.
 

--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -224,7 +224,7 @@ A more detailed list is available in the following sections.
 
 Metrics names may be altered slightly with a suffix appended or by replacing a dot (`.`) with an underscore (`_`) .
 
-####Suffix appended
+#### Suffix appended
 
 By default and unique to Prometheus, the Prometheus exporter adds a `_total` suffix to some metrics to follow Prometheus naming conventions. For example,  `otelcol_exporter_send_failed_spans_total`. 
 However in the list of internal metrics within this document, this is listed as `otelcol_exporter_send_failed_spans`. 

--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -234,7 +234,7 @@ If you leave out service::telemetry::metrics::readers in the Collector config, t
 
 For more information, refer to [Collector v1.25.0/v0.119.0 release notes](https://github.com/codeboten/opentelemetry-collector/blob/313167505b44e5dc9a29c0b9242cc4547db11ec3/CHANGELOG.md#v1250v01190).
 
-####Dot replaced with underscore
+#### Dot replaced with underscore
 
 `http_` and `rpc_` metrics come from instrumentation libraries. While the original metric name uses dots (`.`), when
 exposing internal metrics with Prometheus, the dots change to underscores (`_`) to match Prometheus' naming constraints.

--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -227,7 +227,7 @@ Metrics names may be altered slightly with a suffix appended or by replacing a d
 #### `_total` suffix appended
 
 By default and unique to Prometheus, the Prometheus exporter adds a `_total` suffix to summation metrics to follow Prometheus naming conventions. For example,  `otelcol_exporter_send_failed_spans_total`. 
-However in the list of internal metrics within this document, this is listed as `otelcol_exporter_send_failed_spans`. 
+However in the list of internal metrics within this document, metrics are listed in OTLP format, such as `otelcol_exporter_send_failed_spans`. 
 
 This behavior can be disabled by setting without_type_suffix: false in the exporter's configuration. Any internal metrics exported through OTLP will not have this behavior.
 If you leave out service::telemetry::metrics::readers in the Collector config, the default Prometheus exporter set up by the Collector already has that option set. However, if you customize the readers and add a Prometheus exporter manually, you must set that option to return to the "raw" metric name.

--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -220,6 +220,25 @@ The Collector emits internal metrics for at least the following values:
 
 A more detailed list is available in the following sections.
 
+### Metrics naming
+
+Metrics names may be altered slightly with a suffix appended or by replacing a dot (`.`) with an underscore (`_`) .
+
+####Suffix appended
+
+By default and unique to Prometheus, the Prometheus exporter adds a `_total` suffix to some metrics to follow Prometheus naming conventions. For example,  `otelcol_exporter_send_failed_spans_total`. 
+However in the list of internal metrics within this document, this is listed as `otelcol_exporter_send_failed_spans`. 
+
+This behavior can be disabled by setting without_type_suffix: false in the exporter's configuration. Any internal metrics exported through OTLP will not have this behavior.
+If you leave out service::telemetry::metrics::readers in the Collector config, the default Prometheus exporter set up by the Collector already has that option set. However, if you customize the readers and add a Prometheus exporter manually, you must set that option to return to the "raw" metric name.
+
+For more information, refer to [Collector v1.25.0/v0.119.0 release notes](https://github.com/codeboten/opentelemetry-collector/blob/313167505b44e5dc9a29c0b9242cc4547db11ec3/CHANGELOG.md#v1250v01190).
+
+####Dot replaced with underscore
+
+`http_` and `rpc_` metrics come from instrumentation libraries. While the original metric name uses dots (`.`), when
+exposing internal metrics with Prometheus, the dots change to underscores (`_`) to match Prometheus' naming constraints.
+
 ### Lists of internal metrics
 
 The following tables group each internal metric by level of verbosity: `basic`,

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -3763,6 +3763,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-30T14:41:51.138475-05:00"
   },
+  "https://github.com/codeboten/opentelemetry-collector/blob/313167505b44e5dc9a29c0b9242cc4547db11ec3/CHANGELOG.md#v1250v01190": {
+    "StatusCode": 206,
+    "LastSeen": "2025-06-18T16:37:37.617753182-07:00"
+  },
   "https://github.com/codefromthecrypt": {
     "StatusCode": 200,
     "LastSeen": "2024-11-18T23:18:18.05798173Z"
@@ -5778,6 +5782,10 @@
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/9b28f76c02c18f7479d10e4b6a95a21467fd85d6/processor/transformprocessor/testdata/config.yaml": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:34:12.970839-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CHANGELOG.md#v01200": {
+    "StatusCode": 206,
+    "LastSeen": "2025-06-18T16:37:40.740047715-07:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/README.md": {
     "StatusCode": 206,


### PR DESCRIPTION
Per [this issue](https://github.com/open-telemetry/opentelemetry.io/issues/6642):
Created a new section on metric naming to clarify that some metrics have a suffix added as a result of the Prometheus exporter, and others have the dot replaced with an underscore.

---
**Preview**: https://deploy-preview-6799--opentelemetry.netlify.app/docs/collector/internal-telemetry/