### PR TITLE
Add X-Frame-Options options.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -19,3 +19,11 @@ force = true
   for = "/schemas/:version"
   [headers.values]
     content-type = "application/yaml"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    X-Frame-Options = "SAMEORIGIN"
+    Content-Security-Policy = "frame-ancestors 'self';"


### PR DESCRIPTION
Add X-Frame-Options to prevent embedded iframes from rendering opentelemetry.io and manipulating our clicks or events.
