### PR TITLE
fix: 🐛  oversized grafana-dashboards ConfigMap annotations exceeding Kubernetes limit

### DIFF
--- a/content/en/docs/demo/kubernetes-deployment.md
+++ b/content/en/docs/demo/kubernetes-deployment.md
@@ -41,7 +41,7 @@ The following command will install the demo application to your Kubernetes
 cluster.
 
 ```shell
-kubectl apply --namespace otel-demo -f https://raw.githubusercontent.com/open-telemetry/opentelemetry-demo/main/kubernetes/opentelemetry-demo.yaml
+kubectl create --namespace otel-demo -f https://raw.githubusercontent.com/open-telemetry/opentelemetry-demo/main/kubernetes/opentelemetry-demo.yaml
 ```
 
 > **Note** These manifests are generated from the Helm chart and are provided


### PR DESCRIPTION
✍️ Description

This change addresses the error encountered during deployment of the opentelemetry-demo.yaml manifest:

```bash
The ConfigMap "grafana-dashboards" is invalid: metadata.annotations: Too long: may not be more than 262144 bytes
```

The issue stems from an annotation (likely added by tooling such as kubectl apply --server-side or kubectl.kubernetes.io/last-applied-configuration) exceeding the Kubernetes annotation size limit of 256 KiB.

Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

🔗 Related Issue

Fixes: [#2139](https://github.com/open-telemetry/opentelemetry-demo/issues/2139)

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

📖 Technical References

- Kubernetes [API constraint: metadata.annotations must be ≤ 262144 bytes](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
