### PR TITLE
Remove shortcode and hard code Collector version from receiver docs

### DIFF
--- a/content/en/docs/collector/building/receiver.md
+++ b/content/en/docs/collector/building/receiver.md
@@ -1516,7 +1516,7 @@ convention to represent that information on its `Resource`.
 
 All the resource semantic convention attribute names and well known-values are
 kept within the
-[/semconv/v1.9.0/generated_resource.go](<https://github.com/open-telemetry/opentelemetry-collector/blob/v{{% param vers %}}/semconv/v1.9.0/generated_resource.go>)
+[/semconv/v1.9.0/generated_resource.go](<https://github.com/open-telemetry/opentelemetry-collector/blob/v0.128.0/semconv/v1.9.0/generated_resource.go>)
 file within the Collector's GitHub project.
 
 Let's create a function to read the field values from an `BackendSystem`


### PR DESCRIPTION
The most recent [bot update](https://github.com/open-telemetry/opentelemetry.io/pull/7333) for Collector releases is failing link checking because the go package has since been updated. The receiver page requires a more extensive edit, so the [short-term solution](https://github.com/open-telemetry/opentelemetry.io/pull/7333#issuecomment-3096171286) is to hard code the collector version.