### PR TITLE
Automate Go semconv version updates in documentation

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,22 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: ['config:best-practices'],
+  customManagers: [
+    {
+      customType: 'regex',
+      description: 'Update Go semconv package versions in documentation',
+      managerFilePatterns: [
+        'content/en/docs/languages/go/instrumentation.md',
+        'content/en/docs/collector/extend/custom-component/receiver.md',
+        'content/pt/docs/languages/go/instrumentation.md',
+        'content/ja/docs/languages/go/instrumentation.md',
+        'content/zh/docs/languages/go/instrumentation.md',
+      ],
+      matchStrings: [
+        'go\\.opentelemetry\\.io/otel/semconv/v(?<currentValue>\\d+\\.\\d+\\.\\d+)',
+      ],
+      depNameTemplate: 'go.opentelemetry.io/otel',
+      datasourceTemplate: 'go',
+    },
+  ],
+}


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

## Description

Version updates for `go.opentelemetry.io/otel/semconv` are currently
handled manually across the docs, which is error-prone and can leave
examples outdated after a new release.

This PR adds automation for those updates, as discussed in
[#8930 (comment)](https://github.com/open-telemetry/opentelemetry.io/pull/8930#discussion_r2716506169),
following the same pattern used for Collector and other components.


Fixes #8976
