### PR TITLE
Add UiPath to OpenTelemetry adopter list

### DIFF
--- a/data/ecosystem/adopters.yaml
+++ b/data/ecosystem/adopters.yaml
@@ -159,7 +159,7 @@
   contact: 'santiago.lator@globalprocessing.com.ar'
 - name: UiPath
   url: https://www.uipath.com/
-  components: [Collector, .NET, ]
+  components: [Collector, .NET]
   reference: 'https://engineering.uipath.com/scaling-observability-with-opentelemetry-adx-how-we-improve-the-monitoring-with-cost-reduced-42100a99b89a'
   referenceTitle: blog post
   contact: ''

--- a/data/ecosystem/adopters.yaml
+++ b/data/ecosystem/adopters.yaml
@@ -157,3 +157,9 @@
   reference: 'https://www.linkedin.com/posts/santiago-lator_opentelemetry-opentelemetry-observabilidad-activity-7258132675268354050-oP1q'
   referenceTitle: post
   contact: 'santiago.lator@globalprocessing.com.ar'
+- name: UiPath
+  url: https://www.uipath.com/
+  components: [Collector, .NET, ]
+  reference: 'https://engineering.uipath.com/scaling-observability-with-opentelemetry-adx-how-we-improve-the-monitoring-with-cost-reduced-42100a99b89a'
+  referenceTitle: blog post
+  contact: ''

--- a/data/ecosystem/adopters.yaml
+++ b/data/ecosystem/adopters.yaml
@@ -162,4 +162,4 @@
   components: [Collector, .NET]
   reference: 'https://engineering.uipath.com/scaling-observability-with-opentelemetry-adx-how-we-improve-the-monitoring-with-cost-reduced-42100a99b89a'
   referenceTitle: blog post
-  contact: ''
+  contact: 'junda.yin@uipath.com'

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -2327,6 +2327,10 @@
     "StatusCode": 200,
     "LastSeen": "2025-02-01T07:10:37.497133-05:00"
   },
+  "https://engineering.uipath.com/scaling-observability-with-opentelemetry-adx-how-we-improve-the-monitoring-with-cost-reduced-42100a99b89a": {
+    "StatusCode": 200,
+    "LastSeen": "2025-07-14T17:12:40.842397995Z"
+  },
   "https://erinmeyer.com/books/the-culture-map/": {
     "StatusCode": 200,
     "LastSeen": "2025-01-30T14:42:32.333393-05:00"


### PR DESCRIPTION
Starting last year, UiPath started internal project to migrate observability stack to OpenTelemetry. Thus creating PR for adding company name into the adopter list