### PR TITLE
fix: update sample commands in content/en/docs/contributing/blog.md

### DIFF
--- a/content/en/docs/contributing/blog.md
+++ b/content/en/docs/contributing/blog.md
@@ -95,28 +95,25 @@ instructions provided by the
 After you've set up the local fork you can create a blog post using a template.
 Follow these steps to create a post from the template:
 
-1. Run the following command from the repository root (please ensure the year in
-   the path is correct, as your blog will be created in that directory):
+1. Run the following command from the repository root:
 
    ```sh
-   npx hugo new content/en/blog/2025/short-name-for-post.md
+   npx hugo new content/en/blog/$(date +%Y)/short-name-for-post.md
    ```
 
-   If your post has images or other assets, run the following command (please
-   ensure the year in the path is correct, as your blog will be created in that
-   directory):
+   If your post has images or other assets, run the following command:
 
    ```sh
-   npx hugo new content/en/blog/2025/short-name-for-post/index.md
+   npx hugo new content/en/blog/$(date +%Y)/short-name-for-post/index.md
    ```
 
-1. Edit the Markdown file at the path you provided in the previous command. The
+2. Edit the Markdown file at the path you provided in the previous command. The
    file is initialized from the blog-post starter under
    [archetypes](https://github.com/open-telemetry/opentelemetry.io/tree/main/archetypes/).
 
-1. Put assets, like images or other files, into the folder you've created.
+3. Put assets, like images or other files, into the folder you've created.
 
-1. When your post is ready, submit it through a pull request.
+4. When your post is ready, submit it through a pull request.
 
 ### Use the GitHub UI
 
@@ -132,10 +129,9 @@ new post. Follow these steps to add a post using the UI:
 
 1.  Paste the content from the template you copied in the first step.
 
-1.  Name your file (please ensure the year in the path is correct, as your blog
-    will be created in that directory), for example:
+1.  Name your file, for example (`YYYY` is the current year):
 
-    `content/en/blog/2025/short-name-for-your-blog-post/index.md`.
+    `content/en/blog/YYYY/short-name-for-your-blog-post/index.md`.
 
 1.  Edit the Markdown file in GitHub.
 


### PR DESCRIPTION
Hi all,

I’d like to propose this small change in [Docs/Contributing/Blog](https://opentelemetry.io/docs/contributing/blog/) after encountering some issues while creating my recent blog post. I blindly copied and pasted the sample commands, which still referenced the year 2024, resulting in my new blog post being created in the wrong directory. I then had to fix this in my local repository and move it to 2025.

To help prevent this for others, I have:

Updated the sample commands to use 2025 in the path
Added comments in brackets reminding users to check the path and year

Ideally, it would be great to have automation that updates sample commands across the docs each year on January 1st :)

Thank you for considering this improvement!