### PR TITLE
Add 2025 blog index files for Spanish and Portuguese

### DIFF
--- a/content/es/blog/2025/_index.md
+++ b/content/es/blog/2025/_index.md
@@ -1,0 +1,5 @@
+---
+title: 2025
+weight: -2025
+default_lang_commit: 24319ddf6d8912b9ea74c00201a7b6d6af69f5bb
+---

--- a/content/pt/blog/2025/_index.md
+++ b/content/pt/blog/2025/_index.md
@@ -1,0 +1,5 @@
+---
+title: 2025
+weight: -2025
+default_lang_commit: 24319ddf6d8912b9ea74c00201a7b6d6af69f5bb
+---

--- a/content/pt/blog/_index.md
+++ b/content/pt/blog/_index.md
@@ -2,5 +2,6 @@
 title: Blog
 menu: { main: { weight: 50 } }
 outputs: [HTML, RSS]
-default_lang_commit: 505e2d1d650a80f8a8d72206f2e285430bc6b36a
+default_lang_commit: 8db6d6246fb8479c02c320d9acb451d9f3c9df4b
+drifted_from_default: true
 ---


### PR DESCRIPTION
- Without these index pages, the 2025 posts show up at the top level of the left nav. See below
- The pt blog index doesn't match the en blog index page: it's missing the script element. That's why, in the screenshot below, that 2025 isn't open.

| Before | After |
|--------|--------|
| <img width="248" height="458" alt="image" src="https://github.com/user-attachments/assets/7687ab8d-eca8-4391-8f54-4771bf377a39" /> | <img width="248" height="448" alt="image" src="https://github.com/user-attachments/assets/574d9c46-e387-4b0b-855d-431251a27ac3" /> | 