### PR TITLE
(docs/internal-telemetry): add example for labels

### DIFF
--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -71,6 +71,22 @@ service:
                 port: 8888
 ```
 
+If you want to add additional labels to the Prometheus metrics you can add them with `prometheus::with_resource_constant_labels`:
+```yaml
+prometheus:
+  host: '0.0.0.0'
+  port: 8888
+  with_resource_constant_labels:
+    included:
+    - label_key
+```
+
+And referencing the labels in `service::telemetry::resource`:
+```yaml
+resource:
+  label_key: label_value
+```
+
 {{% alert title="Internal telemetry configuration changes" %}}
 
 As of Collector [v0.123.0], the `service::telemetry::metrics::address` setting


### PR DESCRIPTION

This PR adds an example on how to add additional labels to internal metrics generated by the Collector. I stumbled across this problem and could not yet find an example that explained how to do it. 

I also saw a major change to this document with https://github.com/open-telemetry/opentelemetry.io/pull/7035. If agreed, this commit could be included there. 