### PR TITLE
Add New Relic Distribution (NRDOT)

### DIFF
--- a/data/ecosystem/distributions.yaml
+++ b/data/ecosystem/distributions.yaml
@@ -171,6 +171,10 @@
   url: https://github.com/DataDog/datadog-agent/tree/main/comp/otelcol
   docsUrl: https://docs.datadoghq.com/opentelemetry/setup/ddot_collector
   components: [Collector]
+- name: New Relic Distribution of the OpenTelemetry Collector (NRDOT)
+  url: https://github.com/newrelic/nrdot-collector-releases
+  docsUrl: https://docs.newrelic.com/docs/opentelemetry/nrdot/nrdot-collector/
+  components: [Collector]
 
 # OSS Collector Distros
 - name: OpenTelemetry Collector Core Distro

--- a/data/ecosystem/distributions.yaml
+++ b/data/ecosystem/distributions.yaml
@@ -1,4 +1,4 @@
-# cSpell:ignore Splunk AWS ADOT Grafana observIQ BindPlane RHOSDT RedHat Sumo Liatrio Lumigo Distro Dynatrace Datadog Contrib DDOT eBPF
+# cSpell:ignore Splunk AWS ADOT Grafana observIQ BindPlane RHOSDT RedHat Sumo Liatrio Lumigo Distro Dynatrace Datadog Contrib DDOT eBPF NRDOT
 - name: Splunk Distribution of OpenTelemetry Collector
   url: https://github.com/signalfx/splunk-otel-collector
   docsUrl: https://docs.splunk.com/observability/en/gdi/opentelemetry/opentelemetry.html

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -1683,6 +1683,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-02-01T06:38:32.230398-05:00"
   },
+  "https://docs.newrelic.com/docs/opentelemetry/nrdot/nrdot-collector/": {
+    "StatusCode": 206,
+    "LastSeen": "2025-06-19T11:34:02.818605+01:00"
+  },
   "https://docs.nxlog.co/agent/current/im/otel.html": {
     "StatusCode": 200,
     "LastSeen": "2024-12-04T08:47:08.501353757Z"
@@ -5402,6 +5406,10 @@
   "https://github.com/nemoshlag": {
     "StatusCode": 206,
     "LastSeen": "2025-01-13T12:11:32.489901-05:00"
+  },
+  "https://github.com/newrelic/nrdot-collector-releases": {
+    "StatusCode": 206,
+    "LastSeen": "2025-06-19T11:34:31.186395+01:00"
   },
   "https://github.com/nginxinc": {
     "StatusCode": 206,


### PR DESCRIPTION
Adds New Relic Distribution of the OpenTelemetry Collector (NRDOT) to the list of distributions on the website.
