### PR TITLE
Retrospective for September 25th incident on go.opentelemetry.io

### DIFF
--- a/content/en/blog/2025/go-opentelemetry-io-expired-certificate.md
+++ b/content/en/blog/2025/go-opentelemetry-io-expired-certificate.md
@@ -15,7 +15,7 @@ This endpoint is the canonical URL for most Go modules within the OpenTelemetry
 organization. As a result, downloading any modules from that endpoint was
 impossible.
 
-## What happened ?
+## What happened?
 
 This endpoint currently runs on the Google App Engine platform, and its SSL
 certificate is managed by Google. This is the only endpoint under the

--- a/content/en/blog/2025/go-opentelemetry-io-expired-certificate.md
+++ b/content/en/blog/2025/go-opentelemetry-io-expired-certificate.md
@@ -85,7 +85,7 @@ have been able to fix this issue ourselves.
 
 ## Action items
 
-We have started improving our playbooks to access the AppEngine console, so we
+We have started [improving our playbooks](https://github.com/open-telemetry/community/pull/3021) to access the AppEngine console, so we
 can get access more quickly.
 
 We need to ensure this application is not a snowflake anymore, so we can operate

--- a/content/en/blog/2025/go-opentelemetry-io-expired-certificate.md
+++ b/content/en/blog/2025/go-opentelemetry-io-expired-certificate.md
@@ -19,20 +19,20 @@ impossible.
 
 This endpoint currently runs on the Google App Engine platform, and its SSL
 certificate is managed by Google. This is the only endpoint under the
-[opentelemetry.io](http://opentelemetry.io) domain that runs on this platform.
+[opentelemetry.io](https://opentelemetry.io) domain that runs on this platform.
 
 Last July, we were alerted by a security researcher that the root OpenTelemetry
-domain ([opentelemetry.io](http://opentelemetry.io)) lacked
+domain ([opentelemetry.io](https://opentelemetry.io)) lacked
 [CAA DNS records](https://en.wikipedia.org/wiki/DNS_Certification_Authority_Authorization).
 We therefore added one with LetsEncrypt as the sole issuer, since that’s
 [the authority used for the root domain’s certificate](https://docs.netlify.com/manage/domains/secure-domains-with-https/https-ssl/#netlify-managed-certificates).
 
 Since Google's CA was not listed as an issuer in the CAA record,the AppEngine
-platform couldn’t renew the [go.opentelemetry.io](http://go.opentelemetry.io)
+platform couldn’t renew the [go.opentelemetry.io](https://go.opentelemetry.io)
 certificate. So on September 25th at 10:08:10 UTC, when it expired, every
 request returned an error with the expired certificate. This caused issues on
 build systems and when viewing the documentation of
-[go.opentelemetry.io](http://go.opentelemetry.io) packages.
+[go.opentelemetry.io](https://go.opentelemetry.io) packages.
 
 Since this is the only app we maintain that runs on that platform, only a few
 people based in the US have experience with it, so until they were awake we had
@@ -58,7 +58,7 @@ requests succeeding again.
 ## Detailed timeline
 
 - 10:08 UTC – SSL certificate for
-  [go.opentelemetry.io](http://go.opentelemetry.io) expired
+  [go.opentelemetry.io](https://go.opentelemetry.io) expired
 - 10:35 UTC – First notification from users about the issue
 - 11:31 UTC – Created
   [public issue tracking this incident](https://github.com/open-telemetry/opentelemetry-go-vanityurls/issues/81)
@@ -70,7 +70,7 @@ requests succeeding again.
   had not been renewed
 - 14:54 UTC – Disabled and enabled managed security on the SSL certificate
 - 15:16 UTC – Confirmed a new SSL certificate had been issued for
-  [go.opentelemetry.io](http://go.opentelemetry.io)
+  [go.opentelemetry.io](https://go.opentelemetry.io)
 
 ## Lessons learned
 
@@ -95,9 +95,9 @@ it the same way we operate every other public website OpenTelemetry maintains.
 We are therefore
 [going to look](https://github.com/open-telemetry/opentelemetry-go-vanityurls/issues/83)
 into moving away from the AppEngine platform and into Netlify, the platform that
-runs the [opentelemetry.io](http://opentelemetry.io) website.
+runs the [opentelemetry.io](https://opentelemetry.io) website.
 
 We also identified with the help of a user a number of unused subdomains of
-[opentelemetry.io](http://opentelemetry.io) that are serving an expired
+[opentelemetry.io](https://opentelemetry.io) that are serving an expired
 certificate. While these have no impact for our users, we are going to
 [look into removing them](https://github.com/open-telemetry/community/issues/3022).

--- a/content/en/blog/2025/go-opentelemetry-io-expired-certificate.md
+++ b/content/en/blog/2025/go-opentelemetry-io-expired-certificate.md
@@ -8,7 +8,7 @@ author: >-
 cSpell:ignore: baeyens goog
 ---
 
-On September 26th, at 10:35 UTC, we were notified that the
+On September 25th, at 10:35 UTC, we were notified that the
 `go.opentelemetry.io`’s SSL certificate had expired.
 
 This endpoint is the canonical URL for most Go modules within the OpenTelemetry
@@ -24,12 +24,12 @@ certificate is managed by Google. This is the only endpoint under the
 Last July, we were alerted by a security researcher that the root OpenTelemetry
 domain ([opentelemetry.io](http://opentelemetry.io)) lacked
 [CAA DNS records](https://en.wikipedia.org/wiki/DNS_Certification_Authority_Authorization).
-We therefore added one for LetsEncrypt, since that’s
+We therefore added one with LetsEncrypt as the sole issuer, since that’s
 [the authority used for the root domain’s certificate](https://docs.netlify.com/manage/domains/secure-domains-with-https/https-ssl/#netlify-managed-certificates).
 
-Because of that configuration change, the AppEngine platform couldn’t renew the
+Since Google's CA was not listed as an issuer in the CAA record,the AppEngine platform couldn’t renew the
 [go.opentelemetry.io](http://go.opentelemetry.io) certificate. So on September
-26th at 10:08:10 UTC, when it expired, every request returned an error with the
+25th at 10:08:10 UTC, when it expired, every request returned an error with the
 expired certificate. This caused issues on build systems and when viewing the
 documentation of [go.opentelemetry.io](http://go.opentelemetry.io) packages.
 
@@ -95,7 +95,7 @@ We are therefore
 into moving away from the AppEngine platform and into Netlify, the platform that
 runs the [opentelemetry.io](http://opentelemetry.io) website.
 
-We also identified with the help of an user a number of unused subdomains of
+We also identified with the help of a user a number of unused subdomains of
 [opentelemetry.io](http://opentelemetry.io) that are serving an expired
 certificate. While these have no impact for our users, we are going to
 [look into removing them](https://github.com/open-telemetry/community/issues/3022).

--- a/content/en/blog/2025/go-opentelemetry-io-expired-certificate.md
+++ b/content/en/blog/2025/go-opentelemetry-io-expired-certificate.md
@@ -5,6 +5,7 @@ date: 2025-09-26
 author: >-
   [Damien Mathieu](https://github.com/dmathieu) (Elastic)
   [Pablo Baeyens](https://github.com/mx-psi) (Datadog)
+cSpell:ignore: baeyens goog
 ---
 
 On September 26th, at 10:35 UTC, we were notified that the `go.opentelemetry.io`’s SSL certificate had expired.

--- a/content/en/blog/2025/go-opentelemetry-io-expired-certificate.md
+++ b/content/en/blog/2025/go-opentelemetry-io-expired-certificate.md
@@ -1,6 +1,6 @@
 ---
 title: Retrospective of September 25th go.opentelemetry.io incident
-linkTitle: Retrospective for September 25th incident on go.opentelemetry.io
+linkTitle: Retrospective of go.opentelemetry.io incident
 date: 2025-09-26
 author: >-
   [Damien Mathieu](https://github.com/dmathieu) (Elastic) [Pablo

--- a/content/en/blog/2025/go-opentelemetry-io-expired-certificate.md
+++ b/content/en/blog/2025/go-opentelemetry-io-expired-certificate.md
@@ -1,0 +1,61 @@
+---
+title: Retrospective for September 25th incident on go.opentelemetry.io
+linkTitle: Retrospective for September 25th incident on go.opentelemetry.io
+date: 2025-09-26
+author: >-
+  [Damien Mathieu](https://github.com/dmathieu) (Elastic)
+  [Pablo Baeyens](https://github.com/mx-psi) (Datadog)
+---
+
+On September 26th, at 10:35 UTC, we were notified that the `go.opentelemetry.io`’s SSL certificate had expired.
+
+This endpoint is the canonical URL for most Go modules within the OpenTelemetry organization. As a result, downloading any modules from that endpoint was impossible.
+
+## What happened ?
+
+This endpoint currently runs on the Google App Engine platform, and its SSL certificate is managed by Google.
+This is the only endpoint under the [opentelemetry.io](http://opentelemetry.io) domain that runs on this platform.
+
+Last July, we were alerted by a security researcher that the root OpenTelemetry domain ([opentelemetry.io](http://opentelemetry.io)) lacked [CAA DNS records](https://en.wikipedia.org/wiki/DNS_Certification_Authority_Authorization).
+We therefore added one for LetsEncrypt, since that’s [the authority used for the root domain’s certificate](https://docs.netlify.com/manage/domains/secure-domains-with-https/https-ssl/#netlify-managed-certificates).
+
+Because of that configuration change, the AppEngine platform couldn’t renew the [go.opentelemetry.io](http://go.opentelemetry.io) certificate. So on September 26th at 10:08:10 UTC, when it expired, every request returned an error with the expired certificate. This caused issues on build systems and when viewing the documentation of [go.opentelemetry.io](http://go.opentelemetry.io) packages.
+
+Since this is the only app we maintain that runs on that platform, only a few people based in the US have experience with it, so until they were awake we had difficulties operating efficiently. At 12:03 UTC, we were able to get access to the Google Cloud console, and at 12:14 UTC, we identified the issue as being with the [CAA record](https://cloud.google.com/load-balancing/docs/ssl-certificates/google-managed-certs#caa).
+
+At 12:16 UTC, we deployed a new CAA record so Google could properly generate certificates.
+We assumed the platform would regenerate new SSL certificates once it noticed the DNS changes. This assumption appears to be valid, but it can take up to a day for the platform to refresh the CAA records.
+
+By 13:58 UTC, we were seeing the DNS record as being propagated, but no certificate was generated.
+Unfortunately, the folks involved in the incident had little knowledge of the platform, and we didn’t know how to force-regenerate the certificate.
+
+At 14:54 UTC, we disabled and reenabled managed security on the SSL certificate, which force regenerated a certificate.
+A few minutes later, we started seeing requests succeeding again.
+
+## Detailed timeline
+
+* 10:08 UTC – SSL certificate for [go.opentelemetry.io](http://go.opentelemetry.io) expired
+* 10:35 UTC – First notification from users about the issue
+* 11:31 UTC – Created [public issue tracking this incident](https://github.com/open-telemetry/opentelemetry-go-vanityurls/issues/81)
+* 12:03 UTC – Got access to the Google Cloud Console for the golang-imports project
+* 12:14 UTC – Identified the CAA record was missing the "pki.goog" issuer
+* 12:16 UTC – Deployed a new CAA record with the correct set of issuers
+* 13:58 UTC – Confirmed the CAA record had propagated but the SSL certificate had not been renewed
+* 14:54 UTC – Disabled and enabled managed security on the SSL certificate
+* 15:16 UTC – Confirmed a new SSL certificate had been issued for [go.opentelemetry.io](http://go.opentelemetry.io)
+
+## Lessons learned
+
+As we discovered this incident, we had several people jump in and try to figure out what was happening. For an Open Source project where people are scattered across the globe, this was a positive thing to notice.
+
+We are lacking knowledge of the platform this application runs on, which caused this incident to last much longer than it needed to.
+However, we were glad that [a little over a year ago](https://opentelemetry.io/blog/2024/go-opentelemetry-io/), we changed the Google account this app runs on, as we previously wouldn’t even have been able to fix this issue ourselves.
+
+## Action items
+
+We have started improving our playbooks to access the AppEngine console, so we can get access more quickly.
+
+We need to ensure this application is not a snowflake anymore, so we can operate it the same way we operate every other public website OpenTelemetry maintains.
+We are therefore [going to look](https://github.com/open-telemetry/opentelemetry-go-vanityurls/issues/83) into moving away from the AppEngine platform and into Netlify, the platform that runs the [opentelemetry.io](http://opentelemetry.io) website.
+
+We also identified with the help of an user a number of unused subdomains of [opentelemetry.io](http://opentelemetry.io) that are serving an expired certificate. While these have no impact for our users, we are going to [look into removing them](https://github.com/open-telemetry/community/issues/3022).

--- a/content/en/blog/2025/go-opentelemetry-io-expired-certificate.md
+++ b/content/en/blog/2025/go-opentelemetry-io-expired-certificate.md
@@ -27,11 +27,12 @@ domain ([opentelemetry.io](http://opentelemetry.io)) lacked
 We therefore added one with LetsEncrypt as the sole issuer, since that’s
 [the authority used for the root domain’s certificate](https://docs.netlify.com/manage/domains/secure-domains-with-https/https-ssl/#netlify-managed-certificates).
 
-Since Google's CA was not listed as an issuer in the CAA record,the AppEngine platform couldn’t renew the
-[go.opentelemetry.io](http://go.opentelemetry.io) certificate. So on September
-25th at 10:08:10 UTC, when it expired, every request returned an error with the
-expired certificate. This caused issues on build systems and when viewing the
-documentation of [go.opentelemetry.io](http://go.opentelemetry.io) packages.
+Since Google's CA was not listed as an issuer in the CAA record,the AppEngine
+platform couldn’t renew the [go.opentelemetry.io](http://go.opentelemetry.io)
+certificate. So on September 25th at 10:08:10 UTC, when it expired, every
+request returned an error with the expired certificate. This caused issues on
+build systems and when viewing the documentation of
+[go.opentelemetry.io](http://go.opentelemetry.io) packages.
 
 Since this is the only app we maintain that runs on that platform, only a few
 people based in the US have experience with it, so until they were awake we had
@@ -85,8 +86,9 @@ have been able to fix this issue ourselves.
 
 ## Action items
 
-We have started [improving our playbooks](https://github.com/open-telemetry/community/pull/3021) to access the AppEngine console, so we
-can get access more quickly.
+We have started
+[improving our playbooks](https://github.com/open-telemetry/community/pull/3021)
+to access the AppEngine console, so we can get access more quickly.
 
 We need to ensure this application is not a snowflake anymore, so we can operate
 it the same way we operate every other public website OpenTelemetry maintains.

--- a/content/en/blog/2025/go-opentelemetry-io-expired-certificate.md
+++ b/content/en/blog/2025/go-opentelemetry-io-expired-certificate.md
@@ -1,5 +1,5 @@
 ---
-title: Retrospective for September 25th incident on go.opentelemetry.io
+title: Retrospective of September 25th go.opentelemetry.io incident
 linkTitle: Retrospective for September 25th incident on go.opentelemetry.io
 date: 2025-09-26
 author: >-

--- a/content/en/blog/2025/go-opentelemetry-io-expired-certificate.md
+++ b/content/en/blog/2025/go-opentelemetry-io-expired-certificate.md
@@ -80,9 +80,9 @@ across the globe, this was a positive thing to notice.
 
 We are lacking knowledge of the platform this application runs on, which caused
 this incident to last much longer than it needed to. However, we were glad that
-[a little over a year ago](/blog/2024/go-opentelemetry-io/),
-we changed the Google account this app runs on, as we previously wouldn’t even
-have been able to fix this issue ourselves.
+[a little over a year ago](/blog/2024/go-opentelemetry-io/), we changed the
+Google account this app runs on, as we previously wouldn’t even have been able
+to fix this issue ourselves.
 
 ## Action items
 
@@ -98,6 +98,6 @@ into moving away from the AppEngine platform and into Netlify, the platform that
 runs the [opentelemetry.io](/) website.
 
 We also identified with the help of a user a number of unused subdomains of
-[opentelemetry.io](/) that are serving an expired
-certificate. While these have no impact for our users, we are going to
+[opentelemetry.io](/) that are serving an expired certificate. While these have
+no impact for our users, we are going to
 [look into removing them](https://github.com/open-telemetry/community/issues/3022).

--- a/content/en/blog/2025/go-opentelemetry-io-expired-certificate.md
+++ b/content/en/blog/2025/go-opentelemetry-io-expired-certificate.md
@@ -3,60 +3,99 @@ title: Retrospective for September 25th incident on go.opentelemetry.io
 linkTitle: Retrospective for September 25th incident on go.opentelemetry.io
 date: 2025-09-26
 author: >-
-  [Damien Mathieu](https://github.com/dmathieu) (Elastic)
-  [Pablo Baeyens](https://github.com/mx-psi) (Datadog)
+  [Damien Mathieu](https://github.com/dmathieu) (Elastic) [Pablo
+  Baeyens](https://github.com/mx-psi) (Datadog)
 cSpell:ignore: baeyens goog
 ---
 
-On September 26th, at 10:35 UTC, we were notified that the `go.opentelemetry.io`’s SSL certificate had expired.
+On September 26th, at 10:35 UTC, we were notified that the
+`go.opentelemetry.io`’s SSL certificate had expired.
 
-This endpoint is the canonical URL for most Go modules within the OpenTelemetry organization. As a result, downloading any modules from that endpoint was impossible.
+This endpoint is the canonical URL for most Go modules within the OpenTelemetry
+organization. As a result, downloading any modules from that endpoint was
+impossible.
 
 ## What happened ?
 
-This endpoint currently runs on the Google App Engine platform, and its SSL certificate is managed by Google.
-This is the only endpoint under the [opentelemetry.io](http://opentelemetry.io) domain that runs on this platform.
+This endpoint currently runs on the Google App Engine platform, and its SSL
+certificate is managed by Google. This is the only endpoint under the
+[opentelemetry.io](http://opentelemetry.io) domain that runs on this platform.
 
-Last July, we were alerted by a security researcher that the root OpenTelemetry domain ([opentelemetry.io](http://opentelemetry.io)) lacked [CAA DNS records](https://en.wikipedia.org/wiki/DNS_Certification_Authority_Authorization).
-We therefore added one for LetsEncrypt, since that’s [the authority used for the root domain’s certificate](https://docs.netlify.com/manage/domains/secure-domains-with-https/https-ssl/#netlify-managed-certificates).
+Last July, we were alerted by a security researcher that the root OpenTelemetry
+domain ([opentelemetry.io](http://opentelemetry.io)) lacked
+[CAA DNS records](https://en.wikipedia.org/wiki/DNS_Certification_Authority_Authorization).
+We therefore added one for LetsEncrypt, since that’s
+[the authority used for the root domain’s certificate](https://docs.netlify.com/manage/domains/secure-domains-with-https/https-ssl/#netlify-managed-certificates).
 
-Because of that configuration change, the AppEngine platform couldn’t renew the [go.opentelemetry.io](http://go.opentelemetry.io) certificate. So on September 26th at 10:08:10 UTC, when it expired, every request returned an error with the expired certificate. This caused issues on build systems and when viewing the documentation of [go.opentelemetry.io](http://go.opentelemetry.io) packages.
+Because of that configuration change, the AppEngine platform couldn’t renew the
+[go.opentelemetry.io](http://go.opentelemetry.io) certificate. So on September
+26th at 10:08:10 UTC, when it expired, every request returned an error with the
+expired certificate. This caused issues on build systems and when viewing the
+documentation of [go.opentelemetry.io](http://go.opentelemetry.io) packages.
 
-Since this is the only app we maintain that runs on that platform, only a few people based in the US have experience with it, so until they were awake we had difficulties operating efficiently. At 12:03 UTC, we were able to get access to the Google Cloud console, and at 12:14 UTC, we identified the issue as being with the [CAA record](https://cloud.google.com/load-balancing/docs/ssl-certificates/google-managed-certs#caa).
+Since this is the only app we maintain that runs on that platform, only a few
+people based in the US have experience with it, so until they were awake we had
+difficulties operating efficiently. At 12:03 UTC, we were able to get access to
+the Google Cloud console, and at 12:14 UTC, we identified the issue as being
+with the
+[CAA record](https://cloud.google.com/load-balancing/docs/ssl-certificates/google-managed-certs#caa).
 
-At 12:16 UTC, we deployed a new CAA record so Google could properly generate certificates.
-We assumed the platform would regenerate new SSL certificates once it noticed the DNS changes. This assumption appears to be valid, but it can take up to a day for the platform to refresh the CAA records.
+At 12:16 UTC, we deployed a new CAA record so Google could properly generate
+certificates. We assumed the platform would regenerate new SSL certificates once
+it noticed the DNS changes. This assumption appears to be valid, but it can take
+up to a day for the platform to refresh the CAA records.
 
-By 13:58 UTC, we were seeing the DNS record as being propagated, but no certificate was generated.
-Unfortunately, the folks involved in the incident had little knowledge of the platform, and we didn’t know how to force-regenerate the certificate.
+By 13:58 UTC, we were seeing the DNS record as being propagated, but no
+certificate was generated. Unfortunately, the folks involved in the incident had
+little knowledge of the platform, and we didn’t know how to force-regenerate the
+certificate.
 
-At 14:54 UTC, we disabled and reenabled managed security on the SSL certificate, which force regenerated a certificate.
-A few minutes later, we started seeing requests succeeding again.
+At 14:54 UTC, we disabled and reenabled managed security on the SSL certificate,
+which force regenerated a certificate. A few minutes later, we started seeing
+requests succeeding again.
 
 ## Detailed timeline
 
-* 10:08 UTC – SSL certificate for [go.opentelemetry.io](http://go.opentelemetry.io) expired
-* 10:35 UTC – First notification from users about the issue
-* 11:31 UTC – Created [public issue tracking this incident](https://github.com/open-telemetry/opentelemetry-go-vanityurls/issues/81)
-* 12:03 UTC – Got access to the Google Cloud Console for the golang-imports project
-* 12:14 UTC – Identified the CAA record was missing the "pki.goog" issuer
-* 12:16 UTC – Deployed a new CAA record with the correct set of issuers
-* 13:58 UTC – Confirmed the CAA record had propagated but the SSL certificate had not been renewed
-* 14:54 UTC – Disabled and enabled managed security on the SSL certificate
-* 15:16 UTC – Confirmed a new SSL certificate had been issued for [go.opentelemetry.io](http://go.opentelemetry.io)
+- 10:08 UTC – SSL certificate for
+  [go.opentelemetry.io](http://go.opentelemetry.io) expired
+- 10:35 UTC – First notification from users about the issue
+- 11:31 UTC – Created
+  [public issue tracking this incident](https://github.com/open-telemetry/opentelemetry-go-vanityurls/issues/81)
+- 12:03 UTC – Got access to the Google Cloud Console for the golang-imports
+  project
+- 12:14 UTC – Identified the CAA record was missing the "pki.goog" issuer
+- 12:16 UTC – Deployed a new CAA record with the correct set of issuers
+- 13:58 UTC – Confirmed the CAA record had propagated but the SSL certificate
+  had not been renewed
+- 14:54 UTC – Disabled and enabled managed security on the SSL certificate
+- 15:16 UTC – Confirmed a new SSL certificate had been issued for
+  [go.opentelemetry.io](http://go.opentelemetry.io)
 
 ## Lessons learned
 
-As we discovered this incident, we had several people jump in and try to figure out what was happening. For an Open Source project where people are scattered across the globe, this was a positive thing to notice.
+As we discovered this incident, we had several people jump in and try to figure
+out what was happening. For an Open Source project where people are scattered
+across the globe, this was a positive thing to notice.
 
-We are lacking knowledge of the platform this application runs on, which caused this incident to last much longer than it needed to.
-However, we were glad that [a little over a year ago](https://opentelemetry.io/blog/2024/go-opentelemetry-io/), we changed the Google account this app runs on, as we previously wouldn’t even have been able to fix this issue ourselves.
+We are lacking knowledge of the platform this application runs on, which caused
+this incident to last much longer than it needed to. However, we were glad that
+[a little over a year ago](https://opentelemetry.io/blog/2024/go-opentelemetry-io/),
+we changed the Google account this app runs on, as we previously wouldn’t even
+have been able to fix this issue ourselves.
 
 ## Action items
 
-We have started improving our playbooks to access the AppEngine console, so we can get access more quickly.
+We have started improving our playbooks to access the AppEngine console, so we
+can get access more quickly.
 
-We need to ensure this application is not a snowflake anymore, so we can operate it the same way we operate every other public website OpenTelemetry maintains.
-We are therefore [going to look](https://github.com/open-telemetry/opentelemetry-go-vanityurls/issues/83) into moving away from the AppEngine platform and into Netlify, the platform that runs the [opentelemetry.io](http://opentelemetry.io) website.
+We need to ensure this application is not a snowflake anymore, so we can operate
+it the same way we operate every other public website OpenTelemetry maintains.
+We are therefore
+[going to look](https://github.com/open-telemetry/opentelemetry-go-vanityurls/issues/83)
+into moving away from the AppEngine platform and into Netlify, the platform that
+runs the [opentelemetry.io](http://opentelemetry.io) website.
 
-We also identified with the help of an user a number of unused subdomains of [opentelemetry.io](http://opentelemetry.io) that are serving an expired certificate. While these have no impact for our users, we are going to [look into removing them](https://github.com/open-telemetry/community/issues/3022).
+We also identified with the help of an user a number of unused subdomains of
+[opentelemetry.io](http://opentelemetry.io) that are serving an expired
+certificate. While these have no impact for our users, we are going to
+[look into removing them](https://github.com/open-telemetry/community/issues/3022).

--- a/content/en/blog/2025/go-opentelemetry-io-expired-certificate.md
+++ b/content/en/blog/2025/go-opentelemetry-io-expired-certificate.md
@@ -19,10 +19,10 @@ impossible.
 
 This endpoint currently runs on the Google App Engine platform, and its SSL
 certificate is managed by Google. This is the only endpoint under the
-[opentelemetry.io](https://opentelemetry.io) domain that runs on this platform.
+[opentelemetry.io](/) domain that runs on this platform.
 
 Last July, we were alerted by a security researcher that the root OpenTelemetry
-domain ([opentelemetry.io](https://opentelemetry.io)) lacked
+domain ([opentelemetry.io](/)) lacked
 [CAA DNS records](https://en.wikipedia.org/wiki/DNS_Certification_Authority_Authorization).
 We therefore added one with LetsEncrypt as the sole issuer, since that’s
 [the authority used for the root domain’s certificate](https://docs.netlify.com/manage/domains/secure-domains-with-https/https-ssl/#netlify-managed-certificates).
@@ -80,7 +80,7 @@ across the globe, this was a positive thing to notice.
 
 We are lacking knowledge of the platform this application runs on, which caused
 this incident to last much longer than it needed to. However, we were glad that
-[a little over a year ago](https://opentelemetry.io/blog/2024/go-opentelemetry-io/),
+[a little over a year ago](/blog/2024/go-opentelemetry-io/),
 we changed the Google account this app runs on, as we previously wouldn’t even
 have been able to fix this issue ourselves.
 
@@ -95,9 +95,9 @@ it the same way we operate every other public website OpenTelemetry maintains.
 We are therefore
 [going to look](https://github.com/open-telemetry/opentelemetry-go-vanityurls/issues/83)
 into moving away from the AppEngine platform and into Netlify, the platform that
-runs the [opentelemetry.io](https://opentelemetry.io) website.
+runs the [opentelemetry.io](/) website.
 
 We also identified with the help of a user a number of unused subdomains of
-[opentelemetry.io](https://opentelemetry.io) that are serving an expired
+[opentelemetry.io](/) that are serving an expired
 certificate. While these have no impact for our users, we are going to
 [look into removing them](https://github.com/open-telemetry/community/issues/3022).

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -851,6 +851,10 @@
     "StatusCode": 200,
     "LastSeen": "2025-06-02T17:40:54.667539308Z"
   },
+  "https://cloud.google.com/load-balancing/docs/ssl-certificates/google-managed-certs#caa": {
+    "StatusCode": 200,
+    "LastSeen": "2025-09-26T10:16:56.118237502Z"
+  },
   "https://cloud.google.com/monitoring/api/metrics_gcp#gcp-cloudfunctions": {
     "StatusCode": 200,
     "LastSeen": "2025-02-06T01:48:12.345Z"
@@ -2119,6 +2123,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-02-01T06:38:32.230398-05:00"
   },
+  "https://docs.netlify.com/manage/domains/secure-domains-with-https/https-ssl/#netlify-managed-certificates": {
+    "StatusCode": 206,
+    "LastSeen": "2025-09-26T10:16:52.942718502Z"
+  },
   "https://docs.newrelic.com/docs/opentelemetry/nrdot/nrdot-collector/": {
     "StatusCode": 206,
     "LastSeen": "2025-06-19T11:34:02.818605+01:00"
@@ -2734,6 +2742,10 @@
   "https://en.wikipedia.org/wiki/Cross-cutting_concern": {
     "StatusCode": 200,
     "LastSeen": "2025-01-06T11:23:53.281475-05:00"
+  },
+  "https://en.wikipedia.org/wiki/DNS_Certification_Authority_Authorization": {
+    "StatusCode": 200,
+    "LastSeen": "2025-09-26T10:16:49.140676751Z"
   },
   "https://en.wikipedia.org/wiki/Data_minimization": {
     "StatusCode": 200,
@@ -6547,6 +6559,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-04-16T08:38:20.431545775-07:00"
   },
+  "https://github.com/open-telemetry/community/issues/3022": {
+    "StatusCode": 206,
+    "LastSeen": "2025-09-26T10:17:12.153498051Z"
+  },
   "https://github.com/open-telemetry/community/issues/828": {
     "StatusCode": 206,
     "LastSeen": "2025-01-13T11:43:27.58776-05:00"
@@ -6570,6 +6586,10 @@
   "https://github.com/open-telemetry/community/pull/2427": {
     "StatusCode": 200,
     "LastSeen": "2024-12-16T14:23:06.692223-05:00"
+  },
+  "https://github.com/open-telemetry/community/pull/3021": {
+    "StatusCode": 206,
+    "LastSeen": "2025-09-26T10:17:03.173810477Z"
   },
   "https://github.com/open-telemetry/community/tree/main/mission-vision-values.md": {
     "StatusCode": 206,
@@ -9558,6 +9578,14 @@
   "https://github.com/open-telemetry/opentelemetry-go-vanityurls": {
     "StatusCode": 200,
     "LastSeen": "2024-08-23T20:33:46.750242014Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-go-vanityurls/issues/81": {
+    "StatusCode": 206,
+    "LastSeen": "2025-09-26T10:17:00.201379743Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-go-vanityurls/issues/83": {
+    "StatusCode": 206,
+    "LastSeen": "2025-09-26T10:17:08.730954128Z"
   },
   "https://github.com/open-telemetry/opentelemetry-go-vanityurls/issues/new": {
     "StatusCode": 200,


### PR DESCRIPTION
This adds the retrospective blog post for yesterday's expired certificate incident on go.opentelemetry.io.

Added by @mx-psi: Issue tracking this #7887