### PR TITLE
Update minimum Ruby version

### DIFF
--- a/content/en/docs/languages/ruby/getting-started.md
+++ b/content/en/docs/languages/ruby/getting-started.md
@@ -15,7 +15,7 @@ You will learn how you can instrument a simple application, in such a way that
 
 Ensure that you have the following installed locally:
 
-- CRuby >= `3.0`, JRuby >= `9.3.2.0`, or TruffleRuby >= `22.1`
+- CRuby >= `3.1`, JRuby >= `9.3.2.0`, or TruffleRuby >= `22.1`
 - [Bundler](https://bundler.io/)
 
 {{% alert  title="Warning" color="warning" %}} While tested, support for `jruby`


### PR DESCRIPTION
Support for Ruby 3.0 was dropped from the latest versions of the gems earlier this year.