### PR TITLE
[pt] add drifted_from_default to out-of-date pt pages

### DIFF
--- a/content/pt/announcements/_index.md
+++ b/content/pt/announcements/_index.md
@@ -5,4 +5,5 @@ cascade:
   params:
     hide_feedback: true
 default_lang_commit: 2291fd884421f8a0bb47c72327c0681fdf116225
+drifted_from_default: true
 ---

--- a/content/pt/docs/_includes/exporters/intro.md
+++ b/content/pt/docs/_includes/exporters/intro.md
@@ -1,5 +1,6 @@
 ---
 default_lang_commit: 02efe39c47d3dbb1a6be680420af7491568a2de3
+drifted_from_default: true
 ---
 
 Envie dados de telemetria para o [OpenTelemetry Collector](/docs/collector/)

--- a/content/pt/docs/concepts/glossary.md
+++ b/content/pt/docs/concepts/glossary.md
@@ -5,6 +5,7 @@ description: >-
   OpenTelemetry.
 weight: 200
 default_lang_commit: 389e023192e051a3a835bfc6a71089c98af3b8a8
+drifted_from_default: true
 ---
 
 Esse glossário define termos e [conceitos](/docs/concepts/) que são novos no

--- a/content/pt/docs/concepts/instrumentation-scope/index.md
+++ b/content/pt/docs/concepts/instrumentation-scope/index.md
@@ -2,6 +2,7 @@
 title: Escopo de instrumentação
 weight: 80
 default_lang_commit: 2f34c456ab38b4d3502cd07bc36fa1455d4ef875 # patched
+drifted_from_default: true
 ---
 
 O [escopo de instrumentação](/docs/specs/otel/common/instrumentation-scope/)

--- a/content/pt/docs/concepts/resources/index.md
+++ b/content/pt/docs/concepts/resources/index.md
@@ -2,6 +2,7 @@
 title: Recursos
 weight: 70
 default_lang_commit: 86d2fbde246b9e56665146db78d4fc1d34d00ddf
+drifted_from_default: true
 ---
 
 ## Introdução {#introduction}

--- a/content/pt/docs/concepts/signals/metrics.md
+++ b/content/pt/docs/concepts/signals/metrics.md
@@ -3,6 +3,7 @@ title: Métricas
 weight: 2
 description: Uma medição capturada em tempo de execução.
 default_lang_commit: 7c0e4db0b6c39b0ca0e7efb17df5610d1b77b8a3
+drifted_from_default: true
 ---
 
 Uma métrica é uma medição de um serviço capturada em tempo de execução. O

--- a/content/pt/docs/concepts/signals/traces.md
+++ b/content/pt/docs/concepts/signals/traces.md
@@ -3,6 +3,7 @@ title: Rastros
 weight: 1
 description: O caminho de uma solicitação através do seu aplicativo.
 default_lang_commit: 7c0e4db0b6c39b0ca0e7efb17df5610d1b77b8a3
+drifted_from_default: true
 ---
 
 Os **rastros** nos fornecem uma visão geral do que acontece quando uma

--- a/content/pt/docs/contributing/blog.md
+++ b/content/pt/docs/contributing/blog.md
@@ -3,6 +3,7 @@ title: Blog
 description: Saiba como enviar uma publicação para o blog.
 weight: 30
 default_lang_commit: 6c676267409eefc15a28c0e2fdd60b26a4687f74
+drifted_from_default: true
 ---
 
 O [_blog_ do OpenTelemetry](/blog/) comunica novas funcionalidades, relatórios

--- a/content/pt/docs/contributing/localization.md
+++ b/content/pt/docs/contributing/localization.md
@@ -4,6 +4,7 @@ description: Criando e mantendo páginas do site em localizações não inglesas
 linkTitle: Localização
 weight: 25
 default_lang_commit: b089f21094014118017cf32ffeea6b50afc3579f
+drifted_from_default: true
 cSpell:ignore: merge ptbr shortcodes
 ---
 

--- a/content/pt/docs/contributing/pr-checks.md
+++ b/content/pt/docs/contributing/pr-checks.md
@@ -4,6 +4,7 @@ description:
   Saiba como fazer seu pull request passar por todas as verificações com sucesso
 weight: 40
 default_lang_commit: 6c676267409eefc15a28c0e2fdd60b26a4687f74
+drifted_from_default: true
 ---
 
 Ao abrir um

--- a/content/pt/docs/contributing/prerequisites.md
+++ b/content/pt/docs/contributing/prerequisites.md
@@ -6,6 +6,7 @@ description:
 aliases: [requirements]
 weight: 1
 default_lang_commit: 1ececa0615b64c5dfd93fd6393f3e4052e0cc496
