### PR TITLE
[ja] docs(i18n): fix a drifted file of content/ja/docs/languages/sdk-configuration/otlp-exporter.md

### DIFF
--- a/content/ja/docs/languages/sdk-configuration/otlp-exporter.md
+++ b/content/ja/docs/languages/sdk-configuration/otlp-exporter.md
@@ -3,7 +3,7 @@ title: OTLPエクスポーター設定
 linkTitle: OTLPエクスポーター
 weight: 20
 aliases: [otlp-exporter-configuration]
-default_lang_commit: 276d7eb3f936deef6487cdd2b1d89822951da6c8
+default_lang_commit: 8587d0c0ff3bc57f99b0ecd461f03dd1f73c07ec
 ---
 
 ## エンドポイントの設定 {#endpoint-configuration}
@@ -126,7 +126,7 @@ OTLP/HTTP を使う場合は、通常 `v1/logs` で終わります。
 
 ## タイムアウトの設定 {#timeout-configuration}
 
-以下の環境変数は、OTLPエクスポーターがデータのネットバッチを送信する前に待つ最大時間（ミリ秒単位）を設定します。
+以下の環境変数は、OTLPエクスポーターがデータの次のバッチを送信する前に待つ最大時間（ミリ秒単位）を設定します。
 
 ### `OTEL_EXPORTER_OTLP_TIMEOUT`
 


### PR DESCRIPTION
<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->

preview.

- https://deploy-preview-8133--opentelemetry.netlify.app/ja/docs/languages/sdk-configuration/otlp-exporter/

original.


- https://deploy-preview-8133--opentelemetry.netlify.app/docs/languages/sdk-configuration/otlp-exporter/

<details>
  <summary>
    drifted diffs
  </summary>
  <div>

```

> check:i18n
> scripts/check-i18n.sh -d content/ja/docs/languages/sdk-configuration/

Processing paths: content/ja/docs/languages/sdk-configuration/
diff --git a/content/en/docs/languages/sdk-configuration/otlp-exporter.md b/content/en/docs/languages/sdk-configuration/otlp-exporter.md
index abd92373f..9f8739f18 100644
--- a/content/en/docs/languages/sdk-configuration/otlp-exporter.md
+++ b/content/en/docs/languages/sdk-configuration/otlp-exporter.md
@@ -128,7 +128,7 @@ A list of headers to apply to all outgoing logs.
 ## Timeout Configuration
 
 The following environment variables configure the maximum time (in milliseconds)
-an OTLP Exporter will wait before transmitting the net batch of data.
+an OTLP Exporter will wait before transmitting the next batch of data.
 
 ### `OTEL_EXPORTER_OTLP_TIMEOUT`
 
DRIFTED files: 1 out of 3

```

  </div>
</details>
