### PR TITLE
Comment out cross-ref link to OBI K8s helm chart setup

### DIFF
--- a/content/en/docs/zero-code/obi/setup/kubernetes.md
+++ b/content/en/docs/zero-code/obi/setup/kubernetes.md
@@ -12,8 +12,8 @@ cSpell:ignore: cap_perfmon containerd goblog kubeadm microk8s replicaset statefu
 This document explains how to manually deploy OBI in Kubernetes, setting up all
 the required entities by yourself.
 
-You might prefer to follow the
-[Deploy OBI in Kubernetes with Helm](../kubernetes-helm/) documentation instead.
+<!-- You might prefer to follow the
+[Deploy OBI in Kubernetes with Helm](../kubernetes-helm/) documentation instead. -->
 
 {{% /alert %}}
 


### PR DESCRIPTION
We have hidden the "deploy OBI in K8s with Helm chart" page from the left nav until the Helm chart work is complete. But a cross-reference link on the manual Kubernetes setup page made the the Helm page still accessible. This PR comments out the cross-ref link.

Helm chart PR for reference: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1704
