### PR TITLE
Replace OTEP 4673 links by reference to OTel spec trace/tracestate-probability-sampling

### DIFF
--- a/content/en/docs/concepts/sampling/index.md
+++ b/content/en/docs/concepts/sampling/index.md
@@ -103,7 +103,7 @@ as possible. A decision to sample or drop a span or trace is not made by
 inspecting the trace as a whole.
 
 For example, the most common form of head sampling is
-[Consistent Probability Sampling](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/trace/4673-experimental-probability-sampling.md).
+[Consistent Probability Sampling](/docs/specs/otel/trace/tracestate-probability-sampling/#consistent-sampling-decision).
 This is also referred to as Deterministic Sampling. In this case, a sampling
 decision is made based on the trace ID and the desired percentage of traces to
 sample. This ensures that whole traces are sampled - no missing spans - at a

--- a/content/ja/docs/concepts/sampling/index.md
+++ b/content/ja/docs/concepts/sampling/index.md
@@ -75,7 +75,7 @@ drifted_from_default: true
 ヘッドサンプリングは、サンプリングの決定をできるだけ早期に行うために用いられるサンプリング技術です。
 スパンやトレースのサンプリングまたはドロップの決定は、トレース全体を検査することによって行われるわけではありません。
 
-たとえば、ヘッドサンプリングのもっとも一般的な形式は、[一貫した確率サンプリング](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/trace/4673-experimental-probability-sampling.md)です。
+たとえば、ヘッドサンプリングのもっとも一般的な形式は、[一貫した確率サンプリング](/docs/specs/otel/trace/tracestate-probability-sampling/#consistent-sampling-decision)です。
 決定論的サンプリングと呼ばれることもあります。
 この場合、サンプリングの決定は、トレースIDと、サンプリングするトレースの望ましい割合に基づいて行われます。
 これにより、全トレースの5%など、一貫した割合で、スパンの欠損無く、全トレースがサンプリングされます。

--- a/content/pt/docs/concepts/sampling/index.md
+++ b/content/pt/docs/concepts/sampling/index.md
@@ -112,7 +112,7 @@ ou descartar um trecho ou um rastro não é feita inspecionando o rastro como um
 todo.
 
 Por exemplo, a forma mais comum de amostragem pela cabeça é a
-[Amostragem de Probabilidade Consistente](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/trace/4673-experimental-probability-sampling.md).
+[Amostragem de Probabilidade Consistente](/docs/specs/otel/trace/tracestate-probability-sampling/#consistent-sampling-decision).
 Isso também é conhecido como Amostragem Determinística. Neste caso, uma decisão
 de amostragem é tomada com base no ID do rastro e na porcentagem desejada de
 rastros a serem amostrados. Isso garante que rastros inteiros sejam amostrados -

--- a/content/zh/docs/concepts/sampling/index.md
+++ b/content/zh/docs/concepts/sampling/index.md
@@ -71,7 +71,7 @@ drifted_from_default: true
 
 头部采样是一种尽早做出采样决策的采样技术。是否采样一个 Span 或链路的决策不是通过检查整个链路来做出的。
 
-例如，最常见的一种头部采样形式是[一致概率采样](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/trace/4673-experimental-probability-sampling.md)。
+例如，最常见的一种头部采样形式是[一致概率采样](/docs/specs/otel/trace/tracestate-probability-sampling/#consistent-sampling-decision)。
 这也被称为确定性采样。在这种情况下，采样决策基于链路 ID 和希望采样的链路百分比。
 这确保了整个链路被采样（不会漏掉任何 Span）并以一致的速率进行采样，例如采样所有链路的 5%。
 

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -11307,10 +11307,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-10-13T18:23:05.618332891Z"
   },
-  "https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/trace/4673-experimental-probability-sampling.md": {
-    "StatusCode": 206,
-    "LastSeen": "2025-10-11T10:15:59.874903-04:00"
-  },
   "https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md": {
     "StatusCode": 206,
     "LastSeen": "2025-10-10T10:46:30.12192264Z"


### PR DESCRIPTION
- This redoes #8064
- It resolves https://github.com/open-telemetry/opentelemetry.io/pull/8064/files#r2433276100 according to @jmacd's requested new link as confirmed in https://github.com/open-telemetry/opentelemetry-specification/issues/4687#issuecomment-3407621434

/cc @jmacd - this implements the URL rewrite/replacement we agreed on in Slack.