### PR TITLE
Adding WSO2 opentelemetry integration

### DIFF
--- a/data/registry/application-integration-WSO2-Kubernetes-Gateway.yml
+++ b/data/registry/application-integration-WSO2-Kubernetes-Gateway.yml
@@ -1,0 +1,18 @@
+title: WSO2 Kubernetes Gateway
+registryType: application integration
+language: Java
+tags:
+  - WSO2
+  - API Gateway For Kubernetes
+  - Java
+  - Opentelemetry
+license: Apache-2.0
+description: 'Integration of OpenTelemetry with WSO2 Kubernetes Gateway(WSO2 APK Gateway) enhances observability by providing insights into API metrics, traces, and logs, facilitating better performance monitoring and troubleshooting within Kubernetes environments.'
+authors:
+  - name: WSO2
+    url: https://github.com/wso2
+urls:
+  website: https://wso2.com/api-management/
+  docs: https://apk.docs.wso2.com/en/latest/administration/distributed-tracing/#opentelemetry-protocol-otlp
+createdAt: '2025-05-08'
+isFirstParty: true

--- a/data/registry/application-integration-WSO2-api-manager.yml
+++ b/data/registry/application-integration-WSO2-api-manager.yml
@@ -1,0 +1,18 @@
+title: WSO2 API Manager
+registryType: application integration
+language: Java
+tags:
+  - WSO2
+  - API Manager
+  - Java
+  - Opentelemetry
+license: Apache-2.0
+description: 'Integration of OpenTelemetry with WSO2 API Manager enhances observability by providing insights into API metrics, traces, and logs, facilitating better performance monitoring and troubleshooting.'
+authors:
+  - name: WSO2
+    url: https://github.com/wso2
+urls:
+  website: https://wso2.com/api-management/
+  docs: https://apim.docs.wso2.com/en/latest/observe/api-manager/traces/monitoring-with-opentelemetry/
+createdAt: '2025-05-08'
+isFirstParty: true

--- a/data/registry/application-integration-WSO2-micro-integrator.yml
+++ b/data/registry/application-integration-WSO2-micro-integrator.yml
@@ -1,0 +1,18 @@
+title: WSO2 Micro Integrator
+registryType: application integration
+language: Java
+tags:
+  - WSO2
+  - Micro Integrator
+  - Java
+  - Opentelemetry
+license: Apache-2.0
+description: 'Integration of OpenTelemetry with WSO2 Micro Integrator enhances observability by providing insights into metrics, traces, and logs, facilitating better performance monitoring and troubleshooting.'
+authors:
+  - name: WSO2
+    url: https://github.com/wso2
+urls:
+  website: https://wso2.com/integration/
+  docs: https://mi.docs.wso2.com/en/latest/observe-and-manage/classic-observability-traces/monitoring-with-opentelemetry-mi/
+createdAt: '2025-05-08'
+isFirstParty: true


### PR DESCRIPTION
## Description
This pull request updates the documentation URL for the OpenTelemetry integration with WSO2 API Manager. The previous URL led to a general page, while the new URL directs users specifically to the page detailing how to monitor the WSO2 API Manager using OpenTelemetry. This change ensures that users have direct access to relevant and detailed information about implementing OpenTelemetry for enhanced observability.

## Impact
- Provides users with direct and precise documentation, improving ease of access and user experience.
- Ensures that the information is up-to-date and relevant to current integration capabilities between WSO2 API Manager and OpenTelemetry.

I have signed CLA.

Thank you for considering this update. Please let me know if there are any further adjustments needed.
