### PR TITLE
Add interactive config-to-DC converter

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Create and use reduced-dependencies package.json
         run: |
-          jq '.devDependencies |= with_entries(select(.key | test("prefix|hugo|css|js-yaml"))) | .dependencies |= {minisearch: .minisearch} | del(.optionalDependencies)' package.json > tmp/package-min.json
+          jq '.dependencies |= {minisearch: .minisearch} | del(.optionalDependencies)' package.json > tmp/package-min.json
           cp tmp/package-min.json package.json
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Create and use reduced-dependencies package.json
         run: |
-          jq '.dependencies |= {minisearch: .minisearch} | del(.optionalDependencies)' package.json > tmp/package-min.json
+          jq '.dependencies |= with_entries(select(.key | test("minisearch|js-yaml"))) | del(.optionalDependencies)' package.json > tmp/package-min.json
           cp tmp/package-min.json package.json
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Create and use reduced-dependencies package.json
         run: |
-          jq '.dependencies |= with_entries(select(.key | test("minisearch|js-yaml"))) | del(.optionalDependencies)' package.json > tmp/package-min.json
+          jq '.devDependencies |= with_entries(select(.key | test("prefix|hugo|css|js-yaml"))) | .dependencies |= {minisearch: .minisearch} | del(.optionalDependencies)' package.json > tmp/package-min.json
           cp tmp/package-min.json package.json
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -32,7 +32,7 @@ jobs:
                   select(.key | test("prefix|hugo|css"))
                 )
                 | .dependencies |= with_entries(
-                  select(.key | test("minisearch")))
+                  select(.key | test("minisearch|js-yaml")))
                 | del(.optionalDependencies)' \
             package.json > tmp/package-min.json
           cp tmp/package-min.json package.json

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Create and use reduced-dependencies package.json
         run: |
           jq '.devDependencies |= with_entries(
-                  select(.key | test("prefix|hugo|css"))
+                  select(.key | test("prefix|hugo|css|js-yaml"))
                 )
                 | .dependencies |= with_entries(
-                  select(.key | test("minisearch|js-yaml")))
+                  select(.key | test("minisearch")))
                 | del(.optionalDependencies)' \
             package.json > tmp/package-min.json
           cp tmp/package-min.json package.json

--- a/assets/js/dcConverter.js
+++ b/assets/js/dcConverter.js
@@ -14,8 +14,7 @@ const SPECIAL_MAPPINGS = {
   'otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters':
     'general.sanitization.url.sensitive_query_parameters/development',
   'otel.semconv-stability.opt-in': 'general.semconv_stability.opt_in',
-  'otel.instrumentation.http.known-methods':
-    'java.common.http.known_methods',
+  'otel.instrumentation.http.known-methods': 'java.common.http.known_methods',
   'otel.instrumentation.http.client.experimental.redact-query-parameters':
     'java.common.http.client.redact_query_parameters/development',
   'otel.instrumentation.http.client.emit-experimental-telemetry':
@@ -53,15 +52,32 @@ for (const key of Object.keys(SPECIAL_MAPPINGS)) {
 
 // Known instrumentation names for enable/disable and env var matching
 const KNOWN_INSTRUMENTATIONS = [
-  'jdbc', 'kafka', 'mongo', 'r2dbc', 'micrometer',
-  'logback-appender', 'logback-mdc', 'log4j-appender',
-  'spring-web', 'spring-webmvc', 'spring-webflux',
-  'spring-kafka', 'spring-data', 'spring-jms',
-  'spring-integration', 'spring-rabbit', 'spring-scheduling',
-  'annotations', 'opentelemetry-annotations',
-  'methods', 'external-annotations',
-  'grpc', 'okhttp', 'apache-httpclient',
-  'runtime-telemetry', 'oshi',
+  'jdbc',
+  'kafka',
+  'mongo',
+  'r2dbc',
+  'micrometer',
+  'logback-appender',
+  'logback-mdc',
+  'log4j-appender',
+  'spring-web',
+  'spring-webmvc',
+  'spring-webflux',
+  'spring-kafka',
+  'spring-data',
+  'spring-jms',
+  'spring-integration',
+  'spring-rabbit',
+  'spring-scheduling',
+  'annotations',
+  'opentelemetry-annotations',
+  'methods',
+  'external-annotations',
+  'grpc',
+  'okhttp',
+  'apache-httpclient',
+  'runtime-telemetry',
+  'oshi',
 ];
 
 // ── Parsing ────────────────────────────────────────────────────────────
@@ -70,12 +86,16 @@ function parseProperties(text) {
   const result = [];
   for (const line of text.split('\n')) {
     const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith('//')) continue;
+    if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith('//'))
+      continue;
     // Strip -D prefix for sys props
     const clean = trimmed.startsWith('-D') ? trimmed.slice(2) : trimmed;
     const eq = clean.indexOf('=');
     if (eq === -1) continue;
-    result.push({ key: clean.slice(0, eq).trim(), value: clean.slice(eq + 1).trim() });
+    result.push({
+      key: clean.slice(0, eq).trim(),
+      value: clean.slice(eq + 1).trim(),
+    });
   }
   return result;
 }
