### PR TITLE
Clean the refcache of about 900 unused URLs

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -80,27 +80,6 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   # TODO move into content/en/blog/2023/contributing-to-otel/index.md once https://github.com/open-telemetry/opentelemetry.io/issues/3889 is implemented
   - ^https://shorturl.at/vLYZ0$
 
-  # Temporary until semconv is updated to 1.30.0+
-  - ^https://cloud.google.com/apis/design/resource_names#full_resource_name
-  - ^https://cloud.google.com/functions/docs/concepts/exec#function_scope_versus_global_scope
-  - ^https://developer.apple.com/documentation/uikit/uiapplicationdelegate#1656902
-  - ^https://docs.docker.com/registry/spec/manifest-v2-2/#example-image-manifest
-  - ^https://www.openssl.org/docs/man1.1.1/man3/SSL_get_version.html#RETURN-VALUES
-  - ^https://www.erlang.org/doc/man/erl_error.html#format_exception-3
-  # Fixed via https://github.com/open-telemetry/semantic-conventions/pull/1814
-  - ^https://github.com/open-telemetry/opentelemetry-specification/tree/v1.41.0/specification/logs/api.md#emit-an-event
-
   # Temporary until
-  # https://pkg.go.dev/go.opentelemetry.io/collector/config/configauth@v0.120.0+
-  # is published to include
-  # https://github.com/open-telemetry/opentelemetry-collector/pull/12309
-  - ^https://pkg.go.dev/go.opentelemetry.io/collector/config/configauth#client-authenticators
-  - ^https://pkg.go.dev/go.opentelemetry.io/collector/config/configauth#server-authenticators
-
-  # Temporary until
-  # https://github.com/open-telemetry/opentelemetry.io/issues/6237 is resolved
-  - ^https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md#
-
-  # Temporary until
-  # https://github.com/open-telemetry/opentelemetry-specification/pull/4554 is resolved
-  - ^/docs/specs/semconv/attributes-registry/process/#process-attributes
+  # https://github.com/open-telemetry/semantic-conventions/issues/2844
+  - ^https://learn.microsoft.com/rest/api/subscription/subscriptions/list-locations

--- a/scripts/clean-refcache.js
+++ b/scripts/clean-refcache.js
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+/**
+ * ---
+ * THIS SCRIPT IS STILL WIP, but it works well enough to be committed.
+ * To generate the input txt file run:
+ *   npm install -g @untitaker/hyperlink
+ *   (cd public; hyperlink dump-external-links --base-path=. | grep -Ev '^[^h]|^http://(127|localhost)' > ../tmp/external-links.txt)
+ * ---
+ * Script to clean up refcache.json by removing entries that don't appear in external-links.txt.
+ *
+ * Usage:
+ *     node clean_refcache.js
+ *
+ * This script will:
+ * 1. Read the current refcache.json file
+ * 2. Read the external-links.txt file
+ * 3. Remove any entries from refcache.json whose URLs don't appear in external-links.txt
+ * 4. Write the cleaned refcache.json back to the file
+ * 5. Create a backup of the original file
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// File paths
+const REFCACHE_PATH = 'static/refcache.json';
+const EXTERNAL_LINKS_PATH = 'tmp/external-links.txt';
+
+/**
+ * Read and parse the refcache.json file
+ */
+function readRefcache(filePath) {
+  try {
+    const data = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(data);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      console.error(`Error: ${filePath} not found`);
+    } else if (error instanceof SyntaxError) {
+      console.error(`Error parsing ${filePath}: ${error.message}`);
+    } else {
+      console.error(`Error reading ${filePath}: ${error.message}`);
+    }
+    return null;
+  }
+}
+
+/**
+ * Read the external-links.txt file and return a set of URLs
+ */
+function readExternalLinks(filePath) {
+  try {
+    const data = fs.readFileSync(filePath, 'utf8');
+    const lines = data.split('\n');
+    // Filter out empty lines and strip whitespace
+    const urls = new Set(
+      lines.map((line) => line.trim()).filter((line) => line.length > 0),
+    );
+    return urls;
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      console.error(`Error: ${filePath} not found`);
+    } else {
+      console.error(`Error reading ${filePath}: ${error.message}`);
+    }
+    return new Set();
+  }
+}
+
+/**
+ * Normalize URL for comparison by decoding URL-encoded characters, HTML entities, and removing query parameters while preserving fragment identifiers
+ */
+function normalizeUrl(url) {
+  try {
+    // First decode URL-encoded characters
+    let normalized = decodeURIComponent(url);
+
+    // Decode common HTML entities
+    normalized = normalized
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'")
+      .replace(/&apos;/g, "'");
+
+    // Handle query parameters and fragments
+    const questionMarkIndex = normalized.indexOf('?');
+    const hashIndex = normalized.indexOf('#');
+
+    if (questionMarkIndex !== -1) {
+      if (hashIndex !== -1 && hashIndex > questionMarkIndex) {
+        // URL has both query params and fragment: remove only query params
+        normalized =
+          normalized.substring(0, questionMarkIndex) +
+          normalized.substring(hashIndex);
+      } else {
+        // URL has only query params: remove them
+        normalized = normalized.substring(0, questionMarkIndex);
+      }
+    }
+    // If no query params but has fragment, keep the fragment as is
+
+    return normalized;
+  } catch (error) {
+    // If decoding fails, try to handle HTML entities and remove query parameters from original URL
+    let fallback = url
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'")
+      .replace(/&apos;/g, "'");
+
+    // Handle query parameters and fragments
+    const questionMarkIndex = fallback.indexOf('?');
+    const hashIndex = fallback.indexOf('#');
+
+    if (questionMarkIndex !== -1) {
+      if (hashIndex !== -1 && hashIndex > questionMarkIndex) {
+        // URL has both query params and fragment: remove only query params
+        fallback =
+          fallback.substring(0, questionMarkIndex) +
+          fallback.substring(hashIndex);
+      } else {
+        // URL has only query params: remove them
+        fallback = fallback.substring(0, questionMarkIndex);
+      }
+    }
+    // If no query params but has fragment, keep the fragment as is
+
+    return fallback;
+  }
+}
+
+/**
+ * Create a backup of the original file with timestamp
+ */
+function backupFile(filePath) {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, -5);
+  const backupPath = `${filePath}.backup_${timestamp}`;
+
+  try {
+    fs.copyFileSync(filePath, backupPath);
+    console.log(`Backup created: ${backupPath}`);
+    return backupPath;
+  } catch (error) {
+    console.error(`Error creating backup: ${error.message}`);
+    return null;
+  }
+}
+
+/**
+ * Write the cleaned refcache data back to the file
+ */
+function writeRefcache(filePath, data) {
+  try {
+    const jsonString = JSON.stringify(data, null, 2);
+    fs.writeFileSync(filePath, jsonString, 'utf8');
+    console.log(`Cleaned refcache written to: ${filePath}`);
+  } catch (error) {
+    console.error(`Error writing to ${filePath}: ${error.message}`);
+  }
+}
+
+/**
+ * Main function to clean the refcache
+ */
+function main() {
+  console.log('Starting refcache cleanup...');
+
+  // Read the refcache
+  console.log(`Reading ${REFCACHE_PATH}...`);
+  const refcache = readRefcache(REFCACHE_PATH);
+  if (!refcache) {
+    process.exit(1);
+  }
+
+  const originalCount = Object.keys(refcache).length;
+  console.log(`Found ${originalCount} entries in refcache`);
+
+  // Read external links
+  console.log(`Reading ${EXTERNAL_LINKS_PATH}...`);
+  const externalLinks = readExternalLinks(EXTERNAL_LINKS_PATH);
+  if (externalLinks.size === 0) {
+    process.exit(1);
+  }
+
+  console.log(`Found ${externalLinks.size} URLs in external-links.txt`);
+
+  // Create a set of normalized external links for faster lookup
+  const normalizedExternalLinks = new Set();
+  for (const url of externalLinks) {
+    normalizedExternalLinks.add(normalizeUrl(url));
+  }
+
+  // Find URLs in refcache that are not in external-links.txt
+  const urlsToRemove = [];
+  for (const url of Object.keys(refcache)) {
+    const normalizedUrl = normalizeUrl(url);
+    if (!normalizedExternalLinks.has(normalizedUrl)) {
+      urlsToRemove.push(url);
+    }
+  }
+
+  console.log(`Found ${urlsToRemove.length} entries to remove`);
+
+  if (urlsToRemove.length === 0) {
+    console.log(
+      'No cleanup needed - all refcache entries are in external-links.txt',
+    );
+    return;
+  }
+
+  // Create backup
+  console.log('Creating backup...');
+  const backupPath = backupFile(REFCACHE_PATH);
+  if (!backupPath) {
+    console.error('Failed to create backup, aborting cleanup');
+    process.exit(1);
+  }
+
+  // Remove the entries
+  for (const url of urlsToRemove) {
+    delete refcache[url];
+  }
+
+  // Write the cleaned refcache
+  console.log('Writing cleaned refcache...');
+  writeRefcache(REFCACHE_PATH, refcache);
+
+  // Summary
+  const finalCount = Object.keys(refcache).length;
+  const removedCount = originalCount - finalCount;
+  console.log('\nCleanup complete!');
+  console.log(`Original entries: ${originalCount}`);
+  console.log(`Removed entries: ${removedCount}`);
+  console.log(`Remaining entries: ${finalCount}`);
+  console.log(`Backup saved to: ${backupPath}`);
+}
+
+// Run the script
+if (require.main === module) {
+  main();
+}

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -1,27 +1,7 @@
 {
-  "http://connect.build": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T01:30:18.284Z"
-  },
-  "http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-24T14:46:01.790558-05:00"
-  },
   "http://logback.qos.ch/": {
     "StatusCode": 206,
     "LastSeen": "2025-09-11T16:08:17.45712-04:00"
-  },
-  "http://macias.info": {
-    "StatusCode": 200,
-    "LastSeen": "2025-07-24T21:20:18.386726+02:00"
-  },
-  "http://publicsuffix.org": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-01T06:58:22.17757-05:00"
-  },
-  "http://unitsofmeasure.org/ucum.html": {
-    "StatusCode": 200,
-    "LastSeen": "2025-01-06T11:32:47.471695-05:00"
   },
   "http://www.powerjob.tech/": {
     "StatusCode": 206,
@@ -362,10 +342,6 @@
   "https://cdn.jsdelivr.net/npm/chart.js@2.9.2/dist/Chart.min.js": {
     "StatusCode": 206,
     "LastSeen": "2025-01-30T14:41:06.741129-05:00"
-  },
-  "https://cdn.jsdelivr.net/npm/minisearch@7.1.0/dist/umd/index.min.js": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-02T10:41:32.401888-05:00"
   },
   "https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/openai-java-1.1": {
     "StatusCode": 200,
@@ -895,10 +871,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-02-01T06:58:05.02751-05:00"
   },
-  "https://code.visualstudio.com": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-22T19:19:29.392140654Z"
-  },
   "https://code.visualstudio.com/": {
     "StatusCode": 206,
     "LastSeen": "2025-01-30T16:59:55.593014-05:00"
@@ -910,10 +882,6 @@
   "https://cohere.com/": {
     "StatusCode": 200,
     "LastSeen": "2025-08-28T17:30:05.484176-04:00"
-  },
-  "https://collectd.org/wiki/index.php/Binary_protocol": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-13T11:43:49.558162-05:00"
   },
   "https://colocatedeventseu2023.sched.com/event/1Jo8E/ingesting-65-tb-of-telemetry-data-daily-through-open-telemetry-protocol-and-collectors-gustavo-pantuza-vtex": {
     "StatusCode": 200,
@@ -950,10 +918,6 @@
   "https://conan.io/center/recipes/opentelemetry-cpp": {
     "StatusCode": 200,
     "LastSeen": "2025-01-30T16:49:48.720833-05:00"
-  },
-  "https://connect.build/docs/protocol/#error-codes": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T01:50:12.345Z"
   },
   "https://connectrpc.com/": {
     "StatusCode": 206,
@@ -1243,10 +1207,6 @@
     "StatusCode": 200,
     "LastSeen": "2025-02-02T15:38:54.472Z"
   },
-  "https://devblogs.microsoft.com/semantic-kernel/microsofts-agentic-ai-frameworks-autogen-and-semantic-kernel/": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-22T07:14:39.38564227-08:00"
-  },
   "https://devcenter.heroku.com/articles/dyno-metadata": {
     "StatusCode": 206,
     "LastSeen": "2025-01-13T11:43:48.044034-05:00"
@@ -1286,10 +1246,6 @@
   "https://developer.apple.com/documentation/uikit/uiapplicationdelegate": {
     "StatusCode": 206,
     "LastSeen": "2025-02-11T12:45:19.457932-05:00"
-  },
-  "https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor": {
-    "StatusCode": 200,
-    "LastSeen": "2025-01-06T11:23:38.683032-05:00"
   },
   "https://developer.apple.com/documentation/uikit/uidevice/identifierforvendor": {
     "StatusCode": 200,
@@ -1667,10 +1623,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-05-19T15:44:14.8206+02:00"
   },
-  "https://docs.datadoghq.com/tracing/connect_logs_and_traces/java/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-02T10:59:08.050666-05:00"
-  },
   "https://docs.datadoghq.com/tracing/other_telemetry/connect_logs_and_traces/java/": {
     "StatusCode": 206,
     "LastSeen": "2025-07-18T18:23:31.519652742Z"
@@ -1799,10 +1751,6 @@
     "StatusCode": 200,
     "LastSeen": "2024-08-15T15:44:20.868165+02:00"
   },
-  "https://docs.google.com/document/d/15vR7D1x2tKd7u3zaTF0yH1WaHkUr2T4hhr7OyiZgmBg/edit#heading=h.4xuru5ljcups": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-05T18:59:11.983079-05:00"
-  },
   "https://docs.google.com/document/d/16Vsdh-DM72AfMg_FIt9yT9ExEWF4A_vRbQ3jRNBe09w": {
     "StatusCode": 200,
     "LastSeen": "2025-01-30T14:41:10.634013-05:00"
@@ -1810,10 +1758,6 @@
   "https://docs.google.com/document/d/1D7ZD93LxSWexHeztHohRp5yeoTzsi9Dj1HRm7Tad-hM": {
     "StatusCode": 200,
     "LastSeen": "2024-12-16T14:23:02.463228-05:00"
-  },
-  "https://docs.google.com/document/d/1KtH5atZQUs9Achbce6LiOaJxLbksNJenvgvyKLsJrkc/edit#heading=h.ioikt02qpy5f": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-05T18:58:36.657181-05:00"
   },
   "https://docs.google.com/document/d/1LPhVRSFkGNSuU1fBd81ulhsCPR4hkSZyyBj1SZ8fWOM/edit#heading=h.3p42p5s8n0ui": {
     "StatusCode": 200,
@@ -1831,10 +1775,6 @@
     "StatusCode": 200,
     "LastSeen": "2024-12-17T18:17:17.288770786Z"
   },
