### PR TITLE
[CI] Disable StripQueryString htmltest config, and update refcache

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -5,7 +5,7 @@ IgnoreAltMissing: true
 IgnoreCanonicalBrokenLinks: false
 IgnoreInternalEmptyHash: true # TODO: remove after resolution of https://github.com/google/docsy/issues/1995
 CheckMailto: false
-# StripQueryString: false # TODO: enable once htmltest is fixed
+StripQueryString: false
 TestFilesConcurrently: true
 # RetryCachedErrors: for docs, see https://github.com/chalin/htmltest/blob/dev/main/README.md
 RetryCachedErrors: false
@@ -61,6 +61,10 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - ^https://x.ai
   - ^https://www.deepseek.com
   - ^https://www.perplexity.ai
+
+  # Ignore issues and discussions with query parameters, e.g.:
+  - ^https://github\.com/open-telemetry/opentelemetry\.io/issues\?q=
+  - ^https://github\.com/open-telemetry/opentelemetry\.io/discussions\?discussions_q=
 
   # Ignore Docsy-generated GitHub links for now, until
   # https://github.com/google/docsy/issues/1432 is fixed

--- a/scripts/unescape-refcache-json.mjs
+++ b/scripts/unescape-refcache-json.mjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+// Script to unescape refcache.json, which is necessary because of a bug in htmltest.
+// See https://github.com/wjdp/htmltest/issues/239
+
+import { readFileSync, writeFileSync } from 'fs';
+
+const refcacheFile = 'static/refcache.json';
+
+console.log(
+  `Unescaping ${refcacheFile}, which is necessary because of a bug in htmltest ...`,
+);
+
+const data = JSON.parse(readFileSync(refcacheFile, 'utf8'));
+writeFileSync(refcacheFile, JSON.stringify(data, null, 2) + '\n');
+
+console.log('Done.');

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -3,9 +3,17 @@
     "StatusCode": 206,
     "LastSeen": "2025-10-15T10:09:24.782965934Z"
   },
+  "http://logback.qos.ch/?disable_http_check": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:27.28043-04:00"
+  },
   "http://www.powerjob.tech/": {
     "StatusCode": 206,
     "LastSeen": "2025-10-15T10:10:26.334541023Z"
+  },
+  "http://www.powerjob.tech/?disable_http_check": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:28.494457-04:00"
   },
   "https://7asecurity.com/": {
     "StatusCode": 206,
@@ -291,6 +299,10 @@
     "StatusCode": 200,
     "LastSeen": "2025-10-14T17:45:42.529Z"
   },
+  "https://calendar.google.com/calendar/embed?src=c_6b6b343737cc9bbf0393ba40c101d6b017514751e66951c9890d089eedd78a37@group.calendar.google.com\u0026mode=WEEK\u0026dates=20250331/20250406": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:33.948578-04:00"
+  },
   "https://calendly.com/euwg-user-feedback-session/end-user-feedback-session": {
     "StatusCode": 200,
     "LastSeen": "2025-10-18T18:31:23.566585421Z"
@@ -303,17 +315,37 @@
     "StatusCode": 200,
     "LastSeen": "2025-10-18T18:31:34.297778024Z"
   },
+  "https://calendly.com/euwg-user-feedback-session/end-user-feedback-session-comms?month=2024-03": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:31.299898-04:00"
+  },
   "https://calendly.com/euwg-user-feedback-session/end-user-feedback-session-javascript": {
     "StatusCode": 200,
     "LastSeen": "2025-10-18T18:31:29.052594184Z"
+  },
+  "https://calendly.com/euwg-user-feedback-session/end-user-feedback-session-javascript?month=2024-03": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:30.665074-04:00"
   },
   "https://calendly.com/euwg-user-feedback-session/end-user-feedback-session-profiling": {
     "StatusCode": 200,
     "LastSeen": "2025-10-18T18:59:49.313230832Z"
   },
+  "https://calendly.com/euwg-user-feedback-session/end-user-feedback-session-profiling?month=2024-03": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:31.665214-04:00"
+  },
   "https://calendly.com/euwg-user-feedback-session/end-user-feedback-session-semantic-conventions": {
     "StatusCode": 200,
     "LastSeen": "2025-10-18T18:31:31.812204233Z"
+  },
+  "https://calendly.com/euwg-user-feedback-session/end-user-feedback-session-semantic-conventions?month=2024-03": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:30.995599-04:00"
+  },
+  "https://calendly.com/euwg-user-feedback-session/end-user-feedback-session?month=2024-03": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:30.283372-04:00"
   },
   "https://calendly.com/otel-euwg/humans-of-otel": {
     "StatusCode": 200,
@@ -667,6 +699,10 @@
     "StatusCode": 200,
     "LastSeen": "2025-10-18T18:58:51.280692034Z"
   },
