### PR TITLE
[ja] add translation of zero-code/python

### DIFF
--- a/content/ja/docs/zero-code/python/_index.md
+++ b/content/ja/docs/zero-code/python/_index.md
@@ -1,0 +1,78 @@
+---
+title: Pythonゼロコード・計装
+linkTitle: Python
+weight: 30
+aliases: [/docs/languages/python/automatic]
+cSpell: ignore: distro myapp
+default_lang_commit: 3d737b777f7bfa070f7f14835570add916d4dcb0
+---
+
+Pythonによる自動計装は、任意のPythonアプリケーションにアタッチ可能なPythonエージェントを使用します。
+このエージェントは、主に[モンキーパッチ](https://en.wikipedia.org/wiki/Monkey_patch)を使用して、実行時にライブラリ関数を変更し、多くの一般的なライブラリとフレームワークからのテレメトリーデータのキャプチャを可能にします。
+
+## セットアップ {#setup}
+
+以下のコマンドを実行して、適切なパッケージをインストールします。
+
+```sh
+pip install opentelemetry-distro opentelemetry-exporter-otlp
+opentelemetry-bootstrap -a install
+```
+
+`opentelemetry-distro` パッケージは API、SDK、`opentelemetry-bootstrap` と `opentelemetry-instrument` ツールをインストールします。
+
+{{% alert title="Note" %}}
+自動計装を動作させるには、distro パッケージをインストールする必要があります。
+`opentelemetry-distro` パッケージには、デフォルトの distro が含まれており、いくつかの一般的なオプションを自動的に設定できます。
+詳しくは、[OpenTelemetry distro](/docs/languages/python/distro/) を参照してください。
+{{% /alert %}}
+
+`opentelemetry-bootstrap -a install` コマンドは、アクティブな `site-packages` フォルダにインストールされているパッケージのリストを読み込んで、該当するパッケージがあれば、対応する計装ライブラリをインストールします。
+たとえば、既に `flask` パッケージをインストールしている場合、 `opentelemetry-bootstrap -a install` を実行すると、かわりに `opentelemetry-instrumentation-flask` がインストールされます。
+OpenTelemetry Python エージェントはモンキーパッチを使って、実行時にこれらのライブラリの関数を変更します。
+
+引数なしで `opentelemetry-bootstrap` を実行すると、インストールされる推奨計装ライブラリが一覧表示されます。
+詳細については、[`opentelemetry-bootstrap`](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-instrumentation#opentelemetry-bootstrap) を参照してください。
+
+{{% alert title="<code>uv</code>を使いますか?" color="warning" %}}
+[uv](https://docs.astral.sh/uv/)パッケージマネージャーを使用している場合、`opentelemetry-bootstrap -a install` を実行する際に何らかの困難に直面するかもしれません。
+詳しくは[uvを使ったブートストラップ](troubleshooting/#bootstrap-using-uv)を参照してください。
+{{% /alert %}}
+
+## エージェントの設定 {#configuring-the-agent}
+
+エージェントは高度に設定可能です。
+
+選択肢の1つめは、CLIから設定プロパティによってエージェントを設定することです。
+
+```sh
+opentelemetry-instrument \
+    --traces_exporter console,otlp \
+    --metrics_exporter console \
+    --service_name your-service-name \
+    --exporter_otlp_endpoint 0.0.0.0:4317 \
+    python myapp.py
+```
+
+あるいは、環境変数を使ってエージェントを設定することも可能です。
+
+```sh
+OTEL_SERVICE_NAME=your-service-name \
+OTEL_TRACES_EXPORTER=console,otlp \
+OTEL_METRICS_EXPORTER=console \
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=0.0.0.0:4317
+opentelemetry-instrument \
+    python myapp.py
+```
+
+設定オプションの全範囲を見るには、[エージェント設定](configuration)を参照してください。
+
+## サポートされるライブラリとフレームワーク {#supported-libraries-and-frameworks}
+
+[Flask](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-flask) や [Django](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-django) など、人気のある Python ライブラリの多くが自動計装に対応しています。
+全リストは [レジストリ](/ecosystem/registry/?language=python&component=instrumentation) を参照してください。
+
+## トラブルシューティング {#troubleshooting}
+
+一般的なトラブルシューティングの手順と特定の問題に対する解決策については、[トラブルシューティング](./troubleshooting/) を参照してください。
+

--- a/content/ja/docs/zero-code/python/_index.md
+++ b/content/ja/docs/zero-code/python/_index.md
@@ -75,4 +75,3 @@ opentelemetry-instrument \
 ## トラブルシューティング {#troubleshooting}
 
 一般的なトラブルシューティングの手順と特定の問題に対する解決策については、[トラブルシューティング](./troubleshooting/) を参照してください。
-

--- a/content/ja/docs/zero-code/python/_index.md
+++ b/content/ja/docs/zero-code/python/_index.md
@@ -2,7 +2,6 @@
 title: Pythonゼロコード・計装
 linkTitle: Python
 weight: 30
-aliases: [/docs/languages/python/automatic]
 cSpell: ignore: distro myapp
 default_lang_commit: 3d737b777f7bfa070f7f14835570add916d4dcb0
 ---

--- a/content/ja/docs/zero-code/python/_index.md
+++ b/content/ja/docs/zero-code/python/_index.md
@@ -2,7 +2,6 @@
 title: Pythonゼロコード・計装
 linkTitle: Python
 weight: 30
-cSpell: ignore: distro myapp
 default_lang_commit: 3d737b777f7bfa070f7f14835570add916d4dcb0
 ---
 

--- a/content/ja/docs/zero-code/python/configuration.md
+++ b/content/ja/docs/zero-code/python/configuration.md
@@ -1,0 +1,149 @@
+---
+title: エージェント設定
+linkTitle: Configuration
+weight: 10
+aliases:
+- /docs/languages/python/automatic/configuration
+- /docs/languages/python/automatic/agent-config
+cSpell: ignore: healthcheck instrumentor myapp pyproject Starlette urllib
+default_lang_commit: 3d737b777f7bfa070f7f14835570add916d4dcb0
+---
+
+
+エージェントは次のいずれかの方法で高度に設定可能です。
+
+- CLIから設定プロパティを渡す
+- [環境変数](/docs/specs/otel/configuration/sdk-environment-variables/)の設定
+
+## 設定プロパティ {#configuration-properties}
+
+以下は、設定プロパティによるエージェント設定の例です。
+
+```sh
+opentelemetry-instrument \
+    --traces_exporter console,otlp \
+    --metrics_exporter console \
+    --service_name your-service-name \
+    --exporter_otlp_endpoint 0.0.0.0:4317 \
+    python myapp.py
+```
+
+ここでは、それぞれの設定が何をするのかを説明します。
+
+- `traces_exporter`は、使用するトレースエクスポーターを指定します。
+  この場合、トレースは `console` （標準出力） と `otlp` にエクスポートされます。
+  `otlp` オプションは、gRPC 経由で OTLP を受け付けるエンドポイントにトレースを送信するように `opentelemetry-instrument` に指示します。
+  gRPC のかわりに HTTP を使用するには、`--exporter_otlp_protocol http/protobuf` を追加します。
+  traces_exporter で利用可能なオプションの完全なリストは Python contrib [OpenTelemetry Instrumentation](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-instrumentation) を参照してください。
+- `metrics_exporter` は使用するメトリクスエクスポーターを指定します。
+  この場合、メトリクスは `console` (標準出力) にエクスポートされます。
+  現在、メトリクスエクスポーターの指定は必須です。
+  メトリクスをエクスポートしない場合は、かわりに `none` を指定してください。
+- `service_name` はテレメトリーに関連するサービス名を設定し、[オブザーバビリティバックエンド](/ecosystem/vendors/) に送信します。
+- `exporter_otlp_endpoint`は、テレメトリーをエクスポートするエンドポイントを設定します。
+  省略した場合は、デフォルトの [コレクター](/docs/collector/) のエンドポイントが使用され、gRPC の場合は `0.0.0.0:4317`、HTTP の場合は `0.0.0.0:4318` となります。
+- `exporter_otlp_headers`は、選択したオブザーバビリティバックエンドに応じて必要となります。
+  OTLPエクスポーターヘッダーの詳細については、[OTEL_EXPORTER_OTLP_HEADERS](/docs/languages/sdk-configuration/otlp-exporter/#otel_exporter_otlp_headers)を参照してください。
+
+
+## 環境変数 {#environment-variables}
+
+場合によっては、[環境変数](/docs/languages/sdk-configuration/)を使って設定する方が望ましいこともあります。
+コマンドライン引数で設定可能なすべての設定は、環境変数でも設定できます。
+
+以下の手順を適用して、目的の構成プロパティの正しい名前マッピングを決定できます。
+
+- 設定プロパティを大文字に変換します。
+- 環境変数のプレフィックスを `OTEL_` にします。
+
+たとえば、`exporter_otlp_endpoint` は `OTEL_EXPORTER_OTLP_ENDPOINT` に変換されます。
+
+## Python 固有の設定 {#python-specific-configuration}
+
+環境変数の前に `OTEL_PYTHON_` を付けて設定できる Python 固有の設定オプションがいくつかあります。
+
+### 除外されるURL {#excluded-urls}
+
+カンマ区切りの正規表現で、すべての計装で除外するURLを表します。
+
+- `OTEL_PYTHON_EXCLUDED_URLS`
+
+変数 `OTEL_PYTHON_<library>_EXCLUDED_URLS` を使って、特定の計装の URL を除外することもできます。
+ここで `library` は Django、Falcon、FastAPI、Flask、Pyramid、Requests、Starlette、Tornado、urllib、 urllib3 のいずれかのライブラリ名を大文字化したものです。
+
+例を挙げましょう。
+
+```sh
+export OTEL_PYTHON_EXCLUDED_URLS="client/.*/info,healthcheck"
+export OTEL_PYTHON_URLLIB3_EXCLUDED_URLS="client/.*/info"
+export OTEL_PYTHON_REQUESTS_EXCLUDED_URLS="healthcheck"
+```
+
+### リクエスト属性名 {#request-attribute-names}
+
+リクエストオブジェクトから抽出され、スパンの属性として設定される名前のカンマ区切りリスト。
+
+- `OTEL_PYTHON_DJANGO_TRACED_REQUEST_ATTRS`
+- `OTEL_PYTHON_FALCON_TRACED_REQUEST_ATTRS`
+- `OTEL_PYTHON_TORNADO_TRACED_REQUEST_ATTRS`
+
+例を挙げましょう。
+
+```sh
+export OTEL_PYTHON_DJANGO_TRACED_REQUEST_ATTRS='path_info,content_type'
+export OTEL_PYTHON_FALCON_TRACED_REQUEST_ATTRS='query_string,uri_template'
+export OTEL_PYTHON_TORNADO_TRACED_REQUEST_ATTRS='uri,query'
+```
+
+### ロギング {#logging}
+
+出力されるログを制御するための設定オプションがいくつかあります。
+
+- `OTEL_PYTHON_LOG_CORRELATION`: ログへのトレースコンテキストの注入を有効にする (true、false)。
+- `OTEL_PYTHON_LOG_FORMAT`: カスタムログフォーマットを使うように設定します。
+- `OTEL_PYTHON_LOG_LEVEL`: カスタムのログレベル (情報、エラー、デバッグ、警告) を設定します。
+- `OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED`: ログの自動計装を有効にします。
+  Pythonルートロガーに OTLP ハンドラーをアタッチします。
+  例については、[ログの自動計装](/docs/zero-code/python/logs-example/) を参照してください。
+
+例を挙げましょう。
+
+```sh
+export OTEL_PYTHON_LOG_CORRELATION=true
+export OTEL_PYTHON_LOG_FORMAT="%(msg)s [span_id=%(span_id)s]"
+export OTEL_PYTHON_LOG_LEVEL=debug
+export OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
+```
+
+### その他 {#other}
+
+特定のカテゴリーに分類されない設定オプションもいくつかあります。
+
+- `OTEL_PYTHON_DJANGO_INSTRUMENT`: Django 計装のデフォルトの有効状態を無効にするために `false` を設定します。
+- `OTEL_PYTHON_ELASTICSEARCH_NAME_PREFIX`: Elasticsearch の操作名のデフォルトのプレフィックスを "Elasticsearch" からここで設定したものに変更します。
+- `OTEL_PYTHON_GRPC_EXCLUDED_SERVICES`: gRPC 計装から除外するサービスをカンマ区切りで指定します。
+- `OTEL_PYTHON_ID_GENERATOR`: グローバルトレーサプロバイダーに使用する ID ジェネレータを指定します。
+- `OTEL_PYTHON_INSTRUMENTATION_SANITIZE_REDIS`: クエリーのサニタイズ処理を有効にします。
+
+例を挙げましょう。
+
+```sh
+export OTEL_PYTHON_DJANGO_INSTRUMENT=false
+export OTEL_PYTHON_ELASTICSEARCH_NAME_PREFIX=my-custom-prefix
+export OTEL_PYTHON_GRPC_EXCLUDED_SERVICES="GRPCTestServer,GRPCHealthServer"
+export OTEL_PYTHON_ID_GENERATOR=xray
+export OTEL_PYTHON_INSTRUMENTATION_SANITIZE_REDIS=true
+```
+
+## 特定の計装を無効にする {#disabling-specific-instrumentations}
+
+デフォルトのPythonエージェントは、Pythonプログラムのパッケージを検出し、可能な限りのパッケージを計装します。
+これは計装を簡単にしますが、結果的にデータが多すぎたり、不要になったりすることがあります。
+
+`OTEL_PYTHON_DISABLED_INSTRUMENTATIONS` 環境変数を使うことで、特定のパッケージを計装から除外できます。
+この環境変数には、計装から除外する計装のエントリーポイント名をカンマ区切りで指定します。
+ほとんどの場合、エントリーポイント名はパッケージ名と同じで、パッケージの `pyproject.toml` ファイル内の `project.entry-points.opentelemetry_instrumentor` テーブルに設定されます。
+
+たとえば、Python プログラムが `redis`、`kafka-python`、`grpc` パッケージを使用している場合、デフォルトではエージェントは `opentelemetry-instrumentation-redis`、`opentelemetry-instrumentation-kafka-python`、`opentelemetry-instrumentation-grpc` パッケージを使用して計装を行います。
+これを無効にするには、`OTEL_PYTHON_DISABLED_INSTRUMENTATIONS=redis,kafka,grpc_client` を設定します。
+

--- a/content/ja/docs/zero-code/python/configuration.md
+++ b/content/ja/docs/zero-code/python/configuration.md
@@ -2,9 +2,6 @@
 title: エージェント設定
 linkTitle: Configuration
 weight: 10
-aliases:
-- /docs/languages/python/automatic/configuration
-- /docs/languages/python/automatic/agent-config
 cSpell: ignore: healthcheck instrumentor myapp pyproject Starlette urllib
 default_lang_commit: 3d737b777f7bfa070f7f14835570add916d4dcb0
 ---

--- a/content/ja/docs/zero-code/python/configuration.md
+++ b/content/ja/docs/zero-code/python/configuration.md
@@ -9,7 +9,6 @@ cSpell: ignore: healthcheck instrumentor myapp pyproject Starlette urllib
 default_lang_commit: 3d737b777f7bfa070f7f14835570add916d4dcb0
 ---
 
-
 エージェントは次のいずれかの方法で高度に設定可能です。
 
 - CLIから設定プロパティを渡す
@@ -44,7 +43,6 @@ opentelemetry-instrument \
   省略した場合は、デフォルトの [コレクター](/docs/collector/) のエンドポイントが使用され、gRPC の場合は `0.0.0.0:4317`、HTTP の場合は `0.0.0.0:4318` となります。
 - `exporter_otlp_headers`は、選択したオブザーバビリティバックエンドに応じて必要となります。
   OTLPエクスポーターヘッダーの詳細については、[OTEL_EXPORTER_OTLP_HEADERS](/docs/languages/sdk-configuration/otlp-exporter/#otel_exporter_otlp_headers)を参照してください。
-
 
 ## 環境変数 {#environment-variables}
 
@@ -146,4 +144,3 @@ export OTEL_PYTHON_INSTRUMENTATION_SANITIZE_REDIS=true
 
 たとえば、Python プログラムが `redis`、`kafka-python`、`grpc` パッケージを使用している場合、デフォルトではエージェントは `opentelemetry-instrumentation-redis`、`opentelemetry-instrumentation-kafka-python`、`opentelemetry-instrumentation-grpc` パッケージを使用して計装を行います。
 これを無効にするには、`OTEL_PYTHON_DISABLED_INSTRUMENTATIONS=redis,kafka,grpc_client` を設定します。
-

--- a/content/ja/docs/zero-code/python/configuration.md
+++ b/content/ja/docs/zero-code/python/configuration.md
@@ -2,7 +2,6 @@
 title: エージェント設定
 linkTitle: Configuration
 weight: 10
-cSpell: ignore: healthcheck instrumentor myapp pyproject Starlette urllib
 default_lang_commit: 3d737b777f7bfa070f7f14835570add916d4dcb0
 ---
 

--- a/content/ja/docs/zero-code/python/example.md
+++ b/content/ja/docs/zero-code/python/example.md
@@ -2,7 +2,6 @@
 title: 自動計装の例
 linkTitle: Example
 weight: 20
-cSpell: ignore: distro instrumentor mkdir MSIE Referer Starlette venv
 default_lang_commit: 3d737b777f7bfa070f7f14835570add916d4dcb0
 ---
 

--- a/content/ja/docs/zero-code/python/example.md
+++ b/content/ja/docs/zero-code/python/example.md
@@ -1,0 +1,330 @@
+---
+title: 自動計装の例
+linkTitle: Example
+weight: 20
+aliases: [/docs/languages/python/automatic/example]
+cSpell: ignore: distro instrumentor mkdir MSIE Referer Starlette venv
+default_lang_commit: 3d737b777f7bfa070f7f14835570add916d4dcb0
+---
+
+このページでは、OpenTelemetry で Python 自動計装を使う方法を示します。
+この例は [OpenTracing の例][OpenTracing example] に基づいています。
+このページで使用されている [ソースファイル][source files] は `opentelemetry-python` リポジトリからダウンロードしたり閲覧できます。
+
+この例では、3つの異なるスクリプトを使用しています。
+それぞれの主な違いは、計装の方法です。
+
+1. `server_manual.py`は _手動_ で計装されます。
+2. `server_automatic.py` は _自動_ で計装されます。
+3. `server_programmatic.py` は _プログラム_ で計装されます。
+
+[_プログラムによる_ 計装](#execute-the-programmatically-instrumented-server)は、最小限の計装コードをアプリケーションに追加する必要のある計装の一種です。
+いくつかの計装ライブラリだけが、プログラム的に使用されるとき、計装プロセスをより大きく制御する追加機能を提供します。
+
+最初のスクリプトを自動計装エージェントなしで実行し、2番目のスクリプトをエージェントありで実行します。
+どちらも同じ結果が得られるはずで、自動計装エージェントが手動計装とまったく同じことを行うことを示しています。
+
+自動計装は、[計装ライブラリ][instrumentation]を通じて、実行時にメソッドやクラスを動的に書き換えるために、[モンキーパッチ][monkey-patching]を利用します。
+これにより、OpenTelemetry をアプリケーションコードに統合するのに必要な作業量を減らせます。
+以下に、手動、自動、プログラムで計装された Flask ルートの違いを示します。
+
+### 手動計測サーバー {#manually-instrumented-server}
+
+`server_manual.py`
+
+```python
+@app.route("/server_request")
+def server_request():
+    with tracer.start_as_current_span(
+        "server_request",
+        context=extract(request.headers),
+        kind=trace.SpanKind.SERVER,
+        attributes=collect_request_attributes(request.environ),
+    ):
+        print(request.args.get("param"))
+        return "served"
+```
+
+### 自動計装サーバー {#automatically-instrumented-server}
+
+`server_automatic.py`
+
+```python
+@app.route("/server_request")
+def server_request():
+    print(request.args.get("param"))
+    return "served"
+```
+
+### プログラム計測サーバー {#programmatically-instrumented-server}
+
+`server_programmatic.py`
+
+```python
+instrumentor = FlaskInstrumentor()
+
+app = Flask(__name__)
+
+instrumentor.instrument_app(app)
+# instrumentor.instrument_app(app, excluded_urls="/server_request")
+@app.route("/server_request")
+def server_request():
+    print(request.args.get("param"))
+    return "served"
+```
+
+## 準備 {#prepare}
+
+別の仮想環境で以下の例を実行します。
+以下のコマンドを実行して、自動計装の準備をします。
+
+```sh
+mkdir auto_instrumentation
+cd auto_instrumentation
+python -m venv venv
+source ./venv/bin/activate
+```
+
+## インストール {#install}
+
+以下のコマンドを実行して、適切なパッケージをインストールしてください。
+`opentelemetry-distro` パッケージは、カスタム計装用の `opentelemetry-sdk` や、プログラムを自動的に計装するためのいくつかのコマンドを提供する `opentelemetry-instrumentation` など、他のいくつかのパッケージに依存しています。
+
+```sh
+pip install opentelemetry-distro
+pip install flask requests
+```
+
+`opentelemetry-bootstrap` コマンドを実行します。
+
+```shell
+opentelemetry-bootstrap -a install
+```
+
+この後の例では、計装結果をコンソールに送信します。
+コレクターのような他の送信先にテレメトリーを送信するための [OpenTelemetry Distro](/docs/languages/python/distro) のインストールと設定については、こちらを参照してください。
+
+> **注**: `opentelemetry-instrument` による自動計装を使用するには、
+> 環境変数またはコマンドラインで設定する必要があります。
+> エージェントはテレメトリーパイプラインを作成するので、
+> これらの手段以外では変更できません。
+> テレメトリーパイプラインのカスタマイズが必要な場合は、エージェントを使用せず、
+> OpenTelemetry SDK と計装ライブラリをコードにインポートし、そこで設定する必要があります。
+> また、OpenTelemetry API をインポートすることで自動計装を拡張することもできます。
+> 詳細については、[API リファレンス][API reference] を参照してください。
+
+## 実行 {#execute}
+
+この節では、サーバーの計装を手動で行うプロセスと、自動的に計装されたサーバーを実行するプロセスについて説明します。
+
+### 手動で計測したサーバーを実行する {#execute-the-manually-instrumented-server}
+
+この例を構成するスクリプトをそれぞれ実行するために、2つの別々のコンソールでサーバーを実行します。
+
+```sh
+source ./venv/bin/activate
+python server_manual.py
+```
+
+```sh
+source ./venv/bin/activate
+python client.py testing
+```
+
+`server_manual.py` を実行しているコンソールは計装によって生成されたスパンをJSONとして表示します。
+スパンは以下の例のように表示されます。
+
+```json
+{
+  "name": "server_request",
+  "context": {
+    "trace_id": "0xfa002aad260b5f7110db674a9ddfcd23",
+    "span_id": "0x8b8bbaf3ca9c5131",
+    "trace_state": "{}"
+  },
+  "kind": "SpanKind.SERVER",
+  "parent_id": null,
+  "start_time": "2020-04-30T17:28:57.886397Z",
+  "end_time": "2020-04-30T17:28:57.886490Z",
+  "status": {
+    "status_code": "OK"
+  },
+  "attributes": {
+    "http.method": "GET",
+    "http.server_name": "127.0.0.1",
+    "http.scheme": "http",
+    "host.port": 8082,
+    "http.host": "localhost:8082",
+    "http.target": "/server_request?param=testing",
+    "net.peer.ip": "127.0.0.1",
+    "net.peer.port": 52872,
+    "http.flavor": "1.1"
+  },
+  "events": [],
+  "links": [],
+  "resource": {
+    "telemetry.sdk.language": "python",
+    "telemetry.sdk.name": "opentelemetry",
+    "telemetry.sdk.version": "0.16b1"
+  }
+}
+```
+
+### 自動計装サーバーの実行 {#execute-the-automatically-instrumented-server}
+
+<kbd>Control+C</kbd> を押して `server_manual.py` の実行を停止し、かわりに以下のコマンドを実行します。
+
+```sh
+opentelemetry-instrument --traces_exporter console --metrics_exporter none --logs_exporter none python server_automatic.py
+```
+
+以前 `client.py` を実行したコンソールで、もう一度以下のコマンドを実行します。
+
+```sh
+python client.py testing
+```
+
+`server_automatic.py` を実行しているコンソールは計装によって生成されたスパンを JSON として表示します。
+スパンは以下の例のように表示されます。
+
+```json
+{
+  "name": "server_request",
+  "context": {
+    "trace_id": "0x9f528e0b76189f539d9c21b1a7a2fc24",
+    "span_id": "0xd79760685cd4c269",
+    "trace_state": "{}"
+  },
+  "kind": "SpanKind.SERVER",
+  "parent_id": "0xb4fb7eee22ef78e4",
+  "start_time": "2020-04-30T17:10:02.400604Z",
+  "end_time": "2020-04-30T17:10:02.401858Z",
+  "status": {
+    "status_code": "OK"
+  },
+  "attributes": {
+    "http.method": "GET",
+    "http.server_name": "127.0.0.1",
+    "http.scheme": "http",
+    "host.port": 8082,
+    "http.host": "localhost:8082",
+    "http.target": "/server_request?param=testing",
+    "net.peer.ip": "127.0.0.1",
+    "net.peer.port": 48240,
+    "http.flavor": "1.1",
+    "http.route": "/server_request",
+    "http.status_text": "OK",
+    "http.status_code": 200
+  },
+  "events": [],
+  "links": [],
+  "resource": {
+    "telemetry.sdk.language": "python",
+    "telemetry.sdk.name": "opentelemetry",
+    "telemetry.sdk.version": "0.16b1",
+    "service.name": ""
+  }
+}
+```
+
+自動計装は手動計測とまったく同じことをするので、両方の出力が同じであることがわかります。
+
+### プログラムで計装されたサーバーを実行する {#execute-the-programmatically-instrumented-server}
+
+計装ライブラリ（`opentelemetry-instrumentation-flask` など）を単独で使うことも可能で、オプションをカスタマイズできるという利点があります。
+しかし、これを選択することは、 `opentelemetry-instrument` を使ってアプリケーションを起動することによる自動計装を見送ることを意味します。
+
+手動計装の場合と同じように、2つの別々のコンソールでサーバーを実行します。
+
+```sh
+source ./venv/bin/activate
+python server_programmatic.py
+```
+
+```sh
+source ./venv/bin/activate
+python client.py testing
+```
+
+結果は、手動の計装を使った場合と同じになるはずです。
+
+#### プログラムによる計装機能の使用 {#using-programmatic-instrumentation-features}
+
+計装ライブラリの中には、プログラムで計装を行う際に、より精密な制御を可能にする機能を備えているものがあり、Flask用の計装ライブラリもその1つです。
+
+この例にはコメントアウトされた行があるので、次のように変更してください。
+
+```python
+# instrumentor.instrument_app(app)
+instrumentor.instrument_app(app, excluded_urls="/server_request")
+```
+
+この例を再度実行すると、サーバー側には計装が表示されなくなります。
+これは `instrument_app` に渡された `excluded_urls` オプションのためで、`server_request` 関数の URL が `excluded_urls` に渡された正規表現にマッチするため、効果的に計装が行われなくなります。
+
+### デバッグ中の計装 {#instrumentation-while-debugging}
+
+デバッグモードは、Flaskアプリで次のように有効にできます。
+
+```python
+if __name__ == "__main__":
+    app.run(port=8082, debug=True)
+```
+
+デバッグモードはリローダを有効にするため、計装を中断させることがあります。
+デバッグモードが有効なときに計装を実行するには、 `use_reloader` オプションを `False` に設定します。
+
+```python
+if __name__ == "__main__":
+    app.run(port=8082, debug=True, use_reloader=False)
+```
+
+## 設定 {#configure}
+
+自動計装は、環境変数から設定を読み込めます。
+
+### HTTP リクエストとレスポンスヘッダーをキャプチャする {#capture-http-request-and-response-headers}
+
+[セマンティック規約][semantic convention]にしたがって、定義済みのHTTPヘッダーをスパン属性として取り込めます。
+
+どのHTTPヘッダーをキャプチャしたいかを定義するには、HTTPヘッダー名のカンマ区切りのリストを環境変数 `OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST` と `OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE` で指定します。
+
+例えば次のように行います。
+
+```sh
+export OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST="Accept-Encoding,User-Agent,Referer"
+export OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE="Last-Modified,Content-Type"
+opentelemetry-instrument --traces_exporter console --metrics_exporter none --logs_exporter none python app.py
+```
+
+これらの設定オプションは、以下のHTTP計装でサポートされています。
+
+- Django
+- Falcon
+- FastAPI
+- Pyramid
+- Starlette
+- Tornado
+- WSGI
+
+これらのヘッダーが利用可能であれば、それらはあなたのスパンに含まれます。
+
+```json
+{
+  "attributes": {
+    "http.request.header.user-agent": [
+      "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0)"
+    ],
+    "http.request.header.accept_encoding": ["gzip, deflate, br"],
+    "http.response.header.last_modified": ["2022-04-20 17:07:13.075765"],
+    "http.response.header.content_type": ["text/html; charset=utf-8"]
+  }
+}
+```
+
+[semantic convention]: /docs/specs/semconv/http/http-spans/
+[api reference]: https://opentelemetry-python.readthedocs.io/en/latest/index.html
+[instrumentation]: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-instrumentation
+[monkey-patching]: https://stackoverflow.com/questions/5626193/what-is-monkey-patching
+[opentracing example]: https://github.com/yurishkuro/opentracing-tutorial/tree/master/python
+[source files]: https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples/auto-instrumentation

--- a/content/ja/docs/zero-code/python/example.md
+++ b/content/ja/docs/zero-code/python/example.md
@@ -2,7 +2,6 @@
 title: 自動計装の例
 linkTitle: Example
 weight: 20
-aliases: [/docs/languages/python/automatic/example]
 cSpell: ignore: distro instrumentor mkdir MSIE Referer Starlette venv
 default_lang_commit: 3d737b777f7bfa070f7f14835570add916d4dcb0
 ---

--- a/content/ja/docs/zero-code/python/example.md
+++ b/content/ja/docs/zero-code/python/example.md
@@ -287,7 +287,7 @@ if __name__ == "__main__":
 
 どのHTTPヘッダーをキャプチャしたいかを定義するには、HTTPヘッダー名のカンマ区切りのリストを環境変数 `OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST` と `OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE` で指定します。
 
-例えば次のように行います。
+たとえば次のように行います。
 
 ```sh
 export OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST="Accept-Encoding,User-Agent,Referer"

--- a/content/ja/docs/zero-code/python/logs-example.md
+++ b/content/ja/docs/zero-code/python/logs-example.md
@@ -71,8 +71,6 @@ pip install opentelemetry-exporter-otlp
 この後の例では、計装結果をコンソールに送信します。
 コレクターのような他の送信先にテレメトリーを送信するための [OpenTelemetry Distro](/docs/languages/python/distro) のインストールと設定については、ドキュメントを参照してください。
 
-The examples that follow send instrumentation results to the console. Learn more about installing and configuring the [OpenTelemetry Distro](/docs/languages/python/distro) to send telemetry to other destinations, like an OpenTelemetry Collector.
-
 > **注**: `opentelemetry-instrument`による自動計装を使用するには、
 > 環境変数またはコマンドラインで設定する必要があります。
 > エージェントはテレメトリーパイプラインを作成するので、これらの手段以外では変更できません。

--- a/content/ja/docs/zero-code/python/logs-example.md
+++ b/content/ja/docs/zero-code/python/logs-example.md
@@ -2,7 +2,6 @@
 title: ログ自動計装の例
 linkTitle: Logs Example
 weight: 20
-cSpell: ignore: distro mkdir virtualenv
 default_lang_commit: 3d737b777f7bfa070f7f14835570add916d4dcb0
 ---
 

--- a/content/ja/docs/zero-code/python/logs-example.md
+++ b/content/ja/docs/zero-code/python/logs-example.md
@@ -1,0 +1,162 @@
+---
+title: ログ自動計装の例
+linkTitle: Logs Example
+weight: 20
+aliases: [/docs/languages/python/automatic/logs-example]
+cSpell: ignore: distro mkdir virtualenv
+default_lang_commit: 3d737b777f7bfa070f7f14835570add916d4dcb0
+---
+
+このページでは、OpenTelemetry で Python ログを自動計装する方法を説明します。
+
+トレースやメトリクスとは異なり、同等のLogs APIはありません。
+あるのはSDKだけです。
+Python の場合は、Python の `logger` ライブラリを使用し、OTel SDK がルートロガーに OTLP ハンドラーをアタッチし、Python ロガーを OTLP ロガーに変えます。
+これを実現する1つの方法は、[OpenTelemetry Python リポジトリ][OpenTelemetry Python repository]のログの例で文書化されています。
+
+これを実現するもう1つの方法は、Pythonがログの自動計装をサポートすることです。
+以下の例は、[OpenTelemetry Python リポジトリ][OpenTelemetry Python repository]のログの例に基づいています。
+
+> しかし、アプリケーション開発者がログを作成するために使用するものではないので、トレースおよびメトリクスAPIとは異なります。
+> かわりに、このブリッジAPIを使用して、標準の言語固有のロギングライブラリでログアペンダーをセットアップします。
+> 詳細については、[Logs API](/docs/specs/otel/logs/api/) を参照のこと。
+
+まずexamplesディレクトリとexample Pythonファイルを作成します。
+
+```sh
+mkdir python-logs-example
+cd python-logs-example
+touch example.py
+```
+
+以下の内容を `example.py` に貼り付けます。
+
+```python
+import logging
+
+from opentelemetry import trace
+
+tracer = trace.get_tracer_provider().get_tracer(__name__)
+
+# トレースコンテキストの相関
+with tracer.start_as_current_span("foo"):
+    # なにかする
+    current_span = trace.get_current_span()
+    current_span.add_event("This is a span event")
+    logging.getLogger().error("This is a log message")
+```
+
+[otel-collector-config.yaml](https://github.com/open-telemetry/opentelemetry-python/blob/main/docs/examples/logs/otel-collector-config.yaml)のサンプルを開いてコピーし、`python-logs-example/otel-collector-config.yaml`に保存します。
+
+
+## 準備 {#prepare}
+
+以下の例を実行します。
+その際、仮想環境を使用することを推奨します。
+以下のコマンドを実行し、ログの自動計装の準備をします。
+
+```sh
+mkdir python_logs_example
+virtualenv python_logs_example
+source python_logs_example/bin/activate
+```
+
+## インストール {#install}
+
+以下のコマンドは適切なパッケージをインストールします。
+`opentelemetry-distro` パッケージは、独自のコードをカスタム計装するための `opentelemetry-sdk` や、プログラムを自動的に計装するためのいくつかのコマンドを提供する `opentelemetry-instrumentation` など、他のいくつかのパッケージに依存しています。
+
+```sh
+pip install opentelemetry-distro
+pip install opentelemetry-exporter-otlp
+```
+
+この後の例では、計装結果をコンソールに送信します。
+コレクターのような他の送信先にテレメトリーを送信するための [OpenTelemetry Distro](/docs/languages/python/distro) のインストールと設定については、ドキュメントを参照してください。
+
+The examples that follow send instrumentation results to the console. Learn more about installing and configuring the [OpenTelemetry Distro](/docs/languages/python/distro) to send telemetry to other destinations, like an OpenTelemetry Collector.
+
+> **注**: `opentelemetry-instrument`による自動計装を使用するには、
+> 環境変数またはコマンドラインで設定する必要があります。
+> エージェントはテレメトリーパイプラインを作成するので、これらの手段以外では変更できません。
+> テレメトリーパイプラインのカスタマイズが必要な場合は、エージェントを使用せず、 OpenTelemetry SDK と計装ライブラリをコードにインポートし、そこで設定する必要があります。
+> また、OpenTelemetry API をインポートすることで > 自動計装を拡張することもできます。
+> 詳細については、[API リファレンス][API reference] を参照してください。
+
+## 実行 {#execute}
+
+この節は、自動計装されたログを実行する手順を説明します。
+
+新しいターミナルウィンドウを開き、コレクターを起動します。
+
+```sh
+docker run -it --rm -p 4317:4317 -p 4318:4318 \
+  -v $(pwd)/otel-collector-config.yaml:/etc/otelcol-config.yml \
+  --name otelcol \
+  otel/opentelemetry-collector-contrib:0.76.1 \
+  "--config=/etc/otelcol-config.yml"
+```
+
+別のターミナルを開き、Pythonプログラムを実行します。
+
+```sh
+source python_logs_example/bin/activate
+
+export OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
+opentelemetry-instrument \
+  --traces_exporter console,otlp \
+  --metrics_exporter console,otlp \
+  --logs_exporter console,otlp \
+  --service_name python-logs-example \
+  python $(pwd)/example.py
+```
+
+サンプル出力は次のとおりです。
+
+```text
+...
+ScopeSpans #0
+ScopeSpans SchemaURL:
+InstrumentationScope __main__
+Span #0
+    Trace ID       : 389d4ac130a390d3d99036f9cd1db75e
+    Parent ID      :
+    ID             : f318281c4654edc5
+    Name           : foo
+    Kind           : Internal
+    Start time     : 2023-08-18 17:04:05.982564 +0000 UTC
+    End time       : 2023-08-18 17:04:05.982667 +0000 UTC
+    Status code    : Unset
+    Status message :
+Events:
+SpanEvent #0
+     -> Name: This is a span event
+     -> Timestamp: 2023-08-18 17:04:05.982586 +0000 UTC
+
+...
+
+ScopeLogs #0
+ScopeLogs SchemaURL:
+InstrumentationScope opentelemetry.sdk._logs._internal
+LogRecord #0
+ObservedTimestamp: 1970-01-01 00:00:00 +0000 UTC
+Timestamp: 2023-08-18 17:04:05.982605056 +0000 UTC
+SeverityText: ERROR
+SeverityNumber: Error(17)
+Body: Str(This is a log message)
+Attributes:
+     -> otelSpanID: Str(f318281c4654edc5)
+     -> otelTraceID: Str(389d4ac130a390d3d99036f9cd1db75e)
+     -> otelTraceSampled: Bool(true)
+     -> otelServiceName: Str(python-logs-example)
+Trace ID: 389d4ac130a390d3d99036f9cd1db75e
+Span ID: f318281c4654edc5
+...
+```
+
+Span イベントとログの両方が同じ SpanID（`f318281c4654edc5`）を持つことに注意してください。
+ロギングSDKは、テレメトリーを相関させる能力を向上させるために、ログに記録されたイベントに現在のスパンのSpanIDを追加します。
+
+[api reference]: https://opentelemetry-python.readthedocs.io/en/latest/index.html
+[OpenTelemetry Python repository]: https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples/logs
+

--- a/content/ja/docs/zero-code/python/logs-example.md
+++ b/content/ja/docs/zero-code/python/logs-example.md
@@ -48,7 +48,6 @@ with tracer.start_as_current_span("foo"):
 
 [otel-collector-config.yaml](https://github.com/open-telemetry/opentelemetry-python/blob/main/docs/examples/logs/otel-collector-config.yaml)のサンプルを開いてコピーし、`python-logs-example/otel-collector-config.yaml`に保存します。
 
-
 ## 準備 {#prepare}
 
 以下の例を実行します。
@@ -159,4 +158,3 @@ Span イベントとログの両方が同じ SpanID（`f318281c4654edc5`）を�
 
 [api reference]: https://opentelemetry-python.readthedocs.io/en/latest/index.html
 [OpenTelemetry Python repository]: https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples/logs
-

--- a/content/ja/docs/zero-code/python/logs-example.md
+++ b/content/ja/docs/zero-code/python/logs-example.md
@@ -2,7 +2,6 @@
 title: ログ自動計装の例
 linkTitle: Logs Example
 weight: 20
-aliases: [/docs/languages/python/automatic/logs-example]
 cSpell: ignore: distro mkdir virtualenv
 default_lang_commit: 3d737b777f7bfa070f7f14835570add916d4dcb0
 ---

--- a/content/ja/docs/zero-code/python/operator.md
+++ b/content/ja/docs/zero-code/python/operator.md
@@ -1,0 +1,33 @@
+---
+title: OpenTelemetryオペレーターを使用して自動計装を注入する
+linkTitle: Operator
+weight: 30
+cSpell:ignore: grpcio myapp psutil PYTHONPATH
+default_lang_commit: 3d737b777f7bfa070f7f14835570add916d4dcb0
+---
+
+
+KubernetesでPythonサービスを実行する場合、[OpenTelemetryオペレーター](https://github.com/open-telemetry/opentelemetry-operator)を活用することで、各サービスを直接修正することなく自動計装を注入できます。
+[詳細はOpenTelemetryオペレーターによる自動計装のドキュメントを参照してください](/docs/platforms/kubernetes/operator/automatic/)
+
+### Python 固有のトピック {#python-specific-topics}
+
+#### バイナリwheel付きライブラリ {#libraries-with-binary-wheels}
+
+私たちが計装を行ったり、計装ライブラリで必要とするPythonのパッケージの中には、バイナリコードが同梱されていることがあります。
+たとえば、`grpcio` や `psutil` (`opentelemetry-instrumentation-system-metrics` で使われている) がそうです。
+
+バイナリコードは、特定のCライブラリのバージョン（glibcまたはmusl）と特定のPythonのバージョンに関連付けられています。
+[OpenTelemetryオペレーター](https://github.com/open-telemetry/opentelemetry-operator)は、glibc Cライブラリに基づいた単一のPythonバージョン用のイメージを提供します。
+もしこれを使いたいのであれば、Python自動計装用のオペレーターDockerイメージを自分で構築する必要があるかもしれません。
+you might need to build your own image operator Docker image for Python auto-instrumentation.
+
+オペレーター v0.113.0以降、glibcとmuslベースの自動計装の両方を持つイメージをビルドし、[実行時に設定する](/docs/platforms/kubernetes/operator/automatic/#annotations-python-musl)ことが可能です。
+
+#### Django アプリケーション {#django-applications}
+
+Django のように独自の実行ファイルから実行されるアプリケーションでは、デプロイファイルに2つの環境変数を設定する必要があります。
+
+- `PYTHONPATH` には Django アプリケーションのルートディレクトリへのパスを指定します（例: "/app"）。
+- `DJANGO_SETTINGS_MODULE` に Django 設定モジュールの名前を指定します（例: "myapp.settings"）。
+

--- a/content/ja/docs/zero-code/python/operator.md
+++ b/content/ja/docs/zero-code/python/operator.md
@@ -18,7 +18,6 @@ KubernetesでPythonサービスを実行する場合、[OpenTelemetryオペレ�
 バイナリコードは、特定のCライブラリのバージョン（glibcまたはmusl）と特定のPythonのバージョンに関連付けられています。
 [OpenTelemetryオペレーター](https://github.com/open-telemetry/opentelemetry-operator)は、glibc Cライブラリに基づいた単一のPythonバージョン用のイメージを提供します。
 もしこれを使いたいのであれば、Python自動計装用のオペレーターDockerイメージを自分で構築する必要があるかもしれません。
-you might need to build your own image operator Docker image for Python auto-instrumentation.
 
 オペレーター v0.113.0以降、glibcとmuslベースの自動計装の両方を持つイメージをビルドし、[実行時に設定する](/docs/platforms/kubernetes/operator/automatic/#annotations-python-musl)ことが可能です。
 

--- a/content/ja/docs/zero-code/python/operator.md
+++ b/content/ja/docs/zero-code/python/operator.md
@@ -2,10 +2,8 @@
 title: OpenTelemetryオペレーターを使用して自動計装を注入する
 linkTitle: Operator
 weight: 30
-cSpell:ignore: grpcio myapp psutil PYTHONPATH
 default_lang_commit: 3d737b777f7bfa070f7f14835570add916d4dcb0
 ---
-
 
 KubernetesでPythonサービスを実行する場合、[OpenTelemetryオペレーター](https://github.com/open-telemetry/opentelemetry-operator)を活用することで、各サービスを直接修正することなく自動計装を注入できます。
 [詳細はOpenTelemetryオペレーターによる自動計装のドキュメントを参照してください](/docs/platforms/kubernetes/operator/automatic/)
@@ -30,4 +28,3 @@ Django のように独自の実行ファイルから実行されるアプリケ�
 
 - `PYTHONPATH` には Django アプリケーションのルートディレクトリへのパスを指定します（例: "/app"）。
 - `DJANGO_SETTINGS_MODULE` に Django 設定モジュールの名前を指定します（例: "myapp.settings"）。
-

--- a/content/ja/docs/zero-code/python/troubleshooting.md
+++ b/content/ja/docs/zero-code/python/troubleshooting.md
@@ -1,0 +1,97 @@
+---
+title: Pythonの自動計装に関する問題のトラブルシューティング
+linkTitle: Troubleshooting
+weight: 40
+default_lang_commit: 3d737b777f7bfa070f7f14835570add916d4dcb0
+---
+
+## インストールに関する問題 {#installation-issues}
+
+### Python パッケージのインストール失敗 {#python-package-installation-failure}
+
+Pythonパッケージのインストールには `gcc` と `gcc-c++` が必要で、CentOSのようなスリムバージョンのLinuxを使用している場合はインストールする必要があるかもしれません。
+
+<!-- markdownlint-disable blanks-around-fences -->
+
+{{< tabpane text=true >}} {{% tab "CentOS" %}}
+
+```sh
+yum -y install python3-devel
+yum -y install gcc-c++
+```
+
+{{% /tab %}} {{% tab "Debian/Ubuntu" %}}
+
+```sh
+apt install -y python3-dev
+apt install -y build-essential
+```
+
+{{% /tab %}} {{% tab "Alpine" %}}
+
+```sh
+apk add python3-dev
+apk add build-base
+```
+
+{{% /tab %}} {{< /tabpane >}}
+
+### uv を使ったブートストラップ {#bootstrap-using-uv}
+
+[uv](https://docs.astral.sh/uv/)パッケージマネージャを使用しているときに `opentelemetry-bootstrap -a install` を実行すると、依存関係の設定がエラーになったり、予期しない結果になったりすることがあります。
+
+かわりに、OpenTelemetry 要件を動的に生成し、`uv` を使ってインストールできます。
+
+まず、適切なパッケージをインストール（またはプロジェクトファイルに追加して `uv sync` を実行）します。
+
+```sh
+uv pip install opentelemetry-distro opentelemetry-exporter-otlp
+```
+
+これで、自動計装をインストールできます。
+
+```sh
+uv run opentelemetry-bootstrap -a requirements | uv pip install --requirement -
+```
+
+最後に、 `uv run` を使用してアプリケーションを起動します（[エージェントの設定](/docs/zero-code/python/#configuring-the-agent)を参照してください）。
+
+```sh
+uv run opentelemetry-instrument python myapp.py
+```
+
+`uv sync` を実行したり、既存のパッケージを更新したりするたびに、自動計装を再インストールする必要があることに注意してください。
+そのため、ビルドパイプラインの一部としてインストールを行うことを推奨します。
+
+## 計装の問題 {#instrumentation-issues}
+
+### リローダによる Flask デバッグモードが計装を壊す {#flask-debug-mode-with-reloader-breaks-instrumentation}
+
+デバッグモードは、Flaskアプリで次のように有効にできます。
+
+```python
+if __name__ == "__main__":
+    app.run(port=8082, debug=True)
+```
+
+デバッグモードはリローダを有効にするため、計装を中断させることがあります。
+デバッグモードが有効なときに計装を実行するには、 `use_reloader` オプションを `False` に設定します。
+
+The debug mode can break instrumentation from happening because it enables a reloader. To run instrumentation while the debug mode is enabled, set the `use_reloader` option to `False`:
+
+```python
+if __name__ == "__main__":
+    app.run(port=8082, debug=True, use_reloader=False)
+```
+
+## 接続性の問題 {#connectivity-issues}
+
+### gRPCコネクティビティ {#grpc-connectivity}
+
+Python gRPC接続の問題をデバッグするには、以下のgRPCデバッグ環境変数を設定します。
+
+```sh
+export GRPC_VERBOSITY=debug
+export GRPC_TRACE=http,call_error,connectivity_state
+opentelemetry-instrument python YOUR_APP.py
+```

--- a/content/ja/docs/zero-code/python/troubleshooting.md
+++ b/content/ja/docs/zero-code/python/troubleshooting.md
@@ -77,8 +77,6 @@ if __name__ == "__main__":
 デバッグモードはリローダを有効にするため、計装を中断させることがあります。
 デバッグモードが有効なときに計装を実行するには、 `use_reloader` オプションを `False` に設定します。
 
-The debug mode can break instrumentation from happening because it enables a reloader. To run instrumentation while the debug mode is enabled, set the `use_reloader` option to `False`:
-
 ```python
 if __name__ == "__main__":
     app.run(port=8082, debug=True, use_reloader=False)


### PR DESCRIPTION
## Files

* _index.md
* configuration.md
* example.md
* logs-example.md
* troubleshooting.md
* operator.md

## Preview 

https://deploy-preview-7145--opentelemetry.netlify.app/ja/docs/zero-code/python/

## Original

https://opentelemetry.io/docs/zero-code/python/