### PR TITLE
[pt] updates content/pt/docs/contributing/development.md

### DIFF
--- a/content/pt/docs/contributing/development.md
+++ b/content/pt/docs/contributing/development.md
@@ -126,10 +126,10 @@ precisar aumentar o limite de descritores de arquivo. Veja
 O site é construído a partir do seguinte conteúdo:
 
 - Arquivos sob `content/`, `static/`, etc. conforme os padrões do [Hugo].
-- Pontos de montagem, definidos pela [configuração][config] do Hugo em `config/_default/module-template.yaml`. As montagens são
-  diretamente de submódulos git sob [content-modules], ou conteúdo
-  pré-processado de `content-modules` (colocado sob `tmp/`), e em nenhum outro
-  lugar.
+- Pontos de montagem, definidos pela [configuração][config] do Hugo em
+  `config/_default/module-template.yaml`. As montagens são diretamente de
+  submódulos git sob [content-modules], ou conteúdo pré-processado de
+  `content-modules` (colocado sob `tmp/`), e em nenhum outro lugar.
 
 [config]: https://github.com/open-telemetry/opentelemetry.io/tree/main/config
 [content-modules]:


### PR DESCRIPTION
- [x] I have read and followed the
      [contribution guidelines](https://opentelemetry.io/docs/contributing/),
      including the **First-time contributing?** note.
- [ ] This PR includes **AI generated content**, and I have read and conform to
      the
      [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).

```diff
--- a/content/en/docs/contributing/development.md
+++ b/content/en/docs/contributing/development.md
@@ -122,12 +122,12 @@ might need to increase the file descriptor limit. See
 The website is built from the following content:
 
 - Files under `content/`, `static/`, etc. per [Hugo] defaults.
-- Mount points, defined in [hugo.yaml] under `mounts`. Mounts are either
-  directly from git submodules under [content-modules], or preprocessed content
-  from `content-modules` (placed under `tmp/`), and no where else.
+- Mount points, defined by Hugo [config] in
+  `config/_default/module-template.yaml`. Mounts are either directly from git
+  submodules under [content-modules], or preprocessed content from
+  `content-modules` (placed under `tmp/`), and no where else.
 
-[hugo.yaml]:
-  https://github.com/open-telemetry/opentelemetry.io/blob/main/hugo.yaml
+[config]: https://github.com/open-telemetry/opentelemetry.io/tree/main/config
 [content-modules]:
   https://github.com/open-telemetry/opentelemetry.io/tree/main/content-modules
 
DRIFTED files: 1 out of 1
