### PR TITLE
Recover homepage CNCF section styles, and improve on them

### DIFF
--- a/assets/scss/_homepage.scss
+++ b/assets/scss/_homepage.scss
@@ -556,11 +556,22 @@
   // CNCF SECTION - Use Docsy's automatic contrast system
   // =============================================================================
 
-  // Note: CNCF section should use class="td-box td-box--secondary" in HTML
-  // This leverages Docsy's box-variant mixin which automatically calculates:
-  // - color: color-contrast($secondary) = white
-  // - Proper link colors via mix($blue, $text-color, lightness($secondary))
-  // No CSS overrides needed here!
+  .td-box--secondary {
+    // TODO: convert $secondary etc to hsl, then oklch.
+    // Then adapt the background here.
+    background-color: hsl(41, 80%, 47.5%);
+  }
+
+  .cncf {
+    a {
+      @extend .link-dark;
+      @extend .link-underline-opacity-0-hover;
+
+      &.external-link:after {
+        display: none;
+      }
+    }
+  }
 }
 
 // =============================================================================


### PR DESCRIPTION
- Fixes #9075
- Fixes CNCF-section link appearance (by recovering styles lost during the revamp), and improves on the old style -- for better ink contrast, etc.
- Tweaks the secondary color as a background, making it a little less saturated and a little less light, for reduced eye strain.
- This fix applies to the new and old (i.e., non-`en`) homepages

**Preview**:

- https://deploy-preview-9076--opentelemetry.netlify.app/
- https://deploy-preview-9076--opentelemetry.netlify.app/pt/

### Screenshots

English homepage:

| Before | After |
|--------|--------|
| <img width="491" height="290" alt="Image" src="https://github.com/user-attachments/assets/2ee3aa1b-cf53-445d-a27d-7551cf1fea5f" /> | <img width="479" height="292" alt="image" src="https://github.com/user-attachments/assets/0970de8d-7552-4e97-a97a-af49277d5bb2" /> | 

Non-`en` homepage, after (see #9075 for before image). No more external link icons:

<img width="490" alt="image" src="https://github.com/user-attachments/assets/a1e5ec87-4f08-4bb7-aaec-726ffa36e69b" />


