### PR TITLE
Add logs_exporter flag to otel instrument examples

### DIFF
--- a/content/en/docs/zero-code/python/example.md
+++ b/content/en/docs/zero-code/python/example.md
@@ -190,7 +190,7 @@ Stop the execution of `server_manual.py` by pressing <kbd>Control+C</kbd> and
 run the following command instead:
 
 ```sh
-opentelemetry-instrument --traces_exporter console --metrics_exporter none python server_automatic.py
+opentelemetry-instrument --traces_exporter console --metrics_exporter none --logs_exporter none python server_automatic.py
 ```
 
 In the console where you previously executed `client.py`, run the following
@@ -323,7 +323,7 @@ of HTTP header names via the environment variables
 ```sh
 export OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST="Accept-Encoding,User-Agent,Referer"
 export OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE="Last-Modified,Content-Type"
-opentelemetry-instrument --traces_exporter console --metrics_exporter none python app.py
+opentelemetry-instrument --traces_exporter console --metrics_exporter none --logs_exporter none python app.py
 ```
 
 These configuration options are supported by the following HTTP


### PR DESCRIPTION
This change adds a `--logs_exporter none` flag in two places in the zero-code python example. I tested this manually against the latest OTel Python auto instrumentation package.

Addresses issue #6825.
