### PR TITLE
[fr] translation for docs "getting started"

### DIFF
--- a/content/fr/docs/concepts/instrumentation/zero-code/index.md
+++ b/content/fr/docs/concepts/instrumentation/zero-code/index.md
@@ -1,39 +1,44 @@
 ---
 title: Instrumentation Zero-code
 description: >-
-  Apprenez comment ajouter l'observabilité à une application sans avoir besoin d'écrire du code
+  Apprenez comment ajouter l'observabilité à une application sans avoir besoin
+  d'écrire du code
 weight: 10
 aliases: [automatic]
 ---
 
-En tant qu'[Ops](/docs/getting-started/ops/) vous pourriez vouloir ajouter l'observabilité à une
-ou plusieurs applications sans avoir à modifier le code source. OpenTelemetry vous permet
-d'obtenir rapidement un certain degré d'observabilité pour un service sans avoir à utiliser l'API et le SDK
-d'OpenTelemetry pour l'[instrumentation avec du code](/docs/concepts/instrumentation/code-based).
+En tant qu'[Ops](/docs/getting-started/ops/) vous pourriez vouloir ajouter
+l'observabilité à une ou plusieurs applications sans avoir à modifier le code
+source. OpenTelemetry vous permet d'obtenir rapidement un certain degré
+d'observabilité pour un service sans avoir à utiliser l'API et le SDK
+d'OpenTelemetry pour
+l'[instrumentation avec du code](/docs/concepts/instrumentation/code-based).
 
 ![Zero Code](./zero-code.svg)
 
-L'instrumentation Zero-code ajoute les capacités de l'API et du SDK OpenTelemetry
-à votre application, généralement à l'aide d'un agent ou d'un concept similaire. Les mécanismes
-spécifiques impliqués peuvent différer selon le langage de programmation, allant de la manipulation de bytecode,
-du monkey patching, ou d'eBPF pour injecter des appels à l'API et au SDK OpenTelemetry dans
-votre application.
+L'instrumentation Zero-code ajoute les capacités de l'API et du SDK
+OpenTelemetry à votre application, généralement à l'aide d'un agent ou d'un
+concept similaire. Les mécanismes spécifiques impliqués peuvent différer selon
+le langage de programmation, allant de la manipulation de bytecode, du monkey
+patching, ou d'eBPF pour injecter des appels à l'API et au SDK OpenTelemetry
+dans votre application.
 
