### PR TITLE
Clarify translation guidelines for alerts

### DIFF
--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -44,14 +44,15 @@ guidance offered in this section.
 <div class="border-start border-warning bg-warning-subtle">
 
 - **Translate**:
+  - [Alert types](../style-guide/#alerts) such as `TIP`, `WARNING`, etc.
+  - Code, including code blocks and inline code (like this
+    `inline code example`)
   - **File or directory** names of resources in this repository
-  - [Links](#links), this includes [heading IDs](#headings) [^*]
-  - Inline code-spans like these: `inline code example`
-  - Markdown elements marked as `notranslate` (usually as a CSS class), in
-    particular for [headings](#headings)
   - [Front matter][] fields other than those listed in [Do](#do). In particular,
     do not translate `aliases`. When in doubt, ask maintainers.
-  - Code
+  - [Links](#links), this includes [heading IDs](#headings) [^*]
+  - Markdown elements marked as `notranslate` (usually as a CSS class), in
+    particular for [headings](#headings)
 - Create **copies of images**, unless you [localize text in the images](#images)
 - Add new or change:
   - **Content** that would be different from the originally intended meaning


### PR DESCRIPTION
- Followup to #9029
- Adds an item to "Do not translate" list for alert types
- Reorders the "Do not translate" list items to be alphabetical

**Preview**: https://deploy-preview-9032--opentelemetry.netlify.app/docs/contributing/localization/#do-not