### PR TITLE
Ensure banners are the same width as the full viewport

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -133,17 +133,23 @@
 }
 
 .o-banner {
-  @include media-breakpoint-up(md) {
-    width: 100%;
-    position: fixed;
-    margin-left: -15px;
-    z-index: 31;
-    top: 4rem;
-  }
-
-  background: var(--td-pre-bg);
+  background: var(--bs-tertiary-bg);
   color: var(--bs-body-color);
   text-align: center;
+
+  @include media-breakpoint-up(md) {
+    position: fixed;
+    top: 4rem;
+    z-index: 31;
+
+    // Handling the x positioning requires some calculations. Assumption is that
+    // the banner is inside a .container-fluid, which has this padding-x:
+    $padding-x: $container-padding-x * 0.5;
+    margin-left: -$padding-x; // Undo left padding of parent
+    left: $padding-x;
+    // Net x position of banner is margin-left + left == 0
+    width: 100%;
+  }
 
   & p {
     padding: 0.5rem;


### PR DESCRIPTION
- Fixes #8934
- Use semantically better var for banner bg

### Screenshots

| When | Screenshot (look at the right margin of the banner) |
|--------|--------|
| Before | <img width="974" height="271" alt="image" src="https://github.com/user-attachments/assets/12057270-31c2-4600-9486-d7916e615090" /> |
| After | <img width="974" height="362" alt="image" src="https://github.com/user-attachments/assets/3fa2d4df-d3f8-4468-86b9-171998286666" /> | 