### PR TITLE
Add minisearch as dependency, remove CDN link

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -28,7 +28,9 @@ jobs:
           jq '.devDependencies |= with_entries(
                   select(.key | test("prefix|hugo|css"))
                 )
-                | del(.dependencies, .optionalDependencies)' \
+                | .dependencies |= with_entries(
+                  select(.key | test("minisearch")))
+                | del(, .optionalDependencies)' \
             package.json > tmp/package-min.json
           cp tmp/package-min.json package.json
 

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -30,7 +30,7 @@ jobs:
                 )
                 | .dependencies |= with_entries(
                   select(.key | test("minisearch")))
-                | del(, .optionalDependencies)' \
+                | del(.optionalDependencies)' \
             package.json > tmp/package-min.json
           cp tmp/package-min.json package.json
 

--- a/assets/js/registrySearch.js
+++ b/assets/js/registrySearch.js
@@ -1,3 +1,5 @@
+import MiniSearch from 'minisearch';
+
 const miniSearchOptions = {
   fields: [
     'title',

--- a/layouts/_shortcodes/ecosystem/registry/search-form.html
+++ b/layouts/_shortcodes/ecosystem/registry/search-form.html
@@ -149,5 +149,4 @@
   </ul>
 </div>
 
-<script src="https://cdn.jsdelivr.net/npm/minisearch@7.1.0/dist/umd/index.min.js" integrity="sha384-58p1D2xuw/76VRFUgDMRcrtnJAW5LWLE02ihn8aITu65c4vgo+BLy7raRKNC7KaL" crossorigin="anonymous"></script>
 {{ partial "script.html" (dict "src" "js/registrySearch.js") -}}

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "@opentelemetry/sdk-trace-base": "^2.0.1",
     "@opentelemetry/sdk-trace-web": "^2.0.1",
     "@opentelemetry/semantic-conventions": "^1.34.0",
+    "minisearch": "^7.1.2",
     "path": "^0.12.7"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Re: #7100 #7223 

Not exactly sure what the problem is, but it seems there is a caching issue with the minisearch from the CDN. 

This PR works around that by adding minisearch as a dependency to package.json and importing it into the registrySearch.js directly.

