### PR TITLE
Update election starting time

### DIFF
--- a/content/en/blog/2025/gc-elections.md
+++ b/content/en/blog/2025/gc-elections.md
@@ -28,8 +28,9 @@ before 23:59 UTC on 24 October 2025 to participate in the election. See the
 with all members of standing and approved exceptions. Approved exceptions will
 be added to the roll continuously.
 
-Voting will be open between 27 October 2025 [~~00:00~~](https://github.com/open-telemetry/community/issues/3001#issuecomment-3449011021) 12:00 UTC and 29 October
-2025, end of day,
+Voting will be open between 27 October 2025
+[~~00:00~~](https://github.com/open-telemetry/community/issues/3001#issuecomment-3449011021)
+12:00 UTC and 29 October 2025, end of day,
 [Anywhere on Earth](https://en.wikipedia.org/wiki/Anywhere_on_Earth) (30 October
 2025 12:00 UTC) on
 [Helios Voting](https://vote.heliosvoting.org/helios/elections/f94a7c58-990b-11f0-a16d-5270fb641b4c/view);

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -6491,6 +6491,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-10-25T16:09:11.849863623Z"
   },
+  "https://github.com/open-telemetry/community/issues/3001#issuecomment-3449011021": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-27T17:02:37.633199+01:00"
+  },
   "https://github.com/open-telemetry/community/issues/3022": {
     "StatusCode": 206,
     "LastSeen": "2025-10-24T09:45:38.429533708Z"


### PR DESCRIPTION
Updating the election blog post to reflect the noon starting time that I accidentally configured within Helios and now can't be changed. See https://github.com/open-telemetry/community/issues/3001#issuecomment-3449011021 for context.