### PR TITLE
[i18n] Move alert prose from `native-libraries` partial into an include file

### DIFF
--- a/content/en/docs/languages/_includes/native-lib-alert.md
+++ b/content/en/docs/languages/_includes/native-lib-alert.md
@@ -1,0 +1,29 @@
+---
+---
+
+{{ if $noIntegrations }}
+
+<div class="alert alert-secondary" role="alert">
+<div class="h4 alert-title">Help wanted!</div>
+
+As of today, we don't know about any {{ $name }} library that has
+OpenTelemetry natively integrated. If you know about such a library,
+[let us know][].
+
+</div>
+
+{{ end }}
+
+{{ if not $noIntegrations }}
+
+<div class="alert alert-info" role="alert">
+
+If you know a {{ $name }} library that has OpenTelemetry natively
+integrated, [let us know][].
+
+</div>
+
+{{ end }}
+
+[let us know]:
+  https://github.com/open-telemetry/opentelemetry.io/issues/new/choose

--- a/content/en/docs/languages/_includes/native-lib-alert.md
+++ b/content/en/docs/languages/_includes/native-lib-alert.md
@@ -3,25 +3,23 @@
 
 {{ if $noIntegrations }}
 
-<div class="alert alert-secondary" role="alert">
-<div class="h4 alert-title">Help wanted!</div>
+{{% alert title="Help wanted!" color=secondary %}}
 
-As of today, we don't know about any {{ $name }} library that has
-OpenTelemetry natively integrated. If you know about such a library,
-[let us know][].
+As of today, we don't know about any {{ $name }} library that has OpenTelemetry
+natively integrated. If you know about such a library, [let us know][].
 
-</div>
+{{% /alert %}}
 
 {{ end }}
 
 {{ if not $noIntegrations }}
 
-<div class="alert alert-info" role="alert">
+{{% alert color=info %}}
 
-If you know a {{ $name }} library that has OpenTelemetry natively
-integrated, [let us know][].
+If you know a {{ $name }} library that has OpenTelemetry natively integrated,
+[let us know][].
 
-</div>
+{{% /alert %}}
 
 {{ end }}
 

--- a/content/en/docs/languages/java/instrumentation.md
+++ b/content/en/docs/languages/java/instrumentation.md
@@ -104,7 +104,7 @@ instrumentation maintained by OpenTelemetry in
 [opentelemetry-java-instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation)
 as a temporary means of filling the gap.
 
-{{% docs/languages/native-libraries "java" %}}
+{{% docs/languages/native-libraries %}}
 
 ### Manual instrumentation
 

