### PR TITLE
Fix Go getting-started: use HandleFunc for route handlers

### DIFF
--- a/content/en/docs/languages/go/getting-started.md
+++ b/content/en/docs/languages/go/getting-started.md
@@ -343,8 +343,8 @@ func newHTTPHandler() http.Handler {
 	mux := http.NewServeMux()
 
 	// Register handlers.
-	mux.Handle("/rolldice/", rolldice)
-	mux.Handle("/rolldice/{player}", rolldice)
+	mux.HandleFunc("/rolldice/", rolldice)
+	mux.HandleFunc("/rolldice/{player}", rolldice)
 
 	// Add HTTP instrumentation for the whole server.
 	handler := otelhttp.NewHandler(mux, "/")


### PR DESCRIPTION
mux.Handle() expects a value implementing http.Handler (a type with ServeHTTP method), but rolldice is a plain function. Using HandleFunc() correctly adapts the function signature func(http.ResponseWriter, *http.Request) to satisfy the http.Handler interface.