### PR TITLE
Zero-code .NET index page heading ID fixes

### DIFF
--- a/content/en/docs/zero-code/dotnet/_index.md
+++ b/content/en/docs/zero-code/dotnet/_index.md
@@ -316,12 +316,12 @@ custom telemetry data.
 
 ## Uninstall
 
-### Linux and macOS { #uninstall-unix }
+### Linux and macOS {#uninstall-unix}
 
 On Linux and macOS, the installation steps only affect the current shell session
 so no explicit uninstallation is required.
 
-### Windows (PowerShell) { #uninstall-windows }
+### Windows (PowerShell) {#uninstall-windows}
 
 On Windows, use the PowerShell module as an Administrator.
 

--- a/content/fr/docs/zero-code/dotnet/_index.md
+++ b/content/fr/docs/zero-code/dotnet/_index.md
@@ -330,12 +330,12 @@ collecter des données de télémétrie personnalisées.
 
 ## Désinstallation {#uninstall}
 
-### Linux et macOS { #uninstall-unix } {#linux-and-macos--uninstall-unix-}
+### Linux et macOS {#uninstall-unix}
 
 Sur Linux et macOS, les étapes d'installation n'affectent que la session shell
 actuelle donc aucune désinstallation explicite n'est requise.
 
-### Windows (PowerShell) { #uninstall-windows } {#windows-powershell--uninstall-windows-}
+### Windows (PowerShell) {#uninstall-windows}
 
 Sur Windows, utilisez le module PowerShell en tant qu'Administrateur.
 


### PR DESCRIPTION
- Fixes #8125
- Normalized the heading ID syntax in the `en` page
- Fixed the invalid heading title (by removing the duplicate heading ID) from the `fr` page

**Preview**:

- https://deploy-preview-8126--opentelemetry.netlify.app/fr/docs/zero-code/dotnet/#uninstall
- https://deploy-preview-8126--opentelemetry.netlify.app/en/docs/zero-code/dotnet/#uninstall