### PR TITLE
Update dependabot.yml - ignore hugo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: hugo-extended
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
There is rarely an urgency to upgrade Hugo. Let's keep Hugo upgrades manual, for [reasons explained in the maintainer slack](https://cloud-native.slack.com/archives/C06EDFPQ5EH/p1753708092512489).