### PR TITLE
- Add  Oracle Database opentelemetry integration in registry

### DIFF
--- a/data/registry/instrumentation-js-oracledb.yml
+++ b/data/registry/instrumentation-js-oracledb.yml
@@ -1,0 +1,22 @@
+title: OpenTelemetry Instrumentation for Oracle Database
+registryType: instrumentation
+language: js
+tags:
+  - Node.js
+  - js
+  - instrumentation
+  - oracledb
+  - database
+license: Apache 2.0
+description: Instrumentation library for Oracle Database.
+authors:
+  - name: Sudarshan Soma
+    email: sudarshan12s@gmail.com
+urls:
+  repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-oracledb
+createdAt: 2025-05-22
+package:
+  registry: npm
+  name: '@opentelemetry/instrumentation-oracledb'
+  version: 0.27.0
+isFirstParty: false

--- a/data/registry/instrumentation-js-oracledb.yml
+++ b/data/registry/instrumentation-js-oracledb.yml
@@ -1,3 +1,4 @@
+# cSpell:ignore sudarshan oracledb
 title: OpenTelemetry Instrumentation for Oracle Database
 registryType: instrumentation
 language: js
@@ -11,7 +12,7 @@ license: Apache 2.0
 description: Instrumentation library for Oracle Database.
 authors:
   - name: Sudarshan Soma
-    email: sudarshan12s@gmail.com
+    email: sudarshan.ss.s@oracle.com
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-oracledb
 createdAt: 2025-05-22

--- a/data/registry/instrumentation-js-oracledb.yml
+++ b/data/registry/instrumentation-js-oracledb.yml
@@ -1,17 +1,16 @@
-# cSpell:ignore sudarshan oracledb
+# cSpell:ignore sudarshan oracledb oracledatabase
 title: OpenTelemetry Instrumentation for Oracle Database
 registryType: instrumentation
 language: js
 tags:
   - Node.js
-  - js
   - instrumentation
-  - oracledb
+  - oracledatabase
   - database
 license: Apache 2.0
 description: Instrumentation library for Oracle Database.
 authors:
-  - name: Sudarshan Soma
+  - name: Sudarshan Soma (Oracle)
     email: sudarshan.ss.s@oracle.com
 urls:
   repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-oracledb

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -9179,6 +9179,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:39:48.079304-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-oracledb": {
+    "StatusCode": 206,
+    "LastSeen": "2025-05-22T13:12:13.410404+05:30"
+  },
   "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-pg": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:39:50.193601-05:00"
@@ -15818,6 +15822,10 @@
   "https://npmjs.com/package/@opentelemetry/instrumentation-net": {
     "StatusCode": 200,
     "LastSeen": "2024-08-09T11:07:52.613505-04:00"
+  },
+  "https://npmjs.com/package/@opentelemetry/instrumentation-oracledb": {
+    "StatusCode": 200,
+    "LastSeen": "2025-05-22T13:12:27.838725+05:30"
   },
   "https://npmjs.com/package/@opentelemetry/instrumentation-pg": {
     "StatusCode": 200,


### PR DESCRIPTION
## Description

"Added a Registry entry for the recently released Oracle Database instrumentation package, available [here](https://www.npmjs.com/package/@opentelemetry/instrumentation-oracledb)."

