### PR TITLE
docs: update Docsy alert links and refcache

### DIFF
--- a/content/en/docs/contributing/style-guide.md
+++ b/content/en/docs/contributing/style-guide.md
@@ -90,14 +90,14 @@ These render as:
 
 {{% _param alertExamples %}}
 
-For details about Hugo's blockquote alert syntax, see [Alerts][hugo-alerts] from
-the Hugo docs.
+For details about the blockquote alert syntax, see [Alerts][docsy-alerts] from
+the Docsy docs.
 
 [gfm-alerts]:
   https://docs.github.com/en/contributing/style-guide-and-content-model/style-guide#alerts
 [GFM]: https://github.github.com/gfm/
 [Goldmark]: https://gohugo.io/configuration/markup/#goldmark
-[hugo-alerts]: https://gohugo.io/render-hooks/blockquotes/#alerts
+[docsy-alerts]: https://www.docsy.dev/docs/content/adding-content/#alerts
 [Obsidian callout]: https://help.obsidian.md/callouts
 
 ### Link references

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -21331,6 +21331,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-19T09:52:44.00352514Z"
   },
+  "https://www.docsy.dev/docs/content/adding-content/#alerts": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-24T14:18:56.088546355Z"
+  },
   "https://www.docsy.dev/docs/content/shortcodes/#alert": {
     "StatusCode": 206,
     "LastSeen": "2026-02-13T09:52:26.921677024Z"


### PR DESCRIPTION
- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

## DESCRIPTION

- Changed the links pointing to Hugo's documentation for blockquote alerts, to instead point to Docsy's own Alerts documentation.
- static/refcache.json updated automatically by running npm run fix:all