### PR TITLE
Update distributions for Embrace Web SDK

### DIFF
--- a/data/ecosystem/distributions.yaml
+++ b/data/ecosystem/distributions.yaml
@@ -163,6 +163,10 @@
   url: https://github.com/embrace-io/embrace-react-native-sdk
   docsUrl: https://embrace.io/docs/open-telemetry/integration/#react-native
   components: [React Native, Javascript]
+- name: Embrace Web Distribution for OpenTelemetry
+  url: https://github.com/embrace-io/embrace-web-sdk/
+  docsUrl: https://embrace.io/docs/web/getting-started/
+  components: [Javascript, React, Browser]
 - name: Dynatrace Distribution of the OpenTelemetry Collector
   url: https://github.com/Dynatrace/dynatrace-otel-collector
   docsUrl: https://docs.dynatrace.com/docs/shortlink/opentelemetry-collector


### PR DESCRIPTION
This updates the distributions list for a new distribution from Embrace, a Web-specific SDK that can be found [here](https://github.com/embrace-io/embrace-web-sdk). 

Please let me know if the components I've tagged are questionable, or if there are any other questions!