### PR TITLE
Comment out cross-ref to OBI Helm on Set up landing page

### DIFF
--- a/content/en/docs/zero-code/obi/setup/_index.md
+++ b/content/en/docs/zero-code/obi/setup/_index.md
@@ -8,7 +8,7 @@ weight: 10
 There are different options to set up and run OBI:
 
 - [Set up OBI on Kubernetes](kubernetes/)
-- [Set up OBI on Kubernetes with Helm](kubernetes-helm/)
+<!-- - [Set up OBI on Kubernetes with Helm](kubernetes-helm/) -->
 - [Set up OBI on Docker](docker/)
 - [Set up OBI as a standalone process](standalone/)
 


### PR DESCRIPTION
One more cross-ref link to OBI Helm that needs to be commented out. This is the second of three PRs to address the accidental publishing of the Helm chart page. Follow up to #7566. 