### PR TITLE
Refactor resource-intro: get default resource from include file

### DIFF
--- a/content/en/docs/_includes/resources-intro.md
+++ b/content/en/docs/_includes/resources-intro.md
@@ -1,4 +1,6 @@
 ---
+params:
+  aResource: a process
 ---
 
 A [resource]({{ $resourceHRef }}) represents the entity producing telemetry as

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -3,9 +3,6 @@ title: Documentation
 linkTitle: Docs
 menu: { main: { weight: 10 } }
 aliases: [/docs/workshop/*]
-cascade:
-  params:
-    resource_intro_default_rsrc: a process # LOCALES can translate this value
 ---
 
 OpenTelemetry, also known as OTel, is a vendor-neutral open source

--- a/content/en/docs/concepts/resources/index.md
+++ b/content/en/docs/concepts/resources/index.md
@@ -1,7 +1,5 @@
 ---
 title: Resources
-params:
-  resource_intro_default_rsrc: a process # LOCALES can translate this value
 weight: 70
 ---
 

--- a/content/en/docs/concepts/resources/index.md
+++ b/content/en/docs/concepts/resources/index.md
@@ -1,5 +1,7 @@
 ---
 title: Resources
+params:
+  resource_intro_default_rsrc: a process # LOCALES can translate this value
 weight: 70
 ---
 

--- a/layouts/partials/include.html
+++ b/layouts/partials/include.html
@@ -16,7 +16,8 @@ include functionality:
 
 {{ $path := ._path -}}
 {{ $args := . -}}
-{{ $page := partial "func/find-include.html"  (dict "path" $path "page" ._dot.Page) -}}
+{{ $page := ._page |
+    default (partial "func/find-include.html"  (dict "path" $path "page" ._dot.Page)) -}}
 {{ with $page -}}
   {{ $content := .RenderShortcodes -}}
   {{ range $_k, $v := $args -}}

--- a/layouts/shortcodes/docs/languages/resources-intro.md
+++ b/layouts/shortcodes/docs/languages/resources-intro.md
@@ -1,19 +1,20 @@
-{{ $aResource := .Get 0 |
-  default .Page.Params.resource_intro_default_rsrc |
-  default (site.Sites.Default.GetPage "docs").Params.resource_intro_default_rsrc
--}}
+{{ $resourceConceptsPagePath := "/docs/concepts/resources/" -}}
+{{ $aResource := .Get 0 -}}
 {{ if not $aResource -}}
-  {{ errorf "%s: shortcode %q param 'resource_intro_default_rsrc' isn't defined" .Position .Name -}}
-{{ end -}}
-{{ $resourceHRef := "/docs/concepts/resources/" -}}
-{{ if eq .Page.RelPermalink $resourceHRef -}}
-  {{ $resourceHRef = "/docs/specs/otel/resource/sdk/" -}}
+  {{ with .Page.GetPage $resourceConceptsPagePath -}}
+    {{ $aResource = .Params.resource_intro_default_rsrc |
+        default (index (where .Translations "Lang" "en") 0).Params.resource_intro_default_rsrc -}}
+  {{ else -}}
+    {{ errorf "%s: shortcode %q param 'resource_intro_default_rsrc' isn't defined" .Position .Name -}}
+  {{ end -}}
 {{ end -}}
 
 {{ $args := dict
   "_dot" .
   "_path" "resources-intro.md"
   "aResource" $aResource
-  "resourceHRef" $resourceHRef
+  "resourceHRef" (cond (eq .Page.RelPermalink $resourceConceptsPagePath)
+      "/docs/specs/otel/resource/sdk/"
+      $resourceConceptsPagePath)
 -}}
 {{ partial "include" $args -}}

--- a/layouts/shortcodes/docs/languages/resources-intro.md
+++ b/layouts/shortcodes/docs/languages/resources-intro.md
@@ -1,20 +1,27 @@
-{{ $resourceConceptsPagePath := "/docs/concepts/resources/" -}}
-{{ $aResource := .Get 0 -}}
+{{ $aResource := "" -}}
+{{ $path := "resources-intro.md" -}}
+{{ $includePage := partial "func/find-include.html"  (dict "path" $path "page" .Page) -}}
+{{ if $includePage }}
+  {{ $aResource = .Get 0 | default $includePage.Params.aResource -}}
+{{ else -}}
+  {{ errorf "%s: include file '%s' not found" .Position $path -}}
+{{ end -}}
+
 {{ if not $aResource -}}
-  {{ with .Page.GetPage $resourceConceptsPagePath -}}
-    {{ $aResource = .Params.resource_intro_default_rsrc |
-        default (index (where .Translations "Lang" "en") 0).Params.resource_intro_default_rsrc -}}
-  {{ else -}}
-    {{ errorf "%s: shortcode %q param 'resource_intro_default_rsrc' isn't defined" .Position .Name -}}
-  {{ end -}}
+  {{ errorf "%s: shortcode %q param 'resource_intro_default_rsrc' isn't defined" .Position .Name -}}
+{{ end -}}
+
+{{ $resourceConceptsPagePath := "/docs/concepts/resources/" -}}
+{{ $resourceHRef := $resourceConceptsPagePath -}}
+{{ if eq .Page.RelPermalink $resourceConceptsPagePath -}}
+  {{ $resourceHRef = "/docs/specs/otel/resource/sdk/" -}}
 {{ end -}}
 
 {{ $args := dict
   "_dot" .
   "_path" "resources-intro.md"
+  "_page" $includePage
   "aResource" $aResource
-  "resourceHRef" (cond (eq .Page.RelPermalink $resourceConceptsPagePath)
-      "/docs/specs/otel/resource/sdk/"
-      $resourceConceptsPagePath)
+  "resourceHRef" $resourceHRef
 -}}
 {{ partial "include" $args -}}


### PR DESCRIPTION
- Contributes to  #6460
- Follow up to #6816
- Refactors resource-intro files so that the default resource string is fetched from the include file front matter
- (This PR has two solutions in two different commits. The latter commit is the final solution we're opting for. Committing both solutions, for the record. :)

There are no changes to generated site files:

```console
$ (cd public && g diff -bw --ignore-blank-lines -I 'modified_time|dateModified|proofer-ignore') | grep ^diff | grep -v \.xml
diff --git a/site/index.html b/site/index.html
diff --git a/zh/docs/index.html b/zh/docs/index.html
```

(The zh page diff is because of Git commit hashes in the page drifted banner.)