### PR TITLE
Fix PHP SDK Manual setup

### DIFF
--- a/content/en/docs/languages/php/sdk.md
+++ b/content/en/docs/languages/php/sdk.md
@@ -19,7 +19,7 @@ $meterProvider = new NoopMeterProvider();
 $tracerProvider =  new TracerProvider(
     new BatchSpanProcessor(
         $exporter,
-        ClockFactory::getDefault(),
+        Clock::getDefault(),
         2048, //max queue size
         5000, //scheduled delay millis
         5000, //export timeout


### PR DESCRIPTION
Fixed the sample code that creates a new BatchSpanProcessor.

- `BatchSpanProcessor` requires at least 7 constructor arguments
    - https://github.com/open-telemetry/opentelemetry-php/blob/7a0727f144235f01d0d8c29020fd450bdddc56ab/src/SDK/Trace/SpanProcessor/BatchSpanProcessor.php#L62-L69
-  `ClockFactory` is now deprecated
    - https://github.com/open-telemetry/opentelemetry-php/blob/7a0727f144235f01d0d8c29020fd450bdddc56ab/src/SDK/Common/Time/ClockFactory.php#L11