### PR TITLE
add Triagers to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ These are the members of [@open-telemetry/docs-triagers]:
 - [Emídio Neto](https://github.com/emdneto)
 - [Ezzio Moreira](https://github.com/EzzioMoreira), PicPay
 - [Kazunori Otani](https://github.com/katzchang), Splunk
-- [Masaki Sugimoto](https://github.com/Msksgm)
+- [Masaki Sugimoto](https://github.com/Msksgm), Henry, Inc.
 - [Michael Yao](https://github.com/windsonsea), DaoCloud
 - [Yoshi Yamaguchi](https://github.com/ymotongpoo), AWS
 


### PR DESCRIPTION
Adding the triagers to our README.md

@open-telemetry/docs-triagers PTAL if I got your details correct
@emdneto @Msksgm I didn't find your affiliation, you can keep it empty, but feel free to put your company name behind your own