### PR TITLE
Add AI tool usage guidance to localization docs

### DIFF
--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -66,18 +66,18 @@ guidance offered in this section.
 #### Use of AI tools {#ai-tools}
 
 If you use generative AI tools (such as ChatGPT, Gemini, or similar) to assist
-with translations, you must follow the OpenTelemetry
-[Generative AI Contribution Policy][genai-policy] and the Linux Foundation
-[Generative AI Policy][lf-ai-policy]. In particular:
+with translations, you must follow the OpenTelemetry [Generative AI Contribution
+Policy][genai-policy] and the Linux Foundation [Generative AI
+Policy][lf-ai-policy]. In particular:
 
-- **Disclose** that you used AI by checking the appropriate box in the
-  [pull request template][].
+- **Disclose** that you used AI by checking the appropriate box in the [pull
+  request template][].
 - **Review and validate** all AI-generated translations for accuracy. You are
   responsible for the content you submit.
 - **Do not submit** AI-generated translations that you cannot review and verify
-  yourself (e.g., submissions in languages you are not proficient in). This creates
-  a significant review bottleneck, and your PR may be closed to protect maintainer
-  bandwidth.
+  yourself (e.g., submissions in languages you are not proficient in). This
+  creates a significant review bottleneck, and your PR may be closed to protect
+  maintainer bandwidth.
 
 [genai-policy]:
   https://github.com/open-telemetry/community/blob/main/policies/genai.md

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -14667,6 +14667,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-03-10T09:52:23.35558422Z"
   },
+  "https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/PULL_REQUEST_TEMPLATE.md": {
+    "StatusCode": 206,
+    "LastSeen": "2026-03-27T13:36:24.100525737Z"
+  },
   "https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/component-label-map.yml": {
     "StatusCode": 206,
     "LastSeen": "2026-03-18T09:54:25.041802798Z"
@@ -23030,6 +23034,10 @@
   "https://www.linuxfoundation.org/": {
     "StatusCode": 200,
     "LastSeen": "2026-03-10T09:52:44.896396671Z"
+  },
+  "https://www.linuxfoundation.org/legal/generative-ai": {
+    "StatusCode": 200,
+    "LastSeen": "2026-03-27T13:36:23.167950371Z"
   },
   "https://www.linuxfoundation.org/legal/privacy-policy": {
     "StatusCode": 200,


### PR DESCRIPTION
- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.

---

Adds a new "Use of AI tools" section to the localization guide (`content/en/docs/contributing/localization.md`), placed in the translation guidance summary alongside the existing Do/Do NOT sections.

The section links to:
- The OpenTelemetry [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md)
- The Linux Foundation [Generative AI Policy](https://www.linuxfoundation.org/legal/generative-ai)
- The PR template's AI disclosure checkbox

This makes the AI policy visible where localizers will see it while reading translation guidance, rather than only in the PR template.

Fixes #8010

This contribution was developed with AI assistance (Claude Code).