### PR TITLE
ci: improve the error message when the 'REFCACHE updates?' check fails

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -115,7 +115,10 @@ jobs:
             exit 1
           fi
       - name: Does the refcache need updating?
-        run: npm run diff:fail
+        run: |
+          echo "If the diff check below fails, then update static/refcache.json by"
+          echo "running 'npm run fix:refcache' locally and commiting the changes."
+          npm run _diff:fail
 
   check-build-log-for-issues:
     name: WARNINGS in build log?

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -117,7 +117,8 @@ jobs:
       - name: Does the refcache need updating?
         run: |
           echo "If the diff check below fails, then update static/refcache.json by"
-          echo "running 'npm run fix:refcache' locally and commiting the changes."
+          echo "running 'npm run fix:refcache' locally and committing the changes"
+          echo "or adding the comment '/fix:refcache' to your PR in GitHub."
           npm run _diff:fail
 
   check-build-log-for-issues:


### PR DESCRIPTION
In this PR I hit a "Links / REFCACHE updates?" check failure in CI:
https://github.com/open-telemetry/opentelemetry.io/pull/7606#issuecomment-3208176252

The error message in the GitHub Actions log was:

```
> _diff:check
> git diff --name-only --exit-code

static/refcache.json

ERROR: the files above have changed. Locally rerun `npm run test-and-fix` and commit changes
```

which is misleading, because (I'm told) the correct action to fix is `npm run fix:refcache`.  This attempts to improve that error message.