### PR TITLE
[pt] Update drifted content for `content/pt/docs/languages/sdk-configuration/general.md`

### DIFF
--- a/content/pt/docs/languages/sdk-configuration/general.md
+++ b/content/pt/docs/languages/sdk-configuration/general.md
@@ -1,9 +1,9 @@
 ---
 title: Configurações gerais de SDK
 linkTitle: Geral
+weight: 10
 aliases: [general-sdk-configuration]
-default_lang_commit: 1e4970e9193c8af1d1f9b86901b13492071aecc7 # patched
-drifted_from_default: true
+default_lang_commit: a5691930635b4e2033946f3a85ae7a527c3eba06
 cSpell:ignore: ottrace
 ---
 
@@ -114,7 +114,7 @@ Dependendo do valor definido em `OTEL_TRACES_SAMPLER`, a definição de
 
 Especifica os Propagators a serem utilizados em uma lista separada por vírgulas.
 
-**Valor padrão:** `"tracecontext,baggage"
+**Valor padrão:** `"tracecontext,baggage"`
 
 **Exemplo:**
 


### PR DESCRIPTION
Contributes to #7492.

Updates the drifted content for the following files:

#### content/pt/docs/languages/sdk-configuration/general.md

```diff
❯ npm run check:i18n -- -d content/pt/docs/languages/sdk-configuration/general.md

> check:i18n
> scripts/check-i18n.sh -d content/pt/docs/languages/sdk-configuration/general.md

Processing paths: content/pt/docs/languages/sdk-configuration/general.md
diff --git a/content/en/docs/languages/sdk-configuration/general.md b/content/en/docs/languages/sdk-configuration/general.md
index 56006ed7d..2a956c57a 100644
--- a/content/en/docs/languages/sdk-configuration/general.md
+++ b/content/en/docs/languages/sdk-configuration/general.md
@@ -1,11 +1,12 @@
 ---
 title: General SDK Configuration
 linkTitle: General
+weight: 10
 aliases: [general-sdk-configuration]
 cSpell:ignore: ottrace
 ---
 
-{{% alert title="Note" color="info" %}}
+{{% alert title="Note" %}}
 
 Support for environment variables is optional. For detailed information on which
 environment variables each language implementation supports, please consult the
@@ -108,7 +109,7 @@ be set as follows:
 
 Specifies Propagators to be used in a comma-separated list.
 
-**Default value:** `"tracecontext,baggage"
+**Default value:** `"tracecontext,baggage"`
 
 **Example:**
 
@@ -165,7 +166,7 @@ Accepted values for `OTEL_METRICS_EXPORTER` are:
 
 - `"otlp"`: [OTLP][]
 - `"prometheus"`:
-  [Prometheus](https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md)
+  [Prometheus](https://github.com/prometheus/docs/blob/main/docs/instrumenting/exposition_formats.md)
 - `"console"`: [Standard Output](/docs/specs/otel/metrics/sdk_exporters/stdout/)
 - `"none"`: No automatically configured exporter for metrics.
 
DRIFTED files: 1 out of 1
```