### PR TITLE
Update docker-deployment.md

### DIFF
--- a/content/en/docs/demo/docker-deployment.md
+++ b/content/en/docs/demo/docker-deployment.md
@@ -13,6 +13,7 @@ cSpell:ignore: otlphttp spanmetrics tracetest tracetesting
 - [Docker Compose](https://docs.docker.com/compose/install/) v2.0.0+
 - Make (optional)
 - 6 GB of RAM for the application
+- 14 GB of disk space
 
 ## Get and run the demo
 


### PR DESCRIPTION
add disk space requirement, so that users avoid running into disk full problems

<!--
when using cloud environments, many come with 8 GB disks by default. That's not enough for the astro shop demo.
-->
