### PR TITLE
Add 'epbf' to eBPF textlint rules

### DIFF
--- a/.textlintrc.yml
+++ b/.textlintrc.yml
@@ -132,6 +132,7 @@ rules:
         - '(?<=(^|\s))(?:\bdot|\.)net\b'
         - .NET
       - [ebpf, eBPF]
+      - [epbf, eBPF]
       - ['http[ /]?2(?:\.0)?', HTTP/2]
       - [he(/| or )she, they]
       - [\(s\)he, they]


### PR DESCRIPTION
- Adds a textlint rule to catch the typo fixed by #8525