### PR TITLE
Update README: Fix @maryliag profile link and update @vitorvasc affiliation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ These are the members of [@open-telemetry/docs-maintainers]:
 - [Phillip Carter](https://github.com/cartermp), Salesforce
 - [Severin Neumann](https://github.com/svrnm), Causely
 - [Tiffany Hrabusa](https://github.com/tiffany76), Grafana Labs
-- [Vitor Vasconcellos](https://github.com/vitorvasc), MercadoLibre, Inc.
+- [Vitor Vasconcellos](https://github.com/vitorvasc), Mercado Libre
 
 For more information about the maintainer role, see the
 [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer).
@@ -74,7 +74,7 @@ For more information about the maintainer role, see the
 
 These are the members of [@open-telemetry/docs-approvers]:
 
-- [Marylia Gutierrez](maryliag), Grafana Labs
+- [Marylia Gutierrez](https://github.com/maryliag), Grafana Labs
 
 For more information about the approver role, see the
 [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver).


### PR DESCRIPTION
- Fixes the link to @maryliag's profile  
- Updates @vitorvasc's affiliation to use the brand name instead of company's legal name
