### PR TITLE
pt(docs/demo): localize all services section pages

### DIFF
--- a/content/pt/docs/demo/services/_index.md
+++ b/content/pt/docs/demo/services/_index.md
@@ -1,0 +1,24 @@
+---
+title: Serviços
+aliases: [service_table, service-table]
+---
+
+Para visualizar os fluxos de requisições, consulte o [Diagrama de Serviços](../architecture/).
+
+| Serviço                               | Linguagem      | Descrição                                                                                                                          |
+| ------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| [accounting](accounting/)             | .NET          | Processa pedidos recebidos e conta a soma de todos os pedidos (simulado/).                                                                   |
+| [ad](ad/)                             | Java          | Fornece anúncios de texto baseados em palavras-chave de contexto fornecidas.                                                                                      |
+| [cart](cart/)                         | .NET          | Armazena os itens no carrinho de compras do usuário no Valkey e os recupera.                                                             |
+| [checkout](checkout/)                 | Go            | Recupera o carrinho do usuário, prepara o pedido e orquestra o pagamento, envio e a notificação por email.                               |
+| [currency](currency/)                 | C++           | Converte um valor monetário para outra moeda. Usa valores reais obtidos do Banco Central Europeu. É o serviço com maior QPS.    |
+| [email](email/)                       | Ruby          | Envia aos usuários um email de confirmação do pedido (simulado/).                                                                                     |
+| [fraud-detection](fraud-detection/)   | Kotlin        | Analisa pedidos recebidos e detecta tentativas de fraude (simulado/).                                                                         |
+| [frontend](frontend/)                 | TypeScript    | Expõe um servidor HTTP para servir o site. Não requer cadastro/login e gera IDs de sessão para todos os usuários automaticamente. |
+| [load-generator](load-generator/)     | Python/Locust | Envia continuamente requisições imitando fluxos de compra realistas de usuários para o frontend.                                                 |
+| [payment](payment/)                   | JavaScript    | Cobra as informações do cartão de crédito fornecido (simulado/) com o valor fornecido e retorna um ID de transação.                                       |
+| [product-catalog](product-catalog/)   | Go            | Fornece a lista de produtos de um arquivo JSON e a capacidade de pesquisar produtos e obter produtos individuais.                           |
+| [quote](quote/)                       | PHP           | Calcula os custos de envio, baseado no número de itens a serem enviados.                                                           |
+| [recommendation](recommendation/)     | Python        | Recomenda outros produtos baseado no que está no carrinho.                                                                         |
+| [shipping](shipping/)                 | Rust          | Fornece estimativas de custo de envio baseadas no carrinho de compras. Envia itens para o endereço fornecido (simulado/).                                  |
+| [react-native-app](react-native-app/) | TypeScript    | Aplicativo móvel React Native que fornece uma interface sobre os serviços de compras.                                                  |

