### PR TITLE
JS instrumentation/propagation docs: switch to tsx for on-the-fly TypeScript compilation

### DIFF
--- a/content/en/docs/languages/js/instrumentation.md
+++ b/content/en/docs/languages/js/instrumentation.md
@@ -46,11 +46,8 @@ Next, install Express dependencies.
 {{< tabpane text=true >}} {{% tab TypeScript %}}
 
 ```sh
-npm install typescript \
-  ts-node \
-  @types/node \
-  express \
-  @types/express
+npm install express @types/express
+npm install -D tsx  # a tool to run TypeScript (.ts) files directly with node
 ```
 
 {{% /tab %}} {{% tab JavaScript %}}
@@ -115,7 +112,7 @@ add the following code to it:
 
 ```ts
 /*app.ts*/
-import express, { Express } from 'express';
+import express, { type Express } from 'express';
 import { rollTheDice } from './dice';
 
 const PORT: number = parseInt(process.env.PORT || '8080');
@@ -171,7 +168,7 @@ open <http://localhost:8080/rolldice?rolls=12> in your web browser.
 {{< tabpane text=true >}} {{% tab TypeScript %}}
 
 ```console
-$ npx ts-node app.ts
+$ npx tsx app.ts
 Listening for requests on http://localhost:8080
 ```
 
@@ -244,18 +241,18 @@ sdk.start();
 {{% /tab %}} {{% tab JavaScript %}}
 
 ```js