+  "https://cloud-native.slack.com/archives/C033BJ8BASU/p1709128862949249?thread_ts=1709081221.484429\u0026cid=C033BJ8BASU": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:31.287155-04:00"
+  },
   "https://cloud-native.slack.com/archives/C033BJ8BASU/p1709321896612279": {
     "StatusCode": 200,
     "LastSeen": "2025-10-18T18:31:45.915007492Z"
@@ -802,6 +838,10 @@
   "https://cloud.google.com/kubernetes-engine": {
     "StatusCode": 200,
     "LastSeen": "2025-10-14T17:38:33.673675816Z"
+  },
+  "https://cloud.google.com/kubernetes-engine?hl=en": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:16.508548-04:00"
   },
   "https://cloud.google.com/load-balancing/docs/ssl-certificates/google-managed-certs#caa": {
     "StatusCode": 200,
@@ -1779,9 +1819,17 @@
     "StatusCode": 200,
     "LastSeen": "2025-10-18T18:31:27.101824474Z"
   },
+  "https://docs.google.com/forms/d/e/1FAIpQLScoG279ZhRuMu8J_8BebGEVtMOS8BgD9cpQUJ6xSnNIAUtedw/viewform?usp=header": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:30.036901-04:00"
+  },
   "https://docs.google.com/forms/d/e/1FAIpQLSeSA09xDIv0uyb6vrP8xBbLjm8NsgihrG8GHxacbigF17sNDw/viewform": {
     "StatusCode": 200,
     "LastSeen": "2025-10-15T10:11:25.588736823Z"
+  },
+  "https://docs.google.com/forms/d/e/1FAIpQLSeSA09xDIv0uyb6vrP8xBbLjm8NsgihrG8GHxacbigF17sNDw/viewform?usp=dialog": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:29.83898-04:00"
   },
   "https://docs.google.com/presentation/d/1YaJvAWnNcUJd1RNsqvEYCcqvJUoj0TDd": {
     "StatusCode": 200,
@@ -1791,6 +1839,10 @@
     "StatusCode": 200,
     "LastSeen": "2025-10-15T17:06:16.456289586Z"
   },
+  "https://docs.google.com/spreadsheets/d/1E23Dkz1B2us71BtlQq8oG4o_QFsTeLPeh-X2uVnlubg/edit?usp=sharing": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:30.258613-04:00"
+  },
   "https://docs.google.com/spreadsheets/d/1I2ACFAgzWaa1H5EQx99-rLTro2FHlS44gsWuQsU8Ssw/edit#gid=191407209": {
     "StatusCode": 200,
     "LastSeen": "2025-10-14T12:59:00.157199054Z"
@@ -1798,6 +1850,10 @@
   "https://docs.google.com/spreadsheets/d/1Kk6io9V6Q1nluq6H05zGjwvWlXwxh9IwjiThBGJP1Rw/edit": {
     "StatusCode": 200,
     "LastSeen": "2025-10-15T17:06:18.593691372Z"
+  },
+  "https://docs.google.com/spreadsheets/d/1Kk6io9V6Q1nluq6H05zGjwvWlXwxh9IwjiThBGJP1Rw/edit?usp=sharing": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:29.769442-04:00"
   },
   "https://docs.google.com/spreadsheets/d/1SYKfjYhZdm2Wh2Cl6KVQalKg_m4NhTPZqq-8SzEVO6s": {
     "StatusCode": 200,
@@ -1947,6 +2003,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-10-18T18:30:16.683687897Z"
   },
+  "https://docs.microsoft.com/en-us/dotnet/api/System.IO.Path.GetTempPath?view=net-6.0": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:28.399668-04:00"
+  },
   "https://docs.microsoft.com/en-us/dotnet/api/system.appdomain.unhandledexception": {
     "StatusCode": 206,
     "LastSeen": "2025-10-18T18:30:08.506935307Z"
@@ -1958,6 +2018,10 @@
   "https://docs.microsoft.com/en-us/dotnet/api/system.type.assemblyqualifiedname": {
     "StatusCode": 206,
     "LastSeen": "2025-10-15T17:00:47.57391199Z"
+  },
+  "https://docs.microsoft.com/en-us/dotnet/api/system.type.assemblyqualifiedname?view=net-6.0#system-type-assemblyqualifiedname": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:27.773607-04:00"
   },
   "https://docs.microsoft.com/en-us/dotnet/core/deploying/runtime-store": {
     "StatusCode": 206,
@@ -2439,6 +2503,10 @@
     "StatusCode": 200,
     "LastSeen": "2025-10-18T18:34:25.227661083Z"
   },
