### PR TITLE
update php SemConv usage

### DIFF
--- a/content/en/docs/languages/php/instrumentation.md
+++ b/content/en/docs/languages/php/instrumentation.md
@@ -178,15 +178,17 @@ use OpenTelemetry\SDK\Trace\Sampler\AlwaysOnSampler;
 use OpenTelemetry\SDK\Trace\Sampler\ParentBased;
 use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
 use OpenTelemetry\SDK\Trace\TracerProvider;
-use OpenTelemetry\SemConv\ResourceAttributes;
+use OpenTelemetry\SemConv\Attributes\ServiceAttributes;
+use OpenTelemetry\SemConv\Incubating\Attributes\DeploymentIncubatingAttributes;
+use OpenTelemetry\SemConv\Incubating\Attributes\ServiceIncubatingAttributes;
 
 require 'vendor/autoload.php';
 
 $resource = ResourceInfoFactory::emptyResource()->merge(ResourceInfo::create(Attributes::create([
-    ResourceAttributes::SERVICE_NAMESPACE => 'demo',
-    ResourceAttributes::SERVICE_NAME => 'test-application',
-    ResourceAttributes::SERVICE_VERSION => '0.1',
-    ResourceAttributes::DEPLOYMENT_ENVIRONMENT_NAME => 'development',
+    ServiceIncubatingAttributes::SERVICE_NAMESPACE => 'demo',
+    ServiceAttributes::SERVICE_NAME => 'test-application',
+    ServiceAttributes::SERVICE_VERSION => '0.1',
+    DeploymentIncubatingAttributes::DEPLOYMENT_ENVIRONMENT_NAME => 'development',
 ])));
 $spanExporter = new SpanExporter(
     (new StreamTransportFactory())->create('php://stdout', 'application/json')
@@ -583,15 +585,14 @@ composer require open-telemetry/sem-conv
 Add the following to the top of your file:
 
 ```php
-use OpenTelemetry\SemConv\TraceAttributes;
-use OpenTelemetry\SemConv\TraceAttributeValues;
+use OpenTelemetry\SemConv\Attributes\CodeAttributes;
 ```
 
 Finally, you can update your file to include semantic attributes:
 
 ```php
-$span->setAttribute(TraceAttributes::CODE_FUNCTION, 'rollOnce');
-$span->setAttribute(TraceAttributes::CODE_FILEPATH, __FILE__);
+$span->setAttribute(CodeAttributes::CODE_FUNCTION_NAME, 'rollOnce');
+$span->setAttribute(CodeAttributes::CODE_FILE_PATH, __FILE__);
 ```
 
 ### Create Spans with events


### PR DESCRIPTION
since 1.36.0 PHP semantic conventions have been reorganised. The previous classes still exist but are deprecated.

Fixes: #7704 
<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->
