### PR TITLE
Fix two anchors link in collector pages

### DIFF
--- a/content/en/docs/collector/building/receiver.md
+++ b/content/en/docs/collector/building/receiver.md
@@ -53,7 +53,7 @@ above in order to create the receiver, so let's get started.
 First use the [Building a Custom Collector](/docs/collector/custom-collector)
 tutorial to create a Collector instance named `otelcol-dev`; all you need is to
 copy the `builder-config.yaml` described on
-[Step 2](/docs/collector/custom-collector#step-2---create-a-builder-manifest-file)
+[Step 2](/docs/collector/custom-collector#step-2-create-a-builder-manifest-file)
 and run the builder. As an outcome you should now have a folder structure like
 this:
 

--- a/content/en/docs/collector/custom-collector.md
+++ b/content/en/docs/collector/custom-collector.md
@@ -195,7 +195,7 @@ registry entries provide the full name and version you need to add to your
 This step is used to build your custom collector distribution using the `ocb`
 binary. If you would like to build and deploy your custom Collector distribution
 to a container orchestrator (for example, Kubernetes), skip this step and go to
-[Step 3b](#step-3b---containerize-your-collectors-distribution).
+[Step 3b](#step-3b-containerize-your-collectors-distribution).
 
 {{% /alert %}}
 
@@ -252,7 +252,7 @@ This step will build your collector distribution inside a `Dockerfile`. Follow
 this step if you need to deploy your Collector distribution to a container
 orchestrator (for example, Kubernetes). If you would like to _only_ build your
 collector distribution without containerization, go to
-[Step 3a](#step-3a---generate-the-code-and-build-your-collectors-distribution).
+[Step 3a](#step-3a-generate-the-code-and-build-your-collectors-distribution).
 
 {{% /alert %}}
 


### PR DESCRIPTION
While translating #7496, I noticed that two anchors were incorrect and failed the link check.
