### PR TITLE
Update docsy to v0.12.0-25-g82d492bb for TOC highlighting, etc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,7 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/google/docsy.git
-	docsy-pin = v0.12.0
+	docsy-pin = v0.12.0-25-g82d492bb
 	docsy-note = "2024-04-01 Switching to google/docsy.git from cncf/docsy.git since we don't have any CNCF customizations."
 	docsy-reminder = "Ensure that any tag referenced by `docsy-pin` is present in the remote repo (url), otherwise add (push) the tags to the repo."
 [submodule "content-modules/opentelemetry-specification"]

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -105,12 +105,6 @@
   }
 }
 
-// Adjust the spacing of page-meta and page-TOC (https://github.com/open-telemetry/opentelemetry.io/pull/354)
-// TODO: upstream
-.td-toc #TableOfContents {
-  padding-top: 1rem;
-}
-
 .td-home {
   .cncf {
     text-align: center;

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -42,4 +42,3 @@ $otel-registry-license-colors: (
 
 $primary: map-get($otel-colors, 'blue');
 $secondary: map-get($otel-colors, 'orange');
-$td-enable-google-fonts: false;

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -401,7 +401,7 @@ content][ali-dowair-2024].
   https://www.writethedocs.org/conf/atlantic/2024/speakers/#speaker-ali-dowair-what-s-in-a-word-lessons-from-localizing-kubernetes-documentation-to-arabic-ali-dowair
 [ali-d-youtube]: https://youtu.be/HY3LZOQqdig
 
-### 5. Localize the remaining site pages
+### 5. Localize the remaining site pages {#rest}
 
 With terminology established, you can now localize the remaining site pages.
 

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -1,7 +1,9 @@
 {{/* Docsy-delta */ -}}
-
 <!doctype html>
-<html lang="{{ .Site.Language.Lang }}" class="no-js">
+<html itemscope itemtype="http://schema.org/WebPage"
+    {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
+    {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
+    class="no-js">
   <head>
     {{ partial "head.html" . }}
   </head>

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -14,7 +14,7 @@
       {{ partial "navbar.html" . }}
     </header>
     <div class="container-fluid td-outer">
-      <div class="td-main">
+      <div class="td-main" {{- partialCached "td/scrollspy-attr.txt" . .Section | safeHTMLAttr }}>
         <div class="row flex-xl-nowrap">
           <aside class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
             <div id="google_translate_element"></div>


### PR DESCRIPTION
This Docsy update

- Fixes #7436
  > <img width="444" height="714" alt="image" src="https://github.com/user-attachments/assets/81bd7a96-b2af-4c69-aa2c-de8e2a029338" />
- Prepares us for #5646
- Adds dynamic TOC entry highlighting as a reader scrolls through a page. Implemented via Bootstrap's ScrollSpy (see https://github.com/google/docsy/pull/2287).
- Improves colors for alerts (see https://github.com/google/docsy/pull/2285)
- There's a bug with the scrolling (for details see https://github.com/google/docsy/issues/2329), but it doesn't happen for many pages, so I'll tackle it later.

### Previews

- https://deploy-preview-7104--opentelemetry.netlify.app/docs/platforms/kubernetes/getting-started/#filelog-receiver - deep linking example
- https://deploy-preview-7104--opentelemetry.netlify.app/community/
- https://deploy-preview-7104--opentelemetry.netlify.app/ecosystem/distributions/ for the warning alert
- https://deploy-preview-7104--opentelemetry.netlify.app/blog/2025/ai-agent-observability/ - test page illustrating console error as reported in https://github.com/google/docsy/issues/2329

### Screenshots

TOC:

> <img width="1235" alt="image" src="https://github.com/user-attachments/assets/0fc06b27-4035-4804-9195-01d5779adc11" />

### Related

- https://github.com/google/docsy/issues/2289
- https://github.com/google/docsy/issues/2329
