### PR TITLE
[CI] Refcache-refresh: only push once, and add oldest entry to comment

### DIFF
--- a/.github/workflows/refcache-refresh.yml
+++ b/.github/workflows/refcache-refresh.yml
@@ -97,7 +97,10 @@ jobs:
           git fetch origin
           git $merge_or_rebase origin/main
           if [ "$(git rev-parse HEAD)" != "$previous" ]; then
-            git push $push_args origin $BRANCH
+            DELAYED_PUSH_CMD="git push $push_args origin $BRANCH"
+            echo "We'll push later, after committing the refcache updates."
+            echo "DELAYED_PUSH_CMD=$DELAYED_PUSH_CMD"
+            echo "DELAYED_PUSH_CMD=$DELAYED_PUSH_CMD" >> $GITHUB_ENV
           fi
 
       - uses: actions/setup-node@v5
@@ -115,7 +118,10 @@ jobs:
           npm run _refcache:prune -- -n $REFRESH_COUNT
 
       - name: List oldest entry after pruning
-        run: npm run _refcache:prune -- --list -n 1
+        run: |
+          OLDEST_ENTRY=$(npm run _refcache:prune -- --list -n 1 | grep '^\s')
+          echo "Oldest entry after pruning: $OLDEST_ENTRY"
+          echo "OLDEST_ENTRY=$OLDEST_ENTRY" >> $GITHUB_ENV
 
       - name: Build site and update refcache
         run: |
@@ -142,11 +148,18 @@ jobs:
           $CHROME_PATH --version
           ./scripts/double-check-refcache-4XX.mjs --verbose
 
-      - name: Commit refcache updates if any
+      - name: Commit refcache updates and push changes if any
         run: |
           git add -A
           if ! git diff-index --quiet --cached HEAD; then
             git commit -am "Update refcache"
+          fi
+
+          # Push if we have any commits to push (refcache updates or sync from main)
+          if [[ -n "$DELAYED_PUSH_CMD" ]]; then
+            echo "Executing: $DELAYED_PUSH_CMD"
+            $DELAYED_PUSH_CMD
+          elif ! git diff --quiet origin/$BRANCH; then
             git push
           fi
 
@@ -163,7 +176,7 @@ jobs:
           fi
 
           if gh pr create --title "Refresh refcache" \
-              --body "Refreshes the oldest ${{ env.REFRESH_COUNT }} refcache entries." \
+              --body "- Refreshes the oldest ${{ env.REFRESH_COUNT }} refcache entries.\n- Oldest entry after pruning: \`${{ env.OLDEST_ENTRY }}\`" \
               --draft;
           then
             PR_URL=$(gh pr view --json url --jq '.url')


### PR DESCRIPTION
- Contributes to #2554
- Changes workflow so that there's only one push to the existing PR branch (otherwise CI checks get triggered more than once, which we want to avoid).
- Adds to the PR comment (when created) the date of the new oldest entry