### PR TITLE
chore: convert Docsy warnings, cautions, and tips to Hugo Markdown syntax

### DIFF
--- a/content/en/blog/2025/expose-otel-collector-gateway-api/index.md
+++ b/content/en/blog/2025/expose-otel-collector-gateway-api/index.md
@@ -197,16 +197,15 @@ openssl req -newkey rsa:4096 -nodes -keyout client.key -out client.csr -subj "${
 openssl x509 -req -in client.csr -CA rootCA.crt -CAkey rootCA.key -CAcreateserial -out client.crt -days 365 -sha256
 ```
 
-{{% alert title="Warning" color=warning %}}
-
-For production, never use self-signed certificates for external-facing endpoints
-accessible from the public internet. Use certificates issued by a trusted public
-CA (e.g., Let's Encrypt through cert-manager) or a managed internal PKI system.
-The process of obtaining certs would differ, but the concepts of using them in
-Kubernetes remain similar. Ensure the server certificate's Common Name (CN) or
-Subject Alternative Name (SAN) matches the hostname clients use to connect.
-
-{{% /alert %}}
+> [!WARNING]
+>
+> For production, never use self-signed certificates for external-facing
+> endpoints accessible from the public internet. Use certificates issued by a
+> trusted public CA (e.g., Let's Encrypt through cert-manager) or a managed
+> internal PKI system. The process of obtaining certs would differ, but the
+> concepts of using them in Kubernetes remain similar. Ensure the server
+> certificate's Common Name (CN) or Subject Alternative Name (SAN) matches the
+> hostname clients use to connect.
 
 ### Step 3: Create `otel-collector` namespace
 

--- a/content/en/docs/collector/architecture.md
+++ b/content/en/docs/collector/architecture.md
@@ -127,18 +127,16 @@ flowchart LR
   P2 ~~~ M2[...]
 ```
 
-{{% alert title="Important" color="warning" %}}
-
-When the same receiver is referenced in more than one pipeline, the Collector
-creates only one receiver instance at runtime that sends the data to a fan-out
-consumer. The fan-out consumer in turn sends the data to the first processor of
-each pipeline. The data propagation from receiver to the fan-out consumer and
-then to processors is completed using a synchronous function call. This means
-that if one processor blocks the call, the other pipelines attached to this
-receiver are blocked from receiving the same data, and the receiver itself stops
-processing and forwarding newly received data.
-
-{{% /alert %}}
+> [!WARNING]
+>
+> When the same receiver is referenced in more than one pipeline, the Collector
+> creates only one receiver instance at runtime that sends the data to a fan-out
+> consumer. The fan-out consumer in turn sends the data to the first processor
+> of each pipeline. The data propagation from receiver to the fan-out consumer
+> and then to processors is completed using a synchronous function call. This
+> means that if one processor blocks the call, the other pipelines attached to
+> this receiver are blocked from receiving the same data, and the receiver
+> itself stops processing and forwarding newly received data.
 
 ### Exporters
 

--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -65,13 +65,11 @@ otelcol --config=env:MY_CONFIG_IN_AN_ENVVAR --config=https://server/config.yaml
 otelcol --config="yaml:exporters::debug::verbosity: normal"
 ```
 
-{{% alert title="Tip" %}}
-
-When referring to nested keys in YAML paths, make sure to use double colons (::)
-to avoid confusion with namespaces that contain dots. For example:
-`receivers::docker_stats::metrics::container.cpu.utilization::enabled: false`.
-
-{{% /alert %}}
+> [!TIP]
+>
+> When referring to nested keys in YAML paths, make sure to use double colons
+> (`::`) to avoid confusion with namespaces that contain dots. For example:
+> `receivers::docker_stats::metrics::container.cpu.utilization::enabled: false`.
 
 To validate a configuration file, use the `validate` command. For example:
 
@@ -104,19 +102,17 @@ are enabled through the [service](#service) section.
 <a id="endpoint-0.0.0.0-warning"></a> The following is an example of Collector
 configuration with a receiver, a processor, an exporter, and three extensions.
 
-{{% alert title="Important" color="warning" %}}
-
-While it is generally preferable to bind endpoints to `localhost` when all
-clients are local, our example configurations use the "unspecified" address
-`0.0.0.0` as a convenience. The Collector currently defaults to `0.0.0.0`, but
-the default will be changed to `localhost` in the near future. For details
-concerning either of these choices as endpoint configuration value, see
-[Safeguards against denial of service attacks].
+> [!WARNING]
+>
+> While it is generally preferable to bind endpoints to `localhost` when all
+> clients are local, our example configurations use the "unspecified" address
+> `0.0.0.0` as a convenience. The Collector currently defaults to `0.0.0.0`, but
+> the default will be changed to `localhost` in the near future. For details
+> concerning either of these choices as endpoint configuration value, see
+> [Safeguards against denial of service attacks][].
 
 [Safeguards against denial of service attacks]:
   https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md#safeguards-against-denial-of-service-attacks
-
-{{% /alert %}}
 
 ```yaml
 receivers:
@@ -914,17 +910,15 @@ key:
 If you need to represent more complex data structures, the use of YAML is highly
 recommended.
 
-{{% alert title="Important" color="warning" %}}
-
-The `--set` option has the following limitations:
-
-1. Does not support setting a key that contains a dot `.`.
-2. Does not support setting a key that contains an equal sign `=`.
-3. The configuration key separator inside the value part of the property is
-   "::". For example `--set "name={a::b: c}"` is equivalent with
-   `--set name::a::b=c`.
-
-{{% /alert %}}
+> [!CAUTION]
+>
+> The `--set` option has the following limitations:
+>
+> 1. Does not support setting a key that contains a dot `.`.
+> 2. Does not support setting a key that contains an equal sign `=`.
+> 3. The configuration key separator inside the value part of the property is
+>    "::". For example `--set "name={a::b: c}"` is equivalent with
+>    `--set name::a::b=c`.
 
 ## Embedding other configuration providers
 
@@ -977,12 +971,10 @@ extensions:
 
 ## How to examine the final configuration
 
-{{% alert title="Important" color="warning" %}}
-
-This command is an experimental functionality. Its behavior may change with no
-warning.
-
-{{% /alert %}}
+> [!CAUTION]
+>
+> This command is an experimental functionality. Its behavior may change with no
+> warning.
 
 Use `print-config` in the default mode (`--mode=redacted`) and
 `--feature-gates=otelcol.printInitialConfig`:
@@ -1006,12 +998,10 @@ otelcol print-config --mode=unredacted --config=file:examples/local/otel-config.
 
 ### How to print the final configuration in JSON format
 
-{{% alert title="Important" color="warning" %}}
-
-This command is an experimental functionality. Its behavior may change with no
-warning.
-
-{{% /alert %}}
+> [!CAUTION]
+>
+> This command is an experimental functionality. Its behavior may change with no
+> warning.
 
 Use `print-config` with `--format=json` and
 `--feature-gates=otelcol.printInitialConfig`. Note that JSON format is

--- a/content/en/docs/collector/extend/ocb.md
+++ b/content/en/docs/collector/extend/ocb.md
@@ -185,14 +185,12 @@ To configure `ocb`, follow these steps:
          providers-vers %}}
    ```
 
-{{% alert title="Tip" %}}
-
-For a list of components that you can add to your custom Collector, see the
-[OpenTelemetry Registry](/ecosystem/registry/?language=collector). Each registry
-entry contains the full name and version you need to add to your
-`builder-config.yaml`.
-
-{{% /alert %}}
+> [!TIP]
+>
+> For a list of components that you can add to your custom Collector, see the
+> [OpenTelemetry Registry](/ecosystem/registry/?language=collector). Each
+> registry entry contains the full name and version you need to add to your
+> `builder-config.yaml`.
 
 ## Generate the code and build your Collector distribution
 

--- a/content/en/docs/collector/internal-telemetry.md
+++ b/content/en/docs/collector/internal-telemetry.md
@@ -10,17 +10,17 @@ configure it to help you
 [monitor](#use-internal-telemetry-to-monitor-the-collector) and
 [troubleshoot](/docs/collector/troubleshooting/) the Collector.
 
-{{% alert title="Important" color="warning" %}} The Collector uses the
-OpenTelemetry SDK
-[declarative configuration schema](https://github.com/open-telemetry/opentelemetry-configuration)
-for configuring how to export its internal telemetry. This schema is still under
-[development](/docs/specs/otel/document-status/) and may undergo **breaking
-changes** in future releases. We intend to keep supporting older schemas until a
-1.0 schema release is available, and offer a transition period for users to
-update their configurations before dropping pre-1.0 schemas. For details and to
-track progress see
-[issue #10808](https://github.com/open-telemetry/opentelemetry-collector/issues/10808).
-{{% /alert %}}
+> [!WARNING]
+>
+> The Collector uses the OpenTelemetry SDK
+> [declarative configuration schema](https://github.com/open-telemetry/opentelemetry-configuration)
+> for configuring how to export its internal telemetry. This schema is still
+> under [development](/docs/specs/otel/document-status/) and may undergo
+> **breaking changes** in future releases. We intend to keep supporting older
+> schemas until a 1.0 schema release is available, and offer a transition period
+> for users to update their configurations before dropping pre-1.0 schemas. For
+> details and to track progress see
+> [issue #10808](https://github.com/open-telemetry/opentelemetry-collector/issues/10808).
 
 ## Activate internal telemetry in the Collector
 
@@ -238,12 +238,10 @@ service:
 
 The Collector does not expose traces by default, but it can be configured to.
 
-{{% alert title="Caution" color="warning" %}}
-
-Internal tracing is an experimental feature, and no guarantees are made as to
-the stability of the emitted span names and attributes.
-
-{{% /alert %}}
+> [!CAUTION]
+>
+> Internal tracing is an experimental feature, and no guarantees are made as to
+> the stability of the emitted span names and attributes.
 
 The following configuration can be used to emit internal traces from the
 Collector to an OTLP backend:

--- a/content/en/docs/collector/resiliency.md
+++ b/content/en/docs/collector/resiliency.md
@@ -58,12 +58,12 @@ sending queue.
         max_elapsed_time: 10m # Increase max retry time (default 300s)
   ```
 
