### PR TITLE
chore: start using blockquote alert syntax

### DIFF
--- a/content/en/_includes/otel-does-not-validate-3rd-pty-distros.md
+++ b/content/en/_includes/otel-does-not-validate-3rd-pty-distros.md
@@ -1,9 +1,7 @@
 ---
 ---
 
-{{% alert title="Disclaimer" color="warning" %}}
-
-OpenTelemetry **does not validate or endorse** the third-party distributions
-listed below. This list is provided as a convenience for the community.
-
-{{% /alert %}}
+> [!WARNING] Disclaimer
+>
+> OpenTelemetry **does not validate or endorse** the third-party distributions
+> listed below. This list is provided as a convenience for the community.

--- a/layouts/_markup/render-blockquote-alert.html
+++ b/layouts/_markup/render-blockquote-alert.html
@@ -16,7 +16,7 @@
 -}}
 
 <div class="alert alert-{{ $alertClass }}" role="alert">
-{{ with $title -}}
+{{- with $title -}}
   <div class="h4 alert-heading" role="heading">
     {{- . -}}
   </div>


### PR DESCRIPTION
- Contributes to #8862
- Adjusts the render hook spacing so that it matches the Docsy alert shortcode. This will make it easier to confirm that the HTML rendered for alerts are unchanged after the change in syntax
- Updates the syntax of one alert as a test
- There is no change in the generated HTML for the pages using the include with the updated alert syntax

**Preview**: https://deploy-preview-8886--opentelemetry.netlify.app/ecosystem/distributions/