### PR TITLE
Fix homepage horizontal overflow and some shortcodes do support md

### DIFF
--- a/assets/scss/_homepage.scss
+++ b/assets/scss/_homepage.scss
@@ -120,13 +120,9 @@
 
   .td-default main section.main-features-section {
     padding: 0;
-    // Full bleed
-    position: relative;
-    left: 50%;
-    right: 50%;
-    margin-left: -50vw;
-    margin-right: -50vw;
-    width: 100vw;
+    margin-left: calc(var(--bs-gutter-x) * -0.5);
+    margin-right: calc(var(--bs-gutter-x) * -0.5);
+    width: calc(100% + var(--bs-gutter-x));
   }
 
   .main-features {

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -41,7 +41,7 @@ show_banner: true
 
 {{< homepage/hero-search placeholder="Search OpenTelemetry docs..." >}}
 
-{{< homepage/intro-section image="/img/homepage/collector-pipeline.svg" imageAlt="OpenTelemetry overview" >}}
+{{% homepage/intro-section image="/img/homepage/collector-pipeline.svg" imageAlt="OpenTelemetry overview" %}}
 
 **OpenTelemetry** is an open source observability framework for cloud native
 software. It provides a single set of APIs, libraries, agents, and collector
@@ -51,33 +51,42 @@ OpenTelemetry builds upon years of experience from the OpenTracing and
 OpenCensus projects, combined with best-of-breed ideas and practices from the
 community.
 
-{{< /homepage/intro-section >}}
+{{% /homepage/intro-section %}}
 
 {{< homepage/main-features >}}
 
-{{< homepage/main-feature
+{{% homepage/main-feature
       title="Vendor-neutral instrumentation"
       image="/img/homepage/data-sources.svg"
-      imagePosition="left" >}} Instrument your code once using OpenTelemetry
-APIs and SDKs. Export telemetry data to any observability backend—Jaeger,
-Prometheus, commercial vendors, or your own solution. Switch backends without
-touching your application code. {{< /homepage/main-feature >}}
+      imagePosition="left" %}}
 
-{{< homepage/main-feature
+Instrument your code once using OpenTelemetry APIs and SDKs. Export telemetry
+data to any observability backend—Jaeger, Prometheus, commercial vendors, or
+your own solution. Switch backends without touching your application code.
+
+{{% /homepage/main-feature %}}
+
+{{% homepage/main-feature
       title="Unified observability signals"
       image="/img/homepage/unified-signals.svg"
-      imagePosition="right" >}} Correlate traces, metrics, and logs with shared
-context that flows through your entire request path. Get a complete picture of
-your application's behavior across all components and services.
-{{< /homepage/main-feature >}}
+      imagePosition="right" %}}
 
-{{< homepage/main-feature
+Correlate traces, metrics, and logs with shared context that flows through your
+entire request path. Get a complete picture of your application's behavior
+across all components and services.
+
+{{% /homepage/main-feature %}}
+
+{{% homepage/main-feature
       title="Run anywhere"
       image="/img/homepage/global-deployment.svg"
-      imagePosition="left" >}} OpenTelemetry is 100% open source and
-vendor-neutral. Deploy on-premises, in hybrid environments, or across multiple
-clouds with full flexibility and zero lock-in. Move workloads wherever they
-matter to you. {{< /homepage/main-feature >}}
+      imagePosition="left" %}}
+
+OpenTelemetry is 100% open source and vendor-neutral. Deploy on-premises, in
+hybrid environments, or across multiple clouds with full flexibility and zero
+lock-in. Move workloads wherever they matter to you.
+
+{{% /homepage/main-feature %}}
 
 {{< /homepage/main-features >}}
 

--- a/layouts/_shortcodes/homepage/intro-section.html
+++ b/layouts/_shortcodes/homepage/intro-section.html
@@ -8,7 +8,7 @@
     <div class="container">
       <div class="intro-content">
         <div class="intro-text">
-          {{ .Inner | .Page.RenderString }}
+          {{ .Inner -}}
         </div>
         {{ with $image -}}
         <div class="intro-image">

--- a/layouts/_shortcodes/homepage/main-feature.html
+++ b/layouts/_shortcodes/homepage/main-feature.html
@@ -9,7 +9,6 @@
       {{ with $image }}
       <img src="{{ . }}" alt="{{ $title }}" loading="lazy">
       {{ else }}
-      <!-- Placeholder for image -->
       <div class="main-feature__placeholder">
         <i class="fas fa-image fa-3x"></i>
       </div>
@@ -22,7 +21,7 @@
         {{- with $url }}</a>{{ end -}}
       </h3>
       <div class="main-feature__description">
-        {{ .Inner | .Page.RenderString }}
+        {{ .Inner -}}
       </div>
     </div>
   </div>


### PR DESCRIPTION
- Fixes #9071
- Fixes `.main-features-section` overflow by setting the width exactly. (Tip: avoid 100vw, it can lead to subtle problems like the one we faced)
- Converts the following shortcodes so that they can be called with md content w/o using a render function:
  - `homepage/intro-section`
  - `homepage/main-feature`
- I've checked both mobile and desktop and the issue seems resolved in both

**Preview**: https://deploy-preview-9072--opentelemetry.netlify.app

### Screenshots

| Before | After |
|--------|--------|
| <img width=400 alt="opentelemetry io_ (1)" src="https://github.com/user-attachments/assets/fd3d69c4-50a4-4a6f-a522-c0b3196b0adc" /> | <img width=400 alt="deploy-preview-9072--opentelemetry netlify app_" src="https://github.com/user-attachments/assets/751cbc39-731d-4b0e-b534-1b40e3ecc930" /> | 






