### PR TITLE
Update Hugo to 0.154.5

### DIFF
--- a/layouts/_partials/redirects/localization.txt
+++ b/layouts/_partials/redirects/localization.txt
@@ -21,9 +21,11 @@
 
 {{/* Add redirect rules for non-default languages. */ -}}
 
-{{ range after 1 .Sites -}}
+{{ range .Sites -}}
 
   {{ $siteLang := .Language.Lang -}}
+
+  {{ if eq $defaultLang $siteLang }}{{ continue }}{{ end -}}
 
   # Site localization {{ $siteLang }}
   {{ range $p := .Pages -}}

--- a/layouts/_shortcodes/spec_status.html
+++ b/layouts/_shortcodes/spec_status.html
@@ -4,7 +4,7 @@
 {{ if not (hasPrefix $pageRef "/") -}}
   {{ $pageRef = printf "/docs/specs/%s" $pageRef -}}
 {{ end -}}
-{{ $enSite := index site.Sites 0 -}}
+{{ $enSite := site.Sites.Default -}}
 {{ $page := $enSite.GetPage $pageRef -}}
 {{ if not $page -}}
   {{ warnf "spec_status: Can't find page at '%s'." $pageRef -}}

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "autoprefixer": "^10.4.23",
     "cspell": "^9.4.0",
     "gulp": "^5.0.1",
-    "hugo-extended": "0.152.2",
+    "hugo-extended": "0.154.5",
     "js-yaml": "^4.1.1",
     "markdown-it": "^14.1.0",
     "markdown-link-check": "^3.14.2",


### PR DESCRIPTION
- Fixes #8839
- Updates Hugo to 0.154.5
- Adjusts shortcodes to ensure that we test for the default language in a way that works under the new Hugo dimensions

### Site diff

```console
$ (cd public && git diff -bw --ignore-blank-lines -I 'class="(cl|cp|gi|k|nn|nt)"' -I '_hu_' -I 'Hugo 0.15' -- ':(exclude)*.xml' ':(exclude)*.jpg') 
diff --git a/js/registrySearch.js b/js/registrySearch.js
index f0170b261..b0a07d34b 100644
--- a/js/registrySearch.js
+++ b/js/registrySearch.js
@@ -1694,7 +1694,7 @@
       }
     }
   };
-  MiniSearch.wildcard = Symbol("*");
+  MiniSearch.wildcard = /* @__PURE__ */ Symbol("*");
   var getOwnProperty = (object, property) => Object.prototype.hasOwnProperty.call(object, property) ? object[property] : void 0;
   var combinators = {
     [OR]: (a, b) => {
diff --git a/site/index.html b/site/index.html
index e06c0e09f..f00e56627 100644
--- a/site/index.html
+++ b/site/index.html
@@ -312,7 +312,7 @@ Share your thoughts by providing [feedback](https://github.com/open-telemetry/op
 <script>
 document.addEventListener("DOMContentLoaded", function() {
   var options = { hour: '2-digit', hour12: false, minute: '2-digit', timeZoneName: 'short' };
-  var buildDate = new Date("2026-01-11T18:40:50-05:00");
+  var buildDate = new Date("2026-01-11T18:46:24-05:00");
   document.getElementById("local-time").innerText = buildDate.toLocaleString(undefined, options);
 });
 </script>
```

What we ignore in the diff:

- Chroma changes, where some empty spans in highlighted code, no longer get generated
- Image fingerprints: the `_hu_` pattern catches the paths to images that are fingerprinted
- Hugo version in the generator ID meta element