### PR TITLE
docs: fix link to deprecated crate

### DIFF
--- a/content/en/docs/languages/rust/libraries.md
+++ b/content/en/docs/languages/rust/libraries.md
@@ -12,7 +12,7 @@ description: How to instrument libraries an app depends on
 Each instrumentation library is a [crate](https://crates.io/).
 
 For example, the
-[instrumentation library for Actix Web](https://crates.io/crates/actix-web-opentelemetry)
+[instrumentation library for Actix Web](https://crates.io/crates/opentelemetry-instrumentation-actix-web)
 will automatically create [spans](/docs/concepts/signals/traces/#spans) and
 [metrics](/docs/concepts/signals/metrics/) based on the inbound HTTP requests.
 


### PR DESCRIPTION
- Fixes #7663 by changing the crate link for the documentation.