### PR TITLE
fix: correct processor count in pipeline example description

### DIFF
--- a/content/en/docs/collector/architecture.md
+++ b/content/en/docs/collector/architecture.md
@@ -80,7 +80,7 @@ service:
 ```
 
 The previous example defines a pipeline for the traces type of telemetry data,
-with two receivers, two processors, and two exporters.
+with two receivers, one processor, and two exporters.
 
 ### Receivers
 


### PR DESCRIPTION
In `content/en/docs/collector/architecture.md`, the pipeline configuration example shows:

  receivers: [otlp, zipkin]
  processors: [memory_limiter]
  exporters: [otlp, zipkin]

That is 2 receivers, 1 processor, and 2 exporters.

But the accompanying text said "with two receivers, two processors, and two exporters." — which is incorrect.

This PR corrects the text to "one processor".

---

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.
