### PR TITLE
Add 3rd-party-distros disclaimer via shortcode and include - keeping things DRY

### DIFF
--- a/content/en/_includes/otel-does-not-validate-3rd-pty-distros.md
+++ b/content/en/_includes/otel-does-not-validate-3rd-pty-distros.md
@@ -1,0 +1,9 @@
+---
+---
+
+{{% alert title="Disclaimer" color="warning" %}}
+
+OpenTelemetry **does not validate or endorse** the third-party distributions
+listed below. This list is provided as a convenience for the community.
+
+{{% /alert %}}

--- a/content/en/docs/collector/distributions.md
+++ b/content/en/docs/collector/distributions.md
@@ -29,10 +29,6 @@ Some organizations provide a Collector distribution with additional capabilities
 or for improved ease of use. What follows is a list of Collector distributions
 maintained by third parties.
 
-{{% alert title="Note" color="warning" %}} OpenTelemetry **does not validate or
-endorse** the third-party distributions listed in the following table. The list
-is provided as a convenience for the community. {{% /alert %}}
-
 {{% ecosystem/distributions-table filter="third-party-collector" %}}
 
 ## Adding your Collector distribution {#how-to-add}

--- a/content/en/ecosystem/distributions.md
+++ b/content/en/ecosystem/distributions.md
@@ -19,10 +19,6 @@ distributions and the component they customize. For
 [OpenTelemetry Collector](/docs/collector/) distributions, see
 [Collector distributions](/docs/collector/distributions/).
 
-{{% alert title="Note" color="warning" %}} OpenTelemetry **does not validate or
-endorse** the third-party distributions listed below. This list is provided as a
-convenience for the community. {{% /alert %}}
-
 {{% ecosystem/distributions-table filter="non-collector" %}}
 
 ## Adding your distribution {#how-to-add}

--- a/layouts/_shortcodes/ecosystem/distributions-table.md
+++ b/layouts/_shortcodes/ecosystem/distributions-table.md
@@ -36,6 +36,13 @@
   {{ $data = $filtered -}}
 {{ end -}}
 
+{{ if ne $filter "first-party-collector" -}}
+{{ partial "include" (dict
+    "_dot" .
+    "_path" "otel-does-not-validate-3rd-pty-distros.md")
+-}}
+{{ end }}
+
 Name[^1]     | Components |  Learn more
 ------------ | ---------- |  ----------
 {{- range $data }}


### PR DESCRIPTION
- Followup to: #6918
- Moves repeated alert text into an include file
- Moves the alert into the distros table shortcode

**Previews**:

- https://deploy-preview-7041--opentelemetry.netlify.app/ecosystem/distributions/
- https://deploy-preview-7041--opentelemetry.netlify.app/docs/collector/distributions/