### PR TITLE
[k8s operator] Update OpenTelemetry Operator example

### DIFF
--- a/content/en/docs/platforms/kubernetes/operator/_index.md
+++ b/content/en/docs/platforms/kubernetes/operator/_index.md
@@ -41,12 +41,12 @@ Collector (otelcol) instance, like:
 
 ```console
 $ kubectl apply -f - <<EOF
-apiVersion: opentelemetry.io/v1alpha1
+apiVersion: opentelemetry.io/v1beta1
 kind: OpenTelemetryCollector
 metadata:
   name: simplest
 spec:
-  config: |
+  config:
     receivers:
       otlp:
         protocols:
@@ -55,16 +55,23 @@ spec:
           http:
             endpoint: 0.0.0.0:4318
     processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 75
+        spike_limit_percentage: 15
+      batch:
+        send_batch_size: 10000
+        timeout: 10s
 
     exporters:
       # NOTE: Prior to v0.86.0 use `logging` instead of `debug`.
-      debug:
+      debug: {}
 
     service:
       pipelines:
         traces:
           receivers: [otlp]
-          processors: []
+          processors: [memory_limiter, batch]
           exporters: [debug]
 EOF
 ```


### PR DESCRIPTION
Updates the OpenTelemetry Operator for Kubernetes [example](https://opentelemetry.io/docs/platforms/kubernetes/operator/#getting-started) to address the warnings about migrating to v1beta1 and using empty objects. It also adds processors, which was previously empty. Now the example reflects that in the open-telemetry/opentelemetry-operator [README](https://github.com/open-telemetry/opentelemetry-operator?tab=readme-ov-file#getting-started).

Fixes https://github.com/open-telemetry/opentelemetry.io/issues/6926.

<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->
