### PR TITLE
chore(link-hook+): move checks from render hook into per-pattern mdl rules

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -2,7 +2,7 @@ customRules:
   - ./scripts/_md-rules/alert-type-not-translated.mjs
   - ./scripts/_md-rules/unindent-code-blocks.js
   - ./scripts/_md-rules/trim-code-blank-lines.js
-  - ./scripts/_md-rules/validate-links/index.mjs
+  - ./scripts/_md-rules/link-rules.mjs
 
 ignores:
   - '.github/**'

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -15,7 +15,7 @@
 # <!-- markdownlint-enable line-length -->
 #
 # Or:
-# <!-- markdownlint-disable-next-line validate-links -->
+# <!-- markdownlint-disable-next-line no-http-urls -->
 
 default: true
 
@@ -36,31 +36,57 @@ table-column-style: false # Causes problems in ja and zh pages
 # Custom rules below this point:
 trim-code-blank-lines: true
 unindent-code-blocks: true
-validate-links:
-  # TODO: document this custom rule in the contrib section of the site and link
-  # to it here and in the rule message for further details.
-  patterns:
-    - description: Flag likely typosquatting GitHub URLs
-      regex: 'https://github\.(?!com|blog|io|github.com)'
-      message: >-
-        GitHub URLs should use `github.(com|blog|io|github.com)` domains to
-        avoid typosquatting. For details, see
-        https://github.com/open-telemetry/opentelemetry.io/issues/8085.
-    - description: Report `http` URLs that are not localhost/127.0.0.1
-      regex: 'http://(?!([\w-]+\.)?localhost\b)(?!127\.0)(?!.*[\?&]http_ok\b)'
-      message: >-
-        'http' URLs are only permitted for localhost/127.0.0.1. Use 'https' or
-        add 'http_ok' as a query parameter to the URL, such as:
-        https://example.com?http_ok or http://example.com?q=search&http_ok.
 
-    - description: >-
-        Link paths should not start with a language code. This rule might cause
-        false positives if pages need to reach across locale sites, but that
-        seems unlikely. What has happened often enough is for locale authors to
-        prefix paths with their locale's language code; but that isn't
-        necessary, since absolute paths resolve to the locale's site root. See
-        https://gohugo.io/quick-reference/glossary/#site-relative
-      regex: '^/..(-..)?/.+'
-      # Note: ^/../$ is accepted
-      message: >-
-        Don't prefix paths with a language code.
+# -----------------------------------------------------------------------------
+# Link-validation rules (from scripts/_md-rules/link-rules.mjs)
+
+# TODO: document the custom rules in the contrib section of the site and link
+# to it here and in the rule message for further details.
+
+no-typosquatting-urls:
+  regex: 'https://github\.(?!com|blog|io|github.com)'
+  message: >-
+    GitHub URLs should use `github.(com|blog|io|github.com)` domains to avoid
+    typosquatting. For details, see
+    https://github.com/open-telemetry/opentelemetry.io/issues/8085.
+
+no-http-urls:
+  regex: 'http://(?!([\w-]+\.)?localhost\b)(?!127\.0)(?!.*[\?&]http_ok\b)'
+  message: >-
+    'http' URLs are only permitted for localhost/127.0.0.1. Use 'https' or add
+    'http_ok' as a query parameter to the URL, such as:
+    https://example.com?http_ok or http://example.com?q=search&http_ok.
+
+no-lang-prefix-in-paths:
+  # This rule might cause false positives if pages need to reach across locale
+  # sites, but that seems unlikely. What has happened often enough is for locale
+  # authors to prefix paths with their locale's language code; but that isn't
+  # necessary, since absolute paths resolve to the locale's site root. See
+  # https://gohugo.io/quick-reference/glossary/#site-relative
+  regex: '^/..(-..)?/.+'
+  # Note: ^/../$ is accepted
+  message: >-
+    Don't prefix paths with a language code.
+
+no-otel-io-external-urls:
+  regex: 'https?://(?:www\.)?opentelemetry\.io/'
+  message: >-
+    Use a site-relative path instead of the full opentelemetry.io URL.
+
+no-spec-github-urls:
+  regex: 'https://github\.com/open-telemetry/opentelemetry-specification/(blob|tree)/main/specification/\w'
+  message: >-
+    Use a local path, not a GitHub URL, for references to specification pages
+    that are hosted on this site.
+
+no-proto-spec-github-urls:
+  regex: 'https://github\.com/open-telemetry/opentelemetry-proto/(blob|tree)/main/docs/specification'
+  message: >-
+    Use a local path, not a GitHub URL, for references to specification pages
+    that are hosted on this site.
+
+no-semconv-github-urls:
+  regex: 'https://github\.com/open-telemetry/semantic-conventions/(blob|tree)/main/docs'
+  message: >-
+    Use a local path, not a GitHub URL, for references to semantic conventions
+    pages that are hosted on this site.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing to OpenTelemetry.io
 
