### PR TITLE
[js] Fix typo in `languages/js/instrumentation` documentation

### DIFF
--- a/content/en/docs/languages/js/instrumentation.md
+++ b/content/en/docs/languages/js/instrumentation.md
@@ -1561,7 +1561,7 @@ module.exports = { rollTheDice };
 
 {{% /tab %}} {{< /tabpane >}}
 
-Now that you have [meters](/docs/concepts/signals/metrics/#meter) initialized.
+Now that you have [meters](/docs/concepts/signals/metrics/#meter) initialized,
 you can create
 [metric instruments](/docs/concepts/signals/metrics/#metric-instruments).
 


### PR DESCRIPTION
- Fixes typos in `content/en/docs/languages/js/instrumentation.md`