-{{% alert title="Tip: Use sending queues for remote exporters" %}} Enable
-sending queues for any exporter sending data over a network. Adjust `queue_size`
-and `max_elapsed_time` based on expected data volume, available Collector
-memory, and acceptable downtime for the endpoint. Monitor queue metrics
-(`otelcol_exporter_queue_size`, `otelcol_exporter_queue_capacity`).
-{{% /alert %}}
+> [!TIP] Tip: Use sending queues for remote exporters
+>
+> Enable sending queues for any exporter sending data over a network. Adjust
+> `queue_size` and `max_elapsed_time` based on expected data volume, available
+> Collector memory, and acceptable downtime for the endpoint. Monitor queue
+> metrics (`otelcol_exporter_queue_size`, `otelcol_exporter_queue_capacity`).
 
 ## Persistent storage (write-ahead log - WAL)
 
@@ -103,11 +103,12 @@ restarts, you can enable persistent storage for the sending queue using the
         exporters: [otlp]
   ```
 
-{{% alert title="Tip: Use WALs for selected Collectors" %}} Use persistent
-storage for critical Collectors (like Gateway instances or Agents collecting
-crucial data) where data loss due to Collector crashes is unacceptable. Ensure
-the chosen directory has sufficient disk space and appropriate permissions.
-{{% /alert %}}
+> [!TIP] Tip: Use WALs for selected Collectors
+>
+> Use persistent storage for critical Collectors (like Gateway instances or
+> Agents collecting crucial data) where data loss due to Collector crashes is
+> unacceptable. Ensure the chosen directory has sufficient disk space and
+> appropriate permissions.
 
 ## Message queues
 
@@ -172,12 +173,13 @@ backend, you can introduce a dedicated message queue like Kafka.
           exporters: [otlp]
     ```
 
-{{% alert title="Tip: Use message queues for critical hops" %}} Use a message
-queue for critical data paths requiring high durability, especially across
-network boundaries (e.g., between data centers, availability zones, or to a
-cloud vendor). This approach leverages the robust, built-in resilience of
-systems like Kafka but adds operational complexity and requires expertise in
-managing the message queue system. {{% /alert %}}
+> [!TIP] Tip: Use message queues for critical hops
+>
+> Use a message queue for critical data paths requiring high durability,
+> especially across network boundaries (e.g., between data centers, availability
+> zones, or to a cloud vendor). This approach leverages the robust, built-in
+> resilience of systems like Kafka but adds operational complexity and requires
+> expertise in managing the message queue system.
 
 ## Circumstances of data loss
 

--- a/content/en/docs/contributing/_index.md
+++ b/content/en/docs/contributing/_index.md
@@ -5,34 +5,30 @@ sidebar_root_for: self
 weight: 980
 cascade:
   chooseAnIssueAtYourLevel: |
-    Make sure to [choose an issue] that matches your level of **experience** and
-    **understanding** of OpenTelemetry. Avoid overreaching your capabilities.
+    Make sure to [choose an issue][] that matches your level of **experience**
+    and **understanding** of OpenTelemetry. Avoid overreaching your capabilities.
   _issues: https://github.com/open-telemetry/opentelemetry.io/issues
   _issue: https://github.com/open-telemetry/opentelemetry.io/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A
 ---
 
-{{% alert title="Thank you for your interest!" color=success %}}
-
-Thank you for your interest in contributing to the OpenTelemetry docs and
-website.
-
-{{% /alert %}}
+> [!TIP] Thank you for your interest!
+>
+> Thank you for your interest in contributing to the OpenTelemetry docs and
+> website.
 
 ## <i class='far fa-exclamation-triangle text-warning '></i> First time contributing? {#first-time-contributing}
 
-- **[Choose an issue]** with the following labels:
+- **[Choose an issue][]** with the following labels:
   - [Good first issue](<{{% param _issue %}}%22good+first+issue%22>)
   - [Help wanted](<{{% param _issue %}}%3A%22help+wanted%22>)
 
-  {{% alert title="We do not assign issues" color="warning" %}}
-
-  We **_do not_ assign issues** to those who have not already made contributions
-  to the [OpenTelemetry organization][org], unless part of a confirmed
-  mentorship or onboarding process.
-
-  [org]: https://github.com/open-telemetry
-
-  {{% /alert %}}
+  > [!WARNING] We do not assign issues
+  >
+  > We **_do not_ assign issues** to those who have not already made
+  > contributions to the [OpenTelemetry organization][org], unless part of a
+  > confirmed mentorship or onboarding process.
+  >
+  > [org]: https://github.com/open-telemetry
 
 - {{% param chooseAnIssueAtYourLevel %}}
 

--- a/content/en/docs/contributing/development.md
+++ b/content/en/docs/contributing/development.md
@@ -9,14 +9,12 @@ what-next: >
 weight: 60
 ---
 
