### PR TITLE
Update adjust-pages.pl: drop obsolete patch, adjust apply cond for others

### DIFF
--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -155,24 +155,12 @@ sub patchSpec_because_of_SpecName_SomeDescription_AsTemplate() {
   }{$1/v1.52/$3}gx;
 }
 
-sub patchSpec_because_of_SemConv_DockerAPIVersions() {
-  return unless
-    # Restrict the patch to the proper spec, and section or file:
-    $ARGV =~ m|^tmp/semconv/docs/|
-    &&
-    applyPatchOrPrintMsgIf('2025-11-21-docker-api-versions', 'semconv', '1.38.0');
-
-  s{
-    (https://docs.docker.com/reference/api/engine/version)/v1.(43|51)/(\#tag/)
-  }{$1/v1.52/$3}gx;
-}
-
 sub patchSpec_because_of_SemConv_DatabaseRenamedToDb() {
   return unless
     # Restrict the patch to the proper spec, and section or file:
     # Note that here we replace links into semconv from the spec
     $ARGV =~ m|^tmp/otel/specification/|
-      && applyPatchOrPrintMsgIf('2025-11-26-database-section-renamed-to-db', 'semconv', '1.39.0');
+      && applyPatchOrPrintMsgIf('2025-11-26-database-section-renamed-to-db', 'spec', '1.53.0');
 
   # Give infor about the patch, see:
   # https://github.com/open-telemetry/opentelemetry.io/pull/8311#issue-3577941378
@@ -184,12 +172,13 @@ sub patchSpec_because_of_SemConv_DatabaseRenamedToDb() {
 sub patchSpec_because_of_SemConv_MetricRPCServerDurationRenamedToMetricRPCServerCallDuration() {
   return unless
     $ARGV =~ m|^tmp/otel/specification/|
-      && applyPatchOrPrintMsgIf('2025-12-05-metric-rpc-server-duration-renamed-to-rpc-server-call-duration', 'semconv', '1.39.0');
+      && applyPatchOrPrintMsgIf('2025-12-05-metric-rpc-server-duration-renamed-to-rpc-server-call-duration', 'spec', '1.53.0');
 
   # Give infor about the patch, see:
   # https://github.com/open-telemetry/opentelemetry-specification/pull/4778
 
   # Replace the old metric anchor with the new one
+  # cSpell:disable-next-line
   s|#metric-rpcserverduration|#metric-rpcservercallduration|g;
 }
 
@@ -278,8 +267,6 @@ while(<>) {
     s|(\]\()/docs/|$1$specBasePath/semconv/|g;
     s|(\]:\s*)/docs/|$1$specBasePath/semconv/|;
     s|\((/model/.*?)\)|($semconvSpecRepoUrl/tree/v$semconvVers/$1)|g;
-
-    patchSpec_because_of_SemConv_DockerAPIVersions();
   }
 
 


### PR DESCRIPTION
- Drops obsolete patch
- Fixes the apply conditions for the remaining patches -- they need to gate on the spec not semconv because the affected links are in the spec
- Contributes to #8873

/cc @vitorvasc 