### PR TITLE
[ja]Translate content/en/docs/languages/_includes/instrumentation-int…

### DIFF
--- a/content/ja/docs/languages/_includes/instrumentation-intro.md
+++ b/content/ja/docs/languages/_includes/instrumentation-intro.md
@@ -1,0 +1,15 @@
+---
+default_lang_commit: 1ececa0615b64c5dfd93fd6393f3e4052e0cc496
+---
+
+[計装](/docs/concepts/instrumentation/)とは、あなた自身がアプリにオブザーバビリティコードを追加する行為です。
+
+アプリを計装する場合、あなたが使用する言語に対応したOpenTelemetry SDKを使用する必要があります。
+SDKを使用してOpenTelemetryを初期化し、APIを使用してコードを計装します。
+これにより、アプリ本体だけでなく、計装が含まれるライブラリからもテレメトリーが出力されるようになります。
+
+ライブラリを計装する場合、使用する言語に対応したOpenTelemetry APIパッケージのみをインストールしてます。
+ライブラリ自体はテレメトリーを出力しません。
+ライブラリの計装についての詳細は、[ライブラリ](/docs/concepts/instrumentation/libraries/)を参照してください。
+
+OpenTelemetry APIとSDKついての詳細は、[仕様](/docs/specs/otel/)を参照してください。

--- a/content/ja/docs/languages/_includes/instrumentation-intro.md
+++ b/content/ja/docs/languages/_includes/instrumentation-intro.md
@@ -5,7 +5,7 @@ default_lang_commit: 1ececa0615b64c5dfd93fd6393f3e4052e0cc496
 [計装](/docs/concepts/instrumentation/)とは、あなた自身がアプリにオブザーバビリティコードを追加する行為です。
 
 アプリを計装する場合、あなたが使用する言語に対応したOpenTelemetry SDKを使用する必要があります。
-SDKを使用してOpenTelemetryを初期化し、APIを使用してコードを計装します。
+次に、SDKを使用してOpenTelemetryを初期化し、APIを使用してコードを計装します。
 これにより、アプリ本体だけでなく、計装が含まれるライブラリからもテレメトリーが出力されるようになります。
 
 ライブラリを計装する場合、使用する言語に対応したOpenTelemetry APIパッケージのみをインストールしてます。


### PR DESCRIPTION
## Original page

Common `_includes` component at the top of `Instrumentation` page
For example:
- https://opentelemetry.io/docs/languages/cpp/instrumentation/
- https://opentelemetry.io/docs/languages/dotnet/instrumentation/

### File with SHA

https://github.com/open-telemetry/opentelemetry.io/blob/1ececa0615b64c5dfd93fd6393f3e4052e0cc496/content/en/docs/languages/_includes/instrumentation-intro.md

## Preview

For example:
- https://deploy-preview-7533--opentelemetry.netlify.app/ja/docs/languages/cpp/instrumentation/
- https://deploy-preview-7533--opentelemetry.netlify.app/ja/docs/languages/dotnet/instrumentation/