### PR TITLE
Use canonical link to moved page that is now OTEP 4673

### DIFF
--- a/content/en/docs/concepts/sampling/index.md
+++ b/content/en/docs/concepts/sampling/index.md
@@ -103,7 +103,7 @@ as possible. A decision to sample or drop a span or trace is not made by
 inspecting the trace as a whole.
 
 For example, the most common form of head sampling is
-[Consistent Probability Sampling](/docs/specs/otel/trace/tracestate-probability-sampling-experimental/#consistent-probability-sampling).
+[Consistent Probability Sampling](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/trace/4673-experimental-probability-sampling.md).
 This is also referred to as Deterministic Sampling. In this case, a sampling
 decision is made based on the trace ID and the desired percentage of traces to
 sample. This ensures that whole traces are sampled - no missing spans - at a

--- a/content/ja/docs/concepts/sampling/index.md
+++ b/content/ja/docs/concepts/sampling/index.md
@@ -2,7 +2,7 @@
 title: サンプリング
 description: サンプリングとOpenTelemetryで利用可能なさまざまなサンプリングオプションについて学びましょう。
 weight: 80
-default_lang_commit: 8d115a9df96c52dbbb3f96c05a843390d90a9800
+default_lang_commit: 8d115a9df96c52dbbb3f96c05a843390d90a9800 # patched
 ---
 
 分散システムでは、[トレース](/docs/concepts/signals/traces)で、リクエストが分散システム内のあるサービスから別のサービスに移動するのを観察できます。
@@ -74,7 +74,7 @@ default_lang_commit: 8d115a9df96c52dbbb3f96c05a843390d90a9800
 ヘッドサンプリングは、サンプリングの決定をできるだけ早期に行うために用いられるサンプリング技術です。
 スパンやトレースのサンプリングまたはドロップの決定は、トレース全体を検査することによって行われるわけではありません。
 
-たとえば、ヘッドサンプリングのもっとも一般的な形式は、[一貫した確率サンプリング](/docs/specs/otel/trace/tracestate-probability-sampling-experimental/#consistent-probability-sampling)です。
+たとえば、ヘッドサンプリングのもっとも一般的な形式は、[一貫した確率サンプリング](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/trace/4673-experimental-probability-sampling.md)です。
 決定論的サンプリングと呼ばれることもあります。
 この場合、サンプリングの決定は、トレースIDと、サンプリングするトレースの望ましい割合に基づいて行われます。
 これにより、全トレースの5%など、一貫した割合で、スパンの欠損無く、全トレースがサンプリングされます。

--- a/content/pt/docs/concepts/sampling/index.md
+++ b/content/pt/docs/concepts/sampling/index.md
@@ -4,7 +4,7 @@ description:
   Aprenda sobre amostragem e explore as diferentes opções disponíveis no
   OpenTelemetry.
 weight: 80
-default_lang_commit: 49879d0c00a4a28c963a76998f7213af7b539c77
+default_lang_commit: 49879d0c00a4a28c963a76998f7213af7b539c77 # patched
 ---
 
 Com [rastros](/docs/concepts/signals/traces), você pode observar as requisições
@@ -111,7 +111,7 @@ ou descartar um trecho ou um rastro não é feita inspecionando o rastro como um
 todo.
 
 Por exemplo, a forma mais comum de amostragem pela cabeça é a
-[Amostragem de Probabilidade Consistente](/docs/specs/otel/trace/tracestate-probability-sampling-experimental/#consistent-probability-sampling).
+[Amostragem de Probabilidade Consistente](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/trace/4673-experimental-probability-sampling.md).
 Isso também é conhecido como Amostragem Determinística. Neste caso, uma decisão
 de amostragem é tomada com base no ID do rastro e na porcentagem desejada de
 rastros a serem amostrados. Isso garante que rastros inteiros sejam amostrados -

--- a/content/zh/docs/concepts/sampling/index.md
+++ b/content/zh/docs/concepts/sampling/index.md
@@ -2,7 +2,7 @@
 title: 采样
 description: 了解采样以及 OpenTelemetry 中可用的各种采样选项。
 weight: 80
-default_lang_commit: deb98d0648c4833d9e9d77d42e91e2872658b50c
+default_lang_commit: deb98d0648c4833d9e9d77d42e91e2872658b50c # patched
 ---
 
 通过[链路](/docs/concepts/signals/traces)，你可以观测请求在分布式系统中从一个服务传递到另一个服务的过程。
@@ -70,7 +70,7 @@ default_lang_commit: deb98d0648c4833d9e9d77d42e91e2872658b50c
 
 头部采样是一种尽早做出采样决策的采样技术。是否采样一个 Span 或链路的决策不是通过检查整个链路来做出的。
 
-例如，最常见的一种头部采样形式是[一致概率采样](/docs/specs/otel/trace/tracestate-probability-sampling-experimental/#consistent-probability-sampling)。
+例如，最常见的一种头部采样形式是[一致概率采样](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/trace/4673-experimental-probability-sampling.md)。
 这也被称为确定性采样。在这种情况下，采样决策基于链路 ID 和希望采样的链路百分比。
 这确保了整个链路被采样（不会漏掉任何 Span）并以一致的速率进行采样，例如采样所有链路的 5%。
 

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -11263,6 +11263,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-10-10T10:51:12.275035485Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/trace/4673-experimental-probability-sampling.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-11T10:15:59.874903-04:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md": {
     "StatusCode": 206,
     "LastSeen": "2025-10-10T10:46:30.12192264Z"


### PR DESCRIPTION
Fixes links to **spec page that has been moved** in the spec's `main` branch. For details, see:

- https://github.com/open-telemetry/opentelemetry-specification/issues/4687
- New page location: https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/trace/4673-experimental-probability-sampling.md

Rather than accumulate this change in #7872, I'm doing it now since the page has moved already. This makes it less of a risk to lose the change in  #7872.

/cc @open-telemetry/specs-maintainers 

#### To do

- [x] Rebase #7872 after this lands.