### PR TITLE
chore(blog/2026): replace GitHub URL branch name with commit hash

### DIFF
--- a/content/en/blog/2026/2025-year-in-review/index.md
+++ b/content/en/blog/2026/2025-year-in-review/index.md
@@ -205,7 +205,7 @@ You can also join us:
 Let's make 2026 another amazing year for [opentelemetry.io](/)!
 
 [redesign]:
-  https://github.com/open-telemetry/opentelemetry.io/blob/main/projects/landing-page-redesign.md
+  https://github.com/open-telemetry/opentelemetry.io/blob/9bd13bd/projects/landing-page-redesign.md?from_branch=main
 [refactoring]: https://github.com/orgs/open-telemetry/projects/174/views/3
 [Comms meetings]:
   https://docs.google.com/document/d/1wW0jLldwXN8Nptq2xmgETGbGn9eWP8fitvD5njM-xZY

--- a/content/en/blog/2026/demystifying-opentelemetry/index.md
+++ b/content/en/blog/2026/demystifying-opentelemetry/index.md
@@ -310,7 +310,7 @@ break it down.
 
 Many organizations rely on SQL Server databases for production, analytics, or
 inventory. With the OpenTelemetry Collector’s
-[sqlserver receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sqlserverreceiver),
+[sqlserver receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/ab56dd4/receiver/sqlserverreceiver?from_branch=main),
 you can scrape health and performance metrics directly, without needing agents
 on your database hosts. The following is a sample configuration showing how to
 set this up:
@@ -348,7 +348,7 @@ pool, locks, batch rates, and more), exposing them to observability backends.
 ### Observing Windows machines with the Windows performance counters receiver
 
 Classic Windows hosts still drive many production and control environments. The
-[Windows performance counters receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/windowsperfcountersreceiver)
+[Windows performance counters receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/ab56dd4/receiver/windowsperfcountersreceiver?from_branch=main)
 (part of the OpenTelemetry Collector Contrib distribution) lets you collect a
 wide array of system, application, or custom metrics right from the Windows
 registry using the native PDH interface. The following is a sample configuration

--- a/content/en/blog/2026/kubecon-eu.md
+++ b/content/en/blog/2026/kubecon-eu.md
@@ -250,6 +250,6 @@ Come listen, learn, and get involved in OpenTelemetry. See you in Amsterdam!
 [maintainer summit]:
   https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/features-add-ons/maintainer-summit/
 [membership]:
-  https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#member
+  https://github.com/open-telemetry/community/blob/25f0275/guides/contributor/membership.md#member?from_branch=main
 [obs-day-sched]:
   https://colocatedeventseu2026.sched.com/overview/type/Observability+Day

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -6031,6 +6031,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-11T09:59:07.194803024Z"
   },
+  "https://github.com/kaspernissen/pizza/tree/b09aaf5?from_branch=agentic-workflows": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-12T20:44:29.884032-05:00"
+  },
   "https://github.com/katzchang": {
     "StatusCode": 206,
     "LastSeen": "2026-02-12T09:53:40.813992985Z"
@@ -6787,6 +6791,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-12T09:58:41.628055286Z"
   },
+  "https://github.com/open-telemetry/community/blob/25f0275/guides/contributor/membership.md#member?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-12T20:44:29.597738-05:00"
+  },
   "https://github.com/open-telemetry/community/blob/47813530864b9fe5a5146f466a58bd2bb94edc72/maturity-matrix.yaml#L57": {
     "StatusCode": 206,
     "LastSeen": "2026-01-30T09:55:01.816066431Z"
@@ -7490,6 +7498,14 @@
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/6a2bd15cc941859767c7043a0597b8b0f6dd9f64/receiver/sapmreceiver#sapm-receiver": {
     "StatusCode": 206,
     "LastSeen": "2026-02-03T09:57:27.574631644Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/ab56dd4/receiver/sqlserverreceiver?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-12T20:44:30.361588-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/ab56dd4/receiver/windowsperfcountersreceiver?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-12T20:44:31.07881-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/e228ef6c18aa2f05b2173f20be0578f714d0128b/receiver/opencensusreceiver#opencensus-receiver": {
     "StatusCode": 206,
@@ -13238,6 +13254,10 @@
   "https://github.com/open-telemetry/opentelemetry.io/": {
     "StatusCode": 206,
     "LastSeen": "2026-01-30T09:51:34.019367975Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry.io/blob/9bd13bd/projects/landing-page-redesign.md?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-12T20:44:28.834333-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry.io/blob/bc94737/hugo.yaml": {
     "StatusCode": 206,


### PR DESCRIPTION
- Contributes #8578 by enforcing the guidance
- Replaces GitHub URL branch name with the last commit hash of the named resrouce. Tags `?from_branch=BRANCH_NAME` as a query parameter.

/cc @svrnm @vitorvasc 