### PR TITLE
Fix typo in content/en/docs/languages/java/instrumentation.md

### DIFF
--- a/content/en/docs/languages/java/instrumentation.md
+++ b/content/en/docs/languages/java/instrumentation.md
@@ -106,7 +106,7 @@ as a temporary means of filling the gap.
 
 Native instrumentation should interact with the OpenTelemetry Java agent as
 follows: On startup, the Java agent initializes an
-[OpenTelemetry](../api/#opentelemetry)) instance and installs
+[OpenTelemetry](../api/#opentelemetry) instance and installs
 [zero-code](#zero-code-java-agent) instrumentation. Libraries adding native
 instrumentation should allow users to customize the `OpenTelemetry` instance
 used, but should automatically use the instance initialized by the Java agent


### PR DESCRIPTION
- [x] I have read and followed the
      [contribution guidelines](https://opentelemetry.io/docs/contributing/),
      including the **First-time contributing?** note.
- [ ] This PR includes **AI generated content**, and I have read and conform to
      the
      [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).

Removes the extra `)` from `content/en/docs/languages/java/instrumentation.md`. 