### PR TITLE
[es] Fix es/status frontmatter

### DIFF
--- a/content/es/status.md
+++ b/content/es/status.md
@@ -3,9 +3,9 @@ title: Estado
 menu: { main: { weight: 30 } }
 aliases: [/project-status, /releases]
 description: Nivel de madurez de los principales componentes de OpenTelemetry
-cascade: { type: docs }
+type: docs
 body_class: td-no-left-sidebar
-default_lang_commit: f9a0439ac56dba1515283e1a1cb6d6a90634a20f
+default_lang_commit: 8252c194ab8d214f2bad084ab283986b3f3d7a6c
 ---
 
 OpenTelemetry está compuesto por


### PR DESCRIPTION
- Contributes to #8839
- This PR is over `content/es/status.md`:
  - While this es page did not show any drift relative to the en page, the front matter didn't match, and this caused the page to be misformated (when built with the next version of Hugo).
  - Removed `cascade` specified from front matter

**Preview**: https://deploy-preview-8833--opentelemetry.netlify.app/es/status/

### Screenshots

Before (using Hugo 0.154.x):

> <img width="737" height="491" alt="image" src="https://github.com/user-attachments/assets/02b3dc91-c82e-4c26-8422-9bd43e766f65" />

After:

> <img width="737" height="655" alt="image" src="https://github.com/user-attachments/assets/b9326ed1-14c7-40a3-8b4b-08068c8deb4a" />

