### PR TITLE
Fix file resolution for spellcheck in collector sync

### DIFF
--- a/scripts/collector-sync/src/documentation_sync/fix_spelling.py
+++ b/scripts/collector-sync/src/documentation_sync/fix_spelling.py
@@ -164,10 +164,22 @@ def fix_component_spelling() -> dict[str, int]:
     files_updated = 0
     total_words_added = 0
 
+    cwd = Path.cwd()
+
     for filepath, words in misspellings.items():
         file_path = Path(filepath)
+
+        if not file_path.exists():
+            # Try relative to current working directory
+            file_path = cwd / filepath
+
+        if not file_path.exists():
+            # Try as absolute path
+            file_path = Path(filepath).resolve()
+
         if not file_path.exists():
             logger.warning(f"  ⚠️  File not found: {filepath}")
+            logger.debug(f"      Tried: {Path(filepath)}, {cwd / filepath}, {Path(filepath).resolve()}")
             continue
 
         component_words = set(words)


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

The new automation generated #9282 but spellchecking is not working due to things being moved around. This fixes that.

Ran this locally:

```
============================================================
Fixing Spelling Errors
============================================================

Running cspell to detect spelling errors...
Found spelling errors in 1 file(s)

receiver.md:
  Processing 1 words: bigipreceiver

✓ Updated 1 file(s), added 1 words total
Verifying spelling errors are fixed...
✓ All component name spelling errors fixed!
```
