### PR TITLE
[Infra] Update component owners

### DIFF
--- a/.github/component-owners.yml
+++ b/.github/component-owners.yml
@@ -32,6 +32,8 @@ components:
     - open-telemetry/operator-approvers
   content/en/docs/platforms/client-apps/android:
     - open-telemetry/android-approvers
+  content/en/docs/platforms/client-apps/ios:
+    - open-telemetry/swift-approvers
   content/en/docs/platforms/client-apps/web:
     - open-telemetry/web-approvers
   content/en/docs/platforms/faas:


### PR DESCRIPTION
Updates `.github/component-owners.yml`:

* Adds @open-telemetry/swift-approvers for `content/en/docs/platforms/client-apps/ios`
* Adds @open-telemetry/browser-approvers for `content/en/docs/platforms/client-apps/web`
* Updates `content/en/docs/languages/net` to `content/en/docs/languages/dotnet`
* Removes the nonexistent path for `content/en/ecosystem/demo`



