### PR TITLE
[blog] Open the current and prev year-group in the sidenav + copyedit

### DIFF
--- a/content/en/blog/2025/calling-new-contributors.md
+++ b/content/en/blog/2025/calling-new-contributors.md
@@ -5,7 +5,7 @@ title:
 linkTitle: New Contributor Research Study
 date: 2025-12-05
 author: >-
-  [Amy Super](https://github.com/amy-super)(Grafana Labs)
+  [Amy Super](https://github.com/amy-super) (Grafana Labs)
 issue: 7966
 sig: Contributor Experience
 ---

--- a/content/en/blog/_index.md
+++ b/content/en/blog/_index.md
@@ -16,9 +16,13 @@ description: OpenTelemetry blog
     document.addEventListener("DOMContentLoaded", function () {
         if (window.location.pathname.includes('/page/')) return;
 
-        var checkbox = document.getElementById("m-blog2025-check");
-        if (checkbox) checkbox.checked = true;
-        checkbox = document.getElementById("m-blog2024-check");
-        if (checkbox) checkbox.checked = true;
+        // Open the sidebar year-groups for the current and previous years
+        var currentYear = new Date().getFullYear();
+        var yearsToCheck = [currentYear, currentYear - 1];
+
+        yearsToCheck.forEach(function(year) {
+            var checkbox = document.getElementById("m-blog" + year + "-check");
+            if (checkbox) checkbox.checked = true;
+        });
     });
 </script>


### PR DESCRIPTION
- Updates blog-index script to open the sidenav year-group for the current and previous years dynamically.
- Copyedit: add missing space in 2025 blog, and rename solo index file to folder name

**Preview**: https://deploy-preview-8759--opentelemetry.netlify.app/blog/

### Screenshot

> <img width="838" alt="image" src="https://github.com/user-attachments/assets/66622410-c940-428c-b020-6e33e3975a98" />
