### PR TITLE
Update meeting day and time in repo README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ before opening an issue.
 
 ## Meetings
 
-We, the OTel Communications SIG, meet every two weeks on Monday at 10:00 PT.
+We, the OTel Communications SIG, meet every two weeks on Tuesday at 9:00 AM PT.
 Check out the [OpenTelemetry community calendar][] for the Zoom link and any
 updates to this schedule.
 


### PR DESCRIPTION
I just noticed we hadn't updated the repo's README to reflect the new meeting day and time. 