### PR TITLE
Update component-owners.yml

### DIFF
--- a/.github/component-owners.yml
+++ b/.github/component-owners.yml
@@ -24,15 +24,15 @@ components:
     - open-telemetry/docs-maintainers
   content/en/docs/demo:
     - open-telemetry/demo-approvers
-  content/en/docs/platform/kubernetes/collector:
+  content/en/docs/platforms/kubernetes/collector:
     - open-telemetry/collector-approvers
-  content/en/docs/platform/kubernetes/helm:
+  content/en/docs/platforms/kubernetes/helm:
     - open-telemetry/helm-approvers
-  content/en/docs/platform/kubernetes/operator:
+  content/en/docs/platforms/kubernetes/operator:
     - open-telemetry/operator-approvers
-  content/en/docs/platform/android:
+  content/en/docs/platforms/client-apps/android:
     - open-telemetry/android-approvers
-  content/en/docs/platform/faas:
+  content/en/docs/platforms/faas:
     - open-telemetry/lambda-extension-approvers
   content/en/docs/languages/cpp:
     - open-telemetry/cpp-approvers


### PR DESCRIPTION
Fixes #7512 

Previously, the platforms path was `content/en/docs/platform`; the actual path is `content/en/docs/platforms`. The changes are:

- content/en/docs/platform/kubernetes/collector -> content/en/docs/platforms/kubernetes/collector
- content/en/docs/platform/kubernetes/helm -> content/en/docs/platforms/kubernetes/helm
- content/en/docs/platform/kubernetes/operator -> content/en/docs/platforms/kubernetes/operator
- content/en/docs/platform/android -> content/en/docs/platforms/client-apps/android
- content/en/docs/platform/faas -> content/en/docs/platforms/faas

@tiffany76 We should update all the owners for components under `platforms` directory, right?
