### PR TITLE
[pt] Localize in instrumentation.md

### DIFF
--- a/content/pt/docs/languages/java/instrumentation.md
+++ b/content/pt/docs/languages/java/instrumentation.md
@@ -93,7 +93,7 @@ envolve ou usa os pontos de extensão para instrumentar a biblioteca, obrigando
 os usuários a instalar e/ou adaptar o uso da biblioteca.
 
 Para uma lista de bibliotecas de instrumentação, veja a coluna _"Standalone
-Library Instrumentation [1]"_ (Biblioteca autônoma de instrumentação) em
+Library Instrumentation"_ (Biblioteca autônoma de instrumentação) em
 [bibliotecas suportadas](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/supported-libraries.md).
 
 ### Instrumentação nativa {#native-instrumentation}


### PR DESCRIPTION
This fixes #7112

- [X] I have read and followed the
      [contribution guidelines](https://opentelemetry.io/docs/contributing/),
      including the **First-time contributing?** note.
- [ ] This PR includes **AI generated content**, and I have read and conform to
      the
      [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).

## Description

Removes erroneous `[1]` reference from the "Standalone Library Instrumentation" column name in the Portuguese translation of the Java instrumentation documentation.

The English version does not contain this reference, and it doesn't correspond to any footnote in the document. This change aligns the PT-BR translation with the source.

**Changed:** `Library Instrumentation [1]"` → `Library Instrumentation"`