### PR TITLE
Revert "[experimental] enable pt/ja maintainers to merge PRs"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,9 +13,4 @@
 #
 
 # Global owners, will be the owners for everything in the repo.
-*             @open-telemetry/docs-approvers
-
-# Localization maintainers should be able to approve & merge PRs on their own
-# This is experimental
-content/pt    @open-telemetry/docs-pt-maintainers
-content/ja    @open-telemetry/docs-ja-maintainers
+* @open-telemetry/docs-approvers


### PR DESCRIPTION
Keep this PR as a reminder that we want to revisit the docs localization maintainership by end of september

cc @open-telemetry/docs-maintainers @open-telemetry/docs-ja-maintainers @open-telemetry/docs-pt-maintainers 