### PR TITLE
OBI: fix link to metrics features

### DIFF
--- a/content/en/docs/zero-code/obi/network/config.md
+++ b/content/en/docs/zero-code/obi/network/config.md
@@ -43,7 +43,8 @@ endpoint to export the network metrics (in the previous example,
 
 ## Network metrics configuration properties
 
-To enable network metrics, add one of the following `features` to the first-level
+To enable network metrics, add one of the following `features` to the
+first-level
 [metrics section](../../configure/export-data/#metrics-export-features):
 
 - `network` enables the `obi_network_flow_bytes` metric: the number of bytes


### PR DESCRIPTION
- [X] I have read and followed the
      [contribution guidelines](https://opentelemetry.io/docs/contributing/),
      including the **First-time contributing?** note.
- [ ] This PR includes **AI generated content**, and I have read and conform to
      the
      [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).

The way of enabling network metrics has been updated, but this paragraph still described the old procedure.