### PR TITLE
[ja] docs(i18n): Update drifted content under ` content/ja/docs/languages/ruby/`

### DIFF
--- a/content/ja/docs/languages/ruby/_index.md
+++ b/content/ja/docs/languages/ruby/_index.md
@@ -1,12 +1,11 @@
 ---
 title: Ruby
 description: >
-  <img width="35" class="img-initial" src="/img/logos/32x32/Ruby_SDK.svg"
-  alt="Ruby"> RubyにおけるOpenTelemetryの言語固有の実装。
+  <img width="35" class="img-initial otel-icon"
+  src="/img/logos/32x32/Ruby_SDK.svg" alt="Ruby"> RubyにおけるOpenTelemetryの言語固有の実装。
 aliases: [/ruby, /ruby/metrics, /ruby/tracing]
 weight: 24
-default_lang_commit: 06837fe15457a584f6a9e09579be0f0400593d57
-drifted_from_default: true
+default_lang_commit: 3d401ad8e2e5d528c107d83d202b4c6f62c020ef
 ---
 
 {{% docs/languages/index-intro ruby /%}}

--- a/content/ja/docs/languages/ruby/exporters.md
+++ b/content/ja/docs/languages/ruby/exporters.md
@@ -1,8 +1,7 @@
 ---
 title: エクスポーター
 weight: 50
-default_lang_commit: 5db74ea69e5f5f8918cf2ef2030560bd083a7cda
-drifted_from_default: true
+default_lang_commit: 5a3937c47b391b207465e0e464006f3b03bf242f
 ---
 
 {{% docs/languages/exporters/intro %}}
@@ -70,6 +69,8 @@ docker run -d --name jaeger \
   -p 9411:9411 \
   jaegertracing/all-in-one:latest
 ```
+
+ブラウザで`localhost:16686`にアクセスして、JaegerのトレースUIを介してトレースを視覚化できます。
 
 ## Zipkin {#zipkin}
 


### PR DESCRIPTION
- [x] I have read and followed the
      [contribution guidelines](https://opentelemetry.io/docs/contributing/),
      including the **First-time contributing?** note.
- [ ] This PR includes **AI generated content**, and I have read and conform to
      the
      [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).

---

### `content/ja/docs/languages/ruby/_index.md`

https://deploy-preview-8903--opentelemetry.netlify.app/ja/docs/languages/ruby/

```diff
diff --git a/content/en/docs/languages/ruby/_index.md b/content/en/docs/languages/ruby/_index.md
index 15ec15d0d..cb9f7d88f 100644
--- a/content/en/docs/languages/ruby/_index.md
+++ b/content/en/docs/languages/ruby/_index.md
@@ -1,8 +1,9 @@
 ---
 title: Ruby
 description: >
-  <img width="35" class="img-initial" src="/img/logos/32x32/Ruby_SDK.svg"
-  alt="Ruby"> A language-specific implementation of OpenTelemetry in Ruby.
+  <img width="35" class="img-initial otel-icon"
+  src="/img/logos/32x32/Ruby_SDK.svg" alt="Ruby"> A language-specific
+  implementation of OpenTelemetry in Ruby.
 aliases: [/ruby, /ruby/metrics, /ruby/tracing]
 weight: 24
 ---

```

### `content/ja/docs/languages/ruby/exporters.md`

https://deploy-preview-8903--opentelemetry.netlify.app/ja/docs/languages/ruby/exporters/

https://github.com/open-telemetry/opentelemetry.io/commit/5a3937c47b391b207465e0e464006f3b03bf242f