### PR TITLE
New stubs for client apps platform documentation

### DIFF
--- a/content/en/docs/platforms/android/_index.md
+++ b/content/en/docs/platforms/android/_index.md
@@ -1,6 +1,0 @@
----
-title: Android
-# description:
----
-
-Content coming soon!

--- a/content/en/docs/platforms/client-apps/_index.md
+++ b/content/en/docs/platforms/client-apps/_index.md
@@ -1,0 +1,10 @@
+---
+title: Client-Side Apps
+---
+
+Instrumentation for apps running on end-user devices like phones and desktop
+commuters require additional attention, even for folks familiar with
+OpenTelemetry. The content in this section outlines best practices for using
+OpenTelemetry in these types of environments to maximize the utility of the
+collected telemetry and avoid pitfalls that are non-obvious for those who are
+just starting out with OTel on these platforms.

--- a/content/en/docs/platforms/client-apps/android/_index.md
+++ b/content/en/docs/platforms/client-apps/android/_index.md
@@ -1,0 +1,7 @@
+---
+title: Android
+description: >-
+  Using OpenTelemetry in apps running on Android platforms
+---
+
+Content coming soon!

--- a/content/en/docs/platforms/client-apps/ios/_index.md
+++ b/content/en/docs/platforms/client-apps/ios/_index.md
@@ -1,0 +1,7 @@
+---
+title: iOS
+description: >-
+  Using OpenTelemetry in apps running on iOS and iPadOS
+---
+
+Content coming soon!

--- a/content/en/docs/platforms/client-apps/overview.md
+++ b/content/en/docs/platforms/client-apps/overview.md
@@ -1,0 +1,10 @@
+---
+title: Overview
+weight: 1
+description: >-
+  Using OpenTelemetry on end-user controlled apps running on devices like mobile
+  phones, desktop computers, and retail kiosks.
+redirects: [{ from: /docs/platforms/android/*, to: ':splat' }] # cSpell:disable-line
+---
+
+Content coming soon!

--- a/content/en/docs/platforms/client-apps/web/_index.md
+++ b/content/en/docs/platforms/client-apps/web/_index.md
@@ -1,0 +1,7 @@
+---
+title: Web
+description: >-
+  Using OpenTelemetry in apps running on web browsers
+---
+
+Content coming soon!


### PR DESCRIPTION
Under the [Platforms](https://opentelemetry.io/docs/platforms/) section of the website, there's a stub for Android that contains no information. This PR replaces this stub with other stubs, including a general landing page for all client-side apps, as well as individual ones for Android, iOS, and web, in preparation for adding additional content shortly.

The reason I want to merge the stubs instead of waiting for more fully fleshed out content to be ready is so we can more easily collaborate, as there are a number of unique best practices, conventions, and warnings on the go for client platforms that we want to document this way. For instance:

- A more detailed description of the types of apps that fit into the "client-side apps" umbrella as defined in the [glossary](https://opentelemetry.io/docs/concepts/glossary/#client-side-app)
- Why OTel metrics is not a good fit
- Sessions
- Sampling
- Gotchas like dealing with loss of connectivity and unexpected termination
- etc.