--- a/content/pt/docs/demo/services/accounting.md
+++ b/content/pt/docs/demo/services/accounting.md
@@ -1,0 +1,29 @@
+---
+title: Serviço de Contabilidade
+linkTitle: Contabilidade
+aliases: [accountingservice]
+---
+
+Este serviço calcula o valor total dos produtos vendidos. Isso é apenas simulado
+e os pedidos recebidos são impressos.
+
+[Serviço de Contabilidade](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/accounting/)
+
+## Auto-instrumentação
+
+Este serviço depende da Instrumentação Automática do OpenTelemetry .NET para
+instrumentar automaticamente bibliotecas como Kafka e configurar o
+SDK do OpenTelemetry. A instrumentação é adicionada via pacote Nuget
+[OpenTelemetry.AutoInstrumentation](https://www.nuget.org/packages/OpenTelemetry.AutoInstrumentation)
+e ativada usando variáveis de ambiente que são obtidas de `instrument.sh`.
+Usar essa abordagem de instalação também garante que todas as dependências de
+instrumentação estejam adequadamente alinhadas com a aplicação.
+
+## Publicação
+
+Adicione `--use-current-runtime` ao comando `dotnet publish` para distribuir
+componentes de runtime nativo apropriados.
+
+```sh
+dotnet publish "./AccountingService.csproj" --use-current-runtime -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+```

--- a/content/pt/docs/demo/services/ad.md
+++ b/content/pt/docs/demo/services/ad.md
@@ -1,0 +1,130 @@
+---
+title: Serviço de Anúncios
+linkTitle: Anúncios
+aliases: [adservice]
+---
+
+Este serviço determina anúncios apropriados para servir aos usuários baseado em chaves de contexto.
+Os anúncios serão para produtos disponíveis na loja.
+
+[Código fonte do serviço de anúncios](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/ad/)
+
+## Auto-instrumentação
+
+Este serviço depende do agente Java do OpenTelemetry para instrumentar automaticamente
+bibliotecas como gRPC e configurar o SDK do OpenTelemetry. O agente é
+passado para o processo usando o argumento de linha de comando `-javaagent`. Argumentos de
+linha de comando são adicionados através do `JAVA_TOOL_OPTIONS` no `Dockerfile`,
+e utilizados durante o script de inicialização do Gradle gerado automaticamente.
+
+```dockerfile
+ENV JAVA_TOOL_OPTIONS=-javaagent:/app/opentelemetry-javaagent.jar
+```
+
+## Rastreamentos
+
+### Adicionar atributos a spans auto-instrumentados
+
+Dentro da execução de código auto-instrumentado você pode obter o span atual do
+contexto.
+
+```java
+Span span = Span.current();
+```
+
+Adicionar atributos a um span é realizado usando `setAttribute` no objeto
+span. Na função `getAds` múltiplos atributos são adicionados ao span.
+
+```java
+span.setAttribute("app.ads.contextKeys", req.getContextKeysList().toString());
+span.setAttribute("app.ads.contextKeys.count", req.getContextKeysCount());
+```
+
+### Adicionar eventos de span
+
+Adicionar um evento a um span é realizado usando `addEvent` no objeto span.
+Na função `getAds` um evento com um atributo é adicionado quando uma exceção
+é capturada.
+
+```java
+span.addEvent("Error", Attributes.of(AttributeKey.stringKey("exception.message"), e.getMessage()));
+```
+
+### Definir status do span
+
+Se o resultado da operação é um erro, o status do span deve ser definido
+adequadamente usando `setStatus` no objeto span. Na função `getAds` o
+status do span é definido quando uma exceção é capturada.
+
+```java
+span.setStatus(StatusCode.ERROR);
+```
+
+### Criar novos spans
+
+Novos spans podem ser criados e iniciados usando
+`Tracer.spanBuilder("spanName").startSpan()`. Spans recém-criados devem ser definidos
+no contexto usando `Span.makeCurrent()`. A função `getRandomAds` criará
+um novo span, defini-lo no contexto, executar uma operação e finalmente encerrar o span.
+
+```java
+// criar e iniciar um novo span manualmente
+Tracer tracer = GlobalOpenTelemetry.getTracer("ad");
+Span span = tracer.spanBuilder("getRandomAds").startSpan();
+
+// colocar o span no contexto, para que se qualquer span filho for iniciado o pai será definido adequadamente
+try (Scope ignored = span.makeCurrent()) {
+
+  Collection<Ad> allAds = adsMap.values();
+  for (int i = 0; i < MAX_ADS_TO_SERVE; i++) {
+    ads.add(Iterables.get(allAds, random.nextInt(allAds.size())));
+  }
+  span.setAttribute("app.ads.count", ads.size());
+
+} finally {
+  span.end();
+}
+```
+
+## Métricas
+
+### Inicializando Métricas
+
+Similar a criar spans, o primeiro passo na criação de métricas é inicializar uma
+instância `Meter`, ex. `GlobalOpenTelemetry.getMeter("ad")`. A partir daí, use os
+vários métodos builder disponíveis na instância `Meter` para criar o
+instrumento de métrica desejado, ex.:
+
+```java
+meter
+  .counterBuilder("app.ads.ad_requests")
+  .setDescription("Counts ad requests by request and response type")
+  .build();
+```
+
+### Métricas Atuais Produzidas
+
+Note que todos os nomes de métricas abaixo aparecem no Prometheus/Grafana com caracteres `.`
+transformados em `_`.
+
+#### Métricas personalizadas
+
+As seguintes métricas personalizadas estão atualmente disponíveis:
+
+- `app.ads.ad_requests`: Um contador de requisições de anúncios com dimensões descrevendo
+  se a requisição foi direcionada com chaves de contexto ou não, e se a
+  resposta foi anúncios direcionados ou aleatórios.
+
+#### Métricas auto-instrumentadas
+
+As seguintes métricas auto-instrumentadas estão disponíveis para a aplicação:
+
+- [Métricas de runtime para a JVM](/docs/specs/semconv/runtime/jvm-metrics/).
+- [Métricas de latência para RPCs](/docs/specs/semconv/rpc/rpc-metrics/#rpc-server)
+
+## Logs
+
+O Serviço de Anúncios usa Log4J, que é automaticamente configurado pelo agente OTel Java.
+
+Ele inclui o contexto de rastreamento nos registros de log, permitindo correlação de log com
+rastreamentos.

--- a/content/pt/docs/demo/services/cart/index.md
+++ b/content/pt/docs/demo/services/cart/index.md
@@ -1,0 +1,178 @@
+---
+title: Serviço de Carrinho
+linkTitle: Carrinho
+aliases: [cartservice]
+---
+
+Este serviço mantém itens colocados no carrinho de compras pelos usuários. Ele interage
+com um serviço de cache Valkey para acesso rápido aos dados do carrinho de compras.
+
+[Código fonte do serviço de carrinho](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/cart/)
+
+> **Nota** O OpenTelemetry para .NET usa a biblioteca `System.Diagnostic.DiagnosticSource`
+> como sua API em vez da API padrão do OpenTelemetry para Rastreamentos e
+> Métricas. A biblioteca `Microsoft.Extensions.Logging.Abstractions` é usada para Logs.
+
+## Rastreamentos
+
+### Inicializando Rastreamento
+
+O OpenTelemetry é configurado no container de injeção de dependência .NET. O
+método builder `AddOpenTelemetry()` é usado para configurar bibliotecas de instrumentação
+desejadas, adicionar exportadores, e definir outras opções. Configuração do exportador
+e atributos de recurso é realizada através de variáveis de ambiente.
+
+```cs
+Action<ResourceBuilder> appResourceBuilder =
+    resource => resource
+        .AddContainerDetector()
+        .AddHostDetector();
+
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(appResourceBuilder)
+    .WithTracing(tracerBuilder => tracerBuilder
+        .AddSource("OpenTelemetry.Demo.Cart")
+        .AddRedisInstrumentation(
+            options => options.SetVerboseDatabaseStatements = true)
+        .AddAspNetCoreInstrumentation()
+        .AddGrpcClientInstrumentation()
+        .AddHttpClientInstrumentation()
+        .AddOtlpExporter());
+```
+
+### Adicionar atributos a spans auto-instrumentados
+
+Dentro da execução de código auto-instrumentado você pode obter o span atual
+(activity) do contexto.
+
+```cs
+var activity = Activity.Current;
+```
+
+Adicionar atributos (tags em .NET) a um span (activity) é realizado usando
+`SetTag` no objeto activity. Na função `AddItem` do
+`services/CartService.cs` vários atributos são adicionados ao span
+auto-instrumentado.
+
+```cs
+activity?.SetTag("app.user.id", request.UserId);
+activity?.SetTag("app.product.quantity", request.Item.Quantity);
+activity?.SetTag("app.product.id", request.Item.ProductId);
+```
+
+### Adicionar eventos de span
+
+Adicionar eventos de span (activity) é realizado usando `AddEvent` no objeto
+activity. Na função `GetCart` do `services/CartService.cs` um evento de span é
+adicionado.
+
+```cs
+activity?.AddEvent(new("Fetch cart"));
+```
+
+## Métricas
+
+### Inicializando Métricas
+
+Similar a configurar Rastreamentos OpenTelemetry, o container de injeção de dependência .NET
+requer uma chamada para `AddOpenTelemetry()`. Este builder configura
+bibliotecas de instrumentação desejadas, exportadores, etc.
+
+```cs
+Action<ResourceBuilder> appResourceBuilder =
+    resource => resource
+        .AddContainerDetector()
+        .AddHostDetector();
+
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(appResourceBuilder)
+    .WithMetrics(meterBuilder => meterBuilder
+        .AddMeter("OpenTelemetry.Demo.Cart")
+        .AddProcessInstrumentation()
+        .AddRuntimeInstrumentation()
+        .AddAspNetCoreInstrumentation()
+        .SetExemplarFilter(ExemplarFilterType.TraceBased)
+        .AddOtlpExporter());
+```
+
+### Exemplares
+
+[Exemplares](/docs/specs/otel/metrics/data-model/#exemplars) são configurados no
+serviço Cart com filtro de exemplar baseado em trace, que habilita o
+SDK OpenTelemetry a anexar exemplares às métricas.
+
+Primeiro ele cria um `CartActivitySource`, `Meter` e dois `Histograms`. O
+histograma mantém controle da latência dos métodos `AddItem` e `GetCart`,
+já que esses são dois métodos importantes no serviço Cart.
+
+Esses dois métodos são críticos para o serviço Cart já que usuários não devem esperar muito
+tempo ao adicionar um item ao carrinho, ou ao visualizar seu carrinho antes de prosseguir
+para o processo de checkout.
+
+```cs
+private static readonly ActivitySource CartActivitySource = new("OpenTelemetry.Demo.Cart");
+private static readonly Meter CartMeter = new Meter("OpenTelemetry.Demo.Cart");
+private static readonly Histogram<long> addItemHistogram = CartMeter.CreateHistogram<long>(
+    "app.cart.add_item.latency",
+    advice: new InstrumentAdvice<long>
+    {
+        HistogramBucketBoundaries = [ 500000, 600000, 700000, 800000, 900000, 1000000, 1100000 ]
+    });
+private static readonly Histogram<long> getCartHistogram = CartMeter.CreateHistogram<long>(
+    "app.cart.get_cart.latency",
+    advice: new InstrumentAdvice<long>
+    {
+        HistogramBucketBoundaries = [ 300000, 400000, 500000, 600000, 700000, 800000, 900000 ]
+    });
+```
+
+Note que um limite de bucket personalizado também é definido, já que os valores padrão não
+se adequam aos resultados de microssegundos que o serviço Cart tem.
+
+Uma vez que as variáveis são definidas, a latência da execução de cada método é
+rastreada com um `StopWatch` da seguinte forma:
+
+```cs
+var stopwatch = Stopwatch.StartNew();
+
+(lógica do método)
+
+addItemHistogram.Record(stopwatch.ElapsedTicks);
+```
+
+Para conectar tudo, no pipeline de Rastreamentos, é necessário adicionar a
+fonte criada. (Já presente no snippet acima, mas adicionado aqui para
+referência):
+
+```cs
+.AddSource("OpenTelemetry.Demo.Cart")
+```
+
+E, no pipeline de Métricas, o `Meter` e o `ExemplarFilter`:
+
+```cs
+.AddMeter("OpenTelemetry.Demo.Cart")
+.SetExemplarFilter(ExemplarFilterType.TraceBased)
+```
+
+Para visualizar os Exemplares, navegue para Grafana
+<http://localhost:8080/grafana> > Dashboards > Demo > Cart Service Exemplars.
+
+Exemplares aparecem como "pontos em forma de diamante" especiais no gráfico do 95º percentil
+ou como pequenos quadrados no gráfico de mapa de calor. Selecione qualquer exemplar para visualizar seus dados,
+que incluem o timestamp da medição, o valor bruto, e o contexto de trace
+no momento do registro. O `trace_id` habilita navegação para o
+backend de rastreamento (Jaeger, neste caso).
+
+![Cart Service Exemplars](exemplars.png)
+
+## Logs
+
+Logs são configurados no container de injeção de dependência .NET no
+nível `LoggingBuilder` chamando `AddOpenTelemetry()`. Este builder configura
+opções desejadas, exportadores, etc.
+
+```cs
+builder.Logging
+    .AddOpenTelemetry(options => options.AddOtlpExporter());
+```

--- a/content/pt/docs/demo/services/checkout.md
+++ b/content/pt/docs/demo/services/checkout.md
@@ -1,0 +1,260 @@
+---
+title: Serviço de Checkout
+linkTitle: Checkout
+aliases: [checkoutservice]
+# prettier-ignore
+cSpell:ignore: fatalf otelgrpc otelsarama otlpmetricgrpc otlptracegrpc sarama sdkmetric sdktrace
+---
+
+Este serviço é responsável por processar um pedido de checkout do usuário. O
+serviço de checkout chamará muitos outros serviços para processar um pedido.
+
+[Código fonte do serviço de checkout](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/checkout/)
+
+## Rastreamentos
+
+### Inicializando Rastreamento
+
+O SDK do OpenTelemetry é inicializado a partir de `main` usando a função `initTracerProvider`.
+
+```go
+func initTracerProvider() *sdktrace.TracerProvider {
+    ctx := context.Background()
+
+    exporter, err := otlptracegrpc.New(ctx)
+    if err != nil {
+        log.Fatal(err)
+    }
+    tp := sdktrace.NewTracerProvider(
+        sdktrace.WithBatcher(exporter),
+        sdktrace.WithResource(initResource()),
+    )
+    otel.SetTracerProvider(tp)
+    otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
+    return tp
+}
+```
+
+Você deve chamar `TracerProvider.Shutdown()` quando seu serviço for encerrado para
+garantir que todos os spans sejam exportados. Este serviço faz essa chamada como parte de uma
+função diferida em main
+
+```go
+tp := initTracerProvider()
+defer func() {
+    if err := tp.Shutdown(context.Background()); err != nil {
+        log.Printf("Error shutting down tracer provider: %v", err)
+    }
+}()
+```
+
+### Adicionando auto-instrumentação gRPC
+
+Este serviço recebe requisições gRPC, que são instrumentadas na função main
+como parte da criação do servidor gRPC.
+
+```go
+var srv = grpc.NewServer(
+    grpc.StatsHandler(otelgrpc.NewServerHandler()),
+)
+```
+
+Este serviço fará várias chamadas gRPC de saída, que são todas instrumentadas
+envolvendo o cliente gRPC com instrumentação
+
+```go
+func createClient(ctx context.Context, svcAddr string) (*grpc.ClientConn, error) {
+    return grpc.DialContext(ctx, svcAddr,
+        grpc.WithTransportCredentials(insecure.NewCredentials()),
+        grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+    )
+}
+```
+
+### Adicionando auto-instrumentação Kafka (Sarama)
+
+Este serviço escreverá os resultados processados em um tópico Kafka que será então
+processado por outros microsserviços. Para instrumentar o cliente Kafka
+o Producer deve ser envolvido após ter sido criado.
+
+```go
+saramaConfig := sarama.NewConfig()
+producer, err := sarama.NewAsyncProducer(brokers, saramaConfig)
+if err != nil {
+    return nil, err
+}
+producer = otelsarama.WrapAsyncProducer(saramaConfig, producer)
+```
+
+### Adicionar atributos a spans auto-instrumentados
+
+Dentro da execução de código auto-instrumentado você pode obter o span atual do
+contexto.
+
+```go
+span := trace.SpanFromContext(ctx)
+```
+
+Adicionar atributos a um span é realizado usando `SetAttributes` no objeto
+span. Na função `PlaceOrder` vários atributos são adicionados ao span.
+
+```go
+span.SetAttributes(
+    attribute.String("app.order.id", orderID.String()), shippingTrackingAttribute,
+    attribute.Float64("app.shipping.amount", shippingCostFloat),
+    attribute.Float64("app.order.amount", totalPriceFloat),
+    attribute.Int("app.order.items.count", len(prep.orderItems)),
+)
+```
+
+### Adicionar eventos de span
+
+Adicionar eventos de span é realizado usando `AddEvent` no objeto span. Na
+função `PlaceOrder` vários eventos de span são adicionados. Alguns eventos têm atributos
+adicionais, outros não.
+
+Adicionando um evento de span sem atributos:
+
+```go
+span.AddEvent("prepared")
+```
+
+Adicionando um evento de span com atributos adicionais:
+
+```go
+span.AddEvent("charged",
+    trace.WithAttributes(attribute.String("app.payment.transaction.id", txID)))
+```
+
+## Métricas
+
+### Inicializando Métricas
+
+O SDK do OpenTelemetry é inicializado a partir de `main` usando a função `initMeterProvider`.
+
+```go
+func initMeterProvider() *sdkmetric.MeterProvider {
+    ctx := context.Background()
+
+    exporter, err := otlpmetricgrpc.New(ctx)
+    if err != nil {
+        log.Fatalf("new otlp metric grpc exporter failed: %v", err)
+    }
+
+    mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter)))
+    global.SetMeterProvider(mp)
+    return mp
+}
+```
+
+Você deve chamar `MeterProvider.Shutdown()` quando seu serviço for encerrado para
+garantir que todos os registros sejam exportados. Este serviço faz essa chamada como parte de uma
+função diferida em main
+
+```go
+mp := initMeterProvider()
+defer func() {
+    if err := mp.Shutdown(context.Background()); err != nil {
+        log.Printf("Error shutting down meter provider: %v", err)
+    }
+}()
+```
+
+### Adicionando auto-instrumentação de runtime golang
+
+O runtime do Golang é instrumentado na função main
+
+```go
+err := runtime.Start(runtime.WithMinimumReadMemStatsInterval(time.Second))
+if err != nil {
+    log.Fatal(err)
+}
+```
+
+## Logs
+
+Você pode enviar seus logs para o Coletor OpenTelemetry de duas maneiras:
+
+- Diretamente para o Coletor
+- Através de um arquivo ou `stdout`
+
+Você pode encontrar documentação especificando como usar ambas essas abordagens na
+seção [Logs](/docs/languages/go/instrumentation/#logs) da
+documentação [Instrumentação Manual](/docs/languages/go/instrumentation/).
+
+O serviço Checkout envia os logs diretamente para o Coletor e usa uma
+ponte de log para enviar seus logs, fazendo ponte para o pacote de logging `slog`, que produz
+logs estruturados.
+
+## Inicialização do LoggerProvider
+
+O SDK do OpenTelemetry é inicializado a partir de `main` usando a função `initLoggerProvider`.
+
+```go
+ctx := context.Background()
+
+logExporter, err := otlploggrpc.New(ctx)
+if err != nil {
+	return nil
+}
+
+loggerProvider := sdklog.NewLoggerProvider(
+	sdklog.WithProcessor(sdklog.NewBatchProcessor(logExporter)),
+)
+global.SetLoggerProvider(loggerProvider)
+
+return loggerProvider
+```
+
+Chame `LoggerProvider.Shutdown()` quando seu serviço estiver inativo para garantir que todos os logs
+sejam exportados. Este serviço faz essa chamada como parte de uma função diferida em
+`main`:
+
+```go
+lp := initLoggerProvider()
+defer func() {
+	if err := lp.Shutdown(context.Background()); err != nil {
+		logger.Error(fmt.Sprintf("Logger Provider Shutdown: %v", err))
+	}
+	logger.Info("Shutdown logger provider")
+}()
+```
+
+### Funcionalidade de logging
+
+Este serviço envia logs para o Coletor usando chamadas gRPC. Os logs são produzidos
+em um formato estruturado usando o pacote `slog`.
+
+Primeiro, inicialize o logger:
+
+```go
+logger   *slog.Logger
+logger = otelslog.NewLogger("checkout")
+```
+
+Note o uso de `fmt.Sprintf` para formatar a saída antes de ser enviada para o
+logger:
+
+```go
+logger.Info(fmt.Sprintf("order confirmation email sent to %q", req.Email))
+logger.Warn(fmt.Sprintf("failed to send order confirmation to %q: %+v", req.Email, err))
+logger.Error(fmt.Sprintf("Error shutting down logger provider: %v", err))
+```
+
+A vantagem de usar `slog` é a capacidade de anexar atributos adicionais à
+saída. O seguinte exemplo anexa alguns atributos como `orderID`,
+`shippingCost` e `totalPrice`. Isso torna possível visualizar e analisar estes
+como parte da saída do log e facilita visualizá-los como colunas separadas
+no Grafana:
+
+```go
+logger.LogAttrs(
+    ctx,
+    slog.LevelInfo, "order placed",
+    slog.String("app.order.id", orderID.String()),
+    slog.Float64("app.shipping.amount", shippingCostFloat),
+    slog.Float64("app.order.amount", totalPriceFloat),
+    slog.Int("app.order.items.count", len(prep.orderItems)),
+    slog.String("app.shipping.tracking.id", shippingTrackingID),
+)
+```

--- a/content/pt/docs/demo/services/currency.md
+++ b/content/pt/docs/demo/services/currency.md
@@ -1,0 +1,235 @@
+---
+title: Serviço de Moeda
+linkTitle: Moeda
+aliases: [currencyservice]
+cSpell:ignore: decltype labelkv noexcept nostd
+---
+
+Este serviço fornece funcionalidade para converter valores entre diferentes
+moedas.
+
+[Código fonte do serviço de moeda](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/currency/)
+
+## Rastreamentos
+
+### Inicializando Rastreamento
+
+O SDK do OpenTelemetry é inicializado a partir de `main` usando a função `initTracer`
+definida em `tracer_common.h`
+
+```cpp
+void initTracer()
+{
+  auto exporter = opentelemetry::exporter::otlp::OtlpGrpcExporterFactory::Create();
+  auto processor =
+      opentelemetry::sdk::trace::SimpleSpanProcessorFactory::Create(std::move(exporter));
+  std::vector<std::unique_ptr<opentelemetry::sdk::trace::SpanProcessor>> processors;
+  processors.push_back(std::move(processor));
+  std::shared_ptr<opentelemetry::sdk::trace::TracerContext> context =
+      opentelemetry::sdk::trace::TracerContextFactory::Create(std::move(processors));
+  std::shared_ptr<opentelemetry::trace::TracerProvider> provider =
+      opentelemetry::sdk::trace::TracerProviderFactory::Create(context);
+ // Set the global trace provider
+  opentelemetry::trace::Provider::SetTracerProvider(provider);
+
+ // set global propagator
+  opentelemetry::context::propagation::GlobalTextMapPropagator::SetGlobalPropagator(
+      opentelemetry::nostd::shared_ptr<opentelemetry::context::propagation::TextMapPropagator>(
+          new opentelemetry::trace::propagation::HttpTraceContext()));
+}
+```
+
+### Criar novos spans
+
+Novos spans podem ser criados e iniciados usando
+`Tracer->StartSpan("spanName", attributes, options)`. Após um span ser criado
+você precisa iniciá-lo e colocá-lo no contexto ativo usando
+`Tracer->WithActiveSpan(span)`. Você pode encontrar um exemplo disso na função `Convert`.
+
+```cpp
+std::string span_name = "CurrencyService/Convert";
+auto span =
+    get_tracer("currency")->StartSpan(span_name,
+                                  {{SemanticConventions::kRpcSystem, "grpc"},
+                                   {SemanticConventions::kRpcService, "oteldemo.CurrencyService"},
+                                   {SemanticConventions::kRpcMethod, "Convert"},
+                                   {SemanticConventions::kRpcGrpcStatusCode, 0}},
+                                  options);
+auto scope = get_tracer("currency")->WithActiveSpan(span);
+```
+
+### Adicionando atributos a spans
+
+Você pode adicionar um atributo a um span usando `Span->SetAttribute(key, value)`.
+
+```cpp
+span->SetAttribute("app.currency.conversion.from", from_code);
+span->SetAttribute("app.currency.conversion.to", to_code);
+```
+
+### Adicionar eventos de span
+
+Adicionar eventos de span é realizado usando `Span->AddEvent(name)`.
+
+```cpp
+span->AddEvent("Conversion successful, response sent back");
+```
+
+### Definir status do span
+
+Certifique-se de definir o status do seu span para `Ok`, ou `Error` adequadamente. Você pode fazer
+isso usando `Span->SetStatus(status)`
+
+```cpp
+span->SetStatus(StatusCode::kOk);
+```
+
+### Propagação de contexto de rastreamento
+
+Em C++ a propagação não é tratada automaticamente. Você precisa extraí-la do
+chamador e injetar o contexto de propagação em spans subsequentes. A
+classe `GrpcServerCarrier` define um método para extrair contexto de requisições gRPC
+de entrada que é utilizada nas implementações de chamada do serviço.
+
+A classe `GrpcServerCarrier` é definida em `tracer_common.h` da seguinte forma:
+
+```cpp
+class GrpcServerCarrier : public opentelemetry::context::propagation::TextMapCarrier
+{
+public:
+  GrpcServerCarrier(ServerContext *context) : context_(context) {}
+  GrpcServerCarrier() = default;
+  virtual opentelemetry::nostd::string_view Get(
+      opentelemetry::nostd::string_view key) const noexcept override
+  {
+    auto it = context_->client_metadata().find(key.data());
+    if (it != context_->client_metadata().end())
+    {
+      return it->second.data();
+    }
+    return "";
+  }
+
+  virtual void Set(opentelemetry::nostd::string_view key,
+                   opentelemetry::nostd::string_view value) noexcept override
+  {
+   // Not required for server
+  }
+
+  ServerContext *context_;
+};
+```
+
+Esta classe é utilizada no método `Convert` para extrair contexto e criar um
+objeto `StartSpanOptions` para conter o contexto correto que é usado quando
+criando novos spans.
+
+```cpp
+StartSpanOptions options;
+options.kind = SpanKind::kServer;
+GrpcServerCarrier carrier(context);
+
+auto prop        = context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
+auto current_ctx = context::RuntimeContext::GetCurrent();
+auto new_context = prop->Extract(carrier, current_ctx);
+options.parent   = GetSpan(new_context)->GetContext();
+```
+
+## Métricas
+
+### Inicializando Métricas
+
+O `MeterProvider` do OpenTelemetry é inicializado a partir de `main()` usando a
+função `initMeter()` definida em `meter_common.h`.
+
+```cpp
+void initMeter()
+{
+  // Build MetricExporter
+  otlp_exporter::OtlpGrpcMetricExporterOptions otlpOptions;
+  auto exporter = otlp_exporter::OtlpGrpcMetricExporterFactory::Create(otlpOptions);
+
+  // Build MeterProvider and Reader
+  metric_sdk::PeriodicExportingMetricReaderOptions options;
+  std::unique_ptr<metric_sdk::MetricReader> reader{
+      new metric_sdk::PeriodicExportingMetricReader(std::move(exporter), options) };
+  auto provider = std::shared_ptr<metrics_api::MeterProvider>(new metric_sdk::MeterProvider());
+  auto p = std::static_pointer_cast<metric_sdk::MeterProvider>(provider);
+  p->AddMetricReader(std::move(reader));
+  metrics_api::Provider::SetMeterProvider(provider);
+}
+```
+
+### Iniciando IntCounter
+
+Uma variável global `currency_counter` é criada em `main()` chamando a função
+`initIntCounter()` definida em `meter_common.h`.
+
+```cpp
+nostd::unique_ptr<metrics_api::Counter<uint64_t>> initIntCounter()
+{
+  std::string counter_name = name + "_counter";
+  auto provider = metrics_api::Provider::GetMeterProvider();
+  nostd::shared_ptr<metrics_api::Meter> meter = provider->GetMeter(name, version);
+  auto int_counter = meter->CreateUInt64Counter(counter_name);
+  return int_counter;
+}
+```
+
+### Contando requisições de conversão de moeda
+
+O método `CurrencyCounter()` é implementado da seguinte forma:
+
+```cpp
+void CurrencyCounter(const std::string& currency_code)
+{
+    std::map<std::string, std::string> labels = { {"currency_code", currency_code} };
+    auto labelkv = common::KeyValueIterableView<decltype(labels)>{ labels };
+    currency_counter->Add(1, labelkv);
+}
+```
+
+Toda vez que a função `Convert()` é chamada, o código de moeda recebido como
+`to_code` é usado para contar as conversões.
+
+```cpp
+CurrencyCounter(to_code);
+```
+
+## Logs
+
+O `LoggerProvider` do OpenTelemetry é inicializado a partir de `main()` usando a
+função `initLogger()` definida em `logger_common.h`.
+
+```cpp
+void initLogger() {
+  otlp::OtlpGrpcLogRecordExporterOptions loggerOptions;
+  auto exporter  = otlp::OtlpGrpcLogRecordExporterFactory::Create(loggerOptions);
+  auto processor = logs_sdk::SimpleLogRecordProcessorFactory::Create(std::move(exporter));
+  std::vector<std::unique_ptr<logs_sdk::LogRecordProcessor>> processors;
+  processors.push_back(std::move(processor));
+  auto context = logs_sdk::LoggerContextFactory::Create(std::move(processors));
+  std::shared_ptr<logs::LoggerProvider> provider = logs_sdk::LoggerProviderFactory::Create(std::move(context));
+  opentelemetry::logs::Provider::SetLoggerProvider(provider);
+}
+```
+
+### Usando o LoggerProvider
+
+O Logger Provider inicializado é chamado de `main` em `server.cpp`:
+
+```cpp
+logger = getLogger(name);
+```
+
+Ele atribui o logger a uma variável local chamada `logger`:
+
+```cpp
+nostd::shared_ptr<opentelemetry::logs::Logger> logger;
+```
+
+Que é então usado em todo o código sempre que precisamos registrar uma linha:
+
+```cpp
+logger->Info(std::string(__func__) + " conversion successful");
+```

--- a/content/pt/docs/demo/services/email.md
+++ b/content/pt/docs/demo/services/email.md
@@ -1,0 +1,81 @@
+---
+title: Serviço de Email
+linkTitle: Email
+aliases: [emailservice]
+cSpell:ignore: sinatra
+---
+
+Este serviço enviará um email de confirmação para o usuário quando um pedido for feito.
+
+[Código fonte do serviço de email](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/email/)
+
+## Inicializando Rastreamento
+
+Você precisará requerer as gems do SDK e exportador core do OpenTelemetry, bem
+como qualquer gem que será necessária para bibliotecas de auto-instrumentação (ex:
+Sinatra)
+
+```ruby
+require "opentelemetry/sdk"
+require "opentelemetry/exporter/otlp"
+require "opentelemetry/instrumentation/sinatra"
+```
+
+O SDK Ruby usa variáveis de ambiente padrão do OpenTelemetry para configurar exportação OTLP,
+atributos de recurso e nome do serviço automaticamente. Ao inicializar
+o SDK do OpenTelemetry, você também especificará quais bibliotecas de auto-instrumentação
+aproveitar (ex: Sinatra)
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use "OpenTelemetry::Instrumentation::Sinatra"
+end
+```
+
+## Rastreamentos
+
+### Adicionar atributos a spans auto-instrumentados
+
+Dentro da execução de código auto-instrumentado você pode obter o span atual do
+contexto.
+
+```ruby
+current_span = OpenTelemetry::Trace.current_span
+```
+
+Adicionar múltiplos atributos a um span é realizado usando `add_attributes` no
+objeto span.
+
+```ruby
+current_span.add_attributes({
+  "app.order.id" => data.order.order_id,
+})
+```
+
+Adicionar apenas um único atributo pode ser realizado usando `set_attribute` no
+objeto span.
+
+```ruby
+span.set_attribute("app.email.recipient", data.email)
+```
+
+### Criar novos spans
+
+Novos spans podem ser criados e colocados no contexto ativo usando `in_span` de um
+objeto Tracer do OpenTelemetry. Quando usado em conjunto com um bloco `do..end`,
+o span será automaticamente encerrado quando o bloco terminar a execução.
+
+```ruby
+tracer = OpenTelemetry.tracer_provider.tracer('email')
+tracer.in_span("send_email") do |span|
+  # lógica no contexto do span aqui
+end
+```
+
+## Métricas
+
+TBD
+
+## Logs
+
+TBD

--- a/content/pt/docs/demo/services/fraud-detection.md
+++ b/content/pt/docs/demo/services/fraud-detection.md
@@ -1,0 +1,22 @@
+---
+title: Serviço de Detecção de Fraude
+linkTitle: Detecção de Fraude
+aliases: [frauddetectionservice]
+---
+
+Este serviço analisa pedidos recebidos e detecta clientes maliciosos. Isso é
+apenas simulado e os pedidos recebidos são impressos.
+
+[Código fonte do serviço de detecção de fraude](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/fraud-detection/)
+
+## Auto-instrumentação
+
+Este serviço depende do agente Java do OpenTelemetry para instrumentar automaticamente
+bibliotecas como Kafka e configurar o SDK do OpenTelemetry. O agente é
+passado para o processo usando o argumento de linha de comando `-javaagent`. Argumentos de
+linha de comando são adicionados através do `JAVA_TOOL_OPTIONS` no `Dockerfile`,
+e utilizados durante o script de inicialização do Gradle gerado automaticamente.
+
+```dockerfile
+ENV JAVA_TOOL_OPTIONS=-javaagent:/app/opentelemetry-javaagent.jar
+```

--- a/content/pt/docs/demo/services/frontend-proxy.md
+++ b/content/pt/docs/demo/services/frontend-proxy.md
@@ -1,0 +1,66 @@
+---
+title: Proxy Frontend (Envoy)
+linkTitle: Proxy Frontend
+aliases: [frontendproxy]
+cSpell:ignore: upstreams
+---
+
+O proxy frontend é usado como um proxy reverso para interfaces web voltadas ao usuário
+como o frontend, Jaeger, Grafana, gerador de carga e serviço de feature flag.
+
+[Código fonte da configuração do proxy frontend](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/frontend-proxy/)
+
+## Habilitando OpenTelemetry
+
+**NOTA: Apenas requisições não sintéticas irão acionar o rastreamento do envoy.**
+
+Para habilitar o Envoy a produzir spans sempre que receber uma requisição, a
+seguinte configuração é necessária:
+
+```yaml
+static_resources:
+  listeners:
+    - address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: ${ENVOY_PORT}
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                codec_type: AUTO
+                stat_prefix: ingress_http
+                tracing:
+                  provider:
+                    name: envoy.tracers.opentelemetry
+                    typed_config:
+                      '@type': type.googleapis.com/envoy.config.trace.v3.OpenTelemetryConfig
+                      grpc_service:
+                        envoy_grpc:
+                          cluster_name: opentelemetry_collector
+                        timeout: 0.250s
+                      service_name: frontend-proxy
+
+  clusters:
+    - name: opentelemetry_collector
+      type: STRICT_DNS
+      lb_policy: ROUND_ROBIN
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: opentelemetry_collector
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: ${OTEL_COLLECTOR_HOST}
+                      port_value: ${OTEL_COLLECTOR_PORT}
+```
+
+Onde `OTEL_COLLECTOR_HOST` e `OTEL_COLLECTOR_PORT` são passados via variáveis de
+ambiente.

--- a/content/pt/docs/demo/services/frontend.md
+++ b/content/pt/docs/demo/services/frontend.md
@@ -1,0 +1,235 @@
+---
+title: Frontend
+cSpell:ignore: typeof
+---
+
+O frontend é responsável por fornecer uma interface para usuários, bem como uma API
+utilizada pela interface ou outros clientes. A aplicação é baseada em
+[Next.JS](https://nextjs.org/) para fornecer uma interface web React e rotas de API.
+
+[Código fonte do frontend](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/frontend/)
+
+## Instrumentação do Servidor
+
+É recomendado usar um módulo Node requerido ao iniciar sua aplicação Node.js
+para inicializar o SDK e auto-instrumentação. Ao inicializar
+o SDK Node.js do OpenTelemetry, você opcionalmente especifica quais bibliotecas de auto-instrumentação
+aproveitar, ou fazer uso da função `getNodeAutoInstrumentations()`
+que inclui os frameworks mais populares. O
+arquivo `utils/telemetry/Instrumentation.js` contém todo o código necessário para
+inicializar o SDK e auto-instrumentação baseado em variáveis de ambiente padrão do
+[OpenTelemetry](/docs/specs/otel/configuration/sdk-environment-variables/)
+para exportação OTLP, atributos de recurso e nome do serviço.
+
+```javascript
+const FrontendTracer = async () => {
+  const { ZoneContextManager } = await import('@opentelemetry/context-zone');
+
+  let resource = new Resource({
+    [SEMRESATTRS_SERVICE_NAME]: NEXT_PUBLIC_OTEL_SERVICE_NAME,
+  });
+  const detectedResources = detectResourcesSync({
+    detectors: [browserDetector],
+  });
+  resource = resource.merge(detectedResources);
+
+  const provider = new WebTracerProvider({
+    resource,
+    spanProcessors: [
+      new SessionIdProcessor(),
+      new BatchSpanProcessor(
+        new OTLPTraceExporter({
+          url:
+            NEXT_PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT ||
+            'http://localhost:4318/v1/traces',
+        }),
+        {
+          scheduledDelayMillis: 500,
+        },
+      ),
+    ],
+  });
+
+  const contextManager = new ZoneContextManager();
+
+  provider.register({
+    contextManager,
+    propagator: new CompositePropagator({
+      propagators: [
+        new W3CBaggagePropagator(),
+        new W3CTraceContextPropagator(),
+      ],
+    }),
+  });
+
+  registerInstrumentations({
+    tracerProvider: provider,
+    instrumentations: [
+      getWebAutoInstrumentations({
+        '@opentelemetry/instrumentation-fetch': {
+          propagateTraceHeaderCorsUrls: /.*/,
+          clearTimingResources: true,
+          applyCustomAttributesOnSpan(span) {
+            span.setAttribute('app.synthetic_request', IS_SYNTHETIC_REQUEST);
+          },
+        },
+      }),
+    ],
+  });
+};
+```
+
+Módulos Node requeridos são carregados usando o argumento de linha de comando `--require`.
+Isso pode ser feito na seção `scripts.start` do `package.json` e iniciando
+a aplicação usando `npm start`.
+
+```json
+"scripts": {
+  "start": "node --require ./Instrumentation.js server.js",
+},
+```
+
+## Rastreamentos
+
+### Exceções de Span e status
+
+Você pode usar a função `recordException` do objeto span para criar um evento de span
+com o stack trace completo de um erro tratado. Ao registrar uma exceção também
+certifique-se de definir o status do span adequadamente. Você pode ver isso no bloco
+catch da função `NextApiHandler` no
+arquivo `utils/telemetry/InstrumentationMiddleware.ts`.
+
+```typescript
+span.recordException(error as Exception);
+span.setStatus({ code: SpanStatusCode.ERROR });
+```
+
+### Criar novos spans
+
+Novos spans podem ser criados e iniciados usando
+`Tracer.startSpan("spanName", options)`. Várias opções podem ser usadas para especificar
+como o span pode ser criado.
+
+- `root: true` criará um novo trace, definindo este span como a raiz.
+- `links` são usados para especificar links para outros spans (mesmo dentro de outro trace)
+  que devem ser referenciados.
+- `attributes` são pares chave/valor adicionados a um span, tipicamente usados para
+  contexto da aplicação.
+
+```typescript
+span = tracer.startSpan(`HTTP ${method}`, {
+  root: true,
+  kind: SpanKind.SERVER,
+  links: [{ context: syntheticSpan.spanContext() }],
+  attributes: {
+    'app.synthetic_request': true,
+    [SEMATTRS_HTTP_TARGET]: target,
+    [SEMATTRS_HTTP_STATUS_CODE]: response.statusCode,
+    [SEMATTRS_HTTP_METHOD]: method,
+    [SEMATTRS_HTTP_USER_AGENT]: headers['user-agent'] || '',
+    [SEMATTRS_HTTP_URL]: `${headers.host}${url}`,
+    [SEMATTRS_HTTP_FLAVOR]: httpVersion,
+  },
+});
+```
+
+## Instrumentação do Navegador
+
+A interface web que o frontend fornece também é instrumentada para
+navegadores web. A instrumentação OpenTelemetry é incluída como parte do componente App do Next.js
+em `pages/_app.tsx`. Aqui a instrumentação é importada e inicializada.
+
+```typescript
+import FrontendTracer from '../utils/telemetry/FrontendTracer';
+
+if (typeof window !== 'undefined') FrontendTracer();
+```
+
+O arquivo `utils/telemetry/FrontendTracer.ts` contém código para inicializar um
+TracerProvider, estabelecer uma exportação OTLP, registrar propagadores de contexto de trace,
+e registrar bibliotecas de auto-instrumentação específicas para web. Como o navegador
+enviará dados para um Coletor OpenTelemetry que provavelmente estará em um
+domínio separado, cabeçalhos CORS também são configurados adequadamente.
+
+Como parte das mudanças para carregar o atributo `synthetic_request` para
+os serviços de backend, a função de configuração `applyCustomAttributesOnSpan`
+foi adicionada à lógica de atributos de span personalizados da biblioteca `instrumentation-fetch`
+dessa forma cada span do lado do navegador incluirá isso.
+
+```typescript
+import {
+  CompositePropagator,
+  W3CBaggagePropagator,
+  W3CTraceContextPropagator,
+} from '@opentelemetry/core';
+import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
+import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web';
+import { Resource } from '@opentelemetry/resources';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+
+const FrontendTracer = async () => {
+  const { ZoneContextManager } = await import('@opentelemetry/context-zone');
+
+  const provider = new WebTracerProvider({
+    resource: new Resource({
+      [SEMRESATTRS_SERVICE_NAME]: process.env.NEXT_PUBLIC_OTEL_SERVICE_NAME,
+    }),
+    spanProcessors: [new SimpleSpanProcessor(new OTLPTraceExporter())],
+  });
+
+  const contextManager = new ZoneContextManager();
+
+  provider.register({
+    contextManager,
+    propagator: new CompositePropagator({
+      propagators: [
+        new W3CBaggagePropagator(),
+        new W3CTraceContextPropagator(),
+      ],
+    }),
+  });
+
+  registerInstrumentations({
+    tracerProvider: provider,
+    instrumentations: [
+      getWebAutoInstrumentations({
+        '@opentelemetry/instrumentation-fetch': {
+          propagateTraceHeaderCorsUrls: /.*/,
+          clearTimingResources: true,
+          applyCustomAttributesOnSpan(span) {
+            span.setAttribute('app.synthetic_request', 'false');
+          },
+        },
+      }),
+    ],
+  });
+};
+
+export default FrontendTracer;
+```
+
+## Métricas
+
+TBD
+
+## Logs
+
+TBD
+
+## Baggage
+
+O Baggage do OpenTelemetry é utilizado no frontend para verificar se a requisição é
+sintética (do gerador de carga). Requisições sintéticas forçarão a criação
+de um novo trace. O span raiz do novo trace conterá muitos dos mesmos
+atributos que um span de requisição HTTP instrumentado.
+
+Para determinar se um item de Baggage está definido, você pode aproveitar a API `propagation`
+para analisar o cabeçalho Baggage, e aproveitar a API `baggage` para obter ou definir entradas.
+
+```typescript
+const baggage = propagation.getBaggage(context.active());
+if (baggage?.getEntry("synthetic_request")?.value == "true") {...}
+```

--- a/content/pt/docs/demo/services/image-provider.md
+++ b/content/pt/docs/demo/services/image-provider.md
@@ -1,0 +1,12 @@
+---
+title: Serviço de Provedor de Imagens
+linkTitle: Provedor de Imagens
+aliases: [imageprovider] # cSpell:disable-line
+---
+
+Este serviço fornece as imagens que são usadas no frontend. As imagens são
+hospedadas estaticamente em uma instância NGINX. O servidor NGINX é instrumentado com o
+[módulo nginx-otel](https://github.com/nginxinc/nginx-otel/tree/main).
+
+Para detalhes, consulte o
+[código fonte do serviço de provedor de imagens](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/image-provider/).

--- a/content/pt/docs/demo/services/kafka.md
+++ b/content/pt/docs/demo/services/kafka.md
@@ -1,0 +1,25 @@
+---
+title: Kafka
+cSpell:ignore: Dotel
+---
+
+Este é usado como um serviço de fila de mensagens para conectar o serviço de checkout com os
+serviços de contabilidade e detecção de fraude.
+
+[Código fonte do serviço Kafka](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/kafka/)
+
+## Auto-instrumentação
+
+Este serviço depende do agente Java do OpenTelemetry e do
+[Módulo de Insight de Métricas JMX integrado](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/jmx-metrics/javaagent)
+para capturar
+[métricas do broker Kafka](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/javaagent/kafka-broker.md)
+e enviá-las para o coletor via OTLP.
+
+O agente é passado para o processo usando o argumento de linha de comando `-javaagent`.
+Argumentos de linha de comando são adicionados através do `KAFKA_OPTS` no
+`Dockerfile`.
+
+```dockerfile
+ENV KAFKA_OPTS="-javaagent:/tmp/opentelemetry-javaagent.jar -Dotel.jmx.target.system=kafka-broker"
+```

--- a/content/pt/docs/demo/services/load-generator.md
+++ b/content/pt/docs/demo/services/load-generator.md
@@ -1,0 +1,70 @@
+---
+title: Gerador de Carga
+aliases: [loadgenerator]
+cSpell:ignore: instrumentor instrumentors locustfile urllib
+---
+
+O gerador de carga é baseado no framework de teste de carga Python
+[Locust](https://locust.io). Por padrão ele simulará usuários solicitando
+várias rotas diferentes do frontend.
+
+[Código fonte do gerador de carga](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/load-generator/)
+
+## Rastreamentos
+
+### Inicializando Rastreamento
+
+Como este serviço é um
+[locustfile](https://docs.locust.io/en/stable/writing-a-locustfile.html), o
+SDK do OpenTelemetry é inicializado após as declarações de import. Este código
+criará um provedor de tracer e estabelecerá um Processador de Span para usar. Pontos de
+exportação, atributos de recurso e nome do serviço são automaticamente definidos usando
+[variáveis de ambiente do OpenTelemetry](/docs/specs/otel/configuration/sdk-environment-variables/).
+
+```python
+tracer_provider = TracerProvider()
+trace.set_tracer_provider(tracer_provider)
+tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+```
+
+### Adicionando bibliotecas de instrumentação
+
+Para adicionar bibliotecas de instrumentação você precisa importar os Instrumentors para cada
+biblioteca no seu código Python. O Locust usa as bibliotecas `Requests` e `URLLib3`,
+então importaremos seus Instrumentors.
+
+```python
+from opentelemetry.instrumentation.requests import RequestsInstrumentor
+from opentelemetry.instrumentation.urllib3 import URLLib3Instrumentor
+```
+
+No seu código antes da biblioteca ser utilizada, o Instrumentor precisa ser
+inicializado chamando `instrument()`.
+
+```python
+RequestsInstrumentor().instrument()
+URLLib3Instrumentor().instrument()
+```
+
+Uma vez inicializado, toda requisição Locust para este gerador de carga terá seu
+próprio trace com um span para cada uma das bibliotecas `Requests` e `URLLib3`.
+
+## Métricas
+
+TBD
+
+## Logs
+
+TBD
+
+## Baggage
+
+O Baggage do OpenTelemetry é usado pelo gerador de carga para indicar que os traces
+são gerados sinteticamente. Isso é feito na função `on_start` criando
+um objeto de contexto contendo o item de baggage, e associando esse contexto para
+todas as tarefas pelo gerador de carga.
+
+```python
+ctx = baggage.set_baggage("synthetic_request", "true")
+context.attach(ctx)
+```

--- a/content/pt/docs/demo/services/payment.md
+++ b/content/pt/docs/demo/services/payment.md
@@ -1,0 +1,166 @@
+---
+title: Serviço de Pagamento
+linkTitle: Pagamento
+aliases: [paymentservice]
+cSpell:ignore: nanos
+---
+
+Este serviço é responsável por processar pagamentos com cartão de crédito para pedidos. Ele
+retornará um erro se o cartão de crédito for inválido ou o pagamento não puder ser
+processado.
+
+[Código fonte do serviço de pagamento](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/payment/)
+
+## Inicializando OpenTelemetry
+
+É recomendado `require` a aplicação Node.js usando um arquivo inicializador que
+inicializa o SDK e auto-instrumentação. Ao inicializar o
+SDK Node.js do OpenTelemetry nesse módulo, você opcionalmente especifica quais
+bibliotecas de auto-instrumentação aproveitar, ou fazer uso da
+função `getNodeAutoInstrumentations()` que inclui os frameworks mais populares.
+O exemplo abaixo de um arquivo inicializador (`opentelemetry.js`) contém todo o código
+necessário para inicializar o SDK e auto-instrumentação baseado em variáveis de ambiente padrão do OpenTelemetry
+para exportação OTLP, atributos de recurso e nome do serviço. Ele então `require`s sua aplicação em `./index.js` para iniciá-la uma vez
+que o SDK esteja inicializado.
+
+```javascript
+const opentelemetry = require('@opentelemetry/sdk-node');
+const {
+  getNodeAutoInstrumentations,
+} = require('@opentelemetry/auto-instrumentations-node');
+const {
+  OTLPTraceExporter,
+} = require('@opentelemetry/exporter-trace-otlp-grpc');
+const {
+  OTLPMetricExporter,
+} = require('@opentelemetry/exporter-metrics-otlp-grpc');
+const { PeriodicExportingMetricReader } = require('@opentelemetry/sdk-metrics');
+const {
+  alibabaCloudEcsDetector,
+} = require('@opentelemetry/resource-detector-alibaba-cloud');
+const {
+  awsEc2Detector,
+  awsEksDetector,
+} = require('@opentelemetry/resource-detector-aws');
+const {
+  containerDetector,
+} = require('@opentelemetry/resource-detector-container');
+const { gcpDetector } = require('@opentelemetry/resource-detector-gcp');
+const {
+  envDetector,
+  hostDetector,
+  osDetector,
+  processDetector,
+} = require('@opentelemetry/resources');
+
+const sdk = new opentelemetry.NodeSDK({
+  traceExporter: new OTLPTraceExporter(),
+  instrumentations: [
+    getNodeAutoInstrumentations({
+      // only instrument fs if it is part of another trace
+      '@opentelemetry/instrumentation-fs': {
+        requireParentSpan: true,
+      },
+    }),
+  ],
+  metricReader: new PeriodicExportingMetricReader({
+    exporter: new OTLPMetricExporter(),
+  }),
+  resourceDetectors: [
+    containerDetector,
+    envDetector,
+    hostDetector,
+    osDetector,
+    processDetector,
+    alibabaCloudEcsDetector,
+    awsEksDetector,
+    awsEc2Detector,
+    gcpDetector,
+  ],
+});
+
+sdk.start();
+```
+
+Você pode então usar `opentelemetry.js` para iniciar sua aplicação. Isso pode ser feito no
+comando `ENTRYPOINT` para o `Dockerfile` do serviço.
+
+```dockerfile
+ENTRYPOINT [ "node", "--require", "./opentelemetry.js", "./index.js" ]
+```
+
+## Rastreamentos
+
+### Adicionar atributos a spans auto-instrumentados
+
+Dentro da execução de código auto-instrumentado você pode obter o span atual do
+contexto.
+
+```javascript
+const span = opentelemetry.trace.getActiveSpan();
+```
+
+Adicionar atributos a um span é realizado usando `setAttributes` no objeto
+span. Na função `chargeServiceHandler` um atributo é adicionado ao
+span como um objeto anônimo (mapa) para o par chave/valor do atributo.
+
+```javascript
+span.setAttributes({
+  'app.payment.amount': parseFloat(`${amount.units}.${amount.nanos}`),
+});
+```
+
+### Exceções de Span e status
+
+Você pode usar a função `recordException` do objeto span para criar um evento de span
+com o stack trace completo de um erro tratado. Ao registrar uma exceção também
+certifique-se de definir o status do span adequadamente. Você pode ver isso na
+função `chargeServiceHandler`
+
+```javascript
+span.recordException(err);
+span.setStatus({ code: opentelemetry.SpanStatusCode.ERROR });
+```
+
+## Métricas
+
+### Criando Medidores e Instrumentos
+
+Medidores podem ser criados usando o pacote `@opentelemetry/api-metrics`. Você pode
+criar medidores como visto abaixo, e então usar o medidor criado para criar
+instrumentos.
+
+```javascript
+const { metrics } = require('@opentelemetry/api-metrics');
+
+const meter = metrics.getMeter('payment');
+const transactionsCounter = meter.createCounter('app.payment.transactions');
+```
+
+Medidores e Instrumentos devem permanecer. Isso significa que você deve obter um
+Medidor ou um Instrumento uma vez, e então reutilizá-lo conforme necessário, se possível.
+
+## Logs
+
+TBD
+
+## Baggage
+
+O Baggage do OpenTelemetry é utilizado neste serviço para verificar se a requisição é
+sintética (do gerador de carga). Requisições sintéticas não serão cobradas,
+o que é indicado com um atributo de span. O arquivo `charge.js` que faz o
+processamento real de pagamento, tem lógica para verificar o baggage.
+
+```javascript
+// verificar baggage para synthetic_request=true, e adicionar atributo charged adequadamente
+const baggage = propagation.getBaggage(context.active());
+if (
+  baggage &&
+  baggage.getEntry('synthetic_request') &&
+  baggage.getEntry('synthetic_request').value == 'true'
+) {
+  span.setAttribute('app.payment.charged', false);
+} else {
+  span.setAttribute('app.payment.charged', true);
+}
+```

--- a/content/pt/docs/demo/services/product-catalog.md
+++ b/content/pt/docs/demo/services/product-catalog.md
@@ -1,0 +1,242 @@
+---
+title: Serviço de Catálogo de Produtos
+linkTitle: Catálogo de Produtos
+aliases: [productcatalogservice]
+# prettier-ignore
+cSpell:ignore: fatalf otelcodes otelgrpc otlpmetricgrpc otlptracegrpc sdkmetric sdktrace sprintf
+---
+
+Este serviço é responsável por retornar informações sobre produtos. O serviço
+pode ser usado para obter todos os produtos, pesquisar por produtos específicos, ou retornar detalhes
+sobre qualquer produto individual.
+
+[Código fonte do serviço de catálogo de produtos](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/product-catalog/)
+
+## Rastreamentos
+
+### Inicializando Rastreamento
+
+O SDK do OpenTelemetry é inicializado a partir de `main` usando a função `initTracerProvider`.
+
+```go
+func initTracerProvider() *sdktrace.TracerProvider {
+    ctx := context.Background()
+
+    exporter, err := otlptracegrpc.New(ctx)
+    if err != nil {
+        log.Fatalf("OTLP Trace gRPC Creation: %v", err)
+    }
+    tp := sdktrace.NewTracerProvider(
+        sdktrace.WithBatcher(exporter),
+        sdktrace.WithResource(initResource()),
+    )
+    otel.SetTracerProvider(tp)
+    otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
+    return tp
+}
+```
+
+Você deve chamar `TracerProvider.Shutdown()` quando seu serviço for encerrado para
+garantir que todos os spans sejam exportados. Este serviço faz essa chamada como parte de uma
+função diferida em main
+
+```go
+tp := InitTracerProvider()
+defer func() {
+    if err := tp.Shutdown(context.Background()); err != nil {
+        log.Fatalf("Tracer Provider Shutdown: %v", err)
+    }
+}()
+```
+
+### Adicionando auto-instrumentação gRPC
+
+Este serviço recebe requisições gRPC, que são instrumentadas na função main
+como parte da criação do servidor gRPC.
+
+```go
+srv := grpc.NewServer(
+    grpc.StatsHandler(otelgrpc.NewServerHandler()),
+)
+```
+
+Este serviço fará chamadas gRPC de saída, que são todas instrumentadas
+envolvendo o cliente gRPC com instrumentação.
+
+```go
+func createClient(ctx context.Context, svcAddr string) (*grpc.ClientConn, error) {
+    return grpc.DialContext(ctx, svcAddr,
+        grpc.WithTransportCredentials(insecure.NewCredentials()),
+        grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+    )
+}
+```
+
+### Adicionar atributos a spans auto-instrumentados
+
+Dentro da execução de código auto-instrumentado você pode obter o span atual do
+contexto.
+
+```go
+span := trace.SpanFromContext(ctx)
+```
+
+Adicionar atributos a um span é realizado usando `SetAttributes` no objeto
+span. Na função `GetProduct` um atributo para o ID do produto é adicionado ao
+span.
+
+```go
+span.SetAttributes(
+    attribute.String("app.product.id", req.Id),
+)
+```
+
+### Definir status do span
+
+Este serviço pode capturar e tratar uma condição de erro baseada em uma feature flag. Em
+uma condição de erro, o status do span é definido adequadamente usando `SetStatus` no
+objeto span. Você pode ver isso na função `GetProduct`.
+
+```go
+msg := fmt.Sprintf("Error: ProductCatalogService Fail Feature Flag Enabled")
+span.SetStatus(otelcodes.Error, msg)
+```
+
+### Adicionar eventos de span
+
+Adicionar eventos de span é realizado usando `AddEvent` no objeto span. Na
+função `GetProduct` um evento de span é adicionado quando uma condição de erro é tratada,
+ou quando um produto é encontrado com sucesso.
+
+```go
+span.AddEvent(msg)
+```
+
+## Métricas
+
+### Inicializando Métricas
+
+O SDK do OpenTelemetry é inicializado a partir de `main` usando a função `initMeterProvider`.
+
+```go
+func initMeterProvider() *sdkmetric.MeterProvider {
+    ctx := context.Background()
+
+    exporter, err := otlpmetricgrpc.New(ctx)
+    if err != nil {
+        log.Fatalf("new otlp metric grpc exporter failed: %v", err)
+    }
+
+    mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter)))
+    global.SetMeterProvider(mp)
+    return mp
+}
+```
+
+Você deve chamar `initMeterProvider.Shutdown()` quando seu serviço for encerrado para
+garantir que todos os registros sejam exportados. Este serviço faz essa chamada como parte de uma
+função diferida em main.
+
+```go
+mp := initMeterProvider()
+defer func() {
+    if err := mp.Shutdown(context.Background()); err != nil {
+        log.Fatalf("Error shutting down meter provider: %v", err)
+    }
+}()
+```
+
+### Adicionando auto-instrumentação de runtime golang
+
+O runtime do Golang é instrumentado na função main
+
+```go
+err := runtime.Start(runtime.WithMinimumReadMemStatsInterval(time.Second))
+if err != nil {
+    log.Fatal(err)
+}
+```
+
+## Logs
+
+Você pode enviar seus logs para o Coletor OpenTelemetry de duas maneiras:
+
+- Diretamente para o Coletor
+- Através de um arquivo ou `stdout`
+
+Você pode encontrar documentação especificando como usar ambas essas abordagens na
+seção [Logs](/docs/languages/go/instrumentation/#logs) da
+documentação [Instrumentação Manual](/docs/languages/go/instrumentation/).
+
+O serviço Product Catalog envia os logs diretamente para o Coletor e usa uma
+ponte de log para enviar seus logs, fazendo ponte para o pacote de logging `slog`, que
+produz logs estruturados.
+
+## Inicialização do LoggerProvider
+
+O SDK do OpenTelemetry é inicializado a partir de `main` usando a função `initLoggerProvider`.
+
+```go
+ctx := context.Background()
+
+logExporter, err := otlploggrpc.New(ctx)
+if err != nil {
+	return nil
+}
+
+loggerProvider := sdklog.NewLoggerProvider(
+	sdklog.WithProcessor(sdklog.NewBatchProcessor(logExporter)),
+)
+global.SetLoggerProvider(loggerProvider)
+
+return loggerProvider
+```
+
+Chame `LoggerProvider.Shutdown()` quando seu serviço estiver inativo para garantir que todos os logs
+sejam exportados. Este serviço faz essa chamada como parte de uma função diferida em
+`main`:
+
+```go
+lp := initLoggerProvider()
+defer func() {
+	if err := lp.Shutdown(context.Background()); err != nil {
+		logger.Error(fmt.Sprintf("Logger Provider Shutdown: %v", err))
+	}
+	logger.Info("Shutdown logger provider")
+}()
+```
+
+### Funcionalidade de logging
+
+Este serviço envia logs para o Coletor usando chamadas gRPC. Os logs são produzidos
+em um formato estruturado usando o pacote `slog`.
+
+Primeiro, inicialize o logger:
+
+```go
+logger   *slog.Logger
+logger = otelslog.NewLogger("product-catalog")
+```
+
+Note o uso de `fmt.Sprintf` para formatar a saída antes de ser enviada para o
+logger:
+
+```go
+logger.Info("Loading Product Catalog...")
+logger.Info(fmt.Sprintf("Product Catalog reload interval: %d", interval))
+logger.Error(fmt.Sprintf("Error shutting down meter provider: %v", err))
+```
+
+A vantagem de usar `slog` é a capacidade de anexar atributos adicionais à
+saída. O seguinte exemplo anexa os atributos `product.name` e `product.id`.
+Isso torna possível visualizar e analisar estes como parte da saída do log e facilita visualizá-los como colunas separadas
+no Grafana:
+
+```go
+logger.LogAttrs(
+	ctx,
+	slog.LevelInfo, "Product Found",
+	slog.String("app.product.name", found.Name),
+	slog.String("app.product.id", req.Id),
+)
+```

--- a/content/pt/docs/demo/services/quote.md
+++ b/content/pt/docs/demo/services/quote.md
@@ -1,0 +1,124 @@
+---
+title: Serviço de Cotação
+linkTitle: Cotação
+aliases: [quoteservice]
+cSpell:ignore: getquote
+---
+
+Este serviço é responsável por calcular custos de envio, baseado no número
+de itens a serem enviados. O serviço de cotação é chamado do Serviço de Envio via
+HTTP.
+
+O Serviço de Cotação é implementado usando o framework Slim e php-di para
+gerenciar a Injeção de Dependência.
+
+A instrumentação PHP pode variar ao usar um framework diferente.
+
+[Código fonte do serviço de cotação](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/quote/)
+
+## Rastreamentos
+
+### Inicializando Rastreamento
+
+Neste demo, o SDK do OpenTelemetry foi automaticamente criado como parte do
+carregamento automático do SDK, que acontece como parte do carregamento automático do composer.
+
+Isso é habilitado definindo a variável de ambiente
+`OTEL_PHP_AUTOLOAD_ENABLED=true`.
+
+```php
+require __DIR__ . '/../vendor/autoload.php';
+```
+
+Há múltiplas maneiras de criar ou obter um `Tracer`, neste exemplo nós
+obtemos um do provedor de tracer global que foi inicializado acima, como parte
+do carregamento automático do SDK:
+
+```php
+$tracer = Globals::tracerProvider()->getTracer('manual-instrumentation');
+```
+
+### Criando spans manualmente
+
+Criar um span manualmente pode ser feito via um `Tracer`. O span será por padrão
+um filho do span ativo no contexto de execução atual:
+
+```php
+$span = Globals::tracerProvider()
+    ->getTracer('manual-instrumentation')
+    ->spanBuilder('calculate-quote')
+    ->setSpanKind(SpanKind::KIND_INTERNAL)
+    ->startSpan();
+/* calculate quote */
+$span->end();
+```
+
+### Adicionar atributos de span
+
+Você pode obter o span atual usando `OpenTelemetry\API\Trace\Span`.
+
+```php
+$span = Span::getCurrent();
+```
+
+Adicionar atributos a um span é realizado usando `setAttribute` no objeto
+span. Na função `calculateQuote` 2 atributos são adicionados ao
+`childSpan`.
+
+```php
+$childSpan->setAttribute('app.quote.items.count', $numberOfItems);
+$childSpan->setAttribute('app.quote.cost.total', $quote);
+```
+
+### Adicionar eventos de span
+
+Adicionar eventos de span é realizado usando `addEvent` no objeto span. Na
+rota `getquote` eventos de span são adicionados. Alguns eventos têm atributos
+adicionais, outros não.
+
+Adicionando um evento de span sem atributos:
+
+```php
+$span->addEvent('Received get quote request, processing it');
+```
+
+Adicionando um evento de span com atributos adicionais:
+
+```php
+$span->addEvent('Quote processed, response sent back', [
+    'app.quote.cost.total' => $payload
+]);
+```
+
+## Métricas
+
+Neste demo, métricas são emitidas pelos processadores de trace e logs em lote. As
+métricas descrevem o estado interno do processador, como número de spans ou logs exportados, o limite da fila, e uso da fila.
+
+Você pode habilitar métricas definindo a variável de ambiente
+`OTEL_PHP_INTERNAL_METRICS_ENABLED` para `true`.
+
+Uma métrica manual também é emitida, que conta o número de cotações geradas,
+incluindo um atributo para o número de itens.
+
+Um contador é criado do Provedor de Medidor configurado globalmente, e é
+incrementado cada vez que uma cotação é gerada:
+
+```php
+static $counter;
+$counter ??= Globals::meterProvider()
+    ->getMeter('quotes')
+    ->createCounter('quotes', 'quotes', 'number of quotes calculated');
+$counter->add(1, ['number_of_items' => $numberOfItems]);
+```
+
+Métricas acumulam e são exportadas periodicamente baseado no valor configurado
+em `OTEL_METRIC_EXPORT_INTERVAL`.
+
+## Logs
+
+O serviço de cotação emite uma mensagem de log após uma cotação ser calculada. O pacote de logging
+Monolog é configurado com uma
+[Ponte de Logs](/docs/concepts/signals/logs/#log-appender--bridge) que converte
+logs Monolog para o formato OpenTelemetry. Logs enviados para este logger serão
+exportados via o logger OpenTelemetry configurado globalmente.

--- a/content/pt/docs/demo/services/react-native-app.md
+++ b/content/pt/docs/demo/services/react-native-app.md
@@ -1,0 +1,148 @@
+---
+title: Aplicativo React Native
+---
+
+O aplicativo React Native fornece uma interface móvel para usuários em dispositivos Android e iOS
+interagirem com os serviços do demo. Ele é construído com
+[Expo](https://docs.expo.dev/get-started/introduction/) e usa o roteamento baseado em arquivos do Expo
+para layout das telas do aplicativo.
+
+[Código fonte do aplicativo React Native](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/react-native-app/)
+
+## Instrumentação
+
+A aplicação usa os pacotes OpenTelemetry para instrumentar a aplicação na
+camada JS.
+
+{{% alert title="Importante" color="warning" %}}
+
+Os pacotes JS OTel são suportados para ambientes node e web. Embora eles
+funcionem para React Native também, eles não são explicitamente suportados para esse
+ambiente, onde podem quebrar compatibilidade com atualizações de versão menor ou
+requerer soluções alternativas. Construir suporte de pacotes JS OTel para React Native é uma
+área de desenvolvimento ativo.
+
+{{% /alert %}}
+
+O ponto de entrada principal para a aplicação é `app/_layout.tsx` onde um hook é
+usado para inicializar a instrumentação e garantir que ela seja carregada antes de
+exibir a interface:
+
+```typescript
+import { useTracer } from '@/hooks/useTracer';
+
+const { loaded: tracerLoaded } = useTracer();
+```
+
+`hooks/useTracer.ts` contém todo o código para configurar instrumentação
+incluindo inicializar um TracerProvider, estabelecer uma exportação OTLP,
+registrar propagadores de contexto de trace, e registrar auto-instrumentação de
+requisições de rede.
+
+```typescript
+import {
+  CompositePropagator,
+  W3CBaggagePropagator,
+  W3CTraceContextPropagator,
+} from '@opentelemetry/core';
+import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
+import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { resourceFromAttributes } from '@opentelemetry/resources';
+import {
+  ATTR_DEVICE_ID,
+  ATTR_OS_NAME,
+  ATTR_OS_VERSION,
+  ATTR_SERVICE_NAME,
+  ATTR_SERVICE_VERSION,
+} from '@opentelemetry/semantic-conventions/incubating';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import getLocalhost from '@/utils/Localhost';
+import { useEffect, useState } from 'react';
+import {
+  getDeviceId,
+  getSystemVersion,
+  getVersion,
+} from 'react-native-device-info';
+import { Platform } from 'react-native';
+import { SessionIdProcessor } from '@/utils/SessionIdProcessor';
+
+const Tracer = async () => {
+  const localhost = await getLocalhost();
+
+  const resource = resourceFromAttributes({
+    [ATTR_SERVICE_NAME]: 'react-native-app',
+    [ATTR_OS_NAME]: Platform.OS,
+    [ATTR_OS_VERSION]: getSystemVersion(),
+    [ATTR_SERVICE_VERSION]: getVersion(),
+    [ATTR_DEVICE_ID]: getDeviceId(),
+  });
+
+  const provider = new WebTracerProvider({
+    resource,
+    spanProcessors: [
+      new BatchSpanProcessor(
+        new OTLPTraceExporter({
+          url: `http://${localhost}:${process.env.EXPO_PUBLIC_FRONTEND_PROXY_PORT}/otlp-http/v1/traces`,
+        }),
+        {
+          scheduledDelayMillis: 500,
+        },
+      ),
+      new SessionIdProcessor(),
+    ],
+  });
+
+  provider.register({
+    propagator: new CompositePropagator({
+      propagators: [
+        new W3CBaggagePropagator(),
+        new W3CTraceContextPropagator(),
+      ],
+    }),
+  });
+
+  registerInstrumentations({
+    instrumentations: [
+      // Some tiptoeing required here, propagateTraceHeaderCorsUrls is required to make the instrumentation
+      // work in the context of a mobile app even though we are not making CORS requests. `clearTimingResources` must
+      // be turned off to avoid using the web-only Performance API
+      new FetchInstrumentation({
+        propagateTraceHeaderCorsUrls: /.*/,
+        clearTimingResources: false,
+      }),
+
+      // The React Native implementation of fetch is simply a polyfill on top of XMLHttpRequest:
+      // https://github.com/facebook/react-native/blob/7ccc5934d0f341f9bc8157f18913a7b340f5db2d/packages/react-native/Libraries/Network/fetch.js#L17
+      // Because of this when making requests using `fetch` there will an additional span created for the underlying
+      // request made with XMLHttpRequest. Since in this demo calls to /api/ are made using fetch, turn off
+      // instrumentation for that path to avoid the extra spans.
+      new XMLHttpRequestInstrumentation({
+        ignoreUrls: [/\/api\/.*/],
+      }),
+    ],
+  });
+};
+
+export interface TracerResult {
+  loaded: boolean;
+}
+
+export const useTracer = (): TracerResult => {
+  const [loaded, setLoaded] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!loaded) {
+      Tracer()
+        .catch(() => console.warn('failed to setup tracer'))
+        .finally(() => setLoaded(true));
+    }
+  }, [loaded]);
+
+  return {
+    loaded,
+  };
+};
+```

--- a/content/pt/docs/demo/services/recommendation.md
+++ b/content/pt/docs/demo/services/recommendation.md
@@ -1,0 +1,137 @@
+---
+title: Serviço de Recomendação
+linkTitle: Recomendação
+aliases: [recommendationservice]
+cSpell:ignore: cpython instrumentor NOTSET
+---
+
+Este serviço é responsável por obter uma lista de produtos recomendados para o usuário
+baseado em IDs de produtos existentes que o usuário está navegando.
+
+[Código fonte do serviço de recomendação](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/recommendation/)
+
+## Auto-instrumentação
+
+Este serviço baseado em Python, faz uso do auto-instrumentador OpenTelemetry para
+Python, realizado aproveitando o wrapper Python `opentelemetry-instrument`
+para executar os scripts. Isso pode ser feito no comando `ENTRYPOINT` para o
+`Dockerfile` do serviço.
+
+```dockerfile
+ENTRYPOINT [ "opentelemetry-instrument", "python", "recommendation_server.py" ]
+```
+
+## Rastreamentos
+
+### Inicializando Rastreamento
+
+O SDK do OpenTelemetry é inicializado no bloco de código `__main__`. Este código
+criará um provedor de tracer e estabelecerá um Processador de Span para usar. Pontos de
+exportação, atributos de recurso e nome do serviço são automaticamente definidos pelo
+auto instrumentador OpenTelemetry baseado em variáveis de ambiente.
+
+```python
+tracer = trace.get_tracer_provider().get_tracer("recommendation")
+```
+
+### Adicionar atributos a spans auto-instrumentados
+
+Dentro da execução de código auto-instrumentado você pode obter o span atual do
+contexto.
+
+```python
+span = trace.get_current_span()
+```
+
+Adicionar atributos a um span é realizado usando `set_attribute` no objeto
+span. Na função `ListRecommendations` um atributo é adicionado ao span.
+
+```python
+span.set_attribute("app.products_recommended.count", len(prod_list))
+```
+
+### Criar novos spans
+
+Novos spans podem ser criados e colocados no contexto ativo usando
+`start_as_current_span` de um objeto Tracer do OpenTelemetry. Quando usado em
+conjunto com um bloco `with`, o span será automaticamente encerrado quando o
+bloco terminar a execução. Isso é feito na função `get_product_list`.
+
+```python
+with tracer.start_as_current_span("get_product_list") as span:
+```
+
+## Métricas
+
+### Inicializando Métricas
+
+O SDK do OpenTelemetry é inicializado no bloco de código `__main__`. Este código
+criará um provedor de medidor. Pontos de exportação, atributos de recurso e nome do
+serviço são automaticamente definidos pelo auto instrumentador OpenTelemetry baseado em variáveis de ambiente.
+
+```python
+meter = metrics.get_meter_provider().get_meter("recommendation")
+```
+
+### Métricas personalizadas
+
+As seguintes métricas personalizadas estão atualmente disponíveis:
+
+- `app_recommendations_counter`: Contagem cumulativa de # produtos recomendados por
+  chamada de serviço
+
+### Métricas auto-instrumentadas
+
+As seguintes métricas estão disponíveis através de auto-instrumentação, cortesia do
+`opentelemetry-instrumentation-system-metrics`, que é instalado como parte do
+`opentelemetry-bootstrap` ao construir a imagem Docker do serviço de recomendação:
+
+- `runtime.cpython.cpu_time`
+- `runtime.cpython.memory`
+- `runtime.cpython.gc_count`
+
+## Logs
+
+### Inicializando logs
+
+O SDK do OpenTelemetry é inicializado no bloco de código `__main__`. O seguinte
+código cria um provedor de logger com um processador em lote, um exportador de log OTLP, e
+um manipulador de logging. Finalmente, ele cria um logger para uso em toda a
+aplicação.
+
+```python
+logger_provider = LoggerProvider(
+    resource=Resource.create(
+        {
+            'service.name': service_name,
+        }
+    ),
+)
+set_logger_provider(logger_provider)
+log_exporter = OTLPLogExporter(insecure=True)
+logger_provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter))
+handler = LoggingHandler(level=logging.NOTSET, logger_provider=logger_provider)
+
+logger = logging.getLogger('main')
+logger.addHandler(handler)
+```
+
+### Criar registros de log
+
+Crie logs usando o logger. Exemplos podem ser encontrados nas funções `ListRecommendations` e
+`get_product_list`.
+
+```python
+logger.info(f"Receive ListRecommendations for product ids:{prod_list}")
+```
+
+Como você pode ver, após a inicialização, registros de log podem ser criados da mesma
+maneira que no Python padrão. Bibliotecas OpenTelemetry automaticamente adicionam um trace ID
+e span ID para cada registro de log e, dessa forma, habilitam correlacionar logs e
+rastreamentos.
+
+### Notas
+
+Logs para Python ainda são experimentais, e algumas mudanças podem ser esperadas. A
+implementação neste serviço segue o
+[exemplo de log Python](https://github.com/open-telemetry/opentelemetry-python/blob/stable/docs/examples/logs/example.py).

--- a/content/pt/docs/demo/services/shipping.md
+++ b/content/pt/docs/demo/services/shipping.md
@@ -1,0 +1,241 @@
+---
+title: Serviço de Envio
+linkTitle: Envio
+aliases: [shippingservice]
+cSpell:ignore: sdktrace
+---
+
+Este serviço é responsável por fornecer informações de envio incluindo preços
+e informações de rastreamento, quando solicitado do Serviço de Checkout.
+
+O serviço de envio é construído com [Actix Web](https://actix.rs/),
+[Tracing](https://tracing.rs/) para logs e Bibliotecas OpenTelemetry. Todas as outras
+sub-dependências estão incluídas no `Cargo.toml`.
+
+Dependendo do seu framework e runtime, você pode considerar consultar a
+[documentação Rust](/docs/languages/rust/) para complementar. Você encontrará exemplos de spans
+assíncronos e síncronos em requisições de cotação e IDs de rastreamento respectivamente.
+
+[Código fonte do serviço de envio](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/shipping/)
+
+## Instrumentação
+
+O SDK do OpenTelemetry é configurado no arquivo `telemetry_conf`.
+
+Uma função `get_resource()` é implementada para criar um Resource usando os
+Detectores de Resource padrão mais detectores `OS` e `Process`:
+
+```rust
+fn get_resource() -> Resource {
+    let detectors: Vec<Box<dyn ResourceDetector>> = vec![
+        Box::new(OsResourceDetector),
+        Box::new(ProcessResourceDetector),
+    ];
+
+    Resource::builder().with_detectors(&detectors).build()
+}
+```
+
+Com `get_resource()` no lugar, a função pode ser chamada múltiplas vezes em
+todas as inicializações de provedor.
+
+### Inicializando Provedor de Tracer
+
+```rust
+fn init_tracer_provider() {
+    global::set_text_map_propagator(TraceContextPropagator::new());
+
+    let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+        .with_resource(get_resource())
+        .with_batch_exporter(
+            opentelemetry_otlp::SpanExporter::builder()
+                .with_tonic()
+                .build()
+                .expect("Failed to initialize tracing provider"),
+        )
+        .build();
+
+    global::set_tracer_provider(tracer_provider);
+}
+```
+
+### Inicializando Provedor de Medidor
+
+```rust
+fn init_meter_provider() -> opentelemetry_sdk::metrics::SdkMeterProvider {
+    let meter_provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+        .with_resource(get_resource())
+        .with_periodic_exporter(
+            opentelemetry_otlp::MetricExporter::builder()
+                .with_temporality(opentelemetry_sdk::metrics::Temporality::Delta)
+                .with_tonic()
+                .build()
+                .expect("Failed to initialize metric exporter"),
+        )
+        .build();
+    global::set_meter_provider(meter_provider.clone());
+
+    meter_provider
+}
+```
+
+### Inicializando Provedor de Logger
+
+Para logs, o serviço de envio usa Tracing, então a `OpenTelemetryTracingBridge`
+é usada para fazer ponte de logs da crate tracing para OpenTelemetry.
+
+```rust
+fn init_logger_provider() {
+    let logger_provider = opentelemetry_sdk::logs::SdkLoggerProvider::builder()
+        .with_resource(get_resource())
+        .with_batch_exporter(
+            opentelemetry_otlp::LogExporter::builder()
+                .with_tonic()
+                .build()
+                .expect("Failed to initialize logger provider"),
+        )
+        .build();
+
+    let otel_layer = OpenTelemetryTracingBridge::new(&logger_provider);
+    let filter_otel = EnvFilter::new("info");
+    let otel_layer = otel_layer.with_filter(filter_otel);
+
+    tracing_subscriber::registry().with(otel_layer).init();
+}
+```
+
+### Inicialização de Instrumentação
+
+Após definir as funções para inicializar os provedores para Rastreamentos, Métricas e
+Logs, uma função pública `init_otel()` é criada:
+
+```rust
+pub fn init_otel() -> Result<()> {
+    init_logger_provider();
+    init_tracer_provider();
+    init_meter_provider();
+    Ok(())
+}
+```
+
+Esta função chama todos os inicializadores e retorna `OK(())` se tudo iniciar
+adequadamente.
+
+A função `init_otel()` é então chamada em `main`:
+
+```rust
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    match init_otel() {
+        Ok(_) => {
+            info!("Successfully configured OTel");
+        }
+        Err(err) => {
+            panic!("Couldn't start OTel: {0}", err);
+        }
+    };
+
+    [...]
+
+}
+```
+
+### Configuração de Instrumentação
+
+Com os provedores agora configurados e inicializados, o Shipping usa a
+[crate `opentelemetry-instrumentation-actix-web`](https://crates.io/crates/opentelemetry-instrumentation-actix-web)
+para instrumentar a aplicação durante a configuração do lado do servidor e do cliente.
+
+#### Lado do servidor
+
+O servidor é envolvido com `RequestTracing` e `RequestMetrics` para
+criar automaticamente Rastreamentos e Métricas ao receber requisições:
+
+```rust
+HttpServer::new(|| {
+    App::new()
+        .wrap(RequestTracing::new())
+        .wrap(RequestMetrics::default())
+        .service(get_quote)
+        .service(ship_order)
+})
+```
+
+#### Lado do cliente
+
+Ao fazer uma requisição para outro serviço, `trace_request()` é adicionado à
+chamada:
+
+```rust
+let mut response = client
+    .post(quote_service_addr)
+    .trace_request()
+    .send_json(&reqbody)
+    .await
+    .map_err(|err| anyhow::anyhow!("Failed to call quote service: {err}"))?;
+```
+
+### Instrumentação manual
+
+A crate `opentelemetry-instrumentation-actix-web` nos permite instrumentar
+lado do servidor e do cliente adicionando os comandos mencionados na seção anterior.
+
+No Demo também demonstramos como aprimorar manualmente spans criados automaticamente
+e como criar métricas manuais na aplicação.
+
+#### Spans manuais
+
+No seguinte snippet, o span ativo atual é aprimorado com um evento de span
+e um atributo de span:
+
+```rust
+Ok(get_active_span(|span| {
+    let q = create_quote_from_float(f);
+    span.add_event(
+        "Received Quote".to_string(),
+        vec![KeyValue::new("app.shipping.cost.total", format!("{}", q))],
+    );
+    span.set_attribute(KeyValue::new("app.shipping.cost.total", format!("{}", q)));
+    q
+}))
+```
+
+#### Métricas manuais
+
+Um contador de métrica personalizado é criado para contar quantos itens estão na
+requisição de envio:
+
+```rust
+let meter = global::meter("otel_demo.shipping.quote");
+let counter = meter.u64_counter("app.shipping.items_count").build();
+counter.add(count as u64, &[]);
+```
+
+### Logs
+
+Como o serviço de envio está usando Tracing como uma interface de log, ele usa a
+crate `opentelemetry-appender-tracing` para fazer ponte de logs Tracing para logs OpenTelemetry.
+
+O appender já foi configurado durante a
+[inicialização do provedor de logger](#initializing-logger-provider), com as
+seguintes duas linhas:
+
+```rust
+let otel_layer = OpenTelemetryTracingBridge::new(&logger_provider);
+tracing_subscriber::registry().with(otel_layer).init();
+```
+
+Com isso no lugar, podemos usar Tracing como normalmente faríamos, por exemplo:
+
+```rust
+info!(
+    name = "SendingQuoteValue",
+    quote.dollars = quote.dollars,
+    quote.cents = quote.cents,
+    message = "Sending Quote"
+);
+```
+
+A crate `opentelemetry-appender-tracing` cuida de adicionar contexto OpenTelemetry
+à entrada de log, e o log final exportado contém todos os atributos de recurso
+configurados e informações de `TraceContext`.


### PR DESCRIPTION
<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->
## What this PR does

Adds Portuguese (pt-BR) localization for the entire Demo services section, including the services index and all 18 individual service pages.

## Files added

- `content/pt/docs/demo/services/_index.md` - Services overview table
- `content/pt/docs/demo/services/accounting.md` - Accounting service
- `content/pt/docs/demo/services/ad.md` - Ad service  
- `content/pt/docs/demo/services/cart/index.md` - Cart service
- `content/pt/docs/demo/services/checkout.md` - Checkout service
- `content/pt/docs/demo/services/currency.md` - Currency service
- `content/pt/docs/demo/services/email.md` - Email service
- `content/pt/docs/demo/services/fraud-detection.md` - Fraud detection service
- `content/pt/docs/demo/services/frontend-proxy.md` - Frontend proxy (Envoy)
- `content/pt/docs/demo/services/frontend.md` - Frontend service
- `content/pt/docs/demo/services/image-provider.md` - Image provider service
- `content/pt/docs/demo/services/kafka.md` - Kafka service
- `content/pt/docs/demo/services/load-generator.md` - Load generator service
- `content/pt/docs/demo/services/payment.md` - Payment service
- `content/pt/docs/demo/services/product-catalog.md` - Product catalog service
- `content/pt/docs/demo/services/quote.md` - Quote service
- `content/pt/docs/demo/services/react-native-app.md` - React Native app
- `content/pt/docs/demo/services/recommendation.md` - Recommendation service
- `content/pt/docs/demo/services/shipping.md` - Shipping service

## Context and notes

- Part of the Portuguese localization effort tracked in #7544.
- Preserves front matter structure (titles, linkTitles, aliases, cSpell directives).
- Localizes all descriptive text while keeping code blocks, configuration examples, and technical terms intact.
- Maintains internal link structure and external GitHub links.
- All service descriptions, technical explanations, and code comments are translated to Portuguese.

## How to verify

Start the site and navigate to:
- http://localhost:1313/pt/docs/demo/services/
- http://localhost:1313/pt/docs/demo/services/accounting/
- http://localhost:1313/pt/docs/demo/services/checkout/
- (and all other service pages)

Confirm:
- Services table renders correctly with Portuguese descriptions.
- All service pages display with proper Portuguese titles and content.
- Code blocks and technical examples remain unchanged.
- Internal links resolve properly.

## Related issues/PRs

Progress toward #7544.

## Checklist

- [x] Content localized for all 19 services files
- [x] Front matter preserved for all files
- [x] Code blocks and technical content maintained
- [x] Internal links verified
- [x] Markdown formatting verified