### PR TITLE
Add cardinality definition to English glossary

### DIFF
--- a/content/en/docs/concepts/glossary.md
+++ b/content/en/docs/concepts/glossary.md
@@ -53,6 +53,14 @@ examples include bytecode injection or monkey patching.
 A mechanism for propagating [Metadata](#metadata) to help establish a causal
 relationship between events and services. See [baggage spec][baggage].
 
+### Cardinality
+
+The number of unique values for a given [Attribute](#attribute) or set of
+attributes. High cardinality means many unique values, which can impact the
+performance and storage requirements of telemetry backends. For example, a
+`user_id` attribute would have high cardinality, while a `status_code` attribute
+with values like "200", "404", "500" would have low cardinality.
+
 ### Client library
 
 See [Instrumented library](#instrumented-library).


### PR DESCRIPTION
This PR adds a definition for 'cardinality' to the English glossary.

The definition explains:
- What cardinality means (number of unique values for attributes)
- The impact of high vs low cardinality on telemetry backends
- Examples of high cardinality (user_id) vs low cardinality (status_code) attributes

This is part of a series of improvements to help users understand key OpenTelemetry concepts.