### PR TITLE
Patch broken URL to Prometheus docs

### DIFF
--- a/content/en/blog/2024/prometheus-compatibility-survey/index.md
+++ b/content/en/blog/2024/prometheus-compatibility-survey/index.md
@@ -21,7 +21,7 @@ At this point, there is a
 describing how to convert between the
 [OpenTelemetry metrics data model](/docs/specs/otel/metrics/data-model/#opentelemetry-protocol-data-model)
 and
-[Prometheus metric formats](https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md).
+[Prometheus metric formats](https://github.com/prometheus/docs/blob/main/docs/instrumenting/exposition_formats.md).
 It has been used to implement Prometheus
 [(pull) exporters for OpenTelemetry SDKs](https://pkg.go.dev/go.opentelemetry.io/otel/exporters/prometheus),
 [OTLP export from Prometheus libraries](https://prometheus.github.io/client_java/otel/otlp/),

--- a/content/ja/docs/languages/sdk-configuration/general.md
+++ b/content/ja/docs/languages/sdk-configuration/general.md
@@ -2,7 +2,7 @@
 title: 一般的なSDK設定
 linkTitle: 一般
 aliases: [general-sdk-configuration]
-default_lang_commit: d0a90db560d4f15934bdb43d994eabcfd91c515a
+default_lang_commit: d0a90db560d4f15934bdb43d994eabcfd91c515a # patched
 cSpell:ignore: ottrace
 ---
 
@@ -148,7 +148,7 @@ export OTEL_TRACES_SAMPLER_ARG="0.5"
 
 - `"otlp"`: [OTLP][]
 - `"prometheus"`:
-  [Prometheus](https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md)
+  [Prometheus](https://github.com/prometheus/docs/blob/main/docs/instrumenting/exposition_formats.md)
 - `"console"`: [標準出力](/docs/specs/otel/metrics/sdk_exporters/stdout/)
 - `"none"`: メトリクスのエクスポーターが自動的に設定されない。
 

--- a/content/pt/docs/languages/sdk-configuration/general.md
+++ b/content/pt/docs/languages/sdk-configuration/general.md
@@ -2,7 +2,7 @@
 title: Configurações gerais de SDK
 linkTitle: Geral
 aliases: [general-sdk-configuration]
-default_lang_commit: 1e4970e9193c8af1d1f9b86901b13492071aecc7
+default_lang_commit: 1e4970e9193c8af1d1f9b86901b13492071aecc7 # patched
 cSpell:ignore: ottrace
 ---
 
@@ -170,7 +170,7 @@ Os valores aceitos para `OTEL_METRICS_EXPORTER` são:
 
 - `"otlp"`: [OTLP][]
 - `"prometheus"`:
-  [Prometheus](https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md)
+  [Prometheus](https://github.com/prometheus/docs/blob/main/docs/instrumenting/exposition_formats.md)
 - `"console"`: [Saída Padrão](/docs/specs/otel/metrics/sdk_exporters/stdout/)
 - `"none"`: Nenhum exportador de métricas configurado automaticamente.
 

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -14791,14 +14791,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-16T13:35:17.361251-05:00"
   },
-  "https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T13:34:58.350786-05:00"
-  },
-  "https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md#text-based-format": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:21:12.345Z"
-  },
   "https://github.com/prometheus/docs/blob/main/docs/instrumenting/exposition_formats.md": {
     "StatusCode": 206,
     "LastSeen": "2025-06-05T10:38:34.828266434Z"


### PR DESCRIPTION
This PR follows up on #7441 and updates the broken URLs in localized files and a blog post. It also updates the refcache to remove this URL.