### PR TITLE
Add missing install to browser snippet

### DIFF
--- a/content/en/docs/languages/js/getting-started/browser.md
+++ b/content/en/docs/languages/js/getting-started/browser.md
@@ -250,7 +250,6 @@ npm install @opentelemetry/instrumentation-user-interaction \
 import { UserInteractionInstrumentation } from '@opentelemetry/instrumentation-user-interaction';
 import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
 
-// Registering instrumentations
 registerInstrumentations({
   instrumentations: [
     new DocumentLoadInstrumentation(),


### PR DESCRIPTION
The previous code snippet for adding instrumentations to the browser setup mentioned the need to register the new instrumentations but did not specify downloading or importing the packages.

- fixes https://github.com/open-telemetry/opentelemetry.io/issues/4951
- replaces https://github.com/open-telemetry/opentelemetry.io/pull/5710