### PR TITLE
[pt] Update drifted content under `content/pt/ecosystem`

### DIFF
--- a/content/pt/ecosystem/distributions.md
+++ b/content/pt/ecosystem/distributions.md
@@ -3,33 +3,30 @@ title: Distribuições
 description:
   Lista de distribuições de código aberto do OpenTelemetry mantidas por
   terceiros.
-default_lang_commit: b6ddba1118d07bc3c8d1d07b293f227686d0290e
-drifted_from_default: true
+default_lang_commit: c392c714849921cd56aca8ca99ab11e0e4cb16f4
 ---
 
-As [distribuições](/docs/concepts/distributions/) do OpenTelemetry são uma forma
-de personalizar os componentes do OpenTelemetry para torná-los mais fáceis de
+As [distribuições][distributions] do OpenTelemetry são uma forma de personalizar
+os [componentes][components] do OpenTelemetry para torná-los mais fáceis de
 implantar e utilizar com _backends_ de observabilidade específicos.
 
 Qualquer terceiro pode personalizar os componentes do OpenTelemetry com
-alterações específicas para _backends_, fornecedores ou usuários finais. Não é
-obrigatório utilizar distribuições para utilizar os componentes do
-OpenTelemetry, embora elas possam facilitar o uso em determinadas
-circunstâncias, como requisitos específicos de fornecedores.
+alterações específicas para _backends_, [fornecedores][vendor] ou usuários
+finais. É possível utilizar componentes do OpenTelemetry sem uma distribuição,
+mas uma distribuição pode facilitar as coisas em alguns casos, por exemplo
+quando um fornecedor possui requisitos específicos.
 
-A lista a seguir contém uma amostra de distribuições do OpenTelemetry e seus
-componentes personalizados.
+A lista a seguir contém exemplos de distribuições do OpenTelemetry que não são
+do Collector e o componente que elas customizam. Para distribuições do
+[OpenTelemetry COllector](/docs/collector), consulte
+[Distribuições do Collector](/docs/collector/distributions/).
 
-{{% alert title="Nota" color="warning" %}} O OpenTelemetry **não valida nem
-endossa** as distribuições de terceiros listadas na tabela a seguir. A lista é
-fornecida como uma conveniência para a comunidade. {{% /alert %}}
-
-{{% ecosystem/distributions-table %}}
+{{% ecosystem/distributions-table filter="non-collector" %}}
 
 ## Adicionando sua distribuição {#how-to-add}
 
 Para que sua distribuição seja listada, [envie um PR] com uma entrada adicionada
-à [lista de distribuições]. A entrada deve incluir:
+à [lista de distribuições][distributions list]. A entrada deve incluir:
 
 - Link para a página principal da sua distribuição
 - Link para a documentação que explica como utilizar a distribuição
@@ -53,7 +50,10 @@ Para que sua distribuição seja listada, [envie um PR] com uma entrada adiciona
 
 [envie um PR]: /docs/contributing/pull-requests/
 
-{{% include keep-up-to-date.md distribuições %}}
+{{% include keep-up-to-date.md distributions %}}
 
-[lista de distribuições]:
+[components]: /docs/concepts/components/
+[distributions]: /docs/concepts/distributions/
+[distributions list]:
   https://github.com/open-telemetry/opentelemetry.io/tree/main/data/ecosystem/distributions.yaml
+[vendor]: ../vendors/

--- a/content/pt/ecosystem/integrations.md
+++ b/content/pt/ecosystem/integrations.md
@@ -3,8 +3,7 @@ title: Integrações
 description:
   Bibliotecas, serviços e aplicações com suporte nativo para o OpenTelemetry.
 aliases: [/integrations]
-default_lang_commit: b6ddba1118d07bc3c8d1d07b293f227686d0290e
-drifted_from_default: true
+default_lang_commit: c392c714849921cd56aca8ca99ab11e0e4cb16f4
 ---
 
 A missão do OpenTelemetry é

--- a/content/pt/ecosystem/registry/_index.md
+++ b/content/pt/ecosystem/registry/_index.md
@@ -7,8 +7,7 @@ type: default
 layout: registry
 body_class: registry td-content
 weight: 20
-default_lang_commit: fd873ed11bfa9920c2e8b0726784f482368e85c2
-drifted_from_default: true
+default_lang_commit: c392c714849921cd56aca8ca99ab11e0e4cb16f4
 ---
 
 {{% blocks/lead color="dark" %}}


### PR DESCRIPTION
## Description

Contributes to #7942 

Updates the drifted content for the following files:

### content/pt/ecosystem/distributions.md

<details>
<summary>Diff content/pt/ecosystem/distributions.md</summary>

