### PR TITLE
Update content/en/docs/platforms/kubernetes/collector/components.md

### DIFF
--- a/content/en/docs/platforms/kubernetes/collector/components.md
+++ b/content/en/docs/platforms/kubernetes/collector/components.md
@@ -188,9 +188,9 @@ roleRef:
 | Deployment (gateway) | Yes, but will only collect metrics from the node it is deployed on |
 | Sidecar              | No                                                                 |
 
-Each Kubernetes node runs a kubelet that includes an API server. The Kubeletstats
-Receiver connects to that kubelet via the API server to collect metrics about
-the node and the workloads running on the node.
+Each Kubernetes node runs a kubelet that includes an API server. The
+Kubeletstats Receiver connects to that kubelet via the API server to collect
+metrics about the node and the workloads running on the node.
 
 There are different methods for authentication, but typically a service account
 is used. The service account will also need proper permissions to pull data from


### PR DESCRIPTION
It is better to change `The Kubernetes Receiver` to `The Kubeletstats Receiver`, which is more consistent with the chapter title and also makes it easier for technical readers to understand the corresponding component (avoiding confusion with the Kubernetes cluster as a whole and precisely referring to the receiver for kubelet statistics).