### PR TITLE
[pt] Fix link definition labels for pages under content/pt/docs/concepts

### DIFF
--- a/content/pt/docs/concepts/distributions.md
+++ b/content/pt/docs/concepts/distributions.md
@@ -4,8 +4,7 @@ description: >-
   Uma distribuição, que não deve ser confundida com um fork, é uma versão
   customizada de um componente do OpenTelemetry.
 weight: 190
-default_lang_commit: 2f34c456ab38b4d3502cd07bc36fa1455d4ef875
-drifted_from_default: true
+default_lang_commit: 55f9c9d07ba35c241048ffc0d756d67843d68805
 ---
 
 Os projetos do OpenTelemetry consistem de múltiplos [componentes](../components)
@@ -101,7 +100,7 @@ instrumentação:
 Ao utilizar materiais relacionados ao projeto do OpenTelemetry para
 distribuição, como logotipo e nome, certifique-se de estar alinhado com as
 [Diretrizes de Marketing do OpenTelemetry para Organizações
-Contribuintes][diretrizes].
+Contribuintes][guidelines].
 
 O projeto do OpenTelemetry não certifica distribuições neste momento. No futuro,
 o OpenTelemetry poderá certificar distribuições e parceiros de maneira
@@ -112,5 +111,5 @@ assegure-se de que seu uso não irá resultar em uma dependência de fornecedor
 > Qualquer suporte para uma distribuição deve ser fornecido diretamente por quem
 > a criou e não pelas pessoas envolvidas no projeto do OpenTelemetry.
 
-[diretrizes]:
+[guidelines]:
   https://github.com/open-telemetry/community/blob/main/marketing-guidelines.md

--- a/content/pt/docs/concepts/instrumentation/libraries.md
+++ b/content/pt/docs/concepts/instrumentation/libraries.md
@@ -5,9 +5,10 @@ weight: 40
 default_lang_commit: d8e58463c6e7c324b01115ab4f88d1f2bcf802c2
 ---
 
-O OpenTelemetry fornece [bibliotecas de instrumentação][] para várias
-bibliotecas, geralmente feitas por meio de _hooks_ de biblioteca ou
-_monkey-patching_ do código da biblioteca.
+O OpenTelemetry fornece [bibliotecas de
+instrumentação][instrumentation libraries] para várias bibliotecas, geralmente
+feitas por meio de _hooks_ de biblioteca ou _monkey-patching_ do código da
+biblioteca.
 
 A instrumentação nativa de bibliotecas com OpenTelemetry oferece melhor
 observabilidade e experiência para desenvolvedores, eliminando a necessidade das
