### PR TITLE
[CI] Unshallow fetch submodule when commit or tag not found

### DIFF
--- a/scripts/pin-submodules.pl
+++ b/scripts/pin-submodules.pl
@@ -8,6 +8,8 @@ use warnings;
 use FileHandle;
 
 my $submodule_skip_regex = shift @ARGV;
+my $baseDir = `pwd`;
+chomp $baseDir;
 
 print "Using submodule-path skip regex: $submodule_skip_regex\n\n"
   if $submodule_skip_regex;
@@ -30,13 +32,33 @@ for (my $i = 0; $i < @submodules; $i += 2) {
       next;
     }
 
-    my $command = "cd $submodule_path && git switch --detach $commit";
+    chdir($baseDir) or die "Failed to change directory to $baseDir: $!";
+    chdir($submodule_path) or die "Failed to change directory to $submodule_path: $!";
+
+    # Verify that the commit exists in the submodule
+    my $verify_cmd = "git rev-parse --verify $commit > /dev/null 2>&1";
+    system($verify_cmd);
+    if ($? == -1) {
+      die "Failed to execute '$verify_cmd': $!";
+    } elsif ($? >> 8) {
+      # Commit not found. The most common reason is that the submodule was
+      # cloned with a fixed depth, and the commit is outside of the shallow
+      # clone depth. Let's check if it's shallow or not.
+
+      my $is_shallow_cmd = "git rev-parse --is-shallow-repository";
+      die "Commit $commit does not exist in $submodule_path (and the submodule is not shallow)."
+        if `$is_shallow_cmd` !~ /true/;
+
+      warn "Commit $commit does not exist in $submodule_path, " .
+        "but the submodule is a shallow clone. Let's unshallow it and try again.";
+
+      my $unshallow_cmd = "git fetch --unshallow";
+      system($unshallow_cmd);
+      die "Failed to execute '$verify_cmd': $!" if $? != 0;
+    }
+
+    my $command = "git switch --detach $commit";
     print "> $command\n";
     system($command);
-
-    if ($? == -1) {
-        die "Failed to execute command: $!";
-    } elsif ($? >> 8) {
-        die "Command exited with error: $!";
-    }
+    die "Command exited with error: $!" if $? != 0;
 }


### PR DESCRIPTION
- Fixes #6999
- Closes #6998
- Does so by checking if a submodule pin commit/tag is present. If not, and the submodule is shallow, then the script unshallows the submodule (does a full clone).