### PR TITLE
[pt] updates content/pt/docs/zero-code/java/agent/api.md

### DIFF
--- a/content/pt/docs/zero-code/java/agent/api.md
+++ b/content/pt/docs/zero-code/java/agent/api.md
@@ -5,8 +5,7 @@ description:
   Use a API do OpenTelemetry em combinação com o Java agent para estender a
   telemetria gerada automaticamente com spans e métricas personalizadas.
 weight: 21
-default_lang_commit: c392c714849921cd56aca8ca99ab11e0e4cb16f4
-drifted_from_default: true
+default_lang_commit: 505e2d1d650a80f8a8d72206f2e285430bc6b36a
 ---
 
 ## Introdução {#introduction}
@@ -44,8 +43,8 @@ dependencies {
 ## OpenTelemetry {#opentelemetry}
 
 O Java agent é um caso especial onde `GlobalOpenTelemetry` é definido pelo
-agente. Simplesmente chame a função `GlobalOpenTelemetry.getOrNoop()` para acessar a
-instância `OpenTelemetry`.
+agente. Simplesmente chame a função `GlobalOpenTelemetry.getOrNoop()` para
+acessar a instância `OpenTelemetry`.
 
 ## Trecho {#span}
 


### PR DESCRIPTION
- [x] I have read and followed the
      [contribution guidelines](https://opentelemetry.io/docs/contributing/),
      including the **First-time contributing?** note.
- [ ] This PR includes **AI generated content**, and I have read and conform to
      the
      [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).

```diff
--- a/content/en/docs/zero-code/java/agent/api.md
+++ b/content/en/docs/zero-code/java/agent/api.md
@@ -42,8 +42,8 @@ dependencies {
 ## OpenTelemetry
 
 The Java agent is a special case where `GlobalOpenTelemetry` is set by the
-agent. Simply call `GlobalOpenTelemetry.get()` to access the `OpenTelemetry`
-instance.
+agent. Simply call `GlobalOpenTelemetry.getOrNoop()` to access the
+`OpenTelemetry` instance.
 
 ## Span
 
DRIFTED files: 1 out of 1