### PR TITLE
chore(render-link): normalize external links

### DIFF
--- a/layouts/_markup/render-link.html
+++ b/layouts/_markup/render-link.html
@@ -1,7 +1,5 @@
 {{ $u := urls.Parse .Destination -}}
 {{- $href := $u.String -}}
-{{/* TODO: drop this next line that we're keeping to minimize diffs for now */ -}}
-{{- $href = .Destination -}}
 
 {{/* This processing part is for OTel specs only ------------------------- */ -}}
 


### PR DESCRIPTION
- Contributes to #9167
- This change allows external links to be normalized, e.g.:
  - Empty fragments are dropped: `https://docs.google.com/.../edit#` becomes `https://docs.google.com/.../edit`
  - Escaped URL codes uses uppercase letters only 
  - Escaping of query parameters is cleaned up (and only done is parts where it is necessary).
  - Possibly more

```console
$ (cd public && git diff -bw --ignore-blank-lines -- ':(exclude)*.xml') | grep ^diff
diff --git a/blog/2022/kubecon-na-project-update/index.html b/blog/2022/kubecon-na-project-update/index.html
diff --git a/blog/2023/end-user-q-and-a-01/index.html b/blog/2023/end-user-q-and-a-01/index.html
diff --git a/blog/2023/end-user-q-and-a-04/index.html b/blog/2023/end-user-q-and-a-04/index.html
diff --git a/bn/docs/languages/cpp/instrumentation/index.html b/bn/docs/languages/cpp/instrumentation/index.html
diff --git a/docs/languages/cpp/instrumentation/index.html b/docs/languages/cpp/instrumentation/index.html
diff --git a/docs/specs/otel/logs/data-model/index.html b/docs/specs/otel/logs/data-model/index.html
diff --git a/es/docs/concepts/components/index.html b/es/docs/concepts/components/index.html
diff --git a/es/docs/contributing/index.html b/es/docs/contributing/index.html
diff --git a/es/docs/languages/cpp/instrumentation/index.html b/es/docs/languages/cpp/instrumentation/index.html
diff --git a/fr/docs/languages/cpp/instrumentation/index.html b/fr/docs/languages/cpp/instrumentation/index.html
diff --git a/ja/docs/contributing/issues/index.html b/ja/docs/contributing/issues/index.html
diff --git a/ja/docs/languages/cpp/instrumentation/index.html b/ja/docs/languages/cpp/instrumentation/index.html
diff --git a/pt/docs/contributing/index.html b/pt/docs/contributing/index.html
diff --git a/pt/docs/languages/cpp/instrumentation/index.html b/pt/docs/languages/cpp/instrumentation/index.html
diff --git a/ro/docs/contributing/index.html b/ro/docs/contributing/index.html
diff --git a/ro/docs/languages/cpp/instrumentation/index.html b/ro/docs/languages/cpp/instrumentation/index.html
diff --git a/site/index.html b/site/index.html
diff --git a/uk/docs/languages/cpp/instrumentation/index.html b/uk/docs/languages/cpp/instrumentation/index.html
diff --git a/zh/docs/concepts/observability-primer/index.html b/zh/docs/concepts/observability-primer/index.html
diff --git a/zh/docs/contributing/issues/index.html b/zh/docs/contributing/issues/index.html
diff --git a/zh/docs/languages/cpp/instrumentation/index.html b/zh/docs/languages/cpp/instrumentation/index.html
```

Here's an example of the diffs:

