### PR TITLE
[pt] updates content/pt/docs/languages/go/sampling.md

### DIFF
--- a/content/pt/docs/languages/go/sampling.md
+++ b/content/pt/docs/languages/go/sampling.md
@@ -1,8 +1,7 @@
 ---
 title: Amostragem
 weight: 80
-default_lang_commit: 06837fe15457a584f6a9e09579be0f0400593d57
-drifted_from_default: true
+default_lang_commit: 505e2d1d650a80f8a8d72206f2e285430bc6b36a
 ---
 
 A [Amostragem](/docs/concepts/sampling/) é um processo que restringe a
@@ -37,10 +36,10 @@ Outros amostradores disponíveis são:
   amostrados.
 - [`ParentBased`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/trace#ParentBased),
   é um decorador de amostrador que se comporta de maneira diferente, com base no
-  pai do trecho. Caso o trecho não possua um pai, o amostrador decorado
-  é usado para tomar a decisão de amostragem. Por
-  padrão, `ParentBased` amostra trechos que possuem pais que foram
-  amostrados, e não amostra trechos cujos pais não foram amostrados.
+  pai do trecho. Caso o trecho não possua um pai, o amostrador decorado é usado
+  para tomar a decisão de amostragem. Por padrão, `ParentBased` amostra trechos
+  que possuem pais que foram amostrados, e não amostra trechos cujos pais não
+  foram amostrados.
 
 Por padrão, o Tracer Provider utiliza o amostrador `ParentBased` com o
 amostrador `AlwaysSample`


### PR DESCRIPTION
- [x] I have read and followed the
      [contribution guidelines](https://opentelemetry.io/docs/contributing/),
      including the **First-time contributing?** note.
- [ ] This PR includes **AI generated content**, and I have read and conform to
      the
      [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).

```diff
--- a/content/en/docs/languages/go/sampling.md
+++ b/content/en/docs/languages/go/sampling.md
@@ -33,10 +33,9 @@ Other samplers include:
   If you set .5, half of all the spans are sampled.
 - [`ParentBased`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/trace#ParentBased),
   is a sampler decorator which behaves differently, based on the parent of the
-  span. If the span has no parent, the decorated sampler is used to make
-  sampling decision based on the parent of the span. By default, `ParentBased`
-  samples spans that have parents that were sampled, and doesn't sample spans
-  whose parents were not sampled.
+  span. If the span has no parent, the decorated sampler is used to make the
+  sampling decision. By default, `ParentBased` samples spans that have parents
+  that were sampled, and doesn't sample spans whose parents were not sampled.
 
 By default, the tracer provider uses a `ParentBased` sampler with the
 `AlwaysSample` sampler.
DRIFTED files: 1 out of 1