### PR TITLE
[refcache] Update Knative documentation URL to remove invalid URL fragment

### DIFF
--- a/data/registry/application-integration-go-knative.yml
+++ b/data/registry/application-integration-go-knative.yml
@@ -13,7 +13,7 @@ authors:
     url: https://github.com/knative
 urls:
   website: https://knative.dev/
-  docs: https://knative.dev/docs/eventing/observability/metrics/collecting-metrics/#about-opentelemetry
+  docs: https://knative.dev/docs/eventing/observability/metrics/collecting-metrics/
 createdAt: '2024-08-06'
 cncfProjectLevel: incubating
 isNative: true

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -15379,6 +15379,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-12-08T09:50:56.314804917Z"
   },
+  "https://knative.dev/docs/eventing/observability/metrics/collecting-metrics/": {
+    "StatusCode": 206,
+    "LastSeen": "2025-12-09T12:34:49.452997-03:00"
+  },
   "https://knative.dev/docs/eventing/observability/metrics/collecting-metrics/#about-opentelemetry": {
     "StatusCode": 206,
     "LastSeen": "2025-11-30T09:44:53.111982828Z"


### PR DESCRIPTION
- Fixes invalid fragment in docs URL for Knative vendor entry
- Unblocks #8613 

```bash
./scripts/double-check-refcache-4XX.mjs -v
Checking static/refcache.json for 4XX status URLs ...
Skipping -10: https://knative.dev/docs/eventing/observability/metrics/collecting-metrics/#about-opentelemetry (last seen 12/9/2025) INVALID FRAGMENT
```