### PR TITLE
[a11y] Improve navbar color contrast, switch to secondary color for hover color

### DIFF
--- a/assets/scss/_dark-adjustments.scss
+++ b/assets/scss/_dark-adjustments.scss
@@ -6,6 +6,10 @@
   }
 }
 
+// TODO: remove once Docsy is fixed and makes these variables accessible.
+$lighten-amount-for-dark-color-variant: 22% !default;
+$secondary-lighter: lighten($secondary, 30%) !default;
+
 // Make box-shadow color contrast more obvious in dark mode.
 // https://github.com/twbs/bootstrap/issues/39053 reports this issue.
 // TODO: upstream this to Docsy.
@@ -28,4 +32,13 @@ $box-shadow-color-rgb-dark: var(--bs-black-rgb) !default;
   --bs-box-shadow-sm: 0 0.125rem 0.25rem #{$box-shadow-color-rgba-dark};
   --bs-box-shadow-lg: 0 1rem 3rem #{$box-shadow-color-rgba-dark};
   --bs-box-shadow-inset: inset 0 1px 2px #{$box-shadow-color-rgba-dark};
+
+  // --------------------------------
+
+  --bs-secondary: #{$secondary-lighter} !important;
 }
+
+$primary-darker: shade-color(
+  $primary,
+  $lighten-amount-for-dark-color-variant
+) !default;

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -4,9 +4,9 @@
 @import 'registry';
 @import 'tabs';
 @import 'external_link';
-@import 'dark-adjustments';
 @import 'td/color-adjustments-dark';
 @import 'td/code-dark';
+@import 'dark-adjustments';
 @import 'td/gcs-search-dark';
 @import '_page_no_left_sidebar';
 
@@ -95,6 +95,54 @@
 }
 
 .td-navbar {
+  $navbar-nav-link-color-active: $gray-100;
+  // Slightly dim base / non-active nav links:
+  $navbar-nav-link-color-base: $gray-400;
+
+  background-color: $primary-darker;
+
+  // On the home page, color all nav links as if active.
+  @at-root .td-home & {
+    .nav-link {
+      color: $navbar-nav-link-color-active;
+    }
+  }
+
+  //--------------------------------
+  // TODO: upstream to Docsy
+  // Improve color contrast DRAFT
+  .nav-link {
+    color: $navbar-nav-link-color-base;
+
+    &.active {
+      // Actually, give the active nav link a hover tint instead of
+      // $navbar-nav-link-color-active.
+      color: tint-color($navbar-dark-hover-color, 50%);
+      text-decoration: $link-decoration;
+    }
+
+    &:hover {
+      color: var(--bs-navbar-hover-color); // default
+    }
+
+    &:focus,
+    // Bootstrap sets .nav-link:focus-visible, but in a way that isn't
+    // compatible with dark mode. This is a known issue, see
+    // https://github.com/twbs/bootstrap/issues/37549:
+    //
+    // > [ ] Docs navbar blue focus visible is almost invisible!
+    //
+    // Fallback to browser default:
+    &:focus-visible {
+      outline: revert;
+      box-shadow: none;
+    }
+  }
+  .td-search:not(:focus-within) {
+    color: $gray-200;
+  }
+  //--------------------------------
+
   .navbar-brand {
     @include media-breakpoint-up(md) {
       padding: 0;

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -42,3 +42,7 @@ $otel-registry-license-colors: (
 
 $primary: map-get($otel-colors, 'blue');
 $secondary: map-get($otel-colors, 'orange');
+
+// Link hover: use secondary as color base
+$navbar-dark-hover-color: $secondary;
+$link-hover-color: darken($secondary, 20%);


### PR DESCRIPTION
- Fixes #8938
- Switches to using `secondary` as the base color for link hover color. This PR uses this color for navbar nav-links, and plain links. (What isn't changed (yet), is nav-links in the sidenavs. I'll maybe do that later. This is a useful increment.)
- Improves the navbar entry color contrast. See in-code comments for all the details

**Preview**:

### Screenshots

### Homepage

In these screenshots, the OTel unplugged link shows the hover state.

Before:

<img width="999" height="152" alt="image" src="https://github.com/user-attachments/assets/fccd07b3-1084-4814-aeb3-1b2932f7c706" />

After:

<img width="1001" height="191" alt="image" src="https://github.com/user-attachments/assets/0999d2da-6e15-4297-9da8-3d4f0485252d" />

---

### Non-homepage

In these screen shots:

- **Status** is the **active** nav entry
- **Training** shows the `focus-visible` state (you can _barely_ see it in the before screenshot)
- **Language**/ localization menu shows the **hover** state

Before:

<img width="999" height="340" alt="image" src="https://github.com/user-attachments/assets/a5f695fc-c16e-4d08-8a55-406b0d750dd5" />

After:

<img width="999" height="339" alt="image" src="https://github.com/user-attachments/assets/1e6f41b5-40ee-4650-877c-8fbf98243b6e" />