-  "https://docs.google.com/forms/d/1orPz5ayzosFrgYRm3-y90UMrt2ZjvIBKMDL_a2E3Fq8/viewform": {
-    "StatusCode": 200,
-    "LastSeen": "2024-12-17T10:19:55.279945432Z"
-  },
   "https://docs.google.com/forms/d/e/1FAIpQLScoG279ZhRuMu8J_8BebGEVtMOS8BgD9cpQUJ6xSnNIAUtedw/viewform": {
     "StatusCode": 200,
     "LastSeen": "2025-01-31T13:07:08.936780845Z"
@@ -1842,10 +1782,6 @@
   "https://docs.google.com/forms/d/e/1FAIpQLSeSA09xDIv0uyb6vrP8xBbLjm8NsgihrG8GHxacbigF17sNDw/viewform": {
     "StatusCode": 200,
     "LastSeen": "2025-09-29T06:00:32.66684632Z"
-  },
-  "https://docs.google.com/forms/d/e/1FAIpQLSfbpqBcCVfmRj_Rk_Sd6zaBGpfzGSBvSZ6CdVn6PPBbbmPIOw/viewform": {
-    "StatusCode": 200,
-    "LastSeen": "2025-08-27T07:08:20.568520677Z"
   },
   "https://docs.google.com/presentation/d/1YaJvAWnNcUJd1RNsqvEYCcqvJUoj0TDd": {
     "StatusCode": 200,
@@ -1867,10 +1803,6 @@
     "StatusCode": 200,
     "LastSeen": "2024-12-17T17:45:19.478549783-08:00"
   },
-  "https://docs.google.com/spreadsheets/d/1kpJQYiEGtpZorICbl-QfYL3mKfeoRLiUywvKcV8fcNA/edit": {
-    "StatusCode": 200,
-    "LastSeen": "2024-12-13T20:24:13.356675448-08:00"
-  },
   "https://docs.gradle.org/current/userguide/dependency_resolution.html#2_perform_conflict_resolution": {
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:05:12.345Z"
@@ -1878,10 +1810,6 @@
   "https://docs.greptime.com/user-guide/ingest-data/for-observability/opentelemetry/": {
     "StatusCode": 200,
     "LastSeen": "2025-03-11T15:00:43.727668424Z"
-  },
-  "https://docs.greptime.com/user-guide/ingest-data/for-observerbility/opentelemetry": {
-    "StatusCode": 200,
-    "LastSeen": "2024-10-29T16:21:59.273877+08:00"
   },
   "https://docs.groundcover.com/integrations/data-sources/opentelemetry/traces-and-logs": {
     "StatusCode": 200,
@@ -1894,10 +1822,6 @@
   "https://docs.immersivefusion.com/instrument": {
     "StatusCode": 206,
     "LastSeen": "2025-10-01T03:34:56.597318-04:00"
-  },
-  "https://docs.insights.randoli.io/troubleshooting-observability/config/open-telemetry/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-29T12:05:04.323101368-07:00"
   },
   "https://docs.itrsgroup.com/docs/geneos/data-collection/opentelemetry/current/opentelemetry.html": {
     "StatusCode": 206,
@@ -1927,10 +1851,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-02-01T07:12:10.237206-05:00"
   },
-  "https://docs.last9.io/docs/levitate-integrations-opentelemetry": {
-    "StatusCode": 206,
-    "LastSeen": "2024-08-29T21:34:44.961120166Z"
-  },
   "https://docs.lightstep.com/docs/about-sending-data": {
     "StatusCode": 206,
     "LastSeen": "2025-02-01T07:10:00.406188-05:00"
@@ -1958,10 +1878,6 @@
   "https://docs.lumigo.io/docs/opentelemetry": {
     "StatusCode": 200,
     "LastSeen": "2025-10-01T03:34:58.219494-04:00"
-  },
-  "https://docs.micrometer.io/micrometer/reference/implementations/otlp.html": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-01T07:12:05.346585-05:00"
   },
   "https://docs.micrometer.io/tracing/reference/api.html#_micrometer_tracing_opentelemetry_setup": {
     "StatusCode": 200,
@@ -2007,10 +1923,6 @@
     "StatusCode": 200,
     "LastSeen": "2025-01-30T16:48:30.148569-05:00"
   },
-  "https://docs.microsoft.com/dotnet/api/system.servicemodel.servicesecuritycontext": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-30T17:00:15.734633-05:00"
-  },
   "https://docs.microsoft.com/dotnet/core/extensions/logger-message-generator": {
     "StatusCode": 206,
     "LastSeen": "2025-08-05T12:22:30.286575+02:00"
@@ -2041,7 +1953,7 @@
   },
   "https://docs.microsoft.com/en-us/dotnet/api/system.type.assemblyqualifiedname": {
     "StatusCode": 200,
-    "LastSeen": "2025-01-30T16:48:26.213726-05:00"
+    "LastSeen": "2025-10-01T11:51:19.669666-04:00"
   },
   "https://docs.microsoft.com/en-us/dotnet/core/deploying/runtime-store": {
     "StatusCode": 200,
@@ -2063,10 +1975,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-04-29T20:43:15.99694+02:00"
   },
-  "https://docs.microsoft.com/rest/api/resources/resources/get-by-id": {
-    "StatusCode": 200,
-    "LastSeen": "2025-01-30T17:00:05.39766-05:00"
-  },
   "https://docs.microsoft.com/sql/relational-databases/errors-events/database-engine-events-and-errors": {
     "StatusCode": 200,
     "LastSeen": "2024-10-09T10:19:36.80293+02:00"
@@ -2078,10 +1986,6 @@
   "https://docs.microsoft.com/windows/win32/api/netioapi/ns-netioapi-mib_if_row2": {
     "StatusCode": 200,
     "LastSeen": "2025-01-30T16:54:21.609891-05:00"
-  },
-  "https://docs.microsoft.com/windows/win32/api/winbase/nf-winbase-setenvironmentvariable": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-14T12:26:46.310425-04:00"
   },
   "https://docs.microsoft.com/windows/win32/api/winsock2/nf-winsock2-bind": {
     "StatusCode": 200,
@@ -2371,10 +2275,6 @@
     "StatusCode": 200,
     "LastSeen": "2025-01-13T11:43:31.15958-05:00"
   },
-  "https://docs.pytest.org/en/stable/how-to/monkeypatch.html#monkeypatching-functions": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:07:12.345Z"
-  },
   "https://docs.python.org/3/library/gc.html#gc.get_stats": {
     "StatusCode": 200,
     "LastSeen": "2025-05-03T11:59:12.345Z"
@@ -2410,22 +2310,6 @@
   "https://docs.roadrunner.dev/docs/logging-and-observability/otel": {
     "StatusCode": 200,
     "LastSeen": "2025-02-02T10:24:24.658768-05:00"
-  },
-  "https://docs.rs/opentelemetry/0.17.0/opentelemetry/trace/struct.SpanRef.html": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-02T10:58:43.879804-05:00"
-  },
-  "https://docs.rs/opentelemetry/latest/opentelemetry/context/struct.ContextGuard.html": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-06T14:53:33.181281606Z"
-  },
-  "https://docs.rs/opentelemetry/latest/opentelemetry/struct.ContextGuard.html": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-02T10:58:39.202151-05:00"
-  },
-  "https://docs.rs/opentelemetry/latest/opentelemetry/trace/trait.Span.html#method.add_event": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:07:12.345Z"
   },
   "https://docs.ruby-lang.org/en/3.4/Exception.html#method-i-full_message": {
     "StatusCode": 200,
@@ -2675,17 +2559,9 @@
     "StatusCode": 206,
     "LastSeen": "2025-02-01T06:58:03.661155-05:00"
   },
-  "https://en.cppreference.com/w/cpp/container/set": {
-    "StatusCode": 200,
-    "LastSeen": "2025-01-06T11:23:54.76141-05:00"
-  },
   "https://en.cppreference.com/w/cpp/container/set.html": {
     "StatusCode": 206,
     "LastSeen": "2025-07-18T18:23:14.831787049Z"
-  },
-  "https://en.cppreference.com/w/cpp/container/vector": {
-    "StatusCode": 200,
-    "LastSeen": "2025-01-06T11:23:51.473219-05:00"
   },
   "https://en.cppreference.com/w/cpp/container/vector.html": {
     "StatusCode": 206,
@@ -2778,10 +2654,6 @@
   "https://en.wikipedia.org/wiki/Letter_case#Kebab_case": {
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:07:12.345Z"
-  },
-  "https://en.wikipedia.org/wiki/Log_file": {
-    "StatusCode": 200,
-    "LastSeen": "2025-01-06T11:23:56.789376-05:00"
   },
   "https://en.wikipedia.org/wiki/Monkey_patch": {
     "StatusCode": 200,
@@ -2894,10 +2766,6 @@
   "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/register/": {
     "StatusCode": 200,
     "LastSeen": "2025-01-15T13:17:55.721664-05:00"
-  },
-  "https://events.linuxfoundation.org/kubecon-cloudnativecon-india/register/": {
-    "StatusCode": 200,
-    "LastSeen": "2025-06-12T12:42:59.514980977Z"
   },
   "https://events.linuxfoundation.org/kubecon-cloudnativecon-japan//": {
     "StatusCode": 200,
@@ -3287,10 +3155,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-05-30T11:16:18.337986+02:00"
   },
-  "https://github.com/DataDog/datadog-agent/tree/main/comp/otelcol/collector-contrib/impl": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-19T15:44:13.98324+02:00"
-  },
   "https://github.com/DataDog/dd-opentelemetry-exporter-ruby": {
     "StatusCode": 206,
     "LastSeen": "2025-01-07T10:32:12.142183-05:00"
@@ -3373,7 +3237,7 @@
   },
   "https://github.com/GoogleChrome/web-vitals": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-03T07:51:26.978446-04:00"
+    "LastSeen": "2025-10-01T11:51:30.643932-04:00"
   },
   "https://github.com/GoogleCloudPlatform": {
     "StatusCode": 206,
@@ -3430,10 +3294,6 @@
   "https://github.com/HudsonHumphries": {
     "StatusCode": 200,
     "LastSeen": "2025-02-02T15:18:24.46Z"
-  },
-  "https://github.com/IAMebonyhope": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-02T10:13:07.706819-05:00"
   },
   "https://github.com/IBM/sarama": {
     "StatusCode": 206,
@@ -3535,10 +3395,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-07-02T23:23:38.415771294Z"
   },
-  "https://github.com/Mrod1598": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-02T10:15:14.045458-05:00"
-  },
   "https://github.com/Msksgm": {
     "StatusCode": 206,
     "LastSeen": "2025-05-13T08:46:28.009528342-07:00"
@@ -3567,14 +3423,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-02-02T10:27:23.589509-05:00"
   },
-  "https://github.com/OpenObservability/OpenMetrics/blob/1386544931307dff279688f332890c31b6c5de36/specification/OpenMetrics.md#protobuf-format": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:08:12.345Z"
-  },
-  "https://github.com/OpenObservability/OpenMetrics/blob/1386544931307dff279688f332890c31b6c5de36/specification/OpenMetrics.md#text-format": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:08:12.345Z"
-  },
   "https://github.com/OutThereLabs/actix-web-opentelemetry": {
     "StatusCode": 206,
     "LastSeen": "2025-01-07T10:33:07.69982-05:00"
@@ -3591,21 +3439,9 @@
     "StatusCode": 206,
     "LastSeen": "2025-02-02T10:27:25.538726-05:00"
   },
-  "https://github.com/PeterF778": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-02T10:15:14.646401-05:00"
-  },
   "https://github.com/Prometheus/Prometheus/blob/main/prompb/remote.proto": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T13:32:59.446378-05:00"
-  },
-  "https://github.com/Prometheus/docs/blob/777846211d502a287ab2b304cb515dc779de3474/content/docs/instrumenting/exposition_formats.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:49:01.466493-05:00"
-  },
-  "https://github.com/Prometheus/docs/blob/777846211d502a287ab2b304cb515dc779de3474/content/docs/instrumenting/exposition_formats.md#exposition-formats": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:08:12.345Z"
   },
   "https://github.com/RassK": {
     "StatusCode": 206,
@@ -3795,10 +3631,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-07-15T10:04:38.010387094Z"
   },
-  "https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:37:41.194349-05:00"
-  },
   "https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md": {
     "StatusCode": 206,
     "LastSeen": "2025-02-05T14:08:07.215377044Z"
@@ -3910,10 +3742,6 @@
   "https://github.com/angular/angular/tree/main/packages/zone.js": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:37:41.941513-05:00"
-  },
-  "https://github.com/anosek-an": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-02T10:15:12.676127-05:00"
   },
   "https://github.com/anunarapureddy": {
     "StatusCode": 206,
@@ -4057,7 +3885,7 @@
   },
   "https://github.com/avillela/otel-target-allocator-talk/tree/main": {
     "StatusCode": 206,
-    "LastSeen": "2025-01-16T13:05:48.070495-05:00"
+    "LastSeen": "2025-10-01T11:51:50.825593-04:00"
   },
   "https://github.com/aws-observability/aws-otel-dotnet-instrumentation": {
     "StatusCode": 206,
@@ -4298,10 +4126,6 @@
   "https://github.com/christiand93": {
     "StatusCode": 200,
     "LastSeen": "2024-11-14T11:47:25.995535+01:00"
-  },
-  "https://github.com/christophe-kamphaus-jemmic": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-21T09:21:44.140010645Z"
   },
   "https://github.com/christos68k": {
     "StatusCode": 206,
@@ -5099,57 +4923,9 @@
     "StatusCode": 206,
     "LastSeen": "2025-02-01T06:58:07.09925-05:00"
   },
-  "https://github.com/grafana/beyla/blob/main/charts/beyla/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-24T21:20:17.290188+02:00"
-  },
-  "https://github.com/grafana/beyla/blob/main/docs/sources/setup/standalone.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-24T21:20:17.189848+02:00"
-  },
-  "https://github.com/grafana/beyla/releases": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-24T21:20:17.488278+02:00"
-  },
-  "https://github.com/grafana/beyla/tree/main/examples/k8s/unprivileged.yaml": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-24T21:20:19.948267+02:00"
-  },
-  "https://github.com/grafana/beyla/tree/main/examples/quickstart/cpp": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-24T21:20:17.138165+02:00"
-  },
-  "https://github.com/grafana/beyla/tree/main/examples/quickstart/golang": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-24T21:20:16.962642+02:00"
-  },
-  "https://github.com/grafana/beyla/tree/main/examples/quickstart/java": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-24T21:20:17.053331+02:00"
-  },
-  "https://github.com/grafana/beyla/tree/main/examples/quickstart/nodejs": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-24T21:20:16.965089+02:00"
-  },
-  "https://github.com/grafana/beyla/tree/main/examples/quickstart/python": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-24T21:20:16.227203+02:00"
-  },
-  "https://github.com/grafana/beyla/tree/main/examples/quickstart/ruby": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-24T21:20:19.056454+02:00"
-  },
-  "https://github.com/grafana/beyla/tree/main/examples/quickstart/rust": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-24T21:20:17.499378+02:00"
-  },
   "https://github.com/grafana/docker-otel-lgtm": {
     "StatusCode": 206,
     "LastSeen": "2024-12-19T14:40:49.726333554+01:00"
-  },
-  "https://github.com/grafana/docker-otel-lgtm/tree/main/examples/java/json-logging-otlp": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:38:13.947924-05:00"
   },
   "https://github.com/grafana/grafana-ansible-collection/tree/main/roles/opentelemetry_collector": {
     "StatusCode": 206,
@@ -5279,10 +5055,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-02-02T10:41:26.369038-05:00"
   },
-  "https://github.com/hgaol": {
-    "StatusCode": 200,
-    "LastSeen": "2024-12-22T16:09:53.208899753Z"
-  },
   "https://github.com/hibernate/hibernate-orm": {
     "StatusCode": 206,
     "LastSeen": "2025-09-11T16:07:29.576045-04:00"
@@ -5290,14 +5062,6 @@
   "https://github.com/horovits/": {
     "StatusCode": 206,
     "LastSeen": "2025-02-10T23:16:26.095914793Z"
-  },
-  "https://github.com/http4k/": {
-    "StatusCode": 200,
-    "LastSeen": "2024-11-14T11:48:15.408686+01:00"
-  },
-  "https://github.com/http4k/http4k/tree/master/core/opentelemetry": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:31.36569-05:00"
   },
   "https://github.com/huikang": {
     "StatusCode": 200,
@@ -5318,10 +5082,6 @@
   "https://github.com/hvaghani221": {
     "StatusCode": 200,
     "LastSeen": "2025-02-02T15:18:59.819Z"
-  },
-  "https://github.com/hyperium/tonic/blob/master/examples/helloworld-tutorial.md#writing-our-server": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:09:12.345Z"
   },
   "https://github.com/i-am-bee": {
     "StatusCode": 206,
@@ -5371,10 +5131,6 @@
     "StatusCode": 200,
     "LastSeen": "2024-11-13T13:16:21.346606655Z"
   },
-  "https://github.com/in-toto/attestation/blob/main/spec/README.md#in-toto-attestation-framework-spec": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:09:12.345Z"
-  },
   "https://github.com/in-toto/attestation/tree/main/spec": {
     "StatusCode": 206,
     "LastSeen": "2025-01-24T14:37:00.495896-05:00"
@@ -5382,10 +5138,6 @@
   "https://github.com/influxdata/influxdb-java": {
     "StatusCode": 206,
     "LastSeen": "2025-09-11T16:07:35.396308-04:00"
-  },
-  "https://github.com/instana": {
-    "StatusCode": 200,
-    "LastSeen": "2024-11-14T11:47:17.991776+01:00"
   },
   "https://github.com/instana/": {
     "StatusCode": 200,
@@ -5402,10 +5154,6 @@
   "https://github.com/instana/nodejs/tree/main/packages/opentelemetry-exporter": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:38:42.108962-05:00"
-  },
-  "https://github.com/instana/otel-dc/tree/main/llm": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:38:00.408787-05:00"
   },
   "https://github.com/iredelmeier": {
     "StatusCode": 200,
@@ -5458,10 +5206,6 @@
   "https://github.com/jaegertracing/jaeger-idl/blob/main/proto/api_v2/sampling.proto": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:37:41.542412-05:00"
-  },
-  "https://github.com/jaegertracing/jaeger-idl/blob/master/proto/api_v2/sampling.proto": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:38:06.508222-05:00"
   },
   "https://github.com/james-bebbington": {
     "StatusCode": 200,
@@ -5754,10 +5498,6 @@
   "https://github.com/kishannsangani": {
     "StatusCode": 200,
     "LastSeen": "2025-02-02T15:45:21.751Z"
-  },
-  "https://github.com/kittylyst": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-02T15:45:24.589Z"
   },
   "https://github.com/knative": {
     "StatusCode": 206,
@@ -6079,10 +5819,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-04-24T05:50:03.356710098-07:00"
   },
-  "https://github.com/microsft": {
-    "StatusCode": 206,
-    "LastSeen": "2024-12-12T21:04:04.691776+01:00"
-  },
   "https://github.com/microsoft": {
     "StatusCode": 200,
     "LastSeen": "2024-12-26T01:30:01.335046861Z"
@@ -6142,10 +5878,6 @@
   "https://github.com/moby/buildkit": {
     "StatusCode": 206,
     "LastSeen": "2025-02-02T10:40:29.715767-05:00"
-  },
-  "https://github.com/moh-osman3": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-02T15:45:55.786Z"
   },
   "https://github.com/mongodb/mongo-go-driver": {
     "StatusCode": 206,
@@ -6307,10 +6039,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-04-16T05:21:38.768508867-07:00"
   },
-  "https://github.com/oertl": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-02T10:15:14.368523-05:00"
-  },
   "https://github.com/onurtemizkan": {
     "StatusCode": 206,
     "LastSeen": "2025-02-18T04:17:05.364919203Z"
@@ -6339,17 +6067,9 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-30T16:54:05.682883-05:00"
   },
-  "https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/README.md#code-generator": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:10:12.345Z"
-  },
   "https://github.com/open-telemetry/build-tools/blob/v0.25.0/semantic-conventions/README.md": {
     "StatusCode": 206,
     "LastSeen": "2025-05-21T15:12:32.311011-04:00"
-  },
-  "https://github.com/open-telemetry/build-tools/tree/main/semantic-conventions#code-generator": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:10:12.345Z"
   },
   "https://github.com/open-telemetry/community": {
     "StatusCode": 206,
@@ -6615,10 +6335,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-05-01T12:54:48.484239+02:00"
   },
-  "https://github.com/open-telemetry/opamp-spec/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-24T10:00:32.770402-05:00"
-  },
   "https://github.com/open-telemetry/opamp-spec/blob/main/proto/opamp.proto": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:38:07.885812-05:00"
