### PR TITLE
[CI] Support `keep` directive for announcements and other md pages that expire

### DIFF
--- a/content/en/announcements/kubecon-china.md
+++ b/content/en/announcements/kubecon-china.md
@@ -2,7 +2,7 @@
 title: KubeCon + CloudNativeCon China 2025
 linkTitle: KubeCon China 2025
 date: 2025-05-20
-expiryDate: 2025-06-11
+expiryDate: 2025-06-11 # keep
 ---
 
 <i class="fas fa-bullhorn"></i> [**{{% param title %}}**][LF],

--- a/content/en/announcements/kubecon-japan.md
+++ b/content/en/announcements/kubecon-japan.md
@@ -2,7 +2,7 @@
 title: KubeCon + CloudNativeCon Japan 2025
 linkTitle: KubeCon Japan 2025
 date: 2025-05-20
-expiryDate: 2025-06-17
+expiryDate: 2025-06-17 # keep
 ---
 
 <i class="fas fa-bullhorn"></i> [**{{% param title %}}**][LF],

--- a/scripts/list-expired.pl
+++ b/scripts/list-expired.pl
@@ -16,9 +16,16 @@ BEGIN {
 }
 
 while (<>) {
-    if (/^expiryDate:\s*([^#\n]+)/ && $1 le $cut_off_date) {
+    if (/^expiryDate:\s*([^#\s]+)((?i)\s*#\s*keep)?/ && $1 le $cut_off_date) {
+        my $expiryDate = $1;
+        my $keep = ($2 || '') =~ /keep/i;
+        next if $keep && $quiet;
+
         print "$ARGV";
-        printf "\t expired on %s", $1 unless $quiet;
+        if (!$quiet) {
+          printf "\tEXPIRED ON %s", $expiryDate;
+          printf " (KEEP)" if $keep;
+        }
         print "\n";
     }
 }


### PR DESCRIPTION
- Fixes #6946
- Adds support for the following: to ensure that announcements (or any other expired markdown file) isn't deleted by `fix:expired`, add `keep` as a comment after the expiry date. The post will still be removed on the expiry date, but the file won't be deleted even if `fix:expired` is run.

/cc @tiffany76 - this is in contrast to what we had discussed during the Comms meeting. I've implemented support for `keep` after all.