### PR TITLE
Fix: port-forward example to clarify service name usage and namespace

### DIFF
--- a/content/en/docs/demo/kubernetes-deployment.md
+++ b/content/en/docs/demo/kubernetes-deployment.md
@@ -82,10 +82,10 @@ LoadBalancer) with optionally deployed ingress resources.
 ### Expose services using kubectl port-forward
 
 To expose the frontend-proxy service use the following command (replace
-`my-otel-demo` with your Helm chart release name accordingly):
+`default` with your Helm chart release namespace accordingly):
 
 ```shell
-kubectl port-forward svc/my-otel-demo-frontend-proxy 8080:8080
+kubectl --namespace default port-forward svc/frontend-proxy 8080:8080
 ```
 
 {{% alert title="Note" color="info" %}}


### PR DESCRIPTION
### What this PR does

Updates the `kubectl port-forward` command in the demo documentation to reflect the current Helm chart behavior, where the service name is now simply `frontend-proxy`.

### Why

The Helm chart previously generated service names with the release name as a prefix (e.g., `my-otel-demo-frontend-proxy`). This changed in [PR #1520](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1520), which simplified component naming. However, the demo documentation was not updated accordingly and still refers to the old naming convention, which can lead to confusion or non-working commands for new users.

### How

- Replaced the incorrect service name with `frontend-proxy`
- Updated to reflect the namespace (`--namespace default`) as indicated in the Helm install summary
```
$ helm install my-otel-demo open-telemetry/opentelemetry-demo
...
 ██████╗ ████████╗███████╗██╗         ██████╗ ███████╗███╗   ███╗ ██████╗
██╔═══██╗╚══██╔══╝██╔════╝██║         ██╔══██╗██╔════╝████╗ ████║██╔═══██╗
██║   ██║   ██║   █████╗  ██║         ██║  ██║█████╗  ██╔████╔██║██║   ██║
██║   ██║   ██║   ██╔══╝  ██║         ██║  ██║██╔══╝  ██║╚██╔╝██║██║   ██║
╚██████╔╝   ██║   ███████╗███████╗    ██████╔╝███████╗██║ ╚═╝ ██║╚██████╔╝
 ╚═════╝    ╚═╝   ╚══════╝╚══════╝    ╚═════╝ ╚══════╝╚═╝     ╚═╝ ╚═════╝


- All services are available via the Frontend proxy: http://localhost:8080
  by running these commands:
     kubectl --namespace default port-forward svc/frontend-proxy 8080:8080
...
```

### References

- Current `NOTES.txt`: https://github.com/open-telemetry/opentelemetry-helm-charts/blob/9237a88c4e2dddcc7dac6e3092cc3acf3b38a717/charts/opentelemetry-demo/templates/NOTES.txt#L14
- Pre-change `NOTES.txt`: https://github.com/open-telemetry/opentelemetry-helm-charts/blob/1a6761a48a0c50fb40a0ed6278bbbb90501fc132/charts/opentelemetry-demo/templates/NOTES.txt#L14
- Naming change PR: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1520