### PR TITLE
Rework render-link hook: simplify i18n path handling code

### DIFF
--- a/layouts/_markup/render-link.html
+++ b/layouts/_markup/render-link.html
@@ -60,14 +60,11 @@
   */ -}}
 
   {{- $href := $u.String -}}
-  {{- if hasPrefix $href "#" -}}
-    {{/* Do nothing: leave $href as is */ -}}
-  {{- else if and $href (not $u.IsAbs) -}}
-    {{- $path := strings.TrimPrefix "./" $u.Path -}}
+  {{- if and $href (not $u.IsAbs) -}}
     {{- with or
-      ($.PageInner.GetPage $path)
-      ($.PageInner.Resources.Get $path)
-      (resources.Get $path)
+      ($.PageInner.GetPage $u.Path)
+      ($.PageInner.Resources.Get $u.Path)
+      (resources.Get $u.Path)
     -}}
       {{- $href = .RelPermalink -}}
       {{- with $u.RawQuery -}}


### PR DESCRIPTION
- Contributes to #9167
- Fixes #8161
- Simplifies the render-link's processing of locale-local absolute paths w/o a scheme. Falls back to Hugo functionality rather than using custom code
- Adds extra code to maintain backwards compatibility with the old path processing code (this extra code will be dropped in a followup PR)
- Drops now obsolete extra guard in http-check section

There are no changes to non-sitemap generated files other than due to the timestamp:

```console
$ (cd public && git diff -bw --ignore-blank-lines -- ':(exclude)*.xml') | grep ^diff
diff --git a/site/index.html b/site/index.html
```

**Preview** (sanity): https://deploy-preview-9168--opentelemetry.netlify.app/docs/