### PR TITLE
Version update script: drop collector/configuration.md

### DIFF
--- a/scripts/auto-update/all-versions.sh
+++ b/scripts/auto-update/all-versions.sh
@@ -10,8 +10,7 @@ function auto_update_versions() {
       "opentelemetry-collector-releases
         vers content/en/docs/collector/_index.md
         collector_vers content/en/docs/security/_index.md
-        collector_vers content/en/docs/zero-code/python/_index.md
-        collector_vers content/en/docs/collector/configuration.md"
+        collector_vers content/en/docs/zero-code/python/_index.md"
       "opentelemetry-java
         otel content/en/docs/languages/java/_index.md
         otel content/en/docs/zero-code/java/_index.md"


### PR DESCRIPTION
- [x] I have read and followed the
      [contribution guidelines](https://opentelemetry.io/docs/contributing/),
      including the **First-time contributing?** note.
- [ ] This PR includes **AI generated content**, and I have read and conform to
      the
      [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).

We released the java agent yesterday and i noticed the PRs didnt open. 

The [action failed](https://github.com/open-telemetry/opentelemetry.io/actions/runs/21093408601/job/60667696710)

```
+ sed -i.bak -e 's/\(^ *collector_vers:\) .*/\1 0.143.1/' content/en/docs/zero-code/python/_index.md
SEARCHING for:   '^ *collector_vers:' in content/en/docs/collector/configuration.md
Could not find regex "^ *collector_vers:" in content/en/docs/collector/configuration.md. Aborting.
```

This was added in #8692 but I don't think its needed because that page uses the {{% param vers %}} variable

