### PR TITLE
docs: merge js tracer code examples

### DIFF
--- a/content/en/docs/languages/js/instrumentation.md
+++ b/content/en/docs/languages/js/instrumentation.md
@@ -488,119 +488,6 @@ rather than exporting the `tracer` instance to the rest of your app. This helps
 avoid trickier application load issues when other required dependencies are
 involved.
 
-In the case of the [example app](#example-app), there are two places where a
-tracer may be acquired with an appropriate Instrumentation Scope:
-
-First, in the _application file_ `app.ts` (or `app.js`):
-
-{{< tabpane text=true >}} {{% tab TypeScript %}}
-
-```ts
-/*app.ts*/
-import { trace } from '@opentelemetry/api';
-import express, { type Express } from 'express';
-import { rollTheDice } from './dice';
-
-const tracer = trace.getTracer('dice-server', '0.1.0');
-
-const PORT: number = parseInt(process.env.PORT || '8080');
-const app: Express = express();
-
-app.get('/rolldice', (req, res) => {
-  const rolls = req.query.rolls ? parseInt(req.query.rolls.toString()) : NaN;
-  if (isNaN(rolls)) {
-    res
-      .status(400)
-      .send("Request parameter 'rolls' is missing or not a number.");
-    return;
-  }
-  res.send(JSON.stringify(rollTheDice(rolls, 1, 6)));
-});
-
-app.listen(PORT, () => {
-  console.log(`Listening for requests on http://localhost:${PORT}`);
-});
-```
-
-{{% /tab %}} {{% tab JavaScript %}}
-
-```js
-/*app.js*/
-const { trace } = require('@opentelemetry/api');
-const express = require('express');
-const { rollTheDice } = require('./dice.js');
-
-const tracer = trace.getTracer('dice-server', '0.1.0');
-
-const PORT = parseInt(process.env.PORT || '8080');
-const app = express();
-
-app.get('/rolldice', (req, res) => {
-  const rolls = req.query.rolls ? parseInt(req.query.rolls.toString()) : NaN;
-  if (isNaN(rolls)) {
-    res
-      .status(400)
-      .send("Request parameter 'rolls' is missing or not a number.");
-    return;
-  }
-  res.send(JSON.stringify(rollTheDice(rolls, 1, 6)));
-});
-
-app.listen(PORT, () => {
-  console.log(`Listening for requests on http://localhost:${PORT}`);
-});
-```
-
-{{% /tab %}} {{< /tabpane >}}
-
-And second, in the _library file_ `dice.ts` (or `dice.js`):
-
-{{< tabpane text=true >}} {{% tab TypeScript %}}
-
-```ts
-/*dice.ts*/
-import { trace } from '@opentelemetry/api';
-
-const tracer = trace.getTracer('dice-lib');
-
-function rollOnce(min: number, max: number) {
-  return Math.floor(Math.random() * (max - min + 1) + min);
-}
-
-export function rollTheDice(rolls: number, min: number, max: number) {
-  const result: number[] = [];
-  for (let i = 0; i < rolls; i++) {
-    result.push(rollOnce(min, max));
-  }
-  return result;
-}
-```
-
-{{% /tab %}} {{% tab JavaScript %}}
-
-```js
-/*dice.js*/
-const { trace } = require('@opentelemetry/api');
-
-const tracer = trace.getTracer('dice-lib');
-
-function rollOnce(min, max) {
-  return Math.floor(Math.random() * (max - min + 1) + min);
-}
-
-function rollTheDice(rolls, min, max) {
-  const result = [];
-  for (let i = 0; i < rolls; i++) {
-    result.push(rollOnce(min, max));
-  }
-  return result;
-}
-
-module.exports = { rollTheDice };
-```
-
-{{% /tab %}} {{< /tabpane >}}
-
 ### Create spans
 
 Now that you have [tracers](/docs/concepts/signals/traces/#tracer) initialized,
@@ -625,8 +512,11 @@ The code below illustrates how to create an active span.
 
 ```ts
 import { trace, type Span } from '@opentelemetry/api';
+const tracer = trace.getTracer('dice-lib');
 
-/* ... */
+function rollOnce(min: number, max: number) {
+  return Math.floor(Math.random() * (max - min + 1) + min);
+}
 
 export function rollTheDice(rolls: number, min: number, max: number) {
   // Create a span. A span must be closed.
@@ -645,6 +535,13 @@ export function rollTheDice(rolls: number, min: number, max: number) {
 {{% /tab %}} {{% tab JavaScript %}}
 
 ```js
+const { trace } = require('@opentelemetry/api');
+const tracer = trace.getTracer('dice-lib');
+
+function rollOnce(min, max) {
+  return Math.floor(Math.random() * (max - min + 1) + min);
+}
+
 function rollTheDice(rolls, min, max) {
   // Create a span. A span must be closed.
   return tracer.startActiveSpan('rollTheDice', (span) => {
@@ -720,6 +617,9 @@ nested operation. The following sample creates a nested span that tracks
 {{< tabpane text=true >}} {{% tab TypeScript %}}
 
 ```ts
+import { trace, type Span } from '@opentelemetry/api';
+const tracer = trace.getTracer('dice-lib');
+
 function rollOnce(i: number, min: number, max: number) {
   return tracer.startActiveSpan(`rollOnce:${i}`, (span: Span) => {
     const result = Math.floor(Math.random() * (max - min + 1) + min);
@@ -745,6 +645,9 @@ export function rollTheDice(rolls: number, min: number, max: number) {
 {{% /tab %}} {{% tab JavaScript %}}
 
 ```js
+const { trace } = require('@opentelemetry/api');
+const tracer = trace.getTracer('dice-lib');
+
 function rollOnce(i, min, max) {
   return tracer.startActiveSpan(`rollOnce:${i}`, (span) => {
     const result = Math.floor(Math.random() * (max - min + 1) + min);


### PR DESCRIPTION
The removed code example is confusing because the acquired tracer is unused. Merging acquisition and usage makes examples more readable.