### PR TITLE
Adding Oodle AI to the OTel vendors list

### DIFF
--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -572,3 +572,9 @@
   commercial: true
   url: https://www.velodb.io/solutions/use-cases/observability
   contact: owen@velodb.io
+- name: Oodle AI
+  nativeOTLP: true
+  url: https://docs.oodle.ai/integrations/metrics/otel/
+  contact: support@oodle.ai
+  oss: false
+  commercial: true

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -2131,6 +2131,10 @@
     "StatusCode": 206,
     "LastSeen": "2024-12-23T14:51:42.30807+02:00"
   },
+  "https://docs.oodle.ai/integrations/metrics/otel/": {
+    "StatusCode": 206,
+    "LastSeen": "2025-09-17T12:11:50.412974509Z"
+  },
   "https://docs.openfaas.com/architecture/metrics/": {
     "StatusCode": 206,
     "LastSeen": "2024-12-18T05:52:18.080718-05:00"


### PR DESCRIPTION
Request to add Oodle AI to the list of vendors

Here's our docs page for Otel integration - https://docs.oodle.ai/integrations/metrics/otel/
Our company website - https://oodle.ai

Incase of any questions, please reach-out to the same github handle(prameelaks) or support@oodle.ai
