### PR TITLE
Add FusionCache to registry

### DIFF
--- a/data/registry/instrumentation-dotnet-fusioncache.yml
+++ b/data/registry/instrumentation-dotnet-fusioncache.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore fusioncache
+# cSpell:ignore fusioncache donetti
 title: FusionCache .NET caching library
 registryType: instrumentation
 language: dotnet
@@ -21,4 +21,5 @@ isNative: true
 package:
   name: ZiggyCreatures.FusionCache
   registry: nuget
+
   version: 2.5.0


### PR DESCRIPTION
- [x] I have read and followed the
      [contribution guidelines](https://opentelemetry.io/docs/contributing/),
      including the **First-time contributing?** note.

## Description

FusionCache is an easy to use, fast and robust .NET hybrid cache with advanced resiliency features.

Since FusionCache natively supports OpenTelemetry ([docs](https://github.com/ZiggyCreatures/FusionCache/blob/main/docs/OpenTelemetry.md)), I'm proposing adding it to the registry.

## Pending Questions

Since FusionCache is a .NET library, it natively supports `ActivitySource`, `Activity`, `Meter` and `Counter` as a native bridge to OpenTelemetry: this way it does not require any custom package to work with it.

Because of this, in the YAML file I marked it as "native" and as the Nuget package I simply specified the [main one](https://www.nuget.org/packages/ZiggyCreatures.FusionCache/).

Having said that, I also created a [specific package](https://www.nuget.org/packages/ZiggyCreatures.FusionCache.OpenTelemetry/) to offer a more native experience for people wanting to explicitly use OpenTelemetry: this package offers a setup experience in line with the standard OTEL experience in .NET, like this:

```c#
services.AddOpenTelemetry()
  // SETUP TRACES
  .WithTracing(tracing => tracing
    .AddFusionCacheInstrumentation()
    .AddConsoleExporter()
  )
  // SETUP METRICS
  .WithMetrics(metrics => metrics
    .AddFusionCacheInstrumentation()
    .AddConsoleExporter()
  );
```

This is not strictly needed, but it's still nice to have.

So my question is: what should I do?

Meaning, one of:
- keep the YAML file as-is, simply stating the native experience without the separate package?
- create an additional YAML file for the separate package?
- somehow list both in one YAMl file? (I don't know if it's possible to list multiple entries in the `package` element in the YAML file)

I'm adding the PR as draft to resolve this, please let me know.

Thanks!