### PR TITLE
[ja][i18n] Update `ja` drifted status

### DIFF
--- a/content/ja/docs/collector/_index.md
+++ b/content/ja/docs/collector/_index.md
@@ -5,6 +5,7 @@ cascade:
   vers: 0.128.0
 weight: 270
 default_lang_commit: e8f94839e85df475fe8c5ff995c18eefa5220635
+drifted_from_default: true
 ---
 
 ![Jaeger、OTLP、Prometheusを統合したOpenTelemetryコレクターのダイアグラム](img/otel-collector.svg)

--- a/content/ja/docs/concepts/context-propagation.md
+++ b/content/ja/docs/concepts/context-propagation.md
@@ -3,6 +3,7 @@ title: コンテキスト伝搬
 weight: 10
 description: 分散トレーシングを可能にする概念について学ぶ
 default_lang_commit: d2368c7e90e6abeb4580193aa305dfabd21ed4f7
+drifted_from_default: true
 ---
 
 コンテキスト伝搬により、[シグナル](../signals/)は、それらが生成された場所に関係なく、互いを相関させられます。

--- a/content/ja/docs/concepts/glossary.md
+++ b/content/ja/docs/concepts/glossary.md
@@ -3,6 +3,7 @@ title: 用語集
 description: OpenTelemetry で使用されるテレメトリー用語の定義と規則
 weight: 200
 default_lang_commit: 6c676267409eefc15a28c0e2fdd60b26a4687f74
+drifted_from_default: true
 ---
 
 この用語集は、OpenTelemetry プロジェクトに対して新しい、用語と[概念](/docs/concepts/)を定義し、オブザーバビリティの分野で一般的に使われている OpenTelemetry 特有の使用法を明確にします。

--- a/content/ja/docs/concepts/signals/metrics.md
+++ b/content/ja/docs/concepts/signals/metrics.md
@@ -3,6 +3,7 @@ title: メトリクス
 weight: 2
 description: 実行時に取得された測定値
 default_lang_commit: f15873cbe9b2c3f3b51ef4629a6116de84eae08f
+drifted_from_default: true
 ---
 
 **メトリクス**とは、実行時に取得されるサービスの**測定値**のことです。

--- a/content/ja/docs/contributing/blog.md
+++ b/content/ja/docs/contributing/blog.md
@@ -3,6 +3,7 @@ title: ブログ
 description: ブログ投稿する方法を学びます。
 weight: 30
 default_lang_commit: 87f313117340a9fb3bb58d33a66111c29323a5b7
+drifted_from_default: true
 ---
 
 [OpenTelemetry ブログ](/blog/)は OpenTelemetry に関連する可能性のある、新機能、コミュニティレポートそしてニュースを発信します。

--- a/content/ja/docs/contributing/issues.md
+++ b/content/ja/docs/contributing/issues.md
@@ -5,7 +5,6 @@ weight: 10
 _issues: https://github.com/open-telemetry/opentelemetry.io/issues
 _issue: https://github.com/open-telemetry/opentelemetry.io/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A
 default_lang_commit: 8eda3ad35e6fbeea601a033023f694c8750fd1b9
-drifted_from_default: true
 ---
 
 <style>

--- a/content/ja/docs/contributing/localization.md
+++ b/content/ja/docs/contributing/localization.md
@@ -4,6 +4,7 @@ description: 非英語ローカリゼーションのサイトページの作成�
 linkTitle: ローカリゼーション
 weight: 25
 default_lang_commit: 548e5e29f574fddc3ca683989a458e9a6800242f # patched
+drifted_from_default: true
 cSpell:ignore: shortcodes
 ---
 

--- a/content/ja/docs/contributing/pr-checks.md
+++ b/content/ja/docs/contributing/pr-checks.md
@@ -3,6 +3,7 @@ title: プルリクエストのチェック
 description: プルリクエストがすべてのチェックをパスする方法学ぶ
 weight: 40
 default_lang_commit: d0a90db560d4f15934bdb43d994eabcfd91c515a
