### PR TITLE
Add redirects to Go, Java, JS, and PHP landing pages to address top 404s

### DIFF
--- a/content/en/docs/languages/go/_index.md
+++ b/content/en/docs/languages/go/_index.md
@@ -4,6 +4,9 @@ description: >-
   <img width="35" class="img-initial" src="/img/logos/32x32/Golang_SDK.svg"
   alt="Go"> A language-specific implementation of OpenTelemetry in Go.
 aliases: [/golang, /golang/metrics, /golang/tracing]
+redirects:
+  - { from: /go/*, to: ':splat' }
+  - { from: /docs/go/*, to: ':splat' }
 weight: 16
 ---
 

--- a/content/en/docs/languages/java/_index.md
+++ b/content/en/docs/languages/java/_index.md
@@ -3,7 +3,10 @@ title: Java
 description: >-
   <img width="35" class="img-initial" src="/img/logos/32x32/Java_SDK.svg"
   alt="Java"> Language-specific implementation of OpenTelemetry in Java.
-aliases: [/java, /java/metrics, /java/tracing]
+aliases: [/java/metrics, /java/tracing]
+redirects:
+  - { from: /java/*, to: ':splat' }
+  - { from: /docs/java/*, to: ':splat' }
 cascade:
   vers:
     instrumentation: 2.20.1

--- a/content/en/docs/languages/js/_index.md
+++ b/content/en/docs/languages/js/_index.md
@@ -4,7 +4,10 @@ description: >-
   <img width="35" class="img-initial" src="/img/logos/32x32/JS_SDK.svg"
   alt="JavaScript"> A language-specific implementation of OpenTelemetry in
   JavaScript (for Node.js & the browser).
-aliases: [/js, /js/metrics, /js/tracing]
+aliases: [/js/metrics, /js/tracing, nodejs]
+redirects:
+  - { from: /js/*, to: ':splat' }
+  - { from: /docs/js/*, to: ':splat' }
 weight: 20
 ---
 

--- a/content/en/docs/languages/php/_index.md
+++ b/content/en/docs/languages/php/_index.md
@@ -3,6 +3,9 @@ title: PHP
 description: >-
   <img width="35" class="img-initial" src="/img/logos/32x32/PHP.svg" alt="PHP">
   A language-specific implementation of OpenTelemetry in PHP.
+redirects:
+  - { from: /php/*, to: ':splat' }
+  - { from: /docs/php/*, to: ':splat' }
 weight: 21
 cSpell:ignore: mbstring opcache
 ---

--- a/content/en/docs/zero-code/java/spring-boot-starter/_index.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/_index.md
@@ -1,6 +1,7 @@
 ---
 title: Spring Boot starter
 aliases:
+  - /docs/languages/java/spring-boot
   - /docs/languages/java/automatic/spring-boot
   - /docs/zero-code/java/agent/spring-boot
   - /docs/zero-code/java/spring-boot


### PR DESCRIPTION
- Fixes #8105
- Adds `redirects` as needed to address top 404s
- Adds an alias for `/docs/languages/nodejs/`, which had over 160 404s in the past 12 months
- Adds an alias for `/docs/languages/java/spring-boot/`, which had 100 or so 404s in the path 12 months