### PR TITLE
[ja] docs(i18n): fix a drifted file of a content/ja/docs/languages/java/_index.md

### DIFF
--- a/content/ja/docs/languages/java/_index.md
+++ b/content/ja/docs/languages/java/_index.md
@@ -3,16 +3,18 @@ title: Java
 description: >-
   <img width="35" class="img-initial" src="/img/logos/32x32/Java_SDK.svg"
   alt="Java"> JavaにおけるOpenTelemetryの言語固有の実装。
-aliases: [/java, /java/metrics, /java/tracing]
+aliases: [/java/metrics, /java/tracing]
+redirects:
+  - { from: /java/*, to: ':splat' }
+  - { from: /docs/java/*, to: ':splat' }
 cascade:
   vers:
     instrumentation: 2.20.1
-    otel: 1.54.1
-    contrib: 1.49.0
+    otel: 1.55.0
+    contrib: 1.50.0
     semconv: 1.37.0
 weight: 18
-default_lang_commit: 276d7eb3f936deef6487cdd2b1d89822951da6c8
-drifted_from_default: true
+default_lang_commit: 68e94a4555606e74c27182b79789d46faf84ec25
 ---
 
 {{% docs/languages/index-intro java /%}}


### PR DESCRIPTION
<!--
Please provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->

preview.

- https://deploy-preview-8135--opentelemetry.netlify.app/ja/docs/languages/java/

original

- https://deploy-preview-8135--opentelemetry.netlify.app/docs/languages/java/


<details>
  <summary>
    drifted diffs
  </summary>
  <div>

```

> check:i18n
> scripts/check-i18n.sh -d content/ja/docs/languages/java

Processing paths: content/ja/docs/languages/java
diff --git a/content/en/docs/languages/java/_index.md b/content/en/docs/languages/java/_index.md
index 3c8593d6c..c1fefc044 100644
--- a/content/en/docs/languages/java/_index.md
+++ b/content/en/docs/languages/java/_index.md
@@ -3,12 +3,15 @@ title: Java
 description: >-
   <img width="35" class="img-initial" src="/img/logos/32x32/Java_SDK.svg"
   alt="Java"> Language-specific implementation of OpenTelemetry in Java.
-aliases: [/java, /java/metrics, /java/tracing]
+aliases: [/java/metrics, /java/tracing]
+redirects:
+  - { from: /java/*, to: ':splat' }
+  - { from: /docs/java/*, to: ':splat' }
 cascade:
   vers:
     instrumentation: 2.20.1
-    otel: 1.54.1
-    contrib: 1.49.0
+    otel: 1.55.0
+    contrib: 1.50.0
     semconv: 1.37.0
 weight: 18
 ---
DRIFTED files: 1 out of 7

```

  </div>
</details>
