### PR TITLE
fix(script): TARGET_PATHS handling in check-i18n script

### DIFF
--- a/scripts/check-i18n.sh
+++ b/scripts/check-i18n.sh
@@ -155,10 +155,12 @@ function process_CLI_args() {
     echo "Processing paths: $TARGET_PATHS"
   fi
 
-  if [[ -f "TARGET_PATHS" && ! -e "$TARGET_PATHS" ]] ; then
-    echo -e "ERROR: path not found: '$TARGET_PATHS'\n" >&2
-    exit 2
-  fi
+  for path in $TARGET_PATHS; do
+    if [[ ! -e $path ]]; then
+      echo -e "ERROR: path not found: '$path'\n" >&2
+      exit 2
+    fi
+  done
 }
 
 validate_hash() {


### PR DESCRIPTION
- [x] I have read and followed the
      [contribution guidelines](https://opentelemetry.io/docs/contributing/),
      including the **First-time contributing?** note.
- [ ] This PR includes **AI generated content**, and I have read and conform to
      the
      [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).

---

The existing code had issues with `TARGET_PATHS` expansion, conditional checks, and multiple path handling.

```bash
# "TARGET_PATHS" -> "$TARGET_PATHS"?
if [[ -f "TARGET_PATHS" && ! -e "$TARGET_PATHS" ]] ; then # always false?
  echo -e "ERROR: path not found: '$TARGET_PATHS'\n" >&2 # treated as a single path?
  exit 2
fi
```

This change fixes the bug by validating each path individually.

### Bug reproduction

When passing two paths, the script reports unrelated errors instead of the expected `ERROR: path not found: ...`.

```console
$ ./scripts/check-i18n.sh foo bar
Processing paths: foo bar
find: foo: No such file or directory
find: bar: No such file or directory
ERROR: target directory contains no markdown files: 'foo bar'
```

Even after fixing the conditional, multiple paths are still evaluated as a single path.

```console
$ ./scripts/check-i18n.sh foo bar
Processing paths: foo bar
ERROR: path not found: 'foo bar'
```

### After this change
```console
$ ./scripts/check-i18n.sh content/ja/_index.md foo                         
Processing paths: content/ja/_index.md foo
ERROR: path not found: 'foo'
```

---

Hi, I'm new to this repo, so please let me know any additional guidelines or conventions I should follow 🙏 

Thanks for your review.

