### PR TITLE
Update Swift SignpostIntegration Instructions

### DIFF
--- a/content/en/docs/languages/swift/libraries.md
+++ b/content/en/docs/languages/swift/libraries.md
@@ -23,7 +23,7 @@ network requests made with NSURLSessions.
 ## Setup
 
 All instrumentation libraries are available in OpenTelemetry Swift. To turn on
-an instrumentation, follow its usage instructions.
+an instrumentation, follow its instructions.
 
 ## `SDKResourceExtension`
 


### PR DESCRIPTION
## Summary

* Updates the Signpost Integration section in the Swift library documentation to reflect recent changes introduced in https://github.com/open-telemetry/opentelemetry-swift/pull/818.
* Introduces `OSSignposterIntegration` as a modern replacement for the existing `SignpostIntegration`, leveraging Apple’s [OSSignposter API](https://developer.apple.com/documentation/os/ossignposter) for improved performance and system integration.

<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->
