### PR TITLE
Add YAML examples for OBI service discovery exclusion configuration

### DIFF
--- a/content/en/docs/zero-code/obi/configure/service-discovery.md
+++ b/content/en/docs/zero-code/obi/configure/service-discovery.md
@@ -229,9 +229,9 @@ discovery:
           skip-instrumentation: 'true'
 ```
 
-In this example, `skip-instrumentation` is a user-defined Kubernetes pod label,
-not a built-in OBI field. You can use any custom label key and value for
-matching or exclusion based on your organization's labeling conventions.
+In this example, `skip-instrumentation` is a user-defined Kubernetes pod label.
+You can use any custom label key and value for matching or exclusion based on
+your organization's labeling conventions.
 
 ### Example: Exclude specific executables
 


### PR DESCRIPTION
- [x] I have read and followed the
      [contribution guidelines](https://opentelemetry.io/docs/contributing/),
      including the **First-time contributing?** note.
- [x] This PR includes **AI generated content**, and I have read and conform to
      the
      [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).

### Summary
Add practical examples to help users configure service exclusion and
inclusion in OBI. The documentation previously lacked examples for
exclude_instrument and default_exclude_instrument sections.

New examples include:
- Excluding specific namespaces, labels, and executables
- Enabling instrumentation for default-excluded namespaces (e.g., monitoring)
- Disabling all default exclusions
- Fine-grained control with namespace + label selectors

Fixes user confusion when trying to instrument services in namespaces
that are excluded by default (like monitoring, kube-system, etc.).

Closes https://github.com/open-telemetry/opentelemetry.io/issues/8583
