### PR TITLE
[locales] Fix: prevent dark mode inversion for course badge image in Training page

### DIFF
--- a/content/es/training/index.md
+++ b/content/es/training/index.md
@@ -9,7 +9,7 @@ hide_feedback: true
 # https://training.linuxfoundation.org/wp-content/uploads/2024/10/LFS148-Course-Badge-300x300.png
 params:
   LFS148: https://training.linuxfoundation.org/training/getting-started-with-opentelemetry-lfs148/
-default_lang_commit: c767488390fabceb1b5b87569f3e6f68d3188519
+default_lang_commit: 662edd797da7c0d65ffb50537187c736a081ba2a
 cSpell:ignore: otca
 ---
 
@@ -40,7 +40,7 @@ OpenTelemetry][CNTCOT] y ofrecido por la Linux Foundation:
 
 <!-- prettier-ignore -->
 ![LFS148 course badge][]
-{.img-initial .no-dark-mode-invert .pt-3 .w-75 .m-auto}
+{.border-0 .pt-3 .w-75 .m-auto}
 
 <div class="card-body ps-4 pe-4 bg-light-subtle">
   <div class="h4 card-title pt-2 pb-2">

--- a/content/pt/training/index.md
+++ b/content/pt/training/index.md
@@ -4,7 +4,7 @@ menu: { main: { weight: 45 } }
 description: Certificações e cursos do OpenTelemetry
 type: docs
 body_class: ot-training
-default_lang_commit: c767488390fabceb1b5b87569f3e6f68d3188519
+default_lang_commit: 662edd797da7c0d65ffb50537187c736a081ba2a
 hide_feedback: true
 # LF course image from:
 # https://training.linuxfoundation.org/wp-content/uploads/2024/10/LFS148-Course-Badge-300x300.png
@@ -40,7 +40,7 @@ OpenTelemetry][CNTCOT] e oferecido pela Linux Foundation:
 
 <!-- prettier-ignore -->
 ![LFS148 course badge][]
-{.img-initial .no-dark-mode-invert .pt-3 .w-75 .m-auto}
+{.border-0 .pt-3 .w-75 .m-auto}
 
 <div class="card-body ps-4 pe-4 bg-light-subtle">
   <div class="h4 card-title pt-2 pb-2">

--- a/content/zh/training/index.md
+++ b/content/zh/training/index.md
@@ -9,7 +9,7 @@ hide_feedback: true
 # https://training.linuxfoundation.org/wp-content/uploads/2024/10/LFS148-Course-Badge-300x300.png
 params:
   LFS148: https://training.linuxfoundation.org/training/getting-started-with-opentelemetry-lfs148/
-default_lang_commit: c767488390fabceb1b5b87569f3e6f68d3188519
+default_lang_commit: 662edd797da7c0d65ffb50537187c736a081ba2a
 cSpell:ignore: otca
 ---
 
@@ -38,7 +38,7 @@ cSpell:ignore: otca
 
 <!-- prettier-ignore -->
 ![LFS148 course badge][]
-{.img-initial .no-dark-mode-invert .pt-3 .w-75 .m-auto}
+{.border-0 .pt-3 .w-75 .m-auto}
 
 <div class="card-body ps-4 pe-4 bg-light-subtle">
   <div class="h4 card-title pt-2 pb-2">


### PR DESCRIPTION
## Description

Fix was originally implemented in #8254, this PR spans the fix for localizations and also updates the `default_lang_commit` hashes.

In the training page, the LFS148 course badge image appears white in dark mode.

- Adds a reusable `no-dark-mode-invert` class to the course badge image
- Updates the dark mode CSS to exclude elements with this class from color inversion

---

**Before (Dark Mode):**
Training page: https://opentelemetry.io/training/

<img width="955" height="861" alt="image" src="https://github.com/user-attachments/assets/d2981807-5d03-42ad-b438-d35d52cb8c35" />

----

**After (Dark Mode):**
Preview: https://deploy-preview-8254--opentelemetry.netlify.app/training/
 
<img width="952" height="848" alt="image" src="https://github.com/user-attachments/assets/a546eadb-2400-401e-9be2-b09372c35d63" />

----

## Diffs

`content/es/training/index.md`: 

```diff
❯ npm run check:i18n -- -d content/es/training/index.md

> check:i18n
> scripts/check-i18n.sh -d content/es/training/index.md

Processing paths: content/es/training/index.md
diff --git a/content/en/training/index.md b/content/en/training/index.md
index 06395d8ee..05792fa3c 100644
--- a/content/en/training/index.md
+++ b/content/en/training/index.md
@@ -38,7 +38,7 @@ OpenTelemetry][CNTCOT] and offered by the Linux Foundation:
 
 <!-- prettier-ignore -->
 ![LFS148 course badge][]
-{.img-initial .pt-3 .w-75 .m-auto}
+{.border-0 .pt-3 .w-75 .m-auto}
 
 <div class="card-body ps-4 pe-4 bg-light-subtle">
   <div class="h4 card-title pt-2 pb-2">
DRIFTED files: 1 out of 1
```

`content/pt/training/index.md`: 

```diff
❯ npm run check:i18n -- -d content/pt/training/index.md

> check:i18n
> scripts/check-i18n.sh -d content/pt/training/index.md

Processing paths: content/pt/training/index.md
diff --git a/content/en/training/index.md b/content/en/training/index.md
index 06395d8ee..05792fa3c 100644
--- a/content/en/training/index.md
+++ b/content/en/training/index.md
@@ -38,7 +38,7 @@ OpenTelemetry][CNTCOT] and offered by the Linux Foundation:
 
 <!-- prettier-ignore -->
 ![LFS148 course badge][]
-{.img-initial .pt-3 .w-75 .m-auto}
+{.border-0 .pt-3 .w-75 .m-auto}
 
 <div class="card-body ps-4 pe-4 bg-light-subtle">
   <div class="h4 card-title pt-2 pb-2">
DRIFTED files: 1 out of 1
```

`content/zh/training/index.md`:

```diff
❯ npm run check:i18n -- -d content/zh/training/index.md

> check:i18n
> scripts/check-i18n.sh -d content/zh/training/index.md

Processing paths: content/zh/training/index.md
diff --git a/content/en/training/index.md b/content/en/training/index.md
index 06395d8ee..05792fa3c 100644
--- a/content/en/training/index.md
+++ b/content/en/training/index.md
@@ -38,7 +38,7 @@ OpenTelemetry][CNTCOT] and offered by the Linux Foundation:
 
 <!-- prettier-ignore -->
 ![LFS148 course badge][]
-{.img-initial .pt-3 .w-75 .m-auto}
+{.border-0 .pt-3 .w-75 .m-auto}
 
 <div class="card-body ps-4 pe-4 bg-light-subtle">
   <div class="h4 card-title pt-2 pb-2">
DRIFTED files: 1 out of 1
```