### PR TITLE
[CI] Semconv integration workflow: allow link-checking to fail

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -74,5 +74,6 @@ words: # Valid words across all locales
   - Docsy
   - htmltest
   - jsonify
+  - nvmrc
   - opentelemetrybot
   - warnf

--- a/.github/workflows/update-semconv-integration-branch.yml
+++ b/.github/workflows/update-semconv-integration-branch.yml
@@ -105,15 +105,18 @@ jobs:
         with:
           node-version-file: .nvmrc
 
-      - name: Fix refcache
+      - name: Update refcache
         run: |
           npm install --omit=optional
-          npm run fix:refcache
+          # Ignore link-check failures so we can still commit refcache updates
+          npm run fix:refcache || true
+          # Prune 404 entries, if any
+          npm run _refcache:prune
 
           git add -A
 
           if ! git diff-index --quiet --cached HEAD; then
-            git commit -am "Fix refcache"
+            git commit -am "Update refcache"
             git push
           fi
 


### PR DESCRIPTION
- Contributes to #7844
- Renamed the `Fix refcache` step to `Update refcache`, since we're actually updating it with new entries
- Adjusted the `Update refcache` step so that it ignores link-check failures so that the refcache can still be updated with any new (non-404) entries, and so as to not fail the job