### PR TITLE
Add Apache Doris and VeloDB to OpenTelemetry vendors

### DIFF
--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -548,3 +548,15 @@
   url: https://github.com/coroot/coroot
   documentation: https://docs.coroot.com/tracing/opentelemetry-go
   contact: alamberton@coroot.com
+- name: Apache Doris
+  nativeOTLP: true
+  oss: true
+  commercial: false
+  url: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/dorisexporter
+  contact: kxiao@apache.org
+- name: VeloDB
+  nativeOTLP: true
+  oss: false
+  commercial: true
+  url: https://www.velodb.io/solutions/use-cases/observability
+  contact: owen@velodb.io

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -23143,6 +23143,10 @@
     "StatusCode": 200,
     "LastSeen": "2025-01-30T22:06:20.869Z"
   },
+  "https://www.velodb.io/solutions/use-cases/observability": {
+    "StatusCode": 200,
+    "LastSeen": "2025-08-17T14:00:24.895684766Z"
+  },
   "https://www.w3.org/TR/NOTE-datetime": {
     "StatusCode": 206,
     "LastSeen": "2025-01-07T10:31:58.913992-05:00"


### PR DESCRIPTION
No code changes, added [Apache Doris](https://github.com/apache/doris) and [VeloDB](https://www.velodb.io) as OpenTelemetry vendors.

Apache Doris is an open source OLAP database for real-time analytics.One of its major use cases is logging and observability. It's already in the eco-system of [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/dorisexporter) as a storage backend. And the [doris-opentelemetry-demo](https://github.com/apache/doris-opentelemetry-demo) project is created to for Doris backend based on the latest offical opentelemetry-demo.

VeloDB is a commercial product based on Apache Doris. One of its major solutions is [logging and observability](https://www.velodb.io/solutions/use-cases/observability).

Here's the docs on OTel support:  
https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/dorisexporter
https://www.velodb.io/solutions/use-cases/observability