### PR TITLE
docs(i18n): fix drift of content/ja/announcements/kubecon-japan.md

### DIFF
--- a/content/ja/announcements/kubecon-japan.md
+++ b/content/ja/announcements/kubecon-japan.md
@@ -1,9 +1,10 @@
 ---
 title: KubeCon + CloudNativeCon Japan 2025
 linkTitle: KubeCon Japan 2025
-date: 2025-05-20
+date: 2025-06-11 # Show once combined banner is hidden
 expiryDate: 2025-06-17 # keep
-default_lang_commit: e05fefe6c9f7d8b159d9a9a95128098c646c78c4
+weight: 20250616
+default_lang_commit: dcd079d98e749febcefd4d7bb1da361770ec8ed3
 ---
 
 <i class="fas fa-bullhorn"></i> [**{{% param title %}}**][LF]が **6月16・17日に東京で開催**


### PR DESCRIPTION
<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->


I updated an announcement of kubecon japan.

Preview

- https://deploy-preview-7053--opentelemetry.netlify.app/announcements/kubecon-japan/
