### PR TITLE
docs: add Langfuse to vendors.yaml

### DIFF
--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -210,6 +210,12 @@
   contact: https://github.com/cartersocha
   oss: false
   commercial: true
+- name: Langfuse
+  nativeOTLP: true
+  url: https://langfuse.com/docs/opentelemetry/get-started
+  contact: support@langfuse.com
+  oss: true
+  commercial: true
 - name: Last9
   nativeOTLP: true
   url: https://last9.io/docs/integrations-opentelemetry/

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -15787,6 +15787,10 @@
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:26:59.999Z"
   },
+  "https://langfuse.com/docs/opentelemetry/get-started": {
+    "StatusCode": 206,
+    "LastSeen": "2025-07-05T16:36:41.645396004Z"
+  },
   "https://last9.io/docs/integrations-opentelemetry/": {
     "StatusCode": 206,
     "LastSeen": "2025-04-08T07:13:45.660164039Z"


### PR DESCRIPTION
- Link to the documentation that details how your offering consumes OpenTelemetry natively via OTLP: https://langfuse.com/docs/opentelemetry/get-started

- Link to your distribution: https://langfuse.com/

- Link that proves that your offering is open source, if applicable. An open source distribution does not qualify your offering to be marked “open source”: https://langfuse.com/open-source

- GitHub handle or email address as a point of contact so that we can reach out in case we have questions: https://github.com/jannikmaierhoefer