### PR TITLE
Add Descope into vendors.yml

### DIFF
--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -132,6 +132,12 @@
   contact:
   oss: false
   commercial: true
+- name: Descope
+  nativeOTLP: true
+  url: https://docs.descope.com/connectors/connector-configuration-guides/analytics/open-telemetry
+  contact: support@descope.com
+  oss: false
+  commercial: true
 - name: Dynatrace
   nativeOTLP: true
   url: https://www.dynatrace.com/support/help/how-to-use-dynatrace/transactions-and-services/service-monitoring-settings/opentelemetry/


### PR DESCRIPTION
Descope recently added native Open Telemetry support

Descope is a low-code CIAM and AI Identity tool, and can now push logs directly into Open Telemetry

https://docs.descope.com/connectors/connector-configuration-guides/analytics/open-telemetry