### PR TITLE
docs(contrib): document common build error

### DIFF
--- a/content/en/docs/contributing/development.md
+++ b/content/en/docs/contributing/development.md
@@ -92,9 +92,10 @@ npm run build
 
 The generated site files are under `public`.
 
-If you see an error like `failed to load modules: module
-"github.com/FortAwesome/Font-Awesome" not found`, you probably forgot running
-the [setup instructions](#local-setup) (especially `npm install`) above.
+If you see an error like
+`failed to load modules: module "github.com/FortAwesome/Font-Awesome" not found`,
+you probably forgot running the [setup instructions](#local-setup) (especially
+`npm install`) above.
 
 ### Serve
 


### PR DESCRIPTION
I spent more time than I'm willing to admit chasing down this error, only to realize I hadn't run `npm install`.  In my defense, it's easy to miss since the other commands under *Local setup* didn't apply to me (not using `nvm`) -- hence, I'll claim it's a *common* build error. ;-)

Given that the *Serve* section also has troubleshooting information, this seems appropriate.

<!-- MAINTAINER NOTE: each list item should be on a single line. -->
---

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.