### PR TITLE
[Infra] Add fix:refcache to auto-update-community-members.yml workflow

### DIFF
--- a/.github/workflows/auto-update-community-members.yml
+++ b/.github/workflows/auto-update-community-members.yml
@@ -36,7 +36,6 @@ jobs:
 
       - name: Fix refcache
         run: |
-          npm install --omit=optional
           npm run fix:refcache
 
           git add -A

--- a/.github/workflows/auto-update-community-members.yml
+++ b/.github/workflows/auto-update-community-members.yml
@@ -34,6 +34,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
 
+      - name: Fix refcache
+        run: |
+          npm install --omit=optional
+          npm run fix:refcache
+
+          git add -A
+
+          if ! git diff-index --quiet --cached HEAD; then
+            git commit -am "Fix refcache"
+            git push
+          fi
+
       - name: Create pull request
         uses: peter-evans/create-pull-request@v7
         with:

--- a/data/registry/instrumentation-ruby-all.yml
+++ b/data/registry/instrumentation-ruby-all.yml
@@ -14,5 +14,5 @@ createdAt: 2020-11-09
 package:
   registry: gems
   name: opentelemetry-instrumentation-all
-  version: 0.78.0
+  version: 0.79.0
 isFirstParty: false


### PR DESCRIPTION
## Description

Closes #6966.

Adds the `fix:refcache` command to the execution of the `auto-update-community-members.yml` workflow, since we often need to manually trigger refcache update before merging the PRs.

FYI @open-telemetry/docs-maintainers 