### PR TITLE
Add new section in /doc/platforms containing a mainframe overview

### DIFF
--- a/content/en/docs/platforms/mainframe/_index.md
+++ b/content/en/docs/platforms/mainframe/_index.md
@@ -87,7 +87,7 @@ In a mainframe context, the Collector often runs **off-platform** (for example, 
 - Mainframe-specific telemetry sources, and  
 - Your enterprise observability backends (metrics/logs platforms, tracing backends, APM tools, SIEMs, and data lakes).
 
-## Current Status
+## Current status
 
 OpenTelemetry instrumentation already exists for mainframes.  
 


### PR DESCRIPTION
This PR adds a new mainframe section in /docs/platforms and contains a gentle introduction to mainframe systems.  This new mainframe section is targeted at readers who may be familiar with cloud-native environments and OpenTelemetry, but who may be unfamiliar with legacy mainframe systems. 

- [x] I have read and followed the
      [contribution guidelines](https://opentelemetry.io/docs/contributing/),
      including the **First-time contributing?** note.
- [x] This PR includes **AI generated content**, and I have read and conform to
      the
      [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).