### PR TITLE
[k8s operator] Provide link to cert-manager installation

### DIFF
--- a/content/en/docs/platforms/kubernetes/operator/_index.md
+++ b/content/en/docs/platforms/kubernetes/operator/_index.md
@@ -30,7 +30,7 @@ The operator manages:
 ## Getting started
 
 To install the operator in an existing cluster, make sure you have
-[`cert-manager` installed](https://cert-manager.io/docs/installation/) and run:
+[`cert-manager`](https://cert-manager.io/docs/installation/) installed and run:
 
 ```bash
 kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml

--- a/content/en/docs/platforms/kubernetes/operator/_index.md
+++ b/content/en/docs/platforms/kubernetes/operator/_index.md
@@ -29,8 +29,8 @@ The operator manages:
 
 ## Getting started
 
-To install the operator in an existing cluster, make sure you have cert-manager
-installed and run:
+To install the operator in an existing cluster, make sure you have
+[`cert-manager` installed](https://cert-manager.io/docs/installation/) and run:
 
 ```bash
 kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml


### PR DESCRIPTION
Updates the OpenTelemetry Operator [Getting started](https://opentelemetry.io/docs/platforms/kubernetes/operator/#getting-started) guide with a link the to `cert-manager` installation docs, so that users more easily know what software they need to install.

The same can be found in the open-telemetry/opentelemetry-operator [README](https://github.com/open-telemetry/opentelemetry-operator/blob/2bae42922d067e8978ec534e959a808a1a87acbd/README.md?plain=1#L24).

<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->