### PR TITLE
[en] remove duplicate text in IA policy alert

### DIFF
--- a/content/en/docs/contributing/pull-requests.md
+++ b/content/en/docs/contributing/pull-requests.md
@@ -21,11 +21,8 @@ To contribute new or improve existing documentation, submit a [pull request][PR]
 
 If you are a [first-time contributor], please note the following:
 
-Your first 3 contributions to our repository need to be human created with minor
-Generative AI assistance
-([AIL1](https://danielmiessler.com/blog/ai-influence-level-ail)). Your first 3
-contributions to our repository must be primarily human-written, with only minor
-AI assistance allowed
+Your first 3 contributions to our repository must be primarily human-written,
+with only minor AI assistance allowed
 ([AIL1](https://danielmiessler.com/blog/ai-influence-level-ail)). This means
 your code should be written by hand, but AI may assist with code completion,
 formatting, linting, and following best practices. Your PR description must be


### PR DESCRIPTION
- [x] I have read and followed the
      [contribution guidelines](https://opentelemetry.io/docs/contributing/),
      including the **First-time contributing?** note.
- [ ] This PR includes **AI generated content**, and I have read and conform to
      the
      [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).

Remove one of the sentences, since they were almost the same.