### PR TITLE
Update pr-actions.yml: allow action step to fail so file changes can be committed

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -1,4 +1,5 @@
 name: PR actions
+# cSpell:ignore otelbot
 
 on:
   issue_comment:
@@ -16,7 +17,7 @@ env:
 
 jobs:
   generate-patch:
-    name: Run fixer and generate patch (untrusted)
+    name: Run PR action and generate patch (untrusted)
     runs-on: ubuntu-latest
     if: |
       github.event.issue.pull_request &&
@@ -24,6 +25,7 @@ jobs:
 
     outputs:
       action_name: ${{ steps.extract.outputs.action_name }}
+      action_exit_status: ${{ steps.run_action.outputs.action_exit_status }}
       patch_name: pr-fix-${{ github.run_id }}
       patch_skipped: ${{ steps.check_patch.outputs.skipped }}
 
@@ -32,9 +34,8 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          fetch-depth: 999
+      - uses: actions/checkout@v5
+        with: { fetch-depth: 0 }
 
       - name: Extract action name
         id: extract
@@ -46,15 +47,26 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Setup Node
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+      - uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
 
-      - name: Install deps & run fixer
+      - run: npm install --omit=optional
+
+      - name: Run PR action
+        id: run_action
+        # Allow the PR action to fail without failing the step, so that we can
+        # commit any file changes. For example, we want to commit updates to the
+        # refcache even if there might still be some broken links.
+        continue-on-error: true
         run: |
-          npm install --omit=optional
           npm run fix:${{ steps.extract.outputs.action_name }}
+          action_exit_status=$?
+          echo "action_exit_status=$action_exit_status" >> "$GITHUB_OUTPUT"
+          echo "PR action exit status: $action_exit_status"
+
+          # For refcache updates, prune 404 entries, if any
+          npm run _refcache:prune
 
       - name: Generate and validate patch
         id: check_patch
@@ -149,16 +161,20 @@ jobs:
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
 
       - name: Comment success
-        if: ${{ !failure() && !cancelled() }}
+        if:
+          ${{ !failure() && !cancelled() &&
+          needs.generate-patch.outputs.action_exit_status == '0' }}
         run: |
-          gh pr comment $PR_NUM --body "✅ \`fix:${{ needs.generate-patch.outputs.action_name }}\` applied successfully in [this run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
+          gh pr comment $PR_NUM --body "✅ \`fix:${{ needs.generate-patch.outputs.action_name }}\` applied successfully in [run $GITHUB_RUN_ID]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
         env:
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
 
       - name: Comment failure
-        if: ${{ failure() || cancelled() }}
+        if:
+          ${{ failure() || cancelled() ||
+          needs.generate-patch.outputs.action_exit_status != '0' }}
         run: |
-          gh pr comment $PR_NUM --body "❌ \`fix:${{ needs.generate-patch.outputs.action_name }}\` failed. See logs: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          gh pr comment $PR_NUM --body "❌ \`fix:${{ needs.generate-patch.outputs.action_name }}\` failed or exited with a non-zero error code (${{ needs.generate-patch.outputs.action_exit_status }}). See logs: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
         env:
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
 


### PR DESCRIPTION
- Fixes #6458 
- Allows the PR action / fix step to fail so that we can commit any possibly partial file changes. This is useful for refcache updates. I've implemented a generalized solution here for all `fix:*` directives. Hopefully it is useful in all cases. We can always adjust if not, but I can't think of a case now that wouldn't benefit from partial file changes being committed.