### PR TITLE
Refactor SCSS: move styles into separate files

### DIFF
--- a/assets/scss/_blog.scss
+++ b/assets/scss/_blog.scss
@@ -1,0 +1,50 @@
+.td-blog.otel-with-contributions-from {
+  .td-content {
+    .td-byline {
+      margin: 0 !important;
+    }
+    .article-meta {
+      margin: 0;
+    }
+    p:first-of-type {
+      @extend .small;
+      opacity: 0.65;
+      padding-top: 0.2rem;
+      margin-bottom: 1.5rem;
+    }
+  }
+}
+
+.ot-integration-badge {
+  @extend .btn;
+  @extend .shadow;
+
+  border-radius: 0 !important;
+
+  position: relative;
+  float: right;
+  transform: rotate(6deg);
+  background: hsl(60, 100%, 60%);
+  border-color: hsl(60, 100%, 60%);
+  padding: 1rem;
+  margin: 0 1rem 1rem 1rem;
+
+  &__text {
+    font-weight: $font-weight-semibold;
+  }
+
+  &__info {
+    @extend .text-warning;
+    @extend .translate-middle;
+
+    position: absolute;
+    top: 0;
+    left: 100%;
+  }
+
+  &:hover {
+    background: hsl(60, 100%, 60%);
+    transform: rotate(4deg);
+    transition: transform 0.2s linear;
+  }
+}

--- a/assets/scss/_buttons.scss
+++ b/assets/scss/_buttons.scss
@@ -1,0 +1,48 @@
+// Button and button groups
+
+.l-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+
+  > ul {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+
+    margin: 0;
+    padding: 0;
+
+    > li {
+      display: inline;
+      > a {
+        @extend .btn;
+
+        &:hover {
+          text-decoration: none;
+        }
+      }
+    }
+  }
+}
+// TODO: remove once all locale homepages have been updated
+.l-get-started-buttons {
+  @extend .l-buttons;
+
+  > ul > li > a /*, > p > a*/ {
+    @extend .btn-lg;
+    @extend .btn-secondary;
+  }
+}
+
+.l-primary-buttons {
+  @extend .l-buttons;
+
+  > ul > li > a {
+    @extend .btn-lg;
+    @extend .btn-primary;
+  }
+}

--- a/assets/scss/_docsy.scss
+++ b/assets/scss/_docsy.scss
@@ -1,0 +1,42 @@
+// Docsy style customization and overrides
+
+.td-content img:not(.img-initial) {
+  display: block;
+  border: $border-width solid $border-color;
+  margin-bottom: $paragraph-margin-bottom;
+  @extend .td-max-width-on-larger-screens;
+}
+
+// Workaround for iOS and macOS Safari 17+. For details see:
+// https://github.com/open-telemetry/opentelemetry.io/issues/3538
+
+.td-content .highlight > pre {
+  > .click-to-copy,
+  > code {
+    overflow-y: auto;
+  }
+}
+
+.td-page-meta__child {
+  display: none !important;
+}
+
+// Contribution section in community page
+.community-contribution {
+  text-align: center;
+
+  & > p {
+    font-size: $h3-font-size;
+    font-weight: $headings-font-weight;
+    line-height: $headings-line-height;
+    margin-bottom: $headings-margin-bottom;
+  }
+}
+
+// TODO: upstream to Docsy
+
+.hk-no-external-icon {
+  a.external-link:after {
+    display: none !important;
+  }
+}

