### PR TITLE
Update faas nodejs supported runtime version

### DIFF
--- a/content/en/docs/platforms/faas/lambda-auto-instrument.md
+++ b/content/en/docs/platforms/faas/lambda-auto-instrument.md
@@ -70,7 +70,7 @@ OTEL_INSTRUMENTATION_AWS_SDK_ENABLED=true
 
 {{% /tab %}} {{% tab JavaScript %}}
 
-The Lambda layer supports Node.js v14+ Lambda runtimes. For more information
+The Lambda layer supports Node.js v18+ Lambda runtimes. For more information
 about supported JavaScript and Node.js versions, see the
 [OpenTelemetry JavaScript documentation](https://github.com/open-telemetry/opentelemetry-js).
 


### PR DESCRIPTION
This information is outdated. We dropped support for node 16 when we upgraded to the v2 js sdk. (https://github.com/open-telemetry/opentelemetry-js?tab=readme-ov-file#supported-runtimes)

nodejs16.x lambda runtimes are also deprecated already and will no longer be supported starting late 2025: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-deprecated
