### PR TITLE
[OBI] Update Docker image references to use a consistent format

### DIFF
--- a/content/en/docs/zero-code/obi/distributed-traces.md
+++ b/content/en/docs/zero-code/obi/distributed-traces.md
@@ -104,7 +104,7 @@ spec:
         limits:
           memory: 120Mi
       terminationMessagePolicy: FallbackToLogsOnError
-      image: 'otel/ebpf-instrument:main'
+      image: 'docker.io/otel/ebpf-instrument:main'
       imagePullPolicy: 'Always'
       env:
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -207,7 +207,7 @@ configuration, which ensures OBI has sufficient information to determine the
 services:
   ...
   obi:
-    image: 'otel/ebpf-instrument:main'
+    image: 'docker.io/otel/ebpf-instrument:main'
     environment:
       OTEL_EBPF_CONFIG_PATH: "/configs/obi-config.yml"
     volumes:


### PR DESCRIPTION
Use `otel/ebpf-instrument:main` consistently. 