+drifted_from_default: true
 ---
 
 Para contribuir com este repositório, você precisa estar familiarizado com as

--- a/content/pt/docs/contributing/pull-requests.md
+++ b/content/pt/docs/contributing/pull-requests.md
@@ -6,6 +6,7 @@ description:
 aliases: [new-content]
 weight: 15
 default_lang_commit: bc14fe46c2f358c8c0b6dc7f394535787bd4fff3
+drifted_from_default: true
 ---
 
 Para contribuir com novos conteúdos ou melhorar a documentação existente,

--- a/content/pt/docs/contributing/style-guide.md
+++ b/content/pt/docs/contributing/style-guide.md
@@ -4,6 +4,7 @@ description: Terminologia e estilo ao escrever a documentação do OpenTelemetry
 linkTitle: Manual de estilo
 weight: 20
 default_lang_commit: 4d9d9039bc658ad691d12710016c2d491550feec
+drifted_from_default: true
 cSpell:ignore: open-telemetry opentelemetryio postgre style-guide textlintrc
 ---
 

--- a/content/pt/docs/languages/_includes/exporters/prometheus-setup.md
+++ b/content/pt/docs/languages/_includes/exporters/prometheus-setup.md
@@ -1,5 +1,6 @@
 ---
 default_lang_commit: 7d0c3f247ee77671d1135b0af535a2aca05fe359 # patched
+drifted_from_default: true
 ---
 
 ## Prometheus

--- a/content/pt/docs/languages/_includes/exporters/zipkin-setup.md
+++ b/content/pt/docs/languages/_includes/exporters/zipkin-setup.md
@@ -1,5 +1,6 @@
 ---
 default_lang_commit: 7d0c3f247ee77671d1135b0af535a2aca05fe359 # patched
+drifted_from_default: true
 ---
 
 ## Zipkin

--- a/content/pt/docs/languages/_index.md
+++ b/content/pt/docs/languages/_index.md
@@ -5,6 +5,7 @@ description:
   populares de programação.
 weight: 250
 default_lang_commit: d1ef521ee4a777881fb99c3ec2b506e068cdec4c
+drifted_from_default: true
 ---
 
 A [instrumentação][] de código do OpenTelemetry é suportada para as linguagens

--- a/content/pt/docs/languages/go/api.md
+++ b/content/pt/docs/languages/go/api.md
@@ -6,4 +6,5 @@ manualLinkTarget: _blank
 build: { render: link }
 weight: 210
 default_lang_commit: 06837fe15457a584f6a9e09579be0f0400593d57
+drifted_from_default: true
 ---

--- a/content/pt/docs/languages/go/examples.md
+++ b/content/pt/docs/languages/go/examples.md
@@ -5,4 +5,5 @@ manualLinkTarget: _blank
 build: { render: link }
 weight: 220
 default_lang_commit: 5e2a0b43c1f9f42824a024206e797cf7041ed9db
+drifted_from_default: true
 ---

--- a/content/pt/docs/languages/go/getting-started.md
+++ b/content/pt/docs/languages/go/getting-started.md
@@ -2,6 +2,7 @@
 title: Primeiros Passos
 weight: 10
 default_lang_commit: dc20c29a4c79ad0424c0fcc3271216af7e035d9b
+drifted_from_default: true
 # prettier-ignore
 cSpell:ignore: chan fatalln funcs intn itoa khtml otelhttp rolldice stdouttrace strconv
 ---

--- a/content/pt/docs/languages/go/instrumentation.md
+++ b/content/pt/docs/languages/go/instrumentation.md
@@ -6,6 +6,7 @@ aliases:
 weight: 30
 description: Instrumentação manual para OpenTelemetry Go
 default_lang_commit: dc20c29a4c79ad0424c0fcc3271216af7e035d9b
+drifted_from_default: true
 cSpell:ignore: fatalf logr logrus otlplog otlploghttp sdktrace sighup updown
 ---
 

--- a/content/pt/docs/languages/go/registry.md
+++ b/content/pt/docs/languages/go/registry.md
@@ -7,4 +7,5 @@ redirect: /ecosystem/registry/?language=go
 build: { render: link }
 weight: 300
 default_lang_commit: 1e0c316e3bdac625edc51f0a5037bff6e4611b65
+drifted_from_default: true
 ---

--- a/content/pt/docs/languages/java/_index.md
+++ b/content/pt/docs/languages/java/_index.md
@@ -12,6 +12,7 @@ cascade:
     semconv: 1.32.0
 weight: 18
 default_lang_commit: 3512b0ae11f72d3a954d86da59ad7f98d064bdad
+drifted_from_default: true
 ---
 
 {{% docs/languages/index-intro java /%}}

