### PR TITLE
Make Collector docs a sidebar root

### DIFF
--- a/content/en/docs/collector/_index.md
+++ b/content/en/docs/collector/_index.md
@@ -5,6 +5,7 @@ aliases: [./about]
 cascade:
   vers: 0.138.0
 weight: 270
+sidebar_root_for: self
 ---
 
 ![OpenTelemetry Collector diagram with Jaeger, OTLP and Prometheus integration](img/otel-collector.svg)


### PR DESCRIPTION
- Kind of a followup to #8001
- Makes the Collector section of the docs its own sidebar root. See screenshots below
- **Preview**: https://deploy-preview-8344--opentelemetry.netlify.app/docs/collector/

WDYT @tiffany76 @jaydeluca et all?

### Screenshots

Before:

> <img width="888" height="1166" alt="image" src="https://github.com/user-attachments/assets/02b3ee7d-efad-4f0e-84be-1c3112129e34" />

After:

> <img width="888" height="885" alt="image" src="https://github.com/user-attachments/assets/5e2a783a-f1e4-4d5f-a916-1e34b0c60b5c" />

