### PR TITLE
Update nvm install command in development.md doc

### DIFF
--- a/content/en/docs/contributing/development.md
+++ b/content/en/docs/contributing/development.md
@@ -60,7 +60,7 @@ Your development environment will be initialized via the
     specified in the .nvmrc file:
 
     ```sh
-    nvm install
+    nvm install --lts
     ```
 
     To [install under Windows][nodejs-win], use [nvm-windows]:


### PR DESCRIPTION
Rhe first command under the development local setup `nvm install` does not correctly install the latest version. Changing to `nvm install --lts`. 

I validated the change after running ` npm run serve`.

<img width="1646" alt="image" src="https://github.com/user-attachments/assets/23b3b6e7-3efb-47cf-8ada-7e875c70a782" />


