### PR TITLE
remove hash lifecycle status from link in internal telemetry

### DIFF
--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -14,11 +14,11 @@ configure it to help you
 OpenTelemetry SDK
 [declarative configuration schema](https://github.com/open-telemetry/opentelemetry-configuration)
 for configuring how to export its internal telemetry. This schema is still under
-[development](/docs/specs/otel/document-status/) and may
-undergo **breaking changes** in future releases. We intend to keep supporting
-older schemas until a 1.0 schema release is available, and offer a transition
-period for users to update their configurations before dropping pre-1.0 schemas.
-For details and to track progress see
+[development](/docs/specs/otel/document-status/) and may undergo **breaking
+changes** in future releases. We intend to keep supporting older schemas until a
+1.0 schema release is available, and offer a transition period for users to
+update their configurations before dropping pre-1.0 schemas. For details and to
+track progress see
 [issue #10808](https://github.com/open-telemetry/opentelemetry-collector/issues/10808).
 {{% /alert %}}
 

--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -14,7 +14,7 @@ configure it to help you
 OpenTelemetry SDK
 [declarative configuration schema](https://github.com/open-telemetry/opentelemetry-configuration)
 for configuring how to export its internal telemetry. This schema is still under
-[development](/docs/specs/otel/document-status/#lifecycle-status) and may
+[development](/docs/specs/otel/document-status/) and may
 undergo **breaking changes** in future releases. We intend to keep supporting
 older schemas until a 1.0 schema release is available, and offer a transition
 period for users to update their configurations before dropping pre-1.0 schemas.


### PR DESCRIPTION
This removes the broken hash to #lifecycle-status making the spec build work again:

https://github.com/open-telemetry/opentelemetry.io/issues/7324

We can update the link afterwards to point to the new #maturity-levels but since the document almost only has that chapter we might even leave it like that for now.