### PR TITLE
chore(registry): add instrumentation for confluent kafka javascript

### DIFF
--- a/data/registry/instrumentation-js-confluent-kafka.yml
+++ b/data/registry/instrumentation-js-confluent-kafka.yml
@@ -1,0 +1,22 @@
+# cSpell:ignore Drazke
+title: OpenTelemetry confluent-kafka-javascript Instrumentation
+registryType: instrumentation
+language: js
+tags:
+  - confluent-kafka-javascript
+  - instrumentation
+  - kafka
+  - javascript
+urls:
+  repo: https://github.com/Drazke/instrumentation-confluent-kafka-javascript
+license: Apache 2.0
+description:
+  This library allows tracing requests made by the
+  [confluent-kafka-javascript](https://github.com/confluentinc/confluent-kafka-javascript)
+  library.
+authors:
+  - name: Drazke
+    url: https://github.com/Drazke
+createdAt: 2025-10-26
+isNative: false
+isFirstParty: false

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -3319,6 +3319,14 @@
     "StatusCode": 206,
     "LastSeen": "2025-11-13T09:49:18.337288026Z"
   },
+  "https://github.com/Drazke": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-26T18:40:17.558352998+01:00"
+  },
+  "https://github.com/Drazke/instrumentation-confluent-kafka-javascript": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-26T18:40:16.932419705+01:00"
+  },
   "https://github.com/DrewCorlin": {
     "StatusCode": 206,
     "LastSeen": "2025-11-12T09:48:42.525016849Z"
@@ -4458,6 +4466,10 @@
   "https://github.com/confluentinc/confluent-kafka-go": {
     "StatusCode": 206,
     "LastSeen": "2025-11-13T09:48:44.406578466Z"
+  },
+  "https://github.com/confluentinc/confluent-kafka-javascript": {
+    "StatusCode": 206,
+    "LastSeen": "2025-10-26T18:40:18.210288937+01:00"
   },
   "https://github.com/congim": {
     "StatusCode": 206,


### PR DESCRIPTION
Hello,

I would like to add a new instrumentation to the registry, which is for the confluent-kafka-javascript package.
Feel free to tell me if I forgot something, thank you.

This is a new PR following the renaming of the branch as instructed here : [https://github.com/open-telemetry/opentelemetry.io/pull/8240](https://github.com/open-telemetry/opentelemetry.io/pull/8240)