### PR TITLE
docs: fix tag for ebpf-instrument

### DIFF
--- a/content/en/docs/zero-code/obi/setup/docker.md
+++ b/content/en/docs/zero-code/obi/setup/docker.md
@@ -102,7 +102,7 @@ services:
       - '18443:8443'
 
   autoinstrumenter:
-    image: docker.io/otel/ebpf-instrument:latest
+    image: docker.io/otel/ebpf-instrument:main
     pid: 'host'
     privileged: true
     environment:


### PR DESCRIPTION
Fixed tag.

On [top](https://github.com/open-telemetry/opentelemetry.io/pull/7661/files#diff-5c7e631c8ca42007a7ea3b3f23c3542e1c5833eee416387a384ddc697f31435aR64) it was correct (`main`), here it was wrong (`latest`)