### PR TITLE
Registry page: ensure md alert renders correctly

### DIFF
--- a/content/en/ecosystem/registry/_index.md
+++ b/content/en/ecosystem/registry/_index.md
@@ -37,7 +37,7 @@ redirects: [{ from: /ecosystem/registry*, to: '/ecosystem/registry?' }]
 
 {{% /blocks/lead %}}
 
-{{< blocks/section color="white" type="container-lg" >}}
+{{% blocks/section color="white pb-0" type="container-lg" %}}
 
 > [!NOTE]
 >
@@ -45,6 +45,10 @@ redirects: [{ from: /ecosystem/registry*, to: '/ecosystem/registry?' }]
 > collector components, utilities, and other useful projects in the
 > OpenTelemetry ecosystem. If you are a project maintainer, you can
 > [add your project to the OpenTelemetry Registry](adding/).
+
+{{% /blocks/lead %}}
+
+{{< blocks/section color="white pt-0" type="container-lg" >}}
 
 {{< ecosystem/registry/search-form >}}
 


### PR DESCRIPTION
- Fixes #8967
- **Preview**: https://deploy-preview-8968--opentelemetry.netlify.app/ecosystem/registry/

### Screenshots

| When | Screenshot |
|--------|--------|
| Before | <img width="827" height="646" alt="image" src="https://github.com/user-attachments/assets/d7925e5d-65f9-41f1-b3fb-fe4850bd70be" /> |
| After | <img width="824" height="727" alt="image" src="https://github.com/user-attachments/assets/b03e8f04-a59f-4fe9-89db-36dfb6d1d3b1" /> | 

Reference:

- Preview of site before we switched to Markdown alert syntax, e.g., see https://deploy-preview-8854--opentelemetry.netlify.app/ecosystem/registry/