### PR TITLE
chore: rewrite in Hugo syntax all note alerts with bare titles

### DIFF
--- a/content/en/docs/_includes/exporters/intro.md
+++ b/content/en/docs/_includes/exporters/intro.md
@@ -42,13 +42,11 @@ them up.
 
 {{ if $zeroConfigPageExists }}
 
-{{% alert title=Note %}}
-
-If you use [zero-code instrumentation](</docs/zero-code/{{ $langIdAsPath }}>),
-you can learn how to set up exporters by following the
-[Configuration Guide](</docs/zero-code/{{ $langIdAsPath }}/configuration/>).
-
-{{% /alert %}}
+> [!NOTE]
+>
+> If you use [zero-code instrumentation](</docs/zero-code/{{ $langIdAsPath }}>),
+> you can learn how to set up exporters by following the
+> [Configuration Guide](</docs/zero-code/{{ $langIdAsPath }}/configuration/>).
 
 {{ end }}
 
@@ -58,13 +56,11 @@ you can learn how to set up exporters by following the
 
 ### Collector Setup
 
-{{% alert title=Note %}}
-
-If you have a OTLP collector or backend already set up, you can skip this
-section and [setup the OTLP exporter dependencies](#otlp-dependencies) for your
-application.
-
-{{% /alert %}}
+> [!NOTE]
+>
+> If you have a OTLP collector or backend already set up, you can skip this
+> section and [setup the OTLP exporter dependencies](#otlp-dependencies) for
+> your application.
 
 To try out and verify your OTLP exporters, you can run the collector in a docker
 container that writes telemetry directly to the console.

--- a/content/en/docs/languages/_includes/exporters/prometheus-setup.md
+++ b/content/en/docs/languages/_includes/exporters/prometheus-setup.md
@@ -8,13 +8,11 @@ Prometheus text format on request.
 
 ### Backend Setup {#prometheus-setup}
 
-{{% alert title=Note %}}
-
-If you have Prometheus or a Prometheus-compatible backend already set up, you
-can skip this section and setup the [Prometheus](#prometheus-dependencies) or
-[OTLP](#otlp-dependencies) exporter dependencies for your application.
-
-{{% /alert %}}
+> [!NOTE]
+>
+> If you have Prometheus or a Prometheus-compatible backend already set up, you
+> can skip this section and setup the [Prometheus](#prometheus-dependencies) or
+> [OTLP](#otlp-dependencies) exporter dependencies for your application.
 
 You can run [Prometheus](https://prometheus.io) in a docker container,
 accessible on port `9090` by following these instructions:
@@ -35,13 +33,11 @@ Run Prometheus in a docker container with the UI accessible on port `9090`:
 docker run --rm -v ${PWD}/prometheus.yml:/prometheus/prometheus.yml -p 9090:9090 prom/prometheus --web.enable-otlp-receiver
 ```
 
-{{% alert title=Note %}}
-
-When using Prometheus' OTLP Receiver, make sure that you set the OTLP endpoint
-for metrics in your application to `http://localhost:9090/api/v1/otlp`.
-
-Not all docker environments support `host.docker.internal`. In some cases you
-may need to replace `host.docker.internal` with `localhost` or the IP address of
-your machine.
-
-{{% /alert %}}
+> [!NOTE]
+>
+> When using Prometheus' OTLP Receiver, make sure that you set the OTLP endpoint
+> for metrics in your application to `http://localhost:9090/api/v1/otlp`.
+>
+> Not all docker environments support `host.docker.internal`. In some cases you
+> may need to replace `host.docker.internal` with `localhost` or the IP address
+> of your machine.

--- a/content/en/docs/languages/_includes/exporters/zipkin-setup.md
+++ b/content/en/docs/languages/_includes/exporters/zipkin-setup.md
@@ -2,13 +2,11 @@
 
 ### Backend Setup {#zipkin-setup}
 
-{{% alert title=Note %}}
-
-If you have Zipkin or a Zipkin-compatible backend already set up, you can skip
-this section and setup the [Zipkin exporter dependencies](#zipkin-dependencies)
-for your application.
-
-{{% /alert %}}
+> [!NOTE]
+>
+> If you have Zipkin or a Zipkin-compatible backend already set up, you can skip
+> this section and setup the
+> [Zipkin exporter dependencies](#zipkin-dependencies) for your application.
 
 You can run [Zipkin](https://zipkin.io/) on in a Docker container by executing
 the following command:

--- a/scripts/docsy-alerts-to-md/convert.pl
+++ b/scripts/docsy-alerts-to-md/convert.pl
@@ -11,7 +11,7 @@ use strict;
 use warnings;
 use FileHandle;
 
-my $ALERT_OPEN = qr/\{\{%\s*alert\s+title="Notes?"\s*%\}\}/;
+my $ALERT_OPEN = qr/\{\{%\s*alert\s+title="?Notes?"?\s*%\}\}/;
 my $ALERT_CLOSE = qr/\{\{%\s*\/alert\s*%\}\}/;
 
 sub has_html_shortcode {

--- a/scripts/docsy-alerts-to-md/test.js
+++ b/scripts/docsy-alerts-to-md/test.js
@@ -34,7 +34,7 @@ function runConvert(input) {
 
 // Test 2: Multi-line alert with blank lines
 {
-  const input = `{{% alert title="Note" %}}
+  const input = `{{% alert title=Note %}}
 
 Some content here
 spanning multiple lines.


### PR DESCRIPTION
- Contributes to #8895
- Rewrites to Hugo alert syntax the remaining Docsy alerts with `title=Note` (w/o quotes)
- Updated helper script to handle the case where `title=Note` (w/o quotes)

After the rewrite to GFM syntax, but before fixing the formatting, there were no changes to the generated site pages (other than the timestamp):

```console
$ (cd public && git diff -bw --ignore-blank-lines -- ':(exclude)*.xml') | grep ^diff                                                
diff --git a/site/index.html b/site/index.html
```