### PR TITLE
Copyright year range: use present for current year

### DIFF
--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -106,6 +106,7 @@ params:
       OpenTelemetry Authors | Docs [CC BY
       4.0](https://creativecommons.org/licenses/by/4.0)
     from_year: 2019
+    to_year: present
   tagline: Effective observability requires high-quality telemetry
   sub_tagline: >-
     **OpenTelemetry** makes robust, portable telemetry a built-in feature of


### PR DESCRIPTION
- Switches to using "present" for the current year in the copyright year range. This avoids unnecessary deltas to the generated site pages across the years.