### PR TITLE
[pt] Add localize content/pt/docs/contributing/style-guide.md

### DIFF
--- a/content/pt/docs/contributing/style-guide.md
+++ b/content/pt/docs/contributing/style-guide.md
@@ -72,9 +72,10 @@ Execute:
 - `npm run fix:markdown` para corrigir problemas de formatação relacionados ao
   Markdown
 
-Também aplicamos o padrão [file format](#file-format) ao Markdown, que remove espaços
-em branco no final das linhas. Isso exclui a [line break syntax] com dois ou mais espaços.
-Para forçar a quebra de linha, use `<br>` em vez disso ou reformate seu texto.
+Também aplicamos o padrão [file format](#file-format) ao Markdown, que remove
+espaços em branco no final das linhas. Isso exclui a [line break syntax] com
+dois ou mais espaços. Para forçar a quebra de linha, use `<br>` em vez disso ou
+reformate seu texto.
 
 ## Verificação ortográfica {#spell-checking}
 

--- a/content/pt/docs/contributing/style-guide.md
+++ b/content/pt/docs/contributing/style-guide.md
@@ -29,7 +29,7 @@ problemas comuns.
 
 {{% /alert %}}
 
-## Lista de palavras do OpenTelemetry.io
+## Lista de palavras do OpenTelemetry.io {#opentelemetryio-word-list}
 
 Uma lista de termos e palavras específicas do OpenTelemetry que devem ser usadas
 de forma consistente em todo o site:

--- a/content/pt/docs/contributing/style-guide.md
+++ b/content/pt/docs/contributing/style-guide.md
@@ -41,7 +41,7 @@ de forma consistente em todo o site:
 - [OpAMP](/docs/concepts/glossary/#opamp)
 
 Para uma lista completa de termos do OpenTelemetry e suas definições, consulte o
-[Glossário](/docs/concepts/glossary/).
+[Glossary](/docs/concepts/glossary/).
 
 Certifique-se de que nomes próprios, como outros projetos da CNCF ou ferramentas
 de terceiros, sejam escritos corretamente e utilizem a capitalização original.
@@ -72,9 +72,9 @@ Execute:
 - `npm run fix:markdown` para corrigir problemas de formatação relacionados ao
   Markdown
 
-Também aplicamos o [formato de arquivo](#file-format) do Markdown e removemos
-espaços em branco no final das linhas. Isso exclui a [sintaxe de quebra de
-linha] de 2+ espaços; use `<br>` em vez disso ou reformate seu texto.
+Também aplicamos o [file format](#file-format) do Markdown e removemos espaços
+em branco no final das linhas. Isso exclui a [line break syntax] de 2+ espaços;
+use `<br>` em vez disso ou reformate seu texto.
 
 ## Verificação ortográfica
 
@@ -98,7 +98,7 @@ cSpell:ignore: <palavra>
 
 Para qualquer outro arquivo, adicione `cSpell:ignore <palavra>` em uma linha de
 comentário apropriada para o contexto do arquivo. Para um arquivo YAML de
-entrada de [registro](/ecosystem/registry/), pode ser assim:
+entrada de [registry](/ecosystem/registry/), pode ser assim:
 
 ```yaml
 # cSpell:ignore <palavra>
@@ -123,7 +123,6 @@ Todos os nomes de arquivos devem estar em
 
 [.markdownlint.json]:
   https://github.com/open-telemetry/opentelemetry.io/blob/main/.markdownlint.json
-[sintaxe de quebra de linha]:
-  https://www.markdownguide.org/basic-syntax/#line-breaks
+[line break syntax]: https://www.markdownguide.org/basic-syntax/#line-breaks
 [markdownlint]: https://github.com/DavidAnson/markdownlint
 [Prettier]: https://prettier.io

--- a/content/pt/docs/contributing/style-guide.md
+++ b/content/pt/docs/contributing/style-guide.md
@@ -4,7 +4,7 @@ description: Terminologia e estilo ao escrever a documentação do OpenTelemetry
 linkTitle: Manual de estilo
 weight: 20
 default_lang_commit: 4d9d9039bc658ad691d12710016c2d491550feec
-cSpell:ignore: open-telemetry postgre style-guide textlintrc opentelemetryio
+cSpell:ignore: open-telemetry opentelemetryio postgre style-guide textlintrc
 ---
 
 Ainda não possuímos um manual de estilo oficial, porém, a atual aparência da

--- a/content/pt/docs/contributing/style-guide.md
+++ b/content/pt/docs/contributing/style-guide.md
@@ -4,7 +4,7 @@ description: Terminologia e estilo ao escrever a documentação do OpenTelemetry
 linkTitle: Manual de estilo
 weight: 20
 default_lang_commit: 4d9d9039bc658ad691d12710016c2d491550feec
-cSpell:ignore: open-telemetry postgre style-guide textlintrc
+cSpell:ignore: open-telemetry postgre style-guide textlintrc opentelemetryio
 ---
 
 Ainda não possuímos um manual de estilo oficial, porém, a atual aparência da

--- a/content/pt/docs/contributing/style-guide.md
+++ b/content/pt/docs/contributing/style-guide.md
@@ -1,0 +1,129 @@
+---
+title: Manual de estilo da documentação
+description: Terminologia e estilo ao escrever a documentação do OpenTelemetry.
+linkTitle: Manual de estilo
+weight: 20
+cSpell:ignore: open-telemetry postgre style-guide textlintrc
+default_lang_commit: 4d9d9039bc658ad691d12710016c2d491550feec
+---
+
+Ainda não possuímos um manual de estilo oficial, porém, a atual aparência da
+documentação do OpenTelemetry é influenciada pelos seguintes manuais de estilo:
+
+- [Google Developer Documentation Style Guide](https://developers.google.com/style)
+- [Kubernetes Style Guide](https://kubernetes.io/docs/contribute/style/style-guide/)
+
+As seções a seguir contêm orientações específicas para o projeto OpenTelemetry.
+
+{{% alert title="Nota" color="primary" %}}
+
+Muitos requisitos do nosso manual de estilo podem ser aplicados automaticamente:
+antes de enviar uma
+[pull request](https://docs.github.com/en/get-started/learning-about-github/github-glossary#pull-request)
+(PR), execute `npm run fix:all` na sua máquina local e faça o commit das
+alterações.
+
+Se você encontrar erros ou [falhas nas verificações de PR](../pr-checks), leia
+sobre nosso manual de estilo e aprenda o que pode ser feito para corrigir certos
+problemas comuns.
+
+{{% /alert %}}
+
+## Lista de palavras do OpenTelemetry.io
+
+Uma lista de termos e palavras específicas do OpenTelemetry que devem ser usadas
+de forma consistente em todo o site:
+
+- [OpenTelemetry](/docs/concepts/glossary/#opentelemetry) e
+  [OTel](/docs/concepts/glossary/#otel)
+- [Collector](/docs/concepts/glossary/#collector)
+- [OTEP](/docs/concepts/glossary/#otep)
+- [OpAMP](/docs/concepts/glossary/#opamp)
+
+Para uma lista completa de termos do OpenTelemetry e suas definições, consulte o
+[Glossário](/docs/concepts/glossary/).
+
+Certifique-se de que nomes próprios, como outros projetos da CNCF ou ferramentas
+de terceiros, sejam escritos corretamente e utilizem a capitalização original.
+Por exemplo, escreva "PostgreSQL" em vez de "postgre". Para uma lista completa,
+verifique o arquivo
+[`.textlintrc.yml`](https://github.com/open-telemetry/opentelemetry.io/blob/main/.textlintrc.yml).
+
+{{% alert title="Dica" %}}
+
+Execute `npm run check:text` para verificar se todos os termos e palavras estão
+escritos corretamente.
+
+Execute `npm run check:text -- --fix` para corrigir termos e palavras que não
+estão escritos corretamente.
+
+{{% /alert %}}
+
+## Padrões de Markdown
+
+Para garantir padrões e consistência nos arquivos Markdown, todos os arquivos
+devem seguir certas regras, aplicadas pelo [markdownlint]. Para uma lista
+completa, verifique o arquivo [.markdownlint.json].
+
+Execute:
+
+- `npm run check:markdown` para garantir que todos os arquivos sigam nossos
+  padrões
+- `npm run fix:markdown` para corrigir problemas de formatação relacionados ao
+  Markdown
+
+Também aplicamos o [formato de arquivo](#file-format) do Markdown e removemos
+espaços em branco no final das linhas. Isso exclui a [sintaxe de quebra de
+linha] de 2+ espaços; use `<br>` em vez disso ou reformate seu texto.
+
+## Verificação ortográfica
+
+Use [CSpell](https://github.com/streetsidesoftware/cspell) para garantir que
+todo o texto esteja escrito corretamente. Para uma lista de palavras específicas
+do site OpenTelemetry, consulte o arquivo
+[`.cspell.yml`](https://github.com/open-telemetry/opentelemetry.io/blob/main/.cspell.yml).
+
+Execute `npm run check:spelling` para verificar se todas as palavras estão
+escritas corretamente. Se o `cspell` indicar um erro de `Unknown word`,
+verifique se você escreveu essa palavra corretamente. Se sim, adicione essa
+palavra à seção `cSpell:ignore` no início do seu arquivo. Se essa seção não
+existir, você pode adicioná-la ao front matter de um arquivo Markdown:
+
+```markdown
+---
+title: TituloDaPagina
+cSpell:ignore: <palavra>
+---
+```
+
+Para qualquer outro arquivo, adicione `cSpell:ignore <palavra>` em uma linha de
+comentário apropriada para o contexto do arquivo. Para um arquivo YAML de
+entrada de [registro](/ecosystem/registry/), pode ser assim:
+
+```yaml
+# cSpell:ignore <palavra>
+title: TituloDoRegistro
+```
+
+As ferramentas do site normalizam os dicionários específicos de página (ou seja,
+as listas de palavras `cSpell:ignore`), removendo palavras duplicadas, excluindo
+palavras na lista global e ordenando as palavras. Para normalizar os dicionários
+específicos de página, execute `npm run fix:dict`.
+
+## Formato de arquivo
+
+Aplicamos formatação de arquivos usando o [Prettier]. Execute-o com
+`npm run fix:format`.
+
+## Nomes de arquivos
+
+Todos os nomes de arquivos devem estar em
+[kebab case](https://en.wikipedia.org/wiki/Letter_case#Kebab_case). Execute
+`npm run fix:filenames` para renomear automaticamente seus arquivos.
+
+[.markdownlint.json]:
+  https://github.com/open-telemetry/opentelemetry.io/blob/main/.markdownlint.json
+[sintaxe de quebra de linha]:
+  https://www.markdownguide.org/basic-syntax/#line-breaks
+[markdownlint]: https://github.com/DavidAnson/markdownlint
+[Prettier]: https://prettier.io

--- a/content/pt/docs/contributing/style-guide.md
+++ b/content/pt/docs/contributing/style-guide.md
@@ -3,8 +3,8 @@ title: Manual de estilo da documentação
 description: Terminologia e estilo ao escrever a documentação do OpenTelemetry.
 linkTitle: Manual de estilo
 weight: 20
-cSpell:ignore: open-telemetry postgre style-guide textlintrc
 default_lang_commit: 4d9d9039bc658ad691d12710016c2d491550feec
+cSpell:ignore: open-telemetry postgre style-guide textlintrc
 ---
 
 Ainda não possuímos um manual de estilo oficial, porém, a atual aparência da

--- a/content/pt/docs/contributing/style-guide.md
+++ b/content/pt/docs/contributing/style-guide.md
@@ -41,7 +41,7 @@ de forma consistente em todo o site:
 - [OpAMP](/docs/concepts/glossary/#opamp)
 
 Para uma lista completa de termos do OpenTelemetry e suas definições, consulte o
-[Glossary](/docs/concepts/glossary/).
+[Glossário](/docs/concepts/glossary/).
 
 Certifique-se de que nomes próprios, como outros projetos da CNCF ou ferramentas
 de terceiros, sejam escritos corretamente e utilizem a capitalização original.
@@ -59,7 +59,7 @@ estão escritos corretamente.
 
 {{% /alert %}}
 
-## Padrões de Markdown
+## Padrões de Markdown {#markdown-standards}
 
 Para garantir padrões e consistência nos arquivos Markdown, todos os arquivos
 devem seguir certas regras, aplicadas pelo [markdownlint]. Para uma lista
@@ -76,7 +76,7 @@ Também aplicamos o [file format](#file-format) do Markdown e removemos espaços
 em branco no final das linhas. Isso exclui a [line break syntax] de 2+ espaços;
 use `<br>` em vez disso ou reformate seu texto.
 
-## Verificação ortográfica
+## Verificação ortográfica {#spell-checking}
 
 Use [CSpell](https://github.com/streetsidesoftware/cspell) para garantir que
 todo o texto esteja escrito corretamente. Para uma lista de palavras específicas
@@ -110,12 +110,12 @@ as listas de palavras `cSpell:ignore`), removendo palavras duplicadas, excluindo
 palavras na lista global e ordenando as palavras. Para normalizar os dicionários
 específicos de página, execute `npm run fix:dict`.
 
-## Formato de arquivo
+## Formato de arquivo {#file-format}
 
 Aplicamos formatação de arquivos usando o [Prettier]. Execute-o com
 `npm run fix:format`.
 
-## Nomes de arquivos
+## Nomes de arquivos {#file-names}
 
 Todos os nomes de arquivos devem estar em
 [kebab case](https://en.wikipedia.org/wiki/Letter_case#Kebab_case). Execute

--- a/content/pt/docs/contributing/style-guide.md
+++ b/content/pt/docs/contributing/style-guide.md
@@ -19,8 +19,8 @@ As seções a seguir contêm orientações específicas para o projeto OpenTelem
 
 Muitos requisitos do nosso manual de estilo podem ser aplicados automaticamente:
 antes de enviar uma
-[pull request](https://docs.github.com/en/get-started/learning-about-github/github-glossary#pull-request)
-(PR), execute `npm run fix:all` na sua máquina local e faça o commit das
+[_pull request_](https://docs.github.com/en/get-started/learning-about-github/github-glossary#pull-request)
+(PR), execute `npm run fix:all` na sua máquina local e faça o _commit_ das
 alterações.
 
 Se você encontrar erros ou [falhas nas verificações de PR](../pr-checks), leia
@@ -98,7 +98,7 @@ cSpell:ignore: <palavra>
 
 Para qualquer outro arquivo, adicione `cSpell:ignore <palavra>` em uma linha de
 comentário apropriada para o contexto do arquivo. Para um arquivo YAML de
-entrada de [registry](/ecosystem/registry/), pode ser assim:
+entrada de [registro](/ecosystem/registry/), pode ser assim:
 
 ```yaml
 # cSpell:ignore <palavra>

--- a/content/pt/docs/contributing/style-guide.md
+++ b/content/pt/docs/contributing/style-guide.md
@@ -72,9 +72,9 @@ Execute:
 - `npm run fix:markdown` para corrigir problemas de formatação relacionados ao
   Markdown
 
-Também aplicamos o [file format](#file-format) do Markdown e removemos espaços
-em branco no final das linhas. Isso exclui a [line break syntax] de 2+ espaços;
-use `<br>` em vez disso ou reformate seu texto.
+Também aplicamos o padrão [file format](#file-format) ao Markdown, que remove espaços
+em branco no final das linhas. Isso exclui a [line break syntax] com dois ou mais espaços.
+Para forçar a quebra de linha, use `<br>` em vez disso ou reformate seu texto.
 
 ## Verificação ortográfica {#spell-checking}
 


### PR DESCRIPTION
This pull request adds a new style guide for documentation in Portuguese (`content/pt/docs/contributing/style-guide.md`). The guide provides guidelines for terminology, formatting, and tools to ensure consistency and quality in the OpenTelemetry documentation.

### Issue:
 - https://github.com/open-telemetry/opentelemetry.io/issues/6854