### PR TITLE
(es): Add Spanish translation for dotnet nuget packages

### DIFF
--- a/content/es/docs/zero-code/dotnet/nuget-packages.md
+++ b/content/es/docs/zero-code/dotnet/nuget-packages.md
@@ -43,7 +43,7 @@ dotnet add [<PROYECTO>] package OpenTelemetry.AutoInstrumentation
 
 Si la aplicación hace referencia a paquetes que pueden instrumentarse, pero que
 requieren otros paquetes para que la instrumentación funcione, la compilación
-fallará y te pedirá que añade la biblioteca de instrumentación que falta o que
+fallará y te pedirá que añada la biblioteca de instrumentación que falta o que
 omita la instrumentación del paquete correspondiente:
 
 ```terminal


### PR DESCRIPTION
This PR adds Spanish (es) translation for the .NET NuGet packages documentation page located at [nuget-packages](https://github.com/open-telemetry/opentelemetry.io/blob/main/content/en/docs/zero-code/dotnet/nuget-packages.md).

- Created Spanish translation of the .NET NuGet packages documentation
- Ref: [#7841](https://github.com/open-telemetry/opentelemetry.io/issues/7841)