### PR TITLE
docs(collector): fix incorrect Grafana dashboard reference in Collector docs

### DIFF
--- a/content/en/docs/demo/collector-data-flow-dashboard/index.md
+++ b/content/en/docs/demo/collector-data-flow-dashboard/index.md
@@ -79,8 +79,8 @@ processor, which is used by both traces and metrics pipelines.
 ## Dashboard
 
 You can access the dashboard by navigating to the Grafana UI, selecting the
-**OpenTelemetry Collector** dashboard under browse icon on the
-left-hand side of the screen.
+**OpenTelemetry Collector** dashboard under browse icon on the left-hand side of
+the screen.
 
 ![OpenTelemetry Collector dashboard](otelcol-data-flow-dashboard.png)
 


### PR DESCRIPTION
Fix incorrect Grafana dashboard reference in Collector docs

- Remove reference to non-existent 'OpenTelemetry Collector Data Flow' dashboard
- Issue: [#7669](https://github.com/open-telemetry/opentelemetry.io/issues/7669)
