### PR TITLE
Configure Hugo to emit deprecation warnings

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -25,4 +25,4 @@ validate-links:
       message: >-
         GitHub URLs should use `github.(com|blog|io)` domains to avoid
         typosquatting. For details, see
-        https://github.com/open-telemetry/opentelemetry.io/issues/8085
+        https://github.com/open-telemetry/opentelemetry.io/issues/8085.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "__check:links": "make --keep-going check-links",
     "__check:format:nowrap": "npm run _check:format:any -- --prose-wrap preserve",
-    "_build": "npm run _hugo -- -e dev --buildDrafts --buildFuture --baseURL \"${DEPLOY_PRIME_URL:-http://localhost}\"",
+    "_build": "npm run _hugo -- --logLevel info -e dev --buildDrafts --buildFuture --baseURL \"${DEPLOY_PRIME_URL:-http://localhost}\"",
     "__check:format": "./scripts/npx-helper.sh prettier --ignore-unknown",
     "_check:format:any": "npm run __check:format -- --check --ignore-path ''",
     "_check:format:nowrap": "npm run __check:format:nowrap -- content/ja content/uk content/zh",


### PR DESCRIPTION
- Contributes to #8839
- Adds `--logLevel info` flag to `_build` script invocation of Hugo
- Fixes mdl message