### PR TITLE
Fix broken links to api.md after refactoring

### DIFF
--- a/content/en/blog/2023/end-user-q-and-a-04.md
+++ b/content/en/blog/2023/end-user-q-and-a-04.md
@@ -326,7 +326,7 @@ generated? One of a bunch of things."
 ### Kubernetes modes on OTel
 
 The OTel Operator supports four
-[deployment modes](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md#opentelemetrycollectorspec)
+[deployment modes](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/opentelemetrycollectors.md)
 for the OTel Collector in Kubernetes:
 
 - [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) -

--- a/content/en/blog/2024/otel-operator-q-and-a/index.md
+++ b/content/en/blog/2024/otel-operator-q-and-a/index.md
@@ -24,7 +24,7 @@ easier. It does the following:
   [custom resource (CR)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
 - Manages the configuration of a fleet of OpenTelemetry Collectors via
   [OpAMP](/docs/specs/opamp/) integration, supported by the
-  [`OpAMPBridge`](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md#opampbridge)
+  [`OpAMPBridge`](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/opampbridges.md)
   custom resource.
 - Provides
   [integration with the Prometheus Operator's `PodMonitor` and `ServiceMonitor` CRs](https://github.com/open-telemetry/opentelemetry-operator/tree/main/cmd/otel-allocator).
@@ -202,7 +202,7 @@ to authenticate against that private registry. For more info on how to use
 [the instructions](https://github.com/open-telemetry/opentelemetry-operator?tab=readme-ov-file#using-imagepullsecrets).
 
 For more info, check out the
-[OpenTelemetryCollector CR API docs](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md#opentelemetrycollector).
+[OpenTelemetryCollector CR API docs](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/opentelemetrycollectors.md).
 
 ### Q5: Does the Target Allocator work for all deployment types?
 
@@ -322,7 +322,7 @@ yourself (see
 [Q7](#q7-do-i-need-to-create-a-service-account-to-use-the-target-allocator)).
 
 For more info, check out the
-[Target Allocator API docs](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md#opentelemetrycollectorspectargetallocator).
+[Target Allocator API docs](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/targetallocators.md).
 
 ### Q10: Is there a version lag between the OTel Operator auto-instrumentation and auto-instrumentation of supported languages?
 

--- a/content/en/docs/platforms/kubernetes/operator/automatic.md
+++ b/content/en/docs/platforms/kubernetes/operator/automatic.md
@@ -108,7 +108,7 @@ an endpoint for auto-instrumentation in your pods.
 To be able to manage automatic instrumentation, the Operator needs to be
 configured to know what pods to instrument and which automatic instrumentation
 to use for those pods. This is done via the
-[Instrumentation CRD](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md#instrumentation).
+[Instrumentation CRD](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/instrumentations.md).
 
 Creating the Instrumentation resource correctly is paramount to getting
 auto-instrumentation working. Making sure all endpoints and env vars are correct

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -9775,6 +9775,14 @@
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:15:12.345Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/instrumentations.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-06-18T18:26:06.843991+05:30"
+  },
+  "https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/opampbridges.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-06-18T18:27:29.702111+05:30"
+  },
   "https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/opentelemetrycollectors.md": {
     "StatusCode": 206,
     "LastSeen": "2025-04-06T04:35:11.407913032Z"
@@ -9782,6 +9790,10 @@
   "https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/opentelemetrycollectors.md#opentelemetryiov1beta1": {
     "StatusCode": 206,
     "LastSeen": "2025-05-03T12:00:59.999Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/targetallocators.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-06-18T18:27:34.253691+05:30"
   },
   "https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/targetallocators.md#targetallocatorspecprometheuscr": {
     "StatusCode": 200,


### PR DESCRIPTION
A number of pages linked to  [open-telemetry/opentelemetry-operator/docs/api.md](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md), that was refactored and thus the links needed a fix. 

Fixes: https://github.com/open-telemetry/opentelemetry.io/issues/6237
