### PR TITLE
[pt] Add shortcodes for pt/docs/languages/_includes/exporters

### DIFF
--- a/content/pt/docs/languages/_includes/exporters/jaeger.md
+++ b/content/pt/docs/languages/_includes/exporters/jaeger.md
@@ -1,0 +1,26 @@
+---
+default_lang_commit: 7d0c3f247ee77671d1135b0af535a2aca05fe359
+---
+
+## Jaeger
+
+### Configuração do Backend {#jaeger-backend-setup}
+
+O [Jaeger](https://www.jaegertracing.io/) suporta nativamente o OTLP para
+receber dados de rastros. O Jaeger pode ser executado através de um contêiner
+Docker com uma UI acessível através da porta 16686 e OTLP habilitados nas portas
+4317 e 4318:
+
+```shell
+docker run --rm \
+  -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
+  -p 16686:16686 \
+  -p 4317:4317 \
+  -p 4318:4318 \
+  -p 9411:9411 \
+  jaegertracing/all-in-one:latest
+```
+
+### Uso {#jaeger-usage}
+
+Siga as instruções para configurar os [exportadores OTLP](#otlp-dependencies).

--- a/content/pt/docs/languages/_includes/exporters/outro.md
+++ b/content/pt/docs/languages/_includes/exporters/outro.md
@@ -1,0 +1,15 @@
+---
+default_lang_commit: 7d0c3f247ee77671d1135b0af535a2aca05fe359
+---
+
+## Exportadores personalizados {#custom-exporters}
+
+Por fim, também é possível escrever o seu próprio exportador. Para mais
+informações, consulte [SpanExporter Interface na documentação da API]({{ $1 }}).
+
+## Agrupamento de trechos e registros de log {#batching-span-and-log-records}
+
+O SDK do OpenTelemetry fornece um conjunto de processadores padrão de trechos e
+registros de log, que permitem emitir trechos um-a-um ("simples") ou em lotes. O
+uso de agrupamentos é recomendado, mas caso não deseje agrupar seus trechos ou
+registros de log, é possível utilizar um processador simples da seguinte forma:

--- a/content/pt/docs/languages/_includes/exporters/prometheus-setup.md
+++ b/content/pt/docs/languages/_includes/exporters/prometheus-setup.md
@@ -18,7 +18,7 @@ serializando para o formato de texto do Prometheus sob demanda.
 Caso já possua o Prometheus ou um _backend_ compatível com Prometheus
 configurado, poderá pular esta seção e configurar as dependências do exportador
 [Prometheus](#prometheus-dependencies) ou [OTLP](#otlp-dependencies) para a
-suaaplicação.
+sua aplicação.
 
 {{% /alert-md %}}
 

--- a/content/pt/docs/languages/_includes/exporters/prometheus-setup.md
+++ b/content/pt/docs/languages/_includes/exporters/prometheus-setup.md
@@ -45,8 +45,6 @@ docker run --rm -v ${PWD}/prometheus.yml:/prometheus/prometheus.yml -p 9090:9090
 
 {{% alert-md title=Nota color=info %}}
 
-<div class="alert alert-info" role="alert"><h4 class="alert-heading">Nota</h4>
-
 Ao utilizar o OTLP Receiver do Prometheus, certifique-se de definir o endpoint
 OTLP das métricas em sua aplicação para `http://localhost:9090/api/v1/otlp`.
 

--- a/content/pt/docs/languages/_includes/exporters/prometheus-setup.md
+++ b/content/pt/docs/languages/_includes/exporters/prometheus-setup.md
@@ -17,8 +17,8 @@ serializando para o formato de texto do Prometheus sob demanda.
 
 Caso já possua o Prometheus ou um _backend_ compatível com Prometheus
 configurado, poderá pular esta seção e configurar as dependências do exportador
-[Prometheus](#prometheus-dependencies) ou [OTLP](#otlp-dependencies) para a
-sua aplicação.
+[Prometheus](#prometheus-dependencies) ou [OTLP](#otlp-dependencies) para a sua
+aplicação.
 
 {{% /alert-md %}}
 

--- a/content/pt/docs/languages/_includes/exporters/prometheus-setup.md
+++ b/content/pt/docs/languages/_includes/exporters/prometheus-setup.md
@@ -1,0 +1,57 @@
+---
+default_lang_commit: 7d0c3f247ee77671d1135b0af535a2aca05fe359
+---
+
+## Prometheus
+
+Para enviar dados de métricas para o [Prometheus](https://prometheus.io/), você
+pode
+[ativar o OTLP Receiver do Prometheus](https://prometheus.io/docs/prometheus/2.55/feature_flags/#otlp-receiver)
+e utilizar o [exportador OTLP](#otlp) ou você pode utilizar o exportador do
+Prometheus, um `MetricReader` que inicia um servidor HTTP e coleta métricas,
+serializando para o formato de texto do Prometheus sob demanda.
+
+### Configuração do Backend {#prometheus-setup}
+
+{{% alert-md title=Nota color=info %}}
+
+Caso já possua o Prometheus ou um _backend_ compatível com Prometheus
+configurado, poderá pular esta seção e configurar as dependências do exportador
+[Prometheus](#prometheus-dependencies) ou [OTLP](#otlp-dependencies) para a
+suaaplicação.
+
+{{% /alert-md %}}
+
+É possível executar o [Prometheus](https://prometheus.io) em um contêiner Docker
+acessível na porta `9090` através das seguintes instruções:
+
+Em uma pasta vazia, crie um arquivo chamado `prometheus.yml` e adicione o
+seguinte conteúdo:
+
+```yaml
+scrape_configs:
+  - job_name: dice-service
+    scrape_interval: 5s
+    static_configs:
+      - targets: [host.docker.internal:9464]
+```
+
+Em seguida, execute o Prometheus em um contêiner Docker que ficará acessível na
+porta `9090` através do seguinte comando:
+
+```shell
+docker run --rm -v ${PWD}/prometheus.yml:/prometheus/prometheus.yml -p 9090:9090 prom/prometheus --enable-feature=otlp-write-receive
+```
+
+{{% alert-md title=Nota color=info %}}
+
+<div class="alert alert-info" role="alert"><h4 class="alert-heading">Nota</h4>
+
+Ao utilizar o OTLP Receiver do Prometheus, certifique-se de definir o endpoint
+OTLP das métricas em sua aplicação para `http://localhost:9090/api/v1/otlp`.
+
+Nem todos os ambientes Docker suportam `host.docker.internal`. Em alguns casos,
+será necessário alterar o valor `host.docker.internal` para `localhost` ou o
+endereço de IP de sua máquina.
+
+{{% /alert-md %}}

--- a/content/pt/docs/languages/_includes/exporters/zipkin-setup.md
+++ b/content/pt/docs/languages/_includes/exporters/zipkin-setup.md
@@ -1,0 +1,22 @@
+---
+default_lang_commit: 7d0c3f247ee77671d1135b0af535a2aca05fe359
+---
+
+## Zipkin
+
+### Configuração do Backend {#zipkin-setup}
+
+{{% alert-md title=Nota color=info %}}
+
+Caso já possua o Zipkin ou um _backend_ compatível com Zipkin configurado,
+poderá pular esta seção e configurar as
+[dependências do exportador Zipkin](#zipkin-dependencies) para a sua aplicação.
+
+{{% /alert-md %}}
+
+É possível executar o [Zipkin][Zipkin](https://zipkin.io/) em um contêiner
+Docker através do seguinte comando:
+
+```shell
+docker run --rm -d -p 9411:9411 --name zipkin openzipkin/zipkin
+```


### PR DESCRIPTION
## Description

Closes #6848

Fixes the Portuguese shortcodes for the pages that were rendering the original content in English.

- [pt/docs/languages/python/exporters.md](https://github.com/open-telemetry/opentelemetry.io/blob/main/content/pt/docs/languages/python/exporters.md) ([see the docs](https://opentelemetry.io/pt/docs/languages/python/exporters))