### PR TITLE
[ja] docs(i18n): fix drift of content/ja/blog/2025/kubecon-japan.md

### DIFF
--- a/content/ja/blog/2025/kubecon-japan.md
+++ b/content/ja/blog/2025/kubecon-japan.md
@@ -4,13 +4,13 @@ title: KubeCon + CloudNativeCon Japan 2025で、
 linkTitle: KubeCon Japan '25
 date: 2025-05-29
 author: '[Tiffany Hrabusa](https://github.com/tiffany76) (Grafana Labs)'
-default_lang_commit: 6d798b20803204f4a23ee454422fa79827948cef
+default_lang_commit: adc4264c2926e3d767b6a56affb19fb4ae3f2a22
 # prettier-ignore
 cSpell:ignore: Baazi Chauhan Hrabusa Kang Kasper Mostafa Nissen Radwan Shivay Siddharth Vijay
 ---
 
 OpenTelemetryプロジェクトは、[KubeCon + CloudNativeCon Japan][]（[参加登録][registration]）
-および東京で同時開催される[Community Day][]（2025年6月15日〜17日）で、OpenTelemetryコミュニティのメンバーと一緒に過ごすことを皆さんにご案内します。
+および東京で同時開催される[Community Day][]（2025年6月14日〜17日）で、OpenTelemetryコミュニティのメンバーと一緒に過ごすことを皆さんにご案内します。
 
 この記事では、KubeCon期間中に予定されているOpenTelemetry関連のすべてのアクティビティを紹介しています。カンファレンス開始前に、随時更新情報をチェックしてください！
 


### PR DESCRIPTION
<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->

Original English page.

- https://deploy-preview-7143--opentelemetry.netlify.app/blog/2025/kubecon-japan/

Preview

- https://deploy-preview-7143--opentelemetry.netlify.app/ja/blog/2025/kubecon-japan/
