### PR TITLE
[i18n] Move concepts/context-propagation.md for es, fr, ja, zh

### DIFF
--- a/content/es/docs/concepts/context-propagation/index.md
+++ b/content/es/docs/concepts/context-propagation/index.md
@@ -2,8 +2,8 @@
 title: Propagación de Contexto
 weight: 10
 description: Aprende sobre el concepto que habilita el trazado distribuido.
-default_lang_commit: 9a1f7271288a46049ae28785f04a67fb77f677f7
-drifted_from_default: file not found
+default_lang_commit: 9a1f7271288a46049ae28785f04a67fb77f677f7 # patched
+drifted_from_default: true
 ---
 
 Con la propagación de contexto, las [señales](../signals/) pueden

--- a/content/fr/docs/concepts/context-propagation/index.md
+++ b/content/fr/docs/concepts/context-propagation/index.md
@@ -2,8 +2,8 @@
 title: Propagation du contexte
 weight: 10
 description: Présentation du concept permettant le traçage distribué.
-default_lang_commit: 71833a5f8b84110dadf1e98604b87a900724ac33
-drifted_from_default: file not found
+default_lang_commit: 71833a5f8b84110dadf1e98604b87a900724ac33 # patched
+drifted_from_default: true
 ---
 
 La propagation du contexte permet de mettre en corrélation les

--- a/content/ja/docs/concepts/context-propagation/index.md
+++ b/content/ja/docs/concepts/context-propagation/index.md
@@ -2,8 +2,8 @@
 title: コンテキスト伝搬
 weight: 10
 description: 分散トレーシングを可能にする概念について学ぶ
-default_lang_commit: 9b427bf25703c33a2c6e05c2a7b58e0f768f7bad
-drifted_from_default: file not found
+default_lang_commit: 9b427bf25703c33a2c6e05c2a7b58e0f768f7bad # patched
+drifted_from_default: true
 ---
 
 コンテキスト伝搬により、[シグナル](../signals/)は、それらが生成された場所に関係なく、互いを相関させられます。

--- a/content/zh/docs/concepts/context-propagation/index.md
+++ b/content/zh/docs/concepts/context-propagation/index.md
@@ -2,8 +2,8 @@
 title: 上下文传播
 weight: 10
 description: 了解实现分布式追踪的概念。
-default_lang_commit: 7bb7dbb6
-drifted_from_default: file not found
+default_lang_commit: 7bb7dbb6 # patched
+drifted_from_default: true
 ---
 
 通过上下文传播，无论[信号](/docs/concepts/signals)在何处生成，信号彼此之间都可以相互关联。


### PR DESCRIPTION
- Similar to #8845, but for **es, fr, ja, zh** since I noticed that those needed updating too
- Contributes to #8839
- Moves 'XX/docs/concepts/context-propagation.md' to `XX/docs/concepts/context-propagation/index.md` so it matches the `en` page structure.
- No change in content. Page marked as "patched" and drifted