### PR TITLE
chore(render-link): support new link normal form

### DIFF
--- a/layouts/_markup/render-link.html
+++ b/layouts/_markup/render-link.html
@@ -78,15 +78,6 @@
 
   {{ $url = $href -}}
 
-  {{/* Backwards compatibility with the previous version of this render-link hook */ -}}
-  {{ if hasSuffix $url (add .Destination "/") -}}
-    {{ $url = strings.TrimSuffix "/" $url -}}
-  {{ else if eq .Destination (add $url "#") -}}
-    {{ $url = .Destination -}}
-  {{ else if hasSuffix $url (add $u.Path "/#" $u.Fragment) -}}
-    {{ $url = replace $url "/#" "#" -}}
-  {{ end -}}
-
 {{ else if and $u.IsAbs (eq $u.Scheme "http")
     (not ($u.Query.Has "disable_http_check"))
     (not (findRE `\blocalhost\b|^127\.0` $u.Host))


### PR DESCRIPTION
- Contributes to #9167
- Generated links will be normalized -- such as always end with a slash, even if there is no slash in the md