### PR TITLE
Fix spellcheck npm install in collector sync job

### DIFF
--- a/scripts/collector-sync/src/documentation_sync/main.py
+++ b/scripts/collector-sync/src/documentation_sync/main.py
@@ -46,8 +46,8 @@ def find_repo_root() -> Path:
 
 def configure_logging() -> None:
     logging.basicConfig(
-        level=logging.DEBUG,
-        format="%(levelname)s: %(message)s",
+        level=logging.INFO,
+        format="%(message)s",
         handlers=[logging.StreamHandler(sys.stdout)],
     )
 


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

spellcheck is still failing because I had moved npm install to after the documentation ran, but we need it installed before.

Tested on my fork: https://github.com/jaydeluca/opentelemetry.io/pull/35/files#diff-757519e775a43bce046863d4cc7b5d8c9acce5e6d79d386f15e141667faf1e6eR6