### PR TITLE
Fixes several links from the 

### DIFF
--- a/content/en/docs/zero-code/js/configuration.md
+++ b/content/en/docs/zero-code/js/configuration.md
@@ -62,7 +62,7 @@ prefix.
 For example, to enable only
 [@opentelemetry/instrumentation-http](https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-http)
 and
-[@opentelemetry/instrumentation-express](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-express)
+[@opentelemetry/instrumentation-express](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-express)
 instrumentations:
 
 ```shell
@@ -77,7 +77,7 @@ comma-separated list of the instrumentation library names without the
 `@opentelemetry/instrumentation-` prefix.
 
 For example, to disable only
-[@opentelemetry/instrumentation-fs](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-fs)
+[@opentelemetry/instrumentation-fs](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-fs)
 and
 [@opentelemetry/instrumentation-grpc](https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-grpc)
 instrumentations:

--- a/data/registry/instrumentation-js-amqplib.yml
+++ b/data/registry/instrumentation-js-amqplib.yml
@@ -16,6 +16,6 @@ package:
   registry: npm
   version: 0.49.0
 urls:
-  repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-amqplib
+  repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-amqplib
 createdAt: 2020-06-15
 isFirstParty: false

--- a/data/registry/instrumentation-js-cucumber.yml
+++ b/data/registry/instrumentation-js-cucumber.yml
@@ -12,7 +12,7 @@ description:
 authors:
   - name: OpenTelemetry Authors
 urls:
-  repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-cucumber
+  repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-cucumber
 createdAt: 2022-10-27
 package:
   registry: npm

--- a/data/registry/instrumentation-js-dataloader.yml
+++ b/data/registry/instrumentation-js-dataloader.yml
@@ -12,7 +12,7 @@ description:
   This module provides an instrumentation library for the injection of trace
   context to dataloader
 urls:
-  repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-dataloader
+  repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-dataloader
 createdAt: 2022-10-27
 package:
   registry: npm

--- a/data/registry/instrumentation-js-fs.yml
+++ b/data/registry/instrumentation-js-fs.yml
@@ -10,7 +10,7 @@ description: This module provides an instrumentation library for fs.
 authors:
   - name: OpenTelemetry Authors
 urls:
-  repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-fs
+  repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-fs
 createdAt: 2021-07-08
 package:
   registry: npm

--- a/data/registry/instrumentation-js-lru-memoizer.yml
+++ b/data/registry/instrumentation-js-lru-memoizer.yml
@@ -12,7 +12,7 @@ description:
 authors:
   - name: OpenTelemetry Authors
 urls:
-  repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-lru-memoizer
+  repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-lru-memoizer
 createdAt: 2022-10-27
 package:
   registry: npm

--- a/data/registry/instrumentation-js-mongoose-instrumentation.yml
+++ b/data/registry/instrumentation-js-mongoose-instrumentation.yml
@@ -11,7 +11,7 @@ description: Mongoose instrumentation for Node.js.
 authors:
   - name: OpenTelemetry Authors
 urls:
-  repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-mongoose
+  repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-mongoose
 createdAt: 2021-02-17
 package:
   registry: npm

--- a/data/registry/instrumentation-js-runtimenode.yml
+++ b/data/registry/instrumentation-js-runtimenode.yml
@@ -7,7 +7,7 @@ tags:
   - instrumentation
   - js
 urls:
-  repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-runtime-node
+  repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-runtime-node
 license: Apache 2.0
 description:
   This module provides automatic metric instrumentation that exposes

--- a/data/registry/instrumentation-js-socket.io.yml
+++ b/data/registry/instrumentation-js-socket.io.yml
@@ -11,7 +11,7 @@ description:
 authors:
   - name: OpenTelemetry Authors
 urls:
-  repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-socket.io
+  repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-socket.io
 createdAt: 2022-10-27
 package:
   registry: npm

--- a/data/registry/instrumentation-js-tedious.yml
+++ b/data/registry/instrumentation-js-tedious.yml
@@ -11,7 +11,7 @@ description:
 authors:
   - name: OpenTelemetry Authors
 urls:
-  repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-tedious
+  repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-tedious
 createdAt: 2022-10-27
 package:
   registry: npm

--- a/data/registry/instrumentation-js-undici.yml
+++ b/data/registry/instrumentation-js-undici.yml
@@ -7,7 +7,7 @@ tags:
   - instrumentation
   - js
 urls:
-  repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-undici
+  repo: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-undici
 license: Apache 2.0
 description:
   This module provides automatic instrumentation for

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -9487,43 +9487,43 @@
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:15:12.345Z"
   },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-amqplib": {
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-amqplib": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:39:31.909108-05:00"
   },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-cucumber": {
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-cucumber": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:39:35.72653-05:00"
   },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-dataloader": {
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-dataloader": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:39:36.276663-05:00"
   },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-fs": {
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-fs": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:37:43.088777-05:00"
   },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-lru-memoizer": {
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-lru-memoizer": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:39:43.860538-05:00"
   },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-mongoose": {
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-mongoose": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:39:45.519694-05:00"
   },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-runtime-node": {
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-runtime-node": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:39:54.75628-05:00"
   },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-socket.io": {
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-socket.io": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:39:55.793418-05:00"
   },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-tedious": {
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-tedious": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:39:56.34055-05:00"
   },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-undici": {
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-undici": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:39:57.529249-05:00"
   },


### PR DESCRIPTION
This PR fixes several broken links from the documentation site to different instrumentation packages. I'm assuming this was missed during a migration of packages from `plugins/node` -> `packages`.

**Example:**

Looking at this [documentation](https://opentelemetry.io/docs/zero-code/js/configuration/#enable-specific-instrumentations), clicking the second link takes you to a 404 page.

> For example, to disable only [@opentelemetry/instrumentation-fs](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-fs) and [@opentelemetry/instrumentation-grpc](https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-grpc) instrumentations: