### PR TITLE
Add guidance for custom samplers

### DIFF
--- a/content/en/docs/languages/go/sampling.md
+++ b/content/en/docs/languages/go/sampling.md
@@ -164,6 +164,6 @@ When implementing custom samplers, keep these points in mind:
    sampling decisions, wrap your sampler with `ParentBased` or check
    `psc.IsSampled()` manually.
 
-2. **Heavy computations in ShouldSample**: The `ShouldSample` function is called synchronously
-   for every span creation. Avoid expensive operations like network calls or
-   complex computations that could impact performance.
+2. **Heavy computations in ShouldSample**: The `ShouldSample` function is called
+   synchronously for every span creation. Avoid expensive operations like
+   network calls or complex computations that could impact performance.


### PR DESCRIPTION
- [x] I have read and followed the
      [contribution guidelines](https://opentelemetry.io/docs/contributing/),
      including the **First-time contributing?** note.
- [x] This PR includes **AI generated content**, and I have read and conform to
      the
      [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).

This PR adds a new "Custom samplers" section to the Go sampling documentation that provides guidance on creating custom samplers.

The current documentation only covers built-in samplers and lacks guidance on:

How to implement the Sampler interface
How SamplingResult should be handled to ensure correct context propagation
The critical importance of preserving tracestate from the parent span
This is especially important because an incorrectly implemented custom sampler can break distributed tracing by dropping or modifying tracestate and baggage.

### Fixes:
Closes https://github.com/open-telemetry/opentelemetry.io/issues/7558