### PR TITLE
[chore] Fix links to JMX Metric Insights docs

### DIFF
--- a/content/en/blog/2023/jmx-metric-insight/index.md
+++ b/content/en/blog/2023/jmx-metric-insight/index.md
@@ -16,7 +16,7 @@ can diagnose them with the help of metrics collected, and fine-tune the system
 for optimal performance.
 
 With the addition of the
-[JMX Metric Insight](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/jmx-metrics)
+[JMX Metric Insight](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/README.md)
 module into the
 [OpenTelemetry Java agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation),
 we don't need to deploy a separate service just to collect JMX metrics for
@@ -31,15 +31,13 @@ configurations containing curated sets of JMX metrics for popular application
 servers or frameworks, such as:
 
 - [ActiveMQ](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/javaagent/activemq.md)
+- [Camel](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/javaagent/camel.md)
 - [Hadoop](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/javaagent/hadoop.md)
-- [Jetty](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/javaagent/jetty.md)
 - [Kafka Broker](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/javaagent/kafka-broker.md)
-- [Tomcat](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/javaagent/tomcat.md)
-- [WildFly](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/javaagent/wildfly.md)
 
 You can also provide your own metric definitions, through one or more YAML
 files. For more information, see the
-[YAML file syntax documentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/jmx-metrics/javaagent#configuration-files).
+[YAML file syntax documentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/README.md#configuration-files).
 
 ## Observe Kafka Broker metrics
 
@@ -221,7 +219,7 @@ specified under `mapping`. The metric reported will have the name
 metric is a monotonic sum. It's unit will be `{messages}`. We have also provided
 a description of the metric. This yaml segment is simple, to try out more
 configuration options, you can head to the
-[documentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/javaagent/README.md)
+[documentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/README.md)
 to understand and try out all the features of the module.
 
 Lastly, if you feel some metrics are important to be in the predefined sets of

--- a/content/en/docs/demo/services/kafka.md
+++ b/content/en/docs/demo/services/kafka.md
@@ -11,7 +11,7 @@ accounting and fraud detection services.
 ## Auto-instrumentation
 
 This service relies on the OpenTelemetry Java agent and the built in
-[JMX Metric Insight Module](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/jmx-metrics/javaagent)
+[JMX Metric Insight Module](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/jmx-metrics/README.md)
 to capture
 [Kafka broker metrics](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/javaagent/kafka-broker.md)
 and send them off to the collector via OTLP.

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -9987,6 +9987,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-11-28T09:41:06.933369058Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/jmx-metrics/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-12-01T09:26:25.392491996Z"
+  },
   "https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/jmx-metrics/javaagent": {
     "StatusCode": 206,
     "LastSeen": "2025-11-20T09:40:44.328738087Z"


### PR DESCRIPTION
<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->

This PR updates links to the JMX Metric Insights module documentation. The README file seems to have moved from 
`instrumentation/jmx-metrics/javaagent/README.md`
to
`instrumentation/jmx-metrics/README.md`.

I opted to explicitly link to `README.md` in a few cases so that it will be easier to find these dead links.

https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/README.md

I also updated the links to the built-in rules files to reflect the current state of the repo.
