### PR TITLE
Configuration docs (WIP)

### DIFF
--- a/assets/js/sdkLangStatusAccordion.js
+++ b/assets/js/sdkLangStatusAccordion.js
@@ -1,0 +1,238 @@
+/**
+ * SDK Language Implementation Status Accordion
+ * Collapsible list view for browsing language support
+ */
+
+let statusData = {
+  languages: {
+    cpp: { name: 'C++', version: '', types: {} },
+    go: { name: 'Go', version: '', types: {} },
+    java: { name: 'Java', version: '', types: {} },
+    js: { name: 'JavaScript', version: '', types: {} }
+  },
+  types: []
+};
+
+/**
+ * Parses the existing markdown rendered content to populate our data structure
+ */
+function parseExistingContent() {
+  const content = document.querySelector('.language-implementation-status-content');
+  if (!content) {
+    console.error('Could not find language implementation status content');
+    return;
+  }
+
+  const sections = content.querySelectorAll('h3');
+
+  sections.forEach(section => {
+    const langId = section.id;
+    if (!statusData.languages[langId]) return;
+
+    // Version is in a <p> after the heading
+    let currentElement = section.nextElementSibling;
+    let table = null;
+
+    while (currentElement) {
+      console.log(currentElement);
+      const versionMatch = currentElement.textContent?.match(/Latest supported file format:\s*([^`]+)/);
+      if (versionMatch) {
+        console.log(currentElement.textContent)
+        console.log(`Found version for ${langId}: ${versionMatch} ${versionMatch[1]}`);
+        statusData.languages[langId].version = versionMatch[1];
+      }
+
+      if (currentElement.tagName === 'TABLE') {
+        table = currentElement;
+        break;
+      }
+
+      currentElement = currentElement.nextElementSibling;
+    }
+
+    if (table) {
+      const rows = table.querySelectorAll('tbody tr');
+      rows.forEach(row => {
+        const cells = row.querySelectorAll('td');
+        if (cells.length >= 2) {
+          const typeLink = cells[0].querySelector('a');
+          const typeName = typeLink?.textContent.trim() || cells[0].textContent.trim();
+          const status = cells[1].textContent.trim();
+          const notes = cells[2]?.textContent.trim() || '';
+          const details = cells[3]?.innerHTML || '';
+
+          if (!statusData.types.includes(typeName)) {
+            statusData.types.push(typeName);
+          }
+
+          statusData.languages[langId].types[typeName] = {
+            status: status,
+            notes: notes,
+            details: details
+          };
+        }
+      });
+    }
+  });
+
+  statusData.types.sort();
+}
+
+function getStatusBadge(status) {
+  const badges = {
+    supported: '<span class="badge bg-success">✓ Supported</span>',
+    not_implemented: '<span class="badge bg-danger">✗ Not implemented</span>',
+    unknown: '<span class="badge bg-warning text-dark">? Unknown</span>',
+    not_applicable: '<span class="badge bg-secondary">N/A</span>',
+    ignored: '<span class="badge bg-info">○ Ignored</span>'
+  };
+  return badges[status] || `<span class="badge bg-light text-dark">${status}</span>`;
+}
+
+function renderAccordion() {
+  const accordion = document.getElementById('statusAccordion');
+  if (!accordion) return;
+
+  accordion.innerHTML = '';
+
+  statusData.types.forEach((typeName, index) => {
+    const item = document.createElement('div');
+    item.className = 'accordion-item';
+    item.dataset.typeName = typeName;
+    item.dataset.experimental = typeName.startsWith('Experimental') ? 'true' : 'false';
+
+    const headerId = `heading-${index}`;
+    const collapseId = `collapse-${index}`;
+
+    // Build language status summary for header
+    const statusSummary = ['cpp', 'go', 'java', 'js'].map(langId => {
+      const typeData = statusData.languages[langId].types[typeName];
+      if (typeData) {
+        return `<span class="lang-status-pill status-${typeData.status}" title="${statusData.languages[langId].name}: ${typeData.status}"></span>`;
+      }
+      return '<span class="lang-status-pill status-missing" title="No data"></span>';
+    }).join('');
+
+    item.innerHTML = `
+      <h2 class="accordion-header" id="${headerId}">
+        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#${collapseId}" aria-expanded="false" aria-controls="${collapseId}">
+          <div class="d-flex w-100 justify-content-between align-items-center pe-3">
+            <span class="type-name">
+              <a href="../types#${typeName.toLowerCase()}" onclick="event.stopPropagation();">${typeName}</a>
+            </span>
+            <span class="lang-status-summary">${statusSummary}</span>
+          </div>
+        </button>
+      </h2>
+      <div id="${collapseId}" class="accordion-collapse collapse" aria-labelledby="${headerId}" data-bs-parent="#statusAccordion">
+        <div class="accordion-body">
+          ${generateAccordionBody(typeName)}
+        </div>
+      </div>
+    `;
+
+    accordion.appendChild(item);
+  });
+
+  updateStats();
+}
+
+function generateAccordionBody(typeName) {
+  let html = '<div class="row g-3">';
+
+  ['cpp', 'go', 'java', 'js'].forEach(langId => {
+    const langData = statusData.languages[langId];
+    const typeData = langData.types[typeName];
+
+    html += '<div class="col-md-6">';
+    html += `<div class="lang-support-card">`;
+    html += `<h6>${langData.name} <small class="text-muted"> (version: ${langData.version})</small></h6>`;
+
+    if (typeData) {
+      html += `<div class="mb-2">${getStatusBadge(typeData.status)}</div>`;
+
+      if (typeData.notes) {
+        html += `<p class="small"><strong>Notes:</strong> ${typeData.notes}</p>`;
+      }
+
+      if (typeData.details) {
+        html += `<div class="property-support"><strong>Properties:</strong><br />${typeData.details}</div>`;
+      }
+    } else {
+      html += '<p class="text-muted">No data available</p>';
+    }
+
+    html += '</div></div>';
+  });
+
+  html += '</div>';
+  return html;
+}
+
+function updateStats() {
+  const items = document.querySelectorAll('.accordion-item');
+  const visibleItems = Array.from(items).filter(item => !item.classList.contains('d-none'));
+
+  document.getElementById('accordion-visible-count').textContent = visibleItems.length;
+  document.getElementById('accordion-total-count').textContent = items.length;
+}
+
+function applyFilters() {
+  const searchTerm = document.getElementById('accordion-search').value.toLowerCase();
+  const typeFilter = document.getElementById('accordion-type-filter').value;
+
+  const items = document.querySelectorAll('.accordion-item');
+
+  items.forEach(item => {
+    const typeName = item.dataset.typeName.toLowerCase();
+    const isExperimental = item.dataset.experimental === 'true';
+
+    const matchesSearch = typeName.includes(searchTerm);
+
+    let matchesTypeFilter = true;
+    if (typeFilter === 'stable') {
+      matchesTypeFilter = !isExperimental;
+    } else if (typeFilter === 'experimental') {
+      matchesTypeFilter = isExperimental;
+    }
+
+    if (matchesSearch && matchesTypeFilter) {
+      item.classList.remove('d-none');
+    } else {
+      item.classList.add('d-none');
+    }
+  });
+
+  updateStats();
+}
+
+function expandAll() {
+  const buttons = document.querySelectorAll('.accordion-button.collapsed');
+  buttons.forEach(button => button.click());
+}
+
+function collapseAll() {
+  const buttons = document.querySelectorAll('.accordion-button:not(.collapsed)');
+  buttons.forEach(button => button.click());
+}
+
+// Initialize
+function init() {
+  if (!document.getElementById('sdk-lang-status-accordion-container')) {
+    return;
+  }
+
+  parseExistingContent();
+  renderAccordion();
+
+  document.getElementById('accordion-search').addEventListener('input', applyFilters);
+  document.getElementById('accordion-type-filter').addEventListener('change', applyFilters);
+  document.getElementById('expand-all').addEventListener('click', expandAll);
+  document.getElementById('collapse-all').addEventListener('click', collapseAll);
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}

--- a/assets/js/sdkLangStatusAccordion.js
+++ b/assets/js/sdkLangStatusAccordion.js
@@ -34,11 +34,8 @@ function parseExistingContent() {
     let table = null;
 
     while (currentElement) {
-      console.log(currentElement);
       const versionMatch = currentElement.textContent?.match(/Latest supported file format:\s*([^`]+)/);
       if (versionMatch) {
-        console.log(currentElement.textContent)
-        console.log(`Found version for ${langId}: ${versionMatch} ${versionMatch[1]}`);
         statusData.languages[langId].version = versionMatch[1];
       }
 

--- a/assets/scss/_sdk_lang_status_accordion.scss
+++ b/assets/scss/_sdk_lang_status_accordion.scss
@@ -1,0 +1,168 @@
+// SDK Language Implementation Status Accordion Styles
+
+.sdk-lang-status-accordion {
+  margin: 2rem 0;
+
+  .accordion-controls {
+    background: var(--bs-light);
+    padding: 1.5rem;
+    border-radius: 0.5rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .accordion-stats {
+    font-size: 0.875rem;
+    color: var(--bs-secondary);
+  }
+
+  .accordion-item {
+    border: 1px solid var(--bs-border-color);
+    margin-bottom: 0.5rem;
+    border-radius: 0.375rem !important;
+
+    &.d-none {
+      display: none !important;
+    }
+
+    &:first-child,
+    &:last-child {
+      border-radius: 0.375rem !important;
+    }
+  }
+
+  .accordion-header {
+    .accordion-button {
+      background-color: var(--bs-body-bg);
+      color: var(--bs-body-color);
+      padding: 1rem 1.25rem;
+      font-weight: 500;
+
+      &:not(.collapsed) {
+        background-color: var(--bs-primary);
+        color: white;
+
+        .lang-status-pill {
+          border-color: rgba(255, 255, 255, 0.3);
+        }
+      }
+
+      &:focus {
+        box-shadow: none;
+        border-color: var(--bs-border-color);
+      }
+
+      .type-name {
+        flex: 1;
+
+        a {
+          color: inherit;
+          text-decoration: none;
+
+          &:hover {
+            text-decoration: underline;
+          }
+        }
+      }
+
+      .lang-status-summary {
+        display: flex;
+        gap: 0.25rem;
+        margin-left: 1rem;
+      }
+    }
+  }
+
+  .accordion-body {
+    padding: 1.5rem 1.25rem;
+    background-color: var(--bs-body-bg);
+  }
+
+  .lang-support-card {
+    padding: 1rem;
+    border: 1px solid var(--bs-border-color);
+    border-radius: 0.375rem;
+    background-color: var(--bs-light);
+    height: 100%;
+
+    h6 {
+      margin-bottom: 0.75rem;
+      font-weight: 600;
+    }
+
+    .property-support {
+      margin-top: 0.75rem;
+      font-size: 0.875rem;
+
+      ul {
+        margin-top: 0.5rem;
+        margin-bottom: 0;
+      }
+    }
+  }
+}
+
+// Language status pills (mini indicators in header)
+.lang-status-pill {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 2px solid rgba(0, 0, 0, 0.1);
+
+  &.status-supported {
+    background-color: #28a745;
+  }
+
+  &.status-not_implemented {
+    background-color: #dc3545;
+  }
+
+  &.status-unknown {
+    background-color: #ffc107;
+  }
+
+  &.status-not_applicable {
+    background-color: #6c757d;
+  }
+
+  &.status-ignored {
+    background-color: #17a2b8;
+  }
+
+  &.status-missing {
+    background-color: #e9ecef;
+  }
+}
+
+// Dark mode support
+@media (prefers-color-scheme: dark) {
+  .sdk-lang-status-accordion {
+    .accordion-controls {
+      background: rgba(255, 255, 255, 0.05);
+    }
+
+    .lang-support-card {
+      background-color: rgba(255, 255, 255, 0.03);
+    }
+
+    .lang-status-pill {
+      border-color: rgba(255, 255, 255, 0.2);
+    }
+  }
+}
+
+// Responsive adjustments
+@media (max-width: 768px) {
+  .sdk-lang-status-accordion {
+    .accordion-button {
+      .lang-status-summary {
+        flex-direction: column;
+        gap: 0.125rem !important;
+      }
+    }
+
+    .lang-support-card {
+      margin-bottom: 1rem;
+    }
+  }
+}

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -9,6 +9,7 @@
 @import 'td/code-dark';
 @import 'td/gcs-search-dark';
 @import '_page_no_left_sidebar';
+@import 'sdk_lang_status_accordion';
 
 .td-home {
   .otel-logo {

--- a/content/en/docs/languages/sdk-configuration/language-implementation-status.md
+++ b/content/en/docs/languages/sdk-configuration/language-implementation-status.md
@@ -3,10 +3,467 @@ title: Language Implementation Status
 linkTitle: Language Implementation Status
 weight: 10
 aliases: [general-sdk-configuration]
+notoc: true
 ---
 
 ## Language Implementation Status
 
 <!-- BEGIN GENERATED: language-implementation-status SOURCE: opentelemetry-configuration -->
+{{< sdk-lang-status-accordion >}}
 
+<div class="language-implementation-status-content" style="display: none;">
+
+### cpp {#cpp}
+
+Latest supported file format: `1.0.0-rc.2`
+
+| Type | Status | Notes | Support Status Details |
+|---|---|---|---|
+| [`Aggregation`](../types#aggregation) | supported |  | • `base2_exponential_bucket_histogram`: supported<br>• `default`: supported<br>• `drop`: supported<br>• `explicit_bucket_histogram`: supported<br>• `last_value`: supported<br>• `sum`: supported<br> |
+| [`AlwaysOffSampler`](../types#alwaysoffsampler) | supported |  |  |
+| [`AlwaysOnSampler`](../types#alwaysonsampler) | supported |  |  |
+| [`AttributeLimits`](../types#attributelimits) | supported |  | • `attribute_count_limit`: supported<br>• `attribute_value_length_limit`: supported<br> |
+| [`AttributeNameValue`](../types#attributenamevalue) | supported |  | • `name`: supported<br>• `type`: supported<br>• `value`: supported<br> |
+| [`AttributeType`](../types#attributetype) | supported |  | • `bool`: supported<br>• `bool_array`: supported<br>• `double`: supported<br>• `double_array`: supported<br>• `int`: supported<br>• `int_array`: supported<br>• `string`: supported<br>• `string_array`: supported<br> |
+| [`B3MultiPropagator`](../types#b3multipropagator) | supported |  |  |
+| [`B3Propagator`](../types#b3propagator) | supported |  |  |
+| [`BaggagePropagator`](../types#baggagepropagator) | supported |  |  |
+| [`Base2ExponentialBucketHistogramAggregation`](../types#base2exponentialbuckethistogramaggregation) | supported |  | • `max_scale`: supported<br>• `max_size`: supported<br>• `record_min_max`: supported<br> |
+| [`BatchLogRecordProcessor`](../types#batchlogrecordprocessor) | supported |  | • `export_timeout`: supported<br>• `exporter`: supported<br>• `max_export_batch_size`: supported<br>• `max_queue_size`: supported<br>• `schedule_delay`: supported<br> |
+| [`BatchSpanProcessor`](../types#batchspanprocessor) | supported |  | • `export_timeout`: supported<br>• `exporter`: supported<br>• `max_export_batch_size`: supported<br>• `max_queue_size`: supported<br>• `schedule_delay`: supported<br> |
+| [`CardinalityLimits`](../types#cardinalitylimits) | not_implemented |  | • `counter`: not_implemented<br>• `default`: not_implemented<br>• `gauge`: not_implemented<br>• `histogram`: not_implemented<br>• `observable_counter`: not_implemented<br>• `observable_gauge`: not_implemented<br>• `observable_up_down_counter`: not_implemented<br>• `up_down_counter`: not_implemented<br> |
+| [`ConsoleExporter`](../types#consoleexporter) | supported |  |  |
+| [`ConsoleMetricExporter`](../types#consolemetricexporter) | supported |  | • `default_histogram_aggregation`: supported<br>• `temporality_preference`: supported<br> |
+| [`DefaultAggregation`](../types#defaultaggregation) | supported |  |  |
+| [`Distribution`](../types#distribution) | unknown |  |  |
+| [`DropAggregation`](../types#dropaggregation) | supported |  |  |
+| [`ExemplarFilter`](../types#exemplarfilter) | not_implemented |  | • `always_off`: not_implemented<br>• `always_on`: not_implemented<br>• `trace_based`: not_implemented<br> |
+| [`ExplicitBucketHistogramAggregation`](../types#explicitbuckethistogramaggregation) | supported |  | • `boundaries`: supported<br>• `record_min_max`: supported<br> |
+| [`ExporterDefaultHistogramAggregation`](../types#exporterdefaulthistogramaggregation) | supported |  | • `base2_exponential_bucket_histogram`: supported<br>• `explicit_bucket_histogram`: supported<br> |
+| [`ExporterTemporalityPreference`](../types#exportertemporalitypreference) | supported |  | • `cumulative`: supported<br>• `delta`: supported<br>• `low_memory`: supported<br> |
+| [`GrpcTls`](../types#grpctls) | unknown |  | • `ca_file`: unknown<br>• `cert_file`: unknown<br>• `insecure`: unknown<br>• `key_file`: unknown<br> |
+| [`HttpTls`](../types#httptls) | unknown |  | • `ca_file`: unknown<br>• `cert_file`: unknown<br>• `key_file`: unknown<br> |
+| [`IncludeExclude`](../types#includeexclude) | supported |  | • `excluded`: supported<br>• `included`: supported<br> |
+| [`InstrumentType`](../types#instrumenttype) | supported |  | • `counter`: supported<br>• `gauge`: supported<br>• `histogram`: supported<br>• `observable_counter`: supported<br>• `observable_gauge`: supported<br>• `observable_up_down_counter`: supported<br>• `up_down_counter`: supported<br> |
+| [`JaegerPropagator`](../types#jaegerpropagator) | supported |  |  |
+| [`LastValueAggregation`](../types#lastvalueaggregation) | supported |  |  |
+| [`LoggerProvider`](../types#loggerprovider) | supported |  | • `limits`: supported<br>• `processors`: supported<br>• `logger_configurator/development`: supported<br> |
+| [`LogRecordExporter`](../types#logrecordexporter) | supported |  | • `console`: supported<br>• `otlp_grpc`: supported<br>• `otlp_http`: supported<br>• `otlp_file/development`: supported<br> |
+| [`LogRecordLimits`](../types#logrecordlimits) | supported |  | • `attribute_count_limit`: supported<br>• `attribute_value_length_limit`: supported<br> |
+| [`LogRecordProcessor`](../types#logrecordprocessor) | supported |  | • `batch`: supported<br>• `simple`: supported<br> |
+| [`MeterProvider`](../types#meterprovider) | supported |  | • `exemplar_filter`: supported<br>• `readers`: supported<br>• `views`: supported<br>• `meter_configurator/development`: supported<br> |
+| [`MetricProducer`](../types#metricproducer) | supported |  | • `opencensus`: supported<br> |
+| [`MetricReader`](../types#metricreader) | supported |  | • `periodic`: supported<br>• `pull`: supported<br> |
+| [`NameStringValuePair`](../types#namestringvaluepair) | supported |  | • `name`: supported<br>• `value`: supported<br> |
+| [`OpenCensusMetricProducer`](../types#opencensusmetricproducer) | supported |  |  |
+| [`OpenTelemetryConfiguration`](../types#opentelemetryconfiguration) | supported |  | • `attribute_limits`: supported<br>• `disabled`: supported<br>• `distribution`: supported<br>• `file_format`: supported<br>• `log_level`: supported<br>• `logger_provider`: supported<br>• `meter_provider`: supported<br>• `propagator`: supported<br>• `resource`: supported<br>• `tracer_provider`: supported<br>• `instrumentation/development`: supported<br> |
+| [`OpenTracingPropagator`](../types#opentracingpropagator) | not_implemented |  |  |
+| [`OtlpGrpcExporter`](../types#otlpgrpcexporter) | supported |  | • `compression`: supported<br>• `endpoint`: supported<br>• `headers`: supported<br>• `headers_list`: supported<br>• `timeout`: supported<br>• `tls`: supported<br> |
+| [`OtlpGrpcMetricExporter`](../types#otlpgrpcmetricexporter) | supported |  | • `compression`: supported<br>• `default_histogram_aggregation`: supported<br>• `endpoint`: supported<br>• `headers`: supported<br>• `headers_list`: supported<br>• `temporality_preference`: supported<br>• `timeout`: supported<br>• `tls`: supported<br> |
+| [`OtlpHttpEncoding`](../types#otlphttpencoding) | supported |  | • `json`: supported<br>• `protobuf`: supported<br> |
+| [`OtlpHttpExporter`](../types#otlphttpexporter) | supported |  | • `compression`: supported<br>• `encoding`: supported<br>• `endpoint`: supported<br>• `headers`: supported<br>• `headers_list`: supported<br>• `timeout`: supported<br>• `tls`: supported<br> |
+| [`OtlpHttpMetricExporter`](../types#otlphttpmetricexporter) | supported |  | • `compression`: supported<br>• `default_histogram_aggregation`: supported<br>• `encoding`: supported<br>• `endpoint`: supported<br>• `headers`: supported<br>• `headers_list`: supported<br>• `temporality_preference`: supported<br>• `timeout`: supported<br>• `tls`: supported<br> |
+| [`ParentBasedSampler`](../types#parentbasedsampler) | supported |  | • `local_parent_not_sampled`: supported<br>• `local_parent_sampled`: supported<br>• `remote_parent_not_sampled`: supported<br>• `remote_parent_sampled`: supported<br>• `root`: supported<br> |
+| [`PeriodicMetricReader`](../types#periodicmetricreader) | supported |  | • `cardinality_limits`: supported<br>• `exporter`: supported<br>• `interval`: supported<br>• `producers`: supported<br>• `timeout`: supported<br> |
+| [`Propagator`](../types#propagator) | supported |  | • `composite`: supported<br>• `composite_list`: supported<br> |
+| [`PullMetricExporter`](../types#pullmetricexporter) | supported |  | • `prometheus/development`: supported<br> |
+| [`PullMetricReader`](../types#pullmetricreader) | supported |  | • `cardinality_limits`: supported<br>• `exporter`: supported<br>• `producers`: supported<br> |
+| [`PushMetricExporter`](../types#pushmetricexporter) | supported |  | • `console`: supported<br>• `otlp_grpc`: supported<br>• `otlp_http`: supported<br>• `otlp_file/development`: supported<br> |
+| [`Resource`](../types#resource) | supported |  | • `attributes`: supported<br>• `attributes_list`: supported<br>• `schema_url`: supported<br>• `detection/development`: supported<br> |
+| [`Sampler`](../types#sampler) | supported |  | • `always_off`: supported<br>• `always_on`: supported<br>• `parent_based`: supported<br>• `trace_id_ratio_based`: supported<br>• `composite/development`: supported<br>• `jaeger_remote/development`: supported<br>• `probability/development`: supported<br> |
+| [`SeverityNumber`](../types#severitynumber) | unknown |  | • `debug`: unknown<br>• `debug2`: unknown<br>• `debug3`: unknown<br>• `debug4`: unknown<br>• `error`: unknown<br>• `error2`: unknown<br>• `error3`: unknown<br>• `error4`: unknown<br>• `fatal`: unknown<br>• `fatal2`: unknown<br>• `fatal3`: unknown<br>• `fatal4`: unknown<br>• `info`: unknown<br>• `info2`: unknown<br>• `info3`: unknown<br>• `info4`: unknown<br>• `trace`: unknown<br>• `trace2`: unknown<br>• `trace3`: unknown<br>• `trace4`: unknown<br>• `warn`: unknown<br>• `warn2`: unknown<br>• `warn3`: unknown<br>• `warn4`: unknown<br> |
+| [`SimpleLogRecordProcessor`](../types#simplelogrecordprocessor) | supported |  | • `exporter`: supported<br> |
+| [`SimpleSpanProcessor`](../types#simplespanprocessor) | supported |  | • `exporter`: supported<br> |
+| [`SpanExporter`](../types#spanexporter) | supported |  | • `console`: supported<br>• `otlp_grpc`: supported<br>• `otlp_http`: supported<br>• `otlp_file/development`: supported<br> |
+| [`SpanKind`](../types#spankind) | unknown |  | • `client`: unknown<br>• `consumer`: unknown<br>• `internal`: unknown<br>• `producer`: unknown<br>• `server`: unknown<br> |
+| [`SpanLimits`](../types#spanlimits) | supported |  | • `attribute_count_limit`: supported<br>• `attribute_value_length_limit`: supported<br>• `event_attribute_count_limit`: supported<br>• `event_count_limit`: supported<br>• `link_attribute_count_limit`: supported<br>• `link_count_limit`: supported<br> |
+| [`SpanProcessor`](../types#spanprocessor) | supported |  | • `batch`: supported<br>• `simple`: supported<br> |
+| [`SumAggregation`](../types#sumaggregation) | supported |  |  |
+| [`TextMapPropagator`](../types#textmappropagator) | supported |  | • `b3`: supported<br>• `b3multi`: supported<br>• `baggage`: supported<br>• `jaeger`: supported<br>• `ottrace`: supported<br>• `tracecontext`: supported<br> |
+| [`TraceContextPropagator`](../types#tracecontextpropagator) | supported |  |  |
+| [`TraceIdRatioBasedSampler`](../types#traceidratiobasedsampler) | supported |  | • `ratio`: supported<br> |
+| [`TracerProvider`](../types#tracerprovider) | supported |  | • `limits`: supported<br>• `processors`: supported<br>• `sampler`: supported<br>• `tracer_configurator/development`: supported<br> |
+| [`View`](../types#view) | supported |  | • `selector`: supported<br>• `stream`: supported<br> |
+| [`ViewSelector`](../types#viewselector) | supported |  | • `instrument_name`: supported<br>• `instrument_type`: supported<br>• `meter_name`: supported<br>• `meter_schema_url`: supported<br>• `meter_version`: supported<br>• `unit`: supported<br> |
+| [`ViewStream`](../types#viewstream) | supported |  | • `aggregation`: supported<br>• `aggregation_cardinality_limit`: supported<br>• `attribute_keys`: supported<br>• `description`: supported<br>• `name`: supported<br> |
+| [`ExperimentalComposableAlwaysOffSampler`](../types#experimentalcomposablealwaysoffsampler) | unknown |  |  |
+| [`ExperimentalComposableAlwaysOnSampler`](../types#experimentalcomposablealwaysonsampler) | unknown |  |  |
+| [`ExperimentalComposableParentThresholdSampler`](../types#experimentalcomposableparentthresholdsampler) | unknown |  | • `root`: unknown<br> |
+| [`ExperimentalComposableProbabilitySampler`](../types#experimentalcomposableprobabilitysampler) | unknown |  | • `ratio`: unknown<br> |
+| [`ExperimentalComposableRuleBasedSampler`](../types#experimentalcomposablerulebasedsampler) | unknown |  | • `rules`: unknown<br> |
+| [`ExperimentalComposableRuleBasedSamplerRule`](../types#experimentalcomposablerulebasedsamplerrule) | unknown |  | • `attribute_patterns`: unknown<br>• `attribute_values`: unknown<br>• `parent`: unknown<br>• `sampler`: unknown<br>• `span_kinds`: unknown<br> |
+| [`ExperimentalComposableRuleBasedSamplerRuleAttributePatterns`](../types#experimentalcomposablerulebasedsamplerruleattributepatterns) | unknown |  | • `excluded`: unknown<br>• `included`: unknown<br>• `key`: unknown<br> |
+| [`ExperimentalComposableRuleBasedSamplerRuleAttributeValues`](../types#experimentalcomposablerulebasedsamplerruleattributevalues) | unknown |  | • `key`: unknown<br>• `values`: unknown<br> |
+| [`ExperimentalComposableSampler`](../types#experimentalcomposablesampler) | unknown |  | • `always_off`: unknown<br>• `always_on`: unknown<br>• `parent_threshold`: unknown<br>• `probability`: unknown<br>• `rule_based`: unknown<br> |
+| [`ExperimentalContainerResourceDetector`](../types#experimentalcontainerresourcedetector) | not_implemented |  |  |
+| [`ExperimentalGeneralInstrumentation`](../types#experimentalgeneralinstrumentation) | not_applicable |  | • `http`: not_applicable<br>• `peer`: not_applicable<br> |
+| [`ExperimentalHostResourceDetector`](../types#experimentalhostresourcedetector) | not_implemented |  |  |
+| [`ExperimentalHttpClientInstrumentation`](../types#experimentalhttpclientinstrumentation) | not_applicable |  | • `request_captured_headers`: not_applicable<br>• `response_captured_headers`: not_applicable<br> |
+| [`ExperimentalHttpInstrumentation`](../types#experimentalhttpinstrumentation) | not_applicable |  | • `client`: not_applicable<br>• `server`: not_applicable<br> |
+| [`ExperimentalHttpServerInstrumentation`](../types#experimentalhttpserverinstrumentation) | not_applicable |  | • `request_captured_headers`: not_applicable<br>• `response_captured_headers`: not_applicable<br> |
+| [`ExperimentalInstrumentation`](../types#experimentalinstrumentation) | not_applicable |  | • `cpp`: not_applicable<br>• `dotnet`: not_applicable<br>• `erlang`: not_applicable<br>• `general`: not_applicable<br>• `go`: not_applicable<br>• `java`: not_applicable<br>• `js`: not_applicable<br>• `php`: not_applicable<br>• `python`: not_applicable<br>• `ruby`: not_applicable<br>• `rust`: not_applicable<br>• `swift`: not_applicable<br> |
+| [`ExperimentalJaegerRemoteSampler`](../types#experimentaljaegerremotesampler) | not_implemented |  | • `endpoint`: not_implemented<br>• `initial_sampler`: not_implemented<br>• `interval`: not_implemented<br> |
+| [`ExperimentalLanguageSpecificInstrumentation`](../types#experimentallanguagespecificinstrumentation) | not_applicable |  |  |
+| [`ExperimentalLoggerConfig`](../types#experimentalloggerconfig) | not_implemented |  | • `disabled`: not_implemented<br>• `minimum_severity`: not_implemented<br>• `trace_based`: not_implemented<br> |
+| [`ExperimentalLoggerConfigurator`](../types#experimentalloggerconfigurator) | not_implemented |  | • `default_config`: not_implemented<br>• `loggers`: not_implemented<br> |
+| [`ExperimentalLoggerMatcherAndConfig`](../types#experimentalloggermatcherandconfig) | not_implemented |  | • `config`: not_implemented<br>• `name`: not_implemented<br> |
+| [`ExperimentalMeterConfig`](../types#experimentalmeterconfig) | not_implemented |  | • `disabled`: not_implemented<br> |
+| [`ExperimentalMeterConfigurator`](../types#experimentalmeterconfigurator) | not_implemented |  | • `default_config`: not_implemented<br>• `meters`: not_implemented<br> |
+| [`ExperimentalMeterMatcherAndConfig`](../types#experimentalmetermatcherandconfig) | not_implemented |  | • `config`: not_implemented<br>• `name`: not_implemented<br> |
+| [`ExperimentalOtlpFileExporter`](../types#experimentalotlpfileexporter) | supported |  | • `output_stream`: supported<br> |
+| [`ExperimentalOtlpFileMetricExporter`](../types#experimentalotlpfilemetricexporter) | supported |  | • `default_histogram_aggregation`: supported<br>• `output_stream`: supported<br>• `temporality_preference`: supported<br> |
+| [`ExperimentalPeerInstrumentation`](../types#experimentalpeerinstrumentation) | not_implemented |  | • `service_mapping`: not_implemented<br> |
+| [`ExperimentalPeerServiceMapping`](../types#experimentalpeerservicemapping) | not_implemented |  | • `peer`: not_implemented<br>• `service`: not_implemented<br> |
+| [`ExperimentalProbabilitySampler`](../types#experimentalprobabilitysampler) | not_implemented |  | • `ratio`: not_implemented<br> |
+| [`ExperimentalProcessResourceDetector`](../types#experimentalprocessresourcedetector) | not_implemented |  |  |
+| [`ExperimentalPrometheusMetricExporter`](../types#experimentalprometheusmetricexporter) | supported |  | • `host`: supported<br>• `port`: supported<br>• `translation_strategy`: supported<br>• `with_resource_constant_labels`: supported<br>• `without_scope_info`: unknown<br>• `without_target_info`: unknown<br> |
+| [`ExperimentalPrometheusTranslationStrategy`](../types#experimentalprometheustranslationstrategy) | unknown |  | • `no_translation`: unknown<br>• `no_utf8_escaping_with_suffixes`: unknown<br>• `underscore_escaping_with_suffixes`: unknown<br>• `underscore_escaping_without_suffixes`: unknown<br> |
+| [`ExperimentalResourceDetection`](../types#experimentalresourcedetection) | not_implemented |  | • `attributes`: not_implemented<br>• `detectors`: not_implemented<br> |
+| [`ExperimentalResourceDetector`](../types#experimentalresourcedetector) | not_implemented |  | • `container`: not_implemented<br>• `host`: not_implemented<br>• `process`: not_implemented<br>• `service`: not_implemented<br> |
+| [`ExperimentalServiceResourceDetector`](../types#experimentalserviceresourcedetector) | not_implemented |  |  |
+| [`ExperimentalSpanParent`](../types#experimentalspanparent) | unknown |  | • `local`: unknown<br>• `none`: unknown<br>• `remote`: unknown<br> |
+| [`ExperimentalTracerConfig`](../types#experimentaltracerconfig) | not_implemented |  | • `disabled`: not_implemented<br> |
+| [`ExperimentalTracerConfigurator`](../types#experimentaltracerconfigurator) | not_implemented |  | • `default_config`: not_implemented<br>• `tracers`: not_implemented<br> |
+| [`ExperimentalTracerMatcherAndConfig`](../types#experimentaltracermatcherandconfig) | not_implemented |  | • `config`: not_implemented<br>• `name`: not_implemented<br> |
+
+### go {#go}
+
+Latest supported file format: `0.3.0`
+
+| Type | Status | Notes | Support Status Details |
+|---|---|---|---|
+| [`Aggregation`](../types#aggregation) | unknown |  | • `base2_exponential_bucket_histogram`: unknown<br>• `default`: unknown<br>• `drop`: unknown<br>• `explicit_bucket_histogram`: unknown<br>• `last_value`: unknown<br>• `sum`: unknown<br> |
+| [`AlwaysOffSampler`](../types#alwaysoffsampler) | unknown |  |  |
+| [`AlwaysOnSampler`](../types#alwaysonsampler) | unknown |  |  |
+| [`AttributeLimits`](../types#attributelimits) | unknown |  | • `attribute_count_limit`: unknown<br>• `attribute_value_length_limit`: unknown<br> |
+| [`AttributeNameValue`](../types#attributenamevalue) | unknown |  | • `name`: unknown<br>• `type`: unknown<br>• `value`: unknown<br> |
+| [`AttributeType`](../types#attributetype) | unknown |  | • `bool`: unknown<br>• `bool_array`: unknown<br>• `double`: unknown<br>• `double_array`: unknown<br>• `int`: unknown<br>• `int_array`: unknown<br>• `string`: unknown<br>• `string_array`: unknown<br> |
+| [`B3MultiPropagator`](../types#b3multipropagator) | unknown |  |  |
+| [`B3Propagator`](../types#b3propagator) | unknown |  |  |
+| [`BaggagePropagator`](../types#baggagepropagator) | unknown |  |  |
+| [`Base2ExponentialBucketHistogramAggregation`](../types#base2exponentialbuckethistogramaggregation) | unknown |  | • `max_scale`: unknown<br>• `max_size`: unknown<br>• `record_min_max`: unknown<br> |
+| [`BatchLogRecordProcessor`](../types#batchlogrecordprocessor) | unknown |  | • `export_timeout`: unknown<br>• `exporter`: unknown<br>• `max_export_batch_size`: unknown<br>• `max_queue_size`: unknown<br>• `schedule_delay`: unknown<br> |
+| [`BatchSpanProcessor`](../types#batchspanprocessor) | unknown |  | • `export_timeout`: unknown<br>• `exporter`: unknown<br>• `max_export_batch_size`: unknown<br>• `max_queue_size`: unknown<br>• `schedule_delay`: unknown<br> |
+| [`CardinalityLimits`](../types#cardinalitylimits) | unknown |  | • `counter`: unknown<br>• `default`: unknown<br>• `gauge`: unknown<br>• `histogram`: unknown<br>• `observable_counter`: unknown<br>• `observable_gauge`: unknown<br>• `observable_up_down_counter`: unknown<br>• `up_down_counter`: unknown<br> |
+| [`ConsoleExporter`](../types#consoleexporter) | unknown |  |  |
+| [`ConsoleMetricExporter`](../types#consolemetricexporter) | unknown |  | • `default_histogram_aggregation`: unknown<br>• `temporality_preference`: unknown<br> |
+| [`DefaultAggregation`](../types#defaultaggregation) | unknown |  |  |
+| [`Distribution`](../types#distribution) | unknown |  |  |
+| [`DropAggregation`](../types#dropaggregation) | unknown |  |  |
+| [`ExemplarFilter`](../types#exemplarfilter) | unknown |  | • `always_off`: unknown<br>• `always_on`: unknown<br>• `trace_based`: unknown<br> |
+| [`ExplicitBucketHistogramAggregation`](../types#explicitbuckethistogramaggregation) | unknown |  | • `boundaries`: unknown<br>• `record_min_max`: unknown<br> |
+| [`ExporterDefaultHistogramAggregation`](../types#exporterdefaulthistogramaggregation) | unknown |  | • `base2_exponential_bucket_histogram`: unknown<br>• `explicit_bucket_histogram`: unknown<br> |
+| [`ExporterTemporalityPreference`](../types#exportertemporalitypreference) | unknown |  | • `cumulative`: unknown<br>• `delta`: unknown<br>• `low_memory`: unknown<br> |
+| [`GrpcTls`](../types#grpctls) | unknown |  | • `ca_file`: unknown<br>• `cert_file`: unknown<br>• `insecure`: unknown<br>• `key_file`: unknown<br> |
+| [`HttpTls`](../types#httptls) | unknown |  | • `ca_file`: unknown<br>• `cert_file`: unknown<br>• `key_file`: unknown<br> |
+| [`IncludeExclude`](../types#includeexclude) | unknown |  | • `excluded`: unknown<br>• `included`: unknown<br> |
+| [`InstrumentType`](../types#instrumenttype) | unknown |  | • `counter`: unknown<br>• `gauge`: unknown<br>• `histogram`: unknown<br>• `observable_counter`: unknown<br>• `observable_gauge`: unknown<br>• `observable_up_down_counter`: unknown<br>• `up_down_counter`: unknown<br> |
+| [`JaegerPropagator`](../types#jaegerpropagator) | unknown |  |  |
+| [`LastValueAggregation`](../types#lastvalueaggregation) | unknown |  |  |
+| [`LoggerProvider`](../types#loggerprovider) | unknown |  | • `limits`: unknown<br>• `processors`: unknown<br>• `logger_configurator/development`: unknown<br> |
+| [`LogRecordExporter`](../types#logrecordexporter) | unknown |  | • `console`: unknown<br>• `otlp_grpc`: unknown<br>• `otlp_http`: unknown<br>• `otlp_file/development`: unknown<br> |
+| [`LogRecordLimits`](../types#logrecordlimits) | unknown |  | • `attribute_count_limit`: unknown<br>• `attribute_value_length_limit`: unknown<br> |
+| [`LogRecordProcessor`](../types#logrecordprocessor) | unknown |  | • `batch`: unknown<br>• `simple`: unknown<br> |
+| [`MeterProvider`](../types#meterprovider) | unknown |  | • `exemplar_filter`: unknown<br>• `readers`: unknown<br>• `views`: unknown<br>• `meter_configurator/development`: unknown<br> |
+| [`MetricProducer`](../types#metricproducer) | unknown |  | • `opencensus`: unknown<br> |
+| [`MetricReader`](../types#metricreader) | unknown |  | • `periodic`: unknown<br>• `pull`: unknown<br> |
+| [`NameStringValuePair`](../types#namestringvaluepair) | unknown |  | • `name`: unknown<br>• `value`: unknown<br> |
+| [`OpenCensusMetricProducer`](../types#opencensusmetricproducer) | unknown |  |  |
+| [`OpenTelemetryConfiguration`](../types#opentelemetryconfiguration) | unknown |  | • `attribute_limits`: unknown<br>• `disabled`: unknown<br>• `distribution`: unknown<br>• `file_format`: unknown<br>• `log_level`: unknown<br>• `logger_provider`: unknown<br>• `meter_provider`: unknown<br>• `propagator`: unknown<br>• `resource`: unknown<br>• `tracer_provider`: unknown<br>• `instrumentation/development`: unknown<br> |
+| [`OpenTracingPropagator`](../types#opentracingpropagator) | unknown |  |  |
+| [`OtlpGrpcExporter`](../types#otlpgrpcexporter) | unknown |  | • `compression`: unknown<br>• `endpoint`: unknown<br>• `headers`: unknown<br>• `headers_list`: unknown<br>• `timeout`: unknown<br>• `tls`: unknown<br> |
+| [`OtlpGrpcMetricExporter`](../types#otlpgrpcmetricexporter) | unknown |  | • `compression`: unknown<br>• `default_histogram_aggregation`: unknown<br>• `endpoint`: unknown<br>• `headers`: unknown<br>• `headers_list`: unknown<br>• `temporality_preference`: unknown<br>• `timeout`: unknown<br>• `tls`: unknown<br> |
+| [`OtlpHttpEncoding`](../types#otlphttpencoding) | unknown |  | • `json`: unknown<br>• `protobuf`: unknown<br> |
+| [`OtlpHttpExporter`](../types#otlphttpexporter) | unknown |  | • `compression`: unknown<br>• `encoding`: unknown<br>• `endpoint`: unknown<br>• `headers`: unknown<br>• `headers_list`: unknown<br>• `timeout`: unknown<br>• `tls`: unknown<br> |
+| [`OtlpHttpMetricExporter`](../types#otlphttpmetricexporter) | unknown |  | • `compression`: unknown<br>• `default_histogram_aggregation`: unknown<br>• `encoding`: unknown<br>• `endpoint`: unknown<br>• `headers`: unknown<br>• `headers_list`: unknown<br>• `temporality_preference`: unknown<br>• `timeout`: unknown<br>• `tls`: unknown<br> |
+| [`ParentBasedSampler`](../types#parentbasedsampler) | unknown |  | • `local_parent_not_sampled`: unknown<br>• `local_parent_sampled`: unknown<br>• `remote_parent_not_sampled`: unknown<br>• `remote_parent_sampled`: unknown<br>• `root`: unknown<br> |
+| [`PeriodicMetricReader`](../types#periodicmetricreader) | unknown |  | • `cardinality_limits`: unknown<br>• `exporter`: unknown<br>• `interval`: unknown<br>• `producers`: unknown<br>• `timeout`: unknown<br> |
+| [`Propagator`](../types#propagator) | unknown |  | • `composite`: unknown<br>• `composite_list`: unknown<br> |
+| [`PullMetricExporter`](../types#pullmetricexporter) | unknown |  | • `prometheus/development`: unknown<br> |
+| [`PullMetricReader`](../types#pullmetricreader) | unknown |  | • `cardinality_limits`: unknown<br>• `exporter`: unknown<br>• `producers`: unknown<br> |
+| [`PushMetricExporter`](../types#pushmetricexporter) | unknown |  | • `console`: unknown<br>• `otlp_grpc`: unknown<br>• `otlp_http`: unknown<br>• `otlp_file/development`: unknown<br> |
+| [`Resource`](../types#resource) | unknown |  | • `attributes`: unknown<br>• `attributes_list`: unknown<br>• `schema_url`: unknown<br>• `detection/development`: unknown<br> |
+| [`Sampler`](../types#sampler) | unknown |  | • `always_off`: unknown<br>• `always_on`: unknown<br>• `parent_based`: unknown<br>• `trace_id_ratio_based`: unknown<br>• `composite/development`: unknown<br>• `jaeger_remote/development`: unknown<br>• `probability/development`: unknown<br> |
+| [`SeverityNumber`](../types#severitynumber) | unknown |  | • `debug`: unknown<br>• `debug2`: unknown<br>• `debug3`: unknown<br>• `debug4`: unknown<br>• `error`: unknown<br>• `error2`: unknown<br>• `error3`: unknown<br>• `error4`: unknown<br>• `fatal`: unknown<br>• `fatal2`: unknown<br>• `fatal3`: unknown<br>• `fatal4`: unknown<br>• `info`: unknown<br>• `info2`: unknown<br>• `info3`: unknown<br>• `info4`: unknown<br>• `trace`: unknown<br>• `trace2`: unknown<br>• `trace3`: unknown<br>• `trace4`: unknown<br>• `warn`: unknown<br>• `warn2`: unknown<br>• `warn3`: unknown<br>• `warn4`: unknown<br> |
+| [`SimpleLogRecordProcessor`](../types#simplelogrecordprocessor) | unknown |  | • `exporter`: unknown<br> |
+| [`SimpleSpanProcessor`](../types#simplespanprocessor) | unknown |  | • `exporter`: unknown<br> |
+| [`SpanExporter`](../types#spanexporter) | unknown |  | • `console`: unknown<br>• `otlp_grpc`: unknown<br>• `otlp_http`: unknown<br>• `otlp_file/development`: unknown<br> |
+| [`SpanKind`](../types#spankind) | unknown |  | • `client`: unknown<br>• `consumer`: unknown<br>• `internal`: unknown<br>• `producer`: unknown<br>• `server`: unknown<br> |
+| [`SpanLimits`](../types#spanlimits) | unknown |  | • `attribute_count_limit`: unknown<br>• `attribute_value_length_limit`: unknown<br>• `event_attribute_count_limit`: unknown<br>• `event_count_limit`: unknown<br>• `link_attribute_count_limit`: unknown<br>• `link_count_limit`: unknown<br> |
+| [`SpanProcessor`](../types#spanprocessor) | unknown |  | • `batch`: unknown<br>• `simple`: unknown<br> |
+| [`SumAggregation`](../types#sumaggregation) | unknown |  |  |
+| [`TextMapPropagator`](../types#textmappropagator) | unknown |  | • `b3`: unknown<br>• `b3multi`: unknown<br>• `baggage`: unknown<br>• `jaeger`: unknown<br>• `ottrace`: unknown<br>• `tracecontext`: unknown<br> |
+| [`TraceContextPropagator`](../types#tracecontextpropagator) | unknown |  |  |
+| [`TraceIdRatioBasedSampler`](../types#traceidratiobasedsampler) | unknown |  | • `ratio`: unknown<br> |
+| [`TracerProvider`](../types#tracerprovider) | unknown |  | • `limits`: unknown<br>• `processors`: unknown<br>• `sampler`: unknown<br>• `tracer_configurator/development`: unknown<br> |
+| [`View`](../types#view) | unknown |  | • `selector`: unknown<br>• `stream`: unknown<br> |
+| [`ViewSelector`](../types#viewselector) | unknown |  | • `instrument_name`: unknown<br>• `instrument_type`: unknown<br>• `meter_name`: unknown<br>• `meter_schema_url`: unknown<br>• `meter_version`: unknown<br>• `unit`: unknown<br> |
+| [`ViewStream`](../types#viewstream) | unknown |  | • `aggregation`: unknown<br>• `aggregation_cardinality_limit`: unknown<br>• `attribute_keys`: unknown<br>• `description`: unknown<br>• `name`: unknown<br> |
+| [`ExperimentalComposableAlwaysOffSampler`](../types#experimentalcomposablealwaysoffsampler) | unknown |  |  |
+| [`ExperimentalComposableAlwaysOnSampler`](../types#experimentalcomposablealwaysonsampler) | unknown |  |  |
+| [`ExperimentalComposableParentThresholdSampler`](../types#experimentalcomposableparentthresholdsampler) | unknown |  | • `root`: unknown<br> |
+| [`ExperimentalComposableProbabilitySampler`](../types#experimentalcomposableprobabilitysampler) | unknown |  | • `ratio`: unknown<br> |
+| [`ExperimentalComposableRuleBasedSampler`](../types#experimentalcomposablerulebasedsampler) | unknown |  | • `rules`: unknown<br> |
+| [`ExperimentalComposableRuleBasedSamplerRule`](../types#experimentalcomposablerulebasedsamplerrule) | unknown |  | • `attribute_patterns`: unknown<br>• `attribute_values`: unknown<br>• `parent`: unknown<br>• `sampler`: unknown<br>• `span_kinds`: unknown<br> |
+| [`ExperimentalComposableRuleBasedSamplerRuleAttributePatterns`](../types#experimentalcomposablerulebasedsamplerruleattributepatterns) | unknown |  | • `excluded`: unknown<br>• `included`: unknown<br>• `key`: unknown<br> |
+| [`ExperimentalComposableRuleBasedSamplerRuleAttributeValues`](../types#experimentalcomposablerulebasedsamplerruleattributevalues) | unknown |  | • `key`: unknown<br>• `values`: unknown<br> |
+| [`ExperimentalComposableSampler`](../types#experimentalcomposablesampler) | unknown |  | • `always_off`: unknown<br>• `always_on`: unknown<br>• `parent_threshold`: unknown<br>• `probability`: unknown<br>• `rule_based`: unknown<br> |
+| [`ExperimentalContainerResourceDetector`](../types#experimentalcontainerresourcedetector) | unknown |  |  |
+| [`ExperimentalGeneralInstrumentation`](../types#experimentalgeneralinstrumentation) | unknown |  | • `http`: unknown<br>• `peer`: unknown<br> |
+| [`ExperimentalHostResourceDetector`](../types#experimentalhostresourcedetector) | unknown |  |  |
+| [`ExperimentalHttpClientInstrumentation`](../types#experimentalhttpclientinstrumentation) | unknown |  | • `request_captured_headers`: unknown<br>• `response_captured_headers`: unknown<br> |
+| [`ExperimentalHttpInstrumentation`](../types#experimentalhttpinstrumentation) | unknown |  | • `client`: unknown<br>• `server`: unknown<br> |
+| [`ExperimentalHttpServerInstrumentation`](../types#experimentalhttpserverinstrumentation) | unknown |  | • `request_captured_headers`: unknown<br>• `response_captured_headers`: unknown<br> |
+| [`ExperimentalInstrumentation`](../types#experimentalinstrumentation) | unknown |  | • `cpp`: unknown<br>• `dotnet`: unknown<br>• `erlang`: unknown<br>• `general`: unknown<br>• `go`: unknown<br>• `java`: unknown<br>• `js`: unknown<br>• `php`: unknown<br>• `python`: unknown<br>• `ruby`: unknown<br>• `rust`: unknown<br>• `swift`: unknown<br> |
+| [`ExperimentalJaegerRemoteSampler`](../types#experimentaljaegerremotesampler) | unknown |  | • `endpoint`: unknown<br>• `initial_sampler`: unknown<br>• `interval`: unknown<br> |
+| [`ExperimentalLanguageSpecificInstrumentation`](../types#experimentallanguagespecificinstrumentation) | unknown |  |  |
+| [`ExperimentalLoggerConfig`](../types#experimentalloggerconfig) | unknown |  | • `disabled`: unknown<br>• `minimum_severity`: unknown<br>• `trace_based`: unknown<br> |
+| [`ExperimentalLoggerConfigurator`](../types#experimentalloggerconfigurator) | unknown |  | • `default_config`: unknown<br>• `loggers`: unknown<br> |
+| [`ExperimentalLoggerMatcherAndConfig`](../types#experimentalloggermatcherandconfig) | unknown |  | • `config`: unknown<br>• `name`: unknown<br> |
+| [`ExperimentalMeterConfig`](../types#experimentalmeterconfig) | unknown |  | • `disabled`: unknown<br> |
+| [`ExperimentalMeterConfigurator`](../types#experimentalmeterconfigurator) | unknown |  | • `default_config`: unknown<br>• `meters`: unknown<br> |
+| [`ExperimentalMeterMatcherAndConfig`](../types#experimentalmetermatcherandconfig) | unknown |  | • `config`: unknown<br>• `name`: unknown<br> |
+| [`ExperimentalOtlpFileExporter`](../types#experimentalotlpfileexporter) | unknown |  | • `output_stream`: unknown<br> |
+| [`ExperimentalOtlpFileMetricExporter`](../types#experimentalotlpfilemetricexporter) | unknown |  | • `default_histogram_aggregation`: unknown<br>• `output_stream`: unknown<br>• `temporality_preference`: unknown<br> |
+| [`ExperimentalPeerInstrumentation`](../types#experimentalpeerinstrumentation) | unknown |  | • `service_mapping`: unknown<br> |
+| [`ExperimentalPeerServiceMapping`](../types#experimentalpeerservicemapping) | unknown |  | • `peer`: unknown<br>• `service`: unknown<br> |
+| [`ExperimentalProbabilitySampler`](../types#experimentalprobabilitysampler) | unknown |  | • `ratio`: unknown<br> |
+| [`ExperimentalProcessResourceDetector`](../types#experimentalprocessresourcedetector) | unknown |  |  |
+| [`ExperimentalPrometheusMetricExporter`](../types#experimentalprometheusmetricexporter) | unknown |  | • `host`: unknown<br>• `port`: unknown<br>• `translation_strategy`: unknown<br>• `with_resource_constant_labels`: unknown<br>• `without_scope_info`: unknown<br>• `without_target_info`: unknown<br> |
+| [`ExperimentalPrometheusTranslationStrategy`](../types#experimentalprometheustranslationstrategy) | unknown |  | • `no_translation`: unknown<br>• `no_utf8_escaping_with_suffixes`: unknown<br>• `underscore_escaping_with_suffixes`: unknown<br>• `underscore_escaping_without_suffixes`: unknown<br> |
+| [`ExperimentalResourceDetection`](../types#experimentalresourcedetection) | unknown |  | • `attributes`: unknown<br>• `detectors`: unknown<br> |
+| [`ExperimentalResourceDetector`](../types#experimentalresourcedetector) | unknown |  | • `container`: unknown<br>• `host`: unknown<br>• `process`: unknown<br>• `service`: unknown<br> |
+| [`ExperimentalServiceResourceDetector`](../types#experimentalserviceresourcedetector) | unknown |  |  |
+| [`ExperimentalSpanParent`](../types#experimentalspanparent) | unknown |  | • `local`: unknown<br>• `none`: unknown<br>• `remote`: unknown<br> |
+| [`ExperimentalTracerConfig`](../types#experimentaltracerconfig) | unknown |  | • `disabled`: unknown<br> |
+| [`ExperimentalTracerConfigurator`](../types#experimentaltracerconfigurator) | unknown |  | • `default_config`: unknown<br>• `tracers`: unknown<br> |
+| [`ExperimentalTracerMatcherAndConfig`](../types#experimentaltracermatcherandconfig) | unknown |  | • `config`: unknown<br>• `name`: unknown<br> |
+
+### java {#java}
+
+Latest supported file format: `1.0.0-rc.1`
+
+| Type | Status | Notes | Support Status Details |
+|---|---|---|---|
+| [`Aggregation`](../types#aggregation) | supported |  | • `base2_exponential_bucket_histogram`: supported<br>• `default`: supported<br>• `drop`: supported<br>• `explicit_bucket_histogram`: supported<br>• `last_value`: supported<br>• `sum`: supported<br> |
+| [`AlwaysOffSampler`](../types#alwaysoffsampler) | supported |  |  |
+| [`AlwaysOnSampler`](../types#alwaysonsampler) | supported |  |  |
+| [`AttributeLimits`](../types#attributelimits) | supported |  | • `attribute_count_limit`: supported<br>• `attribute_value_length_limit`: supported<br> |
+| [`AttributeNameValue`](../types#attributenamevalue) | supported |  | • `name`: supported<br>• `type`: supported<br>• `value`: supported<br> |
+| [`AttributeType`](../types#attributetype) | supported |  | • `bool`: supported<br>• `bool_array`: supported<br>• `double`: supported<br>• `double_array`: supported<br>• `int`: supported<br>• `int_array`: supported<br>• `string`: supported<br>• `string_array`: supported<br> |
+| [`B3MultiPropagator`](../types#b3multipropagator) | supported |  |  |
+| [`B3Propagator`](../types#b3propagator) | supported |  |  |
+| [`BaggagePropagator`](../types#baggagepropagator) | supported |  |  |
+| [`Base2ExponentialBucketHistogramAggregation`](../types#base2exponentialbuckethistogramaggregation) | supported |  | • `max_scale`: supported<br>• `max_size`: supported<br>• `record_min_max`: not_implemented<br> |
+| [`BatchLogRecordProcessor`](../types#batchlogrecordprocessor) | supported |  | • `export_timeout`: supported<br>• `exporter`: supported<br>• `max_export_batch_size`: supported<br>• `max_queue_size`: supported<br>• `schedule_delay`: supported<br> |
+| [`BatchSpanProcessor`](../types#batchspanprocessor) | supported |  | • `export_timeout`: supported<br>• `exporter`: supported<br>• `max_export_batch_size`: supported<br>• `max_queue_size`: supported<br>• `schedule_delay`: supported<br> |
+| [`CardinalityLimits`](../types#cardinalitylimits) | supported |  | • `counter`: supported<br>• `default`: supported<br>• `gauge`: supported<br>• `histogram`: supported<br>• `observable_counter`: supported<br>• `observable_gauge`: supported<br>• `observable_up_down_counter`: supported<br>• `up_down_counter`: supported<br> |
+| [`ConsoleExporter`](../types#consoleexporter) | supported |  |  |
+| [`ConsoleMetricExporter`](../types#consolemetricexporter) | supported |  | • `default_histogram_aggregation`: not_implemented<br>• `temporality_preference`: ignored<br> |
+| [`DefaultAggregation`](../types#defaultaggregation) | supported |  |  |
+| [`Distribution`](../types#distribution) | unknown |  |  |
+| [`DropAggregation`](../types#dropaggregation) | supported |  |  |
+| [`ExemplarFilter`](../types#exemplarfilter) | supported |  | • `always_off`: supported<br>• `always_on`: supported<br>• `trace_based`: supported<br> |
+| [`ExplicitBucketHistogramAggregation`](../types#explicitbuckethistogramaggregation) | supported |  | • `boundaries`: supported<br>• `record_min_max`: not_implemented<br> |
+| [`ExporterDefaultHistogramAggregation`](../types#exporterdefaulthistogramaggregation) | supported |  | • `base2_exponential_bucket_histogram`: supported<br>• `explicit_bucket_histogram`: supported<br> |
+| [`ExporterTemporalityPreference`](../types#exportertemporalitypreference) | supported |  | • `cumulative`: supported<br>• `delta`: supported<br>• `low_memory`: supported<br> |
+| [`GrpcTls`](../types#grpctls) | not_implemented |  | • `ca_file`: not_implemented<br>• `cert_file`: not_implemented<br>• `insecure`: not_implemented<br>• `key_file`: not_implemented<br> |
+| [`HttpTls`](../types#httptls) | not_implemented |  | • `ca_file`: not_implemented<br>• `cert_file`: not_implemented<br>• `key_file`: not_implemented<br> |
+| [`IncludeExclude`](../types#includeexclude) | supported |  | • `excluded`: supported<br>• `included`: supported<br> |
+| [`InstrumentType`](../types#instrumenttype) | supported |  | • `counter`: supported<br>• `gauge`: supported<br>• `histogram`: supported<br>• `observable_counter`: supported<br>• `observable_gauge`: supported<br>• `observable_up_down_counter`: supported<br>• `up_down_counter`: supported<br> |
+| [`JaegerPropagator`](../types#jaegerpropagator) | supported |  |  |
+| [`LastValueAggregation`](../types#lastvalueaggregation) | supported |  |  |
+| [`LoggerProvider`](../types#loggerprovider) | supported |  | • `limits`: supported<br>• `processors`: supported<br>• `logger_configurator/development`: supported<br> |
+| [`LogRecordExporter`](../types#logrecordexporter) | supported |  | • `console`: supported<br>• `otlp_grpc`: supported<br>• `otlp_http`: supported<br>• `otlp_file/development`: supported<br> |
+| [`LogRecordLimits`](../types#logrecordlimits) | supported |  | • `attribute_count_limit`: supported<br>• `attribute_value_length_limit`: supported<br> |
+| [`LogRecordProcessor`](../types#logrecordprocessor) | supported |  | • `batch`: supported<br>• `simple`: supported<br> |
+| [`MeterProvider`](../types#meterprovider) | supported |  | • `exemplar_filter`: supported<br>• `readers`: supported<br>• `views`: supported<br>• `meter_configurator/development`: supported<br> |
+| [`MetricProducer`](../types#metricproducer) | ignored |  | • `opencensus`: ignored<br> |
+| [`MetricReader`](../types#metricreader) | supported |  | • `periodic`: supported<br>• `pull`: supported<br> |
+| [`NameStringValuePair`](../types#namestringvaluepair) | supported |  | • `name`: supported<br>• `value`: supported<br> |
+| [`OpenCensusMetricProducer`](../types#opencensusmetricproducer) | ignored |  |  |
+| [`OpenTelemetryConfiguration`](../types#opentelemetryconfiguration) | supported |  | • `attribute_limits`: supported<br>• `disabled`: supported<br>• `distribution`: supported<br>• `file_format`: supported<br>• `log_level`: not_implemented<br>• `logger_provider`: supported<br>• `meter_provider`: supported<br>• `propagator`: supported<br>• `resource`: supported<br>• `tracer_provider`: supported<br>• `instrumentation/development`: supported<br> |
+| [`OpenTracingPropagator`](../types#opentracingpropagator) | supported |  |  |
+| [`OtlpGrpcExporter`](../types#otlpgrpcexporter) | supported |  | • `compression`: supported<br>• `endpoint`: supported<br>• `headers`: supported<br>• `headers_list`: supported<br>• `timeout`: supported<br>• `tls`: ignored<br> |
+| [`OtlpGrpcMetricExporter`](../types#otlpgrpcmetricexporter) | supported |  | • `compression`: supported<br>• `default_histogram_aggregation`: supported<br>• `endpoint`: supported<br>• `headers`: supported<br>• `headers_list`: supported<br>• `temporality_preference`: supported<br>• `timeout`: supported<br>• `tls`: ignored<br> |
+| [`OtlpHttpEncoding`](../types#otlphttpencoding) | not_implemented |  | • `json`: not_implemented<br>• `protobuf`: not_implemented<br> |
+| [`OtlpHttpExporter`](../types#otlphttpexporter) | supported |  | • `compression`: supported<br>• `encoding`: not_implemented<br>• `endpoint`: supported<br>• `headers`: supported<br>• `headers_list`: supported<br>• `timeout`: supported<br>• `tls`: ignored<br> |
+| [`OtlpHttpMetricExporter`](../types#otlphttpmetricexporter) | supported |  | • `compression`: supported<br>• `default_histogram_aggregation`: supported<br>• `encoding`: not_implemented<br>• `endpoint`: supported<br>• `headers`: supported<br>• `headers_list`: supported<br>• `temporality_preference`: supported<br>• `timeout`: supported<br>• `tls`: ignored<br> |
+| [`ParentBasedSampler`](../types#parentbasedsampler) | supported |  | • `local_parent_not_sampled`: supported<br>• `local_parent_sampled`: supported<br>• `remote_parent_not_sampled`: supported<br>• `remote_parent_sampled`: supported<br>• `root`: supported<br> |
+| [`PeriodicMetricReader`](../types#periodicmetricreader) | supported |  | • `cardinality_limits`: supported<br>• `exporter`: supported<br>• `interval`: supported<br>• `producers`: not_implemented<br>• `timeout`: supported<br> |
+| [`Propagator`](../types#propagator) | supported |  | • `composite`: supported<br>• `composite_list`: supported<br> |
+| [`PullMetricExporter`](../types#pullmetricexporter) | supported |  | • `prometheus/development`: supported<br> |
+| [`PullMetricReader`](../types#pullmetricreader) | supported |  | • `cardinality_limits`: supported<br>• `exporter`: supported<br>• `producers`: not_implemented<br> |
+| [`PushMetricExporter`](../types#pushmetricexporter) | supported |  | • `console`: supported<br>• `otlp_grpc`: supported<br>• `otlp_http`: supported<br>• `otlp_file/development`: supported<br> |
+| [`Resource`](../types#resource) | supported |  | • `attributes`: supported<br>• `attributes_list`: supported<br>• `schema_url`: ignored<br>• `detection/development`: supported<br> |
+| [`Sampler`](../types#sampler) | supported |  | • `always_off`: supported<br>• `always_on`: supported<br>• `parent_based`: supported<br>• `trace_id_ratio_based`: supported<br>• `composite/development`: supported<br>• `jaeger_remote/development`: supported<br>• `probability/development`: ignored<br> |
+| [`SeverityNumber`](../types#severitynumber) | unknown |  | • `debug`: unknown<br>• `debug2`: unknown<br>• `debug3`: unknown<br>• `debug4`: unknown<br>• `error`: unknown<br>• `error2`: unknown<br>• `error3`: unknown<br>• `error4`: unknown<br>• `fatal`: unknown<br>• `fatal2`: unknown<br>• `fatal3`: unknown<br>• `fatal4`: unknown<br>• `info`: unknown<br>• `info2`: unknown<br>• `info3`: unknown<br>• `info4`: unknown<br>• `trace`: unknown<br>• `trace2`: unknown<br>• `trace3`: unknown<br>• `trace4`: unknown<br>• `warn`: unknown<br>• `warn2`: unknown<br>• `warn3`: unknown<br>• `warn4`: unknown<br> |
+| [`SimpleLogRecordProcessor`](../types#simplelogrecordprocessor) | supported |  | • `exporter`: supported<br> |
+| [`SimpleSpanProcessor`](../types#simplespanprocessor) | supported |  | • `exporter`: supported<br> |
+| [`SpanExporter`](../types#spanexporter) | supported |  | • `console`: supported<br>• `otlp_grpc`: supported<br>• `otlp_http`: supported<br>• `otlp_file/development`: supported<br> |
+| [`SpanKind`](../types#spankind) | unknown |  | • `client`: unknown<br>• `consumer`: unknown<br>• `internal`: unknown<br>• `producer`: unknown<br>• `server`: unknown<br> |
+| [`SpanLimits`](../types#spanlimits) | supported |  | • `attribute_count_limit`: supported<br>• `attribute_value_length_limit`: supported<br>• `event_attribute_count_limit`: supported<br>• `event_count_limit`: supported<br>• `link_attribute_count_limit`: supported<br>• `link_count_limit`: supported<br> |
+| [`SpanProcessor`](../types#spanprocessor) | supported |  | • `batch`: supported<br>• `simple`: supported<br> |
+| [`SumAggregation`](../types#sumaggregation) | supported |  |  |
+| [`TextMapPropagator`](../types#textmappropagator) | supported |  | • `b3`: supported<br>• `b3multi`: supported<br>• `baggage`: supported<br>• `jaeger`: supported<br>• `ottrace`: supported<br>• `tracecontext`: supported<br> |
+| [`TraceContextPropagator`](../types#tracecontextpropagator) | supported |  |  |
+| [`TraceIdRatioBasedSampler`](../types#traceidratiobasedsampler) | supported |  | • `ratio`: supported<br> |
+| [`TracerProvider`](../types#tracerprovider) | supported |  | • `limits`: supported<br>• `processors`: supported<br>• `sampler`: supported<br>• `tracer_configurator/development`: supported<br> |
+| [`View`](../types#view) | supported |  | • `selector`: supported<br>• `stream`: supported<br> |
+| [`ViewSelector`](../types#viewselector) | supported |  | • `instrument_name`: supported<br>• `instrument_type`: supported<br>• `meter_name`: supported<br>• `meter_schema_url`: supported<br>• `meter_version`: supported<br>• `unit`: ignored<br> |
+| [`ViewStream`](../types#viewstream) | supported |  | • `aggregation`: supported<br>• `aggregation_cardinality_limit`: supported<br>• `attribute_keys`: supported<br>• `description`: supported<br>• `name`: supported<br> |
+| [`ExperimentalComposableAlwaysOffSampler`](../types#experimentalcomposablealwaysoffsampler) | unknown |  |  |
+| [`ExperimentalComposableAlwaysOnSampler`](../types#experimentalcomposablealwaysonsampler) | unknown |  |  |
+| [`ExperimentalComposableParentThresholdSampler`](../types#experimentalcomposableparentthresholdsampler) | unknown |  | • `root`: unknown<br> |
+| [`ExperimentalComposableProbabilitySampler`](../types#experimentalcomposableprobabilitysampler) | unknown |  | • `ratio`: unknown<br> |
+| [`ExperimentalComposableRuleBasedSampler`](../types#experimentalcomposablerulebasedsampler) | unknown |  | • `rules`: unknown<br> |
+| [`ExperimentalComposableRuleBasedSamplerRule`](../types#experimentalcomposablerulebasedsamplerrule) | unknown |  | • `attribute_patterns`: unknown<br>• `attribute_values`: unknown<br>• `parent`: unknown<br>• `sampler`: unknown<br>• `span_kinds`: unknown<br> |
+| [`ExperimentalComposableRuleBasedSamplerRuleAttributePatterns`](../types#experimentalcomposablerulebasedsamplerruleattributepatterns) | unknown |  | • `excluded`: unknown<br>• `included`: unknown<br>• `key`: unknown<br> |
+| [`ExperimentalComposableRuleBasedSamplerRuleAttributeValues`](../types#experimentalcomposablerulebasedsamplerruleattributevalues) | unknown |  | • `key`: unknown<br>• `values`: unknown<br> |
+| [`ExperimentalComposableSampler`](../types#experimentalcomposablesampler) | unknown |  | • `always_off`: unknown<br>• `always_on`: unknown<br>• `parent_threshold`: unknown<br>• `probability`: unknown<br>• `rule_based`: unknown<br> |
+| [`ExperimentalContainerResourceDetector`](../types#experimentalcontainerresourcedetector) | supported |  |  |
+| [`ExperimentalGeneralInstrumentation`](../types#experimentalgeneralinstrumentation) | supported |  | • `http`: supported<br>• `peer`: supported<br> |
+| [`ExperimentalHostResourceDetector`](../types#experimentalhostresourcedetector) | supported |  |  |
+| [`ExperimentalHttpClientInstrumentation`](../types#experimentalhttpclientinstrumentation) | supported |  | • `request_captured_headers`: supported<br>• `response_captured_headers`: supported<br> |
+| [`ExperimentalHttpInstrumentation`](../types#experimentalhttpinstrumentation) | supported |  | • `client`: supported<br>• `server`: supported<br> |
+| [`ExperimentalHttpServerInstrumentation`](../types#experimentalhttpserverinstrumentation) | supported |  | • `request_captured_headers`: supported<br>• `response_captured_headers`: supported<br> |
+| [`ExperimentalInstrumentation`](../types#experimentalinstrumentation) | supported |  | • `cpp`: not_applicable<br>• `dotnet`: not_applicable<br>• `erlang`: not_applicable<br>• `general`: supported<br>• `go`: not_applicable<br>• `java`: supported<br>• `js`: not_applicable<br>• `php`: not_applicable<br>• `python`: not_applicable<br>• `ruby`: not_applicable<br>• `rust`: not_applicable<br>• `swift`: not_applicable<br> |
+| [`ExperimentalJaegerRemoteSampler`](../types#experimentaljaegerremotesampler) | ignored |  | • `endpoint`: ignored<br>• `initial_sampler`: ignored<br>• `interval`: ignored<br> |
+| [`ExperimentalLanguageSpecificInstrumentation`](../types#experimentallanguagespecificinstrumentation) | supported |  |  |
+| [`ExperimentalLoggerConfig`](../types#experimentalloggerconfig) | supported |  | • `disabled`: supported<br>• `minimum_severity`: not_implemented<br>• `trace_based`: not_implemented<br> |
+| [`ExperimentalLoggerConfigurator`](../types#experimentalloggerconfigurator) | supported |  | • `default_config`: supported<br>• `loggers`: supported<br> |
+| [`ExperimentalLoggerMatcherAndConfig`](../types#experimentalloggermatcherandconfig) | supported |  | • `config`: supported<br>• `name`: supported<br> |
+| [`ExperimentalMeterConfig`](../types#experimentalmeterconfig) | supported |  | • `disabled`: supported<br> |
+| [`ExperimentalMeterConfigurator`](../types#experimentalmeterconfigurator) | supported |  | • `default_config`: supported<br>• `meters`: supported<br> |
+| [`ExperimentalMeterMatcherAndConfig`](../types#experimentalmetermatcherandconfig) | supported |  | • `config`: supported<br>• `name`: supported<br> |
+| [`ExperimentalOtlpFileExporter`](../types#experimentalotlpfileexporter) | supported |  | • `output_stream`: not_implemented<br> |
+| [`ExperimentalOtlpFileMetricExporter`](../types#experimentalotlpfilemetricexporter) | supported |  | • `default_histogram_aggregation`: supported<br>• `output_stream`: not_implemented<br>• `temporality_preference`: supported<br> |
+| [`ExperimentalPeerInstrumentation`](../types#experimentalpeerinstrumentation) | supported |  | • `service_mapping`: supported<br> |
+| [`ExperimentalPeerServiceMapping`](../types#experimentalpeerservicemapping) | supported |  | • `peer`: supported<br>• `service`: supported<br> |
+| [`ExperimentalProbabilitySampler`](../types#experimentalprobabilitysampler) | ignored |  | • `ratio`: ignored<br> |
+| [`ExperimentalProcessResourceDetector`](../types#experimentalprocessresourcedetector) | supported |  |  |
+| [`ExperimentalPrometheusMetricExporter`](../types#experimentalprometheusmetricexporter) | supported |  | • `host`: supported<br>• `port`: supported<br>• `translation_strategy`: not_implemented<br>• `with_resource_constant_labels`: supported<br>• `without_scope_info`: ignored<br>• `without_target_info`: ignored<br> |
+| [`ExperimentalPrometheusTranslationStrategy`](../types#experimentalprometheustranslationstrategy) | unknown |  | • `no_translation`: unknown<br>• `no_utf8_escaping_with_suffixes`: unknown<br>• `underscore_escaping_with_suffixes`: unknown<br>• `underscore_escaping_without_suffixes`: unknown<br> |
+| [`ExperimentalResourceDetection`](../types#experimentalresourcedetection) | supported |  | • `attributes`: supported<br>• `detectors`: supported<br> |
+| [`ExperimentalResourceDetector`](../types#experimentalresourcedetector) | supported |  | • `container`: supported<br>• `host`: supported<br>• `process`: supported<br>• `service`: supported<br> |
+| [`ExperimentalServiceResourceDetector`](../types#experimentalserviceresourcedetector) | supported |  |  |
+| [`ExperimentalSpanParent`](../types#experimentalspanparent) | unknown |  | • `local`: unknown<br>• `none`: unknown<br>• `remote`: unknown<br> |
+| [`ExperimentalTracerConfig`](../types#experimentaltracerconfig) | supported |  | • `disabled`: supported<br> |
+| [`ExperimentalTracerConfigurator`](../types#experimentaltracerconfigurator) | supported |  | • `default_config`: supported<br>• `tracers`: supported<br> |
+| [`ExperimentalTracerMatcherAndConfig`](../types#experimentaltracermatcherandconfig) | supported |  | • `config`: supported<br>• `name`: supported<br> |
+
+### js {#js}
+
+Latest supported file format: `1.0.0-rc.2`
+
+| Type | Status | Notes | Support Status Details |
+|---|---|---|---|
+| [`Aggregation`](../types#aggregation) | unknown |  | • `base2_exponential_bucket_histogram`: unknown<br>• `default`: unknown<br>• `drop`: unknown<br>• `explicit_bucket_histogram`: unknown<br>• `last_value`: unknown<br>• `sum`: unknown<br> |
+| [`AlwaysOffSampler`](../types#alwaysoffsampler) | unknown |  |  |
+| [`AlwaysOnSampler`](../types#alwaysonsampler) | unknown |  |  |
+| [`AttributeLimits`](../types#attributelimits) | unknown |  | • `attribute_count_limit`: unknown<br>• `attribute_value_length_limit`: unknown<br> |
+| [`AttributeNameValue`](../types#attributenamevalue) | unknown |  | • `name`: unknown<br>• `type`: unknown<br>• `value`: unknown<br> |
+| [`AttributeType`](../types#attributetype) | unknown |  | • `bool`: unknown<br>• `bool_array`: unknown<br>• `double`: unknown<br>• `double_array`: unknown<br>• `int`: unknown<br>• `int_array`: unknown<br>• `string`: unknown<br>• `string_array`: unknown<br> |
+| [`B3MultiPropagator`](../types#b3multipropagator) | unknown |  |  |
+| [`B3Propagator`](../types#b3propagator) | unknown |  |  |
+| [`BaggagePropagator`](../types#baggagepropagator) | unknown |  |  |
+| [`Base2ExponentialBucketHistogramAggregation`](../types#base2exponentialbuckethistogramaggregation) | unknown |  | • `max_scale`: unknown<br>• `max_size`: unknown<br>• `record_min_max`: unknown<br> |
+| [`BatchLogRecordProcessor`](../types#batchlogrecordprocessor) | unknown |  | • `export_timeout`: unknown<br>• `exporter`: unknown<br>• `max_export_batch_size`: unknown<br>• `max_queue_size`: unknown<br>• `schedule_delay`: unknown<br> |
+| [`BatchSpanProcessor`](../types#batchspanprocessor) | unknown |  | • `export_timeout`: unknown<br>• `exporter`: unknown<br>• `max_export_batch_size`: unknown<br>• `max_queue_size`: unknown<br>• `schedule_delay`: unknown<br> |
+| [`CardinalityLimits`](../types#cardinalitylimits) | unknown |  | • `counter`: unknown<br>• `default`: unknown<br>• `gauge`: unknown<br>• `histogram`: unknown<br>• `observable_counter`: unknown<br>• `observable_gauge`: unknown<br>• `observable_up_down_counter`: unknown<br>• `up_down_counter`: unknown<br> |
+| [`ConsoleExporter`](../types#consoleexporter) | unknown |  |  |
+| [`ConsoleMetricExporter`](../types#consolemetricexporter) | unknown |  | • `default_histogram_aggregation`: unknown<br>• `temporality_preference`: unknown<br> |
+| [`DefaultAggregation`](../types#defaultaggregation) | unknown |  |  |
+| [`Distribution`](../types#distribution) | unknown |  |  |
+| [`DropAggregation`](../types#dropaggregation) | unknown |  |  |
+| [`ExemplarFilter`](../types#exemplarfilter) | unknown |  | • `always_off`: unknown<br>• `always_on`: unknown<br>• `trace_based`: unknown<br> |
+| [`ExplicitBucketHistogramAggregation`](../types#explicitbuckethistogramaggregation) | unknown |  | • `boundaries`: unknown<br>• `record_min_max`: unknown<br> |
+| [`ExporterDefaultHistogramAggregation`](../types#exporterdefaulthistogramaggregation) | unknown |  | • `base2_exponential_bucket_histogram`: unknown<br>• `explicit_bucket_histogram`: unknown<br> |
+| [`ExporterTemporalityPreference`](../types#exportertemporalitypreference) | unknown |  | • `cumulative`: unknown<br>• `delta`: unknown<br>• `low_memory`: unknown<br> |
+| [`GrpcTls`](../types#grpctls) | unknown |  | • `ca_file`: unknown<br>• `cert_file`: unknown<br>• `insecure`: unknown<br>• `key_file`: unknown<br> |
+| [`HttpTls`](../types#httptls) | unknown |  | • `ca_file`: unknown<br>• `cert_file`: unknown<br>• `key_file`: unknown<br> |
+| [`IncludeExclude`](../types#includeexclude) | unknown |  | • `excluded`: unknown<br>• `included`: unknown<br> |
+| [`InstrumentType`](../types#instrumenttype) | unknown |  | • `counter`: unknown<br>• `gauge`: unknown<br>• `histogram`: unknown<br>• `observable_counter`: unknown<br>• `observable_gauge`: unknown<br>• `observable_up_down_counter`: unknown<br>• `up_down_counter`: unknown<br> |
+| [`JaegerPropagator`](../types#jaegerpropagator) | unknown |  |  |
+| [`LastValueAggregation`](../types#lastvalueaggregation) | unknown |  |  |
+| [`LoggerProvider`](../types#loggerprovider) | unknown |  | • `limits`: unknown<br>• `processors`: unknown<br>• `logger_configurator/development`: unknown<br> |
+| [`LogRecordExporter`](../types#logrecordexporter) | unknown |  | • `console`: unknown<br>• `otlp_grpc`: unknown<br>• `otlp_http`: unknown<br>• `otlp_file/development`: unknown<br> |
+| [`LogRecordLimits`](../types#logrecordlimits) | unknown |  | • `attribute_count_limit`: unknown<br>• `attribute_value_length_limit`: unknown<br> |
+| [`LogRecordProcessor`](../types#logrecordprocessor) | unknown |  | • `batch`: unknown<br>• `simple`: unknown<br> |
+| [`MeterProvider`](../types#meterprovider) | unknown |  | • `exemplar_filter`: unknown<br>• `readers`: unknown<br>• `views`: unknown<br>• `meter_configurator/development`: unknown<br> |
+| [`MetricProducer`](../types#metricproducer) | unknown |  | • `opencensus`: unknown<br> |
+| [`MetricReader`](../types#metricreader) | unknown |  | • `periodic`: unknown<br>• `pull`: unknown<br> |
+| [`NameStringValuePair`](../types#namestringvaluepair) | unknown |  | • `name`: unknown<br>• `value`: unknown<br> |
+| [`OpenCensusMetricProducer`](../types#opencensusmetricproducer) | unknown |  |  |
+| [`OpenTelemetryConfiguration`](../types#opentelemetryconfiguration) | unknown |  | • `attribute_limits`: unknown<br>• `disabled`: unknown<br>• `distribution`: unknown<br>• `file_format`: unknown<br>• `log_level`: unknown<br>• `logger_provider`: unknown<br>• `meter_provider`: unknown<br>• `propagator`: unknown<br>• `resource`: unknown<br>• `tracer_provider`: unknown<br>• `instrumentation/development`: unknown<br> |
+| [`OpenTracingPropagator`](../types#opentracingpropagator) | unknown |  |  |
+| [`OtlpGrpcExporter`](../types#otlpgrpcexporter) | unknown |  | • `compression`: unknown<br>• `endpoint`: unknown<br>• `headers`: unknown<br>• `headers_list`: unknown<br>• `timeout`: unknown<br>• `tls`: unknown<br> |
+| [`OtlpGrpcMetricExporter`](../types#otlpgrpcmetricexporter) | unknown |  | • `compression`: unknown<br>• `default_histogram_aggregation`: unknown<br>• `endpoint`: unknown<br>• `headers`: unknown<br>• `headers_list`: unknown<br>• `temporality_preference`: unknown<br>• `timeout`: unknown<br>• `tls`: unknown<br> |
+| [`OtlpHttpEncoding`](../types#otlphttpencoding) | unknown |  | • `json`: unknown<br>• `protobuf`: unknown<br> |
+| [`OtlpHttpExporter`](../types#otlphttpexporter) | unknown |  | • `compression`: unknown<br>• `encoding`: unknown<br>• `endpoint`: unknown<br>• `headers`: unknown<br>• `headers_list`: unknown<br>• `timeout`: unknown<br>• `tls`: unknown<br> |
+| [`OtlpHttpMetricExporter`](../types#otlphttpmetricexporter) | unknown |  | • `compression`: unknown<br>• `default_histogram_aggregation`: unknown<br>• `encoding`: unknown<br>• `endpoint`: unknown<br>• `headers`: unknown<br>• `headers_list`: unknown<br>• `temporality_preference`: unknown<br>• `timeout`: unknown<br>• `tls`: unknown<br> |
+| [`ParentBasedSampler`](../types#parentbasedsampler) | unknown |  | • `local_parent_not_sampled`: unknown<br>• `local_parent_sampled`: unknown<br>• `remote_parent_not_sampled`: unknown<br>• `remote_parent_sampled`: unknown<br>• `root`: unknown<br> |
+| [`PeriodicMetricReader`](../types#periodicmetricreader) | unknown |  | • `cardinality_limits`: unknown<br>• `exporter`: unknown<br>• `interval`: unknown<br>• `producers`: unknown<br>• `timeout`: unknown<br> |
+| [`Propagator`](../types#propagator) | unknown |  | • `composite`: unknown<br>• `composite_list`: unknown<br> |
+| [`PullMetricExporter`](../types#pullmetricexporter) | unknown |  | • `prometheus/development`: unknown<br> |
+| [`PullMetricReader`](../types#pullmetricreader) | unknown |  | • `cardinality_limits`: unknown<br>• `exporter`: unknown<br>• `producers`: unknown<br> |
+| [`PushMetricExporter`](../types#pushmetricexporter) | unknown |  | • `console`: unknown<br>• `otlp_grpc`: unknown<br>• `otlp_http`: unknown<br>• `otlp_file/development`: unknown<br> |
+| [`Resource`](../types#resource) | unknown |  | • `attributes`: unknown<br>• `attributes_list`: unknown<br>• `schema_url`: unknown<br>• `detection/development`: unknown<br> |
+| [`Sampler`](../types#sampler) | unknown |  | • `always_off`: unknown<br>• `always_on`: unknown<br>• `parent_based`: unknown<br>• `trace_id_ratio_based`: unknown<br>• `composite/development`: unknown<br>• `jaeger_remote/development`: unknown<br>• `probability/development`: unknown<br> |
+| [`SeverityNumber`](../types#severitynumber) | unknown |  | • `debug`: unknown<br>• `debug2`: unknown<br>• `debug3`: unknown<br>• `debug4`: unknown<br>• `error`: unknown<br>• `error2`: unknown<br>• `error3`: unknown<br>• `error4`: unknown<br>• `fatal`: unknown<br>• `fatal2`: unknown<br>• `fatal3`: unknown<br>• `fatal4`: unknown<br>• `info`: unknown<br>• `info2`: unknown<br>• `info3`: unknown<br>• `info4`: unknown<br>• `trace`: unknown<br>• `trace2`: unknown<br>• `trace3`: unknown<br>• `trace4`: unknown<br>• `warn`: unknown<br>• `warn2`: unknown<br>• `warn3`: unknown<br>• `warn4`: unknown<br> |
+| [`SimpleLogRecordProcessor`](../types#simplelogrecordprocessor) | unknown |  | • `exporter`: unknown<br> |
+| [`SimpleSpanProcessor`](../types#simplespanprocessor) | unknown |  | • `exporter`: unknown<br> |
+| [`SpanExporter`](../types#spanexporter) | unknown |  | • `console`: unknown<br>• `otlp_grpc`: unknown<br>• `otlp_http`: unknown<br>• `otlp_file/development`: unknown<br> |
+| [`SpanKind`](../types#spankind) | unknown |  | • `client`: unknown<br>• `consumer`: unknown<br>• `internal`: unknown<br>• `producer`: unknown<br>• `server`: unknown<br> |
+| [`SpanLimits`](../types#spanlimits) | unknown |  | • `attribute_count_limit`: unknown<br>• `attribute_value_length_limit`: unknown<br>• `event_attribute_count_limit`: unknown<br>• `event_count_limit`: unknown<br>• `link_attribute_count_limit`: unknown<br>• `link_count_limit`: unknown<br> |
+| [`SpanProcessor`](../types#spanprocessor) | unknown |  | • `batch`: unknown<br>• `simple`: unknown<br> |
+| [`SumAggregation`](../types#sumaggregation) | unknown |  |  |
+| [`TextMapPropagator`](../types#textmappropagator) | unknown |  | • `b3`: unknown<br>• `b3multi`: unknown<br>• `baggage`: unknown<br>• `jaeger`: unknown<br>• `ottrace`: unknown<br>• `tracecontext`: unknown<br> |
+| [`TraceContextPropagator`](../types#tracecontextpropagator) | unknown |  |  |
+| [`TraceIdRatioBasedSampler`](../types#traceidratiobasedsampler) | unknown |  | • `ratio`: unknown<br> |
+| [`TracerProvider`](../types#tracerprovider) | unknown |  | • `limits`: unknown<br>• `processors`: unknown<br>• `sampler`: unknown<br>• `tracer_configurator/development`: unknown<br> |
+| [`View`](../types#view) | unknown |  | • `selector`: unknown<br>• `stream`: unknown<br> |
+| [`ViewSelector`](../types#viewselector) | unknown |  | • `instrument_name`: unknown<br>• `instrument_type`: unknown<br>• `meter_name`: unknown<br>• `meter_schema_url`: unknown<br>• `meter_version`: unknown<br>• `unit`: unknown<br> |
+| [`ViewStream`](../types#viewstream) | unknown |  | • `aggregation`: unknown<br>• `aggregation_cardinality_limit`: unknown<br>• `attribute_keys`: unknown<br>• `description`: unknown<br>• `name`: unknown<br> |
+| [`ExperimentalComposableAlwaysOffSampler`](../types#experimentalcomposablealwaysoffsampler) | unknown |  |  |
+| [`ExperimentalComposableAlwaysOnSampler`](../types#experimentalcomposablealwaysonsampler) | unknown |  |  |
+| [`ExperimentalComposableParentThresholdSampler`](../types#experimentalcomposableparentthresholdsampler) | unknown |  | • `root`: unknown<br> |
+| [`ExperimentalComposableProbabilitySampler`](../types#experimentalcomposableprobabilitysampler) | unknown |  | • `ratio`: unknown<br> |
+| [`ExperimentalComposableRuleBasedSampler`](../types#experimentalcomposablerulebasedsampler) | unknown |  | • `rules`: unknown<br> |
+| [`ExperimentalComposableRuleBasedSamplerRule`](../types#experimentalcomposablerulebasedsamplerrule) | unknown |  | • `attribute_patterns`: unknown<br>• `attribute_values`: unknown<br>• `parent`: unknown<br>• `sampler`: unknown<br>• `span_kinds`: unknown<br> |
+| [`ExperimentalComposableRuleBasedSamplerRuleAttributePatterns`](../types#experimentalcomposablerulebasedsamplerruleattributepatterns) | unknown |  | • `excluded`: unknown<br>• `included`: unknown<br>• `key`: unknown<br> |
+| [`ExperimentalComposableRuleBasedSamplerRuleAttributeValues`](../types#experimentalcomposablerulebasedsamplerruleattributevalues) | unknown |  | • `key`: unknown<br>• `values`: unknown<br> |
+| [`ExperimentalComposableSampler`](../types#experimentalcomposablesampler) | unknown |  | • `always_off`: unknown<br>• `always_on`: unknown<br>• `parent_threshold`: unknown<br>• `probability`: unknown<br>• `rule_based`: unknown<br> |
+| [`ExperimentalContainerResourceDetector`](../types#experimentalcontainerresourcedetector) | unknown |  |  |
+| [`ExperimentalGeneralInstrumentation`](../types#experimentalgeneralinstrumentation) | unknown |  | • `http`: unknown<br>• `peer`: unknown<br> |
+| [`ExperimentalHostResourceDetector`](../types#experimentalhostresourcedetector) | unknown |  |  |
+| [`ExperimentalHttpClientInstrumentation`](../types#experimentalhttpclientinstrumentation) | unknown |  | • `request_captured_headers`: unknown<br>• `response_captured_headers`: unknown<br> |
+| [`ExperimentalHttpInstrumentation`](../types#experimentalhttpinstrumentation) | unknown |  | • `client`: unknown<br>• `server`: unknown<br> |
+| [`ExperimentalHttpServerInstrumentation`](../types#experimentalhttpserverinstrumentation) | unknown |  | • `request_captured_headers`: unknown<br>• `response_captured_headers`: unknown<br> |
+| [`ExperimentalInstrumentation`](../types#experimentalinstrumentation) | unknown |  | • `cpp`: unknown<br>• `dotnet`: unknown<br>• `erlang`: unknown<br>• `general`: unknown<br>• `go`: unknown<br>• `java`: unknown<br>• `js`: unknown<br>• `php`: unknown<br>• `python`: unknown<br>• `ruby`: unknown<br>• `rust`: unknown<br>• `swift`: unknown<br> |
+| [`ExperimentalJaegerRemoteSampler`](../types#experimentaljaegerremotesampler) | unknown |  | • `endpoint`: unknown<br>• `initial_sampler`: unknown<br>• `interval`: unknown<br> |
+| [`ExperimentalLanguageSpecificInstrumentation`](../types#experimentallanguagespecificinstrumentation) | unknown |  |  |
+| [`ExperimentalLoggerConfig`](../types#experimentalloggerconfig) | unknown |  | • `disabled`: unknown<br>• `minimum_severity`: unknown<br>• `trace_based`: unknown<br> |
+| [`ExperimentalLoggerConfigurator`](../types#experimentalloggerconfigurator) | unknown |  | • `default_config`: unknown<br>• `loggers`: unknown<br> |
+| [`ExperimentalLoggerMatcherAndConfig`](../types#experimentalloggermatcherandconfig) | unknown |  | • `config`: unknown<br>• `name`: unknown<br> |
+| [`ExperimentalMeterConfig`](../types#experimentalmeterconfig) | unknown |  | • `disabled`: unknown<br> |
+| [`ExperimentalMeterConfigurator`](../types#experimentalmeterconfigurator) | unknown |  | • `default_config`: unknown<br>• `meters`: unknown<br> |
+| [`ExperimentalMeterMatcherAndConfig`](../types#experimentalmetermatcherandconfig) | unknown |  | • `config`: unknown<br>• `name`: unknown<br> |
+| [`ExperimentalOtlpFileExporter`](../types#experimentalotlpfileexporter) | unknown |  | • `output_stream`: unknown<br> |
+| [`ExperimentalOtlpFileMetricExporter`](../types#experimentalotlpfilemetricexporter) | unknown |  | • `default_histogram_aggregation`: unknown<br>• `output_stream`: unknown<br>• `temporality_preference`: unknown<br> |
+| [`ExperimentalPeerInstrumentation`](../types#experimentalpeerinstrumentation) | unknown |  | • `service_mapping`: unknown<br> |
+| [`ExperimentalPeerServiceMapping`](../types#experimentalpeerservicemapping) | unknown |  | • `peer`: unknown<br>• `service`: unknown<br> |
+| [`ExperimentalProbabilitySampler`](../types#experimentalprobabilitysampler) | unknown |  | • `ratio`: unknown<br> |
+| [`ExperimentalProcessResourceDetector`](../types#experimentalprocessresourcedetector) | unknown |  |  |
+| [`ExperimentalPrometheusMetricExporter`](../types#experimentalprometheusmetricexporter) | unknown |  | • `host`: unknown<br>• `port`: unknown<br>• `translation_strategy`: unknown<br>• `with_resource_constant_labels`: unknown<br>• `without_scope_info`: unknown<br>• `without_target_info`: unknown<br> |
+| [`ExperimentalPrometheusTranslationStrategy`](../types#experimentalprometheustranslationstrategy) | unknown |  | • `no_translation`: unknown<br>• `no_utf8_escaping_with_suffixes`: unknown<br>• `underscore_escaping_with_suffixes`: unknown<br>• `underscore_escaping_without_suffixes`: unknown<br> |
+| [`ExperimentalResourceDetection`](../types#experimentalresourcedetection) | unknown |  | • `attributes`: unknown<br>• `detectors`: unknown<br> |
+| [`ExperimentalResourceDetector`](../types#experimentalresourcedetector) | unknown |  | • `container`: unknown<br>• `host`: unknown<br>• `process`: unknown<br>• `service`: unknown<br> |
+| [`ExperimentalServiceResourceDetector`](../types#experimentalserviceresourcedetector) | unknown |  |  |
+| [`ExperimentalSpanParent`](../types#experimentalspanparent) | unknown |  | • `local`: unknown<br>• `none`: unknown<br>• `remote`: unknown<br> |
+| [`ExperimentalTracerConfig`](../types#experimentaltracerconfig) | unknown |  | • `disabled`: unknown<br> |
+| [`ExperimentalTracerConfigurator`](../types#experimentaltracerconfigurator) | unknown |  | • `default_config`: unknown<br>• `tracers`: unknown<br> |
+| [`ExperimentalTracerMatcherAndConfig`](../types#experimentaltracermatcherandconfig) | unknown |  | • `config`: unknown<br>• `name`: unknown<br> |
+
+</div>
 <!-- END GENERATED: language-implementation-status SOURCE: opentelemetry-configuration -->

--- a/content/en/docs/languages/sdk-configuration/language-implementation-status.md
+++ b/content/en/docs/languages/sdk-configuration/language-implementation-status.md
@@ -3,7 +3,6 @@ title: Language Implementation Status
 linkTitle: Language Implementation Status
 weight: 10
 aliases: [general-sdk-configuration]
-cSpell:ignore: ottrace
 ---
 
 ## Language Implementation Status

--- a/content/en/docs/languages/sdk-configuration/language-implementation-status.md
+++ b/content/en/docs/languages/sdk-configuration/language-implementation-status.md
@@ -1,0 +1,13 @@
+---
+title: Language Implementation Status
+linkTitle: Language Implementation Status
+weight: 10
+aliases: [general-sdk-configuration]
+cSpell:ignore: ottrace
+---
+
+## Language Implementation Status
+
+<!-- BEGIN GENERATED: language-implementation-status SOURCE: opentelemetry-configuration -->
+
+<!-- END GENERATED: language-implementation-status SOURCE: opentelemetry-configuration -->

--- a/content/en/docs/languages/sdk-configuration/types.md
+++ b/content/en/docs/languages/sdk-configuration/types.md
@@ -4,6 +4,1521 @@ weight: 10
 aliases: [general-sdk-configuration]
 ---
 
-<!-- BEGIN GENERATED: types SOURCE: opentelemetry-configuration -->
+<style>
 
+.types-table {
+  td:first-child {
+    max-width: 200px;
+  }
+}
+
+</style>
+
+# Configuration Types
+
+This page documents all configuration types for the OpenTelemetry SDK declarative configuration.
+
+{{% alert title="Note" %}}
+* Properties marked with <sup>*</sup> are required.
+* Default behavior will also apply if a property is explicitly set to `null`.
+{{% /alert %}}
+
+
+<!-- BEGIN GENERATED: types SOURCE: opentelemetry-configuration -->
+## Stable Types
+
+### Aggregation {#aggregation}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `base2_exponential_bucket_histogram` | [`Base2ExponentialBucketHistogramAggregation`](#base2exponentialbuckethistogramaggregation) | If omitted, ignore. | Configures the stream to collect data for the exponential histogram metric point, which uses a base-2 exponential formula to determine bucket boundaries and an integer scale parameter to control resolution. ([See here for more details](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#base2-exponential-bucket-histogram-aggregation)). |
+| `default` | [`DefaultAggregation`](#defaultaggregation) | If omitted, ignore. | Configures the stream to use the instrument kind to select an aggregation and advisory parameters to influence aggregation configuration parameters. ([See here for more details](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#default-aggregation)). |
+| `drop` | [`DropAggregation`](#dropaggregation) | If omitted, ignore. | Configures the stream to ignore/drop all instrument measurements. ([See here for more details](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#drop-aggregation)). |
+| `explicit_bucket_histogram` | [`ExplicitBucketHistogramAggregation`](#explicitbuckethistogramaggregation) | If omitted, ignore. | Configures the stream to collect data for the histogram metric point using a set of explicit boundary values for histogram bucketing. ([See here for more details](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#explicit-bucket-histogram-aggregation)) |
+| `last_value` | [`LastValueAggregation`](#lastvalueaggregation) | If omitted, ignore. | Configures the stream to collect data using the last measurement. ([See here for more details](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#last-value-aggregation)). |
+| `sum` | [`SumAggregation`](#sumaggregation) | If omitted, ignore. | Configures the stream to collect the arithmetic sum of measurement values. ([See here for more details](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#sum-aggregation)). |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `false`<br>• `minProperties`: `1`<br>• `maxProperties`: `1`<br>
+### AlwaysOffSampler {#alwaysoffsampler}
+
+**No properties.**
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### AlwaysOnSampler {#alwaysonsampler}
+
+**No properties.**
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### AttributeLimits {#attributelimits}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `attribute_count_limit` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, 128 is used. | `minimum`: `0` | Configure max attribute count. <br>Value must be non-negative.<br> |
+| `attribute_value_length_limit` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, there is no limit. | `minimum`: `0` | Configure max attribute value size. <br>Value must be non-negative.<br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### AttributeNameValue {#attributenamevalue}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `name`<sup>*</sup> | `string` | Property is required and must be non-null. | The attribute name.<br> |
+| `type` | [`AttributeType`](#attributetype) | If omitted, string is used. | The attribute type.<br> |
+| `value`<sup>*</sup> | `oneOf` | Property is required and must be non-null. | The attribute value.<br>The type of value must match .type.<br> |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `false`<br>• `required`: `["name","value"]`<br>
+### AttributeType {#attributetype}
+
+**This is an enum type.**
+
+<div class="types-table">
+
+| Value | Description |
+|---|---|
+| `bool` | Boolean attribute value. |
+| `bool_array` | Boolean array attribute value. |
+| `double` | Double attribute value. |
+| `double_array` | Double array attribute value. |
+| `int` | Integer attribute value. |
+| `int_array` | Integer array attribute value. |
+| `string` | String attribute value. |
+| `string_array` | String array attribute value. |
+
+</div>
+
+### B3MultiPropagator {#b3multipropagator}
+
+**No properties.**
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### B3Propagator {#b3propagator}
+
+**No properties.**
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### BaggagePropagator {#baggagepropagator}
+
+**No properties.**
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### Base2ExponentialBucketHistogramAggregation {#base2exponentialbuckethistogramaggregation}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `max_scale` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, 20 is used. | • `minimum`: `-10`<br>• `maximum`: `20`<br> | Configure the max scale factor. |
+| `max_size` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, 160 is used. | `minimum`: `2` | Configure the maximum number of buckets in each of the positive and negative ranges, not counting the special zero bucket. |
+| `record_min_max` | one of:<br>• `boolean`<br>• `null`<br> | If omitted or null, true is used. | None. | Configure whether or not to record min and max. |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### BatchLogRecordProcessor {#batchlogrecordprocessor}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `export_timeout` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, 30000 is used. | `minimum`: `0` | Configure maximum allowed time (in milliseconds) to export data. <br>Value must be non-negative. A value of 0 indicates no limit (infinity).<br> |
+| `exporter`<sup>*</sup> | [`LogRecordExporter`](#logrecordexporter) | Property is required and must be non-null. | None. | Configure exporter. |
+| `max_export_batch_size` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, 512 is used. | `exclusiveMinimum`: `0` | Configure maximum batch size. Value must be positive.<br> |
+| `max_queue_size` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, 2048 is used. | `exclusiveMinimum`: `0` | Configure maximum queue size. Value must be positive.<br> |
+| `schedule_delay` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, 1000 is used. | `minimum`: `0` | Configure delay interval (in milliseconds) between two consecutive exports. <br>Value must be non-negative.<br> |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `false`<br>• `required`: `["exporter"]`<br>
+### BatchSpanProcessor {#batchspanprocessor}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `export_timeout` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, 30000 is used. | `minimum`: `0` | Configure maximum allowed time (in milliseconds) to export data. <br>Value must be non-negative. A value of 0 indicates no limit (infinity).<br> |
+| `exporter`<sup>*</sup> | [`SpanExporter`](#spanexporter) | Property is required and must be non-null. | None. | Configure exporter. |
+| `max_export_batch_size` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, 512 is used. | `exclusiveMinimum`: `0` | Configure maximum batch size. Value must be positive.<br> |
+| `max_queue_size` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, 2048 is used. | `exclusiveMinimum`: `0` | Configure maximum queue size. Value must be positive.<br> |
+| `schedule_delay` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, 5000 is used. | `minimum`: `0` | Configure delay interval (in milliseconds) between two consecutive exports. <br>Value must be non-negative.<br> |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `false`<br>• `required`: `["exporter"]`<br>
+### CardinalityLimits {#cardinalitylimits}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `counter` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, the value from .default is used. | `exclusiveMinimum`: `0` | Configure default cardinality limit for counter instruments.<br> |
+| `default` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, 2000 is used. | `exclusiveMinimum`: `0` | Configure default cardinality limit for all instrument types.<br>Instrument-specific cardinality limits take priority. <br> |
+| `gauge` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, the value from .default is used. | `exclusiveMinimum`: `0` | Configure default cardinality limit for gauge instruments.<br> |
+| `histogram` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, the value from .default is used. | `exclusiveMinimum`: `0` | Configure default cardinality limit for histogram instruments.<br> |
+| `observable_counter` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, the value from .default is used. | `exclusiveMinimum`: `0` | Configure default cardinality limit for observable_counter instruments.<br> |
+| `observable_gauge` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, the value from .default is used. | `exclusiveMinimum`: `0` | Configure default cardinality limit for observable_gauge instruments.<br> |
+| `observable_up_down_counter` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, the value from .default is used. | `exclusiveMinimum`: `0` | Configure default cardinality limit for observable_up_down_counter instruments.<br> |
+| `up_down_counter` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, the value from .default is used. | `exclusiveMinimum`: `0` | Configure default cardinality limit for up_down_counter instruments.<br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ConsoleExporter {#consoleexporter}
+
+**No properties.**
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ConsoleMetricExporter {#consolemetricexporter}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `default_histogram_aggregation` | [`ExporterDefaultHistogramAggregation`](#exporterdefaulthistogramaggregation) | If omitted, explicit_bucket_histogram is used. | Configure default histogram aggregation.<br> |
+| `temporality_preference` | [`ExporterTemporalityPreference`](#exportertemporalitypreference) | If omitted, cumulative is used. | Configure temporality preference.<br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### DefaultAggregation {#defaultaggregation}
+
+**No properties.**
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### Distribution {#distribution}
+
+**No properties.**
+
+**Constraints:**
+
+• `additionalProperties`: `{"type":"object"}`<br>• `minProperties`: `1`<br>
+### DropAggregation {#dropaggregation}
+
+**No properties.**
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExemplarFilter {#exemplarfilter}
+
+**This is an enum type.**
+
+<div class="types-table">
+
+| Value | Description |
+|---|---|
+| `always_off` | ExemplarFilter which makes no measurements eligible for being an Exemplar. |
+| `always_on` | ExemplarFilter which makes all measurements eligible for being an Exemplar. |
+| `trace_based` | ExemplarFilter which makes measurements recorded in the context of a sampled parent span eligible for being an Exemplar. |
+
+</div>
+
+### ExplicitBucketHistogramAggregation {#explicitbuckethistogramaggregation}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `boundaries` | `array` of `number` | If omitted, [0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000] is used. | `minItems`: `0` | Configure bucket boundaries.<br> |
+| `record_min_max` | one of:<br>• `boolean`<br>• `null`<br> | If omitted or null, true is used. | None. | Configure record min and max.<br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExporterDefaultHistogramAggregation {#exporterdefaulthistogramaggregation}
+
+**This is an enum type.**
+
+<div class="types-table">
+
+| Value | Description |
+|---|---|
+| `base2_exponential_bucket_histogram` | Use base2 exponential histogram as the default aggregation for histogram instruments. |
+| `explicit_bucket_histogram` | Use explicit bucket histogram as the default aggregation for histogram instruments. |
+
+</div>
+
+### ExporterTemporalityPreference {#exportertemporalitypreference}
+
+**This is an enum type.**
+
+<div class="types-table">
+
+| Value | Description |
+|---|---|
+| `cumulative` | Use cumulative aggregation temporality for all instrument types. |
+| `delta` | Use delta aggregation for all instrument types except up down counter and asynchronous up down counter. |
+| `low_memory` | Use delta aggregation temporality for counter and histogram instrument types. Use cumulative aggregation temporality for all other instrument types. |
+
+</div>
+
+### GrpcTls {#grpctls}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `ca_file` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, system default certificate verification is used for secure connections. | Configure certificate used to verify a server's TLS credentials. <br>Absolute path to certificate file in PEM format.<br> |
+| `cert_file` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, mTLS is not used. | Configure mTLS client certificate. <br>Absolute path to client certificate file in PEM format. If set, .client_key must also be set.<br> |
+| `insecure` | one of:<br>• `boolean`<br>• `null`<br> | If omitted or null, false is used. | Configure client transport security for the exporter's connection. <br>Only applicable when .endpoint is provided without http or https scheme. Implementations may choose to ignore .insecure.<br> |
+| `key_file` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, mTLS is not used. | Configure mTLS private client key. <br>Absolute path to client key file in PEM format. If set, .client_certificate must also be set.<br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### HttpTls {#httptls}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `ca_file` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, system default certificate verification is used for secure connections. | Configure certificate used to verify a server's TLS credentials. <br>Absolute path to certificate file in PEM format.<br> |
+| `cert_file` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, mTLS is not used. | Configure mTLS client certificate. <br>Absolute path to client certificate file in PEM format. If set, .client_key must also be set.<br> |
+| `key_file` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, mTLS is not used. | Configure mTLS private client key. <br>Absolute path to client key file in PEM format. If set, .client_certificate must also be set.<br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### IncludeExclude {#includeexclude}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `excluded` | `array` of `string` | If omitted, .included attributes are included. | `minItems`: `1` | Configure list of value patterns to exclude. Applies after .included (i.e. excluded has higher priority than included).<br>Values are evaluated to match as follows:<br> * If the value exactly matches.<br> * If the value matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.<br> |
+| `included` | `array` of `string` | If omitted, all values are included. | `minItems`: `1` | Configure list of value patterns to include.<br>Values are evaluated to match as follows:<br> * If the value exactly matches.<br> * If the value matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.<br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### InstrumentType {#instrumenttype}
+
+**This is an enum type.**
+
+<div class="types-table">
+
+| Value | Description |
+|---|---|
+| `counter` | Synchronous counter instruments. |
+| `gauge` | Synchronous gauge instruments. |
+| `histogram` | Synchronous histogram instruments. |
+| `observable_counter` | Asynchronous counter instruments. |
+| `observable_gauge` | Asynchronous gauge instruments. |
+| `observable_up_down_counter` | Asynchronous up down counter instruments. |
+| `up_down_counter` | Synchronous up down counter instruments. |
+
+</div>
+
+### JaegerPropagator {#jaegerpropagator}
+
+**No properties.**
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### LastValueAggregation {#lastvalueaggregation}
+
+**No properties.**
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### LoggerProvider {#loggerprovider}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `limits` | [`LogRecordLimits`](#logrecordlimits) | If omitted, default values as described in LogRecordLimits are used. | None. | Configure log record limits. See also attribute_limits. |
+| `processors`<sup>*</sup> | `array` of [`LogRecordProcessor`](#logrecordprocessor) | Property is required and must be non-null. | `minItems`: `1` | Configure log record processors. |
+| `logger_configurator/development`<br>**⚠ Experimental** | [`ExperimentalLoggerConfigurator`](#experimentalloggerconfigurator) | If omitted, all loggers use default values as described in ExperimentalLoggerConfig. | None. | Configure loggers.<br> |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `false`<br>• `required`: `["processors"]`<br>
+### LogRecordExporter {#logrecordexporter}
+
+`LogRecordExporter` is an SDK extension plugin point.
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `console` | [`ConsoleExporter`](#consoleexporter) | If omitted, ignore. | Configure exporter to be console. |
+| `otlp_grpc` | [`OtlpGrpcExporter`](#otlpgrpcexporter) | If omitted, ignore. | Configure exporter to be OTLP with gRPC transport. |
+| `otlp_http` | [`OtlpHttpExporter`](#otlphttpexporter) | If omitted, ignore. | Configure exporter to be OTLP with HTTP transport. |
+| `otlp_file/development`<br>**⚠ Experimental** | [`ExperimentalOtlpFileExporter`](#experimentalotlpfileexporter) | If omitted, ignore. | Configure exporter to be OTLP with file transport.<br> |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `{"type":["object","null"]}`<br>• `minProperties`: `1`<br>• `maxProperties`: `1`<br>
+### LogRecordLimits {#logrecordlimits}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `attribute_count_limit` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, 128 is used. | `minimum`: `0` | Configure max attribute count. Overrides .attribute_limits.attribute_count_limit. <br>Value must be non-negative.<br> |
+| `attribute_value_length_limit` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, there is no limit. | `minimum`: `0` | Configure max attribute value size. Overrides .attribute_limits.attribute_value_length_limit. <br>Value must be non-negative.<br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### LogRecordProcessor {#logrecordprocessor}
+
+`LogRecordProcessor` is an SDK extension plugin point.
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `batch` | [`BatchLogRecordProcessor`](#batchlogrecordprocessor) | If omitted, ignore. | Configure a batch log record processor. |
+| `simple` | [`SimpleLogRecordProcessor`](#simplelogrecordprocessor) | If omitted, ignore. | Configure a simple log record processor. |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `{"type":["object","null"]}`<br>• `minProperties`: `1`<br>• `maxProperties`: `1`<br>
+### MeterProvider {#meterprovider}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `exemplar_filter` | [`ExemplarFilter`](#exemplarfilter) | If omitted, trace_based is used. | None. | Configure the exemplar filter. <br> |
+| `readers`<sup>*</sup> | `array` of [`MetricReader`](#metricreader) | Property is required and must be non-null. | `minItems`: `1` | Configure metric readers. |
+| `views` | `array` of [`View`](#view) | If omitted, no views are registered. | `minItems`: `1` | Configure views. <br>Each view has a selector which determines the instrument(s) it applies to, and a configuration for the resulting stream(s).<br> |
+| `meter_configurator/development`<br>**⚠ Experimental** | [`ExperimentalMeterConfigurator`](#experimentalmeterconfigurator) | If omitted, all meters use default values as described in ExperimentalMeterConfig. | None. | Configure meters.<br> |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `false`<br>• `required`: `["readers"]`<br>
+### MetricProducer {#metricproducer}
+
+`MetricProducer` is an SDK extension plugin point.
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `opencensus` | [`OpenCensusMetricProducer`](#opencensusmetricproducer) | If omitted, ignore. | Configure metric producer to be opencensus. |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `{"type":["object","null"]}`<br>• `minProperties`: `1`<br>• `maxProperties`: `1`<br>
+### MetricReader {#metricreader}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `periodic` | [`PeriodicMetricReader`](#periodicmetricreader) | If omitted, ignore. | Configure a periodic metric reader. |
+| `pull` | [`PullMetricReader`](#pullmetricreader) | If omitted, ignore. | Configure a pull based metric reader. |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `false`<br>• `minProperties`: `1`<br>• `maxProperties`: `1`<br>
+### NameStringValuePair {#namestringvaluepair}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `name`<sup>*</sup> | `string` | Property is required and must be non-null. | The name of the pair. |
+| `value`<sup>*</sup> | one of:<br>• `string`<br>• `null`<br> | Property must be present, but if null the behavior is dependent on usage context. | The value of the pair. |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `false`<br>• `required`: `["name","value"]`<br>
+### OpenCensusMetricProducer {#opencensusmetricproducer}
+
+**No properties.**
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### OpenTelemetryConfiguration {#opentelemetryconfiguration}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `attribute_limits` | [`AttributeLimits`](#attributelimits) | If omitted, default values as described in AttributeLimits are used. | Configure general attribute limits. See also tracer_provider.limits, logger_provider.limits.<br> |
+| `disabled` | one of:<br>• `boolean`<br>• `null`<br> | If omitted or null, false is used. | Configure if the SDK is disabled or not.<br> |
+| `distribution` | [`Distribution`](#distribution) | If omitted, distribution defaults are used. | Defines configuration parameters specific to a particular OpenTelemetry distribution or vendor.<br>This section provides a standardized location for distribution-specific settings<br>that are not part of the OpenTelemetry configuration model.<br>It allows vendors to expose their own extensions and general configuration options.<br> |
+| `file_format`<sup>*</sup> | `string` | Property is required and must be non-null. | The file format version.<br>Represented as a string including the semver major, minor version numbers (and optionally the meta tag). For example: "0.4", "1.0-rc.2", "1.0" (after stable release).<br>([See here for more details](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/VERSIONING.md)).<br>The yaml format is documented at https://github.com/open-telemetry/opentelemetry-configuration/tree/main/schema<br> |
+| `log_level` | [`SeverityNumber`](#severitynumber) | If omitted, INFO is used. | Configure the log level of the internal logger used by the SDK.<br> |
+| `logger_provider` | [`LoggerProvider`](#loggerprovider) | If omitted, a noop logger provider is used. | Configure logger provider.<br> |
+| `meter_provider` | [`MeterProvider`](#meterprovider) | If omitted, a noop meter provider is used. | Configure meter provider.<br> |
+| `propagator` | [`Propagator`](#propagator) | If omitted, a noop propagator is used. | Configure text map context propagators.<br> |
+| `resource` | [`Resource`](#resource) | If omitted, the default resource is used. | Configure resource for all signals.<br> |
+| `tracer_provider` | [`TracerProvider`](#tracerprovider) | If omitted, a noop tracer provider is used. | Configure tracer provider.<br> |
+| `instrumentation/development`<br>**⚠ Experimental** | [`ExperimentalInstrumentation`](#experimentalinstrumentation) | If omitted, instrumentation defaults are used. | Configure instrumentation.<br> |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `true`<br>• `required`: `["file_format"]`<br>
+### OpenTracingPropagator {#opentracingpropagator}
+
+**No properties.**
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### OtlpGrpcExporter {#otlpgrpcexporter}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `compression` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, none is used. | None. | Configure compression.<br>Known values include: gzip, none. Implementations may support other compression algorithms.<br> |
+| `endpoint` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, http://localhost:4317 is used. | None. | Configure endpoint.<br> |
+| `headers` | `array` of [`NameStringValuePair`](#namestringvaluepair) | If omitted, no headers are added. | `minItems`: `1` | Configure headers. Entries have higher priority than entries from .headers_list.<br>If an entry's .value is null, the entry is ignored.<br> |
+| `headers_list` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, no headers are added. | None. | Configure headers. Entries have lower priority than entries from .headers.<br>The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. ([See here for more details](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options)).<br> |
+| `timeout` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, 10000 is used. | `minimum`: `0` | Configure max time (in milliseconds) to wait for each export.<br>Value must be non-negative. A value of 0 indicates no limit (infinity).<br> |
+| `tls` | [`GrpcTls`](#grpctls) | If omitted, system default TLS settings are used. | None. | Configure TLS settings for the exporter. |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### OtlpGrpcMetricExporter {#otlpgrpcmetricexporter}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `compression` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, none is used. | None. | Configure compression.<br>Known values include: gzip, none. Implementations may support other compression algorithms.<br> |
+| `default_histogram_aggregation` | [`ExporterDefaultHistogramAggregation`](#exporterdefaulthistogramaggregation) | If omitted, explicit_bucket_histogram is used. | None. | Configure default histogram aggregation.<br> |
+| `endpoint` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, http://localhost:4317 is used. | None. | Configure endpoint.<br> |
+| `headers` | `array` of [`NameStringValuePair`](#namestringvaluepair) | If omitted, no headers are added. | `minItems`: `1` | Configure headers. Entries have higher priority than entries from .headers_list.<br>If an entry's .value is null, the entry is ignored.<br> |
+| `headers_list` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, no headers are added. | None. | Configure headers. Entries have lower priority than entries from .headers.<br>The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. ([See here for more details](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options)).<br> |
+| `temporality_preference` | [`ExporterTemporalityPreference`](#exportertemporalitypreference) | If omitted, cumulative is used. | None. | Configure temporality preference.<br> |
+| `timeout` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, 10000 is used. | `minimum`: `0` | Configure max time (in milliseconds) to wait for each export.<br>Value must be non-negative. A value of 0 indicates no limit (infinity).<br> |
+| `tls` | [`GrpcTls`](#grpctls) | If omitted, system default TLS settings are used. | None. | Configure TLS settings for the exporter. |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### OtlpHttpEncoding {#otlphttpencoding}
+
+**This is an enum type.**
+
+<div class="types-table">
+
+| Value | Description |
+|---|---|
+| `json` | Protobuf JSON encoding. |
+| `protobuf` | Protobuf binary encoding. |
+
+</div>
+
+### OtlpHttpExporter {#otlphttpexporter}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `compression` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, none is used. | None. | Configure compression.<br>Known values include: gzip, none. Implementations may support other compression algorithms.<br> |
+| `encoding` | [`OtlpHttpEncoding`](#otlphttpencoding) | If omitted, protobuf is used. | None. | Configure the encoding used for messages. <br>Implementations may not support json.<br> |
+| `endpoint` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, the http://localhost:4318/v1/{signal} (where signal is 'traces', 'logs', or 'metrics') is used. | None. | Configure endpoint, including the signal specific path.<br> |
+| `headers` | `array` of [`NameStringValuePair`](#namestringvaluepair) | If omitted, no headers are added. | `minItems`: `1` | Configure headers. Entries have higher priority than entries from .headers_list.<br>If an entry's .value is null, the entry is ignored.<br> |
+| `headers_list` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, no headers are added. | None. | Configure headers. Entries have lower priority than entries from .headers.<br>The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. ([See here for more details](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options)).<br> |
+| `timeout` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, 10000 is used. | `minimum`: `0` | Configure max time (in milliseconds) to wait for each export.<br>Value must be non-negative. A value of 0 indicates no limit (infinity).<br> |
+| `tls` | [`HttpTls`](#httptls) | If omitted, system default TLS settings are used. | None. | Configure TLS settings for the exporter. |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### OtlpHttpMetricExporter {#otlphttpmetricexporter}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `compression` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, none is used. | None. | Configure compression.<br>Known values include: gzip, none. Implementations may support other compression algorithms.<br> |
+| `default_histogram_aggregation` | [`ExporterDefaultHistogramAggregation`](#exporterdefaulthistogramaggregation) | If omitted, explicit_bucket_histogram is used. | None. | Configure default histogram aggregation.<br> |
+| `encoding` | [`OtlpHttpEncoding`](#otlphttpencoding) | If omitted, protobuf is used. | None. | Configure the encoding used for messages. <br>Implementations may not support json.<br> |
+| `endpoint` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, http://localhost:4318/v1/metrics is used. | None. | Configure endpoint.<br> |
+| `headers` | `array` of [`NameStringValuePair`](#namestringvaluepair) | If omitted, no headers are added. | `minItems`: `1` | Configure headers. Entries have higher priority than entries from .headers_list.<br>If an entry's .value is null, the entry is ignored.<br> |
+| `headers_list` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, no headers are added. | None. | Configure headers. Entries have lower priority than entries from .headers.<br>The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. ([See here for more details](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options)).<br> |
+| `temporality_preference` | [`ExporterTemporalityPreference`](#exportertemporalitypreference) | If omitted, cumulative is used. | None. | Configure temporality preference.<br> |
+| `timeout` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, 10000 is used. | `minimum`: `0` | Configure max time (in milliseconds) to wait for each export.<br>Value must be non-negative. A value of 0 indicates no limit (infinity).<br> |
+| `tls` | [`HttpTls`](#httptls) | If omitted, system default TLS settings are used. | None. | Configure TLS settings for the exporter. |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ParentBasedSampler {#parentbasedsampler}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `local_parent_not_sampled` | [`Sampler`](#sampler) | If omitted, always_off is used. | Configure local_parent_not_sampled sampler.<br> |
+| `local_parent_sampled` | [`Sampler`](#sampler) | If omitted, always_on is used. | Configure local_parent_sampled sampler.<br> |
+| `remote_parent_not_sampled` | [`Sampler`](#sampler) | If omitted, always_off is used. | Configure remote_parent_not_sampled sampler.<br> |
+| `remote_parent_sampled` | [`Sampler`](#sampler) | If omitted, always_on is used. | Configure remote_parent_sampled sampler.<br> |
+| `root` | [`Sampler`](#sampler) | If omitted, always_on is used. | Configure root sampler.<br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### PeriodicMetricReader {#periodicmetricreader}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `cardinality_limits` | [`CardinalityLimits`](#cardinalitylimits) | If omitted, default values as described in CardinalityLimits are used. | None. | Configure cardinality limits. |
+| `exporter`<sup>*</sup> | [`PushMetricExporter`](#pushmetricexporter) | Property is required and must be non-null. | None. | Configure exporter. |
+| `interval` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, 60000 is used. | `minimum`: `0` | Configure delay interval (in milliseconds) between start of two consecutive exports. <br>Value must be non-negative.<br> |
+| `producers` | `array` of [`MetricProducer`](#metricproducer) | If omitted, no metric producers are added. | `minItems`: `1` | Configure metric producers. |
+| `timeout` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, 30000 is used. | `minimum`: `0` | Configure maximum allowed time (in milliseconds) to export data. <br>Value must be non-negative. A value of 0 indicates no limit (infinity).<br> |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `false`<br>• `required`: `["exporter"]`<br>
+### Propagator {#propagator}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `composite` | `array` of [`TextMapPropagator`](#textmappropagator) | If omitted, and .composite_list is omitted or null, a noop propagator is used. | `minItems`: `1` | Configure the propagators in the composite text map propagator. Entries from .composite_list are appended to the list here with duplicates filtered out.<br>Built-in propagator keys include: tracecontext, baggage, b3, b3multi, jaeger, ottrace. Known third party keys include: xray. <br> |
+| `composite_list` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, and .composite is omitted or null, a noop propagator is used. | None. | Configure the propagators in the composite text map propagator. Entries are appended to .composite with duplicates filtered out.<br>The value is a comma separated list of propagator identifiers matching the format of OTEL_PROPAGATORS. ([See here for more details](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration)).<br>Built-in propagator identifiers include: tracecontext, baggage, b3, b3multi, jaeger, ottrace. Known third party identifiers include: xray. <br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### PullMetricExporter {#pullmetricexporter}
+
+`PullMetricExporter` is an SDK extension plugin point.
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `prometheus/development`<br>**⚠ Experimental** | [`ExperimentalPrometheusMetricExporter`](#experimentalprometheusmetricexporter) | If omitted, ignore. | Configure exporter to be prometheus.<br> |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `{"type":["object","null"]}`<br>• `minProperties`: `1`<br>• `maxProperties`: `1`<br>
+### PullMetricReader {#pullmetricreader}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `cardinality_limits` | [`CardinalityLimits`](#cardinalitylimits) | If omitted, default values as described in CardinalityLimits are used. | None. | Configure cardinality limits. |
+| `exporter`<sup>*</sup> | [`PullMetricExporter`](#pullmetricexporter) | Property is required and must be non-null. | None. | Configure exporter. |
+| `producers` | `array` of [`MetricProducer`](#metricproducer) | If omitted, no metric producers are added. | `minItems`: `1` | Configure metric producers. |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `false`<br>• `required`: `["exporter"]`<br>
+### PushMetricExporter {#pushmetricexporter}
+
+`PushMetricExporter` is an SDK extension plugin point.
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `console` | [`ConsoleMetricExporter`](#consolemetricexporter) | If omitted, ignore. | Configure exporter to be console.<br> |
+| `otlp_grpc` | [`OtlpGrpcMetricExporter`](#otlpgrpcmetricexporter) | If omitted, ignore. | Configure exporter to be OTLP with gRPC transport.<br> |
+| `otlp_http` | [`OtlpHttpMetricExporter`](#otlphttpmetricexporter) | If omitted, ignore. | Configure exporter to be OTLP with HTTP transport.<br> |
+| `otlp_file/development`<br>**⚠ Experimental** | [`ExperimentalOtlpFileMetricExporter`](#experimentalotlpfilemetricexporter) | If omitted, ignore. | Configure exporter to be OTLP with file transport.<br> |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `{"type":["object","null"]}`<br>• `minProperties`: `1`<br>• `maxProperties`: `1`<br>
+### Resource {#resource}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `attributes` | `array` of [`AttributeNameValue`](#attributenamevalue) | If omitted, no resource attributes are added. | `minItems`: `1` | Configure resource attributes. Entries have higher priority than entries from .resource.attributes_list.<br> |
+| `attributes_list` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, no resource attributes are added. | None. | Configure resource attributes. Entries have lower priority than entries from .resource.attributes.<br>The value is a list of comma separated key-value pairs matching the format of OTEL_RESOURCE_ATTRIBUTES. ([See here for more details](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration)).<br> |
+| `schema_url` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, no schema URL is used. | None. | Configure resource schema URL.<br> |
+| `detection/development`<br>**⚠ Experimental** | [`ExperimentalResourceDetection`](#experimentalresourcedetection) | If omitted, resource detection is disabled. | None. | Configure resource detection.<br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### Sampler {#sampler}
+
+`Sampler` is an SDK extension plugin point.
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `always_off` | [`AlwaysOffSampler`](#alwaysoffsampler) | If omitted, ignore. | Configure sampler to be always_off. |
+| `always_on` | [`AlwaysOnSampler`](#alwaysonsampler) | If omitted, ignore. | Configure sampler to be always_on. |
+| `parent_based` | [`ParentBasedSampler`](#parentbasedsampler) | If omitted, ignore. | Configure sampler to be parent_based. |
+| `trace_id_ratio_based` | [`TraceIdRatioBasedSampler`](#traceidratiobasedsampler) | If omitted, ignore. | Configure sampler to be trace_id_ratio_based. |
+| `composite/development`<br>**⚠ Experimental** | [`ExperimentalComposableSampler`](#experimentalcomposablesampler) | If omitted, ignore. | Configure sampler to be composite. |
+| `jaeger_remote/development`<br>**⚠ Experimental** | [`ExperimentalJaegerRemoteSampler`](#experimentaljaegerremotesampler) | If omitted, ignore. | Configure sampler to be jaeger_remote. |
+| `probability/development`<br>**⚠ Experimental** | [`ExperimentalProbabilitySampler`](#experimentalprobabilitysampler) | If omitted, ignore. | Configure sampler to be probability. |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `{"type":["object","null"]}`<br>• `minProperties`: `1`<br>• `maxProperties`: `1`<br>
+### SeverityNumber {#severitynumber}
+
+**This is an enum type.**
+
+<div class="types-table">
+
+| Value | Description |
+|---|---|
+| `debug` | debug, severity number 5. |
+| `debug2` | debug2, severity number 6. |
+| `debug3` | debug3, severity number 7. |
+| `debug4` | debug4, severity number 8. |
+| `error` | error, severity number 17. |
+| `error2` | error2, severity number 18. |
+| `error3` | error3, severity number 19. |
+| `error4` | error4, severity number 20. |
+| `fatal` | fatal, severity number 21. |
+| `fatal2` | fatal2, severity number 22. |
+| `fatal3` | fatal3, severity number 23. |
+| `fatal4` | fatal4, severity number 24. |
+| `info` | info, severity number 9. |
+| `info2` | info2, severity number 10. |
+| `info3` | info3, severity number 11. |
+| `info4` | info4, severity number 12. |
+| `trace` | trace, severity number 1. |
+| `trace2` | trace2, severity number 2. |
+| `trace3` | trace3, severity number 3. |
+| `trace4` | trace4, severity number 4. |
+| `warn` | warn, severity number 13. |
+| `warn2` | warn2, severity number 14. |
+| `warn3` | warn3, severity number 15. |
+| `warn4` | warn4, severity number 16. |
+
+</div>
+
+### SimpleLogRecordProcessor {#simplelogrecordprocessor}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `exporter`<sup>*</sup> | [`LogRecordExporter`](#logrecordexporter) | Property is required and must be non-null. | Configure exporter. |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `false`<br>• `required`: `["exporter"]`<br>
+### SimpleSpanProcessor {#simplespanprocessor}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `exporter`<sup>*</sup> | [`SpanExporter`](#spanexporter) | Property is required and must be non-null. | Configure exporter. |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `false`<br>• `required`: `["exporter"]`<br>
+### SpanExporter {#spanexporter}
+
+`SpanExporter` is an SDK extension plugin point.
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `console` | [`ConsoleExporter`](#consoleexporter) | If omitted, ignore. | Configure exporter to be console. |
+| `otlp_grpc` | [`OtlpGrpcExporter`](#otlpgrpcexporter) | If omitted, ignore. | Configure exporter to be OTLP with gRPC transport. |
+| `otlp_http` | [`OtlpHttpExporter`](#otlphttpexporter) | If omitted, ignore. | Configure exporter to be OTLP with HTTP transport. |
+| `otlp_file/development`<br>**⚠ Experimental** | [`ExperimentalOtlpFileExporter`](#experimentalotlpfileexporter) | If omitted, ignore. | Configure exporter to be OTLP with file transport.<br> |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `{"type":["object","null"]}`<br>• `minProperties`: `1`<br>• `maxProperties`: `1`<br>
+### SpanKind {#spankind}
+
+**This is an enum type.**
+
+<div class="types-table">
+
+| Value | Description |
+|---|---|
+| `client` | client, a client span. |
+| `consumer` | consumer, a consumer span. |
+| `internal` | internal, an internal span. |
+| `producer` | producer, a producer span. |
+| `server` | server, a server span. |
+
+</div>
+
+### SpanLimits {#spanlimits}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `attribute_count_limit` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, 128 is used. | `minimum`: `0` | Configure max attribute count. Overrides .attribute_limits.attribute_count_limit. <br>Value must be non-negative.<br> |
+| `attribute_value_length_limit` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, there is no limit. | `minimum`: `0` | Configure max attribute value size. Overrides .attribute_limits.attribute_value_length_limit. <br>Value must be non-negative.<br> |
+| `event_attribute_count_limit` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, 128 is used. | `minimum`: `0` | Configure max attributes per span event. <br>Value must be non-negative.<br> |
+| `event_count_limit` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, 128 is used. | `minimum`: `0` | Configure max span event count. <br>Value must be non-negative.<br> |
+| `link_attribute_count_limit` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, 128 is used. | `minimum`: `0` | Configure max attributes per span link. <br>Value must be non-negative.<br> |
+| `link_count_limit` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, 128 is used. | `minimum`: `0` | Configure max span link count. <br>Value must be non-negative.<br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### SpanProcessor {#spanprocessor}
+
+`SpanProcessor` is an SDK extension plugin point.
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `batch` | [`BatchSpanProcessor`](#batchspanprocessor) | If omitted, ignore. | Configure a batch span processor. |
+| `simple` | [`SimpleSpanProcessor`](#simplespanprocessor) | If omitted, ignore. | Configure a simple span processor. |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `{"type":["object","null"]}`<br>• `minProperties`: `1`<br>• `maxProperties`: `1`<br>
+### SumAggregation {#sumaggregation}
+
+**No properties.**
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### TextMapPropagator {#textmappropagator}
+
+`TextMapPropagator` is an SDK extension plugin point.
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `b3` | [`B3Propagator`](#b3propagator) | If omitted, ignore. | Include the zipkin b3 propagator. |
+| `b3multi` | [`B3MultiPropagator`](#b3multipropagator) | If omitted, ignore. | Include the zipkin b3 multi propagator. |
+| `baggage` | [`BaggagePropagator`](#baggagepropagator) | If omitted, ignore. | Include the w3c baggage propagator. |
+| `jaeger` | [`JaegerPropagator`](#jaegerpropagator) | If omitted, ignore. | Include the jaeger propagator. |
+| `ottrace` | [`OpenTracingPropagator`](#opentracingpropagator) | If omitted, ignore. | Include the opentracing propagator. |
+| `tracecontext` | [`TraceContextPropagator`](#tracecontextpropagator) | If omitted, ignore. | Include the w3c trace context propagator. |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `{"type":["object","null"]}`<br>• `minProperties`: `1`<br>• `maxProperties`: `1`<br>
+### TraceContextPropagator {#tracecontextpropagator}
+
+**No properties.**
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### TraceIdRatioBasedSampler {#traceidratiobasedsampler}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `ratio` | one of:<br>• `number`<br>• `null`<br> | If omitted or null, 1.0 is used. | • `minimum`: `0`<br>• `maximum`: `1`<br> | Configure trace_id_ratio.<br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### TracerProvider {#tracerprovider}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `limits` | [`SpanLimits`](#spanlimits) | If omitted, default values as described in SpanLimits are used. | None. | Configure span limits. See also attribute_limits. |
+| `processors`<sup>*</sup> | `array` of [`SpanProcessor`](#spanprocessor) | Property is required and must be non-null. | `minItems`: `1` | Configure span processors. |
+| `sampler` | [`Sampler`](#sampler) | If omitted, parent based sampler with a root of always_on is used. | None. | Configure the sampler.<br> |
+| `tracer_configurator/development`<br>**⚠ Experimental** | [`ExperimentalTracerConfigurator`](#experimentaltracerconfigurator) | If omitted, all tracers use default values as described in ExperimentalTracerConfig. | None. | Configure tracers.<br> |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `false`<br>• `required`: `["processors"]`<br>
+### View {#view}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `selector`<sup>*</sup> | [`ViewSelector`](#viewselector) | Property is required and must be non-null. | Configure view selector. <br>Selection criteria is additive as described in https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-selection-criteria.<br> |
+| `stream`<sup>*</sup> | [`ViewStream`](#viewstream) | Property is required and must be non-null. | Configure view stream. |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `false`<br>• `required`: `["selector","stream"]`<br>
+### ViewSelector {#viewselector}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `instrument_name` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, all instrument names match. | Configure instrument name selection criteria.<br> |
+| `instrument_type` | [`InstrumentType`](#instrumenttype) | If omitted, all instrument types match. | Configure instrument type selection criteria.<br> |
+| `meter_name` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, all meter names match. | Configure meter name selection criteria.<br> |
+| `meter_schema_url` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, all meter schema URLs match. | Configure meter schema url selection criteria.<br> |
+| `meter_version` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, all meter versions match. | Configure meter version selection criteria.<br> |
+| `unit` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, all instrument units match. | Configure the instrument unit selection criteria.<br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ViewStream {#viewstream}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `aggregation` | [`Aggregation`](#aggregation) | If omitted, default is used. | None. | Configure aggregation of the resulting stream(s). <br> |
+| `aggregation_cardinality_limit` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, the metric reader's default cardinality limit is used. | `exclusiveMinimum`: `0` | Configure the aggregation cardinality limit.<br> |
+| `attribute_keys` | [`IncludeExclude`](#includeexclude) | If omitted, all attribute keys are retained. | None. | Configure attribute keys retained in the resulting stream(s).<br> |
+| `description` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, the instrument's origin description is used. | None. | Configure metric description of the resulting stream(s).<br> |
+| `name` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, the instrument's original name is used. | None. | Configure metric name of the resulting stream(s).<br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+## Experimental Types
+
+> **Warning:** Experimental types are subject to breaking changes.
+
+### ExperimentalComposableAlwaysOffSampler {#experimentalcomposablealwaysoffsampler}
+
+**No properties.**
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExperimentalComposableAlwaysOnSampler {#experimentalcomposablealwaysonsampler}
+
+**No properties.**
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExperimentalComposableParentThresholdSampler {#experimentalcomposableparentthresholdsampler}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `root`<sup>*</sup> | [`ExperimentalComposableSampler`](#experimentalcomposablesampler) | Property is required and must be non-null. | Sampler to use when there is no parent. |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `false`<br>• `required`: `["root"]`<br>
+### ExperimentalComposableProbabilitySampler {#experimentalcomposableprobabilitysampler}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `ratio` | one of:<br>• `number`<br>• `null`<br> | If omitted or null, 1.0 is used. | • `minimum`: `0`<br>• `maximum`: `1`<br> | Configure ratio.<br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExperimentalComposableRuleBasedSampler {#experimentalcomposablerulebasedsampler}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `rules` | one of:<br>• `array`<br>• `null`<br> | If omitted or null, no span is sampled. | The rules for the sampler, matched in order. If no rules match, the span is not sampled.<br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExperimentalComposableRuleBasedSamplerRule {#experimentalcomposablerulebasedsamplerrule}
+
+A rule for ExperimentalComposableRuleBasedSampler. A rule can have multiple match conditions - the sampler will be applied if all match.
+If no conditions are specified, the rule matches all spans that reach it.
+
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `attribute_patterns` | [`ExperimentalComposableRuleBasedSamplerRuleAttributePatterns`](#experimentalcomposablerulebasedsamplerruleattributepatterns) | If omitted, ignore. | None. | Patterns to match against a single attribute. Non-string attributes are matched using their string representation:<br>for example, a pattern of "4*" would match any http.response.status_code in 400-499. For array attributes, if any<br>item matches, it is considered a match.<br> |
+| `attribute_values` | [`ExperimentalComposableRuleBasedSamplerRuleAttributeValues`](#experimentalcomposablerulebasedsamplerruleattributevalues) | If omitted, ignore. | None. | Values to match against a single attribute. Non-string attributes are matched using their string representation:<br>for example, a value of "404" would match the http.response.status_code 404. For array attributes, if any<br>item matches, it is considered a match.<br> |
+| `parent` | `array` of [`ExperimentalSpanParent`](#experimentalspanparent) | If omitted, ignore. | `minItems`: `1` | The parent span types to match. |
+| `sampler`<sup>*</sup> | [`ExperimentalComposableSampler`](#experimentalcomposablesampler) | Property is required and must be non-null. | None. | The sampler to use for matching spans. |
+| `span_kinds` | `array` of [`SpanKind`](#spankind) | If omitted, ignore. | `minItems`: `1` | The span kinds to match. If the span's kind matches any of these, it matches. |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `false`<br>• `required`: `["sampler"]`<br>
+### ExperimentalComposableRuleBasedSamplerRuleAttributePatterns {#experimentalcomposablerulebasedsamplerruleattributepatterns}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `excluded` | `array` of `string` | If omitted, .included attributes are included. | `minItems`: `1` | Configure list of value patterns to exclude. Applies after .included (i.e. excluded has higher priority than included).<br>Values are evaluated to match as follows:<br> * If the value exactly matches.<br> * If the value matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.<br> |
+| `included` | `array` of `string` | If omitted, all values are included. | `minItems`: `1` | Configure list of value patterns to include.<br>Values are evaluated to match as follows:<br> * If the value exactly matches.<br> * If the value matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.<br> |
+| `key`<sup>*</sup> | `string` | Property is required and must be non-null. | None. | The attribute key to match against. |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `false`<br>• `required`: `["key"]`<br>
+### ExperimentalComposableRuleBasedSamplerRuleAttributeValues {#experimentalcomposablerulebasedsamplerruleattributevalues}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `key`<sup>*</sup> | `string` | Property is required and must be non-null. | None. | The attribute key to match against. |
+| `values`<sup>*</sup> | `array` of `string` | Property is required and must be non-null. | `minItems`: `1` | The attribute values to match against. If the attribute's value matches any of these, it matches. |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `false`<br>• `required`: `["key","values"]`<br>
+### ExperimentalComposableSampler {#experimentalcomposablesampler}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `always_off` | [`ExperimentalComposableAlwaysOffSampler`](#experimentalcomposablealwaysoffsampler) | If omitted, ignore. | Configure sampler to be always_off. |
+| `always_on` | [`ExperimentalComposableAlwaysOnSampler`](#experimentalcomposablealwaysonsampler) | If omitted, ignore. | Configure sampler to be always_on. |
+| `parent_threshold` | [`ExperimentalComposableParentThresholdSampler`](#experimentalcomposableparentthresholdsampler) | If omitted, ignore. | Configure sampler to be parent_threshold.<br> |
+| `probability` | [`ExperimentalComposableProbabilitySampler`](#experimentalcomposableprobabilitysampler) | If omitted, ignore. | Configure sampler to be probability. |
+| `rule_based` | [`ExperimentalComposableRuleBasedSampler`](#experimentalcomposablerulebasedsampler) | If omitted, ignore. | Configure sampler to be rule_based. |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `{"type":["object","null"]}`<br>• `minProperties`: `1`<br>• `maxProperties`: `1`<br>
+### ExperimentalContainerResourceDetector {#experimentalcontainerresourcedetector}
+
+**No properties.**
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExperimentalGeneralInstrumentation {#experimentalgeneralinstrumentation}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `http` | [`ExperimentalHttpInstrumentation`](#experimentalhttpinstrumentation) | If omitted, defaults as described in ExperimentalHttpInstrumentation are used. | Configure instrumentations following the http semantic conventions.<br>See http semantic conventions: https://opentelemetry.io/docs/specs/semconv/http/<br> |
+| `peer` | [`ExperimentalPeerInstrumentation`](#experimentalpeerinstrumentation) | If omitted, defaults as described in ExperimentalPeerInstrumentation are used. | Configure instrumentations following the peer semantic conventions.<br>See peer semantic conventions: https://opentelemetry.io/docs/specs/semconv/attributes-registry/peer/<br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExperimentalHostResourceDetector {#experimentalhostresourcedetector}
+
+**No properties.**
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExperimentalHttpClientInstrumentation {#experimentalhttpclientinstrumentation}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `request_captured_headers` | `array` of `string` | If omitted, no outbound request headers are captured. | `minItems`: `1` | Configure headers to capture for outbound http requests.<br> |
+| `response_captured_headers` | `array` of `string` | If omitted, no inbound response headers are captured. | `minItems`: `1` | Configure headers to capture for inbound http responses.<br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExperimentalHttpInstrumentation {#experimentalhttpinstrumentation}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `client` | [`ExperimentalHttpClientInstrumentation`](#experimentalhttpclientinstrumentation) | If omitted, defaults as described in ExperimentalHttpClientInstrumentation are used. | Configure instrumentations following the http client semantic conventions. |
+| `server` | [`ExperimentalHttpServerInstrumentation`](#experimentalhttpserverinstrumentation) | If omitted, defaults as described in ExperimentalHttpServerInstrumentation are used. | Configure instrumentations following the http server semantic conventions. |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExperimentalHttpServerInstrumentation {#experimentalhttpserverinstrumentation}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `request_captured_headers` | `array` of `string` | If omitted, no request headers are captured. | `minItems`: `1` | Configure headers to capture for inbound http requests.<br> |
+| `response_captured_headers` | `array` of `string` | If omitted, no response headers are captures. | `minItems`: `1` | Configure headers to capture for outbound http responses.<br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExperimentalInstrumentation {#experimentalinstrumentation}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `cpp` | [`ExperimentalLanguageSpecificInstrumentation`](#experimentallanguagespecificinstrumentation) | If omitted, instrumentation defaults are used. | Configure C++ language-specific instrumentation libraries. |
+| `dotnet` | [`ExperimentalLanguageSpecificInstrumentation`](#experimentallanguagespecificinstrumentation) | If omitted, instrumentation defaults are used. | Configure .NET language-specific instrumentation libraries.<br>Each entry's key identifies a particular instrumentation library. The corresponding value configures it.<br> |
+| `erlang` | [`ExperimentalLanguageSpecificInstrumentation`](#experimentallanguagespecificinstrumentation) | If omitted, instrumentation defaults are used. | Configure Erlang language-specific instrumentation libraries.<br>Each entry's key identifies a particular instrumentation library. The corresponding value configures it.<br> |
+| `general` | [`ExperimentalGeneralInstrumentation`](#experimentalgeneralinstrumentation) | If omitted, default values as described in ExperimentalGeneralInstrumentation are used. | Configure general SemConv options that may apply to multiple languages and instrumentations.<br>Instrumenation may merge general config options with the language specific configuration at .instrumentation.<language>.<br> |
+| `go` | [`ExperimentalLanguageSpecificInstrumentation`](#experimentallanguagespecificinstrumentation) | If omitted, instrumentation defaults are used. | Configure Go language-specific instrumentation libraries.<br>Each entry's key identifies a particular instrumentation library. The corresponding value configures it.<br> |
+| `java` | [`ExperimentalLanguageSpecificInstrumentation`](#experimentallanguagespecificinstrumentation) | If omitted, instrumentation defaults are used. | Configure Java language-specific instrumentation libraries.<br>Each entry's key identifies a particular instrumentation library. The corresponding value configures it.<br> |
+| `js` | [`ExperimentalLanguageSpecificInstrumentation`](#experimentallanguagespecificinstrumentation) | If omitted, instrumentation defaults are used. | Configure JavaScript language-specific instrumentation libraries.<br>Each entry's key identifies a particular instrumentation library. The corresponding value configures it.<br> |
+| `php` | [`ExperimentalLanguageSpecificInstrumentation`](#experimentallanguagespecificinstrumentation) | If omitted, instrumentation defaults are used. | Configure PHP language-specific instrumentation libraries.<br>Each entry's key identifies a particular instrumentation library. The corresponding value configures it.<br> |
+| `python` | [`ExperimentalLanguageSpecificInstrumentation`](#experimentallanguagespecificinstrumentation) | If omitted, instrumentation defaults are used. | Configure Python language-specific instrumentation libraries.<br>Each entry's key identifies a particular instrumentation library. The corresponding value configures it.<br> |
+| `ruby` | [`ExperimentalLanguageSpecificInstrumentation`](#experimentallanguagespecificinstrumentation) | If omitted, instrumentation defaults are used. | Configure Ruby language-specific instrumentation libraries.<br>Each entry's key identifies a particular instrumentation library. The corresponding value configures it.<br> |
+| `rust` | [`ExperimentalLanguageSpecificInstrumentation`](#experimentallanguagespecificinstrumentation) | If omitted, instrumentation defaults are used. | Configure Rust language-specific instrumentation libraries.<br>Each entry's key identifies a particular instrumentation library. The corresponding value configures it.<br> |
+| `swift` | [`ExperimentalLanguageSpecificInstrumentation`](#experimentallanguagespecificinstrumentation) | If omitted, instrumentation defaults are used. | Configure Swift language-specific instrumentation libraries.<br>Each entry's key identifies a particular instrumentation library. The corresponding value configures it.<br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExperimentalJaegerRemoteSampler {#experimentaljaegerremotesampler}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `endpoint`<sup>*</sup> | `string` | Property is required and must be non-null. | None. | Configure the endpoint of the jaeger remote sampling service. |
+| `initial_sampler`<sup>*</sup> | [`Sampler`](#sampler) | Property is required and must be non-null. | None. | Configure the initial sampler used before first configuration is fetched. |
+| `interval` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, 60000 is used. | `minimum`: `0` | Configure the polling interval (in milliseconds) to fetch from the remote sampling service. |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `false`<br>• `required`: `["endpoint","initial_sampler"]`<br>
+### ExperimentalLanguageSpecificInstrumentation {#experimentallanguagespecificinstrumentation}
+
+**No properties.**
+
+**Constraints:**
+
+`additionalProperties`: `{"type":"object"}`
+### ExperimentalLoggerConfig {#experimentalloggerconfig}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `disabled` | one of:<br>• `boolean`<br>• `null`<br> | If omitted or null, false is used. | Configure if the logger is enabled or not.<br> |
+| `minimum_severity` | [`SeverityNumber`](#severitynumber) | If omitted, severity filtering is not applied. | Configure severity filtering.<br>Log records with an non-zero (i.e. unspecified) severity number which is less than minimum_severity are not processed.<br> |
+| `trace_based` | one of:<br>• `boolean`<br>• `null`<br> | If omitted or null, trace based filtering is not applied. | Configure trace based filtering.<br>If true, log records associated with unsampled trace contexts traces are not processed. If false, or if a log record is not associated with a trace context, trace based filtering is not applied.<br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExperimentalLoggerConfigurator {#experimentalloggerconfigurator}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `default_config` | [`ExperimentalLoggerConfig`](#experimentalloggerconfig) | If omitted, unmatched .loggers use default values as described in ExperimentalLoggerConfig. | None. | Configure the default logger config used there is no matching entry in .logger_configurator/development.loggers. |
+| `loggers` | `array` of [`ExperimentalLoggerMatcherAndConfig`](#experimentalloggermatcherandconfig) | If omitted, all loggers use .default_config. | `minItems`: `1` | Configure loggers. |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExperimentalLoggerMatcherAndConfig {#experimentalloggermatcherandconfig}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `config`<sup>*</sup> | [`ExperimentalLoggerConfig`](#experimentalloggerconfig) | Property is required and must be non-null. | The logger config. |
+| `name`<sup>*</sup> | `string` | Property is required and must be non-null. | Configure logger names to match, evaluated as follows:<br><br> * If the logger name exactly matches.<br> * If the logger name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.<br> |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `false`<br>• `required`: `["name","config"]`<br>
+### ExperimentalMeterConfig {#experimentalmeterconfig}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `disabled` | `boolean` | If omitted, false is used. | Configure if the meter is enabled or not. |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExperimentalMeterConfigurator {#experimentalmeterconfigurator}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `default_config` | [`ExperimentalMeterConfig`](#experimentalmeterconfig) | If omitted, unmatched .meters use default values as described in ExperimentalMeterConfig. | None. | Configure the default meter config used there is no matching entry in .meter_configurator/development.meters. |
+| `meters` | `array` of [`ExperimentalMeterMatcherAndConfig`](#experimentalmetermatcherandconfig) | If omitted, all meters used .default_config. | `minItems`: `1` | Configure meters. |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExperimentalMeterMatcherAndConfig {#experimentalmetermatcherandconfig}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `config`<sup>*</sup> | [`ExperimentalMeterConfig`](#experimentalmeterconfig) | Property is required and must be non-null. | The meter config. |
+| `name`<sup>*</sup> | `string` | Property is required and must be non-null. | Configure meter names to match, evaluated as follows:<br><br> * If the meter name exactly matches.<br> * If the meter name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.<br> |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `false`<br>• `required`: `["name","config"]`<br>
+### ExperimentalOtlpFileExporter {#experimentalotlpfileexporter}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `output_stream` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, stdout is used. | Configure output stream. <br>Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.<br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExperimentalOtlpFileMetricExporter {#experimentalotlpfilemetricexporter}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `default_histogram_aggregation` | [`ExporterDefaultHistogramAggregation`](#exporterdefaulthistogramaggregation) | If omitted, explicit_bucket_histogram is used. | Configure default histogram aggregation.<br> |
+| `output_stream` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, stdout is used. | Configure output stream. <br>Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.<br> |
+| `temporality_preference` | [`ExporterTemporalityPreference`](#exportertemporalitypreference) | If omitted, cumulative is used. | Configure temporality preference.<br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExperimentalPeerInstrumentation {#experimentalpeerinstrumentation}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `service_mapping` | `array` of [`ExperimentalPeerServiceMapping`](#experimentalpeerservicemapping) | If omitted, no peer service mappings are used. | `minItems`: `1` | Configure the service mapping for instrumentations following peer.service semantic conventions.<br>See peer.service semantic conventions: https://opentelemetry.io/docs/specs/semconv/general/attributes/#general-remote-service-attributes<br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExperimentalPeerServiceMapping {#experimentalpeerservicemapping}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `peer`<sup>*</sup> | `string` | Property is required and must be non-null. | The IP address to map.<br> |
+| `service`<sup>*</sup> | `string` | Property is required and must be non-null. | The logical name corresponding to the IP address of .peer.<br> |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `false`<br>• `required`: `["peer","service"]`<br>
+### ExperimentalProbabilitySampler {#experimentalprobabilitysampler}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `ratio` | one of:<br>• `number`<br>• `null`<br> | If omitted or null, 1.0 is used. | • `minimum`: `0`<br>• `maximum`: `1`<br> | Configure ratio.<br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExperimentalProcessResourceDetector {#experimentalprocessresourcedetector}
+
+**No properties.**
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExperimentalPrometheusMetricExporter {#experimentalprometheusmetricexporter}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `host` | one of:<br>• `string`<br>• `null`<br> | If omitted or null, localhost is used. | Configure host.<br> |
+| `port` | one of:<br>• `integer`<br>• `null`<br> | If omitted or null, 9464 is used. | Configure port.<br> |
+| `translation_strategy` | [`ExperimentalPrometheusTranslationStrategy`](#experimentalprometheustranslationstrategy) | If omitted, underscore_escaping_with_suffixes is used. | Configure how metric names are translated to Prometheus metric names. |
+| `with_resource_constant_labels` | [`IncludeExclude`](#includeexclude) | If omitted, no resource attributes are added. | Configure Prometheus Exporter to add resource attributes as metrics attributes, where the resource attribute keys match the patterns. |
+| `without_scope_info` | one of:<br>• `boolean`<br>• `null`<br> | If omitted or null, false is used. | Configure Prometheus Exporter to produce metrics without a scope info metric.<br> |
+| `without_target_info` | one of:<br>• `boolean`<br>• `null`<br> | If omitted or null, false is used. | Configure Prometheus Exporter to produce metrics without a target info metric for the resource.<br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExperimentalPrometheusTranslationStrategy {#experimentalprometheustranslationstrategy}
+
+**This is an enum type.**
+
+<div class="types-table">
+
+| Value | Description |
+|---|---|
+| `no_translation` | Special character escaping is disabled. Type and unit suffixes are disabled. Metric names are unaltered. |
+| `no_utf8_escaping_with_suffixes` | Special character escaping is disabled. Type and unit suffixes are enabled. |
+| `underscore_escaping_with_suffixes` | Special character escaping is enabled. Type and unit suffixes are enabled. |
+| `underscore_escaping_without_suffixes` | Special character escaping is enabled. Type and unit suffixes are disabled. This represents classic Prometheus metric name compatibility. |
+
+</div>
+
+### ExperimentalResourceDetection {#experimentalresourcedetection}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `attributes` | [`IncludeExclude`](#includeexclude) | If omitted, all attributes from resource detectors are added. | None. | Configure attributes provided by resource detectors. |
+| `detectors` | `array` of [`ExperimentalResourceDetector`](#experimentalresourcedetector) | If omitted, no resource detectors are enabled. | `minItems`: `1` | Configure resource detectors.<br>Resource detector names are dependent on the SDK language ecosystem. Please consult documentation for each respective language. <br> |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExperimentalResourceDetector {#experimentalresourcedetector}
+
+`ExperimentalResourceDetector` is an SDK extension plugin point.
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `container` | [`ExperimentalContainerResourceDetector`](#experimentalcontainerresourcedetector) | If omitted, ignore. | Enable the container resource detector, which populates container.* attributes.<br> |
+| `host` | [`ExperimentalHostResourceDetector`](#experimentalhostresourcedetector) | If omitted, ignore. | Enable the host resource detector, which populates host.* and os.* attributes.<br> |
+| `process` | [`ExperimentalProcessResourceDetector`](#experimentalprocessresourcedetector) | If omitted, ignore. | Enable the process resource detector, which populates process.* attributes.<br> |
+| `service` | [`ExperimentalServiceResourceDetector`](#experimentalserviceresourcedetector) | If omitted, ignore. | Enable the service detector, which populates service.name based on the OTEL_SERVICE_NAME environment variable and service.instance.id.<br> |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `{"type":["object","null"]}`<br>• `minProperties`: `1`<br>• `maxProperties`: `1`<br>
+### ExperimentalServiceResourceDetector {#experimentalserviceresourcedetector}
+
+**No properties.**
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExperimentalSpanParent {#experimentalspanparent}
+
+**This is an enum type.**
+
+<div class="types-table">
+
+| Value | Description |
+|---|---|
+| `local` | local, a local parent. |
+| `none` | none, no parent, i.e., the trace root. |
+| `remote` | remote, a remote parent. |
+
+</div>
+
+### ExperimentalTracerConfig {#experimentaltracerconfig}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `disabled` | `boolean` | If omitted, false is used. | Configure if the tracer is enabled or not. |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExperimentalTracerConfigurator {#experimentaltracerconfigurator}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Constraints | Description |
+|---|---|---|---|---|
+| `default_config` | [`ExperimentalTracerConfig`](#experimentaltracerconfig) | If omitted, unmatched .tracers use default values as described in ExperimentalTracerConfig. | None. | Configure the default tracer config used there is no matching entry in .tracer_configurator/development.tracers. |
+| `tracers` | `array` of [`ExperimentalTracerMatcherAndConfig`](#experimentaltracermatcherandconfig) | If omitted, all tracers use .default_config. | `minItems`: `1` | Configure tracers. |
+
+</div>
+
+**Constraints:**
+
+`additionalProperties`: `false`
+### ExperimentalTracerMatcherAndConfig {#experimentaltracermatcherandconfig}
+
+<div class="types-table">
+
+| Property | Type | Default Behavior | Description |
+|---|---|---|---|
+| `config`<sup>*</sup> | [`ExperimentalTracerConfig`](#experimentaltracerconfig) | Property is required and must be non-null. | The tracer config. |
+| `name`<sup>*</sup> | `string` | Property is required and must be non-null. | Configure tracer names to match, evaluated as follows:<br><br> * If the tracer name exactly matches.<br> * If the tracer name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.<br> |
+
+</div>
+
+**Constraints:**
+
+• `additionalProperties`: `false`<br>• `required`: `["name","config"]`<br>
 <!-- END GENERATED: types SOURCE: opentelemetry-configuration -->

--- a/content/en/docs/languages/sdk-configuration/types.md
+++ b/content/en/docs/languages/sdk-configuration/types.md
@@ -1,0 +1,9 @@
+---
+linkTitle: Types
+weight: 10
+aliases: [general-sdk-configuration]
+---
+
+<!-- BEGIN GENERATED: types SOURCE: opentelemetry-configuration -->
+
+<!-- END GENERATED: types SOURCE: opentelemetry-configuration -->

--- a/layouts/_shortcodes/sdk-lang-status-accordion.html
+++ b/layouts/_shortcodes/sdk-lang-status-accordion.html
@@ -1,0 +1,41 @@
+{{- /* SDK Language Implementation Status Accordion Viewer */ -}}
+<div id="sdk-lang-status-accordion-container" class="sdk-lang-status-accordion">
+  <div class="accordion-controls mb-4">
+    <div class="row g-3">
+      <div class="col-md-8">
+        <label for="accordion-search" class="form-label">Search types</label>
+        <input
+          type="text"
+          id="accordion-search"
+          class="form-control"
+          placeholder="Filter by type name..."
+        />
+      </div>
+      <div class="col-md-4">
+        <label for="accordion-type-filter" class="form-label">Type category</label>
+        <select id="accordion-type-filter" class="form-select">
+          <option value="all">All types</option>
+          <option value="stable">Stable only</option>
+          <option value="experimental">Experimental only</option>
+        </select>
+      </div>
+    </div>
+    <div class="mt-3">
+      <button class="btn btn-sm btn-outline-primary" id="expand-all">Expand all</button>
+      <button class="btn btn-sm btn-outline-secondary" id="collapse-all">Collapse all</button>
+    </div>
+  </div>
+
+  <div class="accordion-stats mb-3">
+    <small class="text-muted">
+      Showing <span id="accordion-visible-count">0</span> of <span id="accordion-total-count">0</span> types
+    </small>
+  </div>
+
+  <div class="accordion" id="statusAccordion">
+    <!-- Accordion items will be populated by JavaScript -->
+  </div>
+</div>
+
+{{- $js := resources.Get "js/sdkLangStatusAccordion.js" | js.Build | minify | fingerprint -}}
+<script type="module" src="{{ $js.RelPermalink }}" defer></script>


### PR DESCRIPTION
Exploring ways of showing this information in a more dynamic way. 

The content is mirrored from: https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema-docs.md

I have automation that will update the markdown table, and then there's some javascript that parses that data and replaces it with an accordion style display of the information.

I wanted to see if there are thoughts or concerns with this type of addition, where much of the content is managed in some javascript, which might not be ideal. I'm happy to revisit and come back with some different iterations.

Deploy preview: https://deploy-preview-8723--opentelemetry.netlify.app/docs/languages/sdk-configuration/language-implementation-status/

cc @jack-berg 