### PR TITLE
[bn] Localize 'page not translated' banner

### DIFF
--- a/content/bn/_includes/page-not-translated-msg.md
+++ b/content/bn/_includes/page-not-translated-msg.md
@@ -1,0 +1,5 @@
+---
+default_lang_commit: 1ececa0615b64c5dfd93fd6393f3e4052e0cc496
+---
+
+<i class="fa-solid fa-circle-info" style="margin-left: -1.5rem"></i> আপনি এই পৃষ্ঠার **ইংরেজি সংস্করণ** দেখছেন কারণ এটি এখনও সম্পূর্ণভাবে অনূদিত হয়নি। সাহায্য করতে আগ্রহী? দেখুন [Contributing](/docs/contributing/)।


### PR DESCRIPTION
This PR adds a Bengali (bn) translation of the `page not translated` documentation page.

- Translated from the original English content at `content/en/_includes/page-not-translated-msg.md`
- File added: architecture.md under appropriate Bengali content directory, which is `content/bn/_includes/page-not-translated-msg.md`
- The translation maintains consistency with terminology used across the OpenTelemetry docs

Contributes to: [[i18n] Localize "page not translated" banner #6288
](https://github.com/open-telemetry/opentelemetry.io/issues/6288#issuecomment-3245310712)
Let me know if any changes are needed. Thank you!