```diff
diff --git a/blog/2022/kubecon-na-project-update/index.html b/blog/2022/kubecon-na-project-update/index.html
index a1f24244ee..cd4dbcd772 100644
--- a/blog/2022/kubecon-na-project-update/index.html
+++ b/blog/2022/kubecon-na-project-update/index.html
@@ -1275,7 +1275,7 @@ making it even more useful for everyone.</p>
 users will be gathered discussing OpenTelemetry and how it’s being used, how it
 can be improved, and where we should go from here. In May of this year at
 KubeCon EU we
-<a href="https://docs.google.com/document/d/1jt47KPwgDG_-4kR4J5GtFSCEhQO3CHgUdAwpCKTQHO8/edit#" target="_blank" rel="noopener" class="external-link">started a process to create a more formal OpenTelemetry roadmap</a>,
+<a href="https://docs.google.com/document/d/1jt47KPwgDG_-4kR4J5GtFSCEhQO3CHgUdAwpCKTQHO8/edit" target="_blank" rel="noopener" class="external-link">started a process to create a more formal OpenTelemetry roadmap</a>,
 and we’ll be continuing that process in Detroit. I’m writing this post in
 advance of the conference, so I won’t be able to post the full outcome, but here
 are some of the items that we think are most important:</p>
diff --git a/blog/2023/end-user-q-and-a-01/index.html b/blog/2023/end-user-q-and-a-01/index.html
index cd0f4a6f3a..e115aefb75 100644
--- a/blog/2023/end-user-q-and-a-01/index.html
+++ b/blog/2023/end-user-q-and-a-01/index.html
@@ -1489,7 +1489,7 @@ manage the contrib repositories (e.g. GraphQL). This is a known problem, and
 there is currently no solution in place. The OpenTelemetry Community welcomes
 any suggestions for improvement!</p>
 <p>There is also a huge focus on
-<a href="https://docs.google.com/document/d/1ghvajKaipiNZso3fDtyNxU7x1zx0_Eyd02OGpMGEpLE/edit#" target="_blank" rel="noopener" class="external-link">stabilizing semantic conventions</a>,
+<a href="https://docs.google.com/document/d/1ghvajKaipiNZso3fDtyNxU7x1zx0_Eyd02OGpMGEpLE/edit" target="_blank" rel="noopener" class="external-link">stabilizing semantic conventions</a>,
 and as part of that effort, maintainers plan to go through the existing
 instrumentation libraries and to make sure that they’re all up to date with the
 latest conventions. While it’s very well-maintained for certain languages, such
diff --git a/blog/2023/end-user-q-and-a-04/index.html b/blog/2023/end-user-q-and-a-04/index.html
index 623cadc0fc..89f52ff281 100644
--- a/blog/2023/end-user-q-and-a-04/index.html
+++ b/blog/2023/end-user-q-and-a-04/index.html
@@ -1489,7 +1489,7 @@ can be picked out from the bundle.yaml file.</p>
 still have a problem for querying, since Prometheus is also a database and not
 just a scraper. You have to do some amount of coordination within these
 Prometheus instances, which can get expensive, or use a Prometheus scaling
-solution such as <a href="https://github.com/thanos-io/thanos#" target="_blank" rel="noopener" class="external-link">Thanos</a> or
+solution such as <a href="https://github.com/thanos-io/thanos" target="_blank" rel="noopener" class="external-link">Thanos</a> or
 <a href="https://cortexmetrics.io" target="_blank" rel="noopener" class="external-link">Cortex</a> &ndash; however, this would involve running more
 components that you&rsquo;ll need to monitor.</p>
 <p>&ldquo;In OTel, we tack on this
diff --git a/bn/docs/languages/cpp/instrumentation/index.html b/bn/docs/languages/cpp/instrumentation/index.html
index e547b217b2..0dc51909ca 100644
--- a/bn/docs/languages/cpp/instrumentation/index.html
+++ b/bn/docs/languages/cpp/instrumentation/index.html
@@ -2147,7 +2147,7 @@ mapping between Instrument and Aggregation.</p>
 </span></span><span class="line"><span class="cl">         <span class="n">std</span><span class="o">::</span><span class="n">move</span><span class="p">(</span><span class="n">observable_sum_view</span><span class="p">));</span>
 </span></span></code></pre></div><h3 id="further-reading-1">Further reading<a class="td-heading-self-link" href="#further-reading-1" aria-label="Heading self-link"></a></h3>
 <ul>
-<li><a href="https://opentelemetry-cpp.readthedocs.io/en/latest/otel_docs/namespace_opentelemetry__metrics.html#" target="_blank" rel="noopener" class="external-link">Metrics API</a></li>
+<li><a href="https://opentelemetry-cpp.readthedocs.io/en/latest/otel_docs/namespace_opentelemetry__metrics.html" target="_blank" rel="noopener" class="external-link">Metrics API</a></li>
 <li><a href="https://opentelemetry-cpp.readthedocs.io/en/latest/otel_docs/namespace_opentelemetry__sdk__metrics.html" target="_blank" rel="noopener" class="external-link">Metrics SDK</a></li>
 <li><a href="https://github.com/open-telemetry/opentelemetry-cpp/tree/main/examples/metrics_simple" target="_blank" rel="noopener" class="external-link">Simple Metrics Example</a></li>
 </ul>
...
```