### PR TITLE
chore: cleanup en i18n multiline formatted entries

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -18,9 +18,9 @@ community_introduce: >-
   {{ .Site.Title }} is an open source project that anyone in the community can
   use, improve, and enjoy. We'd love you to join us!
 
-community_contribute: |
-  To learn how to contribute to {{ .Site.Title }} documentation,
-  see [Contributing](/docs/contributing/). Other useful links:
+community_contribute: >-
+  To learn how to contribute to {{ .Site.Title }} documentation, see
+  [Contributing](/docs/contributing/). Other useful links:
 
 community_how_to: For our documentation style guide and more, see
 community_guideline: Contributing
@@ -28,10 +28,11 @@ community_guideline: Contributing
 # Search AI
 ui_search_ai_modal_title: OpenTelemetry's AI Assistant
 
-ui_search_ai_modal_disclaimer: |
-  This **experimental feature** uses AI to answer questions based on the site's documentation,
-  OpenTelemetry GitHub, Stack Overflow, and other resources.
-  The AI may not always provide accurate or relevant information.
-  Share your thoughts by providing [feedback](https://github.com/open-telemetry/opentelemetry.io/discussions/6802).
+ui_search_ai_modal_disclaimer: >-
+  This **experimental feature** uses AI to answer questions based on the site's
+  documentation, OpenTelemetry GitHub, Stack Overflow, and other resources. The
+  AI may not always provide accurate or relevant information. Share your
+  thoughts by providing
+  [feedback](https://github.com/open-telemetry/opentelemetry.io/discussions/6802).
 ui_search_ai_popover_content: >-
   <a id='ask-ai-trigger' href='#'>Ask AI</a> (&#x2318;-K)


### PR DESCRIPTION
- Contributes to #8862
- Followup to #8865, which avoided any generated files changes other than whitespace
- This PR fixes the `en` i18n translation formatting so that Prettier can fix indentation etc. All rendered fields are conceptually a single paragraph anyways.
- No change in content