### PR TITLE
[fr] Move zero-code/go index to its new position

### DIFF
--- a/content/fr/docs/zero-code/go/_index.md
+++ b/content/fr/docs/zero-code/go/_index.md
@@ -2,8 +2,7 @@
 title: Instrumentation Zero-code Go
 linkTitle: Go
 weight: 16
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649
-drifted_from_default: file not found
+default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649 # patched
 ---
 
 L'instrumentation Zero-code pour Go fournit un moyen d'instrumenter n'importe


### PR DESCRIPTION
- Contributes to #8839
- Moves fr/docs/zero-code/go.md into go/_index.md so as to match the `en` page structure. If we don't do this, the `en` go/autodesk.md page ends up in the wrong place (immediately under zero-code) in the sidenav.
- No change in content. Page marked as "patched"

**Preview**: https://deploy-preview-8844--opentelemetry.netlify.app/fr/docs/zero-code/go/

### Screenshots when using Hugo 0.154.5+

| Before | After |
|--------|--------|
| <img width="255" height="274" alt="image" src="https://github.com/user-attachments/assets/426b9e13-dbbf-4ad9-ad5e-cb4a7b144145" /> | <img width="249" height="276" alt="image" src="https://github.com/user-attachments/assets/085610f5-c2c0-4721-bb13-7a3116a8f649" /> | 

