### PR TITLE
Update community repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 [submodule "content-modules/community"]
 	path = content-modules/community
 	url = https://github.com/open-telemetry/community
-	community-pin = f16a58e
+	community-pin = e9411ee
 [submodule "content-modules/opentelemetry-proto"]
 	path = content-modules/opentelemetry-proto
 	url = https://github.com/open-telemetry/opentelemetry-proto

--- a/.prettierignore
+++ b/.prettierignore
@@ -13,10 +13,6 @@
 /content/ja
 /content/zh
 
-# Ignore content-modules except for published Community pages
+# Ignore content-modules
 
 /content-modules/*
-!/content-modules/community
-/content-modules/community/*
-!/content-modules/community/mission-vision-values.md
-!/content-modules/community/roadmap.md


### PR DESCRIPTION
- Fixes #6561
- Updates the community submodule and it's pinned commit hash
- Drops requiring that the community submodule mission and roadmap files be formatted