+  "https://documentation.softwareag.com/?pf=adabas": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:21.637703-04:00"
+  },
   "https://documentation.solarwinds.com/en/success_center/observability/content/intro/otel.htm": {
     "StatusCode": 206,
     "LastSeen": "2025-10-14T12:56:32.294120286Z"
@@ -2558,6 +2626,10 @@
   "https://embrace.io/docs/open-telemetry/integration/#react-native": {
     "StatusCode": 206,
     "LastSeen": "2025-10-14T12:59:31.494341907Z"
+  },
+  "https://embrace.io/docs/open-telemetry/integration/?android-language=java": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:17.125146-04:00"
   },
   "https://embrace.io/docs/web/getting-started/": {
     "StatusCode": 206,
@@ -2783,13 +2855,25 @@
     "StatusCode": 200,
     "LastSeen": "2025-10-14T17:43:59.637960136Z"
   },
+  "https://events.linuxfoundation.org/kubecon-cloudnativecon-china/?utm_source=opentelemetry\u0026utm_medium=all\u0026utm_campaign=KubeCon-EU-2025\u0026utm_content=blog": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:31.032879-04:00"
+  },
   "https://events.linuxfoundation.org/kubecon-cloudnativecon-china/reg/register/": {
     "StatusCode": 200,
     "LastSeen": "2025-10-14T17:44:05.024830557Z"
   },
+  "https://events.linuxfoundation.org/kubecon-cloudnativecon-china/reg/register/?utm_source=opentelemetry\u0026utm_medium=all\u0026utm_campaign=KubeCon-China-2025": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:31.751668-04:00"
+  },
   "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/": {
     "StatusCode": 200,
     "LastSeen": "2025-10-16T09:45:51.082554382Z"
+  },
+  "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/?utm_source=opentelemetry\u0026utm_medium=all\u0026utm_campaign=KubeCon-EU-2025\u0026utm_content=blog": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:32.795963-04:00"
   },
   "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/co-located-events/observability-day/": {
     "StatusCode": 200,
@@ -2799,13 +2883,25 @@
     "StatusCode": 206,
     "LastSeen": "2025-10-16T09:45:56.860869466Z"
   },
+  "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/register/?utm_source=opentelemetry\u0026utm_medium=all\u0026utm_campaign=KubeCon-EU-2025\u0026utm_content=blog": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:33.597445-04:00"
+  },
   "https://events.linuxfoundation.org/kubecon-cloudnativecon-japan//": {
     "StatusCode": 200,
     "LastSeen": "2025-10-14T17:40:08.695675438Z"
   },
+  "https://events.linuxfoundation.org/kubecon-cloudnativecon-japan//?utm_source=opentelemetry\u0026utm_medium=all\u0026utm_campaign=KubeCon-Japan-2025\u0026utm_content=blog": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:31.154075-04:00"
+  },
   "https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/register/": {
     "StatusCode": 200,
     "LastSeen": "2025-10-14T17:40:11.499190578Z"
+  },
+  "https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/register/?utm_source=opentelemetry\u0026utm_medium=all\u0026utm_campaign=KubeCon-Japan-2025": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:31.851778-04:00"
   },
   "https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/": {
     "StatusCode": 200,
@@ -3287,6 +3383,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-10-15T17:03:28.295607888Z"
   },
+  "https://github.com/GoogleChrome/web-vitals?tab=readme-ov-file#report-only-the-delta-of-changes": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:18.162319-04:00"
+  },
   "https://github.com/GoogleCloudPlatform": {
     "StatusCode": 206,
     "LastSeen": "2025-10-14T09:57:57.847221985Z"
@@ -3651,6 +3751,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-10-18T18:31:30.600536718Z"
   },
+  "https://github.com/XSAM/otelsql?tab=readme-ov-file#communication": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:30.667117-04:00"
+  },
   "https://github.com/YanivD": {
     "StatusCode": 206,
     "LastSeen": "2025-10-14T09:57:54.965168034Z"
@@ -3946,6 +4050,10 @@
   "https://github.com/avillela/otel-target-allocator-talk/tree/main": {
     "StatusCode": 206,
     "LastSeen": "2025-10-15T17:05:51.001554984Z"
+  },
+  "https://github.com/avillela/otel-target-allocator-talk/tree/main?tab=readme-ov-file#3b--kubernetes-deployment-servicenow-cloud-observability-backend": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:30.786346-04:00"
   },
   "https://github.com/aws-observability/aws-otel-dotnet-instrumentation": {
     "StatusCode": 206,
@@ -6211,6 +6319,26 @@
     "StatusCode": 206,
     "LastSeen": "2025-10-15T17:06:18.072224801Z"
   },