@@ -6671,45 +6387,21 @@
     "StatusCode": 206,
     "LastSeen": "2025-05-12T10:09:03.596342+02:00"
   },
-  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T14:34:48.902535-05:00"
-  },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/kafkaexporter/README.md": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:36:00.479836-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/lokiexporter/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T14:34:33.670548-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/otelarrowexporter/README.md#batching-configuration": {
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:10:12.345Z"
   },
-  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/prometheusexporter/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T14:34:32.684942-05:00"
-  },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/prometheusremotewriteexporter/README.md": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:34:31.265625-05:00"
   },
-  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/basicauthextension/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T14:34:51.578896-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/bearertokenauthextension/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T14:34:52.547433-05:00"
-  },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/healthcheckextension/README.md": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:34:50.347077-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/oauth2clientauthextension/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T14:34:53.601334-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/pprofextension/README.md": {
     "StatusCode": 206,
@@ -6731,21 +6423,9 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:34:39.234992-05:00"
   },
-  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/filterprocessor/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T14:34:40.312743-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/k8sattributesprocessor/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T14:34:42.083244-05:00"
-  },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/resourcedetectionprocessor/README.md": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:34:11.332376-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/routingprocessor/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T14:34:46.89984-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/transformprocessor": {
     "StatusCode": 206,
@@ -6763,17 +6443,9 @@
     "StatusCode": 200,
     "LastSeen": "2025-02-24T18:45:12.345Z"
   },
-  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/transformprocessor/README.md#context-inferred-configurations": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-24T18:45:59.999Z"
-  },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/hostmetricsreceiver/README.md": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:34:35.525335-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/k8sclusterreceiver/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T14:34:37.169684-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/k8sclusterreceiver/documentation.md": {
     "StatusCode": 206,
@@ -6938,10 +6610,6 @@
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.127.0/receiver/kubeletstatsreceiver/internal/kubelet/cpu.go#L25-L26": {
     "StatusCode": 200,
     "LastSeen": "2025-10-01T13:48:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.95.0/processor/spanmetricsprocessor/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T15:48:51.581459-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/issues": {
     "StatusCode": 200,
@@ -7131,10 +6799,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:34:37.932018-05:00"
   },
-  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/kineticaexporter": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T14:34:39.967534-05:00"
-  },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/loadbalancingexporter": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:34:03.979971-05:00"
@@ -7151,17 +6815,9 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:34:45.177457-05:00"
   },
-  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/lokiexporter": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T14:34:46.696032-05:00"
-  },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/mezmoexporter": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:34:49.038174-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/opencensusexporter": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T14:34:50.347161-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/opensearchexporter": {
     "StatusCode": 206,
@@ -7451,10 +7107,6 @@
     "StatusCode": 200,
     "LastSeen": "2025-02-24T18:46:12.345Z"
   },
-  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor#context-inference": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-24T18:46:12.345Z"
-  },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:34:08.529327-05:00"
@@ -7474,10 +7126,6 @@
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/apachesparkreceiver": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:35:17.406702-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awscloudwatchmetricsreceiver": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T14:35:19.249178-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awscloudwatchreceiver": {
     "StatusCode": 206,
@@ -7715,10 +7363,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:35:40.064363-05:00"
   },
-  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/opencensusreceiver": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T14:35:40.547763-05:00"
-  },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/opencensusreceiver#opencensus-receiver": {
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:11:12.345Z"
@@ -7786,10 +7430,6 @@
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/saphanareceiver": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:35:47.208735-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sapmreceiver": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T14:35:47.746236-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sapmreceiver#sapm-receiver": {
     "StatusCode": 200,
@@ -7915,14 +7555,6 @@
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:12:12.345Z"
   },
-  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/processor/resourcedetectionprocessor": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T14:34:23.658479-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/receiver/fluentforwardreceiver": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T14:34:25.853743-05:00"
-  },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.117.0/extension/observer/k8sobserver": {
     "StatusCode": 206,
     "LastSeen": "2025-01-23T00:42:06.341804585Z"
@@ -7987,10 +7619,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-07T10:31:44.0381-05:00"
   },
-  "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/tag/cmd%2Fbuilder%2Fv0.107.0": {
-    "StatusCode": 200,
-    "LastSeen": "2024-08-14T14:05:43.795512556Z"
-  },
   "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/tag/v0.102.0": {
     "StatusCode": 206,
     "LastSeen": "2025-02-01T07:10:42.822948-05:00"
@@ -8042,10 +7670,6 @@
   "https://github.com/open-telemetry/opentelemetry-collector/blob/677b87e3ab5c615bc3f93b8f99bb1fa5be951751/component/config.go#L28": {
     "StatusCode": 200,
     "LastSeen": "2025-05-03T13:11:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/ed09fb912b2ff7cb3998cdb0b54027471ed65eaa/service%2Ftelemetry%2Fotelconftelemetry%2Fconfig.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-12T19:54:18.355513797Z"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/blob/main/VERSIONING.md": {
     "StatusCode": 206,
@@ -8127,337 +7751,13 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-17T16:08:11.963521-05:00"
   },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/main/service/telemetry/config.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:08:06.815186-05:00"
-  },
   "https://github.com/open-telemetry/opentelemetry-collector/blob/main/service/telemetry/otelconftelemetry/config.go": {
     "StatusCode": 206,
     "LastSeen": "2025-08-29T12:44:18.469858282Z"
   },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/master/docs/vision.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:08:29.724977-05:00"
