### PR TITLE
Expire KubeCon announcements the day after they end

### DIFF
--- a/content/en/announcements/kubecon-asia.md
+++ b/content/en/announcements/kubecon-asia.md
@@ -3,7 +3,7 @@ title: KubeCon + CloudNativeCon Asia 2025
 linkTitle: KubeCon Asia 2025
 date: 2025-05-20
 # Expire after China event so we can fall back to single Japan event banner
-expiryDate: 2025-06-11 # keep
+expiryDate: 2025-06-12 # keep
 weight: 20250610
 ---
 

--- a/content/en/announcements/kubecon-china.md
+++ b/content/en/announcements/kubecon-china.md
@@ -2,7 +2,7 @@
 title: KubeCon + CloudNativeCon China 2025
 linkTitle: KubeCon China 2025
 date: 2025-05-20
-expiryDate: 2025-06-11 # keep
+expiryDate: 2025-06-12 # keep
 build: { list: never, render: never } # Hide in favor of new Asia banner
 weight: 20250610
 ---

--- a/content/en/announcements/kubecon-japan.md
+++ b/content/en/announcements/kubecon-japan.md
@@ -1,8 +1,8 @@
 ---
 title: KubeCon + CloudNativeCon Japan 2025
 linkTitle: KubeCon Japan 2025
-date: 2025-06-11 # Show once combined banner is hidden
-expiryDate: 2025-06-17 # keep
+date: 2025-06-12 # Show once combined banner is hidden
+expiryDate: 2025-06-18 # keep
 weight: 20250616
 ---
 


### PR DESCRIPTION
Expiring the Asia announcement today (6/11) is too earlier. Let's use the day after the Hong Kong event ends. Ditto for other events.