### PR TITLE
Update language docs weights while preserving order

### DIFF
--- a/content/en/docs/languages/cpp/_index.md
+++ b/content/en/docs/languages/cpp/_index.md
@@ -1,6 +1,6 @@
 ---
 title: C++
-weight: 11
+weight: 110
 description: >
   <img width="35" class="img-initial otel-icon"
   src="/img/logos/32x32/C++_SDK.svg" alt="C++"> A language-specific

--- a/content/en/docs/languages/dotnet/_index.md
+++ b/content/en/docs/languages/dotnet/_index.md
@@ -5,7 +5,7 @@ description: >
   src="/img/logos/32x32/dotnet.svg" alt=".NET"> A language-specific
   implementation of OpenTelemetry in .NET.
 aliases: [net, /csharp, /csharp/metrics, /csharp/tracing]
-weight: 12
+weight: 120
 ---
 
 {{% docs/languages/index-intro dotnet /%}}

--- a/content/en/docs/languages/erlang/_index.md
+++ b/content/en/docs/languages/erlang/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Erlang/Elixir
-weight: 14
+weight: 130
 description: >
   <img width="35" class="img-initial otel-icon"
   src="/img/logos/32x32/Erlang_SDK.svg" alt="Erlang/Elixir"> A language-specific

--- a/content/en/docs/languages/go/_index.md
+++ b/content/en/docs/languages/go/_index.md
@@ -8,7 +8,7 @@ aliases: [/golang, /golang/metrics, /golang/tracing]
 redirects:
   - { from: /go/*, to: ':splat' }
   - { from: /docs/go/*, to: ':splat' }
-weight: 16
+weight: 140
 ---
 
 {{% docs/languages/index-intro go /%}}

--- a/content/en/docs/languages/java/_index.md
+++ b/content/en/docs/languages/java/_index.md
@@ -14,7 +14,7 @@ cascade:
     otel: 1.58.0
     contrib: 1.53.0
     semconv: 1.37.0
-weight: 18
+weight: 150
 ---
 
 {{% docs/languages/index-intro java /%}}

--- a/content/en/docs/languages/js/_index.md
+++ b/content/en/docs/languages/js/_index.md
@@ -8,7 +8,7 @@ aliases: [/js/metrics, /js/tracing, nodejs]
 redirects:
   - { from: /js/*, to: ':splat' }
   - { from: /docs/js/*, to: ':splat' }
-weight: 20
+weight: 160
 ---
 
 {{% docs/languages/index-intro js /%}}

--- a/content/en/docs/languages/kotlin/_index.md
+++ b/content/en/docs/languages/kotlin/_index.md
@@ -3,7 +3,7 @@ title: Kotlin
 description: >-
   <img width="35" class="img-initial otel-icon" src="/img/logos/32x32/SDK.svg"
   alt="Kotlin"> A language-specific implementation of OpenTelemetry in Kotlin.
-weight: 20
+weight: 170
 ---
 
 {{% docs/languages/index-intro kotlin /%}}

--- a/content/en/docs/languages/other/_index.md
+++ b/content/en/docs/languages/other/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Other languages
 linkTitle: Other
-weight: 99
+weight: 999
 description: >-
   Language-specific implementation of OpenTelemetry for other languages.
 ---

--- a/content/en/docs/languages/php/_index.md
+++ b/content/en/docs/languages/php/_index.md
@@ -6,7 +6,7 @@ description: >-
 redirects:
   - { from: /php/*, to: ':splat' }
   - { from: /docs/php/*, to: ':splat' }
-weight: 21
+weight: 180
 cSpell:ignore: mbstring opcache
 ---
 

--- a/content/en/docs/languages/python/_index.md
+++ b/content/en/docs/languages/python/_index.md
@@ -5,7 +5,7 @@ description: >-
   src="/img/logos/32x32/Python_SDK.svg" alt="Python"> A language-specific
   implementation of OpenTelemetry in Python.
 aliases: [/python, /python/metrics, /python/tracing]
-weight: 22
+weight: 190
 ---
 
 {{% docs/languages/index-intro python /%}}

--- a/content/en/docs/languages/ruby/_index.md
+++ b/content/en/docs/languages/ruby/_index.md
@@ -5,7 +5,7 @@ description: >
   src="/img/logos/32x32/Ruby_SDK.svg" alt="Ruby"> A language-specific
   implementation of OpenTelemetry in Ruby.
 aliases: [/ruby, /ruby/metrics, /ruby/tracing]
-weight: 24
+weight: 200
 ---
 
 {{% docs/languages/index-intro ruby /%}}

--- a/content/en/docs/languages/rust/_index.md
+++ b/content/en/docs/languages/rust/_index.md
@@ -3,7 +3,7 @@ title: Rust
 description: >-
   <img width="35" class="img-initial otel-icon" src="/img/logos/32x32/Rust.svg"
   alt="Rust"> A language-specific implementation of OpenTelemetry in Rust.
-weight: 26
+weight: 210
 cSpell:ignore: stackdriver
 ---
 

--- a/content/en/docs/languages/sdk-configuration/_index.md
+++ b/content/en/docs/languages/sdk-configuration/_index.md
@@ -3,7 +3,7 @@ title: SDK Configuration
 linkTitle: SDK Config
 aliases: [/docs/concepts/sdk-configuration]
 redirects: [{ from: /docs/concepts/sdk-configuration/*, to: ':splat' }]
-weight: 1
+weight: 10
 ---
 
 OpenTelemetry SDKs support configuration in each language and with environment

--- a/content/en/docs/languages/swift/_index.md
+++ b/content/en/docs/languages/swift/_index.md
@@ -3,7 +3,7 @@ title: Swift
 description: >-
   <img width="35" class="img-initial otel-icon" src="/img/logos/32x32/Swift.svg"
   alt="Swift"> A language-specific implementation of OpenTelemetry in Swift.
-weight: 28
+weight: 220
 ---
 
 {{% docs/languages/index-intro swift /%}}


### PR DESCRIPTION
- Followup to #9023
- Adjusts the language section weights to that:
  - SDK Config at the top (10)
  - Other at the bottom (999)
  - The rest in alphabetical order, but ...
  - .NET treated as if named “DotNet”
  - We have weight-space between languages

| Section | Before | After |
|---------|--------|-------|
| SDK Configuration | 1 | 10 |
| C++ | 11 | 110 |
| .NET | 12 | 120 |
| Erlang/Elixir | 14 | 130 |
| Go | 16 | 140 |
| Java | 18 | 150 |
| JavaScript | 20 | 160 |
| Kotlin | 20 | 170 |
| PHP | 21 | 180 |
| Python | 22 | 190 |
| Ruby | 24 | 200 |
| Rust | 26 | 210 |
| Swift | 28 | 220 |
| Other | 99 | 999 |
