### PR TITLE
Add collector extension subtypes

### DIFF
--- a/content/en/docs/collector/components/exporter.md
+++ b/content/en/docs/collector/components/exporter.md
@@ -67,9 +67,6 @@ more information on how to configure exporters, see the
 | [tinybirdexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/tinybirdexporter)                               | contrib                  | alpha       | alpha       | alpha       |
 | [zipkinexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/zipkinexporter)                                   | contrib, core            | beta        | -           | -           |
 
-⚠️ **Note:** Components marked with ⚠️ are unmaintained and have no active
-codeowners. They may not receive regular updates or bug fixes.
-
 [^1]:
     Shows which [distributions](/docs/collector/distributions/) (core, contrib,
     K8s, etc.) include this component.

--- a/content/en/docs/collector/components/extension.md
+++ b/content/en/docs/collector/components/extension.md
@@ -3,12 +3,14 @@ title: Extensions
 description: List of available OpenTelemetry Collector extensions
 weight: 350
 # prettier-ignore
-cSpell:ignore: ackextension asapauthextension authextension awsproxy azureauthextension basicauthextension bearertokenauthextension cgroupruntimeextension clientauthextension datadogextension googleclientauthextension headerssetterextension healthcheckextension healthcheckv httpforwarderextension jaegerremotesampling memorylimiterextension oidcauthextension opampextension pprofextension remotetapextension sigv sleaderelector solarwindsapmsettingsextension sumologicextension zpagesextension
+cSpell:ignore: ackextension asapauthextension authextension avrologencodingextension awscloudwatchmetricstreamsencodingextension awslogsencodingextension awsproxy azureauthextension azureencodingextension basicauthextension bearertokenauthextension cfgardenobserver cgroupruntimeextension clientauthextension datadogextension dockerobserver ecsobserver endpointswatcher googleclientauthextension googlecloudlogentryencodingextension headerssetterextension healthcheckextension healthcheckv httpforwarderextension jaegerencodingextension jaegerremotesampling jsonlogencodingextension kafkatopicsobserver memorylimiterextension oidcauthextension opampextension otlpencodingextension pprofextension redisstorageextension remotetapextension sigv skywalkingencodingextension sleaderelector solarwindsapmsettingsextension sumologicextension textencodingextension zipkinencodingextension zpagesextension
 ---
 
 Extensions provide additional capabilities like health checks and service
 discovery. For more information on how to configure extensions, see the
 [Collector configuration documentation](/docs/collector/configuration/#extensions).
+
+## Extensions
 
 <!-- BEGIN GENERATED: extension-table SOURCE: collector-watcher -->
 
@@ -40,8 +42,57 @@ discovery. For more information on how to configure extensions, see the
 | [sumologicextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/sumologicextension)                         | contrib            | alpha         |
 | [zpagesextension](https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/zpagesextension)                                       | contrib, core, K8s | beta          |
 
-⚠️ **Note:** Components marked with ⚠️ are unmaintained and have no active
-codeowners. They may not receive regular updates or bug fixes.
+<!-- END GENERATED: extension-table SOURCE: collector-watcher -->
+
+## Encoding Extensions
+
+<!-- BEGIN GENERATED: extension-encoding-table SOURCE: collector-watcher -->
+
+| Name                                                                                                                                                                                      | Distributions[^1] | Stability[^2] |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- | ------------- |
+| [avrologencodingextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding/avrologencodingextension)                                       | contrib           | development   |
+| [awscloudwatchmetricstreamsencodingextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding/awscloudwatchmetricstreamsencodingextension) | contrib           | alpha         |
+| [awslogsencodingextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding/awslogsencodingextension)                                       | contrib           | alpha         |
+| [azureencodingextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding/azureencodingextension)                                           | contrib           | development   |
+| [googlecloudlogentryencodingextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding/googlecloudlogentryencodingextension)               | contrib           | alpha         |
+| [jaegerencodingextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding/jaegerencodingextension)                                         | contrib           | alpha         |
+| [jsonlogencodingextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding/jsonlogencodingextension)                                       | contrib           | alpha         |
+| [otlpencodingextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding/otlpencodingextension)                                             | contrib           | beta          |
+| [skywalkingencodingextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding/skywalkingencodingextension)                                 | contrib           | alpha         |
+| [textencodingextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding/textencodingextension)                                             | contrib           | beta          |
+| [zipkinencodingextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding/zipkinencodingextension)                                         | contrib           | alpha         |
+
+<!-- END GENERATED: extension-encoding-table SOURCE: collector-watcher -->
+
+## Observer Extensions
+
+<!-- BEGIN GENERATED: extension-observer-table SOURCE: collector-watcher -->
+
+| Name                                                                                                                                      | Distributions[^1] | Stability[^2] |
+| ----------------------------------------------------------------------------------------------------------------------------------------- | ----------------- | ------------- |
+| [cfgardenobserver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/cfgardenobserver)       | contrib           | alpha         |
+| [dockerobserver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/dockerobserver)           | contrib           | beta          |
+| [ecsobserver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/ecsobserver)                 | contrib           | beta          |
+| [endpointswatcher](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/endpointswatcher)       | contrib           | N/A           |
+| [hostobserver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/hostobserver)               | contrib, K8s      | beta          |
+| [k8sobserver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/k8sobserver)                 | contrib, K8s      | alpha         |
+| [kafkatopicsobserver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/kafkatopicsobserver) | contrib           | alpha         |
+
+<!-- END GENERATED: extension-observer-table SOURCE: collector-watcher -->
+
+## Storage Extensions
+
+<!-- BEGIN GENERATED: extension-storage-table SOURCE: collector-watcher -->
+
+| Name                                                                                                                                         | Distributions[^1] | Stability[^2] |
+| -------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- | ------------- |
+| [dbstorage](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/dbstorage)                         | contrib           | alpha         |
+| [filestorage](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/filestorage)                     | contrib, K8s      | beta          |
+| [redisstorageextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/redisstorageextension) | contrib           | alpha         |
+
+<!-- END GENERATED: extension-storage-table SOURCE: collector-watcher -->
+
+<!-- BEGIN GENERATED: extension-footnotes-table SOURCE: collector-watcher -->
 
 [^1]:
     Shows which [distributions](/docs/collector/distributions/) (core, contrib,
@@ -51,4 +102,4 @@ codeowners. They may not receive regular updates or bug fixes.
     For details about component stability levels, see the
     [OpenTelemetry Collector component stability definitions](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md).
 
-<!-- END GENERATED: extension-table SOURCE: collector-watcher -->
+<!-- END GENERATED: extension-footnotes-table SOURCE: collector-watcher -->

--- a/content/en/docs/collector/components/processor.md
+++ b/content/en/docs/collector/components/processor.md
@@ -47,9 +47,6 @@ pipeline. For more information on how to configure processors, see the
 | [transformprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor)                       | contrib, K8s       | beta        | beta        | beta        |
 | [unrollprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/unrollprocessor)                             | contrib            | -           | -           | alpha       |
 
-⚠️ **Note:** Components marked with ⚠️ are unmaintained and have no active
-codeowners. They may not receive regular updates or bug fixes.
-
 [^1]:
     Shows which [distributions](/docs/collector/distributions/) (core, contrib,
     K8s, etc.) include this component.

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -7423,6 +7423,50 @@
     "StatusCode": 206,
     "LastSeen": "2025-11-27T09:47:27.298818795Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding/avrologencodingextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-12-03T11:36:52.528215-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding/awscloudwatchmetricstreamsencodingextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-12-03T11:36:55.441941-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding/awslogsencodingextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-12-03T11:36:57.584308-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding/azureencodingextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-12-03T11:36:58.302325-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding/googlecloudlogentryencodingextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-12-03T11:36:59.368729-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding/jaegerencodingextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-12-03T11:37:01.18692-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding/jsonlogencodingextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-12-03T11:37:02.316803-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding/otlpencodingextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-12-03T11:37:03.205243-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding/skywalkingencodingextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-12-03T11:37:04.3252-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding/textencodingextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-12-03T11:37:05.566563-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/encoding/zipkinencodingextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-12-03T11:37:05.987972-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/googleclientauthextension": {
     "StatusCode": 206,
     "LastSeen": "2025-11-24T00:03:59.784708285Z"
@@ -7467,9 +7511,37 @@
     "StatusCode": 206,
     "LastSeen": "2025-11-27T09:47:27.703165407Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/cfgardenobserver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-12-03T11:37:07.878672-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/dockerobserver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-12-03T11:37:08.496317-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/ecsobserver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-12-03T11:37:09.938741-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/endpointswatcher": {
+    "StatusCode": 206,
+    "LastSeen": "2025-12-03T11:37:10.998753-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/hostobserver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-12-03T11:37:13.070011-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/k8sobserver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-12-03T11:37:14.312228-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/k8sobserver#setting-up-rbac-permissions": {
     "StatusCode": 206,
     "LastSeen": "2025-11-27T09:41:49.415492952Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/observer/kafkatopicsobserver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-12-03T11:37:15.383189-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/oidcauthextension": {
     "StatusCode": 206,
@@ -7494,6 +7566,18 @@
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/solarwindsapmsettingsextension": {
     "StatusCode": 206,
     "LastSeen": "2025-11-27T09:42:44.750478683Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/dbstorage": {
+    "StatusCode": 206,
+    "LastSeen": "2025-12-03T11:37:16.983676-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/filestorage": {
+    "StatusCode": 206,
+    "LastSeen": "2025-12-03T11:37:20.524602-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/redisstorageextension": {
+    "StatusCode": 206,
+    "LastSeen": "2025-12-03T11:37:24.897668-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/sumologicextension": {
     "StatusCode": 206,


### PR DESCRIPTION
Resolves #8568

- Adds new tables for extension subtypes
- Removes footnote for unmaintained components on pages where there are no unmaintained components listed

Deploy preview: https://deploy-preview-8570--opentelemetry.netlify.app/docs/collector/components/extension/