### PR TITLE
collector: update resource attributes section

### DIFF
--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -34,8 +34,8 @@ By default, the Collector exposes its own telemetry in two ways:
 
 The Collector's automatically attaches the `service.name`, `service.version`,
 and `service.instance.id` (randomly generated) resource attributes to its
-internal telemetry signals. These can be disabled by setting the attribute
-value to `null` (ex. `service.name: null`).
+internal telemetry signals. These can be disabled by setting the attribute value
+to `null` (ex. `service.name: null`).
 
 If you'd like to add additional resource attributes to the Collector's internal
 telemetry signals (traces, metrics, and logs) you can set them under


### PR DESCRIPTION
- [x] I have read and followed the
      [contribution guidelines](https://opentelemetry.io/docs/contributing/),
      including the **First-time contributing?** note.
- [ ] ~This PR includes **AI generated content**, and I have read and conform to
      the
      [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).~

Moving the resource attributes configuration into its own section.

Fixes #6226
