### PR TITLE
[CI] Adjust link-warnings for semconv resource pages

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -77,3 +77,4 @@ words: # Valid words across all locales
   - nvmrc
   - opentelemetrybot
   - warnf
+  - warnidf

--- a/.warnings-skip-list.txt
+++ b/.warnings-skip-list.txt
@@ -1,29 +1,2 @@
 _filename-error
 The following package was not found and will be installed
-# Temporary until the spec is updated to v1.147+:
-specification/profiles/mappings.md: cannot resolve spec link reference '/docs/specs/semconv/attributes-registry/process/#process-attributes'
-# Temporary until the following is resolved:
-# https://github.com/open-telemetry/semantic-conventions/issues/2690
-semconv/docs/gen-ai/aws-bedrock.md: cannot resolve spec link reference '/docs/specs/semconv/gen-ai/gen-ai-input-messages.json' (/docs/specs/semconv/gen-ai/gen-ai-input-messages.json)
-semconv/docs/gen-ai/aws-bedrock.md: cannot resolve spec link reference '/docs/specs/semconv/gen-ai/gen-ai-output-messages.json' (/docs/specs/semconv/gen-ai/gen-ai-output-messages.json)
-semconv/docs/gen-ai/aws-bedrock.md: cannot resolve spec link reference '/docs/specs/semconv/gen-ai/gen-ai-system-instructions.json' (/docs/specs/semconv/gen-ai/gen-ai-system-instructions.json)
-semconv/docs/gen-ai/gen-ai-events.md: cannot resolve spec link reference '/docs/specs/semconv/gen-ai/gen-ai-input-messages.json' (/docs/specs/semconv/gen-ai/gen-ai-input-messages.json)
-semconv/docs/gen-ai/azure-ai-inference.md: cannot resolve spec link reference '/docs/specs/semconv/gen-ai/gen-ai-input-messages.json' (/docs/specs/semconv/gen-ai/gen-ai-input-messages.json)
-semconv/docs/gen-ai/gen-ai-events.md: cannot resolve spec link reference '/docs/specs/semconv/gen-ai/gen-ai-output-messages.json' (/docs/specs/semconv/gen-ai/gen-ai-output-messages.json)
-semconv/docs/gen-ai/azure-ai-inference.md: cannot resolve spec link reference '/docs/specs/semconv/gen-ai/gen-ai-output-messages.json' (/docs/specs/semconv/gen-ai/gen-ai-output-messages.json)
-semconv/docs/gen-ai/gen-ai-agent-spans.md: cannot resolve spec link reference '/docs/specs/semconv/gen-ai/gen-ai-input-messages.json' (/docs/specs/semconv/gen-ai/gen-ai-input-messages.json)
-semconv/docs/gen-ai/azure-ai-inference.md: cannot resolve spec link reference '/docs/specs/semconv/gen-ai/gen-ai-system-instructions.json' (/docs/specs/semconv/gen-ai/gen-ai-system-instructions.json)
-semconv/docs/gen-ai/gen-ai-agent-spans.md: cannot resolve spec link reference '/docs/specs/semconv/gen-ai/gen-ai-output-messages.json' (/docs/specs/semconv/gen-ai/gen-ai-output-messages.json)
-semconv/docs/gen-ai/gen-ai-events.md: cannot resolve spec link reference '/docs/specs/semconv/gen-ai/gen-ai-system-instructions.json' (/docs/specs/semconv/gen-ai/gen-ai-system-instructions.json)
-semconv/docs/gen-ai/gen-ai-agent-spans.md: cannot resolve spec link reference '/docs/specs/semconv/gen-ai/gen-ai-system-instructions.json' (/docs/specs/semconv/gen-ai/gen-ai-system-instructions.json)
-semconv/docs/gen-ai/gen-ai-spans.md: cannot resolve spec link reference '/docs/specs/semconv/gen-ai/gen-ai-input-messages.json' (/docs/specs/semconv/gen-ai/gen-ai-input-messages.json)
-semconv/docs/gen-ai/gen-ai-spans.md: cannot resolve spec link reference '/docs/specs/semconv/gen-ai/gen-ai-output-messages.json' (/docs/specs/semconv/gen-ai/gen-ai-output-messages.json)
-semconv/docs/gen-ai/gen-ai-spans.md: cannot resolve spec link reference '/docs/specs/semconv/gen-ai/gen-ai-system-instructions.json' (/docs/specs/semconv/gen-ai/gen-ai-system-instructions.json)
-semconv/docs/gen-ai/gen-ai-spans.md: cannot resolve spec link reference '/docs/specs/semconv/gen-ai/non-normative/models.ipynb' (/docs/specs/semconv/gen-ai/non-normative/models.ipynb)
-semconv/docs/gen-ai/openai.md: cannot resolve spec link reference '/docs/specs/semconv/gen-ai/gen-ai-input-messages.json' (/docs/specs/semconv/gen-ai/gen-ai-input-messages.json)
-semconv/docs/gen-ai/openai.md: cannot resolve spec link reference '/docs/specs/semconv/gen-ai/gen-ai-output-messages.json' (/docs/specs/semconv/gen-ai/gen-ai-output-messages.json)
-semconv/docs/gen-ai/openai.md: cannot resolve spec link reference '/docs/specs/semconv/gen-ai/gen-ai-system-instructions.json' (/docs/specs/semconv/gen-ai/gen-ai-system-instructions.json)
-semconv/docs/registry/attributes/gen-ai.md: cannot resolve spec link reference '/docs/specs/semconv/gen-ai/gen-ai-input-messages.json' (/docs/specs/semconv/gen-ai/gen-ai-input-messages.json)
-semconv/docs/registry/attributes/gen-ai.md: cannot resolve spec link reference '/docs/specs/semconv/gen-ai/gen-ai-output-messages.json' (/docs/specs/semconv/gen-ai/gen-ai-output-messages.json)
-semconv/docs/registry/attributes/gen-ai.md: cannot resolve spec link reference '/docs/specs/semconv/gen-ai/gen-ai-system-instructions.json' (/docs/specs/semconv/gen-ai/gen-ai-system-instructions.json)
-semconv/docs/gen-ai/non-normative/examples-llm-calls.md: cannot resolve spec link reference '/docs/specs/semconv/gen-ai/gen-ai-input-messages.json' (/docs/specs/semconv/gen-ai/gen-ai-input-messages.json)

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -5,6 +5,7 @@ disableKinds: [taxonomy]
 theme: [docsy]
 disableAliases: true # We do redirects via Netlify's _redirects file
 enableGitInfo: true
