### PR TITLE
Add endpoint configs for extension examples

### DIFF
--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -120,8 +120,11 @@ exporters:
 
 extensions:
   health_check:
+    endpoint: 0.0.0.0:13133
   pprof:
+    endpoint: 0.0.0.0:1777
   zpages:
+    endpoint: 0.0.0.0:55679
 
 service:
   extensions: [health_check, pprof, zpages]
@@ -170,8 +173,11 @@ exporters:
 
 extensions:
   health_check:
+    endpoint: 0.0.0.0:13133
   pprof:
+    endpoint: 0.0.0.0:1777
   zpages:
+    endpoint: 0.0.0.0:55679
 
 service:
   extensions: [health_check, pprof, zpages]
@@ -576,8 +582,11 @@ extensions configured in the same file:
 ```yaml
 extensions:
   health_check:
+    endpoint: 0.0.0.0:13133
   pprof:
+    endpoint: 0.0.0.0:1777
   zpages:
+    endpoint: 0.0.0.0:55679
 ```
 
 > For detailed extension configuration, see the


### PR DESCRIPTION
Adds endpoint configuration to the example extension configs.

The docs currently say:
> While it is generally preferable to bind endpoints to `localhost` when all clients are local, our example configurations use the "unspecified" address `0.0.0.0` as a convenience

However, the extension examples are not following this same convention of using `0.0.0.0` for convenience. It took me a while to figure out that my pod was not becoming healthy because I needed to bind to `0.0.0.0`, and it looks like others have hit confusion over this as well: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34133 - specifically, several folks upvoted [this comment](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34133#issuecomment-2233611831).