### PR TITLE
Fix propogation link to express instrumentation

### DIFF
--- a/content/en/docs/languages/js/propagation.md
+++ b/content/en/docs/languages/js/propagation.md
@@ -12,7 +12,7 @@ cSpell:ignore: rolldice
 [Instrumentation libraries](../libraries/) like
 [`@opentelemetry/instrumentation-http`](https://www.npmjs.com/package/@opentelemetry/instrumentation-http)
 or
-[`@opentelemetry/instrumentation-express`](https://www.npmjs.com/package/@opentelemetry/instrumentation-http)
+[`@opentelemetry/instrumentation-express`](https://www.npmjs.com/package/@opentelemetry/instrumentation-express)
 propagate context across services for you.
 
 If you followed the [Getting Started Guide](../getting-started/nodejs) you can


### PR DESCRIPTION
In the "Automatic context propogation" section for JS SDK, there are two links, one that states "@opentelemetry/instrumentation-http" and one that states "@opentelemetry/instrumentation-express". 
However both these links point to the instrumentation-http package. 

This fixes the express link to point to express npm package.