### PR TITLE
[style-only] Ensure OTel icons display correctly in dark mode

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -212,11 +212,8 @@
   @extend .td-max-width-on-larger-screens;
 }
 
-.td-content .img-initial {
-  filter: none;
-}
-
-[data-bs-theme='dark'] .td-content .img-initial {
+// Ensure OTel icons display correctly in dark mode
+[data-bs-theme='dark'] .otel-icon {
   filter: brightness(0) invert(1);
 }
 

--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -70,13 +70,13 @@ The structure of any Collector configuration file consists of four classes of
 pipeline components that access telemetry data:
 
 - [Receivers](#receivers)
-  <img width="32" alt="" class="img-initial" src="/img/logos/32x32/Receivers.svg">
+  <img width="32" alt="" class="img-initial otel-icon" src="/img/logos/32x32/Receivers.svg">
 - [Processors](#processors)
-  <img width="32" alt="" class="img-initial" src="/img/logos/32x32/Processors.svg">
+  <img width="32" alt="" class="img-initial otel-icon" src="/img/logos/32x32/Processors.svg">
 - [Exporters](#exporters)
-  <img width="32" alt="" class="img-initial" src="/img/logos/32x32/Exporters.svg">
+  <img width="32" alt="" class="img-initial otel-icon" src="/img/logos/32x32/Exporters.svg">
 - [Connectors](#connectors)
-  <img width="32" alt="" class="img-initial" src="/img/logos/32x32/Load_Balancer.svg">
+  <img width="32" alt="" class="img-initial otel-icon" src="/img/logos/32x32/Load_Balancer.svg">
 
 After each pipeline component is configured you must enable it using the
 pipelines within the [service](#service) section of the configuration file.
@@ -250,7 +250,7 @@ service:
       exporters: [otlp]
 ```
 
-## Receivers <img width="35" class="img-initial" alt="" src="/img/logos/32x32/Receivers.svg"> {#receivers}
+## Receivers <img width="35" class="img-initial otel-icon" alt="" src="/img/logos/32x32/Receivers.svg"> {#receivers}
 
 Receivers collect telemetry from one or more sources. They can be pull or push
 based, and may support one or more [data sources](/docs/concepts/signals/).
@@ -329,7 +329,7 @@ receivers:
 > For detailed receiver configuration, see the
 > [receiver README](https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/README.md).
 
-## Processors <img width="35" class="img-initial" alt="" src="/img/logos/32x32/Processors.svg"> {#processors}
+## Processors <img width="35" class="img-initial otel-icon" alt="" src="/img/logos/32x32/Processors.svg"> {#processors}
 
 Processors take the data collected by receivers and modify or transform it
 before sending it to the exporters. Data processing happens according to rules
@@ -429,7 +429,7 @@ processors:
 > For detailed processor configuration, see the
 > [processor README](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/README.md).
 
-## Exporters <img width="35" class="img-initial" alt="" src="/img/logos/32x32/Exporters.svg"> {#exporters}
+## Exporters <img width="35" class="img-initial otel-icon" alt="" src="/img/logos/32x32/Exporters.svg"> {#exporters}
 
 Exporters send data to one or more backends or destinations. Exporters can be
 pull or push based, and may support one or more
@@ -512,7 +512,7 @@ secure connections, as described in
 > For more information on exporter configuration, see the
 > [exporter README.md](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/README.md).
 
-## Connectors <img width="32" class="img-initial" alt="" src="/img/logos/32x32/Load_Balancer.svg"> {#connectors}
+## Connectors <img width="32" class="img-initial otel-icon" alt="" src="/img/logos/32x32/Load_Balancer.svg"> {#connectors}
 
 Connectors join two pipelines, acting as both exporter and receiver. A connector
 consumes data as an exporter at the end of one pipeline and emits data as a
@@ -561,7 +561,7 @@ service:
 > For detailed connector configuration, see the
 > [connector README](https://github.com/open-telemetry/opentelemetry-collector/blob/main/connector/README.md).
 
-## Extensions <img width="32" class="img-initial" alt="" src="/img/logos/32x32/Extensions.svg"> {#extensions}
+## Extensions <img width="32" class="img-initial otel-icon" alt="" src="/img/logos/32x32/Extensions.svg"> {#extensions}
 
 Extensions are optional components that expand the capabilities of the Collector
 to accomplish tasks not directly involved with processing telemetry data. For

--- a/content/en/docs/languages/cpp/_index.md
+++ b/content/en/docs/languages/cpp/_index.md
@@ -2,8 +2,9 @@
 title: C++
 weight: 11
 description: >
-  <img width="35" class="img-initial otel-icon" src="/img/logos/32x32/C++_SDK.svg"
-  alt="C++"> A language-specific implementation of OpenTelemetry in C++.
+  <img width="35" class="img-initial otel-icon"
+  src="/img/logos/32x32/C++_SDK.svg" alt="C++"> A language-specific
+  implementation of OpenTelemetry in C++.
 ---
 
 {{% docs/languages/index-intro cpp /%}}

--- a/content/en/docs/languages/cpp/_index.md
+++ b/content/en/docs/languages/cpp/_index.md
@@ -2,7 +2,7 @@
 title: C++
 weight: 11
 description: >
-  <img width="35" class="img-initial" src="/img/logos/32x32/C++_SDK.svg"
+  <img width="35" class="img-initial otel-icon" src="/img/logos/32x32/C++_SDK.svg"
   alt="C++"> A language-specific implementation of OpenTelemetry in C++.
 ---
 

--- a/content/en/docs/languages/dotnet/_index.md
+++ b/content/en/docs/languages/dotnet/_index.md
@@ -1,8 +1,9 @@
 ---
 title: .NET
 description: >
-  <img width="35" class="img-initial otel-icon" src="/img/logos/32x32/dotnet.svg"
-  alt=".NET"> A language-specific implementation of OpenTelemetry in .NET.
+  <img width="35" class="img-initial otel-icon"
+  src="/img/logos/32x32/dotnet.svg" alt=".NET"> A language-specific
+  implementation of OpenTelemetry in .NET.
 aliases: [net, /csharp, /csharp/metrics, /csharp/tracing]
 weight: 12
 ---

--- a/content/en/docs/languages/dotnet/_index.md
+++ b/content/en/docs/languages/dotnet/_index.md
@@ -1,7 +1,7 @@
 ---
 title: .NET
 description: >
-  <img width="35" class="img-initial" src="/img/logos/32x32/dotnet.svg"
+  <img width="35" class="img-initial otel-icon" src="/img/logos/32x32/dotnet.svg"
   alt=".NET"> A language-specific implementation of OpenTelemetry in .NET.
 aliases: [net, /csharp, /csharp/metrics, /csharp/tracing]
 weight: 12

--- a/content/en/docs/languages/erlang/_index.md
+++ b/content/en/docs/languages/erlang/_index.md
@@ -2,7 +2,7 @@
 title: Erlang/Elixir
 weight: 14
 description: >
-  <img width="35" class="img-initial" src="/img/logos/32x32/Erlang_SDK.svg"
+  <img width="35" class="img-initial otel-icon" src="/img/logos/32x32/Erlang_SDK.svg"
   alt="Erlang/Elixir"> A language-specific implementation of OpenTelemetry in
   Erlang/Elixir.
 cascade:

--- a/content/en/docs/languages/erlang/_index.md
+++ b/content/en/docs/languages/erlang/_index.md
@@ -2,9 +2,9 @@
 title: Erlang/Elixir
 weight: 14
 description: >
-  <img width="35" class="img-initial otel-icon" src="/img/logos/32x32/Erlang_SDK.svg"
-  alt="Erlang/Elixir"> A language-specific implementation of OpenTelemetry in
-  Erlang/Elixir.
+  <img width="35" class="img-initial otel-icon"
+  src="/img/logos/32x32/Erlang_SDK.svg" alt="Erlang/Elixir"> A language-specific
+  implementation of OpenTelemetry in Erlang/Elixir.
 cascade:
   versions:
     otelSdk: 1.3

--- a/content/en/docs/languages/go/_index.md
+++ b/content/en/docs/languages/go/_index.md
@@ -1,8 +1,9 @@
 ---
 title: Go
 description: >-
-  <img width="35" class="img-initial otel-icon" src="/img/logos/32x32/Golang_SDK.svg"
-  alt="Go"> A language-specific implementation of OpenTelemetry in Go.
+  <img width="35" class="img-initial otel-icon"
+  src="/img/logos/32x32/Golang_SDK.svg" alt="Go"> A language-specific
+  implementation of OpenTelemetry in Go.
 aliases: [/golang, /golang/metrics, /golang/tracing]
 redirects:
   - { from: /go/*, to: ':splat' }

--- a/content/en/docs/languages/go/_index.md
+++ b/content/en/docs/languages/go/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Go
 description: >-
-  <img width="35" class="img-initial" src="/img/logos/32x32/Golang_SDK.svg"
+  <img width="35" class="img-initial otel-icon" src="/img/logos/32x32/Golang_SDK.svg"
   alt="Go"> A language-specific implementation of OpenTelemetry in Go.
 aliases: [/golang, /golang/metrics, /golang/tracing]
 redirects:

--- a/content/en/docs/languages/java/_index.md
+++ b/content/en/docs/languages/java/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Java
 description: >-
-  <img width="35" class="img-initial" src="/img/logos/32x32/Java_SDK.svg"
+  <img width="35" class="img-initial otel-icon" src="/img/logos/32x32/Java_SDK.svg"
   alt="Java"> Language-specific implementation of OpenTelemetry in Java.
 aliases: [/java/metrics, /java/tracing]
 redirects:

--- a/content/en/docs/languages/java/_index.md
+++ b/content/en/docs/languages/java/_index.md
@@ -1,8 +1,9 @@
 ---
 title: Java
 description: >-
-  <img width="35" class="img-initial otel-icon" src="/img/logos/32x32/Java_SDK.svg"
-  alt="Java"> Language-specific implementation of OpenTelemetry in Java.
+  <img width="35" class="img-initial otel-icon"
+  src="/img/logos/32x32/Java_SDK.svg" alt="Java"> Language-specific
+  implementation of OpenTelemetry in Java.
 aliases: [/java/metrics, /java/tracing]
 redirects:
   - { from: /java/*, to: ':splat' }

--- a/content/en/docs/languages/js/_index.md
+++ b/content/en/docs/languages/js/_index.md
@@ -1,7 +1,7 @@
 ---
 title: JavaScript
 description: >-
-  <img width="35" class="img-initial" src="/img/logos/32x32/JS_SDK.svg"
+  <img width="35" class="img-initial otel-icon" src="/img/logos/32x32/JS_SDK.svg"
   alt="JavaScript"> A language-specific implementation of OpenTelemetry in
   JavaScript (for Node.js & the browser).
 aliases: [/js/metrics, /js/tracing, nodejs]

--- a/content/en/docs/languages/js/_index.md
+++ b/content/en/docs/languages/js/_index.md
@@ -1,9 +1,9 @@
 ---
 title: JavaScript
 description: >-
-  <img width="35" class="img-initial otel-icon" src="/img/logos/32x32/JS_SDK.svg"
-  alt="JavaScript"> A language-specific implementation of OpenTelemetry in
-  JavaScript (for Node.js & the browser).
+  <img width="35" class="img-initial otel-icon"
+  src="/img/logos/32x32/JS_SDK.svg" alt="JavaScript"> A language-specific
+  implementation of OpenTelemetry in JavaScript (for Node.js & the browser).
 aliases: [/js/metrics, /js/tracing, nodejs]
 redirects:
   - { from: /js/*, to: ':splat' }

--- a/content/en/docs/languages/php/_index.md
+++ b/content/en/docs/languages/php/_index.md
@@ -1,8 +1,8 @@
 ---
 title: PHP
 description: >-
-  <img width="35" class="img-initial otel-icon" src="/img/logos/32x32/PHP.svg" alt="PHP">
-  A language-specific implementation of OpenTelemetry in PHP.
+  <img width="35" class="img-initial otel-icon" src="/img/logos/32x32/PHP.svg"
+  alt="PHP"> A language-specific implementation of OpenTelemetry in PHP.
 redirects:
   - { from: /php/*, to: ':splat' }
   - { from: /docs/php/*, to: ':splat' }

--- a/content/en/docs/languages/php/_index.md
+++ b/content/en/docs/languages/php/_index.md
@@ -1,7 +1,7 @@
 ---
 title: PHP
 description: >-
-  <img width="35" class="img-initial" src="/img/logos/32x32/PHP.svg" alt="PHP">
+  <img width="35" class="img-initial otel-icon" src="/img/logos/32x32/PHP.svg" alt="PHP">
   A language-specific implementation of OpenTelemetry in PHP.
 redirects:
   - { from: /php/*, to: ':splat' }

--- a/content/en/docs/languages/python/_index.md
+++ b/content/en/docs/languages/python/_index.md
@@ -1,8 +1,9 @@
 ---
 title: Python
 description: >-
-  <img width="35" class="img-initial otel-icon" src="/img/logos/32x32/Python_SDK.svg"
-  alt="Python"> A language-specific implementation of OpenTelemetry in Python.
+  <img width="35" class="img-initial otel-icon"
+  src="/img/logos/32x32/Python_SDK.svg" alt="Python"> A language-specific
+  implementation of OpenTelemetry in Python.
 aliases: [/python, /python/metrics, /python/tracing]
 weight: 22
 ---

--- a/content/en/docs/languages/python/_index.md
+++ b/content/en/docs/languages/python/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Python
 description: >-
-  <img width="35" class="img-initial" src="/img/logos/32x32/Python_SDK.svg"
+  <img width="35" class="img-initial otel-icon" src="/img/logos/32x32/Python_SDK.svg"
   alt="Python"> A language-specific implementation of OpenTelemetry in Python.
 aliases: [/python, /python/metrics, /python/tracing]
 weight: 22

--- a/content/en/docs/languages/ruby/_index.md
+++ b/content/en/docs/languages/ruby/_index.md
@@ -1,8 +1,9 @@
 ---
 title: Ruby
 description: >
-  <img width="35" class="img-initial otel-icon" src="/img/logos/32x32/Ruby_SDK.svg"
-  alt="Ruby"> A language-specific implementation of OpenTelemetry in Ruby.
+  <img width="35" class="img-initial otel-icon"
+  src="/img/logos/32x32/Ruby_SDK.svg" alt="Ruby"> A language-specific
+  implementation of OpenTelemetry in Ruby.
 aliases: [/ruby, /ruby/metrics, /ruby/tracing]
 weight: 24
 ---

--- a/content/en/docs/languages/ruby/_index.md
+++ b/content/en/docs/languages/ruby/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Ruby
 description: >
-  <img width="35" class="img-initial" src="/img/logos/32x32/Ruby_SDK.svg"
+  <img width="35" class="img-initial otel-icon" src="/img/logos/32x32/Ruby_SDK.svg"
   alt="Ruby"> A language-specific implementation of OpenTelemetry in Ruby.
 aliases: [/ruby, /ruby/metrics, /ruby/tracing]
 weight: 24

--- a/content/en/docs/languages/rust/_index.md
+++ b/content/en/docs/languages/rust/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Rust
 description: >-
-  <img width="35" class="img-initial" src="/img/logos/32x32/Rust.svg"
+  <img width="35" class="img-initial otel-icon" src="/img/logos/32x32/Rust.svg"
   alt="Rust"> A language-specific implementation of OpenTelemetry in Rust.
 weight: 26
 cSpell:ignore: stackdriver

--- a/content/en/docs/languages/swift/_index.md
+++ b/content/en/docs/languages/swift/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Swift
 description: >-
-  <img width="35" class="img-initial" src="/img/logos/32x32/Swift.svg"
+  <img width="35" class="img-initial otel-icon" src="/img/logos/32x32/Swift.svg"
   alt="Swift"> A language-specific implementation of OpenTelemetry in Swift.
 weight: 28
 ---


### PR DESCRIPTION
- Followup to #7748
- Defines a CSS class specifically for OTel icons and applies the dark-mode styling just to it, rather than to all `.img-initial` images
- Fixes #7548

### Preview

- https://deploy-preview-8259--opentelemetry.netlify.app/docs/languages/go/
- https://deploy-preview-8259--opentelemetry.netlify.app/docs/collector/configuration/#basics

### Screenshots

(Same as before)

> <img width="619" height="158" alt="image" src="https://github.com/user-attachments/assets/b5cfc5b9-8320-46a4-8b0e-2a1c45801f58" />

> <img width="546" height="254" alt="image" src="https://github.com/user-attachments/assets/d1af40f3-15a6-4ccf-9bab-fa5849a59a51" />


/cc @vitorvasc 