-  },
   "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.103.0/receiver/otlpreceiver/config.md": {
     "StatusCode": 206,
     "LastSeen": "2025-01-17T16:08:35.109982-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.104.0/component/config.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:08:07.978231-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.104.0/pdata/internal/data/protogen/trace/v1/trace.pb.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:08:15.802335-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.104.0/pdata/pcommon/map.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:08:18.596206-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.104.0/receiver/receiver.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:08:12.791749-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.104.0/receiver/receiver.go#L58": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:12:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.104.0/semconv/v1.9.0/generated_resource.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:08:20.547146-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.117.0/component/config.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:08:34.326095-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.117.0/pdata/internal/data/protogen/trace/v1/trace.pb.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:08:40.308745-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.117.0/pdata/pcommon/map.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:08:41.716774-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.117.0/receiver/receiver.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:08:36.556261-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.117.0/receiver/receiver.go#L58": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:12:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.117.0/semconv/v1.9.0/generated_resource.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:08:43.267915-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.118.0/component/config.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-22T00:02:47.599232692Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.118.0/pdata/internal/data/protogen/trace/v1/trace.pb.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-22T00:03:00.78394421Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.118.0/pdata/pcommon/map.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-22T00:03:03.429922189Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.118.0/receiver/receiver.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-22T00:02:57.576779974Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.118.0/receiver/receiver.go#L58": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:12:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.118.0/semconv/v1.9.0/generated_resource.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-22T00:03:05.685713808Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.119.0/component/config.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-10T19:31:48.400126029Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.119.0/pdata/internal/data/protogen/trace/v1/trace.pb.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-10T19:32:00.294981201Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.119.0/pdata/pcommon/map.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-10T19:32:07.453307907Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.119.0/receiver/receiver.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-10T19:31:58.756540779Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.119.0/receiver/receiver.go#L58": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-11T11:40:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.119.0/semconv/v1.9.0/generated_resource.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-10T19:32:07.109251077Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.120.0/component/config.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-19T19:17:45.009325266Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.120.0/pdata/internal/data/protogen/trace/v1/trace.pb.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-19T19:17:51.838725231Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.120.0/pdata/pcommon/map.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-19T19:17:55.427696696Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.120.0/receiver/receiver.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-19T19:17:50.788198899Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.120.0/receiver/receiver.go#L58": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-24T18:46:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.120.0/semconv/v1.9.0/generated_resource.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-19T19:17:58.227636872Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.121.0/component/config.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-04T16:42:33.627960963Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.121.0/pdata/internal/data/protogen/trace/v1/trace.pb.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-04T16:42:48.019582158Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.121.0/pdata/pcommon/map.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-04T16:42:50.592860024Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.121.0/receiver/receiver.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-04T16:42:39.068905901Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.121.0/receiver/receiver.go#L58": {
-    "StatusCode": 200,
-    "LastSeen": "2025-03-21T21:16:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.121.0/semconv/v1.9.0/generated_resource.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-04T16:42:52.650816272Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.122.0/component/config.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T14:58:14.990145874Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.122.0/pdata/internal/data/protogen/trace/v1/trace.pb.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T14:58:22.456112498Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.122.0/pdata/pcommon/map.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T14:58:24.473110889Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.122.0/receiver/receiver.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T14:58:21.264301982Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.122.0/receiver/receiver.go#L58": {
-    "StatusCode": 200,
-    "LastSeen": "2025-03-21T21:16:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.122.0/semconv/v1.9.0/generated_resource.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T14:58:27.420035502Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.122.1/component/config.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-19T17:17:02.759189183Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.122.1/pdata/internal/data/protogen/trace/v1/trace.pb.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-19T17:17:06.698511968Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.122.1/pdata/pcommon/map.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-19T17:17:09.06173497Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.122.1/receiver/receiver.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-19T17:17:05.62594325Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.122.1/receiver/receiver.go#L58": {
-    "StatusCode": 200,
-    "LastSeen": "2025-03-21T21:16:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.122.1/semconv/v1.9.0/generated_resource.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-19T17:17:12.402805501Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.123.0/component/config.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-01T18:29:26.095073697Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.123.0/pdata/internal/data/protogen/trace/v1/trace.pb.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-01T18:29:35.842552126Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.123.0/pdata/pcommon/map.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-01T18:29:39.228136421Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.123.0/receiver/receiver.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-01T18:29:33.97608775Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.123.0/receiver/receiver.go#L58": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T11:59:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.123.0/semconv/v1.9.0/generated_resource.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-01T18:29:43.474929598Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.124.0/component/config.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-15T13:47:27.990928097-07:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.124.0/pdata/internal/data/protogen/trace/v1/trace.pb.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-15T13:47:31.066320743-07:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.124.0/pdata/pcommon/map.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-15T13:47:32.735540725-07:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.124.0/receiver/receiver.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-15T13:47:29.522658269-07:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.124.0/receiver/receiver.go#L58": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T11:59:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.124.0/semconv/v1.9.0/generated_resource.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-15T13:47:34.063940743-07:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.125.0/component/config.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-29T08:26:06.413480423-07:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.125.0/component/config.go#L50": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-03T12:28:59.999Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.125.0/pdata/internal/data/protogen/trace/v1/trace.pb.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-29T08:26:11.412280872-07:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.125.0/pdata/pcommon/map.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-29T08:26:13.124232329-07:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.125.0/receiver/receiver.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-29T08:26:12.36803455-07:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.125.0/receiver/receiver.go#L58": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-03T11:59:59.999Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.125.0/semconv/v1.9.0/generated_resource.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-29T08:26:13.809334931-07:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.126.0/component/config.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-13T15:37:11.30762975-07:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.126.0/pdata/internal/data/protogen/trace/v1/trace.pb.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-13T15:37:15.433331245-07:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.126.0/pdata/pcommon/map.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-13T15:37:17.085229179-07:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.126.0/receiver/receiver.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-13T15:37:14.337514269-07:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.126.0/receiver/receiver.go#L58": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-13T22:39:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.126.0/semconv/v1.9.0/generated_resource.go": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-13T22:40:00.139Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.127.0/component/config.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-27T08:58:49.399398011-07:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.127.0/pdata/internal/data/protogen/trace/v1/trace.pb.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-27T08:58:53.503285745-07:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.127.0/pdata/pcommon/map.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-27T08:58:54.959968361-07:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.127.0/receiver/receiver.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-27T08:58:51.934707737-07:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.127.0/receiver/receiver.go#L58": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:48:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.127.0/semconv/v1.9.0/generated_resource.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-27T08:58:55.789897207-07:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.128.0/component/config.go": {
     "StatusCode": 206,
@@ -8483,46 +7783,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-06-09T21:30:37.610440029Z"
   },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.130.1/component/config.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-22T20:15:19.124124327Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.130.1/pdata/internal/data/protogen/trace/v1/trace.pb.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-22T20:15:28.346824661Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.130.1/pdata/pcommon/map.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-22T20:15:31.270805176Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.130.1/receiver/receiver.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-22T20:15:24.03196882Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.130.1/receiver/receiver.go#L58": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:48:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.131.0/component/config.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-30T10:33:20.059487948Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.131.0/pdata/internal/data/protogen/trace/v1/trace.pb.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-30T10:33:30.653613891Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.131.0/pdata/pcommon/map.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-30T10:33:36.591729049Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.131.0/receiver/receiver.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-30T10:33:27.544593005Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.131.0/receiver/receiver.go#L58": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:48:12.345Z"
-  },
   "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.132.0/component/config.go": {
     "StatusCode": 206,
     "LastSeen": "2025-08-13T12:23:00.093140987Z"
@@ -8542,46 +7802,6 @@
   "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.132.0/receiver/receiver.go#L58": {
     "StatusCode": 200,
     "LastSeen": "2025-10-01T13:48:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.133.0/component/config.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-26T01:37:41.677823984Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.133.0/pdata/internal/data/protogen/trace/v1/trace.pb.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-26T01:37:49.266818796Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.133.0/pdata/pcommon/map.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-26T01:37:51.823678361Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.133.0/receiver/receiver.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-26T01:37:47.988817842Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.133.0/receiver/receiver.go#L58": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:48:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.135.0/component/config.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-09-10T08:25:35.409607787Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.135.0/pdata/internal/data/protogen/trace/v1/trace.pb.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-09-10T08:25:46.318875476Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.135.0/pdata/pcommon/map.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-09-10T08:25:50.372093063Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.135.0/receiver/receiver.go": {
-    "StatusCode": 206,
-    "LastSeen": "2025-09-10T08:25:41.422149618Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.135.0/receiver/receiver.go#L58": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:49:12.345Z"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/blob/v0.136.0/component/config.go": {
     "StatusCode": 206,
@@ -8638,10 +7858,6 @@
   "https://github.com/open-telemetry/opentelemetry-collector/pull/10352": {
     "StatusCode": 206,
     "LastSeen": "2025-02-01T07:12:53.252075-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-collector/releases/tag/cmd%2Fbuilder%2Fv0.107.0": {
-    "StatusCode": 200,
-    "LastSeen": "2024-08-13T07:39:54.969829391Z"
   },
   "https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.102.1": {
     "StatusCode": 206,
@@ -8999,10 +8215,6 @@
     "StatusCode": 200,
     "LastSeen": "2025-10-01T13:49:12.345Z"
   },
-  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/Instrumentation.AspNet-1.9.0-beta.1/src/OpenTelemetry.Instrumentation.AspNet/README.md#list-of-metrics-produced": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:13:12.345Z"
-  },
   "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/Instrumentation.AspNetCore-1.11.0/src/OpenTelemetry.Instrumentation.AspNetCore/README.md#list-of-metrics-produced": {
     "StatusCode": 200,
     "LastSeen": "2025-02-06T11:45:12.345Z"
@@ -9011,10 +8223,6 @@
     "StatusCode": 200,
     "LastSeen": "2025-10-01T13:49:12.345Z"
   },
-  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/Instrumentation.AspNetCore-1.9.0/src/OpenTelemetry.Instrumentation.AspNetCore/README.md#list-of-metrics-produced": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:13:12.345Z"
-  },
   "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/Instrumentation.Http-1.11.0/src/OpenTelemetry.Instrumentation.Http/README.md#list-of-metrics-produced": {
     "StatusCode": 200,
     "LastSeen": "2025-02-06T11:45:12.345Z"
@@ -9022,14 +8230,6 @@
   "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/Instrumentation.Http-1.12.0/src/OpenTelemetry.Instrumentation.Http/README.md#list-of-metrics-produced": {
     "StatusCode": 200,
     "LastSeen": "2025-10-01T13:49:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/Instrumentation.Http-1.9.0/src/OpenTelemetry.Instrumentation.Http/README.md#list-of-metrics-produced": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:13:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/Instrumentation.Process-0.5.0-beta.6/src/OpenTelemetry.Instrumentation.Process/README.md#metrics": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:13:12.345Z"
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/Instrumentation.Process-1.11.0-beta.1/src/OpenTelemetry.Instrumentation.Process/README.md#metrics": {
     "StatusCode": 200,
@@ -9046,10 +8246,6 @@
   "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/Instrumentation.Runtime-1.12.0/src/OpenTelemetry.Instrumentation.Runtime/README.md#metrics": {
     "StatusCode": 200,
     "LastSeen": "2025-10-01T13:49:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/Instrumentation.Runtime-1.9.0/src/OpenTelemetry.Instrumentation.Runtime/README.md#metrics": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:13:12.345Z"
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/Resources.Azure-1.0.0-beta.9/src/OpenTelemetry.Resources.Azure/README.md": {
     "StatusCode": 206,
@@ -9262,10 +8458,6 @@
   "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/main/src/OpenTelemetry.AutoInstrumentation/OpenTelemetry.AutoInstrumentation.csproj": {
     "StatusCode": 206,
     "LastSeen": "2025-01-17T16:27:43.550924-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/v1.9.0/docker/centos-build.dockerfile": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:33:15.208069-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/1744": {
     "StatusCode": 206,
@@ -9743,10 +8935,6 @@
     "StatusCode": 200,
     "LastSeen": "2025-01-06T11:32:23.080955-05:00"
   },
-  "https://github.com/open-telemetry/opentelemetry-java#releases": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:14:12.345Z"
-  },
   "https://github.com/open-telemetry/opentelemetry-java-contrib": {
     "StatusCode": 206,
     "LastSeen": "2025-01-13T11:43:26.584947-05:00"
@@ -9786,10 +8974,6 @@
   "https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/resource-providers": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:40:47.236991-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-java-docs#java-opentelemetry-examples": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:14:12.345Z"
   },
   "https://github.com/open-telemetry/opentelemetry-java-docs/tree/main/log-appender": {
     "StatusCode": 206,
@@ -9862,10 +9046,6 @@
   "https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/OsResourceProvider.java": {
     "StatusCode": 206,
     "LastSeen": "2025-01-17T16:40:51.924211-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/spring/spring-boot-autoconfigure/README.md#features": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-06T02:14:59.999Z"
   },
   "https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/OpenTelemetryAutoConfiguration.java": {
     "StatusCode": 206,
@@ -9986,10 +9166,6 @@
   "https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/cassandra": {
     "StatusCode": 206,
     "LastSeen": "2025-01-17T16:41:44.957887-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/clickhouse-client-0.5": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:41:45.531816-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/couchbase": {
     "StatusCode": 206,
@@ -10519,34 +9695,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:37:42.643576-05:00"
   },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-alibaba-cloud": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:40:47.744785-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-aws": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:40:48.164699-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-azure": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:40:48.681516-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-container": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:40:49.08505-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-gcp": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:40:49.501101-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-github": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:40:49.89747-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-instana": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:40:50.29364-05:00"
-  },
   "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/metapackages/auto-instrumentations-node#supported-instrumentations": {
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:15:12.345Z"
@@ -10759,30 +9907,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-07-10T09:53:57.850909-07:00"
   },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-aws-lambda": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:32.368568-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-aws-sdk": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:32.869828-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-bunyan": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:33.92546-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-cassandra": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:34.378411-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-connect": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:35.32671-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-dns": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:36.848624-05:00"
-  },
   "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-express": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T11:37:42.15101-05:00"
@@ -10790,106 +9914,6 @@
   "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-express#express-instrumentation-options": {
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:15:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-fastify": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:38.360617-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-generic-pool": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:39.347828-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-graphql": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:39.876087-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-hapi": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:40.307826-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-ioredis": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:40.754959-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-knex": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:41.789927-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-koa": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:42.280287-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-memcached": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:44.350277-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-mongodb": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:44.858666-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-mysql": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:46.10613-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-mysql2": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:46.53617-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-nestjs-core": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:47.580767-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-net": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:48.079304-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-oracledb": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-22T13:12:13.410404+05:30"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-pg": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:50.193601-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-pino": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:51.434079-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-redis": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:52.764607-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-redis-4": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:53.226909-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-restify": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:50.808776-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-router": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:54.330903-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-winston": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:58.62194-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/web/opentelemetry-instrumentation-document-load": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:37.486944-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/web/opentelemetry-instrumentation-long-task": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:43.247999-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/web/opentelemetry-instrumentation-user-interaction": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:58.072428-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/web/opentelemetry-plugin-react-load": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T11:39:52.315617-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-js/": {
     "StatusCode": 206,
@@ -10943,10 +9967,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-05-03T12:00:59.999Z"
   },
-  "https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#what-is-js-sdk-2x": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-03T12:00:59.999Z"
-  },
   "https://github.com/open-telemetry/opentelemetry-js/discussions": {
     "StatusCode": 206,
     "LastSeen": "2025-01-13T12:10:34.858443-05:00"
@@ -10954,14 +9974,6 @@
   "https://github.com/open-telemetry/opentelemetry-js/issues/4083": {
     "StatusCode": 206,
     "LastSeen": "2025-03-20T10:14:29.294035439Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js/issues/4551": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-01T06:58:03.438269-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-js/issues/4552": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-01T06:58:05.138567-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-js/releases": {
     "StatusCode": 206,
@@ -11021,7 +10033,7 @@
   },
   "https://github.com/open-telemetry/opentelemetry-lambda/": {
     "StatusCode": 206,
-    "LastSeen": "2025-02-04T12:41:09.851793718Z"
+    "LastSeen": "2025-10-01T11:51:49.722668-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-lambda/blob/main/collector/README.md": {
     "StatusCode": 206,
@@ -11315,10 +10327,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-02-01T06:38:27.024849-05:00"
   },
-  "https://github.com/open-telemetry/opentelemetry-proto/#maturity-level": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:16:12.345Z"
-  },
   "https://github.com/open-telemetry/opentelemetry-proto/blob/38b5b9b6e5257c6500a843f7fdacf89dd95833e8/opentelemetry/proto/common/v1/common.proto#L27": {
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:16:12.345Z"
@@ -11387,10 +10395,6 @@
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:16:12.345Z"
   },
-  "https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:47:28.595168-05:00"
-  },
   "https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/design-goals.md": {
     "StatusCode": 206,
     "LastSeen": "2025-01-17T16:47:21.083652-05:00"
@@ -11406,14 +10410,6 @@
   "https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/metrics/v1/metrics.proto": {
     "StatusCode": 206,
     "LastSeen": "2025-01-17T16:47:27.397166-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-proto/blob/master/opentelemetry/proto/logs/v1/logs.proto": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:47:25.240211-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-proto/blob/master/opentelemetry/proto/metrics/v1/metrics.proto": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:47:23.413599-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-proto/blob/v0.9.0/opentelemetry/proto/metrics/v1/metrics.proto#L200": {
     "StatusCode": 200,
@@ -11450,102 +10446,6 @@
   "https://github.com/open-telemetry/opentelemetry-proto/tree/main/docs/specification.md": {
     "StatusCode": 206,
     "LastSeen": "2025-01-17T16:47:23.298398-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-proto/tree/v1.5.0/README.md#maturity-level": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:17:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-proto/tree/v1.5.0/examples/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:47:34.913815-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-proto/tree/v1.5.0/opentelemetry/proto": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:47:31.710004-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-proto/tree/v1.5.0/opentelemetry/proto/collector": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:47:30.185148-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-proto/tree/v1.5.0/opentelemetry/proto/collector/logs/v1/logs_service.proto": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:47:25.103637-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-proto/tree/v1.5.0/opentelemetry/proto/collector/metrics/v1/metrics_service.proto": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:47:26.384658-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-proto/tree/v1.5.0/opentelemetry/proto/collector/profiles/v1development/profiles_service.proto": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:47:29.545725-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-proto/tree/v1.5.0/opentelemetry/proto/collector/trace/v1/trace_service.proto": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:47:28.391998-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-proto/tree/v1.6.0/README.md#maturity-level": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T12:12:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-proto/tree/v1.6.0/examples/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-29T09:16:30.63842-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-proto/tree/v1.6.0/opentelemetry/proto": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-29T09:16:24.164941-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-proto/tree/v1.6.0/opentelemetry/proto/collector": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-29T09:16:20.617027-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-proto/tree/v1.6.0/opentelemetry/proto/collector/logs/v1/logs_service.proto": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-29T09:16:12.838299-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-proto/tree/v1.6.0/opentelemetry/proto/collector/metrics/v1/metrics_service.proto": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-29T09:16:14.153166-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-proto/tree/v1.6.0/opentelemetry/proto/collector/profiles/v1development/profiles_service.proto": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-29T09:16:17.773581-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-proto/tree/v1.6.0/opentelemetry/proto/collector/trace/v1/trace_service.proto": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-29T09:16:16.334448-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-proto/tree/v1.7.0/README.md#maturity-level": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:50:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-proto/tree/v1.7.0/examples/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-21T15:13:44.261317084Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-proto/tree/v1.7.0/opentelemetry/proto": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-21T15:13:43.046394815Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-proto/tree/v1.7.0/opentelemetry/proto/collector": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-21T15:13:42.071953058Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-proto/tree/v1.7.0/opentelemetry/proto/collector/logs/v1/logs_service.proto": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-21T15:13:32.793248157Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-proto/tree/v1.7.0/opentelemetry/proto/collector/metrics/v1/metrics_service.proto": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-21T15:13:35.356880234Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-proto/tree/v1.7.0/opentelemetry/proto/collector/profiles/v1development/profiles_service.proto": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-21T15:13:40.523728179Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-proto/tree/v1.7.0/opentelemetry/proto/collector/trace/v1/trace_service.proto": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-21T15:13:38.682438465Z"
   },
   "https://github.com/open-telemetry/opentelemetry-proto/tree/v1.8.0/README.md#maturity-level": {
     "StatusCode": 200,
@@ -11610,10 +10510,6 @@
   "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation-genai/opentelemetry-instrumentation-openai-v2/examples/": {
     "StatusCode": 206,
     "LastSeen": "2025-01-17T16:50:44.877731-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation-genai/opentelemetry-instrumentation-vertexai": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-20T09:23:54.377272992-08:00"
   },
   "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-aio-pika": {
     "StatusCode": 206,
@@ -12267,70 +11163,6 @@
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:17:12.345Z"
   },
-  "https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md#events": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-06T02:17:59.999Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-05T12:22:29.41183+02:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#trace-context-fields": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:50:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-05T12:22:30.315187+02:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#counter": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:50:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:50:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#meter": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:51:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#exemplar": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:51:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:51:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#links-between-spans": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:51:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-05T12:22:37.267237+02:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-05T12:22:29.334454+02:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-05T12:22:30.891967+02:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#span": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:51:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#spankind": {
-    "StatusCode": 200,
-    "LastSeen": "2025-03-21T21:16:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#tracer": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:51:12.345Z"
-  },
   "https://github.com/open-telemetry/opentelemetry-specification/blob/v1.14.0/specification/sdk-environment-variables.md#general-sdk-configuration": {
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:17:12.345Z"
@@ -12385,15 +11217,7 @@
   },
   "https://github.com/open-telemetry/opentelemetry-specification/blob/v1.35.0/specification/metrics/sdk_exporters/otlp.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:51:59.59941-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/blob/v1.39.0/specification/logs/api.md#emit-a-logrecord": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:18:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/blob/v1.39.0/specification/logs/api.md#emit-an-event": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:18:12.345Z"
+    "LastSeen": "2025-10-01T11:51:18.321076-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-specification/blob/v1.40.0/specification/logs/api.md#emit-an-event": {
     "StatusCode": 200,
@@ -12403,14 +11227,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-22T05:55:29.317655-05:00"
   },
-  "https://github.com/open-telemetry/opentelemetry-specification/blob/v1.41.0/specification/logs/data-model.md#events": {
-    "StatusCode": 200,
-    "LastSeen": "2025-03-21T21:16:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/blob/v1.44.0/specification/common/README.md#attribute": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:51:12.345Z"
-  },
   "https://github.com/open-telemetry/opentelemetry-specification/blob/v1.45.0/specification/entities/README.md#overview": {
     "StatusCode": 200,
     "LastSeen": "2025-10-01T13:51:12.345Z"
@@ -12419,21 +11235,9 @@
     "StatusCode": 200,
     "LastSeen": "2025-10-01T13:51:12.345Z"
   },
-  "https://github.com/open-telemetry/opentelemetry-specification/issues/1413": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-13T11:43:48.297045-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/issues/3966": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-01T06:58:30.055743-05:00"
-  },
   "https://github.com/open-telemetry/opentelemetry-specification/issues/3967": {
     "StatusCode": 206,
     "LastSeen": "2025-02-01T06:58:28.518782-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/issues/437": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-07T10:32:16.200954-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-specification/issues/617": {
     "StatusCode": 206,
@@ -12683,10 +11487,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-17T16:52:11.908369-05:00"
   },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/project-management.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:52:05.39722-05:00"
-  },
   "https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/protocol/README.md": {
     "StatusCode": 206,
     "LastSeen": "2025-01-17T16:52:08.665507-05:00"
@@ -12710,10 +11510,6 @@
   "https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/protocol/requirements.md": {
     "StatusCode": 206,
     "LastSeen": "2025-01-17T16:52:05.623881-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/resource#telescoping": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:51:12.345Z"
   },
   "https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/resource/README.md": {
     "StatusCode": 206,
@@ -12807,1137 +11603,33 @@
     "StatusCode": 200,
     "LastSeen": "2025-05-03T11:57:12.345Z"
   },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.39.0/specification/common#attribute": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:18:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.39.0/specification/compatibility/prometheus_and_openmetrics.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:51:58.694304-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.39.0/specification/configuration/sdk-environment-variables.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:52:04.266569-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.39.0/specification/context/api-propagators.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:52:01.965445-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.39.0/specification/document-status.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:51:57.780216-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.39.0/specification/logs/api.md#emit-a-logrecord": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:18:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.39.0/specification/logs/api.md#logger": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:18:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.39.0/specification/logs/data-model.md#log-and-event-record-definition": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:18:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.39.0/specification/logs/event-api.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:52:04.108023-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.39.0/specification/metrics/api.md#instrument-advisory-parameters": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:18:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.39.0/specification/resource/sdk.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:51:59.359966-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.39.0/specification/resource/sdk.md#sdk-provided-resource-attributes": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:18:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.39.0/specification/trace/api.md#record-exception": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:18:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.39.0/specification/trace/api.md#set-status": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:18:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.39.0/specification/trace/api.md#span": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:18:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.39.0/specification/trace/api.md#spankind": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:18:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.39.0/specification/trace/sdk.md#span-processor": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:19:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.41.0/oteps/0232-maturity-of-otel.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-13T21:34:46.214059431Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.41.0/spec-compliance-matrix.md#logs": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:19:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.41.0/specification/common#attribute": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-18T20:50:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.41.0/specification/compatibility/prometheus_and_openmetrics.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:48:32.733049-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.41.0/specification/configuration/sdk-environment-variables.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:48:54.896052-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.41.0/specification/context/api-propagators.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:48:42.470261-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.41.0/specification/document-status.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:48:34.590453-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.41.0/specification/logs/api.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:48:32.932795-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.41.0/specification/logs/api.md#emit-a-logrecord": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-18T20:50:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.41.0/specification/logs/api.md#logger": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:19:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.41.0/specification/logs/data-model.md#field-eventname": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-18T20:50:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.41.0/specification/logs/data-model.md#log-and-event-record-definition": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-18T20:50:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.41.0/specification/metrics/api.md#instrument-advisory-parameters": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-18T20:50:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.41.0/specification/resource/sdk.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:48:28.751624-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.41.0/specification/resource/sdk.md#sdk-provided-resource-attributes": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-18T20:50:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.41.0/specification/trace/api.md#set-status": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-18T20:50:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.41.0/specification/trace/api.md#span": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-18T20:50:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.41.0/specification/trace/api.md#spankind": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-18T20:50:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.41.0/specification/trace/sdk.md#span-processor": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-18T20:50:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/0035-opentelemetry-protocol.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:49:02.679076-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/0152-telemetry-schemas.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:49:04.258874-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/0232-maturity-of-otel.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-11T12:45:13.888118813Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/0232-maturity-of-otel.md#explanation": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-18T20:50:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/logs/0091-logs-vocabulary.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:49:05.633812-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/logs/0092-logs-vision.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:49:07.915352-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/logs/0097-log-data-model.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:49:03.121255-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/logs/0097-log-data-model.md#appendix-a-example-mappings": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-18T20:50:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/logs/0150-logging-library-sdk.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:48:53.816777-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/metrics/0003-measure-metric-type.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:49:04.269144-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/metrics/0008-metric-observer.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:49:05.590752-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/metrics/0009-metric-handles.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:49:07.507028-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/metrics/0010-cumulative-to-counter.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:49:09.009451-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/metrics/0049-metric-label-set.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:49:02.874191-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/metrics/0070-metric-bound-instrument.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:49:12.797637-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/metrics/0072-metric-observer.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:49:15.149625-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/metrics/0080-remove-metric-gauge.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:49:18.403055-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/metrics/0088-metric-instrument-optional-refinements.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:49:23.588078-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/metrics/0090-remove-labelset-from-metrics-api.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:49:27.183928-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/metrics/0098-metric-instruments-explained.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:49:30.157664-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/metrics/0108-naming-guidelines.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:49:34.124814-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/metrics/0113-exemplars.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:48:54.18727-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/metrics/0126-Configurable-Metric-Aggregations.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:48:55.204211-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/metrics/0131-otlp-export-behavior.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:49:02.418228-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/metrics/0146-metrics-prototype-scenarios.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:48:57.567607-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/profiles/0239-profiles-data-model.md#message-mapping": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-18T20:51:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/oteps/trace/0235-sampling-threshold-in-trace-state.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:49:01.492329-05:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/spec-compliance-matrix.md#logs": {
-    "StatusCode": 200,
-    "LastSeen": "2025-03-21T21:16:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/specification/common#attribute": {
-    "StatusCode": 200,
-    "LastSeen": "2025-03-21T21:16:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/specification/compatibility/prometheus_and_openmetrics.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T15:00:29.582891807Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/specification/configuration/sdk-environment-variables.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T15:00:14.111548373Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/specification/context/api-propagators.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T15:00:30.329864256Z"
-  },
   "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/specification/document-status.md": {
     "StatusCode": 206,
     "LastSeen": "2025-03-18T15:00:19.829756377Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/specification/logs/api.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T15:00:22.058048578Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/specification/logs/api.md#emit-a-logrecord": {
-    "StatusCode": 200,
-    "LastSeen": "2025-03-21T21:16:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/specification/logs/api.md#logger": {
-    "StatusCode": 200,
-    "LastSeen": "2025-03-21T21:16:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/specification/logs/data-model.md#events": {
-    "StatusCode": 200,
-    "LastSeen": "2025-03-21T21:17:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/specification/logs/data-model.md#field-eventname": {
-    "StatusCode": 200,
-    "LastSeen": "2025-03-21T21:17:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/specification/logs/data-model.md#log-and-event-record-definition": {
-    "StatusCode": 200,
-    "LastSeen": "2025-03-21T21:17:12.345Z"
   },
   "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/specification/metrics/api.md#instrument-advisory-parameters": {
     "StatusCode": 200,
     "LastSeen": "2025-03-21T21:17:12.345Z"
   },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/specification/resource/sdk.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T15:00:13.209988081Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/specification/resource/sdk.md#sdk-provided-resource-attributes": {
-    "StatusCode": 200,
-    "LastSeen": "2025-03-21T21:17:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/specification/trace/api.md#set-status": {
-    "StatusCode": 200,
-    "LastSeen": "2025-03-21T21:17:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/specification/trace/api.md#span": {
-    "StatusCode": 200,
-    "LastSeen": "2025-03-21T21:17:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/specification/trace/api.md#spankind": {
-    "StatusCode": 200,
-    "LastSeen": "2025-03-21T21:17:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.42.0/specification/trace/sdk.md#span-processor": {
-    "StatusCode": 200,
-    "LastSeen": "2025-03-21T21:17:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/0035-opentelemetry-protocol.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T14:59:50.56492374Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/0152-telemetry-schemas.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T14:59:46.220380874Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/0232-maturity-of-otel.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-31T17:26:51.612413675Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/0232-maturity-of-otel.md#explanation": {
-    "StatusCode": 200,
-    "LastSeen": "2025-03-21T21:18:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/logs/0091-logs-vocabulary.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T14:59:50.574995344Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/logs/0092-logs-vision.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T14:59:53.354116031Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/logs/0097-log-data-model.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T14:59:48.763216917Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/logs/0097-log-data-model.md#appendix-a-example-mappings": {
-    "StatusCode": 200,
-    "LastSeen": "2025-03-21T21:18:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/logs/0150-logging-library-sdk.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T14:59:51.800307342Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/metrics/0003-measure-metric-type.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T14:59:55.38592527Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/metrics/0008-metric-observer.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T15:00:00.246697616Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/metrics/0009-metric-handles.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T15:00:01.504822992Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/metrics/0010-cumulative-to-counter.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T15:00:06.667286929Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/metrics/0049-metric-label-set.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T14:59:51.294842894Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/metrics/0070-metric-bound-instrument.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T15:00:13.331056134Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/metrics/0072-metric-observer.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T15:00:15.154229822Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/metrics/0080-remove-metric-gauge.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T15:00:19.151150006Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/metrics/0088-metric-instrument-optional-refinements.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T15:00:22.646779167Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/metrics/0090-remove-labelset-from-metrics-api.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T15:00:26.603218229Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/metrics/0098-metric-instruments-explained.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T15:00:31.700880675Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/metrics/0108-naming-guidelines.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T15:00:32.668191463Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/metrics/0113-exemplars.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T14:59:53.454964457Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/metrics/0126-Configurable-Metric-Aggregations.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T15:00:00.452301984Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/metrics/0131-otlp-export-behavior.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T14:59:52.62821009Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/metrics/0146-metrics-prototype-scenarios.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T14:59:52.668673991Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/profiles/0239-profiles-data-model.md#message-mapping": {
-    "StatusCode": 200,
-    "LastSeen": "2025-03-21T21:18:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/oteps/trace/0235-sampling-threshold-in-trace-state.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-18T14:59:55.264770798Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/spec-compliance-matrix.md#logs": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-03T12:12:59.999Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/specification/logs/api.md#logger": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-03T12:12:59.999Z"
-  },
   "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.43.0/specification/trace/api.md#span": {
     "StatusCode": 200,
     "LastSeen": "2025-05-14T16:28:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.44.0/oteps/0232-maturity-of-otel.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-03T07:51:18.306395-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.44.0/spec-compliance-matrix.md#logs": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-03T12:12:59.999Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.44.0/specification/common#attribute": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T12:12:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.44.0/specification/compatibility/prometheus_and_openmetrics.md": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T11:57:53.01Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.44.0/specification/configuration/sdk-environment-variables.md": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T11:57:56.007Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.44.0/specification/context/api-propagators.md": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T11:58:03.633Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.44.0/specification/document-status.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-03T08:07:40.092971-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.44.0/specification/logs/api.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-03T07:55:00.819514-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.44.0/specification/logs/api.md#emit-a-logrecord": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-03T12:12:59.999Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.44.0/specification/logs/api.md#logger": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-03T12:12:59.999Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.44.0/specification/logs/data-model.md#events": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T12:17:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.44.0/specification/logs/data-model.md#field-eventname": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T12:17:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.44.0/specification/logs/data-model.md#log-and-event-record-definition": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T12:17:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.44.0/specification/metrics/api.md#instrument-advisory-parameters": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T12:17:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.44.0/specification/resource/sdk.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-03T07:54:59.318089-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.44.0/specification/resource/sdk.md#sdk-provided-resource-attributes": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T12:17:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.44.0/specification/trace/api.md#set-status": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T12:18:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.44.0/specification/trace/api.md#span": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T12:18:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.44.0/specification/trace/api.md#spankind": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T12:18:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.44.0/specification/trace/sdk.md#span-processor": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T12:18:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/0035-opentelemetry-protocol.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-14T12:26:37.010973-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/0152-telemetry-schemas.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-14T12:26:47.112374-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/0232-maturity-of-otel.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-21T16:22:23.191179445Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/0232-maturity-of-otel.md#explanation": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-14T16:28:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/logs/0091-logs-vocabulary.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-14T12:26:45.441108-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/logs/0092-logs-vision.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-14T12:26:46.565222-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/logs/0097-log-data-model.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-14T12:26:42.68476-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/logs/0097-log-data-model.md#appendix-a-example-mappings": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-14T16:28:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/logs/0150-logging-library-sdk.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-14T12:26:40.224601-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/metrics/0003-measure-metric-type.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-14T12:26:39.156186-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/metrics/0008-metric-observer.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-14T12:26:39.95416-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/metrics/0009-metric-handles.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-14T12:26:41.9215-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/metrics/0010-cumulative-to-counter.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-14T12:26:42.696623-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/metrics/0049-metric-label-set.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-14T12:26:38.816537-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/metrics/0070-metric-bound-instrument.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-14T12:26:43.287068-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/metrics/0072-metric-observer.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-14T12:26:43.86376-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/metrics/0080-remove-metric-gauge.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-14T12:26:45.040259-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/metrics/0088-metric-instrument-optional-refinements.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-14T12:26:46.23271-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/metrics/0090-remove-labelset-from-metrics-api.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-14T12:26:47.0384-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/metrics/0098-metric-instruments-explained.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-14T12:26:47.943051-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/metrics/0108-naming-guidelines.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-14T12:26:49.202454-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/metrics/0113-exemplars.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-14T12:26:39.953688-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/metrics/0126-Configurable-Metric-Aggregations.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-14T12:26:47.014588-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/metrics/0131-otlp-export-behavior.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-14T12:26:39.020412-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/metrics/0146-metrics-prototype-scenarios.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-14T12:26:40.9596-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/oteps/profiles/0239-profiles-data-model.md#message-mapping": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-14T16:28:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/spec-compliance-matrix.md#logs": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:51:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/specification/common#attribute": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:51:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/specification/compatibility/prometheus_and_openmetrics.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:40.652656122Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/specification/configuration/sdk-environment-variables.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:35.039170073Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/specification/context/api-propagators.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:31.114891408Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/specification/document-status.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:40.245876713Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/specification/logs/api.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:40.988722085Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/specification/logs/api.md#emit-a-logrecord": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:51:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/specification/logs/api.md#logger": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:51:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/specification/logs/data-model.md#events": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:52:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/specification/logs/data-model.md#field-eventname": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:52:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/specification/logs/data-model.md#log-and-event-record-definition": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:52:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/specification/metrics/api.md#instrument-advisory-parameters": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:52:12.345Z"
   },
   "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/specification/resource#overview": {
     "StatusCode": 200,
     "LastSeen": "2025-10-01T13:52:12.345Z"
   },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/specification/resource/sdk.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:32.034408607Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/specification/resource/sdk.md#sdk-provided-resource-attributes": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:52:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/specification/trace/api.md#set-status": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:52:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/specification/trace/api.md#span": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:52:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/specification/trace/api.md#spankind": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:52:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.45.0/specification/trace/sdk.md#span-processor": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:52:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/oteps/0035-opentelemetry-protocol.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:22.088870495Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/oteps/0152-telemetry-schemas.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:29.780458239Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/oteps/0232-maturity-of-otel.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-17T10:35:59.914463702Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/oteps/0232-maturity-of-otel.md#explanation": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:52:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/oteps/logs/0091-logs-vocabulary.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:14.532928311Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/oteps/logs/0092-logs-vision.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:17.048501852Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/oteps/logs/0097-log-data-model.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:23.630533098Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/oteps/logs/0097-log-data-model.md#appendix-a-example-mappings": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:52:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/oteps/logs/0150-logging-library-sdk.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:17.56657599Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/oteps/metrics/0003-measure-metric-type.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:21.335719219Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/oteps/metrics/0008-metric-observer.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:22.858752511Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/oteps/metrics/0009-metric-handles.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:25.143698787Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/oteps/metrics/0010-cumulative-to-counter.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:30.012598841Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/oteps/metrics/0049-metric-label-set.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:10.839423936Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/oteps/metrics/0070-metric-bound-instrument.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:32.881721368Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/oteps/metrics/0072-metric-observer.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:35.99407716Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/oteps/metrics/0080-remove-metric-gauge.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:41.963503884Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/oteps/metrics/0088-metric-instrument-optional-refinements.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:46.176722151Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/oteps/metrics/0090-remove-labelset-from-metrics-api.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:46.892783072Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/oteps/metrics/0098-metric-instruments-explained.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:51.457239264Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/oteps/metrics/0108-naming-guidelines.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:56.170871777Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/oteps/metrics/0113-exemplars.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:15.679677359Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/oteps/metrics/0126-Configurable-Metric-Aggregations.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:19.575695509Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/oteps/metrics/0131-otlp-export-behavior.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:18.673010356Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/oteps/metrics/0146-metrics-prototype-scenarios.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T21:20:20.564650234Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/oteps/profiles/0239-profiles-data-model.md#message-mapping": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:52:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/spec-compliance-matrix.md#logs": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:52:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/specification/compatibility/prometheus_and_openmetrics.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:22:33.364019051Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/specification/configuration/sdk-environment-variables.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:22:28.264439796Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/specification/context/api-propagators.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:01.287349247Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/specification/document-status.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:22:11.727581271Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/specification/logs/api.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:22:30.515367294Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/specification/logs/api.md#emit-a-logrecord": {
-    "StatusCode": 200,
-    "LastSeen": "2025-10-01T13:52:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/specification/logs/api.md#logger": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-17T10:36:27.4417685Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/specification/logs/data-model.md#events": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:07.833281818Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/specification/logs/data-model.md#field-attributes": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:22:36.572591114Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/specification/logs/data-model.md#field-body": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:22:38.848163768Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/specification/logs/data-model.md#field-eventname": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:22:32.950769149Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/specification/logs/data-model.md#field-severitynumber": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:22:42.961909087Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/specification/logs/data-model.md#log-and-event-record-definition": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:22:35.822927914Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/specification/logs/data-model.md#type-any": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-17T10:35:48.424910817Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/specification/metrics/api.md#instrument-advisory-parameters": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:22:11.38260575Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/specification/resource/sdk.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:22:23.51540642Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/specification/resource/sdk.md#sdk-provided-resource-attributes": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:22:32.354185313Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/specification/trace/api.md#set-status": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:22:33.578419631Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/specification/trace/api.md#span": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:22:26.218771674Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/specification/trace/api.md#spankind": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:22:36.430347577Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.46.0/specification/trace/sdk.md#span-processor": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:22:38.851677347Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/0035-opentelemetry-protocol.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:15.448164402Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/0152-telemetry-schemas.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:24.894774955Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/0232-maturity-of-otel.md#explanation": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:13.639187855Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/logs/0091-logs-vocabulary.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:35.40533857Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/logs/0092-logs-vision.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:37.582840135Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/logs/0097-log-data-model.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:07.787415895Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/logs/0097-log-data-model.md#appendix-a-example-mappings": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:26.32067083Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/logs/0150-logging-library-sdk.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:16.875038881Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/metrics/0003-measure-metric-type.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:24.353176897Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/metrics/0008-metric-observer.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:28.022589652Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/metrics/0009-metric-handles.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:31.418874449Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/metrics/0010-cumulative-to-counter.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:34.989924113Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/metrics/0049-metric-label-set.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:20.114784289Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/metrics/0070-metric-bound-instrument.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:37.21051731Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/metrics/0072-metric-observer.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:39.589899771Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/metrics/0080-remove-metric-gauge.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:45.103284625Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/metrics/0088-metric-instrument-optional-refinements.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:49.819075476Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/metrics/0090-remove-labelset-from-metrics-api.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:54.12795937Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/metrics/0098-metric-instruments-explained.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:59.297396932Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/metrics/0108-naming-guidelines.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:24:03.905307792Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/metrics/0113-exemplars.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:13.173713393Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/metrics/0126-Configurable-Metric-Aggregations.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:16.126622708Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/metrics/0131-otlp-export-behavior.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:22.434171447Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/metrics/0146-metrics-prototype-scenarios.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:15.733565551Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/profiles/0239-profiles-data-model.md#message-mapping": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:28.959916936Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/trace/0235-sampling-threshold-in-trace-state.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:25.854515936Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.47.0/oteps/trace/0250-Composite_Samplers.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:30.069188446Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/0035-opentelemetry-protocol.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:38:00.684683687Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/0152-telemetry-schemas.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:37:50.025277817Z"
-  },
   "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/0232-maturity-of-otel.md": {
     "StatusCode": 206,
     "LastSeen": "2025-08-28T17:29:51.077678-04:00"
   },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/0232-maturity-of-otel.md#explanation": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:37:49.964764008Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/logs/0091-logs-vocabulary.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:38:01.717880995Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/logs/0092-logs-vision.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:38:04.546117403Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/logs/0097-log-data-model.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:37:59.926649931Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/logs/0097-log-data-model.md#appendix-a-example-mappings": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:38:01.594285277Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/logs/0150-logging-library-sdk.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:38:01.574086212Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/metrics/0003-measure-metric-type.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:38:17.414434109Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/metrics/0008-metric-observer.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:38:19.106208838Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/metrics/0009-metric-handles.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:38:22.246032523Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/metrics/0010-cumulative-to-counter.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:38:26.352188362Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/metrics/0049-metric-label-set.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:38:17.230515642Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/metrics/0070-metric-bound-instrument.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:38:30.588850965Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/metrics/0072-metric-observer.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:38:33.63947439Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/metrics/0080-remove-metric-gauge.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:38:37.510948185Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/metrics/0088-metric-instrument-optional-refinements.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:38:42.087265571Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/metrics/0090-remove-labelset-from-metrics-api.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:38:47.14020013Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/metrics/0098-metric-instruments-explained.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:38:52.220366722Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/metrics/0108-naming-guidelines.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:38:56.342587228Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/metrics/0113-exemplars.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:38:15.660052919Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/metrics/0126-Configurable-Metric-Aggregations.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:38:18.133021564Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/metrics/0131-otlp-export-behavior.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:38:14.572176923Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/metrics/0146-metrics-prototype-scenarios.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:38:15.599376685Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/profiles/0239-profiles-data-model.md#message-mapping": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:37:53.17819196Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/trace/0235-sampling-threshold-in-trace-state.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:38:15.619555556Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/oteps/trace/0250-Composite_Samplers.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-13T18:38:17.117282548Z"
-  },
   "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/spec-compliance-matrix.md#logs": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-28T17:30:02.495164-04:00"
+    "StatusCode": 200,
+    "LastSeen": "2025-10-01T15:26:12.345Z"
   },
   "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/specification/common/README.md#attribute": {
-    "StatusCode": 206,
-    "LastSeen": "2025-09-24T10:03:19.850216-04:00"
+    "StatusCode": 200,
+    "LastSeen": "2025-10-01T15:26:12.345Z"
   },
   "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/specification/compatibility/prometheus_and_openmetrics.md": {
     "StatusCode": 206,
@@ -13960,16 +11652,16 @@
     "LastSeen": "2025-09-17T09:41:42.669923706Z"
   },
   "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/specification/logs/api.md#emit-a-logrecord": {
-    "StatusCode": 206,
-    "LastSeen": "2025-09-17T09:40:43.511578607Z"
+    "StatusCode": 200,
+    "LastSeen": "2025-10-01T15:26:12.345Z"
   },
   "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/specification/logs/api.md#logger": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-28T17:29:49.528572-04:00"
+    "StatusCode": 200,
+    "LastSeen": "2025-10-01T15:26:12.345Z"
   },
   "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/specification/logs/data-model.md#events": {
-    "StatusCode": 206,
-    "LastSeen": "2025-09-17T09:40:40.459693489Z"
+    "StatusCode": 200,
+    "LastSeen": "2025-10-01T15:27:12.345Z"
   },
   "https://github.com/open-telemetry/opentelemetry-specification/tree/v1.48.0/specification/logs/data-model.md#field-attributes": {
     "StatusCode": 206,
@@ -14146,10 +11838,6 @@
   "https://github.com/open-telemetry/opentelemetry-swift/blob/main/Sources/OpenTelemetryApi/OpenTelemetry.swift#L11": {
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:19:12.345Z"
-  },
-  "https://github.com/open-telemetry/opentelemetry-swift/blob/main/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T18:23:29.870351024Z"
   },
   "https://github.com/open-telemetry/opentelemetry-swift/releases": {
     "StatusCode": 206,
@@ -14351,121 +12039,9 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-17T16:59:04.947627-05:00"
   },
-  "https://github.com/open-telemetry/oteps/blob/main/text/0152-telemetry-schemas.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:59:07.409447-05:00"
-  },
-  "https://github.com/open-telemetry/oteps/blob/main/text/0202-events-and-logs-api.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:59:07.342232-05:00"
-  },
-  "https://github.com/open-telemetry/oteps/blob/main/text/0232-maturity-of-otel.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:59:02.007154-05:00"
-  },
-  "https://github.com/open-telemetry/oteps/blob/main/text/0232-maturity-of-otel.md#explanation": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:19:12.345Z"
-  },
-  "https://github.com/open-telemetry/oteps/blob/main/text/logs/0091-logs-vocabulary.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:59:10.792484-05:00"
-  },
-  "https://github.com/open-telemetry/oteps/blob/main/text/logs/0092-logs-vision.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:59:14.046979-05:00"
-  },
-  "https://github.com/open-telemetry/oteps/blob/main/text/logs/0097-log-data-model.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:59:10.815621-05:00"
-  },
-  "https://github.com/open-telemetry/oteps/blob/main/text/logs/0097-log-data-model.md#appendix-a-example-mappings": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:19:12.345Z"
-  },
-  "https://github.com/open-telemetry/oteps/blob/main/text/logs/0150-logging-library-sdk.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:59:08.070241-05:00"
-  },
-  "https://github.com/open-telemetry/oteps/blob/main/text/metrics/0003-measure-metric-type.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:59:05.452588-05:00"
-  },
-  "https://github.com/open-telemetry/oteps/blob/main/text/metrics/0008-metric-observer.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:59:08.232794-05:00"
-  },
-  "https://github.com/open-telemetry/oteps/blob/main/text/metrics/0009-metric-handles.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:59:10.951423-05:00"
-  },
-  "https://github.com/open-telemetry/oteps/blob/main/text/metrics/0010-cumulative-to-counter.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:59:11.674782-05:00"
-  },
-  "https://github.com/open-telemetry/oteps/blob/main/text/metrics/0049-metric-label-set.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:59:06.072726-05:00"
-  },
-  "https://github.com/open-telemetry/oteps/blob/main/text/metrics/0070-metric-bound-instrument.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:59:12.557046-05:00"
-  },
-  "https://github.com/open-telemetry/oteps/blob/main/text/metrics/0072-metric-observer.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:59:13.771883-05:00"
-  },
-  "https://github.com/open-telemetry/oteps/blob/main/text/metrics/0080-remove-metric-gauge.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:59:15.57106-05:00"
-  },
-  "https://github.com/open-telemetry/oteps/blob/main/text/metrics/0088-metric-instrument-optional-refinements.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:59:17.482553-05:00"
-  },
-  "https://github.com/open-telemetry/oteps/blob/main/text/metrics/0090-remove-labelset-from-metrics-api.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:59:18.505479-05:00"
-  },
-  "https://github.com/open-telemetry/oteps/blob/main/text/metrics/0098-metric-instruments-explained.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:59:19.253545-05:00"
-  },
-  "https://github.com/open-telemetry/oteps/blob/main/text/metrics/0108-naming-guidelines.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:59:21.544203-05:00"
-  },
-  "https://github.com/open-telemetry/oteps/blob/main/text/metrics/0113-exemplars.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:59:07.435818-05:00"
-  },
-  "https://github.com/open-telemetry/oteps/blob/main/text/metrics/0126-Configurable-Metric-Aggregations.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:59:09.670559-05:00"
-  },
-  "https://github.com/open-telemetry/oteps/blob/main/text/metrics/0131-otlp-export-behavior.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:59:14.855786-05:00"
-  },
-  "https://github.com/open-telemetry/oteps/blob/main/text/metrics/0146-metrics-prototype-scenarios.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:59:08.297221-05:00"
-  },
-  "https://github.com/open-telemetry/oteps/blob/main/text/profiles/0239-profiles-data-model.md#message-mapping": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:19:12.345Z"
-  },
-  "https://github.com/open-telemetry/oteps/blob/main/text/trace/0235-sampling-threshold-in-trace-state.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T16:59:11.69607-05:00"
-  },
   "https://github.com/open-telemetry/oteps/pull/108/files": {
     "StatusCode": 206,
     "LastSeen": "2025-01-07T10:31:53.193878-05:00"
-  },
-  "https://github.com/open-telemetry/oteps/pull/173": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-13T11:43:32.888525-05:00"
   },
   "https://github.com/open-telemetry/oteps/pull/212": {
     "StatusCode": 206,
@@ -14503,25 +12079,9 @@
     "StatusCode": 206,
     "LastSeen": "2025-02-01T06:38:26.391953-05:00"
   },
