### PR TITLE
Fix OBI test service image references, ports, and registry typo - Fix…

### DIFF
--- a/content/en/docs/zero-code/obi/cilium-compatibility.md
+++ b/content/en/docs/zero-code/obi/cilium-compatibility.md
@@ -103,12 +103,12 @@ spec:
     spec:
       containers:
         - name: nodejs-service
-          image: ghcr.io/open-teletry/obi-testimg:node-0.1.1
+          image: ghcr.io/open-telemetry/obi-testimg:node-0.1.0
           ports:
-            - containerPort: 3000
+            - containerPort: 3030
           env:
             - name: NODEJS_SERVICE_PORT
-              value: '3000'
+              value: '3030'
             - name: NODEJS_SERVICE_HOST
               value: '0.0.0.0'
 ---
@@ -120,8 +120,8 @@ spec:
   selector:
     app: nodejs-service
   ports:
-    - port: 3000
-      targetPort: 3000
+    - port: 3030
+      targetPort: 3030
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -139,7 +139,7 @@ spec:
     spec:
       containers:
         - name: go-service
-          image: ghcr.io/open-teletry/obi-testimg:go-0.1.1
+          image: ghcr.io/open-telemetry/obi-testimg:go-0.1.0
           ports:
             - containerPort: 8080
           env:
@@ -175,12 +175,12 @@ spec:
     spec:
       containers:
         - name: python-service
-          image: ghcr.io/open-teletry/obi-testimg:python-0.1.1
+          image: ghcr.io/open-telemetry/obi-testimg:python-0.1.0
           ports:
-            - containerPort: 8080
+            - containerPort: 8380
           env:
             - name: PYTHON_SERVICE_PORT
-              value: '8080'
+              value: '8380'
             - name: PYTHON_SERVICE_HOST
               value: '0.0.0.0'
 ---
@@ -192,8 +192,8 @@ spec:
   selector:
     app: python-service
   ports:
-    - port: 8080
-      targetPort: 8080
+    - port: 8380
+      targetPort: 8380
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -211,12 +211,12 @@ spec:
     spec:
       containers:
         - name: ruby-service
-          image: ghcr.io/open-telemetry/obi-testimg:rails-0.1.1
+          image: ghcr.io/open-telemetry/obi-testimg:rails-0.1.0
           ports:
-            - containerPort: 3000
+            - containerPort: 3040
           env:
             - name: RAILS_SERVICE_PORT
-              value: '3000'
+              value: '3040'
             - name: RAILS_SERVICE_HOST
               value: '0.0.0.0'
 ---
@@ -228,8 +228,8 @@ spec:
   selector:
     app: ruby-service
   ports:
-    - port: 3000
-      targetPort: 3000
+    - port: 3040
+      targetPort: 3040
 ```
 
 ### Deploy OBI
@@ -347,8 +347,8 @@ spec:
 Forward a port to the host and trigger a request:
 
 ```shell
-kubectl port-forward services/nodejs-service 3000:3000 &
-curl http://localhost:3000/traceme
+kubectl port-forward services/nodejs-service 3030:3030 &
+curl http://localhost:3030/traceme
 ```
 
 Finally check your OBI Pod logs:


### PR DESCRIPTION
…es #9227

<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [X] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [X] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

### Description

OBI and Cilium compatibility demo had several incorrect values that were likely carried over from the pre-donation Beyla configuration. 
PR fixes:

- Registry typo: `ghcr.io/open-teletry/obi-testimg` -> `ghcr.io/open-telemetry/obi-testimg` (node, go, python images)
- Image tags: `0.1.1` -> `0.1.0` (matching the actual published versions in GHCR)
- Nodejs port: `3000` -> `3030` (verified against [nodejsserver Dockerfile](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/internal/test/integration/components/nodejsserver/Dockerfile))
- python port: `8080` -> `8380` (verified against [pythonserver Dockerfile](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/internal/test/integration/components/pythonserver/Dockerfile))
- Rails port: `3000` -> `3040` (verified against [rubytestserver Dockerfile](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/internal/test/integration/components/rubytestserver/testapi/Dockerfile))
- Port-forward and curl command updated to use correct Nodejs port `3030`

### Changes made

- `content/en/docs/zero-code/obi/cilium-compatibility.md`

### Verification

- Confirmed image tags exist via [GHCR package registry](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkgs/container/obi-testimg/versions)
- Confirmed ports agianst upstream Dockerfiles and source code in `opentelemetry-ebpf-instrumentation`
- Hugo dev server renders the page without errors