+  "https://github.com/open-telemetry/community/?tab=coc-ov-file#opentelemetry-community-code-of-conduct": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:21.579477-04:00"
+  },
+  "https://github.com/open-telemetry/community/?tab=readme-ov-file#calendar": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:29.028434-04:00"
+  },
+  "https://github.com/open-telemetry/community/?tab=readme-ov-file#cross-cutting-sigs": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:29.768621-04:00"
+  },
+  "https://github.com/open-telemetry/community/?tab=readme-ov-file#implementation-sigs": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:29.028421-04:00"
+  },
+  "https://github.com/open-telemetry/community/?tab=readme-ov-file#sig-mainframes": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:29.430023-04:00"
+  },
   "https://github.com/open-telemetry/community/blob/47813530864b9fe5a5146f466a58bd2bb94edc72/maturity-matrix.yaml#L57": {
     "StatusCode": 206,
     "LastSeen": "2025-10-14T12:56:46.964639008Z"
@@ -6454,6 +6582,14 @@
   "https://github.com/open-telemetry/community/tree/main/roadmap.md": {
     "StatusCode": 206,
     "LastSeen": "2025-10-17T09:41:06.312196775Z"
+  },
+  "https://github.com/open-telemetry/community?tab=readme-ov-file#calendar": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:29.683624-04:00"
+  },
+  "https://github.com/open-telemetry/community?tab=readme-ov-file#special-interest-groups": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:29.114081-04:00"
   },
   "https://github.com/open-telemetry/opamp-go": {
     "StatusCode": 206,
@@ -6806,6 +6942,10 @@
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39650": {
     "StatusCode": 206,
     "LastSeen": "2025-10-14T17:44:17.684857422Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+label%3Adata%3Aprofiles": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:30.350604-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35139": {
     "StatusCode": 206,
@@ -8255,6 +8395,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-10-14T17:41:24.124595037Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-configuration?tab=readme-ov-file#stability-definition": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:21.92139-04:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-cpp": {
     "StatusCode": 206,
     "LastSeen": "2025-10-16T09:40:27.286820635Z"
@@ -8330,6 +8474,10 @@
   "https://github.com/open-telemetry/opentelemetry-demo/blob/main/README.md": {
     "StatusCode": 206,
     "LastSeen": "2025-10-17T09:39:57.750781232Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-demo/blob/main/README.md?plain=1": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:16.993828-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/accounting/": {
     "StatusCode": 206,
@@ -9159,6 +9307,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-10-14T12:53:40.640362458Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-helm-charts?tab=readme-ov-file#opentelemetry-collector": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:30.529837-04:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-injector": {
     "StatusCode": 206,
     "LastSeen": "2025-10-14T17:44:02.859806108Z"
@@ -9911,6 +10063,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-10-14T12:53:42.974234842Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-java?tab=readme-ov-file#contributing": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:30.742103-04:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-js": {
     "StatusCode": 206,
     "LastSeen": "2025-10-16T09:40:44.604918762Z"
@@ -10271,6 +10427,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-10-15T17:05:48.932472119Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-lambda/?tab=readme-ov-file#extension-layer-language-support": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:28.316239-04:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-lambda/blob/main/collector/README.md": {
     "StatusCode": 206,
     "LastSeen": "2025-10-18T18:31:29.608527992Z"
@@ -10323,6 +10483,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-10-14T12:53:53.198553583Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-operator/blob/main/README.md?plain=1#L151-L156": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:18.773927-04:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-operator/blob/main/autoinstrumentation/python/requirements.txt": {
     "StatusCode": 206,
     "LastSeen": "2025-10-18T09:38:35.299877341Z"
@@ -10334,6 +10498,10 @@
   "https://github.com/open-telemetry/opentelemetry-operator/blob/main/cmd/otel-allocator/README.md#discovery-of-prometheus-custom-resources": {
     "StatusCode": 206,
     "LastSeen": "2025-10-14T12:53:37.522896575Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-operator/blob/main/cmd/otel-allocator/README.md?plain=1#L128-L134": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:17.596067-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/instrumentations.md": {
     "StatusCode": 206,
@@ -10398,6 +10566,22 @@
   "https://github.com/open-telemetry/opentelemetry-operator/tree/main/cmd/otel-allocator#target-allocator": {
     "StatusCode": 206,
     "LastSeen": "2025-10-14T12:59:10.108793061Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-operator?tab=readme-ov-file#deployment-modes": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:30.215229-04:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-operator?tab=readme-ov-file#getting-started": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:30.194413-04:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-operator?tab=readme-ov-file#opentelemetry-auto-instrumentation-injection": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:30.266572-04:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-operator?tab=readme-ov-file#using-imagepullsecrets": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:30.91355-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry-php": {
     "StatusCode": 206,
@@ -11475,6 +11659,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-10-15T17:00:42.205636255Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-specification/blob/v1.35.0/specification/metrics/sdk_exporters/otlp.md?plain=1#L48": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:26.939011-04:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-specification/blob/v1.40.0/specification/logs/api.md#emit-an-event": {
     "StatusCode": 206,
     "LastSeen": "2025-10-14T17:43:55.657738245Z"
@@ -12207,6 +12395,14 @@
     "StatusCode": 206,
     "LastSeen": "2025-10-18T18:29:50.942976465Z"
   },
+  "https://github.com/open-telemetry/opentelemetry.io/pulls?q=is%3Apr+is%3Amerged+merged%3A2024-01-01..2024-12-31": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:31.129716-04:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry.io/pulls?q=is%3Apr+java+is%3Aclosed+label%3Asig%3Ajava+merged%3A2024-01-01..2024-12-31+author%3Ajack-berg": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:30.451731-04:00"
+  },
   "https://github.com/open-telemetry/opentelemetry.io/releases": {
     "StatusCode": 206,
     "LastSeen": "2025-10-16T09:46:21.878515011Z"
@@ -12474,6 +12670,10 @@
   "https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/rpc/rpc-spans.md": {
     "StatusCode": 206,
     "LastSeen": "2025-10-15T17:02:27.731779216Z"
+  },
+  "https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/docs/rpc/rpc-spans.md?plain=1#L26-L50": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:28.29124-04:00"
   },
   "https://github.com/open-telemetry/semantic-conventions/blob/v1.36.0/docs/gen-ai/README.md": {
     "StatusCode": 206,
@@ -12762,6 +12962,10 @@
   "https://github.com/opentracing/specification/blob/master/specification.md#references-between-spans": {
     "StatusCode": 206,
     "LastSeen": "2025-10-14T17:41:36.975814533Z"
+  },
+  "https://github.com/opentracing?q=basic\u0026type=\u0026language=": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:20.932519-04:00"
   },
   "https://github.com/openzipkin/b3-propagation": {
     "StatusCode": 206,
@@ -13479,6 +13683,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-10-14T17:44:32.450046142Z"
   },
+  "https://github.com/slsa-framework/slsa?tab=License-1-ov-file": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:30.392787-04:00"
+  },
   "https://github.com/smith": {
     "StatusCode": 206,
     "LastSeen": "2025-10-14T17:40:17.729971356Z"
@@ -13614,6 +13822,10 @@
   "https://github.com/tbrockman/browser-extension-for-opentelemetry": {
     "StatusCode": 206,
     "LastSeen": "2025-10-14T09:57:56.122949083Z"
+  },
+  "https://github.com/tbrockman/browser-extension-for-opentelemetry?tab=readme-ov-file#browser-extension-for-opentelemetry": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:30.969383-04:00"
   },
   "https://github.com/tedsuo": {
     "StatusCode": 206,
@@ -14395,6 +14607,10 @@
     "StatusCode": 200,
     "LastSeen": "2025-10-16T09:40:46.124199613Z"
   },
+  "https://hex.pm/packages?search=opentelemetry\u0026sort=recent_downloads": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:26.043635-04:00"
+  },
   "https://hexdocs.pm/bandit/Bandit.Telemetry.html#content": {
     "StatusCode": 200,
     "LastSeen": "2025-10-14T17:44:34.699228975Z"
@@ -14499,9 +14715,17 @@
     "StatusCode": 200,
     "LastSeen": "2025-10-18T18:32:53.389792454Z"
   },