-  "https://github.com/open-telemetry/semantic-conventions/blob/main/docs/exceptions/exceptions-spans.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-05T12:22:29.136319+02:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metrics.md#instrument-naming": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-26T16:48:07.30351+03:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-05T12:22:28.644975+02:00"
-  },
   "https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/general/general-attributes.md#server-and-client-attributes": {
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:19:12.345Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/system/hardware-metrics.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:24.04451-05:00"
   },
   "https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/system/process-metrics.md": {
     "StatusCode": 206,
@@ -14599,62 +12159,6 @@
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:20:12.345Z"
   },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:25.115337-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/database-metrics.md#metric-dbclientconnectioncount": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:20:12.345Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/database-metrics.md#metric-dbclientconnectioncreate_time": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:20:12.345Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/database-metrics.md#metric-dbclientconnectionidlemax": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:20:12.345Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/database-metrics.md#metric-dbclientconnectionidlemin": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:20:12.345Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/database-metrics.md#metric-dbclientconnectionmax": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:20:12.345Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/database-metrics.md#metric-dbclientconnectionpending_requests": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:20:12.345Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/database-metrics.md#metric-dbclientconnectiontimeouts": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:20:12.345Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/database-metrics.md#metric-dbclientconnectionuse_time": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:20:12.345Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/database-metrics.md#metric-dbclientconnectionwait_time": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:20:12.345Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/database-metrics.md#metric-dbclientoperationduration": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:20:12.345Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/database-spans.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:29.09376-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.28.0/docs/database/database-spans.md#name": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:20:12.345Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/attributes-registry/code.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-24T14:36:46.234005-05:00"