```diff
distributions.md

❯ npm run check:i18n -- -d content/pt/ecosystem/distributions.md

> check:i18n
> scripts/check-i18n.sh -d content/pt/ecosystem/distributions.md

Processing paths: content/pt/ecosystem/distributions.md
diff --git a/content/en/ecosystem/distributions.md b/content/en/ecosystem/distributions.md
index 67d562fa3..92ae17a80 100644
--- a/content/en/ecosystem/distributions.md
+++ b/content/en/ecosystem/distributions.md
@@ -1,26 +1,25 @@
 ---
-title: Distributions
+title: Third-party distributions
+linkTitle: Distributions
 description:
   List of open source OpenTelemetry distributions maintained by third parties.
 ---
 
-OpenTelemetry [distributions](/docs/concepts/distributions/) are a way of
-customizing OpenTelemetry components so that they're easier to deploy and use
-with specific observability backends.
+OpenTelemetry [distributions] are a way of customizing OpenTelemetry
+[components] so that they're easier to deploy and use with specific
+observability backends.
 
-Any third-party can customize OpenTelemetry components with backend, vendor, or
-end-user specific changes. You don't have to use a distributions in order to use
-OpenTelemetry components, though distributions might facilitate usage under
-certain circumstances, such as specific vendor requirements.
+Any third-party can customize OpenTelemetry components with backend, [vendor],
+or end-user specific changes. You can use OpenTelemetry components without a
+distribution, but a distribution might make things easier in some cases, like
+when a vendor has specific requirements.
 
-The following list contains a sample of OpenTelemetry distributions and the
-component they customize.
+The following list contains a sample of non-collector OpenTelemetry
+distributions and the component they customize. For
+[OpenTelemetry Collector](/docs/collector/) distributions, see
+[Collector distributions](/docs/collector/distributions/).
 
-{{% alert title="Note" color="warning" %}} OpenTelemetry **does not validate or
-endorse** the third-party distributions listed in the following table. The list
-is provided as a convenience for the community. {{% /alert %}}
-
-{{% ecosystem/distributions-table %}}
+{{% ecosystem/distributions-table filter="non-collector" %}}
 
 ## Adding your distribution {#how-to-add}
 
@@ -33,7 +32,7 @@ To have your distribution listed, [submit a PR] with an entry added to the
 - GitHub handle or email address as a point of contact so that we can reach out
   in case we have questions
 
-{{% alert title="Notes" color="info" %}}
+{{% alert title="Notes" %}}
 
 - If you provide external integration of OpenTelemetry for any kind of library,
   service, or app, then consider
@@ -50,5 +49,8 @@ To have your distribution listed, [submit a PR] with an entry added to the
 
 {{% include keep-up-to-date.md distribution %}}
 
+[components]: /docs/concepts/components/
+[distributions]: /docs/concepts/distributions/
 [distributions list]:
   https://github.com/open-telemetry/opentelemetry.io/tree/main/data/ecosystem/distributions.yaml
+[vendor]: ../vendors/
DRIFTED files: 1 out of 1
```
</details>

### content/pt/ecosystem/integrations.md

<details>
<summary>Diff content/pt/ecosystem/integrations.md</summary>

```diff
integrations.md

❯ npm run check:i18n -- -d content/pt/ecosystem/integrations.md

> check:i18n
> scripts/check-i18n.sh -d content/pt/ecosystem/integrations.md

Processing paths: content/pt/ecosystem/integrations.md
diff --git a/content/en/ecosystem/integrations.md b/content/en/ecosystem/integrations.md
index 15471d88e..d6e9af64a 100644
--- a/content/en/ecosystem/integrations.md
+++ b/content/en/ecosystem/integrations.md
@@ -52,7 +52,7 @@ following:
 - Link to the documentation that explains how enable observability using
   OpenTelemetry
 
-{{% alert title="Note" color="info" %}}
+{{% alert title="Note" %}}
 
 If you provide external integration of OpenTelemetry for any kind of library,
 service, or app, then
DRIFTED files: 1 out of 1
```
</details>

### content/pt/ecosystem/registry/_index.md

<details>
<summary>Diff content/pt/ecosystem/registry/_index.md</summary>

```diff
registry/_index.md

❯ npm run check:i18n -- -d content/pt/ecosystem/registry/_index.md

> check:i18n
> scripts/check-i18n.sh -d content/pt/ecosystem/registry/_index.md

Processing paths: content/pt/ecosystem/registry/_index.md
diff --git a/content/en/ecosystem/registry/_index.md b/content/en/ecosystem/registry/_index.md
index fb60269d3..34cf893b5 100644
--- a/content/en/ecosystem/registry/_index.md
+++ b/content/en/ecosystem/registry/_index.md
@@ -39,7 +39,7 @@ redirects: [{ from: /ecosystem/registry*, to: '/ecosystem/registry?' }]
 
 {{< blocks/section color="white" type="container-lg" >}}
 
-{{% alert color="info" %}}
+{{% alert %}}
 
 The OpenTelemetry Registry allows you to search for instrumentation libraries,
 collector components, utilities, and other useful projects in the OpenTelemetry
DRIFTED files: 1 out of 1
```
</details>