### PR TITLE
[CI] Dynamically generate locale list for Google Translate widget

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -58,7 +58,7 @@ languages:
       description: Сайт проєкту OpenTelemetry
   zh:
     languageName: 中文 (Chinese)
-    languageCode: zh-cn
+    languageCode: zh-CN
     params:
       description: OpenTelemetry 项目网站
 

--- a/layouts/_partials/func/locales-for-google-translate.html
+++ b/layouts/_partials/func/locales-for-google-translate.html
@@ -1,0 +1,23 @@
+{{/*
+
+  Return a slice of language codes for all locales as expected by Google
+  Translate.
+
+  Google Translate (GT) seems particular about language tags. For zh it needs to
+  be the full tag, including the region code: zh-cn. But for other languages, GT
+  seems to want only the primary subtag.
+
+  References:
+  - https://gohugo.io/methods/site/language/
+  - https://datatracker.ietf.org/doc/html/rfc5646
+
+  */ -}}
+
+{{ $locales := slice -}}
+{{ range site.Languages -}}
+  {{ $langCode := .LanguageCode -}}
+  {{ $primaryTag := index (split $langCode "-") 0 -}}
+  {{ $localeTagForGT := cond (eq .Lang "zh") .LanguageCode $primaryTag -}}
+  {{ $locales = $locales | append $localeTagForGT -}}
+{{ end -}}
+{{ return $locales -}}

--- a/layouts/_partials/translate-scripts.html
+++ b/layouts/_partials/translate-scripts.html
@@ -3,6 +3,10 @@
 {{ $siteLang := .Site.Language.Lang -}}
 
 {{ if ne $siteLang $pageProseLang -}}
+{{ $locales := partialCached "func/locales-for-google-translate.html" . -}}
+
+{{/* NOTE: Google Translate Website Translator widget has been deprecated since
+2019, however it continues to work. */ -}}
 
 <script type="text/javascript">
   const infoToConsole = false;
@@ -74,10 +78,16 @@
   function googleTranslateElementInit() {
     const pageLanguage = '{{ $pageProseLang }}';
     // Languages codes supported by Google for the locales in OTel.io site
-    let allLangArr = ['en', 'es', 'fr', 'ja', 'pt', 'zh-cn'];
+    let allLang = {{ delimit $locales " " }};
+    let allLangArr = allLang.split(' ');
     const allLangButPageLang = allLangArr
       .filter((lang) => !lang.startsWith(pageLanguage))
       .join(',');
+      consoleInfo({
+        pageLanguage,
+        allLangArr,
+        allLangButPageLang,
+      });
     new google.translate.TranslateElement(
       {
         pageLanguage: pageLanguage,


### PR DESCRIPTION
- Fixes #7799
- Adds code to generate the list of currently active locales for use by the Google Translate Website Translator widget.