### PR TITLE
[i18n] Make resources-intro an include for `en`

### DIFF
--- a/content/en/docs/_includes/resources-intro.md
+++ b/content/en/docs/_includes/resources-intro.md
@@ -1,0 +1,13 @@
+---
+---
+
+A [resource]({{ $resourceHRef }}) represents the entity producing telemetry as
+resource attributes. For example, {{ $aResource }} producing telemetry that is
+running in a container on Kubernetes has {{ $aResource }} name, a pod name, a
+namespace, and possibly a deployment name. All four of these attributes can be
+included in the resource.
+
+In your observability backend, you can use resource information to better
+investigate interesting behavior. For example, if your trace or metrics data
+indicate latency in your system, you can narrow it down to a specific container,
+pod, or Kubernetes deployment.

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -3,6 +3,9 @@ title: Documentation
 linkTitle: Docs
 menu: { main: { weight: 10 } }
 aliases: [/docs/workshop/*]
+cascade:
+  params:
+    resource_intro_default_rsrc: a process # LOCALES can translate this value
 ---
 
 OpenTelemetry, also known as OTel, is a vendor-neutral open source

--- a/layouts/shortcodes/docs/languages/resources-intro.md
+++ b/layouts/shortcodes/docs/languages/resources-intro.md
@@ -1,17 +1,21 @@
+{{/* TODO: Cleanup: drop the prettier-ignore directive. */ -}}
 <!-- prettier-ignore -->
-{{ $processWord := .Get 0 | default "a process"  -}}
+{{ $aResource := .Get 0 |
+  default .Page.Params.resource_intro_default_rsrc |
+  default (site.Sites.Default.GetPage "docs").Params.resource_intro_default_rsrc
+-}}
+{{ if not $aResource -}}
+  {{ errorf "%s: shortcode %q param 'resource_intro_default_rsrc' isn't defined" .Position .Name -}}
+{{ end -}}
 {{ $resourceHRef := "/docs/concepts/resources/" -}}
 {{ if eq .Page.RelPermalink $resourceHRef -}}
   {{ $resourceHRef = "/docs/specs/otel/resource/sdk/" -}}
 {{ end -}}
 
-A [resource]({{ $resourceHRef }}) represents the entity producing telemetry as
-resource attributes. For example, {{ $processWord }} producing telemetry that is
-running in a container on Kubernetes has {{ $processWord }} name, a pod name, a
-namespace, and possibly a deployment name. All four of these attributes can be
-included in the resource.
-
-In your observability backend, you can use resource information to better
-investigate interesting behavior. For example, if your trace or metrics data
-indicate latency in your system, you can narrow it down to a specific container,
-pod, or Kubernetes deployment.
+{{ $args := dict
+  "_dot" .
+  "_path" "resources-intro.md"
+  "aResource" $aResource
+  "resourceHRef" $resourceHRef
+-}}
+{{ partial "include" $args -}}


### PR DESCRIPTION
- Contributes to #6460
- Moves prose out of `layouts/shortcodes/docs/languages/resources-intro.md` into an include file of the same name.
- There a bit of extra complexity because I chose to preserve the default-resource parameter "a process", which needs to be defined in the `content` not the shortcode. I can always simplify this by inlining the "a process". Reviewers can let me know what you think.

**Preview**:

- https://deploy-preview-6816--opentelemetry.netlify.app/docs/concepts/resources/
- And any one of the languages, such as https://deploy-preview-6816--opentelemetry.netlify.app/docs/languages/go/resources/