### PR TITLE
Drop Prettier directives from layouts

### DIFF
--- a/layouts/partials/docs/native-libraries.md
+++ b/layouts/partials/docs/native-libraries.md
@@ -1,4 +1,3 @@
-<!-- prettier-ignore -->
 {{ $howMany := .Get 1 | default 10 -}}
 {{ $langIndex := .Get 0 }}
 {{ $lang := index $.Site.Data.instrumentation $langIndex -}}
@@ -8,9 +7,7 @@
 {{ if and (and (eq $entry.language $langIndex) (eq $entry.isNative true)) (eq $entry.registryType "instrumentation") }}
 {{ $integrations = $integrations | append $entry }} {{ end }} {{ end }}
 
-{{ range first $howMany (sort $integrations "name") -}}
-
-<!-- prettier-ignore -->
+{{ range first $howMany (sort $integrations "name") }}
 - [{{ .title }}]({{ .urls.docs }})
 {{- end }}
 

--- a/layouts/shortcodes/docs/languages/index-adopters.md
+++ b/layouts/shortcodes/docs/languages/index-adopters.md
@@ -1,4 +1,3 @@
-<!-- prettier-ignore -->
 {{ $lang := .Get 0 -}}
 {{ $Lang := $lang | humanize -}}
 {{ $howMany := .Get 1 | default 10 -}}
@@ -8,9 +7,7 @@
 
 OpenTelemetry {{ $Lang }} is in use by a number of organizations, including:
 
-{{ range first $howMany (sort $adopters "name") -}}
-
-<!-- prettier-ignore -->
+{{ range first $howMany (sort $adopters "name") }}
 - [{{ .name }}]({{ .url }})
 {{- end }}
 

--- a/layouts/shortcodes/docs/languages/index-intro.md
+++ b/layouts/shortcodes/docs/languages/index-intro.md
@@ -1,7 +1,3 @@
-{{ $prettier_ignore := `
-
-<!-- prettier-ignore -->
-` -}}
 {{ $lang := .Get 0 -}}
 {{ $data := index $.Site.Data.instrumentation $lang }}
 {{ $name := $data.name -}}

--- a/layouts/shortcodes/docs/languages/libraries-intro.md
+++ b/layouts/shortcodes/docs/languages/libraries-intro.md
@@ -1,12 +1,14 @@
-<!-- prettier-ignore -->
 {{ $howMany := .Get 1 | default 10 -}}
-{{ $langIndex := .Get 0 }}
+{{ $langIndex := .Get 0 -}}
 {{ $lang := index $.Site.Data.instrumentation $langIndex -}}
 {{ $integrations := where (slice ) ".language" $langIndex -}}
 
-{{ $integrations := slice }} {{ range $entry := $.Site.Data.registry }}
-{{ if and (and (eq $entry.language $langIndex) (eq $entry.isNative true)) (eq $entry.registryType "instrumentation") }}
-{{ $integrations = $integrations | append $entry }} {{ end }} {{ end }}
+{{ $integrations := slice -}}
+{{ range $entry := $.Site.Data.registry -}}
+  {{ if and (and (eq $entry.language $langIndex) (eq $entry.isNative true)) (eq $entry.registryType "instrumentation") -}}
+    {{ $integrations = $integrations | append $entry -}}
+  {{ end }}
+{{ end }}
 
 When you develop an app, you might use third-party libraries and frameworks to
 accelerate your work. If you then instrument your app using OpenTelemetry, you

--- a/layouts/shortcodes/docs/languages/resources-intro.md
+++ b/layouts/shortcodes/docs/languages/resources-intro.md
@@ -1,5 +1,3 @@
-{{/* TODO: Cleanup: drop the prettier-ignore directive. */ -}}
-<!-- prettier-ignore -->
 {{ $aResource := .Get 0 |
   default .Page.Params.resource_intro_default_rsrc |
   default (site.Sites.Default.GetPage "docs").Params.resource_intro_default_rsrc

--- a/layouts/shortcodes/ja/docs/languages/resources-intro.md
+++ b/layouts/shortcodes/ja/docs/languages/resources-intro.md
@@ -1,8 +1,7 @@
 {{/*
-default_lang_commit: 1f992fb2
+default_lang_commit: 1f992fb2 # patched
 */ -}}
 
-<!-- prettier-ignore -->
 {{ $processWord := .Get 0 | default "プロセス"  -}}
 {{ $resourceHRef := "/docs/concepts/resources/" -}}
 {{ if eq .Page.RelPermalink $resourceHRef -}}

--- a/layouts/shortcodes/pt/docs/languages/resources-intro.md
+++ b/layouts/shortcodes/pt/docs/languages/resources-intro.md
@@ -1,8 +1,7 @@
 {{/*
-default_lang_commit: a1740fd934e595f1396f2eb82a58a80824369b09
+default_lang_commit: a1740fd934e595f1396f2eb82a58a80824369b09 # patched
 */ -}}
 
-<!-- prettier-ignore -->
 {{ $processWord := .Get 0 | default "processo"  -}}
 {{ $resourceHRef := "/docs/concepts/resources/" -}}
 {{ if eq .Page.RelPermalink $resourceHRef -}}


### PR DESCRIPTION
- This is cleanup in support of #6460
- Drops Prettier directives from layouts, because we don't prettify them anymore.
- No visual changes to generated site files (for the pages I sampled).

### Preview

For example:

- https://deploy-preview-6821--opentelemetry.netlify.app/docs/languages/dotnet/libraries/#use-natively-instrumented-libraries