### PR TITLE
[ja] docs(i18n): fix drift of content/ja/docs/languages/*.md files

### DIFF
--- a/content/ja/docs/_includes/exporters/intro.md
+++ b/content/ja/docs/_includes/exporters/intro.md
@@ -1,5 +1,5 @@
 ---
-default_lang_commit: ba402271eeb1bd5e83c37f2fadc3b50e89aca66b
+default_lang_commit: d0a90db560d4f15934bdb43d994eabcfd91c515a
 ---
 
 [OpenTelemetryコレクター](/docs/collector/)にテレメトリーを送信し、正しくエクスポートされることを確認してください。
@@ -39,9 +39,11 @@ OTLPについて詳細に学習したい場合は、[OTLP仕様][OTLP]を参照�
 
 {{ if $zeroConfigPageExists }}
 
-<div class="alert alert-info" role="alert"><h4 class="alert-heading">注意</h4>
+{{% alert title=Note %}}
+
 [ゼロコード計装](/docs/zero-code/{{ $l }})を使用している場合は、[設定ガイド](/docs/zero-code/{{ $l }}/configuration/)に従ってエクスポーターの設定方法を学ぶことができます。
-</div>
+
+{{% /alert %}}
 
 {{ end }}
 
@@ -51,11 +53,11 @@ OTLPについて詳細に学習したい場合は、[OTLP仕様][OTLP]を参照�
 
 ### コレクターのセットアップ {#collector-setup}
 
-<div class="alert alert-info" role="alert"><h4 class="alert-heading">注意</h4>
+{{% alert title=Note %}}
 
 OTLPコレクターまたはバックエンドがすでにセットアップされている場合は、このセクションをスキップして、アプリケーション用の[OTLPエクスポーター依存関係のセットアップ](#otlp-dependencies)に進むことができます。
 
-</div>
+{{% /alert %}}
 
 OTLPエクスポーターを試し、検証するために、テレメトリーを直接コンソールに書き込むDockerコンテナでコレクターを実行できます。
 空のディレクトリで、以下の内容で`collector-config.yaml`というファイルを作成します。

--- a/content/ja/docs/languages/_index.md
+++ b/content/ja/docs/languages/_index.md
@@ -3,7 +3,7 @@ title: 言語API & SDK
 description: OpenTelemetryのコード計装は、多くの一般的なプログラミング言語でサポートされています。
 weight: 250
 aliases: [/docs/instrumentation]
-default_lang_commit: 548e5e29f574fddc3ca683989a458e9a6800242f
+default_lang_commit: d0a90db560d4f15934bdb43d994eabcfd91c515a
 redirects:
   - { from: 'net/*', to: 'dotnet/:splat' }
 ---

--- a/content/ja/docs/languages/sdk-configuration/general.md
+++ b/content/ja/docs/languages/sdk-configuration/general.md
@@ -2,7 +2,7 @@
 title: 一般的なSDK設定
 linkTitle: 一般
 aliases: [general-sdk-configuration]
-default_lang_commit: 9ba98f4fded66ec78bfafa189ab2d15d66df2309
+default_lang_commit: d0a90db560d4f15934bdb43d994eabcfd91c515a
 cSpell:ignore: ottrace
 ---
 


### PR DESCRIPTION
<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->

Current English files.

- https://deploy-preview-7096--opentelemetry.netlify.app/docs/languages/
- https://deploy-preview-7096--opentelemetry.netlify.app/docs/languages/sdk-configuration/general/

Preview.

- https://deploy-preview-7096--opentelemetry.netlify.app/ja/docs/languages/
- https://deploy-preview-7096--opentelemetry.netlify.app/ja/docs/languages/sdk-configuration/general/
