### PR TITLE
[ja] docs(i18n): fix drift of content/ja/languages/sdk-configuration/general.md

### DIFF
--- a/content/ja/docs/languages/sdk-configuration/general.md
+++ b/content/ja/docs/languages/sdk-configuration/general.md
@@ -2,8 +2,7 @@
 title: 一般的なSDK設定
 linkTitle: 一般
 aliases: [general-sdk-configuration]
-default_lang_commit: d0a90db560d4f15934bdb43d994eabcfd91c515a # patched
-drifted_from_default: true
+default_lang_commit: 9b427bf25703c33a2c6e05c2a7b58e0f768f7bad
 cSpell:ignore: ottrace
 ---
 


### PR DESCRIPTION
Closes #7562.

<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->

There is no difference between English and Japanese.
I just update `default_lang_commit`.


A preview page.

- https://deploy-preview-7617--opentelemetry.netlify.app/ja/docs/languages/sdk-configuration/general/

An original page.

- https://deploy-preview-7617--opentelemetry.netlify.app/docs/languages/sdk-configuration/general/
