### PR TITLE
[blog] Create call-to-action post for CNCF Slack changes

### DIFF
--- a/content/en/blog/2025/slack-workspace-changes.md
+++ b/content/en/blog/2025/slack-workspace-changes.md
@@ -2,8 +2,7 @@
 title: Action Required - Slack Workspace Changes are Coming Friday, June 20
 linkTitle: Slack Workspace Changes
 date: 2025-06-17
-author: >-
-  OpenTelemetry Authors
+author: OpenTelemetry maintainers
 ---
 
 Yesterday the Cloud Native Computing Foundation (CNCF)

--- a/content/en/blog/2025/slack-workspace-changes.md
+++ b/content/en/blog/2025/slack-workspace-changes.md
@@ -1,0 +1,35 @@
+---
+title: Action Required - Slack Workspace Changes are Coming Friday, June 20
+linkTitle: Slack Workspace Changes
+date: 2025-06-17
+author: >-
+  OpenTelemetry Authors
+---
+
+Yesterday the Cloud Native Computing Foundation (CNCF)
+[announced](https://www.cncf.io/blog/2025/06/16/cncf-slack-workspace-changes-coming-on-friday-june-20/)
+that CNCF Slack workspace will be converted from an enterprise plan to a free
+plan on Friday, June 20, 2025.
+
+Although there will be no disruption to OpenTelemetry's access to the Slack
+workspace, all users and project contributors should consider taking the
+following actions:
+
+- **Export private channel histories and direct messages.** The new free Slack
+  plan keeps posts for only 90 days. Come Friday, you will no longer have access
+  to any posts older than 90 days. CNCF is backing up all public channel
+  histories. If you have private channels or direct messages that you would like
+  to keep, follow the
+  [CNCF guide](https://github.com/cncf/foundation/blob/main/policies-guidance/slack-backup.md)
+  to export and store the content locally.
+- **Back up files.** If you have files stored in Slack, they will be deleted!
+  Download and save them to GitHub or Google Docs before Friday.
+- **Save pinned posts.** If you have important information stored in pinned
+  posts, it might not be accessible on Friday. Make a copy of the information
+  and store it in GitHub or Google Docs. You can add a bookmark to your channel
+  that links to that location.
+
+See the CNCF's
+[blog post](https://www.cncf.io/blog/2025/06/16/cncf-slack-workspace-changes-coming-on-friday-june-20/)
+for more details. For questions or to follow the discussion, join the
+[#slack-faq](https://cloud-native.slack.com/archives/C091NUGP5KN) channel.

--- a/content/en/blog/2025/slack-workspace-changes.md
+++ b/content/en/blog/2025/slack-workspace-changes.md
@@ -9,7 +9,10 @@ author: >-
 Yesterday the Cloud Native Computing Foundation (CNCF)
 [announced](https://www.cncf.io/blog/2025/06/16/cncf-slack-workspace-changes-coming-on-friday-june-20/)
 that CNCF Slack workspace will be converted from an enterprise plan to a free
-plan on Friday, June 20, 2025.
+plan on Friday, June 20, 2025. This will have implications for how Slack works
+for the OpenTelemetry community, including a few limitations that we will need
+to be aware of; however, we don’t anticipate this change to radically impact our
+collaboration.
 
 Although there will be no disruption to OpenTelemetry's access to the Slack
 workspace, all users and project contributors should consider taking the

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -443,6 +443,10 @@
     "StatusCode": 200,
     "LastSeen": "2025-01-17T12:58:36.720595Z"
   },
+  "https://cloud-native.slack.com/archives/C091NUGP5KN": {
+    "StatusCode": 200,
+    "LastSeen": "2025-06-17T15:26:30.536617059-07:00"
+  },
   "https://cloud-native.slack.com/archives/CJFCJHG4Q": {
     "StatusCode": 200,
     "LastSeen": "2025-02-02T10:58:45.786902-05:00"
@@ -3738,6 +3742,10 @@
   "https://github.com/cncf/foundation/blob/main/code-of-conduct.md": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:37:38.183934-05:00"
+  },
+  "https://github.com/cncf/foundation/blob/main/policies-guidance/slack-backup.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-06-17T15:26:29.588240192-07:00"
   },
   "https://github.com/cncf/glossary/blob/main/CODEOWNERS": {
     "StatusCode": 206,
@@ -20006,6 +20014,10 @@
   "https://www.cncf.io/blog/2025/01/20/opentelemetry-for-generative-ai/": {
     "StatusCode": 200,
     "LastSeen": "2025-02-14T12:23:38.590496-05:00"
+  },
+  "https://www.cncf.io/blog/2025/06/16/cncf-slack-workspace-changes-coming-on-friday-june-20/": {
+    "StatusCode": 200,
+    "LastSeen": "2025-06-17T15:26:29.150378304-07:00"
   },
   "https://www.cncf.io/enduser/": {
     "StatusCode": 200,


### PR DESCRIPTION
This PR creates a short call-to-action blog post for OTel community members to save their data in Slack before Friday.

Fixes #7135. 
