### PR TITLE
Update .textlintrc.yml

### DIFF
--- a/.textlintrc.yml
+++ b/.textlintrc.yml
@@ -132,7 +132,7 @@ rules:
         - '(?<=(^|\s))(?:\bdot|\.)net\b'
         - .NET
       - [ebpf, eBPF]
-      - [epbf, eBPF]
+      - [epbf, eBPF] # cSpell:disable-line
       - ['http[ /]?2(?:\.0)?', HTTP/2]
       - [he(/| or )she, they]
       - [\(s\)he, they]
@@ -150,9 +150,13 @@ rules:
       - [nd-?json, NDJSON]
       - [node\.?js, Node.js]
       - [open-source, open source]
-      - # OpenTelemetry
-        # Catch typos like: OpenTelemtry, opentelementry
-        # Exclude occurrences like:
+
+      - # OpenTelemetry rule
+        #
+        # Use to catch typos like: # cSpell:disable-next
+        # - OpenTelemtry, opentelementry
+        #
+        # We exclude (i.e., allow) occurrences like:
         # - Compound names: go.opentelemetry.io
         # - Paths: medium.com/opentelemetry
         # - Repo names: opentelemetry-cpp or ocaml-opentelemetry
@@ -161,6 +165,7 @@ rules:
         # cSpell:ignore teleme
         - '(?<![-#@./])\bopen[- ]?teleme?n?try\b(?![-./])'
         - OpenTelemetry
+
       - [os x, macOS]
       - [protable, portable]
       - [postgres, PostgreSQL]
@@ -174,6 +179,7 @@ rules:
       - ["uid['’]?(s)?", UID$1]
       - ['(walk)-(throughs?)', $1$2] # cSpell:disable-line
       - ['(work)-(arounds?)', $1$2]
+
       # Enable the following to find and replace "instrumentation module/package" with "instrumentation library":
       # - ["(auto(matic)?[- ])?instrumentation (module|package)", "instrumentation library"]
       # - ["(auto(matic)?[- ])?instrumentation (modules|packages)", "instrumentation libraries"]


### PR DESCRIPTION
- Adds cSpell:ignore directives to textlintrc file to stop flagging known invalid spellings that textlint corrects.
- Only comments / whitespace added or changed. No rules or config parameters have been changed.
- Copyedits to OTel rule comments
- This is in prep for #7671