### PR TITLE
chore: rewrite in Hugo syntax all note alerts with custom colors or titles

### DIFF
--- a/content/en/blog/2024/kubecon-eu.md
+++ b/content/en/blog/2024/kubecon-eu.md
@@ -87,16 +87,14 @@ from 9:00 - 17:35. There will be several sessions on OpenTelemetry as well:
 - **[OpAMP in Action: User Configurable Observability Pipelines](https://sched.co/1YFk6)**<br>
   by Srikanth Chekuri, SigNoz<br> Tuesday, March 19th • 17:00 - 17:25
 
-{{% alert title="Important access note" color="danger" %}}
-
-You need an _in-person all-access_ pass for on-site access to **Observability
-Day**. For details, see [KubeCon registration]. If you have a virtual ticket,
-you will be able to follow **Observability Day** through a live stream.
+> [!IMPORTANT] Important access note
+>
+> You need an _in-person all-access_ pass for on-site access to **Observability
+> Day**. For details, see [KubeCon registration]. If you have a virtual ticket,
+> you will be able to follow **Observability Day** through a live stream.
 
 [kubecon registration]:
   https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/register/
-
-{{% /alert %}}
 
 ## OpenTelemetry Observatory
 

--- a/content/en/blog/2025/expose-otel-collector-gateway-api/index.md
+++ b/content/en/blog/2025/expose-otel-collector-gateway-api/index.md
@@ -69,15 +69,13 @@ Before we start, ensure you have the following:
     [CLI](https://github.com/openssl/openssl/wiki/Binaries) for generating
     certificates.
 
-{{% alert title="API stability note" color=warning %}}
-
-Since certain parts of the Gateway API are still in alpha/beta phase, the
-support for specific aspects may vary or may not be enabled by default. Please
-refer to the documentation of the Gateway implementation that you are using. For
-example, at the time of writing, if you are using Istio, ensure that
-`PILOT_ENABLE_ALPHA_GATEWAY_API` is enabled during the install.
-
-{{% /alert %}}
+> [!WARNING] API stability note
+>
+> Since certain parts of the Gateway API are still in alpha/beta phase, the
+> support for specific aspects may vary or may not be enabled by default. Refer
+> to the documentation of the Gateway implementation that you are using. For
+> example, at the time of writing, if you are using Istio, ensure that
+> `PILOT_ENABLE_ALPHA_GATEWAY_API` is enabled during the install.
 
 ## What is the Kubernetes Gateway API?
 

--- a/content/en/blog/2025/kubecon-eu.md
+++ b/content/en/blog/2025/kubecon-eu.md
@@ -113,12 +113,10 @@ cloud native observability projects. This event will be held on Tuesday, April
 1, 2025, from 9:00 - 17:25. There will be several sessions on OpenTelemetry as
 well.
 
-{{% alert title="Important access note" color="danger" %}}
-
-You need an _all-access_ pass to attend **Observability Day**. For details, see
-[KubeCon registration][registration].
-
-{{% /alert %}}
+> [!IMPORTANT] Important access note
+>
+> You need an _all-access_ pass to attend **Observability Day**. For details,
+> see [KubeCon registration][registration].
 
 - **[Sponsored Keynote: The Future of Observability: Trends, AI, and New Relic’s Vision for a Smarter Stack](https://sched.co/1u5jm)**<br>
   by Harry Kimpel, New Relic<br> Tuesday, April 1 • 10:00 - 10:05

--- a/content/en/blog/2025/kubecon-na.md
+++ b/content/en/blog/2025/kubecon-na.md
@@ -118,13 +118,11 @@ enrich their projects. Prepared talks, project meetings, and unconference
 sessions run from 9:00 to 17:00. See the [full schedule][summit schedule] for
 all the details. [Sign up][maintainer summit] today!
 
-{{% alert title="Important access note" %}}
-
-You must be registered for KubeCon + CloudNativeCon to access the **Maintainer
-Summit**. You also must be a member of a CNCF incubating project, such as
-OpenTelemetry. For eligibility requirements, see [Maintainer Summit].
-
-{{% /alert %}}
+> [!IMPORTANT] Important access note
+>
+> You must be registered for KubeCon + CloudNativeCon to access the **Maintainer
+> Summit**. You also must be a member of a CNCF incubating project, such as
+> OpenTelemetry. For eligibility requirements, see [Maintainer Summit][].
 
 ## Observability Day
 
@@ -133,12 +131,10 @@ with a focus on cloud native observability projects. This event will be held on
 November 10, 2025 from 9:00 to 18:00. Look for your favorite talks about
 Observability and OpenTelemetry in the [schedule][obs-day-sched].
 
-{{% alert title="Important access note" %}}
-
-You need an _all-access_ pass to attend **Observability Day**. For details, see
-[KubeCon registration].
-
-{{% /alert %}}
+> [!IMPORTANT] Important access note
+>
+> You need an _all-access_ pass to attend **Observability Day**. For details,
+> see [KubeCon registration][].
 
 ## OpenTelemetry Observatory
 

--- a/content/en/docs/zero-code/dotnet/_index.md
+++ b/content/en/docs/zero-code/dotnet/_index.md
@@ -143,15 +143,17 @@ Install-OpenTelemetryCore
 Register-OpenTelemetryForWindowsService -WindowsServiceName "WindowsServiceName" -OTelServiceName "MyServiceDisplayName"
 ```
 
-{{% alert title="Note" color="warning" %}}
-`Register-OpenTelemetryForWindowsService` performs a service restart.
-{{% /alert %}}
+> [!CAUTION]
+>
+> `Register-OpenTelemetryForWindowsService` performs a service restart.
 
 ### Configuration for Windows Service
 
-{{% alert title="Note" color="warning" %}} Remember to restart the Windows
-Service after making configuration changes. You can do it by running
-`Restart-Service -Name $WindowsServiceName -Force` in PowerShell. {{% /alert %}}
+> [!IMPORTANT]
+>
+> Remember to restart the Windows Service after making configuration changes.
+> You can do it by running `Restart-Service -Name $WindowsServiceName -Force` in
+> PowerShell.
 
 For .NET Framework applications you can configure
 [the most common `OTEL_` settings](/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration)
@@ -176,8 +178,9 @@ Var2=Value2
 
 ## Instrument an ASP.NET application deployed on IIS
 
-{{% alert title="Note" color="warning" %}} The following instructions apply to
-.NET Framework applications. {{% /alert %}}
+> [!NOTE]
+>
+> The following instructions apply to .NET Framework applications.
 
 Use the `OpenTelemetry.DotNet.Auto.psm1` PowerShell module to set up automatic
 instrumentation for IIS:
@@ -193,13 +196,15 @@ Install-OpenTelemetryCore
 Register-OpenTelemetryForIIS
 ```
 
-{{% alert title="Note" color="warning" %}} `Register-OpenTelemetryForIIS`
-performs an IIS restart. {{% /alert %}}
+> [!CAUTION]
+>
+> `Register-OpenTelemetryForIIS` performs an IIS restart.
 
 ### Configuration for ASP.NET applications
 
-{{% alert title="Note" color="warning" %}} The following instructions apply to
-.NET Framework applications. {{% /alert %}}
+> [!NOTE]
+>
+> The following instructions apply to .NET Framework applications.
 
 For ASP.NET applications you can configure
 [the most common `OTEL_` settings](/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration)
@@ -214,8 +219,10 @@ For ASP.NET Core application you can use the
 elements inside the `<aspNetCore>` block of your `Web.config` file to set
 configuration via environment variables.
 
-{{% alert title="Note" color="warning" %}} Remember to restart IIS after making
-configuration changes. You can do it by executing `iisreset.exe`. {{% /alert %}}
+> [!IMPORTANT]
+>
+> Remember to restart IIS after making configuration changes. You can do it by
+> executing `iisreset.exe`.
 
 ### Advanced configuration
 
@@ -227,9 +234,10 @@ pools.
 Consider setting common environment variables, for all applications deployed to
 IIS by setting the environment variables for `W3SVC` and `WAS` Windows Services.
 
-{{% alert title="Note" color="warning" %}} For IIS versions older than 10.0, you
-can consider creating a distinct user, set its environment variables and use it
-as the application pool user. {{% /alert %}}
+> [!TIP]
+>
+> For IIS versions older than 10.0, you can consider creating a distinct user,
+> set its environment variables and use it as the application pool user.
 
 ## NuGet package
 
@@ -254,11 +262,14 @@ To see the full range of configuration options, see
 
 ## Log to trace correlation
 
-{{% alert title="Note" color="warning" %}} Automatic log to trace correlation
-provided by OpenTelemetry .NET Automatic Instrumentation currently works only
-for .NET applications using `Microsoft.Extensions.Logging`. See
-[#2310](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/2310)
-for more details. {{% /alert %}}
+> [!NOTE]
+>
+> Automatic log to trace correlation provided by OpenTelemetry .NET Automatic
+> Instrumentation currently works only for .NET applications using
+> `Microsoft.Extensions.Logging`. For more details, see [#2310].
+
+[#2310]:
+  https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/2310
 
 OpenTelemetry .NET SDK automatically correlates logs to trace data. When logs
 are emitted in the context of an active trace, trace context
@@ -324,15 +335,15 @@ so no explicit uninstallation is required.
 
 On Windows, use the PowerShell module as an Administrator.
 
-{{% alert title="Version note" color="warning" %}}
+> [!IMPORTANT] Version note
+>
+> Windows [PowerShell Desktop][] (v5.1) is required. Other [versions], including
+> PowerShell Core (v6.0+) are not supported at this time.
 
-Windows
-[PowerShell Desktop](https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_windows_powershell_5.1#powershell-editions)
-(v5.1) is required. Other
-[versions](https://learn.microsoft.com/previous-versions/powershell/scripting/overview),
-including PowerShell Core (v6.0+) are not supported at this time.
-
-{{% /alert %}}
+[PowerShell Desktop]:
+  https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_windows_powershell_5.1#powershell-editions
+[versions]:
+  https://learn.microsoft.com/previous-versions/powershell/scripting/overview
 
 ```powershell
 # PowerShell 5.1 is required

--- a/content/en/docs/zero-code/dotnet/custom.md
+++ b/content/en/docs/zero-code/dotnet/custom.md
@@ -43,9 +43,11 @@ To create your custom traces manually, follow these steps:
    `Examples.ManualInstrumentations.Registered` or to
    `Examples.ManualInstrumentations.*`, which registers the entire prefix.
 
-{{% alert title="Note" color="warning" %}} An `Activity` created for
-`NonRegistered.ManualInstrumentations` `ActivitySource` is not handled by the
-OpenTelemetry Automatic Instrumentation. {{% /alert %}}
+> [!WARNING]
+>
+> An `Activity` created for `NonRegistered.ManualInstrumentations`
+> `ActivitySource` is not handled by the OpenTelemetry Automatic
+> Instrumentation.
 
 ## Metrics
 

--- a/content/en/docs/zero-code/java/agent/disable.md
+++ b/content/en/docs/zero-code/java/agent/disable.md
@@ -26,11 +26,13 @@ to have more control of which instrumentation is applied.
 {{% config_option name="otel.instrumentation.[name].enabled" %}} Set to `true`
 to enable each desired instrumentation individually. {{% /config_option %}}
 
-{{% alert title="Note" color="warning" %}} Some instrumentation relies on other
-instrumentation to function properly. When selectively enabling instrumentation,
-be sure to enable the transitive dependencies too. Determining this dependency
-relationship is left as an exercise to the user. This is considered advanced
-usage and is not recommended for most users. {{% /alert %}}
+> [!WARNING]
+>
+> Some instrumentation relies on other instrumentation to function properly.
+> When selectively enabling instrumentation, be sure to enable the transitive
+> dependencies too. Determining this dependency relationship is left as an
+> exercise to the user. This is considered advanced usage and is not recommended
+> for most users.
 
 ## Enable manual instrumentation only
 


### PR DESCRIPTION
- Followup to #8894
- Contributes to #8895
- Converts remaining `en` alerts with a note title, but that also had a custom color or title (like "foo note")
- Some very minor copyedits

**Preview**: for example, see the many alerts in https://deploy-preview-8901--opentelemetry.netlify.app/docs/zero-code/dotnet/
