### PR TITLE
Link KubeCon announcements to blog posts

### DIFF
--- a/content/en/announcements/kubecon-china.md
+++ b/content/en/announcements/kubecon-china.md
@@ -6,9 +6,11 @@ expiryDate: 2025-06-11
 ---
 
 <i class="fas fa-bullhorn"></i> [**{{% param title %}}**][LF],
-**<span class="text-nowrap">June 10 - 11,</span> Hong Kong**
-<span class="d-none d-md-inline"><br></span> Come collaborate, learn, and
-share<span class="d-none d-sm-inline"> with the Cloud Native community</span>!
+**<span class="text-nowrap">June 10 - 11,</span> Hong Kong**.
+<span class="d-none d-md-inline"><br></span> [Come collaborate, learn, and
+share][blog]<span class="d-none d-sm-inline"> with the Cloud Native
+community</span>!
 
+[blog]: blog/2025/kubecon-china/
 [LF]:
   https://events.linuxfoundation.org/kubecon-cloudnativecon-china/reg/register/?utm_source=opentelemetry&utm_medium=all&utm_campaign=KubeCon-China-2025&utm_content=slim-banner

--- a/content/en/announcements/kubecon-china.md
+++ b/content/en/announcements/kubecon-china.md
@@ -11,6 +11,6 @@ expiryDate: 2025-06-11
 share][blog]<span class="d-none d-sm-inline"> with the Cloud Native
 community</span>!
 
-[blog]: blog/2025/kubecon-china/
+[blog]: /blog/2025/kubecon-china/
 [LF]:
   https://events.linuxfoundation.org/kubecon-cloudnativecon-china/reg/register/?utm_source=opentelemetry&utm_medium=all&utm_campaign=KubeCon-China-2025&utm_content=slim-banner

--- a/content/en/announcements/kubecon-japan.md
+++ b/content/en/announcements/kubecon-japan.md
@@ -6,9 +6,11 @@ expiryDate: 2025-06-17
 ---
 
 <i class="fas fa-bullhorn"></i> [**{{% param title %}}**][LF],
-**<span class="text-nowrap">June 16 - 17,</span> Tokyo**
-<span class="d-none d-md-inline"><br></span> Come collaborate, learn, and
-share<span class="d-none d-sm-inline"> with the Cloud Native community</span>!
+**<span class="text-nowrap">June 16 - 17,</span> Tokyo**.
+<span class="d-none d-md-inline"><br></span> [Come collaborate, learn, and
+share][blog]<span class="d-none d-sm-inline"> with the Cloud Native
+community</span>!
 
+[blog]: blog/2025/kubecon-japan/
 [LF]:
   https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/register/?utm_source=opentelemetry&utm_medium=all&utm_campaign=KubeCon-Japan-2025&utm_content=slim-banner

--- a/content/en/announcements/kubecon-japan.md
+++ b/content/en/announcements/kubecon-japan.md
@@ -11,6 +11,6 @@ expiryDate: 2025-06-17
 share][blog]<span class="d-none d-sm-inline"> with the Cloud Native
 community</span>!
 
-[blog]: blog/2025/kubecon-japan/
+[blog]: /blog/2025/kubecon-japan/
 [LF]:
   https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/register/?utm_source=opentelemetry&utm_medium=all&utm_campaign=KubeCon-Japan-2025&utm_content=slim-banner

--- a/content/en/blog/2025/kubecon-china.md
+++ b/content/en/blog/2025/kubecon-china.md
@@ -36,4 +36,4 @@ Come listen, learn, and get involved in OpenTelemetry. See you in Hong!
 [KubeCon + CloudNativeCon China]:
   https://events.linuxfoundation.org/kubecon-cloudnativecon-china/?utm_source=opentelemetry&utm_medium=all&utm_campaign=KubeCon-EU-2025&utm_content=blog
 [registration]:
-  https://events.linuxfoundation.org/kubecon-cloudnativecon-china/reg/register/
+  https://events.linuxfoundation.org/kubecon-cloudnativecon-china/reg/register/?utm_source=opentelemetry&utm_medium=all&utm_campaign=KubeCon-China-2025

--- a/content/en/blog/2025/kubecon-japan.md
+++ b/content/en/blog/2025/kubecon-japan.md
@@ -55,6 +55,6 @@ Come listen, learn, and get involved in OpenTelemetry. See you in Tokyo!
 [KubeCon + CloudNativeCon Japan]:
   https://events.linuxfoundation.org/kubecon-cloudnativecon-japan//?utm_source=opentelemetry&utm_medium=all&utm_campaign=KubeCon-Japan-2025&utm_content=blog
 [registration]:
-  https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/register/
+  https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/register/?utm_source=opentelemetry&utm_medium=all&utm_campaign=KubeCon-Japan-2025
 [Community Day]:
   https://community.cncf.io/events/details/cncf-cloud-native-community-japan-presents-japan-community-day-at-kubecon-cloudnativecon-japan-2025/


### PR DESCRIPTION
- Links KubeCon China and Japan announcements to their respective blog posts
- Adds UTM query attributes to the registration links in the blog posts

/cc @tiffany76 @katzchang