### PR TITLE
[zh][editorial] Java API - Update link for specs reference

### DIFF
--- a/content/zh/docs/languages/java/api.md
+++ b/content/zh/docs/languages/java/api.md
@@ -3,7 +3,7 @@ title: 通过 API 记录遥测数据
 weight: 11
 aliases:
   - /docs/languages/java/api-components/
-default_lang_commit: 7c6d317a1ed969bd03f0aa8297f068ca29c2b459
+default_lang_commit: 7c6d317a1ed969bd03f0aa8297f068ca29c2b459 # patched
 logBridgeWarning: >
   虽然 `LoggerProvider` 、 `Logger` API 在结构上与对应的链路和指标 API 相似，
   但它们的使用场景不同。目前，`LoggerProvider` 、 `Logger` 及相关类代表的是[日志桥接 API](/docs/specs/otel/logs/api/)，


### PR DESCRIPTION
- Fixes https://github.com/open-telemetry/opentelemetry-specification/issues/4712

As the latest (unreleased) version of the specification is currently being tracked in #8183, we noticed a broken link in the Java API page. The link currently refers to a section that will be removed in the next specification update.

This PR updates that link to the correct location and fixes the issue.

**Preview**: https://deploy-preview-8291--opentelemetry.netlify.app/zh/docs/languages/java/api/#attributes