### PR TITLE
Add missing OBI instrumentation configuration options

### DIFF
--- a/content/en/docs/zero-code/obi/configure/export-data.md
+++ b/content/en/docs/zero-code/obi/configure/export-data.md
@@ -111,7 +111,7 @@ The list of instrumentation areas OBI can collection data from:
 - `sql`: SQL database client call metrics
 - `redis`: Redis client/server database metrics
 - `kafka`: Kafka client/server message queue metrics
-- `gpu`: GPU usage metrics
+- `gpu`: GPU performance metrics
 - `mongo`: MongoDB client call metrics
 - `dns`: DNS query metrics
 


### PR DESCRIPTION
Document all [instrumentation options](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/70c388d41aee6375cdb019352a2e6fa404878813/pkg/export/instrumentations/instr_options.go#L9-L17) available for OBI.