### PR TITLE
Update front matter to better hide OBI Helm chart page

### DIFF
--- a/content/en/docs/zero-code/obi/setup/kubernetes-helm.md
+++ b/content/en/docs/zero-code/obi/setup/kubernetes-helm.md
@@ -3,6 +3,9 @@ title: Deploy OBI in Kubernetes with Helm
 linkTitle: Helm chart
 description: Learn how to deploy OBI as a Helm chart in Kubernetes.
 weight: 3
+build:
+  list: never
+draft: true
 toc_hide: true
 ---
 


### PR DESCRIPTION
Follow up to #7566 and #7567, this PR changes the front matter to remove the Helm chart page from the website build. This will be reversed once the Helm chart work is complete.