--- a/content/ja/docs/languages/java/instrumentation.md
+++ b/content/ja/docs/languages/java/instrumentation.md
@@ -68,7 +68,7 @@ Spring Bootスターターは、Springの自動構成を活用して[ライブ�
 OpenTelemetryは、[API](../api/)を使用してネイティブ計装を追加することをライブラリ作成者に推奨しています。
 長期的には、ネイティブ計装が標準になることを期待しており、[opentelemetry-java-instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation)でOpenTelemetryによって維持される計装は、ギャップを埋める一時的な手段と見なしています。
 
-{{% docs/languages/native-libraries "java" %}}
+{{% docs/languages/native-libraries %}}
 
 ### 手動計装 {#manual-instrumentation}
 

--- a/content/ja/docs/languages/java/instrumentation.md
+++ b/content/ja/docs/languages/java/instrumentation.md
@@ -8,7 +8,7 @@ aliases:
   - libraries
 weight: 10
 description: OpenTelemetry Javaにおける計装エコシステム
-default_lang_commit: beb85b4f56de76aa8a8d6e96cd7528396476f95a
+default_lang_commit: beb85b4f56de76aa8a8d6e96cd7528396476f95a # patched
 cSpell:ignore: logback
 ---
 

--- a/content/pt/docs/languages/java/instrumentation.md
+++ b/content/pt/docs/languages/java/instrumentation.md
@@ -8,7 +8,7 @@ aliases:
   - libraries
 weight: 10
 description: Ecossistema de Instrumentação no OpenTelemetry Java
-default_lang_commit: dc20c29a4c79ad0424c0fcc3271216af7e035d9b
+default_lang_commit: dc20c29a4c79ad0424c0fcc3271216af7e035d9b # patched
 cSpell:ignore: logback
 ---
 

--- a/content/pt/docs/languages/java/instrumentation.md
+++ b/content/pt/docs/languages/java/instrumentation.md
@@ -106,7 +106,7 @@ padrão, e que a instrumentação mantida pelo OpenTelemetry em
 [opentelemetry-java-instrumentação](https://github.com/open-telemetry/opentelemetry-java-instrumentation)
 seja um meio temporário de preencher a lacuna.
 
-{{% docs/languages/native-libraries "java" %}}
+{{% docs/languages/native-libraries %}}
 
 ### Instrumentação manual {#manual-instrumentation}
 

--- a/layouts/_partials/docs/native-libraries.md
+++ b/layouts/_partials/docs/native-libraries.md
@@ -1,6 +1,11 @@
+{{ $langIndex := partial "func/get-lang.html" (dict
+    "page" .Page
+    "lang" (.Get 0)
+    "componentName" "native-libraries.md")
+-}}
 {{ $howMany := .Get 1 | default 10 -}}
-{{ $langIndex := .Get 0 -}}
-{{ $lang := index $.Site.Data.instrumentation $langIndex -}}
+
+{{ $langData := index $.Site.Data.instrumentation $langIndex -}}
 {{ $integrations := slice -}}
 
 {{ range $entry := $.Site.Data.registry -}}
@@ -13,27 +18,14 @@
 - [{{ .title }}]({{ .urls.docs }})
 {{- end }}
 
-{{ if eq (len $integrations) 0 -}}
+{{ $langName := $langData.name | default "ERROR-LANG-MISSING" -}}
+{{ $noIntegrations := eq (len $integrations) 0 -}}
 
-<div class="alert alert-secondary" role="alert">
-<div class="h4 alert-title">Help wanted!</div>
+{{ $args := dict
+    "_dot" .
+    "_path" "native-lib-alert.md"
+    "name" $langName
+    "noIntegrations" $noIntegrations
+-}}
 
-As of today, we don't know about any {{ $lang.name }} library that has
-OpenTelemetry natively integrated. If you know about such a library,
-[let us know][].
-
-</div>
-
-{{- else -}}
-
-<div class="alert alert-info" role="alert">
-
-If you know a {{ $lang.name }} library that has OpenTelemetry natively
-integrated, [let us know][].
-
-</div>
-
-{{- end }}
-
-[let us know]:
-  https://github.com/open-telemetry/opentelemetry.io/issues/new/choose
+{{ partial "include" $args -}}

--- a/layouts/_partials/func/get-lang.html
+++ b/layouts/_partials/func/get-lang.html
@@ -1,0 +1,22 @@
+{{/*
+  ARGS: .lang .page .componentName
+
+  RETURNS: .lang if truthy, otherwise the language extracted from
+  .page.RelPermalink when of the form `/docs/languages/LANG/...` optionally
+  prefixed with a locale code.
+
+  EXAMPLE: when .page is `docs/languages/go/...`, the return value is `go`.
+*/ -}}
+
+{{ $lang := .lang -}}
+{{ if not $lang }}
+  {{ $matches := findRESubmatch `docs/languages/([^/]+)` .page.RelPermalink -}}
+  {{ $lang = index (index $matches 0) 1 -}}
+  {{ if not $lang -}}
+    {{ $msg := printf "%q: Cannot determine language from page file path." .page.File.Path -}}
+    {{ $fix := printf "Add a language argument to the shortcode or partial call of %q" .componentName -}}
+    {{ errorf "%s %s" $msg $fix -}}
+  {{ end -}}
+{{ end -}}
+
+{{ return $lang -}}


### PR DESCRIPTION
- Contributes to #6460
- Factors out the prose part of the `native-libraries` partial, putting it into an include file
  - Replaces the inline alert-shortcode HTML by a call to the alert shortcode
- Adds a `func` partial used to determine the language that a page is a part of when under `docs/languages`
- There was not change to the generated site code as a result of the refactoring. Changes were introduced by using the alert shortcode instead of hard-coded (obsolete) HTML.

### Preview

- https://deploy-preview-7452--opentelemetry.netlify.app/docs/languages/cpp/library/#use-natively-instrumented-libraries - shows "Help wanted" alert
- https://deploy-preview-7452--opentelemetry.netlify.app/docs/languages/java/instrumentation/#native-instrumentation - shows an info alert