+drifted_from_default: true
 ---
 
 [opentelemetry.io リポジトリ](https://github.com/open-telemetry/opentelemetry.io)に[pull request](https://docs.github.com/en/get-started/learning-about-github/github-glossary#pull-request)（PR）を作成した際に、一連のチェックが実行されます。

--- a/content/ja/docs/contributing/style-guide.md
+++ b/content/ja/docs/contributing/style-guide.md
@@ -4,6 +4,7 @@ description: OpenTelemetry のドキュメントを書く際の用語とスタ�
 linkTitle: スタイルガイド
 weight: 20
 default_lang_commit: d0a90db560d4f15934bdb43d994eabcfd91c515a
+drifted_from_default: true
 cSpell:ignore: open-telemetry postgre style-guide textlintrc
 ---
 

--- a/content/ja/docs/demo/architecture.md
+++ b/content/ja/docs/demo/architecture.md
@@ -4,6 +4,7 @@ linkTitle: アーキテクチャ
 aliases: [current_architecture]
 body_class: otel-mermaid-max-width
 default_lang_commit: e8f94839e85df475fe8c5ff995c18eefa5220635
+drifted_from_default: true
 ---
 
 **OpenTelemetryデモ** は、異なるプログラミング言語で書かれた複数のマイクロサービスから構成されており、gRPCとHTTPを使って相互に通信を行います。

--- a/content/ja/docs/languages/java/_index.md
+++ b/content/ja/docs/languages/java/_index.md
@@ -12,6 +12,7 @@ cascade:
     semconv: 1.32.0
 weight: 18
 default_lang_commit: e05fefe6c9f7d8b159d9a9a95128098c646c78c4
+drifted_from_default: true
 ---
 
 {{% docs/languages/index-intro java /%}}

--- a/content/ja/docs/languages/java/configuration.md
+++ b/content/ja/docs/languages/java/configuration.md
@@ -4,6 +4,7 @@ linkTitle: SDKの設定
 weight: 13
 aliases: [config]
 default_lang_commit: 6f3712c5cda4ea79f75fb410521880396ca30c91
+drifted_from_default: true
 # prettier-ignore
 cSpell:ignore: autoconfigured blrp Customizer Dotel ignore LOWMEMORY ottrace PKCS
 ---

--- a/content/ja/docs/languages/java/getting-started.md
+++ b/content/ja/docs/languages/java/getting-started.md
@@ -3,6 +3,7 @@ title: サンプルによる入門
 description: 5分以内にアプリのテレメトリーを取得しましょう！
 weight: 10
 default_lang_commit: beb85b4f56de76aa8a8d6e96cd7528396476f95a
+drifted_from_default: true
 ---
 
 <!-- markdownlint-disable blanks-around-fences -->

--- a/content/ja/docs/languages/java/instrumentation.md
+++ b/content/ja/docs/languages/java/instrumentation.md
@@ -9,6 +9,7 @@ aliases:
 weight: 10
 description: OpenTelemetry Javaにおける計装エコシステム
 default_lang_commit: beb85b4f56de76aa8a8d6e96cd7528396476f95a # patched
+drifted_from_default: true
 cSpell:ignore: logback
 ---
 

--- a/content/ja/docs/languages/sdk-configuration/general.md
+++ b/content/ja/docs/languages/sdk-configuration/general.md
@@ -3,6 +3,7 @@ title: 一般的なSDK設定
 linkTitle: 一般
 aliases: [general-sdk-configuration]
 default_lang_commit: d0a90db560d4f15934bdb43d994eabcfd91c515a # patched
+drifted_from_default: true
 cSpell:ignore: ottrace
 ---
 

--- a/content/ja/docs/platforms/android/_index.md
+++ b/content/ja/docs/platforms/android/_index.md
@@ -2,6 +2,7 @@
 title: Android
 # description:
 default_lang_commit: 9ba98f4fded66ec78bfafa189ab2d15d66df2309
+drifted_from_default: file not found
 ---
 
 コンテンツは近日公開！

--- a/content/ja/docs/platforms/faas/lambda-auto-instrument.md
+++ b/content/ja/docs/platforms/faas/lambda-auto-instrument.md
@@ -3,6 +3,7 @@ title: Lambda 自動計装
 weight: 11
 description: あなたのLambdaをOpenTelemetryで自動的に計装する
 default_lang_commit: 9ba98f4fded66ec78bfafa189ab2d15d66df2309
+drifted_from_default: true
 cSpell:ignore: Corretto
 ---
 

--- a/content/ja/docs/platforms/kubernetes/collector/components.md
+++ b/content/ja/docs/platforms/kubernetes/collector/components.md
@@ -2,6 +2,7 @@
 title: Kubernetesのための重要なコンポーネント
 linkTitle: コンポーネント
 default_lang_commit: e8f18928513b726068be250802ebe7ece25e8851
+drifted_from_default: true
 # prettier-ignore
 cSpell:ignore: alertmanagers filelog horizontalpodautoscalers hostfs hostmetrics k8sattributes kubelet kubeletstats replicasets replicationcontrollers resourcequotas statefulsets varlibdockercontainers varlogpods
 ---

--- a/content/ja/docs/platforms/kubernetes/getting-started.md
+++ b/content/ja/docs/platforms/kubernetes/getting-started.md
@@ -2,6 +2,7 @@
 title: はじめに
 weight: 1
 default_lang_commit: 0cdf20f0dcbf7305541f8eab3001c95ce805fbc0
+drifted_from_default: true
 # prettier-ignore
 cSpell:ignore: filelog kubelet kubeletstats kubeletstatsreceiver loggingexporter otlpexporter sattributes sattributesprocessor sclusterreceiver sobjectsreceiver
 ---

--- a/content/ja/docs/platforms/kubernetes/operator/_index.md
+++ b/content/ja/docs/platforms/kubernetes/operator/_index.md
@@ -11,6 +11,7 @@ redirects:
   - { from: /docs/k8s-operator/*, to: ':splat' }
   - { from: /docs/platforms/kubernetes-operator/*, to: ':splat' }
 default_lang_commit: c392c714849921cd56aca8ca99ab11e0e4cb16f4
+drifted_from_default: true
 ---
 
 ## はじめに {#introduction}

--- a/content/ja/docs/security/_index.md
+++ b/content/ja/docs/security/_index.md
@@ -4,6 +4,7 @@ cascade:
   collector_vers: 0.130.1
 weight: 970
 default_lang_commit: 179f03bf118e1e8a3cc195ab56fc09d85c476394
+drifted_from_default: true
 ---
 
 このセクションでは、OpenTelemetryプロジェクトがどのように脆弱性を公開し、インシデントに対応しているかを学び、あなたがテレメトリーを安全に収集し、送信するために何ができるかを知ることができます。

--- a/content/ja/docs/what-is-opentelemetry.md
+++ b/content/ja/docs/what-is-opentelemetry.md
@@ -3,6 +3,7 @@ title: OpenTelemetryとは
 description: OpenTelemetryが何であり、何でないかについての簡潔な説明。
 weight: 150
 default_lang_commit: 548e5e29f574fddc3ca683989a458e9a6800242f
+drifted_from_default: true
 ---
 
 OpenTelemetry とは、次のようなものです。

--- a/content/ja/docs/zero-code/python/example.md
+++ b/content/ja/docs/zero-code/python/example.md
@@ -3,6 +3,7 @@ title: 自動計装の例
 linkTitle: Example
 weight: 20
 default_lang_commit: 3d737b777f7bfa070f7f14835570add916d4dcb0
+drifted_from_default: true
 ---
 
 このページでは、OpenTelemetry で Python 自動計装を使う方法を示します。


### PR DESCRIPTION
Updates the drifted status for `ja` pages.

Follow up on #7562.