### PR TITLE
[Infra] Fix: `auto-update-community-members` workflow, use CLA approved GitHub bot

### DIFF
--- a/.github/workflows/auto-update-community-members.yml
+++ b/.github/workflows/auto-update-community-members.yml
@@ -34,6 +34,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
 
+      - name: Use CLA approved github bot
+        run: |
+          git config user.name opentelemetrybot
+          git config user.email 107717825+opentelemetrybot@users.noreply.github.com
+
       - name: Fix refcache
         run: |
           npm install --omit=optional


### PR DESCRIPTION
This PR complements #7743 and #7598.

After #7743 was merged, the workflow is still failing because no GitHub user was set up to commit the result from `fix:refcache`.

Workflow execution: https://github.com/open-telemetry/opentelemetry.io/actions/runs/17642564004/job/50132831137

