### PR TITLE
Style training page image in support light & dark mode

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -216,8 +216,7 @@
   filter: none;
 }
 
-// Dark mode inversion for .img-initial, excluding course badges
-[data-bs-theme='dark'] .td-content .img-initial:not(.no-dark-mode-invert) {
+[data-bs-theme='dark'] .td-content .img-initial {
   filter: brightness(0) invert(1);
 }
 

--- a/content/en/training/index.md
+++ b/content/en/training/index.md
@@ -38,7 +38,7 @@ OpenTelemetry][CNTCOT] and offered by the Linux Foundation:
 
 <!-- prettier-ignore -->
 ![LFS148 course badge][]
-{.img-initial .no-dark-mode-invert .pt-3 .w-75 .m-auto}
+{.border-0 .pt-3 .w-75 .m-auto}
 
 <div class="card-body ps-4 pe-4 bg-light-subtle">
   <div class="h4 card-title pt-2 pb-2">


### PR DESCRIPTION
- Followup to #8254. Thanks for noticing the issue in dark mode @vitorvasc!
- Proposes a simpler styling solution, one that supports light and dark mode more directly
- Reverts 8254

/cc @vitorvasc - hopefully you agree that this is simpler and more direct 

### Preview

- https://deploy-preview-8256--opentelemetry.netlify.app/training/

### Screenshot

> <img width="888" height="549" alt="image" src="https://github.com/user-attachments/assets/b47b6247-e2e4-4aa8-a4e2-bc50a8b34505" />

