### PR TITLE
Cleanup homepage SCSS and search structure

### DIFF
--- a/assets/scss/_homepage.scss
+++ b/assets/scss/_homepage.scss
@@ -1,785 +1,744 @@
-// Ensure homepage SVGs have transparent backgrounds
-.td-home,
-.intro-section,
-.main-feature,
-.otel-feature,
-.signal-card {
+.td-home {
+  // Ensure all SVGs have transparent backgrounds
   img[src$='.svg'],
   svg {
     background: transparent !important;
   }
-}
 
-// =============================================================================
-// HERO WITH BACKGROUND - Hero section with background image support
-// =============================================================================
+  // =============================================================================
+  // HERO WITH BACKGROUND - Hero section with background image support
+  // =============================================================================
 
-// Semantic overlay system with dark mode support
-:root {
-  --hero-overlay-bg: rgba(0, 0, 0, 0.3);
-}
+  @at-root {
+    // Semantic overlay system with dark mode support
+    :root {
+      --hero-overlay-bg: rgba(0, 0, 0, 0.3);
+    }
 
-@include color-mode(dark) {
-  :root {
-    --hero-overlay-bg: rgba(0, 0, 0, 0.5); // Darker overlay for dark mode
-  }
-}
-
-.hero-with-bg {
-  background-image: var(--hero-bg-image);
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
-  position: relative;
-
-  // Semantic overlay for better text contrast
-  &::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: var(--hero-overlay-bg);
-    pointer-events: none;
-  }
-
-  // Ensure content is above the overlay
-  > .col {
-    position: relative;
-    z-index: 1;
-  }
-
-  // Use high contrast colors for background images
-  // Leverage Docsy's color-contrast system instead of !important
-  &,
-  .hero-simple,
-  .hero-simple__tagline,
-  .hero-simple__content,
-  .hero-simple__content p,
-  .hero-simple__content a,
-  .hero-simple__content li,
-  .l-primary-buttons ul li a {
-    color: var(--bs-white);
-  }
-}
-
-// =============================================================================
-// HERO SIMPLE - Simplified hero section using Docsy's blocks/section
-// =============================================================================
-
-.hero-simple {
-  max-width: 800px;
-  margin: 0 auto;
-
-  &__logo {
-    .hero-simple__logo-img {
-      height: 120px;
-      width: auto;
-      max-width: 100%;
-
-      @include media-breakpoint-up(md) {
-        height: 144px;
-      }
-
-      @include media-breakpoint-up(lg) {
-        height: 168px;
+    @include color-mode(dark) {
+      :root {
+        --hero-overlay-bg: rgba(0, 0, 0, 0.5); // Darker overlay for dark mode
       }
     }
   }
 
-  &__tagline {
-    font-size: 1.5rem;
-    font-weight: 500;
-    line-height: 1.4;
+  .hero-with-bg {
+    background-image: var(--hero-bg-image);
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    position: relative;
+
+    // Semantic overlay for better text contrast
+    &::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: var(--hero-overlay-bg);
+      pointer-events: none;
+    }
+
+    // Ensure content is above the overlay
+    > .col {
+      position: relative;
+      z-index: 1;
+    }
+
+    // TODO(chalin): clean this up
+    // Use high contrast colors for background images
+    // Leverage Docsy's color-contrast system instead of !important
+    &,
+    .hero-simple,
+    .hero-simple__tagline,
+    .hero-simple__content,
+    .hero-simple__content p,
+    .hero-simple__content a,
+    .hero-simple__content li,
+    .l-primary-buttons ul li a {
+      color: var(--bs-white);
+    }
+  }
+
+  // =============================================================================
+  // HERO SIMPLE - Simplified hero section using Docsy's blocks/section
+  // =============================================================================
+
+  .hero-simple {
+    max-width: 800px;
+    margin: 0 auto;
+
+    &__logo {
+      .hero-simple__logo-img {
+        height: 120px;
+        width: auto;
+        max-width: 100%;
+
+        @include media-breakpoint-up(md) {
+          height: 144px;
+        }
+
+        @include media-breakpoint-up(lg) {
+          height: 168px;
+        }
+      }
+    }
+
+    &__tagline {
+      font-size: 1.5rem;
+      font-weight: 500;
+      line-height: 1.4;
+
+      @include media-breakpoint-up(md) {
+        font-size: 1.75rem;
+      }
+
+      @include media-breakpoint-up(lg) {
+        font-size: 2rem;
+      }
+    }
+  }
+
+  // =============================================================================
+  // HERO TAGLINE - Tagline for compact hero (legacy, kept for compatibility)
+  // =============================================================================
+
+  .hero-tagline {
+    font-size: 2rem;
+    line-height: 1.3;
+    max-width: 800px;
+    margin: 2rem auto 0;
 
     @include media-breakpoint-up(md) {
-      font-size: 1.75rem;
+      font-size: 2.5rem;
+      margin-top: 3rem;
     }
+  }
+
+  // =============================================================================
+  // HERO SEARCH - Search bar section below compact hero
+  // =============================================================================
+
+  // Override td-box default padding for compact search section
+  section.td-box.hero-search-section {
+    padding-top: 3rem;
+    padding-bottom: 3rem;
+    border-bottom: 1px solid var(--bs-border-color);
+  }
+
+  .hero-search {
+    max-width: 70%;
+    margin: 0 auto;
+    text-align: center;
+
+    @include media-breakpoint-down(md) {
+      max-width: 90%;
+    }
+
+    &__input-wrapper {
+      margin-bottom: 0.125rem;
+    }
+
+    &__search {
+      width: 100%;
+
+      .td-search__input {
+        width: 100%;
+        padding: 0.75rem 0.75rem 0.75rem 2.5rem;
+        font-size: $font-size-base;
+        border-radius: 2rem;
+        border: 2px solid var(--bs-border-color);
+        transition:
+          border-color 0.2s ease,
+          box-shadow 0.2s ease;
+
+        &:focus {
+          border-color: var(--bs-primary);
+          box-shadow: 0 0 0 3px rgba(var(--bs-primary-rgb), 0.15);
+        }
+      }
+
+      .td-search__icon {
+        left: 1rem;
+        top: 50%;
+        transform: translateY(-50%);
+      }
+    }
+
+    &__extra {
+      font-size: $font-size-sm;
+      color: var(--bs-secondary-color);
+
+      a {
+        color: var(--bs-primary);
+      }
+    }
+  }
+
+  // =============================================================================
+  // INTRO SECTION - What is OpenTelemetry description
+  // =============================================================================
+
+  .intro-content {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 0 1rem;
+    display: grid;
+    gap: 2rem;
+    align-items: center;
 
     @include media-breakpoint-up(lg) {
-      font-size: 2rem;
+      grid-template-columns: 1fr 1fr;
+    }
+
+    .intro-text {
+      p {
+        font-size: 1.2rem;
+        line-height: 1.7;
+        margin-bottom: 1rem;
+
+        @include media-breakpoint-up(md) {
+          font-size: 1.2rem;
+        }
+
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
+    }
+
+    .intro-image {
+      text-align: center;
+
+      img {
+        max-width: 100%;
+        height: auto;
+        max-height: 350px;
+        border-radius: var(--bs-border-radius-lg);
+      }
     }
   }
 
-  // Button list styling
-  .l-primary-buttons {
-    margin-top: 1.5rem;
+  // =============================================================================
+  // MAIN FEATURES - Three key features with images (like K8s)
+  // =============================================================================
 
-    ul {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-      display: flex;
-      gap: 4px;
-      flex-wrap: wrap;
-      justify-content: center;
+  .td-default main section.main-features-section {
+    padding: 0;
+    // Full bleed
+    position: relative;
+    left: 50%;
+    right: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    width: 100vw;
+  }
 
+  .main-features {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .main-feature-wrapper {
+    padding: 2.5rem 1rem;
+
+    // Alternating backgrounds using semantic variables
+    &:nth-child(odd) {
+      background: var(--bs-tertiary-bg);
+    }
+
+    &:nth-child(even) {
+      background: var(--bs-body-bg);
+    }
+  }
+
+  .main-feature {
+    display: grid;
+    gap: 2rem;
+    align-items: center;
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 0 1rem;
+
+    @include media-breakpoint-up(lg) {
+      grid-template-columns: 1fr 1fr;
+      gap: 3rem;
+    }
+
+    &--image-right {
       @include media-breakpoint-up(lg) {
-        gap: 1rem;
+        .main-feature__image {
+          order: 2;
+        }
+        .main-feature__content {
+          order: 1;
+        }
       }
     }
 
-    li {
-      margin: 0;
-    }
-  }
-}
+    &__image {
+      text-align: center;
 
-// =============================================================================
-// HERO TAGLINE - Tagline for compact hero (legacy, kept for compatibility)
-// =============================================================================
-
-.hero-tagline {
-  font-size: 2rem;
-  line-height: 1.3;
-  max-width: 800px;
-  margin: 2rem auto 0;
-
-  @include media-breakpoint-up(md) {
-    font-size: 2.5rem;
-    margin-top: 3rem;
-  }
-}
-
-// =============================================================================
-// HERO SEARCH - Search bar section below compact hero
-// =============================================================================
-
-// Override td-box default padding for compact search section
-.td-home section.td-box.hero-search-section {
-  padding-top: 3rem;
-  padding-bottom: 3rem;
-  border-bottom: 1px solid var(--bs-border-color);
-}
-
-.hero-search {
-  max-width: 70%;
-  margin: 0 auto;
-  text-align: center;
-
-  @include media-breakpoint-down(md) {
-    max-width: 90%;
-  }
-
-  &__input-wrapper {
-    margin-bottom: 0.125rem;
-  }
-
-  &__search {
-    width: 100%;
-
-    .td-search__input {
-      width: 100%;
-      padding: 0.75rem 0.75rem 0.75rem 2.5rem;
-      font-size: $font-size-base;
-      border-radius: 2rem;
-      border: 2px solid var(--bs-border-color);
-      transition:
-        border-color 0.2s ease,
-        box-shadow 0.2s ease;
-
-      &:focus {
-        border-color: var(--bs-primary);
-        box-shadow: 0 0 0 3px rgba(var(--bs-primary-rgb), 0.15);
+      img {
+        max-width: 100%;
+        height: auto;
+        max-height: 250px;
+        object-fit: contain;
+        border-radius: var(--bs-border-radius-lg);
       }
     }
 
-    .td-search__icon {
-      left: 1rem;
-      top: 50%;
-      transform: translateY(-50%);
+    &__placeholder {
+      background: var(--bs-secondary-bg);
+      border: 2px dashed var(--bs-border-color);
+      border-radius: 8px;
+      padding: 4rem 2rem;
+      color: var(--bs-secondary-color);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 200px;
     }
-  }
 
-  &__extra {
-    font-size: $font-size-sm;
-    color: var(--bs-secondary-color);
+    &__title {
+      font-size: $h4-font-size;
+      font-weight: $font-weight-bold;
+      margin-bottom: 0.75rem;
 
-    a {
-      color: var(--bs-primary);
+      a {
+        color: inherit;
+        text-decoration: none;
+
+        &:hover {
+          text-decoration: underline;
+        }
+      }
     }
-  }
-}
 
-// =============================================================================
-// INTRO SECTION - What is OpenTelemetry description
-// =============================================================================
-
-.intro-section {
-  padding: 2.5rem 0;
-}
-
-.intro-content {
-  max-width: 1000px;
-  margin: 0 auto;
-  padding: 0 1rem;
-  display: grid;
-  gap: 2rem;
-  align-items: center;
-
-  @include media-breakpoint-up(lg) {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .intro-text {
-    p {
+    &__description {
       font-size: 1.2rem;
       line-height: 1.7;
-      margin-bottom: 1rem;
 
-      @include media-breakpoint-up(md) {
-        font-size: 1.2rem;
-      }
-
-      &:last-child {
+      p:last-child {
         margin-bottom: 0;
       }
     }
   }
 
-  .intro-image {
-    text-align: center;
+  // =============================================================================
+  // SIGNALS SHOWCASE - Four observability signals
+  // =============================================================================
 
-    img {
-      max-width: 100%;
-      height: auto;
-      max-height: 350px;
-      border-radius: var(--bs-border-radius-lg);
+  .signals-showcase {
+    &-section {
+      border-top: 1px solid var(--bs-border-color-translucent);
+      border-bottom: 1px solid var(--bs-border-color-translucent);
     }
-  }
-}
 
-// =============================================================================
-// MAIN FEATURES - Three key features with images (like K8s)
-// =============================================================================
+    &__title {
+      text-align: center;
+      font-size: $h2-font-size;
+      margin-bottom: 2rem;
+      color: var(--bs-body-color);
+    }
 
-.td-default main section.main-features-section {
-  padding: 0;
-  // Full bleed
-  position: relative;
-  left: 50%;
-  right: 50%;
-  margin-left: -50vw;
-  margin-right: -50vw;
-  width: 100vw;
-}
+    &__grid {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 2rem;
+      max-width: 1000px;
+      margin: 0 auto;
 
-.main-features {
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-}
-
-.main-feature-wrapper {
-  padding: 2.5rem 1rem;
-
-  // Alternating backgrounds using semantic variables
-  &:nth-child(odd) {
-    background: var(--bs-tertiary-bg);
-  }
-
-  &:nth-child(even) {
-    background: var(--bs-body-bg);
-  }
-}
-
-.main-feature {
-  display: grid;
-  gap: 2rem;
-  align-items: center;
-  max-width: 1000px;
-  margin: 0 auto;
-  padding: 0 1rem;
-
-  @include media-breakpoint-up(lg) {
-    grid-template-columns: 1fr 1fr;
-    gap: 3rem;
-  }
-
-  &--image-right {
-    @include media-breakpoint-up(lg) {
-      .main-feature__image {
-        order: 2;
+      @include media-breakpoint-down(md) {
+        grid-template-columns: repeat(2, 1fr);
       }
-      .main-feature__content {
-        order: 1;
+
+      @include media-breakpoint-down(sm) {
+        grid-template-columns: 1fr;
       }
     }
   }
 
-  &__image {
-    text-align: center;
-
-    img {
-      max-width: 100%;
-      height: auto;
-      max-height: 250px;
-      object-fit: contain;
-      border-radius: var(--bs-border-radius-lg);
-    }
-  }
-
-  &__placeholder {
-    background: var(--bs-secondary-bg);
-    border: 2px dashed var(--bs-border-color);
-    border-radius: 8px;
-    padding: 4rem 2rem;
-    color: var(--bs-secondary-color);
+  .signal-card {
     display: flex;
+    flex-direction: column;
     align-items: center;
-    justify-content: center;
-    min-height: 200px;
+    text-align: center;
+    padding: 1rem;
+    background: transparent;
+    border-radius: 8px;
+    text-decoration: none;
+    color: var(--bs-body-color);
+    transition: all 0.2s ease;
+
+    &:hover {
+      transform: translateY(-2px);
+      color: var(--bs-primary);
+      text-decoration: none;
+    }
+
+    &__icon {
+      font-size: 2.5rem;
+      margin-bottom: 0.5rem;
+      color: var(--bs-primary);
+    }
+
+    &__img {
+      width: 140px;
+      height: 140px;
+      object-fit: contain;
+      margin-bottom: 0.5rem;
+      border-radius: var(--bs-border-radius-lg);
+    }
+
+    &__name {
+      font-size: 1.6rem;
+      font-weight: $font-weight-bold;
+    }
+
+    &__description {
+      font-size: 1rem;
+      opacity: 0.6;
+      margin-top: 0.125rem;
+    }
   }
 
-  &__title {
-    font-size: $h4-font-size;
-    font-weight: $font-weight-bold;
-    margin-bottom: 0.75rem;
+  // =============================================================================
+  // OTEL FEATURES GRID - "Why OpenTelemetry?" section
+  // =============================================================================
 
-    a {
-      color: inherit;
-      text-decoration: none;
+  .otel-features {
+    display: grid;
+    gap: 1.5rem 2rem;
+    margin-top: 1.5rem;
+    max-width: 1000px;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 0 1rem;
 
-      &:hover {
-        text-decoration: underline;
+    // Default: 3 columns on desktop
+    &--cols-3 {
+      @include media-breakpoint-up(lg) {
+        grid-template-columns: repeat(3, 1fr);
+      }
+      @include media-breakpoint-only(md) {
+        grid-template-columns: repeat(2, 1fr);
       }
     }
-  }
 
-  &__description {
-    font-size: 1.2rem;
-    line-height: 1.7;
+    // Alternative: 2 columns
+    &--cols-2 {
+      @include media-breakpoint-up(md) {
+        grid-template-columns: repeat(2, 1fr);
+      }
+    }
 
-    p:last-child {
-      margin-bottom: 0;
+    &__title {
+      font-size: $h2-font-size;
+      margin-bottom: 0.5rem;
+      text-align: center;
+    }
+
+    &__subtitle {
+      font-size: $lead-font-size;
+      opacity: 0.8;
+      margin-bottom: 2rem;
     }
   }
-}
 
-// =============================================================================
-// SIGNALS SHOWCASE - Four observability signals
-// =============================================================================
-
-.signals-showcase-section {
-  background: var(--bs-body-bg);
-  color: var(--bs-body-color);
-  padding: 1rem 0; // Reduced vertical padding
-  border-top: 1px solid var(--bs-border-color-translucent);
-  border-bottom: 1px solid var(--bs-border-color-translucent);
-}
-
-.signals-showcase {
-  &__title {
+  .otel-feature {
     text-align: center;
-    font-size: $h2-font-size;
-    margin-bottom: 2rem;
-    color: var(--bs-body-color);
-  }
+    padding: 1rem;
 
-  &__grid {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 2rem;
-    max-width: 1000px;
-    margin: 0 auto;
+    &__icon {
+      font-size: 128px;
+      margin-bottom: 1.5rem;
+      color: var(--bs-primary);
+      display: flex;
+      justify-content: center;
 
-    @include media-breakpoint-down(md) {
-      grid-template-columns: repeat(2, 1fr);
+      svg {
+        width: 128px;
+        height: 128px;
+        fill: currentColor;
+      }
+
+      i {
+        font-size: 128px;
+      }
     }
 
-    @include media-breakpoint-down(sm) {
-      grid-template-columns: 1fr;
-    }
-  }
-}
-
-.signal-card {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  padding: 1rem;
-  background: transparent;
-  border-radius: 8px;
-  text-decoration: none;
-  color: var(--bs-body-color);
-  transition: all 0.2s ease;
-
-  &:hover {
-    transform: translateY(-2px);
-    color: var(--bs-primary);
-    text-decoration: none;
-  }
-
-  &__icon {
-    font-size: 2.5rem;
-    margin-bottom: 0.5rem;
-    color: var(--bs-primary);
-  }
-
-  &__img {
-    width: 140px;
-    height: 140px;
-    object-fit: contain;
-    margin-bottom: 0.5rem;
-    border-radius: var(--bs-border-radius-lg);
-  }
-
-  &__name {
-    font-size: 1.6rem;
-    font-weight: $font-weight-bold;
-  }
-
-  &__description {
-    font-size: 1rem;
-    opacity: 0.6;
-    margin-top: 0.125rem;
-  }
-}
-
-// =============================================================================
-// OTEL FEATURES GRID - "Why OpenTelemetry?" section
-// =============================================================================
-
-.otel-features-section {
-  padding: 3rem 0;
-}
-
-.otel-features {
-  display: grid;
-  gap: 1.5rem 2rem;
-  margin-top: 1.5rem;
-  max-width: 1000px;
-  margin-left: auto;
-  margin-right: auto;
-  padding: 0 1rem;
-
-  // Default: 3 columns on desktop
-  &--cols-3 {
-    @include media-breakpoint-up(lg) {
-      grid-template-columns: repeat(3, 1fr);
-    }
-    @include media-breakpoint-only(md) {
-      grid-template-columns: repeat(2, 1fr);
-    }
-  }
-
-  // Alternative: 2 columns
-  &--cols-2 {
-    @include media-breakpoint-up(md) {
-      grid-template-columns: repeat(2, 1fr);
-    }
-  }
-
-  &__title {
-    font-size: $h2-font-size;
-    margin-bottom: 0.5rem;
-    text-align: center;
-  }
-
-  &__subtitle {
-    font-size: $lead-font-size;
-    opacity: 0.8;
-    margin-bottom: 2rem;
-  }
-}
-
-.otel-feature {
-  text-align: center;
-  padding: 1rem;
-
-  &__icon {
-    font-size: 128px;
-    margin-bottom: 1.5rem;
-    color: var(--bs-primary);
-    display: flex;
-    justify-content: center;
-
-    svg {
+    &__img {
       width: 128px;
       height: 128px;
-      fill: currentColor;
+      object-fit: contain;
+      border-radius: var(--bs-border-radius-lg);
+      margin-bottom: 1.5rem;
     }
 
-    i {
-      font-size: 128px;
-    }
-  }
+    &__title {
+      font-size: 1.4rem;
+      font-weight: $font-weight-bold;
+      margin-bottom: 0.5rem;
+      text-align: center;
 
-  &__img {
-    width: 128px;
-    height: 128px;
-    object-fit: contain;
-    border-radius: var(--bs-border-radius-lg);
-    margin-bottom: 1.5rem;
-  }
+      a {
+        color: var(--bs-link-color);
+        text-decoration: none;
 
-  &__title {
-    font-size: 1.4rem;
-    font-weight: $font-weight-bold;
-    margin-bottom: 0.5rem;
-    text-align: center;
-
-    a {
-      color: var(--bs-link-color);
-      text-decoration: none;
-
-      &:hover {
-        color: var(--bs-link-hover-color);
-        text-decoration: underline;
-      }
-    }
-  }
-
-  &__description {
-    font-size: 1.1rem;
-    line-height: 1.6;
-    opacity: 0.8;
-    text-align: center;
-  }
-}
-
-// =============================================================================
-// ECOSYSTEM STATS - Key numbers display
-// =============================================================================
-
-.ecosystem-stats-section {
-  padding: 3rem 0;
-}
-
-.ecosystem-stats {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 4rem;
-  max-width: 1000px;
-  margin: 0 auto;
-  padding: 0 1rem;
-
-  @include media-breakpoint-down(md) {
-    gap: 2rem;
-  }
-}
-
-.ecosystem-stat {
-  text-align: center;
-  min-width: 120px;
-
-  &__number {
-    font-size: 3rem;
-    font-weight: $font-weight-bold;
-    line-height: 1;
-    // Use Bootstrap's semantic white variable (works in both modes)
-    color: var(--bs-white);
-
-    // Let Docsy's box-variant handle link colors automatically
-    // This ensures proper contrast on colored backgrounds
-    a {
-      color: inherit; // Inherit the white color
-      text-decoration: none;
-
-      &:hover {
-        color: rgba(
-          var(--bs-white-rgb),
-          0.85
-        ); // Use RGB variable for transparency
+        &:hover {
+          color: var(--bs-link-hover-color);
+          text-decoration: underline;
+        }
       }
     }
 
-    @include media-breakpoint-down(md) {
-      font-size: 2.5rem;
+    &__description {
+      font-size: 1.1rem;
+      line-height: 1.6;
+      opacity: 0.8;
+      text-align: center;
     }
   }
 
-  &__label {
-    font-size: $font-size-base;
-    margin-top: 0.5rem;
-    // Use Bootstrap's semantic white variable with transparency
-    color: rgba(var(--bs-white-rgb), 0.8);
-  }
-}
+  // =============================================================================
+  // ECOSYSTEM STATS - Key numbers display
+  // =============================================================================
 
-// =============================================================================
-// ARCHITECTURE DIAGRAM - Visual data flow
-// =============================================================================
-
-.architecture-diagram {
-  padding: 2rem 0;
-  text-align: center;
-
-  &__container {
+  .ecosystem-stats {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 4rem;
     max-width: 1000px;
     margin: 0 auto;
-    padding: 2rem 1rem;
-  }
-
-  &__title {
-    font-size: $h3-font-size;
-    margin-bottom: 1.5rem;
-  }
-
-  // For inline SVG diagrams
-  svg {
-    max-width: 100%;
-    height: auto;
-  }
-
-  // For Mermaid diagrams
-  .mermaid {
-    background: transparent;
-  }
-}
-
-// =============================================================================
-// ADOPTERS SHOWCASE - Company logo grid
-// =============================================================================
-
-.adopters-showcase-section {
-  padding: 3rem 0;
-}
-
-.adopters-showcase {
-  &__title {
-    text-align: center;
-    font-size: $h2-font-size;
-    margin-bottom: 2rem;
-  }
-
-  &__grid {
-    display: grid;
-    grid-template-columns: repeat(5, 1fr);
-    gap: 2.5rem 3rem;
-    align-items: center;
-    justify-items: center;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0;
-
-    @include media-breakpoint-down(lg) {
-      grid-template-columns: repeat(4, 1fr);
-      gap: 2rem 2.5rem;
-    }
+    padding: 0 1rem;
 
     @include media-breakpoint-down(md) {
-      grid-template-columns: repeat(3, 1fr);
-      gap: 1.5rem 2rem;
-    }
-
-    @include media-breakpoint-down(sm) {
-      grid-template-columns: repeat(2, 1fr);
-      gap: 1.5rem;
+      gap: 2rem;
     }
   }
 
-  &__item {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 1rem;
-    transition: transform 0.2s ease;
-
-    &:hover {
-      transform: scale(1.05);
-    }
-
-    img {
-      object-fit: contain;
-      transition: all 0.2s ease;
-    }
-  }
-
-  // Text-only adopter display (when logos aren't available)
-  &__item--text {
-    font-size: $font-size-lg;
-    font-weight: $font-weight-semibold;
-    color: $text-muted;
-    text-decoration: none;
-
-    &:hover {
-      color: $primary;
-    }
-  }
-
-  &__cta {
+  .ecosystem-stat {
     text-align: center;
-    margin-top: 2rem;
+    min-width: 120px;
+
+    &__number {
+      font-size: 3rem;
+      font-weight: $font-weight-bold;
+      line-height: 1;
+      // Use Bootstrap's semantic white variable (works in both modes)
+      color: var(--bs-white);
+
+      // Let Docsy's box-variant handle link colors automatically
+      // This ensures proper contrast on colored backgrounds
+      a {
+        color: inherit; // Inherit the white color
+        text-decoration: none;
+
+        &:hover {
+          color: rgba(
+            var(--bs-white-rgb),
+            0.85
+          ); // Use RGB variable for transparency
+        }
+      }
+
+      @include media-breakpoint-down(md) {
+        font-size: 2.5rem;
+      }
+    }
+
+    &__label {
+      font-size: $font-size-base;
+      margin-top: 0.5rem;
+      // Use Bootstrap's semantic white variable with transparency
+      color: rgba(var(--bs-white-rgb), 0.8);
+    }
   }
+
+  // =============================================================================
+  // ARCHITECTURE DIAGRAM - Visual data flow
+  // =============================================================================
+
+  .architecture-diagram {
+    padding: 2rem 0;
+    text-align: center;
+
+    &__container {
+      max-width: 1000px;
+      margin: 0 auto;
+      padding: 2rem 1rem;
+    }
+
+    &__title {
+      font-size: $h3-font-size;
+      margin-bottom: 1.5rem;
+    }
+
+    // For inline SVG diagrams
+    svg {
+      max-width: 100%;
+      height: auto;
+    }
+
+    // For Mermaid diagrams
+    .mermaid {
+      background: transparent;
+    }
+  }
+
+  // =============================================================================
+  // ADOPTERS SHOWCASE - Company logo grid
+  // =============================================================================
+
+  .adopters-showcase {
+    &__title {
+      text-align: center;
+      font-size: $h2-font-size;
+      margin-bottom: 2rem;
+    }
+
+    &__grid {
+      display: grid;
+      grid-template-columns: repeat(5, 1fr);
+      gap: 2.5rem 3rem;
+      align-items: center;
+      justify-items: center;
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 0;
+
+      @include media-breakpoint-down(lg) {
+        grid-template-columns: repeat(4, 1fr);
+        gap: 2rem 2.5rem;
+      }
+
+      @include media-breakpoint-down(md) {
+        grid-template-columns: repeat(3, 1fr);
+        gap: 1.5rem 2rem;
+      }
+
+      @include media-breakpoint-down(sm) {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 1.5rem;
+      }
+    }
+
+    &__item {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1rem;
+      transition: transform 0.2s ease;
+
+      &:hover {
+        transform: scale(1.05);
+      }
+
+      img {
+        object-fit: contain;
+        transition: all 0.2s ease;
+      }
+    }
+
+    // Text-only adopter display (when logos aren't available)
+    &__item--text {
+      font-size: $font-size-lg;
+      font-weight: $font-weight-semibold;
+      color: $text-muted;
+      text-decoration: none;
+
+      &:hover {
+        color: $primary;
+      }
+    }
+
+    &__cta {
+      text-align: center;
+      margin-top: 2rem;
+    }
+  }
+
+  // =============================================================================
+  // CNCF SECTION - Use Docsy's automatic contrast system
+  // =============================================================================
+
+  // Note: CNCF section should use class="td-box td-box--secondary" in HTML
+  // This leverages Docsy's box-variant mixin which automatically calculates:
+  // - color: color-contrast($secondary) = white
+  // - Proper link colors via mix($blue, $text-color, lightness($secondary))
+  // No CSS overrides needed here!
 }
-
-// =============================================================================
-// CNCF SECTION - Use Docsy's automatic contrast system
-// =============================================================================
-
-// Note: CNCF section should use class="td-box td-box--secondary" in HTML
-// This leverages Docsy's box-variant mixin which automatically calculates:
-// - color: color-contrast($secondary) = white
-// - Proper link colors via mix($blue, $text-color, lightness($secondary))
-// No CSS overrides needed here!
 
 // =============================================================================
 // MINIMAL DARK MODE ADJUSTMENTS
 // =============================================================================
 
 @include color-mode(dark) {
-  // Most dark mode styling is now handled automatically by Bootstrap CSS variables!
-  // Only a few specific cases need overrides:
+  .td-home {
+    // Most dark mode styling is now handled automatically by Bootstrap CSS variables!
+    // Only a few specific cases need overrides:
 
-  // Fix missing dark mode support for td-box--light (same as Docsy's td-box--white)
-  .td-box--light {
-    color: var(--bs-body-color);
-    background-color: var(--bs-body-bg);
+    // Fix missing dark mode support for td-box--light (same as Docsy's td-box--white)
+    .td-box--light {
+      color: var(--bs-body-color);
+      background-color: var(--bs-body-bg);
 
-    p > a,
-    span > a {
-      color: var(--bs-link-color);
-      &:focus,
-      &:hover {
-        color: rgba(var(--bs-link-color-rgb), var(--bs-link-opacity, 1));
+      p > a,
+      span > a {
+        color: var(--bs-link-color);
+        &:focus,
+        &:hover {
+          color: rgba(var(--bs-link-color-rgb), var(--bs-link-opacity, 1));
+        }
+      }
+
+      .td-arrow-down::before {
+        border-color: var(--bs-body-bg) transparent transparent transparent;
       }
     }
 
-    .td-arrow-down::before {
-      border-color: var(--bs-body-bg) transparent transparent transparent;
-    }
-  }
+    // Fix CNCF section (td-box--secondary) link contrast
+    // Override Docsy's calculated link color to use semantic white in both modes
+    .td-box--secondary {
+      p > a,
+      span > a {
+        color: var(--bs-white);
 
-  // Fix CNCF section (td-box--secondary) link contrast
-  // Override Docsy's calculated link color to use semantic white in both modes
-  .td-box--secondary {
-    p > a,
-    span > a {
-      color: var(--bs-white);
-
-      &:focus,
-      &:hover {
-        color: rgba(var(--bs-white-rgb), 0.85);
+        &:focus,
+        &:hover {
+          color: rgba(var(--bs-white-rgb), 0.85);
+        }
       }
     }
-  }
 
-  // Search input styling for dark mode
-  .hero-search__search .td-search__input {
-    background-color: var(--bs-tertiary-bg);
-    border-color: var(--bs-border-color);
-    color: var(--bs-body-color);
+    // Search input styling for dark mode
+    .hero-search__search .td-search__input {
+      background-color: var(--bs-tertiary-bg);
+      border-color: var(--bs-border-color);
+      color: var(--bs-body-color);
 
-    &::placeholder {
-      color: var(--bs-secondary-color);
+      &::placeholder {
+        color: var(--bs-secondary-color);
+      }
+
+      &:focus {
+        border-color: var(--bs-primary);
+        box-shadow: 0 0 0 3px rgba(var(--bs-primary-rgb), 0.25);
+      }
     }
 
-    &:focus {
-      border-color: var(--bs-primary);
-      box-shadow: 0 0 0 3px rgba(var(--bs-primary-rgb), 0.25);
-    }
-  }
+    // Adopter logos need slight opacity adjustment for dark backgrounds
+    .adopters-showcase__item img {
+      opacity: 0.8;
 
-  // Adopter logos need slight opacity adjustment for dark backgrounds
-  .adopters-showcase__item img {
-    opacity: 0.8;
-
-    &:hover {
-      opacity: 1;
+      &:hover {
+        opacity: 1;
+      }
     }
   }
 }

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -32,6 +32,10 @@
 
   > ul {
     list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+
     margin: 0;
     padding: 0;
 
@@ -39,7 +43,6 @@
       display: inline;
       > a {
         @extend .btn;
-        margin: 0.25rem;
 
         &:hover {
           text-decoration: none;
@@ -49,6 +52,7 @@
   }
 }
 
+// TODO: remove once all locale homepages have been updated
 .l-get-started-buttons {
   @extend .l-buttons;
 

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -32,7 +32,6 @@ show_banner: true
 {{% /homepage/hero %}}
 
 {{< homepage/hero-search placeholder="Search OpenTelemetry docs..." >}}
-{{< /homepage/hero-search >}}
 
 {{< homepage/intro-section image="/img/homepage/collector-pipeline.svg" imageAlt="OpenTelemetry overview" >}}
 

--- a/layouts/_shortcodes/homepage/hero-search.html
+++ b/layouts/_shortcodes/homepage/hero-search.html
@@ -21,11 +21,6 @@
               autocomplete="off">
           </div>
         </div>
-        {{ with .Inner }}
-        <div class="hero-search__extra">
-          {{ . | $.Page.RenderString }}
-        </div>
-        {{ end }}
       </div>
     </div>
   </div>


### PR DESCRIPTION
- Followup to #9033
- Contributes to #8899
- Adds a wrapping `.td-home` around all (non-`:root`) homepage styles
- Drops section padding which wasn't being used anyways (the defaults were kicking in)
- Drops the Inner from the search section -- I doubt that we'll ever have a need for shortcode content
- Tweaks the global `.l-primary-buttons` and deletes the homepage override

### Screenshots

#### Light mode

| Before | After |
|--------|--------|
| <img width=400 alt="opentelemetry io_" src="https://github.com/user-attachments/assets/13842479-a748-4955-8636-2134c3c28747" /> | <img width=400 alt="deploy-preview-9042--opentelemetry netlify app_" src="https://github.com/user-attachments/assets/e745a788-f19d-482d-8fb6-30f46401f499" /> | 

#### Dark mode

| Before | After |
|--------|--------|
| <img width=400 alt="opentelemetry io_ (2)" src="https://github.com/user-attachments/assets/f084dcec-9897-4809-b721-ecf17ba5f20c" /> | <img width=400 alt="deploy-preview-9042--opentelemetry netlify app_ (1)" src="https://github.com/user-attachments/assets/8489efbb-8ec8-44ad-b07d-8a9ca426f474" /> |