+  "https://img.shields.io/badge/changed-orange?style=flat": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:17.831009-04:00"
+  },
   "https://img.shields.io/badge/warning-yellow": {
     "StatusCode": 200,
     "LastSeen": "2025-10-14T17:42:10.379419847Z"
+  },
+  "https://img.shields.io/badge/warning-yellow?style=flat": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:17.696525-04:00"
   },
   "https://istio.io/": {
     "StatusCode": 206,
@@ -14959,6 +15183,26 @@
     "StatusCode": 206,
     "LastSeen": "2025-10-18T18:34:15.117653347Z"
   },
+  "https://learn.microsoft.com/azure/azure-monitor/app/opentelemetry-enable?tabs=aspnetcore": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:13.969852-04:00"
+  },
+  "https://learn.microsoft.com/azure/azure-monitor/app/opentelemetry-enable?tabs=java": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:14.284805-04:00"
+  },
+  "https://learn.microsoft.com/azure/azure-monitor/app/opentelemetry-enable?tabs=java-native": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:15.120799-04:00"
+  },
+  "https://learn.microsoft.com/azure/azure-monitor/app/opentelemetry-enable?tabs=nodejs": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:15.52636-04:00"
+  },
+  "https://learn.microsoft.com/azure/azure-monitor/app/opentelemetry-enable?tabs=python": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:16.014707-04:00"
+  },
   "https://learn.microsoft.com/azure/azure-monitor/essentials/resource-logs-schema#top-level-common-schema": {
     "StatusCode": 206,
     "LastSeen": "2025-10-14T17:42:11.844030599Z"
@@ -15147,6 +15391,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-10-15T09:40:31.82741526Z"
   },
