### PR TITLE
feat: Add nativeOTLP status to sentry vendor

### DIFF
--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -355,7 +355,7 @@
   oss: true
   commercial: true
 - name: Sentry
-  nativeOTLP: false
+  nativeOTLP: true
   url: https://sentry.io/for/opentelemetry/
   contact:
   oss: false


### PR DESCRIPTION
Sentry now supports OTLP natively: https://sentry.io/changelog/otlp-ingestion-endpoints-for-traces-and-logs-are-in-open-beta/

This is documented in Sentry here: https://docs.sentry.io/concepts/otlp/

This PR updates the vendor chart so `nativeOTLP` is set to `true` for the Sentry entry.