### PR TITLE
Added faro receiver, faro exporter to registry

### DIFF
--- a/data/registry/collector-exporter-faro.yml
+++ b/data/registry/collector-exporter-faro.yml
@@ -1,0 +1,20 @@
+# cSpell:ignore faroexporter
+title: Faro Exporter
+registryType: exporter
+language: collector
+tags:
+  - go
+  - exporter
+  - faro
+  - collector
+license: Apache 2.0
+description: The OpenTelemetry Collector Exporter for Faro
+authors:
+  - name: OpenTelemetry Authors
+urls:
+  repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/faroexporter
+createdAt: 2025-06-19
+package:
+  registry: go-collector
+  name: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/faroexporter
+  version: v0.128.0

--- a/data/registry/collector-receiver-faro.yml
+++ b/data/registry/collector-receiver-faro.yml
@@ -1,0 +1,20 @@
+# cSpell:ignore faroreceiver
+title: Faro Receiver
+registryType: receiver
+language: collector
+tags:
+  - go
+  - receiver
+  - faro
+  - collector
+license: Apache 2.0
+description: The OpenTelemetry Collector Receiver for Faro
+authors:
+  - name: OpenTelemetry Authors
+urls:
+  repo: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/faroreceiver
+createdAt: 2025-06-19
+package:
+  registry: go-collector
+  name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/faroreceiver
+  version: v0.128.0

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -6203,6 +6203,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:34:30.806697-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/faroexporter": {
+    "StatusCode": 206,
+    "LastSeen": "2025-06-19T10:10:58.701250216Z"
+  },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/fileexporter": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:34:31.623458-05:00"
@@ -6662,6 +6666,10 @@
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/expvarreceiver": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:35:27.261154-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/faroreceiver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-06-19T10:11:18.238891535Z"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver": {
     "StatusCode": 206,
@@ -17199,6 +17207,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-09T10:47:18.18299-04:00"
   },
+  "https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/exporter/faroexporter": {
+    "StatusCode": 200,
+    "LastSeen": "2025-06-19T10:11:01.147293909Z"
+  },
   "https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter": {
     "StatusCode": 200,
     "LastSeen": "2024-08-09T10:47:23.770703-04:00"
@@ -17602,6 +17614,10 @@
   "https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver": {
     "StatusCode": 200,
     "LastSeen": "2024-08-09T10:55:07.309438-04:00"
+  },
+  "https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/faroreceiver": {
+    "StatusCode": 200,
+    "LastSeen": "2025-06-19T10:11:18.360124961Z"
   },
   "https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver": {
     "StatusCode": 200,


### PR DESCRIPTION
Faro receiver and faro exporter components were added to the opentelemetry collector contrib distribution:
https://github.com/open-telemetry/opentelemetry-collector-releases/pull/955
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/40822

Adding them to the registry

<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->
