### PR TITLE
[CI] Enforce Istio and mTLS capitalization, and spelling of portable

### DIFF
--- a/.cspell/en-words.txt
+++ b/.cspell/en-words.txt
@@ -1,6 +1,8 @@
 # Words listed here are only for their spelling. If there is a certain way to
 # capitalize the word, add capitalization rules to text-lint rules in
 # .textlintrc.yml
+#
+# cSpell:ignore textlintrc
 
 accountingservice
 actix

--- a/.textlintrc.yml
+++ b/.textlintrc.yml
@@ -66,6 +66,7 @@ rules:
       - macOS
       - Markdown
       - MongoDB
+      - mTLS
       - MySQL
       - NDJSON
       - Netlify

--- a/.textlintrc.yml
+++ b/.textlintrc.yml
@@ -1,4 +1,4 @@
-# cspell:ignore ebpf matic postgres
+# cspell:ignore ebpf matic postgres protable
 plugins:
   '@textlint/markdown':
     extensions: [.yml]
@@ -155,6 +155,7 @@ rules:
         - '(?<![-#@./])\bopen[- ]?telemetry\b(?![-./])'
         - OpenTelemetry
       - [os x, macOS]
+      - [protable, portable]
       - [postgres, PostgreSQL]
       - ['psr[ -]?([0-9]+)', PSR-$1]
       - ['react[ .]js', React]

--- a/.textlintrc.yml
+++ b/.textlintrc.yml
@@ -49,6 +49,7 @@ rules:
       - HTTPS
       - ID
       - iOS
+      - Istio
       - Jaeger
       - JavaScript
       - JBoss

--- a/content/en/blog/2024/kubecon-china.md
+++ b/content/en/blog/2024/kubecon-china.md
@@ -26,7 +26,7 @@ conference begins.
 
 - **[Adaptive Tracing Propagation with OpenTelemetry: Navigating Protocol Diversity in the Cloud | Project Lightning Talk](https://sched.co/1f4zX)**<br>
   Wednesday, August 21 • 12:03 - 12:08
-- **[Telemetry API and OpenTelemetry: the answer of istio monitoring? | Project Lightning Talk](https://sched.co/1f4zz)**<br>
+- **[Telemetry API and OpenTelemetry: the answer of Istio monitoring? | Project Lightning Talk](https://sched.co/1f4zz)**<br>
   Wednesday, August 21 • 12:24 - 12:29
 
 ## KubeCon talks


### PR DESCRIPTION
- Inspired by https://github.com/open-telemetry/opentelemetry.io/pull/6655/files#r2092834799
- I don't know why cSpell is allowing "protable", other than because it is a product name. The simplest fix (implemented here) seems to be to use textlint to enforce the correct spelling of portable.