### PR TITLE
[ja] docs(i18n): fix removed file of content/ja/docs/demo/feature-flags.md

### DIFF
--- a/content/ja/docs/demo/feature-flags/_index.md
+++ b/content/ja/docs/demo/feature-flags/_index.md
@@ -2,10 +2,10 @@
 title: フィーチャーフラグ
 aliases:
   - feature_flags
+  - scenarios
   - services/feature-flag
   - services/featureflagservice
-default_lang_commit: ea3b23ce16243364ae03d368d49af870454f686f
-drifted_from_default: file not found
+default_lang_commit: d7a61cc489f25935348229d0743fba9b8828dbc1
 cSpell:ignore: OLJCESPC7Z
 ---
 
@@ -35,6 +35,10 @@ cSpell:ignore: OLJCESPC7Z
 | `loadgeneratorFloodHomepage`        | 負荷生成ツール     | 大量のリクエストでホームページにフラッディングを開始します。 これは状態である flagd JSON の変更で設定可能です                        |
 | `kafkaQueueProblems`                | キュー             | Kafka キューに過負荷がかかり、同時にコンシューマー側の遅延も発生し、ラグの急増を引き起こします                                       |
 | `imageSlowLoad`                     | フロントエンド     | Envoy フォールトインジェクションを利用し、フロントエンドでの製品画像の読み込みに遅延を発生させます                                   |
+
+## ガイド付きデバッグシナリオ {#guided-debugging-scenario}
+
+`recommendationServiceCacheFailure` シナリオには、OpenTelemetry を使用してメモリリークをデバッグする方法を理解するのに役立つ[専用のウォークスルードキュメント](recommendation-cache/)があります。
 
 ## フューチャーフラグアーキテクチャ {#feature-flag-architecture}
 


### PR DESCRIPTION
<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->

I moved content/ja/docs/demo/feature-flags.md to content/ja/docs/demo/feature-flags/_index.md due to https://github.com/open-telemetry/opentelemetry.io/pull/6798.
The current target page is not shown now.

preview

https://deploy-preview-6906--opentelemetry.netlify.app/ja/docs/demo/


