### PR TITLE
Add MCP server instrumentation for Go to registry

### DIFF
--- a/.cspell/en-words.txt
+++ b/.cspell/en-words.txt
@@ -114,6 +114,7 @@ Rexed
 runbook
 runbooks
 Rynn
+Safonova
 semconv
 servlet
 Severin

--- a/data/registry/instrumentation-go-mcp.yml
+++ b/data/registry/instrumentation-go-mcp.yml
@@ -1,0 +1,24 @@
+title: MCP Server Instrumentation
+registryType: instrumentation
+language: go
+tags:
+  - go
+  - instrumentation
+  - mcp
+  - model-context-protocol
+  - gen-ai
+license: MIT
+description: >-
+  OpenTelemetry middleware for Go MCP servers built with the official go-sdk.
+  Instruments every incoming method call with spans and duration histograms,
+  following the OTel semantic conventions for MCP. Covers both protocol-level
+  errors and application-level tool handler errors.
+authors:
+  - name: Olga Safonova
+    url: https://github.com/olgasafonova
+urls:
+  repo: https://github.com/olgasafonova/mcp-otel-go
+  docs: https://pkg.go.dev/github.com/olgasafonova/mcp-otel-go/mcpotel
+createdAt: 2026-02-21
+isNative: false
+isFirstParty: false

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -6779,6 +6779,14 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-13T09:52:44.900745758Z"
   },
+  "https://github.com/olgasafonova": {
+    "StatusCode": 200,
+    "LastSeen": "2026-02-23T19:31:59.063605199Z"
+  },
+  "https://github.com/olgasafonova/mcp-otel-go": {
+    "StatusCode": 200,
+    "LastSeen": "2026-02-23T19:31:58.708405006Z"
+  },
   "https://github.com/onurtemizkan": {
     "StatusCode": 206,
     "LastSeen": "2026-02-14T09:48:25.239273547Z"
@@ -18130,6 +18138,10 @@
   "https://pkg.go.dev/github.com/mitchellh/mapstructure": {
     "StatusCode": 200,
     "LastSeen": "2026-02-13T09:52:00.673511168Z"
+  },
+  "https://pkg.go.dev/github.com/olgasafonova/mcp-otel-go/mcpotel": {
+    "StatusCode": 200,
+    "LastSeen": "2026-02-23T19:32:00.352985133Z"
   },
   "https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor": {
     "StatusCode": 200,


### PR DESCRIPTION
## What

Adds [mcp-otel-go](https://github.com/olgasafonova/mcp-otel-go) to the OTel ecosystem registry as a Go instrumentation library.

## What it instruments

Go MCP servers built with the official [go-sdk](https://github.com/modelcontextprotocol/go-sdk). One middleware function instruments every incoming MCP method call with:

- Spans named `{method} {target}` (e.g., `tools/call miro_create_sticky`)
- Duration histogram (`mcp.server.operation.duration`)
- Attributes following the [OTel semantic conventions for MCP](https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/)
- Both protocol-level and application-level error detection

## Project details

- **pkg.go.dev**: [github.com/olgasafonova/mcp-otel-go/mcpotel](https://pkg.go.dev/github.com/olgasafonova/mcp-otel-go/mcpotel)
- **License**: MIT
- **Go Report Card**: A+ ([report](https://goreportcard.com/report/github.com/olgasafonova/mcp-otel-go))
- **CI**: GitHub Actions with Go 1.23/1.24, race detector, golangci-lint
- **Current version**: v0.1.0