### PR TITLE
[es][i18n] Update `es` drifted status

### DIFF
--- a/content/es/docs/concepts/semantic-conventions.md
+++ b/content/es/docs/concepts/semantic-conventions.md
@@ -3,6 +3,7 @@ title: Convenciones Semánticas
 description: Nombres comunes para diferentes tipos de operaciones y datos.
 weight: 30
 default_lang_commit: 4f38b130938b017a283457de2404a4cd0fd77819
+drifted_from_default: true
 ---
 
 OpenTelemetry define [Convenciones Semánticas](/docs/specs/semconv/), a veces

--- a/content/es/docs/contributing/localization.md
+++ b/content/es/docs/contributing/localization.md
@@ -6,6 +6,7 @@ description:
 linkTitle: Localización
 weight: 25
 default_lang_commit: e1bf6c870fbf82791a3826baaf276bc0ca79c88b # patched
+drifted_from_default: true
 cSpell:ignore: shortcodes
 ---
 

--- a/content/es/docs/contributing/pr-checks.md
+++ b/content/es/docs/contributing/pr-checks.md
@@ -4,6 +4,7 @@ description:
   Aprenda cómo hacer que su PR pase con éxito todas las comprobaciones
 weight: 40
 default_lang_commit: 565307515b288bf5e8bee88d73ff4fac1fd93d5e # patched
+drifted_from_default: true
 cSpell:ignore: REFCACHE
 ---
 

--- a/content/es/docs/contributing/prerequisites.md
+++ b/content/es/docs/contributing/prerequisites.md
@@ -6,6 +6,7 @@ description:
 aliases: [requisitos]
 weight: 1
 default_lang_commit: 2127d75cef0be2f2554f5b47520a108ba381b790
+drifted_from_default: true
 ---
 
 Para contribuir a este repositorio, necesitas estar familiarizado con las

--- a/content/es/docs/contributing/style-guide.md
+++ b/content/es/docs/contributing/style-guide.md
@@ -5,6 +5,7 @@ description:
 linkTitle: Guía de estilo de documentación
 weight: 20
 default_lang_commit: 99f0ae5760038d51f9e9eb376bb428a2caca8167
+drifted_from_default: true
 cSpell:ignore: open-telemetry opentelemetryio postgre style-guide textlintrc
 ---
 

--- a/content/es/docs/platforms/kubernetes/_index.md
+++ b/content/es/docs/platforms/kubernetes/_index.md
@@ -4,6 +4,7 @@ linkTitle: Kubernetes
 weight: 350
 description: Usando OpenTelemetry con Kubernetes
 default_lang_commit: d638c386ae327328ff35604df54fa6ddd8b51b65
+drifted_from_default: true
 ---
 
 ## Introducción

--- a/content/es/docs/platforms/kubernetes/collector/_index.md
+++ b/content/es/docs/platforms/kubernetes/collector/_index.md
@@ -2,6 +2,7 @@
 title: OpenTelemetry Collector y Kubernetes
 linkTitle: Colector
 default_lang_commit: f7cb8b65a478450d80d703b34c8473c579702108
+drifted_from_default: true
 ---
 
 El [OpenTelemetry Collector](/docs/collector/) es una forma de recibir, procesar

--- a/content/es/docs/platforms/kubernetes/collector/components.md
+++ b/content/es/docs/platforms/kubernetes/collector/components.md
@@ -2,6 +2,7 @@
 title: Componentes clave para Kubernetes
 linkTitle: Componentes
 default_lang_commit: 3815d1481fe753df10ea3dc26cbe64dba0230579 # with patched links
+drifted_from_default: true
 # prettier-ignore
 cSpell:ignore: alertmanagers asignador containerd crio filelog gotime horizontalpodautoscalers hostfs hostmetrics iostream k8sattributes kubelet kubeletstats logtag paginación replicasets replicationcontrollers resourcequotas statefulsets varlibdockercontainers varlogpods
 ---


### PR DESCRIPTION
Updates the drifted status for `ja` pages.

Follow up on #7571.