### PR TITLE
docs(registry): clarify authors must include email or URL in registry…

### DIFF
--- a/templates/registry-entry.yml
+++ b/templates/registry-entry.yml
@@ -11,8 +11,10 @@ license: Apache 2.0 # or whatever your OSS license is (see https://opensource.or
 description: A friendly description of your integration/plugin
 authors:
   - name: First author name
-    email: first author email (optional)
-    url: first author URL (github handle, optional)
+  # NOTE: At least one of the following is REQUIRED by the registry validator:
+  # Provide either `email` OR `url`. Do NOT leave both empty.
+    email: first author email
+    url: first author URL (github handle or personal websites)
 createdAt: <date> # Set todays date
 isNative: false # set this to true only if OpenTelemetry is directly integrated into your software (no plugin, no instrumentation library)
 isFirstParty: false # set this to true if "isNative" is set to false, but the plugin / instrumentation library is from the same vendor/project as the instrumented software


### PR DESCRIPTION
This update improves the registry-entry.yml template by clearly stating that an author must provide either an email or a URL. 

Currently, the template marks both fields as optional, but the registry schema requires at least one of them. This leads to contributors accidentally leaving both empty, which causes the CI validation to fail with the error: "An author must have an email or a URL".

This PR adds a simple note to the template to guide contributors and prevent those CI failures. No schema or validation logic was changed.