### PR TITLE
[pt] Update localized content on content/pt/docs/languages/java/instrumentation.md

### DIFF
--- a/content/pt/docs/languages/java/instrumentation.md
+++ b/content/pt/docs/languages/java/instrumentation.md
@@ -22,15 +22,10 @@ produzida pelas chamadas de instrumentação da API. Esta página discute o
 ecossistema de instrumentação no OpenTelemetry Java, incluindo recursos para
 usuários finais e tópicos relacionados à instrumentação:
 
-- [Categorias de instrumentação](#instrumentation-categories): Existem diversas
-  categorias de instrumentação para diferentes casos de uso e padrões de
-  instalação.
-- [Propagação de Contexto](#context-propagation): Propagação de Contexto provê
-  uma correlação entre rastros, métricas, e logs, permitindo que os sinais se
-  complementem.
-- [Convenções semânticas](#semantic-conventions): As convenções semânticas
-  definem como produzir telemetria para operações padrão.
-- [Log instrumentation](#log-instrumentation)
+- [Categorias de instrumentação](#instrumentation-categories) abordando diferentes casos de uso e padrões de instalação.
+- [Propagação de Contexto](#context-propagation) fornece correlação entre rastros, métricas e logs, permitindo que os sinais se complementem.
+- [Convenções semânticas](#semantic-conventions) definem como produzir telemetria para operações padrão.
+- [Instrumentação de Log](#log-instrumentation), que é utilizada para obter logs de um _framework_ de logging existente no Java para o OpenTelemetry.
 
 {{% alert %}} Embora as
 [categorias de instrumentação](#instrumentation-categories) enumerem diversas
@@ -129,7 +124,7 @@ Shims mantidos no ecossistema OpenTelemetry Java:
 | Bridge [OpenTracing](https://opentracing.io/) no OpenTelemetry                                              | [LEIA-ME](https://github.com/open-telemetry/opentelemetry-java/tree/main/opentracing-shim)                                                                                       | Rastros           | `io.opentelemetry:opentelemetry-opentracing-shim:{{% param vers.otel %}}`                                                       |
 | Bridge [Opencensus](https://opencensus.io/) no OpenTelemetry                                                | [LEIA-ME](https://github.com/open-telemetry/opentelemetry-java/tree/main/opencensus-shim)                                                                                        | Rastros, Métricas | `io.opentelemetry:opentelemetry-opencensus-shim:{{% param vers.otel %}}-alpha`                                                  |
 | Bridge [Micrometer](https://micrometer.io/) no OpenTelemetry                                                | [LEIA-ME](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/micrometer/micrometer-1.5/library)                                      | Métricas          | `io.opentelemetry.instrumentation:opentelemetry-micrometer-1.5:{{% param vers.instrumentation %}}-alpha`                        |
-| Bridge [JMX](https://docs.oracle.com/javase/7/docs/technotes/guides/management/agent.html) no OpenTelemetry | [LEIA-ME](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/javaagent/README.md)                                        | Métricas          | `io.opentelemetry.instrumentation:opentelemetry-jmx-metrics:{{% param vers.instrumentation %}}-alpha`                           |
+| Bridge [JMX](https://docs.oracle.com/javase/7/docs/technotes/guides/management/agent.html) no OpenTelemetry | [LEIA-ME](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/README.md)                                        | Métricas          | `io.opentelemetry.instrumentation:opentelemetry-jmx-metrics:{{% param vers.instrumentation %}}-alpha`                           |
 | Bridge OpenTelemetry no [Prometheus Java client](https://github.com/prometheus/client_java)                 | [LEIA-ME](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/prometheus-client-bridge)                                                                       | Métricas          | `io.opentelemetry.contrib:opentelemetry-prometheus-client-bridge:{{% param vers.contrib %}}-alpha`                              |
 | Bridge OpenTelemetry no [Micrometer](https://micrometer.io/)                                                | [LEIA-ME](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/micrometer-meter-provider)                                                                      | Métricas          | `io.opentelemetry.contrib:opentelemetry-micrometer-meter-provider:{{% param vers.contrib %}}-alpha`                             |
 | Bridge [Log4j](https://logging.apache.org/log4j/2.x/index.html) no OpenTelemetry                            | [LEIA-ME](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/log4j/log4j-appender-2.17/library)                                      | Logs              | `io.opentelemetry.instrumentation:opentelemetry-log4j-appender-2.17:{{% param vers.instrumentation %}}-alpha`                   |

--- a/content/pt/docs/languages/java/instrumentation.md
+++ b/content/pt/docs/languages/java/instrumentation.md
@@ -8,8 +8,7 @@ aliases:
   - libraries
 weight: 10
 description: Ecossistema de Instrumentação no OpenTelemetry Java
-default_lang_commit: 748555c22f43476291ae0c7974ca4a2577da0472
-drifted_from_default: true
+default_lang_commit: dc20c29a4c79ad0424c0fcc3271216af7e035d9b
 cSpell:ignore: logback
 ---
 
@@ -22,10 +21,14 @@ produzida pelas chamadas de instrumentação da API. Esta página discute o
 ecossistema de instrumentação no OpenTelemetry Java, incluindo recursos para
 usuários finais e tópicos relacionados à instrumentação:
 
-- [Categorias de instrumentação](#instrumentation-categories) abordando diferentes casos de uso e padrões de instalação.
-- [Propagação de Contexto](#context-propagation) fornece correlação entre rastros, métricas e logs, permitindo que os sinais se complementem.
-- [Convenções semânticas](#semantic-conventions) definem como produzir telemetria para operações padrão.
-- [Instrumentação de Log](#log-instrumentation), que é utilizada para obter logs de um _framework_ de _logging_ existente no Java para o OpenTelemetry.
+- [Categorias de instrumentação](#instrumentation-categories) abordando
+  diferentes casos de uso e padrões de instalação.
+- [Propagação de Contexto](#context-propagation) fornece correlação entre
+  rastros, métricas e logs, permitindo que os sinais se complementem.
+- [Convenções semânticas](#semantic-conventions) definem como produzir
+  telemetria para operações padrão.
+- [Instrumentação de Log](#log-instrumentation), que é utilizada para obter logs
+  de um _framework_ de _logging_ existente no Java para o OpenTelemetry.
 
 {{% alert %}} Embora as
 [categorias de instrumentação](#instrumentation-categories) enumerem diversas
@@ -124,7 +127,7 @@ Shims mantidos no ecossistema OpenTelemetry Java:
 | Bridge [OpenTracing](https://opentracing.io/) no OpenTelemetry                                              | [LEIA-ME](https://github.com/open-telemetry/opentelemetry-java/tree/main/opentracing-shim)                                                                                       | Rastros           | `io.opentelemetry:opentelemetry-opentracing-shim:{{% param vers.otel %}}`                                                       |
 | Bridge [Opencensus](https://opencensus.io/) no OpenTelemetry                                                | [LEIA-ME](https://github.com/open-telemetry/opentelemetry-java/tree/main/opencensus-shim)                                                                                        | Rastros, Métricas | `io.opentelemetry:opentelemetry-opencensus-shim:{{% param vers.otel %}}-alpha`                                                  |
 | Bridge [Micrometer](https://micrometer.io/) no OpenTelemetry                                                | [LEIA-ME](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/micrometer/micrometer-1.5/library)                                      | Métricas          | `io.opentelemetry.instrumentation:opentelemetry-micrometer-1.5:{{% param vers.instrumentation %}}-alpha`                        |
-| Bridge [JMX](https://docs.oracle.com/javase/7/docs/technotes/guides/management/agent.html) no OpenTelemetry | [LEIA-ME](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/README.md)                                        | Métricas          | `io.opentelemetry.instrumentation:opentelemetry-jmx-metrics:{{% param vers.instrumentation %}}-alpha`                           |
+| Bridge [JMX](https://docs.oracle.com/javase/7/docs/technotes/guides/management/agent.html) no OpenTelemetry | [LEIA-ME](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/README.md)                                                  | Métricas          | `io.opentelemetry.instrumentation:opentelemetry-jmx-metrics:{{% param vers.instrumentation %}}-alpha`                           |
 | Bridge OpenTelemetry no [Prometheus Java client](https://github.com/prometheus/client_java)                 | [LEIA-ME](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/prometheus-client-bridge)                                                                       | Métricas          | `io.opentelemetry.contrib:opentelemetry-prometheus-client-bridge:{{% param vers.contrib %}}-alpha`                              |
 | Bridge OpenTelemetry no [Micrometer](https://micrometer.io/)                                                | [LEIA-ME](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/micrometer-meter-provider)                                                                      | Métricas          | `io.opentelemetry.contrib:opentelemetry-micrometer-meter-provider:{{% param vers.contrib %}}-alpha`                             |
 | Bridge [Log4j](https://logging.apache.org/log4j/2.x/index.html) no OpenTelemetry                            | [LEIA-ME](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/log4j/log4j-appender-2.17/library)                                      | Logs              | `io.opentelemetry.instrumentation:opentelemetry-log4j-appender-2.17:{{% param vers.instrumentation %}}-alpha`                   |

--- a/content/pt/docs/languages/java/instrumentation.md
+++ b/content/pt/docs/languages/java/instrumentation.md
@@ -25,7 +25,7 @@ usuários finais e tópicos relacionados à instrumentação:
 - [Categorias de instrumentação](#instrumentation-categories) abordando diferentes casos de uso e padrões de instalação.
 - [Propagação de Contexto](#context-propagation) fornece correlação entre rastros, métricas e logs, permitindo que os sinais se complementem.
 - [Convenções semânticas](#semantic-conventions) definem como produzir telemetria para operações padrão.
-- [Instrumentação de Log](#log-instrumentation), que é utilizada para obter logs de um _framework_ de logging existente no Java para o OpenTelemetry.
+- [Instrumentação de Log](#log-instrumentation), que é utilizada para obter logs de um _framework_ de _logging_ existente no Java para o OpenTelemetry.
 
 {{% alert %}} Embora as
 [categorias de instrumentação](#instrumentation-categories) enumerem diversas


### PR DESCRIPTION
## Description

Tracked on #6662 

Updates the drifted content for `content/pt/docs/languages/java/instrumentation.md`

<details>
<summary>Diff</summary>

```diff
❯ npm run check:i18n -- -d content/pt/docs/languages/java/instrumentation.md

> check:i18n
> scripts/check-i18n.sh -d content/pt/docs/languages/java/instrumentation.md

Processing paths: content/pt/docs/languages/java/instrumentation.md
diff --git a/content/en/docs/languages/java/instrumentation.md b/content/en/docs/languages/java/instrumentation.md
index 1b1e4c0d..7abeee63 100644
--- a/content/en/docs/languages/java/instrumentation.md
+++ b/content/en/docs/languages/java/instrumentation.md
@@ -20,16 +20,14 @@ instrumentation API calls. This page discusses the OpenTelemetry ecosystem in
 OpenTelemetry Java, including resources for end users and cross-cutting
 instrumentation topics:
 
-- [Instrumentation categories](#instrumentation-categories): There are a variety
-  of categories of instrumentation addressing different use cases and
-  installation patterns.
-- [Context propagation](#context-propagation): Context propagation provides
-  correlation between traces, metrics, and logs, allowing the signals to
-  complement each other.
-- [Semantic conventions](#semantic-conventions): The semantic conventions define
-  how to produce telemetry for standard operations.
-- [Log instrumentation](#log-instrumentation): The semantic conventions define
-  how to produce telemetry for standard operations.
+- [Instrumentation categories](#instrumentation-categories) addressing different
+  use cases and installation patterns.
+- [Context propagation](#context-propagation) provides correlation between
+  traces, metrics, and logs, allowing the signals to complement each other.
+- [Semantic conventions](#semantic-conventions) define how to produce telemetry
+  for standard operations.
+- [Log instrumentation](#log-instrumentation), which is used to get logs from an
+  existing Java logging framework into OpenTelemetry.
 
 {{% alert %}} While [instrumentation categories](#instrumentation-categories)
 enumerates several options for instrumenting an application, we recommend users
@@ -126,7 +124,7 @@ Shims maintained in the OpenTelemetry Java ecosystem:
 | Bridge [OpenTracing](https://opentracing.io/) into OpenTelemetry                                              | [README](https://github.com/open-telemetry/opentelemetry-java/tree/main/opentracing-shim)                                                                                       | Traces          | `io.opentelemetry:opentelemetry-opentracing-shim:{{% param vers.otel %}}`                                                       |
 | Bridge [Opencensus](https://opencensus.io/) into OpenTelemetry                                                | [README](https://github.com/open-telemetry/opentelemetry-java/tree/main/opencensus-shim)                                                                                        | Traces, Metrics | `io.opentelemetry:opentelemetry-opencensus-shim:{{% param vers.otel %}}-alpha`                                                  |
 | Bridge [Micrometer](https://micrometer.io/) into OpenTelemetry                                                | [README](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/micrometer/micrometer-1.5/library)                                      | Metrics         | `io.opentelemetry.instrumentation:opentelemetry-micrometer-1.5:{{% param vers.instrumentation %}}-alpha`                        |
-| Bridge [JMX](https://docs.oracle.com/javase/7/docs/technotes/guides/management/agent.html) into OpenTelemetry | [README](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/javaagent/README.md)                                        | Metrics         | `io.opentelemetry.instrumentation:opentelemetry-jmx-metrics:{{% param vers.instrumentation %}}-alpha`                           |
+| Bridge [JMX](https://docs.oracle.com/javase/7/docs/technotes/guides/management/agent.html) into OpenTelemetry | [README](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/README.md)                                                  | Metrics         | `io.opentelemetry.instrumentation:opentelemetry-jmx-metrics:{{% param vers.instrumentation %}}-alpha`                           |
 | Bridge OpenTelemetry into [Prometheus Java client](https://github.com/prometheus/client_java)                 | [README](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/prometheus-client-bridge)                                                                       | Metrics         | `io.opentelemetry.contrib:opentelemetry-prometheus-client-bridge:{{% param vers.contrib %}}-alpha`                              |
 | Bridge OpenTelemetry into [Micrometer](https://micrometer.io/)                                                | [README](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/micrometer-meter-provider)                                                                      | Metrics         | `io.opentelemetry.contrib:opentelemetry-micrometer-meter-provider:{{% param vers.contrib %}}-alpha`                             |
 | Bridge [Log4j](https://logging.apache.org/log4j/2.x/index.html) into OpenTelemetry                            | [README](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/log4j/log4j-appender-2.17/library)                                      | Logs            | `io.opentelemetry.instrumentation:opentelemetry-log4j-appender-2.17:{{% param vers.instrumentation %}}-alpha`                   |
@@ -178,9 +176,6 @@ OpenTelemetry Java [publishes artifacts](../api/#semantic-attributes) to assist
 in conforming to the semantic conventions, including generated constants for
 attribute keys and values.
 
-TODO: discuss instrumentation API and how it helps conform to semantic
-conventions
-
 ## Log instrumentation
 
 While the [LoggerProvider](../api/#loggerprovider) / [Logger](../api/#logger)
DRIFTED files: 1 out of 1
```
</details>