### PR TITLE
CHORE - fix: correction opentelemetry word

### DIFF
--- a/content/en/blog/2025/otel-arrow-phase-2.md
+++ b/content/en/blog/2025/otel-arrow-phase-2.md
@@ -24,7 +24,7 @@ improved data compression and performance.
 
 We are choosing to investigate this phase of the project in Rust. With the help
 of the OpenTelemetry Governance Committee, we've defined a project scope that
-entails studying the potential for Rust-based OpenTelemtry pipelines without
+entails studying the potential for Rust-based OpenTelemetry pipelines without
 "being" a Collector. We will investigate both the performance of Rust pipelines
 as well as how to successfully integrate our work with the OpenTelemetry
 Collector's Golang-based ecosystem.

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -103,7 +103,7 @@ the label as translated link text. For example, consider the following Markdown:
 [Hello], world! Welcome to the [OTel website][].
 
 [hello]: https://code.org/helloworld
-[OTel website]: https://opentelementry.io
+[OTel website]: https://opentelemetry.io
 ```
 
 This would be translated in French as:
@@ -112,7 +112,7 @@ This would be translated in French as:
 [Bonjour][hello], le monde! Bienvenue sur le [site OTel][OTel website].
 
 [hello]: https://code.org/helloworld
-[OTel website]: https://opentelementry.io
+[OTel website]: https://opentelemetry.io
 ```
 
 [labels]: https://spec.commonmark.org/0.31.2/#link-label

--- a/content/ja/docs/contributing/localization.md
+++ b/content/ja/docs/contributing/localization.md
@@ -91,7 +91,7 @@ Markdown の[リンク定義][link definitions]の[ラベル][labels]は**翻訳
 [Hello], world! Welcome to the [OTel website][].
 
 [hello]: https://code.org/helloworld
-[OTel website]: https://opentelementry.io
+[OTel website]: https://opentelemetry.io
 ```
 
 これをフランス語に翻訳すると次のようになります。
@@ -100,7 +100,7 @@ Markdown の[リンク定義][link definitions]の[ラベル][labels]は**翻訳
 [Bonjour][hello], le monde! Bienvenue sur le [site OTel][OTel website].
 
 [hello]: https://code.org/helloworld
-[OTel website]: https://opentelementry.io
+[OTel website]: https://opentelemetry.io
 ```
 
 [labels]: https://spec.commonmark.org/0.31.2/#link-label


### PR DESCRIPTION
This pull request includes corrections to link definitions and updates to improve clarity in documentation across multiple files. The most important changes involve fixing a typo in the URL for the OpenTelemetry website and ensuring consistency in localized documentation.

### Documentation updates:

* [`content/en/docs/contributing/localization.md`](diffhunk://#diff-95e7906a1be8699bb50d991938c4cc6fd2d3e3288bf9a09fe5acc8d9b86938bfL106-R106): Corrected the URL for the OpenTelemetry website in both English and French examples to ensure accuracy. [[1]](diffhunk://#diff-95e7906a1be8699bb50d991938c4cc6fd2d3e3288bf9a09fe5acc8d9b86938bfL106-R106) [[2]](diffhunk://#diff-95e7906a1be8699bb50d991938c4cc6fd2d3e3288bf9a09fe5acc8d9b86938bfL115-R115)
* [`content/ja/docs/contributing/localization.md`](diffhunk://#diff-c11fc7894a039cb4c676be4c1fe0acef90e22ebd9a25585591b9e2f5cb6da641L94-R94): Updated the URL for the OpenTelemetry website in Japanese documentation to match the corrected English version. [[1]](diffhunk://#diff-c11fc7894a039cb4c676be4c1fe0acef90e22ebd9a25585591b9e2f5cb6da641L94-R94) [[2]](diffhunk://#diff-c11fc7894a039cb4c676be4c1fe0acef90e22ebd9a25585591b9e2f5cb6da641L103-R103)

### Minor adjustments:

* [`content/en/blog/2025/otel-arrow-phase-2.md`](diffhunk://#diff-a4af36dcf22bfd90b7d15252fbd95bc938850d229d1ba400fdabdbf1815f9ff4L27-R27): Adjusted phrasing for clarity in the description of Rust-based OpenTelemetry pipelines.