### PR TITLE
Installing dependencies so fix:refcache can work properly

### DIFF
--- a/.github/workflows/auto-update-community-members.yml
+++ b/.github/workflows/auto-update-community-members.yml
@@ -36,6 +36,7 @@ jobs:
 
       - name: Fix refcache
         run: |
+          npm install --omit=optional
           npm run fix:refcache
 
           git add -A


### PR DESCRIPTION
# Overview
This PR attempts to fix the `auto-update-community-members` workflow.

# Details
The `auto-update-community-members` job has been failing for the past 3 weeks ([first failure](https://github.com/open-telemetry/opentelemetry.io/actions/runs/17087983520)). The last successful run was https://github.com/open-telemetry/opentelemetry.io/actions/runs/17059027027.

The issue stems from the introduction of the `fix:refcache` step, which internally executes `npm run _hugo`. This command was failing because the required dependencies weren't installed in the current working directory. While the workflow does install dependencies earlier, it does so in the subdirectory of the script to generate the community data (`./scripts/generate-community-data`), but the `fix:refcache` command runs from the root directory where `node_modules` aren't available.

The fix is simple: add `npm install --omit=optional` before running `npm run fix:refcache` to ensure all necessary dependencies are available when the script executes.