### PR TITLE
[CI] Refcache refresh: fix PR body

### DIFF
--- a/.github/workflows/refcache-refresh.yml
+++ b/.github/workflows/refcache-refresh.yml
@@ -166,6 +166,9 @@ jobs:
       - name: Create PR if needed
         env:
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+          PR_BODY: |-
+            - Refreshes the oldest ${{ env.REFRESH_COUNT }} refcache entries.
+            - Oldest entry after pruning: `${{ env.OLDEST_ENTRY }}`
         run: |
           prs=$(gh pr list --state open --head $BRANCH)
           echo "Existing PR(s):"
@@ -176,8 +179,7 @@ jobs:
           fi
 
           if gh pr create --title "Refresh refcache" \
-              --body "- Refreshes the oldest ${{ env.REFRESH_COUNT }} refcache entries.\n- Oldest entry after pruning: \`${{ env.OLDEST_ENTRY }}\`" \
-              --draft;
+              --body "$PR_BODY" --draft;
           then
             PR_URL=$(gh pr view --json url --jq '.url')
             printf "PR created: %s\n" "$PR_URL"


### PR DESCRIPTION
- Fixes refcache-refresh workflow. It currently produced mis-formatted markdown, see #8052
- Puts the multi-line PR body text in an env var, and uses that in the call to `gh pr`