-/*instrumentation.js*/
-const { NodeSDK } = require('@opentelemetry/sdk-node');
-const { ConsoleSpanExporter } = require('@opentelemetry/sdk-trace-node');
-const {
+/*instrumentation.mjs*/
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-node';
+import {
   PeriodicExportingMetricReader,
   ConsoleMetricExporter,
-} = require('@opentelemetry/sdk-metrics');
-const { resourceFromAttributes } = require('@opentelemetry/resources');
-const {
+} from '@opentelemetry/sdk-metrics';
+import { resourceFromAttributes } from '@opentelemetry/resources';
+import {
   ATTR_SERVICE_NAME,
   ATTR_SERVICE_VERSION,
-} = require('@opentelemetry/semantic-conventions');
+} from '@opentelemetry/semantic-conventions';
 
 const sdk = new NodeSDK({
   resource: resourceFromAttributes({
@@ -287,18 +284,20 @@ API or implementation.
 Alternative methods exist for setting up resource attributes. For more
 information, see [Resources](/docs/languages/js/resources/).
 
-To verify your code, run the app by requiring the library:
+{{% alert title="Note" %}} The following examples using
+`--import instrumentation.ts` (TypeScript) require Node.js v20 or later. If you
+are using Node.js v18, please use the JavaScript example. {{% /alert %}}
 
 {{< tabpane text=true >}} {{% tab TypeScript %}}
 
 ```sh
-npx ts-node --require ./instrumentation.ts app.ts
+npx tsx --import ./instrumentation.ts app.ts
 ```
 
 {{% /tab %}} {{% tab JavaScript %}}
 
 ```sh
-node --require ./instrumentation.js app.js
+node --import ./instrumentation.mjs app.js
 ```
 
 {{% /tab %}} {{< /tabpane >}}
@@ -499,7 +498,7 @@ First, in the _application file_ `app.ts` (or `app.js`):
 ```ts
 /*app.ts*/
 import { trace } from '@opentelemetry/api';
-import express, { Express } from 'express';
+import express, { type Express } from 'express';
 import { rollTheDice } from './dice';
 
 const tracer = trace.getTracer('dice-server', '0.1.0');
@@ -625,7 +624,7 @@ The code below illustrates how to create an active span.
 {{< tabpane text=true >}} {{% tab TypeScript %}}
 
 ```ts
-import { trace, Span } from '@opentelemetry/api';
+import { trace, type Span } from '@opentelemetry/api';
 
 /* ... */
 
@@ -672,13 +671,13 @@ Start your app as follows, and then send it requests by visiting
 {{< tabpane text=true >}} {{% tab TypeScript %}}
 
 ```sh
-ts-node --require ./instrumentation.ts app.ts
+npx tsx --import ./instrumentation.ts app.ts
 ```
 
 {{% /tab %}} {{% tab JavaScript %}}
 
 ```sh
-node --require ./instrumentation.js app.js
+node --import ./instrumentation.mjs app.js
 ```
 
 {{% /tab %}} {{< /tabpane >}}
@@ -686,19 +685,28 @@ node --require ./instrumentation.js app.js
 After a while, you should see the spans printed in the console by the
 `ConsoleSpanExporter`, something like this:
 
-```json
+```js
 {
-  "traceId": "6cc927a05e7f573e63f806a2e9bb7da8",
-  "parentId": undefined,
-  "name": "rollTheDice",
-  "id": "117d98e8add5dc80",
-  "kind": 0,
-  "timestamp": 1688386291908349,
-  "duration": 501,
-  "attributes": {},
-  "status": { "code": 0 },
-  "events": [],
-  "links": []
+  resource: {
+    attributes: {
+      'service.name': 'dice-server',
+      'service.version': '0.1.0',
+      // ...
+    }
+  },
+  instrumentationScope: { name: 'dice-lib', version: undefined, schemaUrl: undefined },
+  traceId: '30d32251088ba9d9bca67b09c43dace0',
+  parentSpanContext: undefined,
+  traceState: undefined,
+  name: 'rollTheDice',
+  id: 'cc8a67c2d4840402',
+  kind: 0,
+  timestamp: 1756165206470000,
+  duration: 35.584,
+  attributes: {},
+  status: { code: 0 },
+  events: [],
+  links: []
 }
 ```
 
@@ -764,32 +772,41 @@ function rollTheDice(rolls, min, max) {
 This code creates a child span for each _roll_ that has `parentSpan`'s ID as
 their parent ID:
 
-```json
+```js
 {
-  "traceId": "ff1d39e648a3dc53ba710e1bf1b86e06",
-  "parentId": "9214ff209e6a8267",
-  "name": "rollOnce:4",
-  "id": "7eccf70703e2bccd",
-  "kind": 0,
-  "timestamp": 1688387049511591,
-  "duration": 22,
-  "attributes": {},
-  "status": { "code": 0 },
-  "events": [],
-  "links": []
+  traceId: '6469e115dc1562dd768c999da0509615',
+  parentSpanContext: {
+    traceId: '6469e115dc1562dd768c999da0509615',
+    spanId: '38691692d6bc3395',
+    // ...
+  },
+  name: 'rollOnce:0',
+  id: '36423bc1ce7532b0',
+  timestamp: 1756165362215000,
+  duration: 85.667,
+  // ...
 }
 {
-  "traceId": "ff1d39e648a3dc53ba710e1bf1b86e06",
-  "parentId": undefined,
-  "name": "rollTheDice",
-  "id": "9214ff209e6a8267",
-  "kind": 0,
-  "timestamp": 1688387049510303,
-  "duration": 1314,
-  "attributes": {},
-  "status": { "code": 0 },
-  "events": [],
-  "links": []
+  traceId: '6469e115dc1562dd768c999da0509615',
+  parentSpanContext: {
+    traceId: '6469e115dc1562dd768c999da0509615',
+    spanId: '38691692d6bc3395',
+    // ...
+  },
+  name: 'rollOnce:1',
+  id: 'ed9bbba2264d6872',
+  timestamp: 1756165362215000,
+  duration: 16.834,
+  // ...
+}
+{
+  traceId: '6469e115dc1562dd768c999da0509615',
+  parentSpanContext: undefined,
+  name: 'rollTheDice',
+  id: '38691692d6bc3395',
+  timestamp: 1756165362214000,
+  duration: 1022.209,
+  // ...
 }
 ```
 
@@ -799,7 +816,7 @@ The previous examples showed how to create an active span. In some cases, you'll
 want to create inactive spans that are siblings of one another rather than being
 nested.
 
-```javascript
+```js
 const doWork = () => {
   const span1 = tracer.startSpan('work-1');
   // do some work
@@ -949,8 +966,8 @@ Add the following to the top of your application file:
 
 ```ts
 import {
-  SEMATTRS_CODE_FUNCTION,
-  SEMATTRS_CODE_FILEPATH,
+  ATTR_CODE_FUNCTION_NAME,
+  ATTR_CODE_FILE_PATH,
 } from '@opentelemetry/semantic-conventions';
 ```
 
@@ -958,8 +975,8 @@ import {
 
 ```js
 const {
-  SEMATTRS_CODE_FUNCTION,
-  SEMATTRS_CODE_FILEPATH,
+  ATTR_CODE_FUNCTION_NAME,
+  ATTR_CODE_FILE_PATH,
 } = require('@opentelemetry/semantic-conventions');
 ```
 
@@ -970,8 +987,8 @@ Finally, you can update your file to include semantic attributes:
 ```javascript
 const doWork = () => {
   tracer.startActiveSpan('app.doWork', (span) => {
-    span.setAttribute(SEMATTRS_CODE_FUNCTION, 'doWork');
-    span.setAttribute(SEMATTRS_CODE_FILEPATH, __filename);
+    span.setAttribute(ATTR_CODE_FUNCTION_NAME, 'doWork');
+    span.setAttribute(ATTR_CODE_FILE_PATH, __filename);
 
     // Do some work...
 
@@ -1365,18 +1382,18 @@ opentelemetry.metrics.setGlobalMeterProvider(myServiceMeterProvider);
 
 {{% /tab %}} {{< /tabpane >}}
 
-You'll need to `--require` this file when you run your app, such as:
+You'll need to `--import` this file when you run your app, such as:
 
 {{< tabpane text=true >}} {{% tab TypeScript %}}
 
 ```sh
-ts-node --require ./instrumentation.ts app.ts
+npx tsx --import ./instrumentation.ts app.ts
 ```
 
 {{% /tab %}} {{% tab JavaScript %}}
 
 ```sh
-node --require ./instrumentation.js app.js
+node --import ./instrumentation.mjs app.js
 ```
 
 {{% /tab %}} {{< /tabpane >}}
@@ -1437,7 +1454,7 @@ First, in the _application file_ `app.ts` (or `app.js`):
 ```ts
 /*app.ts*/
 import { metrics, trace } from '@opentelemetry/api';
-import express, { Express } from 'express';
+import express, { type Express } from 'express';
 import { rollTheDice } from './dice';
 
 const tracer = trace.getTracer('dice-server', '0.1.0');

--- a/content/en/docs/languages/js/propagation.md
+++ b/content/en/docs/languages/js/propagation.md
@@ -33,15 +33,10 @@ dependencies:
 
 ```sh
 npm init -y
-npm install typescript \
-  ts-node \
-  @types/node \
-  undici \
+npm install undici \
   @opentelemetry/instrumentation-undici \
   @opentelemetry/sdk-node
-
-# initialize typescript
-npx tsc --init
+npm install -D tsx  # a tool to run TypeScript (.ts) files directly with node
 ```
 
 {{% /tab %}} {{% tab JavaScript %}}
@@ -55,12 +50,13 @@ npm install undici \
 
 {{% /tab %}} {{< /tabpane >}}
 
-Next, create a new file called `client.ts` (or client.js) with the following
+Next, create a new file called `client.ts` (or `client.js`) with the following
 content:
 
 {{< tabpane text=true >}} {{% tab TypeScript %}}
 
 ```ts
+/* client.ts */
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import {
   SimpleSpanProcessor,
@@ -84,6 +80,7 @@ request('http://localhost:8080/rolldice').then((response) => {
 {{% /tab %}} {{% tab JavaScript %}}
 
 ```js
+/* instrumentation.mjs */
 const { NodeSDK } = require('@opentelemetry/sdk-node');
 const {
   SimpleSpanProcessor,
@@ -114,14 +111,14 @@ the [Getting Started](../getting-started/nodejs) running in one shell:
 {{< tabpane text=true >}} {{% tab TypeScript %}}
 
 ```console
-$ npx ts-node --require ./instrumentation.ts app.ts
+$ npx tsx --import ./instrumentation.ts app.ts
 Listening for requests on http://localhost:8080
 ```
 
 {{% /tab %}} {{% tab JavaScript %}}
 
 ```console
-$ node --require ./instrumentation.js app.js
+$ node --import ./instrumentation.mjs app.js
 Listening for requests on http://localhost:8080
 ```
 
@@ -132,7 +129,7 @@ Start a second shell and run the `client.ts` (or `client.js`):
 {{< tabpane text=true >}} {{% tab TypeScript %}}
 
 ```shell
-npx ts-node client.ts
+npx tsx client.ts
 ```
 
 {{% /tab %}} {{% tab JavaScript %}}
@@ -154,7 +151,7 @@ similar to the following:
     }
   },
   traceId: 'cccd19c3a2d10e589f01bfe2dc896dc2',
-  parentId: undefined,
+  parentSpanContext: undefined,
   traceState: undefined,
   name: 'GET',
   id: '6f64ce484217a7bf',
@@ -174,14 +171,21 @@ similar to the following:
 Take note of the traceId (`cccd19c3a2d10e589f01bfe2dc896dc2`) and ID
 (`6f64ce484217a7bf`). Both can be found in the output of client as well:
 
-```javascript {hl_lines=["6-7"]}
+XXX HERE nope on express and http isntr. Was that added before? Sigh, no.
+
+```javascript {hl_lines=[6,9]}
 {
   resource: {
     attributes: {
       // ...
   },
   traceId: 'cccd19c3a2d10e589f01bfe2dc896dc2',
-  parentId: '6f64ce484217a7bf',
+  parentSpanContext: {
+    traceId: 'cccd19c3a2d10e589f01bfe2dc896dc2',
+    spanId: '6f64ce484217a7bf',
+    traceFlags: 1,
+    isRemote: true
+  },
   traceState: undefined,
   name: 'GET /rolldice',
   id: '027c5c8b916d29da',
@@ -469,7 +473,7 @@ To enable OpenTelemetry and see the context propagation in action, create an
 additional file called `instrumentation.js` with the following content:
 
 ```javascript
-// instrumentation.js
+// instrumentation.mjs
 const { NodeSDK } = require('@opentelemetry/sdk-node');
 const {
   ConsoleSpanExporter,
@@ -487,14 +491,14 @@ Use this file to run both, the server and the client, with instrumentation
 enabled:
 
 ```console
-$ node -r ./instrumentation.js server.js
+$ node --import ./instrumentation.mjs server.js
 Server listening on port 8124
 ```
 
 and
 
 ```shell
-node -r ./instrumentation client.js
+node --import ./instrumentation.mjs client.js
 ```
 
 After the client has sent data to the server and terminated you should see spans


### PR DESCRIPTION
Similar to https://github.com/open-telemetry/opentelemetry.io/pull/7606
this updates the remaining parts of the JavaScript tracing docs to use
'tsx' rather than the no-longer-maintained 'ts-node' for TypeScript
examples.

As well (as in #7606) this updates to '--import' usage over '--require'
for preloading OTel bootstrap code. This is in prep for future ESM
support, and helps with some confusion around automatic type-stripping
in recent versions of Node.js.

Refs: https://github.com/open-telemetry/opentelemetry.io/issues/7623
