### PR TITLE
Update approver and emeritus approver lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,6 @@ For more information about the maintainer role, see the
 These are the members of [@open-telemetry/docs-approvers]:
 
 - [Marylia Gutierrez](maryliag), Grafana Labs
-- [Michael Hausenblas](https://github.com/mhausenblas), Amazon
-- [Ted Young](https://github.com/tedsuo), Grafana Labs
 
 For more information about the approver role, see the
 [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver).
@@ -93,6 +91,8 @@ For more information about the emeritus role, see the
 ### Emeritus approvers
 
 - [Paul Bruce](https://github.com/paulsbruce)
+- [Michael Hausenblas](https://github.com/mhausenblas)
+- [Ted Young](https://github.com/tedsuo)
 
 For more information about the emeritus role, see the
 [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#emeritus-maintainerapprovertriager).


### PR DESCRIPTION
Removed @mhausenblas and @tedsuo from the list of current approvers and added them to the emeritus approvers section.

Thank you both for all the great work you are doing for the OpenTelemetry, and continue doing, feels odd to change this ;-)

PR against the right repo ;)