### PR TITLE
[experimental] enable pt/ja maintainers to merge PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,4 +13,9 @@
 #
 
 # Global owners, will be the owners for everything in the repo.
-* @open-telemetry/docs-approvers
+*             @open-telemetry/docs-approvers
+
+# Localization maintainers should be able to approve & merge PRs on their own
+# This is experimental
+content/pt    @open-telemetry/docs-pt-maintainers
+content/ja    @open-telemetry/docs-ja-maintainers


### PR DESCRIPTION
With the localization teams becoming more and more self-reliable, enabling them to merge PRs on their own is the next logical step. 

Based on my research this is the easiest option to do so, all other options are much more complex and require additional setup of bots, repositories, etc.

I'd like to run this as an experiment, which means that we enable 2 localization teams (`ja` and `pt`) for a limited time (until end of september) to merge their PRs independently, after that time we will review the outcome and evaluate if we continue with it, or need to put another solution in place.

If this works as expected I suggest that we also not have maintainers per language, but one `docs-localization-maintainers` group which will step to take responsibility for the localization efforts.

@open-telemetry/docs-maintainers PTAL