### PR TITLE
Change dropdown type to markdown in feedback template

### DIFF
--- a/.github/ISSUE_TEMPLATE/PAGE_FEEDBACK.yml
+++ b/.github/ISSUE_TEMPLATE/PAGE_FEEDBACK.yml
@@ -27,15 +27,9 @@ body:
       required: true
   - type: markdown
     attributes:
-      label: Tip
-      description:
-        This element is static, used to render a helpful sub-heading for
-        end-users and community members to help prioritize issues. Please leave
-        as is.
-      options:
-        - <sub>[React](https://github.blog/news-insights/product-news/add-reactions-to-pull-requests-issues-and-comments/)
-          with 👍 to help prioritize this issue. Please use comments to provide
-          useful context, avoiding `+1` or `me too`, to help us triage it. Learn
-          more
-          [here](https://opentelemetry.io/community/end-user/issue-participation/).</sub>
-      default: 0
+      value: |
+        <sub>[React](https://github.blog/news-insights/product-news/add-reactions-to-pull-requests-issues-and-comments/)
+        with 👍 to help prioritize this issue. Please use comments to provide
+        useful context, avoiding `+1` or `me too`, to help us triage it. Learn
+        more
+        [here](https://opentelemetry.io/community/end-user/issue-participation/).</sub>


### PR DESCRIPTION
fixes a bug in the page feedback form which shows the tip as a dropdown, I suspect it should be markdown

cc @danielgblanco 