### PR TITLE
[editorial] Fix lint errors and drift status after markdownlint upgrade

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -15,7 +15,7 @@ no-trailing-spaces:
   br_spaces: 0
   strict: true
 
-# table-column-style: false
+table-column-style: false # Causes problems in ja and zh pages
 
 # Custom rules below this point:
 trim-code-block-and-unindent: true

--- a/content/en/blog/2023/contribfest-na/index.md
+++ b/content/en/blog/2023/contribfest-na/index.md
@@ -15,7 +15,7 @@ In addition, the project continued to grow the number of contributors, being the
 second most active project in the CNCF for a second year in a row, behind
 Kubernetes.
 
-### What's Contribfest?
+## What's Contribfest?
 
 In an effort to bring more contributors to the table, OpenTelemetry maintainers
 hosted the project’s first [Contribfest](https://sched.co/1R2rQ) at KubeCon
@@ -33,7 +33,7 @@ items that would be appropriate to tackle in that time. Some slides were also
 prepared, to give attendees an overview of the project, help them navigate the
 repositories, and explain the process of submitting code.
 
-### The event
+## The event
 
 When the day of the event arrived, the room was completely full. After a few
 minutes to cover the content in the slides, contributors were ready to write

--- a/content/en/blog/2023/demo-birthday/index.md
+++ b/content/en/blog/2023/demo-birthday/index.md
@@ -12,7 +12,7 @@ It's hard to believe as we prepare our 1.4.0 release but the
 since we declared general availability with our
 [1.0.0 release](/blog/2022/announcing-opentelemetry-demo-release/).
 
-### Project Milestones
+## Project Milestones
 
 The demo has achieved remarkable milestones in its first year, with more than
 **70 contributors, 20 official vendor forks, 780 GitHub stars, and 180K Docker
@@ -23,7 +23,7 @@ in new languages, and 7 brand new components / services_.
 Time flies when you're stabilizing semantic conventions. But what's actually
 changed between our 1.0.0 and 1.4.0 releases? Quite a lot actually.
 
-### The Highlights
+## The Highlights
 
 - **2x build time improvements despite adding additional services**
 - _Support added for arm64 architectures (M1 and M2 Macs)_
@@ -51,7 +51,7 @@ For detailed changes, check out our in depth
 or
 [changelog](https://github.com/open-telemetry/opentelemetry-demo/blob/main/CHANGELOG.md).
 
-### Get Involved
+## Get Involved
 
 Our contributors are essential to all of this and the project team can't thank
 them enough. New development is constantly ongoing as we add new capabilities

--- a/content/en/blog/2023/perf-testing/index.md
+++ b/content/en/blog/2023/perf-testing/index.md
@@ -12,7 +12,7 @@ OpenTelemetry will have on their application performance. In this blog post I
 will discuss a few recent improvements in tooling around performance
 benchmarking.
 
-### Measuring performance overhead
+## Measuring performance overhead
 
 Instrumentation is not free. It intercepts an application's operations and
 collects (often) a large amount of data, which takes additional CPU and memory.
@@ -31,7 +31,7 @@ With that said a number of OpenTelemetry components include performance tests
 that help catch regressions and can be used to provide some idea of their
 performance characteristics.
 
-### OpenTelemetry Collector
+## OpenTelemetry Collector
 
 The [OpenTelemetry Collector](/docs/collector/) runs
 [end-to-end load tests](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/workflows/load-tests.yml)
@@ -45,7 +45,7 @@ workflow:
    [complete test results](https://open-telemetry.github.io/opentelemetry-collector-contrib/benchmarks/loadtests/)
    are available as well.
 
-### Language SDKs
+## Language SDKs
 
 A number of OpenTelemetry SDKs already include existing micro-benchmark tests,
 for example:
@@ -73,7 +73,7 @@ results are as consistent as possible.
 
 There is work in progress to make the same updates for Python and Go.
 
-### Conclusion
+## Conclusion
 
 Performance optimization is often considered only as an afterthought, but it
 does not have to be. We are making improvements to automated tooling and

--- a/content/en/blog/2023/synthetic-testing/index.md
+++ b/content/en/blog/2023/synthetic-testing/index.md
@@ -32,7 +32,7 @@ deploy an agent to your preferred environment to test public OR private
 endpoints without the need to whitelist IPs in your firewall and transfer the
 tests between your preferred destination like any other piece of OTel data.
 
-### Deploy your first OTel Synthetic ping test(s)
+## Deploy your first OTel Synthetic ping test(s)
 
 Getting started with OTel synthetics is simple. You configure your Collector
 like usual and add the HTTP Check receiver with your chosen endpoints, HTTP
@@ -68,7 +68,7 @@ service:
       #exporters: [your-exporter]
 ```
 
-### Synthetic Test Output
+## Synthetic Test Output
 
 The receiver generates 3 metrics by default: `httpcheck.duration`
 `httpcheck.status` and `httpcheck.error`. The metrics can be used in
@@ -76,15 +76,15 @@ visualizations or to define alerts. If no errors occur then the
 `httpcheck.error` chart won’t be populated. Here are some example screenshots
 from the `httpcheck.duration` and `httpcheck.status` metrics.
 
-#### Duration Check
+### Duration Check
 
 ![Synthetic duration check result](httpcheck-duration.png 'Synthetic duration check result')
 
-#### Status Check
+### Status Check
 
 ![Synthetic status check result](httpcheck-status.png 'Synthetic status check result')
 
-### What's Next?
+## What's Next?
 
 Synthetic testing is an exciting new capability for OTel that the community
 hopes to evolve over time. If you have any specific requests around new

--- a/content/en/blog/2025/issue-participation.md
+++ b/content/en/blog/2025/issue-participation.md
@@ -39,7 +39,7 @@ SIG, we’ve been working on a small but important change to how we use GitHub:
 [issue reactions](https://github.blog/news-insights/product-news/add-reactions-to-pull-requests-issues-and-comments/)
 as the primary way to express interest.**
 
-### A Better Signal to Help Prioritize
+## A Better Signal to Help Prioritize
 
 The goal here is simple: provide a clear, low-effort, data-driven way for the
 community to signal what matters most. For maintainers, this system cuts through
@@ -63,7 +63,7 @@ You'll also see a friendly reminder in a new footnote on
 across all OTel repositories. If you're opening a new issue, please leave that
 footer in place so that others have first-hand access to this advice.
 
-### Your Quick Guide to Making an Impact
+## Your Quick Guide to Making an Impact
 
 So what does this mean for you in practice? It's easy.
 

--- a/content/en/community/end-user/_index.md
+++ b/content/en/community/end-user/_index.md
@@ -29,7 +29,7 @@ ubiquitous observability. We encourage you to share your successes and failures,
 discover best practices, and meet others who are also on a journey to implement
 observability powered by OpenTelemetry.
 
-### Topics
+## Topics
 
 This group is what its members make it -- whatever is of interest to the group
 is fair game!
@@ -42,7 +42,7 @@ But here are some of the kinds of things we expect will be on the table:
 - Maintaining and scaling OpenTelemetry deployments
 - Writing custom instrumentation
 
-### Questions
+## Questions
 
 **Is this group only for OpenTelemetry end users?**
 

--- a/content/en/docs/contributing/announcements.md
+++ b/content/en/docs/contributing/announcements.md
@@ -13,7 +13,7 @@ fall back to English banners, etc.
 > Announcements are currently used as banners only. We _might_ eventually
 > support slightly more general announcements as well.
 
-### Creating an announcement
+## Creating an announcement
 
 To add a new announcement, create an announcement Markdown file under the
 `announcements` folder of your localization using the following command:
@@ -34,7 +34,7 @@ you use the **same filename** as the English language announcement.
 
 {{% /alert %}}
 
-### Announcement list
+## Announcement list
 
 Any given announcement will appear in a site build when the build date falls
 between the `date` and `expiryDate` fields of the announcement. When those

--- a/content/en/docs/languages/cpp/exporters.md
+++ b/content/en/docs/languages/cpp/exporters.md
@@ -4,11 +4,9 @@ weight: 50
 cSpell:ignore: DWITH
 ---
 
-<!-- markdownlint-disable no-duplicate-heading -->
-
 {{% docs/languages/exporters/intro %}}
 
-### Dependencies {#otlp-dependencies}
+## Dependencies {#otlp-dependencies}
 
 If you want to send telemetry data to an OTLP endpoint (like the
 [OpenTelemetry Collector](#collector-setup), [Jaeger](#jaeger) or
@@ -24,7 +22,7 @@ Make sure that you have set the right cmake build variables while
 - `-DWITH_OTLP_GRPC=ON`: To enable building OTLP gRPC exporter.
 - `-DWITH_OTLP_HTTP=ON`: To enable building OTLP HTTP exporter.
 
-### Usage
+## Usage
 
 Next, configure the exporter to point at an OTLP endpoint in your code.
 
@@ -197,7 +195,7 @@ void InitLogger()
 
 {{% /tab %}} {{< /tabpane >}}
 
-### Console
+## Console
 
 To debug your instrumentation or see the values locally in development, you can
 use exporters writing telemetry data to the console (stdout).
@@ -269,7 +267,7 @@ void InitLogger()
 
 {{% include "exporters/prometheus-setup.md" %}}
 
-### Dependencies {#prometheus-dependencies}
+## Dependencies {#prometheus-dependencies}
 
 To send your trace data to [Prometheus](https://prometheus.io/), make sure that
 you have set the right cmake build variables while
@@ -312,7 +310,7 @@ the metrics from this endpoint.
 
 {{% include "exporters/zipkin-setup.md" %}}
 
-### Dependencies {#zipkin-dependencies}
+## Dependencies {#zipkin-dependencies}
 
 To send your trace data to [Zipkin](https://zipkin.io/), make sure that you have
 set the right cmake build variables while

--- a/content/en/docs/languages/dotnet/exporters.md
+++ b/content/en/docs/languages/dotnet/exporters.md
@@ -5,7 +5,7 @@ weight: 50
 
 {{% docs/languages/exporters/intro %}}
 
-### Dependencies {#otlp-dependencies}
+## Dependencies {#otlp-dependencies}
 
 If you want to send telemetry data to an OTLP endpoint (like the
 [OpenTelemetry Collector](#collector-setup), [Jaeger](#jaeger) or
@@ -31,9 +31,9 @@ package as well:
 dotnet add package OpenTelemetry.Extensions.Hosting
 ```
 
-### Usage
+## Usage
 
-#### ASP.NET Core
+### ASP.NET Core
 
 Configure the exporters in your ASP.NET Core services:
 
@@ -87,7 +87,7 @@ builder.Logging.AddOpenTelemetry(logging => {
 });
 ```
 
-#### Non-ASP.NET Core
+### Non-ASP.NET Core
 
 Configure the exporter when creating a `TracerProvider`, `MeterProvider` or
 `LoggerFactory`:
@@ -129,7 +129,7 @@ production.
 
 ## Console
 
-### Dependencies
+## Dependencies
 
 The console exporter is useful for development and debugging tasks, and is the
 simplest to set up. Start by installing the
@@ -148,9 +148,9 @@ package as well:
 dotnet add package OpenTelemetry.Extensions.Hosting
 ```
 
-### Usage {#console-usage}
+## Usage {#console-usage}
 
-#### ASP.NET Core {#console-usage-asp-net-core}
+### ASP.NET Core {#console-usage-asp-net-core}
 
 Configure the exporter in your ASP.NET Core services:
 
@@ -173,7 +173,7 @@ builder.Logging.AddOpenTelemetry(logging => {
 });
 ```
 
-#### Non-ASP.NET Core {#console-usage-non-asp-net-core}
+### Non-ASP.NET Core {#console-usage-non-asp-net-core}
 
 Configure the exporter when creating a `TracerProvider`, `MeterProvider` or
 `LoggerFactory`:
@@ -202,7 +202,7 @@ var loggerFactory = LoggerFactory.Create(builder =>
 
 {{% include "exporters/prometheus-setup.md" %}}
 
-### Dependencies {#prometheus-dependencies}
+## Dependencies {#prometheus-dependencies}
 
 Install the
 [exporter package](https://www.nuget.org/packages/OpenTelemetry.Exporter.Prometheus.AspNetCore)
@@ -220,9 +220,9 @@ package as well:
 dotnet add package OpenTelemetry.Extensions.Hosting
 ```
 
-### Usage {#prometheus-usage}
+## Usage {#prometheus-usage}
 
-#### ASP.NET Core {#prometheus-asp-net-core-usage}
+### ASP.NET Core {#prometheus-asp-net-core-usage}
 
 Configure the exporter in your ASP.NET Core services:
 
@@ -248,7 +248,7 @@ app.UseOpenTelemetryPrometheusScrapingEndpoint();
 await app.RunAsync();
 ```
 
-#### Non-ASP.NET Core {#prometheus-non-asp-net-core-usage}
+### Non-ASP.NET Core {#prometheus-non-asp-net-core-usage}
 
 {{% alert color="warning" title="Warning" %}}
 
@@ -294,7 +294,7 @@ For more details on configuring the Prometheus exporter, see
 
 {{% include "exporters/zipkin-setup.md" %}}
 
-### Dependencies {#zipkin-dependencies}
+## Dependencies {#zipkin-dependencies}
 
 To send your trace data to [Zipkin](https://zipkin.io/), install the
 [exporter package](https://www.nuget.org/packages/OpenTelemetry.Exporter.Zipkin)
@@ -312,9 +312,9 @@ package as well:
 dotnet add package OpenTelemetry.Extensions.Hosting
 ```
 
-### Usage {#zipkin-usage}
+## Usage {#zipkin-usage}
 
-#### ASP.NET Core {#zipkin-asp-net-core-usage}
+### ASP.NET Core {#zipkin-asp-net-core-usage}
 
 Configure the exporter in your ASP.NET Core services:
 
@@ -330,7 +330,7 @@ builder.Services.AddOpenTelemetry()
         }));
 ```
 
-#### Non-ASP.NET Core {#zipkin-non-asp-net-core-usage}
+### Non-ASP.NET Core {#zipkin-non-asp-net-core-usage}
 
 Configure the exporter when creating a tracer provider:
 

--- a/content/en/docs/languages/js/exporters.md
+++ b/content/en/docs/languages/js/exporters.md
@@ -6,7 +6,7 @@ description: Process and export your telemetry data
 
 {{% docs/languages/exporters/intro %}}
 
-### Dependencies {#otlp-dependencies}
+## Dependencies {#otlp-dependencies}
 
 If you want to send telemetry data to an OTLP endpoint (like the
 [OpenTelemetry Collector](#collector-setup), [Jaeger](#jaeger) or
@@ -43,7 +43,7 @@ npm install --save @opentelemetry/exporter-trace-otlp-grpc \
 
 {{% /tab %}} {{< /tabpane >}}
 
-### Usage with Node.js
+## Usage with Node.js
 
 Next, configure the exporter to point at an OTLP endpoint. For example you can
 update the file `instrumentation.ts` (or `instrumentation.js` if you use
@@ -116,7 +116,7 @@ sdk.start();
 
 {{% /tab %}} {{< /tabpane >}}
 
-### Usage in the Browser
+## Usage in the Browser
 
 When you use the OTLP exporter in a browser-based application, you need to note
 that:
@@ -131,7 +131,7 @@ Below you will find instructions to use the right exporter, to configure your
 CSPs and CORS headers and what precautions you have to take when exposing your
 collector.
 
-#### Use OTLP exporter with HTTP/JSON or HTTP/protobuf
+### Use OTLP exporter with HTTP/JSON or HTTP/protobuf
 
 [OpenTelemetry Collector Exporter with gRPC][] works only with Node.js,
 therefore you are limited to use the [OpenTelemetry Collector Exporter with
@@ -142,7 +142,7 @@ backend) accepts `http/json` if you are using [OpenTelemetry Collector Exporter
 with HTTP/JSON][], and that you are exporting your data to the right endpoint
 with your port set to 4318.
 
-#### Configure CSPs
+### Configure CSPs
 
 If your website is making use of Content Security Policies (CSPs), make sure
 that the domain of your OTLP endpoint is included. If your collector endpoint is
@@ -155,7 +155,7 @@ connect-src collector.example.com:4318/v1/traces
 If your CSP is not including the OTLP endpoint, you will see an error message,
 stating that the request to your endpoint is violating the CSP directive.
 
-#### Configure CORS headers
+### Configure CORS headers
 
 If your website and collector are hosted at a different origin, your browser
 might block the requests going out to your collector. You need to configure
@@ -180,7 +180,7 @@ receivers:
           max_age: 7200
 ```
 
