### PR TITLE
Add @maryliag to approvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ These are the members of [@open-telemetry/docs-maintainers]:
 - [Fabrizio Ferri-Benedetti](https://github.com/theletterf), Elastic
 - [Patrice Chalin](https://github.com/chalin), CNCF
 - [Phillip Carter](https://github.com/cartermp), Salesforce
-- [Severin Neumann](https://github.com/svrnm)
+- [Severin Neumann](https://github.com/svrnm), Causely
 - [Tiffany Hrabusa](https://github.com/tiffany76), Grafana Labs
 - [Vitor Vasconcellos](https://github.com/vitorvasc), MercadoLibre, Inc.
 
@@ -74,6 +74,7 @@ For more information about the maintainer role, see the
 
 These are the members of [@open-telemetry/docs-approvers]:
 
+- [Marylia Gutierrez](maryliag), Grafana Labs
 - [Michael Hausenblas](https://github.com/mhausenblas), Amazon
 - [Ted Young](https://github.com/tedsuo), Grafana Labs
 


### PR DESCRIPTION
This PR adds @maryliag as approver to SIG Comms.

@open-telemetry/docs-maintainers please approve this PR

@maryliag please verify that I have all the details correct & that you agree with becoming an approver:-)

P.S.: I slipped in a change of my own affiliation to this PR as it was missing;-)