### PR TITLE
Add FusionCache to registry

### DIFF
--- a/data/registry/instrumentation-dotnet-fusioncache.yml
+++ b/data/registry/instrumentation-dotnet-fusioncache.yml
@@ -8,7 +8,8 @@ tags:
   - .net
 license: MIT
 description:
-  By using OpenTelemetry with FusionCache, you can gain insights into the performance of your systems and how caching is performing
+  By using OpenTelemetry with FusionCache, you can gain insights into the
+  performance of your systems and how caching is performing
 authors:
   - name: Jody Donetti
     url: https://github.com/jodydonetti

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -3967,6 +3967,14 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-03T09:54:59.549264971Z"
   },
+  "https://github.com/ZiggyCreatures/FusionCache": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-12T09:45:37.324971283Z"
+  },
+  "https://github.com/ZiggyCreatures/FusionCache/blob/main/docs/OpenTelemetry.md": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-12T09:41:07.374973847Z"
+  },
   "https://github.com/a-feld": {
     "StatusCode": 206,
     "LastSeen": "2026-01-30T09:53:43.150747728Z"
@@ -5902,6 +5910,10 @@
   "https://github.com/jodeev": {
     "StatusCode": 206,
     "LastSeen": "2026-01-30T09:52:38.680617249Z"
+  },
+  "https://github.com/jodydonetti": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-12T09:45:39.685564578Z"
   },
   "https://github.com/johannaojeling": {
     "StatusCode": 206,
@@ -21690,6 +21702,10 @@
   "https://www.nuget.org/packages/ThrottlingTroll": {
     "StatusCode": 200,
     "LastSeen": "2026-02-11T10:00:30.947282742Z"
+  },
+  "https://www.nuget.org/packages/ZiggyCreatures.FusionCache": {
+    "StatusCode": 200,
+    "LastSeen": "2026-02-12T09:45:39.878873563Z"
   },
   "https://www.nuget.org/packages/log4net": {
     "StatusCode": 200,


### PR DESCRIPTION
- [x] I have read and followed the
      [contribution guidelines](https://opentelemetry.io/docs/contributing/),
      including the **First-time contributing?** note.

## Description

FusionCache is an easy to use, fast and robust .NET hybrid cache with advanced resiliency features.

Since FusionCache natively supports OpenTelemetry ([docs](https://github.com/ZiggyCreatures/FusionCache/blob/main/docs/OpenTelemetry.md)), I'm proposing adding it to the registry.

## Pending Questions

Since FusionCache is a .NET library, it natively supports `ActivitySource`, `Activity`, `Meter` and `Counter` as a native bridge to OpenTelemetry: this way it does not require any custom package to work with it.

Because of this, in the YAML file I marked it as "native" and as the Nuget package I simply specified the [main one](https://www.nuget.org/packages/ZiggyCreatures.FusionCache/).

Having said that, I also created a [specific package](https://www.nuget.org/packages/ZiggyCreatures.FusionCache.OpenTelemetry/) to offer a more native experience for people wanting to explicitly use OpenTelemetry: this package offers a setup experience in line with the standard OTEL experience in .NET, like this:

```c#
services.AddOpenTelemetry()
  // SETUP TRACES
  .WithTracing(tracing => tracing
    .AddFusionCacheInstrumentation()
    .AddConsoleExporter()
  )
  // SETUP METRICS
  .WithMetrics(metrics => metrics
    .AddFusionCacheInstrumentation()
    .AddConsoleExporter()
  );
```

This is not strictly needed, but it's still nice to have.

So my question is: what should I do?

Meaning, one of:
- keep the YAML file as-is, simply stating the native experience without the separate package?
- create an additional YAML file for the separate package?
- somehow list both in one YAMl file? (I don't know if it's possible to list multiple entries in the `package` element in the YAML file)

I'm adding the PR as draft to resolve this, please let me know.

Thanks!