### PR TITLE
Fix error message on failed check spell

### DIFF
--- a/.github/workflows/check-spelling.yml
+++ b/.github/workflows/check-spelling.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           CHANGES=`git status --porcelain`
           if [[ $CHANGES ]]; then
-            echo "Add comment '/fix:${{ env.FIX_CMD }}' to your PR in GitHub,"
+            echo "Add comment '/${{ env.FIX_CMD }}' to your PR in GitHub,"
             echo "or locally run 'npm run ${{ env.FIX_CMD }}' and commit the changes:"
             echo "$CHANGES"
             exit 1


### PR DESCRIPTION
Currently when a check spell CI test fails, it shows the message `Add comment '/fix:fix:format'` instead of the correct `Add comment '/fix:format'`