### PR TITLE
SDK config copyedits: support copy-code for examples, and drop superfluous quotes

### DIFF
--- a/content/en/docs/languages/sdk-configuration/general.md
+++ b/content/en/docs/languages/sdk-configuration/general.md
@@ -151,7 +151,7 @@ may be a comma-separated list.
 Accepted values for are:
 
 - `otlp`: [OTLP][]
-- `jaeger`: export in Jaeger data model
+- `jaeger`: Export in Jaeger data model.
 - `zipkin`: [Zipkin](https://zipkin.io/zipkin-api/)
 - `console`: [Standard Output](/docs/specs/otel/trace/sdk_exporters/stdout/)
 - `none`: No automatically configured exporter for traces.


### PR DESCRIPTION
- Makes it easier to copy example code by putting it in a code block. See the screenshot below
- Drops unnecessary quotes from values. All env var values are strings, and the value is, e.g., `otlp`, not `"otelp"` (which would be encoded as `\"otlp\"`.
- **Preview**: https://deploy-preview-8312--opentelemetry.netlify.app/docs/languages/sdk-configuration/general/

### Screenshots

Before:

> <img width="600" height="274" alt="image" src="https://github.com/user-attachments/assets/97ebe5a0-eb0d-46cd-8f40-e602dff9e0ad" />


After:

> <img width="600" height="324" alt="image" src="https://github.com/user-attachments/assets/9c35c05a-edbd-4212-bb4a-a9f4d7bc7213" />


