### PR TITLE
chore(deps): update packages, Hugo to 0.157.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,10 +137,10 @@
     "ajv": "^8.18.0",
     "ajv-errors": "^3.0.0",
     "ajv-formats": "^3.0.1",
-    "autoprefixer": "^10.4.24",
+    "autoprefixer": "^10.4.27",
     "cspell": "^9.7.0",
     "gulp": "^5.0.1",
-    "hugo-extended": "0.156.0",
+    "hugo-extended": "0.157.0",
     "js-yaml": "^4.1.1",
     "markdown-it": "^14.1.1",
     "markdown-link-check": "^3.14.2",
@@ -177,8 +177,8 @@
     "path": "^0.12.7"
   },
   "optionalDependencies": {
-    "netlify-cli": "^23.15.1",
-    "npm-check-updates": "^19.4.1"
+    "netlify-cli": "^24.0.0",
+    "npm-check-updates": "^19.5.0"
   },
   "enginesComment": "Ensure that engines.node value stays consistent with the project's .nvmrc",
   "engines": {


### PR DESCRIPTION
- Updates all NPM packages
- Updates Hugo to 0.157.0

No change to generated site files other than hero-image finger prints, the Hugo version, and build timestamp:

```console
$ (cd public && git diff -bw --ignore-blank-lines -I 'meta name="generator" content="Hugo' -I 'hero-background') | grep ^diff
diff --git a/homepage-hero-background_hu_67d6d5a63daca9be.png b/homepage-hero-background_hu_67d6d5a63daca9be.png
diff --git a/homepage-hero-background_hu_9893a5f9192a803a.png b/homepage-hero-background_hu_9893a5f9192a803a.png
diff --git a/site/index.html b/site/index.html
```