### PR TITLE
[ja] Update Collector components table to match English version

### DIFF
--- a/content/ja/docs/collector/components/_includes/unmaintained-components-msg.md
+++ b/content/ja/docs/collector/components/_includes/unmaintained-components-msg.md
@@ -1,0 +1,8 @@
+---
+default_lang_commit: 6bf06ddb9fc057dd6e8092f26d988ffe7b1af5ed
+---
+
+> [!NOTE]
+>
+> Components marked with :warning: are unmaintained and have no active
+> codeowners. They may not receive regular updates or bug fixes.

--- a/content/ja/docs/collector/components/connector.md
+++ b/content/ja/docs/collector/components/connector.md
@@ -2,7 +2,7 @@
 title: コネクター
 description: OpenTelemetry Collectorで利用可能なコネクターの一覧
 weight: 340
-default_lang_commit: 1c2b0563e8e66ef0952c442e3662e4bec18a8762
+default_lang_commit: 1c2b0563e8e66ef0952c442e3662e4bec18a8762 # patched
 drifted_from_default: true
 # prettier-ignore
 cSpell:ignore: countconnector datadogconnector exceptionsconnector failoverconnector forwardconnector grafanacloudconnector otlpjsonconnector roundrobinconnector routingconnector servicegraphconnector signaltometricsconnector slowsqlconnector spanmetricsconnector sumconnector
