### PR TITLE
docs(specs): Publish spec compliance matrix

### DIFF
--- a/config/_default/module-template.yaml
+++ b/config/_default/module-template.yaml
@@ -15,6 +15,8 @@ mounts:
   # Specs, currently en only
   - source: tmp/otel/specification
     target: content/docs/specs/otel
+  - source: tmp/otel/spec-compliance-matrix.md
+    target: content/docs/languages/spec-compliance-matrix.md
   - source: tmp/opamp
     target: content/docs/specs/opamp
   - source: tmp/otlp/docs/specification.md

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -298,7 +298,13 @@ while(<>) {
       [^)]+
     )
   }{$otelSpecRepoUrl/tree/v$otelSpecVers/$2}gx;
-  s|(\]\()(?:\./)?specification/([^)#]+)\.md|$1/docs/specs/otel/$2|g if $ARGV eq "tmp/otel/spec-compliance-matrix.md";
+
+
+  if ($ARGV eq "tmp/otel/spec-compliance-matrix.md") {
+    s|(\]\()(?:\./)?specification/([^)#]+?)\.md|$1/docs/specs/otel/$2|g;
+    # Strip /README.md from relative/absolute (localized) links
+    s|\]\((\.?/[^#) ]+/)README(?:\.md)?((?:#[^) ]*)?)\)|]($1$2)|g;
+  }
 
   s|\.\./((?:examples/)?README\.md)|$otlpSpecRepoUrl/tree/v$otlpSpecVers/$1|g if $ARGV =~ /^tmp\/otlp/;
 

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -53,6 +53,8 @@ sub printFrontMatter() {
     $frontMatterFromFile =~ s/linkTitle: .*/$& $semconvVers/;
     # $frontMatterFromFile =~ s/body_class: .*/$& td-page--draft/;
     # $frontMatterFromFile =~ s/cascade:\n/$&  draft: true\n/;
+  } elsif ($ARGV =~ "tmp/otel/spec-compliance-matrix.md") {
+    $linkTitle = "Spec compliance";
   }
   # elsif ($ARGV =~ m|^tmp/otel/specification/logs/|
   #     && applyPatchOrPrintMsgIf('2026-01-29-hugo01550-alias-processing-diff', 'spec', '1.53.0')) {
@@ -296,6 +298,7 @@ while(<>) {
       [^)]+
     )
   }{$otelSpecRepoUrl/tree/v$otelSpecVers/$2}gx;
+  s|(\]\()(?:\./)?specification/([^)#]+)\.md|$1/docs/specs/otel/$2|g if $ARGV eq "tmp/otel/spec-compliance-matrix.md";
 
   s|\.\./((?:examples/)?README\.md)|$otlpSpecRepoUrl/tree/v$otlpSpecVers/$1|g if $ARGV =~ /^tmp\/otlp/;
 

--- a/scripts/content-modules/cp-pages.sh
+++ b/scripts/content-modules/cp-pages.sh
@@ -5,14 +5,22 @@ DEST_BASE=tmp
 
 ## OTel specification
 
-SRC=content-modules/opentelemetry-specification/specification
-DEST=$DEST_BASE/otel/specification
+DEST=$DEST_BASE/otel/
 
 rm -Rf $DEST
-mkdir -p $DEST
+
+SRC=content-modules/opentelemetry-specification/specification
+SUBDEST=$DEST/specification/
+
+mkdir -p $SUBDEST
 # FIX_FILES=$(find $SRC -name "*.md" -not -path '*/semantic_conventions/*')
 # $SCRIPT_DIR/otel-spec-fix.pl $FIX_FILES
-cp -R $SRC/* $DEST/
+cp -R $SRC/* $SUBDEST/
+
+SRC=content-modules/opentelemetry-specification/spec-compliance-matrix.md
+SUBDEST=$DEST/spec-compliance-matrix.md
+
+cp $SRC $SUBDEST
 
 find $DEST/ -name "README.md" -exec sh -c 'f="{}"; mv -- "$f" "${f%README.md}_index.md"' \;
 


### PR DESCRIPTION
- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

This will publish the `Compliance of Implementations with Specification` matrix, currently only [on Github](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md), under `https://opentelemetry.io/docs/languages/spec-compliance-matrix` (titled *Spec compliance.*)

Preview: https://deploy-preview-9358--opentelemetry.netlify.app/docs/languages/spec-compliance-matrix/