### PR TITLE
Update Keycloak integration

### DIFF
--- a/content/en/docs/languages/go/getting-started.md
+++ b/content/en/docs/languages/go/getting-started.md
@@ -289,7 +289,6 @@ func newLoggerProvider() (*log.LoggerProvider, error) {
 	)
 	return loggerProvider, nil
 }
-
 ```
 <!-- prettier-ignore-end -->
 

--- a/data/registry/application-integration-java-keycloak.yml
+++ b/data/registry/application-integration-java-keycloak.yml
@@ -12,8 +12,8 @@ urls:
   docs: https://www.keycloak.org/observability/telemetry
 license: Apache 2.0
 description:
-  Keycloak utilizes OpenTelemetry for metrics, logging and distributed tracing provided by the
-  Quarkus OpenTelemetry extension.
+  Keycloak utilizes OpenTelemetry for metrics, logging and distributed tracing
+  provided by the Quarkus OpenTelemetry extension.
 authors:
   - name: Keycloak Contributors
     url: https://github.com/keycloak

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -21135,6 +21135,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-01-22T09:54:07.14971801Z"
   },
+  "https://www.keycloak.org/observability/telemetry": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-03T12:18:35.657905382Z"
+  },
   "https://www.keycloak.org/server/tracing": {
     "StatusCode": 206,
     "LastSeen": "2026-01-22T09:54:07.280376491Z"


### PR DESCRIPTION
Keycloak now supports also metrics and logging. With the added functionality, the link to the referenced docs changed.

PS: I'm one of the Keycloak maintainers and I know what I'm writing about (this references the AI policy :smile:)

<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

