### PR TITLE
Create KubeCon NA 2025 blog post

### DIFF
--- a/content/en/announcements/kubecon-na.md
+++ b/content/en/announcements/kubecon-na.md
@@ -5,7 +5,7 @@ expiryDate: 2025-11-13
 ---
 
 <i class="fas fa-bullhorn"></i> Join us in Atlanta, Georgia for [**KubeCon +
-CloudNativeCon North America 2025**][register], November 10 - 13, 2025
+CloudNativeCon North America 2025**][blog], November 10 - 13, 2025
 
-[register]:
-  https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/register/
+[blog]:
+  https://opentelemetry.io/blog/2025/kubecon-na/

--- a/content/en/announcements/kubecon-na.md
+++ b/content/en/announcements/kubecon-na.md
@@ -7,4 +7,4 @@ expiryDate: 2025-11-13
 <i class="fas fa-bullhorn"></i> Join us in Atlanta, Georgia for [**KubeCon +
 CloudNativeCon North America 2025**][blog], November 10 - 13, 2025
 
-[blog]: https://opentelemetry.io/blog/2025/kubecon-na/
+[blog]: /blog/2025/kubecon-na/

--- a/content/en/announcements/kubecon-na.md
+++ b/content/en/announcements/kubecon-na.md
@@ -7,5 +7,4 @@ expiryDate: 2025-11-13
 <i class="fas fa-bullhorn"></i> Join us in Atlanta, Georgia for [**KubeCon +
 CloudNativeCon North America 2025**][blog], November 10 - 13, 2025
 
-[blog]:
-  https://opentelemetry.io/blog/2025/kubecon-na/
+[blog]: https://opentelemetry.io/blog/2025/kubecon-na/

--- a/content/en/blog/2025/kubecon-na.md
+++ b/content/en/blog/2025/kubecon-na.md
@@ -115,9 +115,8 @@ Maintainer Summit is an exclusive opportunity for the people behind the project
 to gather face-to-face. [Members][membership] of the OpenTelemetry organization
 will come together to collaborate, learn, share ideas, solve problems, and
 enrich their projects. Prepared talks, project meetings, and unconference
