### PR TITLE
add additional ignore rules to htmltest.yml

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -53,6 +53,9 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - ^https://twitter.com
   - ^https://www.youtube.com/playlist\?list= # htmltest doesn't process query parameters
   - ^https://x.com
+  - ^https://x.ai
+  - ^https://www.deepseek.com
+  - ^https://www.perplexity.ai
 
   # Ignore Docsy-generated GitHub links for now, until
   # https://github.com/google/docsy/issues/1432 is fixed


### PR DESCRIPTION
this adds additional URLs that give a 403 to the htmltest.yml

https://github.com/open-telemetry/opentelemetry.io/actions/runs/16274549848/job/45950704599

cc @jsuereth 