### PR TITLE
docs(blog): update blog guidelines to avoid linking to main branchFix/blog link guidelines

### DIFF
--- a/content/en/docs/contributing/blog.md
+++ b/content/en/docs/contributing/blog.md
@@ -35,8 +35,9 @@ follow the policies outlined in the
 ### Linking to GitHub repositories
 
 When linking to source code in GitHub repositories, do not link to the `main`
-(or other default) branch. Instead, link to a **specific commit** or a **tagged release**
-that reflects the state of the code at the time the blog post was written.
+(or other default) branch. Instead, link to a **specific commit** or a **tagged
+release** that reflects the state of the code at the time the blog post was
+written.
 
 This ensures that blog posts remain stable and do not break in the future as
 repositories evolve.


### PR DESCRIPTION
This PR updates the blog submission guidelines to clarify that authors should not link to the `main` (or other default) branch of GitHub repositories.

Instead, blog posts should link to a specific commit or a tagged release so that the linked content remains stable over time and does not break as repositories evolve.

This improves long-term reliability of blog content and follows up on issue #8578.
