### PR TITLE
Fixed missing link in authenticator-extension.md

### DIFF
--- a/content/en/docs/collector/building/authenticator-extension.md
+++ b/content/en/docs/collector/building/authenticator-extension.md
@@ -28,7 +28,7 @@ room at the [CNCF Slack workspace](https://slack.cncf.io).
 ## Architecture
 
 [Authenticators] are regular extensions that also satisfy one or more interfaces
-related to the authentication mechanism. [Server authenticators] are used with
+related to the authentication mechanism. [Server authenticators][sa] are used with
 receivers, and are able to intercept HTTP and gRPC requests, while client
 authenticators are used with exporters, able to add authentication data to HTTP
 and gRPC requests. It is possible for authenticators to implement both


### PR DESCRIPTION
Here's a fix for the missing link in authenticator-extension.md