### PR TITLE
Upgrade markdownlint-cli2 and address issues

### DIFF
--- a/content/en/docs/concepts/glossary.md
+++ b/content/en/docs/concepts/glossary.md
@@ -370,25 +370,25 @@ on web pages when requested. See [zPages].
 [baggage]: /docs/specs/otel/baggage/api/
 [context propagation]: /docs/specs/otel/overview#context-propagation
 [dag]: https://en.wikipedia.org/wiki/Directed_acyclic_graph
-[distributed tracing]: /docs/concepts/signals/traces/
-[distributions]: /docs/concepts/distributions/
+[distributed tracing]: ../signals/traces/
+[distributions]: ../distributions/
 [field]: /docs/specs/otel/logs/data-model#field-kinds
 [http]: https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol
 [instrumented library]: /docs/specs/otel/glossary/#instrumented-library
 [json]: https://en.wikipedia.org/wiki/JSON
 [log record]: /docs/specs/otel/glossary#log-record
 [log]: /docs/specs/otel/glossary#log
-[metric]: /docs/concepts/signals/metrics/
+[metric]: ../signals/metrics/
 [opentelemetry-proto]: https://github.com/open-telemetry/opentelemetry-proto
 [propagators]: /docs/languages/go/instrumentation/#propagators-and-context
 [receiver]: /docs/collector/configuration/#receivers
 [rest]: https://en.wikipedia.org/wiki/Representational_state_transfer
 [rpc]: https://en.wikipedia.org/wiki/Remote_procedure_call
 [sampling]: /docs/specs/otel/trace/sdk#sampling
-[signals]: /docs/concepts/signals/
+[signals]: ../signals/
 [span]: /docs/specs/otel/trace/api#span
 [spec-instrumentation-lib]: /docs/specs/otel/glossary/#instrumentation-library
-[specification]: /docs/concepts/components/#specification
+[specification]: ../components/#specification
 [status]: /docs/specs/otel/trace/api#set-status
 [tracer]: /docs/specs/otel/trace/api#tracer
 [traces]: /docs/specs/otel/overview#traces

--- a/content/en/docs/concepts/glossary.md
+++ b/content/en/docs/concepts/glossary.md
@@ -112,7 +112,7 @@ See [Distributed tracing][distributed tracing].
 ### Distribution
 
 A distribution is a wrapper around an upstream OpenTelemetry repository with
-some customizations. See [more][distribution].
+some customizations. See [Distributions].
 
 ### Event
 
