### PR TITLE
Add Python docs mention of sqlcommenter and link to new readthedocs

### DIFF
--- a/content/en/docs/languages/python/propagation.md
+++ b/content/en/docs/languages/python/propagation.md
@@ -2,6 +2,7 @@
 title: Propagation
 description: Context propagation for the Python SDK
 weight: 65
+cSpell:ignore: sqlcommenter
 ---
 
 Propagation is the mechanism that moves data between services and processes.
@@ -109,6 +110,23 @@ if __name__ == '__main__':
 
 From there, when you have a deserialized active context, you can create spans
 that are part of the same trace from the other service.
+
+### sqlcommenter
+
+Some Python instrumentations support sqlcommenter, which enriches database query
+statements with contextual information. Queries made with sqlcommenter enabled
+will have configurable key-value pairs appended to them. For example:
+
+```
+"select * from auth_users; /*traceparent=00-01234567-abcd-01*/"
+```
+
+This supports context propagation between database client and server when
+database log records are enabled. For more information, see:
+
+- [OpenTelemetry Python sqlcommenter example](https://opentelemetry-python.readthedocs.io/en/stable/examples/sqlcommenter/README.html)
+- [Semantic Conventions - Database Spans](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md#sql-commenter>)
+- [sqlcommenter](https://google.github.io/sqlcommenter/)
 
 ## Next steps
 


### PR DESCRIPTION
⚠️ Do not merge until we've merged https://github.com/open-telemetry/opentelemetry-python/pull/4734

Adds a new section to [Python > Propagation](https://opentelemetry.io/docs/languages/python/propagation/) about sqlcommenter.

Fixes: https://github.com/open-telemetry/opentelemetry.io/issues/7689
Relates to: https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3162
