### PR TITLE
Use full-qualified name for OpenTelemetry Collector role name

### DIFF
--- a/content/en/blog/2024/scaling-collectors.md
+++ b/content/en/blog/2024/scaling-collectors.md
@@ -89,7 +89,7 @@ Create a file named `deploy-opentelemetry.yml` in the same directory as your
   tasks:
     - name: Install OpenTelemetry Collector
       ansible.builtin.include_role:
-        name: opentelemetry_collector
+        name: grafana.grafana.opentelemetry_collector
       vars:
         otel_collector_receivers:
           hostmetrics:


### PR DESCRIPTION
When using the built-in task `ansible.builtin.include_role`, a role from a collection must be referenced using its fully-qualified name.

(I just tried to follow the example in my test lab and figured out that this small change is probably needed here)

I assume, that the roles from the Ansible Galaxy collection `grafana.grafana` were installed in the default `roles` folder of the writer of this documentation so the "wrong" role name never was an issue..? 