### PR TITLE
Reworked render-blockquote-alert.html

### DIFF
--- a/layouts/_markup/render-blockquote-alert.html
+++ b/layouts/_markup/render-blockquote-alert.html
@@ -1,18 +1,27 @@
 {{ $colors := dict
-"caution" "warning"
-"important" "danger"
-"note" "info"
-"tip" "success"
-"warning" "warning"
+    "caution" "warning"
+    "important" "danger"
+    "note" "info"
+    "tip" "success"
+    "warning" "warning"
 -}}
 
-<div class="alert alert-{{ index $colors .AlertType -}}">
-  <div class="h4 alert-heading" role="heading">
-    {{ with .AlertTitle -}}
-    {{ . -}}
-    {{ else -}}
-    {{ or (i18n .AlertType) (title .AlertType) -}}
-    {{ end }}
-  </div>
+<div class="alert
+    {{- with index $colors .AlertType -}} alert-{{ . }}
+  {{- end }}">
+  {{ $title := or
+    .AlertTitle
+    (and .AlertType
+      (or
+        (and (ne site.Language.Lang "en") (i18n .AlertType))
+        (title .AlertType)
+      )
+    )
+  -}}
+  {{ with $title -}}
+    <div class="h4 alert-heading" role="heading">
+        {{- . | safeHTML -}}
+    </div>
+  {{- end }}
   {{ .Text }}
 </div>


### PR DESCRIPTION
- Reworks the render hook so that it is more robust when context param are missing or type lookup fails
- Followup to #8445