### PR TITLE
[pt] Move concepts/context-propagation to its new location

### DIFF
--- a/content/fr/docs/zero-code/go/_index.md
+++ b/content/fr/docs/zero-code/go/_index.md
@@ -3,6 +3,7 @@ title: Instrumentation Zero-code Go
 linkTitle: Go
 weight: 16
 default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649 # patched
+drifted_from_default: true
 ---
 
 L'instrumentation Zero-code pour Go fournit un moyen d'instrumenter n'importe

--- a/content/pt/docs/concepts/context-propagation/index.md
+++ b/content/pt/docs/concepts/context-propagation/index.md
@@ -3,8 +3,8 @@ title: Propagação de contexto
 weight: 10
 description:
   Entenda os conceitos que tornam possível o Rastreamento Distribuído.
-default_lang_commit: 9a1f7271288a46049ae28785f04a67fb77f677f7
-drifted_from_default: file not found
+default_lang_commit: 9a1f7271288a46049ae28785f04a67fb77f677f7 # patched
+drifted_from_default: true
 ---
 
 Com a propagação de contexto, os [sinais](../signals/) podem ser correlacionados


### PR DESCRIPTION
- Contributes to #8839
- Moves 'pt/docs/concepts/context-propagation.md' to `pt/docs/concepts/context-propagation/index.md` so it matches the `en` page structure.
- No change in content. Page marked as "patched" and drifted
- (Added drifted status to page modified in #8844)

**Preview**: https://deploy-preview-8845--opentelemetry.netlify.app/pt/docs/concepts/context-propagation/

### Screenshots

Before, if you visited https://opentelemetry.io/pt/docs/concepts/context-propagation/, you'd see the `en` page, despite the pt page being there (though in the wrong place):

> <img width="1077" height="576" alt="image" src="https://github.com/user-attachments/assets/ab16739d-0a66-4172-b4b0-e40cb0fa996f" />

After:

> <img width="1081" height="524" alt="image" src="https://github.com/user-attachments/assets/b9773ff6-4344-48e1-8155-d152555a9d3d" />

Under Hugo 0.154.x, the pt page would be rendered, even if the page source wasn't at the same place.

/cc @vitorvasc 