### PR TITLE
Add @vitorvasc to maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ These are the members of [@open-telemetry/docs-maintainers]:
 - [Phillip Carter](https://github.com/cartermp), Salesforce
 - [Severin Neumann](https://github.com/svrnm)
 - [Tiffany Hrabusa](https://github.com/tiffany76), Grafana Labs
+- [Vitor Vasconcellos](https://github.com/vitorvasc), MercadoLibre, Inc.
 
 For more information about the maintainer role, see the
 [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer).
@@ -75,7 +76,6 @@ These are the members of [@open-telemetry/docs-approvers]:
 
 - [Michael Hausenblas](https://github.com/mhausenblas), Amazon
 - [Ted Young](https://github.com/tedsuo), Grafana Labs
-- [Vitor Vasconcellos](https://github.com/vitorvasc), MercadoLibre, Inc.
 
 For more information about the approver role, see the
 [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver).


### PR DESCRIPTION
@open-telemetry/docs-maintainers please approve this official PR to promote @vitorvasc to become a maintainer of SIG Comms.

@vitorvasc please approve this PR to confirm that you are willing to step up as a maintainer for this SIG :-)