### PR TITLE
chore(blog/2025-26): use full commit hash instead of main in GH repo URL

### DIFF
--- a/content/en/blog/2025/ai-agent-observability/index.md
+++ b/content/en/blog/2025/ai-agent-observability/index.md
@@ -58,7 +58,7 @@ As AI agent ecosystems continue to mature, the need for standardized and robust
 observability has become more apparent. While some frameworks offer built-in
 instrumentation, others rely on integration with observability tools. This
 fragmented landscape underscores the importance of the
-[GenAI observability project](https://github.com/open-telemetry/community/blob/main/projects/gen-ai.md)
+[GenAI observability project](https://github.com/open-telemetry/community/blob/5125996b5d159ff9aaa906f9a25226a821dc7bed/projects/gen-ai.md?from_branch=main)
 and OpenTelemetry’s emerging semantic conventions, which aim to unify how
 telemetry data is collected and reported.
 
@@ -85,7 +85,7 @@ frameworks**:
 ### Establishing a standardized semantic convention
 
 Today, the
-[GenAI observability project](https://github.com/open-telemetry/community/blob/main/projects/gen-ai.md)
+[GenAI observability project](https://github.com/open-telemetry/community/blob/5125996b5d159ff9aaa906f9a25226a821dc7bed/projects/gen-ai.md?from_branch=main)
 within OpenTelemetry is actively working on defining semantic conventions to
 standardize AI agent observability. This effort is primarily driven by:
 
@@ -171,11 +171,11 @@ configured to emit telemetry per OpenTelemetry semantic conventions.
 For publishing instrumentation with OpenTelemetry, there are two options:
 
 - Option 1: External instrumentation in your own repository/package, like
-  [Traceloop OpenTelemetry Instrumentation](https://github.com/traceloop/openllmetry/tree/main/packages),
-  [Langtrace OpenTelemetry Instrumentation](https://github.com/Scale3-Labs/langtrace-python-sdk/tree/main/src/langtrace_python_sdk/instrumentation)
+  [Traceloop OpenTelemetry Instrumentation](https://github.com/traceloop/openllmetry/tree/c2974c94f593df42353ad48c9170d039ab1a0c3f/packages?from_branch=main),
+  [Langtrace OpenTelemetry Instrumentation](https://github.com/Scale3-Labs/langtrace-python-sdk/tree/462a04b361f62314fb6d2d873cd866959152aa35/src/langtrace_python_sdk/instrumentation?from_branch=main)
   etc.
 - Option 2: External instrumentation in OpenTelemetry owned repository, like
-  [instrumentation-genai](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation-genai)
+  [instrumentation-genai](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/5560324cff80148de07324715aef5efa1e6242c1/instrumentation-genai?from_branch=main)
   etc.
 
 Both options work well, but the long term goal is to host the code in
@@ -232,7 +232,7 @@ Looking ahead, AI agent observability will continue to evolve with:
 ## Role of OpenTelemetry's GenAI SIG
 
 The
-[GenAI Special Interest Group (SIG) in OpenTelemetry](https://github.com/open-telemetry/community/blob/main/projects/gen-ai.md)
+[GenAI Special Interest Group (SIG) in OpenTelemetry](https://github.com/open-telemetry/community/blob/5125996b5d159ff9aaa906f9a25226a821dc7bed/projects/gen-ai.md?from_branch=main)
 is actively defining [GenAI semantic conventions](/docs/specs/semconv/gen-ai/)
 that cover key areas such as:
 
@@ -256,4 +256,4 @@ transparent and effective AI ecosystem.
 Don’t miss this opportunity to help shape the future of industry standards for
 GenAI Observability! Join us on the [CNCF Slack](https://slack.cncf.io)
 `#otel-genai-instrumentation` channel, or by attending a
-[GenAI SIG meeting](https://github.com/open-telemetry/community/blob/main/projects/gen-ai.md#meeting-times).
+[GenAI SIG meeting](https://github.com/open-telemetry/community/blob/5125996b5d159ff9aaa906f9a25226a821dc7bed/projects/gen-ai.md?from_branch=main#meeting-times).

--- a/content/en/blog/2025/android-road-to-stable/index.md
+++ b/content/en/blog/2025/android-road-to-stable/index.md
@@ -65,17 +65,17 @@ sync.
 Through community contributions, the OpenTelemetry Android project gained a
 number of useful new instrumentation libraries. These include:
 
-- [android-log](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/android-log) -
+- [android-log](https://github.com/open-telemetry/opentelemetry-android/tree/4d3290f84d2612286eabfb1072f1885905c2b756/instrumentation/android-log?from_branch=main) -
   the ability to generate OTel log records from idiomatic Android `Log.x(...)`
   calls.
-- [httpurlconnection](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/httpurlconnection) -
+- [httpurlconnection](https://github.com/open-telemetry/opentelemetry-android/tree/c090b3c2aa34477879e3481a8e1e06b089406c36/instrumentation/httpurlconnection?from_branch=main) -
   tracing instrumentation for this runtime-supplied HTTP client with a lot of
   history.
-- [view-click](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/view-click)
+- [view-click](https://github.com/open-telemetry/opentelemetry-android/tree/f0cf647e364e290f03ad7d77252fd7209dd2bf41/instrumentation/view-click?from_branch=main)
   – generates click events for user presses on Android Views.
-- [compose-click](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/compose/click)
+- [compose-click](https://github.com/open-telemetry/opentelemetry-android/tree/f0cf647e364e290f03ad7d77252fd7209dd2bf41/instrumentation/compose/click?from_branch=main)
   – generates click events for user presses within Jetpack Compose components
-- [sessions](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/sessions)
+- [sessions](https://github.com/open-telemetry/opentelemetry-android/tree/f0cf647e364e290f03ad7d77252fd7209dd2bf41/instrumentation/sessions?from_branch=main)
   – generates events when the session lifecycle changes
 
 ### Auto-instrumentation
@@ -141,7 +141,7 @@ applications, we have created a new sample app. This demo app is modeled closely
 after the
 [OpenTelemetry Demo](https://github.com/open-telemetry/opentelemetry-demo)
 Astronomy Shop and is
-[included in the Android GitHub repository](https://github.com/open-telemetry/opentelemetry-android/tree/main/demo-app).
+[included in the Android GitHub repository](https://github.com/open-telemetry/opentelemetry-android/tree/c090b3c2aa34477879e3481a8e1e06b089406c36/demo-app?from_branch=main).
 In addition to demonstrating how to set up the agent and install
 instrumentation, the demo app also has features that generate off-the-shelf logs
 and tracing telemetry.

--- a/content/en/blog/2025/contrib-unroll-processor.md
+++ b/content/en/blog/2025/contrib-unroll-processor.md
@@ -176,5 +176,5 @@ good fit for today. Keeping the responsibilities separate lets OTTL focus on
 transforming existing log records while the unroll processor handles expansion
 
 The unroll processor is now available in the official
-[OpenTelemetry Collector Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/unrollprocessor).
+[OpenTelemetry Collector Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/635d4254a3018eb3ca8f1736e71fcb54f8ed6e5a/processor/unrollprocessor?from_branch=main).
 Please feel free to create issues and test it out for your logs pipelines.

--- a/content/en/blog/2025/contribex-survey-results/index.md
+++ b/content/en/blog/2025/contribex-survey-results/index.md
@@ -17,7 +17,7 @@ to contribute to the project and what we can do to improve the contributor
 experience. The Contributor Experience Survey asked contributors for their
 thoughts about the project's organization, SIG contributions, leadership
 committee interactions, and event attendance. We received 120
-[responses](https://github.com/open-telemetry/sig-end-user/tree/main/end-user-surveys/contributor-experience)
+[responses](https://github.com/open-telemetry/sig-end-user/tree/01bdcafbc787c0aa0b076ecd85432c24d50e62ac/end-user-surveys/contributor-experience?from_branch=main)
 and heard from all 47 Special Interest Groups (SIGs). We'll use this feedback to
 make contributing to OpenTelemetry easier and more rewarding. A big thank you to
 everyone who participated in the survey! Let's review the results.
@@ -137,7 +137,7 @@ newer contributors v. 65% of experienced contributors.
 ![A stacked bar chart showing the percentage of newer contributors and experienced contributors who can solve problems](chart-5-solve-problems.png)
 
 We received
-[many thoughtful responses](https://github.com/open-telemetry/sig-end-user/blob/main/end-user-surveys/contributor-experience/otel-contributor-experience-survey-free-form-questions.csv)
+[many thoughtful responses](https://github.com/open-telemetry/sig-end-user/blob/5960784a7e300dc23cbde4fba1bf391180a9e79f/end-user-surveys/contributor-experience/otel-contributor-experience-survey-free-form-questions.csv?from_branch=main)
 to our open-ended questions:
 
 > "Do you have any additional comments regarding project organization or your
@@ -283,7 +283,7 @@ investigate offering future surveys to address this request.
 ## Learn more
 
 For detailed results, see the anonymized
-[survey responses](https://github.com/open-telemetry/sig-end-user/tree/main/end-user-surveys/contributor-experience).
+[survey responses](https://github.com/open-telemetry/sig-end-user/tree/01bdcafbc787c0aa0b076ecd85432c24d50e62ac/end-user-surveys/contributor-experience?from_branch=main).
 
 ## Your feedback is essential
 

--- a/content/en/blog/2025/contribute-to-otel.md
+++ b/content/en/blog/2025/contribute-to-otel.md
@@ -115,7 +115,7 @@ Happy coding!
 [calendar]:
   https://github.com/open-telemetry/community?tab=readme-ov-file#calendar
 [membership]:
-  https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md
+  https://github.com/open-telemetry/community/blob/25f027532a6e9b503d6eb4dd3db0a98eb3b5f1cb/guides/contributor/membership.md?from_branch=main
 [contrib]: /docs/contributing
 [localization]: /docs/contributing/localization/
 [repos]: https://github.com/orgs/open-telemetry/repositories

--- a/content/en/blog/2025/declarative-config-rc3/index.md
+++ b/content/en/blog/2025/declarative-config-rc3/index.md
@@ -103,12 +103,12 @@ hear your feedback on this latest version of the schema!
 [configtls]: https://pkg.go.dev/go.opentelemetry.io/collector/config/configtls
 [severity-levels]: /docs/specs/otel/logs/data-model/#field-severitynumber
 [otel-config-schema]:
-  https://github.com/open-telemetry/opentelemetry-configuration/tree/main/schema
+  https://github.com/open-telemetry/opentelemetry-configuration/tree/6b306495d6285dacfa815b24115f69f0743f9ad1/schema?from_branch=main
 [schema]:
   https://github.com/open-telemetry/opentelemetry-configuration/blob/v1.0.0-rc.3/opentelemetry_configuration.json
 [contrib-doc]:
-  https://github.com/open-telemetry/opentelemetry-configuration/blob/main/CONTRIBUTING.md#project-tooling
+  https://github.com/open-telemetry/opentelemetry-configuration/blob/1905936912045de1cb6ef04d13afe912f462dbe2/CONTRIBUTING.md?from_branch=main#project-tooling
 [version-docs]:
-  https://github.com/open-telemetry/opentelemetry-configuration/blob/main/VERSIONING.md#experimental-features
+  https://github.com/open-telemetry/opentelemetry-configuration/blob/0a18b0c19ba656c22aa2a8dab65d03380fcc2802/VERSIONING.md?from_branch=main#experimental-features
 [schema-docs]:
-  https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema-docs.md#opentelemetryconfiguration
+  https://github.com/open-telemetry/opentelemetry-configuration/blob/28784d4ea2054f95affe3912189ccd51ee6aea3a/schema-docs.md?from_branch=main#opentelemetryconfiguration

--- a/content/en/blog/2025/declarative-config.md
+++ b/content/en/blog/2025/declarative-config.md
@@ -295,16 +295,16 @@ some additional resources to explore:
   https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1060
 [java-project]: https://github.com/orgs/open-telemetry/projects/151
 [migration-file]:
-  https://github.com/open-telemetry/opentelemetry-configuration/blob/main/examples/otel-sdk-migration-config.yaml
+  https://github.com/open-telemetry/opentelemetry-configuration/blob/db08177916083273421c1fd10247b63badd6a87a/examples/otel-sdk-migration-config.yaml?from_branch=main
 [full-file]:
-  https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema-docs.md
+  https://github.com/open-telemetry/opentelemetry-configuration/blob/28784d4ea2054f95affe3912189ccd51ee6aea3a/schema-docs.md?from_branch=main
 [java-sampler]:
-  https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/samplers
+  https://github.com/open-telemetry/opentelemetry-java-contrib/tree/b7a327218c8cf0928c8cb2198e5fa764d530afda/samplers?from_branch=main
 [complete-config]:
   https://gist.github.com/zeitlinger/09585b1ab57c454f87e6dcb9a6f50a5c
 [declarative-docs]: /docs/languages/sdk-configuration/declarative-configuration
 [compliance-matrix]:
-  https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md#declarative-configuration
+  https://github.com/open-telemetry/opentelemetry-specification/blob/af2606810c19c31850738d1fd105b4eca7aa8c98/spec-compliance-matrix.md?from_branch=main#declarative-configuration
 [java-declarative-config]: /docs/zero-code/java/agent/declarative-configuration/
 [slack-java]: https://cloud-native.slack.com/archives/C014L2KCTE3
 [slack-js]: https://cloud-native.slack.com/archives/C01NL1GRPQR
@@ -312,13 +312,13 @@ some additional resources to explore:
 [slack-go]: https://cloud-native.slack.com/archives/C01NPAXACKT
 [slack-config]: https://cloud-native.slack.com/archives/C0476L7UJT1
 [java-bridge]:
-  https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/declarative-config-bridge
+  https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/3c573ea4492a5f25e0f482eb523f829d318d0027/declarative-config-bridge?from_branch=main
 [js-package]:
-  https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/configuration
+  https://github.com/open-telemetry/opentelemetry-js/tree/ad92be4c2c1094745a85b0b7eeff1444a11b1b4a/experimental/packages/configuration?from_branch=main
 [php-docs]:
-  https://github.com/open-telemetry/opentelemetry-php/tree/main/src/Config/SDK#initialization-from-configuration-file
+  https://github.com/open-telemetry/opentelemetry-php/tree/08f0dc1afb23f7ff634cda54de4af8e779e11fe1/src/Config/SDK?from_branch=main#initialization-from-configuration-file
 [go-package]:
-  https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/otelconf
+  https://github.com/open-telemetry/opentelemetry-go-contrib/tree/848eb220bc83bb81d77383bbf39ebd86b5034407/otelconf?from_branch=main
 [go-package-index]: https://pkg.go.dev/go.opentelemetry.io/contrib/otelconf
 [sigs]:
   https://github.com/open-telemetry/community?tab=readme-ov-file#implementation-sigs

--- a/content/en/blog/2025/demystifying-auto-instrumentation.md
+++ b/content/en/blog/2025/demystifying-auto-instrumentation.md
@@ -42,7 +42,7 @@ monkey patching, etc.) that we explore in this blog post. These techniques are
 used by
 [instrumentation libraries](/docs/concepts/glossary/#instrumentation-library)
 that target specific frameworks, for example, libraries that instrument
-[Spring and Spring Boot](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/spring),
+[Spring and Spring Boot](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/f7cba3b86167946b3783fb8e575f1c169aec6972/instrumentation/spring?from_branch=main),
 [Express.js](https://www.npmjs.com/package/@opentelemetry/instrumentation-express),
 [Laravel](https://packagist.org/packages/open-telemetry/opentelemetry-auto-laravel),
 or other popular frameworks. Finally, complete solutions like the OpenTelemetry
@@ -132,9 +132,9 @@ from the lab.
 
 If you’d like to see actively used implementations of monkey patching, you can
 take a look into the instrumentation libraries provided by OpenTelemetry for
-[JavaScript](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages)
+[JavaScript](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/87876b5451052f336bad2f5b9df65d77c75dbd76/packages?from_branch=main)
 or
-[Python](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation).
+[Python](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/413c98e542b747b14bc35d79c18c7d020662f745/instrumentation?from_branch=main).
 
 ### Bytecode instrumentation: Modifying the virtual machine
 
@@ -198,9 +198,9 @@ from the lab.
 If you’d like to see actively used implementations of bytecode instrumentation,
 you can take a look into the instrumentation libraries provided by OpenTelemetry
 for
-[Java](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation)
+[Java](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/bc533f6df8545f79fcce2b138b14a6aca748e7fc/instrumentation?from_branch=main)
 or
-[.NET](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src).
+[.NET](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/4a4fab74f466cdbae23876e88e17b797b7674319/src?from_branch=main).
 
 ### Compile-time instrumentation: Baking observability into the binary
 
@@ -370,7 +370,7 @@ from the lab.
 
 If you’d like to see actively used implementations of API instrumentation, you
 can take a look into the instrumentation libraries provided by OpenTelemetry for
-[PHP](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/src/Instrumentation).
+[PHP](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/2b6a02f67d85f7f94ebc285d2c08c3523d26e093/src/Instrumentation?from_branch=main).
 
 ## A note on context propagation
 

--- a/content/en/blog/2025/deprecating-zipkin-exporters.md
+++ b/content/en/blog/2025/deprecating-zipkin-exporters.md
@@ -42,7 +42,7 @@ If you're currently using a Zipkin exporter, you have two migration paths:
   [Zipkin's OTLP ingestion support](https://github.com/openzipkin-contrib/zipkin-otel).
 - **Use the Collector**: Route your OTLP data through the OpenTelemetry
   Collector with its
-  [Zipkin exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/zipkinexporter).
+  [Zipkin exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/635d4254a3018eb3ca8f1736e71fcb54f8ed6e5a/exporter/zipkinexporter?from_branch=main).
 
 ## Questions?
 

--- a/content/en/blog/2025/devex-survey/index.md
+++ b/content/en/blog/2025/devex-survey/index.md
@@ -106,7 +106,7 @@ deployments. More on this in the Future Plans section.
 Interestingly, _collector-contrib_ had a large percentage of the responses to
 the question, “Which collector do you use?”. Sadly, it is unclear if this is due
 to being unaware of OCB
-([https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder))
+([https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder](https://github.com/open-telemetry/opentelemetry-collector/tree/d25efc7e2f31a3ba5347d0725a22d7bed1b4015d/cmd/builder?from_branch=main))
 for building custom images, disinterest in using it or a lack of adequate
 documentation around its use.
 

--- a/content/en/blog/2025/gc-candidates.md
+++ b/content/en/blog/2025/gc-candidates.md
@@ -11,7 +11,7 @@ The OpenTelemetry Election Committee is excited to announce the final list of
 candidates for the upcoming 2025 OpenTelemetry Governance Committee Election!
 
 If you are an
-[eligible voter](https://github.com/open-telemetry/community/blob/main/elections/2025/governance-committee-election.md#voter-eligibility),
+[eligible voter](https://github.com/open-telemetry/community/blob/55c58353ce8651dbb5269ca91bb6dde5b47bac2e/elections/2025/governance-committee-election.md?from_branch=main#voter-eligibility),
 you’ll have the opportunity to continue shaping the future of OpenTelemetry by
 casting your vote between 27 October 2025 00:00 UTC and 29 October 2025 end of
 day, [Anywhere on Earth](https://en.wikipedia.org/wiki/Anywhere_on_Earth) (30
@@ -19,7 +19,7 @@ October 2025 12:00 UTC). You'll be selecting your preferred candidates to fill
 the five available seats in this year's election.
 
 You can find the candidates' pictures, profile links, and descriptions on the
-[candidates page](https://github.com/open-telemetry/community/blob/main/elections/2025/governance-committee-candidates.md).
+[candidates page](https://github.com/open-telemetry/community/blob/1b7d0d85924677149593a18639ce0b897ed4751f/elections/2025/governance-committee-candidates.md?from_branch=main).
 Here are their names:
 
 - Antoine Toulme
@@ -37,5 +37,5 @@ You can check your eligibility by reviewing
 [this GitHub issue](https://github.com/open-telemetry/community/issues/3001). If
 you have made contributions to our ecosystem not measured by the automatic
 process, you can
-[request an exception](https://github.com/open-telemetry/community/blob/main/governance-charter.md#elections)
+[request an exception](https://github.com/open-telemetry/community/blob/614ece1538e6697842bc25d436d8d70ab6175808/governance-charter.md?from_branch=main#elections)
 before 23:59 UTC on 24 October 2025 to participate in the election.

--- a/content/en/blog/2025/gc-elections-results.md
+++ b/content/en/blog/2025/gc-elections-results.md
@@ -7,7 +7,7 @@ cSpell:ignore: marylia
 ---
 
 We are delighted to announce the results of the
-[2025 OpenTelemetry Governance Committee Election](https://github.com/open-telemetry/community/blob/main/elections/2025/governance-committee-election.md)!
+[2025 OpenTelemetry Governance Committee Election](https://github.com/open-telemetry/community/blob/55c58353ce8651dbb5269ca91bb6dde5b47bac2e/elections/2025/governance-committee-election.md?from_branch=main)!
 
 The OpenTelemetry project continues to bring together an exceptionally vibrant
 community, who are shaping the future of observability with their contributions.

--- a/content/en/blog/2025/gc-elections.md
+++ b/content/en/blog/2025/gc-elections.md
@@ -14,7 +14,7 @@ day, and the final election results will be announced 31 October 2025.
 ## Vote!
 
 If you are a
-[member of standing](https://github.com/open-telemetry/community/blob/main/governance-charter.md#members-of-standing)
+[member of standing](https://github.com/open-telemetry/community/blob/614ece1538e6697842bc25d436d8d70ab6175808/governance-charter.md?from_branch=main#members-of-standing)
 in the OpenTelemetry community, we invite you to participate with your vote in
 this election to ensure that the community is well-represented in the Governance
 Committee. In this election five people must be elected, each with two-year
@@ -22,7 +22,7 @@ terms.
 
 If you have made contributions to our ecosystem not measured by the automatic
 process, you can
-[request an exception](https://github.com/open-telemetry/community/blob/main/governance-charter.md#elections)
+[request an exception](https://github.com/open-telemetry/community/blob/614ece1538e6697842bc25d436d8d70ab6175808/governance-charter.md?from_branch=main#elections)
 before 23:59 UTC on 24 October 2025 to participate in the election. See the
 [voter roll](https://github.com/open-telemetry/community/blob/f7b99ef75580e4d88159e66730e1b8bc6719ce30%5E/elections/2025/voters-roll.csv)
 with all members of standing and approved exceptions. Approved exceptions will
@@ -37,7 +37,7 @@ Voting will be open between 27 October 2025
 voters will need to sign in with their GitHub account.
 
 For more information, see the
-[OpenTelemetry 2025 Governance Committee election](https://github.com/open-telemetry/community/blob/main/elections/2025/governance-committee-election.md).
+[OpenTelemetry 2025 Governance Committee election](https://github.com/open-telemetry/community/blob/55c58353ce8651dbb5269ca91bb6dde5b47bac2e/elections/2025/governance-committee-election.md?from_branch=main).
 
 ## Interested in joining the Governance Committee?
 
@@ -47,11 +47,11 @@ running for a seat on the Governance Committee. You can read about the
 Governance Committee's role in
 [this blog](/blog/2019/opentelemetry-governance-committee-explained/) post or
 refer to the
-[charter document](https://github.com/open-telemetry/community/blob/master/governance-charter.md).
+[charter document](https://github.com/open-telemetry/community/blob/614ece1538e6697842bc25d436d8d70ab6175808/governance-charter.md?from_branch=main).
 You may nominate yourself (or others!) by submitting a Pull Request against the
-[list of candidates](https://github.com/open-telemetry/community/blob/main/elections/2025/governance-committee-candidates.md)
+[list of candidates](https://github.com/open-telemetry/community/blob/1b7d0d85924677149593a18639ce0b897ed4751f/elections/2025/governance-committee-candidates.md?from_branch=main)
 by 17 October 2025 23:59 UTC — see the detailed requirements under
-[nominations](https://github.com/open-telemetry/community/blob/main/elections/2025/governance-committee-election.md#nominations)
+[nominations](https://github.com/open-telemetry/community/blob/55c58353ce8651dbb5269ca91bb6dde5b47bac2e/elections/2025/governance-committee-election.md?from_branch=main#nominations)
 for the Governance Committee election.
 
 We would like to thank the GC members whose term expires this year; they have

--- a/content/en/blog/2025/go-auto-instrumentation-beta.md
+++ b/content/en/blog/2025/go-auto-instrumentation-beta.md
@@ -53,7 +53,7 @@ these key features:
 Getting started with OpenTelemetry Go Auto-Instrumentation is straightforward!
 For detailed instructions on installation, configuration, and running your
 application with auto-instrumentation, check out the
-[Getting Started guide](https://github.com/open-telemetry/opentelemetry-go-instrumentation/blob/main/docs/getting-started.md).
+[Getting Started guide](https://github.com/open-telemetry/opentelemetry-go-instrumentation/blob/407fe957bbd8d9046ad6e29a2ab4a0731219931c/docs/getting-started.md?from_branch=main).
 
 To see a complete example, check out the
 [`rolldice` application](https://github.com/open-telemetry/opentelemetry-go-instrumentation/tree/0ebb7f21116bfdd8e29c315efdbf359cd74bddac/examples/rolldice).

--- a/content/en/blog/2025/go-compile-time-instrumentation.md
+++ b/content/en/blog/2025/go-compile-time-instrumentation.md
@@ -57,7 +57,7 @@ The most exciting part of this announcement is that it won't be Alibaba's or
 Datadog's solution that "wins". In the true spirit of open source collaboration,
 these two organizations have decided to join forces and commit the necessary
 resources to bootstrap a new
-[Go Compile-Time Instrumentation SIG](https://github.com/open-telemetry/community/blob/main/projects/go-compile-instrumentation.md),
+[Go Compile-Time Instrumentation SIG](https://github.com/open-telemetry/community/blob/c5047e230dcd918218de73a05ffdc52db158dc1a/projects/go-compile-instrumentation.md?from_branch=main),
 with the intention of providing a unified, vendor-neutral approach that picks
 the best aspects of each solution and benefits the community as a whole. They
 will be supported with further contributions from Quesma, bringing in experience

--- a/content/en/blog/2025/issue-participation.md
+++ b/content/en/blog/2025/issue-participation.md
@@ -54,12 +54,12 @@ For you, the end-user, it means your feedback is more visible. Instead of your
 of data that helps give the issue more weight.
 
 To make this change stick, we’ve rolled out a few things. We’ve published
-[recommendations](https://github.com/open-telemetry/community/blob/main/guides/maintainer/popular-issues.md)
+[recommendations](https://github.com/open-telemetry/community/blob/706839937eb5886bb07da6bd9d63245839e3cc2f/guides/maintainer/popular-issues.md?from_branch=main)
 for OpenTelemetry maintainers on how to manage and interpret these reactions,
 and our website now has a section explaining
 [what this means for end-users](/community/end-user/issue-participation/).
 You'll also see a friendly reminder in a new footnote on
-[issue templates](https://github.com/open-telemetry/community/blob/main/guides/maintainer/popular-issues.md#recommended-footnote-on-issue-templates)
+[issue templates](https://github.com/open-telemetry/community/blob/706839937eb5886bb07da6bd9d63245839e3cc2f/guides/maintainer/popular-issues.md?from_branch=main#recommended-footnote-on-issue-templates)
 across all OTel repositories. If you're opening a new issue, please leave that
 footer in place so that others have first-hand access to this advice.
 

--- a/content/en/blog/2025/kubecon-na.md
+++ b/content/en/blog/2025/kubecon-na.md
@@ -180,7 +180,7 @@ See you in Atlanta!
 [maintainer summit]:
   https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/features-add-ons/maintainer-summit/
 [membership]:
-  https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#member
+  https://github.com/open-telemetry/community/blob/25f027532a6e9b503d6eb4dd3db0a98eb3b5f1cb/guides/contributor/membership.md?from_branch=main#member
 [obs-day-sched]:
   https://colocatedeventsna2025.sched.com/overview/type/Observability+Day
 [end user]: https://cloud-native.slack.com/archives/C01RT3MSWGZ

--- a/content/en/blog/2025/obi-announcing-first-release.md
+++ b/content/en/blog/2025/obi-announcing-first-release.md
@@ -143,9 +143,9 @@ feedback, and enthusiasm to make this milestone possible.
 [distributed-traces]: /docs/zero-code/obi/distributed-traces/
 [getting-started]: /docs/zero-code/obi/setup/
 [integration-examples]:
-  https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/tree/main/internal/test/integration
+  https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/tree/f6deabc4387de1e0bf4b2acdbc674f7601d4c7f2/internal/test/integration?from_branch=main
 [test-repository]:
-  https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/tree/main/internal/test/integration/k8s/manifests
+  https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/tree/2feaeb84ef7aeeb1e57e642b46c96b965ae4b804/internal/test/integration/k8s/manifests?from_branch=main
 [ebpf-repo]:
   https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation
 [sigs]:

--- a/content/en/blog/2025/observing-lambdas/index.md
+++ b/content/en/blog/2025/observing-lambdas/index.md
@@ -31,7 +31,7 @@ it takes to send the data and with many invocations, this adds up.
 But there is another way! Lambda extension layers allow you to run any process
 alongside your code, sharing the execution runtime and providing additional
 services. With the
-[opentelemetry-lambda](https://github.com/open-telemetry/opentelemetry-lambda/blob/main/collector/README.md)
+[opentelemetry-lambda](https://github.com/open-telemetry/opentelemetry-lambda/blob/653874a89dc684e2408f5eb397e41dd98c56ba83/collector/README.md?from_branch=main)
 extension layer, you get a local endpoint to send data to while it keeps track
 of the Lambda lifecycle and ensures your telemetry gets to the storage layer.
 
@@ -101,7 +101,7 @@ service:
 The `decouple` processor is configured by default if omitted. It is explicitly
 added in this example to illustrate the entire pipeline. For more information,
 see
-[Autoconfiguration](https://github.com/open-telemetry/opentelemetry-lambda/tree/main/collector#auto-configuration).
+[Autoconfiguration](https://github.com/open-telemetry/opentelemetry-lambda/tree/dd62a87dcef7c1a94a02739a2425a1af3770313e/collector?from_branch=main#auto-configuration).
 
 Afterward, set the `OPENTELEMETRY_COLLECTOR_CONFIG_URI` environment variable to
 `/var/task/collector.yaml`. Once the function is redeployed, you’ll see your

--- a/content/en/blog/2025/otel-cicd-sig/index.md
+++ b/content/en/blog/2025/otel-cicd-sig/index.md
@@ -21,7 +21,7 @@ can find
 [designated attributes for reporting CI/CD pipelines](/docs/specs/semconv/registry/attributes/cicd/).
 
 This is the result of the hard work of the
-[CI/CD Observability Special Interest Group (SIG) within OpenTelemetry](https://github.com/open-telemetry/community/blob/main/projects/completed-projects/ci-cd.md).
+[CI/CD Observability Special Interest Group (SIG) within OpenTelemetry](https://github.com/open-telemetry/community/blob/514a684953f114217c7b673471969b3ddec5f3a2/projects/completed-projects/ci-cd.md?from_branch=main).
 As we accomplish this core milestone for the first phase, we thought it’d be a
 good time to share it with the world.
 
@@ -89,7 +89,7 @@ With the feedback from the Technical Oversight Committee and others within the
 CNCF, we’ve taken the path of asking the mandate to start a dedicated Working
 Group for the topic under OpenTelemetry’s Semantic Conventions SIG (SIG SemConv
 in short). With their blessing, we
-[launched the formal CI/CD Observability SIG](https://github.com/open-telemetry/community/blob/main/projects/completed-projects/ci-cd.md)
+[launched the formal CI/CD Observability SIG](https://github.com/open-telemetry/community/blob/514a684953f114217c7b673471969b3ddec5f3a2/projects/completed-projects/ci-cd.md?from_branch=main)
 to formalize our previous Slack group discussions and goals.
 
 ## OpenTelemetry’s CI/CD Observability SIG
@@ -183,7 +183,7 @@ Variable Context Propagation, which was just approved and merged. This OTEP sets
 the foundation for writing the specification.
 
 Since we’ve made progress on our initial milestones, we’ve updated the
-[CI/CD Observability SIG milestones for the remainder of 2024](https://github.com/open-telemetry/community/blob/main/projects/completed-projects/ci-cd.md).
+[CI/CD Observability SIG milestones for the remainder of 2024](https://github.com/open-telemetry/community/blob/514a684953f114217c7b673471969b3ddec5f3a2/projects/completed-projects/ci-cd.md?from_branch=main).
 Our goal is to finish out as many of the defined milestones as possible by the
 end of the year. Notably, we’re focused on:
 

--- a/content/en/blog/2025/otel-js-sdk-2-0.md
+++ b/content/en/blog/2025/otel-js-sdk-2-0.md
@@ -19,7 +19,7 @@ Exciting news: [OpenTelemetry JavaScript](/docs/languages/js/) has released [SDK
 > [Upgrade to OpenTelemetry JS SDK 2.x][migration guide].
 
 [migration guide]:
-  https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md
+  https://github.com/open-telemetry/opentelemetry-js/blob/4636de6a16d338a418ee901ee6b685b887585c4f/doc/upgrade-to-2.x.md?from_branch=main
 
 ## What is JS SDK 2.x?
 
@@ -42,20 +42,20 @@ In summary:
   (from ES2017).
 - The **public interface has changed**.
   - For notes on migrating to 2.x / 0.200.x, see
-    [the upgrade guide](https://github.com/open-telemetry/opentelemetry-js/tree/main/doc/upgrade-to-2.x.md).
+    [the upgrade guide](https://github.com/open-telemetry/opentelemetry-js/tree/4636de6a16d338a418ee901ee6b685b887585c4f/doc/upgrade-to-2.x.md?from_branch=main).
 
 Details:
 
-- [Node.js supported versions](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-nodejs-supported-versions)
-- [TypeScript supported versions](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-typescript-supported-versions)
-- [ES2022 compilation target](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-es2022-compilation-target)
-- [Drop `window.OTEL_*` support in browsers](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-drop-windowotel_-support-in-browsers)
-- [`@opentelemetry/resources` API changes](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-opentelemetryresources-api-changes)
-- [`@opentelemetry/core` API changes](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-opentelemetrycore-api-changes)
-- [Tracing SDK API changes](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-tracing-sdk-api-changes)
-- [`@opentelemetry/sdk-metrics` API changes](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-opentelemetrysdk-metrics-api-changes)
-- [`@opentelemetry/resources` changes for _implementors_ of Resource Detectors](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-opentelemetryresources-changes-for-implementors-of-resource-detectors)
-- [Other changes](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/upgrade-to-2.x.md#-other-changes)
+- [Node.js supported versions](https://github.com/open-telemetry/opentelemetry-js/blob/4636de6a16d338a418ee901ee6b685b887585c4f/doc/upgrade-to-2.x.md?from_branch=main#-nodejs-supported-versions)
+- [TypeScript supported versions](https://github.com/open-telemetry/opentelemetry-js/blob/4636de6a16d338a418ee901ee6b685b887585c4f/doc/upgrade-to-2.x.md?from_branch=main#-typescript-supported-versions)
+- [ES2022 compilation target](https://github.com/open-telemetry/opentelemetry-js/blob/4636de6a16d338a418ee901ee6b685b887585c4f/doc/upgrade-to-2.x.md?from_branch=main#-es2022-compilation-target)
+- [Drop `window.OTEL_*` support in browsers](https://github.com/open-telemetry/opentelemetry-js/blob/4636de6a16d338a418ee901ee6b685b887585c4f/doc/upgrade-to-2.x.md?from_branch=main#-drop-windowotel_-support-in-browsers)
+- [`@opentelemetry/resources` API changes](https://github.com/open-telemetry/opentelemetry-js/blob/4636de6a16d338a418ee901ee6b685b887585c4f/doc/upgrade-to-2.x.md?from_branch=main#-opentelemetryresources-api-changes)
+- [`@opentelemetry/core` API changes](https://github.com/open-telemetry/opentelemetry-js/blob/4636de6a16d338a418ee901ee6b685b887585c4f/doc/upgrade-to-2.x.md?from_branch=main#-opentelemetrycore-api-changes)
+- [Tracing SDK API changes](https://github.com/open-telemetry/opentelemetry-js/blob/4636de6a16d338a418ee901ee6b685b887585c4f/doc/upgrade-to-2.x.md?from_branch=main#-tracing-sdk-api-changes)
+- [`@opentelemetry/sdk-metrics` API changes](https://github.com/open-telemetry/opentelemetry-js/blob/4636de6a16d338a418ee901ee6b685b887585c4f/doc/upgrade-to-2.x.md?from_branch=main#-opentelemetrysdk-metrics-api-changes)
+- [`@opentelemetry/resources` changes for _implementors_ of Resource Detectors](https://github.com/open-telemetry/opentelemetry-js/blob/4636de6a16d338a418ee901ee6b685b887585c4f/doc/upgrade-to-2.x.md?from_branch=main#-opentelemetryresources-changes-for-implementors-of-resource-detectors)
+- [Other changes](https://github.com/open-telemetry/opentelemetry-js/blob/4636de6a16d338a418ee901ee6b685b887585c4f/doc/upgrade-to-2.x.md?from_branch=main#-other-changes)
 
 ## Why was this done?
 
@@ -82,7 +82,7 @@ For a more detailed explanation of why 2.0, see issue [#4083][].
 
 - Try out the [v2.0.0][] and [v0.200.0][] releases and provide feedback.
 - Review our
-  [contributing guide](https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md)
+  [contributing guide](https://github.com/open-telemetry/opentelemetry-js/blob/2d3716cb858aa79be36bca778b0b2301b3d50748/CONTRIBUTING.md?from_branch=main)
   for details on contributing.
 - Attend our
   [SIG meetings](https://groups.google.com/a/opentelemetry.io/g/calendar-js).

--- a/content/en/blog/2025/otel-unplugged-fosdem/index.md
+++ b/content/en/blog/2025/otel-unplugged-fosdem/index.md
@@ -57,7 +57,7 @@ This year's OTel Unplugged EU is hosted by Grafana Labs, with the agenda
 organized and run by the OpenTelemetry [Governance Committee][].
 
 [Governance Committee]:
-  https://github.com/open-telemetry/community/blob/main/community-members.md#governance-committee
+  https://github.com/open-telemetry/community/blob/b35f0f6c9801bfbe894211fb3d95afa3157662ec/community-members.md?from_branch=main#governance-committee
 [OTel Unplugged]: https://events.humanitix.com/otelunplugged-eu2026
 [sponsorship prospectus]:
   https://drive.google.com/file/d/1C4e7OevZ5vXyZLjxZif9Mi06A6uPNH7K/view

--- a/content/en/blog/2025/otel-weaver/index.md
+++ b/content/en/blog/2025/otel-weaver/index.md
@@ -153,7 +153,7 @@ native language, ensuring no typos or inconsistencies.
 
 For example, the code generated from Weaver for the Go client SDK can be found
 in this
-[repository](https://github.com/open-telemetry/opentelemetry-go/tree/main/semconv).
+[repository](https://github.com/open-telemetry/opentelemetry-go/tree/3264bf171b1e6cd70f6be4a483f2bcb84eda6ccf/semconv?from_branch=main).
 The Weaver command used looks like:
 
 ```bash
@@ -175,7 +175,7 @@ weaver registry diff -r current-version-registry-path --baseline-registry previo
 
 **Live instrumentation checks and coverage:**<br/> Users and maintainers can
 leverage Weaver to
-[live-check](https://github.com/open-telemetry/weaver/tree/main/crates/weaver_live_check#readme)
+[live-check](https://github.com/open-telemetry/weaver/tree/4da6fa62e174e1f0df1a990234bd32f5018cb23a/crates/weaver_live_check?from_branch=main#readme)
 that their application correctly emits telemetry conforming to the official
 semantic conventions, or a custom registry (see below).
 
@@ -307,8 +307,9 @@ adopt:
 - **Type-safe semantic-conventions API generation**: Automatically generate
   strongly typed instrumentation libraries to reduce errors and accelerate
   development. An example of a Go type-safe client API for Prometheus is already
-  in progress at [promconv](https://github.com/sh0rez/promconv/tree/main). A
-  more general Go type-safe client API using Weaver is also being developed at
+  in progress at
+  [promconv](https://github.com/sh0rez/promconv/tree/4ef6f697497dec4dc87a0d670cd90ee12335bcdf?from_branch=main).
+  A more general Go type-safe client API using Weaver is also being developed at
   [MrAlias/semconv-go](https://github.com/MrAlias/semconv-go)
 
 Stay tuned, the next generation of semantic convention management is coming, and

--- a/content/en/blog/2025/ottl-contexts-just-got-easier.md
+++ b/content/en/blog/2025/ottl-contexts-just-got-easier.md
@@ -15,9 +15,9 @@ through nested lower-level contexts.
 
 To simplify this process, the OpenTelemetry community is excited to announce
 OTTL
-[context inference](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/transformprocessor/README.md#context-inference)
+[context inference](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/1afa19b190f2b68ffac6dd5bada4b3fd0297d0c9/processor/transformprocessor/README.md?from_branch=main#context-inference)
 support for the
-[transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/transformprocessor).
+[transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/635d4254a3018eb3ca8f1736e71fcb54f8ed6e5a/processor/transformprocessor?from_branch=main).
 This feature removes the need for users to understand the underlying context
 concept of OTTL, allowing them to focus solely on their data. It also improves
 statement processing efficiency by automatically selecting the most appropriate
@@ -34,7 +34,7 @@ format.
 ### Basic configuration
 
 The
-[basic configuration](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/transformprocessor/README.md#basic-config)
+[basic configuration](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/1afa19b190f2b68ffac6dd5bada4b3fd0297d0c9/processor/transformprocessor/README.md?from_branch=main#basic-config)
 style simplifies configuration by allowing users to list all statements
 together, without worrying about OTTL contexts or extra configuration
 structures. This style support statements from multiple OTTL contexts and does
@@ -77,7 +77,7 @@ using OTTL.
 ### Advanced configuration
 
 The context-inferred
-[advanced configuration](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/transformprocessor/README.md#advanced-config)
+[advanced configuration](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/1afa19b190f2b68ffac6dd5bada4b3fd0297d0c9/processor/transformprocessor/README.md?from_branch=main#advanced-config)
 style closely resembles the existing format and allows users to leverage the
 benefits of context inference while providing granular control over statement
 configurations, such as `error_mode` and `conditions`. For example, consider the
@@ -135,7 +135,7 @@ allows the use of additional configuration keys such as `error_mode` and
 `conditions`. It supports statements from multiple OTTL contexts. However,
 unlike the basic configuration style, it may require splitting them into
 separate configuration groups (see
-[advanced config](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor#advanced-config)).
+[advanced config](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/635d4254a3018eb3ca8f1736e71fcb54f8ed6e5a/processor/transformprocessor?from_branch=main#advanced-config)).
 In terms of performance, the advanced configuration is slightly faster than the
 basic configuration, making it a better choice for complex scenarios or
 configurations with a high number of statements.

--- a/content/en/blog/2025/sampling-milestones.md
+++ b/content/en/blog/2025/sampling-milestones.md
@@ -219,7 +219,7 @@ the OpenTelemetry TraceState. It does this by synthesizing an explicit
 randomness value from the hash function that it uses.
 
 [PROBABILISTICSAMPLERPROCESSOR]:
-  https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/probabilisticsamplerprocessor/README.md
+  https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/549e115b28292c164eb671618c0ec8b728b69d2a/processor/probabilisticsamplerprocessor/README.md?from_branch=main
 
 ## Looking forward
 
@@ -230,10 +230,10 @@ components.
 Here are some useful references including the four OpenTelemetry enhancement
 proposals that plotted our course:
 
-- [0168 Sampling Propagation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/trace/0168-sampling-propagation.md)
-- [0170 Sampling Probability](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/trace/0170-sampling-probability.md)
-- [0235 Sampling Threshold in TraceState](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/trace/0235-sampling-threshold-in-trace-state.md)
-- [0250 Composite Samplers](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/trace/0250-Composite_Samplers.md)
+- [0168 Sampling Propagation](https://github.com/open-telemetry/opentelemetry-specification/blob/97c826b70e2f89cfdf655d5150791f3f0c2bae19/oteps/trace/0168-sampling-propagation.md?from_branch=main)
+- [0170 Sampling Probability](https://github.com/open-telemetry/opentelemetry-specification/blob/97c826b70e2f89cfdf655d5150791f3f0c2bae19/oteps/trace/0170-sampling-probability.md?from_branch=main)
+- [0235 Sampling Threshold in TraceState](https://github.com/open-telemetry/opentelemetry-specification/blob/02531b063da09bca753070d8071180ca2c287117/oteps/trace/0235-sampling-threshold-in-trace-state.md?from_branch=main)
+- [0250 Composite Samplers](https://github.com/open-telemetry/opentelemetry-specification/blob/b72b9e1127391871eaedee841895ff9ce52d11f3/oteps/trace/0250-Composite_Samplers.md?from_branch=main)
 
 The following are our primary specification documents:
 

--- a/content/en/blog/2025/slack-workspace-changes.md
+++ b/content/en/blog/2025/slack-workspace-changes.md
@@ -22,7 +22,7 @@ following actions:
   to any posts older than 90 days. CNCF is backing up all public channel
   histories. If you have private channels or direct messages that you would like
   to keep, follow the
-  [CNCF guide](https://github.com/cncf/foundation/blob/main/policies-guidance/slack-backup.md)
+  [CNCF guide](https://github.com/cncf/foundation/blob/268daffb181e0cb2bc36947039c0400c68e506f7/policies-guidance/slack-backup.md?from_branch=main)
   to export and store the content locally.
 - **Back up files.** If you have files stored in Slack, they will be deleted!
   Download and save them to GitHub or Google Docs before Friday.

--- a/content/en/blog/2025/stability-proposal-announcement.md
+++ b/content/en/blog/2025/stability-proposal-announcement.md
@@ -74,7 +74,7 @@ OpenTelemetry has grown into a massive, complex ecosystem. We support four
 different telemetry signals (tracing, metrics, logs, and profiles) across more
 than a dozen programming languages. Each language has its own runtime
 requirements and execution environments. The
-[specification compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md)
+[specification compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/af2606810c19c31850738d1fd105b4eca7aa8c98/spec-compliance-matrix.md?from_branch=main)
 shows just how much we're trying to accomplish – and it's overwhelming.
 
 This complexity creates real barriers to adoption. Organizations ready to deploy

--- a/content/en/blog/2025/tc-election-results.md
+++ b/content/en/blog/2025/tc-election-results.md
@@ -7,7 +7,7 @@ cSpell:ignore: Ashpole
 ---
 
 The OpenTelemetry
-[Technical Committee](https://github.com/open-telemetry/community/blob/main/community-members.md#technical-committee)
+[Technical Committee](https://github.com/open-telemetry/community/blob/b35f0f6c9801bfbe894211fb3d95afa3157662ec/community-members.md?from_branch=main#technical-committee)
 is delighted to announce two new elected members! Please join us in
 congratulating [David Ashpole](https://github.com/dashpole) and
 [Josh MacDonald](https://github.com/jmacd)!

--- a/content/en/blog/2025/ux-research-prometheus-otel/index.md
+++ b/content/en/blog/2025/ux-research-prometheus-otel/index.md
@@ -182,7 +182,7 @@ Here are the key findings:
 
 The survey patterns were consistent with what emerged from my qualitative
 research. For detailed results, see the
-[anonymized survey responses](https://github.com/prometheus-community/ux-research/blob/main/prom-otel-research/survey-results.csv)
+[anonymized survey responses](https://github.com/prometheus-community/ux-research/blob/acc0194a79aa0f2ee1c6eb93462c9488d236a275/prom-otel-research/survey-results.csv?from_branch=main)
 
 ## What I didn’t expect to learn (but did)
 
@@ -273,7 +273,7 @@ foundation for that work.
 If you're interested in the ongoing discussions, proposals, and feedback around
 these ideas, you can check out the GitHub repository where everything is being
 documented:
-[OpenTelemetry Resource Attributes in Prometheus UX Research](https://github.com/prometheus-community/ux-research/tree/main/prom-otel-research)
+[OpenTelemetry Resource Attributes in Prometheus UX Research](https://github.com/prometheus-community/ux-research/tree/a2f8c6684321fd04de7b94cfbd39a48bb1d7beb4/prom-otel-research?from_branch=main)
 
 ## Acknowledgments
 

--- a/content/en/blog/2026/2025-year-in-review/index.md
+++ b/content/en/blog/2026/2025-year-in-review/index.md
@@ -205,7 +205,7 @@ You can also join us:
 Let's make 2026 another amazing year for [opentelemetry.io](/)!
 
 [redesign]:
-  https://github.com/open-telemetry/opentelemetry.io/blob/9bd13bd/projects/landing-page-redesign.md?from_branch=main
+  https://github.com/open-telemetry/opentelemetry.io/blob/9bd13bd7b3ecd76093fa980c44dc10b5611b4ee0/projects/landing-page-redesign.md?from_branch=main
 [refactoring]: https://github.com/orgs/open-telemetry/projects/174/views/3
 [Comms meetings]:
   https://docs.google.com/document/d/1wW0jLldwXN8Nptq2xmgETGbGn9eWP8fitvD5njM-xZY

--- a/content/en/blog/2026/demystifying-opentelemetry/index.md
+++ b/content/en/blog/2026/demystifying-opentelemetry/index.md
@@ -310,7 +310,7 @@ break it down.
 
 Many organizations rely on SQL Server databases for production, analytics, or
 inventory. With the OpenTelemetry Collector’s
-[sqlserver receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/ab56dd4/receiver/sqlserverreceiver?from_branch=main),
+[sqlserver receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/ab56dd45ea2240f7014470bcc31c1b3fafc1ef19/receiver/sqlserverreceiver?from_branch=main),
 you can scrape health and performance metrics directly, without needing agents
 on your database hosts. The following is a sample configuration showing how to
 set this up:
@@ -348,7 +348,7 @@ pool, locks, batch rates, and more), exposing them to observability backends.
 ### Observing Windows machines with the Windows performance counters receiver
 
 Classic Windows hosts still drive many production and control environments. The
-[Windows performance counters receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/ab56dd4/receiver/windowsperfcountersreceiver?from_branch=main)
+[Windows performance counters receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/ab56dd45ea2240f7014470bcc31c1b3fafc1ef19/receiver/windowsperfcountersreceiver?from_branch=main)
 (part of the OpenTelemetry Collector Contrib distribution) lets you collect a
 wide array of system, application, or custom metrics right from the Windows
 registry using the native PDH interface. The following is a sample configuration

--- a/content/en/blog/2026/kubecon-eu.md
+++ b/content/en/blog/2026/kubecon-eu.md
@@ -250,6 +250,6 @@ Come listen, learn, and get involved in OpenTelemetry. See you in Amsterdam!
 [maintainer summit]:
   https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/features-add-ons/maintainer-summit/
 [membership]:
-  https://github.com/open-telemetry/community/blob/25f0275/guides/contributor/membership.md#member?from_branch=main
+  https://github.com/open-telemetry/community/blob/25f027532a6e9b503d6eb4dd3db0a98eb3b5f1cb/guides/contributor/membership.md#member?from_branch=main
 [obs-day-sched]:
   https://colocatedeventseu2026.sched.com/overview/type/Observability+Day

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -3907,6 +3907,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-18T09:53:55.932578963Z"
   },
+  "https://github.com/Scale3-Labs/langtrace-python-sdk/tree/462a04b361f62314fb6d2d873cd866959152aa35/src/langtrace_python_sdk/instrumentation?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:13.932706-05:00"
+  },
   "https://github.com/Scale3-Labs/langtrace-python-sdk/tree/main/src/langtrace_python_sdk/instrumentation": {
     "StatusCode": 206,
     "LastSeen": "2026-02-14T09:48:02.58623808Z"
@@ -4738,6 +4742,10 @@
   "https://github.com/cncf/artwork/tree/master/projects/opentelemetry": {
     "StatusCode": 206,
     "LastSeen": "2026-02-18T09:52:09.16801891Z"
+  },
+  "https://github.com/cncf/foundation/blob/268daffb181e0cb2bc36947039c0400c68e506f7/policies-guidance/slack-backup.md?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:13.143659-05:00"
   },
   "https://github.com/cncf/foundation/blob/main/code-of-conduct.md": {
     "StatusCode": 206,
@@ -6891,9 +6899,25 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-23T19:29:04.701592-05:00"
   },
+  "https://github.com/open-telemetry/community/blob/1b7d0d85924677149593a18639ce0b897ed4751f/elections/2025/governance-committee-candidates.md?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:13.963487-05:00"
+  },
   "https://github.com/open-telemetry/community/blob/25f0275/guides/contributor/membership.md#member?from_branch=main": {
     "StatusCode": 206,
     "LastSeen": "2026-02-12T20:44:29.597738-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/25f027532a6e9b503d6eb4dd3db0a98eb3b5f1cb/guides/contributor/membership.md#member?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:49:57.831037-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/25f027532a6e9b503d6eb4dd3db0a98eb3b5f1cb/guides/contributor/membership.md?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:12.256594-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/25f027532a6e9b503d6eb4dd3db0a98eb3b5f1cb/guides/contributor/membership.md?from_branch=main#member": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:12.434463-05:00"
   },
   "https://github.com/open-telemetry/community/blob/25f027532a6e9b503d6eb4dd3db0a98eb3b5f1cb/guides/contributor/membership.md?from_branch=main#requirements": {
     "StatusCode": 206,
@@ -6907,13 +6931,45 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-23T19:29:06.678347-05:00"
   },
+  "https://github.com/open-telemetry/community/blob/5125996b5d159ff9aaa906f9a25226a821dc7bed/projects/gen-ai.md?from_branch=main#meeting-times": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:14.975205-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/514a684953f114217c7b673471969b3ddec5f3a2/projects/completed-projects/ci-cd.md?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:14.175003-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/55c58353ce8651dbb5269ca91bb6dde5b47bac2e/elections/2025/governance-committee-election.md?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:15.387293-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/55c58353ce8651dbb5269ca91bb6dde5b47bac2e/elections/2025/governance-committee-election.md?from_branch=main#nominations": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:15.098262-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/55c58353ce8651dbb5269ca91bb6dde5b47bac2e/elections/2025/governance-committee-election.md?from_branch=main#voter-eligibility": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:12.366075-05:00"
+  },
   "https://github.com/open-telemetry/community/blob/614ece1538e6697842bc25d436d8d70ab6175808/governance-charter.md?from_branch=main": {
     "StatusCode": 206,
     "LastSeen": "2026-02-23T19:29:05.399173-05:00"
   },
+  "https://github.com/open-telemetry/community/blob/614ece1538e6697842bc25d436d8d70ab6175808/governance-charter.md?from_branch=main#elections": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:14.070775-05:00"
+  },
   "https://github.com/open-telemetry/community/blob/614ece1538e6697842bc25d436d8d70ab6175808/governance-charter.md?from_branch=main#members-of-standing": {
     "StatusCode": 206,
     "LastSeen": "2026-02-23T19:29:04.704732-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/706839937eb5886bb07da6bd9d63245839e3cc2f/guides/maintainer/popular-issues.md?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:12.755451-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/706839937eb5886bb07da6bd9d63245839e3cc2f/guides/maintainer/popular-issues.md?from_branch=main#recommended-footnote-on-issue-templates": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:13.738586-05:00"
   },
   "https://github.com/open-telemetry/community/blob/7e33a8732fb251462808838108c8779f33930669/reports/ADA_Logics-collector-fuzzing-audit-2024.pdf?from_branch=main": {
     "StatusCode": 206,
@@ -6930,6 +6986,10 @@
   "https://github.com/open-telemetry/community/blob/b35f0f6c9801bfbe894211fb3d95afa3157662ec/community-members.md?from_branch=main#technical-committee": {
     "StatusCode": 206,
     "LastSeen": "2026-02-23T19:29:05.525469-05:00"
+  },
+  "https://github.com/open-telemetry/community/blob/c5047e230dcd918218de73a05ffdc52db158dc1a/projects/go-compile-instrumentation.md?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:13.00614-05:00"
   },
   "https://github.com/open-telemetry/community/blob/d90e0a58c738b3287f11aeb738b49eb2d63b6047/project-management.md?from_branch=main": {
     "StatusCode": 206,
@@ -7055,9 +7115,9 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-14T09:47:00.727519514Z"
   },
-  "https://github.com/open-telemetry/community/blob/master/governance-charter.md": {
+  "https://github.com/open-telemetry/community/blob/main/tech-committee-charter.md": {
     "StatusCode": 206,
-    "LastSeen": "2026-02-24T09:58:30.669768773Z"
+    "LastSeen": "2026-02-11T09:58:41.047932684Z"
   },
   "https://github.com/open-telemetry/community/discussions/3098": {
     "StatusCode": 206,
@@ -7255,6 +7315,30 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-13T09:52:35.613211114Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-android/tree/4d3290f84d2612286eabfb1072f1885905c2b756/instrumentation/android-log?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:12.755105-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-android/tree/c090b3c2aa34477879e3481a8e1e06b089406c36/demo-app?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:18.401523-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-android/tree/c090b3c2aa34477879e3481a8e1e06b089406c36/instrumentation/httpurlconnection?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:14.151588-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-android/tree/f0cf647e364e290f03ad7d77252fd7209dd2bf41/instrumentation/compose/click?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:15.961884-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-android/tree/f0cf647e364e290f03ad7d77252fd7209dd2bf41/instrumentation/sessions?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:16.9958-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-android/tree/f0cf647e364e290f03ad7d77252fd7209dd2bf41/instrumentation/view-click?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:15.121464-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-android/tree/main/demo-app": {
     "StatusCode": 206,
     "LastSeen": "2026-02-24T09:53:10.055252961Z"
@@ -7298,6 +7382,26 @@
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/": {
     "StatusCode": 206,
     "LastSeen": "2026-02-19T09:52:17.56764292Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/1afa19b190f2b68ffac6dd5bada4b3fd0297d0c9/processor/transformprocessor/README.md?from_branch=main#advanced-config": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:16.483167-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/1afa19b190f2b68ffac6dd5bada4b3fd0297d0c9/processor/transformprocessor/README.md?from_branch=main#basic-config": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:15.987245-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/1afa19b190f2b68ffac6dd5bada4b3fd0297d0c9/processor/transformprocessor/README.md?from_branch=main#context-inference": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:12.400816-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/549e115b28292c164eb671618c0ec8b728b69d2a/processor/probabilisticsamplerprocessor/README.md?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:13.942865-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/635d4254a3018eb3ca8f1736e71fcb54f8ed6e5a/processor/transformprocessor?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:15.531601-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/9b28f76c02c18f7479d10e4b6a95a21467fd85d6/processor/transformprocessor/testdata/config.yaml": {
     "StatusCode": 206,
@@ -7619,6 +7723,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-23T19:29:07.656774-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/635d4254a3018eb3ca8f1736e71fcb54f8ed6e5a/exporter/zipkinexporter?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:12.797932-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/635d4254a3018eb3ca8f1736e71fcb54f8ed6e5a/extension/awsproxy?from_branch=main#aws-proxy": {
     "StatusCode": 206,
     "LastSeen": "2026-02-23T19:29:16.385629-05:00"
@@ -7642,6 +7750,14 @@
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/635d4254a3018eb3ca8f1736e71fcb54f8ed6e5a/processor/remotetapprocessor?from_branch=main#remote-tap-processor": {
     "StatusCode": 206,
     "LastSeen": "2026-02-23T19:29:19.972759-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/635d4254a3018eb3ca8f1736e71fcb54f8ed6e5a/processor/transformprocessor?from_branch=main#advanced-config": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:17.264954-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/635d4254a3018eb3ca8f1736e71fcb54f8ed6e5a/processor/unrollprocessor?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:14.381015-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/635d4254a3018eb3ca8f1736e71fcb54f8ed6e5a/receiver/awsfirehosereceiver?from_branch=main#aws-kinesis-data-firehose-receiver": {
     "StatusCode": 206,
@@ -7710,6 +7826,14 @@
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/ab56dd4/receiver/windowsperfcountersreceiver?from_branch=main": {
     "StatusCode": 206,
     "LastSeen": "2026-02-12T20:44:31.07881-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/ab56dd45ea2240f7014470bcc31c1b3fafc1ef19/receiver/sqlserverreceiver?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:49:57.625426-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/ab56dd45ea2240f7014470bcc31c1b3fafc1ef19/receiver/windowsperfcountersreceiver?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:49:58.699265-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/b7fedfd4c04c78503c0cac618298a044e04d4b07/exporter/prometheusremotewriteexporter?from_branch=main": {
     "StatusCode": 206,
@@ -9147,6 +9271,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-23T19:29:11.272449-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-collector/tree/d25efc7e2f31a3ba5347d0725a22d7bed1b4015d/cmd/builder?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:14.128332-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-collector/tree/d25efc7e2f31a3ba5347d0725a22d7bed1b4015d/cmd/builder?from_branch=main#configuration": {
     "StatusCode": 206,
     "LastSeen": "2026-02-23T19:29:07.254452-05:00"
@@ -9291,9 +9419,29 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-19T09:52:17.272974216Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-configuration/blob/0a18b0c19ba656c22aa2a8dab65d03380fcc2802/VERSIONING.md?from_branch=main#experimental-features": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:14.995338-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-configuration/blob/1905936912045de1cb6ef04d13afe912f462dbe2/CONTRIBUTING.md?from_branch=main#project-tooling": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:14.174494-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-configuration/blob/28784d4ea2054f95affe3912189ccd51ee6aea3a/schema-docs.md?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:15.450845-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-configuration/blob/28784d4ea2054f95affe3912189ccd51ee6aea3a/schema-docs.md?from_branch=main#opentelemetryconfiguration": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:15.521669-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-configuration/blob/670901762dd5cce1eecee423b8660e69f71ef4be/examples/kitchen-sink.yaml#L438-L439": {
     "StatusCode": 206,
     "LastSeen": "2026-02-14T09:49:32.315866456Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-configuration/blob/db08177916083273421c1fd10247b63badd6a87a/examples/otel-sdk-migration-config.yaml?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:13.963604-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-configuration/blob/f38ac7c3a499ae5f81924ef9c455c27a56130562/schema/tracer_provider.json#L22": {
     "StatusCode": 206,
@@ -9418,6 +9566,10 @@
   "https://github.com/open-telemetry/opentelemetry-configuration/releases/tag/v1.0.0-rc.3": {
     "StatusCode": 206,
     "LastSeen": "2026-02-24T09:58:25.817520044Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-configuration/tree/6b306495d6285dacfa815b24115f69f0743f9ad1/schema?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:12.738773-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-configuration/tree/main/schema": {
     "StatusCode": 206,
@@ -9706,6 +9858,10 @@
   "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/releases/tag/Instrumentation.SqlClient-1.15.0-rc.1": {
     "StatusCode": 206,
     "LastSeen": "2026-02-24T09:54:15.26941551Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/4a4fab74f466cdbae23876e88e17b797b7674319/src?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:17.101361-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src": {
     "StatusCode": 206,
@@ -10079,6 +10235,14 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-24T09:55:07.898933241Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/tree/2feaeb84ef7aeeb1e57e642b46c96b965ae4b804/internal/test/integration/k8s/manifests?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:14.114769-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/tree/f6deabc4387de1e0bf4b2acdbc674f7601d4c7f2/internal/test/integration?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:12.884061-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/tree/main/internal/test/integration": {
     "StatusCode": 206,
     "LastSeen": "2026-02-24T09:58:33.786968836Z"
@@ -10251,6 +10415,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-23T19:29:10.499247-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-go-contrib/tree/848eb220bc83bb81d77383bbf39ebd86b5034407/otelconf?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:23.092698-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/detectors/aws": {
     "StatusCode": 206,
     "LastSeen": "2026-02-13T09:59:07.161485708Z"
@@ -10298,6 +10466,10 @@
   "https://github.com/open-telemetry/opentelemetry-go-instrumentation/blob/0ebb7f21116bfdd8e29c315efdbf359cd74bddac/CONTRIBUTING.md": {
     "StatusCode": 206,
     "LastSeen": "2026-02-13T09:53:02.072025433Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-go-instrumentation/blob/407fe957bbd8d9046ad6e29a2ab4a0731219931c/docs/getting-started.md?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:15.623891-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-go-instrumentation/blob/main/COMPATIBILITY.md#githubcomsegmentiokafka-go": {
     "StatusCode": 206,
@@ -10382,6 +10554,10 @@
   "https://github.com/open-telemetry/opentelemetry-go/releases/tag/v1.36.0": {
     "StatusCode": 206,
     "LastSeen": "2026-02-24T09:53:22.636034392Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-go/tree/3264bf171b1e6cd70f6be4a483f2bcb84eda6ccf/semconv?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:15.295724-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-go/tree/main/exporters/otlp": {
     "StatusCode": 206,
@@ -10486,6 +10662,10 @@
   "https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/inferred-spans": {
     "StatusCode": 206,
     "LastSeen": "2026-02-19T09:52:45.225901371Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-java-contrib/tree/b7a327218c8cf0928c8cb2198e5fa764d530afda/samplers?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:16.555063-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/aws-resources": {
     "StatusCode": 206,
@@ -10671,6 +10851,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-20T09:51:54.577454609Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/3c573ea4492a5f25e0f482eb523f829d318d0027/declarative-config-bridge?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:18.013236-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/afc68b59e011138621bff449432e88de79c54d1f/instrumentation/log4j/log4j-appender-2.17/javaagent?from_branch=main": {
     "StatusCode": 206,
     "LastSeen": "2026-02-23T19:29:06.885684-05:00"
@@ -10678,6 +10862,14 @@
   "https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/afc68b59e011138621bff449432e88de79c54d1f/instrumentation/logback/logback-appender-1.0/javaagent?from_branch=main": {
     "StatusCode": 206,
     "LastSeen": "2026-02-23T19:29:06.35331-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/bc533f6df8545f79fcce2b138b14a6aca748e7fc/instrumentation?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:16.344834-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/f7cba3b86167946b3783fb8e575f1c169aec6972/instrumentation/spring?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:12.332506-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/declarative-config-bridge": {
     "StatusCode": 206,
@@ -11283,6 +11475,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-20T09:52:08.470715909Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/87876b5451052f336bad2f5b9df65d77c75dbd76/packages?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:13.779291-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/e8e3cbdadf439c5bd16dfe5d6fc0714fe0e8235a/metapackages/auto-instrumentations-node/#supported-instrumentations": {
     "StatusCode": 206,
     "LastSeen": "2026-02-24T09:53:25.989336537Z"
@@ -11503,6 +11699,54 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-24T09:52:56.233999324Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-js/blob/2d3716cb858aa79be36bca778b0b2301b3d50748/CONTRIBUTING.md?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:21.823277-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/blob/4636de6a16d338a418ee901ee6b685b887585c4f/doc/upgrade-to-2.x.md?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:14.396437-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/blob/4636de6a16d338a418ee901ee6b685b887585c4f/doc/upgrade-to-2.x.md?from_branch=main#-drop-windowotel_-support-in-browsers": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:17.631336-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/blob/4636de6a16d338a418ee901ee6b685b887585c4f/doc/upgrade-to-2.x.md?from_branch=main#-es2022-compilation-target": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:17.389246-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/blob/4636de6a16d338a418ee901ee6b685b887585c4f/doc/upgrade-to-2.x.md?from_branch=main#-nodejs-supported-versions": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:17.004157-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/blob/4636de6a16d338a418ee901ee6b685b887585c4f/doc/upgrade-to-2.x.md?from_branch=main#-opentelemetrycore-api-changes": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:18.487791-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/blob/4636de6a16d338a418ee901ee6b685b887585c4f/doc/upgrade-to-2.x.md?from_branch=main#-opentelemetryresources-api-changes": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:18.080395-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/blob/4636de6a16d338a418ee901ee6b685b887585c4f/doc/upgrade-to-2.x.md?from_branch=main#-opentelemetryresources-changes-for-implementors-of-resource-detectors": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:20.996625-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/blob/4636de6a16d338a418ee901ee6b685b887585c4f/doc/upgrade-to-2.x.md?from_branch=main#-opentelemetrysdk-metrics-api-changes": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:20.258765-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/blob/4636de6a16d338a418ee901ee6b685b887585c4f/doc/upgrade-to-2.x.md?from_branch=main#-other-changes": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:21.183319-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/blob/4636de6a16d338a418ee901ee6b685b887585c4f/doc/upgrade-to-2.x.md?from_branch=main#-tracing-sdk-api-changes": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:18.96827-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/blob/4636de6a16d338a418ee901ee6b685b887585c4f/doc/upgrade-to-2.x.md?from_branch=main#-typescript-supported-versions": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:17.33517-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md": {
     "StatusCode": 206,
     "LastSeen": "2026-02-19T09:52:33.798477565Z"
@@ -11575,6 +11819,14 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-18T09:52:53.757324318Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-js/tree/4636de6a16d338a418ee901ee6b685b887585c4f/doc/upgrade-to-2.x.md?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:16.603108-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-js/tree/ad92be4c2c1094745a85b0b7eeff1444a11b1b4a/experimental/packages/configuration?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:19.317069-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-js/tree/main/doc/upgrade-to-2.x.md": {
     "StatusCode": 206,
     "LastSeen": "2026-02-18T09:52:59.975034761Z"
@@ -11639,6 +11891,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-12T09:58:40.485884301Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-lambda/blob/653874a89dc684e2408f5eb397e41dd98c56ba83/collector/README.md?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:12.36463-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-lambda/blob/main/collector/README.md": {
     "StatusCode": 206,
     "LastSeen": "2026-02-13T09:52:31.446921944Z"
@@ -11650,6 +11906,10 @@
   "https://github.com/open-telemetry/opentelemetry-lambda/releases/tag/layer-collector%2F0.12.0": {
     "StatusCode": 206,
     "LastSeen": "2026-02-13T09:52:41.895114433Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-lambda/tree/dd62a87dcef7c1a94a02739a2425a1af3770313e/collector?from_branch=main#auto-configuration": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:14.889144-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-lambda/tree/main/collector#auto-configuration": {
     "StatusCode": 206,
@@ -11803,6 +12063,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-14T09:52:53.303761133Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/2b6a02f67d85f7f94ebc285d2c08c3523d26e093/src/Instrumentation?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:17.548618-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/examples": {
     "StatusCode": 206,
     "LastSeen": "2026-02-20T09:52:17.517388458Z"
@@ -11918,6 +12182,10 @@
   "https://github.com/open-telemetry/opentelemetry-php/releases/latest": {
     "StatusCode": 206,
     "LastSeen": "2026-02-14T09:47:02.159744025Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-php/tree/08f0dc1afb23f7ff634cda54de4af8e779e11fe1/src/Config/SDK?from_branch=main#initialization-from-configuration-file": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:20.690925-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-php/tree/main/examples": {
     "StatusCode": 206,
@@ -12134,6 +12402,10 @@
   "https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/opentelemetry-instrumentation/README.rst#programmatic-auto-instrumentation": {
     "StatusCode": 206,
     "LastSeen": "2026-02-19T09:52:47.563817975Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/413c98e542b747b14bc35d79c18c7d020662f745/instrumentation?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:15.270384-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/5560324cff80148de07324715aef5efa1e6242c1/instrumentation-genai?from_branch=main": {
     "StatusCode": 206,
@@ -12763,6 +13035,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-14T09:50:09.409916421Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-specification/blob/02531b063da09bca753070d8071180ca2c287117/oteps/trace/0235-sampling-threshold-in-trace-state.md?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:17.333309-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-specification/blob/5239912e97a4df50b206f5fa8241dd6cd8d2dbf8/oteps/0156-columnar-encoding.md?from_branch=main#mapping-otel-entities-to-arrow-records": {
     "StatusCode": 206,
     "LastSeen": "2026-02-23T19:29:06.093474-05:00"
@@ -12771,9 +13047,25 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-23T19:29:04.476483-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry-specification/blob/97c826b70e2f89cfdf655d5150791f3f0c2bae19/oteps/trace/0168-sampling-propagation.md?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:15.385354-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-specification/blob/97c826b70e2f89cfdf655d5150791f3f0c2bae19/oteps/trace/0170-sampling-probability.md?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:16.195229-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry-specification/blob/af2606810c19c31850738d1fd105b4eca7aa8c98/spec-compliance-matrix.md?from_branch=main": {
     "StatusCode": 206,
     "LastSeen": "2026-02-23T19:29:06.725694-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-specification/blob/af2606810c19c31850738d1fd105b4eca7aa8c98/spec-compliance-matrix.md?from_branch=main#declarative-configuration": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:17.495219-05:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry-specification/blob/b72b9e1127391871eaedee841895ff9ce52d11f3/oteps/trace/0250-Composite_Samplers.md?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:17.885904-05:00"
   },
   "https://github.com/open-telemetry/opentelemetry-specification/blob/main/development/trace/zpages.md": {
     "StatusCode": 206,
@@ -13475,6 +13767,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-12T20:44:28.834333-05:00"
   },
+  "https://github.com/open-telemetry/opentelemetry.io/blob/9bd13bd7b3ecd76093fa980c44dc10b5611b4ee0/projects/landing-page-redesign.md?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:49:57.555844-05:00"
+  },
   "https://github.com/open-telemetry/opentelemetry.io/blob/bc94737/hugo.yaml": {
     "StatusCode": 206,
     "LastSeen": "2026-02-20T09:53:37.736602618Z"
@@ -14139,6 +14435,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-13T09:56:52.232221185Z"
   },
+  "https://github.com/open-telemetry/sig-end-user/blob/5960784a7e300dc23cbde4fba1bf391180a9e79f/end-user-surveys/contributor-experience/otel-contributor-experience-survey-free-form-questions.csv?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:16.138356-05:00"
+  },
   "https://github.com/open-telemetry/sig-end-user/blob/684fca78b4f13c8ac5009d7a99638f78b336b8d7/end-user-surveys/otel-collector/otel-collector-survey.csv?from_branch=main": {
     "StatusCode": 206,
     "LastSeen": "2026-02-23T19:29:12.121848-05:00"
@@ -14150,6 +14450,10 @@
   "https://github.com/open-telemetry/sig-end-user/blob/main/end-user-surveys/contributor-experience/otel-contributor-experience-survey-free-form-questions.csv": {
     "StatusCode": 206,
     "LastSeen": "2026-02-18T09:53:00.116211225Z"
+  },
+  "https://github.com/open-telemetry/sig-end-user/tree/01bdcafbc787c0aa0b076ecd85432c24d50e62ac/end-user-surveys/contributor-experience?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:14.750168-05:00"
   },
   "https://github.com/open-telemetry/sig-end-user/tree/e834e9da4494b626d1e4a4936fba31563b37b607/end-user-surveys/getting-started?from_branch=main": {
     "StatusCode": 206,
@@ -14206,6 +14510,10 @@
   "https://github.com/open-telemetry/weaver/releases": {
     "StatusCode": 206,
     "LastSeen": "2026-02-18T09:52:52.043290481Z"
+  },
+  "https://github.com/open-telemetry/weaver/tree/4da6fa62e174e1f0df1a990234bd32f5018cb23a/crates/weaver_live_check?from_branch=main#readme": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:16.409755-05:00"
   },
   "https://github.com/open-telemetry/weaver/tree/main/crates/weaver_live_check#readme": {
     "StatusCode": 206,
@@ -14583,9 +14891,17 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-23T19:29:15.01785-05:00"
   },
+  "https://github.com/prometheus-community/ux-research/blob/acc0194a79aa0f2ee1c6eb93462c9488d236a275/prom-otel-research/survey-results.csv?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:13.884906-05:00"
+  },
   "https://github.com/prometheus-community/ux-research/blob/main/prom-otel-research/survey-results.csv": {
     "StatusCode": 206,
     "LastSeen": "2026-02-18T09:52:59.822708718Z"
+  },
+  "https://github.com/prometheus-community/ux-research/tree/a2f8c6684321fd04de7b94cfbd39a48bb1d7beb4/prom-otel-research?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:15.183076-05:00"
   },
   "https://github.com/prometheus-community/ux-research/tree/main/prom-otel-research": {
     "StatusCode": 206,
@@ -14950,6 +15266,10 @@
   "https://github.com/serverless/serverless": {
     "StatusCode": 206,
     "LastSeen": "2026-02-13T09:52:29.590922488Z"
+  },
+  "https://github.com/sh0rez/promconv/tree/4ef6f697497dec4dc87a0d670cd90ee12335bcdf?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:17.950619-05:00"
   },
   "https://github.com/sh0rez/promconv/tree/main": {
     "StatusCode": 206,
@@ -15318,6 +15638,10 @@
   "https://github.com/traceloop/jest-opentelemetry": {
     "StatusCode": 206,
     "LastSeen": "2026-02-24T10:01:16.883999171Z"
+  },
+  "https://github.com/traceloop/openllmetry/tree/c2974c94f593df42353ad48c9170d039ab1a0c3f/packages?from_branch=main": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T07:00:12.332415-05:00"
   },
   "https://github.com/traceloop/openllmetry/tree/main/packages": {
     "StatusCode": 206,


### PR DESCRIPTION
- Contributes #8578 by enforcing the guidance in that issue
- Replaces `main` in GH repo URL with the last commit hash of the named resource. Tags `?from_branch=main` as a query parameter.
- This is the last of the blog subsections
