### PR TITLE
chore(blog/2019-22): take 2 - use FULL commit hash instead of `main`

### DIFF
--- a/content/en/blog/2019/opentelemetry-governance-committee-explained/index.md
+++ b/content/en/blog/2019/opentelemetry-governance-committee-explained/index.md
@@ -8,7 +8,7 @@ cSpell:ignore: Kanzhelev Novotny Sergey
 ---
 
 This article describes the functions and responsibilities of the
-[OpenTelemetry Governance Committee's charter document](https://github.com/open-telemetry/community/blob/614ece1/governance-charter.md?from_branch=main).
+[OpenTelemetry Governance Committee's charter document](https://github.com/open-telemetry/community/blob/614ece1538e6697842bc25d436d8d70ab6175808/governance-charter.md?from_branch=main).
 It is an opinion, not the formal definition. The primary role of the Governance
 Committee is not to centralize power, but to enable and empower the broader
 community by establishing processes. Let me explain.

--- a/content/en/blog/2022/announcing-opentelemetry-demo-release/index.md
+++ b/content/en/blog/2022/announcing-opentelemetry-demo-release/index.md
@@ -61,7 +61,7 @@ for Swift, and more.
 
 We’d love for you to take the demo for a spin and let us know what you think!
 Check out the
-[docs](https://github.com/open-telemetry/opentelemetry-demo/tree/06aa374/docs?from_branch=main#opentelemetry-demo-documentation),
+[docs](https://github.com/open-telemetry/opentelemetry-demo/tree/06aa374799319143c15bf7add18a5f056a2c4504/docs?from_branch=main#opentelemetry-demo-documentation),
 or run the demo using [Docker](/docs/demo/docker-deployment/) or
 [Kubernetes](/docs/demo/kubernetes-deployment/), and let us know your thoughts.
 If you’d like to contribute, please file an

--- a/content/en/blog/2022/apisix/index.md
+++ b/content/en/blog/2022/apisix/index.md
@@ -47,7 +47,7 @@ You need to enable `opentelemetry` plugin and modify collector configuration in
 
 We assume that you have already deployed the OpenTelemetry Collector on the same
 node as the APISIX and enabled the
-[OTLP HTTP Receiver](https://github.com/open-telemetry/opentelemetry-collector/blob/b3125ce/receiver/otlpreceiver/README.md?from_branch=main).
+[OTLP HTTP Receiver](https://github.com/open-telemetry/opentelemetry-collector/blob/b3125cea266d6453df1bd48a17686f752f7d07d9/receiver/otlpreceiver/README.md?from_branch=main).
 
 > Need help completing deployment of the OpenTelemetry Collector? See the
 > scenario [Example](#example) below.

--- a/content/en/blog/2022/collector-builder-sample/index.md
+++ b/content/en/blog/2022/collector-builder-sample/index.md
@@ -17,7 +17,7 @@ allows users to configure telemetry pipelines that are customized to their use
 case.
 
 The
-[collector-builder tool](https://github.com/open-telemetry/opentelemetry-collector/tree/d25efc7/cmd/builder?from_branch=main)
+[collector-builder tool](https://github.com/open-telemetry/opentelemetry-collector/tree/d25efc7e2f31a3ba5347d0725a22d7bed1b4015d/cmd/builder?from_branch=main)
 takes that customizability a step further, offering a way to easily compile a
 Collector binary built with only certain ingestion and export components. In
 contrast with publicly available binary releases (which bundle in a number of
@@ -34,7 +34,7 @@ extend it to meet your use-cases.
 This repository will help you:
 
 - **Compile a custom Collector designed for GCP with the**
-  [**collector-builder**](https://github.com/open-telemetry/opentelemetry-collector/tree/d25efc7/cmd/builder?from_branch=main).
+  [**collector-builder**](https://github.com/open-telemetry/opentelemetry-collector/tree/d25efc7e2f31a3ba5347d0725a22d7bed1b4015d/cmd/builder?from_branch=main).
   Low-overhead Collector builds are possible with the upstream collector-builder
   tool, so we’ve provided the setup files for building a lightweight collector
   with GCP services in mind. This is GCP's recommended base set of components to
@@ -62,18 +62,18 @@ While there are
 [public Docker images for the Collector](https://hub.docker.com/r/otel/opentelemetry-collector-contrib/tags)
 published by the OpenTelemetry community, these images can be as large as 40MB.
 This is due to all of the
-[receivers](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/944d4a8/receiver?from_branch=main),
-[processors](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/7c7beff/processor?from_branch=main),
+[receivers](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/944d4a82c408d58f9d8ba1a1d4783094301af0de/receiver?from_branch=main),
+[processors](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/7c7beffbf95ce2d3ea7159cc4c48ecde8a73c82a/processor?from_branch=main),
 and
-[exporters](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/8d0362c/exporter?from_branch=main)
+[exporters](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/8d0362c4a63f6b4e6f106f007977b6d75e4bd272/exporter?from_branch=main)
 that are bundled into the image by default. With all of these default
 components, there is also the potential for security issues to arise, part of
 the reason why the
-[Collector maintainers recommend only enabling necessary components](https://github.com/open-telemetry/opentelemetry-collector/blob/5ab00fc/docs/security.md)
+[Collector maintainers recommend only enabling necessary components](https://github.com/open-telemetry/opentelemetry-collector/blob/5ab00fcf51bd74acbc3ac95946e38adb8cfa25e5/docs/security.md)
 in your Collector.
 
 The
-[collector-builder tool](https://github.com/open-telemetry/opentelemetry-collector/tree/d25efc7/cmd/builder?from_branch=main)
+[collector-builder tool](https://github.com/open-telemetry/opentelemetry-collector/tree/d25efc7e2f31a3ba5347d0725a22d7bed1b4015d/cmd/builder?from_branch=main)
 accelerates compiling stripped-down Collector images with a simple YAML config
 file. This file declares which components to include in the build, and
 collector-builder includes only those components (and nothing else). This is in
@@ -105,7 +105,7 @@ exporters:
 ```
 
 Edit
-[this file](https://github.com/GoogleCloudPlatform/opentelemetry-collector-builder-sample/blob/3bd4826/build/local/builder-config.yaml?from_branch=main)
+[this file](https://github.com/GoogleCloudPlatform/opentelemetry-collector-builder-sample/blob/3bd48267a6d0e4a84da913a0b15434bc59f95426/build/local/builder-config.yaml?from_branch=main)
 in the repository and run `make build` to automatically generate a local binary,
 or `make docker-build` to compile a container image.
 
@@ -113,7 +113,7 @@ or `make docker-build` to compile a container image.
 
 For convenience, this repository includes the minimum Kubernetes manifests used
 to deploy the Collector in a GKE cluster, with a compatible
-[runtime configuration](https://github.com/GoogleCloudPlatform/opentelemetry-collector-builder-sample/blob/3bd4826/deploy/gke/simple/otel-config.yaml?from_branch=main)
+[runtime configuration](https://github.com/GoogleCloudPlatform/opentelemetry-collector-builder-sample/blob/3bd48267a6d0e4a84da913a0b15434bc59f95426/deploy/gke/simple/otel-config.yaml?from_branch=main)
 for the sample collector-builder components built by default. When used
 together, the Make commands provided to build and push an image to Artifact
 Registry will automatically update those manifests in the repository to use the
@@ -129,7 +129,7 @@ can be sent to an observability backend of your choice. It then opens up
 flexibility to process and export your other telemetry signals to any backend.
 
 With the
-[provided Kubernetes manifests](https://github.com/GoogleCloudPlatform/opentelemetry-collector-builder-sample/blob/11493d2/deploy/gke/simple/manifest.yaml?from_branch=main),
+[provided Kubernetes manifests](https://github.com/GoogleCloudPlatform/opentelemetry-collector-builder-sample/blob/11493d29e986695710ac265d08f4d6b59f503494/deploy/gke/simple/manifest.yaml?from_branch=main),
 you only need one `kubectl` command to deploy the Collector:
 
 ```shell
@@ -197,15 +197,15 @@ After restarting the Collector pod (such as with `kubectl delete` or by applying
 a new manifest, as we’ll show below), the new config changes will take effect.
 This workflow can be used to enable or disable any OpenTelemetry exporter, with
 exporters available for
-[many popular observability backends](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/8d0362c/exporter?from_branch=main).
+[many popular observability backends](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/8d0362c4a63f6b4e6f106f007977b6d75e4bd272/exporter?from_branch=main).
 
 ### Adding a receiver and processor
 
 You can add more components and follow the same process as above to build and
 deploy a new Collector image. For example, you can enable the
-[Zipkin exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/635d425/exporter/zipkinexporter?from_branch=main)
+[Zipkin exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/635d4254a3018eb3ca8f1736e71fcb54f8ed6e5a/exporter/zipkinexporter?from_branch=main)
 (for sending traces to a [Zipkin](https://zipkin.io/) backend service) and the
-[batch processor](https://github.com/open-telemetry/opentelemetry-collector/tree/811b514/processor/batchprocessor?from_branch=main)
+[batch processor](https://github.com/open-telemetry/opentelemetry-collector/tree/811b5147d3ae2da9610f85265305dd46c79de179/processor/batchprocessor?from_branch=main)
 by editing your builder config from earlier like so:
 
 ```yaml
@@ -232,7 +232,7 @@ Running `make docker-build` then compiles a new version of your Collector image.
 If you have an Artifact Registry set up for hosting Collector images, you can
 also run `make docker-push` with environment variables set to make the image
 available in your GKE cluster (setup steps for this are documented in the
-[README](https://github.com/GoogleCloudPlatform/opentelemetry-collector-builder-sample/tree/3bd4826/build/cloudbuild?from_branch=main#building-with-cloud-build)).
+[README](https://github.com/GoogleCloudPlatform/opentelemetry-collector-builder-sample/tree/3bd48267a6d0e4a84da913a0b15434bc59f95426/build/cloudbuild?from_branch=main#building-with-cloud-build)).
 
 Enabling the new receiver and processor also follows the same steps as above,
 starting with editing your local Collector config:

--- a/content/en/blog/2022/frontend-overhaul/index.md
+++ b/content/en/blog/2022/frontend-overhaul/index.md
@@ -135,14 +135,14 @@ in combination with the
 [Node.js SDK](https://www.npmjs.com/package/@opentelemetry/sdk-node).
 
 You can find the full
-[implementation here](https://github.com/open-telemetry/opentelemetry-demo/blob/298c930/src/frontend/utils/telemetry/Instrumentation.js?from_branch=main).
+[implementation here](https://github.com/open-telemetry/opentelemetry-demo/blob/298c93016e9cf03a06b9dbe07d6306c5040e52a0/src/frontend/utils/telemetry/Instrumentation.js?from_branch=main).
 The basic instrumentation includes auto instrumentation for most of the commonly
 used
 [libraries and tools for Node.js](https://www.npmjs.com/package/@opentelemetry/auto-instrumentations-node).
 As part of providing a better example for users, a manual instrumentation in the
 form of route middleware was added. This would catch the incoming HTTP request
 and create a span based on it, including the context propagation. The
-[implementation can be found here](https://github.com/open-telemetry/opentelemetry-demo/blob/2596ca0/src/frontend/utils/telemetry/InstrumentationMiddleware.ts?from_branch=main).
+[implementation can be found here](https://github.com/open-telemetry/opentelemetry-demo/blob/2596ca097ee4ecda43b2379dd8a2637669d45948/src/frontend/utils/telemetry/InstrumentationMiddleware.ts?from_branch=main).
 
 The front-end was a little trickier, as the
 [initial rendering is server-side](https://nextjs.org/docs/app/building-your-application/rendering#fundamentals).
@@ -151,7 +151,7 @@ code is executed.
 
 After adding validations to check the browser side, we then loaded the custom
 front-end tracing module, which included creating the
-[web tracer provider and the automatic web instrumentations](https://github.com/open-telemetry/opentelemetry-demo/blob/6674686/src/frontend/utils/telemetry/FrontendTracer.ts?from_branch=main).
+[web tracer provider and the automatic web instrumentations](https://github.com/open-telemetry/opentelemetry-demo/blob/6674686ef389791c65f10c9e3dbb4078e0c12b63/src/frontend/utils/telemetry/FrontendTracer.ts?from_branch=main).
 
 The automatic front-end instrumentation captures the most common user actions
 such as clicks, fetch requests, and page loads. In order to allow the browser

--- a/content/en/blog/2022/gc-candidates.md
+++ b/content/en/blog/2022/gc-candidates.md
@@ -12,7 +12,7 @@ candidates running for one of the four available seats. We encourage all voters
 to take a moment and review all candidates, picking the one that best represents
 your interest. You can find their pictures, profile link, and descriptions on
 the
-[candidates page](https://github.com/open-telemetry/community/blob/24b30b9/elections/2022/governance-committee-candidates.md?from_branch=main),
+[candidates page](https://github.com/open-telemetry/community/blob/24b30b978af4a71066655c62dfc50a2e60101d06/elections/2022/governance-committee-candidates.md?from_branch=main),
 but here are their names:
 
 - Alolita Sharma

--- a/content/en/blog/2022/gc-elections.md
+++ b/content/en/blog/2022/gc-elections.md
@@ -17,14 +17,14 @@ be announced 22 October 2022.
 ## Vote!
 
 If you are a
-[member of standing](https://github.com/open-telemetry/community/blob/614ece1/governance-charter.md?from_branch=main#members-of-standing)
+[member of standing](https://github.com/open-telemetry/community/blob/614ece1538e6697842bc25d436d8d70ab6175808/governance-charter.md?from_branch=main#members-of-standing)
 in the OpenTelemetry community, we invite you to participate in this election to
 ensure that the community is well-represented in the Governance Committee. In
 this election four people must be elected, each with two-year terms.
 
 If you have made contributions to our ecosystem not measured by the automatic
 process, you can request
-[an exception](https://github.com/open-telemetry/community/blob/614ece1/governance-charter.md?from_branch=main#members-of-standing)
+[an exception](https://github.com/open-telemetry/community/blob/614ece1538e6697842bc25d436d8d70ab6175808/governance-charter.md?from_branch=main#members-of-standing)
 to participate in the election before 23:59 UTC on 17 October 2022. The voter
 roll with all members of standing and approved exceptions will be published here
 by 11 October 2022 and continuously updated.
@@ -35,7 +35,7 @@ October 2022 23:59 UTC on
 voters will need to sign in with their GitHub account.
 
 For more information, see the
-[OpenTelemetry 2022 Governance Committee election](https://github.com/open-telemetry/community/blob/fe12ecb/elections/2022/governance-committee-election.md?from_branch=main).
+[OpenTelemetry 2022 Governance Committee election](https://github.com/open-telemetry/community/blob/fe12ecb89802550b4d3daa9a30646157c540b391/elections/2022/governance-committee-election.md?from_branch=main).
 
 ## Interested in joining the Governance Committee?
 
@@ -45,11 +45,11 @@ running for a seat on the Governance Committee. You can read about the
 Governance Committee's role in
 [this blog](/blog/2019/opentelemetry-governance-committee-explained/) post or
 refer to the
-[charter document](https://github.com/open-telemetry/community/blob/614ece1/governance-charter.md?from_branch=main).
+[charter document](https://github.com/open-telemetry/community/blob/614ece1538e6697842bc25d436d8d70ab6175808/governance-charter.md?from_branch=main).
 You may nominate yourself (or others!) by submitting a Pull Request against the
-[list of candidates](https://github.com/open-telemetry/community/blob/24b30b9/elections/2022/governance-committee-candidates.md?from_branch=main)
+[list of candidates](https://github.com/open-telemetry/community/blob/24b30b978af4a71066655c62dfc50a2e60101d06/elections/2022/governance-committee-candidates.md?from_branch=main)
 by 7 October 2022 23:59 UTC — see the detailed requirements under
-[nominations](https://github.com/open-telemetry/community/blob/fe12ecb/elections/2022/governance-committee-election.md?from_branch=main#nominations)
+[nominations](https://github.com/open-telemetry/community/blob/fe12ecb89802550b4d3daa9a30646157c540b391/elections/2022/governance-committee-election.md?from_branch=main#nominations)
 for the Governance Committee election.
 
 We would like to thank the GC members who have helped grow OpenTelemetry, and

--- a/content/en/blog/2022/go-web-app-instrumentation/index.md
+++ b/content/en/blog/2022/go-web-app-instrumentation/index.md
@@ -14,7 +14,7 @@ with OpenTelemetry Go without prior knowledge.
 We will start with creating a simple to-do app that uses Mongo and the Gin
 framework. Then, we will send tracing data to Jaeger Tracing for visualization.
 You can find all the relevant files in this
-[GitHub repository](https://github.com/aspecto-io/opentelemetry-examples/tree/d522230/go?from_branch=master).
+[GitHub repository](https://github.com/aspecto-io/opentelemetry-examples/tree/d522230db13780dfd0352ccb7ac63cf021d62108/go?from_branch=master).
 
 ![OpenTelemetry Go - The Mandalorian](OpenTelemetry-Go-The-Mandalorian-2048x1406.png)
 
@@ -411,7 +411,7 @@ further investigate on your own:
 
 That’s all folks! We hope this guide was informative and easy to follow. You can
 find all files ready to use in our GitHub
-[repository](https://github.com/aspecto-io/opentelemetry-examples/tree/d522230/go?from_branch=master).
+[repository](https://github.com/aspecto-io/opentelemetry-examples/tree/d522230db13780dfd0352ccb7ac63cf021d62108/go?from_branch=master).
 
 _A version of this article was [originally posted][] on the Aspecto blog._
 

--- a/content/en/blog/2022/instrument-apache-httpd-server/index.md
+++ b/content/en/blog/2022/instrument-apache-httpd-server/index.md
@@ -257,11 +257,11 @@ writing this blog, support for other architectures is not provided.
 [^1]: {{% param notes.docker-compose-v2 %}}
 
 [docker-compose.yml]:
-  https://github.com/open-telemetry/opentelemetry-cpp-contrib/blob/f6d2942/instrumentation/otel-webserver-module/docker-compose.yml?from_branch=main
+  https://github.com/open-telemetry/opentelemetry-cpp-contrib/blob/f6d29426ee9b4d6b476c09ca3cb9bed3cf23906f/instrumentation/otel-webserver-module/docker-compose.yml?from_branch=main
 [localhost:9004]: http://localhost:9004
 [localhost:9004/index.html]: http://localhost:9004/index.html
 [localhost:9411]: http://localhost:9411
 [opentelemetry_module.conf]:
-  https://github.com/open-telemetry/opentelemetry-cpp-contrib/blob/715bab8/instrumentation/otel-webserver-module/opentelemetry_module.conf?from_branch=main
+  https://github.com/open-telemetry/opentelemetry-cpp-contrib/blob/715bab89e061b23ad95856d5a50e72f3ac9a42cb/instrumentation/otel-webserver-module/opentelemetry_module.conf?from_branch=main
 [opentelemetry module for apache http server]:
-  https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/5009fb7/instrumentation/otel-webserver-module?from_branch=main
+  https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/5009fb7c0428ab7e3c18dd8eb283482ac77de932/instrumentation/otel-webserver-module?from_branch=main

--- a/content/en/blog/2022/instrument-nginx/index.md
+++ b/content/en/blog/2022/instrument-nginx/index.md
@@ -374,7 +374,7 @@ you run into any problems, [create an issue][].
 [create an issue]:
   https://github.com/open-telemetry/opentelemetry-cpp-contrib/issues
 [full list of directives]:
-  https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/5009fb7/instrumentation/otel-webserver-module?from_branch=main#configuration-1
+  https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/5009fb7c0428ab7e3c18dd8eb283482ac77de932/instrumentation/otel-webserver-module?from_branch=main#configuration-1
 [localhost:16686]: http://localhost:16686
 [opentelemetry-webserver-sdk-x64-linux]:
   https://github.com/open-telemetry/opentelemetry-cpp-contrib/releases/download/webserver%2Fv1.0.0/opentelemetry-webserver-sdk-x64-linux.tgz.zip

--- a/content/en/blog/2022/k8s-metadata/index.md
+++ b/content/en/blog/2022/k8s-metadata/index.md
@@ -251,7 +251,7 @@ sidecar, or when one collector as an agent report to another collector.
 - [K8sattributes processor documentation][k8sattributesprocessor]
 - [K8sattributes processor RBAC](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor#hdr-RBAC)
 - [OpenTelemetry Kubernetes attributes](/docs/specs/semconv/resource/k8s)
-- [Resource detector processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/549e115/processor/resourcedetectionprocessor/README.md?from_branch=main)
+- [Resource detector processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/549e115b28292c164eb671618c0ec8b728b69d2a/processor/resourcedetectionprocessor/README.md?from_branch=main)
 
 [pr#832]: https://github.com/open-telemetry/opentelemetry-operator/pull/832
 [opentelemetry operator]:

--- a/content/en/blog/2022/knative/index.md
+++ b/content/en/blog/2022/knative/index.md
@@ -95,7 +95,7 @@ facts from the observability perspective:
   started in the Knative activator service with spans created in the workload
   and further link it with outbound spans - e.g. to calls to the second service.
 - The workload is using instrumented
-  [Cloudevents client/SDK](https://github.com/cloudevents/sdk-go/tree/15a1151/observability/opentelemetry/v2?from_branch=main) -
+  [Cloudevents client/SDK](https://github.com/cloudevents/sdk-go/tree/15a1151928556770f2a76faa5547278545fce8cb/observability/opentelemetry/v2?from_branch=main) -
   similarly to the previous point it allows us to continue the trace in the
   outbound request (in this scenario to the second service).
 
@@ -209,6 +209,6 @@ instrumentation libraries explicitly in the code or even
 - [Cloud events](https://cloudevents.io)
 - [Zipkin B3](https://github.com/openzipkin/b3-propagation)
 - [W3C Trace-Context](https://www.w3.org/TR/trace-context/)
-- [OpenTelemetry instrumentation for Cloudevents Golang SDK](https://github.com/cloudevents/sdk-go/tree/15a1151/observability/opentelemetry/v2?from_branch=main)
+- [OpenTelemetry instrumentation for Cloudevents Golang SDK](https://github.com/cloudevents/sdk-go/tree/15a1151928556770f2a76faa5547278545fce8cb/observability/opentelemetry/v2?from_branch=main)
 - [Cloudevents OpenTelemetry attributes](/docs/specs/semconv/cloudevents/cloudevents-spans/)
 - [Knative tracing demo](https://github.com/pavolloffay/knative-tracing)

--- a/content/en/blog/2022/opamp/index.md
+++ b/content/en/blog/2022/opamp/index.md
@@ -25,7 +25,7 @@ telemetry without those barriers? Thanks to
 behind it, I believe that the answer is about to change.
 
 OpAMP stands for
-[Open Agent Management Protocol](https://github.com/open-telemetry/opamp-spec/blob/49860fd/specification.md?from_branch=main).
+[Open Agent Management Protocol](https://github.com/open-telemetry/opamp-spec/blob/49860fd67177e4f80d9778831472ab106e4ae951/specification.md?from_branch=main).
 It aims at managing large fleets of data collection agents, and its GoLang
 [implementation](https://github.com/open-telemetry/opamp-go/) is at the Beta
 stage. It allows configuration changes as well as package downloads. It defines

--- a/content/en/blog/2022/otel-demo-app-nomad/index.md
+++ b/content/en/blog/2022/otel-demo-app-nomad/index.md
@@ -11,7 +11,7 @@ cSpell:ignore: Aoqui Daniela entrypoints ffspostgres hashi hashiqube jobspec job
 Y’all… I’m so excited, because I finally got to work on an item on my tech
 bucket list. Last week, I began the process of translating
 [OpenTelemetry Demo App](/docs/demo/)’s
-[Helm Charts](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/146b47d/charts/opentelemetry-demo?from_branch=main)
+[Helm Charts](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/146b47dd310628c8a8d0b0a19ff1e813560b2599/charts/opentelemetry-demo?from_branch=main)
 to [HashiCorp](https://hashicorp.com) [Nomad][] job specs. Today I’ll be talking
 about how to run the OpenTelemetry Demo App on Nomad, using my favorite
 Hashi-in-a-box tool, [HashiQube](https://rubiksqube.com/#/).
@@ -239,9 +239,9 @@ The OTel Demo App uses [Envoy](https://www.envoyproxy.io) to expose a number of
 front-end services: the web store, [Jaeger](https://www.jaegertracing.io/),
 [Grafana](https://grafana.com/), Load Generator, and Feature Flag. These are all
 managed by the
-[frontendproxy](https://github.com/avillela/nomad-conversions/blob/1d160b0/otel-demo-app/jobspec/frontendproxy.nomad?from_branch=main)
+[frontendproxy](https://github.com/avillela/nomad-conversions/blob/1d160b0b63ceb5f7cddda795fa54cdcf067c47d5/otel-demo-app/jobspec/frontendproxy.nomad?from_branch=main)
 service. Traefik makes the
-[frontendproxy](https://github.com/avillela/nomad-conversions/blob/1d160b0/otel-demo-app/jobspec/frontendproxy.nomad?from_branch=main)
+[frontendproxy](https://github.com/avillela/nomad-conversions/blob/1d160b0b63ceb5f7cddda795fa54cdcf067c47d5/otel-demo-app/jobspec/frontendproxy.nomad?from_branch=main)
 service available via the `otel-demo.localhost` address.
 
 This is configured via the code snippet below, in the `service` stanza of
@@ -271,7 +271,7 @@ buy a few. 😉🔭
 ![Screen capture of the Jaeger UI](jaeger.png 'Screen capture of the Jaeger UI')
 
 In the screen capture above, we can see a sample Trace from the
-[checkoutservice](https://github.com/avillela/nomad-conversions/blob/f546f90/otel-demo-app/jobspec/checkoutservice.nomad?from_branch=main).
+[checkoutservice](https://github.com/avillela/nomad-conversions/blob/f546f9079a97fcbdfc814b82dbe6eec8a5005d7d/otel-demo-app/jobspec/checkoutservice.nomad?from_branch=main).
 
 **Grafana:** <http://otel-demo.localhost/grafana/>
 
@@ -301,10 +301,10 @@ services.
 Although all of the services appear to start up properly, in some cases, some
 services appear to be unable to connect to the OTel Collector. I haven’t quite
 figured out why this is happening, so for now, I just restart
-[otel-collector.nomad](https://github.com/avillela/nomad-conversions/blob/ed12ec3/otel-demo-app/jobspec/otel-collector.nomad?from_branch=main).
+[otel-collector.nomad](https://github.com/avillela/nomad-conversions/blob/ed12ec3d4092a7816aadd2d761a98f9ef51dfb74/otel-demo-app/jobspec/otel-collector.nomad?from_branch=main).
 If things are looking a little weird in the Webapp UI (like missing products or
 currency), I also restart
-[frontend.nomad](https://github.com/avillela/nomad-conversions/blob/add469c/otel-demo-app/jobspec/frontend.nomad?from_branch=main).
+[frontend.nomad](https://github.com/avillela/nomad-conversions/blob/add469c5ad127cfb0956fd3da49c8a65160e1281/otel-demo-app/jobspec/frontend.nomad?from_branch=main).
 Usually a good indicator that services aren’t sending telemetry to the Collector
 is to look at the number of services showing up in Jaeger. You should see 14
 services, including the `jaeger-query` service.

--- a/content/en/blog/2022/tail-sampling/index.md
+++ b/content/en/blog/2022/tail-sampling/index.md
@@ -60,7 +60,7 @@ only be interested in traces with errors or latency for debugging.
 
 To use tail sampling in OpenTelemetry, you need to implement a component called
 the
-[tail sampling processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/635d425/processor/tailsamplingprocessor?from_branch=main).
+[tail sampling processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/635d4254a3018eb3ca8f1736e71fcb54f8ed6e5a/processor/tailsamplingprocessor?from_branch=main).
 This component samples traces based on a set of policies that you can choose
 from and define. **First, to ensure that you’re capturing all spans, use either
 the default sampler or the AlwaysOn sampler in your SDKs.**
@@ -192,7 +192,7 @@ which the collector is deployed in an agent-collector configuration. You also
 need each collector to have a full view of the traces it receives. This means
 that all spans with the same trace ID need to go to the same collector instance,
 or you’ll end up with fragmented traces. You can use a
-[load-balancing exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/8d0362c/exporter/loadbalancingexporter/README.md?from_branch=main)
+[load-balancing exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/8d0362c4a63f6b4e6f106f007977b6d75e4bd272/exporter/loadbalancingexporter/README.md?from_branch=main)
 if you're running multiple instances of the agent/collector with the tail
 sampling processor. This exporter ensures that all spans with the same trace ID
 end up in the same agent/collector. But there may be additional overhead with


### PR DESCRIPTION
- Contributes #8578 by enforcing the guidance
- Followup to #9262. Switches to using full hashes, otherwise GH can sometimes report 404 for potentially valid partial hashes.
- Replaces `main` in GH repo URL with the last commit hash of the named resource. Tags `?from_branch=main` as a query parameter.
