### PR TITLE
Add opentelemetry-kotlin to registry

### DIFF
--- a/data/registry/otel-kotlin-multiplatform.yml
+++ b/data/registry/otel-kotlin-multiplatform.yml
@@ -1,0 +1,19 @@
+title: Kotlin Multiplatform
+registryType: core
+language: kotlin
+tags:
+  - Kotlin
+  - Js
+  - Jvm
+  - Native
+  - Kotlin Multiplatform
+  - Android
+  - iOS
+urls:
+  repo: https://github.com/embrace-io/opentelemetry-kotlin
+license: Apache 2.0
+description: An OpenTelemetry API and SDK for Kotlin Multiplatform.
+authors:
+  - name: Embrace
+    url: https://embrace.io/
+createdAt: 2025-10-02


### PR DESCRIPTION
## Goal

Adds opentelemetry-kotlin to the registry so that folks can find the repository when searching for Kotlin. This was suggested as part of the [donation proposal](https://github.com/open-telemetry/community/issues/2975#issuecomment-3348216067).