### PR TITLE
OTel .NET Auto - remove OTEL_DOTNET_AUTO_LOGS_INCLUDE_FORMATTED_MESSAGE from internal logs section

### DIFF
--- a/content/en/docs/zero-code/dotnet/configuration.md
+++ b/content/en/docs/zero-code/dotnet/configuration.md
@@ -380,4 +380,3 @@ instead.
 | ------------------------------------------------- | ----------------------------------------------------------------------- | ---------------------------------------- | --------------------------------------------------------- |
 | `OTEL_DOTNET_AUTO_LOG_DIRECTORY`                  | Directory of the .NET Tracer logs.                                      | _See the previous note on default paths_ | [Experimental](/docs/specs/otel/versioning-and-stability) |
 | `OTEL_LOG_LEVEL`                                  | SDK log level. (supported values: `none`,`error`,`warn`,`info`,`debug`) | `info`                                   | [Stable](/docs/specs/otel/versioning-and-stability)       |
-| `OTEL_DOTNET_AUTO_LOGS_INCLUDE_FORMATTED_MESSAGE` | Whether the log state should be formatted.                              | `false`                                  | [Experimental](/docs/specs/otel/versioning-and-stability) |


### PR DESCRIPTION
Propagates changes from https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/4339

The descriptions should be only under https://opentelemetry.io/docs/zero-code/dotnet/configuration/#logs-exporter