### PR TITLE
Adjust GFM alert-type to alert-style mapping and more

### DIFF
--- a/content/en/docs/contributing/style-guide.md
+++ b/content/en/docs/contributing/style-guide.md
@@ -15,17 +15,17 @@ documentation style is inspired by the following style guides:
 The following sections contain guidance that is specific to the OpenTelemetry
 project.
 
-{{% alert title="Note" %}}
+> [!NOTE]
+>
+> Many requirements of our style guide can be enforced by running automation:
+> before submitting a [pull request][] (PR), run `npm run fix:all` on your local
+> machine and commit the changes.
+>
+> If you run into errors or [failed PR checks](../pr-checks), read about our
+> style guide and learn what you can do to fix certain common issues.
 
-Many requirements of our style guide can be enforced by running automation:
-before submitting a
-[pull request](https://docs.github.com/en/get-started/learning-about-github/github-glossary#pull-request)
-(PR), run `npm run fix:all` on your local machine and commit the changes.
-
-If you run into errors or [failed PR checks](../pr-checks), read about our style
-guide and learn what you can do to fix certain common issues.
-
-{{% /alert %}}
+[pull request]:
+  https://docs.github.com/en/get-started/learning-about-github/github-glossary#pull-request
 
 ## OpenTelemetry.io word list
 

--- a/layouts/_markup/render-blockquote-alert.html
+++ b/layouts/_markup/render-blockquote-alert.html
@@ -1,14 +1,14 @@
 {{ $colors := dict
     "caution" "warning"
-    "important" "danger"
-    "note" "info"
+    "important" "info"
+    "note" "primary"
     "tip" "success"
     "warning" "warning"
 -}}
 
 <div class="alert
     {{- with index $colors .AlertType }} alert-{{ . }}
-  {{- end }}">
+  {{- end }}" role="alert">
   {{ $title := or
     .AlertTitle
     (and .AlertType


### PR DESCRIPTION
- Contributes to #8862
- Introduces the first non-spec page use of a GFM alert in the contrib style guide
- Adjusts the mapping of GFM alert type to Bootstrap alert kind
- Adds role to the alert `div`

**Preview**: https://deploy-preview-8863--opentelemetry.netlify.app/docs/contributing/style-guide/