### PR TITLE
PR Actions workflow: use GitHub App token for checkout

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -34,16 +34,8 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
-        id: otelbot-token
-        with:
-          app-id: ${{ vars.OTELBOT_DOCS_APP_ID }}
-          private-key: ${{ secrets.OTELBOT_DOCS_PRIVATE_KEY }}
-
       - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-          token: ${{ steps.otelbot-token.outputs.token }}
+        with: { fetch-depth: 0 }
 
       - name: Extract action name
         id: extract


### PR DESCRIPTION
Updates the `pr-action.yml` workflow to retrieve and pass the GitHub App token when using `actions/checkout`. 

This change contributes to #4339 and attempts to fix workflows that get stuck when `/fix:*` commands are executed.