-{{% alert title="Supported build environments" color=warning %}}
-
-Builds are officially supported on Linux-based environments and macOS. Other
-environments, such as [DevContainers](#devcontainers), are supported on a
-best-effort basis. For builds on Windows, you can follow steps similar to those
-for Linux using Windows Subsystem for Linux command line [WSL][windows-wsl].
-
-{{% /alert %}}
+> [!WARNING] Supported build environments
+>
+> Builds are officially supported on Linux-based environments and macOS. Other
+> environments, such as [DevContainers](#devcontainers), are supported on a
+> best-effort basis. For builds on Windows, you can follow steps similar to
+> those for Linux using Windows Subsystem for Linux command line [WSL][].
 
 The following instructions explain how to set up a development environment for
 this website.
@@ -179,8 +177,4 @@ such as (in alphabetical order):
 [nvm]:
   https://github.com/nvm-sh/nvm/blob/master/README.md#installing-and-updating
 [nvm-windows]: https://github.com/coreybutler/nvm-windows
-[windows-wsl]: https://learn.microsoft.com/en-us/windows/wsl/install
-
-<!-- markdownlint-disable link-image-reference-definitions -->
-
-[Submitting content]: ../pull-requests/
+[WSL]: https://learn.microsoft.com/en-us/windows/wsl/install

--- a/content/en/docs/contributing/issues.md
+++ b/content/en/docs/contributing/issues.md
@@ -16,11 +16,9 @@ issue.
 1. Browse through the list of [issues]({{% param _issues %}}).
 2. Select an issue that you would like to work on.
 
-   {{% alert color="warning" %}}
-
-   {{% param chooseAnIssueAtYourLevel %}}
-
-   {{% /alert %}}
+   > [!WARNING] Important!
+   >
+   > {{% param chooseAnIssueAtYourLevel %}}
 
 3. Read through the issue comments, if any.
 4. Ask maintainers if this issue is still relevant, and ask any questions you
@@ -82,3 +80,7 @@ Keep the following in mind when filing an issue:
   [Code of Conduct](https://github.com/open-telemetry/community/blob/main/code-of-conduct.md).
   Respect your fellow contributors. For example, "The docs are terrible" is not
   helpful or polite feedback.
+
+<!-- markdownlint-disable link-image-reference-definitions -->
+
+[choose an issue]: <{{% param _issues %}}>

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -252,14 +252,12 @@ As you update your localized pages to match changes made to the corresponding
 English language page, ensure that you also update the `default_lang_commit`
 commit hash.
 
-{{% alert title="Tip" %}}
-
-If your localized page now corresponds to the English language version in `main`
-at `HEAD`, then erase the commit hash value in the front matter, and run the
-**add** command given in the previous section to automatically refresh the
-`default_lang_commit` field value.
-
-{{% /alert %}}
+> [!TIP]
+>
+> If your localized page now corresponds to the English language version in
+> `main` at `HEAD`, then erase the commit hash value in the front matter, and
+> run the **add** command given in the previous section to automatically refresh
+> the `default_lang_commit` field value.
 
 If you have batch updated all of your localization pages that had drifted, you
 can update the commit hash of these files using the `-c` flag followed by a
@@ -270,13 +268,11 @@ npm run check:i18n -- -c <hash> <PATH-TO-YOUR-NEW-FILES>
 npm run check:i18n -- -c HEAD <PATH-TO-YOUR-NEW-FILES>
 ```
 
-{{% alert title="Important" %}}
-
-When you use `HEAD` as a hash specifier, the script will use the hash of `main`
-at HEAD in your **local environment**. Make sure that you fetch and pull `main`,
-if you want HEAD to correspond to `main` in GitHub.
-
-{{% /alert %}}
+> [!IMPORTANT]
+>
+> When you use `HEAD` as a hash specifier, the script will use the hash of
+> `main` at HEAD in your **local environment**. Make sure that you fetch and
+> pull `main`, if you want HEAD to correspond to `main` in GitHub.
 
 ### Drift status
 

--- a/content/en/docs/contributing/pr-checks.md
+++ b/content/en/docs/contributing/pr-checks.md
@@ -120,21 +120,19 @@ success status for, you can add the following query parameter to your URL to
 have the link checker ignore it: `?no-link-check`. For example,
 <https:/some-example.org?no-link-check> will be ignored by the link checker.
 
-{{% alert title="Maintainers tip" %}}
-
-Maintainers can run the following script immediately after having run the link
-checker to have Puppeteer attempt to validate links with non-ok statuses:
-
-```sh
-./scripts/double-check-refcache-4XX.mjs
-```
-
-Use the `-f` flag to also validate URL fragments (anchors) in external links,
-which `htmltest` doesn't do. We don't currently run this often, so you will
-probably want to limit the number of updated entries using the `-m N` flag. For
-usage info, run with `-h`.
-
-{{% /alert %}}
+> [!TIP] Maintainers tip
+>
+> Maintainers can run the following script immediately after having run the link
+> checker to have Puppeteer attempt to validate links with non-ok statuses:
+>
+> ```sh
+> ./scripts/double-check-refcache-4XX.mjs
+> ```
+>
+> Use the `-f` flag to also validate URL fragments (anchors) in external links,
+> which `htmltest` doesn't do. We don't currently run this often, so you will
+> probably want to limit the number of updated entries using the `-m N` flag.
+> For usage info, run with `-h`.
 
 ### `WARNINGS in build log?` {.notranslate lang=en}
 

--- a/content/en/docs/contributing/pull-requests.md
+++ b/content/en/docs/contributing/pull-requests.md
@@ -17,28 +17,27 @@ To contribute new or improve existing documentation, submit a [pull request][PR]
 
 ## Generative AI contribution policy {#using-ai}
 
-{{% alert color="warning" title="Important note for first time contributors" %}}
-
-If you are a [first-time contributor], please note the following:
-
-Your first 3 contributions to our repository must be primarily human-written,
-with only minor AI assistance allowed
-([AIL1](https://danielmiessler.com/blog/ai-influence-level-ail)). This means
-your code should be written by hand, but AI may assist with code completion,
-formatting, linting, and following best practices. Your PR description must be
-entirely human-written, with no AI involvement (AIL0).
-
-Of course, you can use AI tools to ask questions and learn about our repository,
-our project, how to contribute, and more.
-
-We put this requirement in place to help you learn while contributing and to
-help maintainers and approvers to protect their time and bandwidth, which is a
-scarce resource.
-
-Maintainers may make an exception, if it is clear that your contribution is
-"drive-by" and can be merged without a lot of additional effort from their side.
-
-{{% /alert %}}
+> [!WARNING] **First time contributors** take note!
+>
+> If you are a [first-time contributor], please note the following:
+>
+> Your first 3 contributions to our repository must be primarily human-written,
+> with only minor AI assistance allowed
+> ([AIL1](https://danielmiessler.com/blog/ai-influence-level-ail)). This means
+> your code should be written by hand, but AI may assist with code completion,
+> formatting, linting, and following best practices. Your PR description must be
+> entirely human-written, with no AI involvement (AIL0).
+>
+> Of course, you can use AI tools to ask questions and learn about our
+> repository, our project, how to contribute, and more.
+>
+> We put this requirement in place to help you learn while contributing and to
+> help maintainers and approvers to protect their time and bandwidth, which is a
+> scarce resource.
+>
+> Maintainers may make an exception, if it is clear that your contribution is
+> "drive-by" and can be merged without a lot of additional effort from their
+> side.
 
 Generative AI is allowed, but **you are responsible** for **reviewing and
 _validating_** all AI-generated content &mdash; if you don't understand it,
@@ -75,14 +74,12 @@ class first,second white
 
 _Figure 1. Contributing new content._
 
-{{% alert title="Tip: Draft status" %}}
-
-Set the status of your pull request to **Draft** to let maintainers know that
-the content isn't ready for review yet. Maintainers may still comment or do
-high-level reviews, though they won't review the content in full until you
-remove the draft status.
-
-{{% /alert %}}
+> [!TIP]
+>
+> Set the status of your pull request to **Draft** to let maintainers know that
+> the content isn't ready for review yet. Maintainers may still comment or do
+> high-level reviews, though they won't review the content in full until you
+> remove the draft status.
 
 ## Using GitHub {#changes-using-github}
 
@@ -181,12 +178,10 @@ fix:submodule
 fix:text
 ```
 
-{{% alert title="Pro tip" %}}
-
-You can also run the `fix` commands locally. For the complete list of fix
-commands, run `npm run -s '_list:fix:*'`.
-
-{{% /alert %}}
+> [!TIP] Pro tip
+>
+> You can also run the `fix` commands locally. For the complete list of fix
+> commands, run `npm run -s '_list:fix:*'`.
 
 ## Working locally {#fork-the-repo}
 

--- a/content/en/docs/demo/services/react-native-app.md
+++ b/content/en/docs/demo/services/react-native-app.md
@@ -14,15 +14,13 @@ file-based routing to layout the screens for the app.
 The application uses the OpenTelemetry packages to instrument the application at
 the JS layer.
 
-{{% alert title="Important" color="warning" %}}
-
-The JS OTel packages are supported for node and web environments. While they
-work for React Native as well, they are not explicitly supported for that
-environment, where they might break compatibility with minor version updates or
-require workarounds. Building JS OTel package support for React Native is an
-area of active development.
-
-{{% /alert %}}
+> [!CAUTION]
+>
+> The JS OTel packages are supported for node and web environments. While they
+> work for React Native as well, they are not explicitly supported for that
+> environment, where they might break compatibility with minor version updates
+> or require workarounds. Building JS OTel package support for React Native is
+> an area of active development.
 
 The main entry point for the application is `app/_layout.tsx` where a hook is
 used to initialize the instrumentation and make sure it is loaded before

--- a/content/en/docs/languages/_index.md
+++ b/content/en/docs/languages/_index.md
@@ -28,17 +28,16 @@ application.
 The current status of the major functional components for OpenTelemetry is as
 follows:
 
-{{% alert title="Important" color="warning" %}}
-
-Regardless of an API/SDK's status, if your instrumentation relies on [semantic
-conventions][] that are marked as [Experimental] in the [semantic conventions
-specification][], your data flow might be subject to **breaking changes**.
-
-[semantic conventions]: /docs/concepts/semantic-conventions/
-[Experimental]: /docs/specs/otel/document-status/
-[semantic conventions specification]: /docs/specs/semconv/
-
-{{% /alert %}}
+> [!WARNING]
+>
+> Regardless of an API/SDK's status, if your instrumentation relies on [semantic
+> conventions][semconv] that are marked as [Experimental] in the [semantic
+> conventions specification][semconv-spec], your data flow might be subject to
+> **breaking changes**.
+>
+> [semconv]: /docs/concepts/semantic-conventions/
+> [Experimental]: /docs/specs/otel/document-status/
+> [semconv-spec]: /docs/specs/semconv/
 
 {{% telemetry-support-table " " %}}
 

--- a/content/en/docs/languages/dotnet/exporters.md
+++ b/content/en/docs/languages/dotnet/exporters.md
@@ -250,16 +250,14 @@ await app.RunAsync();
 
 ### Non-ASP.NET Core {#prometheus-non-asp-net-core-usage}
 
-{{% alert color="warning" title="Warning" %}}
-
-This component is intended for dev inner-loop, there is no plan to make it
-production ready. Production environments should use
-[`OpenTelemetry.Exporter.Prometheus.AspNetCore`](#prometheus-asp-net-core-usage),
-or a combination of
-[`OpenTelemetry.Exporter.OpenTelemetryProtocol`](#aspnet-core) and
-[OpenTelemetry Collector](/docs/collector).
-
-{{% /alert %}}
+> [!WARNING]
+>
+> This component is intended for dev inner-loop, there is no plan to make it
+> production ready. Production environments should use
+> [`OpenTelemetry.Exporter.Prometheus.AspNetCore`](#prometheus-asp-net-core-usage),
+> or a combination of
+> [`OpenTelemetry.Exporter.OpenTelemetryProtocol`](#aspnet-core) and
+> [OpenTelemetry Collector](/docs/collector).
 
 For applications not using ASP.NET Core, you can use the `HttpListener` version
 which is available in a

--- a/content/en/docs/languages/dotnet/logs/best-practices.md
+++ b/content/en/docs/languages/dotnet/logs/best-practices.md
@@ -102,10 +102,10 @@ logger.LogInformation("Hello from {food} {price}.", food, price);
 
 Avoid string interpolation. For example:
 
-{{% alert title="Warning" color="warning" %}} The following code has bad
-performance due to
-[string interpolation](https://learn.microsoft.com/dotnet/csharp/tutorials/string-interpolation):
-{{% /alert %}}
+> [!WARNING]
+>
+> The following code has bad performance due to
+> [string interpolation](https://learn.microsoft.com/dotnet/csharp/tutorials/string-interpolation).
 
 ```csharp
 var food = "tomato";
@@ -152,10 +152,10 @@ Avoid the extension methods from
 [LoggerExtensions](https://learn.microsoft.com/dotnet/api/microsoft.extensions.logging.loggerextensions),
 these methods are not optimized for performance. For example:
 
-{{% alert title="Warning" color="warning" %}} The following code has bad
-performance due to
-[boxing](https://learn.microsoft.com/dotnet/csharp/programming-guide/types/boxing-and-unboxing):
-{{% /alert %}}
+> [!WARNING]
+>
+> The following code has bad performance due to
+> [boxing](https://learn.microsoft.com/dotnet/csharp/programming-guide/types/boxing-and-unboxing).
 
 ```csharp
 var food = "tomato";
@@ -171,9 +171,10 @@ The logging API is highly optimized for the scenario where most loggers are
 **disabled** for certain log levels. Making an extra call to `IsEnabled` before
 logging will not give you any performance gain. For example:
 
-{{% alert title="Warning" color="warning" %}} The
-`logger.IsEnabled(LogLevel.Information)` call in the following code is not going
-to give any performance gain. {{% /alert %}}
+> [!WARNING]
+>
+> The `logger.IsEnabled(LogLevel.Information)` call in the following code is not
+> going to give any performance gain.
 
 ```csharp
 var food = "tomato";

--- a/content/en/docs/languages/dotnet/metrics/best-practices.md
+++ b/content/en/docs/languages/dotnet/metrics/best-practices.md
@@ -85,8 +85,10 @@ Avoid invalid instrument names.
 
 Avoid changing the order of tags while reporting measurements. For example:
 
-{{% alert title="Warning" color="warning" %}} The last line of code has bad
-performance since the tags are not following the same order: {{% /alert %}}
+> [!WARNING]
+>
+> The last line of code below has bad performance since the tags are not
+> following the same order.
 
 ```csharp
 counter.Add(2, new("name", "apple"), new("color", "red"));

--- a/content/en/docs/languages/dotnet/traces/best-practices.md
+++ b/content/en/docs/languages/dotnet/traces/best-practices.md
@@ -84,9 +84,10 @@ events, a better model is to use
 [Activity.Links](https://learn.microsoft.com/dotnet/api/system.diagnostics.activity.links).
 For example:
 
-{{% alert title="Warning" color="warning" %}} The following code is not modeling
-`Activity.Events` correctly, and is very likely to have usability and
-performance problems. {{% /alert %}}
+> [!WARNING]
+>
+> The following code is not modeling `Activity.Events` correctly, and is very
+> likely to have usability and performance problems.
 
 ```csharp
 private static async Task Test()

--- a/content/en/docs/languages/dotnet/traces/reporting-exceptions.md
+++ b/content/en/docs/languages/dotnet/traces/reporting-exceptions.md
@@ -183,9 +183,10 @@ public class Program
 }
 ```
 
-{{% alert title="Caution" %}} Use `AppDomain.UnhandledException` with care.
-Throwing an exception in this handler puts the process into an unrecoverable
-state. {{% /alert %}}
+> [!CAUTION]
+>
+> Use `AppDomain.UnhandledException` with care. Throwing an exception in this
+> handler puts the process into an unrecoverable state.
 
 ## Best practices
 

--- a/content/en/docs/languages/dotnet/troubleshooting.md
+++ b/content/en/docs/languages/dotnet/troubleshooting.md
@@ -47,21 +47,19 @@ the following content:
 
 To disable self-diagnostics, delete the configuration file.
 
-{{% alert title="Tip" %}}
-
-In most cases, you can drop the file alongside your application. On Windows, you
-can use
-[Process Explorer](https://docs.microsoft.com/sysinternals/downloads/process-explorer),
-double-click on the process to open the Properties dialog, and find "Current
-directory" in the "Image" tab.
-
-Internally, the SDK looks for the configuration file located in
-[GetCurrentDirectory](https://docs.microsoft.com/dotnet/api/system.io.directory.getcurrentdirectory),
-and then
-[AppContext.BaseDirectory](https://docs.microsoft.com/dotnet/api/system.appcontext.basedirectory).
-You can also find the exact directory by calling these methods from your code.
-
-{{% /alert %}}
+> [!TIP]
+>
+> In most cases, you can drop the file alongside your application. On Windows,
+> you can use
+> [Process Explorer](https://docs.microsoft.com/sysinternals/downloads/process-explorer),
+> double-click on the process to open the Properties dialog, and find "Current
+> directory" in the "Image" tab.
+>
+> Internally, the SDK looks for the configuration file located in
+> [GetCurrentDirectory](https://docs.microsoft.com/dotnet/api/system.io.directory.getcurrentdirectory),
+> and then
+> [AppContext.BaseDirectory](https://docs.microsoft.com/dotnet/api/system.appcontext.basedirectory).
+> You can also find the exact directory by calling these methods from your code.
 
 ### Configuration parameters
 

--- a/content/en/docs/languages/erlang/instrumentation.md
+++ b/content/en/docs/languages/erlang/instrumentation.md
@@ -398,7 +398,7 @@ suited for your use case, see
 
 ### Initialize Metrics
 
-{{% alert %}} If you’re instrumenting a library, skip this step. {{% /alert %}}
+> [!NOTE] If you’re instrumenting a library, skip this step.
 
 To enable metrics in your application, you’ll need to have an initialized
 `MeterProvider` with a `Reader`. This is done through configuration of the

--- a/content/en/docs/languages/go/instrumentation.md
+++ b/content/en/docs/languages/go/instrumentation.md
@@ -92,14 +92,12 @@ func main() {
 
 You can now access `tracer` to manually instrument your code.
 
-{{% alert title="Important" color="warning" %}}
-
-If you are adding manual spans in conjunction with eBPF-based
-[Go zero-code instrumentation](/docs/zero-code/go), such as with
-[OBI](/docs/zero-code/obi), do not set a global Tracer Provider. See the
-[Auto SDK](/docs/zero-code/go/autosdk) docs for more information.
-
-{{% /alert %}}
+> [!WARNING]
+>
+> If you are adding manual spans in conjunction with eBPF-based
+> [Go zero-code instrumentation](/docs/zero-code/go), such as with
+> [OBI](/docs/zero-code/obi), do not set a global Tracer Provider. See the
+> [Auto SDK](/docs/zero-code/go/autosdk) docs for more information.
 
 ### Creating Spans
 
@@ -334,7 +332,7 @@ Here you can find more detailed package documentation for:
 
 ### Initialize Metrics
 
-{{% alert %}} If you’re instrumenting a library, skip this step. {{% /alert %}}
+> [!NOTE] If you’re instrumenting a library, skip this step.
 
 To enable [metrics](/docs/concepts/signals/metrics/) in your app, you'll need to
 have an initialized

--- a/content/en/docs/languages/java/api.md
+++ b/content/en/docs/languages/java/api.md
@@ -386,7 +386,9 @@ scope:
 - [LoggerProvider](#loggerprovider) provides scoped [Loggers](#logger) for
   recording logs.
 
-{{% alert %}} {{% param logBridgeWarning %}} {{% /alert %}}
+> [!WARNING]
+>
+> {{% param logBridgeWarning %}}
 
 A scope is identified by the triplet (name, version, schemaUrl). Care must be
 taken to ensure the scope identity is unique. A typical approach is to set the
@@ -1429,7 +1431,9 @@ is the API entry point for logs and provides [Loggers](#logger). See
 [providers and scopes](#providers-and-scopes) for information on providers and
 scopes.
 
-{{% alert %}} {{% param logBridgeWarning %}} {{% /alert %}}
+> [!WARNING]
+>
+> {{% param logBridgeWarning %}}
 
 #### Logger
 
@@ -1623,14 +1627,16 @@ help instrumentation conform:
 | Generated code for stable semantic conventions     | `io.opentelemetry.semconv:opentelemetry-semconv:{{% param vers.semconv %}}-alpha`            |
 | Generated code for incubating semantic conventions | `io.opentelemetry.semconv:opentelemetry-semconv-incubating:{{% param vers.semconv %}}-alpha` |
 
-{{% alert %}} While both `opentelemetry-semconv` and
-`opentelemetry-semconv-incubating` include the `-alpha` suffix and are subject
-to breaking changes, the intent is to stabilize `opentelemetry-semconv` and
-leave the `-alpha` suffix on `opentelemetry-semconv-incubating` permanently.
-Libraries can use `opentelemetry-semconv-incubating` for testing, but should not
-include it as a dependency: since attributes may come and go from version to
-version, including it as a dependency may expose end users to runtime errors
-when transitive version conflicts occur. {{% /alert %}}
+> [!NOTE]
+>
+> While both `opentelemetry-semconv` and `opentelemetry-semconv-incubating`
+> include the `-alpha` suffix and are subject to breaking changes, the intent is
+> to stabilize `opentelemetry-semconv` and leave the `-alpha` suffix on
+> `opentelemetry-semconv-incubating` permanently. Libraries can use
+> `opentelemetry-semconv-incubating` for testing, but should not include it as a
+> dependency: since attributes may come and go from version to version,
+> including it as a dependency may expose end users to runtime errors when
+> transitive version conflicts occur.
 
 The attribute constants generated from semantic conventions are instances of
 `AttributeKey<T>`, and can be used anywhere the OpenTelemetry API accepts

--- a/content/en/docs/languages/java/configuration.md
+++ b/content/en/docs/languages/java/configuration.md
@@ -26,16 +26,17 @@ configures SDK components through system properties or environment variables,
 with various extension points for instances where the properties are
 insufficient.
 
-{{% alert %}} We recommend using the
-[zero-code SDK autoconfigure](#zero-code-sdk-autoconfigure) module since it
-reduces boilerplate code, allows reconfiguration without rewriting code or
-recompiling the application, and has language interoperability. {{% /alert %}}
-
-{{% alert %}} The [Java agent](/docs/zero-code/java/agent/) and
-[Spring starter](/docs/zero-code/java/spring-boot-starter/) automatically
-configure the SDK using the zero-code SDK autoconfigure module, and install
-instrumentation with it. All autoconfigure content is applicable to Java agent
-and Spring starter users. {{% /alert %}}
+> [!NOTE] **Notes**
+>
+> - We recommend using the
+>   [zero-code SDK autoconfigure](#zero-code-sdk-autoconfigure) module since it
+>   reduces boilerplate code, allows reconfiguration without rewriting code or
+>   recompiling the application, and has language interoperability.
+> - The [Java agent](/docs/zero-code/java/agent/) and
+>   [Spring starter](/docs/zero-code/java/spring-boot-starter/) automatically
+>   configure the SDK using the zero-code SDK autoconfigure module, and install
+>   instrumentation with it. All autoconfigure content is applicable to Java
+>   agent and Spring starter users.
 
 ## Programmatic configuration
 
@@ -91,21 +92,22 @@ public class AutoConfiguredSdk {
 ```
 <!-- prettier-ignore-end -->
 
-{{% alert %}} The [Java agent](/docs/zero-code/java/agent/) and
-[Spring starter](/docs/zero-code/java/spring-boot-starter/) automatically
-configure the SDK using the zero-code SDK autoconfigure module, and install
-instrumentation with it. All autoconfigure content is applicable to Java agent
-and Spring starter users. {{% /alert %}}
-
-{{% alert %}} The autoconfigure module registers Java shutdown hooks to shut
-down the SDK when appropriate. Because OpenTelemetry Java
-[uses `java.util.logging` for internal logging](../sdk/#internal-logging), some
-logging might be suppressed during shutdown hooks. This is a bug in the JDK
-itself, and not something under the control of OpenTelemetry Java. If you
-require logging during shutdown hooks, consider using `System.out` rather than a
-logging framework which might shut itself down in a shutdown hook, thus
-suppressing your log messages. For more details, see this
-[JDK bug](https://bugs.openjdk.java.net/browse/JDK-8161253). {{% /alert %}}
+> [!NOTE] **Notes**
+>
+> - The [Java agent](/docs/zero-code/java/agent/) and
+>   [Spring starter](/docs/zero-code/java/spring-boot-starter/) automatically
+>   configure the SDK using the zero-code SDK autoconfigure module, and install
+>   instrumentation with it. All autoconfigure content is applicable to Java
+>   agent and Spring starter users.
+> - The autoconfigure module registers Java shutdown hooks to shut down the SDK
+>   when appropriate. Because OpenTelemetry Java
+>   [uses `java.util.logging` for internal logging](../sdk/#internal-logging),
+>   some logging might be suppressed during shutdown hooks. This is a bug in the
+>   JDK itself, and not something under the control of OpenTelemetry Java. If
+>   you require logging during shutdown hooks, consider using `System.out`
+>   rather than a logging framework which might shut itself down in a shutdown
+>   hook, thus suppressing your log messages. For more details, see this
+>   [JDK bug](https://bugs.openjdk.java.net/browse/JDK-8161253).
 
 ### Environment variables and system properties
 

--- a/content/en/docs/languages/java/getting-started.md
+++ b/content/en/docs/languages/java/getting-started.md
@@ -142,11 +142,8 @@ agent][] in a number of ways, the steps below use environment variables.
    curl -L -O https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar
    ```
 
-   {{% alert %}}
-
-   <i class="fas fa-edit"></i> Take note of the path to the JAR file.
-
-   {{% /alert %}}
+   > [!IMPORTANT] <i class="fas fa-edit"></i> Take note of the path to the JAR
+   > file.
 
 2. Set and export variables that specify the Java agent JAR and a [console
    exporter][], using a notation suitable for your shell/terminal environment
@@ -160,13 +157,17 @@ agent][] in a number of ways, the steps below use environment variables.
      OTEL_METRIC_EXPORT_INTERVAL=15000
    ```
 
-   {{% alert title="Important" color="warning" %}}
-   - Replace `PATH/TO` above, with your path to the JAR.
-   - Set `OTEL_METRIC_EXPORT_INTERVAL` to a value well below the default, as we
-     illustrate above, **only during testing** to help you more quickly ensure
-     that metrics are properly generated.
+   <!-- markdownlint-disable no-blanks-blockquote -->
 
-   {{% /alert %}}
+   > [!NOTE]
+   >
+   > Replace `PATH/TO` above, with your path to the JAR.
+
+   > [!WARNING]
+   >
+   > Set `OTEL_METRIC_EXPORT_INTERVAL` to a value well below the default, as we
+   > illustrate above, **only during testing** to help you more quickly ensure
+   > that metrics are properly generated.
 
 3. Run your **application** once again:
 

--- a/content/en/docs/languages/java/instrumentation.md
+++ b/content/en/docs/languages/java/instrumentation.md
@@ -29,11 +29,13 @@ instrumentation topics:
 - [Log instrumentation](#log-instrumentation), which is used to get logs from an
   existing Java logging framework into OpenTelemetry.
 
-{{% alert %}} While [instrumentation categories](#instrumentation-categories)
-enumerates several options for instrumenting an application, we recommend users
-start with the [Java agent](#zero-code-java-agent). The Java agent has a simple
-installation process, and automatically detects and installs instrumentation
-from a large library. {{% /alert %}}
+> [!NOTE]
+>
+> While [instrumentation categories](#instrumentation-categories) enumerates
+> several options for instrumenting an application, we recommend users start
+> with the [Java agent](#zero-code-java-agent). The Java agent has a simple
+> installation process, and automatically detects and installs instrumentation
+> from a large library.
 
 ## Instrumentation categories
 

--- a/content/en/docs/languages/java/intro.md
+++ b/content/en/docs/languages/java/intro.md
@@ -112,9 +112,11 @@ dependencies aligned. OpenTelemetry Java publishes several BOMs catering to
 different use cases, listed below in order of increasing scope. We highly
 recommend using a BOM.
 
-{{% alert %}} Because the BOMs are hierarchical, adding dependencies on multiple
-BOMs is not recommended, as it is redundant and can lead unintuitive dependency
-version resolution. {{% /alert %}}
+> [!NOTE]
+>
+> Because the BOMs are hierarchical, adding dependencies on multiple BOMs is not
+> recommended, as it is redundant and can lead unintuitive dependency version
+> resolution.
 
 Click the link in the "Managed Dependencies" column to see a list of the
 artifacts managed by the BOM.

--- a/content/en/docs/languages/java/sdk.md
+++ b/content/en/docs/languages/java/sdk.md
@@ -121,11 +121,13 @@ is a set of attributes defining the telemetry source. An application should
 associate the same resource with [SdkTracerProvider](#sdktracerprovider),
 [SdkMeterProvider](#sdkmeterprovider), [SdkLoggerProvider](#sdkloggerprovider).
 
-{{% alert %}} [ResourceProviders](../configuration/#resourceprovider) contribute
-contextual information to the
-[autoconfigured](../configuration/#zero-code-sdk-autoconfigure) resource based
-on the environment. See documentation for list of available `ResourceProvider`s.
-{{% /alert %}}
+> [!NOTE]
+>
+> [ResourceProviders](../configuration/#resourceprovider) contribute contextual
+> information to the
+> [autoconfigured](../configuration/#zero-code-sdk-autoconfigure) resource based
+> on the environment. See documentation for list of available
+> `ResourceProvider`s.
 
 The following code snippet demonstrates `Resource` programmatic configuration:
 
@@ -195,10 +197,12 @@ A
 is a [plugin extension interface](#sdk-plugin-extension-interfaces) responsible
 for determining which spans are recorded and sampled.
 
-{{% alert %}} By default `SdkTracerProvider` is configured with the
-`ParentBased(root=AlwaysOn)` sampler. This results in 100% of spans being
-sampled unless a calling application performs sampling. If this is too noisy /
-expensive, change the sampler. {{% /alert %}}
+> [!NOTE]
+>
+> By default `SdkTracerProvider` is configured with the
+> `ParentBased(root=AlwaysOn)` sampler. This results in 100% of spans being
+> sampled unless a calling application performs sampling. If this is too noisy /
+> expensive, change the sampler.
 
 Samplers built-in to the SDK and maintained by the community in
 `opentelemetry-java-contrib`:
@@ -888,14 +892,16 @@ allow metric streams to be customized, including changing metric names, metric
 descriptions, metric aggregations (i.e. histogram bucket boundaries), the set of
 attribute keys to retain, cardinality limit, etc.
 
-{{% alert %}} Views have somewhat unintuitive behavior when multiple match a
-particular instrument. If one matching view changes the metric name and another
-changes the metric aggregation, you might expect the name and aggregation are
-changed, but this is not the case. Instead, two metric streams are produced: one
-with the configured metric name and the default aggregation, and another with
-the original metric name and the configured aggregation. In other words,
-matching views _do not merge_. For best results, configure views with narrow
-selection criteria (i.e. select a single specific instrument). {{% /alert %}}
+> [!NOTE]
+>
+> Views have somewhat unintuitive behavior when multiple match a particular
+> instrument. If one matching view changes the metric name and another changes
+> the metric aggregation, you might expect the name and aggregation are changed,
+> but this is not the case. Instead, two metric streams are produced: one with
+> the configured metric name and the default aggregation, and another with the
+> original metric name and the configured aggregation. In other words, matching
+> views _do not merge_. For best results, configure views with narrow selection
+> criteria (i.e. select a single specific instrument).
 
 The following code snippet demonstrates `View` programmatic configuration:
 

--- a/content/en/docs/languages/js/_includes/browser-instrumentation-warning.md
+++ b/content/en/docs/languages/js/_includes/browser-instrumentation-warning.md
@@ -1,13 +1,11 @@
 ---
 ---
 
-{{% alert title=Warning color=warning %}}
+> [!WARNING]
+>
+> Client instrumentation for the browser is **experimental** and mostly
+> **unspecified**. If you are interested in helping out, get in touch with the
+> [Client Instrumentation SIG][].
 
-Client instrumentation for the browser is **experimental** and mostly
-**unspecified**. If you are interested in helping out, get in touch with the
-[Client Instrumentation SIG][sig].
-
-[sig]:
+[Client Instrumentation SIG]:
   https://docs.google.com/document/d/16Vsdh-DM72AfMg_FIt9yT9ExEWF4A_vRbQ3jRNBe09w
-
-{{% /alert %}}

--- a/content/en/docs/languages/js/instrumentation.md
+++ b/content/en/docs/languages/js/instrumentation.md
@@ -191,9 +191,7 @@ npm install @opentelemetry/api @opentelemetry/resources @opentelemetry/semantic-
 
 ### Initialize the SDK
 
-> [!NOTE]
->
-> If you’re instrumenting a library, **skip this step**.
+> [!IMPORTANT] If you’re instrumenting a library, **skip this step**.
 
 If you instrument a Node.js application install the
 [OpenTelemetry SDK for Node.js](https://www.npmjs.com/package/@opentelemetry/sdk-node):
@@ -314,9 +312,7 @@ information, see [Libraries](/docs/languages/js/libraries/).
 
 ### Initialize Tracing
 
-> [!NOTE]
->
-> If you’re instrumenting a library, **skip this step**.
+> [!IMPORTANT] If you’re instrumenting a library, **skip this step**.
 
 To enable [tracing](/docs/concepts/signals/traces/) in your app, you'll need to
 have an initialized
@@ -1267,7 +1263,7 @@ spans by helping to identify trends and providing application runtime telemetry.
 
 ### Initialize Metrics
 
-{{% alert %}} If you’re instrumenting a library, skip this step. {{% /alert %}}
+> [!IMPORTANT] If you’re instrumenting a library, **skip this step**.
 
 To enable [metrics](/docs/concepts/signals/metrics/) in your app, you'll need to
 have an initialized

--- a/content/en/docs/languages/ruby/getting-started.md
+++ b/content/en/docs/languages/ruby/getting-started.md
@@ -18,8 +18,10 @@ Ensure that you have the following installed locally:
 - CRuby >= `3.1`, JRuby >= `9.3.2.0`, or TruffleRuby >= `22.1`
 - [Bundler](https://bundler.io/)
 
-{{% alert  title="Warning" color="warning" %}} While tested, support for `jruby`
-and `truffleruby` are on a best-effort basis at this time. {{% /alert %}}
+> [!WARNING]
+>
+> While tested, support for `jruby` and `truffleruby` are on a best-effort basis
+> at this time.
 
 ## Example Application
 

--- a/content/en/docs/languages/sdk-configuration/declarative-configuration.md
+++ b/content/en/docs/languages/sdk-configuration/declarative-configuration.md
@@ -12,8 +12,9 @@ This approach is useful when:
 - You want to use configuration options that are not available as environment
   variables.
 
-{{% alert title="Warning" %}} Declarative configuration is experimental.
-{{% /alert %}}
+> [!WARNING]
+>
+> Declarative configuration is experimental.
 
 ## Supported languages
 
@@ -88,8 +89,10 @@ resource:
   attributes_list: ${OTEL_RESOURCE_ATTRIBUTES}
 ```
 
-{{% alert title="Warning" %}} All environment variables are ignored unless you
-explicitly add them to the config file. {{% /alert %}}
+> [!WARNING]
+>
+> All environment variables are ignored unless you explicitly add them to the
+> config file.
 
 ## Migration configuration
 

--- a/content/en/docs/platforms/kubernetes/operator/troubleshooting/target-allocator.md
+++ b/content/en/docs/platforms/kubernetes/operator/troubleshooting/target-allocator.md
@@ -130,15 +130,13 @@ Where `otelcol-targetallocator` is the value of `metadata.name` in your
 `opentelemetry` is the namespace to which the `OpenTelemetryCollector` CR is
 deployed.
 
-{{% alert title="Tip" %}}
-
-You can also get the service name by running
-
-```shell
-kubectl get svc -l app.kubernetes.io/component=opentelemetry-targetallocator -n <namespace>
-```
-
-{{% /alert %}}
+> [!TIP]
+>
+> You can also get the service name by running
+>
+> ```shell
+> kubectl get svc -l app.kubernetes.io/component=opentelemetry-targetallocator -n <namespace>
+> ```
 
 Next, get a list of jobs registered with the Target Allocator:
 
@@ -375,13 +373,10 @@ example.
 If your `ServiceMonitor` resource is missing that label, then the Target
 Allocator will fail to discover scrape targets from that `ServiceMonitor`.
 
-{{% alert title="Tip" %}}
-
-The same applies if you're using a [PodMonitor]. In that case, you would use a
-[`podMonitorSelector`](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/targetallocators.md#targetallocatorspecprometheuscr)
-instead of a `serviceMonitorSelector`.
-
-{{% /alert %}}
+> [!TIP]
+>
+> The same applies if you're using a [PodMonitor]. In that case, you would use a
+> [`podMonitorSelector`] instead of a `serviceMonitorSelector`.
 
 ### Did you leave out the serviceMonitorSelector and/or podMonitorSelector configuration altogether?
 
@@ -496,12 +491,12 @@ spec:
       port: 8080
 ```
 
-{{% alert title="Tip" %}}
+> [!TIP]
+>
+> If you're using `PodMonitor`, the same applies, except that it picks up
+> Kubernetes pods that match on labels, namespaces, and named ports.
 
-If you're using `PodMonitor`, the same applies, except that it picks up
-Kubernetes pods that match on labels, namespaces, and named ports.
-
-{{% /alert %}}
-
+[`podMonitorSelector`]:
+  https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/targetallocators.md#targetallocatorspecprometheuscr
 [PodMonitor]:
   https://prometheus-operator.dev/docs/developer/getting-started/#using-podmonitors

--- a/content/en/docs/security/handling-sensitive-data.md
+++ b/content/en/docs/security/handling-sensitive-data.md
@@ -100,13 +100,11 @@ transform:
         - delete_key(attributes, "user.id")
 ```
 
-{{% alert title="Risk and limitations of hashing for anonymization" color="warning" %}}
-
-Hashing the ID or name of a user may not provide the level of anonymization you
-need, since hashes are reversible in practice if the input space is small and
-predictable (e.g. numeric user IDs).
-
-{{% /alert %}}
+> [!WARNING] Risk and limitations of hashing for anonymization
+>
+> Hashing the ID or name of a user may not provide the level of anonymization
+> you need, since hashes are reversible in practice if the input space is small
+> and predictable (e.g. numeric user IDs).
 
 ### Truncating IP addresses
 

--- a/content/en/docs/zero-code/dotnet/configuration.md
+++ b/content/en/docs/zero-code/dotnet/configuration.md
@@ -245,16 +245,15 @@ Important environment variables include:
 
 **Status**: [Experimental](/docs/specs/otel/versioning-and-stability)
 
-{{% alert title="Warning" color="warning" %}} **Do NOT use in production.**
-
-Prometheus exporter is intended for the inner dev loop. Production environments
-can use a combination of OTLP exporter with
-[OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector-releases)
-having
-[`otlp` receiver](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.61.0/receiver/otlpreceiver)
-and
-[`prometheus` exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.61.0/exporter/prometheusexporter).
-{{% /alert %}}
+> [!WARNING] Warning: **do NOT use in production**
+>
+> Prometheus exporter is intended for the inner dev loop. Production
+> environments can use a combination of OTLP exporter with
+> [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector-releases)
+> having
+> [`otlp` receiver](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.61.0/receiver/otlpreceiver)
+> and
+> [`prometheus` exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.61.0/exporter/prometheusexporter).
 
 To enable the Prometheus exporter, set the `OTEL_METRICS_EXPORTER` environment
 variable to `prometheus`.

--- a/content/en/docs/zero-code/go/autosdk.md
+++ b/content/en/docs/zero-code/go/autosdk.md
@@ -77,14 +77,12 @@ create manual spans in an application instrumented by a Go zero-code agent. As
 long as you don't manually register a global TracerProvider, the Auto SDK will
 automatically be enabled.
 
-{{% alert title="Important" color="warning" %}}
-
-Manually setting a global TracerProvider will conflict with the Auto SDK and
-prevent manual spans from properly correlating with eBPF-based spans. If you are
-creating manual spans in a Go application that is also instrumented by eBPF, do
-not initialize your own global TracerProvider.
-
-{{% /alert %}}
+> [!WARNING]
+>
+> Manually setting a global TracerProvider will conflict with the Auto SDK and
+> prevent manual spans from properly correlating with eBPF-based spans. If you
+> are creating manual spans in a Go application that is also instrumented by
+> eBPF, do not initialize your own global TracerProvider.
 
 ### Auto SDK TracerProvider
 

--- a/content/en/docs/zero-code/java/agent/configuration.md
+++ b/content/en/docs/zero-code/java/agent/configuration.md
@@ -87,13 +87,11 @@ The SDK's autoconfiguration module is used for basic configuration of the agent.
 Read the [docs](/docs/languages/java/configuration) to find settings such as
 configuring export or sampling.
 
-{{% alert title="Important" color="warning" %}}
-
-Unlike the SDK autoconfiguration, versions 2.0+ of the Java agent and
-OpenTelemetry Spring Boot starter use `http/protobuf` as the default protocol,
-not `grpc`.
-
-{{% /alert %}}
+> [!IMPORTANT]
+>
+> Unlike the SDK autoconfiguration, versions 2.0+ of the Java agent and
+> OpenTelemetry Spring Boot starter use `http/protobuf` as the default protocol,
+> not `grpc`.
 
 ## Enable Resource Providers that are disabled by default
 

--- a/content/en/docs/zero-code/java/agent/declarative-configuration.md
+++ b/content/en/docs/zero-code/java/agent/declarative-configuration.md
@@ -18,8 +18,9 @@ Just like environment variables, the configuration syntax is language-agnostic
 and works for all OpenTelemetry Java SDKs that support declarative
 configuration, including the OpenTelemetry Java agent.
 
-{{% alert title="Warning" %}} Declarative configuration is experimental.
-{{% /alert %}}
+> [!WARNING]
+>
+> Declarative configuration is experimental.
 
 ## Supported versions
 

--- a/content/en/docs/zero-code/obi/configure/service-discovery.md
+++ b/content/en/docs/zero-code/obi/configure/service-discovery.md
@@ -319,13 +319,11 @@ discovery:
   default_exclude_instrument: []
 ```
 
-{{% alert title="Warning" color="warning" %}}
-
-Disabling all default exclusions may cause increased resource usage and
-potential feedback loops if OBI instruments itself or other telemetry
-collectors. Use this configuration carefully in production environments.
-
-{{% /alert %}}
+> [!WARNING]
+>
+> Disabling all default exclusions may cause increased resource usage and
+> potential feedback loops if OBI instruments itself or other telemetry
+> collectors. Use this configuration carefully in production environments.
 
 ## Skip go specific tracers
 

--- a/content/en/docs/zero-code/obi/network/config.md
+++ b/content/en/docs/zero-code/obi/network/config.md
@@ -210,11 +210,12 @@ Allows selecting which flows to trace according to its direction in the
 interface where they are captured from. Accepted values are `ingress`, `egress`,
 or `both` (default).
 
-{{% alert type="note" %}} In this context, _ingress_ or _egress_ are not related
-to incoming/outgoing traffic from outside the node or the cluster, but the
-network interface. This means that the same network packet could be seen as
-"ingress" in a virtual network device and as "egress" in the backing physical
-network interface. {{% /alert %}}
+> [!NOTE]
+>
+> In this context, _ingress_ or _egress_ are not related to incoming/outgoing
+> traffic from outside the node or the cluster, but the network interface. This
+> means that the same network packet could be seen as "ingress" in a virtual
+> network device and as "egress" in the backing physical network interface.
 
 | YAML       | Environment variable         | Type    | Default        |
 | ---------- | ---------------------------- | ------- | -------------- |

--- a/content/en/docs/zero-code/obi/setup/kubernetes.md
+++ b/content/en/docs/zero-code/obi/setup/kubernetes.md
@@ -7,15 +7,13 @@ weight: 3
 cSpell:ignore: cap_perfmon containerd goblog kubeadm microk8s replicaset statefulset
 ---
 
-{{% alert type="note" %}}
-
-This document explains how to manually deploy OBI in Kubernetes, setting up all
-the required entities by yourself.
-
-<!-- You might prefer to follow the
-[Deploy OBI in Kubernetes with Helm](../kubernetes-helm/) documentation instead. -->
-
-{{% /alert %}}
+> [!NOTE]
+>
+> This document explains how to manually deploy OBI in Kubernetes, setting up
+> all the required entities by yourself.
+>
+> <!-- You might prefer to follow the
+> [Deploy OBI in Kubernetes with Helm](../kubernetes-helm/) documentation instead. -->
 
 ## Configuring Kubernetes metadata decoration
 

--- a/content/en/docs/zero-code/php.md
+++ b/content/en/docs/zero-code/php.md
@@ -20,8 +20,9 @@ Automatic instrumentation with PHP requires:
 
 ## Install the OpenTelemetry extension
 
-{{% alert title="Important" color="warning" %}}Installing the OpenTelemetry
-extension by itself does not generate traces. {{% /alert %}}
+> [!IMPORTANT]
+>
+> Installing the OpenTelemetry extension by itself does not generate traces.
 
 The extension can be installed via pecl,
 [pickle](https://github.com/FriendsOfPHP/pickle),

--- a/content/en/docs/zero-code/python/_index.md
+++ b/content/en/docs/zero-code/python/_index.md
@@ -45,10 +45,11 @@ Running `opentelemetry-bootstrap` without arguments lists the recommended
 instrumentation libraries to be installed. For more information, see
 [`opentelemetry-bootstrap`](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-instrumentation#opentelemetry-bootstrap).
 
-{{% alert title="Using <code>uv</code>?" color="warning" %}} If you are using
-the [uv](https://docs.astral.sh/uv/) package manager, you might face some
-difficulty when running `opentelemetry-bootstrap -a install`. For details, see
-[Bootstrap using uv](troubleshooting/#bootstrap-using-uv). {{% /alert %}}
+> [!WARNING] Using `uv`?
+>
+> If you are using the [uv](https://docs.astral.sh/uv/) package manager, you
+> might face some difficulty when running `opentelemetry-bootstrap -a install`.
+> For details, see [Bootstrap using uv](troubleshooting/#bootstrap-using-uv).
 
 {#configuring-the-agent}
 

--- a/content/en/ecosystem/adopters.md
+++ b/content/en/ecosystem/adopters.md
@@ -10,14 +10,12 @@ is a non-exhaustive list of
 [_end-user_ organizations](https://www.cncf.io/enduser/) that have adopted
 OpenTelemetry for [Observability](/docs/concepts/observability-primer/).
 
-{{% alert color="success" title="Help us showcase the growing OpenTelemetry community!" %}}
-
-If your company is using OpenTelemetry in production or experimentation, we’d
-love to add you to the official adopters list. You can either
-[submit a PR](#how-to-add) or
-[fill out this form](https://forms.gle/K3pKmQdTc2eevLJv9).
-
-{{% /alert %}}
+> [!TIP] Help us showcase the growing OpenTelemetry community!
+>
+> If your company is using OpenTelemetry in production or experimentation, we’d
+> love to add you to the official adopters list. You can either
+> [submit a PR](#how-to-add) or fill out the [Join the OpenTelemetry Adopters
+> List][form] form.
 
 {{% ecosystem/adopters-table %}}
 
@@ -45,3 +43,4 @@ If your organization provides a solution that consumes OpenTelemetry to offer
 
 [adopters list]:
   https://github.com/open-telemetry/opentelemetry.io/tree/main/data/ecosystem/adopters.yaml
+[form]: https://forms.gle/K3pKmQdTc2eevLJv9

--- a/content/en/ecosystem/registry/_index.md
+++ b/content/en/ecosystem/registry/_index.md
@@ -39,14 +39,12 @@ redirects: [{ from: /ecosystem/registry*, to: '/ecosystem/registry?' }]
 
 {{< blocks/section color="white" type="container-lg" >}}
 
-{{% alert %}}
-
-The OpenTelemetry Registry allows you to search for instrumentation libraries,
-collector components, utilities, and other useful projects in the OpenTelemetry
-ecosystem. If you are a project maintainer, you can
-[add your project to the OpenTelemetry Registry](adding/).
-
-{{% /alert %}}
+> [!NOTE]
+>
+> The OpenTelemetry Registry allows you to search for instrumentation libraries,
+> collector components, utilities, and other useful projects in the
+> OpenTelemetry ecosystem. If you are a project maintainer, you can
+> [add your project to the OpenTelemetry Registry](adding/).
 
 {{< ecosystem/registry/search-form >}}
 

--- a/layouts/_markup/render-blockquote-alert.html
+++ b/layouts/_markup/render-blockquote-alert.html
@@ -15,11 +15,18 @@
   )
 -}}
 
+{{/* For single-line alerts without a body, use the title as the body */ -}}
+{{ $body := .Text -}}
+{{ if and (not $body) .AlertTitle -}}
+  {{ $body = .AlertTitle -}}
+  {{ $title = "" -}}
+{{ end -}}
+
 <div class="alert alert-{{ $alertClass }}" role="alert">
 {{- with $title -}}
   <div class="h4 alert-heading" role="heading">
     {{- . -}}
   </div>
 {{- end }}
-{{ .Text }}
+{{ $body }}
 </div>

--- a/scripts/docsy-alerts-to-md/test.js
+++ b/scripts/docsy-alerts-to-md/test.js
@@ -204,4 +204,105 @@ last line with closing tag. {{% /alert %}}
   console.log('✓ Inline content with closing tag on same line as last content');
 }
 
+// Test 11: Alert with title="Warning"
+{
+  const input = `{{% alert color="warning" title="Warning" %}}
+
+This component is intended for dev inner-loop, there is no plan to make it
+production ready. Production environments should use something else.
+
+{{% /alert %}}
+`;
+  const expected = `> [!WARNING]
+>
+> This component is intended for dev inner-loop, there is no plan to make it
+> production ready. Production environments should use something else.
+`;
+  const result = runConvert(input);
+  assert.strictEqual(result, expected, 'Alert with title="Warning" failed');
+  console.log('✓ Alert with title="Warning"');
+}
+
+// Test 12: Alert with color="warning" only
+{
+  const input = `{{% alert color="warning" %}} Warning content here. {{% /alert %}}
+`;
+  const expected = `> [!WARNING]
+>
+> Warning content here.
+`;
+  const result = runConvert(input);
+  assert.strictEqual(result, expected, 'Alert with color="warning" failed');
+  console.log('✓ Alert with color="warning"');
+}
+
+// Test 13: Alert with no arguments defaults to NOTE
+{
+  const input = `{{% alert %}} This alert has no arguments. {{% /alert %}}
+
+And some more text.`;
+  const expected = `> [!NOTE]
+>
+> This alert has no arguments.
+
+And some more text.`;
+  const result = runConvert(input);
+  assert.strictEqual(
+    result,
+    expected,
+    'Alert without arguments should default to NOTE',
+  );
+  console.log('✓ Alert with no arguments defaults to NOTE');
+}
+
+// Test 14: Alert with color="success" and title
+{
+  const input = `{{% alert color="success" title="Pro tip" %}}
+
+You can also run the \`fix\` commands locally.
+
+{{% /alert %}}
+`;
+  const expected = `> [!TIP] Pro tip
+>
+> You can also run the \`fix\` commands locally.
+`;
+  const result = runConvert(input);
+  assert.strictEqual(
+    result,
+    expected,
+    'Alert with color="success" and title failed',
+  );
+  console.log('✓ Alert with color="success" and title');
+}
+
+// Test 15: Alert with title="Caution"
+{
+  const input = `{{% alert title="Caution" %}}
+
+This feature has limitations.
+
+{{% /alert %}}
+`;
+  const expected = `> [!CAUTION]
+>
+> This feature has limitations.
+`;
+  const result = runConvert(input);
+  assert.strictEqual(result, expected, 'Alert with title="Caution" failed');
+  console.log('✓ Alert with title="Caution"');
+}
+
+// Test 16: Alert with unsupported color (passthrough)
+{
+  const input = `{{% alert color="blue" %}} This alert has an unsupported color attribute. {{% /alert %}}`;
+  const result = runConvert(input);
+  assert.strictEqual(
+    result,
+    input,
+    'Alert with unsupported color should be unchanged',
+  );
+  console.log('✓ Alert with unsupported color (passthrough)');
+}
+
 console.log('\nAll tests passed!');


### PR DESCRIPTION
- Contributes to #8895
- Rewrites Docsy warning alerts in Hugo Markdown syntax. 
- Updated helper script to handle warnings, and more.
- Applies some minor copyedits
- Changed the alert type in some cases when the alert body warranted it
- Changed the alert render hook so that alerts can be a single line, in which case the line text is taken as the alert body

**Preview**: for example see ...

- https://deploy-preview-8904--opentelemetry.netlify.app/docs/languages/js/instrumentation/
- https://deploy-preview-8904--opentelemetry.netlify.app/docs/languages/js/instrumentation/#initialize-the-sdk