### PR TITLE
[fr] Localize 'page not translated' banner

### DIFF
--- a/content/fr/_includes/page-not-translated-msg.md
+++ b/content/fr/_includes/page-not-translated-msg.md
@@ -2,6 +2,7 @@
 default_lang_commit: 1ececa0615b64c5dfd93fd6393f3e4052e0cc496
 ---
 
-<i class="fa-solid fa-circle-info" style="margin-left: -1.5rem"></i> Vous 
+<i class="fa-solid fa-circle-info" style="margin-left: -1.5rem"></i> Vous
 consultez la **version anglaise** de cette page car elle n’a pas encore été
-entièrement traduite. Vous souhaitez contribuer ? Voir [Contribuer](/docs/contributing/).
+entièrement traduite. Vous souhaitez contribuer ? Voir
+[Contribuer](/docs/contributing/).


### PR DESCRIPTION
Contributes to #6288.

It adds the French localization to the 'page not translated' banner.

@open-telemetry/docs-fr-approvers PTAL! 