+  "https://learn.microsoft.com/dotnet/api/system.diagnostics.taglist?#remarks": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:29.336348-04:00"
+  },
   "https://learn.microsoft.com/dotnet/api/system.environment.processorcount": {
     "StatusCode": 206,
     "LastSeen": "2025-10-15T17:04:01.162817928Z"
@@ -15243,6 +15491,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-10-15T17:05:52.032313908Z"
   },
+  "https://learn.microsoft.com/dotnet/aspire/fundamentals/dashboard/standalone?tabs=bash": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:30.311436-04:00"
+  },
   "https://learn.microsoft.com/dotnet/core/diagnostics/compare-metric-apis#systemdiagnosticsmetrics": {
     "StatusCode": 206,
     "LastSeen": "2025-10-14T17:38:30.865749574Z"
@@ -15303,6 +15555,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-10-14T17:38:57.826047642Z"
   },
+  "https://learn.microsoft.com/en-us/azure/aks/custom-node-configuration?tabs=linux-node-pools": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:26.702899-04:00"
+  },
   "https://learn.microsoft.com/en-us/azure/azure-monitor/app/opentelemetry-enable": {
     "StatusCode": 206,
     "LastSeen": "2025-10-18T18:29:34.113763913Z"
@@ -15323,9 +15579,17 @@
     "StatusCode": 206,
     "LastSeen": "2025-10-18T18:29:54.621740005Z"
   },
+  "https://learn.microsoft.com/en-us/dotnet/api/system.reflection.assembly.getentryassembly?view=net-7.0": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:25.792755-04:00"
+  },
   "https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/dashboard/standalone": {
     "StatusCode": 206,
     "LastSeen": "2025-10-16T09:47:03.638849845Z"
+  },
+  "https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/dashboard/standalone?tabs=bash": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:31.37421-04:00"
   },
   "https://learn.microsoft.com/en-us/dotnet/core/deploying/": {
     "StatusCode": 206,
@@ -16247,13 +16511,25 @@
     "StatusCode": 200,
     "LastSeen": "2025-10-14T17:44:11.074244654Z"
   },
+  "https://opentelemetry.devstats.cncf.io/d/50/countries-statistics-in-repository-groups?orgId=1": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:29.793147-04:00"
+  },
   "https://opentelemetry.devstats.cncf.io/d/8/dashboards": {
     "StatusCode": 200,
     "LastSeen": "2025-10-16T09:40:34.35884132Z"
   },
+  "https://opentelemetry.devstats.cncf.io/d/8/dashboards?orgId=1\u0026refresh=15m": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:14.024818-04:00"
+  },
   "https://opentelemetry.devstats.cncf.io/d/9/developer-activity-counts-by-repository-group-table": {
     "StatusCode": 200,
     "LastSeen": "2025-10-18T18:31:31.447969892Z"
+  },
+  "https://opentelemetry.devstats.cncf.io/d/9/developer-activity-counts-by-repository-group-table?orgId=1": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:30.305567-04:00"
   },
   "https://opentracing.io": {
     "StatusCode": 206,
@@ -16554,6 +16830,10 @@
   "https://packagist.org/search/": {
     "StatusCode": 200,
     "LastSeen": "2025-10-16T09:40:26.644622744Z"
+  },
+  "https://packagist.org/search/?query=open-telemetry\u0026tags=instrumentation": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:26.261705-04:00"
   },
   "https://parceljs.org/": {
     "StatusCode": 206,
@@ -17815,6 +18095,14 @@
     "StatusCode": 200,
     "LastSeen": "2025-10-16T09:41:05.653450198Z"
   },
+  "https://pkgs.alpinelinux.org/packages?name=*pecl-opentelemetry": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:25.758188-04:00"
+  },
+  "https://pkgs.alpinelinux.org/packages?name=opentelemetry-cpp-*": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:31.291786-04:00"
+  },
   "https://plugins.jenkins.io/opentelemetry/": {
     "StatusCode": 206,
     "LastSeen": "2025-10-18T18:35:15.119554346Z"
@@ -18043,6 +18331,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-10-14T17:40:54.882857268Z"
   },
