### PR TITLE
update obi metrics with new attributes

### DIFF
--- a/.cspell/en-words.txt
+++ b/.cspell/en-words.txt
@@ -150,3 +150,4 @@ wordpress
 WSGI
 zend
 zipkin
+geoip

--- a/content/en/docs/zero-code/obi/metrics.md
+++ b/content/en/docs/zero-code/obi/metrics.md
@@ -106,6 +106,12 @@ check the `attributes`->`select` section in the
 | `obi.network.flow.bytes`       | `src.port`                   | hidden                                            |
 | `obi.network.flow.bytes`       | `src.zone` (only Kubernetes) | hidden                                            |
 | `obi.network.flow.bytes`       | `transport`                  | hidden                                            |
+| `obi.network.flow.bytes`       | `network.type`               | hidden                                            |
+| `obi.network.flow.bytes`       | `network.protocol.name`      | hidden                                            |
+| `obi.network.flow.bytes`       | `src.country`                | shown if the `geoip` configuration section exists |
+| `obi.network.flow.bytes`       | `src.asn`                    | shown if the `geoip` configuration section exists |
+| `obi.network.flow.bytes`       | `dst.country`                | shown if the `geoip` configuration section exists |
+| `obi.network.flow.bytes`       | `dst.asn`                    | shown if the `geoip` configuration section exists |
 | Traces (SQL, Redis)            | `db.query.text`              | hidden                                            |
 
 {{< alert type="note" >}} The `obi.network.inter.zone.bytes` metric supports the


### PR DESCRIPTION
- [X] I have read and followed the
      [contribution guidelines](https://opentelemetry.io/docs/contributing/),
      including the **First-time contributing?** note.
- [ ] ~This PR includes **AI generated content**, and I have read and conform to
      the
      [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md)~.

This PR documents new metric attributes for the OBI `network.flow.bytes` metric introduced in https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1088, https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1027 and https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/887
