### PR TITLE
Add cardinality definition to Portuguese glossary

### DIFF
--- a/content/pt/docs/concepts/glossary.md
+++ b/content/pt/docs/concepts/glossary.md
@@ -104,7 +104,7 @@ rastreamento. Consulte a [especificação de campos][field].
 
 O número de valores únicos para um determinado [Atributo](#attribute) ou
 conjunto de atributos. Alta cardinalidade significa muitos valores únicos, o que
-pode impactar o desempenho e os requisitos de armazenamento dos backends de
+pode impactar o desempenho e os requisitos de armazenamento dos _backends_ de
 telemetria. Por exemplo, um atributo `user_id` teria alta cardinalidade,
 enquanto um atributo `status_code` com valores como "200", "404", "500" teria
 baixa cardinalidade.


### PR DESCRIPTION
This PR adds a definition for 'cardinalidade' to the Portuguese glossary.

The definition explains:
- What cardinality means (número de valores únicos para atributos)
- The impact of high vs low cardinality on telemetry backends
- Examples of high cardinality (user_id) vs low cardinality (status_code) attributes

This is part of a series of improvements to help users understand key OpenTelemetry concepts.