### PR TITLE
[pt] Localization of blog post "How to Contribute to OpenTelemetry"

### DIFF
--- a/content/pt/blog/2025/contribute-to-otel.md
+++ b/content/pt/blog/2025/contribute-to-otel.md
@@ -1,6 +1,6 @@
 ---
-title: Como Começar a Contribuir para o OpenTelemetry
-linkTitle: Como Começar a Contribuir para o OpenTelemetry
+title: Como Contribuir para o OpenTelemetry
+linkTitle: Como Contribuir para o OpenTelemetry
 date: 2025-09-12
 author: >-
   [Marylia Gutierrez](https://github.com/maryliag) (Grafana Labs)

--- a/content/pt/blog/2025/contribute-to-otel.md
+++ b/content/pt/blog/2025/contribute-to-otel.md
@@ -19,7 +19,7 @@ O código aberto prospera com a comunidade, apoio mútuo e desenvolvimento
 colaborativo de tecnologia inovadora. No entanto, também apresenta desafios,
 especialmente se você é novo neste ecossistema.
 
-## Dinâmicas de contribuição em código aberto
+## Dinâmicas de contribuição em código aberto {#open-source-contribution-dynamics}
 
 Em código aberto, você é o arquiteto da sua própria jornada de contribuição.
 Ninguém atribuirá tarefas ou ditará cada movimento seu. Em vez disso, você
@@ -30,12 +30,12 @@ a iniciativa de trabalhar nelas.
 tradicional onde um gerente ou líder técnico atribui tarefas. No código aberto,
 a decisão sobre no que você vai trabalhar é sua.
 
-## Identificando uma área para contribuição
+## Identificando uma área para contribuição {#identifying-your-contribution-area}
 
 Você pode querer contribuir por diferentes razões: desenvolver uma
-funcionalidade essencial para sua organização; corrigir um bug em um componente
-que você usa ativamente; adquirir novas habilidades e expandir sua base de
-conhecimento; se tornar um membro ativo de uma comunidade vibrante e
+funcionalidade essencial para sua organização; corrigir um _bug_ em um
+componente que você usa ativamente; adquirir novas habilidades e expandir sua
+base de conhecimento; se tornar um membro ativo de uma comunidade vibrante e
 colaborativa; expandir suas conexões profissionais na indústria de tecnologia,
 etc.
 
@@ -45,20 +45,20 @@ vasto, que abrange inúmeros componentes, diversas linguagens de programação e
 funcionalidades com vários níveis de complexidade. Considere o que mais ressoa
 com você.
 
-Esta página lista todos os SIGs existentes com seus respectivos canais no Slack
-e horários de reunião: [SIGs][sigs]. Você também pode se inscrever no calendário
-do OpenTelemetry e verificar as reuniões de seu interesse:
-[Calendário][calendar].
+Esta página lista todos os Grupo de Interesse Especial (SIG) existentes com seus
+respectivos canais no Slack e horários de reunião: [SIGs][sigs]. Você também
+pode se inscrever no calendário do OpenTelemetry e verificar as reuniões de seu
+interesse: [Calendário][calendar].
 
 Embora possa ser tentador escolher repositórios muito ativos, já que você
-provavelmente receberá feedback em seu PR e respostas mais rapidamente, não
+provavelmente receberá _feedback_ em seu PR e respostas mais rapidamente, não
 ignore os menos ativos, pois eles se beneficiariam muito da ajuda de novas
 pessoas. Se seu objetivo de longo prazo é alcançar um status como "Aprovador" ou
 "Mantenedor", contribuir para repositórios menos ativos pode acelerar essa
 progressão devido ao maior impacto que suas contribuições terão. Saiba mais
 sobre o status de membro aqui: [_Membership_][membership].
 
-Para os recém-chegados, procurar _issues_ com o label "good first issue" (boa
+Para os recém-chegados, procurar _issues_ com o label "_good first issue_" (boa
 primeira _issue_) nestes repositórios é uma excelente estratégia. Essas _issues_
 geralmente são projetadas para serem acessíveis a novos contribuidores,
 oferecendo um ponto de entrada mais acessível para o projeto. Se você não tem
@@ -75,7 +75,7 @@ não há pressão! Você pode se apresentar se quiser, mas, em geral, pode
 simplesmente entrar, ouvir e determinar se a área lhe interessa. Se interessar,
 você pode começar a participar das discussões ou trazer seus próprios tópicos.
 
-## Contribuições substanciais
+## Contribuições substanciais {#substantial-contributions}
 
 Se você está considerando uma contribuição mais substancial ou inovadora, é
 aconselhável consultar os mantenedores do SIG relevante. Eles podem fornecer
@@ -87,7 +87,7 @@ Todos os repositórios do OpenTelemetry podem ser encontrados em [Repositórios
 OTel][repos]. Esta página fornece uma visão geral de cada repositório, incluindo
 as linguagens de programação utilizadas e uma breve descrição.
 
-A maioria dos repositórios do OpenTelemetry inclui uma aba "contributing"
+A maioria dos repositórios do OpenTelemetry inclui uma aba "_contributing_"
 (contribuindo). Esta aba fornece orientação específica para o repositório,
 cobrindo informações essenciais como dependências, instruções para rodar testes
 localmente e outros procedimentos de configuração. Caso você encontre alguma
@@ -96,13 +96,13 @@ perguntas nos respectivos [canais do Slack][slack].
 
 Durante sua jornada de contribuição, você pode identificar lacunas ou áreas para
 melhoria na documentação de contribuição existente. Isso apresenta uma
-oportunidade valiosa de contribuir criando um pull request que adicione a
+oportunidade valiosa de contribuir criando um _pull request_ que adicione a
 informação que está faltando. Ao fazer isso, você não apenas contribuirá para o
 projeto, mas também ajudará significativamente futuros contribuidores que possam
 ter perguntas semelhantes. Contribuições de documentação são tão importantes
 quanto contribuições de código.
 
-## Conclusão
+## Conclusão {#final-thoughts}
 
 Uma vez que você decida no que trabalhar, você sempre pode pedir ajuda.
 Lembre-se que a comunidade do OpenTelemetry é um recurso poderoso, e há muitas

--- a/content/pt/blog/2025/contribute-to-otel.md
+++ b/content/pt/blog/2025/contribute-to-otel.md
@@ -4,8 +4,8 @@ linkTitle: Como Contribuir para o OpenTelemetry
 date: 2025-09-12
 author: >-
   [Marylia Gutierrez](https://github.com/maryliag) (Grafana Labs)
-# default_lang_commit:  TODO once en PR gets merged
 cSpell:ignore: marylia
+default_lang_commit: 9383da27dd1d08b0c47e2792376dbd6ebbac1192
 ---
 
 Você pode ter ouvido falar sobre o OpenTelemetry, o achou interessante e quer se

--- a/content/pt/blog/2025/contribute-to-otel.md
+++ b/content/pt/blog/2025/contribute-to-otel.md
@@ -4,8 +4,8 @@ linkTitle: Como Contribuir para o OpenTelemetry
 date: 2025-09-12
 author: >-
   [Marylia Gutierrez](https://github.com/maryliag) (Grafana Labs)
-cSpell:ignore: marylia
 # default_lang_commit:  TODO once en PR gets merged
+cSpell:ignore: marylia
 ---
 
 Você pode ter ouvido falar sobre o OpenTelemetry, o achou interessante e quer se

--- a/content/pt/blog/2025/contribute-to-otel.md
+++ b/content/pt/blog/2025/contribute-to-otel.md
@@ -1,0 +1,120 @@
+---
+title: Como Começar a Contribuir para o OpenTelemetry
+linkTitle: Como Começar a Contribuir para o OpenTelemetry
+date: 2025-09-12
+author: >-
+  [Marylia Gutierrez](https://github.com/maryliag) (Grafana Labs)
+
+# default_lang_commit:  TODO once en PR gets merged
+---
+
+Você pode ter ouvido falar sobre o OpenTelemetry, o achou interessante e quer se
+envolver, mas o caminho para a contribuição não está imediatamente claro. Talvez
+você comece a enviar mensagens para as pessoas pedindo para ser atribuído a
+_issues_, ou apenas diga "Estou aqui para ajudar, é só me falar", mas nunca
+recebe uma resposta. Então, como você pode realmente começar a contribuir para o
+OpenTelemetry?
+
+O código aberto prospera com a comunidade, apoio mútuo e desenvolvimento
+colaborativo de tecnologia inovadora. No entanto, também apresenta desafios,
+especialmente se você é novo neste ecossistema.
+
+## Dinâmicas de contribuição em código aberto
+
+Em código aberto, você é o arquiteto da sua própria jornada de contribuição.
+Ninguém atribuirá tarefas ou ditará cada movimento seu. Em vez disso, você
+precisa ser proativo, identificar áreas onde a assistência é necessária e tomar
+a iniciativa de trabalhar nelas.
+
+É crucial entender que as contribuições de código aberto diferem de um trabalho
+tradicional onde um gerente ou líder técnico atribui tarefas. No código aberto,
+a decisão sobre no que você vai trabalhar é sua.
+
+## Identificando uma área para contribuição
+
+Você pode querer contribuir por diferentes razões: desenvolver uma
+funcionalidade essencial para sua organização; corrigir um bug em um componente
+que você usa ativamente; adquirir novas habilidades e expandir sua base de
+conhecimento; se tornar um membro ativo de uma comunidade vibrante e
+colaborativa; expandir suas conexões profissionais na indústria de tecnologia,
+etc.
+
+Comece explorando áreas dentro do OpenTelemetry que se alinham com sua
+experiência ou que despertam sua curiosidade. O OpenTelemetry é um projeto
+vasto, que abrange inúmeros componentes, diversas linguagens de programação e
+funcionalidades com vários níveis de complexidade. Considere o que mais ressoa
+com você.
+
+Um ótimo ponto de partida é juntar-se a um Grupo de Interesse Especial (SIG)
+dentro do OpenTelemetry. Esses grupos focam em áreas específicas do projeto. Ao
+se imergir em um SIG, você terá acesso às suas prioridades atuais e identificará
+tarefas relevantes. Não sinta que precisa falar nessas reuniões imediatamente,
+não há pressão! Você pode se apresentar se quiser, mas, em geral, pode
+simplesmente entrar, ouvir e determinar se a área lhe interessa. Se interessar,
+você pode começar a participar das discussões ou trazer seus próprios tópicos.
+
+Esta página lista todos os SIGs existentes com seus respectivos canais no Slack
+e horários de reunião:
+[SIGs](https://github.com/open-telemetry/community?tab=readme-ov-file#special-interest-groups).
+Você também pode se inscrever no calendário do OpenTelemetry e verificar as
+reuniões de seu interesse:
+[Calendário](https://github.com/open-telemetry/community?tab=readme-ov-file#calendar).
+
+Embora possa ser tentador escolher repositórios muito ativos, já que você
+provavelmente receberá feedback em seu PR e respostas mais rapidamente, não
+ignore os menos ativos, pois eles se beneficiariam muito da ajuda de novas
+pessoas. Se seu objetivo de longo prazo é alcançar um status como "Aprovador" ou
+"Mantenedor", contribuir para repositórios menos ativos pode acelerar essa
+progressão devido ao maior impacto que suas contribuições terão. Saiba mais
+sobre o status de membro aqui:
+[_Membership_](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md).
+
+Para os recém-chegados, procurar _issues_ com o label "good first issue" (boa
+primeira _issue_) nestes repositórios é uma excelente estratégia. Essas _issues_
+geralmente são projetadas para serem acessíveis a novos contribuidores,
+oferecendo um ponto de entrada mais acessível para o projeto. Se você não tem
+certeza por onde começar a contribuir, a documentação é um excelente ponto de
+partida, pois beneficia diretamente um público amplo. Você pode encontrar mais
+detalhes sobre como contribuir para a documentação aqui:
+https://opentelemetry.io/docs/contributing, o que inclui os esforços de
+[localização](https://opentelemetry.io/docs/contributing/localization/).
+
+## Contribuições substanciais
+
+Se você está considerando uma contribuição mais substancial ou inovadora, é
+aconselhável consultar os mantenedores do SIG relevante. Eles podem fornecer
+informações valiosas e ajudar a determinar se a sua tarefa proposta se alinha
+com os objetivos atuais do projeto e faz sentido para você desenvolver naquele
+momento.
+
+Todos os repositórios do OpenTelemetry podem ser encontrados em
+[Repositórios OTel](https://github.com/orgs/open-telemetry/repositories). Esta
+página fornece uma visão geral de cada repositório, incluindo as linguagens de
+programação utilizadas e uma breve descrição.
+
+A maioria dos repositórios do OpenTelemetry inclui uma aba "contributing"
+(contribuindo). Esta aba fornece orientação específica para o repositório,
+cobrindo informações essenciais como dependências, instruções para rodar testes
+localmente e outros procedimentos de configuração. Caso você encontre alguma
+informação ausente nestes documentos de contribuição, não hesite em fazer
+perguntas nos respectivos
+[canais do Slack](https://opentelemetry.io/community/end-user/slack-channel/).
+
+Durante sua jornada de contribuição, você pode identificar lacunas ou áreas para
+melhoria na documentação de contribuição existente. Isso apresenta uma
+oportunidade valiosa de contribuir criando um pull request que adicione a
+informação que está faltando. Ao fazer isso, você não apenas contribuirá para o
+projeto, mas também ajudará significativamente futuros contribuidores que possam
+ter perguntas semelhantes.
+
+## Conclusão
+
+Uma vez que você decida no que trabalhar, você sempre pode pedir ajuda.
+Lembre-se que a comunidade do OpenTelemetry é um recurso poderoso, e há muitas
+pessoas dispostas a fornecer orientação. Se você tiver ideias sobre como
+melhorar a experiência geral para os contribuidores do OpenTelemetry, nós o
+encorajamos a compartilhá-las no canal do Slack `#otel-contributor-experience`.
+Suas sugestões são altamente valiosas e podem ajudar a moldar um ambiente mais
+acolhedor e eficiente para todos os envolvidos!
+
+Boa contribuição!

--- a/content/pt/blog/2025/contribute-to-otel.md
+++ b/content/pt/blog/2025/contribute-to-otel.md
@@ -105,7 +105,8 @@ melhoria na documentação de contribuição existente. Isso apresenta uma
 oportunidade valiosa de contribuir criando um pull request que adicione a
 informação que está faltando. Ao fazer isso, você não apenas contribuirá para o
 projeto, mas também ajudará significativamente futuros contribuidores que possam
-ter perguntas semelhantes.
+ter perguntas semelhantes. Contribuições de documentação são tão importantes 
+quanto contribuições de código.
 
 ## Conclusão
 

--- a/content/pt/blog/2025/contribute-to-otel.md
+++ b/content/pt/blog/2025/contribute-to-otel.md
@@ -4,7 +4,7 @@ linkTitle: Como Contribuir para o OpenTelemetry
 date: 2025-09-12
 author: >-
   [Marylia Gutierrez](https://github.com/maryliag) (Grafana Labs)
-
+cSpell:ignore: marylia
 # default_lang_commit:  TODO once en PR gets merged
 ---
 
@@ -46,11 +46,9 @@ funcionalidades com vários níveis de complexidade. Considere o que mais ressoa
 com você.
 
 Esta página lista todos os SIGs existentes com seus respectivos canais no Slack
-e horários de reunião:
-[SIGs](https://github.com/open-telemetry/community?tab=readme-ov-file#special-interest-groups).
-Você também pode se inscrever no calendário do OpenTelemetry e verificar as
-reuniões de seu interesse:
-[Calendário](https://github.com/open-telemetry/community?tab=readme-ov-file#calendar).
+e horários de reunião: [SIGs][sigs]. Você também pode se inscrever no calendário
+do OpenTelemetry e verificar as reuniões de seu interesse:
+[Calendário][calendar].
 
 Embora possa ser tentador escolher repositórios muito ativos, já que você
 provavelmente receberá feedback em seu PR e respostas mais rapidamente, não
@@ -58,8 +56,7 @@ ignore os menos ativos, pois eles se beneficiariam muito da ajuda de novas
 pessoas. Se seu objetivo de longo prazo é alcançar um status como "Aprovador" ou
 "Mantenedor", contribuir para repositórios menos ativos pode acelerar essa
 progressão devido ao maior impacto que suas contribuições terão. Saiba mais
-sobre o status de membro aqui:
-[_Membership_](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md).
+sobre o status de membro aqui: [_Membership_][membership].
 
 Para os recém-chegados, procurar _issues_ com o label "good first issue" (boa
 primeira _issue_) nestes repositórios é uma excelente estratégia. Essas _issues_
@@ -67,9 +64,8 @@ geralmente são projetadas para serem acessíveis a novos contribuidores,
 oferecendo um ponto de entrada mais acessível para o projeto. Se você não tem
 certeza por onde começar a contribuir, a documentação é um excelente ponto de
 partida, pois beneficia diretamente um público amplo. Você pode encontrar mais
-detalhes sobre como contribuir para a documentação aqui:
-https://opentelemetry.io/docs/contributing, o que inclui os esforços de
-[localização](https://opentelemetry.io/docs/contributing/localization/).
+detalhes sobre como contribuir para a documentação [aqui][contrib], o que inclui
+os esforços de [localização][localization].
 
 Outro ótimo ponto de partida é juntar-se a um Grupo de Interesse Especial (SIG)
 dentro do OpenTelemetry. Esses grupos focam em áreas específicas do projeto. Ao
@@ -87,25 +83,23 @@ informações valiosas e ajudar a determinar se a sua tarefa proposta se alinha
 com os objetivos atuais do projeto e faz sentido para você desenvolver naquele
 momento.
 
-Todos os repositórios do OpenTelemetry podem ser encontrados em
-[Repositórios OTel](https://github.com/orgs/open-telemetry/repositories). Esta
-página fornece uma visão geral de cada repositório, incluindo as linguagens de
-programação utilizadas e uma breve descrição.
+Todos os repositórios do OpenTelemetry podem ser encontrados em [Repositórios
+OTel][repos]. Esta página fornece uma visão geral de cada repositório, incluindo
+as linguagens de programação utilizadas e uma breve descrição.
 
 A maioria dos repositórios do OpenTelemetry inclui uma aba "contributing"
 (contribuindo). Esta aba fornece orientação específica para o repositório,
 cobrindo informações essenciais como dependências, instruções para rodar testes
 localmente e outros procedimentos de configuração. Caso você encontre alguma
 informação ausente nestes documentos de contribuição, não hesite em fazer
-perguntas nos respectivos
-[canais do Slack](https://opentelemetry.io/community/end-user/slack-channel/).
+perguntas nos respectivos [canais do Slack][slack].
 
 Durante sua jornada de contribuição, você pode identificar lacunas ou áreas para
 melhoria na documentação de contribuição existente. Isso apresenta uma
 oportunidade valiosa de contribuir criando um pull request que adicione a
 informação que está faltando. Ao fazer isso, você não apenas contribuirá para o
 projeto, mas também ajudará significativamente futuros contribuidores que possam
-ter perguntas semelhantes. Contribuições de documentação são tão importantes 
+ter perguntas semelhantes. Contribuições de documentação são tão importantes
 quanto contribuições de código.
 
 ## Conclusão
@@ -119,3 +113,14 @@ Suas sugestões são altamente valiosas e podem ajudar a moldar um ambiente mais
 acolhedor e eficiente para todos os envolvidos!
 
 Boa contribuição!
+
+[sigs]:
+  https://github.com/open-telemetry/community?tab=readme-ov-file#special-interest-groups
+[calendar]:
+  https://github.com/open-telemetry/community?tab=readme-ov-file#calendar
+[membership]:
+  https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md
+[contrib]: /docs/contributing
+[localization]: /docs/contributing/localization/
+[repos]: https://github.com/orgs/open-telemetry/repositories
+[slack]: /community/end-user/slack-channel/

--- a/content/pt/blog/2025/contribute-to-otel.md
+++ b/content/pt/blog/2025/contribute-to-otel.md
@@ -45,14 +45,6 @@ vasto, que abrange inúmeros componentes, diversas linguagens de programação e
 funcionalidades com vários níveis de complexidade. Considere o que mais ressoa
 com você.
 
-Um ótimo ponto de partida é juntar-se a um Grupo de Interesse Especial (SIG)
-dentro do OpenTelemetry. Esses grupos focam em áreas específicas do projeto. Ao
-se imergir em um SIG, você terá acesso às suas prioridades atuais e identificará
-tarefas relevantes. Não sinta que precisa falar nessas reuniões imediatamente,
-não há pressão! Você pode se apresentar se quiser, mas, em geral, pode
-simplesmente entrar, ouvir e determinar se a área lhe interessa. Se interessar,
-você pode começar a participar das discussões ou trazer seus próprios tópicos.
-
 Esta página lista todos os SIGs existentes com seus respectivos canais no Slack
 e horários de reunião:
 [SIGs](https://github.com/open-telemetry/community?tab=readme-ov-file#special-interest-groups).
@@ -78,6 +70,14 @@ partida, pois beneficia diretamente um público amplo. Você pode encontrar mais
 detalhes sobre como contribuir para a documentação aqui:
 https://opentelemetry.io/docs/contributing, o que inclui os esforços de
 [localização](https://opentelemetry.io/docs/contributing/localization/).
+
+Outro ótimo ponto de partida é juntar-se a um Grupo de Interesse Especial (SIG)
+dentro do OpenTelemetry. Esses grupos focam em áreas específicas do projeto. Ao
+se imergir em um SIG, você terá acesso às suas prioridades atuais e identificará
+tarefas relevantes. Não sinta que precisa falar nessas reuniões imediatamente,
+não há pressão! Você pode se apresentar se quiser, mas, em geral, pode
+simplesmente entrar, ouvir e determinar se a área lhe interessa. Se interessar,
+você pode começar a participar das discussões ou trazer seus próprios tópicos.
 
 ## Contribuições substanciais
 

--- a/content/pt/blog/2025/contribute-to-otel.md
+++ b/content/pt/blog/2025/contribute-to-otel.md
@@ -4,8 +4,8 @@ linkTitle: Como Contribuir para o OpenTelemetry
 date: 2025-09-12
 author: >-
   [Marylia Gutierrez](https://github.com/maryliag) (Grafana Labs)
-cSpell:ignore: marylia
 default_lang_commit: 9383da27dd1d08b0c47e2792376dbd6ebbac1192
+cSpell:ignore: marylia
 ---
 
 Você pode ter ouvido falar sobre o OpenTelemetry, o achou interessante e quer se

--- a/content/pt/blog/2025/contribute-to-otel.md
+++ b/content/pt/blog/2025/contribute-to-otel.md
@@ -1,7 +1,7 @@
 ---
 title: Como Contribuir para o OpenTelemetry
 linkTitle: Como Contribuir para o OpenTelemetry
-date: 2025-09-12
+date: 2025-09-15
 author: >-
   [Marylia Gutierrez](https://github.com/maryliag) (Grafana Labs)
 default_lang_commit: 9383da27dd1d08b0c47e2792376dbd6ebbac1192


### PR DESCRIPTION
Add portuguese localization to blog post "How to Contribute to OpenTelemetry"

It will need to wait for #7757 to geet merged, specially so the `default_lang_commit` can get updated in this PR