-  },
   "https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/system/k8s-metrics.md": {
     "StatusCode": 206,
     "LastSeen": "2025-01-24T14:36:51.654867-05:00"
@@ -14662,58 +12166,6 @@
   "https://github.com/open-telemetry/semantic-conventions/blob/v1.30.0/docs/system/k8s-metrics.md": {
     "StatusCode": 206,
     "LastSeen": "2025-06-17T10:35:54.53197191Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.31.0/docs/database/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-31T17:26:46.501439215Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.31.0/docs/database/database-metrics.md#metric-dbclientconnectioncount": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T12:18:12.345Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.31.0/docs/database/database-metrics.md#metric-dbclientconnectioncreate_time": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T12:20:12.345Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.31.0/docs/database/database-metrics.md#metric-dbclientconnectionidlemax": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T12:20:12.345Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.31.0/docs/database/database-metrics.md#metric-dbclientconnectionidlemin": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T12:20:12.345Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.31.0/docs/database/database-metrics.md#metric-dbclientconnectionmax": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T12:20:12.345Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.31.0/docs/database/database-metrics.md#metric-dbclientconnectionpending_requests": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T12:20:12.345Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.31.0/docs/database/database-metrics.md#metric-dbclientconnectiontimeouts": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T12:20:12.345Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.31.0/docs/database/database-metrics.md#metric-dbclientconnectionuse_time": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T12:20:12.345Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.31.0/docs/database/database-metrics.md#metric-dbclientconnectionwait_time": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T12:20:12.345Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.31.0/docs/database/database-metrics.md#metric-dbclientoperationduration": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T12:20:12.345Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.31.0/docs/database/database-spans.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-31T17:26:48.27995036Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/blob/v1.31.0/docs/database/database-spans.md#name": {
-    "StatusCode": 200,
-    "LastSeen": "2025-05-03T12:20:12.345Z"
   },
   "https://github.com/open-telemetry/semantic-conventions/blob/v1.31.0/docs/system/k8s-metrics.md": {
     "StatusCode": 206,
@@ -14773,7 +12225,7 @@
   },
   "https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/rpc/rpc-spans.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-05-30T18:08:02.158367558Z"
+    "LastSeen": "2025-10-01T11:51:49.902075-04:00"
   },
   "https://github.com/open-telemetry/semantic-conventions/blob/v1.36.0/docs/gen-ai/README.md": {
     "StatusCode": 206,
@@ -14806,10 +12258,6 @@
   "https://github.com/open-telemetry/semantic-conventions/issues/1255": {
     "StatusCode": 206,
     "LastSeen": "2025-01-24T14:37:03.357691-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/issues/1309": {
-    "StatusCode": 200,
-    "LastSeen": "2024-10-09T10:19:24.558756+02:00"
   },
   "https://github.com/open-telemetry/semantic-conventions/issues/1357": {
     "StatusCode": 206,
@@ -14867,22 +12315,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-02-10T23:17:41.457142781Z"
   },
-  "https://github.com/open-telemetry/semantic-conventions/pull/1636": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-24T14:36:59.880322-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/pull/1649": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-24T14:37:03.751366-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/pull/1660": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-24T14:37:07.536872-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/pull/1668": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-24T14:37:09.499396-05:00"
-  },
   "https://github.com/open-telemetry/semantic-conventions/pull/2113": {
     "StatusCode": 206,
     "LastSeen": "2025-06-19T10:36:07.545111432Z"
@@ -14906,282 +12338,6 @@
   "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/README.md": {
     "StatusCode": 206,
     "LastSeen": "2025-01-17T17:00:14.594326-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/android.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:23.447463-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/artifact.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:27.28969-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/aspnetcore.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:19.286008-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/aws.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:22.307114-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/azure.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:24.299164-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/browser.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:20.842347-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/cicd.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:20.606688-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/client.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:20.996978-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/cloud.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:19.882797-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/cloudevents.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:18.536022-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/cloudfoundry.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:22.348419-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/code.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:21.388698-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/container.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:19.814375-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/cpu.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:25.117042-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/db.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:21.159886-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/deployment.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:22.613579-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/destination.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:18.938104-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/device.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:24.159609-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/disk.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:22.301784-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/dns.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:22.444162-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/dotnet.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:24.139079-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/enduser.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:21.205742-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/error.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:25.733787-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/event.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:27.986678-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/exception.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:21.75233-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/faas.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:20.581674-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/feature-flag.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:20.696499-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/file.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:18.539239-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/gcp.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:25.380849-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/gen-ai.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:25.972291-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/geo.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:21.261312-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/go.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:15.724496-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/graphql.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:22.297487-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/hardware.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:18.942527-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/heroku.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:23.845911-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/host.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:25.37975-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/http.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:22.272248-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/ios.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:21.925821-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/jvm.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:19.830638-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/k8s.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:19.814221-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/linux.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:23.948607-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/log.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:22.779435-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/messaging.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:21.926702-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/network.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:18.910705-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/nodejs.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:18.735205-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/oci.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:20.06255-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/opentracing.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:18.921244-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/os.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:25.972185-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/otel.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:22.119038-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/peer.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:22.986444-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/process.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:25.962051-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/profile.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:25.624385-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/rpc.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:23.465903-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/server.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:19.222932-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/service.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:23.491421-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/session.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:22.380517-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/signalr.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:15.463626-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/source.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:24.179904-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/system.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:19.961815-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/telemetry.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:24.570497-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/test.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:20.703446-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/thread.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:25.768965-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/tls.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:23.453411-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/url.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:18.565922-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/user-agent.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:18.830259-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/user.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:21.331951-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/v8js.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:27.617419-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/vcs.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:21.464903-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/attributes-registry/webengine.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:18.53532-05:00"
   },
   "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/azure/README.md": {
     "StatusCode": 206,
@@ -15258,10 +12414,6 @@
   "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/database/mongodb.md": {
     "StatusCode": 206,
     "LastSeen": "2025-01-17T17:00:15.579037-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/database/mssql.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:18.535357-05:00"
   },
   "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/database/mysql.md": {
     "StatusCode": 206,
@@ -15647,10 +12799,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-17T17:00:17.906015-05:00"
   },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/system/hardware-metrics.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:19.882462-05:00"
-  },
   "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/system/k8s-metrics.md": {
     "StatusCode": 206,
     "LastSeen": "2025-01-17T17:00:19.507772-05:00"
@@ -15663,10 +12811,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-17T17:00:19.812162-05:00"
   },
-  "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/url/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-17T17:00:19.979061-05:00"
-  },
   "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/url/url.md": {
     "StatusCode": 206,
     "LastSeen": "2025-01-17T17:00:16.347821-05:00"
@@ -15678,34 +12822,6 @@
   "https://github.com/open-telemetry/semantic-conventions/tree/v1.26.0": {
     "StatusCode": 206,
     "LastSeen": "2025-01-17T17:00:28.710746-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/v1.30.0//model/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-11T12:45:05.311341-05:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/v1.31.0//model/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-11T15:36:24.498780567Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/v1.32.0//model/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-31T17:26:47.34879275Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/v1.33.0//model/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-03T07:51:18.308728-04:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/v1.34.0//model/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-21T15:12:28.317486-04:00"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/v1.35.0//model/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-30T20:44:45.902032575Z"
-  },
-  "https://github.com/open-telemetry/semantic-conventions/tree/v1.36.0//model/README.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-17T20:51:44.60409+02:00"
   },
   "https://github.com/open-telemetry/semantic-conventions/tree/v1.37.0//model/README.md": {
     "StatusCode": 206,
@@ -15959,10 +13075,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-31T13:07:53.320508201Z"
   },
-  "https://github.com/orgs/open-telemetry/teams/technical-committee": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-30T16:59:53.246846-05:00"
-  },
   "https://github.com/os-observability/redhat-opentelemetry-collector": {
     "StatusCode": 206,
     "LastSeen": "2025-01-15T11:25:42.517001-05:00"
@@ -16207,10 +13319,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-06-05T10:38:38.399428492Z"
   },
-  "https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-16T13:35:16.035724-05:00"
-  },
   "https://github.com/prometheus/prometheus/blob/main/prompb/remote.proto": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T13:35:14.605396-05:00"
@@ -16307,10 +13415,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-31T07:52:03.302641957Z"
   },