--- a/assets/scss/_home.scss
+++ b/assets/scss/_home.scss
@@ -1,0 +1,59 @@
+// Homepage styles before the revamp of January 2026. The new styles are in
+// _homepage.scss. Keeping these until all locales have been updated their
+// homepages.
+//
+// TODO: remove this file once all locales have been updated their homepages,
+// though keep .o-banner (move to _homepage.scss).
+
+.td-home {
+  .otel-logo {
+    margin-top: 2rem;
+    margin-bottom: 3rem;
+    max-height: 12rem;
+  }
+
+  .td-box--white .container blockquote {
+    font-size: smaller;
+  }
+
+  .cncf {
+    text-align: center;
+
+    p {
+      font-size: 1.2rem;
+      margin-bottom: 0;
+    }
+
+    img {
+      width: 20rem;
+      padding-top: 1rem;
+      max-width: 80%;
+    }
+  }
+}
+
+.o-banner {
+  background: var(--bs-tertiary-bg);
+  color: var(--bs-body-color);
+  text-align: center;
+
+  // Handling the x positioning requires some calculations. Assumption is that
+  // the banner is inside a .container-fluid, which has this padding-x:
+  $padding-x: $container-padding-x * 0.5;
+  margin-left: -$padding-x; // Undo left padding of parent
+  width: calc(100% + 2 * #{$padding-x});
+
+  @include media-breakpoint-up(md) {
+    position: fixed;
+    top: 4rem;
+    left: 0;
+    margin-left: 0;
+    width: 100%;
+    z-index: 31;
+  }
+
+  & p {
+    padding: 0.5rem;
+    margin-bottom: initial;
+  }
+}

--- a/assets/scss/_java.scss
+++ b/assets/scss/_java.scss
@@ -1,0 +1,32 @@
+// Java-SDK page content styles
+
+.config-option {
+  padding-inline-start: 1.5em;
+
+  .label {
+    font-weight: bold;
+  }
+
+  details {
+    background-color: var(--bs-tertiary-bg);
+    margin-bottom: 0.5em;
+
+    summary {
+      display: block;
+      &::-webkit-details-marker {
+        display: none;
+      }
+
+      &::after {
+        color: $secondary;
+        @extend .fas;
+        content: fa-content($nbsp + $fa-var-plus-circle);
+      }
+    }
+
+    &[open] summary::after {
+      @extend .fas;
+      content: fa-content($nbsp + $fa-var-minus-circle);
+    }
+  }
+}

--- a/assets/scss/_navbar.scss
+++ b/assets/scss/_navbar.scss
@@ -1,0 +1,51 @@
+.td-navbar {
+  // By design, the navbar has light text on a dark background. It's children,
+  // like dropdown menus and the search box, follow the page's light/dark color
+  // mode.
+
+  // Bootstrap and Docsy overrides:
+  background-image: none; // Override Bootstrap's default gradient background.
+  --bs-border-color: #{$gray-500}; // for the search box
+  --td-navbar-border-bottom: none;
+
+  //--------------------------------
+  // TODO: upstream some of this to Docsy
+  // Improve color contrast DRAFT
+  .nav-link {
+    --bs-nav-link-color: #{$gray-100};
+
+    &.active {
+      color: tint-color($navbar-dark-hover-color, 65%);
+      text-decoration: $link-decoration;
+    }
+
+    &:focus,
+    // Bootstrap sets .nav-link:focus-visible, but in a way that isn't
+    // compatible with dark mode. This is a known issue, see
+    // https://github.com/twbs/bootstrap/issues/37549:
+    //
+    // > Docs navbar blue focus visible is almost invisible!
+    //
+    // Fallback to browser default:
+    &:focus-visible {
+      outline: revert;
+      box-shadow: none;
+    }
+  }
+  .td-search:not(:focus-within) {
+    color: $gray-200;
+  }
+  //--------------------------------
+
+  .navbar-brand {
+    @include media-breakpoint-up(md) {
+      padding: 0;
+    }
+    svg {
+      height: 48px;
+    }
+    .navbar-brand__name {
+      display: none;
+    }
+  }
+}

--- a/assets/scss/_registry.scss
+++ b/assets/scss/_registry.scss
@@ -1,3 +1,23 @@
+.td-section.registry {
+  .td-outer {
+    height: auto;
+  }
+
+  .registry-entry {
+    display: flex;
+    align-items: flex-start;
+    padding-bottom: 0.5rem;
+
+    .h5 {
+      margin-bottom: 0.2rem;
+    }
+
+    &-body {
+      flex: 1;
+    }
+  }
+}
+
 .badge {
   @each $component, $color in $otel-component-colors {
     &.badge-#{$component} {

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1,5 +1,5 @@
 /* Docsy-delta full file override: we're not tracking changes to the Docsy file of the same name. */
-// cSpell:ignore cncf docsy otca
+// cSpell:ignore docsy
 
 @import 'registry';
 @import 'tabs';
@@ -7,167 +7,20 @@
 @import 'td/color-adjustments-dark';
 @import 'td/code-dark';
 @import 'dark-adjustments';
-@import 'homepage';
 @import 'td/gcs-search-dark';
-@import '_page_no_left_sidebar';
 
-.td-home {
-  .otel-logo {
-    margin-top: 2rem;
-    margin-bottom: 3rem;
-    max-height: 12rem;
-  }
+@import 'blog';
+@import 'buttons';
+@import 'docsy';
+@import 'home';
+@import 'homepage';
+@import 'java';
+@import 'navbar';
+@import 'page_no_left_sidebar';
+@import 'training';
 
-  .td-box--white .container blockquote {
-    font-size: smaller;
-  }
-}
-
-.l-buttons {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  margin-top: 1rem;
-  margin-bottom: 1rem;
-
-  > ul {
-    list-style: none;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1rem;
-
-    margin: 0;
-    padding: 0;
-
-    > li {
-      display: inline;
-      > a {
-        @extend .btn;
-
-        &:hover {
-          text-decoration: none;
-        }
-      }
-    }
-  }
-}
-
-// TODO: remove once all locale homepages have been updated
-.l-get-started-buttons {
-  @extend .l-buttons;
-
-  > ul > li > a /*, > p > a*/ {
-    @extend .btn-lg;
-    @extend .btn-secondary;
-  }
-}
-
-.l-primary-buttons {
-  @extend .l-buttons;
-
-  > ul > li > a {
-    @extend .btn-lg;
-    @extend .btn-primary;
-  }
-}
-
-.td-navbar {
-  // By design, the navbar has light text on a dark background. It's children,
-  // like dropdown menus and the search box, follow the page's light/dark color
-  // mode.
-
-  // Bootstrap and Docsy overrides:
-  background-image: none; // Override Bootstrap's default gradient background.
-  --bs-border-color: #{$gray-500}; // for the search box
-  --td-navbar-border-bottom: none;
-
-  //--------------------------------
-  // TODO: upstream some of this to Docsy
-  // Improve color contrast DRAFT
-  .nav-link {
-    --bs-nav-link-color: #{$gray-100};
-
-    &.active {
-      color: tint-color($navbar-dark-hover-color, 65%);
-      text-decoration: $link-decoration;
-    }
-
-    &:focus,
-    // Bootstrap sets .nav-link:focus-visible, but in a way that isn't
-    // compatible with dark mode. This is a known issue, see
-    // https://github.com/twbs/bootstrap/issues/37549:
-    //
-    // > Docs navbar blue focus visible is almost invisible!
-    //
-    // Fallback to browser default:
-    &:focus-visible {
-      outline: revert;
-      box-shadow: none;
-    }
-  }
-  .td-search:not(:focus-within) {
-    color: $gray-200;
-  }
-  //--------------------------------
-
-  .navbar-brand {
-    @include media-breakpoint-up(md) {
-      padding: 0;
-    }
-    svg {
-      height: 48px;
-    }
-    .navbar-brand__name {
-      display: none;
-    }
-  }
-}
-
-.td-home {
-  .cncf {
-    text-align: center;
-
-    p {
-      font-size: 1.2rem;
-      margin-bottom: 0;
-    }
-
-    img {
-      width: 20rem;
-      padding-top: 1rem;
-      max-width: 80%;
-    }
-  }
-}
-
-.o-banner {
-  background: var(--bs-tertiary-bg);
-  color: var(--bs-body-color);
-  text-align: center;
-
-  // Handling the x positioning requires some calculations. Assumption is that
-  // the banner is inside a .container-fluid, which has this padding-x:
-  $padding-x: $container-padding-x * 0.5;
-  margin-left: -$padding-x; // Undo left padding of parent
-  width: calc(100% + 2 * #{$padding-x});
-
-  @include media-breakpoint-up(md) {
-    position: fixed;
-    top: 4rem;
-    left: 0;
-    margin-left: 0;
-    width: 100%;
-    z-index: 31;
-  }
-
-  & p {
-    padding: 0.5rem;
-    margin-bottom: initial;
-  }
-}
-
-.td-page-meta__child {
-  display: none !important;
+details {
+  margin-bottom: $paragraph-margin-bottom;
 }
 
 .otel-docs-spec {
@@ -176,97 +29,8 @@
   }
 }
 
-// Contribution section in community page
-.community-contribution {
-  text-align: center;
-
-  & > p {
-    font-size: $h3-font-size;
-    font-weight: $headings-font-weight;
-    line-height: $headings-line-height;
-    margin-bottom: $headings-margin-bottom;
-  }
-}
-
-.config-option {
-  padding-inline-start: 1.5em;
-
-  .label {
-    font-weight: bold;
-  }
-
-  details {
-    background-color: var(--bs-tertiary-bg);
-    margin-bottom: 0.5em;
-
-    summary {
-      display: block;
-      &::-webkit-details-marker {
-        display: none;
-      }
-
-      &::after {
-        color: $secondary;
-        @extend .fas;
-        content: fa-content($nbsp + $fa-var-plus-circle);
-      }
-    }
-
-    &[open] summary::after {
-      @extend .fas;
-      content: fa-content($nbsp + $fa-var-minus-circle);
-    }
-  }
-}
-
 .otel-mermaid-max-width pre.mermaid {
   max-width: inherit;
-}
-
-.td-content img:not(.img-initial) {
-  display: block;
-  border: $border-width solid $border-color;
-  margin-bottom: $paragraph-margin-bottom;
-  @extend .td-max-width-on-larger-screens;
-}
-
-.td-blog.otel-with-contributions-from {
-  .td-content {
-    .td-byline {
-      margin: 0 !important;
-    }
-    .article-meta {
-      margin: 0;
-    }
-    p:first-of-type {
-      @extend .small;
-      opacity: 0.65;
-      padding-top: 0.2rem;
-      margin-bottom: 1.5rem;
-    }
-  }
-}
-
-// Registry
-
-.td-section.registry {
-  .td-outer {
-    height: auto;
-  }
-
-  .registry-entry {
-    display: flex;
-    align-items: flex-start;
-    padding-bottom: 0.5rem;
-
-    .h5 {
-      margin-bottom: 0.2rem;
-    }
-
-    &-body {
-      flex: 1;
-    }
-  }
 }
 
 body.td-page--draft .td-content {
@@ -289,54 +53,6 @@ body.td-page--draft .td-content {
   }
 }
 
-details {
-  margin-bottom: $paragraph-margin-bottom;
-}
-
-.ot-integration-badge {
-  @extend .btn;
-  @extend .shadow;
-
-  border-radius: 0 !important;
-
-  position: relative;
-  float: right;
-  transform: rotate(6deg);
-  background: hsl(60, 100%, 60%);
-  border-color: hsl(60, 100%, 60%);
-  padding: 1rem;
-  margin: 0 1rem 1rem 1rem;
-
-  &__text {
-    font-weight: $font-weight-semibold;
-  }
-
-  &__info {
-    @extend .text-warning;
-    @extend .translate-middle;
-
-    position: absolute;
-    top: 0;
-    left: 100%;
-  }
-
-  &:hover {
-    background: hsl(60, 100%, 60%);
-    transform: rotate(4deg);
-    transition: transform 0.2s linear;
-  }
-}
-
-// Workaround for iOS and macOS Safari 17+. For details see:
-// https://github.com/open-telemetry/opentelemetry.io/issues/3538
-
-.td-content .highlight > pre {
-  > .click-to-copy,
-  > code {
-    overflow-y: auto;
-  }
-}
-
 // Google translate select / dropdown
 
 .goog-te-gadget {
@@ -346,54 +62,5 @@ details {
 
   @include media-breakpoint-up(md) {
     padding-left: 0.6rem;
-  }
-}
-
-.ot-training {
-  @extend .td-no-left-sidebar;
-  $card-padding: 2rem;
-
-  .badge--otca {
-    margin-top: map-get($spacers, 4) !important;
-    img {
-      border-style: none !important;
-      display: initial;
-      max-width: 244px;
-    }
-    @include media-breakpoint-up(md) {
-      padding-left: $card-padding;
-    }
-
-    @include media-breakpoint-down(md) {
-      text-align: center;
-    }
-  }
-
-  .card--course-wrapper {
-    @include media-breakpoint-up(md) {
-      padding-left: $card-padding;
-    }
-  }
-
-  .card--course {
-    margin-top: map-get($spacers, 5) !important;
-    margin-bottom: map-get($spacers, 5) !important;
-
-    @include media-breakpoint-down(md) {
-      margin-left: auto !important;
-      margin-right: auto !important;
-    }
-
-    img {
-      padding-bottom: 2.6rem;
-    }
-  }
-}
-
-// TODO: upstream to Docsy
-
-.hk-no-external-icon {
-  a.external-link:after {
-    display: none !important;
   }
 }

--- a/assets/scss/_training.scss
+++ b/assets/scss/_training.scss
@@ -1,0 +1,42 @@
+// cSpell:ignore otca
+
+.ot-training {
+  @extend .td-no-left-sidebar;
+  $card-padding: 2rem;
+
+  .badge--otca {
+    margin-top: map-get($spacers, 4) !important;
+    img {
+      border-style: none !important;
+      display: initial;
+      max-width: 244px;
+    }
+    @include media-breakpoint-up(md) {
+      padding-left: $card-padding;
+    }
+
+    @include media-breakpoint-down(md) {
+      text-align: center;
+    }
+  }
+
+  .card--course-wrapper {
+    @include media-breakpoint-up(md) {
+      padding-left: $card-padding;
+    }
+  }
+
+  .card--course {
+    margin-top: map-get($spacers, 5) !important;
+    margin-bottom: map-get($spacers, 5) !important;
+
+    @include media-breakpoint-down(md) {
+      margin-left: auto !important;
+      margin-right: auto !important;
+    }
+
+    img {
+      padding-bottom: 2.6rem;
+    }
+  }
+}


### PR DESCRIPTION
- Followup to #9048 
- Contributes to #8899
- Now that Docsy has moved it's private SCSS includes into the `td` subfolder, we can split our project styles into files
- Moves styles from `assets/scss/_styles_project.scss` to `assets/scss/_ABC.scss`, where `ABC` is one of `blog`, `buttons`, etc. Adds @imports to get the equivalent effect.
- There are no other changes made to styles.