### PR TITLE
OTel day banner: link to blog, and adjust local word list

### DIFF
--- a/content/en/announcements/open-observability-summit-na.md
+++ b/content/en/announcements/open-observability-summit-na.md
@@ -12,8 +12,7 @@ ready][CNCF-blog] for the inaugural</span> [**{{% param title %}}**][oss] and
 <span class="d-none d-sm-inline">co-located </span>[**OTel Community
 Day**][ocd], **Denver CO, <span class="text-nowrap">June 24-26</span>**
 
-[CNCF-blog]:
-  https://www.cncf.io/announcements/2025/05/21/cncf-shares-schedule-for-open-observability-summit-north-america-gears-up-for-inaugural-event/
+[CNCF-blog]: /blog/2025/otel-day/
 [oss]:
   https://events.linuxfoundation.org/open-source-summit-north-america/?utm_source=opentelemetry&utm_medium=all&utm_campaign=Open-Observability-Summit-2025&utm_content=slim-banner
 [ocd]:

--- a/content/en/blog/2025/otel-day.md
+++ b/content/en/blog/2025/otel-day.md
@@ -5,8 +5,7 @@ title:
 linkTitle: OTel Community Day
 date: 2025-06-13
 author: '[Isabella Langan](https://github.com/isabella-rose-l) (Causely)'
-# prettier-ignore
-cSpell:ignore: Agrawal Aircall Alok Baylis Bhargava Bhattacharya Bhide Braydon Budhaditya Canuel Causely Cijo Danielson Distrogen Heffner Helmuth Horovits Huxing Jernigan Kains Krietz Kumar Kuncham Langan Liudmila Mansi Minghui Molkova Mujumdar Okahu OllyGarden Prasad Radlein Ravindra Roshore Spec-tacular Todea Vashistha Vijay Zhang
+cSpell:ignore: Causely Langan
 ---
 
 On **June 26, 2025**,
@@ -38,6 +37,8 @@ for the topics of interest.
 
 <details>
 <summary class="mb-3">View schedule</summary>
+
+{{< comment >}} cSpell:disable {{< /comment >}}
 
 ### Welcome + Keynotes
 
@@ -150,6 +151,8 @@ for the topics of interest.
 
 - **[From GenAI Applications to AI Models: Unraveling End to End AI Observability With OpenTelemetry](https://otelopenobservabilityna25.sched.com/event/223AL)**<br>
   by Huxing Zhang & Minghui Zhang, Alibaba Cloud<br> 5:30pm – 5:45pm MDT
+
+{{< comment >}} cSpell:enable {{< /comment >}}
 
 </details>
 


### PR DESCRIPTION
- Followup to #7085
- Links to OTel day blog post from the announcement
- Follows through with the suggested cSpell changes made over #7085 but not committed