### PR TITLE
Add declarative configuration docs for Spring Boot starter

### DIFF
--- a/content/en/blog/2024/spring-starter-stable/index.md
+++ b/content/en/blog/2024/spring-starter-stable/index.md
@@ -43,7 +43,7 @@ Here are some scenarios where you might want to use the Spring Starter:
   doesn't work with the OpenTelemetry Java agent
 - **Programmatic configuration** of the OpenTelemetry Spring Boot starter, such
   as
-  [dynamic auth headers](/docs/zero-code/java/spring-boot-starter/sdk-configuration/#configure-the-exporter-programmatically),
+  [dynamic auth headers](/docs/zero-code/java/spring-boot-starter/programmatic-configuration/#configure-the-exporter-programmatically),
   using Spring beans (the OpenTelemetry Java agent requires an
   [extension](/docs/zero-code/java/agent/extensions/) for this)
 - **Uses code dependencies**: You don't need to add any JVM options (e.g. in

--- a/content/en/docs/zero-code/java/_index.md
+++ b/content/en/docs/zero-code/java/_index.md
@@ -8,6 +8,7 @@ cascade:
   vers:
     instrumentation: 2.27.0
     otel: 1.61.0
+    contrib: 1.54.0
 ---
 
 Common options for zero-code instrumentation with Java are the Java agent JAR,

--- a/content/en/docs/zero-code/java/agent/declarative-configuration.md
+++ b/content/en/docs/zero-code/java/agent/declarative-configuration.md
@@ -76,6 +76,8 @@ getting started guide for declarative configuration.
 
 This page focuses on specifics for the
 [OpenTelemetry Java agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation).
+For the Spring Boot starter, see
+[Spring Boot starter declarative configuration](/docs/zero-code/java/spring-boot-starter/declarative-configuration/).
 
 ## Mapping of configuration options
 
@@ -221,14 +223,6 @@ Contrib features that are not yet supported by declarative configuration:
 - [AWS X-Ray](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/aws-xray)
 - [GCP authentication](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/gcp-auth-extension)
 - [Inferred Spans](https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/inferred-spans)
-
-### Spring Boot starter limitations
-
-Lastly, the [Spring Boot starter](/docs/zero-code/java/spring-boot-starter) does
-not yet support declarative configuration:
-
-- however, you can already use `application.yaml` to configure the OpenTelemetry
-  Spring Boot starter
 
 ## Extension API
 

--- a/content/en/docs/zero-code/java/spring-boot-starter/_index.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/_index.md
@@ -24,3 +24,5 @@ OpenTelemetry.
    - **Spring Boot configuration files** (`application.properties`,
      `application.yml`) to configure the OpenTelemetry Spring Boot starter which
      doesn't work with the OpenTelemetry Java agent
+   - **[Declarative configuration](declarative-configuration/)** using a
+     structured YAML format inside `application.yaml`

--- a/content/en/docs/zero-code/java/spring-boot-starter/additional-instrumentations.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/additional-instrumentations.md
@@ -29,9 +29,27 @@ You can find more configuration options for the OpenTelemetry appender in the
 [Log4j](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/log4j/log4j-appender-2.17/library/README.md)
 instrumentation library.
 
+{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
+
 | System property                               | Type    | Default | Description                                                                                     |
 | --------------------------------------------- | ------- | ------- | ----------------------------------------------------------------------------------------------- |
 | `otel.instrumentation.log4j-appender.enabled` | Boolean | true    | Enables the configuration of the Log4j OpenTelemetry appender with an `OpenTelemetry` instance. |
+
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+In [declarative configuration](../declarative-configuration/), use the
+centralized instrumentation lists to enable or disable Log4j:
+
+```yaml
+otel:
+  distribution:
+    spring_starter:
+      instrumentation:
+        disabled:
+          - log4j_appender
+```
+
+{{% /tab %}} {{< /tabpane >}}
 
 ## Instrumentation libraries
 

--- a/content/en/docs/zero-code/java/spring-boot-starter/additional-instrumentations.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/additional-instrumentations.md
@@ -29,7 +29,7 @@ You can find more configuration options for the OpenTelemetry appender in the
 [Log4j](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/log4j/log4j-appender-2.17/library/README.md)
 instrumentation library.
 
-{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
+{{< tabpane text=true >}} {{% tab "Properties" %}}
 
 Enables the configuration of the Log4j OpenTelemetry appender with an
 `OpenTelemetry` instance:

--- a/content/en/docs/zero-code/java/spring-boot-starter/additional-instrumentations.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/additional-instrumentations.md
@@ -31,9 +31,15 @@ instrumentation library.
 
 {{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
 
-| System property                               | Type    | Default | Description                                                                                     |
-| --------------------------------------------- | ------- | ------- | ----------------------------------------------------------------------------------------------- |
-| `otel.instrumentation.log4j-appender.enabled` | Boolean | true    | Enables the configuration of the Log4j OpenTelemetry appender with an `OpenTelemetry` instance. |
+Enables the configuration of the Log4j OpenTelemetry appender with an
+`OpenTelemetry` instance:
+
+```yaml
+otel:
+  instrumentation:
+    log4j-appender:
+      enabled: true # default: true
+```
 
 {{% /tab %}} {{% tab "Declarative Configuration" %}}
 

--- a/content/en/docs/zero-code/java/spring-boot-starter/annotations.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/annotations.md
@@ -116,6 +116,18 @@ dependencies {
 You can disable the OpenTelemetry annotations by setting the
 `otel.instrumentation.annotations.enabled` property to `false`.
 
+In [declarative configuration](../declarative-configuration/), use the
+centralized instrumentation lists instead:
+
+```yaml
+otel:
+  distribution:
+    spring_starter:
+      instrumentation:
+        disabled:
+          - annotations
+```
+
 You can customize the span by using the elements of the `WithSpan` annotation:
 
 | Name    | Type       | Description           | Default Value       |

--- a/content/en/docs/zero-code/java/spring-boot-starter/declarative-configuration.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/declarative-configuration.md
@@ -27,8 +27,8 @@ starter version 2.26.0 and later**.
 
 ## Getting started
 
-Add `otel.file_format: "1.0"` (or the current or desired version) to your `application.yaml` to opt in to
-declarative configuration:
+Add `otel.file_format: "1.0"` (or the current or desired version) to your
+`application.yaml` to opt in to declarative configuration:
 
 ```yaml
 otel:
@@ -83,7 +83,7 @@ In declarative configuration, instrumentation enable/disable uses centralized
 lists instead of individual properties. The instrumentation name uses `_`
 (snake_case), not `-` (kebab-case).
 
-| Properties                                  | Declarative Configuration                                                       |
+| Properties                                            | Declarative Configuration                                                       |
 | ----------------------------------------------------- | ------------------------------------------------------------------------------- |
 | `otel.instrumentation.jdbc.enabled=true`              | `otel.distribution.spring_starter.instrumentation.enabled: [jdbc]`              |
 | `otel.instrumentation.logback-appender.enabled=false` | `otel.distribution.spring_starter.instrumentation.disabled: [logback_appender]` |
@@ -118,13 +118,13 @@ map to `otel.instrumentation/development.java.*`:
 
 For example:
 
-| Properties                                                | Declarative Configuration                                                                        |
+| Properties                                                          | Declarative Configuration                                                                        |
 | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | `otel.instrumentation.logback-appender.experimental-log-attributes` | `otel.instrumentation/development.java.logback_appender.experimental_log_attributes/development` |
 
 Some options have special mappings that don't follow the default algorithm:
 
-| Properties                                                    | Declarative Configuration                                                                          |
+| Properties                                                              | Declarative Configuration                                                                          |
 | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
 | `otel.instrumentation.common.db-statement-sanitizer.enabled`            | `otel.instrumentation/development.java.common.database.statement_sanitizer.enabled`                |
 | `otel.instrumentation.http.client.capture-request-headers`              | `otel.instrumentation/development.general.http.client.request_captured_headers`                    |
@@ -145,7 +145,7 @@ The `instrumentation/development` section has two top-level groups:
 
 ### Disable the SDK
 
-| Properties     | Declarative Configuration |
+| Properties               | Declarative Configuration |
 | ------------------------ | ------------------------- |
 | `otel.sdk.disabled=true` | `otel.disabled: true`     |
 

--- a/content/en/docs/zero-code/java/spring-boot-starter/declarative-configuration.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/declarative-configuration.md
@@ -1,0 +1,198 @@
+---
+title: Declarative configuration
+weight: 25
+cSpell:ignore: Customizer
+---
+
+Declarative configuration uses the
+[OpenTelemetry declarative configuration schema](/docs/languages/sdk-configuration/declarative-configuration/)
+inside your `application.yaml`.
+
+This approach is useful when:
+
+- You have many configuration options to set
+- You want to use configuration options that are not available with
+  `application.properties` or `application.yaml`
+- You want to use the same configuration format as the
+  [Java agent](/docs/zero-code/java/agent/declarative-configuration/)
+
+> [!WARNING]
+>
+> Declarative configuration is experimental.
+
+## Supported versions
+
+Declarative configuration is supported in the **OpenTelemetry Spring Boot
+starter version 2.26.0 and later**.
+
+## Getting started
+
+Add `otel.file_format: "1.0"` to your `application.yaml` to opt in to
+declarative configuration:
+
+```yaml
+otel:
+  file_format: '1.0'
+
+  resource:
+    detection/development:
+      detectors:
+        - service:
+    attributes:
+      - name: service.name
+        value: my-spring-app
+
+  propagator:
+    composite:
+      - tracecontext:
+      - baggage:
+
+  tracer_provider:
+    processors:
+      - batch:
+          exporter:
+            otlp_http:
+              endpoint: ${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:http://localhost:4318/v1/traces}
+
+  meter_provider:
+    readers:
+      - periodic:
+          exporter:
+            otlp_http:
+              endpoint: ${OTEL_EXPORTER_OTLP_METRICS_ENDPOINT:http://localhost:4318/v1/metrics}
+
+  logger_provider:
+    processors:
+      - batch:
+          exporter:
+            otlp_http:
+              endpoint: ${OTEL_EXPORTER_OTLP_LOGS_ENDPOINT:http://localhost:4318/v1/logs}
+```
+
+Note that `${VAR:default}` uses a single colon (Spring syntax), not the
+`${VAR:-default}` syntax used in the agent's standalone YAML file.
+
+## Mapping of configuration options
+
+The following rules describe how `application.properties` /
+`application.yaml` configuration options map to their declarative configuration
+equivalents:
+
+### Instrumentation enable/disable
+
+In declarative configuration, instrumentation enable/disable uses centralized
+lists instead of individual properties. The instrumentation name uses `_`
+(snake_case), not `-` (kebab-case).
+
+| Properties                                       | Declarative Configuration                                                    |
+| ------------------------------------------------ | ---------------------------------------------------------------------------- |
+| `otel.instrumentation.jdbc.enabled=true`         | `otel.distribution.spring_starter.instrumentation.enabled: [jdbc]`           |
+| `otel.instrumentation.logback-appender.enabled=false` | `otel.distribution.spring_starter.instrumentation.disabled: [logback_appender]` |
+| `otel.instrumentation.common.default-enabled=false` | `otel.distribution.spring_starter.instrumentation.default_enabled: false`    |
+
+Example:
+
+```yaml
+otel:
+  distribution:
+    spring_starter:
+      instrumentation:
+        default_enabled: false
+        enabled:
+          - jdbc
+          - spring_web
+        disabled:
+          - logback_appender
+```
+
+### Instrumentation configuration
+
+Configuration options under `otel.instrumentation.*` (other than enable/disable)
+map to `otel.instrumentation/development.java.*`:
+
+1. Strip the `otel.instrumentation.` prefix
+2. Per segment: replace `-` with `_`
+3. Place under `otel.instrumentation/development.java.`
+
+For example:
+
+| Properties                                                            | Declarative Configuration                                                    |
+| --------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `otel.instrumentation.logback-appender.experimental-log-attributes`   | `otel.instrumentation/development.java.logback_appender.experimental_log_attributes` |
+| `otel.instrumentation.common.db-statement-sanitizer.enabled`          | `otel.instrumentation/development.java.common.db_statement_sanitizer.enabled` |
+
+Some options have special mappings that don't follow the default algorithm:
+
+| Properties                                                            | Declarative Configuration                                                    |
+| --------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `otel.instrumentation.http.client.capture-request-headers`            | `otel.instrumentation/development.general.http.client.request_captured_headers` |
+| `otel.instrumentation.http.client.capture-response-headers`           | `otel.instrumentation/development.general.http.client.response_captured_headers` |
+| `otel.instrumentation.http.server.capture-request-headers`            | `otel.instrumentation/development.general.http.server.request_captured_headers` |
+| `otel.instrumentation.http.server.capture-response-headers`           | `otel.instrumentation/development.general.http.server.response_captured_headers` |
+| `otel.instrumentation.http.client.emit-experimental-telemetry`        | `otel.instrumentation/development.java.common.http.client.emit_experimental_telemetry/development` |
+| `otel.instrumentation.http.server.emit-experimental-telemetry`        | `otel.instrumentation/development.java.common.http.server.emit_experimental_telemetry/development` |
+| `otel.instrumentation.http.known-methods`                             | `otel.instrumentation/development.java.common.http.known_methods` |
+| `otel.instrumentation.messaging.experimental.receive-telemetry.enabled` | `otel.instrumentation/development.java.common.messaging.receive_telemetry/development.enabled` |
+| `otel.jmx.enabled`                                                   | `otel.instrumentation/development.java.jmx.enabled`                          |
+
+The `instrumentation/development` section has two top-level groups:
+
+- `general.*` — Cross-language configuration (HTTP headers, semantic convention
+  stability)
+- `java.*` — Java-specific instrumentation configuration
+
+### Disable the SDK
+
+| Properties               | Declarative Configuration |
+| ------------------------ | ------------------------- |
+| `otel.sdk.disabled=true` | `otel.disabled: true`     |
+
+### SDK configuration
+
+SDK-level configuration (exporters, propagators, resources) follows the standard
+[declarative configuration schema](/docs/languages/sdk-configuration/declarative-configuration/)
+directly under `otel:`, as shown in the [Getting started](#getting-started)
+example.
+
+## Differences from agent declarative configuration
+
+| Aspect             | Agent                                                | Spring Boot starter                       |
+| ------------------ | ---------------------------------------------------- | ----------------------------------------- |
+| Config location    | Separate file (`-Dotel.config.file=...`)             | Inside `application.yaml`                 |
+| Variable syntax    | `${VAR:-default}` (double-colon)                     | `${VAR:default}` (single colon, Spring)   |
+| Profiles           | Not supported                                        | Spring profiles work normally              |
+| Enable/disable     | `distribution.javaagent.instrumentation.*`           | `distribution.spring_starter.instrumentation.*` |
+| Default-enabled    | `distribution.javaagent.instrumentation.default_enabled` | `distribution.spring_starter.instrumentation.default_enabled` |
+
+## Environment variable overrides
+
+Spring's relaxed binding lets you override any part of the declarative
+configuration YAML via environment variables:
+
+```shell
+# Override a scalar under instrumentation/development
+OTEL_INSTRUMENTATION/DEVELOPMENT_JAVA_FOO_STRING_KEY=new_value
+
+# Override an indexed list element (e.g. exporter endpoint)
+OTEL_TRACER_PROVIDER_PROCESSORS_0_BATCH_EXPORTER_OTLP_HTTP_ENDPOINT=http://custom:4318/v1/traces
+```
+
+Rules: uppercase, replace `.` with `_`, keep `/` as-is (e.g.
+`INSTRUMENTATION/DEVELOPMENT`), use `_0_`, `_1_` for list indices.
+
+This is a standard Spring feature — it works for any key in `application.yaml`.
+
+## Duration format
+
+Declarative configuration **only supports durations in milliseconds** (e.g.
+`5000` for 5 seconds). You will get an error if you use a duration string like
+`5s`.
+
+## Programmatic configuration
+
+With declarative configuration, `AutoConfigurationCustomizerProvider` (see
+[Programmatic configuration](../programmatic-configuration/)) is replaced by
+`DeclarativeConfigurationCustomizerProvider`. Components such as span exporters
+use the `ComponentProvider` API. See the
+[agent Extension API](/docs/zero-code/java/agent/declarative-configuration/#extension-api)
+for details and examples — the same APIs apply to the Spring Boot starter.

--- a/content/en/docs/zero-code/java/spring-boot-starter/declarative-configuration.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/declarative-configuration.md
@@ -1,7 +1,7 @@
 ---
 title: Declarative configuration
 weight: 25
-cSpell:ignore: Customizer
+cSpell:ignore: Customizer Dotel
 ---
 
 Declarative configuration uses the
@@ -74,9 +74,8 @@ Note that `${VAR:default}` uses a single colon (Spring syntax), not the
 
 ## Mapping of configuration options
 
-The following rules describe how `application.properties` /
-`application.yaml` configuration options map to their declarative configuration
-equivalents:
+The following rules describe how `application.properties` / `application.yaml`
+configuration options map to their declarative configuration equivalents:
 
 ### Instrumentation enable/disable
 
@@ -84,11 +83,11 @@ In declarative configuration, instrumentation enable/disable uses centralized
 lists instead of individual properties. The instrumentation name uses `_`
 (snake_case), not `-` (kebab-case).
 
-| Properties                                       | Declarative Configuration                                                    |
-| ------------------------------------------------ | ---------------------------------------------------------------------------- |
-| `otel.instrumentation.jdbc.enabled=true`         | `otel.distribution.spring_starter.instrumentation.enabled: [jdbc]`           |
+| Properties                                            | Declarative Configuration                                                       |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `otel.instrumentation.jdbc.enabled=true`              | `otel.distribution.spring_starter.instrumentation.enabled: [jdbc]`              |
 | `otel.instrumentation.logback-appender.enabled=false` | `otel.distribution.spring_starter.instrumentation.disabled: [logback_appender]` |
-| `otel.instrumentation.common.default-enabled=false` | `otel.distribution.spring_starter.instrumentation.default_enabled: false`    |
+| `otel.instrumentation.common.default-enabled=false`   | `otel.distribution.spring_starter.instrumentation.default_enabled: false`       |
 
 Example:
 
@@ -119,24 +118,24 @@ map to `otel.instrumentation/development.java.*`:
 
 For example:
 
-| Properties                                                            | Declarative Configuration                                                                |
-| --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `otel.instrumentation.logback-appender.experimental-log-attributes`   | `otel.instrumentation/development.java.logback_appender.experimental_log_attributes/development` |
+| Properties                                                          | Declarative Configuration                                                                        |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `otel.instrumentation.logback-appender.experimental-log-attributes` | `otel.instrumentation/development.java.logback_appender.experimental_log_attributes/development` |
 
 Some options have special mappings that don't follow the default algorithm:
 
-| Properties                                                            | Declarative Configuration                                                    |
-| --------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| `otel.instrumentation.common.db-statement-sanitizer.enabled`            | `otel.instrumentation/development.java.common.database.statement_sanitizer.enabled` |
-| `otel.instrumentation.http.client.capture-request-headers`              | `otel.instrumentation/development.general.http.client.request_captured_headers` |
-| `otel.instrumentation.http.client.capture-response-headers`             | `otel.instrumentation/development.general.http.client.response_captured_headers` |
-| `otel.instrumentation.http.server.capture-request-headers`              | `otel.instrumentation/development.general.http.server.request_captured_headers` |
-| `otel.instrumentation.http.server.capture-response-headers`             | `otel.instrumentation/development.general.http.server.response_captured_headers` |
+| Properties                                                              | Declarative Configuration                                                                          |
+| ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `otel.instrumentation.common.db-statement-sanitizer.enabled`            | `otel.instrumentation/development.java.common.database.statement_sanitizer.enabled`                |
+| `otel.instrumentation.http.client.capture-request-headers`              | `otel.instrumentation/development.general.http.client.request_captured_headers`                    |
+| `otel.instrumentation.http.client.capture-response-headers`             | `otel.instrumentation/development.general.http.client.response_captured_headers`                   |
+| `otel.instrumentation.http.server.capture-request-headers`              | `otel.instrumentation/development.general.http.server.request_captured_headers`                    |
+| `otel.instrumentation.http.server.capture-response-headers`             | `otel.instrumentation/development.general.http.server.response_captured_headers`                   |
 | `otel.instrumentation.http.client.emit-experimental-telemetry`          | `otel.instrumentation/development.java.common.http.client.emit_experimental_telemetry/development` |
 | `otel.instrumentation.http.server.emit-experimental-telemetry`          | `otel.instrumentation/development.java.common.http.server.emit_experimental_telemetry/development` |
-| `otel.instrumentation.http.known-methods`                               | `otel.instrumentation/development.java.common.http.known_methods` |
-| `otel.instrumentation.messaging.experimental.receive-telemetry.enabled` | `otel.instrumentation/development.java.common.messaging.receive_telemetry/development.enabled` |
-| `otel.jmx.enabled`                                                     | `otel.instrumentation/development.java.jmx.enabled`                          |
+| `otel.instrumentation.http.known-methods`                               | `otel.instrumentation/development.java.common.http.known_methods`                                  |
+| `otel.instrumentation.messaging.experimental.receive-telemetry.enabled` | `otel.instrumentation/development.java.common.messaging.receive_telemetry/development.enabled`     |
+| `otel.jmx.enabled`                                                      | `otel.instrumentation/development.java.jmx.enabled`                                                |
 
 The `instrumentation/development` section has two top-level groups:
 
@@ -159,13 +158,13 @@ example.
 
 ## Differences from agent declarative configuration
 
-| Aspect             | Agent                                                | Spring Boot starter                       |
-| ------------------ | ---------------------------------------------------- | ----------------------------------------- |
-| Config location    | Separate file (`-Dotel.config.file=...`)             | Inside `application.yaml`                 |
-| Variable syntax    | `${VAR:-default}` (double-colon)                     | `${VAR:default}` (single colon, Spring)   |
-| Profiles           | Not supported                                        | Spring profiles work normally              |
-| Enable/disable     | `distribution.javaagent.instrumentation.*`           | `distribution.spring_starter.instrumentation.*` |
-| Default-enabled    | `distribution.javaagent.instrumentation.default_enabled` | `distribution.spring_starter.instrumentation.default_enabled` |
+| Aspect          | Agent                                                    | Spring Boot starter                                           |
+| --------------- | -------------------------------------------------------- | ------------------------------------------------------------- |
+| Config location | Separate file (`-Dotel.config.file=...`)                 | Inside `application.yaml`                                     |
+| Variable syntax | `${VAR:-default}` (double-colon)                         | `${VAR:default}` (single colon, Spring)                       |
+| Profiles        | Not supported                                            | Spring profiles work normally                                 |
+| Enable/disable  | `distribution.javaagent.instrumentation.*`               | `distribution.spring_starter.instrumentation.*`               |
+| Default-enabled | `distribution.javaagent.instrumentation.default_enabled` | `distribution.spring_starter.instrumentation.default_enabled` |
 
 ## Environment variable overrides
 

--- a/content/en/docs/zero-code/java/spring-boot-starter/declarative-configuration.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/declarative-configuration.md
@@ -27,7 +27,7 @@ starter version 2.26.0 and later**.
 
 ## Getting started
 
-Add `otel.file_format: "1.0"` to your `application.yaml` to opt in to
+Add `otel.file_format: "1.0"` (or the current or desired version) to your `application.yaml` to opt in to
 declarative configuration:
 
 ```yaml
@@ -196,5 +196,5 @@ With declarative configuration, `AutoConfigurationCustomizerProvider` (see
 [Programmatic configuration](../programmatic-configuration/)) is replaced by
 `DeclarativeConfigurationCustomizerProvider`. Components such as span exporters
 use the `ComponentProvider` API. See the
-[agent Extension API](/docs/zero-code/java/agent/declarative-configuration/#extension-api)
+[agent Extension API section](/docs/zero-code/java/agent/declarative-configuration/)
 for details and examples — the same APIs apply to the Spring Boot starter.

--- a/content/en/docs/zero-code/java/spring-boot-starter/declarative-configuration.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/declarative-configuration.md
@@ -83,7 +83,7 @@ In declarative configuration, instrumentation enable/disable uses centralized
 lists instead of individual properties. The instrumentation name uses `_`
 (snake_case), not `-` (kebab-case).
 
-| Non-DC configuration                                  | Declarative Configuration                                                       |
+| Properties                                  | Declarative Configuration                                                       |
 | ----------------------------------------------------- | ------------------------------------------------------------------------------- |
 | `otel.instrumentation.jdbc.enabled=true`              | `otel.distribution.spring_starter.instrumentation.enabled: [jdbc]`              |
 | `otel.instrumentation.logback-appender.enabled=false` | `otel.distribution.spring_starter.instrumentation.disabled: [logback_appender]` |
@@ -118,13 +118,13 @@ map to `otel.instrumentation/development.java.*`:
 
 For example:
 
-| Non-DC configuration                                                | Declarative Configuration                                                                        |
+| Properties                                                | Declarative Configuration                                                                        |
 | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | `otel.instrumentation.logback-appender.experimental-log-attributes` | `otel.instrumentation/development.java.logback_appender.experimental_log_attributes/development` |
 
 Some options have special mappings that don't follow the default algorithm:
 
-| Non-DC configuration                                                    | Declarative Configuration                                                                          |
+| Properties                                                    | Declarative Configuration                                                                          |
 | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
 | `otel.instrumentation.common.db-statement-sanitizer.enabled`            | `otel.instrumentation/development.java.common.database.statement_sanitizer.enabled`                |
 | `otel.instrumentation.http.client.capture-request-headers`              | `otel.instrumentation/development.general.http.client.request_captured_headers`                    |
@@ -145,7 +145,7 @@ The `instrumentation/development` section has two top-level groups:
 
 ### Disable the SDK
 
-| Non-DC configuration     | Declarative Configuration |
+| Properties     | Declarative Configuration |
 | ------------------------ | ------------------------- |
 | `otel.sdk.disabled=true` | `otel.disabled: true`     |
 

--- a/content/en/docs/zero-code/java/spring-boot-starter/declarative-configuration.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/declarative-configuration.md
@@ -113,27 +113,30 @@ map to `otel.instrumentation/development.java.*`:
 1. Strip the `otel.instrumentation.` prefix
 2. Per segment: replace `-` with `_`
 3. Place under `otel.instrumentation/development.java.`
+4. A `/development` suffix on a key indicates an experimental feature (see the
+   `translateName` method in `ConfigPropertiesBackedDeclarativeConfigProperties`
+   for the reverse mapping)
 
 For example:
 
-| Properties                                                            | Declarative Configuration                                                    |
-| --------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| `otel.instrumentation.logback-appender.experimental-log-attributes`   | `otel.instrumentation/development.java.logback_appender.experimental_log_attributes` |
-| `otel.instrumentation.common.db-statement-sanitizer.enabled`          | `otel.instrumentation/development.java.common.db_statement_sanitizer.enabled` |
+| Properties                                                            | Declarative Configuration                                                                |
+| --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `otel.instrumentation.logback-appender.experimental-log-attributes`   | `otel.instrumentation/development.java.logback_appender.experimental_log_attributes/development` |
 
 Some options have special mappings that don't follow the default algorithm:
 
 | Properties                                                            | Declarative Configuration                                                    |
 | --------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| `otel.instrumentation.http.client.capture-request-headers`            | `otel.instrumentation/development.general.http.client.request_captured_headers` |
-| `otel.instrumentation.http.client.capture-response-headers`           | `otel.instrumentation/development.general.http.client.response_captured_headers` |
-| `otel.instrumentation.http.server.capture-request-headers`            | `otel.instrumentation/development.general.http.server.request_captured_headers` |
-| `otel.instrumentation.http.server.capture-response-headers`           | `otel.instrumentation/development.general.http.server.response_captured_headers` |
-| `otel.instrumentation.http.client.emit-experimental-telemetry`        | `otel.instrumentation/development.java.common.http.client.emit_experimental_telemetry/development` |
-| `otel.instrumentation.http.server.emit-experimental-telemetry`        | `otel.instrumentation/development.java.common.http.server.emit_experimental_telemetry/development` |
-| `otel.instrumentation.http.known-methods`                             | `otel.instrumentation/development.java.common.http.known_methods` |
+| `otel.instrumentation.common.db-statement-sanitizer.enabled`            | `otel.instrumentation/development.java.common.database.statement_sanitizer.enabled` |
+| `otel.instrumentation.http.client.capture-request-headers`              | `otel.instrumentation/development.general.http.client.request_captured_headers` |
+| `otel.instrumentation.http.client.capture-response-headers`             | `otel.instrumentation/development.general.http.client.response_captured_headers` |
+| `otel.instrumentation.http.server.capture-request-headers`              | `otel.instrumentation/development.general.http.server.request_captured_headers` |
+| `otel.instrumentation.http.server.capture-response-headers`             | `otel.instrumentation/development.general.http.server.response_captured_headers` |
+| `otel.instrumentation.http.client.emit-experimental-telemetry`          | `otel.instrumentation/development.java.common.http.client.emit_experimental_telemetry/development` |
+| `otel.instrumentation.http.server.emit-experimental-telemetry`          | `otel.instrumentation/development.java.common.http.server.emit_experimental_telemetry/development` |
+| `otel.instrumentation.http.known-methods`                               | `otel.instrumentation/development.java.common.http.known_methods` |
 | `otel.instrumentation.messaging.experimental.receive-telemetry.enabled` | `otel.instrumentation/development.java.common.messaging.receive_telemetry/development.enabled` |
-| `otel.jmx.enabled`                                                   | `otel.instrumentation/development.java.jmx.enabled`                          |
+| `otel.jmx.enabled`                                                     | `otel.instrumentation/development.java.jmx.enabled`                          |
 
 The `instrumentation/development` section has two top-level groups:
 

--- a/content/en/docs/zero-code/java/spring-boot-starter/declarative-configuration.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/declarative-configuration.md
@@ -83,7 +83,7 @@ In declarative configuration, instrumentation enable/disable uses centralized
 lists instead of individual properties. The instrumentation name uses `_`
 (snake_case), not `-` (kebab-case).
 
-| Properties                                            | Declarative Configuration                                                       |
+| Non-DC configuration                                  | Declarative Configuration                                                       |
 | ----------------------------------------------------- | ------------------------------------------------------------------------------- |
 | `otel.instrumentation.jdbc.enabled=true`              | `otel.distribution.spring_starter.instrumentation.enabled: [jdbc]`              |
 | `otel.instrumentation.logback-appender.enabled=false` | `otel.distribution.spring_starter.instrumentation.disabled: [logback_appender]` |
@@ -118,13 +118,13 @@ map to `otel.instrumentation/development.java.*`:
 
 For example:
 
-| Properties                                                          | Declarative Configuration                                                                        |
+| Non-DC configuration                                                | Declarative Configuration                                                                        |
 | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | `otel.instrumentation.logback-appender.experimental-log-attributes` | `otel.instrumentation/development.java.logback_appender.experimental_log_attributes/development` |
 
 Some options have special mappings that don't follow the default algorithm:
 
-| Properties                                                              | Declarative Configuration                                                                          |
+| Non-DC configuration                                                    | Declarative Configuration                                                                          |
 | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
 | `otel.instrumentation.common.db-statement-sanitizer.enabled`            | `otel.instrumentation/development.java.common.database.statement_sanitizer.enabled`                |
 | `otel.instrumentation.http.client.capture-request-headers`              | `otel.instrumentation/development.general.http.client.request_captured_headers`                    |
@@ -145,7 +145,7 @@ The `instrumentation/development` section has two top-level groups:
 
 ### Disable the SDK
 
-| Properties               | Declarative Configuration |
+| Non-DC configuration     | Declarative Configuration |
 | ------------------------ | ------------------------- |
 | `otel.sdk.disabled=true` | `otel.disabled: true`     |
 

--- a/content/en/docs/zero-code/java/spring-boot-starter/other-spring-autoconfig.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/other-spring-autoconfig.md
@@ -50,6 +50,27 @@ dependencies {
 
 ### Configurations
 
+{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
+
 | Property                       | Default Value | ConditionalOnClass   |
 | ------------------------------ | ------------- | -------------------- |
 | `otel.exporter.zipkin.enabled` | true          | `ZipkinSpanExporter` |
+
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+With [declarative configuration](../declarative-configuration/), the Zipkin
+exporter is configured as part of the standard
+[declarative configuration schema](/docs/languages/sdk-configuration/declarative-configuration/)
+under `tracer_provider.processors`:
+
+```yaml
+otel:
+  tracer_provider:
+    processors:
+      - batch:
+          exporter:
+            zipkin:
+              endpoint: http://localhost:9411/api/v2/spans
+```
+
+{{% /tab %}} {{< /tabpane >}}

--- a/content/en/docs/zero-code/java/spring-boot-starter/other-spring-autoconfig.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/other-spring-autoconfig.md
@@ -50,7 +50,7 @@ dependencies {
 
 ### Configurations
 
-{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
+{{< tabpane text=true >}} {{% tab "Properties" %}}
 
 Enables the Zipkin exporter (requires `ZipkinSpanExporter` on the classpath):
 

--- a/content/en/docs/zero-code/java/spring-boot-starter/other-spring-autoconfig.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/other-spring-autoconfig.md
@@ -52,9 +52,14 @@ dependencies {
 
 {{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
 
-| Property                       | Default Value | ConditionalOnClass   |
-| ------------------------------ | ------------- | -------------------- |
-| `otel.exporter.zipkin.enabled` | true          | `ZipkinSpanExporter` |
+Enables the Zipkin exporter (requires `ZipkinSpanExporter` on the classpath):
+
+```yaml
+otel:
+  exporter:
+    zipkin:
+      enabled: true # default: true
+```
 
 {{% /tab %}} {{% tab "Declarative Configuration" %}}
 

--- a/content/en/docs/zero-code/java/spring-boot-starter/out-of-the-box-instrumentation.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/out-of-the-box-instrumentation.md
@@ -9,6 +9,8 @@ cSpell:ignore: autoconfigurations autoconfigures webflux webmvc
 
 Out of the box instrumentation is available for several frameworks:
 
+{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
+
 | Feature               | Property                                        | Default Value |
 | --------------------- | ----------------------------------------------- | ------------- |
 | JDBC                  | `otel.instrumentation.jdbc.enabled`             | true          |
@@ -22,7 +24,42 @@ Out of the box instrumentation is available for several frameworks:
 | Micrometer            | `otel.instrumentation.micrometer.enabled`       | false         |
 | R2DBC (reactive JDBC) | `otel.instrumentation.r2dbc.enabled`            | true          |
 
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+In [declarative configuration](../declarative-configuration/), instrumentation
+enable/disable uses centralized lists under
+`otel.distribution.spring_starter.instrumentation`. The instrumentation name
+uses `_` (snake_case), not `-` (kebab-case).
+
+| Feature               | Name                | Default |
+| --------------------- | ------------------- | ------- |
+| JDBC                  | `jdbc`              | enabled |
+| Logback               | `logback_appender`  | enabled |
+| Logback MDC           | `logback_mdc`       | enabled |
+| Spring Web            | `spring_web`        | enabled |
+| Spring Web MVC        | `spring_webmvc`     | enabled |
+| Spring WebFlux        | `spring_webflux`    | enabled |
+| Kafka                 | `kafka`             | enabled |
+| MongoDB               | `mongo`             | enabled |
+| Micrometer            | `micrometer`        | disabled |
+| R2DBC (reactive JDBC) | `r2dbc`             | enabled |
+
+To disable a specific instrumentation:
+
+```yaml
+otel:
+  distribution:
+    spring_starter:
+      instrumentation:
+        disabled:
+          - logback_appender
+```
+
+{{% /tab %}} {{< /tabpane >}}
+
 ## Turn on instrumentations selectively
+
+{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
 
 To use only specific instrumentations, turn off all the instrumentations first
 by setting the `otel.instrumentation.common.default-enabled` property to
@@ -31,24 +68,78 @@ by setting the `otel.instrumentation.common.default-enabled` property to
 For example, if you want to only enable the JDBC instrumentation, set
 `otel.instrumentation.jdbc.enabled` to `true`.
 
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+In [declarative configuration](../declarative-configuration/), set
+`default_enabled` to `false` and list the instrumentations you want in
+`enabled`:
+
+```yaml
+otel:
+  distribution:
+    spring_starter:
+      instrumentation:
+        default_enabled: false
+        enabled:
+          - jdbc
+```
+
+{{% /tab %}} {{< /tabpane >}}
+
 ## Common instrumentation configuration
 
 Common properties for all database instrumentations:
+
+{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
 
 | System property                                              | Type    | Default | Description                            |
 | ------------------------------------------------------------ | ------- | ------- | -------------------------------------- |
 | `otel.instrumentation.common.db-statement-sanitizer.enabled` | Boolean | true    | Enables the DB statement sanitization. |
 
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+Enables the DB statement sanitization for all database instrumentations:
+
+```yaml
+otel:
+  instrumentation/development:
+    java:
+      common:
+        db_statement_sanitizer:
+          enabled: true
+```
+
+{{% /tab %}} {{< /tabpane >}}
+
 ## JDBC Instrumentation
+
+{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
 
 | System property                                         | Type    | Default | Description                            |
 | ------------------------------------------------------- | ------- | ------- | -------------------------------------- |
 | `otel.instrumentation.jdbc.statement-sanitizer.enabled` | Boolean | true    | Enables the DB statement sanitization. |
 
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+Enables the DB statement sanitization for JDBC:
+
+```yaml
+otel:
+  instrumentation/development:
+    java:
+      jdbc:
+        statement_sanitizer:
+          enabled: true
+```
+
+{{% /tab %}} {{< /tabpane >}}
+
 ## Logback
 
 You can enable experimental features with system properties to capture
 attributes :
+
+{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
 
 | System property                                                                        | Type    | Default | Description                                                                                                                                     |
 | -------------------------------------------------------------------------------------- | ------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -58,6 +149,26 @@ attributes :
 | `otel.instrumentation.logback-appender.experimental.capture-key-value-pair-attributes` | Boolean | false   | Enable the capture of Logback key value pairs as attributes.                                                                                    |
 | `otel.instrumentation.logback-appender.experimental.capture-logger-context-attributes` | Boolean | false   | Enable the capture of Logback logger context properties as attributes.                                                                          |
 | `otel.instrumentation.logback-appender.experimental.capture-mdc-attributes`            | String  |         | Comma separated list of MDC attributes to capture. Use the wildcard character `*` to capture all attributes.                                    |
+
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+Experimental Logback capture options:
+
+```yaml
+otel:
+  instrumentation/development:
+    java:
+      logback_appender:
+        experimental_log_attributes: false # thread.name and thread.id
+        experimental:
+          capture_code_attributes: false # source code attributes
+          capture_marker_attribute: false # Logback markers
+          capture_key_value_pair_attributes: false # key value pairs
+          capture_logger_context_attributes: false # logger context properties
+          capture_mdc_attributes: '*' # MDC attributes (* = all)
+```
+
+{{% /tab %}} {{< /tabpane >}}
 
 [source code attributes]:
   /docs/specs/semconv/general/attributes/#source-code-attributes
@@ -262,9 +373,25 @@ public class WebClientController {
 
 Provides autoconfiguration for the Kafka client instrumentation.
 
+{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
+
 | System property                                           | Type    | Default | Description                                          |
 | --------------------------------------------------------- | ------- | ------- | ---------------------------------------------------- |
 | `otel.instrumentation.kafka.experimental-span-attributes` | Boolean | false   | Enables the capture of experimental span attributes. |
+
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+Enables the capture of experimental span attributes for Kafka:
+
+```yaml
+otel:
+  instrumentation/development:
+    java:
+      kafka:
+        experimental_span_attributes: false
+```
+
+{{% /tab %}} {{< /tabpane >}}
 
 ## Micrometer Instrumentation
 
@@ -274,14 +401,48 @@ Provides autoconfiguration for the Micrometer to OpenTelemetry bridge.
 
 Provides autoconfiguration for the MongoDB client instrumentation.
 
+{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
+
 | System property                                          | Type    | Default | Description                            |
 | -------------------------------------------------------- | ------- | ------- | -------------------------------------- |
 | `otel.instrumentation.mongo.statement-sanitizer.enabled` | Boolean | true    | Enables the DB statement sanitization. |
+
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+Enables the DB statement sanitization for MongoDB:
+
+```yaml
+otel:
+  instrumentation/development:
+    java:
+      mongo:
+        statement_sanitizer:
+          enabled: true
+```
+
+{{% /tab %}} {{< /tabpane >}}
 
 ## R2DBC Instrumentation
 
 Provides autoconfiguration for the OpenTelemetry R2DBC instrumentation.
 
+{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
+
 | System property                                          | Type    | Default | Description                            |
 | -------------------------------------------------------- | ------- | ------- | -------------------------------------- |
 | `otel.instrumentation.r2dbc.statement-sanitizer.enabled` | Boolean | true    | Enables the DB statement sanitization. |
+
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+Enables the DB statement sanitization for R2DBC:
+
+```yaml
+otel:
+  instrumentation/development:
+    java:
+      r2dbc:
+        statement_sanitizer:
+          enabled: true
+```
+
+{{% /tab %}} {{< /tabpane >}}

--- a/content/en/docs/zero-code/java/spring-boot-starter/out-of-the-box-instrumentation.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/out-of-the-box-instrumentation.md
@@ -40,18 +40,18 @@ enable/disable uses centralized lists under
 `otel.distribution.spring_starter.instrumentation`. The instrumentation name
 uses `_` (snake_case), not `-` (kebab-case).
 
-| Feature               | Name                | Default |
-| --------------------- | ------------------- | ------- |
-| JDBC                  | `jdbc`              | enabled |
-| Logback               | `logback_appender`  | enabled |
-| Logback MDC           | `logback_mdc`       | enabled |
-| Spring Web            | `spring_web`        | enabled |
-| Spring Web MVC        | `spring_webmvc`     | enabled |
-| Spring WebFlux        | `spring_webflux`    | enabled |
-| Kafka                 | `kafka`             | enabled |
-| MongoDB               | `mongo`             | enabled |
-| Micrometer            | `micrometer`        | disabled |
-| R2DBC (reactive JDBC) | `r2dbc`             | enabled |
+| Feature               | Name               | Default  |
+| --------------------- | ------------------ | -------- |
+| JDBC                  | `jdbc`             | enabled  |
+| Logback               | `logback_appender` | enabled  |
+| Logback MDC           | `logback_mdc`      | enabled  |
+| Spring Web            | `spring_web`       | enabled  |
+| Spring Web MVC        | `spring_webmvc`    | enabled  |
+| Spring WebFlux        | `spring_webflux`   | enabled  |
+| Kafka                 | `kafka`            | enabled  |
+| MongoDB               | `mongo`            | enabled  |
+| Micrometer            | `micrometer`       | disabled |
+| R2DBC (reactive JDBC) | `r2dbc`            | enabled  |
 
 To disable a specific instrumentation:
 
@@ -168,14 +168,14 @@ attributes :
 
 {{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
 
-| Property                                                                               | Type    | Default | Description                                                                                                                                     |
-| -------------------------------------------------------------------------------------- | ------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `experimental-log-attributes`                                                          | Boolean | false   | Enable the capture of experimental log attributes `thread.name` and `thread.id`.                                                                |
-| `experimental.capture-code-attributes`                                                 | Boolean | false   | Enable the capture of [source code attributes][]. Note that capturing source code attributes at logging sites might add a performance overhead. |
-| `experimental.capture-marker-attribute`                                                | Boolean | false   | Enable the capture of Logback markers as attributes.                                                                                            |
-| `experimental.capture-key-value-pair-attributes`                                       | Boolean | false   | Enable the capture of Logback key value pairs as attributes.                                                                                    |
-| `experimental.capture-logger-context-attributes`                                       | Boolean | false   | Enable the capture of Logback logger context properties as attributes.                                                                          |
-| `experimental.capture-mdc-attributes`                                                  | String  |         | Comma separated list of MDC attributes to capture. Use the wildcard character `*` to capture all attributes.                                    |
+| Property                                         | Type    | Default | Description                                                                                                                                     |
+| ------------------------------------------------ | ------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `experimental-log-attributes`                    | Boolean | false   | Enable the capture of experimental log attributes `thread.name` and `thread.id`.                                                                |
+| `experimental.capture-code-attributes`           | Boolean | false   | Enable the capture of [source code attributes][]. Note that capturing source code attributes at logging sites might add a performance overhead. |
+| `experimental.capture-marker-attribute`          | Boolean | false   | Enable the capture of Logback markers as attributes.                                                                                            |
+| `experimental.capture-key-value-pair-attributes` | Boolean | false   | Enable the capture of Logback key value pairs as attributes.                                                                                    |
+| `experimental.capture-logger-context-attributes` | Boolean | false   | Enable the capture of Logback logger context properties as attributes.                                                                          |
+| `experimental.capture-mdc-attributes`            | String  |         | Comma separated list of MDC attributes to capture. Use the wildcard character `*` to capture all attributes.                                    |
 
 ```yaml
 otel:
@@ -192,14 +192,14 @@ otel:
 
 {{% /tab %}} {{% tab "Declarative Configuration" %}}
 
-| Property                                           | Type    | Default | Description                                                                                                                                     |
-| -------------------------------------------------- | ------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `experimental_log_attributes/development`          | Boolean | false   | Enable the capture of experimental log attributes `thread.name` and `thread.id`.                                                                |
-| `capture_code_attributes/development`              | Boolean | false   | Enable the capture of [source code attributes][]. Note that capturing source code attributes at logging sites might add a performance overhead. |
-| `capture_marker_attribute/development`             | Boolean | false   | Enable the capture of Logback markers as attributes.                                                                                            |
-| `capture_key_value_pair_attributes/development`    | Boolean | false   | Enable the capture of Logback key value pairs as attributes.                                                                                    |
-| `capture_logger_context_attributes/development`    | Boolean | false   | Enable the capture of Logback logger context properties as attributes.                                                                          |
-| `capture_mdc_attributes/development`               | String  |         | Comma separated list of MDC attributes to capture. Use the wildcard character `*` to capture all attributes.                                    |
+| Property                                        | Type    | Default | Description                                                                                                                                     |
+| ----------------------------------------------- | ------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `experimental_log_attributes/development`       | Boolean | false   | Enable the capture of experimental log attributes `thread.name` and `thread.id`.                                                                |
+| `capture_code_attributes/development`           | Boolean | false   | Enable the capture of [source code attributes][]. Note that capturing source code attributes at logging sites might add a performance overhead. |
+| `capture_marker_attribute/development`          | Boolean | false   | Enable the capture of Logback markers as attributes.                                                                                            |
+| `capture_key_value_pair_attributes/development` | Boolean | false   | Enable the capture of Logback key value pairs as attributes.                                                                                    |
+| `capture_logger_context_attributes/development` | Boolean | false   | Enable the capture of Logback logger context properties as attributes.                                                                          |
+| `capture_mdc_attributes/development`            | String  |         | Comma separated list of MDC attributes to capture. Use the wildcard character `*` to capture all attributes.                                    |
 
 ```yaml
 otel:

--- a/content/en/docs/zero-code/java/spring-boot-starter/out-of-the-box-instrumentation.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/out-of-the-box-instrumentation.md
@@ -11,18 +11,27 @@ Out of the box instrumentation is available for several frameworks:
 
 {{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
 
-| Feature               | Property                                        | Default Value |
-| --------------------- | ----------------------------------------------- | ------------- |
-| JDBC                  | `otel.instrumentation.jdbc.enabled`             | true          |
-| Logback               | `otel.instrumentation.logback-appender.enabled` | true          |
-| Logback MDC           | `otel.instrumentation.logback-mdc.enabled`      | true          |
-| Spring Web            | `otel.instrumentation.spring-web.enabled`       | true          |
-| Spring Web MVC        | `otel.instrumentation.spring-webmvc.enabled`    | true          |
-| Spring WebFlux        | `otel.instrumentation.spring-webflux.enabled`   | true          |
-| Kafka                 | `otel.instrumentation.kafka.enabled`            | true          |
-| MongoDB               | `otel.instrumentation.mongo.enabled`            | true          |
-| Micrometer            | `otel.instrumentation.micrometer.enabled`       | false         |
-| R2DBC (reactive JDBC) | `otel.instrumentation.r2dbc.enabled`            | true          |
+| Feature               | Property                                        | Default |
+| --------------------- | ----------------------------------------------- | ------- |
+| JDBC                  | `otel.instrumentation.jdbc.enabled`             | true    |
+| Logback               | `otel.instrumentation.logback-appender.enabled` | true    |
+| Logback MDC           | `otel.instrumentation.logback-mdc.enabled`      | true    |
+| Spring Web            | `otel.instrumentation.spring-web.enabled`       | true    |
+| Spring Web MVC        | `otel.instrumentation.spring-webmvc.enabled`    | true    |
+| Spring WebFlux        | `otel.instrumentation.spring-webflux.enabled`   | true    |
+| Kafka                 | `otel.instrumentation.kafka.enabled`            | true    |
+| MongoDB               | `otel.instrumentation.mongo.enabled`            | true    |
+| Micrometer            | `otel.instrumentation.micrometer.enabled`       | false   |
+| R2DBC (reactive JDBC) | `otel.instrumentation.r2dbc.enabled`            | true    |
+
+To disable a specific instrumentation:
+
+```yaml
+otel:
+  instrumentation:
+    logback-appender:
+      enabled: false
+```
 
 {{% /tab %}} {{% tab "Declarative Configuration" %}}
 
@@ -62,11 +71,16 @@ otel:
 {{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
 
 To use only specific instrumentations, turn off all the instrumentations first
-by setting the `otel.instrumentation.common.default-enabled` property to
-`false`. Then, turn on instrumentations one by one.
+and then turn on instrumentations one by one:
 
-For example, if you want to only enable the JDBC instrumentation, set
-`otel.instrumentation.jdbc.enabled` to `true`.
+```yaml
+otel:
+  instrumentation:
+    common:
+      default-enabled: false
+    jdbc:
+      enabled: true
+```
 
 {{% /tab %}} {{% tab "Declarative Configuration" %}}
 
@@ -92,9 +106,15 @@ Common properties for all database instrumentations:
 
 {{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
 
-| System property                                              | Type    | Default | Description                            |
-| ------------------------------------------------------------ | ------- | ------- | -------------------------------------- |
-| `otel.instrumentation.common.db-statement-sanitizer.enabled` | Boolean | true    | Enables the DB statement sanitization. |
+Enables the DB statement sanitization for all database instrumentations:
+
+```yaml
+otel:
+  instrumentation:
+    common:
+      db-statement-sanitizer:
+        enabled: true # default: true
+```
 
 {{% /tab %}} {{% tab "Declarative Configuration" %}}
 
@@ -105,8 +125,9 @@ otel:
   instrumentation/development:
     java:
       common:
-        db_statement_sanitizer:
-          enabled: true
+        database:
+          statement_sanitizer:
+            enabled: true
 ```
 
 {{% /tab %}} {{< /tabpane >}}
@@ -115,9 +136,15 @@ otel:
 
 {{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
 
-| System property                                         | Type    | Default | Description                            |
-| ------------------------------------------------------- | ------- | ------- | -------------------------------------- |
-| `otel.instrumentation.jdbc.statement-sanitizer.enabled` | Boolean | true    | Enables the DB statement sanitization. |
+Enables the DB statement sanitization for JDBC:
+
+```yaml
+otel:
+  instrumentation:
+    jdbc:
+      statement-sanitizer:
+        enabled: true # default: true
+```
 
 {{% /tab %}} {{% tab "Declarative Configuration" %}}
 
@@ -141,31 +168,50 @@ attributes :
 
 {{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
 
-| System property                                                                        | Type    | Default | Description                                                                                                                                     |
+| Property                                                                               | Type    | Default | Description                                                                                                                                     |
 | -------------------------------------------------------------------------------------- | ------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `otel.instrumentation.logback-appender.experimental-log-attributes`                    | Boolean | false   | Enable the capture of experimental log attributes `thread.name` and `thread.id`.                                                                |
-| `otel.instrumentation.logback-appender.experimental.capture-code-attributes`           | Boolean | false   | Enable the capture of [source code attributes][]. Note that capturing source code attributes at logging sites might add a performance overhead. |
-| `otel.instrumentation.logback-appender.experimental.capture-marker-attribute`          | Boolean | false   | Enable the capture of Logback markers as attributes.                                                                                            |
-| `otel.instrumentation.logback-appender.experimental.capture-key-value-pair-attributes` | Boolean | false   | Enable the capture of Logback key value pairs as attributes.                                                                                    |
-| `otel.instrumentation.logback-appender.experimental.capture-logger-context-attributes` | Boolean | false   | Enable the capture of Logback logger context properties as attributes.                                                                          |
-| `otel.instrumentation.logback-appender.experimental.capture-mdc-attributes`            | String  |         | Comma separated list of MDC attributes to capture. Use the wildcard character `*` to capture all attributes.                                    |
+| `experimental-log-attributes`                                                          | Boolean | false   | Enable the capture of experimental log attributes `thread.name` and `thread.id`.                                                                |
+| `experimental.capture-code-attributes`                                                 | Boolean | false   | Enable the capture of [source code attributes][]. Note that capturing source code attributes at logging sites might add a performance overhead. |
+| `experimental.capture-marker-attribute`                                                | Boolean | false   | Enable the capture of Logback markers as attributes.                                                                                            |
+| `experimental.capture-key-value-pair-attributes`                                       | Boolean | false   | Enable the capture of Logback key value pairs as attributes.                                                                                    |
+| `experimental.capture-logger-context-attributes`                                       | Boolean | false   | Enable the capture of Logback logger context properties as attributes.                                                                          |
+| `experimental.capture-mdc-attributes`                                                  | String  |         | Comma separated list of MDC attributes to capture. Use the wildcard character `*` to capture all attributes.                                    |
+
+```yaml
+otel:
+  instrumentation:
+    logback-appender:
+      experimental-log-attributes: false
+      experimental:
+        capture-code-attributes: false
+        capture-marker-attribute: false
+        capture-key-value-pair-attributes: false
+        capture-logger-context-attributes: false
+        capture-mdc-attributes: '*'
+```
 
 {{% /tab %}} {{% tab "Declarative Configuration" %}}
 
-Experimental Logback capture options:
+| Property                                           | Type    | Default | Description                                                                                                                                     |
+| -------------------------------------------------- | ------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `experimental_log_attributes/development`          | Boolean | false   | Enable the capture of experimental log attributes `thread.name` and `thread.id`.                                                                |
+| `capture_code_attributes/development`              | Boolean | false   | Enable the capture of [source code attributes][]. Note that capturing source code attributes at logging sites might add a performance overhead. |
+| `capture_marker_attribute/development`             | Boolean | false   | Enable the capture of Logback markers as attributes.                                                                                            |
+| `capture_key_value_pair_attributes/development`    | Boolean | false   | Enable the capture of Logback key value pairs as attributes.                                                                                    |
+| `capture_logger_context_attributes/development`    | Boolean | false   | Enable the capture of Logback logger context properties as attributes.                                                                          |
+| `capture_mdc_attributes/development`               | String  |         | Comma separated list of MDC attributes to capture. Use the wildcard character `*` to capture all attributes.                                    |
 
 ```yaml
 otel:
   instrumentation/development:
     java:
       logback_appender:
-        experimental_log_attributes: false # thread.name and thread.id
-        experimental:
-          capture_code_attributes: false # source code attributes
-          capture_marker_attribute: false # Logback markers
-          capture_key_value_pair_attributes: false # key value pairs
-          capture_logger_context_attributes: false # logger context properties
-          capture_mdc_attributes: '*' # MDC attributes (* = all)
+        experimental_log_attributes/development: false
+        capture_code_attributes/development: false
+        capture_marker_attribute/development: false
+        capture_key_value_pair_attributes/development: false
+        capture_logger_context_attributes/development: false
+        capture_mdc_attributes/development: '*'
 ```
 
 {{% /tab %}} {{< /tabpane >}}
@@ -375,9 +421,14 @@ Provides autoconfiguration for the Kafka client instrumentation.
 
 {{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
 
-| System property                                           | Type    | Default | Description                                          |
-| --------------------------------------------------------- | ------- | ------- | ---------------------------------------------------- |
-| `otel.instrumentation.kafka.experimental-span-attributes` | Boolean | false   | Enables the capture of experimental span attributes. |
+Enables the capture of experimental span attributes for Kafka:
+
+```yaml
+otel:
+  instrumentation:
+    kafka:
+      experimental-span-attributes: false # default: false
+```
 
 {{% /tab %}} {{% tab "Declarative Configuration" %}}
 
@@ -388,7 +439,7 @@ otel:
   instrumentation/development:
     java:
       kafka:
-        experimental_span_attributes: false
+        experimental_span_attributes/development: false
 ```
 
 {{% /tab %}} {{< /tabpane >}}
@@ -403,9 +454,15 @@ Provides autoconfiguration for the MongoDB client instrumentation.
 
 {{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
 
-| System property                                          | Type    | Default | Description                            |
-| -------------------------------------------------------- | ------- | ------- | -------------------------------------- |
-| `otel.instrumentation.mongo.statement-sanitizer.enabled` | Boolean | true    | Enables the DB statement sanitization. |
+Enables the DB statement sanitization for MongoDB:
+
+```yaml
+otel:
+  instrumentation:
+    mongo:
+      statement-sanitizer:
+        enabled: true # default: true
+```
 
 {{% /tab %}} {{% tab "Declarative Configuration" %}}
 
@@ -428,9 +485,15 @@ Provides autoconfiguration for the OpenTelemetry R2DBC instrumentation.
 
 {{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
 
-| System property                                          | Type    | Default | Description                            |
-| -------------------------------------------------------- | ------- | ------- | -------------------------------------- |
-| `otel.instrumentation.r2dbc.statement-sanitizer.enabled` | Boolean | true    | Enables the DB statement sanitization. |
+Enables the DB statement sanitization for R2DBC:
+
+```yaml
+otel:
+  instrumentation:
+    r2dbc:
+      statement-sanitizer:
+        enabled: true # default: true
+```
 
 {{% /tab %}} {{% tab "Declarative Configuration" %}}
 

--- a/content/en/docs/zero-code/java/spring-boot-starter/out-of-the-box-instrumentation.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/out-of-the-box-instrumentation.md
@@ -9,7 +9,7 @@ cSpell:ignore: autoconfigurations autoconfigures webflux webmvc
 
 Out of the box instrumentation is available for several frameworks:
 
-{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
+{{< tabpane text=true >}} {{% tab "Properties" %}}
 
 | Feature               | Property                                        | Default |
 | --------------------- | ----------------------------------------------- | ------- |
@@ -68,7 +68,7 @@ otel:
 
 ## Turn on instrumentations selectively
 
-{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
+{{< tabpane text=true >}} {{% tab "Properties" %}}
 
 To use only specific instrumentations, turn off all the instrumentations first
 and then turn on instrumentations one by one:
@@ -104,7 +104,7 @@ otel:
 
 Common properties for all database instrumentations:
 
-{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
+{{< tabpane text=true >}} {{% tab "Properties" %}}
 
 Enables the DB statement sanitization for all database instrumentations:
 
@@ -134,7 +134,7 @@ otel:
 
 ## JDBC Instrumentation
 
-{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
+{{< tabpane text=true >}} {{% tab "Properties" %}}
 
 Enables the DB statement sanitization for JDBC:
 
@@ -166,7 +166,7 @@ otel:
 You can enable experimental features with system properties to capture
 attributes :
 
-{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
+{{< tabpane text=true >}} {{% tab "Properties" %}}
 
 | Property                                         | Type    | Default | Description                                                                                                                                     |
 | ------------------------------------------------ | ------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -419,7 +419,7 @@ public class WebClientController {
 
 Provides autoconfiguration for the Kafka client instrumentation.
 
-{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
+{{< tabpane text=true >}} {{% tab "Properties" %}}
 
 Enables the capture of experimental span attributes for Kafka:
 
@@ -452,7 +452,7 @@ Provides autoconfiguration for the Micrometer to OpenTelemetry bridge.
 
 Provides autoconfiguration for the MongoDB client instrumentation.
 
-{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
+{{< tabpane text=true >}} {{% tab "Properties" %}}
 
 Enables the DB statement sanitization for MongoDB:
 
@@ -483,7 +483,7 @@ otel:
 
 Provides autoconfiguration for the OpenTelemetry R2DBC instrumentation.
 
-{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
+{{< tabpane text=true >}} {{% tab "Properties" %}}
 
 Enables the DB statement sanitization for R2DBC:
 

--- a/content/en/docs/zero-code/java/spring-boot-starter/programmatic-configuration.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/programmatic-configuration.md
@@ -2,6 +2,8 @@
 title: Programmatic configuration
 weight: 35
 cSpell:ignore: customizer
+vers:
+  contrib: 1.54.0
 ---
 
 <!-- markdownlint-disable blanks-around-fences -->

--- a/content/en/docs/zero-code/java/spring-boot-starter/programmatic-configuration.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/programmatic-configuration.md
@@ -1,9 +1,9 @@
 ---
 title: Programmatic configuration
 weight: 35
-cSpell:ignore: customizer
 vers:
   contrib: 1.54.0
+cSpell:ignore: customizer
 ---
 
 <!-- markdownlint-disable blanks-around-fences -->

--- a/content/en/docs/zero-code/java/spring-boot-starter/programmatic-configuration.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/programmatic-configuration.md
@@ -17,7 +17,7 @@ which are not configurable using properties.
 > [declarative configuration](../declarative-configuration/). With declarative
 > configuration, use `DeclarativeConfigurationCustomizerProvider` instead — see
 > the
-> [agent Extension API](/docs/zero-code/java/agent/declarative-configuration/#extension-api)
+> [agent Extension API section](/docs/zero-code/java/agent/declarative-configuration/)
 > for details and examples.
 
 ## Exclude actuator endpoints from tracing
@@ -32,7 +32,7 @@ from tracing:
   <dependency>
     <groupId>io.opentelemetry.contrib</groupId>
     <artifactId>opentelemetry-samplers</artifactId>
-    <version>1.33.0-alpha</version>
+    <version>{{% param vers.contrib %}}-alpha</version>
   </dependency>
 </dependencies>
 ```
@@ -41,7 +41,7 @@ from tracing:
 
 ```kotlin
 dependencies {
-  implementation("io.opentelemetry.contrib:opentelemetry-samplers:1.33.0-alpha")
+  implementation("io.opentelemetry.contrib:opentelemetry-samplers:{{% param vers.contrib %}}-alpha")
 }
 ```
 

--- a/content/en/docs/zero-code/java/spring-boot-starter/programmatic-configuration.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/programmatic-configuration.md
@@ -6,7 +6,6 @@ vers:
 cSpell:ignore: customizer
 ---
 
-<!-- markdownlint-disable blanks-around-fences -->
 <?code-excerpt path-base="examples/java/spring-starter"?>
 
 You can use the `AutoConfigurationCustomizerProvider` for programmatic
@@ -49,8 +48,8 @@ dependencies {
 
 {{% /tab %}} {{< /tabpane>}}
 
-<!-- prettier-ignore-start -->
 <?code-excerpt "src/main/java/otel/FilterPaths.java"?>
+
 ```java
 package otel;
 
@@ -75,15 +74,14 @@ public class FilterPaths {
   }
 }
 ```
-<!-- prettier-ignore-end -->
 
 ## Configure the exporter programmatically
 
 You can also configure OTLP exporters programmatically. This configuration
 replaces the default OTLP exporter and adds a custom header to the requests.
 
-<!-- prettier-ignore-start -->
 <?code-excerpt "src/main/java/otel/CustomAuth.java"?>
+
 ```java
 package otel;
 
@@ -119,4 +117,3 @@ public class CustomAuth {
   }
 }
 ```
-<!-- prettier-ignore-end -->

--- a/content/en/docs/zero-code/java/spring-boot-starter/programmatic-configuration.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/programmatic-configuration.md
@@ -1,0 +1,119 @@
+---
+title: Programmatic configuration
+weight: 35
+cSpell:ignore: customizer
+---
+
+<!-- markdownlint-disable blanks-around-fences -->
+<?code-excerpt path-base="examples/java/spring-starter"?>
+
+You can use the `AutoConfigurationCustomizerProvider` for programmatic
+configuration. Programmatic configuration is recommended for advanced use cases,
+which are not configurable using properties.
+
+> [!WARNING]
+>
+> `AutoConfigurationCustomizerProvider` does not work with
+> [declarative configuration](../declarative-configuration/). With declarative
+> configuration, use `DeclarativeConfigurationCustomizerProvider` instead — see
+> the [agent Extension API](/docs/zero-code/java/agent/declarative-configuration/#extension-api)
+> for details and examples.
+
+## Exclude actuator endpoints from tracing
+
+As an example, you can customize the sampler to exclude health check endpoints
+from tracing:
+
+{{< tabpane text=true >}} {{% tab header="Maven (`pom.xml`)" lang=Maven %}}
+
+```xml
+<dependencies>
+  <dependency>
+    <groupId>io.opentelemetry.contrib</groupId>
+    <artifactId>opentelemetry-samplers</artifactId>
+    <version>1.33.0-alpha</version>
+  </dependency>
+</dependencies>
+```
+
+{{% /tab %}} {{% tab header="Gradle (`build.gradle`)" lang=Gradle %}}
+
+```kotlin
+dependencies {
+  implementation("io.opentelemetry.contrib:opentelemetry-samplers:1.33.0-alpha")
+}
+```
+
+{{% /tab %}} {{< /tabpane>}}
+
+<!-- prettier-ignore-start -->
+<?code-excerpt "src/main/java/otel/FilterPaths.java"?>
+```java
+package otel;
+
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.contrib.sampler.RuleBasedRoutingSampler;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
+import io.opentelemetry.semconv.UrlAttributes;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FilterPaths {
+
+  @Bean
+  public AutoConfigurationCustomizerProvider otelCustomizer() {
+    return p ->
+        p.addSamplerCustomizer(
+            (fallback, config) ->
+                RuleBasedRoutingSampler.builder(SpanKind.SERVER, fallback)
+                    .drop(UrlAttributes.URL_PATH, "^/actuator")
+                    .build());
+  }
+}
+```
+<!-- prettier-ignore-end -->
+
+## Configure the exporter programmatically
+
+You can also configure OTLP exporters programmatically. This configuration
+replaces the default OTLP exporter and adds a custom header to the requests.
+
+<!-- prettier-ignore-start -->
+<?code-excerpt "src/main/java/otel/CustomAuth.java"?>
+```java
+package otel;
+
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
+import java.util.Collections;
+import java.util.Map;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CustomAuth {
+  @Bean
+  public AutoConfigurationCustomizerProvider otelCustomizer() {
+    return p ->
+        p.addSpanExporterCustomizer(
+            (exporter, config) -> {
+              if (exporter instanceof OtlpHttpSpanExporter) {
+                return ((OtlpHttpSpanExporter) exporter)
+                    .toBuilder().setHeaders(this::headers).build();
+              }
+              return exporter;
+            });
+  }
+
+  private Map<String, String> headers() {
+    return Collections.singletonMap("Authorization", "Bearer " + refreshToken());
+  }
+
+  private String refreshToken() {
+    // e.g. read the token from a kubernetes secret
+    return "token";
+  }
+}
+```
+<!-- prettier-ignore-end -->

--- a/content/en/docs/zero-code/java/spring-boot-starter/programmatic-configuration.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/programmatic-configuration.md
@@ -16,7 +16,8 @@ which are not configurable using properties.
 > `AutoConfigurationCustomizerProvider` does not work with
 > [declarative configuration](../declarative-configuration/). With declarative
 > configuration, use `DeclarativeConfigurationCustomizerProvider` instead — see
-> the [agent Extension API](/docs/zero-code/java/agent/declarative-configuration/#extension-api)
+> the
+> [agent Extension API](/docs/zero-code/java/agent/declarative-configuration/#extension-api)
 > for details and examples.
 
 ## Exclude actuator endpoints from tracing

--- a/content/en/docs/zero-code/java/spring-boot-starter/sdk-configuration.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/sdk-configuration.md
@@ -21,7 +21,7 @@ The OpenTelemetry Starter supports all the
 You can update the configuration with properties in the `application.properties`
 or the `application.yaml` file, or with environment variables.
 
-{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
+{{< tabpane text=true >}} {{% tab "Properties" %}}
 
 `application.yaml` example:
 
@@ -105,7 +105,7 @@ Spring Boot's
 
 ## Disable the OpenTelemetry Starter
 
-{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
+{{< tabpane text=true >}} {{% tab "Properties" %}}
 
 Set `otel.sdk.disabled` to `true` to disable the starter, e.g. for testing
 purposes:
@@ -137,7 +137,7 @@ See [Programmatic configuration](../programmatic-configuration/).
 
 ## Resource Providers
 
-{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
+{{< tabpane text=true >}} {{% tab "Properties" %}}
 
 The OpenTelemetry Starter includes the same resource providers as the Java
 agent:
@@ -201,7 +201,7 @@ Using these resource providers, the service name is determined by the following
 precedence rules, in accordance with the OpenTelemetry
 [specification](/docs/languages/sdk-configuration/general/#otel_service_name):
 
-{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
+{{< tabpane text=true >}} {{% tab "Properties" %}}
 
 1. `otel.service.name` spring property or `OTEL_SERVICE_NAME` environment
    variable (highest precedence)

--- a/content/en/docs/zero-code/java/spring-boot-starter/sdk-configuration.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/sdk-configuration.md
@@ -1,7 +1,7 @@
 ---
 title: SDK configuration
 weight: 30
-cSpell:ignore: customizer distro
+cSpell:ignore: distro
 ---
 
 <!-- markdownlint-disable blanks-around-fences -->
@@ -227,8 +227,7 @@ The service name depends on which resource detectors you include (see
            value: my-spring-app
    ```
 
-2. The `service` detector — if included, auto-detects from
-   `OTEL_SERVICE_NAME`:
+2. The `service` detector — if included, auto-detects from `OTEL_SERVICE_NAME`:
 
    ```yaml
    otel:
@@ -238,8 +237,8 @@ The service name depends on which resource detectors you include (see
            - service:
    ```
 
-3. The `spring` detector — if included, detects from
-   `spring.application.name` and `build-info.properties`:
+3. The `spring` detector — if included, detects from `spring.application.name`
+   and `build-info.properties`:
 
    ```yaml
    otel:

--- a/content/en/docs/zero-code/java/spring-boot-starter/sdk-configuration.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/sdk-configuration.md
@@ -21,6 +21,8 @@ The OpenTelemetry Starter supports all the
 You can update the configuration with properties in the `application.properties`
 or the `application.yaml` file, or with environment variables.
 
+{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
+
 `application.properties` example:
 
 ```properties
@@ -51,6 +53,35 @@ Environment variables example:
 export OTEL_PROPAGATORS="tracecontext,b3"
 export OTEL_RESOURCE_ATTRIBUTES="deployment.environment=dev,service.name=cart,service.namespace=shop"
 ```
+
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+SDK-level settings (resources, propagators, exporters) use the standard
+[declarative configuration schema](/docs/languages/sdk-configuration/declarative-configuration/)
+directly in `application.yaml`. System properties and environment variables
+still work to override values — see
+[Environment variable overrides](../declarative-configuration/#environment-variable-overrides).
+
+```yaml
+otel:
+  file_format: '1.0'
+
+  resource:
+    attributes:
+      - name: deployment.environment
+        value: dev
+      - name: service.name
+        value: cart
+      - name: service.namespace
+        value: shop
+
+  propagator:
+    composite:
+      - tracecontext:
+      - b3:
+```
+
+{{% /tab %}} {{< /tabpane >}}
 
 ## Overriding Resource Attributes
 
@@ -83,118 +114,36 @@ Spring Boot's
 
 ## Disable the OpenTelemetry Starter
 
+{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
+
 {{% config_option name="otel.sdk.disabled" %}}
 
 Set the value to `true` to disable the starter, e.g. for testing purposes.
 
 {{% /config_option %}}
 
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+Set `otel.disabled` to `true` to disable the starter, e.g. for testing purposes.
+
+Note: with [declarative configuration](../declarative-configuration/), the
+property name is `otel.disabled`, not `otel.sdk.disabled`.
+
+```yaml
+otel:
+  file_format: '1.0'
+  disabled: true
+```
+
+{{% /tab %}} {{< /tabpane >}}
+
 ## Programmatic configuration
 
-You can use the `AutoConfigurationCustomizerProvider` for programmatic
-configuration. Programmatic configuration is recommended for advanced use cases,
-which are not configurable using properties.
-
-### Exclude actuator endpoints from tracing
-
-As an example, you can customize the sampler to exclude health check endpoints
-from tracing:
-
-{{< tabpane text=true >}} {{% tab header="Maven (`pom.xml`)" lang=Maven %}}
-
-```xml
-<dependencies>
-  <dependency>
-    <groupId>io.opentelemetry.contrib</groupId>
-    <artifactId>opentelemetry-samplers</artifactId>
-    <version>1.33.0-alpha</version>
-  </dependency>
-</dependencies>
-```
-
-{{% /tab %}} {{% tab header="Gradle (`build.gradle`)" lang=Gradle %}}
-
-```kotlin
-dependencies {
-  implementation("io.opentelemetry.contrib:opentelemetry-samplers:1.33.0-alpha")
-}
-```
-
-{{% /tab %}} {{< /tabpane>}}
-
-<!-- prettier-ignore-start -->
-<?code-excerpt "src/main/java/otel/FilterPaths.java"?>
-```java
-package otel;
-
-import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.contrib.sampler.RuleBasedRoutingSampler;
-import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
-import io.opentelemetry.semconv.UrlAttributes;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
-@Configuration
-public class FilterPaths {
-
-  @Bean
-  public AutoConfigurationCustomizerProvider otelCustomizer() {
-    return p ->
-        p.addSamplerCustomizer(
-            (fallback, config) ->
-                RuleBasedRoutingSampler.builder(SpanKind.SERVER, fallback)
-                    .drop(UrlAttributes.URL_PATH, "^/actuator")
-                    .build());
-  }
-}
-```
-<!-- prettier-ignore-end -->
-
-### Configure the exporter programmatically
-
-You can also configure OTLP exporters programmatically. This configuration
-replaces the default OTLP exporter and adds a custom header to the requests.
-
-<!-- prettier-ignore-start -->
-<?code-excerpt "src/main/java/otel/CustomAuth.java"?>
-```java
-package otel;
-
-import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
-import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
-import java.util.Collections;
-import java.util.Map;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
-@Configuration
-public class CustomAuth {
-  @Bean
-  public AutoConfigurationCustomizerProvider otelCustomizer() {
-    return p ->
-        p.addSpanExporterCustomizer(
-            (exporter, config) -> {
-              if (exporter instanceof OtlpHttpSpanExporter) {
-                return ((OtlpHttpSpanExporter) exporter)
-                    .toBuilder().setHeaders(this::headers).build();
-              }
-              return exporter;
-            });
-  }
-
-  private Map<String, String> headers() {
-    return Collections.singletonMap("Authorization", "Bearer " + refreshToken());
-  }
-
-  private String refreshToken() {
-    // e.g. read the token from a kubernetes secret
-    return "token";
-  }
-}
-```
-<!-- prettier-ignore-end -->
+See [Programmatic configuration](../programmatic-configuration/).
 
 ## Resource Providers
+
+{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
 
 The OpenTelemetry Starter includes the same resource providers as the Java
 agent:
@@ -225,11 +174,40 @@ FQN:
 | `service.name`    | `spring.application.name` or `build.name` from `build-info.properties` (see [Service name](#service-name)) |
 | `service.version` | `build.version` from `build-info.properties`                                                               |
 
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+With [declarative configuration](../declarative-configuration/), resource
+providers are configured explicitly as detectors under
+`resource.detection/development.detectors`. Only listed detectors are active —
+nothing is auto-discovered via SPI.
+
+```yaml
+otel:
+  resource:
+    detection/development:
+      detectors:
+        - container: # container.id
+        - host: # host.name, host.arch
+        - host_id: # host.id
+        - os: # os.type, os.description
+        - process: # process.pid, process.executable.path, process.command_line
+        - process_runtime: # process.runtime.name/version/description
+        - service: # service.name, service.instance.id
+        - spring: # service.name (from spring.application.name), service.version (from build-info)
+```
+
+The `telemetry.distro.name` and `telemetry.distro.version` attributes are always
+added automatically by the starter for troubleshooting purposes.
+
+{{% /tab %}} {{< /tabpane >}}
+
 ## Service name
 
 Using these resource providers, the service name is determined by the following
 precedence rules, in accordance with the OpenTelemetry
 [specification](/docs/languages/sdk-configuration/general/#otel_service_name):
+
+{{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
 
 1. `otel.service.name` spring property or `OTEL_SERVICE_NAME` environment
    variable (highest precedence)
@@ -239,6 +217,47 @@ precedence rules, in accordance with the OpenTelemetry
 4. `build-info.properties`
 5. `Implementation-Title` from META-INF/MANIFEST.MF
 6. The default value is `unknown_service:java` (lowest precedence)
+
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+The service name depends on which resource detectors you include (see
+[Resource Providers](#resource-providers)):
+
+1. `service.name` in `otel.resource.attributes` (highest precedence):
+
+   ```yaml
+   otel:
+     resource:
+       attributes:
+         - name: service.name
+           value: my-spring-app
+   ```
+
+2. The `service` detector — if included, auto-detects from
+   `OTEL_SERVICE_NAME`:
+
+   ```yaml
+   otel:
+     resource:
+       detection/development:
+         detectors:
+           - service:
+   ```
+
+3. The `spring` detector — if included, detects from
+   `spring.application.name` and `build-info.properties`:
+
+   ```yaml
+   otel:
+     resource:
+       detection/development:
+         detectors:
+           - spring:
+   ```
+
+4. The default value is `unknown_service:java` (lowest precedence)
+
+{{% /tab %}} {{< /tabpane >}}
 
 Use the following snippet in your pom.xml file to generate the
 `build-info.properties` file:

--- a/content/en/docs/zero-code/java/spring-boot-starter/sdk-configuration.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/sdk-configuration.md
@@ -23,15 +23,6 @@ or the `application.yaml` file, or with environment variables.
 
 {{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
 
-`application.properties` example:
-
-```properties
-otel.propagators=tracecontext,b3
-otel.resource.attributes.deployment.environment=dev
-otel.resource.attributes.service.name=cart
-otel.resource.attributes.service.namespace=shop
-```
-
 `application.yaml` example:
 
 ```yaml
@@ -116,11 +107,14 @@ Spring Boot's
 
 {{< tabpane text=true >}} {{% tab "not Declarative Configuration" %}}
 
-{{% config_option name="otel.sdk.disabled" %}}
+Set `otel.sdk.disabled` to `true` to disable the starter, e.g. for testing
+purposes:
 
-Set the value to `true` to disable the starter, e.g. for testing purposes.
-
-{{% /config_option %}}
+```yaml
+otel:
+  sdk:
+    disabled: true
+```
 
 {{% /tab %}} {{% tab "Declarative Configuration" %}}
 

--- a/content/zh/docs/zero-code/java/agent/declarative-configuration.md
+++ b/content/zh/docs/zero-code/java/agent/declarative-configuration.md
@@ -164,8 +164,4 @@ Contrib 中尚未被声明式配置支持的功能：
 
 - 但是，你已经可以使用 `application.yaml` 来配置 OpenTelemetry Spring Boot 启动器
 
-## 扩展 API {#extension-api}
-
-有关扩展 API 的详细信息，请参阅[英文版本](/docs/zero-code/java/agent/declarative-configuration/#extension-api)。
-
 [SDK Declarative configuration]: /docs/languages/sdk-configuration/declarative-configuration

--- a/content/zh/docs/zero-code/java/agent/declarative-configuration.md
+++ b/content/zh/docs/zero-code/java/agent/declarative-configuration.md
@@ -164,4 +164,8 @@ Contrib 中尚未被声明式配置支持的功能：
 
 - 但是，你已经可以使用 `application.yaml` 来配置 OpenTelemetry Spring Boot 启动器
 
+## 扩展 API {#extension-api}
+
+有关扩展 API 的详细信息，请参阅[英文版本](/docs/zero-code/java/agent/declarative-configuration/#extension-api)。
+
 [SDK Declarative configuration]: /docs/languages/sdk-configuration/declarative-configuration


### PR DESCRIPTION
## Summary

- New `declarative-configuration.md` page for the Spring Boot starter covering getting started, mapping rules, differences from agent DC, env var overrides, and duration format
- New `programmatic-configuration.md` page (extracted from `sdk-configuration.md`) with a warning that `AutoConfigurationCustomizerProvider` doesn't work with DC
- DC flavor tabs on `out-of-the-box-instrumentation`, `sdk-configuration`, `additional-instrumentations`, and `other-spring-autoconfig` pages
- DC note on `annotations` page for enable/disable mapping
- Updated agent DC page: removed stale "Spring Boot starter limitations" section, added cross-link
- Mentioned DC as a configuration option in `_index.md`

## Follow-up

Automatic converter: https://github.com/open-telemetry/opentelemetry.io/pull/9456

## Test plan

- [ ] Hugo builds without errors (`npm run serve`)
- [ ] New page renders at `/docs/zero-code/java/spring-boot-starter/declarative-configuration/`
- [ ] Tabs render correctly on sibling pages
- [ ] Agent DC page no longer mentions Spring Boot limitation
- [ ] All internal links resolve


Deploy preview:

- https://deploy-preview-9448--opentelemetry.netlify.app/docs/zero-code/java/spring-boot-starter/
- https://deploy-preview-9448--opentelemetry.netlify.app/docs/zero-code/java/spring-boot-starter/declarative-configuration/