### PR TITLE
fix(ci): skip FOSSA workflow on forks

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -10,6 +10,8 @@ permissions:
 
 jobs:
   fossa:
+    # Only run in upstream repository, not in forks
+    if: github.repository == 'open-telemetry/opentelemetry.io'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v5.0.1


### PR DESCRIPTION
Adds a repository check to skip the FOSSA workflow on forks. This prevents job failures caused by the missing `FOSSA_API_KEY` secret.