-#### Securely expose your collector
+### Securely expose your collector
 
 To receive telemetry from a web application you need to allow the browsers of
 your end-users to send data to your collector. If your web application is
@@ -243,7 +243,7 @@ package:
 
 {{% include "exporters/prometheus-setup.md" %}}
 
-### Dependencies {#prometheus-dependencies}
+## Dependencies {#prometheus-dependencies}
 
 Install the
 [exporter package](https://www.npmjs.com/package/@opentelemetry/exporter-prometheus)
@@ -298,7 +298,7 @@ the metrics from this endpoint.
 
 {{% include "exporters/zipkin-setup.md" %}}
 
-### Dependencies {#zipkin-dependencies}
+## Dependencies {#zipkin-dependencies}
 
 To send your trace data to [Zipkin](https://zipkin.io/), you can use the
 `ZipkinExporter`.

--- a/content/en/docs/languages/python/exporters.md
+++ b/content/en/docs/languages/python/exporters.md
@@ -5,11 +5,9 @@ description: Process and export your telemetry data
 cSpell:ignore: LOWMEMORY
 ---
 
-<!-- markdownlint-disable no-duplicate-heading -->
-
 {{% docs/languages/exporters/intro %}}
 
-### Dependencies {#otlp-dependencies}
+## Dependencies {#otlp-dependencies}
 
 If you want to send telemetry data to an OTLP endpoint (like the
 [OpenTelemetry Collector](#collector-setup), [Jaeger](#jaeger) or
@@ -36,7 +34,7 @@ pip install opentelemetry-exporter-otlp-proto-grpc
 
 {{% /tab %}} {{< /tabpane >}}
 
-### Usage
+## Usage
 
 Next, configure the exporter to point at an OTLP endpoint in your code.
 
@@ -192,7 +190,7 @@ variable to `CUMULATIVE`.
 
 {{% include "exporters/prometheus-setup.md" %}}
 
-### Dependencies {#prometheus-dependencies}
+## Dependencies {#prometheus-dependencies}
 
 Install the
 [exporter package](https://pypi.org/project/opentelemetry-exporter-prometheus/)
@@ -233,7 +231,7 @@ the metrics from this endpoint.
 
 {{% include "exporters/zipkin-setup.md" %}}
 
-### Dependencies {#zipkin-dependencies}
+## Dependencies {#zipkin-dependencies}
 
 To send your trace data to [Zipkin](https://zipkin.io/), you can choose between
 two different protocols to transport your data:

--- a/content/en/docs/platforms/faas/_index.md
+++ b/content/en/docs/platforms/faas/_index.md
@@ -16,7 +16,7 @@ The initial vendor scope of the FaaS documentation is around Microsoft Azure,
 Google Cloud Platform (GCP), and Amazon Web Services (AWS). AWS functions are
 also known as Lambda.
 
-### Community Assets
+## Community Assets
 
 The OpenTelemetry community currently provides pre-built Lambda layers able to
 auto-instrument your application as well as the option of a standalone Collector

--- a/content/en/docs/platforms/faas/lambda-auto-instrument.md
+++ b/content/en/docs/platforms/faas/lambda-auto-instrument.md
@@ -18,13 +18,13 @@ instrument your application. These layers do not include the Collector which is
 a required addition unless you configure an external Collector instance to send
 your data.
 
-### Add the ARN of the OTel Collector Lambda layer
+## Add the ARN of the OTel Collector Lambda layer
 
 See the [Collector Lambda layer guidance](../lambda-collector/) to add the layer
 to your application and configure the Collector. We recommend you add this
 first.
 
-### Language Requirements
+## Language Requirements
 
 {{< tabpane text=true >}} {{% tab Java %}}
 
@@ -90,14 +90,14 @@ and the package on [RubyGem](https://rubygems.org/search?query=opentelemetry).
 
 {{% /tab %}} {{< /tabpane >}}
 
-### Configure `AWS_LAMBDA_EXEC_WRAPPER`
+## Configure `AWS_LAMBDA_EXEC_WRAPPER`
 
 Change the entry point of your application by setting
 `AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler` for Node.js, Java, Ruby, or Python.
 This wrapper script invokes your Lambda application with the automatic
 instrumentation applied.
 
-### Add the ARN of Instrumentation Lambda Layer
+## Add the ARN of Instrumentation Lambda Layer
 
 To enable the OTel auto-instrumentation in your Lambda function, you need to add
 and configure the instrumentation and Collector layers, and then enable tracing.
@@ -116,7 +116,7 @@ used in the Region in which they are published. Make sure to use the layer in
 the same region as your Lambda functions. The community publishes layers in all
 available regions.
 
-### Configure your SDK exporters
+## Configure your SDK exporters
 
 The default exporters used by the Lambda layers will work without any changes if
 there is an embedded Collector with gRPC / HTTP receivers. The environment
@@ -146,7 +146,7 @@ uses the protocol `http/protobuf`
 
 {{% /tab %}} {{< /tabpane >}}
 
-### Publish your Lambda
+## Publish your Lambda
 
 Publish a new version of your Lambda to deploy the new changes and
 instrumentation.

--- a/content/en/docs/platforms/faas/lambda-collector.md
+++ b/content/en/docs/platforms/faas/lambda-collector.md
@@ -11,7 +11,7 @@ the instrumentation layers to give users maximum flexibility. This is different
 than the current AWS Distribution of OpenTelemetry (ADOT) implementation which
 bundles instrumentation and the Collector together.
 
-### Add the ARN of the OTel Collector Lambda layer
+## Add the ARN of the OTel Collector Lambda layer
 
 Once you've instrumented your application you should add the Collector Lambda
 layer to collect and submit your data to your chosen backend.
@@ -26,19 +26,19 @@ used in the Region in which they are published. Make sure to use the layer in
 the same region as your Lambda functions. The community publishes layers in all
 available regions.
 
-### Configure the OTel Collector
+## Configure the OTel Collector
 
 The configuration of the OTel Collector Lambda layer follows the OpenTelemetry
 standard.
 
 By default, the OTel Collector Lambda layer uses the config.yaml.
 
-#### Set the Environment Variable for your Preferred Backend
+### Set the Environment Variable for your Preferred Backend
 
 In the Lambda environment variable settings create a new variable that holds
 your authorization token.
 
-#### Update the Default Exporters
+### Update the Default Exporters
 
 In your `config.yaml` file add your preferred exporter(s) if they are not
 already present. Configure your exporter(s) using the environment variables you
@@ -75,17 +75,17 @@ service:
       address: localhost:8888
 ```
 
-### Publish your Lambda
+## Publish your Lambda
 
 Publish a new version of your Lambda to enable the changes you made.
 
-### Advanced OTel Collector Configuration
+## Advanced OTel Collector Configuration
 
 Please find the list of available components supported for custom configuration
 here. To enable debugging, you can use the configuration file to set log level
 to debug. See the example below.
 
-#### Choose your Preferred Confmap Provider
+### Choose your Preferred Confmap Provider
 
 The OTel Lambda Layers supports the following types of confmap providers:
 `file`, `env`, `yaml`, `http`, `https`, and `s3`. To customize the OTel
@@ -93,7 +93,7 @@ collector configuration using different Confmap providers, Please refer to
 [Amazon Distribution of OpenTelemetry Confmap providers document](https://aws-otel.github.io/docs/components/confmap-providers#confmap-providers-supported-by-the-adot-collector)
 for more information.
 
-#### Create a Custom Configuration File
+### Create a Custom Configuration File
 
 Here is a sample configuration file of `collector.yaml` in the root directory:
 
@@ -127,7 +127,7 @@ service:
       address: localhost:8888
 ```
 
-#### Map your Custom Configuration File using Environment Variables
+### Map your Custom Configuration File using Environment Variables
 
 Once your collector configuration is set through a confmap provider, create an
 environment variable on your Lambda function
@@ -136,7 +136,7 @@ the confmap provider as its value. for e.g, if you are using a file configmap
 provider, set its value to `/var/task/<path>/<to>/<filename>`. This will tell
 the extension where to find the collector configuration.
 
-##### Custom Collector Configuration Using the CLI
+#### Custom Collector Configuration Using the CLI
 
 You can set this via the Lambda console, or via the AWS CLI.
 
@@ -144,7 +144,7 @@ You can set this via the Lambda console, or via the AWS CLI.
 aws lambda update-function-configuration --function-name Function --environment Variables={OPENTELEMETRY_COLLECTOR_CONFIG_URI=/var/task/collector.yaml}
 ```
 
-##### Set Configuration Environment Variables from CloudFormation
+#### Set Configuration Environment Variables from CloudFormation
 
 You can configure environment variables via **CloudFormation** template as well:
 
@@ -158,7 +158,7 @@ Function:
         OPENTELEMETRY_COLLECTOR_CONFIG_URI: /var/task/collector.yaml
 ```
 
-##### Load Configuration from an S3 Object
+#### Load Configuration from an S3 Object
 
 Loading configuration from S3 will require that the IAM role attached to your
 function includes read access to the relevant bucket.

--- a/content/en/docs/platforms/faas/lambda-manual-instrument.md
+++ b/content/en/docs/platforms/faas/lambda-manual-instrument.md
@@ -10,18 +10,18 @@ community does not have a standalone instrumentation layer.
 Users will need to follow the generic instrumentation guidance for their chosen
 language and add the Collector Lambda layer to submit their data.
 
-### Add the ARN of the OTel Collector Lambda layer
+## Add the ARN of the OTel Collector Lambda layer
 
 See the [Collector Lambda layer guidance](../lambda-collector/) to add the layer
 to your application and configure the Collector. We recommend you add this
 first.
 
-### Instrument the Lambda with OTel
+## Instrument the Lambda with OTel
 
 Review the [language instrumentation guidance](/docs/languages/) on how to
 manually instrument your application.
 
-### Publish your Lambda
+## Publish your Lambda
 
 Publish a new version of your Lambda to deploy the new changes and
 instrumentation.

--- a/content/en/docs/zero-code/java/spring-boot-starter/getting-started.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/getting-started.md
@@ -11,7 +11,7 @@ application. For the pros and cons, see [Java zero-code instrumentation](..).
 
 {{% /alert %}}
 
-### Compatibility
+## Compatibility
 
 The OpenTelemetry Spring Boot starter works with Spring Boot 2.6+ and 3.1+, and
 Spring Boot native image applications. The
@@ -19,7 +19,7 @@ Spring Boot native image applications. The
 repository contains an example of a Spring Boot Native image application
 instrumented using the OpenTelemetry Spring Boot starter.
 
-### Dependency management
+## Dependency management
 
 A Bill of Material
 ([BOM](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#bill-of-materials-bom-poms))
@@ -101,7 +101,7 @@ with the `io.spring.dependency-management` plugin.
 
 {{% /alert %}}
 
-#### OpenTelemetry Starter dependency
+### OpenTelemetry Starter dependency
 
 Add the dependency given below to enable the OpenTelemetry starter.
 

--- a/content/en/docs/zero-code/obi/configure/export-modes.md
+++ b/content/en/docs/zero-code/obi/configure/export-modes.md
@@ -20,7 +20,7 @@ the OTLP endpoint authentication credentials with these environment variables:
 To run in Direct mode using the Prometheus scrape endpoint, see the
 [configuration documentation](../options/).
 
-### Configure and run OBI
+## Configure and run OBI
 
 This tutorial assumes OBI and OTel Collector are running natively on the same
 host, so there is no need to secure the traffic nor provide authentication in

--- a/content/en/docs/zero-code/python/example.md
+++ b/content/en/docs/zero-code/python/example.md
@@ -35,7 +35,7 @@ integrate OpenTelemetry into your application code. Below, you will see the
 difference between a Flask route instrumented manually, automatically and
 programmatically.
 
-### Manually instrumented server
+## Manually instrumented server
 
 `server_manual.py`
 
@@ -52,7 +52,7 @@ def server_request():
         return "served"
 ```
 
-### Automatically-instrumented server
+## Automatically-instrumented server
 
 `server_automatic.py`
 
@@ -63,7 +63,7 @@ def server_request():
     return "served"
 ```
 
-### Programmatically-instrumented server
+## Programmatically-instrumented server
 
 `server_programmatic.py`
 
@@ -129,7 +129,7 @@ destinations, like an OpenTelemetry Collector.
 This section guides you through the manual process of instrumenting a server as
 well as the process of executing an automatically instrumented server.
 
-### Execute the manually instrumented server
+## Execute the manually instrumented server
 
 Execute the server in two separate consoles, one to run each of the scripts that
 make up this example:
@@ -184,7 +184,7 @@ example:
 }
 ```
 
-### Execute the automatically-instrumented server
+## Execute the automatically-instrumented server
 
 Stop the execution of `server_manual.py` by pressing <kbd>Control+C</kbd> and
 run the following command instead:
@@ -247,7 +247,7 @@ example:
 You can see that both outputs are the same because automatic instrumentation
 does exactly what manual instrumentation does.
 
-### Execute the programmatically-instrumented server
+## Execute the programmatically-instrumented server
 
 It is also possible to use the instrumentation libraries (such as
 `opentelemetry-instrumentation-flask`) by themselves which may have an advantage
@@ -270,7 +270,7 @@ python client.py
 
 The results should be the same as running with manual instrumentation.
 
-#### Using programmatic-instrumentation features
+### Using programmatic-instrumentation features
 
 Some instrumentation libraries include features that allow for more precise
 control while instrumenting programmatically, the instrumentation library for
@@ -288,7 +288,7 @@ side. This is because of the `excluded_urls` option passed to `instrument_app`
 that effectively stops the `server_request` function from being instrumented as
 its URL matches the regular expression passed to `excluded_urls`.
 
-### Instrumentation while debugging
+## Instrumentation while debugging
 
 The debug mode can be enabled in the Flask app like this:
 
@@ -310,7 +310,7 @@ if __name__ == "__main__":
 
 The auto instrumentation can consume configuration from environment variables.
 
-### Capture HTTP request and response headers
+## Capture HTTP request and response headers
 
 You can capture predefined HTTP headers as span attributes, according to the
 [semantic convention][].

--- a/content/en/docs/zero-code/python/operator.md
+++ b/content/en/docs/zero-code/python/operator.md
@@ -12,9 +12,9 @@ to inject auto-instrumentation without having to modify each of your services
 directly.
 [See the OpenTelemetry Operator Auto-instrumentation docs for more details.](/docs/platforms/kubernetes/operator/automatic/)
 
-### Python-specific topics
+## Python-specific topics
 
-#### Libraries with binary wheels
+### Libraries with binary wheels
 
 Some Python packages we instrument or need in our instrumentation libraries,
 might ship with some binary code. This is the case, for example, of `grpcio` and
@@ -31,7 +31,7 @@ Since operator v0.113.0 it is possible to build an image with both glibc and
 musl based auto-instrumentation and
 [configure it at runtime](/docs/platforms/kubernetes/operator/automatic/#annotations-python-musl).
 
-#### Django applications
+### Django applications
 
 Applications that run from their own executable like Django requires to set in
 your deployment file two environment variables:
@@ -41,7 +41,7 @@ your deployment file two environment variables:
 - `DJANGO_SETTINGS_MODULE`, with the name of the Django settings module, e.g.
   "myapp.settings"
 
-#### gevent applications
+### gevent applications
 
 Since the OpenTelemetry Python 1.37.0/0.58b0 release if you set in your
 deployment file the `OTEL_PYTHON_AUTO_INSTRUMENTATION_EXPERIMENTAL_GEVENT_PATCH`

--- a/content/es/docs/contributing/announcements.md
+++ b/content/es/docs/contributing/announcements.md
@@ -2,7 +2,7 @@
 title: Anuncios
 description: Crea anuncios o banners para eventos especiales.
 weight: 50
-default_lang_commit: 645760e1961cb45d9ce6b291887c74ce4efa0398
+default_lang_commit: 645760e1961cb45d9ce6b291887c74ce4efa0398 # patched
 ---
 
 Un anuncio es una _página de Hugo normal_, ubicada en la sección `anuncios` de
@@ -14,7 +14,7 @@ determinar el orden de los banners, gestionar el uso de banners en inglés, etc.
 > Actualmente, los anuncios se usan solo como banners. Es _posible_ que, con el
 > tiempo, también admitamos anuncios más generales.
 
-### Creando un anuncio
+## Creando un anuncio
 
 Para agregar un nuevo anuncio, crea un archivo Markdown de anuncios en la
 carpeta `anuncios` de su localización usando el siguiente comando:
@@ -36,7 +36,7 @@ en idioma inglés.
 
 {{% /alert %}}
 
-### Lista de anuncios
+## Lista de anuncios
 
 Cualquier anuncio aparecerá en la compilación de un sitio web cuando la fecha de
 compilación se encuentre entre los campos `fecha` y `fecha de vencimiento`.

--- a/content/fr/docs/zero-code/java/spring-boot-starter/getting-started.md
+++ b/content/fr/docs/zero-code/java/spring-boot-starter/getting-started.md
@@ -1,7 +1,7 @@
 ---
 title: Démarrage rapide
 weight: 20
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649
+default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649 # patched
 cSpell:ignore: springboot
 ---
 
@@ -13,7 +13,7 @@ consultez [Instrumentation Java Zero-code](..).
 
 {{% /alert %}}
 
-### Compatibilité {#compatibility}
+## Compatibilité {#compatibility}
 
 Le Spring Boot starter OpenTelemetry fonctionne avec Spring Boot 2.6+ et 3.1+,
 et les images d'applications natives à Spring Boot. Le dépôt
@@ -21,7 +21,7 @@ et les images d'applications natives à Spring Boot. Le dépôt
 contient un exemple d'image d'application native à Spring Boot instrumentée à
 l'aide du Spring Boot OpenTelemetry starter.
 
-### Gestion des dépendances {#dependency-management}
+## Gestion des dépendances {#dependency-management}
 
 Une nomenclature
 ([BOM](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#bill-of-materials-bom-poms))
@@ -109,7 +109,7 @@ avec le plugin `io.spring.dependency-management`.
 
 {{% /alert %}}
 
-#### Dépendance du starter OpenTelemetry {#opentelemetry-starter-dependency}
+### Dépendance du starter OpenTelemetry {#opentelemetry-starter-dependency}
 
 Ajoutez la dépendance ci-dessous pour activer le starter OpenTelemetry.
 

--- a/content/fr/docs/zero-code/python/example.md
+++ b/content/fr/docs/zero-code/python/example.md
@@ -3,7 +3,7 @@ title: Exemple d'auto-instrumentation
 linkTitle: Exemple
 weight: 20
 aliases: [/docs/languages/python/automatic/example]
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649
+default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649 # patched
 drifted_from_default: true
 cSpell:ignore: distro instrumentor mkdir MSIE Referer Starlette venv
 ---
@@ -38,7 +38,7 @@ nécessaire pour intégrer OpenTelemetry dans le code de votre application.
 Ci-dessous, vous verrez la différence entre une route Flask instrumentée
 manuellement, automatiquement et programmatiquement.
 
-### Serveur instrumenté manuellement {#manually-instrumented-server}
+## Serveur instrumenté manuellement {#manually-instrumented-server}
 
 `server_manual.py`
 
@@ -55,7 +55,7 @@ def server_request():
         return "served"
 ```
 
-### Serveur instrumenté automatiquement {#automatically-instrumented-server}
+## Serveur instrumenté automatiquement {#automatically-instrumented-server}
 
 `server_automatic.py`
 
@@ -66,7 +66,7 @@ def server_request():
     return "served"
 ```
 
-### Serveur instrumenté programmatiquement {#programmatically-instrumented-server}
+## Serveur instrumenté programmatiquement {#programmatically-instrumented-server}
 
 `server_programmatic.py`
 
@@ -135,7 +135,7 @@ Cette section vous guide à travers le processus manuel d'instrumentation d'un
 serveur ainsi que le processus d'exécution d'un serveur instrumenté
 automatiquement.
 
-### Exécuter le serveur instrumenté manuellement {#execute-the-manually-instrumented-server}
+## Exécuter le serveur instrumenté manuellement {#execute-the-manually-instrumented-server}
 
 Exécutez le serveur dans deux consoles séparées, une pour chacun des scripts à
 exécuter qui composent cet exemple :
@@ -190,7 +190,7 @@ suivant :
 }
 ```
 
-### Exécuter le serveur instrumenté automatiquement {#execute-the-automatically-instrumented-server}
+## Exécuter le serveur instrumenté automatiquement {#execute-the-automatically-instrumented-server}
 
 Arrêtez l'exécution de `server_manual.py` en appuyant sur <kbd>Control+C</kbd>
 et exécutez la commande suivante à la place :
@@ -253,7 +253,7 @@ suivant :
 Vous pouvez voir que les deux sorties sont les mêmes car l'instrumentation
 automatique fait exactement ce que fait l'instrumentation manuelle.
 
-### Exécuter le serveur instrumenté programmatiquement {#execute-the-programmatically-instrumented-server}
+## Exécuter le serveur instrumenté programmatiquement {#execute-the-programmatically-instrumented-server}
 
 Il est également possible d'utiliser les bibliothèques d'instrumentation (telles
 que `opentelemetry-instrumentation-flask`) par elles-mêmes, ce qui peut avoir
@@ -278,7 +278,7 @@ python client.py testing
 Les résultats devraient être les mêmes que lors de l'exécution avec
 l'instrumentation manuelle.
 
-#### Utilisation des fonctionnalités d'instrumentation programmatique {#using-programmatic-instrumentation-features}
+### Utilisation des fonctionnalités d'instrumentation programmatique {#using-programmatic-instrumentation-features}
 
 Certaines bibliothèques d'instrumentation incluent des fonctionnalités qui
 permettent un contrôle plus précis lors de l'instrumentation programmatique, la
@@ -296,7 +296,7 @@ côté serveur. Ceci est dû à l'option `excluded_urls` passée à `instrument_
 qui empêche effectivement la fonction `server_request` d'être instrumentée car
 son URL correspond à l'expression régulière passée à `excluded_urls`.
 
-### Instrumentation pendant le débogage {#instrumentation-while-debugging}
+## Instrumentation pendant le débogage {#instrumentation-while-debugging}
 
 Le mode de débogage peut être activé dans l'application Flask comme ceci :
 
@@ -319,7 +319,7 @@ if __name__ == "__main__":
 L'auto-instrumentation peut consommer la configuration à partir des variables
 d'environnement.
 
-### Capturer les en-têtes de requête et de réponse HTTP {#capture-http-request-and-response-headers}
+## Capturer les en-têtes de requête et de réponse HTTP {#capture-http-request-and-response-headers}
 
 Vous pouvez capturer les en-têtes HTTP prédéfinis en tant qu'attributs de span,
 conformément à la [convention sémantique][].

--- a/content/fr/docs/zero-code/python/operator.md
+++ b/content/fr/docs/zero-code/python/operator.md
@@ -4,7 +4,7 @@ title:
 linkTitle: Opérateur
 aliases: [/docs/languages/python/automatic/operator]
 weight: 30
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649
+default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649 # patched
 drifted_from_default: true
 cSpell:ignore: django-applications grpcio myapp psutil PYTHONPATH
 ---
@@ -16,9 +16,9 @@ pour injecter l'auto-instrumentation sans avoir à modifier directement chacun d
 vos services.
 [Consultez la documentation sur l'auto-instrumentation de l'Opérateur OpenTelemetry pour plus de détails.](/docs/platforms/kubernetes/operator/automatic/)
 
-### Sujets spécifiques à Python {#python-specific-topics}
+## Sujets spécifiques à Python {#python-specific-topics}
 
-#### Bibliothèques avec des roues binaires {#libraries-with-binary-wheels}
+### Bibliothèques avec des roues binaires {#libraries-with-binary-wheels}
 
 Certains paquets Python que nous instrumentons ou dont nous avons besoin dans
 nos bibliothèques d'instrumentation, peuvent être livrés avec du code binaire.
@@ -36,7 +36,7 @@ Depuis la version v0.113.0 de l'opérateur, il est possible de construire une
 image avec une auto-instrumentation basée à la fois sur glibc et musl et de
 [la configurer à l'exécution](/docs/platforms/kubernetes/operator/automatic/#annotations-python-musl).
 
-#### Applications Django {#django-applications}
+### Applications Django {#django-applications}
 
 Les applications qui s'exécutent à partir de leur propre exécutable comme Django
 nécessitent de définir dans votre fichier de déploiement deux variables

--- a/content/ja/docs/concepts/sampling/index.md
+++ b/content/ja/docs/concepts/sampling/index.md
@@ -3,6 +3,7 @@ title: サンプリング
 description: サンプリングとOpenTelemetryで利用可能なさまざまなサンプリングオプションについて学びましょう。
 weight: 80
 default_lang_commit: 8d115a9df96c52dbbb3f96c05a843390d90a9800 # patched
+drifted_from_default: true
 ---
 
 分散システムでは、[トレース](/docs/concepts/signals/traces)で、リクエストが分散システム内のあるサービスから別のサービスに移動するのを観察できます。

--- a/content/ja/docs/concepts/signals/traces.md
+++ b/content/ja/docs/concepts/signals/traces.md
@@ -3,6 +3,7 @@ title: トレース
 weight: 1
 description: アプリケーションを通過するリクエストの経路
 default_lang_commit: 548e5e29f574fddc3ca683989a458e9a6800242f
+drifted_from_default: true
 cSpell:ignore: Guten
 ---
 

--- a/content/ja/docs/contributing/announcements.md
+++ b/content/ja/docs/contributing/announcements.md
@@ -2,7 +2,7 @@
 title: アナウンス
 description: 特別なイベントのためのアナウンスやバナーを作成します。
 weight: 50
-default_lang_commit: d7a61cc489f25935348229d0743fba9b8828dbc1
+default_lang_commit: d7a61cc489f25935348229d0743fba9b8828dbc1 # patched
 ---
 
 アナウンスは、ロケールの `announcements` セクション内に含まれる _通常の Hugo ページ_ です。
@@ -11,7 +11,7 @@ default_lang_commit: d7a61cc489f25935348229d0743fba9b8828dbc1
 > 現在、アナウンスはバナーとしてのみ使用されています。
 > 将来的には、もう少し一般的なアナウンス機能をサポートする _可能性が_ あります。
 
-### アナウンスを作成する {#creating-an-announcement}
+## アナウンスを作成する {#creating-an-announcement}
 
 新しいアナウンスを追加するには、以下のコマンドを使用して、ローカリゼーションフォルダー内の `announcements` フォルダーに Markdown ファイルを作成します。
 
@@ -30,7 +30,7 @@ hugo new --kind announcement content/YOUR-LOCALE/announcements/announcement-file
 
 {{% /alert %}}
 
-### アナウンス一覧 {#announcement-list}
+## アナウンス一覧 {#announcement-list}
 
 各アナウンスは、ビルドの日付が `date` フィールドと `expiryDate` フィールドの間にある場合にサイトのビルドに含まれます。
 これらのフィールドが省略された場合、それぞれ「現在」と「無期限」と見なされます。

--- a/content/ja/docs/languages/js/exporters.md
+++ b/content/ja/docs/languages/js/exporters.md
@@ -2,12 +2,12 @@
 title: エクスポーター
 weight: 50
 description: テレメトリデータの処理とエクスポート
-default_lang_commit: 6f3712c5cda4ea79f75fb410521880396ca30c91
+default_lang_commit: 6f3712c5cda4ea79f75fb410521880396ca30c91 # patched
 ---
 
 {{% docs/languages/exporters/intro %}}
 
-### 依存関係 {#otlp-dependencies}
+## 依存関係 {#otlp-dependencies}
 
 テレメトリーデータをOTLPエンドポイント（[OpenTelemetry Collector](#collector-setup)、[Jaeger](#jaeger)、[Prometheus](#prometheus)など）に送信したい場合、データを転送するために3つの異なるプロトコルから選択できます。
 
@@ -40,7 +40,7 @@ npm install --save @opentelemetry/exporter-trace-otlp-grpc \
 
 {{% /tab %}} {{< /tabpane >}}
 
-### Node.jsでの使用法 {#usage-with-nodejs}
+## Node.jsでの使用法 {#usage-with-nodejs}
 
 次に、OTLPエンドポイントを指すようにエクスポーターを設定します。
 たとえば、[Getting Started](/docs/languages/js/getting-started/nodejs/)の`instrumentation.ts`（またはJavaScriptを使用する場合は`instrumentation.js`）ファイルを以下のように更新して、OTLP（`http/protobuf`）経由でトレースとメトリクスをエクスポートできます。
@@ -110,7 +110,7 @@ sdk.start();
 
 {{% /tab %}} {{< /tabpane >}}
 
-### ブラウザでの使用法 {#usage-in-the-browser}
+## ブラウザでの使用法 {#usage-in-the-browser}
 
 ブラウザベースのアプリケーションでOTLPエクスポーターを使用する場合、以下の点に注意する必要があります。
 
@@ -121,13 +121,13 @@ sdk.start();
 
 以下では、適切なエクスポーターの使用、CSPとCORSヘッダーの設定、およびコレクターを公開する際に取るべき予防措置について説明します。
 
-#### HTTP/JSONまたはHTTP/protobufでOTLPエクスポーターを使用 {#use-otlp-exporter-with-httpjson-or-httpprotobuf}
+### HTTP/JSONまたはHTTP/protobufでOTLPエクスポーターを使用 {#use-otlp-exporter-with-httpjson-or-httpprotobuf}
 
 [OpenTelemetry Collector Exporter with gRPC][]はNode.jsでのみ動作するため、[OpenTelemetry Collector Exporter with HTTP/JSON][]または[OpenTelemetry Collector Exporter with HTTP/protobuf][]の使用に制限されます。
 
 [OpenTelemetry Collector Exporter with HTTP/JSON][]を使用している場合は、エクスポーターの受信側（コレクターまたはオブザーバビリティバックエンド）が`http/json`を受け入れることを確認し、ポートを4318に設定して適切なエンドポイントにデータをエクスポートしていることを確認してください。
 
-#### CSPの設定 {#configure-csps}
+### CSPの設定 {#configure-csps}
 
 WebサイトでContent Security Policies（CSP）を使用している場合は、OTLPエンドポイントのドメインが含まれていることを確認してください。
 コレクターエンドポイントが`https://collector.example.com:4318/v1/traces`の場合、以下のディレクティブを追加します。
@@ -138,7 +138,7 @@ connect-src collector.example.com:4318/v1/traces
 
 CSPがOTLPエンドポイントを含んでいない場合、エンドポイントへのリクエストがCSPディレクティブに違反していることを示すエラーメッセージが表示されます。
 
-#### CORSヘッダーの設定 {#configure-cors-headers}
+### CORSヘッダーの設定 {#configure-cors-headers}
 
 Webサイトとコレクターが異なるオリジンでホストされている場合、ブラウザがコレクターへのリクエストをブロックする可能性があります。
 Cross-Origin Resource Sharing（CORS）のための特別なヘッダーを設定する必要があります。
@@ -160,7 +160,7 @@ receivers:
           max_age: 7200
 ```
 
-#### コレクターの安全な公開 {#securely-expose-your-collector}
+### コレクターの安全な公開 {#securely-expose-your-collector}
 
 Webアプリケーションからテレメトリーを受信するには、エンドユーザーのブラウザがコレクターにデータを送信できるようにする必要があります。
 Webアプリケーションがパブリックインターネットからアクセス可能な場合、コレクターもすべての人がアクセス可能にする必要があります。
@@ -210,7 +210,7 @@ server {
 
 {{% include "exporters/prometheus-setup.md" %}}
 
-### 依存関係 {#prometheus-dependencies}
+## 依存関係 {#prometheus-dependencies}
 
 アプリケーションの依存関係として[エクスポーターパッケージ](https://www.npmjs.com/package/@opentelemetry/exporter-prometheus)をインストールします。
 
@@ -261,7 +261,7 @@ PrometheusまたはPrometheusレシーバーを持つOpenTelemetry Collectorが�
 
 {{% include "exporters/zipkin-setup.md" %}}
 
-### 依存関係 {#zipkin-dependencies}
+## 依存関係 {#zipkin-dependencies}
 
 トレースデータを[Zipkin](https://zipkin.io/)に送信するには、`ZipkinExporter`を使用できます。
 

--- a/content/ja/docs/platforms/faas/_index.md
+++ b/content/ja/docs/platforms/faas/_index.md
@@ -4,7 +4,7 @@ linkTitle: FaaS
 description: >-
   OpenTelemetryは、さまざまなクラウドベンダーが提供するFaaSを監視するさまざまな方法をサポートしています。
 redirects: [{ from: /docs/faas/*, to: ':splat' }] # cSpell:disable-line
-default_lang_commit: 9ba98f4fded66ec78bfafa189ab2d15d66df2309
+default_lang_commit: 9ba98f4fded66ec78bfafa189ab2d15d66df2309 # patched
 ---
 
 Functions as a Service（FaaS）は、[クラウドネイティブアプリ][cloud native apps]にとって重要なサーバーレスコンピュートプラットフォームです。
@@ -13,7 +13,7 @@ Functions as a Service（FaaS）は、[クラウドネイティブアプリ][clo
 FaaSドキュメントの最初のベンダー範囲は、Microsoft Azure、Google Cloud Platform（GCP）、Amazon Web Services（AWS）です。
 AWSのファンクション（関数）はLambdaとしても知られています。
 
-### コミュニティアセット {#community-assets}
+## コミュニティアセット {#community-assets}
 
 現在、OpenTelemetry コミュニティは、アプリケーションを自動計装することができるビルド済みの Lambda レイヤーと、アプリケーションを手動または自動で計装する際に使用できるスタンドアロンの Collector Lambda レイヤーを提供しています。
 

--- a/content/ja/docs/platforms/faas/lambda-auto-instrument.md
+++ b/content/ja/docs/platforms/faas/lambda-auto-instrument.md
@@ -2,7 +2,7 @@
 title: Lambda 自動計装
 weight: 11
 description: あなたのLambdaをOpenTelemetryで自動的に計装する
-default_lang_commit: 9b427bf25703c33a2c6e05c2a7b58e0f768f7bad
+default_lang_commit: 9b427bf25703c33a2c6e05c2a7b58e0f768f7bad # patched
 cSpell:ignore: Corretto
 ---
 
@@ -16,12 +16,12 @@ OpenTelemetryコミュニティは、以下の言語用のスタンドアロン�
 これらのレイヤーは、AWSポータルを使用してLambdaに追加し、アプリケーションを自動的に計装できます。
 これらのレイヤーにはコレクターは含まれておらず、外部コレクターインスタンスを構成してデータを送信しない限り、追加する必要があります。
 
-### OTel Collector LambdaレイヤーのARNを追加する {#add-the-arn-of-the-otel-collector-lambda-layer}
+## OTel Collector LambdaレイヤーのARNを追加する {#add-the-arn-of-the-otel-collector-lambda-layer}
 
 [Collector Lambdaレイヤーのガイダンス](../lambda-collector/)を参照して、アプリケーションにレイヤーを追加し、Collectorを設定してください。
 これを最初に追加することをおすすめします。
 
-### 言語要件 {#language-requirements}
+## 言語要件 {#language-requirements}
 
 {{< tabpane text=true >}} {{% tab Java %}}
 
@@ -67,12 +67,12 @@ Lambda レイヤーは、Ruby 3.2 と 3.3 の Lambda ランタイムをサポー
 
 {{% /tab %}} {{< /tabpane >}}
 
-### `AWS_LAMBDA_EXEC_WRAPPER` を設定する {#configure-aws_lambda_exec_wrapper}
+## `AWS_LAMBDA_EXEC_WRAPPER` を設定する {#configure-aws_lambda_exec_wrapper}
 
 Node.js、Java、Ruby、Pythonの場合は `AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler` を設定して、アプリケーションのエントリーポイントを変更します。
 このラッパースクリプトは、自動計装を適用したLambdaアプリケーションを起動します。
 
-### 計装LambdaレイヤーのARNを追加する {#add-the-arn-of-instrumentation-lambda-layer}
+## 計装LambdaレイヤーのARNを追加する {#add-the-arn-of-instrumentation-lambda-layer}
 
 Lambda関数でOTelの自動計装を有効にするには、計装レイヤーとコレクターレイヤーを追加して設定し、トレースを有効にする必要があります。
 
@@ -85,7 +85,7 @@ Lambda関数でOTelの自動計装を有効にするには、計装レイヤー�
 
 注意: ラムダレイヤーはリージョンで分かれたリソースで、公開されているリージョンでのみ使用できます。Lambda関数と同じリージョンでレイヤーを使用するようにしてください。コミュニティは、利用可能なすべてのリージョンでレイヤーを公開しています。
 
-### SDKのエクスポーターの設定 {#configure-your-sdk-exporters}
+## SDKのエクスポーターの設定 {#configure-your-sdk-exporters}
 
 gRPC/HTTPレシーバーを持つコレクターが組み込まれている場合、Lambdaレイヤーで使用されるデフォルトのエクスポーターは変更なしで動作します。
 環境変数を更新する必要はありません。
@@ -109,6 +109,6 @@ gRPC/HTTPレシーバーを持つコレクターが組み込まれている場�
 
 {{% /tab %}} {{< /tabpane >}}
 
-### Lambdaを公開する {#publish-your-lambda}
+## Lambdaを公開する {#publish-your-lambda}
 
 Lambdaの新しいバージョンを公開して、新しい変更と計装をデプロイします。

--- a/content/ja/docs/platforms/faas/lambda-collector.md
+++ b/content/ja/docs/platforms/faas/lambda-collector.md
@@ -3,14 +3,14 @@ title: Lambdaコレクター設定
 linkTitle: Lambdaコレクター設定
 weight: 11
 description: コレクターLambdaレイヤーをあなたのLambdaに追加して設定する
-default_lang_commit: 9ba98f4fded66ec78bfafa189ab2d15d66df2309
+default_lang_commit: 9ba98f4fded66ec78bfafa189ab2d15d66df2309 # patched
 cSpell:ignore: ADOT awsxray configmap confmap
 ---
 
 OpenTelemetry コミュニティは、ユーザーに最大限の柔軟性を与えるために、コレクターを計装レイヤーとは別のLambdaレイヤーで提供しています。
 これは、計装とコレクターをバンドルしている現在の AWS Distribution of OpenTelemetry (ADOT) の実装とは異なります。
 
-### OTelコレクターLambdaレイヤーのARNを追加する {#add-the-arn-of-the-otel-collector-lambda-layer}
+## OTelコレクターLambdaレイヤーのARNを追加する {#add-the-arn-of-the-otel-collector-lambda-layer}
 
 アプリケーションの計装が完了したら、コレクターLambdaレイヤーを追加してデータを収集し、選択したバックエンドに送信します。
 
@@ -19,17 +19,17 @@ OpenTelemetry コミュニティは、ユーザーに最大限の柔軟性を与
 
 注意: ラムダレイヤーはリージョンで分かれたリソースであり、公開されているリージョンでのみ使用できます。Lambda関数と同じリージョンでレイヤーを使用するようにしてください。コミュニティは、利用可能なすべてのリージョンでレイヤーを公開しています。
 
-### OTelコレクターの設定 {#configure-the-otel-collector}
+## OTelコレクターの設定 {#configure-the-otel-collector}
 
 OTelコレクターLambdaレイヤーの設定は、OpenTelemetry標準にしたがっています。
 
 デフォルトでは、OTelコレクターLambdaレイヤーはconfig.yamlを使用します。
 
-#### 希望するバックエンドの環境変数を設定する {#set-the-environment-variable-for-your-preferred-backend}
+### 希望するバックエンドの環境変数を設定する {#set-the-environment-variable-for-your-preferred-backend}
 
 Lambda環境変数の設定で、認証トークンを格納する新しい変数を作成します。
 
-#### デフォルトエクスポーターを更新する {#update-the-default-exporters}
+### デフォルトエクスポーターを更新する {#update-the-default-exporters}
 
 もしまだ存在していなければ、`config.yaml` ファイルに好みのエクスポーターを追加します。
 前のステップでアクセストークンのために設定した環境変数を使用して、エクスポーターを設定します。
@@ -64,22 +64,22 @@ service:
       address: localhost:8888
 ```
 
-### Lambdaを公開する {#publish-your-lambda}
+## Lambdaを公開する {#publish-your-lambda}
 
 Lambdaの新しいバージョンをパブリッシュして、行った変更を有効にします。
 
-### 高度な OTel コレクターの設定 {#advanced-otel-collector-configuration}
+## 高度な OTel コレクターの設定 {#advanced-otel-collector-configuration}
 
 カスタム構成でサポートされる利用可能なコンポーネントのリストは、こちらをご覧ください。
 デバッグを有効にするには、設定ファイルを使ってログレベルをデバッグに設定します。
 以下の例を参照してください。
 
-#### 希望のConfmapプロバイダーを選択する {#choose-your-preferred-confmap-provider}
+### 希望のConfmapプロバイダーを選択する {#choose-your-preferred-confmap-provider}
 
 OTel Lambdaレイヤーは `file`、`env`、`yaml`、`http`、`https`、`s3` といった種類の Confmap プロバイダーをサポートしています。
 異なる Confmap プロバイダーを使用して OTel コレクターの設定をカスタマイズするには、[Amazon Distribution of OpenTelemetry Confmap providers document](https://aws-otel.github.io/docs/components/confmap-providers#confmap-providers-supported-by-the-adot-collector) を参照してください。
 
-#### カスタム設定ファイルの作成 {#create-a-custom-configuration-file}
+### カスタム設定ファイルの作成 {#create-a-custom-configuration-file}
 
 以下はルートディレクトリにある `collector.yaml` の設定ファイルのサンプルです。
 
@@ -113,13 +113,13 @@ service:
       address: localhost:8888
 ```
 
-#### 環境変数を使ってカスタム設定ファイルをマップする {#map-your-custom-configuration-file-using-environment-variables}
+### 環境変数を使ってカスタム設定ファイルをマップする {#map-your-custom-configuration-file-using-environment-variables}
 
 confmapプロバイダーを通してコレクターを設定したら、Lambda関数に環境変数 `OPENTELEMETRY_COLLECTOR_CONFIG_URI` を作成し、その値としてconfmapプロバイダーの設定のパスを設定します。
 たとえば、ファイルconfigmapプロバイダーを使用している場合は、その値を `/var/task/<path>/<to>/<filename>` に設定します。
 これにより、拡張モジュールにコレクターの設定がどこにあるかを伝えます。
 
-##### CLIを使用したカスタムコレクター設定 {#custom-collector-configuration-using-the-cli}
+#### CLIを使用したカスタムコレクター設定 {#custom-collector-configuration-using-the-cli}
 
 Lambdaコンソール、またはAWS CLIから設定できます。
 
@@ -127,7 +127,7 @@ Lambdaコンソール、またはAWS CLIから設定できます。
 aws lambda update-function-configuration --function-name Function --environment Variables={OPENTELEMETRY_COLLECTOR_CONFIG_URI=/var/task/collector.yaml}
 ```
 
-##### CloudFormationから設定用の環境変数を設定する {#set-configuration-environment-variables-from-cloudformation}
+#### CloudFormationから設定用の環境変数を設定する {#set-configuration-environment-variables-from-cloudformation}
 
 環境変数は**CloudFormation**テンプレートでも設定できます。
 
@@ -141,7 +141,7 @@ Function:
         OPENTELEMETRY_COLLECTOR_CONFIG_URI: /var/task/collector.yaml
 ```
 
-##### S3オブジェクトから設定を読み込む {#load-configuration-from-an-s3-object}
+#### S3オブジェクトから設定を読み込む {#load-configuration-from-an-s3-object}
 
 S3から設定を読み込むには、関数にアタッチされたIAMロールに、関連するバケットへの読み取りアクセスが含まれている必要があります。
 

--- a/content/ja/docs/platforms/faas/lambda-manual-instrument.md
+++ b/content/ja/docs/platforms/faas/lambda-manual-instrument.md
@@ -2,22 +2,22 @@
 title: Lambdaの手動計装
 weight: 11
 description: OpenTelemetryであなたのLambdaを手動計装する
-default_lang_commit: 9ba98f4fded66ec78bfafa189ab2d15d66df2309
+default_lang_commit: 9ba98f4fded66ec78bfafa189ab2d15d66df2309 # patched
 ---
 
 Lambdaの自動計装ドキュメントでカバーされていない言語については、コミュニティはスタンドアロンの計装レイヤーを持っていません。
 
 ユーザーは、選択した言語の汎用計装ガイダンスにしたがい、コレクターLambdaレイヤーを追加してデータを送信する必要があります。
 
-### OTelコレクターLambdaレイヤーのARNを追加する {#add-the-arn-of-the-otel-collector-lambda-layer}
+## OTelコレクターLambdaレイヤーのARNを追加する {#add-the-arn-of-the-otel-collector-lambda-layer}
 
 [コレクターLambdaレイヤーのガイダンス](../lambda-collector/)を参照して、アプリケーションにレイヤーを追加し、コレクターを設定してください。
 これを最初に追加することをおすすめします。
 
-### LambdaをOTelで計装する {#instrument-the-lambda-with-otel}
+## LambdaをOTelで計装する {#instrument-the-lambda-with-otel}
 
 アプリケーションを手動で計装する方法については、[各言語向け計装ガイド](/docs/languages/) を確認してください。
 
-### Lambdaを公開する {#publish-your-lambda}
+## Lambdaを公開する {#publish-your-lambda}
 
 Lambdaの新しいバージョンを公開して、新しい変更と計装をデプロイします。

--- a/content/ja/docs/zero-code/python/example.md
+++ b/content/ja/docs/zero-code/python/example.md
@@ -2,7 +2,7 @@
 title: 自動計装の例
 linkTitle: Example
 weight: 20
-default_lang_commit: 9b427bf25703c33a2c6e05c2a7b58e0f768f7bad
+default_lang_commit: 9b427bf25703c33a2c6e05c2a7b58e0f768f7bad # patched
 ---
 
 このページでは、OpenTelemetry で Python 自動計装を使う方法を示します。
@@ -26,7 +26,7 @@ default_lang_commit: 9b427bf25703c33a2c6e05c2a7b58e0f768f7bad
 これにより、OpenTelemetry をアプリケーションコードに統合するのに必要な作業量を減らせます。
 以下に、手動、自動、プログラムで計装された Flask ルートの違いを示します。
 
-### 手動計測サーバー {#manually-instrumented-server}
+## 手動計測サーバー {#manually-instrumented-server}
 
 `server_manual.py`
 
@@ -43,7 +43,7 @@ def server_request():
         return "served"
 ```
 
-### 自動計装サーバー {#automatically-instrumented-server}
+## 自動計装サーバー {#automatically-instrumented-server}
 
 `server_automatic.py`
 
@@ -54,7 +54,7 @@ def server_request():
     return "served"
 ```
 
-### プログラム計測サーバー {#programmatically-instrumented-server}
+## プログラム計測サーバー {#programmatically-instrumented-server}
 
 `server_programmatic.py`
 
@@ -115,7 +115,7 @@ opentelemetry-bootstrap -a install
 
 この節では、サーバーの計装を手動で行うプロセスと、自動的に計装されたサーバーを実行するプロセスについて説明します。
 
-### 手動で計測したサーバーを実行する {#execute-the-manually-instrumented-server}
+## 手動で計測したサーバーを実行する {#execute-the-manually-instrumented-server}
 
 この例を構成するスクリプトをそれぞれ実行するために、2つの別々のコンソールでサーバーを実行します。
 
@@ -168,7 +168,7 @@ python client.py
 }
 ```
 
-### 自動計装サーバーの実行 {#execute-the-automatically-instrumented-server}
+## 自動計装サーバーの実行 {#execute-the-automatically-instrumented-server}
 
 <kbd>Control+C</kbd> を押して `server_manual.py` の実行を停止し、かわりに以下のコマンドを実行します。
 
@@ -227,7 +227,7 @@ python client.py
 
 自動計装は手動計測とまったく同じことをするので、両方の出力が同じであることがわかります。
 
-### プログラムで計装されたサーバーを実行する {#execute-the-programmatically-instrumented-server}
+## プログラムで計装されたサーバーを実行する {#execute-the-programmatically-instrumented-server}
 
 計装ライブラリ（`opentelemetry-instrumentation-flask` など）を単独で使うことも可能で、オプションをカスタマイズできるという利点があります。
 しかし、これを選択することは、 `opentelemetry-instrument` を使ってアプリケーションを起動することによる自動計装を見送ることを意味します。
@@ -246,7 +246,7 @@ python client.py
 
 結果は、手動の計装を使った場合と同じになるはずです。
 
-#### プログラムによる計装機能の使用 {#using-programmatic-instrumentation-features}
+### プログラムによる計装機能の使用 {#using-programmatic-instrumentation-features}
 
 計装ライブラリの中には、プログラムで計装を行う際に、より精密な制御を可能にする機能を備えているものがあり、Flask用の計装ライブラリもその1つです。
 
@@ -260,7 +260,7 @@ instrumentor.instrument_app(app, excluded_urls="/server_request")
 この例を再度実行すると、サーバー側には計装が表示されなくなります。
 これは `instrument_app` に渡された `excluded_urls` オプションのためで、`server_request` 関数の URL が `excluded_urls` に渡された正規表現にマッチするため、効果的に計装が行われなくなります。
 
-### デバッグ中の計装 {#instrumentation-while-debugging}
+## デバッグ中の計装 {#instrumentation-while-debugging}
 
 デバッグモードは、Flaskアプリで次のように有効にできます。
 
@@ -281,7 +281,7 @@ if __name__ == "__main__":
 
 自動計装は、環境変数から設定を読み込めます。
 
-### HTTP リクエストとレスポンスヘッダーをキャプチャする {#capture-http-request-and-response-headers}
+## HTTP リクエストとレスポンスヘッダーをキャプチャする {#capture-http-request-and-response-headers}
 
 [セマンティック規約][semantic convention]にしたがって、定義済みのHTTPヘッダーをスパン属性として取り込めます。
 

--- a/content/ja/docs/zero-code/python/operator.md
+++ b/content/ja/docs/zero-code/python/operator.md
@@ -2,16 +2,16 @@
 title: OpenTelemetryオペレーターを使用して自動計装を注入する
 linkTitle: Operator
 weight: 30
-default_lang_commit: 3d737b777f7bfa070f7f14835570add916d4dcb0
+default_lang_commit: 3d737b777f7bfa070f7f14835570add916d4dcb0 # patched
 drifted_from_default: true
 ---
 
 KubernetesでPythonサービスを実行する場合、[OpenTelemetryオペレーター](https://github.com/open-telemetry/opentelemetry-operator)を活用することで、各サービスを直接修正することなく自動計装を注入できます。
 [詳細はOpenTelemetryオペレーターによる自動計装のドキュメントを参照してください](/docs/platforms/kubernetes/operator/automatic/)
 
-### Python 固有のトピック {#python-specific-topics}
+## Python 固有のトピック {#python-specific-topics}
 
-#### バイナリwheel付きライブラリ {#libraries-with-binary-wheels}
+### バイナリwheel付きライブラリ {#libraries-with-binary-wheels}
 
 私たちが計装を行ったり、計装ライブラリで必要とするPythonのパッケージの中には、バイナリコードが同梱されていることがあります。
 たとえば、`grpcio` や `psutil` (`opentelemetry-instrumentation-system-metrics` で使われている) がそうです。
@@ -22,7 +22,7 @@ KubernetesでPythonサービスを実行する場合、[OpenTelemetryオペレ�
 
 オペレーター v0.113.0以降、glibcとmuslベースの自動計装の両方を持つイメージをビルドし、[実行時に設定する](/docs/platforms/kubernetes/operator/automatic/#annotations-python-musl)ことが可能です。
 
-#### Django アプリケーション {#django-applications}
+### Django アプリケーション {#django-applications}
 
 Django のように独自の実行ファイルから実行されるアプリケーションでは、デプロイファイルに2つの環境変数を設定する必要があります。
 

--- a/content/pt/community/end-user/_index.md
+++ b/content/pt/community/end-user/_index.md
@@ -3,7 +3,7 @@ title: Recursos de usuário final
 linkTitle: Usuário Final
 description: Recursos agnósticos a fornecedor para usuários do OpenTelemetry
 weight: 40
-default_lang_commit: ee09a3383facebe1937529e9a0129ccf53f94937
+default_lang_commit: ee09a3383facebe1937529e9a0129ccf53f94937 # patched
 ---
 
 Procurando se conectar com outros usuários finais do OpenTelemetry em um espaço
@@ -31,7 +31,7 @@ observabilidade onipresente. Nós encorajamos você a compartilhar seus sucessos
 falhas, descobrir melhores práticas, e conhecer outras pessoas que também estão
 na jornada de implementar observabilidade impulsionada pelo OpenTelemetry.
 
-### Tópicos {#topics}
+## Tópicos {#topics}
 
 Esse grupo é o que os seus membros fazem dele -- qualquer coisa que seja de
 interesse para o grupo é válida!
@@ -44,7 +44,7 @@ Mas aqui tem alguns dos tipos de coisas que esperamos que estejam na mesa:
 - Mantendo e escalando implantações do OpenTelemetry
 - Escrita de instrumentação customizada
 
-### Perguntas {#questions}
+## Perguntas {#questions}
 
 **Esse grupo é apenas para usuários finais do OpenTelemetry?**
 

--- a/content/pt/docs/concepts/sampling/index.md
+++ b/content/pt/docs/concepts/sampling/index.md
@@ -5,6 +5,7 @@ description:
   OpenTelemetry.
 weight: 80
 default_lang_commit: 49879d0c00a4a28c963a76998f7213af7b539c77 # patched
+drifted_from_default: true
 ---
 
 Com [rastros](/docs/concepts/signals/traces), você pode observar as requisições

--- a/content/pt/docs/contributing/announcements.md
+++ b/content/pt/docs/contributing/announcements.md
@@ -2,7 +2,7 @@
 title: Anúncios
 description: Crie anúncios ou banners para eventos especiais.
 weight: 50
-default_lang_commit: 645760e1961cb45d9ce6b291887c74ce4efa0398
+default_lang_commit: 645760e1961cb45d9ce6b291887c74ce4efa0398 # patched
 ---
 
 Um anúncio é uma _regular page_ do Hugo, contida no diretório `announcements` de
@@ -15,7 +15,7 @@ etc.
 > Atualmente, os anúncios são usados apenas como banners. Eventualmente, também
 > poderemos oferecer suporte a anúncios um pouco mais gerais.
 
-### Criando um anúncio {#creating-an-announcement}
+## Criando um anúncio {#creating-an-announcement}
 
 Para adicionar um novo anúncio, crie um arquivo Markdown no diretório
 `announcements` da sua localização utilizando o seguinte comando:
@@ -36,7 +36,7 @@ certifique-se de usar o **mesmo nome de arquivo** do anúncio em inglês.
 
 {{% /alert %}}
 
-### Lista de anúncios {#announcement-list}
+## Lista de anúncios {#announcement-list}
 
 Qualquer anúncio aparecerá no site quando sua data de compilação estiver entre
 os campos `date` e `expiryDate` do anúncio. Quando esses campos estiverem

--- a/content/pt/docs/languages/python/exporters.md
+++ b/content/pt/docs/languages/python/exporters.md
@@ -2,16 +2,14 @@
 title: Exporters
 weight: 50
 description: Processar e exportar seus dados de telemetria
-default_lang_commit: dc20c29a4c79ad0424c0fcc3271216af7e035d9b
+default_lang_commit: dc20c29a4c79ad0424c0fcc3271216af7e035d9b # patched
 drifted_from_default: true
 cSpell:ignore: LOWMEMORY
 ---
 
-<!-- markdownlint-disable no-duplicate-heading -->
-
 {{% docs/languages/exporters/intro %}}
 
-### Dependências {#otlp-dependencies}
+## Dependências {#otlp-dependencies}
 
 Se você deseja enviar dados de telemetria para um endpoint OTLP (como o
 [OpenTelemetry Collector](#collector-setup), [Jaeger](#jaeger) ou
@@ -38,7 +36,7 @@ pip install opentelemetry-exporter-otlp-proto-grpc
 
 {{% /tab %}} {{< /tabpane >}}
 
-### Uso {#usage}
+## Uso {#usage}
 
 Em seguida, configure o exporter para apontar para um endpoint OTLP no seu
 código.
@@ -195,7 +193,7 @@ esta variável de ambiente como `CUMULATIVE`.
 
 {{% include "exporters/prometheus-setup.md" %}}
 
-### Dependências {#prometheus-dependencies}
+## Dependências {#prometheus-dependencies}
 
 Instale o
 [pacote de exporter](https://pypi.org/project/opentelemetry-exporter-prometheus/)
@@ -236,7 +234,7 @@ o receptor Prometheus pode extrair as métricas deste endpoint.
 
 {{% include "exporters/zipkin-setup.md" %}}
 
-### Dependências {#zipkin-dependencies}
+## Dependências {#zipkin-dependencies}
 
 Para enviar seus dados de rastro para o [Zipkin](https://zipkin.io/), você pode
 escolher entre dois protocolos diferentes para transportar seus dados:

--- a/content/zh/community/end-user/_index.md
+++ b/content/zh/community/end-user/_index.md
@@ -3,7 +3,7 @@ title: 最终用户资源
 linkTitle: 最终用户
 description: 面向 OpenTelemetry 用户的厂商无关资源
 weight: 40
-default_lang_commit: b13d5dd3a9f288ab64d2af98c0b4ec1694499ef3
+default_lang_commit: b13d5dd3a9f288ab64d2af98c0b4ec1694499ef3 # patched
 ---
 
 希望在一个厂商无关的环境中与其他 OpenTelemetry 最终用户建立联系，或是了解更多关于 OpenTelemetry 的内容？
@@ -24,7 +24,7 @@ default_lang_commit: b13d5dd3a9f288ab64d2af98c0b4ec1694499ef3
 这些交流平台旨在将来自不同组织的运维与开发工程师聚集在一起，共同探讨实现全方位可观测性过程中的挑战与解决方案。
 我们鼓励你分享成功经验与失败教训，探索最佳实践，并结识也在使用 OpenTelemetry 实现可观测性的同行。
 
-### 讨论主题 {#topics}
+## 讨论主题 {#topics}
 
 这个群组的内容由成员共同塑造 —— 任何大家感兴趣的主题都欢迎提出！
 
@@ -36,7 +36,7 @@ default_lang_commit: b13d5dd3a9f288ab64d2af98c0b4ec1694499ef3
 - OpenTelemetry 的部署维护与扩展
 - 编写自定义插桩
 
-### 常见问题 {#questions}
+## 常见问题 {#questions}
 
 **这个群组仅限 OpenTelemetry 的最终用户参加吗？**
 

--- a/content/zh/docs/concepts/sampling/index.md
+++ b/content/zh/docs/concepts/sampling/index.md
@@ -3,6 +3,7 @@ title: 采样
 description: 了解采样以及 OpenTelemetry 中可用的各种采样选项。
 weight: 80
 default_lang_commit: deb98d0648c4833d9e9d77d42e91e2872658b50c # patched
+drifted_from_default: true
 ---
 
 通过[链路](/docs/concepts/signals/traces)，你可以观测请求在分布式系统中从一个服务传递到另一个服务的过程。

--- a/content/zh/docs/contributing/announcements.md
+++ b/content/zh/docs/contributing/announcements.md
@@ -2,7 +2,7 @@
 title: 公告
 description: 为特别活动创建公告或横幅。
 weight: 50
-default_lang_commit: adc4264c2926e3d767b6a56affb19fb4ae3f2a22
+default_lang_commit: adc4264c2926e3d767b6a56affb19fb4ae3f2a22 # patched
 ---
 
 公告是本地化目录中 `announcements` 部分下的一个**常规 Hugo 页面**。
@@ -11,7 +11,7 @@ default_lang_commit: adc4264c2926e3d767b6a56affb19fb4ae3f2a22
 
 > 目前，公告仅作为横幅使用。将来我们**可能**会支持更通用的公告形式。
 
-### 创建公告 {#creating-an-announcement}
+## 创建公告 {#creating-an-announcement}
 
 要添加一个新的公告，请在你的本地化目录下的 `announcements` 文件夹中使用以下命令创建一个 Markdown 文件：
 
@@ -29,7 +29,7 @@ hugo new --kind announcement content/YOUR-LOCALE/announcements/announcement-file
 
 {{% /alert %}}
 
-### 公告列表 {#announcement-list}
+## 公告列表 {#announcement-list}
 
 当构建日期位于公告的 `date` 和 `expiryDate` 字段之间时，所有提供的公告会出现在站点构建中。
 如果这些字段缺失，则分别默认为 “now” 和 “forever”。

--- a/content/zh/docs/platforms/faas/_index.md
+++ b/content/zh/docs/platforms/faas/_index.md
@@ -4,7 +4,7 @@ linkTitle: FaaS
 description: >-
   OpenTelemetry 支持多种方法监控不同云服务商提供的功能即服务（FaaS）
 redirects: [{ from: /docs/faas/*, to: ':splat' }] # cSpell:disable-line
-default_lang_commit: a18833df3c17db379911a796f1b0a549c4d8f10f
+default_lang_commit: a18833df3c17db379911a796f1b0a549c4d8f10f # patched
 ---
 
 功能即服务（FaaS）是[云原生应用][cloud native apps]的一种重要无服务器计算平台。
@@ -13,7 +13,7 @@ default_lang_commit: a18833df3c17db379911a796f1b0a549c4d8f10f
 FaaS 文档的初始供应商范围涵盖 Microsoft Azure、Google Cloud Platform（GCP）和
 Amazon Web Services（AWS）。AWS 的函数也被称为 Lambda。
 
-### 社区资产 {#community-assets}
+## 社区资产 {#community-assets}
 
 OpenTelemetry 社区目前提供了预构建的 Lambda 层，可实现应用的自动检测，也提供了独立的
 Collector Lambda 层，适用于手动或自动检测应用时使用。

--- a/content/zh/docs/platforms/faas/lambda-collector.md
+++ b/content/zh/docs/platforms/faas/lambda-collector.md
@@ -3,7 +3,7 @@ title: Lambda Collector 配置
 linkTitle: Lambda Collector 配置
 weight: 11
 description: 向你的 Lambda 添加并配置 Collector Lambda 层
-default_lang_commit: f35b3300574b428f94dfeeca970d93c5a6ddbf35
+default_lang_commit: f35b3300574b428f94dfeeca970d93c5a6ddbf35 # patched
 cSpell:ignore: ADOT awsxray confmap
 ---
 
@@ -11,7 +11,7 @@ OpenTelemetry 社区将 Collector 作为独立的 Lambda 层提供，与插桩�
 为用户提供了最大的灵活性。这与当前的 AWS OpenTelemetry 发行版（ADOT）不同，
 后者将插桩和 Collector 打包在一起。
 
-### 添加 OTel Collector Lambda 层的 ARN {#add-the-arn-of-the-otel-collector-lambda-layer}
+## 添加 OTel Collector Lambda 层的 ARN {#add-the-arn-of-the-otel-collector-lambda-layer}
 
 完成应用的自动插桩后，你应添加 Collector Lambda 层来收集并提交数据至所选后端。
 
@@ -21,17 +21,17 @@ OpenTelemetry 社区将 Collector 作为独立的 Lambda 层提供，与插桩�
 注意：Lambda 层是区域性资源，仅能在其发布所在的 AWS 区域中使用。请确保使用与你的
 Lambda 功能相同区域的层。社区会在所有可用区域中发布这些层。
 
-### 配置 OTel Collector {#configure-the-otel-collector}
+## 配置 OTel Collector {#configure-the-otel-collector}
 
 OTel Collector Lambda 层的配置遵循 OpenTelemetry 标准。
 
 默认情况下，OTel Collector Lambda 层使用 `config.yaml` 文件进行配置。
 
-#### 设置目标后端的环境变量 {#set-the-environment-variable-for-your-preferred-backend}
+### 设置目标后端的环境变量 {#set-the-environment-variable-for-your-preferred-backend}
 
 在 Lambda 的环境变量设置中，创建一个新的变量，用于存放你的认证 token。
 
-#### 更新默认的导出器配置 {#update-the-default-exporters}
+### 更新默认的导出器配置 {#update-the-default-exporters}
 
 在你的 `config.yaml` 文件中添加所需的导出器，如果默认中尚未包含。
 使用前一步中设置的环境变量来配置导出器。
@@ -66,23 +66,23 @@ service:
       address: localhost:8888
 ```
 
-### 发布你的 Lambda {#publish-your-lambda}
+## 发布你的 Lambda {#publish-your-lambda}
 
 发布 Lambda 的新版本以使配置更改生效。
 
-### 高级 OTel Collector 配置 {#advanced-otel-collector-configuration}
+## 高级 OTel Collector 配置 {#advanced-otel-collector-configuration}
 
 你可以通过自定义配置启用更多组件。若需调试 Collector，
 可在配置文件中设置日志级别为 debug。如下所示。
 
-#### 选择所用的 Confmap 提供程序 {#choose-your-preferred-confmap-provider}
+### 选择所用的 Confmap 提供程序 {#choose-your-preferred-confmap-provider}
 
 OTel Lambda 层支持以下类型的配置映射提供程序：
 `file`、`env`、`yaml`、`http`、`https` 和 `s3`。
 要使用不同的 Confmap 提供程序来自定义 Collector 配置，请参考
 [Amazon OpenTelemetry 发行版的 Confmap 提供程序文档](https://aws-otel.github.io/docs/components/confmap-providers#confmap-providers-supported-by-the-adot-collector)。
 
-#### 创建自定义配置文件 {#create-a-custom-configuration-file}
+### 创建自定义配置文件 {#create-a-custom-configuration-file}
 
 以下为根目录下 `collector.yaml` 的示例配置文件：
 
@@ -116,13 +116,13 @@ service:
       address: localhost:8888
 ```
 
-#### 通过环境变量映射自定义配置文件 {#map-your-custom-configuration-file-using-environment-variables}
+### 通过环境变量映射自定义配置文件 {#map-your-custom-configuration-file-using-environment-variables}
 
 配置完成后，在 Lambda 功能上设置环境变量 `OPENTELEMETRY_COLLECTOR_CONFIG_URI`，
 值为配置文件的路径（取决于 Confmap 提供程序）。例如，若使用文件 Confmap 提供程序，
 应将其值设置为 `/var/task/<路径>/<文件名>`。该变量告知扩展从哪里加载 Collector 配置。
 
-##### 通过 CLI 设置自定义配置路径 {#custom-collector-configuration-using-the-cli}
+#### 通过 CLI 设置自定义配置路径 {#custom-collector-configuration-using-the-cli}
 
 你可以在 Lambda 控制台中设置，也可以使用 AWS CLI：
 
@@ -130,7 +130,7 @@ service:
 aws lambda update-function-configuration --function-name Function --environment Variables={OPENTELEMETRY_COLLECTOR_CONFIG_URI=/var/task/collector.yaml}
 ```
 
-##### 通过 CloudFormation 设置配置环境变量 {#set-configuration-environment-variables-from-cloudformation}
+#### 通过 CloudFormation 设置配置环境变量 {#set-configuration-environment-variables-from-cloudformation}
 
 也可在 **CloudFormation** 模板中配置环境变量：
 
@@ -144,7 +144,7 @@ Function:
         OPENTELEMETRY_COLLECTOR_CONFIG_URI: /var/task/collector.yaml
 ```
 
-##### 从 S3 加载配置 {#load-configuration-from-an-s3-object}
+#### 从 S3 加载配置 {#load-configuration-from-an-s3-object}
 
 若从 S3 加载配置，需确保绑定至功能的 IAM 角色具有读取相应 S3 桶的权限。
 

--- a/content/zh/docs/platforms/faas/lambda-manual-instrument.md
+++ b/content/zh/docs/platforms/faas/lambda-manual-instrument.md
@@ -2,7 +2,7 @@
 title: Lambda 手动插桩
 weight: 11
 description: 使用 OpenTelemetry 手动插桩 Lambda
-default_lang_commit: 06837fe15457a584f6a9e09579be0f0400593d57 # with links patched
+default_lang_commit: 06837fe15457a584f6a9e09579be0f0400593d57 # patched (links, formatting)
 drifted_from_default: true
 ---
 
@@ -10,15 +10,15 @@ drifted_from_default: true
 
 用户需要遵循其选定语言的通用插桩指导，并添加 Collector Lambda 层来提交数据。
 
-### 添加 OTel Collector Lambda 层的 ARN {#add-the-arn-of-the-otel-collector-lambda-layer}
+## 添加 OTel Collector Lambda 层的 ARN {#add-the-arn-of-the-otel-collector-lambda-layer}
 
 参见 [Collector Lambda 层指导](../lambda-collector/)将层添加到你的应用程序并配置
 Collector。我们建议首先添加此层。
 
-### 使用 OTel 插桩 Lambda {#instrument-the-lambda-with-otel}
+## 使用 OTel 插桩 Lambda {#instrument-the-lambda-with-otel}
 
 查看[语言插桩指导](/docs/languages/)，了解如何手动插桩你的应用程序。
 
-### 发布你的 Lambda {#publish-your-lambda}
+## 发布你的 Lambda {#publish-your-lambda}
 
 发布新的 Lambda 版本以部署新更改和插桩器。

--- a/gulp-src/lint-md.js
+++ b/gulp-src/lint-md.js
@@ -16,7 +16,7 @@ const markdownFiles = [
   '!examples/**',
   '!layouts/**',
   '!**/node_modules/**',
-  '!tools/examples/**',
+  '!tools/**',
   '!themes/**',
   '!tmp/**',
 ];

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "js-yaml": "^4.1.0",
     "markdown-it": "^14.1.0",
     "markdown-link-check": "^3.14.1",
-    "markdownlint": "^0.38.0",
+    "markdownlint": "^0.39.0",
     "markdownlint-cli2": "^0.18.1",
     "postcss-cli": "^11.0.1",
     "prettier": "3.6.2",


### PR DESCRIPTION
- Followup to #8077
- Upgrades `markdownlint` to `@latest`
- Fixes newly reported lint issues, mainly heading levels starting at h3 instead of h2
- Disables `table-column-style`, a new rule, because it reports lots of issues with ja and zh pages, whose md tables aren't styled by Prettier 🤷🏼‍♂️. For the rule doc page, see https://github.com/DavidAnson/markdownlint/blob/main/doc/md060.md.
- Updated drift status for a few pages