### PR TITLE
feat: [es] New translation - docs/zero-code/dotnet

### DIFF
--- a/content/es/docs/zero-code/dotnet/_index.md
+++ b/content/es/docs/zero-code/dotnet/_index.md
@@ -21,7 +21,7 @@ Para aprender a instrumentar el código de su servicio o aplicación, lee el
 
 La instrumentación automática de OpenTelemetry .NET debería funcionar con todos
 los sistemas operativos y versiones oficialmente compatibles de
-[.NET](https://dotnet.microsoft.com/platform/support/policy/dotnet-core).
+[.NET](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core)).
 
 La versión mínima compatible de
 [.NET Framework](https://dotnet.microsoft.com/download/dotnet-framework) es


### PR DESCRIPTION
# Description

Adding Spanish (es) translation for the Zero Code Instrumentation .NET documentation.

## Details
- Translated file: `content/es/docs/zero-code/dotnet/_index.md`
- Related issue: [#7841](https://github.com/open-telemetry/opentelemetry.io/issues/7841)