### PR TITLE
Updating Heroku adopters and vendor information

### DIFF
--- a/data/ecosystem/adopters.yaml
+++ b/data/ecosystem/adopters.yaml
@@ -67,8 +67,8 @@
   contact: ''
 - name: Heroku
   url: https://heroku.com
-  components: [Ruby]
-  reference: ''
+  components: [Collector, Go, Ruby, JavaScript, Operator]
+  reference: 'https://www.heroku.com/blog/opentelemetry-basics-on-heroku-fir/'
   contact: ''
 - name: MercadoLibre
   url: https://www.mercadolibre.com/

--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -156,6 +156,12 @@
   contact:
   oss: false
   commercial: true
+- name: Heroku
+  nativeOTLP: true
+  url: https://devcenter.heroku.com/articles/heroku-telemetry
+  contact:
+  oss: false
+  commercial: true
 - name: Highlight
   nativeOTLP: true
   url: https://www.highlight.io/docs/general/company/open-source/contributing/adding-an-sdk/


### PR DESCRIPTION
With the launch of the [Heroku Fir  Platform](https://www.heroku.com/blog/heroku-fir-generally-available-new-platform-capabilities/) which includes OpenTelemetry integration, we want to update the vendors list to include Heroku.

This PR also updates the adopters list to include updated information about the OpenTelemetry libraries and components we have adopted for internal use.