### PR TITLE
Localization: add guidance about not translating link def labels

### DIFF
--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -109,7 +109,6 @@ the label as translated link text. For example, consider the following markdown:
 This would be translated in French as:
 
 ```markdown
-
 [Bonjour][hello], le monde! Bienvenue sur le [site OTel][OTel website].
 
 [hello]: https://code.org/helloworld
@@ -117,7 +116,8 @@ This would be translated in French as:
 ```
 
 [labels]: https://spec.commonmark.org/0.31.2/#link-label
-[link definitions]: https://spec.commonmark.org/0.31.2/#link-reference-definitions
+[link definitions]:
+  https://spec.commonmark.org/0.31.2/#link-reference-definitions
 
 ### Images and diagrams {#images}
 

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -44,7 +44,8 @@ guidance offered in this section.
 
 - **Translate**:
   - **File or directory** names of resources in this repository
-  - [Links](#links), this includes [heading IDs](#headings).[^*]
+  - [Links](#links), this includes [heading IDs](#headings) [^*]
+  - Markdown [link definition labels](#link-labels)
   - Inline code-spans like these: `inline code example`
   - Markdown elements marked as `notranslate` (usually as a CSS class), in
     particular for [headings](#headings)
@@ -92,6 +93,31 @@ page language code when rendering the link. For example, the previous sample
 path would become `/ja/docs/some-page` when rendered from a Japanese page.
 
 {{% /alert %}}
+
+### Link definition labels {#link-labels}
+
+Do **not** translate [labels] of markdown [link definitions][]. Instead, rewrite
+the label as translated link text. For example, consider the following markdown:
+
+```markdown
+[Hello], world! Welcome to the [OTel website][].
+
+[hello]: https://code.org/helloworld
+[OTel website]: https://opentelementry.io
+```
+
+This would be translated in French as:
+
+```markdown
+
+[Bonjour][hello], le monde! Bienvenue sur le [site OTel][OTel website].
+
+[hello]: https://code.org/helloworld
+[OTel website]: https://opentelementry.io
+```
+
+[labels]: https://spec.commonmark.org/0.31.2/#link-label
+[link definitions]: https://spec.commonmark.org/0.31.2/#link-reference-definitions
 
 ### Images and diagrams {#images}
 

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -18139,6 +18139,14 @@
     "StatusCode": 206,
     "LastSeen": "2025-02-10T23:17:25.614898483Z"
   },
+  "https://spec.commonmark.org/0.31.2/#link-label": {
+    "StatusCode": 206,
+    "LastSeen": "2025-05-07T10:20:22.152156-04:00"
+  },
+  "https://spec.commonmark.org/0.31.2/#link-reference-definitions": {
+    "StatusCode": 206,
+    "LastSeen": "2025-05-07T10:20:24.108059-04:00"
+  },
   "https://spring.io": {
     "StatusCode": 200,
     "LastSeen": "2025-01-06T11:23:17.257754-05:00"


### PR DESCRIPTION
- Context:
  - As endorsed by @svrnm, @tiffany76, and @theletterf in https://cloud-native.slack.com/archives/C06EDFPQ5EH/p1745946122339229
  - https://github.com/open-telemetry/opentelemetry.io/pull/6775#discussion_r2066973571
- Adds guidance that locales should NOT translate markdown link definition labels

**Preview**: https://deploy-preview-6838--opentelemetry.netlify.app/docs/contributing/localization/#do-not