### PR TITLE
Fix TypeError in Python getting-started.md

### DIFF
--- a/content/en/docs/languages/python/getting-started.md
+++ b/content/en/docs/languages/python/getting-started.md
@@ -461,7 +461,7 @@ def roll_dice():
         # This adds 1 to the counter for the given roll value
         roll_counter.add(1, {"roll.value": result})
         if player:
-            logger.warn("{} is rolling the dice: {}", player, result)
+            logger.warn("%s is rolling the dice: %s", player, result)
         else:
             logger.warn("Anonymous player is rolling the dice: %s", result)
         return result


### PR DESCRIPTION
The code under the [Metrics section of Python getting-started.md](https://github.com/open-telemetry/opentelemetry.io/blob/748555c22f43476291ae0c7974ca4a2577da0472/content/en/docs/languages/python/getting-started.md#metrics) fails with the following traceback when the "player" query parameter is specified and not empty:

```
Traceback (most recent call last):
  File \"/Users/jl-martins/Projects/otel-python-getting-started/.venv/lib/python3.13/site-packages/flask/app.py\", line 1511, in wsgi_app
    response = self.full_dispatch_request()
  File \"/Users/jl-martins/Projects/otel-python-getting-started/.venv/lib/python3.13/site-packages/flask/app.py\", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File \"/Users/jl-martins/Projects/otel-python-getting-started/.venv/lib/python3.13/site-packages/flask/app.py\", line 917, in full_dispatch_request
    rv = self.dispatch_request()
  File \"/Users/jl-martins/Projects/otel-python-getting-started/.venv/lib/python3.13/site-packages/flask/app.py\", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File \"/Users/jl-martins/Projects/otel-python-getting-started/app.py\", line 22, in roll_dice
    return str(roll())
               ~~~~^^
  File \"/Users/jl-martins/Projects/otel-python-getting-started/app.py\", line 33, in roll
    logger.info(\"{} is rolling the dice: {}\", player, result)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/Users/jl-martins/.local/share/mise/installs/python/3.13.5/lib/python3.13/logging/__init__.py\", line 1522, in info
    self._log(INFO, msg, args, **kwargs)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/Users/jl-martins/.local/share/mise/installs/python/3.13.5/lib/python3.13/logging/__init__.py\", line 1667, in _log
    self.handle(record)
    ~~~~~~~~~~~^^^^^^^^
  File \"/Users/jl-martins/.local/share/mise/installs/python/3.13.5/lib/python3.13/logging/__init__.py\", line 1686, in handle
    self.callHandlers(record)
    ~~~~~~~~~~~~~~~~~^^^^^^^^
  File \"/Users/jl-martins/.local/share/mise/installs/python/3.13.5/lib/python3.13/logging/__init__.py\", line 1744, in callHandlers
    hdlr.handle(record)
    ~~~~~~~~~~~^^^^^^^^
  File \"/Users/jl-martins/.local/share/mise/installs/python/3.13.5/lib/python3.13/logging/__init__.py\", line 1027, in handle
    self.emit(record)
    ~~~~~~~~~^^^^^^^^
  File \"/Users/jl-martins/Projects/otel-python-getting-started/.venv/lib/python3.13/site-packages/opentelemetry/sdk/_logs/_internal/__init__.py\", line 569, in emit
    logger.emit(self._translate(record))
                ~~~~~~~~~~~~~~~^^^^^^^^
  File \"/Users/jl-martins/Projects/otel-python-getting-started/.venv/lib/python3.13/site-packages/opentelemetry/sdk/_logs/_internal/__init__.py\", line 539, in _translate
    body = record.getMessage()
  File \"/Users/jl-martins/.local/share/mise/installs/python/3.13.5/lib/python3.13/logging/__init__.py\", line 400, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: not all arguments converted during string formatting
```

This happens because "{}" is not a valid format specifier as of [Python 3.13 logging](https://docs.python.org/3.13/library/logging.html).

The closest format supported by the standard logging library is that of [str.format](https://docs.python.org/3.13/library/stdtypes.html#str.format), however, the other log statements in this guide are using % formatting, so this PR fixes the aforementioned error by using % formatting, for the sake of consistency.