### PR TITLE
Clarify the unification of event representation in the Span Events API

### DIFF
--- a/content/en/blog/2026/deprecating-span-events.md
+++ b/content/en/blog/2026/deprecating-span-events.md
@@ -48,7 +48,9 @@ Having two competing APIs for the same concept has several drawbacks:
 The OpenTelemetry community has been converging on a simpler mental model:
 **events are logs with names** emitted via the Logs API, correlated with traces
 and metrics through context, rather than as a special case on spans. This change
-is significant because it unifies how OpenTelemetry represents events.
+is significant because it unifies how OpenTelemetry represents events. For more
+background on this direction, see the earlier blog post
+[OpenTelemetry Logging and You](/blog/2025/opentelemetry-logging-and-you/).
 
 At the same time, we recognize that span events are widely used today. Many
 backends present span events in dedicated trace views, and some users depend on


### PR DESCRIPTION
Addresses https://github.com/open-telemetry/community/issues/3312#issuecomment-4080255128

> I don't understand the benefit of switching to the log API: I don't want information scattered across several systems/APIs, and I'm really happy to have a way to build rich events (spans regular data + span events attached to them with exact timestamps) that carry all the context I need.

This blog post provides more detailed context on the decision and the benefits of moving to the log-based approach.