### PR TITLE
declarative-configuration: kitchen sink url is 404 point to snippets instead

### DIFF
--- a/content/en/docs/languages/sdk-configuration/declarative-configuration.md
+++ b/content/en/docs/languages/sdk-configuration/declarative-configuration.md
@@ -103,7 +103,7 @@ as a starting point to migrate to declarative configuration.
 ## Available config options
 
 A complete list of config options can be found in the
-[kitchen sink example](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/examples/kitchen-sink.yaml).
+[snippets directory](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/snippets).
 
 ## Endpoint per signal
 


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

Looks like the kitchen sink example is gone in favor of smaller snippets, point the readers to the snippets folder then.