-Typiquement, l'instrumentation Zero-code ajoute une instrumentation pour les bibliothèques
-que vous utilisez. Cela signifie que les requêtes et réponses, les appels aux bases de données, les appels
-de file d'attente de messages, et autres, sont instrumentés. Le code de votre application,
-cependant, n'est généralement pas instrumenté. Pour instrumenter votre code, vous devrez
-utiliser l'[instrumentation avec du code](/docs/concepts/instrumentation/code-based).
+Typiquement, l'instrumentation Zero-code ajoute une instrumentation pour les
+bibliothèques que vous utilisez. Cela signifie que les requêtes et réponses, les
+appels aux bases de données, les appels de file d'attente de messages, et
+autres, sont instrumentés. Le code de votre application, cependant, n'est
+généralement pas instrumenté. Pour instrumenter votre code, vous devrez utiliser
+l'[instrumentation avec du code](/docs/concepts/instrumentation/code-based).
 
 De plus, l'instrumentation Zero-code vous permet de configurer les
 [librairies d'instrumentation](/docs/concepts/instrumentation/libraries) et les
 [exportateurs](/docs/concepts/components/#exporters) que vous auriez chargés.
 
-Vous pouvez configurer l'instrumentation Zero-code via des variables d'environnement et
-d'autres mécanismes spécifiques au langage, tels que les propriétés système ou les arguments
-passés aux méthodes d'initialisation. Pour commencer, vous n'avez besoin que d'un nom de service
-configuré afin de pouvoir identifier le service dans la solution d'observabilité de
-votre choix.
+Vous pouvez configurer l'instrumentation Zero-code via des variables
+d'environnement et d'autres mécanismes spécifiques au langage, tels que les
+propriétés système ou les arguments passés aux méthodes d'initialisation. Pour
+commencer, vous n'avez besoin que d'un nom de service configuré afin de pouvoir
+identifier le service dans la solution d'observabilité de votre choix.
 
 D'autres options de configuration sont disponibles, notamment :
 

--- a/content/fr/docs/concepts/instrumentation/zero-code/index.md
+++ b/content/fr/docs/concepts/instrumentation/zero-code/index.md
@@ -5,6 +5,7 @@ description: >-
   d'écrire du code
 weight: 10
 aliases: [automatic]
+default_lang_commit: 3512b0ae11f72d3a954d86da59ad7f98d064bdad
 ---
 
 En tant qu'[Ops](/docs/getting-started/ops/) vous pourriez souhaiter ajouter
@@ -18,10 +19,10 @@ l'[instrumentation avec du code](/docs/concepts/instrumentation/code-based).
 
 L'instrumentation Zero-code ajoute les capacités de l'API et du SDK
 OpenTelemetry à votre application, généralement à l'aide d'un agent ou d'un
-concept similaire. Les mécanismes spécifiques impliqués peuvent différer selon  
-le langage de programmation, allant de la manipulation de bytecode, au monkey  
-patching, en passant par eBPF pour injecter des appels à l'API et au SDK OpenTelemetry
-dans votre application.
+concept similaire. Les mécanismes spécifiques impliqués peuvent différer selon
+le langage de programmation, allant de la manipulation de bytecode, au monkey
+patching, en passant par eBPF pour injecter des appels à l'API et au SDK
+OpenTelemetry dans votre application.
 
 Typiquement, l'instrumentation Zero-code ajoute tout le nécessaire pour les
 bibliothèques que vous utilisez. Cela signifie que les requêtes et réponses, les
@@ -37,7 +38,8 @@ De plus, l'instrumentation Zero-code vous permet de configurer les
 Vous pouvez configurer l'instrumentation Zero-code via des variables
 d'environnement et d'autres mécanismes spécifiques au langage, tels que les
 propriétés système ou les arguments passés aux méthodes d'initialisation. Pour
-commencer, vous n'avez besoin que d'un nom de service configuré afin de pouvoir  
+commencer, vous n'avez besoin que d'un nom de service configuré afin de
+pouvoir
 identifier celui-ci dans la solution d'observabilité de votre choix.
 
 D'autres options de configuration sont disponibles, notamment :

--- a/content/fr/docs/concepts/instrumentation/zero-code/index.md
+++ b/content/fr/docs/concepts/instrumentation/zero-code/index.md
@@ -23,7 +23,7 @@ le langage de programmation, allant de la manipulation de bytecode, du monkey
 patching, ou d'eBPF pour injecter des appels à l'API et au SDK OpenTelemetry
 dans votre application.
 
-Typiquement, l'instrumentation Zero-code ajoute une instrumentation pour les
+Typiquement, l'instrumentation Zero-code ajoute tout le nécessaire pour les
 bibliothèques que vous utilisez. Cela signifie que les requêtes et réponses, les
 appels aux bases de données, les appels de file d'attente de messages, et
 autres, sont instrumentés. Le code de votre application, cependant, n'est

--- a/content/fr/docs/concepts/instrumentation/zero-code/index.md
+++ b/content/fr/docs/concepts/instrumentation/zero-code/index.md
@@ -7,7 +7,7 @@ weight: 10
 aliases: [automatic]
 ---
 
-En tant qu'[Ops](/docs/getting-started/ops/) vous pourriez vouloir ajouter
+En tant qu'[Ops](/docs/getting-started/ops/) vous pourriez souhaiter ajouter
 l'observabilité à une ou plusieurs applications sans avoir à modifier le code
 source. OpenTelemetry vous permet d'obtenir rapidement un certain degré
 d'observabilité pour un service sans avoir à utiliser l'API et le SDK
@@ -18,9 +18,9 @@ l'[instrumentation avec du code](/docs/concepts/instrumentation/code-based).
 
 L'instrumentation Zero-code ajoute les capacités de l'API et du SDK
 OpenTelemetry à votre application, généralement à l'aide d'un agent ou d'un
-concept similaire. Les mécanismes spécifiques impliqués peuvent différer selon
-le langage de programmation, allant de la manipulation de bytecode, du monkey
-patching, ou d'eBPF pour injecter des appels à l'API et au SDK OpenTelemetry
+concept similaire. Les mécanismes spécifiques impliqués peuvent différer selon  
+le langage de programmation, allant de la manipulation de bytecode, au monkey  
+patching, en passant par eBPF pour injecter des appels à l'API et au SDK OpenTelemetry
 dans votre application.
 
 Typiquement, l'instrumentation Zero-code ajoute tout le nécessaire pour les
@@ -37,8 +37,8 @@ De plus, l'instrumentation Zero-code vous permet de configurer les
 Vous pouvez configurer l'instrumentation Zero-code via des variables
 d'environnement et d'autres mécanismes spécifiques au langage, tels que les
 propriétés système ou les arguments passés aux méthodes d'initialisation. Pour
-commencer, vous n'avez besoin que d'un nom de service configuré afin de pouvoir
-identifier le service dans la solution d'observabilité de votre choix.
+commencer, vous n'avez besoin que d'un nom de service configuré afin de pouvoir  
+identifier celui-ci dans la solution d'observabilité de votre choix.
 
 D'autres options de configuration sont disponibles, notamment :
 

--- a/content/fr/docs/concepts/instrumentation/zero-code/index.md
+++ b/content/fr/docs/concepts/instrumentation/zero-code/index.md
@@ -1,0 +1,52 @@
+---
+title: Instrumentation Zero-code
+description: >-
+  Apprenez comment ajouter l'observabilité à une application sans avoir besoin d'écrire du code
+weight: 10
+aliases: [automatic]
+---
+
+En tant qu'[Ops](/docs/getting-started/ops/) vous pourriez vouloir ajouter l'observabilité à une
+ou plusieurs applications sans avoir à modifier le code source. OpenTelemetry vous permet
+d'obtenir rapidement un certain degré d'observabilité pour un service sans avoir à utiliser l'API et le SDK
+d'OpenTelemetry pour l'[instrumentation avec du code](/docs/concepts/instrumentation/code-based).
+
+![Zero Code](./zero-code.svg)
+
+L'instrumentation Zero-code ajoute les capacités de l'API et du SDK OpenTelemetry
+à votre application, généralement à l'aide d'un agent ou d'un concept similaire. Les mécanismes
+spécifiques impliqués peuvent différer selon le langage de programmation, allant de la manipulation de bytecode,
+du monkey patching, ou d'eBPF pour injecter des appels à l'API et au SDK OpenTelemetry dans
+votre application.
+
+Typiquement, l'instrumentation Zero-code ajoute une instrumentation pour les bibliothèques
+que vous utilisez. Cela signifie que les requêtes et réponses, les appels aux bases de données, les appels
+de file d'attente de messages, et autres, sont instrumentés. Le code de votre application,
+cependant, n'est généralement pas instrumenté. Pour instrumenter votre code, vous devrez
+utiliser l'[instrumentation avec du code](/docs/concepts/instrumentation/code-based).
+
+De plus, l'instrumentation Zero-code vous permet de configurer les
+[librairies d'instrumentation](/docs/concepts/instrumentation/libraries) et les
+[exportateurs](/docs/concepts/components/#exporters) que vous auriez chargés.
+
+Vous pouvez configurer l'instrumentation Zero-code via des variables d'environnement et
+d'autres mécanismes spécifiques au langage, tels que les propriétés système ou les arguments
+passés aux méthodes d'initialisation. Pour commencer, vous n'avez besoin que d'un nom de service
+configuré afin de pouvoir identifier le service dans la solution d'observabilité de
+votre choix.
+
+D'autres options de configuration sont disponibles, notamment :
+
+- Configuration spécifique à la source de données
+- Configuration de l'exportateur
+- Configuration du propagateur
+- Configuration des ressources
+
+L'instrumentation automatique est disponible pour les langages suivants :
+
+- [.NET](/docs/zero-code/dotnet/)
+- [Go](/docs/zero-code/go)
+- [Java](/docs/zero-code/java/)
+- [JavaScript](/docs/zero-code/js/)
+- [PHP](/docs/zero-code/php/)
+- [Python](/docs/zero-code/python/)

--- a/content/fr/docs/getting-started/_index.md
+++ b/content/fr/docs/getting-started/_index.md
@@ -14,7 +14,8 @@ Sélectionnez un rôle[^1] pour commencer :
 
 </div>
 
-Vous pouvez également essayer la [démo officielle d'OpenTelemetry][demo] pour _voir_ à quoi ressemble l'observabilité avec OpenTelemetry !
+Vous pouvez également essayer la [démo officielle d'OpenTelemetry][demo] pour
+_voir_ à quoi ressemble l'observabilité avec OpenTelemetry !
 
 <div class="l-primary-buttons justify-content-start mt-3 mb-5 ms-3">
 

--- a/content/fr/docs/getting-started/_index.md
+++ b/content/fr/docs/getting-started/_index.md
@@ -3,6 +3,7 @@ title: Débuter
 description: Débutez avec OpenTelemetry selon votre rôle.
 no_list: true
 weight: 160
+default_lang_commit: 3512b0ae11f72d3a954d86da59ad7f98d064bdad
 ---
 
 Sélectionnez un rôle[^1] pour commencer :

--- a/content/fr/docs/getting-started/_index.md
+++ b/content/fr/docs/getting-started/_index.md
@@ -1,0 +1,29 @@
+---
+title: Débuter
+description: Débutez avec OpenTelemetry selon votre rôle.
+no_list: true
+weight: 160
+---
+
+Sélectionnez un rôle[^1] pour commencer :
+
+<div class="l-get-started-buttons justify-content-start mt-3 ms-3">
+
+- [Dev](dev/)
+- [Ops](ops/)
+
+</div>
+
+Vous pouvez également essayer la [démo officielle d'OpenTelemetry][demo] pour _voir_ à quoi ressemble l'observabilité avec OpenTelemetry !
+
+<div class="l-primary-buttons justify-content-start mt-3 mb-5 ms-3">
+
+- [Essayer la démo][demo]
+
+</div>
+
+[^1]: Si aucun de ces rôles ne s'applique à vous, [faites-le nous savoir][].
+
+[demo]: /ecosystem/demo/
+[faites-le nous savoir]:
+  https://github.com/open-telemetry/opentelemetry.io/issues/new?title=Add%20a%20new%20persona:%20My%20Persona&body=Provide%20a%20description%20of%20your%20role%20and%20responsibilities%20and%20what%20your%20observability%20goals%20are

--- a/content/fr/docs/getting-started/dev.md
+++ b/content/fr/docs/getting-started/dev.md
@@ -3,7 +3,7 @@ title: Débuter pour les développeurs
 linkTitle: Dev
 ---
 
-Cett page [Débuter pour les dev](..) est faite pour vous si :
+Cette page à propos de [comment bien débuter](..) est faite pour vous si :
 
 - Vous développez des logiciels
 - Votre objectif est de rendre observable via l'écriture de code

--- a/content/fr/docs/getting-started/dev.md
+++ b/content/fr/docs/getting-started/dev.md
@@ -9,21 +9,22 @@ Cett page [Débuter pour les dev](..) est faite pour vous si :
 - Votre objectif est de rendre observable via l'écriture de code
 - Vous voulez que vos dépendances émettent automatiquement de la télémétrie
 
-OpenTelemetry peut vous aider ! Pour atteindre vos objectifs d'avoir vos dépendances
-instrumentées automatiquement et d'instrumenter votre propre code avec notre API
-manuellement, nous recommandons que vous appreniez d'abord les concepts suivants :
+OpenTelemetry peut vous aider ! Pour atteindre vos objectifs d'avoir vos
+dépendances instrumentées automatiquement et d'instrumenter votre propre code
+avec notre API manuellement, nous recommandons que vous appreniez d'abord les
+concepts suivants :
 
 - [Qu'est-ce qu'OpenTelemetry ?](../../what-is-opentelemetry/)
 - [Comment puis-je ajouter une instrumentation à mon code ?](../../concepts/instrumentation/code-based/)
 
-Si vous développez des librairies, des frameworks ou des middlewares qui sont utilisés comme dépendance
-dans d'autres logiciels, nous recommandons que vous appreniez comment vous pouvez fournir la télémétrie
-nativement :
+Si vous développez des librairies, des frameworks ou des middlewares qui sont
+utilisés comme dépendance dans d'autres logiciels, nous recommandons que vous
+appreniez comment vous pouvez fournir la télémétrie nativement :
 
 - [Comment puis-je ajouter une instrumentation native à ma librairie ?](../../concepts/instrumentation/libraries/)
 
-Si vous cherchez un ensemble d'applications pour tester, essayez
-notre [démo officielle d'OpenTelemetry](/ecosystem/demo/).
+Si vous cherchez un ensemble d'applications pour tester, essayez notre
+[démo officielle d'OpenTelemetry](/ecosystem/demo/).
 
 Ensuite, vous pouvez approfondir les documentations pour le
 [langage](../../languages/) que vous utilisez :

--- a/content/fr/docs/getting-started/dev.md
+++ b/content/fr/docs/getting-started/dev.md
@@ -1,6 +1,7 @@
 ---
 title: Débuter pour les développeurs
 linkTitle: Dev
+default_lang_commit: 3512b0ae11f72d3a954d86da59ad7f98d064bdad
 ---
 
 Cette page à propos de [comment bien débuter](..) est faite pour vous si :

--- a/content/fr/docs/getting-started/dev.md
+++ b/content/fr/docs/getting-started/dev.md
@@ -1,0 +1,42 @@
+---
+title: Débuter pour les développeurs
+linkTitle: Dev
+---
+
+Cett page [Débuter pour les dev](..) est faite pour vous si :
+
+- Vous développez des logiciels
+- Votre objectif est de rendre observable via l'écriture de code
+- Vous voulez que vos dépendances émettent automatiquement de la télémétrie
+
+OpenTelemetry peut vous aider ! Pour atteindre vos objectifs d'avoir vos dépendances
+instrumentées automatiquement et d'instrumenter votre propre code avec notre API
+manuellement, nous recommandons que vous appreniez d'abord les concepts suivants :
+
+- [Qu'est-ce qu'OpenTelemetry ?](../../what-is-opentelemetry/)
+- [Comment puis-je ajouter une instrumentation à mon code ?](../../concepts/instrumentation/code-based/)
+
+Si vous développez des librairies, des frameworks ou des middlewares qui sont utilisés comme dépendance
+dans d'autres logiciels, nous recommandons que vous appreniez comment vous pouvez fournir la télémétrie
+nativement :
+
+- [Comment puis-je ajouter une instrumentation native à ma librairie ?](../../concepts/instrumentation/libraries/)
+
+Si vous cherchez un ensemble d'applications pour tester, essayez
+notre [démo officielle d'OpenTelemetry](/ecosystem/demo/).
+
+Ensuite, vous pouvez approfondir les documentations pour le
+[langage](../../languages/) que vous utilisez :
+
+- [C++](../../languages/cpp/)
+- [.NET](../../languages/dotnet/)
+- [Erlang / Elixir](../../languages/erlang/)
+- [Go](../../languages/go/)
+- [Java](../../languages/java/)
+- [JavaScript / TypeScript](../../languages/js/)
+- [PHP](../../languages/php/)
+- [Python](../../languages/python/)
+- [Ruby](../../languages/ruby/)
+- [Rust](../../languages/rust/)
+- [Swift](../../languages/swift/)
+- [Autre](../../languages/other/)

--- a/content/fr/docs/getting-started/ops.md
+++ b/content/fr/docs/getting-started/ops.md
@@ -6,17 +6,19 @@ linkTitle: Ops
 Cette page [Commencer pour les Ops](..) est faite pour vous si :
 
 - Vous exécutez un ensemble d'applications en production
-- Votre objectif est d'obtenir de la télémétrie de ces applications sans toucher à leur code
-- Vous voulez collecter des traces, des métriques et des logs de plusieurs services et les
-  envoyer vers votre solution d'observabilité.
+- Votre objectif est d'obtenir de la télémétrie de ces applications sans toucher
+  à leur code
+- Vous voulez collecter des traces, des métriques et des logs de plusieurs
+  services et les envoyer vers votre solution d'observabilité.
 
-OpenTelemetry peut vous aider ! Pour atteindre votre objectif d'obtenir de la télémétrie
-des applications sans toucher à leur code, nous recommandons que vous en appreniez plus sur ces sujets:
+OpenTelemetry peut vous aider ! Pour atteindre votre objectif d'obtenir de la
+télémétrie des applications sans toucher à leur code, nous recommandons que vous
+en appreniez plus sur ces sujets:
 
 - [Qu'est-ce qu'OpenTelemetry ?](../../what-is-opentelemetry/)
 - [Comment puis-je instrumenter des applications sans toucher à leur code ?](../../concepts/instrumentation/zero-code/)
 - [Comment puis-je configurer un collecteur ?](../../collector/)
 - [Comment puis-je automatiser l'instrumentation sur Kubernetes avec l'Opérateur OpenTelemetry ?](../../platforms/kubernetes/operator/)
 
-Si vous cherchez un ensemble d'applications pour tester, essayez
-notre [démo officielle d'OpenTelemetry](/ecosystem/demo/).
+Si vous cherchez un ensemble d'applications pour tester, essayez notre
+[démo officielle d'OpenTelemetry](/ecosystem/demo/).

--- a/content/fr/docs/getting-started/ops.md
+++ b/content/fr/docs/getting-started/ops.md
@@ -1,0 +1,22 @@
+---
+title: Commencer pour les Ops
+linkTitle: Ops
+---
+
+Cette page [Commencer pour les Ops](..) est faite pour vous si :
+
+- Vous exécutez un ensemble d'applications en production
+- Votre objectif est d'obtenir de la télémétrie de ces applications sans toucher à leur code
+- Vous voulez collecter des traces, des métriques et des logs de plusieurs services et les
+  envoyer vers votre solution d'observabilité.
+
+OpenTelemetry peut vous aider ! Pour atteindre votre objectif d'obtenir de la télémétrie
+des applications sans toucher à leur code, nous recommandons que vous en appreniez plus sur ces sujets:
+
+- [Qu'est-ce qu'OpenTelemetry ?](../../what-is-opentelemetry/)
+- [Comment puis-je instrumenter des applications sans toucher à leur code ?](../../concepts/instrumentation/zero-code/)
+- [Comment puis-je configurer un collecteur ?](../../collector/)
+- [Comment puis-je automatiser l'instrumentation sur Kubernetes avec l'Opérateur OpenTelemetry ?](../../platforms/kubernetes/operator/)
+
+Si vous cherchez un ensemble d'applications pour tester, essayez
+notre [démo officielle d'OpenTelemetry](/ecosystem/demo/).

--- a/content/fr/docs/getting-started/ops.md
+++ b/content/fr/docs/getting-started/ops.md
@@ -1,6 +1,7 @@
 ---
 title: Débuter pour les Ops
 linkTitle: Ops
+default_lang_commit: 3512b0ae11f72d3a954d86da59ad7f98d064bdad
 ---
 
 Cette page à propos de [comment bien débuter](..) est faite pour vous si :

--- a/content/fr/docs/getting-started/ops.md
+++ b/content/fr/docs/getting-started/ops.md
@@ -1,14 +1,14 @@
 ---
-title: Commencer pour les Ops
+title: Débuter pour les Ops
 linkTitle: Ops
 ---
 
-Cette page [Commencer pour les Ops](..) est faite pour vous si :
+Cette page à propos de [comment bien débuter](..) est faite pour vous si :
 
 - Vous exécutez un ensemble d'applications en production
 - Votre objectif est d'obtenir de la télémétrie de ces applications sans toucher
   à leur code
-- Vous voulez collecter des traces, des métriques et des logs de plusieurs
+- Vous souhaitez collecter des traces, des métriques et des logs de plusieurs
   services et les envoyer vers votre solution d'observabilité.
 
 OpenTelemetry peut vous aider ! Pour atteindre votre objectif d'obtenir de la


### PR DESCRIPTION
I started the translation of some of the docs toward french (my native language). I saw that those pages were tracked in #5824 so I am starting with these.

I chose to keep `Zero-code` as is. It is translated `no-code` on the homepage, which is not french either. We should stick to the official names or come with a translation ("Instrumentation sans code")