+  "https://qryn.metrico.in/#/support?id=tempo-api": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:14.003177-04:00"
+  },
   "https://quarkus.io": {
     "StatusCode": 206,
     "LastSeen": "2025-10-16T09:42:15.960780271Z"
@@ -18094,6 +18386,30 @@
   "https://reactivex.io/RxJava/2.x/javadoc/index.html": {
     "StatusCode": 206,
     "LastSeen": "2025-10-16T09:40:59.095514204Z"
+  },
+  "https://reactivex.io/RxJava/2.x/javadoc/index.html?io/reactivex/Completable.html": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:27.655447-04:00"
+  },
+  "https://reactivex.io/RxJava/2.x/javadoc/index.html?io/reactivex/Flowable.html": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:28.537038-04:00"
+  },
+  "https://reactivex.io/RxJava/2.x/javadoc/index.html?io/reactivex/Maybe.html": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:28.016885-04:00"
+  },
+  "https://reactivex.io/RxJava/2.x/javadoc/index.html?io/reactivex/Observable.html": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:28.341339-04:00"
+  },
+  "https://reactivex.io/RxJava/2.x/javadoc/index.html?io/reactivex/Single.html": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:28.183605-04:00"
+  },
+  "https://reactivex.io/RxJava/2.x/javadoc/index.html?io/reactivex/parallel/ParallelFlowable.html": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:28.629728-04:00"
   },
   "https://redis.com/": {
     "StatusCode": 200,
@@ -18414,6 +18730,10 @@
   "https://rubygems.org/search": {
     "StatusCode": 200,
     "LastSeen": "2025-10-18T18:56:45.354435201Z"
+  },
+  "https://rubygems.org/search?query=opentelemetry": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:18.428254-04:00"
   },
   "https://rubyonrails.org/": {
     "StatusCode": 206,
@@ -19135,6 +19455,10 @@
     "StatusCode": 200,
     "LastSeen": "2025-10-15T17:03:42.626247103Z"
   },
+  "https://support.google.com/webmasters/answer/10347851?hl=en#:~:text=A%20canonical%20URL%20is%20the,Google%20chooses%20one%20as%20canonical.": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:18.162246-04:00"
+  },
   "https://svelte.dev/": {
     "StatusCode": 206,
     "LastSeen": "2025-10-15T09:46:11.792443445Z"
@@ -19747,6 +20071,10 @@
     "StatusCode": 200,
     "LastSeen": "2025-10-14T17:38:49.843135437Z"
   },
+  "https://www.cncf.io/training/courses/?_sft_lf-project=opentelemetry": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:18.986575-04:00"
+  },
   "https://www.cockroachlabs.com/": {
     "StatusCode": 200,
     "LastSeen": "2025-10-18T18:36:58.434Z"
@@ -20015,13 +20343,25 @@
     "StatusCode": 206,
     "LastSeen": "2025-10-15T17:04:17.493490208Z"
   },
+  "https://www.ibm.com/docs/db2-for-zos/12?topic=codes-sql": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:16.762079-04:00"
+  },
   "https://www.ibm.com/docs/en/instana-observability/1.0.304": {
     "StatusCode": 206,
     "LastSeen": "2025-10-15T10:08:39.92520623Z"
   },
+  "https://www.ibm.com/docs/en/instana-observability/1.0.304?topic=apis-opentelemetry": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:15.059191-04:00"
+  },
   "https://www.ibm.com/docs/en/instana-observability/current": {
     "StatusCode": 206,
     "LastSeen": "2025-10-14T17:39:28.988566048Z"
+  },
+  "https://www.ibm.com/docs/en/instana-observability/current?topic=collectors-instana-distribution-opentelemetry-collector": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-17T21:16:25.512569-04:00"
   },
   "https://www.ibm.com/products/informix": {
     "StatusCode": 206,
@@ -20578,6 +20918,10 @@
   "https://www.npmjs.com/search": {
     "StatusCode": 200,
     "LastSeen": "2025-10-15T17:11:40.633Z"
+  },
+  "https://www.npmjs.com/search?q=%40cspell%2Fdict": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-18T01:17:05.296Z"
   },
   "https://www.nuget.org/packages/Azure.Monitor.OpenTelemetry.Exporter": {
     "StatusCode": 200,
@@ -21295,25 +21639,109 @@
     "StatusCode": 200,
     "LastSeen": "2025-10-16T09:46:02.501405033Z"
   },
