### PR TITLE
Add planned-content outline to site section

### DIFF
--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -251,9 +251,14 @@ params:
     docker-compose-v2: |
       `docker-compose` is deprecated. For details, see
       [Migrate to Compose V2](https://docs.docker.com/compose/).
+
   # Docs helpers: use with _param
   FA: <i class="fa-{1} fa-{2} text-{3} px-1"></i>
+  FAB: <i class="fa-brands fa-{1} text-{2} px-1"></i>
   FAS: <i class="fa-solid fa-{1} text-{2} px-1"></i>
+  FAS_LG: <i class="fa-solid fa-{1} text-{2} fa-lg"></i>
+  # Badge usage: {{% _param BADGE text color %}}
+  BADGE: <span class="badge text-bg-{2} rounded-pill text-small">{1}</span>
 
 security:
   funcs: # cspell:disable-line

--- a/content/en/site/_index.md
+++ b/content/en/site/_index.md
@@ -1,7 +1,39 @@
 ---
-title: Website information
-likeTitle: Site info
-cascade: { type: docs }
+title: About this website
+linkTitle: Website docs
+description: How this site is built, maintained, and deployed.
+# NOTE: aliases are not currently enabled for this section.
+cascade:
+  type: docs
+  params:
+    hide_feedback: true
 ---
+
+This section is for site maintainers and contributors. It documents how the
+OpenTelemetry website is organized, built, maintained, and deployed.
+
+<span class="badge fs-6 py-2">
+{{% _param FAS person-digging " pe-2" %}} Section under construction. {{%
+_param FAS person-digging " ps-2" %}}
+</span>
+
+## Content (planned) {#content}
+
+Tentatively planned content organization:
+
+- **About** — High-level information about the website project, including its
+  purpose, ownership, and overall status.
+- **Design** — Architectural design, Information Architecture (IA), layout, UX
+  choices, theme related decisions, and other design-level artifacts.
+- **Implementation** — Code-level structure and conventions, Hugo/Docsy
+  templates, SCSS/JS customizations, patches, and internal shims.
+- **Build** — Tooling, local development setup, CI/CD workflows, deployment
+  environments, and automation details.
+- **Quality** — Link checking, accessibility standards, tests, review practices,
+  and other quality-related processes.
+- **Roadmap** — Milestones, backlog, priorities, technical debt, and
+  design/implementation decisions.
+
+## Site build information
 
 {{% td/site-build-info/netlify "opentelemetry" %}}


### PR DESCRIPTION
- Contributes to #9237
- Adds planned-content outline to site section
- **Preview**: https://deploy-preview-9236--opentelemetry.netlify.app/site/

---

If you'd like to see an example of site/project section content, see Docsy's [Project][] section, which contains pages such as:
  - About > [Maintainer notes](https://main--docsydocs.netlify.app/project/about/maintainer-notes/)
  -  Build > [Git repos and branches](https://main--docsydocs.netlify.app/project/build/git-repo/)
  - [Style guide](https://main--docsydocs.netlify.app/project/style-guide/)

[Project]: https://main--docsydocs.netlify.app/project/

/cc @vitorvasc 