### PR TITLE
docs(python): add Windows support to Getting Started guide

### DIFF
--- a/content/en/docs/languages/python/getting-started.md
+++ b/content/en/docs/languages/python/getting-started.md
@@ -20,9 +20,8 @@ Ensure that you have the following installed locally:
 
 > [!NOTE]
 >
-> On Windows, Python is typically invoked using `python` rather than
-> `python3`. The following examples show the correct commands for your
-> operating system.
+> On Windows, Python is typically invoked using `python` rather than `python3`.
+> The following examples show the correct commands for your operating system.
 
 ## Example Application
 


### PR DESCRIPTION
- [x] I have read and followed the
      [contribution guidelines](https://opentelemetry.io/docs/contributing/),
      including the **First-time contributing?** note.
- [ ] This PR includes **AI generated content**, and I have read and conform to
      the
      [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).

### Summary
This PR adds Windows-specific commands to the Python Getting Started guide, improving the experience for Windows users by providing explicit instructions for both PowerShell and Command Prompt.

Added Windows-specific commands (PowerShell and Command Prompt) to the Python Getting Started guide using tabpane, similar to how it's done in the .NET and Node.js getting started docs. The main changes are adding tabs wherever there are shell commands that differ between platforms - like setting environment variables, activating the virtual environment, and running the Docker collector. Also added a small note in Prerequisites about python vs python3 on Windows, since that confuses a lot of newcomers.

Preview: https://deploy-preview-8887--opentelemetry.netlify.app/docs/languages/python/getting-started/

Fixes #8750 

### References

- Followed existing `tabpane` patterns used in other documentation, such as:
  - https://opentelemetry.io/docs/zero-code/dotnet/getting-started/
  - https://opentelemetry.io/docs/languages/js/getting-started/nodejs/
- UX inspiration referenced from Tailwind CSS installation documentation as discussed in the comments for this issue.