@@ -145,7 +145,7 @@ Short for [Hypertext Transfer Protocol][http].
 
 Denotes the [Library](#library) for which the telemetry signals
 ([Traces](#trace), [Metrics](#metric), [Logs](#log)) are gathered. See
-[more][spec-instrumented-lib].
+[Instrumented library][].
 
 ### Instrumentation library
 
@@ -177,13 +177,13 @@ A language-specific collection of behavior invoked by an interface.
 Sometimes used to refer to a collection of [Log records](#log-record). Can be
 ambiguous since people also sometimes use [Log](#log) to refer to a single
 [Log record](#log-record). Where ambiguity is possible, use additional
-qualifiers, for example, `Log record`. See [more][log]
+qualifiers, for example, `Log record`. See [Log].
 
 ### Log record
 
 A recording of data with a timestamp and a severity. May also have a
-[Trace ID](#trace) and [Span ID](#span) when correlated with a trace. See
-[more][log record].
+[Trace ID](#trace) and [Span ID](#span) when correlated with a trace. See [Log
+record][].
 
 ### Metadata
 
@@ -195,7 +195,7 @@ while [Logs](#log) have [Fields](#field).
 ### Metric
 
 Records a data point, either raw measurements or predefined aggregation, as time
-series with [Metadata](#metadata). See [more][metric].
+series with [Metadata](#metadata). See [Metric].
 
 ### OC
 
@@ -266,17 +266,17 @@ Short for [OpenTelemetry Protocol](/docs/specs/otlp/).
 ### Propagators
 
 Used to serialize and deserialize specific parts of telemetry data such as span
-context and [Baggage](#baggage) in [Spans](#span). See [more][propagators].
+context and [Baggage](#baggage) in [Spans](#span). See [Propagators].
 
 ### Proto
 
-Language independent interface types. See [more][proto].
+Language independent interface types. See [opentelemetry-proto].
 
 ### Receiver
 
 The term used by the [Collector](/docs/collector/configuration/#receivers) to
 define how telemetry data is received. Receivers can be push- or pull-based. See
-[more][receiver].
+[Receiver].
 
 ### Request
 
@@ -301,7 +301,7 @@ Short for [Remote Procedure Call][rpc].
 ### Sampling
 
 A mechanism to control the amount of data exported. Most commonly used with the
-[Tracing](#trace) [Data Source](#data-source). See [more][sampling].
+[Tracing](#trace) [Data Source](#data-source). See [Sampling].
 
 ### SDK
 
@@ -321,12 +321,11 @@ scalability. A [Service](#service) can be deployed in multiple locations.
 
 ### Signal
 
-One of [Traces](#trace), [Metrics](#metric) or [Logs](#log). More on Signals
-[here][signals].
+One of [Traces](#trace), [Metrics](#metric) or [Logs](#log). See [Signals].
 
 ### Span
 
-Represents a single operation within a [Trace](#trace). See [more][span].
+Represents a single operation within a [Trace](#trace). See [Span].
 
 ### Span link
 
@@ -337,12 +336,12 @@ A span link is a link between causally-related spans. For details see
 ### Specification
 
 Describes the cross-language requirements and expectations for all
-implementations. See [more][specification].
+implementations. See [Specification].
 
 ### Status
 
 The result of the operation. Typically used to indicate whether an error
-occurred. See [more][status].
+occurred. See [Status].
 
 ### Tag
 
@@ -351,11 +350,11 @@ See [Metadata](#metadata).
 ### Trace
 
 A [DAG](#dag) of [Spans](#span), where the edges between [Spans](#span) are
-defined as parent-child relationship. See [more][trace].
+defined as parent-child relationship. See [Traces].
 
 ### Tracer
 
-Responsible for creating [Spans](#span). See [more][tracer].
+Responsible for creating [Spans](#span). See [Tracer].
 
 ### Transaction
 
@@ -365,22 +364,23 @@ See [Distributed Tracing](#distributed-tracing).
 
 An in-process alternative to external exporters. When included, they collect and
 aggregate tracing and metrics information in the background; this data is served
-on web pages when requested. See [more][zpages].
+on web pages when requested. See [zPages].
 
-[baggage]: /docs/specs/otel/baggage/api/
 [attribute]: /docs/specs/otel/common/#attributes
+[baggage]: /docs/specs/otel/baggage/api/
 [context propagation]: /docs/specs/otel/overview#context-propagation
 [dag]: https://en.wikipedia.org/wiki/Directed_acyclic_graph
 [distributed tracing]: /docs/concepts/signals/traces/
-[distribution]: /docs/concepts/distributions/
+[distributions]: /docs/concepts/distributions/
 [field]: /docs/specs/otel/logs/data-model#field-kinds
 [http]: https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol
+[instrumented library]: /docs/specs/otel/glossary/#instrumented-library
 [json]: https://en.wikipedia.org/wiki/JSON
-[log]: /docs/specs/otel/glossary#log
 [log record]: /docs/specs/otel/glossary#log-record
+[log]: /docs/specs/otel/glossary#log
 [metric]: /docs/concepts/signals/metrics/
+[opentelemetry-proto]: https://github.com/open-telemetry/opentelemetry-proto
 [propagators]: /docs/languages/go/instrumentation/#propagators-and-context
-[proto]: https://github.com/open-telemetry/opentelemetry-proto
 [receiver]: /docs/collector/configuration/#receivers
 [rest]: https://en.wikipedia.org/wiki/Representational_state_transfer
 [rpc]: https://en.wikipedia.org/wiki/Remote_procedure_call
@@ -388,10 +388,9 @@ on web pages when requested. See [more][zpages].
 [signals]: /docs/concepts/signals/
 [span]: /docs/specs/otel/trace/api#span
 [spec-instrumentation-lib]: /docs/specs/otel/glossary/#instrumentation-library
-[spec-instrumented-lib]: /docs/specs/otel/glossary/#instrumented-library
 [specification]: /docs/concepts/components/#specification
 [status]: /docs/specs/otel/trace/api#set-status
-[trace]: /docs/specs/otel/overview#traces
 [tracer]: /docs/specs/otel/trace/api#tracer
+[traces]: /docs/specs/otel/overview#traces
 [zpages]:
   https://github.com/open-telemetry/opentelemetry-specification/blob/main/development/trace/zpages.md

--- a/content/pt/docs/concepts/signals/traces.md
+++ b/content/pt/docs/concepts/signals/traces.md
@@ -318,7 +318,7 @@ Os links são opcionais, mas servem como uma boa maneira de associar trechos de
 rastro uns aos outros.
 
 Para mais informações sobre Links de Trechos, consulte
-[Link](/docs/specs/otel/trace/api/#link).
+[Links de Trechos](/docs/specs/otel/trace/api/#link).
 
 ### O estado do Trecho {#span-status}
 

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "js-yaml": "^4.1.0",
     "markdown-link-check": "^3.13.7",
     "markdownlint": "^0.37.4",
-    "markdownlint-cli2": "^0.17.2",
+    "markdownlint-cli2": "^0.18.1",
     "postcss-cli": "^11.0.1",
     "prettier": "3.5.3",
     "puppeteer": "^24.9.0",


### PR DESCRIPTION
- Contributes to #6880
- Updates `markdownlint-cli2` to `@latest`
- Addresses issues raised by linter in Glossary, which detects and reports links with link-text of the form "more" and "link", much like what was done by @jsoref in #6053 etc.
- **Preview**: 