### PR TITLE
Fix GFM alert rendering

### DIFF
--- a/layouts/_markup/render-blockquote-alert.html
+++ b/layouts/_markup/render-blockquote-alert.html
@@ -7,7 +7,7 @@
 -}}
 
 <div class="alert
-    {{- with index $colors .AlertType -}} alert-{{ . }}
+    {{- with index $colors .AlertType }} alert-{{ . }}
   {{- end }}">
   {{ $title := or
     .AlertTitle


### PR DESCRIPTION
- Fixes #8658
- Closes #8665 by superseding it. We don't need extra styles, we needed to fix a bug in the render hook
- Fixes the alert render hook by recovering a missing space between CSS class names
- Note that GFM alerts are styles as Bootstrap alerts, because that's the Docsy default.

**Previews**:

- https://deploy-preview-8859--opentelemetry.netlify.app/docs/specs/otel/telemetry-stability/#stable-instrumentations
- https://deploy-preview-8859--opentelemetry.netlify.app/docs/specs/otel/context/env-carriers/#supplementary-guidelines

### Screenshots

Before:

> <img width="631" height="226" alt="image" src="https://github.com/user-attachments/assets/2d9cb034-227e-4db4-b54c-417ce4a15df0" />

After:

> <img width="639" height="294" alt="image" src="https://github.com/user-attachments/assets/139f7496-643b-4df0-ac76-9c71d3c26d55" />

No non-whitespace changes to the generated site files:

```console
$ (cd public && git diff -bw --ignore-blank-lines -- ':(exclude)*.xml') | grep ^diff                    
diff --git a/site/index.html b/site/index.html
```

p.s. I'm not sure that important should map to danger. I'll propose a change via another PR and maybe look into the possible use of icons. **Edit**: see #8863