### PR TITLE
Fix invalid hash in languages/other external link - use path instead

### DIFF
--- a/content/en/docs/languages/other/_index.md
+++ b/content/en/docs/languages/other/_index.md
@@ -12,7 +12,7 @@ possible to implement it in every language you like.
 
 For some languages, unofficial implementations exist -- you can find them in the
 [registry](/ecosystem/registry/). If you know about an implementation not listed
-there, please [add it to the registry][].
+there, please [add it to the registry](/ecosystem/registry/adding/).
 
 The OpenTelemetry community is open to maintain implementations for additional
 languages and with that make them "official" parts of the OpenTelemetry
@@ -24,6 +24,3 @@ For the following languages a request to create a SIG exists:
 - [Lua](https://github.com/open-telemetry/community/issues/1276)
 - [Perl](https://github.com/open-telemetry/community/issues/828)
 - [Julia](https://github.com/open-telemetry/community/issues/898)
-
-[add it to the registry]:
-  https://github.com/open-telemetry/opentelemetry.io#adding-a-project-to-the-opentelemetry-registry

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -11295,10 +11295,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-30T16:54:06.064738-05:00"
   },
-  "https://github.com/open-telemetry/opentelemetry.io#adding-a-project-to-the-opentelemetry-registry": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-06T02:19:59.999Z"
-  },
   "https://github.com/open-telemetry/opentelemetry.io/": {
     "StatusCode": 206,
     "LastSeen": "2025-01-30T16:59:53.944832-05:00"


### PR DESCRIPTION
- Drops external link with invalid has
- Uses site-local path instead