### PR TITLE
Update Java agent declarative config docs for 2.26.0

### DIFF
--- a/content/en/docs/zero-code/java/agent/declarative-configuration.md
+++ b/content/en/docs/zero-code/java/agent/declarative-configuration.md
@@ -2,7 +2,7 @@
 title: Java Agent Declarative configuration
 linkTitle: Declarative configuration
 weight: 11
-cSpell:ignore: Customizer Dotel genai
+cSpell:ignore: Customizer Dotel
 ---
 
 Declarative configuration uses a YAML file instead of environment variables or


### PR DESCRIPTION
## Summary

- `otel.experimental.config.file` → `otel.config.file` (experimental prefix dropped)
- `file_format: '1.0-rc.1'` → `file_format: "1.0"`
- Minimum version updated to 2.26.0
- Added `distribution` section documenting javaagent-specific config mapping
- Trimmed "not yet supported" lists — most items have been migrated to declarative config

## Test plan

- [ ] Verify page renders correctly
- [ ] Cross-check remaining "not yet supported" items against instrumentation repo