### PR TITLE
docs(collector): add otel-collector-config.yaml example for Docker install

### DIFF
--- a/content/en/docs/collector/install/docker.md
+++ b/content/en/docs/collector/install/docker.md
@@ -61,6 +61,9 @@ otel-collector:
 ```
 
 The `otel-collector-config.yaml` file is required for the Collector to start.
+For more information, see
+[Collector configuration](/docs/collector/configuration/).
+
 Below is a minimal Collector configuration that logs all received telemetry.
 
 ```yaml


### PR DESCRIPTION
Fixes #9209

Added a minimal working example of `otel-collector-config.yaml`
that works with the Docker Compose snippet shown on the page.

The Docker Compose example references this file but the docs
didn't provide an example of its contents, causing confusion
for new users.

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.