+ignoreLogs: [spec-resource-not-found]
 
 # Language settings
 defaultContentLanguage: en

--- a/layouts/_markup/render-link.html
+++ b/layouts/_markup/render-link.html
@@ -16,7 +16,7 @@
 
   */ -}}
 
-
+{{/* Note: $u.IsAbs is true if $url has a scheme (e.g., "http:") */ -}}
 {{ if and
     (hasPrefix $.PageInner.RelPermalink "/docs/specs")
     (not $u.IsAbs)
@@ -33,7 +33,35 @@
     {{ with $u.RawQuery -}}{{ $href = printf "%s?%s" $href . -}}{{ end -}}
     {{ with $u.Fragment -}}{{ $href = printf "%s#%s" $href . -}}{{ end -}}
   {{ else -}}
-    {{ warnf "File %s: cannot resolve spec link reference '%s' (%s)" .Page.File.Filename $url $path -}}
+
+    {{/* We can't find a page for $url.
+
+    - If $url refers to a Markdown file, issue a warning, since we should be
+      able to find it.
+
+    - Otherwise, it's a path to a resource file. Most often, $path is absolute,
+      and the resource is inside a page bundle. Hugo's global or page Resource.Get
+      can't handle that, so just ignore the issue. If there is a real problem, and
+      the path is invalid, it will be caught by the link checker.
+
+    - If the resource path starts with `./`, adjust it to be `../` to match
+      GitHub's relative paths, provide the page this link is in is not an index
+      page.
+
+    */ -}}
+
+    {{ if hasSuffix $path ".md" -}}
+      {{ warnf "File %s: cannot resolve spec link reference '%s' (%s)" .Page.File.Filename $url $path -}}
+    {{ else -}}
+      {{ if and
+            (hasPrefix $href "./")
+            (not (hasSuffix .Page.File.Filename "_index.md"))
+            (not (hasSuffix .Page.File.Filename "README.md"))
+      -}}
+        {{ $href = add "." $href -}}
+      {{ end -}}
+      {{ warnidf "spec-resource-not-found" "File %s: cannot resolve spec link reference '%s' (%s)" .Page.File.Filename $url $href -}}
+    {{ end -}}
   {{ end -}}
   {{ $url = $href -}}
 {{ else if hasPrefix $url "/" -}}

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -95,22 +95,14 @@ sub applyPatchOrPrintMsgIf($$$) {
   return 0;
 }
 
-# sub patchSpec_because_of_SemConv_MetricReqLevelHashDNE() {
-#   return unless $ARGV =~ /^tmp\/semconv\/docs\//
-#     && applyPatchOrPrintMsgIf('2025-08-28-metric-request-level-hash-dne', 'semconv', '1.37.0-dev');
-
-#   # See https://github.com/open-telemetry/semantic-conventions/issues/2690#issuecomment-3235079573
-#   s|/docs/general/metrics.md#metric-requirement-levels|/docs/general/metric-requirement-level.md#recommended|g;
+# sub patchSpec_because_of_SemConv_GenAiSpanRelativePath() {
+#   return unless $ARGV =~ /^tmp\/semconv\/docs\/gen-ai\/gen-ai-spans/
+#     && applyPatchOrPrintMsgIf('2025-08-28-gen-ai-span-relative-path', 'semconv', '1.38.0-dev');
+#
+#   # See https://github.com/open-telemetry/semantic-conventions/issues/2690#issue-3364744586
+#   # Replace [foo](./some-path) with [foo](/docs/gen-ai/some-path)
+#   s|\]\(\./|](/docs/gen-ai/|g;
 # }
-
-sub patchSpec_because_of_SemConv_GenAiSpanRelativePath() {
-  return unless $ARGV =~ /^tmp\/semconv\/docs\/gen-ai\/gen-ai-spans/
-    && applyPatchOrPrintMsgIf('2025-08-28-gen-ai-span-relative-path', 'semconv', '1.38.0-dev');
-
-  # See https://github.com/open-telemetry/semantic-conventions/issues/2690#issue-3364744586
-  # Replace [foo](./some-path) with [foo](/docs/gen-ai/some-path)
-  s|\]\(\./|](/docs/gen-ai/|g;
-}
 
 sub getVersFromSubmodule() {
   my %repoNames = qw(
@@ -194,16 +186,9 @@ while(<>) {
   ## Semconv
 
   if ($ARGV =~ /^tmp\/semconv/) {
-    # patchSpec_because_of_SemConv_MetricReqLevelHashDNE();
-    patchSpec_because_of_SemConv_GenAiSpanRelativePath();
-
     s|(\]\()/docs/|$1$specBasePath/semconv/|g;
     s|(\]:\s*)/docs/|$1$specBasePath/semconv/|;
     s|\((/model/.*?)\)|($semconvSpecRepoUrl/tree/v$semconvVers/$1)|g;
-
-    # Remove the .md extension from the link title
-    # TODO: remove this once the .md extension is removed from the link title
-    s|(<td><a href=")(.*)\.md(#.*">.*</a></td>)|$1$2$3|g;
   }
 
 


### PR DESCRIPTION
- Contributes to #7666
- Fixes semconv link-not-found warnings -- see added info in render-link hook comment for details
- Drops now obsolete warning-skip entries
- Drops unnecessary adjust-pages patches
- Creates a "spec-resource-not-found" warning ID, which we ignore by default