### PR TITLE
add view configuration documentation

### DIFF
--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -129,6 +129,29 @@ service:
       level: detailed
 ```
 
+It is possible to further configure how metrics from the Collector are
+emitted via the use of [Views](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view).
+The following updates the metric named `otelcol_process_uptime` to
+emit a new name `process_uptime` and description:
+
+```yaml
+service:
+  telemetry:
+    metrics:
+      views:
+      - selector:
+          instrument_name: otelcol_process_uptime
+          instrument_type: 
+        stream:
+          name: process_uptime
+          description: The amount of time the Collector has been up
+```
+
+Additional configuration options are available such as updating the
+resulting aggregation, attributes, and cardinality limits amongst them.
+For the full list of options, refer to the examples in the OpenTelemetry
+Configuration schema [repository](https://github.com/open-telemetry/opentelemetry-configuration/blob/f4e9046682d4386ea533ef7ba6ad30a5ce4451b4/examples/kitchen-sink.yaml#L440).
+
 ### Configure internal logs
 
 Log output is found in `stderr`. You can configure logs in the config

--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -129,28 +129,28 @@ service:
       level: detailed
 ```
 
-You can further configure how metrics from the Collector are
-emitted by using [`views`](/docs/specs/otel/metrics/sdk/#view).
-For example, the following configuration updates the metric named `otelcol_process_uptime` to
-emit a new name `process_uptime` and description:
+You can further configure how metrics from the Collector are emitted by using
+[`views`](/docs/specs/otel/metrics/sdk/#view). For example, the following
+configuration updates the metric named `otelcol_process_uptime` to emit a new
+name `process_uptime` and description:
 
 ```yaml
 service:
   telemetry:
     metrics:
       views:
-      - selector:
-          instrument_name: otelcol_process_uptime
-          instrument_type: 
-        stream:
-          name: process_uptime
-          description: The amount of time the Collector has been up
+        - selector:
+            instrument_name: otelcol_process_uptime
+            instrument_type:
+          stream:
+            name: process_uptime
+            description: The amount of time the Collector has been up
 ```
 
-You can also use `views` to update the
-resulting aggregation, attributes, and cardinality limits.
-For the full list of options, see the examples in the OpenTelemetry
-Configuration schema [repository](https://github.com/open-telemetry/opentelemetry-configuration/blob/f4e9046682d4386ea533ef7ba6ad30a5ce4451b4/examples/kitchen-sink.yaml#L440).
+You can also use `views` to update the resulting aggregation, attributes, and
+cardinality limits. For the full list of options, see the examples in the
+OpenTelemetry Configuration schema
+[repository](https://github.com/open-telemetry/opentelemetry-configuration/blob/f4e9046682d4386ea533ef7ba6ad30a5ce4451b4/examples/kitchen-sink.yaml#L440).
 
 ### Configure internal logs
 

--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -129,9 +129,9 @@ service:
       level: detailed
 ```
 
-It is possible to further configure how metrics from the Collector are
-emitted via the use of [Views](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view).
-The following updates the metric named `otelcol_process_uptime` to
+You can further configure how metrics from the Collector are
+emitted by using [`views`](/docs/specs/otel/metrics/sdk/#view).
+For example, the following configuration updates the metric named `otelcol_process_uptime` to
 emit a new name `process_uptime` and description:
 
 ```yaml
@@ -147,9 +147,9 @@ service:
           description: The amount of time the Collector has been up
 ```
 
-Additional configuration options are available such as updating the
-resulting aggregation, attributes, and cardinality limits amongst them.
-For the full list of options, refer to the examples in the OpenTelemetry
+You can also use `views` to update the
+resulting aggregation, attributes, and cardinality limits.
+For the full list of options, see the examples in the OpenTelemetry
 Configuration schema [repository](https://github.com/open-telemetry/opentelemetry-configuration/blob/f4e9046682d4386ea533ef7ba6ad30a5ce4451b4/examples/kitchen-sink.yaml#L440).
 
 ### Configure internal logs

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -7803,6 +7803,10 @@
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:13:12.345Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-configuration/blob/f4e9046682d4386ea533ef7ba6ad30a5ce4451b4/examples/kitchen-sink.yaml#L440": {
+    "StatusCode": 206,
+    "LastSeen": "2025-07-07T22:46:42.063381936Z"
+  },
   "https://github.com/open-telemetry/opentelemetry-configuration/blob/main/CONTRIBUTING.md#property-name-case": {
     "StatusCode": 200,
     "LastSeen": "2025-05-14T16:28:12.345Z"
@@ -10958,6 +10962,10 @@
   "https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md#events": {
     "StatusCode": 206,
     "LastSeen": "2025-02-06T02:17:59.999Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view": {
+    "StatusCode": 206,
+    "LastSeen": "2025-07-07T22:46:40.456342004Z"
   },
   "https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#spankind": {
     "StatusCode": 200,


### PR DESCRIPTION
This updates the collector's internal telemetry documentation to include an example for configuring views.
