### PR TITLE
Add note about updating Dockerfile when customizing dist name

### DIFF
--- a/content/en/docs/collector/extend/ocb.md
+++ b/content/en/docs/collector/extend/ocb.md
@@ -305,6 +305,17 @@ Follow these steps to containerize your custom Collector.
    EXPOSE 4317 4318 12001
    ```
 
+   > [!NOTE]
+   >
+   > The Dockerfile references the distribution name `otelcol-dev` from
+   > `builder-config.yaml` in the `COPY` and `ENTRYPOINT` instructions. If you
+   > change the `name` or `output_path` in the `dist` section of your
+   > `builder-config.yaml`, make sure to update the following lines in the
+   > Dockerfile to match:
+   >
+   > - `COPY --chmod=755 --from=build-stage /build/<dist_name> /otelcol`
+   > - `ENTRYPOINT ["/otelcol/<dist_name>"]`
+
 1. Add the following definition to your `collector-config.yaml` file:
 
    ```yaml


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [X] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [X] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

### Description

When following the [custom Collector build instructions](https://opentelemetry.io/docs/collector/extend/ocb/#containerize-your-collector-distribution), users who change `dist.name` in `builder-config.yaml` encounter a Docker runtime error because the Dockerfile `COPY` and `ENTRYPOINT` instructions still reference the default `otelcol-dev` name.

This PR adds a `[!NOTE]` callout after the Dockerfile code block in the containerization section that reminds users to update `COPY` and `ENTRYPOINT` lines in their Dockerfile if they use a custom distribution name.

### Changes

- Added a note to `content/en/docs/collector/extend/ocb.md` in the "Containerize your Collector distribution" section clarifying the relationship between `dist.name` in `builder-config.yaml` and the Dockerfile

Fixes #8941.