### PR TITLE
[CI] Update pr-actions.yml: delete pr-fix.patch file after it is applied

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -116,6 +116,7 @@ jobs:
             echo "Patch failed to apply"
             exit 1
           }
+          rm pr-fix.patch
 
       - name: Commit and push changes, if any
         run: |


### PR DESCRIPTION
- Contributes to 
- Context: example of us having to delete the file manually, https://github.com/open-telemetry/opentelemetry.io/pull/6948/commits/feaf2dea5d2fba98ba5072b885e7de233fe791ee
- Ensure that `pr-fix.patch` is deleted after the patch is applied so that the file isn't committed.

/cc @svrnm 