@@ -85,9 +105,7 @@ function envVarToProperty(envKey) {
   if (ENV_TO_PROPERTY[envKey]) return ENV_TO_PROPERTY[envKey];
 
   // Handle enable/disable: OTEL_INSTRUMENTATION_<NAME>_ENABLED
-  const enableMatch = envKey.match(
-    /^OTEL_INSTRUMENTATION_(.+)_ENABLED$/
-  );
+  const enableMatch = envKey.match(/^OTEL_INSTRUMENTATION_(.+)_ENABLED$/);
   if (enableMatch) {
     const rawName = enableMatch[1].toLowerCase();
     // Try known instrumentation names
@@ -197,7 +215,10 @@ function classify(key) {
 
   // Generic instrumentation config
   if (key.startsWith('otel.instrumentation.')) {
-    return { type: 'instrumentation', suffix: key.slice('otel.instrumentation.'.length) };
+    return {
+      type: 'instrumentation',
+      suffix: key.slice('otel.instrumentation.'.length),
+    };
   }
 
   // Known SDK properties
@@ -266,7 +287,7 @@ function coerceListValue(value) {
   return coerceValue(value);
 }
 
-function buildDcYaml(properties, source) {
+function buildDcYaml(properties, source, gettingStartedYaml) {
   const warnings = [];
   const enabled = [];
   const disabled = [];
@@ -328,10 +349,6 @@ function buildDcYaml(properties, source) {
     }
   }
 
-  const varSyntax = source === 'spring'
-    ? (name, fallback) => `\${${name}:${fallback}}`
-    : (name, fallback) => `\${${name}:-${fallback}}`;
-
   const dumpOpts = {
     indent: 2,
     lineWidth: -1,
@@ -345,71 +362,26 @@ function buildDcYaml(properties, source) {
     return yaml.dump(obj, dumpOpts).replace(/: null$/gm, ':');
   }
 
-  // ── Recommended skeleton ──────────────────────────────────────────
-  // DC requires explicit config for exporters, propagators, and resource
-  // detectors that were auto-configured before.
+  // ── Getting-started skeleton from opentelemetry-configuration repo ──
+  // For Spring, convert ${VAR:-default} to ${VAR:default} syntax.
+  let skeletonYaml = gettingStartedYaml;
+  if (source === 'spring') {
+    skeletonYaml = skeletonYaml.replace(/\$\{([^}]+?):-/g, '${$1:');
+  }
 
-  const skeleton = {
-    file_format: '1.0',
-    resource: {
-      'detection/development': {
-        detectors: [{ service: null }],
-      },
-    },
-    propagator: sdkConfig.propagator || {
-      composite: [{ tracecontext: null }, { baggage: null }],
-    },
-    tracer_provider: {
-      processors: [
-        {
-          batch: {
-            exporter: {
-              otlp_http: {
-                endpoint: varSyntax(
-                  'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT',
-                  'http://localhost:4318/v1/traces'
-                ),
-              },
-            },
-          },
-        },
-      ],
-    },
-    meter_provider: {
-      readers: [
-        {
-          periodic: {
-            exporter: {
-              otlp_http: {
-                endpoint: varSyntax(
-                  'OTEL_EXPORTER_OTLP_METRICS_ENDPOINT',
-                  'http://localhost:4318/v1/metrics'
-                ),
-              },
-            },
-          },
-        },
-      ],
-    },
-    logger_provider: {
-      processors: [
-        {
-          batch: {
-            exporter: {
-              otlp_http: {
-                endpoint: varSyntax(
-                  'OTEL_EXPORTER_OTLP_LOGS_ENDPOINT',
-                  'http://localhost:4318/v1/logs'
-                ),
-              },
-            },
-          },
-        },
-      ],
-    },
-  };
+  // Parse the skeleton to apply SDK overrides (propagators, resource attributes)
+  let skeleton;
+  try {
+    skeleton = yaml.load(skeletonYaml);
+  } catch {
+    skeleton = {};
+  }
 
+  if (sdkConfig.propagator) {
+    skeleton.propagator = sdkConfig.propagator;
+  }
   if (sdkConfig.resource && sdkConfig.resource.attributes) {
+    if (!skeleton.resource) skeleton.resource = {};
     skeleton.resource.attributes = sdkConfig.resource.attributes;
   }
   if (sdkConfig.disabled != null) skeleton.disabled = sdkConfig.disabled;
@@ -419,11 +391,11 @@ function buildDcYaml(properties, source) {
   const converted = {};
 
   // Distribution (enable/disable)
-  const distroKey =
-    source === 'spring' ? 'spring_starter' : 'javaagent';
+  const distroKey = source === 'spring' ? 'spring_starter' : 'javaagent';
   if (enabled.length || disabled.length || defaultEnabled != null) {
     const instrumentation = {};
-    if (defaultEnabled != null) instrumentation.default_enabled = defaultEnabled;
+    if (defaultEnabled != null)
+      instrumentation.default_enabled = defaultEnabled;
     if (enabled.length) instrumentation.enabled = enabled;
     if (disabled.length) instrumentation.disabled = disabled;
     converted.distribution = { [distroKey]: { instrumentation } };
@@ -437,12 +409,11 @@ function buildDcYaml(properties, source) {
   // ── Assemble output with comments ─────────────────────────────────
 
   const indent = source === 'spring' ? '  ' : '';
-  const wrap = (obj) =>
-    source === 'spring' ? { otel: obj } : obj;
+  const wrap = (obj) => (source === 'spring' ? { otel: obj } : obj);
 
-  let output = '# Recommended: base configuration for declarative config\n';
-  output += '# (exporters, propagators, and resource detectors must be\n';
-  output += '# configured explicitly — see Getting Started above)\n';
+  let output = '# Getting started configuration from\n';
+  output +=
+    '# https://github.com/open-telemetry/opentelemetry-configuration/blob/main/examples/otel-getting-started.yaml\n';
   output += dumpClean(wrap(skeleton));
 
   if (Object.keys(converted).length) {
@@ -487,6 +458,7 @@ function init() {
   if (!output) return;
 
   const source = container.dataset.source || 'agent';
+  const gettingStartedYaml = container.dataset.gettingStarted || '';
 
   function convert() {
     const properties = [
@@ -495,7 +467,7 @@ function init() {
       ...(yamlInput ? parseYamlInput(yamlInput.value) : []),
     ];
 
-    const result = buildDcYaml(properties, source);
+    const result = buildDcYaml(properties, source, gettingStartedYaml);
     output.value = result.yaml;
 
     if (result.warnings.length) {

--- a/assets/js/dcConverter.js
+++ b/assets/js/dcConverter.js
@@ -1,0 +1,539 @@
+import yaml from 'js-yaml';
+
+// Property -> DC path (under instrumentation/development)
+// From ConfigPropertiesBackedDeclarativeConfigProperties.java SPECIAL_MAPPINGS
+const SPECIAL_MAPPINGS = {
+  'otel.instrumentation.http.client.capture-request-headers':
+    'general.http.client.request_captured_headers',
+  'otel.instrumentation.http.client.capture-response-headers':
+    'general.http.client.response_captured_headers',
+  'otel.instrumentation.http.server.capture-request-headers':
+    'general.http.server.request_captured_headers',
+  'otel.instrumentation.http.server.capture-response-headers':
+    'general.http.server.response_captured_headers',
+  'otel.instrumentation.sanitization.url.experimental.sensitive-query-parameters':
+    'general.sanitization.url.sensitive_query_parameters/development',
+  'otel.semconv-stability.opt-in': 'general.semconv_stability.opt_in',
+  'otel.instrumentation.http.known-methods':
+    'java.common.http.known_methods',
+  'otel.instrumentation.http.client.experimental.redact-query-parameters':
+    'java.common.http.client.redact_query_parameters/development',
+  'otel.instrumentation.http.client.emit-experimental-telemetry':
+    'java.common.http.client.emit_experimental_telemetry/development',
+  'otel.instrumentation.http.server.emit-experimental-telemetry':
+    'java.common.http.server.emit_experimental_telemetry/development',
+  'otel.instrumentation.common.db-statement-sanitizer.enabled':
+    'java.common.database.statement_sanitizer.enabled',
+  'otel.instrumentation.common.experimental.db-sqlcommenter.enabled':
+    'java.common.database.sqlcommenter/development.enabled',
+  'otel.instrumentation.messaging.experimental.receive-telemetry.enabled':
+    'java.common.messaging.receive_telemetry/development.enabled',
+  'otel.instrumentation.messaging.experimental.capture-headers':
+    'java.common.messaging.capture_headers/development',
+  'otel.instrumentation.genai.capture-message-content':
+    'java.common.gen_ai.capture_message_content',
+  'otel.instrumentation.experimental.span-suppression-strategy':
+    'java.common.span_suppression_strategy/development',
+  'otel.instrumentation.opentelemetry-annotations.exclude-methods':
+    'java.opentelemetry_extension_annotations.exclude_methods',
+  'otel.experimental.javascript-snippet':
+    'java.servlet.javascript_snippet/development',
+  'otel.jmx.enabled': 'java.jmx.enabled',
+  'otel.jmx.config': 'java.jmx.config',
+  'otel.jmx.target.system': 'java.jmx.target.system',
+};
+
+// Build reverse lookup: env var name -> property key
+// E.g. OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS -> otel.instrumentation.http.known-methods
+const ENV_TO_PROPERTY = {};
+for (const key of Object.keys(SPECIAL_MAPPINGS)) {
+  const envKey = key.toUpperCase().replace(/\./g, '_').replace(/-/g, '_');
+  ENV_TO_PROPERTY[envKey] = key;
+}
+
+// Known instrumentation names for enable/disable and env var matching
+const KNOWN_INSTRUMENTATIONS = [
+  'jdbc', 'kafka', 'mongo', 'r2dbc', 'micrometer',
+  'logback-appender', 'logback-mdc', 'log4j-appender',
+  'spring-web', 'spring-webmvc', 'spring-webflux',
+  'spring-kafka', 'spring-data', 'spring-jms',
+  'spring-integration', 'spring-rabbit', 'spring-scheduling',
+  'annotations', 'opentelemetry-annotations',
+  'methods', 'external-annotations',
+  'grpc', 'okhttp', 'apache-httpclient',
+  'runtime-telemetry', 'oshi',
+];
+
+// ── Parsing ────────────────────────────────────────────────────────────
+
+function parseProperties(text) {
+  const result = [];
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith('//')) continue;
+    // Strip -D prefix for sys props
+    const clean = trimmed.startsWith('-D') ? trimmed.slice(2) : trimmed;
+    const eq = clean.indexOf('=');
+    if (eq === -1) continue;
+    result.push({ key: clean.slice(0, eq).trim(), value: clean.slice(eq + 1).trim() });
+  }
+  return result;
+}
+
+function envVarToProperty(envKey) {
+  // Check known properties first
+  if (ENV_TO_PROPERTY[envKey]) return ENV_TO_PROPERTY[envKey];
+
+  // Handle enable/disable: OTEL_INSTRUMENTATION_<NAME>_ENABLED
+  const enableMatch = envKey.match(
+    /^OTEL_INSTRUMENTATION_(.+)_ENABLED$/
+  );
+  if (enableMatch) {
+    const rawName = enableMatch[1].toLowerCase();
+    // Try known instrumentation names
+    for (const name of KNOWN_INSTRUMENTATIONS) {
+      if (rawName === name.replace(/-/g, '_')) {
+        return `otel.instrumentation.${name}.enabled`;
+      }
+    }
+    // Best guess: use the raw name with . for _
+    return `otel.instrumentation.${rawName.replace(/_/g, '-')}.enabled`;
+  }
+
+  // OTEL_INSTRUMENTATION_COMMON_DEFAULT_ENABLED
+  if (envKey === 'OTEL_INSTRUMENTATION_COMMON_DEFAULT_ENABLED') {
+    return 'otel.instrumentation.common.default-enabled';
+  }
+
+  // SDK properties: straightforward lowercasing
+  if (
+    envKey.startsWith('OTEL_SERVICE_') ||
+    envKey.startsWith('OTEL_RESOURCE_') ||
+    envKey.startsWith('OTEL_PROPAGATORS') ||
+    envKey.startsWith('OTEL_EXPORTER_') ||
+    envKey === 'OTEL_SDK_DISABLED'
+  ) {
+    return envKey.toLowerCase().replace(/_/g, '.');
+  }
+
+  // Fallback: lowercase and replace _ with .
+  return envKey.toLowerCase().replace(/_/g, '.');
+}
+
+function parseEnvVars(text) {
+  const result = [];
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    // Strip "export " prefix
+    const clean = trimmed.startsWith('export ')
+      ? trimmed.slice(7).trim()
+      : trimmed;
+    const eq = clean.indexOf('=');
+    if (eq === -1) continue;
+    const envKey = clean.slice(0, eq).trim();
+    let value = clean.slice(eq + 1).trim();
+    // Strip surrounding quotes
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    result.push({ key: envVarToProperty(envKey), value });
+  }
+  return result;
+}
+
+function flattenYaml(obj, prefix = '') {
+  const result = [];
+  if (obj == null) return result;
+  for (const [key, value] of Object.entries(obj)) {
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+    if (value != null && typeof value === 'object' && !Array.isArray(value)) {
+      result.push(...flattenYaml(value, fullKey));
+    } else {
+      result.push({ key: fullKey, value: String(value) });
+    }
+  }
+  return result;
+}
+
+function parseYamlInput(text) {
+  try {
+    const parsed = yaml.load(text);
+    if (parsed == null || typeof parsed !== 'object') return [];
+    return flattenYaml(parsed);
+  } catch {
+    return [];
+  }
+}
+
+// ── Classification ─────────────────────────────────────────────────────
+
+function classify(key) {
+  // Enable/disable
+  const enableMatch = key.match(/^otel\.instrumentation\.(.+)\.enabled$/);
+  if (enableMatch) {
+    const name = enableMatch[1];
+    if (name === 'common.default') {
+      // otel.instrumentation.common.default-enabled — parsed from .properties
+      // won't match this; handled separately
+    }
+    // Skip if it looks like a sub-property (e.g. common.db-statement-sanitizer.enabled)
+    if (!name.includes('.')) {
+      return { type: 'enable', name };
+    }
+  }
+
+  if (key === 'otel.instrumentation.common.default-enabled') {
+    return { type: 'default-enabled' };
+  }
+
+  // Special mappings
+  if (SPECIAL_MAPPINGS[key]) {
+    return { type: 'special', dcPath: SPECIAL_MAPPINGS[key] };
+  }
+
+  // Generic instrumentation config
+  if (key.startsWith('otel.instrumentation.')) {
+    return { type: 'instrumentation', suffix: key.slice('otel.instrumentation.'.length) };
+  }
+
+  // Known SDK properties
+  if (key === 'otel.sdk.disabled') return { type: 'sdk-disabled' };
+  if (key === 'otel.service.name') return { type: 'sdk-service-name' };
+  if (key === 'otel.propagators') return { type: 'sdk-propagators' };
+
+  return { type: 'unknown' };
+}
+
+// ── Default algorithm: property suffix → DC path ───────────────────────
+
+function defaultInstrumentationPath(suffix) {
+  // suffix: everything after "otel.instrumentation."
+  // e.g. "logback-appender.experimental-log-attributes"
+  const segments = suffix.split('.');
+  const result = [];
+
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i];
+    const dcSeg = seg.replace(/-/g, '_');
+
+    if (seg === 'experimental' && i < segments.length - 1) {
+      // "experimental" as standalone segment: next segment gets /development
+      i++;
+      const next = segments[i].replace(/-/g, '_');
+      result.push(next + '/development');
+    } else if (dcSeg.startsWith('experimental_') || dcSeg === 'experimental') {
+      // Segment name contains "experimental" — add /development
+      result.push(dcSeg + '/development');
+    } else {
+      result.push(dcSeg);
+    }
+  }
+
+  return 'java.' + result.join('.');
+}
+
+// ── Build output ───────────────────────────────────────────────────────
+
+function setNested(obj, dottedPath, value) {
+  const parts = dottedPath.split('.');
+  let current = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const p = parts[i];
+    if (!(p in current) || typeof current[p] !== 'object') {
+      current[p] = {};
+    }
+    current = current[p];
+  }
+  current[parts[parts.length - 1]] = value;
+}
+
+function coerceValue(value) {
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  if (/^\d+$/.test(value)) return Number(value);
+  return value;
+}
+
+function coerceListValue(value) {
+  // Comma-separated → array
+  if (typeof value === 'string' && value.includes(',')) {
+    return value.split(',').map((s) => s.trim());
+  }
+  return coerceValue(value);
+}
+
+function buildDcYaml(properties, source) {
+  const warnings = [];
+  const enabled = [];
+  const disabled = [];
+  let defaultEnabled = null;
+  const instrumentationConfig = {};
+  const sdkConfig = {};
+  const unknownLines = [];
+
+  for (const { key, value } of properties) {
+    const cls = classify(key);
+
+    switch (cls.type) {
+      case 'enable': {
+        const dcName = cls.name.replace(/-/g, '_');
+        if (value === 'true') enabled.push(dcName);
+        else if (value === 'false') disabled.push(dcName);
+        break;
+      }
+
+      case 'default-enabled':
+        defaultEnabled = coerceValue(value);
+        break;
+
+      case 'special':
+        setNested(instrumentationConfig, cls.dcPath, coerceListValue(value));
+        break;
+
+      case 'instrumentation': {
+        const dcPath = defaultInstrumentationPath(cls.suffix);
+        setNested(instrumentationConfig, dcPath, coerceListValue(value));
+        break;
+      }
+
+      case 'sdk-disabled':
+        sdkConfig.disabled = coerceValue(value);
+        break;
+
+      case 'sdk-service-name':
+        if (!sdkConfig.resource) sdkConfig.resource = {};
+        if (!sdkConfig.resource.attributes) sdkConfig.resource.attributes = [];
+        sdkConfig.resource.attributes.push({
+          name: 'service.name',
+          value: value,
+        });
+        break;
+
+      case 'sdk-propagators': {
+        const propagators = value.split(',').map((p) => p.trim());
+        sdkConfig.propagator = {
+          composite: propagators.map((p) => ({ [p]: null })),
+        };
+        break;
+      }
+
+      case 'unknown':
+        unknownLines.push(`${key}=${value}`);
+        warnings.push(`Could not convert: ${key}`);
+        break;
+    }
+  }
+
+  const varSyntax = source === 'spring'
+    ? (name, fallback) => `\${${name}:${fallback}}`
+    : (name, fallback) => `\${${name}:-${fallback}}`;
+
+  const dumpOpts = {
+    indent: 2,
+    lineWidth: -1,
+    quotingType: "'",
+    forceQuotes: false,
+    noRefs: true,
+    sortKeys: false,
+  };
+
+  function dumpClean(obj) {
+    return yaml.dump(obj, dumpOpts).replace(/: null$/gm, ':');
+  }
+
+  // ── Recommended skeleton ──────────────────────────────────────────
+  // DC requires explicit config for exporters, propagators, and resource
+  // detectors that were auto-configured before.
+
+  const skeleton = {
+    file_format: '1.0',
+    resource: {
+      'detection/development': {
+        detectors: [{ service: null }],
+      },
+    },
+    propagator: sdkConfig.propagator || {
+      composite: [{ tracecontext: null }, { baggage: null }],
+    },
+    tracer_provider: {
+      processors: [
+        {
+          batch: {
+            exporter: {
+              otlp_http: {
+                endpoint: varSyntax(
+                  'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT',
+                  'http://localhost:4318/v1/traces'
+                ),
+              },
+            },
+          },
+        },
+      ],
+    },
+    meter_provider: {
+      readers: [
+        {
+          periodic: {
+            exporter: {
+              otlp_http: {
+                endpoint: varSyntax(
+                  'OTEL_EXPORTER_OTLP_METRICS_ENDPOINT',
+                  'http://localhost:4318/v1/metrics'
+                ),
+              },
+            },
+          },
+        },
+      ],
+    },
+    logger_provider: {
+      processors: [
+        {
+          batch: {
+            exporter: {
+              otlp_http: {
+                endpoint: varSyntax(
+                  'OTEL_EXPORTER_OTLP_LOGS_ENDPOINT',
+                  'http://localhost:4318/v1/logs'
+                ),
+              },
+            },
+          },
+        },
+      ],
+    },
+  };
+
+  if (sdkConfig.resource && sdkConfig.resource.attributes) {
+    skeleton.resource.attributes = sdkConfig.resource.attributes;
+  }
+  if (sdkConfig.disabled != null) skeleton.disabled = sdkConfig.disabled;
+
+  // ── Converted from your configuration ─────────────────────────────
+
+  const converted = {};
+
+  // Distribution (enable/disable)
+  const distroKey =
+    source === 'spring' ? 'spring_starter' : 'javaagent';
+  if (enabled.length || disabled.length || defaultEnabled != null) {
+    const instrumentation = {};
+    if (defaultEnabled != null) instrumentation.default_enabled = defaultEnabled;
+    if (enabled.length) instrumentation.enabled = enabled;
+    if (disabled.length) instrumentation.disabled = disabled;
+    converted.distribution = { [distroKey]: { instrumentation } };
+  }
+
+  // Instrumentation config
+  if (Object.keys(instrumentationConfig).length) {
+    converted['instrumentation/development'] = instrumentationConfig;
+  }
+
+  // ── Assemble output with comments ─────────────────────────────────
+
+  const indent = source === 'spring' ? '  ' : '';
+  const wrap = (obj) =>
+    source === 'spring' ? { otel: obj } : obj;
+
+  let output = '# Recommended: base configuration for declarative config\n';
+  output += '# (exporters, propagators, and resource detectors must be\n';
+  output += '# configured explicitly — see Getting Started above)\n';
+  output += dumpClean(wrap(skeleton));
+
+  if (Object.keys(converted).length) {
+    output += `\n${indent}# Converted from your configuration\n`;
+    // Dump converted and strip the top-level wrapper key if Spring
+    if (source === 'spring') {
+      const inner = dumpClean(converted);
+      // Indent each line to sit under "otel:"
+      output += inner
+        .split('\n')
+        .map((line) => (line ? indent + line : line))
+        .join('\n');
+    } else {
+      output += dumpClean(converted);
+    }
+  }
+
+  // Append unknown properties as comments
+  if (unknownLines.length) {
+    output +=
+      '\n# Could not convert the following properties:\n' +
+      unknownLines.map((l) => `# ${l}`).join('\n') +
+      '\n';
+  }
+
+  return { yaml: output, warnings };
+}
+
+// ── DOM wiring ─────────────────────────────────────────────────────────
+
+function init() {
+  const container = document.querySelector('.dc-converter');
+  if (!container) return;
+
+  const propsInput = document.getElementById('dc-input-props');
+  const envInput = document.getElementById('dc-input-env');
+  const yamlInput = document.getElementById('dc-input-yaml');
+  const output = document.getElementById('dc-output');
+  const copyBtn = document.getElementById('dc-copy');
+  const warningsEl = document.getElementById('dc-warnings');
+
+  if (!output) return;
+
+  const source = container.dataset.source || 'agent';
+
+  function convert() {
+    const properties = [
+      ...parseProperties(propsInput ? propsInput.value : ''),
+      ...parseEnvVars(envInput ? envInput.value : ''),
+      ...(yamlInput ? parseYamlInput(yamlInput.value) : []),
+    ];
+
+    const result = buildDcYaml(properties, source);
+    output.value = result.yaml;
+
+    if (result.warnings.length) {
+      warningsEl.textContent = result.warnings.join('\n');
+      warningsEl.classList.remove('d-none');
+    } else {
+      warningsEl.classList.add('d-none');
+    }
+  }
+
+  let debounceTimer;
+  function onInput() {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(convert, 300);
+  }
+
+  if (propsInput) propsInput.addEventListener('input', onInput);
+  if (envInput) envInput.addEventListener('input', onInput);
+  if (yamlInput) yamlInput.addEventListener('input', onInput);
+
+  if (copyBtn) {
+    copyBtn.addEventListener('click', () => {
+      navigator.clipboard.writeText(output.value).then(() => {
+        const original = copyBtn.textContent;
+        copyBtn.textContent = 'Copied!';
+        setTimeout(() => {
+          copyBtn.textContent = original;
+        }, 2000);
+      });
+    });
+  }
+
+  // Show skeleton immediately on page load
+  convert();
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}

--- a/assets/js/dcConverter.js
+++ b/assets/js/dcConverter.js
@@ -194,10 +194,6 @@ function classify(key) {
   const enableMatch = key.match(/^otel\.instrumentation\.(.+)\.enabled$/);
   if (enableMatch) {
     const name = enableMatch[1];
-    if (name === 'common.default') {
-      // otel.instrumentation.common.default-enabled — parsed from .properties
-      // won't match this; handled separately
-    }
     // Skip if it looks like a sub-property (e.g. common.db-statement-sanitizer.enabled)
     if (!name.includes('.')) {
       return { type: 'enable', name };

--- a/content/en/docs/languages/sdk-configuration/declarative-configuration.md
+++ b/content/en/docs/languages/sdk-configuration/declarative-configuration.md
@@ -4,6 +4,8 @@ linkTitle: Declarative configuration
 weight: 30
 ---
 
+<?code-excerpt path-base="examples/otel-config"?>
+
 Declarative configuration uses a YAML file instead of environment variables.
 
 This approach is useful when:
@@ -34,21 +36,45 @@ For details, refer to the
 
 Recommended configuration file:
 
+<!-- prettier-ignore-start -->
+<?code-excerpt "examples/otel-getting-started.yaml"?>
 ```yaml
-file_format: '1.0'
+# otel-getting-started.yaml is a good starting point for configuring the SDK, including exporting to
+# localhost via OTLP.
+#
+# NOTE: With the exception of env var substitution syntax (i.e. ${MY_ENV}), SDKs ignore
+# environment variables when interpreting config files. This including ignoring all env
+# vars defined in https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/.
+#
+# For schema documentation, including required properties, semantics, default behavior, etc,
+# see: https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema-docs.md
+
+file_format: "1.0"
 
 resource:
+  # Read resource attributes from the OTEL_RESOURCE_ATTRIBUTES environment variable.
+  # This aligns well with the OpenTelemetry Operator and other deployment methods.
   attributes_list: ${OTEL_RESOURCE_ATTRIBUTES}
-  detection/development:
+  detection/development: # /development properties may not be supported in all SDKs
     detectors:
-      - service: # will add "service.instance.id" and "service.name" from OTEL_SERVICE_NAME
+      - service: # will add "service.instance.id" and "service.name" from the OTEL_SERVICE_NAME env var
+      - host:
+      - process:
+      - container:
 
 propagator:
   composite:
     - tracecontext:
     - baggage:
 
+# Read backend endpoint from the OTEL_EXPORTER_OTLP_ENDPOINT environment variable.
+# This aligns well with the OpenTelemetry Operator and other deployment methods.
+
 tracer_provider:
+  sampler:
+    parent_based:
+      root:
+        always_on:
   processors:
     - batch:
         exporter:
@@ -69,6 +95,7 @@ logger_provider:
           otlp_http:
             endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}/v1/logs
 ```
+<!-- prettier-ignore-end -->
 
 ## Environment variables
 

--- a/content/en/docs/languages/sdk-configuration/declarative-configuration.md
+++ b/content/en/docs/languages/sdk-configuration/declarative-configuration.md
@@ -4,6 +4,7 @@ linkTitle: Declarative configuration
 weight: 30
 ---
 
+<!-- markdownlint-disable blanks-around-fences -->
 <?code-excerpt path-base="examples/otel-config"?>
 
 Declarative configuration uses a YAML file instead of environment variables.

--- a/content/en/docs/zero-code/java/agent/declarative-configuration.md
+++ b/content/en/docs/zero-code/java/agent/declarative-configuration.md
@@ -79,6 +79,10 @@ This page focuses on specifics for the
 For the Spring Boot starter, see
 [Spring Boot starter declarative configuration](/docs/zero-code/java/spring-boot-starter/declarative-configuration/).
 
+## Convert your existing configuration
+
+{{< dc-converter source="agent" >}}
+
 ## Mapping of configuration options
 
 When you want to map your existing environment variables or system properties

--- a/content/en/docs/zero-code/java/spring-boot-starter/declarative-configuration.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/declarative-configuration.md
@@ -72,6 +72,10 @@ otel:
 Note that `${VAR:default}` uses a single colon (Spring syntax), not the
 `${VAR:-default}` syntax used in the agent's standalone YAML file.
 
+## Convert your existing configuration
+
+{{< dc-converter source="spring" >}}
+
 ## Mapping of configuration options
 
 The following rules describe how `application.properties` / `application.yaml`

--- a/examples/otel-config
+++ b/examples/otel-config
@@ -1,0 +1,1 @@
+../content-modules/opentelemetry-configuration

--- a/layouts/_shortcodes/dc-converter.html
+++ b/layouts/_shortcodes/dc-converter.html
@@ -1,6 +1,7 @@
 {{ $source := .Get "source" | default "agent" -}}
+{{ $gettingStarted := readFile "examples/otel-config/examples/otel-getting-started.yaml" -}}
 
-<div class="dc-converter card p-3 my-4" data-source="{{ $source }}">
+<div class="dc-converter card p-3 my-4" data-source="{{ $source }}" data-getting-started="{{ $gettingStarted | htmlEscape }}">
   <p class="text-body-secondary mb-3">
     Paste your existing configuration below to generate the equivalent
     declarative configuration YAML. You can fill in any combination of inputs.

--- a/layouts/_shortcodes/dc-converter.html
+++ b/layouts/_shortcodes/dc-converter.html
@@ -1,0 +1,41 @@
+{{ $source := .Get "source" | default "agent" -}}
+
+<div class="dc-converter card p-3 my-4" data-source="{{ $source }}">
+  <p class="text-body-secondary mb-3">
+    Paste your existing configuration below to generate the equivalent
+    declarative configuration YAML. You can fill in any combination of inputs.
+  </p>
+
+  <div class="row mb-3">
+    <div class="col-md-6 mb-3 mb-md-0">
+      <label for="dc-input-props" class="form-label">System properties{{ if eq $source "spring" }} / application.properties{{ end }}</label>
+      <textarea id="dc-input-props" class="form-control font-monospace" rows="6"
+        placeholder="otel.instrumentation.jdbc.enabled=false&#10;otel.instrumentation.kafka.experimental-span-attributes=true"></textarea>
+    </div>
+    <div class="col-md-6">
+      <label for="dc-input-env" class="form-label">Environment variables</label>
+      <textarea id="dc-input-env" class="form-control font-monospace" rows="6"
+        placeholder="OTEL_INSTRUMENTATION_JDBC_ENABLED=false&#10;OTEL_SERVICE_NAME=my-app"></textarea>
+    </div>
+  </div>
+
+  {{ if eq $source "spring" -}}
+  <div class="mb-3">
+    <label for="dc-input-yaml" class="form-label">application.yaml</label>
+    <textarea id="dc-input-yaml" class="form-control font-monospace" rows="6"
+      placeholder="otel:&#10;  instrumentation:&#10;    jdbc:&#10;      enabled: false"></textarea>
+  </div>
+  {{ end -}}
+
+  <div class="mb-3">
+    <label for="dc-output" class="form-label">Declarative Configuration output</label>
+    <textarea id="dc-output" class="form-control font-monospace" rows="12" readonly></textarea>
+    <button id="dc-copy" class="btn btn-sm btn-outline-secondary mt-2">
+      Copy to clipboard
+    </button>
+  </div>
+
+  <div id="dc-warnings" class="alert alert-warning d-none mb-0"></div>
+</div>
+
+{{ partial "script.html" (dict "src" "js/dcConverter.js") -}}


### PR DESCRIPTION

See the converter in action:

- https://deploy-preview-9456--opentelemetry.netlify.app/docs/zero-code/java/agent/declarative-configuration/
- https://deploy-preview-9456--opentelemetry.netlify.app/docs/zero-code/java/spring-boot-starter/declarative-configuration/

## Summary

- Adds an interactive converter shortcode that translates existing configuration (system properties, env vars, application.yaml) into declarative configuration YAML
- Supports both Java agent and Spring Boot starter modes
- Handles special mappings, `/development` suffix for experimental features, enable/disable lists, and SDK properties
- Shows recommended base DC skeleton on page load, with converted config appearing as you type

## Test plan

- [ ] Verify converter renders on both DC pages (agent + Spring Boot starter)
- [ ] Test system properties input (with and without `-D` prefix)
- [ ] Test environment variable input (with special mapping lookup)
- [ ] Test application.yaml input (Spring only)
- [ ] Test combined inputs across all three boxes
- [ ] Verify copy button works
- [ ] Verify unknown properties appear as comments with warnings