+<!-- markdownlint-disable no-otel-io-external-urls -->
+
 **Thanks for your interest in contributing to
 [OpenTelemetry.io](https://opentelemetry.io/)!**
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <!-- cSpell:ignore Chalin Ferri Benedetti Hrabusa jparsana -->
+<!-- markdownlint-disable no-otel-io-external-urls -->
 
 # <img src="https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png" alt="OTel logo" width="45"> OpenTelemetry.io
 

--- a/layouts/_markup/render-link.html
+++ b/layouts/_markup/render-link.html
@@ -108,25 +108,9 @@
 
 {{/* General link-render processing */ -}}
 
-{{ $startsWithHttp := hasPrefix $u.Scheme "http" -}}
-{{ if $startsWithHttp -}}
-  {{ $matches := findRESubmatch `^https?://(?:www\.)?opentelemetry.io(/?.*)$` $href -}}
-  {{ $otelIoPath := index (index $matches 0) 1 | default "/" -}}
-  {{ if $matches -}}
-    {{ warnf "%s: use a local path '%s' instead of external URL '%s' for reference to site-local page"
-        .Page.File.Path $otelIoPath $href -}}
-  {{ else if or
-    (findRE "^https://github.com/open-telemetry/opentelemetry-specification/(blob|tree)/main/specification/\\w" $href)
-    (findRE "^https://github.com/open-telemetry/opentelemetry-proto/(blob|tree)/main/docs/specification" $href)
-    (findRE "^https://github.com/open-telemetry/semantic-conventions/(blob|tree)/main/docs" $href)
-    -}}
-    {{ warnf "%s: use a local path, not an external URL, for the following reference to a local specification page: %s"
-    .Page.File.Path $href -}}
-  {{ end -}}
-{{ end -}}
-
 {{/* Until Hugo supports hook params (https://github.com/gohugoio/hugo/issues/6670), we'll inspect .Text. */ -}}
 
+{{ $startsWithHttp := hasPrefix $u.Scheme "http" -}}
 <a href="{{ $href | safeURL }}"
   {{- with .Title}} title="{{ . }}"{{ end -}}
   {{ if $startsWithHttp }} target="_blank" rel="noopener"

--- a/projects/language-sdk-docs-consistency.md
+++ b/projects/language-sdk-docs-consistency.md
@@ -1,5 +1,7 @@
 # Language SDK Documentation Consistency
 
+<!-- markdownlint-disable no-otel-io-external-urls -->
+
 ## Ownership
 
 - Lead: Fabrizio Ferri Benedetti (@theletterf)

--- a/projects/localization-portuguese.md
+++ b/projects/localization-portuguese.md
@@ -1,5 +1,7 @@
 # Portuguese Localization
 
+<!-- markdownlint-disable no-otel-io-external-urls -->
+
 ## Description
 
 > **Note**: This project is part of the broader

--- a/projects/localization.md
+++ b/projects/localization.md
@@ -1,5 +1,7 @@
 # Website Localization
 
+<!-- markdownlint-disable no-otel-io-external-urls -->
+
 ## Ownership
 
 - Lead: Vitor Vasconcellos (@vitorvasc)

--- a/scripts/_md-rules/link-rules.mjs
+++ b/scripts/_md-rules/link-rules.mjs
@@ -1,0 +1,45 @@
+// @ts-check
+//
+// Project-specific link-validation rules built on the generic
+// createLinkPatternRule factory. Each entry becomes an independently
+// configurable (and disableable) markdownlint rule.
+//
+// Rule config (regex + message) lives in .markdownlint.yaml under the rule
+// name. For example:
+//
+//   no-typosquatting-urls:
+//     regex: 'https://github\.(?!com|blog|io|github\.com)'
+//     message: GitHub URLs should use github.(com|blog|io|github.com) domains.
+
+import { createLinkPatternRule } from './validate-links/index.mjs';
+
+export default [
+  createLinkPatternRule(
+    'no-typosquatting-urls',
+    'Flag likely typosquatting GitHub URLs',
+  ),
+  createLinkPatternRule(
+    'no-http-urls',
+    'Report http URLs that are not localhost/127.0.0.1',
+  ),
+  createLinkPatternRule(
+    'no-lang-prefix-in-paths',
+    'Link paths should not start with a language code',
+  ),
+  createLinkPatternRule(
+    'no-otel-io-external-urls',
+    'Use a local path instead of an external URL for site-local pages',
+  ),
+  createLinkPatternRule(
+    'no-spec-github-urls',
+    'Use a local path for OTel specification pages',
+  ),
+  createLinkPatternRule(
+    'no-proto-spec-github-urls',
+    'Use a local path for OTel proto specification pages',
+  ),
+  createLinkPatternRule(
+    'no-semconv-github-urls',
+    'Use a local path for semantic conventions pages',
+  ),
+];

--- a/scripts/_md-rules/validate-links/index.mjs
+++ b/scripts/_md-rules/validate-links/index.mjs
@@ -1,70 +1,68 @@
 // @ts-check
 //
-// Custom markdownlint rule to validate links against given regex patterns.
+// Factory for creating markdownlint rules that validate links against a regex
+// pattern. Each rule created by this factory gets its own name and config,
+// allowing per-rule disable directives.
 
 import { filterByTypes } from 'markdownlint-rule-helpers/micromark';
 
+const linkTokenTypes = /** @type {any} */ ([
+  'resourceDestinationString', // inline link [text](url) or image ![alt](url)
+  'definitionDestinationString', // reference definition [label]: url
+  'autolinkProtocol', // autolink: <https://...>
+  'literalAutolinkHttp', // bare URL: https://... (GFM extension)
+]);
+
 /**
- * Check content for URLs matching the given patterns.
+ * Create a markdownlint rule that checks link URLs against a regex pattern
+ * specified via rule config.
  *
- * @param {string} content - content to check
- * @param {number} lineNumber - line number for error reporting
- * @param {Function} onError - error reporting function
- * @param {Array} urlPatterns - patterns to match against
+ * Config shape (in .markdownlint.yaml):
+ *
+ *   rule-name:
+ *     regex: 'pattern'
+ *     message: 'Error message'
+ *
+ * @param {string} name - rule identifier (used in markdownlint-disable directives)
+ * @param {string} description - human-readable rule description
+ * @returns {import("markdownlint").Rule}
  */
-function checkContentForUrls(content, lineNumber, onError, urlPatterns) {
-  if (!content) return;
+export function createLinkPatternRule(name, description) {
+  return {
+    names: [name],
+    description,
+    tags: ['custom', 'links', 'validation'],
+    parser: 'micromark',
+    function: function (params, onError) {
+      const { regex, message } = params.config;
+      if (!regex || !message) return;
 
-  // Skip URLs that contain Hugo template directives
-  if (content.includes('{{') && content.includes('}}')) return;
+      const compiled = new RegExp(regex, 'g');
 
-  for (const pattern of urlPatterns) {
-    let match;
-    // Reset regex lastIndex to ensure global regex works correctly
-    pattern.regex.lastIndex = 0;
+      const linkDestinations = filterByTypes(
+        params.parsers.micromark.tokens,
+        linkTokenTypes,
+      );
 
-    while ((match = pattern.regex.exec(content)) !== null) {
-      const contextStart = Math.max(0, match.index - 20);
-      const contextEnd = match.index + match[0].length + 20;
-      onError({
-        lineNumber,
-        detail: pattern.message,
-        context: content.substring(contextStart, contextEnd),
-      });
-    }
-  }
+      for (const token of linkDestinations) {
+        const content = token.text;
+        if (!content) continue;
+
+        // Skip URLs that contain Hugo template directives
+        if (content.includes('{{') && content.includes('}}')) continue;
+
+        compiled.lastIndex = 0;
+        let match;
+        while ((match = compiled.exec(content)) !== null) {
+          const contextStart = Math.max(0, match.index - 20);
+          const contextEnd = match.index + match[0].length + 20;
+          onError({
+            lineNumber: token.startLine,
+            detail: message,
+            context: content.substring(contextStart, contextEnd),
+          });
+        }
+      }
+    },
+  };
 }
-
-/** @type {import("markdownlint").Rule} */
-export default {
-  names: ['validate-links'],
-  description: 'Pattern-based link checking',
-  tags: ['custom', 'links', 'validation'],
-  parser: 'micromark',
-  function: function validateLinks(params, onError) {
-    // Get regex patterns from config
-    /** @type {{regex: string, message: string}[]} */
-    const configPatterns = params.config.patterns;
-
-    // Convert string regexes to RegExp objects
-    const urlPatterns = configPatterns.map((p) => ({
-      regex: new RegExp(p.regex, 'g'),
-      message: p.message,
-    }));
-
-    // Find all link destination strings (URLs in various Markdown constructs)
-    const linkDestinations = filterByTypes(
-      params.parsers.micromark.tokens,
-      /** @type {any} */ ([
-        'resourceDestinationString', // inline link [text](url) or image ![alt](url)
-        'definitionDestinationString', // reference definition [label]: url
-        'autolinkProtocol', // autolink: <https://...>
-        'literalAutolinkHttp', // bare URL: https://... (GFM extension)
-      ]),
-    );
-
-    for (const token of linkDestinations) {
-      checkContentForUrls(token.text, token.startLine, onError, urlPatterns);
-    }
-  },
-};

--- a/scripts/_md-rules/validate-links/index.test.mjs
+++ b/scripts/_md-rules/validate-links/index.test.mjs
@@ -1,56 +1,80 @@
 // @ts-check
 //
-// Smoke tests for validate-links rule
+// Tests for the createLinkPatternRule factory
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { lint } from 'markdownlint/promise';
-import rule from './index.mjs';
+import { createLinkPatternRule } from './index.mjs';
 
-const config = {
-  default: false,
-  'validate-links': {
-    patterns: [
-      { regex: 'example\\.com', message: 'Do not link to example.com' },
-      { regex: 'localhost', message: 'Do not link to localhost' },
-    ],
-  },
-};
+const exampleRule = createLinkPatternRule('no-example-com', 'No example.com');
+const localhostRule = createLinkPatternRule('no-localhost', 'No localhost');
 
 /**
- * Run the validate-links rule on markdown content.
- * @param {string} content - Markdown content to lint
- * @returns {Promise<Array>} - Array of lint errors
+ * Run lint with the given rules and config on markdown content.
+ * @param {string} content
+ * @param {import("markdownlint").Rule[]} rules
+ * @param {object} config
+ * @returns {Promise<Array>}
  */
-async function lintContent(content) {
+async function lintContent(content, rules, config) {
   const results = await lint({
     strings: { test: content },
-    customRules: [rule],
+    customRules: rules,
     config,
   });
   return results.test || [];
 }
 
-describe('validate-links', () => {
+describe('createLinkPatternRule', () => {
+  const config = {
+    default: false,
+    'no-example-com': {
+      regex: 'example\\.com',
+      message: 'Do not link to example.com',
+    },
+    'no-localhost': {
+      regex: 'localhost',
+      message: 'Do not link to localhost',
+    },
+  };
+
   it('should pass for links not matching any pattern', async () => {
-    const errors = await lintContent('[link](https://opentelemetry.io)');
+    const errors = await lintContent(
+      '[link](https://opentelemetry.io)',
+      [exampleRule, localhostRule],
+      config,
+    );
     assert.strictEqual(errors.length, 0);
   });
 
   it('should flag links matching a pattern', async () => {
-    const errors = await lintContent('[link](https://example.com/page)');
+    const errors = await lintContent(
+      '[link](https://example.com/page)',
+      [exampleRule],
+      config,
+    );
     assert.strictEqual(errors.length, 1);
-    assert.ok(errors[0].ruleDescription.includes('Validate links'));
+    assert.strictEqual(errors[0].ruleNames[0], 'no-example-com');
   });
 
   it('should flag localhost links', async () => {
-    const errors = await lintContent('[api](http://localhost:8080/api)');
+    const errors = await lintContent(
+      '[api](http://localhost:8080/api)',
+      [localhostRule],
+      config,
+    );
     assert.strictEqual(errors.length, 1);
+    assert.strictEqual(errors[0].ruleNames[0], 'no-localhost');
     assert.ok(errors[0].errorDetail.includes('localhost'));
   });
 
   it('should skip URLs with Hugo template directives', async () => {
-    const errors = await lintContent('[link]({{ site.baseurl }}/example.com)');
+    const errors = await lintContent(
+      '[link]({{ site.baseurl }}/example.com)',
+      [exampleRule],
+      config,
+    );
     assert.strictEqual(errors.length, 0);
   });
 
@@ -60,7 +84,11 @@ describe('validate-links', () => {
 [bad1](https://example.com)
 [bad2](http://localhost:3000)
 `;
-    const errors = await lintContent(content);
+    const errors = await lintContent(
+      content,
+      [exampleRule, localhostRule],
+      config,
+    );
     assert.strictEqual(errors.length, 2);
   });
 
@@ -70,23 +98,59 @@ See [example][] for details.
 
 [example]: https://example.com/page
 `;
-    const errors = await lintContent(content);
+    const errors = await lintContent(content, [exampleRule], config);
     assert.strictEqual(errors.length, 1);
     assert.ok(errors[0].errorDetail.includes('example.com'));
   });
 
   it('should flag image URLs', async () => {
-    const errors = await lintContent('![logo](https://example.com/logo.png)');
+    const errors = await lintContent(
+      '![logo](https://example.com/logo.png)',
+      [exampleRule],
+      config,
+    );
     assert.strictEqual(errors.length, 1);
   });
 
   it('should flag autolinks', async () => {
-    const errors = await lintContent('Visit <https://example.com> for info.');
+    const errors = await lintContent(
+      'Visit <https://example.com> for info.',
+      [exampleRule],
+      config,
+    );
     assert.strictEqual(errors.length, 1);
   });
 
   it('should flag bare URLs', async () => {
-    const errors = await lintContent('Visit https://example.com for info.');
+    const errors = await lintContent(
+      'Visit https://example.com for info.',
+      [exampleRule],
+      config,
+    );
     assert.strictEqual(errors.length, 1);
+  });
+
+  it('should only flag the matching rule, not others', async () => {
+    const errors = await lintContent(
+      '[link](https://example.com)',
+      [exampleRule, localhostRule],
+      config,
+    );
+    assert.strictEqual(errors.length, 1);
+    assert.strictEqual(errors[0].ruleNames[0], 'no-example-com');
+  });
+
+  it('should be independently disableable per rule', async () => {
+    const configWithDisable = {
+      ...config,
+      'no-example-com': false,
+    };
+    const errors = await lintContent(
+      '[a](https://example.com) [b](http://localhost)',
+      [exampleRule, localhostRule],
+      configWithDisable,
+    );
+    assert.strictEqual(errors.length, 1);
+    assert.strictEqual(errors[0].ruleNames[0], 'no-localhost');
   });
 });


### PR DESCRIPTION
- Contributes to #9167
- Moves URL checks (self-links to opentelemetry.io, spec/proto/semconv GitHub URLs) from render-link hook to markdownlint rules
- Refactors `validate-links` into a `createLinkPatternRule` factory, enabling per-pattern rule IDs and independent `markdownlint-disable` directives
- Adds project-specific `link-rules.mjs` wiring module -- keeping `validate-links` rule instance indepdentent
- Simplifies `render-link.html` to focus on URL resolution and rendering only
- No change to generated site files (except for build timestamp)