-sessions run from 9:00 to 17:00. See the
-[full schedule](https://maintainersummitna2025.sched.com/) for all the details.
-[Sign up][maintainer summit] today!
+sessions run from 9:00 to 17:00. See the [full schedule][summit schedule] for
+all the details. [Sign up][maintainer summit] today!
 
 {{% alert title="Important access note" %}}
 
@@ -131,9 +130,8 @@ OpenTelemetry. For eligibility requirements, see [Maintainer Summit].
 
 [Observability Day] fosters collaboration, discussion, and knowledge sharing
 with a focus on cloud native observability projects. This event will be held on
-November 10, 2025 from 9am to 6pm. Check the
-[full schedule](https://colocatedeventsna2025.sched.com/overview/type/Observability+Day)
-to find your favorite talks about observability and OpenTelemetry.
+November 10, 2025 from 9:00 to 18:00. Look for your favorite talks about
+Observability and OpenTelemetry in the [schedule][obs-day-sched].
 
 {{% alert title="Important access note" %}}
 
@@ -142,41 +140,24 @@ You need an _all-access_ pass to attend **Observability Day**. For details, see
 
 {{% /alert %}}
 
-{{% comment %}}
-
 ## OpenTelemetry Observatory
 
 Drop by and say _"Hi!"_ at OpenTelemetry Observatory presented by Splunk in the
 Expo Hall. This will be a place for informal chats, meetups, and other
-discussions led by OpenTelemetry community members and maintainers.
-
-Note that the Observatory might show up as "Splunk Activation Booth" on the
-event map.
-
-For activity details, see the [OTel Observatory Schedule]. Note that this
-schedule might be updated up until the day of the event, so check back for the
-latest!
-
-New for this year!
+discussions led by OpenTelemetry community members and maintainers, such as:
 
 - SIG Office Hours: Come meet the people behind the project, learn about their
   work, ask questions, share feedback, or find out how to contribute.
-- Special Topic Discussions: Come learn about two of the hottest OTEPs right
-  now, Events and Entities!
+- Special Topic Discussions: Come learn about the hottest topics in the OTel
+  community.
 
 If you'd like to participate by leading a discussion, or if there is a
-discussion topic you're interested in, please reach out to the
-[OpenTelemetry End User SIG](https://cloud-native.slack.com/archives/C01RT3MSWGZ)
-to let us know, and we will see what we can do.
+discussion topic you're interested in, please reach out to the [OpenTelemetry
+End User SIG][end user] to let us know, and we will see what we can do.
 
-You can help us improve the project by sharing your thoughts and feedback about
-your OpenTelemetry adoption, implementation, and usage.
-
-We will create action items from your comments as appropriate. Check
-[#otel-sig-end-user] in CNCF's Slack instance for results and action item
-updates to come after KubeCon EU.
-
-{{% /comment %}}
+For activity details, see the [OTel Observatory Schedule]. This schedule is a
+work in progress and will be updated up until the day of the event. Check back
+often for the latest!
 
 ## OpenTelemetry Community Awards
 
@@ -199,9 +180,13 @@ See you in Atlanta!
   https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/co-located-events/observability-day/
 [kubecon registration]:
   https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/register/
+[summit schedule]: https://maintainersummitna2025.sched.com/
 [maintainer summit]:
   https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/features-add-ons/maintainer-summit/
 [membership]:
   https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#member
+[obs-day-sched]:
+  https://colocatedeventsna2025.sched.com/overview/type/Observability+Day
+[end user]: https://cloud-native.slack.com/archives/C01RT3MSWGZ
 [otel observatory schedule]:
-  https://docs.google.com/spreadsheets/d/1E23Dkz1B2us71BtlQq8oG4o_QFsTeLPeh-X2uVnlubg/edit?usp=sharing
+  https://docs.google.com/spreadsheets/d/1Kk6io9V6Q1nluq6H05zGjwvWlXwxh9IwjiThBGJP1Rw/edit?usp=sharing

--- a/content/en/blog/2025/kubecon-na.md
+++ b/content/en/blog/2025/kubecon-na.md
@@ -4,7 +4,7 @@ linkTitle: KubeCon NA '25
 date: 2025-10-03
 author: '[Tiffany Hrabusa](https://github.com/tiffany76) (Grafana Labs)'
 # prettier-ignore
-cSpell:ignore: Aditya Agno Alipio Amir Aronoff Artem Bagga Bodhish Caldwell Chauhan Chomiak CLDF Contribfest CopperPoint Cutsail Célestin Dixit EBPF Fairwinds Faseela Forrester Furst Grcevski Harshita Hodgson Hrabusa Hrittik Jakoby Jitendra Juspay Khallai Kubecon Kubestronaut Kusha Mackie Macías Maharshi Mancioppi Markou Melamed Mohsine Nduka Nilson Octopus Olly Omlet OTEPs Pająk Panos Pavlick Payal Pech Pyroscope Raveesh Reimagining Sandeep Sawmills Shiran Suereth Tkachuk Tsilopoulos unconference Varma Veeam Verma Vijay Wijay Wrike Yahn Zscaler
+cSpell:ignore: Aditya Agno Alipio Amir Aronoff Artem Bagga Bodhish Caldwell Chauhan Chomiak CLDF Contribfest CopperPoint Cutsail Célestin Dixit EBPF Fairwinds Faseela Forrester Furst Grcevski Harshita Hodgson Hrabusa Hrittik Jakoby Jitendra Juspay Khallai Kubecon Kubestronaut Kusha Mackie Macías Maharshi Mancioppi Markou Melamed Mohsine Nduka Nilson Octopus Olly Omlet Pająk Panos Pavlick Payal Pech Pyroscope Raveesh Reimagining Sandeep Sawmills Shiran Suereth Tkachuk Tsilopoulos unconference Varma Veeam Verma Vijay Wijay Wrike Yahn Zscaler
 ---
 
 The OpenTelemetry project maintainers, members of the governance committee, and

--- a/content/en/blog/2025/kubecon-na.md
+++ b/content/en/blog/2025/kubecon-na.md
@@ -1,26 +1,29 @@
 ---
 title: Join us for OpenTelemetry Talks and Activities at KubeCon NA 2025
 linkTitle: KubeCon NA '25
-date: 2025-10-01
+date: 2025-10-03
 author: '[Tiffany Hrabusa](https://github.com/tiffany76) (Grafana Labs)'
 # prettier-ignore
-cSpell:ignore: Aditya Agno Alipio Amir Aronoff Artem Bagga Bodhish Caldwell Chauhan Chomiak CLDF Contribfest CopperPoint Cutsail Célestin Dixit EBPF Fairwinds Faseela Forrester Furst Grcevski Harshita Hodgson Hrabusa Hrittik Jakoby Jitendra Juspay Khallai Kubecon Kubestronaut Kusha Mackie Macías Maharshi Mancioppi Markou Melamed Mohsine Nduka Nilson Octopus Olly Omlet OTEPs Pająk Panos Pavlick Payal Pech Pyroscope Raveesh Reimagining Sandeep Sawmills Shiran Suereth Tkachuk Tsilopoulos Varma Veeam Verma Vijay Wijay Wrike Yahn Zscaler
+cSpell:ignore: Aditya Agno Alipio Amir Aronoff Artem Bagga Bodhish Caldwell Chauhan Chomiak CLDF Contribfest CopperPoint Cutsail Célestin Dixit EBPF Fairwinds Faseela Forrester Furst Grcevski Harshita Hodgson Hrabusa Hrittik Jakoby Jitendra Juspay Khallai Kubecon Kubestronaut Kusha Mackie Macías Maharshi Mancioppi Markou Melamed Mohsine Nduka Nilson Octopus Olly Omlet OTEPs Pająk Panos Pavlick Payal Pech Pyroscope Raveesh Reimagining Sandeep Sawmills Shiran Suereth Tkachuk Tsilopoulos unconference Varma Veeam Verma Vijay Wijay Wrike Yahn Zscaler
 ---
 
 The OpenTelemetry project maintainers, members of the governance committee, and
 technical committee are thrilled to be at [KubeCon NA] in Atlanta from November
-10 - 13, 2025.
+10 - 13, 2025. [Register][kubecon registration] today to join us!
 
 Read on to learn about all the events related to OpenTelemetry during KubeCon.
 
-<!-- ## OpenTelemetry Contribfest
+{{% comment %}}
+
+## OpenTelemetry Contribfest
 
 Join the OpenTelemetry maintainers for the
 [OpenTelemetry Contribfest](https://sched.co/1hoyF) to make the project better
 for everyone. You can choose between several opportunities to contribute, and
 you can count on maintainers from different project areas to help you on your
 first steps: documentation, Collector, Java, JS, Ruby, Python, .NET, and more.
--->
+
+{{% /comment %}}
 
 ## KubeCon Talks and Maintainer Sessions
 
@@ -105,31 +108,54 @@ first steps: documentation, Collector, Java, JS, Ruby, Python, .NET, and more.
   by Aditya Soni, Forrester Research & Hrittik Roy, Loft Labs<br> Thursday
   November 13 • 14:30 - 15:00
 
+## Maintainer Summit
+
+Held on November 9, one day prior to the co-located events and conference, the
+Maintainer Summit is an exclusive opportunity for the people behind the project
+to gather face-to-face. [Members][membership] of the OpenTelemetry organization
+will come together to collaborate, learn, share ideas, solve problems, and
+enrich their projects. Prepared talks, project meetings, and unconference
+sessions run from 9:00 to 17:00. See the
+[full schedule](https://maintainersummitna2025.sched.com/) for all the details.
+[Sign up][maintainer summit] today!
+
+{{% alert title="Important access note" %}}
+
+You must be registered for KubeCon + CloudNativeCon to access the **Maintainer
+Summit**. You also must be a member of a CNCF incubating project, such as
+OpenTelemetry. For eligibility requirements, see [Maintainer Summit].
+
+{{% /alert %}}
+
 ## Observability Day
 
-_[Observability Day] fosters collaboration, discussion, and knowledge sharing of
-cloud native observability projects_. This event will be held on November 10,
-2025 from 9am to 6pm.
-[Check the full schedule](https://colocatedeventsna2025.sched.com/overview/type/Observability+Day)
-to find your favorite talks about Observability and OpenTelemetry.
+[Observability Day] fosters collaboration, discussion, and knowledge sharing
+with a focus on cloud native observability projects. This event will be held on
+November 10, 2025 from 9am to 6pm. Check the
+[full schedule](https://colocatedeventsna2025.sched.com/overview/type/Observability+Day)
+to find your favorite talks about observability and OpenTelemetry.
 
-> <i class="far fa-exclamation-triangle"></i> **IMPORTANT access note**: You
-> need an _in-person all-access_ pass for on-site access to **Observability
-> Day**. For details, see [KubeCon registration].
+{{% alert title="Important access note" %}}
 
-<!-- ## OpenTelemetry Observatory
+You need an _all-access_ pass to attend **Observability Day**. For details, see
+[KubeCon registration].
+
+{{% /alert %}}
+
+{{% comment %}}
+
+## OpenTelemetry Observatory
 
 Drop by and say _"Hi!"_ at OpenTelemetry Observatory presented by Splunk in the
 Expo Hall. This will be a place for informal chats, meetups, and other
 discussions led by OpenTelemetry community members and maintainers.
 
-Note, that the Observatory may show up as "Splunk Activation Booth" on the event
-map.
+Note that the Observatory might show up as "Splunk Activation Booth" on the
+event map.
 
-For the activity schedule, see the
-[OTel Observatory Schedule](https://docs.google.com/spreadsheets/d/1E23Dkz1B2us71BtlQq8oG4o_QFsTeLPeh-X2uVnlubg/edit?usp=sharing).
-Note that this schedule may be updated up until the day of the event, so check
-back for the latest!
+For activity details, see the [OTel Observatory Schedule]. Note that this
+schedule might be updated up until the day of the event, so check back for the
+latest!
 
 New for this year!
 
@@ -149,7 +175,19 @@ your OpenTelemetry adoption, implementation, and usage.
 We will create action items from your comments as appropriate. Check
 [#otel-sig-end-user] in CNCF's Slack instance for results and action item
 updates to come after KubeCon EU.
--->
+
+{{% /comment %}}
+
+## OpenTelemetry Community Awards
+
+OpenTelemetry is a community-driven project, fueled by a group of awesome humans
+who are actively revolutionizing the field of observability with their
+contributions. Whether it’s through code, documentation, project management,
+outreach, adoption, or simply helping others, we want to recognize these
+contributions and the people behind them.
+
+Nominations for this year's awards will open soon, and we'll announce the
+winners during KubeCon + CloudNativeCon North America!
 
 Come join us to listen, learn, and get involved in OpenTelemetry.
 
@@ -161,3 +199,9 @@ See you in Atlanta!
   https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/co-located-events/observability-day/
 [kubecon registration]:
   https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/register/
+[maintainer summit]:
+  https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/features-add-ons/maintainer-summit/
+[membership]:
+  https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#member
+[otel observatory schedule]:
+  https://docs.google.com/spreadsheets/d/1E23Dkz1B2us71BtlQq8oG4o_QFsTeLPeh-X2uVnlubg/edit?usp=sharing

--- a/content/en/blog/2025/kubecon-na.md
+++ b/content/en/blog/2025/kubecon-na.md
@@ -4,7 +4,7 @@ linkTitle: KubeCon NA '25
 date: 2025-10-01
 author: '[Tiffany Hrabusa](https://github.com/tiffany76) (Grafana Labs)'
 # prettier-ignore
-cSpell:ignore: Aditya Agno Alipio Amir Aronoff Artem Bagga Bodhish Caldwell CLDF Célestin Chauhan Chomiak Chronosphere Contribfest CopperPoint Cutsail Dixit EBPF Fairwinds Faseela Forrester Furst Grcevski Harshita Hodgson Hrabusa Hrittik Jakoby Jitendra Juspay Khallai Kröhling Kubecon Kubestronaut Kusha Macías Mackie Maharshi Mancioppi Markou Maurshi Melamed Mohsine Nduka Nilson Octopus Olly Omlet OTEPs Pająk Panos Pavlick Payal Pech Prateek Pyroscope Raveesh Reimagining Sandeep Sawmills Shiran Suereth Tkachuk Tsilopoulos Varma Veeam Verma Vijay Wijay Wrike Yahn Zscaler
+cSpell:ignore: Aditya Agno Alipio Amir Aronoff Artem Bagga Bodhish Caldwell Chauhan Chomiak CLDF Contribfest CopperPoint Cutsail Célestin Dixit EBPF Fairwinds Faseela Forrester Furst Grcevski Harshita Hodgson Hrabusa Hrittik Jakoby Jitendra Juspay Khallai Kubecon Kubestronaut Kusha Mackie Macías Maharshi Mancioppi Markou Melamed Mohsine Nduka Nilson Octopus Olly Omlet OTEPs Pająk Panos Pavlick Payal Pech Pyroscope Raveesh Reimagining Sandeep Sawmills Shiran Suereth Tkachuk Tsilopoulos Varma Veeam Verma Vijay Wijay Wrike Yahn Zscaler
 ---
 
 The OpenTelemetry project maintainers, members of the governance committee, and

--- a/content/en/blog/2025/kubecon-na.md
+++ b/content/en/blog/2025/kubecon-na.md
@@ -1,0 +1,163 @@
+---
+title: Join us for OpenTelemetry Talks and Activities at KubeCon NA 2025
+linkTitle: KubeCon NA '25
+date: 2025-10-01
+author: '[Tiffany Hrabusa](https://github.com/tiffany76) (Grafana Labs)'
+# prettier-ignore
+cSpell:ignore: Aditya Agno Alipio Amir Aronoff Artem Bagga Bodhish Caldwell CLDF Célestin Chauhan Chomiak Chronosphere Contribfest CopperPoint Cutsail Dixit EBPF Fairwinds Faseela Forrester Furst Grcevski Harshita Hodgson Hrabusa Hrittik Jakoby Jitendra Juspay Khallai Kröhling Kubecon Kubestronaut Kusha Macías Mackie Maharshi Mancioppi Markou Maurshi Melamed Mohsine Nduka Nilson Octopus Olly Omlet OTEPs Pająk Panos Pavlick Payal Pech Prateek Pyroscope Raveesh Reimagining Sandeep Sawmills Shiran Suereth Tkachuk Tsilopoulos Varma Veeam Verma Vijay Wijay Wrike Yahn Zscaler
+---
+
+The OpenTelemetry project maintainers, members of the governance committee, and
+technical committee are thrilled to be at [KubeCon NA] in Atlanta from November
+10 - 13, 2025.
+
+Read on to learn about all the things related OpenTelemetry during KubeCon.
+
+<!-- ## OpenTelemetry Contribfest
+
+Join the OpenTelemetry maintainers for the
+[OpenTelemetry Contribfest](https://sched.co/1hoyF) to make the project better
+for everyone. You can choose between several opportunities to contribute, and
+you can count on maintainers from different project areas to help you on your
+first steps: documentation, Collector, Java, JS, Ruby, Python, .NET, and more.
+-->
+
+## KubeCon Talks and Maintainer Sessions
+
+- **[⚡ Project Lightning Talk: Fluent Bit](https://sched.co/27d5X)**<br> by
+  Eduardo Silva, Maintainer<br> Monday, November 10 • 15:00 - 15:05
+- **[Taming Telemetry at Scale: Platform Blueprints for Consistent Observability](https://sched.co/27FUv)**<br>
+  by Nancy Chauhan (Agno); Marino Wijay (Kong Inc.)<br> Tuesday, November 11 •
+  11:15 – 11:45
+- **[Just Do It: OpAMP](https://sched.co/27FWT)**<br> by Panos Tsilopoulos & Bob
+  Johnson, Nike, Inc.<br> Tuesday, November 11 • 15:15 - 15:45
+- **[Reimagining Insurance Infrastructure: CopperPoint's Cloud Native Blueprint](https://sched.co/27FX0)**<br>
+  by Sid Dixit & Sham Rao, CopperPoint Insurance Companies<br> Tuesday, November
+  11 • 16:15 - 16:45
+- **[Instrumentation Score: The Difference Between Telemetry and Good Telemetry](https://sched.co/27FWx)**<br>
+  by Juraci Paixão Kröhling, OllyGarden & Michele Mancioppi, Dash0<br> Tuesday,
+  November 11 • 16:15 - 16:45
+- **[OpenTelemetry: Unpacking 2025, Charting 2026](https://sched.co/27Y2M)**<br>
+  by Alolita Sharma; Trask Stalnaker; Josh Suereth; Austin Parker<br> Tuesday,
+  November 11 • 17:00 – 17:30
+- **[Integrating Data Center Observability Into Cloud Native Environment](https://sched.co/27FXU)**<br>
+  by Pedro Célestin, CLDF & Julia Furst Morgado, Veeam<br> Tuesday, November 11
+  • 17:00 – 17:30
+- **[Sync or Swim: Building Platforms You Can See](https://sched.co/27FY4)**<br>
+  by Heather Lee & Mike Cutsail, Apple<br> Tuesday, November 11 • 17:45 – 18:15
+- **[🪧 Poster Session (PS3): From Noise To Clarity: Humanizing Observability in Cloud Native Systems](https://sched.co/27FYM)**<br>
+  by Nikita Verma, Zscaler & Harshita Varma, Juspay<br> Tuesday, November 11 •
+  18:15 – 19:45
+- **[Keynote: Cloud Native for Good](https://sched.co/27FUj)**<br> by Faseela K,
+  Ericsson Software Technology; Omar Mohsine, United Nations; Roberto Machorro,
+  Child Rescue Coalition; Bodhish Thomas, Open Healthcare Network; Jayson
+  Workman, American Red Cross<br> Wednesday, November 12 • 10:11 - 10:26
+- **[Models as Microservices, Platforms as Partners: Collaboratively Building ML Infra at Hinge](https://sched.co/27FYz)**<br>
+  by Stephanie Pavlick, Hinge<br> Wednesday, November 12 • 11:00 - 11:30
+- **[Retrofitting OTel Collectors & Prometheus: How to Overcome Scale/Design Limitations](https://sched.co/27FYq)**<br>
+  by Vijay Samuel & Sandeep Raveesh (eBay)<br> Wednesday, November 12 • 11:00 –
+  11:30
+- **[OTel+K8s= ❤️: An Introduction To OpenTelemetry for Kubernetes Users](https://sched.co/27FZN)**<br>
+  by Christos Markou, Elastic & Jacob Aronoff, Omlet<br> Wednesday, November 12
+  • 11:45 - 12:15
+- **[Fluent Bit: Smarter Telemetry Routing, Faster Pipelines](https://sched.co/27Nmb)**<br>
+  by Eduardo Silva, Chronosphere<br> Wednesday, November 12 • 11:45 - 12:15
+- **[What's New in gRPC](https://sched.co/27NnZ)**<br> by Kevin Nilson, Google &
+  Israel Shapiro, Broadcom<br> Wednesday, November 12 • 11:45 - 12:15
+- **[Beyond the Dashboard: Modern Observability for Platform Engineering at Scale](https://sched.co/27FaC)**<br>
+  by Danielle Cook, Independent; Whitney Lee, Datadog; Stevie Caldwell,
+  Fairwinds; Khallai Taylor, E.ON Digital Technology GmbH; Payal Bagga,
+  Intuit<br> Wednesday, November 12 • 14:15 - 14:45
+- **[UX Research Report: Prometheus and OTel's Resource Attributes](https://sched.co/27FZr)**<br>
+  by Victoria Nduka, Independent & Amy Super, Grafana Labs<br> Wednesday,
+  November 12 • 14:15 - 14:45
+- **[Building Scalable End-to-end Latency Metrics From Distributed Trace](https://sched.co/27Faj)**<br>
+  by Kusha Maharshi, Bloomberg<br> Wednesday, November 12 • 15:00 - 15:30
+- **[Where's My Pod? End-to-End Tracing for Kubernetes With OpenTelemetry](https://sched.co/27FaO)**<br>
+  by Artem Tkachuk; JP Phillips (Netflix)<br> Wednesday, November 12 • 15:00 –
+  15:30
+- **[From Kubestronaut To Production Hero: Turning Study Paths Into Real-World Wins](https://sched.co/27Fav)**<br>
+  by David Pech, Wrike & Pedro Célestin, CLDF<br> Wednesday, November 12 • 16:00
+  – 16:30
+- **[Debugging Your Cluster When It's on Fire](https://sched.co/27FbD)**<br> by
+  Nikola Grcevski, Grafana Labs & Tyler Yahn, Splunk<br> Wednesday, November 12
+  • 16:00 – 16:25
+- **[Zero-Downtime Telemetry: Hot Reloading OpenTelemetry Collector Pipelines](https://sched.co/27Fas)**<br>
+  by Amir Jakoby (Sawmills); Shiran Melamed (JFrog)<br> Wednesday, November 12 •
+  16:00 – 16:30
+- **[⚡ Lightning Talk: Confidential Observability on Kubernetes: Protecting Telemetry End-to-End](https://sched.co/27Fbn)**<br>
+  by Jitendra Singh, IBM India Pvt. Ltd.<br> Wednesday, November 12 • 16:45 –
+  16:50
+- **[Designing for Observability: From Noise To Insight](https://sched.co/27Fbk)**<br>
+  by Andrea Chomiak, Dash0<br> Wednesday, November 12 • 16:45 – 17:15
+- **[OpenTelemetry Logs Driving a Major Shift: Events, Richer Data, and Smarter Semantics](https://sched.co/27FbP)**<br>
+  by Robert Pająk (Splunk)<br> Wednesday, November 12 • 16:45 – 17:15
+- **[Diagnosing Application Performance With eBPF, Pyroscope, and Kubernetes](https://sched.co/27FcT)**<br>
+  by Liam Mackie, Octopus Deploy<br> Wednesday, November 12 • 17:30 – 18:00
+- **[Observing Dark Matter With OpenTelemetry](https://sched.co/27Fc8)**<br> by
+  Sam Alipio, Pasteur Labs & Mario Macías, Grafana Labs<br> Wednesday, November
+  12 • 17:30 – 18:00
+- **[⚡ Lightning Talk: Tracing the Untraceable: OpenTelemetry for 'Vibe-Coded' LLM Apps](https://sched.co/27Fcf)**<br>
+  by Pranay Prateek, SigNoz<br> Wednesday, November 12 • 17:41 – 17:46
+- **[Feature Flags Suck! - The Problems With Feature Flagging and How To Avoid Them](https://sched.co/27FdI)**<br>
+  by Pete Hodgson, PH1<br> Thursday November 13 • 11:00 - 11:30
+- **[Help! My LLM Is a Resource Hog: How We Tamed Inference With Kubernetes and Open Source Muscle](https://sched.co/27Feq)**<br>
+  by Aditya Soni, Forrester Research & Hrittik Roy, Loft Labs<br> Thursday
+  November 13 • 14:30 - 15:00
+
+## Observability Day
+
+_[Observability Day] fosters collaboration, discussion, and knowledge sharing of
+cloud native observability projects_. This event will be held on November 10,
+2025 from 9am to 6pm.
+[Check the full schedule](https://colocatedeventsna2025.sched.com/overview/type/Observability+Day)
+to find your favorite talks about Observability and OpenTelemetry.
+
+> <i class="far fa-exclamation-triangle"></i> **IMPORTANT access note**: You
+> need an _in-person all-access_ pass for on-site access to **Observability
+> Day**. For details, see [KubeCon registration].
+
+<!-- ## OpenTelemetry Observatory
+
+Drop by and say _"Hi!"_ at OpenTelemetry Observatory presented by Splunk in the
+Expo Hall. This will be a place for informal chats, meetups, and other
+discussions led by OpenTelemetry community members and maintainers.
+
+Note, that the Observatory may show up as "Splunk Activation Booth" on the event
+map.
+
+For the activity schedule, see the
+[OTel Observatory Schedule](https://docs.google.com/spreadsheets/d/1E23Dkz1B2us71BtlQq8oG4o_QFsTeLPeh-X2uVnlubg/edit?usp=sharing).
+Note that this schedule may be updated up until the day of the event, so check
+back for the latest!
+
+New for this year!
+
+- SIG Office Hours: Come meet the people behind the project, learn about their
+  work, ask questions, share feedback, or find out how to contribute.
+- Special Topic Discussions: Come learn about two of the hottest OTEPs right
+  now, Events and Entities!
+
+If you'd like to participate by leading a discussion, or if there is a
+discussion topic you're interested in, please reach out to the
+[OpenTelemetry End User SIG](https://cloud-native.slack.com/archives/C01RT3MSWGZ)
+to let us know, and we will see what we can do.
+
+You can help us improve the project by sharing your thoughts and feedback about
+your OpenTelemetry adoption, implementation, and usage.
+
+We will create action items from your comments as appropriate. Check
+[#otel-sig-end-user] in CNCF's Slack instance for results and action item
+updates to come after KubeCon EU.
+-->
+
+Come join us to listen, learn, and get involved in OpenTelemetry.
+
+See you in Atlanta!
+
+[kubecon na]:
+  https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/
+[Observability Day]:
+  https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/co-located-events/observability-day/
+[kubecon registration]:
+  https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/register/

--- a/content/en/blog/2025/kubecon-na.md
+++ b/content/en/blog/2025/kubecon-na.md
@@ -11,7 +11,7 @@ The OpenTelemetry project maintainers, members of the governance committee, and
 technical committee are thrilled to be at [KubeCon NA] in Atlanta from November
 10 - 13, 2025.
 
-Read on to learn about all the things related OpenTelemetry during KubeCon.
+Read on to learn about all the events related to OpenTelemetry during KubeCon.
 
 <!-- ## OpenTelemetry Contribfest
 

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -1799,6 +1799,10 @@
     "StatusCode": 200,
     "LastSeen": "2025-02-05T18:59:23.117057-05:00"
   },
+  "https://docs.google.com/spreadsheets/d/1Kk6io9V6Q1nluq6H05zGjwvWlXwxh9IwjiThBGJP1Rw/edit": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-02T15:39:54.12103-07:00"
+  },
   "https://docs.google.com/spreadsheets/d/1SYKfjYhZdm2Wh2Cl6KVQalKg_m4NhTPZqq-8SzEVO6s": {
     "StatusCode": 200,
     "LastSeen": "2025-01-15T13:17:24.965812-05:00"

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -891,6 +891,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-10-15T10:14:56.65727+02:00"
   },
+  "https://colocatedeventsna2025.sched.com/overview/type/Observability+Day": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:43:18.079776-07:00"
+  },
   "https://commonmark.org/": {
     "StatusCode": 206,
     "LastSeen": "2025-01-30T16:59:54.034804-05:00"
@@ -18982,6 +18986,126 @@
   "https://sched.co/1yFEh": {
     "StatusCode": 200,
     "LastSeen": "2025-05-16T10:23:42.688359806-07:00"
+  },
+  "https://sched.co/27FUj": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:42:13.193281-07:00"
+  },
+  "https://sched.co/27FUv": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:41:54.334112-07:00"
+  },
+  "https://sched.co/27FWT": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:41:56.251764-07:00"
+  },
+  "https://sched.co/27FWx": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:42:00.023329-07:00"
+  },
+  "https://sched.co/27FX0": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:41:57.643035-07:00"
+  },
+  "https://sched.co/27FXU": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:42:05.221469-07:00"
+  },
+  "https://sched.co/27FY4": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:42:06.939743-07:00"
+  },
+  "https://sched.co/27FYM": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:42:10.490329-07:00"
+  },
+  "https://sched.co/27FYq": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:42:17.621876-07:00"
+  },
+  "https://sched.co/27FYz": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:42:15.801419-07:00"
+  },
+  "https://sched.co/27FZN": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:42:20.450626-07:00"
+  },
+  "https://sched.co/27FZr": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:42:33.676617-07:00"
+  },
+  "https://sched.co/27FaC": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:42:27.13084-07:00"
+  },
+  "https://sched.co/27FaO": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:42:41.684736-07:00"
+  },
+  "https://sched.co/27Faj": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:42:37.899243-07:00"
+  },
+  "https://sched.co/27Fas": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:42:53.149775-07:00"
+  },
+  "https://sched.co/27Fav": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:42:47.407129-07:00"
+  },
+  "https://sched.co/27FbD": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:42:50.908109-07:00"
+  },
+  "https://sched.co/27FbP": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:43:02.732893-07:00"
+  },
+  "https://sched.co/27Fbk": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:42:59.394325-07:00"
+  },
+  "https://sched.co/27Fbn": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:42:55.467985-07:00"
+  },
+  "https://sched.co/27Fc8": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:43:10.163584-07:00"
+  },
+  "https://sched.co/27FcT": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:43:05.55278-07:00"
+  },
+  "https://sched.co/27Fcf": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:43:11.824574-07:00"
+  },
+  "https://sched.co/27FdI": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:43:12.86486-07:00"
+  },
+  "https://sched.co/27Feq": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:43:15.723723-07:00"
+  },
+  "https://sched.co/27Nmb": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:42:23.414005-07:00"
+  },
+  "https://sched.co/27NnZ": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:42:25.596735-07:00"
+  },
+  "https://sched.co/27Y2M": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:42:02.355797-07:00"
+  },
+  "https://sched.co/27d5X": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-01T17:41:51.401381-07:00"
   },
   "https://schemas.dmtf.org/wbem/cim-html/2.31.0/CIM_Battery.html": {
     "StatusCode": 206,

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -2787,6 +2787,10 @@
     "StatusCode": 200,
     "LastSeen": "2025-01-30T16:49:09.827934-05:00"
   },
+  "https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/features-add-ons/maintainer-summit/": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-02T13:58:06.128529-07:00"
+  },
   "https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/register/": {
     "StatusCode": 200,
     "LastSeen": "2025-01-30T16:49:13.676545-05:00"
@@ -6182,6 +6186,10 @@
   "https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md": {
     "StatusCode": 206,
     "LastSeen": "2025-01-16T14:22:47.985212-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#member": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-02T13:58:01.266786-07:00"
   },
   "https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#requirements": {
     "StatusCode": 200,
@@ -15678,6 +15686,10 @@
   "https://mackerel.io/docs/entry/tracing/guide/what-is-opentelemetry": {
     "StatusCode": 200,
     "LastSeen": "2025-09-04T09:00:44.450808035Z"
+  },
+  "https://maintainersummitna2025.sched.com/": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-02T13:58:04.786561-07:00"
   },
   "https://man7.org/linux/man-pages/man1/free.1.html": {
     "StatusCode": 206,


### PR DESCRIPTION
This PR creates the blog post for KubeCon North America 2025. The banner is already published, so this PR updates it to point to the blog post.

To be done:

- [x] Check the deploy preview for formatting errors. I couldn't get the post to show up on a local preview so hopefully the PR deploy preview works.
  - Looks okay to me: https://deploy-preview-7968--opentelemetry.netlify.app/blog/2025/kubecon-na/
- [x] Update the date to October 3 if that's agreed.
- [x] Find out if there will be a Contribfest.
  - So far, the answer is no. 
- [x] Find out if there will be an Observatory.

Fixes #7574 