### PR TITLE
[ja] add translation of Helm charts docs

### DIFF
--- a/content/ja/docs/platforms/kubernetes/helm/collector.md
+++ b/content/ja/docs/platforms/kubernetes/helm/collector.md
@@ -200,7 +200,7 @@ config:
           - otlphttp
 ```
 
-#### Kubernetes属性プリセット {/#kubernetes-attributes-preset}
+#### Kubernetes属性プリセット {#kubernetes-attributes-preset}
 
 OpenTelemetryコレクター は `k8s.pod.name`、`k8s.namespace.name`、`k8s.node.name` などの Kubernetes メタデータをログ、メトリクス、トレースに追加するように設定できます。
 プリセットを使用するか、手動で `k8sattributesprocessor` を有効にすることを強く推奨します。

--- a/content/ja/docs/platforms/kubernetes/helm/collector.md
+++ b/content/ja/docs/platforms/kubernetes/helm/collector.md
@@ -1,0 +1,328 @@
+---
+title: OpenTelemetryコレクターチャート
+linkTitle: コレクターチャート
+default_lang_commit: e8f18928513b726068be250802ebe7ece25e8851
+# prettier-ignore
+cSpell:ignore: debugexporter filelog filelogreceiver hostmetricsreceiver kubelet kubeletstats kubeletstatsreceiver otlphttp sattributesprocessor sclusterreceiver sobjectsreceiver statefulset
+---
+
+## はじめに {#introduction}
+
+[OpenTelemetryコレクター](/docs/collector)は、Kubernetesクラスタとその中のすべてのサービスを監視するための重要なツールです。
+Kubernetesへのコレクターのデプロイメントを容易にし、管理するために、OpenTelemetryコミュニティは[OpenTelemetryコレクターHelmチャート](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector)を作成しました。
+このHelmチャートは、コレクターをデプロイメント、DaemonSet、またはStatefulSetとしてインストールするために使用できます。
+
+### チャートのインストール {#installing-the-chart}
+
+リリース名 `my-opentelemetry-collector` のチャートをインストールするには、以下のコマンドを実行します。
+
+```sh
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+helm install my-opentelemetry-collector open-telemetry/opentelemetry-collector \
+   --set image.repository="otel/opentelemetry-collector-k8s" \
+   --set mode=<daemonset|deployment|statefulset> \
+```
+
+### 設定 {#configuration}
+
+OpenTelemetryコレクターチャートでは `mode` が設定されている必要があります。
+`mode` には、ユースケースに応じたKubernetesデプロイメントに依存して `daemonset` 、 `deployment` 、 `statefulset` のいずれかを指定します。
+
+インストールされると、チャートはいくつかのデフォルトのコレクターコンポーネントを提供します。
+デフォルトでは、コレクターの設定は以下のようになります。
+
+```yaml
+exporters:
+  # 注意: v0.86.0 より前のバージョンでは、`debug` のかわりに `logging` を使用すること
+  debug: {}
+extensions:
+  health_check: {}
+processors:
+  batch: {}
+  memory_limiter:
+    check_interval: 5s
+    limit_percentage: 80
+    spike_limit_percentage: 25
+receivers:
+  jaeger:
+    protocols:
+      grpc:
+        endpoint: ${env:MY_POD_IP}:14250
+      thrift_compact:
+        endpoint: ${env:MY_POD_IP}:6831
+      thrift_http:
+        endpoint: ${env:MY_POD_IP}:14268
+  otlp:
+    protocols:
+      grpc:
+        endpoint: ${env:MY_POD_IP}:4317
+      http:
+        endpoint: ${env:MY_POD_IP}:4318
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: opentelemetry-collector
+          scrape_interval: 10s
+          static_configs:
+            - targets:
+                - ${env:MY_POD_IP}:8888
+  zipkin:
+    endpoint: ${env:MY_POD_IP}:9411
+service:
+  extensions:
+    - health_check
+  pipelines:
+    logs:
+      exporters:
+        - debug
+      processors:
+        - memory_limiter
+        - batch
+      receivers:
+        - otlp
+    metrics:
+      exporters:
+        - debug
+      processors:
+        - memory_limiter
+        - batch
+      receivers:
+        - otlp
+        - prometheus
+    traces:
+      exporters:
+        - debug
+      processors:
+        - memory_limiter
+        - batch
+      receivers:
+        - otlp
+        - jaeger
+        - zipkin
+  telemetry:
+    metrics:
+      address: ${env:MY_POD_IP}:8888
+```
+
+また、このチャートはデフォルトのレシーバーに基づいてポートを有効にします。
+デフォルトの設定は `values.yaml` で `null` に設定することで削除できます。
+ポートも `values.yaml` で無効にできます。
+
+`values.yaml` の `config` セクションを使用して、設定の任意の部分を追加/変更できます。
+パイプラインを変更する場合は、デフォルトのコンポーネントを含め、パイプラインに含まれるすべてのコンポーネントを明示的にリストアップする必要があります。
+
+たとえば、メトリクスとロギングパイプラインと非OTLPレシーバーを無効にするには次のように設定します。
+
+```yaml
+config:
+  receivers:
+    jaeger: null
+    prometheus: null
+    zipkin: null
+  service:
+    pipelines:
+      traces:
+        receivers:
+          - otlp
+      metrics: null
+      logs: null
+ports:
+  jaeger-compact:
+    enabled: false
+  jaeger-thrift:
+    enabled: false
+  jaeger-grpc:
+    enabled: false
+  zipkin:
+    enabled: false
+```
+
+チャートで利用可能なすべての設定オプション（コメント付き）は、その[values.yamlファイル](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/values.yaml)で確認できます。
+
+### プリセット {#presets}
+
+OpenTelemetryコレクターがKubernetesを監視するために使用する重要なコンポーネントの多くは、コレクター自身のKubernetesデプロイメントで特別なセットアップを必要とします。
+これらのコンポーネントをより簡単に使用するために、OpenTelemetryコレクターチャートには、有効にするとこれらの重要なコンポーネントの複雑なセットアップを処理するいくつかのプリセットが付属しています。
+
+プリセットは出発点として使用されるべきです。
+プリセットは、関連するコンポーネントの基本的な、しかし豊富な機能を設定します。
+これらのコンポーネントの追加設定が必要な場合は、プリセットは使用せず、コンポーネントとそれに必要なもの（ボリューム、RBACなど）を手動で設定することをおすすめします。
+
+#### ログコレクションプリセット {#logs-collection-preset}
+
+OpenTelemetryコレクターは、Kubernetesコンテナによって標準出力に送られるログを収集するために使用できます。
+
+この機能はデフォルトでは無効になっています。
+安全に有効にするためには以下の条件があります。
+
+- [ファイルログレシーバー](/docs/platforms/kubernetes/collector/components/#filelog-receiver)が[コレクターのContribディストリビューション](https://github.com/open-telemetry/opentelemetry-collector-releases/pkgs/container/opentelemetry-collector-releases%2Fopentelemetry-collector-contrib)などのコレクターイメージに含まれている必要があります。
+- 厳密な要件ではありませんが、このプリセットは `mode=daemonset` と共に使用することを推奨します。
+  `filelogreceiver`はコレクターが動作しているノード上のログのみを収集することができ、同じノード上に設定された複数のコレクターは重複したデータを生成します。
+
+この機能を有効にするには、`presets.logsCollection.enabled` プロパティを `true` に設定します。
+有効にすると、チャートは `logs` パイプラインに `filelogreceiver` を追加します。
+このレシーバーは、Kubernetes コンテナランタイムがすべてのコンテナのコンソール出力を書き込むファイル（`/var/log/pods/*/*.log`）を読み込むように設定されます。
+
+以下に `values.yaml` の例を示します。
+
+```yaml
+mode: daemonset
+presets:
+  logsCollection:
+    enabled: true
+```
+
+チャートのデフォルトのログパイプラインは `debugexporter` を使用します。
+`logsCollection` プリセットの `filelogreceiver` と組み合わせると、エクスポートしたログを誤ってコレクターに戻してしまい、「ログの爆発」を引き起こす可能性があります。
+
+ループを防止するために、レシーバーのデフォルト設定ではコレクター自身のログを除外しています。
+コレクターのログを含めたい場合は、 `debug` エクスポーターをコレクターの標準出力にログを送信しないエクスポーターに置き換えてください。
+
+以下は `values.yaml` の例で、`logs` パイプラインのデフォルトの `debug` エクスポーターを、コンテナのログを `https://example.com:55681` エンドポイントに送信する `otlphttp` エクスポーターに置き換えたものです。
+また、`presets.logsCollection.includeCollectorLogs` を使用して、コレクターのログの収集を有効にするようにプリセットに指示します。
+
+```yaml
+mode: daemonset
+
+presets:
+  logsCollection:
+    enabled: true
+    includeCollectorLogs: true
+
+config:
+  exporters:
+    otlphttp:
+      endpoint: https://example.com:55681
+  service:
+    pipelines:
+      logs:
+        exporters:
+          - otlphttp
+```
+
+#### Kubernetes属性プリセット {/#kubernetes-attributes-preset}
+
+OpenTelemetryコレクター は `k8s.pod.name`、`k8s.namespace.name`、`k8s.node.name` などの Kubernetes メタデータをログ、メトリクス、トレースに追加するように設定できます。
+プリセットを使用するか、手動で `k8sattributesprocessor` を有効にすることを強く推奨します。
+
+RBACを考慮し、この機能はデフォルトでは無効になっています。
+この機能には以下の要件があります。
+
+- [Kubernetes属性プロセッサー](/docs/platforms/kubernetes/collector/components/#kubernetes-attributes-processor)が[コレクターのContribディストリビューション](https://github.com/open-telemetry/opentelemetry-collector-releases/pkgs/container/opentelemetry-collector-releases%2Fopentelemetry-collector-contrib)などのコレクターイメージに含まれている必要があります。
+
+この機能を有効にするには、`presets.kubernetesAttributes.enabled` プロパティを `true` に設定します。
+有効にすると、チャートはClusterRoleに必要なRBACロールを追加し、有効にした各パイプラインに `k8sattributesprocessor` を追加します。
+
+以下に `values.yaml` の例を示します。
+
+```yaml
+mode: daemonset
+presets:
+  kubernetesAttributes:
+    enabled: true
+```
+
+#### Kubeletメトリクスプリセット {#kubelet-metrics-preset}
+
+OpenTelemetryコレクター は、kubelet 上の API サーバーからノード、ポッド、コンテナのメトリクスを収集するように設定できます。
+
+この機能はデフォルトでは無効になっています。
+この機能には以下の条件があります。
+
+- [Kubeletstatsレシーバー](/docs/platforms/kubernetes/collector/components/#kubeletstats-receiver)が[コレクターのContribディストリビューション](https://github.com/open-telemetry/opentelemetry-collector-releases/pkgs/container/opentelemetry-collector-releases%2Fopentelemetry-collector-contrib)などのコレクターイメージに含まれている必要があります。
+- 厳密な要件ではありませんが、このプリセットは `mode=daemonset` と共に使用することを推奨します。
+  `kubeletstatsreceiver` はコレクターが動作しているノードでのみメトリクスを収集することができ、同じノードに複数の設定されたコレクターがあると重複したデータが生成されます。
+
+この機能を有効にするには、`presets.kubeletMetrics.enabled` プロパティを `true` に設定します。
+有効にすると、チャートはClusterRoleに必要なRBACロールを追加し、メトリクスパイプラインに `kubeletstatsreceiver` を追加します。
+
+以下に`values.yaml`の例を示します。
+
+```yaml
+mode: daemonset
+presets:
+  kubeletMetrics:
+    enabled: true
+```
+
+#### クラスターメトリクスプリセット {#cluster-metrics-preset}
+
+OpenTelemetryコレクターは、Kubernetes APIサーバーからクラスタレベルのメトリクスを収集するように設定できます。
+これらのメトリクスには、Kube State Metricsで収集されるメトリクスの多くが含まれます。
+
+この機能はデフォルトでは無効になっています。
+この機能には以下の条件があります。
+
+- [Kubernetesクラスターレシーバー](/docs/platforms/kubernetes/collector/components/#kubernetes-cluster-receiver)が[コレクターのContribディストリビューション](https://github.com/open-telemetry/opentelemetry-collector-releases/pkgs/container/opentelemetry-collector-releases%2Fopentelemetry-collector-contrib)などのコレクターイメージに含まれている必要があります。
+- 厳密な要件ではありませんが、このプリセットは `mode=deployment` または `mode=statefulset` と共に単一のレプリカで使用することを推奨します。
+  複数のコレクターで `k8sclusterreceiver` を実行すると、重複したデータが生成されます。
+
+この機能を有効にするには、 `presets.clusterMetrics.enabled` プロパティを `true` に設定します。
+有効にすると、チャートは必要なRBACロールをClusterRoleに追加し、 `k8sclusterreceiver` をメトリクスパイプラインに追加します。
+
+以下に `values.yaml` の例を示します。
+
+```yaml
+mode: deployment
+replicaCount: 1
+presets:
+  clusterMetrics:
+    enabled: true
+```
+
+#### Kubernetesイベントプリセット {#kubernetes-events-preset}
+
+OpenTelemetryコレクターはKubernetesイベントを収集するように設定できます。
+
+この機能はデフォルトでは無効になっています。
+この機能には以下の条件があります。
+
+- [Kubernetesオブジェクトレシーバー](/docs/platforms/kubernetes/collector/components/#kubernetes-objects-receiver)が[コレクターのContribディストリビューション](https://github.com/open-telemetry/opentelemetry-collector-releases/pkgs/container/opentelemetry-collector-releases%2Fopentelemetry-collector-contrib)などのコレクターイメージに含まれている必要があります。
+- 厳密な要件ではありませんが、このプリセットは `mode=deployment` または `mode=statefulset` と共に単一のレプリカで使用することを推奨します。
+  複数のコレクターで `k8sclusterreceiver` を実行すると、重複したデータが生成されます。
+
+この機能を有効にするには、`presets.kubernetesEvents.enabled` プロパティを `true` に設定します。
+有効にすると、チャートは ClusterRole に必要な RBAC ロールを追加し、ログパイプラインに `k8sobjectsreceiver` を追加してコレクターイベントのみに設定します。
+
+以下に `values.yaml` の例を示します。
+
+```yaml
+mode: deployment
+replicaCount: 1
+presets:
+  kubernetesEvents:
+    enabled: true
+```
+
+#### ホストメトリクスプリセット {#host-metrics-preset}
+
+OpenTelemetryコレクターは、Kubernetesノードからホストメトリクスを収集するように設定できます。
+
+この機能はデフォルトでは無効になっています。
+この機能には以下の条件があります。
+
+- [コレクターのContribディストリビューション](https://github.com/open-telemetry/opentelemetry-collector-releases/pkgs/container/opentelemetry-collector-releases%2Fopentelemetry-collector-contrib)などのコレクターイメージに[ホストメトリクスレシーバー](/docs/platforms/kubernetes/collector/components/#host-metrics-receiver)が含まれている必要があります。
+- 厳密な要件ではありませんが、このプリセットは `mode=daemonset` と共に使用することを推奨します。
+  `hostmetricsreceiver` は、コレクターが動作しているノード上のメトリクスのみを収集することができ、同じノード上に複数の設定されたコレクターがあると、重複したデータが生成されます。
+
+この機能を有効にするには、`presets.hostMetrics.enabled` プロパティを `true` に設定します。
+有効にすると、チャートは必要なボリュームとボリュームマウントを追加し、 `hostmetricsreceiver` をメトリクスパイプラインに追加します。
+デフォルトでは、メトリクスは10秒ごとにスクレイプされ、以下のスクレイパーが有効になります。
+
+- cpu
+- load
+- memory
+- disk
+- filesystem[^1]
+- network
+
+以下に`values.yaml`の例を示します。
+
+```yaml
+mode: daemonset
+presets:
+  hostMetrics:
+    enabled: true
+```
+
+[^1] `kubeletMetrics` プリセットと重複する部分があるため、デフォルトでは一部のファイルシステムタイプとマウントポイントは除外されています。

--- a/content/ja/docs/platforms/kubernetes/helm/demo.md
+++ b/content/ja/docs/platforms/kubernetes/helm/demo.md
@@ -1,0 +1,54 @@
+---
+title: OpenTelemetryデモチャート
+linkTitle: デモチャート
+default_lang_commit: e8f18928513b726068be250802ebe7ece25e8851
+---
+
+[OpenTelemetry Demo](/docs/demo/) は、実世界に近い環境での OpenTelemetry の実装を説明することを意図した、マイクロサービスベースの分散システムです。
+その一環として、OpenTelemetryコミュニティは、[OpenTelemetryデモHelmチャート](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-demo) を作成し、Kubernetesに簡単にインストールできるようにしています。
+
+## 設定 {#configuration}
+
+デモHelmチャートのデフォルトの `values.yaml` はいつでもインストールできるようになっています。
+すべてのコンポーネントはパフォーマンスを最適化するためにメモリ制限が調整されています。しかし、クラスターが十分に大きくない場合は問題が発生する可能性もあります。
+インストール全体のメモリは4ギガバイト程度に制限されていますが、それ以下になることもあります。
+
+チャートで利用可能なすべての設定オプション（コメント付き）は [`values.yaml` ファイル](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-demo/values.yaml)で見ることができ、詳細な説明は[チャートのREADME](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-demo#chart-parameters)で確認できます。
+
+## インストール {#installation}
+
+OpenTelemetry Helmリポジトリを追加します。
+
+```shell
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+```
+
+リリース名 `my-otel-demo` のチャートをインストールするには、以下のコマンドを実行してください。
+
+```sh
+helm install my-otel-demo open-telemetry/opentelemetry-demo
+```
+
+インストールが完了したら、以下のコマンドを実行することで、すべてのサービスがフロントエンドプロキシ (<http://localhost:8080>) 経由で利用可能になります。
+
+```sh
+kubectl port-forward svc/my-otel-demo-frontendproxy 8080:8080
+```
+
+プロキシが公開されたら、以下のパスにアクセスすることもできます。
+
+| コンポーネント       | パス                              |
+| ----------------- | --------------------------------- |
+| ウェブストア        | <http://localhost:8080>           |
+| Grafana           | <http://localhost:8080/grafana>   |
+| 機能フラグUI        | <http://localhost:8080/feature>   |
+| 負荷生成UI         | <http://localhost:8080/loadgen>   |
+| Jaeger UI         | <http://localhost:8080/jaeger/ui> |
+
+ウェブストアからのスパンを収集するには、OpenTelemetryコレクターOTLP/HTTPレシーバーを公開する必要があります。
+
+```sh
+kubectl port-forward svc/my-otel-demo-otelcol 4318:4318
+```
+
+Kubernetesでデモを使用する詳細については、[Kubernetesデプロイメント](/docs/demo/kubernetes-deployment/)を参照してください。

--- a/content/ja/docs/platforms/kubernetes/helm/demo.md
+++ b/content/ja/docs/platforms/kubernetes/helm/demo.md
@@ -37,13 +37,13 @@ kubectl port-forward svc/my-otel-demo-frontendproxy 8080:8080
 
 プロキシが公開されたら、以下のパスにアクセスすることもできます。
 
-| コンポーネント       | パス                              |
-| ----------------- | --------------------------------- |
-| ウェブストア        | <http://localhost:8080>           |
-| Grafana           | <http://localhost:8080/grafana>   |
-| 機能フラグUI        | <http://localhost:8080/feature>   |
-| 負荷生成UI         | <http://localhost:8080/loadgen>   |
-| Jaeger UI         | <http://localhost:8080/jaeger/ui> |
+| コンポーネント | パス                              |
+| -------------- | --------------------------------- |
+| ウェブストア   | <http://localhost:8080>           |
+| Grafana        | <http://localhost:8080/grafana>   |
+| 機能フラグUI   | <http://localhost:8080/feature>   |
+| 負荷生成UI     | <http://localhost:8080/loadgen>   |
+| Jaeger UI      | <http://localhost:8080/jaeger/ui> |
 
 ウェブストアからのスパンを収集するには、OpenTelemetryコレクターOTLP/HTTPレシーバーを公開する必要があります。
 

--- a/content/ja/docs/platforms/kubernetes/helm/operator.md
+++ b/content/ja/docs/platforms/kubernetes/helm/operator.md
@@ -1,0 +1,48 @@
+---
+title: OpenTelemetryオペレーターチャート
+linkTitle: オペレーターチャート
+default_lang_commit: e8f18928513b726068be250802ebe7ece25e8851
+---
+
+## はじめに {#introduction}
+
+[OpenTelemetryオペレーター](/docs/platforms/kubernetes/operator) は、[OpenTelemetryコレクター](/docs/collector) とワークロードの自動計装を管理するKubernetesオペレーターです。
+OpenTelemetryオペレーターをインストールする方法の1つは、[OpenTelemetry Operator Helm Chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-operator)を経由することです。
+
+OpenTelemetryオペレーターの詳しい使い方については、[ドキュメント](/docs/platforms/kubernetes/operator)を参照してください。
+
+### チャートをインストールする {#installing-the-chart}
+
+リリース名 `my-opentelemetry-operator` のチャートをインストールするには、以下のコマンドを実行します。
+
+```console
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+helm install my-opentelemetry-operator open-telemetry/opentelemetry-operator \
+  --set "manager.collectorImage.repository=otel/opentelemetry-collector-k8s" \
+  --set admissionWebhooks.certManager.enabled=false \
+  --set admissionWebhooks.autoGenerateCert.enabled=true
+```
+
+これにより、自己署名証明書とシークレットを持つOpenTelemetryオペレーターがインストールされます。
+
+### 設定 {#configuration}
+
+オペレーターHelmチャートのデフォルトの `values.yaml` はすぐにでもインストール可能ですが、Cert Managerがクラスタ上にすでに存在していることを想定しています。
+
+Kubernetesでは、APIサーバーがWebhookコンポーネントと通信するために、WebhookはAPIサーバーが信頼するように設定されたTLS証明書を必要とします。
+必要なTLS証明書を生成/設定するには、いくつかの方法があります。
+
+- もっとも簡単でデフォルトの方法は、[cert-manager](https://cert-manager.io/docs/)をインストールし、 `admissionWebhooks.certManager.enabled` を `true` に設定することです。
+  こうすることで、cert-managerが自己署名証明書を生成します。
+  詳細は[cert-managerのインストール](https://cert-manager.io/docs/installation/kubernetes/)を参照してください。
+- `admissionWebhooks.certManager.issuerRef` の値を設定することで、独自のIssuerを提供できます。
+  `kind` (Issuer または ClusterIssuer) と `name` を指定する必要があります。
+  この方法も cert-manager のインストールが必要であることに注意してください。
+- `admissionWebhooks.certManager.enabled` を `false` に、`admissionWebhooks.autoGenerateCert.enabled` を `true` に設定することで、自動生成された自己署名証明書を使用できます。
+  Helm が自己署名証明書とシークレットを作成してくれます。
+- `admissionWebhooks.certManager.enabled` と `admissionWebhooks.autoGenerateCert.enabled` の両方を `false` に設定することで、自分で生成した自己署名証明書を使用できます。
+  必要な値は `admissionWebhooks.cert_file` 、`admissionWebhooks.key_file` 、`admissionWebhooks.ca_file` に指定します。
+- `.Values.admissionWebhooks.create` と `admissionWebhooks.certManager.enabled` を無効にし、`admissionWebhooks.secretName` にカスタム証明書のシークレット名を設定することで、カスタムWebhookと証明書をサイドロードできます。
+- すべてのWebhookを一度に無効にするには、`.Values.admissionWebhooks.create` を無効にし、環境変数 `.Values.manager.env.ENABLE_WEBHOOKS` を `false` に設定します。
+
+チャートで利用可能なすべての設定オプション（コメント付き）は、その[values.yamlファイル](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/values.yaml)で確認できます。


### PR DESCRIPTION
add Japanese translation of the following pages:

- https://opentelemetry.io/ja/docs/platforms/kubernetes/helm/collector/
- https://opentelemetry.io/ja/docs/platforms/kubernetes/helm/demo/
- https://opentelemetry.io/ja/docs/platforms/kubernetes/helm/operator/