### PR TITLE
[pt] update content/pt/docs/languages/java/configuration.md

### DIFF
--- a/content/pt/docs/languages/java/configuration.md
+++ b/content/pt/docs/languages/java/configuration.md
@@ -3,8 +3,7 @@ title: Configure o SDK
 linkTitle: Configure o SDK
 weight: 13
 aliases: [config]
-default_lang_commit: 39ecdf683ae1acb8b51388806eedcedc49355bff
-drifted_from_default: true
+default_lang_commit: 505e2d1d650a80f8a8d72206f2e285430bc6b36a
 # prettier-ignore
 cSpell:ignore: autoconfigured blrp Customizer Dotel ignore LOWMEMORY ottrace PKCS retryable
 ---


### PR DESCRIPTION
- [x] I have read and followed the
      [contribution guidelines](https://opentelemetry.io/docs/contributing/),
      including the **First-time contributing?** note.
- [ ] This PR includes **AI generated content**, and I have read and conform to
      the
      [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).

Already up-to-date

```diff
--- a/content/en/docs/languages/java/configuration.md
+++ b/content/en/docs/languages/java/configuration.md
@@ -253,7 +253,7 @@ Properties for cardinality limits:
 
 #### Properties: logs
 
-Properties for [log record processor(s)](../sdk/#logrecordprocessor) pared with
+Properties for [log record processor(s)](../sdk/#logrecordprocessor) paired with
 exporters via `otel.logs.exporter`:
 
 | System property                   | Description                                                           | Default |
DRIFTED files: 1 out of 1