### PR TITLE
[CI] PR-label-gating fix: use base repo for publish-date API call in fork PRs

### DIFF
--- a/.github/scripts/pr-approval-labels.sh
+++ b/.github/scripts/pr-approval-labels.sh
@@ -179,6 +179,12 @@ get_publish_date() {
     if [[ ! "${file}" == content/en/blog/* && ! "${file}" == content/en/announcements/* ]]; then
       continue
     fi
+    # Skip any file path containing potentially unsafe characters to avoid
+    # shell injection when constructing the GitHub API URL.
+    if [[ ! "${file}" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+      echo "Skipping potentially unsafe file path: ${file}" >&2
+      continue
+    fi
     local content
     content=$(gh api "/repos/${REPO}/contents/${file}?ref=${head_sha}" \
       --jq '.content' 2>/dev/null | base64 --decode 2>/dev/null || true)


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

Updates the `get_publish_date()` method in `pr-approval-label.sh` to use `${REPO}` (base repo) instead of `head_repo` (contributor's fork). The GitHub API call wasn't using the correct `otelbot` token, as it's only available on `open-telemetry/opentelemetry.io`. 