### PR TITLE
Update ParentBased sampler description

### DIFF
--- a/content/en/docs/languages/go/sampling.md
+++ b/content/en/docs/languages/go/sampling.md
@@ -34,9 +34,8 @@ Other samplers include:
 - [`ParentBased`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/trace#ParentBased),
   is a sampler decorator which behaves differently, based on the parent of the
   span. If the span has no parent, the decorated sampler is used to make the
-  sampling decision. By default, `ParentBased`
-  samples spans that have parents that were sampled, and doesn't sample spans
-  whose parents were not sampled.
+  sampling decision. By default, `ParentBased` samples spans that have parents
+  that were sampled, and doesn't sample spans whose parents were not sampled.
 
 By default, the tracer provider uses a `ParentBased` sampler with the
 `AlwaysSample` sampler.


### PR DESCRIPTION
Close issue: #8736.

- [x] I have read and followed the
      [contribution guidelines](https://opentelemetry.io/docs/contributing/),
      including the **First-time contributing?** note.
- [x] This PR includes **AI generated content**, and I have read and conform to
      the
      [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).

Clarify the behavior of the ParentBased sampler in the documentation.
Fix awkward sentence which confuses reader.

In https://opentelemetry.io/docs/languages/go/sampling/ => Description of "ParentBased". There is a awkward sentence 
> If the span has no parent, the decorated sampler is used to make sampling decision based on the parent of the span.

To clarify this, It would be great to changed like below.
> If the span has no parent, the decorated sampler is used to make the sampling decision

Other documentations also using the right sentence.

<!--
Provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->
