### PR TITLE
Update scaling.md,  substitute queue size with capacity

### DIFF
--- a/content/en/docs/collector/scaling.md
+++ b/content/en/docs/collector/scaling.md
@@ -94,7 +94,7 @@ Collectors might cause a harmful side effect.
 Again, one way to catch this situation is by looking at the metrics
 `otelcol_exporter_queue_size` and `otelcol_exporter_queue_capacity`. If you keep
 having the queue size close to the queue capacity, it’s a sign that exporting
-data is slower than receiving data. You can try to increase the queue size,
+data is slower than receiving data. You can try to increase the queue capacity,
 which will cause the Collector to consume more memory, but it will also give
 some room for the backend to breathe without permanently dropping telemetry
 data. But if you keep increasing the queue capacity and the queue size keeps


### PR DESCRIPTION
Did you mean queue capacity instead of size which cannot be manually scaled ?

<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->
