### PR TITLE
Update deprecated semantic conventions resources.md

### DIFF
--- a/content/en/docs/languages/js/resources.md
+++ b/content/en/docs/languages/js/resources.md
@@ -92,15 +92,13 @@ configuration option, where you can set them. For example you can update the
 ```javascript
 ...
 const { resourceFromAttributes } = require('@opentelemetry/resources');
-const { SEMRESATTRS_SERVICE_NAME, SEMRESATTRS_SERVICE_NAMESPACE, SEMRESATTRS_SERVICE_VERSION, SEMRESATTRS_SERVICE_INSTANCE_ID } = require('@opentelemetry/semantic-conventions');
+const { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } = require('@opentelemetry/semantic-conventions');
 ...
 const sdk = new opentelemetry.NodeSDK({
   ...
   resource: resourceFromAttributes({
-    [ SEMRESATTRS_SERVICE_NAME ]: "yourServiceName",
-    [ SEMRESATTRS_SERVICE_NAMESPACE ]: "yourNameSpace",
-    [ SEMRESATTRS_SERVICE_VERSION ]: "1.0",
-    [ SEMRESATTRS_SERVICE_INSTANCE_ID ]: "my-instance-id-1",
+    [ ATTR_SERVICE_NAME ]: "yourServiceName",
+    [ ATTR_SERVICE_VERSION ]: "1.0",
   })
   ...
 });


### PR DESCRIPTION
`SEMRESATTRS_SERVICE_NAME` is deprecated and should be replaced with `ATTR_SERVICE_NAME`.
`SEMRESATTRS_SERVICE_NAMESPACE` is deprecated and should be replaced with `ATTR_SERVICE_VERSION`.
`SEMRESATTRS_SERVICE_VERSION` is an unstable semantic convention.
`SEMRESATTRS_SERVICE_INSTANCE_ID` is an unstable semantic convention.

Source: https://github.com/open-telemetry/opentelemetry-js/blob/main/semantic-conventions/README.md#migrating-from-semattrs_-semresattrs_-