### PR TITLE
Training page: ensure cross-locale page-bundle processing of img

### DIFF
--- a/content/en/training/index.md
+++ b/content/en/training/index.md
@@ -34,32 +34,38 @@ A **FREE** course available from [Cloud Native Training Courses for
 OpenTelemetry][CNTCOT] and offered by the Linux Foundation:
 
 <div class="card--course-wrapper">
-  <div class="card card--course" style="width: 20rem">
-    <img src="LFS148-Course-Badge-300x300.avif"
-      class="img-initial pt-3 w-75 m-auto"
-      alt="LFS148 course badge">
-    <div class="card-body ps-4 pe-4 bg-light-subtle">
-      <div class="h4 card-title pt-2 pb-2">
-        <span class="badge text-bg-secondary float-end">FREE</span>
-        Getting Started with OpenTelemetry
-      </div>
-      <p class="card-text">
-        A course designed for software developers, DevOps engineers, site reliability engineers (SREs), and anyone looking to implement telemetry solutions across apps and environments.
-      </p>
-      <p class="card-text text-body-secondary small">
-        Online, self-paced, 8-10 hrs,
-        <a href="{{% param LFS148 %}}">learn more</a>.
-      </p>
-      <p class="text-center m-0 pt-1 pb-2">
-        <a href="{{% param LFS148 %}}" target="_blank" rel="noopener" class="btn btn-primary">
-          Register
-        </a>
-      </p>
-    </div>
+<div class="card card--course" style="width: 20rem">
+
+<!-- prettier-ignore -->
+![LFS148 course badge][]
+{.img-initial .pt-3 .w-75 .m-auto}
+
+<div class="card-body ps-4 pe-4 bg-light-subtle">
+  <div class="h4 card-title pt-2 pb-2">
+    <span class="badge text-bg-secondary float-end">FREE</span>
+    Getting Started with OpenTelemetry
   </div>
+  <p class="card-text">
+    A course designed for software developers, DevOps engineers, site reliability
+    engineers (SREs), and anyone looking to implement telemetry solutions across
+    apps and environments.
+  </p>
+  <p class="card-text text-body-secondary small">
+    Online, self-paced, 8-10 hrs,
+    <a href="{{% param LFS148 %}}">learn more</a>.
+  </p>
+  <p class="text-center m-0 pt-1 pb-2">
+    <a href="{{% param LFS148 %}}" target="_blank" rel="noopener" class="btn btn-primary">
+      Register
+    </a>
+  </p>
+</div>
+
+</div>
 </div>
 
 [CNTCOT]: https://www.cncf.io/training/courses/?_sft_lf-project=opentelemetry
+[LFS148 course badge]: LFS148-Course-Badge-300x300.avif
 
 {{% comment %}}
 


### PR DESCRIPTION
- Fixes https://github.com/open-telemetry/opentelemetry.io/pull/7273#discussion_r2209729354
- Reverts to using markdown for the card image so that Hugo can handle the page-build resources properly across locales.

> [!NOTE]
> Best [reviewed by ignoring whitespace](https://github.com/open-telemetry/opentelemetry.io/pull/7420/files?diff=unified&w=1).