### PR TITLE
docs(contrib): fix missing `Submitting content` link

### DIFF
--- a/content/en/docs/contributing/development.md
+++ b/content/en/docs/contributing/development.md
@@ -5,7 +5,7 @@ description: Learn how to set up a development environment for this website.
 what-next: >
   You're now ready to [build](#build), [serve](#serve), and make updates to
   website files. For details on how to submit changes, see [Submitting
-  content][pr].
+  content](../pull-requests).
 weight: 60
 ---
 
@@ -178,7 +178,3 @@ such as (in alphabetical order):
   https://github.com/nvm-sh/nvm/blob/master/README.md#installing-and-updating
 [nvm-windows]: https://github.com/coreybutler/nvm-windows
 [WSL]: https://learn.microsoft.com/en-us/windows/wsl/install
-
-<!-- markdownlint-disable link-image-reference-definitions -->
-
-[pr]: ../pull-requests/


### PR DESCRIPTION
This was accidentally broken in 4edfbfc (#8904).

I assume finding the dangling reference was hard because it spans multiple lines (i.e., searching for `Submitting content` would actually not find *any* references) so I also moved from a collapsed to a full reference link while we're here.

<!-- MAINTAINER NOTE: each list item should be on a single line. -->
----

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

**Preview**: https://deploy-preview-9002--opentelemetry.netlify.app/docs/contributing/development/#cloud-ide-setup