### PR TITLE
[Infra] Update component owners

### DIFF
--- a/.github/component-owners.yml
+++ b/.github/component-owners.yml
@@ -35,7 +35,7 @@ components:
   content/en/docs/platforms/client-apps/ios:
     - open-telemetry/swift-approvers
   content/en/docs/platforms/client-apps/web:
-    - open-telemetry/web-approvers
+    - open-telemetry/browser-approvers
   content/en/docs/platforms/faas:
     - open-telemetry/lambda-extension-approvers
   content/en/docs/languages/cpp:


### PR DESCRIPTION
> @vitorvasc Looks like this needs a revision from "web-approvers" to "browser-approvers"
> 
> _Originally posted by @overbalance in https://github.com/open-telemetry/opentelemetry.io/issues/8743#issuecomment-3714906040_

Updates `.github/component-owners.yml`:

* Updates group from nonexisting `open-telemetry/web-approvers` to `open-telemetry/browser-approvers`