+  "https://www.youtube.com/embed/TIMgKXCeiyQ?autoplay=0\u0026controls=1\u0026end=0\u0026loop=0\u0026mute=0\u0026start=0": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:29.985793-04:00"
+  },
   "https://www.youtube.com/embed/bsfMECwmsm0": {
     "StatusCode": 200,
     "LastSeen": "2025-10-18T18:58:39.560718533Z"
+  },
+  "https://www.youtube.com/embed/bsfMECwmsm0?autoplay=0\u0026controls=1\u0026end=0\u0026loop=0\u0026mute=0\u0026start=0": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:29.730339-04:00"
   },
   "https://www.youtube.com/embed/eZ3OrhxUAmU": {
     "StatusCode": 200,
     "LastSeen": "2025-10-14T17:43:55.909604434Z"
   },
+  "https://www.youtube.com/embed/eZ3OrhxUAmU?autoplay=0\u0026controls=1\u0026end=0\u0026loop=0\u0026mute=0\u0026start=0": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:29.260303-04:00"
+  },
   "https://www.youtube.com/embed/fgbB0HhVBq8": {
     "StatusCode": 200,
     "LastSeen": "2025-10-14T17:43:55.980116296Z"
+  },
+  "https://www.youtube.com/embed/fgbB0HhVBq8?autoplay=0\u0026controls=1\u0026end=0\u0026loop=0\u0026mute=0\u0026start=0": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:29.985674-04:00"
   },
   "https://www.youtube.com/embed/iEEIabOha8U": {
     "StatusCode": 200,
     "LastSeen": "2025-10-14T17:39:09.293224194Z"
   },
+  "https://www.youtube.com/embed/iEEIabOha8U?autoplay=0\u0026controls=1\u0026end=0\u0026loop=0\u0026mute=0\u0026start=0": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:29.902767-04:00"
+  },
   "https://www.youtube.com/watch": {
     "StatusCode": 200,
     "LastSeen": "2025-10-16T09:40:37.197621023Z"
+  },
+  "https://www.youtube.com/watch?v=D71fK2MFreI": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:30.646349-04:00"
+  },
+  "https://www.youtube.com/watch?v=LUsfZFRM4yo": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:25.921993-04:00"
+  },
+  "https://www.youtube.com/watch?v=N18z2dOJSd8": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:25.686871-04:00"
+  },
+  "https://www.youtube.com/watch?v=TUiVX-44S9s": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:24.956395-04:00"
+  },
+  "https://www.youtube.com/watch?v=Uwq4EPaMJFM": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:30.346057-04:00"
+  },
+  "https://www.youtube.com/watch?v=VAgT7CY572U": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:14.594891-04:00"
+  },
+  "https://www.youtube.com/watch?v=WhRrwSHDBFs": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:25.378266-04:00"
+  },
+  "https://www.youtube.com/watch?v=aDysORX1zIs": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:30.424164-04:00"
+  },
+  "https://www.youtube.com/watch?v=g8rtqqNTL9Q": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:25.210696-04:00"
+  },
+  "https://www.youtube.com/watch?v=iPGd9_aYu-A": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:30.537164-04:00"
+  },
+  "https://www.youtube.com/watch?v=l4PeclHKl7I": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:30.760387-04:00"
+  },
+  "https://www.youtube.com/watch?v=t550FzDi054": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:25.510173-04:00"
+  },
+  "https://www.youtube.com/watch?v=tZJd6W-CIcU": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:30.299949-04:00"
+  },
+  "https://www.youtube.com/watch?v=uPpZ23iu6kI": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:25.973316-04:00"
+  },
+  "https://www.youtube.com/watch?v=uVs0oUV72CE": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:30.18221-04:00"
+  },
+  "https://www.youtube.com/watch?v=ykq1F_3PmJw": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:30.057625-04:00"
   },
   "https://yaml.org/spec/1.2.2/": {
     "StatusCode": 206,
@@ -21326,6 +21754,10 @@
   "https://youtu.be/5iM8n3uCo_U": {
     "StatusCode": 200,
     "LastSeen": "2025-10-14T17:40:40.644925723Z"
+  },
+  "https://youtu.be/5iM8n3uCo_U?si=PJ6tFYcYED3lhAcK": {
+    "StatusCode": 200,
+    "LastSeen": "2025-10-17T21:16:14.437775-04:00"
   },
   "https://youtu.be/HY3LZOQqdig": {
     "StatusCode": 200,


### PR DESCRIPTION
- Contributes to #7953
- Disables StripQueryString htmltest config parameter so that query strings are saved to the cache
- Implements a workaround for https://github.com/wjdp/htmltest/issues/239, by simply reading in the JSON and writing it back out unescaped