@@ -456,6 +457,6 @@ class TestExporter implements SpanExporter {
 }
 ```
 
-[bibliotecas de instrumentação]:
+[instrumentation libraries]:
   /docs/specs/otel/overview/#instrumentation-libraries
 [span events]: /docs/specs/otel/trace/api/#add-events

--- a/content/pt/docs/concepts/signals/_index.md
+++ b/content/pt/docs/concepts/signals/_index.md
@@ -7,13 +7,14 @@ aliases: [data-sources, otel-concepts]
 default_lang_commit: c370886c9926e6cab3738ababbf6ff5692899bbd
 ---
 
-O propósito do OpenTelemetry é coletar, processar e exportar [sinais]. Sinais
-são dados emitidos que descrevem a atividade subjacente do sistema operacional e
-das aplicações que estão sendo executadas em uma plataforma. Um sinal pode ser
-algo que você deseja medir em um momento específico, como a temperatura ou o uso
-de memória, ou um evento que passa pelos componentes do seu sistema distribuído
-e que você gostaria de rastrear. Você pode agrupar diferentes sinais para
-observar o funcionamento interno de uma mesma tecnologia sob diferentes ângulos.
+O propósito do OpenTelemetry é coletar, processar e exportar [sinais][signals].
+Sinais são dados emitidos que descrevem a atividade subjacente do sistema
+operacional e das aplicações que estão sendo executadas em uma plataforma. Um
+sinal pode ser algo que você deseja medir em um momento específico, como a
+temperatura ou o uso de memória, ou um evento que passa pelos componentes do seu
+sistema distribuído e que você gostaria de rastrear. Você pode agrupar
+diferentes sinais para observar o funcionamento interno de uma mesma tecnologia
+sob diferentes ângulos.
 
 O OpenTelemetry atualmente suporta:
 
@@ -22,15 +23,15 @@ O OpenTelemetry atualmente suporta:
 - [Logs](logs)
 - [Bagagem](baggage)
 
-Também em desenvolvimento ou na fase de [proposta]:
+Também em desenvolvimento ou na fase de [proposta][proposal]:
 
-- [Eventos], um tipo específico de [log](logs)
-- [Perfilamento] está sendo trabalhado pelo Grupo de Trabalho de Perfilamento
-  _(Profiling Working Group)_.
+- [Eventos][Events], um tipo específico de [log](logs)
+- [Perfilamento][Profiles] está sendo trabalhado pelo Grupo de Trabalho de
+  Perfilamento _(Profiling Working Group)_.
 
-[Eventos]: /docs/specs/otel/logs/data-model/#events
-[Perfilamento]:
+[Events]: /docs/specs/otel/logs/data-model/#events
+[Profiles]:
   https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/profiles/0212-profiling-vision.md
-[proposta]:
+[proposal]:
   https://github.com/open-telemetry/opentelemetry-specification/tree/main/oteps/#readme
-[sinais]: /docs/specs/otel/glossary/#signals
+[signals]: /docs/specs/otel/glossary/#signals

--- a/content/pt/docs/concepts/signals/baggage.md
+++ b/content/pt/docs/concepts/signals/baggage.md
@@ -78,6 +78,6 @@ Como um dos casos de uso comum da Bagagem é adicionar dados aos
 linguagens possuem Processadores de Trecho de Bagagem que adicionam dados da
 Bagagem como atributos na criação de trechos.
 
-Para mais informações, consulte a [especificação da Bagagem].
+Para mais informações, consulte a [especificação da Bagagem][baggage specification].
 
-[especificação da Bagagem]: /docs/specs/otel/overview/#baggage-signal
+[baggage specification]: /docs/specs/otel/overview/#baggage-signal

--- a/content/pt/docs/concepts/signals/baggage.md
+++ b/content/pt/docs/concepts/signals/baggage.md
@@ -78,6 +78,7 @@ Como um dos casos de uso comum da Bagagem é adicionar dados aos
 linguagens possuem Processadores de Trecho de Bagagem que adicionam dados da
 Bagagem como atributos na criação de trechos.
 
-Para mais informações, consulte a [especificação da Bagagem][baggage specification].
+Para mais informações, consulte a [especificação da
+Bagagem][baggage specification].
 
 [baggage specification]: /docs/specs/otel/overview/#baggage-signal

--- a/content/pt/docs/concepts/signals/logs.md
+++ b/content/pt/docs/concepts/signals/logs.md
@@ -247,6 +247,6 @@ Para mais detalhes sobre registros de log e campos de log, consulte
 ### Especificação {#specification}
 
 Para saber mais sobre logs no OpenTelemetry, consulte a [especificação de
-logs][].
+logs][logs specification].
 
-[especificação de logs]: /docs/specs/otel/overview/#log-signal
+[logs specification]: /docs/specs/otel/overview/#log-signal


### PR DESCRIPTION
## Description

Tracked on #6878

Updates and fixes the link definition labels for pages under `content/pt/docs/concepts`:
- content/pt/docs/concepts/instrumentation/libraries.md
- content/pt/docs/concepts/signals/_index.md
- content/pt/docs/concepts/signals/baggage.md
- content/pt/docs/concepts/signals/logs.md
- content/pt/docs/concepts/distributions.md

The only drifted file was `content/pt/docs/concepts/distributions.md`, but there wasn't a significant change for the localization. See 55f9c9d07ba35c241048ffc0d756d67843d68805. 