### PR TITLE
Add otel-gui to the registry

### DIFF
--- a/data/registry/tools-js-otel-gui.yml
+++ b/data/registry/tools-js-otel-gui.yml
@@ -1,3 +1,4 @@
+# cSpell:ignore marguerie
 title: otel-gui
 registryType: utilities
 language: js

--- a/data/registry/tools-js-otel-gui.yml
+++ b/data/registry/tools-js-otel-gui.yml
@@ -1,0 +1,25 @@
+title: otel-gui
+registryType: utilities
+language: js
+tags:
+  - otel
+  - gui
+  - traces
+  - viewer
+  - otlp
+  - local
+  - development
+  - debugging
+urls:
+  repo: https://github.com/metafab/otel-gui
+  docs: https://github.com/metafab/otel-gui#readme
+license: MIT
+description:
+  Lightweight, zero-config OpenTelemetry trace viewer for local development with
+  real-time updates, search, and service map visualization.
+authors:
+  - name: Fabrice Marguerie
+    url: https://github.com/metafab
+createdAt: 2026-03-15
+isNative: false
+isFirstParty: false

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -6591,6 +6591,18 @@
     "StatusCode": 206,
     "LastSeen": "2026-03-02T09:53:18.410612568Z"
   },
+  "https://github.com/metafab": {
+    "StatusCode": 206,
+    "LastSeen": "2026-03-16T10:53:40.646391906Z"
+  },
+  "https://github.com/metafab/otel-gui": {
+    "StatusCode": 206,
+    "LastSeen": "2026-03-16T10:53:36.109739647Z"
+  },
+  "https://github.com/metafab/otel-gui#readme": {
+    "StatusCode": 206,
+    "LastSeen": "2026-03-16T10:53:45.422534767Z"
+  },
   "https://github.com/metrico/otel-collector": {
     "StatusCode": 206,
     "LastSeen": "2026-02-28T09:49:58.461060898Z"


### PR DESCRIPTION
This PR adds a new OpenTelemetry Registry entry for [otel-gui](https://github.com/metafab/otel-gui), a lightweight local trace viewer for OpenTelemetry data.

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