@@ -11,25 +11,26 @@ cSpell:ignore: countconnector datadogconnector exceptionsconnector failoverconne
 コネクターは、2つのパイプラインを接続し、エクスポーターとレシーバーの両方として機能します。
 コネクターの詳細な設定方法については、[Collectorの設定ドキュメント](/docs/collector/configuration/#connectors)を参照してください。
 
-<!-- BEGIN GENERATED: connector-table -->
+<!-- BEGIN GENERATED: connector-table SOURCE: scripts/collector-sync -->
 
 | 名前                                                                                                                                       | ディストリビューション[^1] |
 | ------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- |
-| [countconnector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/countconnector)                     | contrib, K8s               |
-| [datadogconnector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/datadogconnector)                 | contrib                    |
-| [exceptionsconnector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/exceptionsconnector)           | contrib, K8s               |
-| [failoverconnector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/failoverconnector)               | contrib, K8s               |
-| [forwardconnector](https://github.com/open-telemetry/opentelemetry-collector/tree/main/connector/forwardconnector)                         | contrib, core, K8s         |
-| [grafanacloudconnector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/grafanacloudconnector)       | contrib                    |
-| [otlpjsonconnector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/otlpjsonconnector)               | contrib, K8s               |
-| [roundrobinconnector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/roundrobinconnector)           | contrib, K8s               |
-| [routingconnector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/routingconnector)                 | contrib, K8s               |
-| [servicegraphconnector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/servicegraphconnector)       | contrib, K8s               |
-| [signaltometricsconnector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/signaltometricsconnector) | contrib                    |
-| [slowsqlconnector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/slowsqlconnector)                 | contrib                    |
-| [spanmetricsconnector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector)         | contrib                    |
-| [sumconnector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/sumconnector)                         | contrib                    |
+| {{< component-link name="countconnector" type="connector" repo="contrib" >}}           | contrib, K8s       |
+| {{< component-link name="datadogconnector" type="connector" repo="contrib" >}}         | contrib            |
+| {{< component-link name="exceptionsconnector" type="connector" repo="contrib" >}}      | contrib, K8s       |
+| {{< component-link name="failoverconnector" type="connector" repo="contrib" >}}        | contrib, K8s       |
+| {{< component-link name="forwardconnector" type="connector" repo="core" >}}            | contrib, core, K8s |
+| {{< component-link name="grafanacloudconnector" type="connector" repo="contrib" >}}    | contrib            |
+| {{< component-link name="metricsaslogsconnector" type="connector" repo="contrib" >}}   | contrib            |
+| {{< component-link name="otlpjsonconnector" type="connector" repo="contrib" >}}        | contrib, K8s       |
+| {{< component-link name="roundrobinconnector" type="connector" repo="contrib" >}}      | contrib, K8s       |
+| {{< component-link name="routingconnector" type="connector" repo="contrib" >}}         | contrib, K8s       |
+| {{< component-link name="servicegraphconnector" type="connector" repo="contrib" >}}    | contrib, K8s       |
+| {{< component-link name="signaltometricsconnector" type="connector" repo="contrib" >}} | contrib            |
+| {{< component-link name="slowsqlconnector" type="connector" repo="contrib" >}}         | contrib            |
+| {{< component-link name="spanmetricsconnector" type="connector" repo="contrib" >}}     | contrib            |
+| {{< component-link name="sumconnector" type="connector" repo="contrib" >}}             | contrib            |
 
 [^1]: このコンポーネントが含まれている[ディストリビューション](/docs/collector/distributions/)（core、contrib、K8sなど）を示します。
 
-<!-- END GENERATED: connector-table -->
+<!-- END GENERATED: connector-table SOURCE: scripts/collector-sync -->

--- a/content/ja/docs/collector/components/connector.md
+++ b/content/ja/docs/collector/components/connector.md
@@ -13,23 +13,23 @@ cSpell:ignore: countconnector datadogconnector exceptionsconnector failoverconne
 
 <!-- BEGIN GENERATED: connector-table SOURCE: scripts/collector-sync -->
 
-| 名前                                                                                                                                       | ディストリビューション[^1] |
-| ------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- |
-| {{< component-link name="countconnector" type="connector" repo="contrib" >}}           | contrib, K8s       |
-| {{< component-link name="datadogconnector" type="connector" repo="contrib" >}}         | contrib            |
-| {{< component-link name="exceptionsconnector" type="connector" repo="contrib" >}}      | contrib, K8s       |
-| {{< component-link name="failoverconnector" type="connector" repo="contrib" >}}        | contrib, K8s       |
-| {{< component-link name="forwardconnector" type="connector" repo="core" >}}            | contrib, core, K8s |
-| {{< component-link name="grafanacloudconnector" type="connector" repo="contrib" >}}    | contrib            |
-| {{< component-link name="metricsaslogsconnector" type="connector" repo="contrib" >}}   | contrib            |
-| {{< component-link name="otlpjsonconnector" type="connector" repo="contrib" >}}        | contrib, K8s       |
-| {{< component-link name="roundrobinconnector" type="connector" repo="contrib" >}}      | contrib, K8s       |
-| {{< component-link name="routingconnector" type="connector" repo="contrib" >}}         | contrib, K8s       |
-| {{< component-link name="servicegraphconnector" type="connector" repo="contrib" >}}    | contrib, K8s       |
-| {{< component-link name="signaltometricsconnector" type="connector" repo="contrib" >}} | contrib            |
-| {{< component-link name="slowsqlconnector" type="connector" repo="contrib" >}}         | contrib            |
-| {{< component-link name="spanmetricsconnector" type="connector" repo="contrib" >}}     | contrib            |
-| {{< component-link name="sumconnector" type="connector" repo="contrib" >}}             | contrib            |
+| 名前                                                                                   | ディストリビューション[^1] |
+| -------------------------------------------------------------------------------------- | -------------------------- |
+| {{< component-link name="countconnector" type="connector" repo="contrib" >}}           | contrib, K8s               |
+| {{< component-link name="datadogconnector" type="connector" repo="contrib" >}}         | contrib                    |
+| {{< component-link name="exceptionsconnector" type="connector" repo="contrib" >}}      | contrib, K8s               |
+| {{< component-link name="failoverconnector" type="connector" repo="contrib" >}}        | contrib, K8s               |
+| {{< component-link name="forwardconnector" type="connector" repo="core" >}}            | contrib, core, K8s         |
+| {{< component-link name="grafanacloudconnector" type="connector" repo="contrib" >}}    | contrib                    |
+| {{< component-link name="metricsaslogsconnector" type="connector" repo="contrib" >}}   | contrib                    |
+| {{< component-link name="otlpjsonconnector" type="connector" repo="contrib" >}}        | contrib, K8s               |
+| {{< component-link name="roundrobinconnector" type="connector" repo="contrib" >}}      | contrib, K8s               |
+| {{< component-link name="routingconnector" type="connector" repo="contrib" >}}         | contrib, K8s               |
+| {{< component-link name="servicegraphconnector" type="connector" repo="contrib" >}}    | contrib, K8s               |
+| {{< component-link name="signaltometricsconnector" type="connector" repo="contrib" >}} | contrib                    |
+| {{< component-link name="slowsqlconnector" type="connector" repo="contrib" >}}         | contrib                    |
+| {{< component-link name="spanmetricsconnector" type="connector" repo="contrib" >}}     | contrib                    |
+| {{< component-link name="sumconnector" type="connector" repo="contrib" >}}             | contrib                    |
 
 [^1]: このコンポーネントが含まれている[ディストリビューション](/docs/collector/distributions/)（core、contrib、K8sなど）を示します。
 

--- a/content/ja/docs/collector/components/exporter.md
+++ b/content/ja/docs/collector/components/exporter.md
@@ -15,60 +15,60 @@ cSpell:ignore: alertmanagerexporter alibabacloudlogserviceexporter awscloudwatch
 
 <!-- BEGIN GENERATED: exporter-table SOURCE: scripts/collector-sync -->
 
-| 名前                                                                                                                                                    | ディストリビューション[^1] | トレース[^2] | メトリクス[^2] | ログ[^2]    |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | ------------ | -------------- | ----------- |
-| {{< component-link name="alertmanagerexporter" type="exporter" repo="contrib" >}}              | contrib                  | development  | -            | -            |
-| {{< component-link name="alibabacloudlogserviceexporter" type="exporter" repo="contrib" >}} ⚠️ | contrib                  | unmaintained | unmaintained | unmaintained |
-| {{< component-link name="awscloudwatchlogsexporter" type="exporter" repo="contrib" >}}         | contrib                  | -            | -            | alpha        |
-| {{< component-link name="awsemfexporter" type="exporter" repo="contrib" >}}                    | contrib                  | -            | beta         | -            |
-| {{< component-link name="awskinesisexporter" type="exporter" repo="contrib" >}}                | contrib                  | beta         | beta         | beta         |
-| {{< component-link name="awss3exporter" type="exporter" repo="contrib" >}}                     | contrib                  | alpha        | alpha        | alpha        |
-| {{< component-link name="awsxrayexporter" type="exporter" repo="contrib" >}}                   | contrib                  | beta         | -            | -            |
-| {{< component-link name="azureblobexporter" type="exporter" repo="contrib" >}}                 | contrib                  | alpha        | alpha        | alpha        |
-| {{< component-link name="azuredataexplorerexporter" type="exporter" repo="contrib" >}}         | contrib                  | beta         | beta         | beta         |
-| {{< component-link name="azuremonitorexporter" type="exporter" repo="contrib" >}}              | contrib                  | beta         | beta         | beta         |
-| {{< component-link name="bmchelixexporter" type="exporter" repo="contrib" >}}                  | contrib                  | -            | alpha        | -            |
-| {{< component-link name="cassandraexporter" type="exporter" repo="contrib" >}}                 | contrib                  | alpha        | -            | alpha        |
-| {{< component-link name="clickhouseexporter" type="exporter" repo="contrib" >}}                | contrib                  | beta         | alpha        | beta         |
-| {{< component-link name="coralogixexporter" type="exporter" repo="contrib" >}}                 | contrib                  | beta         | beta         | beta         |
-| {{< component-link name="datadogexporter" type="exporter" repo="contrib" >}}                   | contrib                  | beta         | beta         | beta         |
-| {{< component-link name="datasetexporter" type="exporter" repo="contrib" >}}                   | contrib                  | alpha        | -            | alpha        |
-| {{< component-link name="debugexporter" type="exporter" repo="core" >}}                        | contrib, core, K8s       | alpha        | alpha        | alpha        |
-| {{< component-link name="dorisexporter" type="exporter" repo="contrib" >}}                     | contrib                  | alpha        | alpha        | alpha        |
-| {{< component-link name="elasticsearchexporter" type="exporter" repo="contrib" >}}             | contrib                  | beta         | development  | beta         |
-| {{< component-link name="faroexporter" type="exporter" repo="contrib" >}}                      | contrib                  | alpha        | -            | alpha        |
-| {{< component-link name="fileexporter" type="exporter" repo="contrib" >}}                      | contrib, core, K8s       | alpha        | alpha        | alpha        |
-| {{< component-link name="googlecloudexporter" type="exporter" repo="contrib" >}}               | contrib                  | beta         | beta         | beta         |
-| {{< component-link name="googlecloudpubsubexporter" type="exporter" repo="contrib" >}}         | contrib                  | beta         | beta         | beta         |
-| {{< component-link name="googlecloudstorageexporter" type="exporter" repo="contrib" >}}        | contrib                  | development  | -            | alpha        |
-| {{< component-link name="googlemanagedprometheusexporter" type="exporter" repo="contrib" >}}   | contrib                  | -            | beta         | -            |
-| {{< component-link name="honeycombmarkerexporter" type="exporter" repo="contrib" >}}           | contrib                  | -            | -            | alpha        |
-| {{< component-link name="influxdbexporter" type="exporter" repo="contrib" >}}                  | contrib                  | beta         | beta         | beta         |
-| {{< component-link name="kafkaexporter" type="exporter" repo="contrib" >}}                     | contrib, core            | beta         | beta         | beta         |
-| {{< component-link name="loadbalancingexporter" type="exporter" repo="contrib" >}}             | contrib, K8s             | beta         | development  | beta         |
-| {{< component-link name="logicmonitorexporter" type="exporter" repo="contrib" >}}              | contrib                  | alpha        | -            | alpha        |
-| {{< component-link name="logzioexporter" type="exporter" repo="contrib" >}}                    | contrib                  | beta         | -            | beta         |
-| {{< component-link name="mezmoexporter" type="exporter" repo="contrib" >}}                     | contrib                  | -            | -            | beta         |
-| {{< component-link name="nopexporter" type="exporter" repo="core" >}}                          | contrib, core, K8s       | beta         | beta         | beta         |
-| {{< component-link name="opensearchexporter" type="exporter" repo="contrib" >}}                | contrib                  | alpha        | -            | alpha        |
-| {{< component-link name="otelarrowexporter" type="exporter" repo="contrib" >}}                 | contrib, K8s             | beta         | beta         | beta         |
-| {{< component-link name="otlpexporter" type="exporter" repo="core" >}}                         | contrib, core, K8s, otlp | stable       | stable       | stable       |
-| {{< component-link name="otlphttpexporter" type="exporter" repo="core" >}}                     | contrib, core, K8s, otlp | stable       | stable       | stable       |
-| {{< component-link name="prometheusexporter" type="exporter" repo="contrib" >}}                | contrib, core            | -            | beta         | -            |
-| {{< component-link name="prometheusremotewriteexporter" type="exporter" repo="contrib" >}}     | contrib, core            | -            | beta         | -            |
-| {{< component-link name="pulsarexporter" type="exporter" repo="contrib" >}}                    | contrib                  | alpha        | alpha        | alpha        |
-| {{< component-link name="rabbitmqexporter" type="exporter" repo="contrib" >}}                  | contrib                  | alpha        | alpha        | alpha        |
-| {{< component-link name="sapmexporter" type="exporter" repo="contrib" >}}                      | contrib                  | deprecated   | -            | -            |
-| {{< component-link name="sematextexporter" type="exporter" repo="contrib" >}}                  | contrib                  | -            | development  | development  |
-| {{< component-link name="sentryexporter" type="exporter" repo="contrib" >}}                    | contrib                  | alpha        | -            | alpha        |
-| {{< component-link name="signalfxexporter" type="exporter" repo="contrib" >}}                  | contrib                  | beta         | beta         | beta         |
-| {{< component-link name="splunkhecexporter" type="exporter" repo="contrib" >}}                 | contrib                  | beta         | beta         | beta         |
-| {{< component-link name="stefexporter" type="exporter" repo="contrib" >}}                      | contrib                  | -            | alpha        | -            |
-| {{< component-link name="sumologicexporter" type="exporter" repo="contrib" >}}                 | contrib                  | beta         | beta         | beta         |
-| {{< component-link name="syslogexporter" type="exporter" repo="contrib" >}}                    | contrib                  | -            | -            | alpha        |
-| {{< component-link name="tencentcloudlogserviceexporter" type="exporter" repo="contrib" >}}    | contrib                  | -            | -            | beta         |
-| {{< component-link name="tinybirdexporter" type="exporter" repo="contrib" >}}                  | contrib                  | alpha        | alpha        | alpha        |
-| {{< component-link name="zipkinexporter" type="exporter" repo="contrib" >}}                    | contrib, core            | beta         | -            | -            |
+| 名前                                                                                           | ディストリビューション[^1] | トレース[^2] | メトリクス[^2] | ログ[^2]     |
+| ---------------------------------------------------------------------------------------------- | -------------------------- | ------------ | -------------- | ------------ |
+| {{< component-link name="alertmanagerexporter" type="exporter" repo="contrib" >}}              | contrib                    | development  | -              | -            |
+| {{< component-link name="alibabacloudlogserviceexporter" type="exporter" repo="contrib" >}} ⚠️ | contrib                    | unmaintained | unmaintained   | unmaintained |
+| {{< component-link name="awscloudwatchlogsexporter" type="exporter" repo="contrib" >}}         | contrib                    | -            | -              | alpha        |
+| {{< component-link name="awsemfexporter" type="exporter" repo="contrib" >}}                    | contrib                    | -            | beta           | -            |
+| {{< component-link name="awskinesisexporter" type="exporter" repo="contrib" >}}                | contrib                    | beta         | beta           | beta         |
+| {{< component-link name="awss3exporter" type="exporter" repo="contrib" >}}                     | contrib                    | alpha        | alpha          | alpha        |
+| {{< component-link name="awsxrayexporter" type="exporter" repo="contrib" >}}                   | contrib                    | beta         | -              | -            |
+| {{< component-link name="azureblobexporter" type="exporter" repo="contrib" >}}                 | contrib                    | alpha        | alpha          | alpha        |
+| {{< component-link name="azuredataexplorerexporter" type="exporter" repo="contrib" >}}         | contrib                    | beta         | beta           | beta         |
+| {{< component-link name="azuremonitorexporter" type="exporter" repo="contrib" >}}              | contrib                    | beta         | beta           | beta         |
+| {{< component-link name="bmchelixexporter" type="exporter" repo="contrib" >}}                  | contrib                    | -            | alpha          | -            |
+| {{< component-link name="cassandraexporter" type="exporter" repo="contrib" >}}                 | contrib                    | alpha        | -              | alpha        |
+| {{< component-link name="clickhouseexporter" type="exporter" repo="contrib" >}}                | contrib                    | beta         | alpha          | beta         |
+| {{< component-link name="coralogixexporter" type="exporter" repo="contrib" >}}                 | contrib                    | beta         | beta           | beta         |
+| {{< component-link name="datadogexporter" type="exporter" repo="contrib" >}}                   | contrib                    | beta         | beta           | beta         |
+| {{< component-link name="datasetexporter" type="exporter" repo="contrib" >}}                   | contrib                    | alpha        | -              | alpha        |
+| {{< component-link name="debugexporter" type="exporter" repo="core" >}}                        | contrib, core, K8s         | alpha        | alpha          | alpha        |
+| {{< component-link name="dorisexporter" type="exporter" repo="contrib" >}}                     | contrib                    | alpha        | alpha          | alpha        |
+| {{< component-link name="elasticsearchexporter" type="exporter" repo="contrib" >}}             | contrib                    | beta         | development    | beta         |
+| {{< component-link name="faroexporter" type="exporter" repo="contrib" >}}                      | contrib                    | alpha        | -              | alpha        |
+| {{< component-link name="fileexporter" type="exporter" repo="contrib" >}}                      | contrib, core, K8s         | alpha        | alpha          | alpha        |
+| {{< component-link name="googlecloudexporter" type="exporter" repo="contrib" >}}               | contrib                    | beta         | beta           | beta         |
+| {{< component-link name="googlecloudpubsubexporter" type="exporter" repo="contrib" >}}         | contrib                    | beta         | beta           | beta         |
+| {{< component-link name="googlecloudstorageexporter" type="exporter" repo="contrib" >}}        | contrib                    | development  | -              | alpha        |
+| {{< component-link name="googlemanagedprometheusexporter" type="exporter" repo="contrib" >}}   | contrib                    | -            | beta           | -            |
+| {{< component-link name="honeycombmarkerexporter" type="exporter" repo="contrib" >}}           | contrib                    | -            | -              | alpha        |
+| {{< component-link name="influxdbexporter" type="exporter" repo="contrib" >}}                  | contrib                    | beta         | beta           | beta         |
+| {{< component-link name="kafkaexporter" type="exporter" repo="contrib" >}}                     | contrib, core              | beta         | beta           | beta         |
+| {{< component-link name="loadbalancingexporter" type="exporter" repo="contrib" >}}             | contrib, K8s               | beta         | development    | beta         |
+| {{< component-link name="logicmonitorexporter" type="exporter" repo="contrib" >}}              | contrib                    | alpha        | -              | alpha        |
+| {{< component-link name="logzioexporter" type="exporter" repo="contrib" >}}                    | contrib                    | beta         | -              | beta         |
+| {{< component-link name="mezmoexporter" type="exporter" repo="contrib" >}}                     | contrib                    | -            | -              | beta         |
+| {{< component-link name="nopexporter" type="exporter" repo="core" >}}                          | contrib, core, K8s         | beta         | beta           | beta         |
+| {{< component-link name="opensearchexporter" type="exporter" repo="contrib" >}}                | contrib                    | alpha        | -              | alpha        |
+| {{< component-link name="otelarrowexporter" type="exporter" repo="contrib" >}}                 | contrib, K8s               | beta         | beta           | beta         |
+| {{< component-link name="otlpexporter" type="exporter" repo="core" >}}                         | contrib, core, K8s, otlp   | stable       | stable         | stable       |
+| {{< component-link name="otlphttpexporter" type="exporter" repo="core" >}}                     | contrib, core, K8s, otlp   | stable       | stable         | stable       |
+| {{< component-link name="prometheusexporter" type="exporter" repo="contrib" >}}                | contrib, core              | -            | beta           | -            |
+| {{< component-link name="prometheusremotewriteexporter" type="exporter" repo="contrib" >}}     | contrib, core              | -            | beta           | -            |
+| {{< component-link name="pulsarexporter" type="exporter" repo="contrib" >}}                    | contrib                    | alpha        | alpha          | alpha        |
+| {{< component-link name="rabbitmqexporter" type="exporter" repo="contrib" >}}                  | contrib                    | alpha        | alpha          | alpha        |
+| {{< component-link name="sapmexporter" type="exporter" repo="contrib" >}}                      | contrib                    | deprecated   | -              | -            |
+| {{< component-link name="sematextexporter" type="exporter" repo="contrib" >}}                  | contrib                    | -            | development    | development  |
+| {{< component-link name="sentryexporter" type="exporter" repo="contrib" >}}                    | contrib                    | alpha        | -              | alpha        |
+| {{< component-link name="signalfxexporter" type="exporter" repo="contrib" >}}                  | contrib                    | beta         | beta           | beta         |
+| {{< component-link name="splunkhecexporter" type="exporter" repo="contrib" >}}                 | contrib                    | beta         | beta           | beta         |
+| {{< component-link name="stefexporter" type="exporter" repo="contrib" >}}                      | contrib                    | -            | alpha          | -            |
+| {{< component-link name="sumologicexporter" type="exporter" repo="contrib" >}}                 | contrib                    | beta         | beta           | beta         |
+| {{< component-link name="syslogexporter" type="exporter" repo="contrib" >}}                    | contrib                    | -            | -              | alpha        |
+| {{< component-link name="tencentcloudlogserviceexporter" type="exporter" repo="contrib" >}}    | contrib                    | -            | -              | beta         |
+| {{< component-link name="tinybirdexporter" type="exporter" repo="contrib" >}}                  | contrib                    | alpha        | alpha          | alpha        |
+| {{< component-link name="zipkinexporter" type="exporter" repo="contrib" >}}                    | contrib, core              | beta         | -              | -            |
 
 [^1]: このコンポーネントが含まれている[ディストリビューション](/docs/collector/distributions/)（core、contrib、K8sなど）を示します。
 

--- a/content/ja/docs/collector/components/exporter.md
+++ b/content/ja/docs/collector/components/exporter.md
@@ -11,67 +11,67 @@ cSpell:ignore: alertmanagerexporter alibabacloudlogserviceexporter awscloudwatch
 エクスポーターは、テレメトリーデータをオブザーバビリティバックエンドや宛先に送信します。
 エクスポーターの詳細な設定方法については、[Collectorの設定ドキュメント](/docs/collector/configuration/#exporters)を参照してください。
 
-<!-- BEGIN GENERATED: exporter-table -->
+{{% include unmaintained-components-msg.md %}}
+
+<!-- BEGIN GENERATED: exporter-table SOURCE: scripts/collector-sync -->
 
 | 名前                                                                                                                                                    | ディストリビューション[^1] | トレース[^2] | メトリクス[^2] | ログ[^2]    |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | ------------ | -------------- | ----------- |
-| [alertmanagerexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/alertmanagerexporter)                       | contrib                    | development  | -              | -           |
-| [alibabacloudlogserviceexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/alibabacloudlogserviceexporter)   | contrib                    | beta         | beta           | beta        |
-| [awscloudwatchlogsexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awscloudwatchlogsexporter)             | contrib                    | -            | -              | alpha       |
-| [awsemfexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awsemfexporter)                                   | contrib                    | -            | beta           | -           |
-| [awskinesisexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awskinesisexporter)                           | contrib                    | beta         | beta           | beta        |
-| [awss3exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awss3exporter)                                     | contrib                    | alpha        | alpha          | alpha       |
-| [awsxrayexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awsxrayexporter)                                 | contrib                    | beta         | -              | -           |
-| [azureblobexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/azureblobexporter)                             | contrib                    | alpha        | alpha          | alpha       |
-| [azuredataexplorerexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/azuredataexplorerexporter)             | contrib                    | beta         | beta           | beta        |
-| [azuremonitorexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/azuremonitorexporter)                       | contrib                    | beta         | beta           | beta        |
-| [bmchelixexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/bmchelixexporter)                               | contrib                    | -            | alpha          | -           |
-| [cassandraexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/cassandraexporter)                             | contrib                    | alpha        | -              | alpha       |
-| [clickhouseexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/clickhouseexporter)                           | contrib                    | beta         | alpha          | beta        |
-| [coralogixexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/coralogixexporter)                             | contrib                    | beta         | beta           | beta        |
-| [datadogexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter)                                 | contrib                    | beta         | beta           | beta        |
-| [datasetexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datasetexporter)                                 | contrib                    | alpha        | -              | alpha       |
-| [debugexporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/debugexporter)                                             | contrib, core, K8s         | alpha        | alpha          | alpha       |
-| [dorisexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/dorisexporter)                                     | contrib                    | alpha        | alpha          | alpha       |
-| [elasticsearchexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/elasticsearchexporter)                     | contrib                    | beta         | development    | beta        |
-| [faroexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/faroexporter)                                       | contrib                    | alpha        | -              | alpha       |
-| [fileexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/fileexporter)                                       | contrib, core, K8s         | alpha        | alpha          | alpha       |
-| [googlecloudexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudexporter)                         | contrib                    | beta         | beta           | beta        |
-| [googlecloudpubsubexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudpubsubexporter)             | contrib                    | beta         | beta           | beta        |
-| [googlecloudstorageexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudstorageexporter)           | contrib                    | -            | -              | alpha       |
-| [googlemanagedprometheusexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlemanagedprometheusexporter) | contrib                    | -            | beta           | -           |
-| [honeycombmarkerexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/honeycombmarkerexporter)                 | contrib                    | -            | -              | alpha       |
-| [influxdbexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/influxdbexporter)                               | contrib                    | beta         | beta           | beta        |
-| [kafkaexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/kafkaexporter)                                     | contrib, core              | beta         | beta           | beta        |
-| [loadbalancingexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/loadbalancingexporter)                     | contrib, K8s               | beta         | development    | beta        |
-| [logicmonitorexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/logicmonitorexporter)                       | contrib                    | alpha        | -              | alpha       |
-| [logzioexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/logzioexporter)                                   | contrib                    | beta         | -              | beta        |
-| [mezmoexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/mezmoexporter)                                     | contrib                    | -            | -              | beta        |
-| [nopexporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/nopexporter)                                                 | contrib, core, K8s         | beta         | beta           | beta        |
-| [opensearchexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/opensearchexporter)                           | contrib                    | alpha        | -              | alpha       |
-| [otelarrowexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/otelarrowexporter)                             | contrib, K8s               | beta         | beta           | beta        |
-| [otlpexporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter)                                               | contrib, core, K8s, otlp   | stable       | stable         | stable      |
-| [otlphttpexporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter)                                       | contrib, core, K8s, otlp   | stable       | stable         | stable      |
-| [prometheusexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusexporter)                           | contrib, core              | -            | beta           | -           |
-| [prometheusremotewriteexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusremotewriteexporter)     | contrib, core              | -            | beta           | -           |
-| [pulsarexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/pulsarexporter)                                   | contrib                    | alpha        | alpha          | alpha       |
-| [rabbitmqexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/rabbitmqexporter)                               | contrib                    | alpha        | alpha          | alpha       |
-| [sematextexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/sematextexporter)                               | contrib                    | -            | development    | development |
-| [sentryexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/sentryexporter)                                   | contrib                    | beta         | -              | -           |
-| [signalfxexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/signalfxexporter)                               | contrib                    | beta         | beta           | beta        |
-| [splunkhecexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/splunkhecexporter)                             | contrib                    | beta         | beta           | beta        |
-| [stefexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/stefexporter)                                       | contrib                    | -            | alpha          | -           |
-| [sumologicexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/sumologicexporter)                             | contrib                    | beta         | beta           | beta        |
-| [syslogexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/syslogexporter)                                   | contrib                    | -            | -              | alpha       |
-| [tencentcloudlogserviceexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/tencentcloudlogserviceexporter)   | contrib                    | -            | -              | beta        |
-| [tinybirdexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/tinybirdexporter)                               | contrib                    | alpha        | alpha          | alpha       |
-| [zipkinexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/zipkinexporter)                                   | contrib, core              | beta         | -              | -           |
-
-⚠️ **注意:** ⚠️ マークが付いているコンポーネントはメンテナンスされておらず、アクティブなコードオーナーがいません。
-それらのコンポーネントは定期的な更新やバグ修正を受け付けていない可能性があります。
+| {{< component-link name="alertmanagerexporter" type="exporter" repo="contrib" >}}              | contrib                  | development  | -            | -            |
+| {{< component-link name="alibabacloudlogserviceexporter" type="exporter" repo="contrib" >}} ⚠️ | contrib                  | unmaintained | unmaintained | unmaintained |
+| {{< component-link name="awscloudwatchlogsexporter" type="exporter" repo="contrib" >}}         | contrib                  | -            | -            | alpha        |
+| {{< component-link name="awsemfexporter" type="exporter" repo="contrib" >}}                    | contrib                  | -            | beta         | -            |
+| {{< component-link name="awskinesisexporter" type="exporter" repo="contrib" >}}                | contrib                  | beta         | beta         | beta         |
+| {{< component-link name="awss3exporter" type="exporter" repo="contrib" >}}                     | contrib                  | alpha        | alpha        | alpha        |
+| {{< component-link name="awsxrayexporter" type="exporter" repo="contrib" >}}                   | contrib                  | beta         | -            | -            |
+| {{< component-link name="azureblobexporter" type="exporter" repo="contrib" >}}                 | contrib                  | alpha        | alpha        | alpha        |
+| {{< component-link name="azuredataexplorerexporter" type="exporter" repo="contrib" >}}         | contrib                  | beta         | beta         | beta         |
+| {{< component-link name="azuremonitorexporter" type="exporter" repo="contrib" >}}              | contrib                  | beta         | beta         | beta         |
+| {{< component-link name="bmchelixexporter" type="exporter" repo="contrib" >}}                  | contrib                  | -            | alpha        | -            |
+| {{< component-link name="cassandraexporter" type="exporter" repo="contrib" >}}                 | contrib                  | alpha        | -            | alpha        |
+| {{< component-link name="clickhouseexporter" type="exporter" repo="contrib" >}}                | contrib                  | beta         | alpha        | beta         |
+| {{< component-link name="coralogixexporter" type="exporter" repo="contrib" >}}                 | contrib                  | beta         | beta         | beta         |
+| {{< component-link name="datadogexporter" type="exporter" repo="contrib" >}}                   | contrib                  | beta         | beta         | beta         |
+| {{< component-link name="datasetexporter" type="exporter" repo="contrib" >}}                   | contrib                  | alpha        | -            | alpha        |
+| {{< component-link name="debugexporter" type="exporter" repo="core" >}}                        | contrib, core, K8s       | alpha        | alpha        | alpha        |
+| {{< component-link name="dorisexporter" type="exporter" repo="contrib" >}}                     | contrib                  | alpha        | alpha        | alpha        |
+| {{< component-link name="elasticsearchexporter" type="exporter" repo="contrib" >}}             | contrib                  | beta         | development  | beta         |
+| {{< component-link name="faroexporter" type="exporter" repo="contrib" >}}                      | contrib                  | alpha        | -            | alpha        |
+| {{< component-link name="fileexporter" type="exporter" repo="contrib" >}}                      | contrib, core, K8s       | alpha        | alpha        | alpha        |
+| {{< component-link name="googlecloudexporter" type="exporter" repo="contrib" >}}               | contrib                  | beta         | beta         | beta         |
+| {{< component-link name="googlecloudpubsubexporter" type="exporter" repo="contrib" >}}         | contrib                  | beta         | beta         | beta         |
+| {{< component-link name="googlecloudstorageexporter" type="exporter" repo="contrib" >}}        | contrib                  | development  | -            | alpha        |
+| {{< component-link name="googlemanagedprometheusexporter" type="exporter" repo="contrib" >}}   | contrib                  | -            | beta         | -            |
+| {{< component-link name="honeycombmarkerexporter" type="exporter" repo="contrib" >}}           | contrib                  | -            | -            | alpha        |
+| {{< component-link name="influxdbexporter" type="exporter" repo="contrib" >}}                  | contrib                  | beta         | beta         | beta         |
+| {{< component-link name="kafkaexporter" type="exporter" repo="contrib" >}}                     | contrib, core            | beta         | beta         | beta         |
+| {{< component-link name="loadbalancingexporter" type="exporter" repo="contrib" >}}             | contrib, K8s             | beta         | development  | beta         |
+| {{< component-link name="logicmonitorexporter" type="exporter" repo="contrib" >}}              | contrib                  | alpha        | -            | alpha        |
+| {{< component-link name="logzioexporter" type="exporter" repo="contrib" >}}                    | contrib                  | beta         | -            | beta         |
+| {{< component-link name="mezmoexporter" type="exporter" repo="contrib" >}}                     | contrib                  | -            | -            | beta         |
+| {{< component-link name="nopexporter" type="exporter" repo="core" >}}                          | contrib, core, K8s       | beta         | beta         | beta         |
+| {{< component-link name="opensearchexporter" type="exporter" repo="contrib" >}}                | contrib                  | alpha        | -            | alpha        |
+| {{< component-link name="otelarrowexporter" type="exporter" repo="contrib" >}}                 | contrib, K8s             | beta         | beta         | beta         |
+| {{< component-link name="otlpexporter" type="exporter" repo="core" >}}                         | contrib, core, K8s, otlp | stable       | stable       | stable       |
+| {{< component-link name="otlphttpexporter" type="exporter" repo="core" >}}                     | contrib, core, K8s, otlp | stable       | stable       | stable       |
+| {{< component-link name="prometheusexporter" type="exporter" repo="contrib" >}}                | contrib, core            | -            | beta         | -            |
+| {{< component-link name="prometheusremotewriteexporter" type="exporter" repo="contrib" >}}     | contrib, core            | -            | beta         | -            |
+| {{< component-link name="pulsarexporter" type="exporter" repo="contrib" >}}                    | contrib                  | alpha        | alpha        | alpha        |
+| {{< component-link name="rabbitmqexporter" type="exporter" repo="contrib" >}}                  | contrib                  | alpha        | alpha        | alpha        |
+| {{< component-link name="sapmexporter" type="exporter" repo="contrib" >}}                      | contrib                  | deprecated   | -            | -            |
+| {{< component-link name="sematextexporter" type="exporter" repo="contrib" >}}                  | contrib                  | -            | development  | development  |
+| {{< component-link name="sentryexporter" type="exporter" repo="contrib" >}}                    | contrib                  | alpha        | -            | alpha        |
+| {{< component-link name="signalfxexporter" type="exporter" repo="contrib" >}}                  | contrib                  | beta         | beta         | beta         |
+| {{< component-link name="splunkhecexporter" type="exporter" repo="contrib" >}}                 | contrib                  | beta         | beta         | beta         |
+| {{< component-link name="stefexporter" type="exporter" repo="contrib" >}}                      | contrib                  | -            | alpha        | -            |
+| {{< component-link name="sumologicexporter" type="exporter" repo="contrib" >}}                 | contrib                  | beta         | beta         | beta         |
+| {{< component-link name="syslogexporter" type="exporter" repo="contrib" >}}                    | contrib                  | -            | -            | alpha        |
+| {{< component-link name="tencentcloudlogserviceexporter" type="exporter" repo="contrib" >}}    | contrib                  | -            | -            | beta         |
+| {{< component-link name="tinybirdexporter" type="exporter" repo="contrib" >}}                  | contrib                  | alpha        | alpha        | alpha        |
+| {{< component-link name="zipkinexporter" type="exporter" repo="contrib" >}}                    | contrib, core            | beta         | -            | -            |
 
 [^1]: このコンポーネントが含まれている[ディストリビューション](/docs/collector/distributions/)（core、contrib、K8sなど）を示します。
 
 [^2]: コンポーネントの安定性レベルの詳細については、[OpenTelemetry Collectorコンポーネントの安定性の定義](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md)を参照してください。
 
-<!-- END GENERATED: exporter-table -->
+<!-- END GENERATED: exporter-table SOURCE: scripts/collector-sync -->

--- a/content/ja/docs/collector/components/extension.md
+++ b/content/ja/docs/collector/components/extension.md
@@ -2,7 +2,7 @@
 title: エクステンション
 description: OpenTelemetry Collectorで利用可能なエクステンションの一覧
 weight: 350
-default_lang_commit: 1c2b0563e8e66ef0952c442e3662e4bec18a8762
+default_lang_commit: 1c2b0563e8e66ef0952c442e3662e4bec18a8762 # patched
 drifted_from_default: true
 # prettier-ignore
 cSpell:ignore: ackextension asapauthextension authextension awsproxy azureauthextension basicauthextension bearertokenauthextension cgroupruntimeextension clientauthextension datadogextension googleclientauthextension headerssetterextension healthcheckextension healthcheckv httpforwarderextension jaegerremotesampling memorylimiterextension oidcauthextension opampextension pprofextension remotetapextension sigv sleaderelector solarwindsapmsettingsextension sumologicextension zpagesextension
@@ -11,41 +11,93 @@ cSpell:ignore: ackextension asapauthextension authextension awsproxy azureauthex
 エクステンションは、ヘルスチェックやサービスディスカバリーなどの追加機能を提供します。
 エクステンションの詳細な設定方法については、[Collectorの設定ドキュメント](/docs/collector/configuration/#extensions)を参照してください。
 
-<!-- BEGIN GENERATED: extension-table -->
+<!-- BEGIN GENERATED: extension-table SOURCE: scripts/collector-sync -->
 
 | 名前                                                                                                                                                   | ディストリビューション[^1] | 安定性[^2]  |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- | ----------- |
-| [ackextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/ackextension)                                     | contrib, K8s               | alpha       |
-| [asapauthextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/asapauthextension)                           | contrib                    | beta        |
-| [awsproxy](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/awsproxy)                                             | contrib                    | beta        |
-| [azureauthextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/azureauthextension)                         | contrib                    | alpha       |
-| [basicauthextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/basicauthextension)                         | contrib, K8s               | beta        |
-| [bearertokenauthextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/bearertokenauthextension)             | contrib, K8s               | beta        |
-| [cgroupruntimeextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/cgroupruntimeextension)                 | contrib                    | alpha       |
-| [datadogextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/datadogextension)                             | contrib                    | alpha       |
-| [googleclientauthextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/googleclientauthextension)           | contrib                    | beta        |
-| [headerssetterextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/headerssetterextension)                 | contrib, K8s               | alpha       |
-| [healthcheckextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckextension)                     | contrib, core, K8s         | alpha       |
-| [healthcheckv2extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckv2extension)                 | contrib                    | development |
-| [httpforwarderextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/httpforwarderextension)                 | contrib, K8s               | beta        |
-| [jaegerremotesampling](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/jaegerremotesampling)                     | contrib                    | alpha       |
-| [k8sleaderelector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/k8sleaderelector)                             | contrib, K8s               | alpha       |
-| [memorylimiterextension](https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/memorylimiterextension)                         | contrib                    | development |
-| [oauth2clientauthextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/oauth2clientauthextension)           | contrib, K8s               | beta        |
-| [oidcauthextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/oidcauthextension)                           | contrib, K8s               | beta        |
-| [opampextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/opampextension)                                 | contrib, K8s               | alpha       |
-| [pprofextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/pprofextension)                                 | contrib, core, K8s         | beta        |
-| [remotetapextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/remotetapextension)                         | contrib                    | development |
-| [sigv4authextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/sigv4authextension)                         | contrib                    | beta        |
-| [solarwindsapmsettingsextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/solarwindsapmsettingsextension) | contrib                    | development |
-| [sumologicextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/sumologicextension)                         | contrib                    | alpha       |
-| [zpagesextension](https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/zpagesextension)                                       | contrib, core, K8s         | beta        |
+| {{< component-link name="ackextension" type="extension" repo="contrib" >}}                   | contrib, K8s       | alpha         |
+| {{< component-link name="asapauthextension" type="extension" repo="contrib" >}}              | contrib            | beta          |
+| {{< component-link name="awsproxy" type="extension" repo="contrib" >}}                       | contrib            | beta          |
+| {{< component-link name="azureauthextension" type="extension" repo="contrib" >}}             | contrib            | alpha         |
+| {{< component-link name="basicauthextension" type="extension" repo="contrib" >}}             | contrib, K8s       | beta          |
+| {{< component-link name="bearertokenauthextension" type="extension" repo="contrib" >}}       | contrib, K8s       | beta          |
+| {{< component-link name="cgroupruntimeextension" type="extension" repo="contrib" >}}         | contrib            | alpha         |
+| {{< component-link name="datadogextension" type="extension" repo="contrib" >}}               | contrib            | alpha         |
+| {{< component-link name="googleclientauthextension" type="extension" repo="contrib" >}}      | contrib            | beta          |
+| {{< component-link name="headerssetterextension" type="extension" repo="contrib" >}}         | contrib, K8s       | alpha         |
+| {{< component-link name="healthcheckextension" type="extension" repo="contrib" >}}           | contrib, core, K8s | alpha         |
+| {{< component-link name="healthcheckv2extension" type="extension" repo="contrib" >}}         | contrib            | development   |
+| {{< component-link name="httpforwarderextension" type="extension" repo="contrib" >}}         | contrib, K8s       | beta          |
+| {{< component-link name="jaegerremotesampling" type="extension" repo="contrib" >}}           | contrib            | alpha         |
+| {{< component-link name="k8sleaderelector" type="extension" repo="contrib" >}}               | contrib, K8s       | alpha         |
+| {{< component-link name="memorylimiterextension" type="extension" repo="core" >}}            | core               | development   |
+| {{< component-link name="oauth2clientauthextension" type="extension" repo="contrib" >}}      | contrib, K8s       | beta          |
+| {{< component-link name="oidcauthextension" type="extension" repo="contrib" >}}              | contrib, K8s       | beta          |
+| {{< component-link name="opampextension" type="extension" repo="contrib" >}}                 | contrib, K8s       | alpha         |
+| {{< component-link name="pprofextension" type="extension" repo="contrib" >}}                 | contrib, core, K8s | beta          |
+| {{< component-link name="remotetapextension" type="extension" repo="contrib" >}}             | contrib            | development   |
+| {{< component-link name="sigv4authextension" type="extension" repo="contrib" >}}             | contrib            | beta          |
+| {{< component-link name="solarwindsapmsettingsextension" type="extension" repo="contrib" >}} | contrib            | development   |
+| {{< component-link name="sumologicextension" type="extension" repo="contrib" >}}             | contrib            | alpha         |
+| {{< component-link name="zpagesextension" type="extension" repo="core" >}}                   | contrib, core, K8s | beta          |
 
-⚠️ **注意:** ⚠️ マークが付いているコンポーネントはメンテナンスされておらず、アクティブなコードオーナーがいません。
-それらのコンポーネントは定期的な更新やバグ修正を受け付けていない可能性があります。
+<!-- END GENERATED: extension-table SOURCE: scripts/collector-sync -->
 
-[^1]: このコンポーネントが含まれている[ディストリビューション](/docs/collector/distributions/)（core、contrib、K8sなど）を示します。
+## Encoding Extensions
 
-[^2]: コンポーネントの安定性レベルの詳細については、[OpenTelemetry Collectorコンポーネントの安定性の定義](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md)を参照してください。
+<!-- BEGIN GENERATED: extension-encoding-table SOURCE: scripts/collector-sync -->
 
-<!-- END GENERATED: extension-table -->
+| Name                                                                                                                         | Distributions[^1] | Stability[^2] |
+| ---------------------------------------------------------------------------------------------------------------------------- | ----------------- | ------------- |
+| {{< component-link name="avrologencodingextension" type="extension" repo="contrib" subtype="encoding" >}}                    | contrib           | development   |
+| {{< component-link name="awscloudwatchmetricstreamsencodingextension" type="extension" repo="contrib" subtype="encoding" >}} | contrib           | alpha         |
+| {{< component-link name="awslogsencodingextension" type="extension" repo="contrib" subtype="encoding" >}}                    | contrib           | alpha         |
+| {{< component-link name="azureencodingextension" type="extension" repo="contrib" subtype="encoding" >}}                      | contrib           | development   |
+| {{< component-link name="googlecloudlogentryencodingextension" type="extension" repo="contrib" subtype="encoding" >}}        | contrib           | alpha         |
+| {{< component-link name="jaegerencodingextension" type="extension" repo="contrib" subtype="encoding" >}}                     | contrib           | alpha         |
+| {{< component-link name="jsonlogencodingextension" type="extension" repo="contrib" subtype="encoding" >}}                    | contrib           | alpha         |
+| {{< component-link name="otlpencodingextension" type="extension" repo="contrib" subtype="encoding" >}}                       | contrib           | beta          |
+| {{< component-link name="skywalkingencodingextension" type="extension" repo="contrib" subtype="encoding" >}}                 | contrib           | alpha         |
+| {{< component-link name="textencodingextension" type="extension" repo="contrib" subtype="encoding" >}}                       | contrib           | beta          |
+| {{< component-link name="zipkinencodingextension" type="extension" repo="contrib" subtype="encoding" >}}                     | contrib           | alpha         |
+
+<!-- END GENERATED: extension-encoding-table SOURCE: scripts/collector-sync -->
+
+## Observer Extensions
+
+<!-- BEGIN GENERATED: extension-observer-table SOURCE: scripts/collector-sync -->
+
+| Name                                                                                                 | Distributions[^1] | Stability[^2] |
+| ---------------------------------------------------------------------------------------------------- | ----------------- | ------------- |
+| {{< component-link name="cfgardenobserver" type="extension" repo="contrib" subtype="observer" >}}    | contrib           | alpha         |
+| {{< component-link name="dockerobserver" type="extension" repo="contrib" subtype="observer" >}}      | contrib           | beta          |
+| {{< component-link name="ecsobserver" type="extension" repo="contrib" subtype="observer" >}}         | contrib           | beta          |
+| {{< component-link name="hostobserver" type="extension" repo="contrib" subtype="observer" >}}        | contrib, K8s      | beta          |
+| {{< component-link name="k8sobserver" type="extension" repo="contrib" subtype="observer" >}}         | contrib, K8s      | alpha         |
+| {{< component-link name="kafkatopicsobserver" type="extension" repo="contrib" subtype="observer" >}} | contrib           | alpha         |
+
+<!-- END GENERATED: extension-observer-table SOURCE: scripts/collector-sync -->
+
+## Storage Extensions
+
+<!-- BEGIN GENERATED: extension-storage-table SOURCE: scripts/collector-sync -->
+
+| Name                                                                                                  | Distributions[^1] | Stability[^2] |
+| ----------------------------------------------------------------------------------------------------- | ----------------- | ------------- |
+| {{< component-link name="dbstorage" type="extension" repo="contrib" subtype="storage" >}}             | contrib           | alpha         |
+| {{< component-link name="filestorage" type="extension" repo="contrib" subtype="storage" >}}           | contrib, K8s      | beta          |
+| {{< component-link name="redisstorageextension" type="extension" repo="contrib" subtype="storage" >}} | contrib           | alpha         |
+
+<!-- END GENERATED: extension-storage-table SOURCE: scripts/collector-sync -->
+
+<!-- BEGIN GENERATED: extension-footnotes-table SOURCE: scripts/collector-sync -->
+
+[^1]:
+    Shows which [distributions](/docs/collector/distributions/) (core, contrib,
+    K8s, etc.) include this component.
+
+[^2]:
+    For details about component stability levels, see the
+    [OpenTelemetry Collector component stability definitions](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md).
+
+<!-- END GENERATED: extension-footnotes-table SOURCE: scripts/collector-sync -->

--- a/content/ja/docs/collector/components/extension.md
+++ b/content/ja/docs/collector/components/extension.md
@@ -13,33 +13,33 @@ cSpell:ignore: ackextension asapauthextension authextension awsproxy azureauthex
 
 <!-- BEGIN GENERATED: extension-table SOURCE: scripts/collector-sync -->
 
-| 名前                                                                                                                                                   | ディストリビューション[^1] | 安定性[^2]  |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- | ----------- |
-| {{< component-link name="ackextension" type="extension" repo="contrib" >}}                   | contrib, K8s       | alpha         |
-| {{< component-link name="asapauthextension" type="extension" repo="contrib" >}}              | contrib            | beta          |
-| {{< component-link name="awsproxy" type="extension" repo="contrib" >}}                       | contrib            | beta          |
-| {{< component-link name="azureauthextension" type="extension" repo="contrib" >}}             | contrib            | alpha         |
-| {{< component-link name="basicauthextension" type="extension" repo="contrib" >}}             | contrib, K8s       | beta          |
-| {{< component-link name="bearertokenauthextension" type="extension" repo="contrib" >}}       | contrib, K8s       | beta          |
-| {{< component-link name="cgroupruntimeextension" type="extension" repo="contrib" >}}         | contrib            | alpha         |
-| {{< component-link name="datadogextension" type="extension" repo="contrib" >}}               | contrib            | alpha         |
-| {{< component-link name="googleclientauthextension" type="extension" repo="contrib" >}}      | contrib            | beta          |
-| {{< component-link name="headerssetterextension" type="extension" repo="contrib" >}}         | contrib, K8s       | alpha         |
-| {{< component-link name="healthcheckextension" type="extension" repo="contrib" >}}           | contrib, core, K8s | alpha         |
-| {{< component-link name="healthcheckv2extension" type="extension" repo="contrib" >}}         | contrib            | development   |
-| {{< component-link name="httpforwarderextension" type="extension" repo="contrib" >}}         | contrib, K8s       | beta          |
-| {{< component-link name="jaegerremotesampling" type="extension" repo="contrib" >}}           | contrib            | alpha         |
-| {{< component-link name="k8sleaderelector" type="extension" repo="contrib" >}}               | contrib, K8s       | alpha         |
-| {{< component-link name="memorylimiterextension" type="extension" repo="core" >}}            | core               | development   |
-| {{< component-link name="oauth2clientauthextension" type="extension" repo="contrib" >}}      | contrib, K8s       | beta          |
-| {{< component-link name="oidcauthextension" type="extension" repo="contrib" >}}              | contrib, K8s       | beta          |
-| {{< component-link name="opampextension" type="extension" repo="contrib" >}}                 | contrib, K8s       | alpha         |
-| {{< component-link name="pprofextension" type="extension" repo="contrib" >}}                 | contrib, core, K8s | beta          |
-| {{< component-link name="remotetapextension" type="extension" repo="contrib" >}}             | contrib            | development   |
-| {{< component-link name="sigv4authextension" type="extension" repo="contrib" >}}             | contrib            | beta          |
-| {{< component-link name="solarwindsapmsettingsextension" type="extension" repo="contrib" >}} | contrib            | development   |
-| {{< component-link name="sumologicextension" type="extension" repo="contrib" >}}             | contrib            | alpha         |
-| {{< component-link name="zpagesextension" type="extension" repo="core" >}}                   | contrib, core, K8s | beta          |
+| 名前                                                                                         | ディストリビューション[^1] | 安定性[^2]  |
+| -------------------------------------------------------------------------------------------- | -------------------------- | ----------- |
+| {{< component-link name="ackextension" type="extension" repo="contrib" >}}                   | contrib, K8s               | alpha       |
+| {{< component-link name="asapauthextension" type="extension" repo="contrib" >}}              | contrib                    | beta        |
+| {{< component-link name="awsproxy" type="extension" repo="contrib" >}}                       | contrib                    | beta        |
+| {{< component-link name="azureauthextension" type="extension" repo="contrib" >}}             | contrib                    | alpha       |
+| {{< component-link name="basicauthextension" type="extension" repo="contrib" >}}             | contrib, K8s               | beta        |
+| {{< component-link name="bearertokenauthextension" type="extension" repo="contrib" >}}       | contrib, K8s               | beta        |
+| {{< component-link name="cgroupruntimeextension" type="extension" repo="contrib" >}}         | contrib                    | alpha       |
+| {{< component-link name="datadogextension" type="extension" repo="contrib" >}}               | contrib                    | alpha       |
+| {{< component-link name="googleclientauthextension" type="extension" repo="contrib" >}}      | contrib                    | beta        |
+| {{< component-link name="headerssetterextension" type="extension" repo="contrib" >}}         | contrib, K8s               | alpha       |
+| {{< component-link name="healthcheckextension" type="extension" repo="contrib" >}}           | contrib, core, K8s         | alpha       |
+| {{< component-link name="healthcheckv2extension" type="extension" repo="contrib" >}}         | contrib                    | development |
+| {{< component-link name="httpforwarderextension" type="extension" repo="contrib" >}}         | contrib, K8s               | beta        |
+| {{< component-link name="jaegerremotesampling" type="extension" repo="contrib" >}}           | contrib                    | alpha       |
+| {{< component-link name="k8sleaderelector" type="extension" repo="contrib" >}}               | contrib, K8s               | alpha       |
+| {{< component-link name="memorylimiterextension" type="extension" repo="core" >}}            | core                       | development |
+| {{< component-link name="oauth2clientauthextension" type="extension" repo="contrib" >}}      | contrib, K8s               | beta        |
+| {{< component-link name="oidcauthextension" type="extension" repo="contrib" >}}              | contrib, K8s               | beta        |
+| {{< component-link name="opampextension" type="extension" repo="contrib" >}}                 | contrib, K8s               | alpha       |
+| {{< component-link name="pprofextension" type="extension" repo="contrib" >}}                 | contrib, core, K8s         | beta        |
+| {{< component-link name="remotetapextension" type="extension" repo="contrib" >}}             | contrib                    | development |
+| {{< component-link name="sigv4authextension" type="extension" repo="contrib" >}}             | contrib                    | beta        |
+| {{< component-link name="solarwindsapmsettingsextension" type="extension" repo="contrib" >}} | contrib                    | development |
+| {{< component-link name="sumologicextension" type="extension" repo="contrib" >}}             | contrib                    | alpha       |
+| {{< component-link name="zpagesextension" type="extension" repo="core" >}}                   | contrib, core, K8s         | beta        |
 
 <!-- END GENERATED: extension-table SOURCE: scripts/collector-sync -->
 

--- a/content/ja/docs/collector/components/processor.md
+++ b/content/ja/docs/collector/components/processor.md
@@ -13,41 +13,41 @@ cSpell:ignore: attributesprocessor batchprocessor coralogixprocessor cumulativet
 
 <!-- BEGIN GENERATED: processor-table SOURCE: scripts/collector-sync -->
 
-| 名前                                                                                                                                                 | ディストリビューション[^1] | トレース[^2] | メトリクス[^2] | ログ[^2]    |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | ------------ | -------------- | ----------- |
-| {{< component-link name="attributesprocessor" type="processor" repo="contrib" >}}           | contrib, core, K8s | beta        | beta        | beta        |
-| {{< component-link name="batchprocessor" type="processor" repo="core" >}}                   | contrib, core, K8s | beta        | beta        | beta        |
-| {{< component-link name="coralogixprocessor" type="processor" repo="contrib" >}}            | contrib            | alpha       | -           | -           |
-| {{< component-link name="cumulativetodeltaprocessor" type="processor" repo="contrib" >}}    | contrib, K8s       | -           | beta        | -           |
-| {{< component-link name="datadogsemanticsprocessor" type="processor" repo="contrib" >}}     | contrib            | deprecated  | -           | -           |
-| {{< component-link name="deltatocumulativeprocessor" type="processor" repo="contrib" >}}    | contrib, K8s       | -           | alpha       | -           |
-| {{< component-link name="deltatorateprocessor" type="processor" repo="contrib" >}}          | contrib, K8s       | -           | alpha       | -           |
-| {{< component-link name="dnslookupprocessor" type="processor" repo="contrib" >}}            | contrib            | development | development | development |
-| {{< component-link name="filterprocessor" type="processor" repo="contrib" >}}               | contrib, core, K8s | alpha       | alpha       | alpha       |
-| {{< component-link name="geoipprocessor" type="processor" repo="contrib" >}}                | contrib            | alpha       | alpha       | alpha       |
-| {{< component-link name="groupbyattrsprocessor" type="processor" repo="contrib" >}}         | contrib, K8s       | beta        | beta        | beta        |
-| {{< component-link name="groupbytraceprocessor" type="processor" repo="contrib" >}}         | contrib, K8s       | beta        | -           | -           |
-| {{< component-link name="intervalprocessor" type="processor" repo="contrib" >}}             | contrib, K8s       | -           | alpha       | -           |
-| {{< component-link name="isolationforestprocessor" type="processor" repo="contrib" >}}      | contrib            | alpha       | alpha       | alpha       |
-| {{< component-link name="k8sattributesprocessor" type="processor" repo="contrib" >}}        | contrib, K8s       | beta        | beta        | beta        |
-| {{< component-link name="logdedupprocessor" type="processor" repo="contrib" >}}             | contrib, K8s       | -           | -           | alpha       |
-| {{< component-link name="logstransformprocessor" type="processor" repo="contrib" >}}        | contrib            | -           | -           | development |
-| {{< component-link name="lookupprocessor" type="processor" repo="contrib" >}}               | contrib            | -           | -           | development |
-| {{< component-link name="memorylimiterprocessor" type="processor" repo="core" >}}           | contrib, core, K8s | beta        | beta        | beta        |
-| {{< component-link name="metricsgenerationprocessor" type="processor" repo="contrib" >}}    | contrib            | -           | alpha       | -           |
-| {{< component-link name="metricstarttimeprocessor" type="processor" repo="contrib" >}}      | contrib            | -           | beta        | -           |
-| {{< component-link name="metricstransformprocessor" type="processor" repo="contrib" >}}     | contrib, K8s       | -           | beta        | -           |
-| {{< component-link name="probabilisticsamplerprocessor" type="processor" repo="contrib" >}} | contrib, core, K8s | beta        | -           | alpha       |
-| {{< component-link name="redactionprocessor" type="processor" repo="contrib" >}}            | contrib, K8s       | beta        | alpha       | alpha       |
-| {{< component-link name="remotetapprocessor" type="processor" repo="contrib" >}}            | contrib, K8s       | alpha       | alpha       | alpha       |
-| {{< component-link name="resourcedetectionprocessor" type="processor" repo="contrib" >}}    | contrib, K8s       | beta        | beta        | beta        |
-| {{< component-link name="resourceprocessor" type="processor" repo="contrib" >}}             | contrib, core, K8s | beta        | beta        | beta        |
-| {{< component-link name="schemaprocessor" type="processor" repo="contrib" >}}               | contrib            | development | development | development |
-| {{< component-link name="spanprocessor" type="processor" repo="contrib" >}}                 | contrib, core      | alpha       | -           | -           |
-| {{< component-link name="sumologicprocessor" type="processor" repo="contrib" >}}            | contrib            | beta        | beta        | beta        |
-| {{< component-link name="tailsamplingprocessor" type="processor" repo="contrib" >}}         | contrib, K8s       | beta        | -           | -           |
-| {{< component-link name="transformprocessor" type="processor" repo="contrib" >}}            | contrib, K8s       | beta        | beta        | beta        |
-| {{< component-link name="unrollprocessor" type="processor" repo="contrib" >}}               | contrib            | -           | -           | alpha       |
+| 名前                                                                                        | ディストリビューション[^1] | トレース[^2] | メトリクス[^2] | ログ[^2]    |
+| ------------------------------------------------------------------------------------------- | -------------------------- | ------------ | -------------- | ----------- |
+| {{< component-link name="attributesprocessor" type="processor" repo="contrib" >}}           | contrib, core, K8s         | beta         | beta           | beta        |
+| {{< component-link name="batchprocessor" type="processor" repo="core" >}}                   | contrib, core, K8s         | beta         | beta           | beta        |
+| {{< component-link name="coralogixprocessor" type="processor" repo="contrib" >}}            | contrib                    | alpha        | -              | -           |
+| {{< component-link name="cumulativetodeltaprocessor" type="processor" repo="contrib" >}}    | contrib, K8s               | -            | beta           | -           |
+| {{< component-link name="datadogsemanticsprocessor" type="processor" repo="contrib" >}}     | contrib                    | deprecated   | -              | -           |
+| {{< component-link name="deltatocumulativeprocessor" type="processor" repo="contrib" >}}    | contrib, K8s               | -            | alpha          | -           |
+| {{< component-link name="deltatorateprocessor" type="processor" repo="contrib" >}}          | contrib, K8s               | -            | alpha          | -           |
+| {{< component-link name="dnslookupprocessor" type="processor" repo="contrib" >}}            | contrib                    | development  | development    | development |
+| {{< component-link name="filterprocessor" type="processor" repo="contrib" >}}               | contrib, core, K8s         | alpha        | alpha          | alpha       |
+| {{< component-link name="geoipprocessor" type="processor" repo="contrib" >}}                | contrib                    | alpha        | alpha          | alpha       |
+| {{< component-link name="groupbyattrsprocessor" type="processor" repo="contrib" >}}         | contrib, K8s               | beta         | beta           | beta        |
+| {{< component-link name="groupbytraceprocessor" type="processor" repo="contrib" >}}         | contrib, K8s               | beta         | -              | -           |
+| {{< component-link name="intervalprocessor" type="processor" repo="contrib" >}}             | contrib, K8s               | -            | alpha          | -           |
+| {{< component-link name="isolationforestprocessor" type="processor" repo="contrib" >}}      | contrib                    | alpha        | alpha          | alpha       |
+| {{< component-link name="k8sattributesprocessor" type="processor" repo="contrib" >}}        | contrib, K8s               | beta         | beta           | beta        |
+| {{< component-link name="logdedupprocessor" type="processor" repo="contrib" >}}             | contrib, K8s               | -            | -              | alpha       |
+| {{< component-link name="logstransformprocessor" type="processor" repo="contrib" >}}        | contrib                    | -            | -              | development |
+| {{< component-link name="lookupprocessor" type="processor" repo="contrib" >}}               | contrib                    | -            | -              | development |
+| {{< component-link name="memorylimiterprocessor" type="processor" repo="core" >}}           | contrib, core, K8s         | beta         | beta           | beta        |
+| {{< component-link name="metricsgenerationprocessor" type="processor" repo="contrib" >}}    | contrib                    | -            | alpha          | -           |
+| {{< component-link name="metricstarttimeprocessor" type="processor" repo="contrib" >}}      | contrib                    | -            | beta           | -           |
+| {{< component-link name="metricstransformprocessor" type="processor" repo="contrib" >}}     | contrib, K8s               | -            | beta           | -           |
+| {{< component-link name="probabilisticsamplerprocessor" type="processor" repo="contrib" >}} | contrib, core, K8s         | beta         | -              | alpha       |
+| {{< component-link name="redactionprocessor" type="processor" repo="contrib" >}}            | contrib, K8s               | beta         | alpha          | alpha       |
+| {{< component-link name="remotetapprocessor" type="processor" repo="contrib" >}}            | contrib, K8s               | alpha        | alpha          | alpha       |
+| {{< component-link name="resourcedetectionprocessor" type="processor" repo="contrib" >}}    | contrib, K8s               | beta         | beta           | beta        |
+| {{< component-link name="resourceprocessor" type="processor" repo="contrib" >}}             | contrib, core, K8s         | beta         | beta           | beta        |
+| {{< component-link name="schemaprocessor" type="processor" repo="contrib" >}}               | contrib                    | development  | development    | development |
+| {{< component-link name="spanprocessor" type="processor" repo="contrib" >}}                 | contrib, core              | alpha        | -              | -           |
+| {{< component-link name="sumologicprocessor" type="processor" repo="contrib" >}}            | contrib                    | beta         | beta           | beta        |
+| {{< component-link name="tailsamplingprocessor" type="processor" repo="contrib" >}}         | contrib, K8s               | beta         | -              | -           |
+| {{< component-link name="transformprocessor" type="processor" repo="contrib" >}}            | contrib, K8s               | beta         | beta           | beta        |
+| {{< component-link name="unrollprocessor" type="processor" repo="contrib" >}}               | contrib                    | -            | -              | alpha       |
 
 [^1]: このコンポーネントが含まれている[ディストリビューション](/docs/collector/distributions/)（core、contrib、K8sなど）を示します。
 

--- a/content/ja/docs/collector/components/processor.md
+++ b/content/ja/docs/collector/components/processor.md
@@ -2,7 +2,7 @@
 title: プロセッサー
 description: OpenTelemetry Collectorで利用可能なプロセッサーの一覧
 weight: 320
-default_lang_commit: 1c2b0563e8e66ef0952c442e3662e4bec18a8762
+default_lang_commit: 1c2b0563e8e66ef0952c442e3662e4bec18a8762 # patched
 drifted_from_default: true
 # prettier-ignore
 cSpell:ignore: attributesprocessor batchprocessor coralogixprocessor cumulativetodeltaprocessor datadogsemanticsprocessor deltatocumulativeprocessor deltatorateprocessor dnslookupprocessor filterprocessor geoipprocessor groupbyattrsprocessor groupbytraceprocessor intervalprocessor isolationforestprocessor logdedupprocessor logstransformprocessor memorylimiterprocessor metricsgenerationprocessor metricstarttimeprocessor metricstransformprocessor probabilisticsamplerprocessor redactionprocessor remotetapprocessor resourcedetectionprocessor resourceprocessor sattributesprocessor schemaprocessor spanprocessor sumologicprocessor tailsamplingprocessor transformprocessor unrollprocessor xprocessor
@@ -11,48 +11,46 @@ cSpell:ignore: attributesprocessor batchprocessor coralogixprocessor cumulativet
 プロセッサーは、パイプラインを通過するテレメトリーデータを変換、フィルタリング、強化します。
 プロセッサーの詳細な設定方法については、[Collectorの設定ドキュメント](/docs/collector/configuration/#processors)を参照してください。
 
-<!-- BEGIN GENERATED: processor-table -->
+<!-- BEGIN GENERATED: processor-table SOURCE: scripts/collector-sync -->
 
 | 名前                                                                                                                                                 | ディストリビューション[^1] | トレース[^2] | メトリクス[^2] | ログ[^2]    |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | ------------ | -------------- | ----------- |
-| [attributesprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/attributesprocessor)                     | contrib, core, K8s         | beta         | beta           | beta        |
-| [batchprocessor](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor)                                       | contrib, core, K8s         | beta         | beta           | beta        |
-| [coralogixprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/coralogixprocessor)                       | contrib                    | alpha        | -              | -           |
-| [cumulativetodeltaprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/cumulativetodeltaprocessor)       | contrib, K8s               | -            | beta           | -           |
-| [datadogsemanticsprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/datadogsemanticsprocessor)         | contrib                    | development  | -              | -           |
-| [deltatocumulativeprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/deltatocumulativeprocessor)       | contrib, K8s               | -            | alpha          | -           |
-| [deltatorateprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/deltatorateprocessor)                   | contrib, K8s               | -            | alpha          | -           |
-| [dnslookupprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/dnslookupprocessor)                       | contrib                    | development  | development    | development |
-| [filterprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor)                             | contrib, core, K8s         | alpha        | alpha          | alpha       |
-| [geoipprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/geoipprocessor)                               | contrib                    | alpha        | alpha          | alpha       |
-| [groupbyattrsprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/groupbyattrsprocessor)                 | contrib, K8s               | beta         | beta           | beta        |
-| [groupbytraceprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/groupbytraceprocessor)                 | contrib, K8s               | beta         | -              | -           |
-| [intervalprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/intervalprocessor)                         | contrib, K8s               | -            | alpha          | -           |
-| [isolationforestprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/isolationforestprocessor)           | contrib                    | alpha        | alpha          | alpha       |
-| [k8sattributesprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor)               | contrib, K8s               | beta         | beta           | beta        |
-| [logdedupprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/logdedupprocessor)                         | contrib, K8s               | -            | -              | alpha       |
-| [logstransformprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/logstransformprocessor)               | contrib                    | -            | -              | development |
-| [memorylimiterprocessor](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor)                       | contrib, core, K8s         | beta         | beta           | beta        |
-| [metricsgenerationprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricsgenerationprocessor)       | contrib                    | -            | alpha          | -           |
-| [metricstarttimeprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstarttimeprocessor)           | contrib                    | -            | beta           | -           |
-| [metricstransformprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor)         | contrib, K8s               | -            | beta           | -           |
-| [probabilisticsamplerprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/probabilisticsamplerprocessor) | contrib, core, K8s         | beta         | -              | alpha       |
-| [redactionprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/redactionprocessor)                       | contrib, K8s               | beta         | alpha          | alpha       |
-| [remotetapprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/remotetapprocessor)                       | contrib, K8s               | alpha        | alpha          | alpha       |
-| [resourcedetectionprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor)       | contrib, K8s               | beta         | beta           | beta        |
-| [resourceprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourceprocessor)                         | contrib, core, K8s         | beta         | beta           | beta        |
-| [schemaprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/schemaprocessor)                             | contrib                    | development  | development    | development |
-| [spanprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/spanprocessor)                                 | contrib, core              | alpha        | -              | -           |
-| [sumologicprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/sumologicprocessor)                       | contrib                    | beta         | beta           | beta        |
-| [tailsamplingprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor)                 | contrib, K8s               | beta         | -              | -           |
-| [transformprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor)                       | contrib, K8s               | beta         | beta           | beta        |
-| [unrollprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/unrollprocessor)                             | contrib                    | -            | -              | alpha       |
-
-⚠️ **注意:** ⚠️ マークが付いているコンポーネントはメンテナンスされておらず、アクティブなコードオーナーがいません。
-それらのコンポーネントは定期的な更新やバグ修正を受け付けていない可能性があります。
+| {{< component-link name="attributesprocessor" type="processor" repo="contrib" >}}           | contrib, core, K8s | beta        | beta        | beta        |
+| {{< component-link name="batchprocessor" type="processor" repo="core" >}}                   | contrib, core, K8s | beta        | beta        | beta        |
+| {{< component-link name="coralogixprocessor" type="processor" repo="contrib" >}}            | contrib            | alpha       | -           | -           |
+| {{< component-link name="cumulativetodeltaprocessor" type="processor" repo="contrib" >}}    | contrib, K8s       | -           | beta        | -           |
+| {{< component-link name="datadogsemanticsprocessor" type="processor" repo="contrib" >}}     | contrib            | deprecated  | -           | -           |
+| {{< component-link name="deltatocumulativeprocessor" type="processor" repo="contrib" >}}    | contrib, K8s       | -           | alpha       | -           |
+| {{< component-link name="deltatorateprocessor" type="processor" repo="contrib" >}}          | contrib, K8s       | -           | alpha       | -           |
+| {{< component-link name="dnslookupprocessor" type="processor" repo="contrib" >}}            | contrib            | development | development | development |
+| {{< component-link name="filterprocessor" type="processor" repo="contrib" >}}               | contrib, core, K8s | alpha       | alpha       | alpha       |
+| {{< component-link name="geoipprocessor" type="processor" repo="contrib" >}}                | contrib            | alpha       | alpha       | alpha       |
+| {{< component-link name="groupbyattrsprocessor" type="processor" repo="contrib" >}}         | contrib, K8s       | beta        | beta        | beta        |
+| {{< component-link name="groupbytraceprocessor" type="processor" repo="contrib" >}}         | contrib, K8s       | beta        | -           | -           |
+| {{< component-link name="intervalprocessor" type="processor" repo="contrib" >}}             | contrib, K8s       | -           | alpha       | -           |
+| {{< component-link name="isolationforestprocessor" type="processor" repo="contrib" >}}      | contrib            | alpha       | alpha       | alpha       |
+| {{< component-link name="k8sattributesprocessor" type="processor" repo="contrib" >}}        | contrib, K8s       | beta        | beta        | beta        |
+| {{< component-link name="logdedupprocessor" type="processor" repo="contrib" >}}             | contrib, K8s       | -           | -           | alpha       |
+| {{< component-link name="logstransformprocessor" type="processor" repo="contrib" >}}        | contrib            | -           | -           | development |
+| {{< component-link name="lookupprocessor" type="processor" repo="contrib" >}}               | contrib            | -           | -           | development |
+| {{< component-link name="memorylimiterprocessor" type="processor" repo="core" >}}           | contrib, core, K8s | beta        | beta        | beta        |
+| {{< component-link name="metricsgenerationprocessor" type="processor" repo="contrib" >}}    | contrib            | -           | alpha       | -           |
+| {{< component-link name="metricstarttimeprocessor" type="processor" repo="contrib" >}}      | contrib            | -           | beta        | -           |
+| {{< component-link name="metricstransformprocessor" type="processor" repo="contrib" >}}     | contrib, K8s       | -           | beta        | -           |
+| {{< component-link name="probabilisticsamplerprocessor" type="processor" repo="contrib" >}} | contrib, core, K8s | beta        | -           | alpha       |
+| {{< component-link name="redactionprocessor" type="processor" repo="contrib" >}}            | contrib, K8s       | beta        | alpha       | alpha       |
+| {{< component-link name="remotetapprocessor" type="processor" repo="contrib" >}}            | contrib, K8s       | alpha       | alpha       | alpha       |
+| {{< component-link name="resourcedetectionprocessor" type="processor" repo="contrib" >}}    | contrib, K8s       | beta        | beta        | beta        |
+| {{< component-link name="resourceprocessor" type="processor" repo="contrib" >}}             | contrib, core, K8s | beta        | beta        | beta        |
+| {{< component-link name="schemaprocessor" type="processor" repo="contrib" >}}               | contrib            | development | development | development |
+| {{< component-link name="spanprocessor" type="processor" repo="contrib" >}}                 | contrib, core      | alpha       | -           | -           |
+| {{< component-link name="sumologicprocessor" type="processor" repo="contrib" >}}            | contrib            | beta        | beta        | beta        |
+| {{< component-link name="tailsamplingprocessor" type="processor" repo="contrib" >}}         | contrib, K8s       | beta        | -           | -           |
+| {{< component-link name="transformprocessor" type="processor" repo="contrib" >}}            | contrib, K8s       | beta        | beta        | beta        |
+| {{< component-link name="unrollprocessor" type="processor" repo="contrib" >}}               | contrib            | -           | -           | alpha       |
 
 [^1]: このコンポーネントが含まれている[ディストリビューション](/docs/collector/distributions/)（core、contrib、K8sなど）を示します。
 
 [^2]: コンポーネントの安定性レベルの詳細については、[OpenTelemetry Collectorコンポーネントの安定性の定義](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md)を参照してください。
 
-<!-- END GENERATED: processor-table -->
+<!-- END GENERATED: processor-table SOURCE: scripts/collector-sync -->

--- a/content/ja/docs/collector/components/receiver.md
+++ b/content/ja/docs/collector/components/receiver.md
@@ -15,123 +15,123 @@ cSpell:ignore: activedirectorydsreceiver aerospikereceiver apachereceiver apache
 
 <!-- BEGIN GENERATED: receiver-table SOURCE: scripts/collector-sync -->
 
-| 名前                                                                                                                                                  | ディストリビューション[^1] | トレース[^2] | メトリクス[^2] | ログ[^2]    |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | ------------ | -------------- | ----------- |
-| {{< component-link name="activedirectorydsreceiver" type="receiver" repo="contrib" >}}      | contrib                  | -           | beta        | -            |
-| {{< component-link name="aerospikereceiver" type="receiver" repo="contrib" >}}              | contrib                  | -           | alpha       | -            |
-| {{< component-link name="apachereceiver" type="receiver" repo="contrib" >}}                 | contrib                  | -           | beta        | -            |
-| {{< component-link name="apachesparkreceiver" type="receiver" repo="contrib" >}}            | contrib                  | -           | alpha       | -            |
-| {{< component-link name="awscloudwatchreceiver" type="receiver" repo="contrib" >}}          | contrib                  | -           | -           | alpha        |
-| {{< component-link name="awscontainerinsightreceiver" type="receiver" repo="contrib" >}}    | contrib                  | -           | beta        | -            |
-| {{< component-link name="awsecscontainermetricsreceiver" type="receiver" repo="contrib" >}} | contrib                  | -           | beta        | -            |
-| {{< component-link name="awsfirehosereceiver" type="receiver" repo="contrib" >}}            | contrib                  | -           | alpha       | alpha        |
-| {{< component-link name="awslambdareceiver" type="receiver" repo="contrib" >}}              | contrib                  | -           | development | development  |
-| {{< component-link name="awss3receiver" type="receiver" repo="contrib" >}}                  | contrib                  | alpha       | alpha       | alpha        |
-| {{< component-link name="awsxrayreceiver" type="receiver" repo="contrib" >}}                | contrib                  | beta        | -           | -            |
-| {{< component-link name="azureblobreceiver" type="receiver" repo="contrib" >}}              | contrib                  | alpha       | -           | alpha        |
-| {{< component-link name="azureeventhubreceiver" type="receiver" repo="contrib" >}}          | contrib                  | beta        | beta        | beta         |
-| {{< component-link name="azuremonitorreceiver" type="receiver" repo="contrib" >}}           | contrib                  | -           | alpha       | -            |
-| {{< component-link name="carbonreceiver" type="receiver" repo="contrib" >}}                 | contrib                  | -           | beta        | -            |
-| {{< component-link name="chronyreceiver" type="receiver" repo="contrib" >}}                 | contrib                  | -           | beta        | -            |
-| {{< component-link name="ciscoosreceiver" type="receiver" repo="contrib" >}}                | contrib                  | -           | alpha       | -            |
-| {{< component-link name="cloudflarereceiver" type="receiver" repo="contrib" >}}             | contrib                  | -           | -           | alpha        |
-| {{< component-link name="cloudfoundryreceiver" type="receiver" repo="contrib" >}}           | contrib                  | -           | beta        | development  |
-| {{< component-link name="collectdreceiver" type="receiver" repo="contrib" >}}               | contrib                  | -           | beta        | -            |
-| {{< component-link name="couchdbreceiver" type="receiver" repo="contrib" >}}                | contrib                  | -           | beta        | -            |
-| {{< component-link name="datadogreceiver" type="receiver" repo="contrib" >}}                | contrib                  | alpha       | alpha       | alpha        |
-| {{< component-link name="dockerstatsreceiver" type="receiver" repo="contrib" >}}            | contrib                  | -           | alpha       | -            |
-| {{< component-link name="elasticsearchreceiver" type="receiver" repo="contrib" >}}          | contrib                  | -           | beta        | -            |
-| {{< component-link name="envoyalsreceiver" type="receiver" repo="contrib" >}}               | contrib                  | -           | -           | alpha        |
-| {{< component-link name="expvarreceiver" type="receiver" repo="contrib" >}}                 | contrib                  | -           | alpha       | -            |
-| {{< component-link name="faroreceiver" type="receiver" repo="contrib" >}}                   | contrib                  | alpha       | -           | alpha        |
-| {{< component-link name="filelogreceiver" type="receiver" repo="contrib" >}}                | contrib, K8s             | -           | -           | beta         |
-| {{< component-link name="filestatsreceiver" type="receiver" repo="contrib" >}}              | contrib                  | -           | beta        | -            |
-| {{< component-link name="flinkmetricsreceiver" type="receiver" repo="contrib" >}}           | contrib                  | -           | alpha       | -            |
-| {{< component-link name="fluentforwardreceiver" type="receiver" repo="contrib" >}}          | contrib, K8s             | -           | -           | beta         |
-| {{< component-link name="githubreceiver" type="receiver" repo="contrib" >}}                 | contrib                  | development | alpha       | -            |
-| {{< component-link name="gitlabreceiver" type="receiver" repo="contrib" >}}                 | contrib                  | alpha       | -           | -            |
-| {{< component-link name="googlecloudmonitoringreceiver" type="receiver" repo="contrib" >}}  | contrib                  | -           | alpha       | -            |
-| {{< component-link name="googlecloudpubsubpushreceiver" type="receiver" repo="contrib" >}}  | contrib                  | -           | -           | development  |
-| {{< component-link name="googlecloudpubsubreceiver" type="receiver" repo="contrib" >}}      | contrib                  | beta        | beta        | beta         |
-| {{< component-link name="googlecloudspannerreceiver" type="receiver" repo="contrib" >}}     | contrib                  | -           | beta        | -            |
-| {{< component-link name="haproxyreceiver" type="receiver" repo="contrib" >}}                | contrib                  | -           | beta        | -            |
-| {{< component-link name="hostmetricsreceiver" type="receiver" repo="contrib" >}}            | contrib, core, K8s       | -           | beta        | development  |
-| {{< component-link name="httpcheckreceiver" type="receiver" repo="contrib" >}}              | contrib, K8s             | -           | alpha       | -            |
-| {{< component-link name="huaweicloudcesreceiver" type="receiver" repo="contrib" >}}         | contrib                  | -           | alpha       | -            |
-| {{< component-link name="icmpcheckreceiver" type="receiver" repo="contrib" >}}              | contrib                  | -           | development | -            |
-| {{< component-link name="iisreceiver" type="receiver" repo="contrib" >}}                    | contrib                  | -           | beta        | -            |
-| {{< component-link name="influxdbreceiver" type="receiver" repo="contrib" >}}               | contrib                  | -           | beta        | -            |
-| {{< component-link name="jaegerreceiver" type="receiver" repo="contrib" >}}                 | contrib, core, K8s       | beta        | -           | -            |
-| {{< component-link name="jmxreceiver" type="receiver" repo="contrib" >}}                    | contrib                  | -           | deprecated  | -            |
-| {{< component-link name="journaldreceiver" type="receiver" repo="contrib" >}}               | contrib, K8s             | -           | -           | alpha        |
-| {{< component-link name="k8sclusterreceiver" type="receiver" repo="contrib" >}}             | contrib, K8s             | -           | beta        | development  |
-| {{< component-link name="k8seventsreceiver" type="receiver" repo="contrib" >}}              | contrib, K8s             | -           | -           | alpha        |
-| {{< component-link name="k8slogreceiver" type="receiver" repo="contrib" >}} ⚠️              | contrib                  | -           | -           | unmaintained |
-| {{< component-link name="k8sobjectsreceiver" type="receiver" repo="contrib" >}}             | contrib, K8s             | -           | -           | beta         |
-| {{< component-link name="kafkametricsreceiver" type="receiver" repo="contrib" >}}           | contrib                  | -           | beta        | -            |
-| {{< component-link name="kafkareceiver" type="receiver" repo="contrib" >}}                  | contrib, core            | beta        | beta        | beta         |
-| {{< component-link name="kubeletstatsreceiver" type="receiver" repo="contrib" >}}           | contrib, K8s             | -           | beta        | -            |
-| {{< component-link name="libhoneyreceiver" type="receiver" repo="contrib" >}}               | contrib                  | alpha       | -           | alpha        |
-| {{< component-link name="lokireceiver" type="receiver" repo="contrib" >}}                   | contrib                  | -           | -           | alpha        |
-| {{< component-link name="macosunifiedloggingreceiver" type="receiver" repo="contrib" >}}    | contrib                  | -           | -           | alpha        |
-| {{< component-link name="memcachedreceiver" type="receiver" repo="contrib" >}}              | contrib                  | -           | beta        | -            |
-| {{< component-link name="mongodbatlasreceiver" type="receiver" repo="contrib" >}}           | contrib                  | -           | beta        | beta         |
-| {{< component-link name="mongodbreceiver" type="receiver" repo="contrib" >}}                | contrib                  | -           | beta        | -            |
-| {{< component-link name="mysqlreceiver" type="receiver" repo="contrib" >}}                  | contrib                  | -           | beta        | development  |
-| {{< component-link name="namedpipereceiver" type="receiver" repo="contrib" >}}              | contrib                  | -           | -           | alpha        |
-| {{< component-link name="netflowreceiver" type="receiver" repo="contrib" >}}                | contrib                  | -           | -           | alpha        |
-| {{< component-link name="nginxreceiver" type="receiver" repo="contrib" >}}                  | contrib                  | -           | beta        | -            |
-| {{< component-link name="nopreceiver" type="receiver" repo="core" >}}                       | contrib, core            | beta        | beta        | beta         |
-| {{< component-link name="nsxtreceiver" type="receiver" repo="contrib" >}}                   | contrib                  | -           | alpha       | -            |
-| {{< component-link name="ntpreceiver" type="receiver" repo="contrib" >}}                    | contrib                  | -           | beta        | -            |
-| {{< component-link name="oracledbreceiver" type="receiver" repo="contrib" >}}               | contrib                  | -           | alpha       | development  |
-| {{< component-link name="osqueryreceiver" type="receiver" repo="contrib" >}}                | contrib                  | -           | -           | development  |
-| {{< component-link name="otelarrowreceiver" type="receiver" repo="contrib" >}}              | contrib, K8s             | beta        | beta        | beta         |
-| {{< component-link name="otlpjsonfilereceiver" type="receiver" repo="contrib" >}}           | contrib                  | alpha       | alpha       | alpha        |
-| {{< component-link name="otlpreceiver" type="receiver" repo="core" >}}                      | contrib, core, K8s, otlp | stable      | stable      | stable       |
-| {{< component-link name="podmanreceiver" type="receiver" repo="contrib" >}}                 | contrib                  | -           | alpha       | -            |
-| {{< component-link name="postgresqlreceiver" type="receiver" repo="contrib" >}}             | contrib                  | -           | beta        | development  |
-| {{< component-link name="pprofreceiver" type="receiver" repo="contrib" >}}                  | contrib                  | -           | -           | -            |
-| {{< component-link name="prometheusreceiver" type="receiver" repo="contrib" >}}             | contrib, core, K8s       | -           | beta        | -            |
-| {{< component-link name="prometheusremotewritereceiver" type="receiver" repo="contrib" >}}  | contrib                  | -           | alpha       | -            |
-| {{< component-link name="pulsarreceiver" type="receiver" repo="contrib" >}}                 | contrib                  | alpha       | alpha       | alpha        |
-| {{< component-link name="purefareceiver" type="receiver" repo="contrib" >}}                 | contrib                  | -           | alpha       | -            |
-| {{< component-link name="purefbreceiver" type="receiver" repo="contrib" >}}                 | contrib                  | -           | alpha       | -            |
-| {{< component-link name="rabbitmqreceiver" type="receiver" repo="contrib" >}}               | contrib                  | -           | beta        | -            |
-| {{< component-link name="receivercreator" type="receiver" repo="contrib" >}}                | contrib, K8s             | alpha       | beta        | alpha        |
-| {{< component-link name="redfishreceiver" type="receiver" repo="contrib" >}}                | contrib                  | -           | development | -            |
-| {{< component-link name="redisreceiver" type="receiver" repo="contrib" >}}                  | contrib                  | -           | beta        | -            |
-| {{< component-link name="riakreceiver" type="receiver" repo="contrib" >}}                   | contrib                  | -           | beta        | -            |
-| {{< component-link name="saphanareceiver" type="receiver" repo="contrib" >}}                | contrib                  | -           | alpha       | -            |
-| {{< component-link name="signalfxreceiver" type="receiver" repo="contrib" >}}               | contrib                  | -           | deprecated  | deprecated   |
-| {{< component-link name="simpleprometheusreceiver" type="receiver" repo="contrib" >}}       | contrib                  | -           | beta        | -            |
-| {{< component-link name="skywalkingreceiver" type="receiver" repo="contrib" >}}             | contrib                  | beta        | development | -            |
-| {{< component-link name="snmpreceiver" type="receiver" repo="contrib" >}}                   | contrib                  | -           | alpha       | -            |
-| {{< component-link name="snowflakereceiver" type="receiver" repo="contrib" >}}              | contrib                  | -           | alpha       | -            |
-| {{< component-link name="solacereceiver" type="receiver" repo="contrib" >}}                 | contrib                  | beta        | -           | -            |
-| {{< component-link name="splunkenterprisereceiver" type="receiver" repo="contrib" >}}       | contrib                  | -           | alpha       | -            |
-| {{< component-link name="splunkhecreceiver" type="receiver" repo="contrib" >}}              | contrib                  | -           | beta        | beta         |
-| {{< component-link name="sqlqueryreceiver" type="receiver" repo="contrib" >}}               | contrib                  | -           | alpha       | development  |
-| {{< component-link name="sqlserverreceiver" type="receiver" repo="contrib" >}}              | contrib                  | -           | beta        | development  |
-| {{< component-link name="sshcheckreceiver" type="receiver" repo="contrib" >}}               | contrib                  | -           | beta        | -            |
-| {{< component-link name="statsdreceiver" type="receiver" repo="contrib" >}}                 | contrib                  | -           | beta        | -            |
-| {{< component-link name="stefreceiver" type="receiver" repo="contrib" >}}                   | contrib                  | -           | alpha       | -            |
-| {{< component-link name="syslogreceiver" type="receiver" repo="contrib" >}}                 | contrib                  | -           | -           | beta         |
-| {{< component-link name="systemdreceiver" type="receiver" repo="contrib" >}}                | contrib                  | -           | alpha       | -            |
-| {{< component-link name="tcpcheckreceiver" type="receiver" repo="contrib" >}}               | contrib                  | -           | alpha       | -            |
-| {{< component-link name="tcplogreceiver" type="receiver" repo="contrib" >}}                 | contrib                  | -           | -           | alpha        |
-| {{< component-link name="tlscheckreceiver" type="receiver" repo="contrib" >}}               | contrib                  | -           | alpha       | -            |
-| {{< component-link name="udplogreceiver" type="receiver" repo="contrib" >}}                 | contrib                  | -           | -           | alpha        |
-| {{< component-link name="vcenterreceiver" type="receiver" repo="contrib" >}}                | contrib                  | -           | alpha       | -            |
-| {{< component-link name="vcrreceiver" type="receiver" repo="contrib" >}}                    | contrib                  | development | development | development  |
-| {{< component-link name="wavefrontreceiver" type="receiver" repo="contrib" >}}              | contrib                  | -           | deprecated  | -            |
-| {{< component-link name="webhookeventreceiver" type="receiver" repo="contrib" >}}           | contrib                  | -           | -           | beta         |
-| {{< component-link name="windowseventlogreceiver" type="receiver" repo="contrib" >}}        | contrib                  | -           | -           | alpha        |
-| {{< component-link name="windowsperfcountersreceiver" type="receiver" repo="contrib" >}}    | contrib                  | -           | beta        | -            |
-| {{< component-link name="windowsservicereceiver" type="receiver" repo="contrib" >}}         | contrib                  | -           | development | -            |
-| {{< component-link name="yanggrpcreceiver" type="receiver" repo="contrib" >}}               | contrib                  | -           | alpha       | -            |
-| {{< component-link name="zipkinreceiver" type="receiver" repo="contrib" >}}                 | contrib, core, K8s       | beta        | -           | -            |
-| {{< component-link name="zookeeperreceiver" type="receiver" repo="contrib" >}}              | contrib                  | -           | alpha       | -            |
+| 名前                                                                                        | ディストリビューション[^1] | トレース[^2] | メトリクス[^2] | ログ[^2]     |
+| ------------------------------------------------------------------------------------------- | -------------------------- | ------------ | -------------- | ------------ |
+| {{< component-link name="activedirectorydsreceiver" type="receiver" repo="contrib" >}}      | contrib                    | -            | beta           | -            |
+| {{< component-link name="aerospikereceiver" type="receiver" repo="contrib" >}}              | contrib                    | -            | alpha          | -            |
+| {{< component-link name="apachereceiver" type="receiver" repo="contrib" >}}                 | contrib                    | -            | beta           | -            |
+| {{< component-link name="apachesparkreceiver" type="receiver" repo="contrib" >}}            | contrib                    | -            | alpha          | -            |
+| {{< component-link name="awscloudwatchreceiver" type="receiver" repo="contrib" >}}          | contrib                    | -            | -              | alpha        |
+| {{< component-link name="awscontainerinsightreceiver" type="receiver" repo="contrib" >}}    | contrib                    | -            | beta           | -            |
+| {{< component-link name="awsecscontainermetricsreceiver" type="receiver" repo="contrib" >}} | contrib                    | -            | beta           | -            |
+| {{< component-link name="awsfirehosereceiver" type="receiver" repo="contrib" >}}            | contrib                    | -            | alpha          | alpha        |
+| {{< component-link name="awslambdareceiver" type="receiver" repo="contrib" >}}              | contrib                    | -            | development    | development  |
+| {{< component-link name="awss3receiver" type="receiver" repo="contrib" >}}                  | contrib                    | alpha        | alpha          | alpha        |
+| {{< component-link name="awsxrayreceiver" type="receiver" repo="contrib" >}}                | contrib                    | beta         | -              | -            |
+| {{< component-link name="azureblobreceiver" type="receiver" repo="contrib" >}}              | contrib                    | alpha        | -              | alpha        |
+| {{< component-link name="azureeventhubreceiver" type="receiver" repo="contrib" >}}          | contrib                    | beta         | beta           | beta         |
+| {{< component-link name="azuremonitorreceiver" type="receiver" repo="contrib" >}}           | contrib                    | -            | alpha          | -            |
+| {{< component-link name="carbonreceiver" type="receiver" repo="contrib" >}}                 | contrib                    | -            | beta           | -            |
+| {{< component-link name="chronyreceiver" type="receiver" repo="contrib" >}}                 | contrib                    | -            | beta           | -            |
+| {{< component-link name="ciscoosreceiver" type="receiver" repo="contrib" >}}                | contrib                    | -            | alpha          | -            |
+| {{< component-link name="cloudflarereceiver" type="receiver" repo="contrib" >}}             | contrib                    | -            | -              | alpha        |
+| {{< component-link name="cloudfoundryreceiver" type="receiver" repo="contrib" >}}           | contrib                    | -            | beta           | development  |
+| {{< component-link name="collectdreceiver" type="receiver" repo="contrib" >}}               | contrib                    | -            | beta           | -            |
+| {{< component-link name="couchdbreceiver" type="receiver" repo="contrib" >}}                | contrib                    | -            | beta           | -            |
+| {{< component-link name="datadogreceiver" type="receiver" repo="contrib" >}}                | contrib                    | alpha        | alpha          | alpha        |
+| {{< component-link name="dockerstatsreceiver" type="receiver" repo="contrib" >}}            | contrib                    | -            | alpha          | -            |
+| {{< component-link name="elasticsearchreceiver" type="receiver" repo="contrib" >}}          | contrib                    | -            | beta           | -            |
+| {{< component-link name="envoyalsreceiver" type="receiver" repo="contrib" >}}               | contrib                    | -            | -              | alpha        |
+| {{< component-link name="expvarreceiver" type="receiver" repo="contrib" >}}                 | contrib                    | -            | alpha          | -            |
+| {{< component-link name="faroreceiver" type="receiver" repo="contrib" >}}                   | contrib                    | alpha        | -              | alpha        |
+| {{< component-link name="filelogreceiver" type="receiver" repo="contrib" >}}                | contrib, K8s               | -            | -              | beta         |
+| {{< component-link name="filestatsreceiver" type="receiver" repo="contrib" >}}              | contrib                    | -            | beta           | -            |
+| {{< component-link name="flinkmetricsreceiver" type="receiver" repo="contrib" >}}           | contrib                    | -            | alpha          | -            |
+| {{< component-link name="fluentforwardreceiver" type="receiver" repo="contrib" >}}          | contrib, K8s               | -            | -              | beta         |
+| {{< component-link name="githubreceiver" type="receiver" repo="contrib" >}}                 | contrib                    | development  | alpha          | -            |
+| {{< component-link name="gitlabreceiver" type="receiver" repo="contrib" >}}                 | contrib                    | alpha        | -              | -            |
+| {{< component-link name="googlecloudmonitoringreceiver" type="receiver" repo="contrib" >}}  | contrib                    | -            | alpha          | -            |
+| {{< component-link name="googlecloudpubsubpushreceiver" type="receiver" repo="contrib" >}}  | contrib                    | -            | -              | development  |
+| {{< component-link name="googlecloudpubsubreceiver" type="receiver" repo="contrib" >}}      | contrib                    | beta         | beta           | beta         |
+| {{< component-link name="googlecloudspannerreceiver" type="receiver" repo="contrib" >}}     | contrib                    | -            | beta           | -            |
+| {{< component-link name="haproxyreceiver" type="receiver" repo="contrib" >}}                | contrib                    | -            | beta           | -            |
+| {{< component-link name="hostmetricsreceiver" type="receiver" repo="contrib" >}}            | contrib, core, K8s         | -            | beta           | development  |
+| {{< component-link name="httpcheckreceiver" type="receiver" repo="contrib" >}}              | contrib, K8s               | -            | alpha          | -            |
+| {{< component-link name="huaweicloudcesreceiver" type="receiver" repo="contrib" >}}         | contrib                    | -            | alpha          | -            |
+| {{< component-link name="icmpcheckreceiver" type="receiver" repo="contrib" >}}              | contrib                    | -            | development    | -            |
+| {{< component-link name="iisreceiver" type="receiver" repo="contrib" >}}                    | contrib                    | -            | beta           | -            |
+| {{< component-link name="influxdbreceiver" type="receiver" repo="contrib" >}}               | contrib                    | -            | beta           | -            |
+| {{< component-link name="jaegerreceiver" type="receiver" repo="contrib" >}}                 | contrib, core, K8s         | beta         | -              | -            |
+| {{< component-link name="jmxreceiver" type="receiver" repo="contrib" >}}                    | contrib                    | -            | deprecated     | -            |
+| {{< component-link name="journaldreceiver" type="receiver" repo="contrib" >}}               | contrib, K8s               | -            | -              | alpha        |
+| {{< component-link name="k8sclusterreceiver" type="receiver" repo="contrib" >}}             | contrib, K8s               | -            | beta           | development  |
+| {{< component-link name="k8seventsreceiver" type="receiver" repo="contrib" >}}              | contrib, K8s               | -            | -              | alpha        |
+| {{< component-link name="k8slogreceiver" type="receiver" repo="contrib" >}} ⚠️              | contrib                    | -            | -              | unmaintained |
+| {{< component-link name="k8sobjectsreceiver" type="receiver" repo="contrib" >}}             | contrib, K8s               | -            | -              | beta         |
+| {{< component-link name="kafkametricsreceiver" type="receiver" repo="contrib" >}}           | contrib                    | -            | beta           | -            |
+| {{< component-link name="kafkareceiver" type="receiver" repo="contrib" >}}                  | contrib, core              | beta         | beta           | beta         |
+| {{< component-link name="kubeletstatsreceiver" type="receiver" repo="contrib" >}}           | contrib, K8s               | -            | beta           | -            |
+| {{< component-link name="libhoneyreceiver" type="receiver" repo="contrib" >}}               | contrib                    | alpha        | -              | alpha        |
+| {{< component-link name="lokireceiver" type="receiver" repo="contrib" >}}                   | contrib                    | -            | -              | alpha        |
+| {{< component-link name="macosunifiedloggingreceiver" type="receiver" repo="contrib" >}}    | contrib                    | -            | -              | alpha        |
+| {{< component-link name="memcachedreceiver" type="receiver" repo="contrib" >}}              | contrib                    | -            | beta           | -            |
+| {{< component-link name="mongodbatlasreceiver" type="receiver" repo="contrib" >}}           | contrib                    | -            | beta           | beta         |
+| {{< component-link name="mongodbreceiver" type="receiver" repo="contrib" >}}                | contrib                    | -            | beta           | -            |
+| {{< component-link name="mysqlreceiver" type="receiver" repo="contrib" >}}                  | contrib                    | -            | beta           | development  |
+| {{< component-link name="namedpipereceiver" type="receiver" repo="contrib" >}}              | contrib                    | -            | -              | alpha        |
+| {{< component-link name="netflowreceiver" type="receiver" repo="contrib" >}}                | contrib                    | -            | -              | alpha        |
+| {{< component-link name="nginxreceiver" type="receiver" repo="contrib" >}}                  | contrib                    | -            | beta           | -            |
+| {{< component-link name="nopreceiver" type="receiver" repo="core" >}}                       | contrib, core              | beta         | beta           | beta         |
+| {{< component-link name="nsxtreceiver" type="receiver" repo="contrib" >}}                   | contrib                    | -            | alpha          | -            |
+| {{< component-link name="ntpreceiver" type="receiver" repo="contrib" >}}                    | contrib                    | -            | beta           | -            |
+| {{< component-link name="oracledbreceiver" type="receiver" repo="contrib" >}}               | contrib                    | -            | alpha          | development  |
+| {{< component-link name="osqueryreceiver" type="receiver" repo="contrib" >}}                | contrib                    | -            | -              | development  |
+| {{< component-link name="otelarrowreceiver" type="receiver" repo="contrib" >}}              | contrib, K8s               | beta         | beta           | beta         |
+| {{< component-link name="otlpjsonfilereceiver" type="receiver" repo="contrib" >}}           | contrib                    | alpha        | alpha          | alpha        |
+| {{< component-link name="otlpreceiver" type="receiver" repo="core" >}}                      | contrib, core, K8s, otlp   | stable       | stable         | stable       |
+| {{< component-link name="podmanreceiver" type="receiver" repo="contrib" >}}                 | contrib                    | -            | alpha          | -            |
+| {{< component-link name="postgresqlreceiver" type="receiver" repo="contrib" >}}             | contrib                    | -            | beta           | development  |
+| {{< component-link name="pprofreceiver" type="receiver" repo="contrib" >}}                  | contrib                    | -            | -              | -            |
+| {{< component-link name="prometheusreceiver" type="receiver" repo="contrib" >}}             | contrib, core, K8s         | -            | beta           | -            |
+| {{< component-link name="prometheusremotewritereceiver" type="receiver" repo="contrib" >}}  | contrib                    | -            | alpha          | -            |
+| {{< component-link name="pulsarreceiver" type="receiver" repo="contrib" >}}                 | contrib                    | alpha        | alpha          | alpha        |
+| {{< component-link name="purefareceiver" type="receiver" repo="contrib" >}}                 | contrib                    | -            | alpha          | -            |
+| {{< component-link name="purefbreceiver" type="receiver" repo="contrib" >}}                 | contrib                    | -            | alpha          | -            |
+| {{< component-link name="rabbitmqreceiver" type="receiver" repo="contrib" >}}               | contrib                    | -            | beta           | -            |
+| {{< component-link name="receivercreator" type="receiver" repo="contrib" >}}                | contrib, K8s               | alpha        | beta           | alpha        |
+| {{< component-link name="redfishreceiver" type="receiver" repo="contrib" >}}                | contrib                    | -            | development    | -            |
+| {{< component-link name="redisreceiver" type="receiver" repo="contrib" >}}                  | contrib                    | -            | beta           | -            |
+| {{< component-link name="riakreceiver" type="receiver" repo="contrib" >}}                   | contrib                    | -            | beta           | -            |
+| {{< component-link name="saphanareceiver" type="receiver" repo="contrib" >}}                | contrib                    | -            | alpha          | -            |
+| {{< component-link name="signalfxreceiver" type="receiver" repo="contrib" >}}               | contrib                    | -            | deprecated     | deprecated   |
+| {{< component-link name="simpleprometheusreceiver" type="receiver" repo="contrib" >}}       | contrib                    | -            | beta           | -            |
+| {{< component-link name="skywalkingreceiver" type="receiver" repo="contrib" >}}             | contrib                    | beta         | development    | -            |
+| {{< component-link name="snmpreceiver" type="receiver" repo="contrib" >}}                   | contrib                    | -            | alpha          | -            |
+| {{< component-link name="snowflakereceiver" type="receiver" repo="contrib" >}}              | contrib                    | -            | alpha          | -            |
+| {{< component-link name="solacereceiver" type="receiver" repo="contrib" >}}                 | contrib                    | beta         | -              | -            |
+| {{< component-link name="splunkenterprisereceiver" type="receiver" repo="contrib" >}}       | contrib                    | -            | alpha          | -            |
+| {{< component-link name="splunkhecreceiver" type="receiver" repo="contrib" >}}              | contrib                    | -            | beta           | beta         |
+| {{< component-link name="sqlqueryreceiver" type="receiver" repo="contrib" >}}               | contrib                    | -            | alpha          | development  |
+| {{< component-link name="sqlserverreceiver" type="receiver" repo="contrib" >}}              | contrib                    | -            | beta           | development  |
+| {{< component-link name="sshcheckreceiver" type="receiver" repo="contrib" >}}               | contrib                    | -            | beta           | -            |
+| {{< component-link name="statsdreceiver" type="receiver" repo="contrib" >}}                 | contrib                    | -            | beta           | -            |
+| {{< component-link name="stefreceiver" type="receiver" repo="contrib" >}}                   | contrib                    | -            | alpha          | -            |
+| {{< component-link name="syslogreceiver" type="receiver" repo="contrib" >}}                 | contrib                    | -            | -              | beta         |
+| {{< component-link name="systemdreceiver" type="receiver" repo="contrib" >}}                | contrib                    | -            | alpha          | -            |
+| {{< component-link name="tcpcheckreceiver" type="receiver" repo="contrib" >}}               | contrib                    | -            | alpha          | -            |
+| {{< component-link name="tcplogreceiver" type="receiver" repo="contrib" >}}                 | contrib                    | -            | -              | alpha        |
+| {{< component-link name="tlscheckreceiver" type="receiver" repo="contrib" >}}               | contrib                    | -            | alpha          | -            |
+| {{< component-link name="udplogreceiver" type="receiver" repo="contrib" >}}                 | contrib                    | -            | -              | alpha        |
+| {{< component-link name="vcenterreceiver" type="receiver" repo="contrib" >}}                | contrib                    | -            | alpha          | -            |
+| {{< component-link name="vcrreceiver" type="receiver" repo="contrib" >}}                    | contrib                    | development  | development    | development  |
+| {{< component-link name="wavefrontreceiver" type="receiver" repo="contrib" >}}              | contrib                    | -            | deprecated     | -            |
+| {{< component-link name="webhookeventreceiver" type="receiver" repo="contrib" >}}           | contrib                    | -            | -              | beta         |
+| {{< component-link name="windowseventlogreceiver" type="receiver" repo="contrib" >}}        | contrib                    | -            | -              | alpha        |
+| {{< component-link name="windowsperfcountersreceiver" type="receiver" repo="contrib" >}}    | contrib                    | -            | beta           | -            |
+| {{< component-link name="windowsservicereceiver" type="receiver" repo="contrib" >}}         | contrib                    | -            | development    | -            |
+| {{< component-link name="yanggrpcreceiver" type="receiver" repo="contrib" >}}               | contrib                    | -            | alpha          | -            |
+| {{< component-link name="zipkinreceiver" type="receiver" repo="contrib" >}}                 | contrib, core, K8s         | beta         | -              | -            |
+| {{< component-link name="zookeeperreceiver" type="receiver" repo="contrib" >}}              | contrib                    | -            | alpha          | -            |
 
 [^1]: このコンポーネントが含まれている[ディストリビューション](/docs/collector/distributions/)（core、contrib、K8sなど）を示します。
 

--- a/content/ja/docs/collector/components/receiver.md
+++ b/content/ja/docs/collector/components/receiver.md
@@ -11,129 +11,130 @@ cSpell:ignore: activedirectorydsreceiver aerospikereceiver apachereceiver apache
 レシーバーは、さまざまなソースとフォーマットからテレメトリーデータを収集します。
 レシーバーの詳細な設定方法については、[コレクターの設定ドキュメント](/docs/collector/configuration/#receivers)を参照してください。
 
-<!-- BEGIN GENERATED: receiver-table -->
+{{% include unmaintained-components-msg.md %}}
+
+<!-- BEGIN GENERATED: receiver-table SOURCE: scripts/collector-sync -->
 
 | 名前                                                                                                                                                  | ディストリビューション[^1] | トレース[^2] | メトリクス[^2] | ログ[^2]    |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | ------------ | -------------- | ----------- |
-| [activedirectorydsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/activedirectorydsreceiver)           | contrib                    | -            | beta           | -           |
-| [aerospikereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/aerospikereceiver)                           | contrib                    | -            | alpha          | -           |
-| [apachereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/apachereceiver)                                 | contrib                    | -            | beta           | -           |
-| [apachesparkreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/apachesparkreceiver)                       | contrib                    | -            | alpha          | -           |
-| [awscloudwatchreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awscloudwatchreceiver)                   | contrib                    | -            | -              | alpha       |
-| [awscontainerinsightreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awscontainerinsightreceiver)       | contrib                    | -            | beta           | -           |
-| [awsecscontainermetricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awsecscontainermetricsreceiver) | contrib                    | -            | beta           | -           |
-| [awsfirehosereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awsfirehosereceiver)                       | contrib                    | -            | alpha          | alpha       |
-| [awslambdareceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awslambdareceiver)                           | contrib                    | -            | -              | development |
-| [awss3receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awss3receiver)                                   | contrib                    | alpha        | alpha          | alpha       |
-| [awsxrayreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awsxrayreceiver)                               | contrib                    | beta         | -              | -           |
-| [azureblobreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/azureblobreceiver)                           | contrib                    | alpha        | -              | alpha       |
-| [azureeventhubreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/azureeventhubreceiver)                   | contrib                    | alpha        | alpha          | alpha       |
-| [azuremonitorreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/azuremonitorreceiver)                     | contrib                    | -            | alpha          | -           |
-| [carbonreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/carbonreceiver) ⚠️                              | contrib                    | -            | unmaintained   | -           |
-| [chronyreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/chronyreceiver)                                 | contrib                    | -            | beta           | -           |
-| [ciscoosreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/ciscoosreceiver)                               | contrib                    | -            | alpha          | -           |
-| [cloudflarereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/cloudflarereceiver)                         | contrib                    | -            | -              | alpha       |
-| [cloudfoundryreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/cloudfoundryreceiver)                     | contrib                    | -            | beta           | development |
-| [collectdreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/collectdreceiver)                             | contrib                    | -            | beta           | -           |
-| [couchdbreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/couchdbreceiver)                               | contrib                    | -            | beta           | -           |
-| [datadogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/datadogreceiver)                               | contrib                    | alpha        | alpha          | alpha       |
-| [dockerstatsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/dockerstatsreceiver)                       | contrib                    | -            | alpha          | -           |
-| [elasticsearchreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/elasticsearchreceiver)                   | contrib                    | -            | beta           | -           |
-| [envoyalsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/envoyalsreceiver)                             | contrib                    | -            | -              | alpha       |
-| [expvarreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/expvarreceiver)                                 | contrib                    | -            | alpha          | -           |
-| [faroreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/faroreceiver)                                     | contrib                    | alpha        | -              | alpha       |
-| [filelogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver)                               | contrib, K8s               | -            | -              | beta        |
-| [filestatsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filestatsreceiver)                           | contrib                    | -            | beta           | -           |
-| [flinkmetricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/flinkmetricsreceiver)                     | contrib                    | -            | alpha          | -           |
-| [fluentforwardreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/fluentforwardreceiver)                   | contrib, K8s               | -            | -              | beta        |
-| [githubreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/githubreceiver)                                 | contrib                    | development  | alpha          | -           |
-| [gitlabreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/gitlabreceiver)                                 | contrib                    | alpha        | -              | -           |
-| [googlecloudmonitoringreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/googlecloudmonitoringreceiver)   | contrib                    | -            | alpha          | -           |
-| [googlecloudpubsubpushreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/googlecloudpubsubpushreceiver)   | contrib                    | -            | -              | development |
-| [googlecloudpubsubreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/googlecloudpubsubreceiver)           | contrib                    | beta         | beta           | beta        |
-| [googlecloudspannerreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/googlecloudspannerreceiver)         | contrib                    | -            | beta           | -           |
-| [haproxyreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/haproxyreceiver)                               | contrib                    | -            | beta           | -           |
-| [hostmetricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver)                       | contrib, core, K8s         | -            | beta           | development |
-| [httpcheckreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/httpcheckreceiver)                           | contrib, K8s               | -            | alpha          | -           |
-| [huaweicloudcesreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/huaweicloudcesreceiver)                 | contrib                    | -            | alpha          | -           |
-| [icmpcheckreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/icmpcheckreceiver)                           | contrib                    | -            | development    | -           |
-| [iisreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/iisreceiver)                                       | contrib                    | -            | beta           | -           |
-| [influxdbreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/influxdbreceiver)                             | contrib                    | -            | beta           | -           |
-| [jaegerreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/jaegerreceiver)                                 | contrib, core, K8s         | beta         | -              | -           |
-| [jmxreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/jmxreceiver)                                       | contrib                    | -            | beta           | -           |
-| [journaldreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/journaldreceiver)                             | contrib, K8s               | -            | -              | alpha       |
-| [k8sclusterreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sclusterreceiver)                         | contrib, K8s               | -            | beta           | development |
-| [k8seventsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8seventsreceiver)                           | contrib, K8s               | -            | -              | alpha       |
-| [k8slogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8slogreceiver)                                 | contrib                    | -            | -              | development |
-| [k8sobjectsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver)                         | contrib, K8s               | -            | -              | beta        |
-| [kafkametricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kafkametricsreceiver)                     | contrib                    | -            | beta           | -           |
-| [kafkareceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kafkareceiver)                                   | contrib, core              | beta         | beta           | beta        |
-| [kubeletstatsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver)                     | contrib, K8s               | -            | beta           | -           |
-| [libhoneyreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/libhoneyreceiver)                             | contrib                    | alpha        | -              | alpha       |
-| [lokireceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/lokireceiver)                                     | contrib                    | -            | -              | alpha       |
-| [memcachedreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/memcachedreceiver)                           | contrib                    | -            | beta           | -           |
-| [mongodbatlasreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/mongodbatlasreceiver)                     | contrib                    | -            | beta           | beta        |
-| [mongodbreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/mongodbreceiver)                               | contrib                    | -            | beta           | -           |
-| [mysqlreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/mysqlreceiver)                                   | contrib                    | -            | beta           | development |
-| [namedpipereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/namedpipereceiver)                           | contrib                    | -            | -              | alpha       |
-| [netflowreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/netflowreceiver)                               | contrib                    | -            | -              | alpha       |
-| [nginxreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/nginxreceiver)                                   | contrib                    | -            | beta           | -           |
-| [nopreceiver](https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/nopreceiver)                                               | contrib, core              | beta         | beta           | beta        |
-| [nsxtreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/nsxtreceiver)                                     | contrib                    | -            | alpha          | -           |
-| [ntpreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/ntpreceiver)                                       | contrib                    | -            | beta           | -           |
-| [oracledbreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/oracledbreceiver)                             | contrib                    | -            | alpha          | development |
-| [osqueryreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/osqueryreceiver)                               | contrib                    | -            | -              | development |
-| [otelarrowreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/otelarrowreceiver)                           | contrib, K8s               | beta         | beta           | beta        |
-| [otlpjsonfilereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/otlpjsonfilereceiver)                     | contrib                    | alpha        | alpha          | alpha       |
-| [otlpreceiver](https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/otlpreceiver)                                             | contrib, core, K8s, otlp   | stable       | stable         | stable      |
-| [podmanreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/podmanreceiver)                                 | contrib                    | -            | alpha          | -           |
-| [postgresqlreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/postgresqlreceiver)                         | contrib                    | -            | beta           | development |
-| [pprofreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/pprofreceiver)                                   | contrib                    | -            | -              | -           |
-| [prometheusreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver)                         | contrib, core, K8s         | -            | beta           | -           |
-| [prometheusremotewritereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusremotewritereceiver)   | contrib                    | -            | alpha          | -           |
-| [pulsarreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/pulsarreceiver)                                 | contrib                    | alpha        | alpha          | alpha       |
-| [purefareceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/purefareceiver)                                 | contrib                    | -            | alpha          | -           |
-| [purefbreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/purefbreceiver)                                 | contrib                    | -            | alpha          | -           |
-| [rabbitmqreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/rabbitmqreceiver)                             | contrib                    | -            | beta           | -           |
-| [receivercreator](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/receivercreator)                               | contrib, K8s               | alpha        | beta           | alpha       |
-| [redfishreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/redfishreceiver)                               | contrib                    | -            | development    | -           |
-| [redisreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/redisreceiver)                                   | contrib                    | -            | beta           | -           |
-| [riakreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/riakreceiver)                                     | contrib                    | -            | beta           | -           |
-| [saphanareceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/saphanareceiver)                               | contrib                    | -            | alpha          | -           |
-| [signalfxreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/signalfxreceiver)                             | contrib                    | -            | beta           | beta        |
-| [simpleprometheusreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/simpleprometheusreceiver)             | contrib                    | -            | beta           | -           |
-| [skywalkingreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/skywalkingreceiver)                         | contrib                    | beta         | development    | -           |
-| [snmpreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/snmpreceiver)                                     | contrib                    | -            | alpha          | -           |
-| [snowflakereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/snowflakereceiver)                           | contrib                    | -            | alpha          | -           |
-| [solacereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/solacereceiver)                                 | contrib                    | beta         | -              | -           |
-| [splunkenterprisereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/splunkenterprisereceiver)             | contrib                    | -            | alpha          | -           |
-| [splunkhecreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/splunkhecreceiver)                           | contrib                    | -            | beta           | beta        |
-| [sqlqueryreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sqlqueryreceiver)                             | contrib                    | -            | alpha          | development |
-| [sqlserverreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sqlserverreceiver)                           | contrib                    | -            | beta           | development |
-| [sshcheckreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/sshcheckreceiver)                             | contrib                    | -            | alpha          | -           |
-| [statsdreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/statsdreceiver)                                 | contrib                    | -            | beta           | -           |
-| [stefreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/stefreceiver)                                     | contrib                    | -            | alpha          | -           |
-| [syslogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/syslogreceiver)                                 | contrib                    | -            | -              | beta        |
-| [systemdreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/systemdreceiver)                               | contrib                    | -            | development    | -           |
-| [tcpcheckreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/tcpcheckreceiver)                             | contrib                    | -            | alpha          | -           |
-| [tcplogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/tcplogreceiver)                                 | contrib                    | -            | -              | alpha       |
-| [tlscheckreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/tlscheckreceiver)                             | contrib                    | -            | alpha          | -           |
-| [udplogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/udplogreceiver)                                 | contrib                    | -            | -              | alpha       |
-| [vcenterreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/vcenterreceiver)                               | contrib                    | -            | alpha          | -           |
-| [wavefrontreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/wavefrontreceiver)                           | contrib                    | -            | beta           | -           |
-| [webhookeventreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/webhookeventreceiver)                     | contrib                    | -            | -              | beta        |
-| [windowseventlogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/windowseventlogreceiver)               | contrib                    | -            | -              | alpha       |
-| [windowsperfcountersreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/windowsperfcountersreceiver)       | contrib                    | -            | beta           | -           |
-| [windowsservicereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/windowsservicereceiver)                 | contrib                    | -            | development    | -           |
-| [yanggrpcreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/yanggrpcreceiver)                             | contrib                    | -            | development    | -           |
-| [zipkinreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/zipkinreceiver)                                 | contrib, core, K8s         | beta         | -              | -           |
-| [zookeeperreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/zookeeperreceiver)                           | contrib                    | -            | alpha          | -           |
-
-⚠️ **注意:** ⚠️ マークが付いているコンポーネントはメンテナンスされておらず、アクティブなコードオーナーがいません。
-それらのコンポーネントは定期的な更新やバグ修正を受け付けていない可能性があります。
+| {{< component-link name="activedirectorydsreceiver" type="receiver" repo="contrib" >}}      | contrib                  | -           | beta        | -            |
+| {{< component-link name="aerospikereceiver" type="receiver" repo="contrib" >}}              | contrib                  | -           | alpha       | -            |
+| {{< component-link name="apachereceiver" type="receiver" repo="contrib" >}}                 | contrib                  | -           | beta        | -            |
+| {{< component-link name="apachesparkreceiver" type="receiver" repo="contrib" >}}            | contrib                  | -           | alpha       | -            |
+| {{< component-link name="awscloudwatchreceiver" type="receiver" repo="contrib" >}}          | contrib                  | -           | -           | alpha        |
+| {{< component-link name="awscontainerinsightreceiver" type="receiver" repo="contrib" >}}    | contrib                  | -           | beta        | -            |
+| {{< component-link name="awsecscontainermetricsreceiver" type="receiver" repo="contrib" >}} | contrib                  | -           | beta        | -            |
+| {{< component-link name="awsfirehosereceiver" type="receiver" repo="contrib" >}}            | contrib                  | -           | alpha       | alpha        |
+| {{< component-link name="awslambdareceiver" type="receiver" repo="contrib" >}}              | contrib                  | -           | development | development  |
+| {{< component-link name="awss3receiver" type="receiver" repo="contrib" >}}                  | contrib                  | alpha       | alpha       | alpha        |
+| {{< component-link name="awsxrayreceiver" type="receiver" repo="contrib" >}}                | contrib                  | beta        | -           | -            |
+| {{< component-link name="azureblobreceiver" type="receiver" repo="contrib" >}}              | contrib                  | alpha       | -           | alpha        |
+| {{< component-link name="azureeventhubreceiver" type="receiver" repo="contrib" >}}          | contrib                  | beta        | beta        | beta         |
+| {{< component-link name="azuremonitorreceiver" type="receiver" repo="contrib" >}}           | contrib                  | -           | alpha       | -            |
+| {{< component-link name="carbonreceiver" type="receiver" repo="contrib" >}}                 | contrib                  | -           | beta        | -            |
+| {{< component-link name="chronyreceiver" type="receiver" repo="contrib" >}}                 | contrib                  | -           | beta        | -            |
+| {{< component-link name="ciscoosreceiver" type="receiver" repo="contrib" >}}                | contrib                  | -           | alpha       | -            |
+| {{< component-link name="cloudflarereceiver" type="receiver" repo="contrib" >}}             | contrib                  | -           | -           | alpha        |
+| {{< component-link name="cloudfoundryreceiver" type="receiver" repo="contrib" >}}           | contrib                  | -           | beta        | development  |
+| {{< component-link name="collectdreceiver" type="receiver" repo="contrib" >}}               | contrib                  | -           | beta        | -            |
+| {{< component-link name="couchdbreceiver" type="receiver" repo="contrib" >}}                | contrib                  | -           | beta        | -            |
+| {{< component-link name="datadogreceiver" type="receiver" repo="contrib" >}}                | contrib                  | alpha       | alpha       | alpha        |
+| {{< component-link name="dockerstatsreceiver" type="receiver" repo="contrib" >}}            | contrib                  | -           | alpha       | -            |
+| {{< component-link name="elasticsearchreceiver" type="receiver" repo="contrib" >}}          | contrib                  | -           | beta        | -            |
+| {{< component-link name="envoyalsreceiver" type="receiver" repo="contrib" >}}               | contrib                  | -           | -           | alpha        |
+| {{< component-link name="expvarreceiver" type="receiver" repo="contrib" >}}                 | contrib                  | -           | alpha       | -            |
+| {{< component-link name="faroreceiver" type="receiver" repo="contrib" >}}                   | contrib                  | alpha       | -           | alpha        |
+| {{< component-link name="filelogreceiver" type="receiver" repo="contrib" >}}                | contrib, K8s             | -           | -           | beta         |
+| {{< component-link name="filestatsreceiver" type="receiver" repo="contrib" >}}              | contrib                  | -           | beta        | -            |
+| {{< component-link name="flinkmetricsreceiver" type="receiver" repo="contrib" >}}           | contrib                  | -           | alpha       | -            |
+| {{< component-link name="fluentforwardreceiver" type="receiver" repo="contrib" >}}          | contrib, K8s             | -           | -           | beta         |
+| {{< component-link name="githubreceiver" type="receiver" repo="contrib" >}}                 | contrib                  | development | alpha       | -            |
+| {{< component-link name="gitlabreceiver" type="receiver" repo="contrib" >}}                 | contrib                  | alpha       | -           | -            |
+| {{< component-link name="googlecloudmonitoringreceiver" type="receiver" repo="contrib" >}}  | contrib                  | -           | alpha       | -            |
+| {{< component-link name="googlecloudpubsubpushreceiver" type="receiver" repo="contrib" >}}  | contrib                  | -           | -           | development  |
+| {{< component-link name="googlecloudpubsubreceiver" type="receiver" repo="contrib" >}}      | contrib                  | beta        | beta        | beta         |
+| {{< component-link name="googlecloudspannerreceiver" type="receiver" repo="contrib" >}}     | contrib                  | -           | beta        | -            |
+| {{< component-link name="haproxyreceiver" type="receiver" repo="contrib" >}}                | contrib                  | -           | beta        | -            |
+| {{< component-link name="hostmetricsreceiver" type="receiver" repo="contrib" >}}            | contrib, core, K8s       | -           | beta        | development  |
+| {{< component-link name="httpcheckreceiver" type="receiver" repo="contrib" >}}              | contrib, K8s             | -           | alpha       | -            |
+| {{< component-link name="huaweicloudcesreceiver" type="receiver" repo="contrib" >}}         | contrib                  | -           | alpha       | -            |
+| {{< component-link name="icmpcheckreceiver" type="receiver" repo="contrib" >}}              | contrib                  | -           | development | -            |
+| {{< component-link name="iisreceiver" type="receiver" repo="contrib" >}}                    | contrib                  | -           | beta        | -            |
+| {{< component-link name="influxdbreceiver" type="receiver" repo="contrib" >}}               | contrib                  | -           | beta        | -            |
+| {{< component-link name="jaegerreceiver" type="receiver" repo="contrib" >}}                 | contrib, core, K8s       | beta        | -           | -            |
+| {{< component-link name="jmxreceiver" type="receiver" repo="contrib" >}}                    | contrib                  | -           | deprecated  | -            |
+| {{< component-link name="journaldreceiver" type="receiver" repo="contrib" >}}               | contrib, K8s             | -           | -           | alpha        |
+| {{< component-link name="k8sclusterreceiver" type="receiver" repo="contrib" >}}             | contrib, K8s             | -           | beta        | development  |
+| {{< component-link name="k8seventsreceiver" type="receiver" repo="contrib" >}}              | contrib, K8s             | -           | -           | alpha        |
+| {{< component-link name="k8slogreceiver" type="receiver" repo="contrib" >}} ⚠️              | contrib                  | -           | -           | unmaintained |
+| {{< component-link name="k8sobjectsreceiver" type="receiver" repo="contrib" >}}             | contrib, K8s             | -           | -           | beta         |
+| {{< component-link name="kafkametricsreceiver" type="receiver" repo="contrib" >}}           | contrib                  | -           | beta        | -            |
+| {{< component-link name="kafkareceiver" type="receiver" repo="contrib" >}}                  | contrib, core            | beta        | beta        | beta         |
+| {{< component-link name="kubeletstatsreceiver" type="receiver" repo="contrib" >}}           | contrib, K8s             | -           | beta        | -            |
+| {{< component-link name="libhoneyreceiver" type="receiver" repo="contrib" >}}               | contrib                  | alpha       | -           | alpha        |
+| {{< component-link name="lokireceiver" type="receiver" repo="contrib" >}}                   | contrib                  | -           | -           | alpha        |
+| {{< component-link name="macosunifiedloggingreceiver" type="receiver" repo="contrib" >}}    | contrib                  | -           | -           | alpha        |
+| {{< component-link name="memcachedreceiver" type="receiver" repo="contrib" >}}              | contrib                  | -           | beta        | -            |
+| {{< component-link name="mongodbatlasreceiver" type="receiver" repo="contrib" >}}           | contrib                  | -           | beta        | beta         |
+| {{< component-link name="mongodbreceiver" type="receiver" repo="contrib" >}}                | contrib                  | -           | beta        | -            |
+| {{< component-link name="mysqlreceiver" type="receiver" repo="contrib" >}}                  | contrib                  | -           | beta        | development  |
+| {{< component-link name="namedpipereceiver" type="receiver" repo="contrib" >}}              | contrib                  | -           | -           | alpha        |
+| {{< component-link name="netflowreceiver" type="receiver" repo="contrib" >}}                | contrib                  | -           | -           | alpha        |
+| {{< component-link name="nginxreceiver" type="receiver" repo="contrib" >}}                  | contrib                  | -           | beta        | -            |
+| {{< component-link name="nopreceiver" type="receiver" repo="core" >}}                       | contrib, core            | beta        | beta        | beta         |
+| {{< component-link name="nsxtreceiver" type="receiver" repo="contrib" >}}                   | contrib                  | -           | alpha       | -            |
+| {{< component-link name="ntpreceiver" type="receiver" repo="contrib" >}}                    | contrib                  | -           | beta        | -            |
+| {{< component-link name="oracledbreceiver" type="receiver" repo="contrib" >}}               | contrib                  | -           | alpha       | development  |
+| {{< component-link name="osqueryreceiver" type="receiver" repo="contrib" >}}                | contrib                  | -           | -           | development  |
+| {{< component-link name="otelarrowreceiver" type="receiver" repo="contrib" >}}              | contrib, K8s             | beta        | beta        | beta         |
+| {{< component-link name="otlpjsonfilereceiver" type="receiver" repo="contrib" >}}           | contrib                  | alpha       | alpha       | alpha        |
+| {{< component-link name="otlpreceiver" type="receiver" repo="core" >}}                      | contrib, core, K8s, otlp | stable      | stable      | stable       |
+| {{< component-link name="podmanreceiver" type="receiver" repo="contrib" >}}                 | contrib                  | -           | alpha       | -            |
+| {{< component-link name="postgresqlreceiver" type="receiver" repo="contrib" >}}             | contrib                  | -           | beta        | development  |
+| {{< component-link name="pprofreceiver" type="receiver" repo="contrib" >}}                  | contrib                  | -           | -           | -            |
+| {{< component-link name="prometheusreceiver" type="receiver" repo="contrib" >}}             | contrib, core, K8s       | -           | beta        | -            |
+| {{< component-link name="prometheusremotewritereceiver" type="receiver" repo="contrib" >}}  | contrib                  | -           | alpha       | -            |
+| {{< component-link name="pulsarreceiver" type="receiver" repo="contrib" >}}                 | contrib                  | alpha       | alpha       | alpha        |
+| {{< component-link name="purefareceiver" type="receiver" repo="contrib" >}}                 | contrib                  | -           | alpha       | -            |
+| {{< component-link name="purefbreceiver" type="receiver" repo="contrib" >}}                 | contrib                  | -           | alpha       | -            |
+| {{< component-link name="rabbitmqreceiver" type="receiver" repo="contrib" >}}               | contrib                  | -           | beta        | -            |
+| {{< component-link name="receivercreator" type="receiver" repo="contrib" >}}                | contrib, K8s             | alpha       | beta        | alpha        |
+| {{< component-link name="redfishreceiver" type="receiver" repo="contrib" >}}                | contrib                  | -           | development | -            |
+| {{< component-link name="redisreceiver" type="receiver" repo="contrib" >}}                  | contrib                  | -           | beta        | -            |
+| {{< component-link name="riakreceiver" type="receiver" repo="contrib" >}}                   | contrib                  | -           | beta        | -            |
+| {{< component-link name="saphanareceiver" type="receiver" repo="contrib" >}}                | contrib                  | -           | alpha       | -            |
+| {{< component-link name="signalfxreceiver" type="receiver" repo="contrib" >}}               | contrib                  | -           | deprecated  | deprecated   |
+| {{< component-link name="simpleprometheusreceiver" type="receiver" repo="contrib" >}}       | contrib                  | -           | beta        | -            |
+| {{< component-link name="skywalkingreceiver" type="receiver" repo="contrib" >}}             | contrib                  | beta        | development | -            |
+| {{< component-link name="snmpreceiver" type="receiver" repo="contrib" >}}                   | contrib                  | -           | alpha       | -            |
+| {{< component-link name="snowflakereceiver" type="receiver" repo="contrib" >}}              | contrib                  | -           | alpha       | -            |
+| {{< component-link name="solacereceiver" type="receiver" repo="contrib" >}}                 | contrib                  | beta        | -           | -            |
+| {{< component-link name="splunkenterprisereceiver" type="receiver" repo="contrib" >}}       | contrib                  | -           | alpha       | -            |
+| {{< component-link name="splunkhecreceiver" type="receiver" repo="contrib" >}}              | contrib                  | -           | beta        | beta         |
+| {{< component-link name="sqlqueryreceiver" type="receiver" repo="contrib" >}}               | contrib                  | -           | alpha       | development  |
+| {{< component-link name="sqlserverreceiver" type="receiver" repo="contrib" >}}              | contrib                  | -           | beta        | development  |
+| {{< component-link name="sshcheckreceiver" type="receiver" repo="contrib" >}}               | contrib                  | -           | beta        | -            |
+| {{< component-link name="statsdreceiver" type="receiver" repo="contrib" >}}                 | contrib                  | -           | beta        | -            |
+| {{< component-link name="stefreceiver" type="receiver" repo="contrib" >}}                   | contrib                  | -           | alpha       | -            |
+| {{< component-link name="syslogreceiver" type="receiver" repo="contrib" >}}                 | contrib                  | -           | -           | beta         |
+| {{< component-link name="systemdreceiver" type="receiver" repo="contrib" >}}                | contrib                  | -           | alpha       | -            |
+| {{< component-link name="tcpcheckreceiver" type="receiver" repo="contrib" >}}               | contrib                  | -           | alpha       | -            |
+| {{< component-link name="tcplogreceiver" type="receiver" repo="contrib" >}}                 | contrib                  | -           | -           | alpha        |
+| {{< component-link name="tlscheckreceiver" type="receiver" repo="contrib" >}}               | contrib                  | -           | alpha       | -            |
+| {{< component-link name="udplogreceiver" type="receiver" repo="contrib" >}}                 | contrib                  | -           | -           | alpha        |
+| {{< component-link name="vcenterreceiver" type="receiver" repo="contrib" >}}                | contrib                  | -           | alpha       | -            |
+| {{< component-link name="vcrreceiver" type="receiver" repo="contrib" >}}                    | contrib                  | development | development | development  |
+| {{< component-link name="wavefrontreceiver" type="receiver" repo="contrib" >}}              | contrib                  | -           | deprecated  | -            |
+| {{< component-link name="webhookeventreceiver" type="receiver" repo="contrib" >}}           | contrib                  | -           | -           | beta         |
+| {{< component-link name="windowseventlogreceiver" type="receiver" repo="contrib" >}}        | contrib                  | -           | -           | alpha        |
+| {{< component-link name="windowsperfcountersreceiver" type="receiver" repo="contrib" >}}    | contrib                  | -           | beta        | -            |
+| {{< component-link name="windowsservicereceiver" type="receiver" repo="contrib" >}}         | contrib                  | -           | development | -            |
+| {{< component-link name="yanggrpcreceiver" type="receiver" repo="contrib" >}}               | contrib                  | -           | alpha       | -            |
+| {{< component-link name="zipkinreceiver" type="receiver" repo="contrib" >}}                 | contrib, core, K8s       | beta        | -           | -            |
+| {{< component-link name="zookeeperreceiver" type="receiver" repo="contrib" >}}              | contrib                  | -           | alpha       | -            |
 
 [^1]: このコンポーネントが含まれている[ディストリビューション](/docs/collector/distributions/)（core、contrib、K8sなど）を示します。
 
 [^2]: コンポーネントの安定性レベルの詳細については、[OpenTelemetry Collectorコンポーネントの安定性の定義](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md)を参照してください。
 
-<!-- END GENERATED: receiver-table -->
+<!-- END GENERATED: receiver-table SOURCE: scripts/collector-sync -->


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

As some of the Collector components have been deprecated over the past few releases, we've started seeing errors in our daily reference cache updates (e.g. [this](https://github.com/open-telemetry/opentelemetry.io/actions/runs/23045651210/job/66934198746?pr=9395) and [this](https://github.com/open-telemetry/opentelemetry.io/actions/runs/22997295247/job/66772928682?pr=9390) workflow run). 

To address this, we initially began manually patching the Japanese Collector component pages by removing them (as seen in [this PR](https://github.com/open-telemetry/opentelemetry.io/pull/9390/changes/80e1842122b426280e85ed7f1a2f22f8de3d2780)). However, following the changes introduced in #9315 , we are now linking deprecated components to their last known versions to avoid them suddently disappearing from the list. This PR synchronizes that same behavior for the Japanese content.

/cc @open-telemetry/docs-ja-approvers 