-  "https://github.com/rapphil": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-02T10:10:44.756747-05:00"
-  },
   "https://github.com/ratpack/ratpack": {
     "StatusCode": 206,
     "LastSeen": "2025-09-11T16:08:43.717542-04:00"
@@ -16382,10 +13486,6 @@
   "https://github.com/robertlaurin": {
     "StatusCode": 206,
     "LastSeen": "2025-02-02T10:41:26.431913-05:00"
-  },
-  "https://github.com/robsunday": {
-    "StatusCode": 200,
-    "LastSeen": "2024-11-06T19:17:41.346472Z"
   },
   "https://github.com/rochdev": {
     "StatusCode": 200,
@@ -16470,10 +13570,6 @@
   "https://github.com/serverless/serverless": {
     "StatusCode": 206,
     "LastSeen": "2025-01-13T11:43:26.698136-05:00"
-  },
-  "https://github.com/sh0rez": {
-    "StatusCode": 200,
-    "LastSeen": "2024-11-06T19:17:43.928734Z"
   },
   "https://github.com/sh0rez/promconv/tree/main": {
     "StatusCode": 206,
@@ -16899,10 +13995,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-13T12:11:00.612549-05:00"
   },
-  "https://github.com/trasktest": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-16T08:37:48.614358524Z"
-  },
   "https://github.com/trentm": {
     "StatusCode": 206,
     "LastSeen": "2025-02-01T07:20:48.278296-05:00"
@@ -17054,10 +14146,6 @@
   "https://github.com/whatyouhide/xandra": {
     "StatusCode": 200,
     "LastSeen": "2024-11-18T16:20:47.564161+01:00"
-  },
-  "https://github.com/willarmiros": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-02T10:15:14.905073-05:00"
   },
   "https://github.com/windsonsea": {
     "StatusCode": 206,
@@ -17295,10 +14383,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-02-01T07:09:56.833746-05:00"
   },
-  "https://golang.org/ref/spec#Slice_types": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:22:12.345Z"
-  },
   "https://google.aip.dev/122#full-resource-names": {
     "StatusCode": 200,
     "LastSeen": "2025-02-11T17:47:12.345Z"
@@ -17322,10 +14406,6 @@
   "https://grafana.com/": {
     "StatusCode": 200,
     "LastSeen": "2025-02-02T10:58:39.144139-05:00"
-  },
-  "https://grafana.com/about/careers/open-positions/": {
-    "StatusCode": 200,
-    "LastSeen": "2024-08-15T15:44:21.083848+02:00"
   },
   "https://grafana.com/blog/2023/07/20/a-practical-guide-to-data-collection-with-opentelemetry-and-prometheus/#6-use-prometheus-remote-write-exporter": {
     "StatusCode": 200,
@@ -17362,54 +14442,6 @@
   "https://grafana.com/docs/grafana/latest/setup-grafana/installation/#supported-operating-systems": {
     "StatusCode": 200,
     "LastSeen": "2025-08-05T12:22:32.290893+02:00"
-  },
-  "https://grafana.com/media/docs/grafana-cloud/beyla/beyla-logo-2.png": {
-    "StatusCode": 200,
-    "LastSeen": "2025-07-24T21:20:16.722097+02:00"
-  },
-  "https://grafana.com/media/docs/grafana-cloud/beyla/quickstart/grouped-traces.png": {
-    "StatusCode": 200,
-    "LastSeen": "2025-07-24T21:20:19.798569+02:00"
-  },
-  "https://grafana.com/media/docs/grafana-cloud/beyla/quickstart/otel-cloud-portal-box.png": {
-    "StatusCode": 200,
-    "LastSeen": "2025-07-24T21:20:17.093822+02:00"
-  },
-  "https://grafana.com/media/docs/grafana-cloud/beyla/quickstart/otlp-connection-headers.png": {
-    "StatusCode": 200,
-    "LastSeen": "2025-07-24T21:20:16.832137+02:00"
-  },
-  "https://grafana.com/media/docs/grafana-cloud/beyla/quickstart/trace-generic.png": {
-    "StatusCode": 200,
-    "LastSeen": "2025-07-24T21:20:17.301484+02:00"
-  },
-  "https://grafana.com/media/docs/grafana-cloud/beyla/quickstart/trace.png": {
-    "StatusCode": 200,
-    "LastSeen": "2025-07-24T21:20:17.660671+02:00"
-  },
-  "https://grafana.com/media/docs/grafana-cloud/beyla/req-life-cycle_2.png": {
-    "StatusCode": 200,
-    "LastSeen": "2025-07-24T21:20:16.413698+02:00"
-  },
-  "https://grafana.com/media/docs/grafana-cloud/beyla/server-side-trace.png": {
-    "StatusCode": 200,
-    "LastSeen": "2025-07-24T21:20:17.836646+02:00"
-  },
-  "https://grafana.com/media/docs/grafana-cloud/beyla/tutorial/k8s/run-query.png": {
-    "StatusCode": 200,
-    "LastSeen": "2025-07-24T21:20:19.948125+02:00"
-  },
-  "https://grafana.com/media/docs/grafana-cloud/beyla/tutorial/k8s/select-traces.png": {
-    "StatusCode": 200,
-    "LastSeen": "2025-07-24T21:20:18.993886+02:00"
-  },
-  "https://grafana.com/media/docs/grafana-cloud/beyla/tutorial/k8s/tut-trace-details.png": {
-    "StatusCode": 200,
-    "LastSeen": "2025-07-24T21:20:21.700895+02:00"
-  },
-  "https://grafana.com/media/docs/grafana-cloud/beyla/tutorial/k8s/tut-traces-list.png": {
-    "StatusCode": 200,
-    "LastSeen": "2025-07-24T21:20:21.075403+02:00"
   },
   "https://grafana.com/oss/grafana/": {
     "StatusCode": 200,
@@ -17631,10 +14663,6 @@
     "StatusCode": 200,
     "LastSeen": "2025-09-11T16:08:00.692614-04:00"
   },
-  "https://hub.docker.com/r/grafana/beyla": {
-    "StatusCode": 200,
-    "LastSeen": "2025-07-24T21:20:17.987768+02:00"
-  },
   "https://hub.docker.com/r/otel/ebpf-instrument": {
     "StatusCode": 200,
     "LastSeen": "2025-07-28T15:15:42.999277+02:00"
@@ -17654,10 +14682,6 @@
   "https://img.shields.io/badge/-development-blue": {
     "StatusCode": 200,
     "LastSeen": "2025-02-12T12:06:58.22778976Z"
-  },
-  "https://img.shields.io/badge/-experimental-blue": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-01T06:58:16.456533-05:00"
   },
   "https://img.shields.io/badge/-mixed-yellow": {
     "StatusCode": 200,
@@ -17711,17 +14735,9 @@
     "StatusCode": 206,
     "LastSeen": "2025-02-01T07:10:44.524151-05:00"
   },
-  "https://ja.wikipedia.org/wiki/ISO_639-1": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-11T15:40:50.656187+09:00"
-  },
   "https://jaegertracing.io/": {
     "StatusCode": 206,
     "LastSeen": "2025-01-30T14:41:09.185172-05:00"
-  },
-  "https://jakarta.ee/specifications/platform/8/apidocs/javax/servlet/http/HttpServletRequest.html": {
-    "StatusCode": 206,
-    "LastSeen": "2024-12-18T05:52:24.064637-05:00"
   },
   "https://jakarta.ee/specifications/xml-web-services/2.3/apidocs/javax/xml/ws/package-summary.html": {
     "StatusCode": 206,
@@ -18563,10 +15579,6 @@
     "StatusCode": 200,
     "LastSeen": "2025-01-30T16:54:24.078292-05:00"
   },
-  "https://learn.microsoft.com/rest/api/subscription/subscriptions/list-locations": {
-    "StatusCode": 200,
-    "LastSeen": "2024-12-04T08:46:56.45309164Z"
-  },
   "https://learn.microsoft.com/sql/connect/jdbc/building-the-connection-url#named-and-multiple-sql-server-instances": {
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:26:12.345Z"
@@ -18731,10 +15743,6 @@
     "StatusCode": 200,
     "LastSeen": "2025-01-30T22:17:16.834Z"
   },
-  "https://maven.org/artifact/org.http4k/http4k-opentelemetry": {
-    "StatusCode": 200,
-    "LastSeen": "2025-01-30T22:17:20.532Z"
-  },
   "https://maxdb.sap.com/": {
     "StatusCode": 200,
     "LastSeen": "2025-01-24T14:37:21.149596-05:00"
@@ -18787,10 +15795,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-09-11T16:07:05.712346-04:00"
   },
-  "https://metricshub.com": {
-    "StatusCode": 200,
-    "LastSeen": "2024-10-07T14:48:00.172830893Z"
-  },
   "https://microcks.io/": {
     "StatusCode": 206,
     "LastSeen": "2025-02-01T06:58:14.031144-05:00"
@@ -18838,10 +15842,6 @@
   "https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java/4.26.1": {
     "StatusCode": 200,
     "LastSeen": "2025-01-30T22:19:12.824Z"
-  },
-  "https://mvnrepository.com/artifact/io.opentelemetry": {
-    "StatusCode": 200,
-    "LastSeen": "2025-01-30T22:19:22.414Z"
   },
   "https://mybatis.org/mybatis-3/": {
     "StatusCode": 206,
@@ -19287,10 +16287,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-06T11:32:22.052087-05:00"
   },
-  "https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_exporter_prometheus.PrometheusExporter.html": {
-    "StatusCode": 206,
-    "LastSeen": "2024-08-14T08:01:01.892463087Z"
-  },
   "https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_api.Tracer.html#startActiveSpan": {
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:27:12.345Z"
@@ -19302,10 +16298,6 @@
   "https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_sdk-trace-base.SpanExporter.html": {
     "StatusCode": 206,
     "LastSeen": "2025-05-24T01:58:06.932001554Z"
-  },
-  "https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_sdk_trace_base.SpanExporter.html": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-30T16:54:28.713498-05:00"
   },
   "https://open-telemetry.github.io/opentelemetry-python/benchmarks/data.js": {
     "StatusCode": 206,
@@ -19344,10 +16336,6 @@
     "LastSeen": "2025-02-02T10:40:27.103505-05:00"
   },
   "https://openfga.dev/docs/getting-started/setup-openfga/configure-openfga#telemetry": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:27:12.345Z"
-  },
-  "https://openid.net/specs/openid-connect-core-1_0.html#IDToken": {
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:27:12.345Z"
   },
@@ -19454,90 +16442,6 @@
   "https://opentelemetry.devstats.cncf.io/d/9/developer-activity-counts-by-repository-group-table": {
     "StatusCode": 200,
     "LastSeen": "2025-01-31T13:07:33.766024682Z"
-  },
-  "https://opentelemetry.io/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-24T21:20:16.939217+02:00"
-  },
-  "https://opentelemetry.io/blog/2025/contribex-survey-results/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T14:07:51.914716+02:00"
-  },
-  "https://opentelemetry.io/docs/concepts/instrumentation/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-20T09:23:52.447657347-08:00"
-  },
-  "https://opentelemetry.io/docs/concepts/resources/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-22T11:21:38.519024472-07:00"
-  },
-  "https://opentelemetry.io/docs/concepts/sdk-configuration/general-sdk-configuration/#otel_traces_sampler": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-24T21:20:16.853244+02:00"
-  },
-  "https://opentelemetry.io/docs/concepts/sdk-configuration/otlp-exporter-configuration/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-24T21:20:15.767147+02:00"
-  },
-  "https://opentelemetry.io/docs/concepts/sdk-configuration/otlp-exporter-configuration/#otel_exporter_otlp_protocol": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-24T21:20:16.262492+02:00"
-  },
-  "https://opentelemetry.io/docs/demo/architecture/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-24T21:20:17.218848+02:00"
-  },
-  "https://opentelemetry.io/docs/instrumentation/net/manual/#creating-new-root-activities": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-05T12:22:28.818593+02:00"
-  },
-  "https://opentelemetry.io/docs/languages/go/instrumentation/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-08T10:40:59.076620479Z"
-  },
-  "https://opentelemetry.io/docs/languages/go/instrumentation/#logs": {
-    "StatusCode": 206,
-    "LastSeen": "2025-08-08T10:40:55.19518975Z"
-  },
-  "https://opentelemetry.io/docs/reference/specification/metrics/semantic_conventions/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-26T16:48:26.73412+03:00"
-  },
-  "https://opentelemetry.io/docs/specs/otel/common/attribute-naming/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-24T21:20:18.130793+02:00"
-  },
-  "https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-25T14:35:48.528151427Z"
-  },
-  "https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponentialhistogram": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-24T21:20:19.941353+02:00"
-  },
-  "https://opentelemetry.io/docs/specs/otel/metrics/sdk/#base2-exponential-bucket-histogram-aggregation": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-24T21:20:16.975398+02:00"
-  },
-  "https://opentelemetry.io/docs/specs/otel/metrics/sdk/#explicit-bucket-histogram-aggregation": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-24T21:20:16.562323+02:00"
-  },
-  "https://opentelemetry.io/docs/specs/otel/metrics/sdk_exporters/otlp/#additional-configuration": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-24T21:20:21.401564+02:00"
-  },
-  "https://opentelemetry.io/docs/specs/semconv/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-02T23:23:22.122093332Z"
-  },
-  "https://opentelemetry.io/docs/zero-code/java/agent/annotations/#creating-spans-around-methods-with-otelinstrumentationmethodsinclude": {
-    "StatusCode": 206,
-    "LastSeen": "2025-09-04T16:04:00.471333193Z"
-  },
-  "https://opentelemetry.io/ecosystem/registry/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-22T07:14:47.144521257-08:00"
   },
   "https://opentracing.io": {
     "StatusCode": 206,
@@ -19826,14 +16730,6 @@
   "https://packagist.org/packages/openai-php/client": {
     "StatusCode": 200,
     "LastSeen": "2025-02-01T06:39:27.381101-05:00"
-  },
-  "https://packagist.org/packages/opentelemetry-auto-curl": {
-    "StatusCode": 200,
-    "LastSeen": "2024-11-18T16:21:13.145885+01:00"
-  },
-  "https://packagist.org/packages/opentelemetry-auto-ext-rdkafka": {
-    "StatusCode": 200,
-    "LastSeen": "2024-11-18T16:21:13.762528+01:00"
   },
   "https://packagist.org/providers/php-http/async-client-implementation": {
     "StatusCode": 200,
@@ -20226,10 +17122,6 @@
   "https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor#readme-role-based-access-control": {
     "StatusCode": 200,
     "LastSeen": "2025-01-21T12:21:51.779082249Z"
-  },
-  "https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sprocessor": {
-    "StatusCode": 200,
-    "LastSeen": "2025-01-06T11:32:47.414799-05:00"
   },
   "https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor": {
     "StatusCode": 200,
@@ -20699,6 +17591,14 @@
     "StatusCode": 200,
     "LastSeen": "2025-01-06T11:32:23.675071-05:00"
   },
+  "https://pkg.go.dev/go.opentelemetry.io/collector/config/configauth#client-authenticators": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-01T11:46:35.234253-04:00"
+  },
+  "https://pkg.go.dev/go.opentelemetry.io/collector/config/configauth#server-authenticators": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-01T11:46:34.764736-04:00"
+  },
   "https://pkg.go.dev/go.opentelemetry.io/collector/config/configgrpc": {
     "StatusCode": 200,
     "LastSeen": "2025-02-24T15:00:02.897452-05:00"
@@ -21155,10 +18055,6 @@
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:29:12.345Z"
   },
-  "https://prometheus.io/docs/prometheus/2.52/querying/basics/#staleness": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:29:12.345Z"
-  },
   "https://prometheus.io/docs/prometheus/2.55/feature_flags/#otlp-receiver": {
     "StatusCode": 200,
     "LastSeen": "2025-02-06T14:42:12.345Z"
@@ -21331,10 +18227,6 @@
     "StatusCode": 200,
     "LastSeen": "2025-01-24T14:37:17.320553-05:00"
   },
-  "https://redis.io/commands/hmset": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-06T11:32:34.775836-05:00"
-  },
   "https://redis.io/docs/latest/commands/evalsha/": {
     "StatusCode": 206,
     "LastSeen": "2025-03-31T17:27:00.671946699Z"
@@ -21363,265 +18255,49 @@
     "StatusCode": 200,
     "LastSeen": "2025-03-18T14:59:52.003381604Z"
   },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom-alpha/2.10.0-alpha/opentelemetry-instrumentation-bom-alpha-2.10.0-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2024-11-13T10:47:55.011955709Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom-alpha/2.11.0-alpha/opentelemetry-instrumentation-bom-alpha-2.11.0-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2024-12-25T05:41:20.94516076Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom-alpha/2.12.0-alpha/opentelemetry-instrumentation-bom-alpha-2.12.0-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-18T17:22:19.446057933Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom-alpha/2.13.1-alpha/opentelemetry-instrumentation-bom-alpha-2.13.1-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T19:31:53.159704042Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom-alpha/2.13.2-alpha/opentelemetry-instrumentation-bom-alpha-2.13.2-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-27T03:47:45.423853537Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom-alpha/2.13.3-alpha/opentelemetry-instrumentation-bom-alpha-2.13.3-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-28T17:42:49.919886094Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom-alpha/2.14.0-alpha/opentelemetry-instrumentation-bom-alpha-2.14.0-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-14T11:18:49.240831716Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom-alpha/2.15.0-alpha/opentelemetry-instrumentation-bom-alpha-2.15.0-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-11T08:28:47.812984827-07:00"
-  },
   "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom-alpha/2.16.0-alpha/opentelemetry-instrumentation-bom-alpha-2.16.0-alpha.pom": {
     "StatusCode": 206,
     "LastSeen": "2025-05-16T08:01:09.322908+02:00"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom-alpha/2.17.0-alpha/opentelemetry-instrumentation-bom-alpha-2.17.0-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-27T12:45:37.689588958Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom-alpha/2.17.1-alpha/opentelemetry-instrumentation-bom-alpha-2.17.1-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-16T20:13:04.085315993Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom-alpha/2.18.0-alpha/opentelemetry-instrumentation-bom-alpha-2.18.0-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T10:51:09.187783858Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom-alpha/2.18.1-alpha/opentelemetry-instrumentation-bom-alpha-2.18.1-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-21T20:14:04.583498443Z"
   },
   "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom-alpha/2.19.0-alpha/opentelemetry-instrumentation-bom-alpha-2.19.0-alpha.pom": {
     "StatusCode": 206,
     "LastSeen": "2025-08-17T13:48:06.238484633Z"
   },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom-alpha/2.20.0-alpha/opentelemetry-instrumentation-bom-alpha-2.20.0-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-09-15T09:41:08.229153333Z"
-  },
   "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom-alpha/2.20.1-alpha/opentelemetry-instrumentation-bom-alpha-2.20.1-alpha.pom": {
     "StatusCode": 206,
     "LastSeen": "2025-09-22T17:34:01.495739002Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom-alpha/2.7.0-alpha/opentelemetry-instrumentation-bom-alpha-2.7.0-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2024-10-23T20:20:08.34491-05:00"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom-alpha/2.9.0-alpha/opentelemetry-instrumentation-bom-alpha-2.9.0-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2024-10-23T20:19:21.596018-05:00"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom/2.10.0/opentelemetry-instrumentation-bom-2.10.0.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2024-11-13T10:47:53.144495226Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom/2.11.0/opentelemetry-instrumentation-bom-2.11.0.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2024-12-25T05:41:17.945836701Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom/2.12.0/opentelemetry-instrumentation-bom-2.12.0.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-18T17:22:16.889560392Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom/2.13.1/opentelemetry-instrumentation-bom-2.13.1.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T19:31:51.417713696Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom/2.13.2/opentelemetry-instrumentation-bom-2.13.2.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-27T03:47:42.481159033Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom/2.13.3/opentelemetry-instrumentation-bom-2.13.3.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-28T17:42:47.206408302Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom/2.14.0/opentelemetry-instrumentation-bom-2.14.0.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-14T11:18:48.069661166Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom/2.15.0/opentelemetry-instrumentation-bom-2.15.0.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-11T08:28:47.731244373-07:00"
   },
   "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom/2.16.0/opentelemetry-instrumentation-bom-2.16.0.pom": {
     "StatusCode": 206,
     "LastSeen": "2025-05-16T08:01:07.050126+02:00"
   },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom/2.17.0/opentelemetry-instrumentation-bom-2.17.0.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-27T12:45:36.025520717Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom/2.17.1/opentelemetry-instrumentation-bom-2.17.1.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-16T20:13:00.437624598Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom/2.18.0/opentelemetry-instrumentation-bom-2.18.0.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-18T10:51:07.27045484Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom/2.18.1/opentelemetry-instrumentation-bom-2.18.1.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-21T20:13:59.719257768Z"
-  },
   "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom/2.19.0/opentelemetry-instrumentation-bom-2.19.0.pom": {
     "StatusCode": 206,
     "LastSeen": "2025-08-17T13:48:04.158823205Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom/2.20.0/opentelemetry-instrumentation-bom-2.20.0.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-09-15T09:41:05.427133368Z"
   },
   "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom/2.20.1/opentelemetry-instrumentation-bom-2.20.1.pom": {
     "StatusCode": 206,
     "LastSeen": "2025-09-22T17:33:59.442670714Z"
   },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom/2.7.0/opentelemetry-instrumentation-bom-2.7.0.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2024-10-23T20:20:07.402964-05:00"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/instrumentation/opentelemetry-instrumentation-bom/2.9.0/opentelemetry-instrumentation-bom-2.9.0.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2024-10-23T20:19:19.595194-05:00"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom-alpha/1.42.1-alpha/opentelemetry-bom-alpha-1.42.1-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2024-10-23T20:20:05.963898-05:00"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom-alpha/1.43.0-alpha/opentelemetry-bom-alpha-1.43.0-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2024-10-23T20:19:18.147885-05:00"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom-alpha/1.44.0-alpha/opentelemetry-bom-alpha-1.44.0-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2024-11-08T22:20:21.413205506Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom-alpha/1.44.1-alpha/opentelemetry-bom-alpha-1.44.1-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2024-11-10T17:00:51.60396563Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom-alpha/1.45.0-alpha/opentelemetry-bom-alpha-1.45.0-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2024-12-07T00:15:11.593236524Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom-alpha/1.46.0-alpha/opentelemetry-bom-alpha-1.46.0-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-10T18:29:08.908200187Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom-alpha/1.47.0-alpha/opentelemetry-bom-alpha-1.47.0-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-10T19:33:27.736469652Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom-alpha/1.48.0-alpha/opentelemetry-bom-alpha-1.48.0-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-08T00:34:16.705548174Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom-alpha/1.49.0-alpha/opentelemetry-bom-alpha-1.49.0-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-06T04:24:06.65469916Z"
