### PR TITLE
[pt] updates content/pt/docs/languages/sdk-configuration/general.md

### DIFF
--- a/content/pt/docs/languages/sdk-configuration/general.md
+++ b/content/pt/docs/languages/sdk-configuration/general.md
@@ -3,8 +3,7 @@ title: Configurações gerais de SDK
 linkTitle: Geral
 weight: 10
 aliases: [general-sdk-configuration]
-default_lang_commit: a5691930635b4e2033946f3a85ae7a527c3eba06 # patched
-drifted_from_default: true
+default_lang_commit: 505e2d1d650a80f8a8d72206f2e285430bc6b36a
 cSpell:ignore: ottrace
 ---
 
@@ -135,9 +134,9 @@ Os valores aceitos para `OTEL_PROPAGATORS` são:
 - `jaeger`: [Jaeger](https://www.jaegertracing.io/sdk-migration/)
 - `xray`:
   [AWS X-Ray](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader)
-  (__terceiro_)
+  (_terceiro_)
 - `ottrace`: [OT Trace](https://github.com/opentracing?q=basic&type=&language=)
-  (__terceiro_)
+  (_terceiro_)
 - `none`: Nenhum propagador configurado automaticamente.
 
 ## `OTEL_TRACES_EXPORTER`


### PR DESCRIPTION
- [x] I have read and followed the
      [contribution guidelines](https://opentelemetry.io/docs/contributing/),
      including the **First-time contributing?** note.
- [ ] This PR includes **AI generated content**, and I have read and conform to
      the
      [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).

```diff
--- a/content/en/docs/languages/sdk-configuration/general.md
+++ b/content/en/docs/languages/sdk-configuration/general.md
@@ -9,7 +9,7 @@ cSpell:ignore: ottrace
 {{% alert title="Note" %}}
 
 Support for environment variables is optional. For detailed information on which
-environment variables each language implementation supports, please consult the
+environment variables each language implementation supports, see the
 [Implementation Compliance Matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md#environment-variables).
 
 {{% /alert %}}
@@ -19,63 +19,70 @@ environment variables each language implementation supports, please consult the
 Sets the value of the [`service.name`](/docs/specs/semconv/resource/#service)
 resource attribute.
 
-**Default value:** `"unknown_service"`
+**Default value:** `unknown_service`
 
 If `service.name` is also provided in `OTEL_RESOURCE_ATTRIBUTES`, then
 `OTEL_SERVICE_NAME` takes precedence.
 
 **Example:**
 
-`export OTEL_SERVICE_NAME="your-service-name"`
+```sh
+export OTEL_SERVICE_NAME="your-service-name"
+```
 
 ## `OTEL_RESOURCE_ATTRIBUTES`
 
-Key-value pairs to be used as resource attributes. See
-[Resource SDK](/docs/specs/otel/resource/sdk#specifying-resource-information-via-an-environment-variable)
-for more details.
-
-**Default value:** Empty.
+Key-value pairs to be used as resource attributes.
 
-See
-[Resource semantic conventions](/docs/specs/semconv/resource/#semantic-attributes-with-sdk-provided-default-value)
-for semantic conventions to follow for common resource types.
+**Default value:** empty
 
 **Example:**
 
-`export OTEL_RESOURCE_ATTRIBUTES="key1=value1,key2=value2"`
+```sh
+export OTEL_RESOURCE_ATTRIBUTES="key1=value1,key2=value2"
+```
+
+**References:**
+
+- [Resource SDK](/docs/specs/otel/resource/sdk#specifying-resource-information-via-an-environment-variable)
+- [Resource semantic conventions](/docs/specs/semconv/resource/#semantic-attributes-with-sdk-provided-default-value)
+  for common resource type semantic conventions
 
 ## `OTEL_TRACES_SAMPLER`
 
 Specifies the Sampler used to sample traces by the SDK.
 
-**Default value:** `"parentbased_always_on"`
+**Default value:** `parentbased_always_on`
 
 **Example:**
 
-`export OTEL_TRACES_SAMPLER="traceidratio"`
+```sh
+export OTEL_TRACES_SAMPLER="traceidratio"
+```
 
 Accepted values for `OTEL_TRACES_SAMPLER` are:
 
-- `"always_on"`: `AlwaysOnSampler`
-- `"always_off"`: `AlwaysOffSampler`
-- `"traceidratio"`: `TraceIdRatioBased`
-- `"parentbased_always_on"`: `ParentBased(root=AlwaysOnSampler)`
-- `"parentbased_always_off"`: `ParentBased(root=AlwaysOffSampler)`
-- `"parentbased_traceidratio"`: `ParentBased(root=TraceIdRatioBased)`
-- `"parentbased_jaeger_remote"`: `ParentBased(root=JaegerRemoteSampler)`
-- `"jaeger_remote"`: `JaegerRemoteSampler`
-- `"xray"`:
-  [AWS X-Ray Centralized Sampling](https://docs.aws.amazon.com/xray/latest/devguide/xray-console-sampling.html)
-  (_third party_)
+- `always_on`: `AlwaysOnSampler`
+- `always_off`: `AlwaysOffSampler`
+- `traceidratio`: `TraceIdRatioBased`
+- `parentbased_always_on`: `ParentBased(root=AlwaysOnSampler)`
+- `parentbased_always_off`: `ParentBased(root=AlwaysOffSampler)`
+- `parentbased_traceidratio`: `ParentBased(root=TraceIdRatioBased)`
+- `parentbased_jaeger_remote`: `ParentBased(root=JaegerRemoteSampler)`
+- `jaeger_remote`: `JaegerRemoteSampler`
+- `xray`: [AWS X-Ray Centralized Sampling][] (_third party_)
+
+[AWS X-Ray Centralized Sampling]:
+  https://docs.aws.amazon.com/xray/latest/devguide/xray-console-sampling.html
 
 ## `OTEL_TRACES_SAMPLER_ARG`
 
-Specifies arguments, if applicable, to the sampler defined in by
+Specifies arguments, if applicable, to the sampler defined by
 `OTEL_TRACES_SAMPLER`. The specified value will only be used if
 `OTEL_TRACES_SAMPLER` is set. Each Sampler type defines its own expected input,
 if any. Invalid or unrecognized input is logged as an error.
 
-**Default value:** Empty.
+**Default value:** empty
 
 **Example:**
 
@@ -93,7 +100,7 @@ be set as follows:
 - For `jaeger_remote` and `parentbased_jaeger_remote`: The value is a comma
   separated list:
   - Example:
-    `"endpoint=http://localhost:14250,pollingIntervalMs=5000,initialSamplingRate=0.25"`
+    `endpoint=http://localhost:14250,pollingIntervalMs=5000,initialSamplingRate=0.25`
   - `endpoint`: the endpoint in form of `scheme://host:port` of gRPC server that
     serves the sampling strategy for the service
     ([sampling.proto](https://github.com/jaegertracing/jaeger-idl/blob/main/proto/api_v2/sampling.proto)).
@@ -109,7 +116,7 @@ be set as follows:
 
 Specifies Propagators to be used in a comma-separated list.
 
-**Default value:** `"tracecontext,baggage"`
+**Default value:** `tracecontext,baggage`
 
 **Example:**
 
@@ -117,27 +124,24 @@ Specifies Propagators to be used in a comma-separated list.
 
 Accepted values for `OTEL_PROPAGATORS` are:
 
-- `"tracecontext"`: [W3C Trace Context](https://www.w3.org/TR/trace-context/)
-- `"baggage"`: [W3C Baggage](https://www.w3.org/TR/baggage/)
-- `"b3"`: [B3 Single](/docs/specs/otel/context/api-propagators#configuration)
-- `"b3multi"`:
-  [B3 Multi](/docs/specs/otel/context/api-propagators#configuration)
-- `"jaeger"`:
-  [Jaeger](https://www.jaegertracing.io/docs/1.21/client-libraries/#propagation-format)
-- `"xray"`:
+- `tracecontext`: [W3C Trace Context](https://www.w3.org/TR/trace-context/)
+- `baggage`: [W3C Baggage](https://www.w3.org/TR/baggage/)
+- `b3`: [B3 Single](/docs/specs/otel/context/api-propagators#configuration)
+- `b3multi`: [B3 Multi](/docs/specs/otel/context/api-propagators#configuration)
+- `jaeger`: [Jaeger](https://www.jaegertracing.io/sdk-migration/)
+- `xray`:
   [AWS X-Ray](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader)
   (_third party_)
-- `"ottrace"`:
-  [OT Trace](https://github.com/opentracing?q=basic&type=&language=) (_third
-  party_)
-- `"none"`: No automatically configured propagator.
+- `ottrace`: [OT Trace](https://github.com/opentracing?q=basic&type=&language=)
+  (_third party_)
+- `none`: No automatically configured propagator.
 
 ## `OTEL_TRACES_EXPORTER`
 
 Specifies which exporter is used for traces. Depending on the implementation it
 may be a comma-separated list.
 
-**Default value:** `"otlp"`
+**Default value:** `otlp`
 
 **Example:**
 
@@ -145,18 +149,18 @@ may be a comma-separated list.
 
 Accepted values for are:
 
-- `"otlp"`: [OTLP][]
-- `"jaeger"`: export in Jaeger data model
-- `"zipkin"`: [Zipkin](https://zipkin.io/zipkin-api/)
-- `"console"`: [Standard Output](/docs/specs/otel/trace/sdk_exporters/stdout/)
-- `"none"`: No automatically configured exporter for traces.
+- `otlp`: [OTLP][]
+- `jaeger`: Export in Jaeger data model.
+- `zipkin`: [Zipkin](https://zipkin.io/zipkin-api/)
+- `console`: [Standard Output](/docs/specs/otel/trace/sdk_exporters/stdout/)
+- `none`: No automatically configured exporter for traces.
 
 ## `OTEL_METRICS_EXPORTER`
 
 Specifies which exporter is used for metrics. Depending on the implementation it
 may be a comma-separated list.
 
-**Default value:** `"otlp"`
+**Default value:** `otlp`
 
 **Example:**
 
@@ -164,18 +168,18 @@ may be a comma-separated list.
 
 Accepted values for `OTEL_METRICS_EXPORTER` are:
 
-- `"otlp"`: [OTLP][]
-- `"prometheus"`:
+- `otlp`: [OTLP]
+- `prometheus`:
   [Prometheus](https://github.com/prometheus/docs/blob/main/docs/instrumenting/exposition_formats.md)
-- `"console"`: [Standard Output](/docs/specs/otel/metrics/sdk_exporters/stdout/)
-- `"none"`: No automatically configured exporter for metrics.
+- `console`: [Standard Output](/docs/specs/otel/metrics/sdk_exporters/stdout/)
+- `none`: No automatically configured exporter for metrics.
 
 ## `OTEL_LOGS_EXPORTER`
 
 Specifies which exporter is used for logs. Depending on the implementation it
 may be a comma-separated list.
 
-**Default value:** `"otlp"`
+**Default value:** `otlp`
 
 **Example:**
 
@@ -183,8 +187,8 @@ may be a comma-separated list.
 
 Accepted values for `OTEL_LOGS_EXPORTER` are:
 
-- `"otlp"`: [OTLP][]
-- `"console"`: [Standard Output](/docs/specs/otel/logs/sdk_exporters/stdout/)
-- `"none"`: No automatically configured exporter for logs.
+- `otlp`: [OTLP]
+- `console`: [Standard Output](/docs/specs/otel/logs/sdk_exporters/stdout/)
+- `none`: No automatically configured exporter for logs.
 
 [otlp]: /docs/specs/otlp/
DRIFTED files: 1 out of 1