### PR TITLE
Add Kotlin to the list of languages in homepage

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -110,8 +110,8 @@ flows through your entire request path, connecting logs, metrics, and traces
 into a unified view. {{< /homepage/otel-feature >}}
 
 {{< homepage/otel-feature image="/img/homepage/feature-multi-language.svg" title="Multi-language support" url="/docs/languages/" >}}
-Native SDKs for 11+ languages including Java, Python, Go, JavaScript, .NET,
-Ruby, PHP, Rust, C++, Swift, and Erlang. Use your preferred language with
+Native SDKs for 12+ languages including Java, Kotlin, Python, Go, JavaScript,
+.NET, Ruby, PHP, Rust, C++, Swift, and Erlang. Use your preferred language with
 first-class OpenTelemetry support. {{< /homepage/otel-feature >}}
 
 {{< homepage/otel-feature image="/img/homepage/feature-production-ready.svg" title="Stable and production-ready" url="/status/" >}}


### PR DESCRIPTION
Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/8899

Adds "Kotlin" to the list of languages in the homepage.