### PR TITLE
Remove unnecessary es include index file

### DIFF
--- a/content/es/docs/languages/_includes/_index.md
+++ b/content/es/docs/languages/_includes/_index.md
@@ -1,7 +1,0 @@
----
-title: # bogus for markdownlint
-cascade:
-  build: { list: never, render: never }
-default_lang_commit: 7811e854ba3b31c56ce681f1d60cf19e8a5c4358
-drifted_from_default: file not found
----


### PR DESCRIPTION
- Contributes to #8839
- Drop obsolete index file under es includes
- There are no changes to generated site files (other than due to the site timestamp)