### PR TITLE
chore(hugo): align hugo imaging.anchor casing with yaml schema

### DIFF
--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -62,7 +62,7 @@ enableEmoji: true
 imaging:
   resampleFilter: CatmullRom # cspell:disable-line
   quality: 75
-  anchor: smart
+  anchor: Smart
 
 markup:
   tableOfContents:


### PR DESCRIPTION
- [x] I have read and followed the
      [contribution guidelines](https://opentelemetry.io/docs/contributing/),
      including the **First-time contributing?** note.
- [ ] This PR includes **AI generated content**, and I have read and conform to
      the
      [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).

---

Updated the `imaging.anchor` value from lowercase to uppercase to match the YAML schema.

See:
- Hugo documentation: https://gohugo.io/content-management/image-processing/#anchor
- Schema definition: https://www.schemastore.org/hugo.json

---

Hi, I'm new to this repo, so please let me know any additional guidelines or conventions I should follow 🙏 

Thanks for your review.