### PR TITLE
fix: handle multiline comments in first-timer-response

### DIFF
--- a/.github/workflows/first-timer-response.yml
+++ b/.github/workflows/first-timer-response.yml
@@ -37,7 +37,10 @@ jobs:
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
-          echo "body_lower=$(echo "$COMMENT_BODY" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+          # Use heredoc delimiter for multiline-safe output
+          echo "body_lower<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$COMMENT_BODY" | tr '[:upper:]' '[:lower:]' >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
       # Check if the comment looks like an assignment request
       - name: Check if comment is assignment request


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

Fixes #9040 

The first-timer-response workflow fails when issue comments contain multiple lines because $GITHUB_OUTPUT expects key=value on a single line.

This PR switches to the [heredoc delimiter syntax](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strings) which properly handles multiline content.