--- a/content/pt/docs/languages/java/instrumentation.md
+++ b/content/pt/docs/languages/java/instrumentation.md
@@ -9,6 +9,7 @@ aliases:
 weight: 10
 description: Ecossistema de Instrumentação no OpenTelemetry Java
 default_lang_commit: dc20c29a4c79ad0424c0fcc3271216af7e035d9b # patched
+drifted_from_default: true
 cSpell:ignore: logback
 ---
 

--- a/content/pt/docs/languages/js/getting-started/nodejs.md
+++ b/content/pt/docs/languages/js/getting-started/nodejs.md
@@ -4,6 +4,7 @@ description: Obtenha telemetria para sua aplicação em menos de 5 minutos!
 aliases: [/docs/js/getting_started/nodejs]
 weight: 10
 default_lang_commit: 1f6a173c26d1e194696ba77e95b6c3af40234952
+drifted_from_default: true
 cSpell:ignore: autoinstrumentations KHTML rolldice
 ---
 

--- a/content/pt/docs/languages/python/_index.md
+++ b/content/pt/docs/languages/python/_index.md
@@ -6,6 +6,7 @@ description: >-
   Python.
 weight: 22
 default_lang_commit: 3fd0bb513e5d3fa6f178a73584322bcc469f15e0 # patched
+drifted_from_default: true
 ---
 
 {{% docs/languages/index-intro python /%}}

--- a/content/pt/docs/languages/python/exporters.md
+++ b/content/pt/docs/languages/python/exporters.md
@@ -3,6 +3,7 @@ title: Exporters
 weight: 50
 description: Processar e exportar seus dados de telemetria
 default_lang_commit: dc20c29a4c79ad0424c0fcc3271216af7e035d9b
+drifted_from_default: true
 cSpell:ignore: LOWMEMORY
 ---
 

--- a/content/pt/docs/languages/python/getting-started.md
+++ b/content/pt/docs/languages/python/getting-started.md
@@ -3,6 +3,7 @@ title: Primeiros Passos
 description: Obtenha telemetria para sua aplicação em menos de 5 minutos!
 weight: 10
 default_lang_commit: 43e2cb3b4d0dd513b436add73236503a8d592b39
+drifted_from_default: true
 # prettier-ignore
 cSpell:ignore: debugexporter diceroller distro maxlen randint rolldice rollspan venv
 ---

--- a/content/pt/docs/languages/sdk-configuration/general.md
+++ b/content/pt/docs/languages/sdk-configuration/general.md
@@ -3,6 +3,7 @@ title: Configurações gerais de SDK
 linkTitle: Geral
 aliases: [general-sdk-configuration]
 default_lang_commit: 1e4970e9193c8af1d1f9b86901b13492071aecc7 # patched
+drifted_from_default: true
 cSpell:ignore: ottrace
 ---
 

--- a/content/pt/docs/what-is-opentelemetry.md
+++ b/content/pt/docs/what-is-opentelemetry.md
@@ -3,6 +3,7 @@ title: O que é o OpenTelemetry?
 description: Uma breve explicação sobre o que o OpenTelemetry é e não é.
 weight: 150
 default_lang_commit: fb38bda3b4b9ae69c99b8d70543d0df37872aeac
+drifted_from_default: true
 cSpell:ignore: youtube
 ---
 

--- a/content/pt/ecosystem/distributions.md
+++ b/content/pt/ecosystem/distributions.md
@@ -4,6 +4,7 @@ description:
   Lista de distribuições de código aberto do OpenTelemetry mantidas por
   terceiros.
 default_lang_commit: b6ddba1118d07bc3c8d1d07b293f227686d0290e
+drifted_from_default: true
 ---
 
 As [distribuições](/docs/concepts/distributions/) do OpenTelemetry são uma forma

--- a/content/pt/ecosystem/integrations.md
+++ b/content/pt/ecosystem/integrations.md
@@ -4,6 +4,7 @@ description:
   Bibliotecas, serviços e aplicações com suporte nativo para o OpenTelemetry.
 aliases: [/integrations]
 default_lang_commit: b6ddba1118d07bc3c8d1d07b293f227686d0290e
+drifted_from_default: true
 ---
 
 A missão do OpenTelemetry é

--- a/content/pt/ecosystem/registry/_index.md
+++ b/content/pt/ecosystem/registry/_index.md
@@ -8,6 +8,7 @@ layout: registry
 body_class: registry td-content
 weight: 20
 default_lang_commit: fd873ed11bfa9920c2e8b0726784f482368e85c2
+drifted_from_default: true
 ---
 
 {{% blocks/lead color="dark" %}}


### PR DESCRIPTION
Add  `drifted_from_default` to out-of-date `pt` pages as reported on #7492 
 