### PR TITLE
[i18n] Assign unique weight for zero-code index in all languages

### DIFF
--- a/content/en/docs/zero-code/_index.md
+++ b/content/en/docs/zero-code/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Zero-code Instrumentation
 redirects: [{ from: 'net/*', to: 'dotnet/:splat' }]
-weight: 260
+weight: 265
 ---
 
 OpenTelemetry [zero-code instrumentation][] is supported for the languages

--- a/content/es/docs/zero-code/_index.md
+++ b/content/es/docs/zero-code/_index.md
@@ -1,8 +1,8 @@
 ---
 title: Instrumentación sin código
 redirects: [{ from: 'net/*', to: 'dotnet/:splat' }]
-weight: 260
-default_lang_commit: 788277e362bc602b72a90aa9191f9c05c403458e
+weight: 265
+default_lang_commit: 788277e362bc602b72a90aa9191f9c05c403458e # patched
 ---
 
 OpenTelemetry [instrumentación sin código][zero-code instrumentation] es

--- a/content/fr/docs/zero-code/_index.md
+++ b/content/fr/docs/zero-code/_index.md
@@ -1,8 +1,8 @@
 ---
 title: Instrumentation Zero-code
 redirects: [{ from: 'net/*', to: 'dotnet/:splat' }]
-weight: 260
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649
+weight: 265
+default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649 # patched
 ---
 
 L'[instrumentation Zero-code][] d'OpenTelemetry est prise en charge pour les

--- a/content/ja/docs/zero-code/_index.md
+++ b/content/ja/docs/zero-code/_index.md
@@ -1,8 +1,8 @@
 ---
 title: ゼロコード計装
 redirects: [{ from: 'net/*', to: 'dotnet/:splat' }]
-weight: 260
-default_lang_commit: d1ef521ee4a777881fb99c3ec2b506e068cdec4c
+weight: 265
+default_lang_commit: d1ef521ee4a777881fb99c3ec2b506e068cdec4c # patched
 ---
 
 OpenTelemetryの[ゼロコード計装][zero-code instrumentation]は、以下のセクションインデックスに記載されている言語でサポートされています。

--- a/content/zh/docs/zero-code/_index.md
+++ b/content/zh/docs/zero-code/_index.md
@@ -1,8 +1,8 @@
 ---
 title: 零代码插桩
 redirects: [{ from: 'net/*', to: 'dotnet/:splat' }]
-weight: 260
-default_lang_commit: 179f03bf118e1e8a3cc195ab56fc09d85c476394
+weight: 265
+default_lang_commit: 179f03bf118e1e8a3cc195ab56fc09d85c476394 # patched
 ---
 
 OpenTelemetry 的[零代码插桩][zero-code instrumentation]已支持下述索引中列出的编程语言。


### PR DESCRIPTION
- Contributes to #8839
- Assigns weight 265 to zero-code index pages across languages so that it is distinct from the weight of Platforms, kept at 260.
- This ensures consistent ordering across locales. (Otherwise, when the two sections have the same weight, then they get sorted alphabetically, which differs across locales.)

**Preview**: for example, see https://deploy-preview-8834--opentelemetry.netlify.app/fr/docs/

### Screenshots of side nav of `/fr/docs/`

| Before | After |
|--------|--------|
| <img width="313" height="385" alt="image" src="https://github.com/user-attachments/assets/b0f553b6-a5d2-4ee5-babb-3a92d3e1c22d" /> | <img width="314" height="378" alt="image" src="https://github.com/user-attachments/assets/c9170efd-38e2-4176-92b8-a0933856f451" /> | 