### PR TITLE
[CI] Auto-update versions in localized content files

### DIFF
--- a/scripts/auto-update/version-in-file.sh
+++ b/scripts/auto-update/version-in-file.sh
@@ -64,10 +64,40 @@ function process_file() {
   fi
 }
 
+function update_locale_files() {
+  # Only expand files under content/en/
+  if [[ ! "$file_name" =~ ^content/en/ ]]; then
+    return
+  fi
+
+  local relative_path="${file_name#content/en/}"
+
+  for locale_dir in content/*/; do
+    local locale="${locale_dir#content/}"
+    locale="${locale%/}"
+    [[ "$locale" == "en" ]] && continue
+
+    local locale_file="content/${locale}/${relative_path}"
+    [[ ! -f "$locale_file" ]] && continue
+
+    local match_regex="^ *$variable_name:"
+    local ver="$latest_semver"
+
+    if ! grep -q "$match_regex" "$locale_file"; then
+      continue
+    fi
+
+    echo "UPDATING locale:  $locale_file"
+    sed -i.bak -e "s/\($match_regex\) .*/\1 $ver/" "$locale_file"
+    rm -f "$locale_file".bak
+  done
+}
+
 while [[ $# -gt 0 ]]; do
   variable_name=$1; shift;
   file_name=$1; shift;
   process_file $variable_name $file_name
+  update_locale_files
 done
 
 if git diff --quiet "${file_names[@]}"; then


### PR DESCRIPTION
- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

The version auto-update script (`scripts/auto-update/version-in-file.sh`) only updates English files listed in `all-versions.sh`. Localized files (ja, zh, etc.) that have the same frontmatter version variables drift behind over time.

This PR adds an `update_locale_files()` function to `version-in-file.sh` that, after updating each English file under `content/en/`, automatically discovers and updates locale equivalents via a `content/*/` glob. It silently skips locales where the file doesn't exist or lacks the relevant variable.
