### PR TITLE
Fix incorrect Logs example in instrumentation.md

### DIFF
--- a/content/en/docs/languages/python/instrumentation.md
+++ b/content/en/docs/languages/python/instrumentation.md
@@ -406,7 +406,7 @@ log records that OpenTelemetry can process.
 import logging
 from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor, ConsoleLogExporter
-from opentelemetry._logs import set_logger_provider, get_logger
+from opentelemetry._logs import set_logger_provider
 
 provider = LoggerProvider()
 processor = BatchLogRecordProcessor(ConsoleLogExporter())
@@ -414,12 +414,10 @@ provider.add_log_record_processor(processor)
 # Sets the global default logger provider
 set_logger_provider(provider)
 
-logger = get_logger(__name__)
-
 handler = LoggingHandler(level=logging.INFO, logger_provider=provider)
 logging.basicConfig(handlers=[handler], level=logging.INFO)
 
-logging.info("This is an OpenTelemetry log record!")
+logging.getLogger(__name__).info("This is an OpenTelemetry log record!")
 ```
 
 ### Further Reading


### PR DESCRIPTION
Fix an incorrect example in the Logs section of instrumentation.md. The logger object should be obtained via `logging.getLogger`, not `opentelemetry._logs.get_logger`, which is something different.

- [x] I have read and followed the
      [contribution guidelines](https://opentelemetry.io/docs/contributing/),
      including the **First-time contributing?** note.
- [ ] This PR includes **AI generated content**, and I have read and conform to
      the
      [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).

<!--
Provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->
