### PR TITLE
fix: remove trailing backslash in helm install command

### DIFF
--- a/content/en/docs/platforms/kubernetes/helm/collector.md
+++ b/content/en/docs/platforms/kubernetes/helm/collector.md
@@ -24,7 +24,7 @@ following commands:
 helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 helm install my-opentelemetry-collector open-telemetry/opentelemetry-collector \
    --set image.repository="otel/opentelemetry-collector-k8s" \
-   --set mode=<daemonset|deployment|statefulset> \
+   --set mode=<daemonset|deployment|statefulset>
 ```
 
 ### Configuration

--- a/content/ja/docs/platforms/kubernetes/helm/collector.md
+++ b/content/ja/docs/platforms/kubernetes/helm/collector.md
@@ -20,7 +20,7 @@ Kubernetesへのコレクターのデプロイメントを容易にし、管理�
 helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 helm install my-opentelemetry-collector open-telemetry/opentelemetry-collector \
    --set image.repository="otel/opentelemetry-collector-k8s" \
-   --set mode=<daemonset|deployment|statefulset> \
+   --set mode=<daemonset|deployment|statefulset>
 ```
 
 ### 設定 {#configuration}


### PR DESCRIPTION
<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->

The example command for installing opentelemetry-collector with helm contained a trailing backslash on the last line, which is unnecessary and may confuse users. This commit removes it for correctness.