-  },
   "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom-alpha/1.50.0-alpha/opentelemetry-bom-alpha-1.50.0-alpha.pom": {
     "StatusCode": 206,
     "LastSeen": "2025-05-10T08:41:18.353351068-07:00"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom-alpha/1.51.0-alpha/opentelemetry-bom-alpha-1.51.0-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-06T20:20:40.263717361Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom-alpha/1.52.0-alpha/opentelemetry-bom-alpha-1.52.0-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-17T19:19:21.695695798Z"
   },
   "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom-alpha/1.53.0-alpha/opentelemetry-bom-alpha-1.53.0-alpha.pom": {
     "StatusCode": 206,
     "LastSeen": "2025-08-08T20:25:21.445618832Z"
   },
-  "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom-alpha/1.54.0-alpha/opentelemetry-bom-alpha-1.54.0-alpha.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-09-10T08:32:10.878488351Z"
-  },
   "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom-alpha/1.54.1-alpha/opentelemetry-bom-alpha-1.54.1-alpha.pom": {
     "StatusCode": 206,
     "LastSeen": "2025-09-19T07:35:13.217306674Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom/1.42.1/opentelemetry-bom-1.42.1.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2024-10-23T20:20:05.242921-05:00"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom/1.43.0/opentelemetry-bom-1.43.0.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2024-10-23T20:19:16.148466-05:00"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom/1.44.0/opentelemetry-bom-1.44.0.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2024-11-08T22:20:19.376698992Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom/1.44.1/opentelemetry-bom-1.44.1.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2024-11-10T17:00:49.274766415Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom/1.45.0/opentelemetry-bom-1.45.0.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2024-12-07T00:15:09.752803166Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom/1.46.0/opentelemetry-bom-1.46.0.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-10T18:29:07.933480696Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom/1.47.0/opentelemetry-bom-1.47.0.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-10T19:33:25.447903622Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom/1.48.0/opentelemetry-bom-1.48.0.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-03-08T00:34:11.79139405Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom/1.49.0/opentelemetry-bom-1.49.0.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-04-06T04:24:04.915975068Z"
   },
   "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom/1.50.0/opentelemetry-bom-1.50.0.pom": {
     "StatusCode": 206,
     "LastSeen": "2025-05-10T08:41:18.242169839-07:00"
   },
-  "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom/1.51.0/opentelemetry-bom-1.51.0.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-06T20:20:38.969599677Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom/1.52.0/opentelemetry-bom-1.52.0.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-07-17T19:19:18.729927831Z"
-  },
   "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom/1.53.0/opentelemetry-bom-1.53.0.pom": {
     "StatusCode": 206,
     "LastSeen": "2025-08-08T20:25:20.787140184Z"
-  },
-  "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom/1.54.0/opentelemetry-bom-1.54.0.pom": {
-    "StatusCode": 206,
-    "LastSeen": "2025-09-10T08:32:07.647131515Z"
   },
   "https://repo1.maven.org/maven2/io/opentelemetry/opentelemetry-bom/1.54.1/opentelemetry-bom-1.54.1.pom": {
     "StatusCode": 206,
@@ -21630,10 +18306,6 @@
   "https://research.facebook.com/file/877841159827226/holistic-configuration-management-at-facebook.pdf": {
     "StatusCode": 206,
     "LastSeen": "2025-01-30T17:00:29.776464-05:00"
-  },
-  "https://resources.realtheory.io/docs/how-to-verify-the-metrics-server-is-installed-in-the-cluster": {
-    "StatusCode": 200,
-    "LastSeen": "2025-06-02T17:41:03.539339472Z"
   },
   "https://resteasy.dev/": {
     "StatusCode": 206,
@@ -21654,10 +18326,6 @@
   "https://rocketmq.apache.org/docs/domainModel/07consumergroup": {
     "StatusCode": 206,
     "LastSeen": "2025-02-01T07:12:27.374727-05:00"
-  },
-  "https://ruby-doc.org/core-2.7.1/Exception.html#method-i-full_message": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:29:12.345Z"
   },
   "https://rubygems.org/gems/elasticsearch": {
     "StatusCode": 200,
@@ -22375,10 +19043,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-02-10T23:17:25.614898483Z"
   },
-  "https://spacelift.io/blog/kubernetes-hpa-horizontal-pod-autoscaler": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-02T17:40:49.644050147Z"
-  },
   "https://spec.commonmark.org/0.31.2/#link-label": {
     "StatusCode": 200,
     "LastSeen": "2025-05-13T22:40:12.345Z"
@@ -22469,7 +19133,7 @@
   },
   "https://support.google.com/webmasters/answer/10347851": {
     "StatusCode": 200,
-    "LastSeen": "2025-01-24T14:36:51.45282-05:00"
+    "LastSeen": "2025-10-01T11:51:27.485433-04:00"
   },
   "https://svelte.dev/": {
     "StatusCode": 206,
@@ -22523,49 +19187,9 @@
     "StatusCode": 206,
     "LastSeen": "2025-09-11T16:09:11.300909-04:00"
   },
-  "https://tools.ietf.org/html/bcp14": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-06T11:33:01.419438-05:00"
-  },
-  "https://tools.ietf.org/html/rfc2119": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-06T11:33:01.743074-05:00"
-  },
-  "https://tools.ietf.org/html/rfc2617": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-06T11:32:38.494164-05:00"
-  },
-  "https://tools.ietf.org/html/rfc4120": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-06T11:32:45.398224-05:00"
-  },
   "https://tools.ietf.org/html/rfc4648#section-8": {
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:29:12.345Z"
-  },
-  "https://tools.ietf.org/html/rfc5234": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-06T11:32:48.59692-05:00"
-  },
-  "https://tools.ietf.org/html/rfc5424": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-06T11:33:04.068661-05:00"
-  },
-  "https://tools.ietf.org/html/rfc6749#section-2.2": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:29:12.345Z"
-  },
-  "https://tools.ietf.org/html/rfc6749#section-4.4": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:29:12.345Z"
-  },
-  "https://tools.ietf.org/html/rfc6750": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-06T11:32:39.0659-05:00"
-  },
-  "https://tools.ietf.org/html/rfc7230#section-3.2.6": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:30:12.345Z"
   },
   "https://tools.ietf.org/html/rfc7230#section-5.4": {
     "StatusCode": 200,
@@ -22579,19 +19203,7 @@
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:30:12.345Z"
   },
-  "https://tools.ietf.org/html/rfc8174": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-06T11:33:02.778737-05:00"
-  },
-  "https://tools.ietf.org/html/rfc9110": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-14T12:26:43.229339-04:00"
-  },
   "https://tools.ietf.org/html/rfc9110#section-7.2": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:30:12.345Z"
-  },
-  "https://tools.ietf.org/html/rfc9110/#name-fields": {
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:30:12.345Z"
   },
@@ -22643,10 +19255,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-02-01T06:59:10.948286-05:00"
   },
-  "https://unitsofmeasure.org/ucum.html": {
-    "StatusCode": 200,
-    "LastSeen": "2025-03-11T12:45:18.011907746Z"
-  },
   "https://uplight.com/": {
     "StatusCode": 200,
     "LastSeen": "2025-01-30T14:41:19.268618-05:00"
@@ -22654,30 +19262,6 @@
   "https://uptrace.dev/get/open-source-apm.html": {
     "StatusCode": 206,
     "LastSeen": "2025-01-06T11:32:22.623244-05:00"
-  },
-  "https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#configmap": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:30:12.345Z"
-  },
-  "https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#downwardapi": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:30:12.345Z"
-  },
-  "https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#emptydir": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:30:12.345Z"
-  },
-  "https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#local": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:30:12.345Z"
-  },
-  "https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#persistentvolumeclaim": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:30:12.345Z"
-  },
-  "https://v1-29.docs.kubernetes.io/docs/concepts/storage/volumes/#secret": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:30:12.345Z"
   },
   "https://v1-30.docs.kubernetes.io/docs/concepts/storage/volumes/#configmap": {
     "StatusCode": 200,
@@ -23067,18 +19651,6 @@
     "StatusCode": 200,
     "LastSeen": "2025-02-01T07:09:56.439513-05:00"
   },
-  "https://www.cncf.io/announcements/2025/05/07/cncf-announces-speakers-and-sessions-for-kubecon-cloudnativecon-india/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-12T12:43:03.865109449Z"
-  },
-  "https://www.cncf.io/announcements/2025/05/21/cncf-shares-schedule-for-open-observability-summit-north-america-gears-up-for-inaugural-event/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-04T14:44:14.433082-04:00"
-  },
-  "https://www.cncf.io/blog/": {
-    "StatusCode": 200,
-    "LastSeen": "2025-01-04T17:12:06.182152-05:00"
-  },
   "https://www.cncf.io/blog/2019/05/21/a-brief-history-of-opentelemetry-so-far/": {
     "StatusCode": 200,
     "LastSeen": "2025-01-13T12:10:36.576771-05:00"
@@ -23110,10 +19682,6 @@
   "https://www.cncf.io/enduser/": {
     "StatusCode": 200,
     "LastSeen": "2025-01-15T13:49:20.913378-05:00"
-  },
-  "https://www.cncf.io/kubecon-cloudnativecon-events": {
-    "StatusCode": 206,
-    "LastSeen": "2025-06-04T14:44:11.337015-04:00"
   },
   "https://www.cncf.io/kubecon-cloudnativecon-events/": {
     "StatusCode": 200,
@@ -23227,17 +19795,9 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-06T11:32:18.361614-05:00"
   },
-  "https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-07T10:32:13.298231-05:00"
-  },
   "https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/index.html": {
     "StatusCode": 206,
     "LastSeen": "2025-01-30T14:41:02.403641-05:00"
-  },
-  "https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/opentelemetry.html": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-30T14:41:03.609364-05:00"
   },
   "https://www.elastic.co/guide/en/elasticsearch/client/java-api/current/index.html": {
     "StatusCode": 206,
@@ -23311,14 +19871,6 @@
     "StatusCode": 200,
     "LastSeen": "2025-01-24T14:36:58.308808-05:00"
   },
-  "https://www.first.org/cvss/calculator/3.1": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-30T16:59:51.985845-05:00"
-  },
-  "https://www.first.org/cvss/specification-document": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-30T16:54:02.392881-05:00"
-  },
   "https://www.flipt.io/docs/configuration/observability#tracing": {
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:31:12.345Z"
@@ -23359,10 +19911,6 @@
     "StatusCode": 200,
     "LastSeen": "2025-07-18T13:36:15.529247-07:00"
   },
-  "https://www.heroku.com/blog/opentelemetry-basics-on-heroku-fir/": {
-    "StatusCode": 200,
-    "LastSeen": "2025-07-17T22:19:23.919614-07:00"
-  },
   "https://www.highlight.io/docs/general/company/open-source/contributing/adding-an-sdk/": {
     "StatusCode": 206,
     "LastSeen": "2025-01-30T14:41:03.613423-05:00"
@@ -23382,10 +19930,6 @@
   "https://www.honeycomb.io/blog/what-is-auto-instrumentation": {
     "StatusCode": 206,
     "LastSeen": "2025-02-01T06:58:40.797008-05:00"
-  },
-  "https://www.http4k.org/ecosystem/http4k/reference/opentelemetry/": {
-    "StatusCode": 206,
-    "LastSeen": "2024-11-18T17:50:29.868646+01:00"
   },
   "https://www.hyperdx.io/docs/install/opentelemetry": {
     "StatusCode": 206,
@@ -23430,10 +19974,6 @@
   "https://www.ibm.com/docs/en/instana-observability/current": {
     "StatusCode": 206,
     "LastSeen": "2025-06-17T16:12:39.207756653Z"
-  },
-  "https://www.ibm.com/docs/en/obi/current": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-06T11:32:36.421442-05:00"
   },
   "https://www.ibm.com/products/informix": {
     "StatusCode": 206,
@@ -23503,10 +20043,6 @@
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:31:12.345Z"
   },
-  "https://www.jaegertracing.io/docs/1.41/apis/#remote-sampling-configuration-stable": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:31:12.345Z"
-  },
   "https://www.jaegertracing.io/docs/1.41/architecture/apis/#remote-sampling-configuration-stable": {
     "StatusCode": 206,
     "LastSeen": "2025-07-18T18:23:26.894316624Z"
@@ -23518,14 +20054,6 @@
   "https://www.jaegertracing.io/docs/1.41/architecture/sampling/#remote-sampling": {
     "StatusCode": 206,
     "LastSeen": "2025-07-18T18:23:24.191808196Z"
-  },
-  "https://www.jaegertracing.io/docs/1.41/sampling/#adaptive-sampling": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:31:12.345Z"
-  },
-  "https://www.jaegertracing.io/docs/1.41/sampling/#remote-sampling": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:31:12.345Z"
   },
   "https://www.jaegertracing.io/docs/1.47/getting-started/": {
     "StatusCode": 206,
@@ -23542,10 +20070,6 @@
   "https://www.jaegertracing.io/docs/1.63/getting-started/#all-in-one": {
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:31:12.345Z"
-  },
-  "https://www.jaegertracing.io/docs/latest/client-libraries/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-15T13:17:29.929303-05:00"
   },
   "https://www.jaegertracing.io/docs/latest/getting-started/": {
     "StatusCode": 206,
@@ -23786,10 +20310,6 @@
   "https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk/latest/io/opentelemetry/sdk/OpenTelemetrySdk.html": {
     "StatusCode": 200,
     "LastSeen": "2025-02-01T07:19:44.039047-05:00"
-  },
-  "https://www.javadoc.io/static/io.opentelemetry/opentelemetry-context/1.41.0/io/opentelemetry/context/ContextStorage.html": {
-    "StatusCode": 200,
-    "LastSeen": "2024-09-30T10:42:16.987832-05:00"
   },
   "https://www.jenkins.io/": {
     "StatusCode": 206,
@@ -24059,10 +20579,6 @@
     "StatusCode": 200,
     "LastSeen": "2025-08-05T12:22:34.167021+02:00"
   },
-  "https://www.nuget.org/packages/Microsoft.Extensions.Telemetry.Abstractions/#supportedframeworks-body-tab": {
-    "StatusCode": 200,
-    "LastSeen": "2025-08-05T12:22:37.260239+02:00"
-  },
   "https://www.nuget.org/packages/MongoDB.Driver": {
     "StatusCode": 200,
     "LastSeen": "2025-02-05T14:08:11.405763332Z"
@@ -24311,10 +20827,6 @@
     "StatusCode": 200,
     "LastSeen": "2025-02-01T07:12:38.618315-05:00"
   },
-  "https://www.otelbin.io/favicon.ico": {
-    "StatusCode": 206,
-    "LastSeen": "2024-11-20T10:59:00.492890749Z"
-  },
   "https://www.otelbin.io/s/69739d790cf279c203fc8efc86ad1a876a2fc01a": {
     "StatusCode": 200,
     "LastSeen": "2024-11-20T10:58:58.366517284Z"
@@ -24346,10 +20858,6 @@
   "https://www.php-fig.org/psr/psr-17/": {
     "StatusCode": 206,
     "LastSeen": "2025-01-13T11:43:29.606488-05:00"
-  },
-  "https://www.php-fig.org/psr/psr-18/": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-13T12:10:37.968116-05:00"
   },
   "https://www.php.net/": {
     "StatusCode": 200,
@@ -24611,10 +21119,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-07T10:31:58.913992-05:00"
   },
-  "https://www.w3.org/TR/baggage": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-30T17:00:20.913678-05:00"
-  },
   "https://www.w3.org/TR/baggage/": {
     "StatusCode": 206,
     "LastSeen": "2025-01-06T11:32:23.30339-05:00"
@@ -24630,14 +21134,6 @@
   "https://www.w3.org/TR/baggage/#key": {
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:32:12.345Z"
-  },
-  "https://www.w3.org/TR/trace-context": {
-    "StatusCode": 206,
-    "LastSeen": "2025-01-30T16:54:36.793368-05:00"
-  },
-  "https://www.w3.org/TR/trace-context-2": {
-    "StatusCode": 206,
-    "LastSeen": "2025-02-18T15:48:55.3615-05:00"
   },
   "https://www.w3.org/TR/trace-context-2/": {
     "StatusCode": 206,
@@ -24672,10 +21168,6 @@
     "LastSeen": "2025-02-06T02:32:12.345Z"
   },
   "https://www.w3.org/TR/trace-context/#mutating-the-tracestate-field": {
-    "StatusCode": 200,
-    "LastSeen": "2025-02-06T02:32:12.345Z"
-  },
-  "https://www.w3.org/TR/trace-context/#sampled-flag": {
     "StatusCode": 200,
     "LastSeen": "2025-02-06T02:32:12.345Z"
   },
@@ -24734,10 +21226,6 @@
   "https://www.youtube.com/embed/bsfMECwmsm0": {
     "StatusCode": 200,
     "LastSeen": "2025-02-01T07:10:38.092527-05:00"
-  },
-  "https://www.youtube.com/embed/d7clTdz0bA4": {
-    "StatusCode": 200,
-    "LastSeen": "2025-07-24T21:20:17.650647+02:00"
   },
   "https://www.youtube.com/embed/eZ3OrhxUAmU": {
     "StatusCode": 200,


### PR DESCRIPTION
- Removes unused URLs from the refcache (about 900). These are unused either because the external URL is no longer references in the docs, or it occurs in an outdated blog post (whose links we no longer check)
- Removes now-irrelevant temporary ignore rules from the htmltest config
- Adds a WIP JS script used to assist in cleaning out the cache