### PR TITLE
Update vendor support count in documentation

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -12,7 +12,7 @@ for instrumenting, generating, collecting, and exporting telemetry data such as
 [logs](concepts/signals/logs/).
 
 As an industry-standard, OpenTelemetry is
-[supported by more than 40 observability vendors](/ecosystem/vendors/),
+[supported by more than 90 observability vendors](/ecosystem/vendors/),
 integrated by many [libraries, services, and apps](/ecosystem/integrations/),
 and adopted by [numerous end users](/ecosystem/adopters/).
 


### PR DESCRIPTION
Just noticed that we've more than doubled the vendor count, so just updating the docs homepage.
