### PR TITLE
Update `deployment.environment` to `deployment.environment.name`

### DIFF
--- a/content/en/docs/concepts/resources/index.md
+++ b/content/en/docs/concepts/resources/index.md
@@ -51,8 +51,8 @@ If applicable, use the
 [semantic conventions for your resource attributes](/docs/specs/semconv/resource).
 For example, you can provide the name of your
 [deployment environment](/docs/specs/semconv/resource/deployment-environment/)
-using `deployment.environment`:
+using `deployment.environment.name`:
 
 ```shell
-env OTEL_RESOURCE_ATTRIBUTES=deployment.environment=production yourApp
+env OTEL_RESOURCE_ATTRIBUTES=deployment.environment.name=production yourApp
 ```


### PR DESCRIPTION
I believe the former is deprecated.
