### PR TITLE
docs(demo): add tail-based sampling example using service.criticality

### DIFF
--- a/content/en/docs/demo/sample-configurations/_index.md
+++ b/content/en/docs/demo/sample-configurations/_index.md
@@ -1,0 +1,10 @@
+---
+title: Sample Configurations
+linkTitle: Sample Configurations
+---
+
+This section provides sample OpenTelemetry Collector configurations that
+demonstrate how to leverage resource attributes and processors available in the
+demo application.
+
+- [Tail-Based Sampling with service.criticality](tail-sampling-service-criticality/)

--- a/content/en/docs/demo/sample-configurations/_index.md
+++ b/content/en/docs/demo/sample-configurations/_index.md
@@ -1,6 +1,5 @@
 ---
 title: Sample Configurations
-linkTitle: Sample Configurations
 ---
 
 This section provides sample OpenTelemetry Collector configurations that

--- a/content/en/docs/demo/sample-configurations/_index.md
+++ b/content/en/docs/demo/sample-configurations/_index.md
@@ -6,4 +6,4 @@ This section provides sample OpenTelemetry Collector configurations that
 demonstrate how to leverage resource attributes and processors available in the
 demo application.
 
-- [Tail-Based Sampling with service.criticality](tail-sampling-service-criticality/)
+- [Tail-Based Sampling with `service.criticality`](tail-sampling-service-criticality/)

--- a/content/en/docs/demo/sample-configurations/tail-sampling-service-criticality.md
+++ b/content/en/docs/demo/sample-configurations/tail-sampling-service-criticality.md
@@ -126,12 +126,12 @@ The tail-sampling processor evaluates completed traces against the configured
 policies. A trace is sampled if **any** policy matches:
 
 - **Critical services** are always sampled to ensure full visibility into
-   payment flows, checkout, and user-facing services.
-- **High-criticality services** are sampled at 50%, balancing observability
-   with data volume.
+  payment flows, checkout, and user-facing services.
+- **High-criticality services** are sampled at 50%, balancing observability with
+  data volume.
 - **Medium and low-criticality services** are progressively sampled at lower
-   rates to reduce noise from less critical paths.
+  rates to reduce noise from less critical paths.
 - **Errors are always captured** regardless of service criticality, ensuring no
-   issues go unnoticed.
+  issues go unnoticed.
 - **Slow traces** (>5s) from critical and high-criticality services are always
-   sampled to help identify performance bottlenecks.
+  sampled to help identify performance bottlenecks.

--- a/content/en/docs/demo/sample-configurations/tail-sampling-service-criticality.md
+++ b/content/en/docs/demo/sample-configurations/tail-sampling-service-criticality.md
@@ -1,6 +1,7 @@
 ---
 title: Tail-Based Sampling with service.criticality
 linkTitle: Tail Sampling
+cSpell:ignore: kafka
 ---
 
 This example demonstrates how to use the

--- a/content/en/docs/demo/sample-configurations/tail-sampling-service-criticality.md
+++ b/content/en/docs/demo/sample-configurations/tail-sampling-service-criticality.md
@@ -11,11 +11,11 @@ OpenTelemetry Collector.
 The demo application assigns a `service.criticality` value to each service,
 classifying them by operational importance:
 
-| Criticality | Sampling Rate | Services |
-| ----------- | ------------- | -------- |
-| `critical`  | 100%          | payment, checkout, frontend, frontend-proxy |
-| `high`      | 50%           | cart, product-catalog, currency, shipping |
-| `medium`    | 10%           | recommendation, ad, product-reviews, email |
+| Criticality | Sampling Rate | Services                                                                                   |
+| ----------- | ------------- | ------------------------------------------------------------------------------------------ |
+| `critical`  | 100%          | payment, checkout, frontend, frontend-proxy                                                |
+| `high`      | 50%           | cart, product-catalog, currency, shipping                                                  |
+| `medium`    | 10%           | recommendation, ad, product-reviews, email                                                 |
 | `low`       | 1%            | accounting, fraud-detection, image-provider, load-generator, quote, flagd, flagd-ui, kafka |
 
 ## Collector Configuration
@@ -131,7 +131,7 @@ policies. A trace is sampled if **any** policy matches:
    with data volume.
 3. **Medium and low-criticality services** are progressively sampled at lower
    rates to reduce noise from less critical paths.
-4. **Errors are always captured** regardless of service criticality, ensuring
-   no issues go unnoticed.
+4. **Errors are always captured** regardless of service criticality, ensuring no
+   issues go unnoticed.
 5. **Slow traces** (>5s) from critical and high-criticality services are always
    sampled to help identify performance bottlenecks.

--- a/content/en/docs/demo/sample-configurations/tail-sampling-service-criticality.md
+++ b/content/en/docs/demo/sample-configurations/tail-sampling-service-criticality.md
@@ -4,9 +4,9 @@ linkTitle: Tail Sampling
 ---
 
 This example demonstrates how to use the
-[`service.criticality`](/docs/specs/semconv/resource/service/#service)
-resource attribute for intelligent tail-based sampling decisions in the
-OpenTelemetry Collector.
+[`service.criticality`](/docs/specs/semconv/resource/service/#service) resource
+attribute for intelligent tail-based sampling decisions in the OpenTelemetry
+Collector.
 
 The demo application assigns a `service.criticality` value to each service,
 classifying them by operational importance:
@@ -16,7 +16,7 @@ classifying them by operational importance:
 | `critical`  | 100%          | payment, checkout, frontend, frontend-proxy                                                |
 | `high`      | 50%           | cart, product-catalog, currency, shipping                                                  |
 | `medium`    | 10%           | recommendation, ad, product-reviews, email                                                 |
-| `low`       | 1%            | accounting, fraud-detection, image-provider, load-generator, quote, flagd, flagd-ui, kafka |
+| `low`       | 1%            | accounting, fraud-detection, image-provider, load-generator, quote, flagd, flagd-ui, Kafka |
 
 ## Collector Configuration
 

--- a/content/en/docs/demo/sample-configurations/tail-sampling-service-criticality.md
+++ b/content/en/docs/demo/sample-configurations/tail-sampling-service-criticality.md
@@ -4,7 +4,7 @@ linkTitle: Tail Sampling
 ---
 
 This example demonstrates how to use the
-[`service.criticality`](https://github.com/open-telemetry/semantic-conventions/issues/2986)
+[`service.criticality`](/docs/specs/semconv/resource/service/#service)
 resource attribute for intelligent tail-based sampling decisions in the
 OpenTelemetry Collector.
 

--- a/content/en/docs/demo/sample-configurations/tail-sampling-service-criticality.md
+++ b/content/en/docs/demo/sample-configurations/tail-sampling-service-criticality.md
@@ -125,13 +125,13 @@ service:
 The tail-sampling processor evaluates completed traces against the configured
 policies. A trace is sampled if **any** policy matches:
 
-1. **Critical services** are always sampled to ensure full visibility into
+- **Critical services** are always sampled to ensure full visibility into
    payment flows, checkout, and user-facing services.
-2. **High-criticality services** are sampled at 50%, balancing observability
+- **High-criticality services** are sampled at 50%, balancing observability
    with data volume.
-3. **Medium and low-criticality services** are progressively sampled at lower
+- **Medium and low-criticality services** are progressively sampled at lower
    rates to reduce noise from less critical paths.
-4. **Errors are always captured** regardless of service criticality, ensuring no
+- **Errors are always captured** regardless of service criticality, ensuring no
    issues go unnoticed.
-5. **Slow traces** (>5s) from critical and high-criticality services are always
+- **Slow traces** (>5s) from critical and high-criticality services are always
    sampled to help identify performance bottlenecks.

--- a/content/en/docs/demo/sample-configurations/tail-sampling-service-criticality.md
+++ b/content/en/docs/demo/sample-configurations/tail-sampling-service-criticality.md
@@ -1,7 +1,6 @@
 ---
 title: Tail-Based Sampling with service.criticality
 linkTitle: Tail Sampling
-cSpell:ignore: kafka
 ---
 
 This example demonstrates how to use the

--- a/content/en/docs/demo/sample-configurations/tail-sampling-service-criticality.md
+++ b/content/en/docs/demo/sample-configurations/tail-sampling-service-criticality.md
@@ -1,0 +1,137 @@
+---
+title: Tail-Based Sampling with service.criticality
+linkTitle: Tail Sampling
+---
+
+This example demonstrates how to use the
+[`service.criticality`](https://github.com/open-telemetry/semantic-conventions/issues/2986)
+resource attribute for intelligent tail-based sampling decisions in the
+OpenTelemetry Collector.
+
+The demo application assigns a `service.criticality` value to each service,
+classifying them by operational importance:
+
+| Criticality | Sampling Rate | Services |
+| ----------- | ------------- | -------- |
+| `critical`  | 100%          | payment, checkout, frontend, frontend-proxy |
+| `high`      | 50%           | cart, product-catalog, currency, shipping |
+| `medium`    | 10%           | recommendation, ad, product-reviews, email |
+| `low`       | 1%            | accounting, fraud-detection, image-provider, load-generator, quote, flagd, flagd-ui, kafka |
+
+## Collector Configuration
+
+To enable tail-based sampling, add the following to your
+`otelcol-config-extras.yml`:
+
+```yaml
+processors:
+  tail_sampling:
+    decision_wait: 10s
+    num_traces: 100000
+    expected_new_traces_per_sec: 1000
+    policies:
+      # Policy 1: Always sample critical services (100%)
+      - name: critical-services-always-sample
+        type: string_attribute
+        string_attribute:
+          key: service.criticality
+          values:
+            - critical
+          enabled_regex_matching: false
+          invert_match: false
+
+      # Policy 2: Sample 50% of high-criticality services
+      - name: high-criticality-probabilistic
+        type: and
+        and:
+          and_sub_policy:
+            - name: is-high-criticality
+              type: string_attribute
+              string_attribute:
+                key: service.criticality
+                values:
+                  - high
+            - name: probabilistic-50
+              type: probabilistic
+              probabilistic:
+                sampling_percentage: 50
+
+      # Policy 3: Sample 10% of medium-criticality services
+      - name: medium-criticality-probabilistic
+        type: and
+        and:
+          and_sub_policy:
+            - name: is-medium-criticality
+              type: string_attribute
+              string_attribute:
+                key: service.criticality
+                values:
+                  - medium
+            - name: probabilistic-10
+              type: probabilistic
+              probabilistic:
+                sampling_percentage: 10
+
+      # Policy 4: Sample 1% of low-criticality services
+      - name: low-criticality-probabilistic
+        type: and
+        and:
+          and_sub_policy:
+            - name: is-low-criticality
+              type: string_attribute
+              string_attribute:
+                key: service.criticality
+                values:
+                  - low
+            - name: probabilistic-1
+              type: probabilistic
+              probabilistic:
+                sampling_percentage: 1
+
+      # Policy 5: Always sample error traces regardless of criticality
+      - name: errors-always-sample
+        type: status_code
+        status_code:
+          status_codes:
+            - ERROR
+
+      # Policy 6: Always sample slow traces from critical/high services
+      - name: slow-critical-traces
+        type: and
+        and:
+          and_sub_policy:
+            - name: is-critical-or-high
+              type: string_attribute
+              string_attribute:
+                key: service.criticality
+                values:
+                  - critical
+                  - high
+            - name: is-slow
+              type: latency
+              latency:
+                threshold_ms: 5000
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [resourcedetection, memory_limiter, transform, tail_sampling]
+      exporters: [otlp, debug, spanmetrics]
+```
+
+## How It Works
+
+The tail-sampling processor evaluates completed traces against the configured
+policies. A trace is sampled if **any** policy matches:
+
+1. **Critical services** are always sampled to ensure full visibility into
+   payment flows, checkout, and user-facing services.
+2. **High-criticality services** are sampled at 50%, balancing observability
+   with data volume.
+3. **Medium and low-criticality services** are progressively sampled at lower
+   rates to reduce noise from less critical paths.
+4. **Errors are always captured** regardless of service criticality, ensuring
+   no issues go unnoticed.
+5. **Slow traces** (>5s) from critical and high-criticality services are always
+   sampled to help identify performance bottlenecks.


### PR DESCRIPTION
 This PR adds documentation for opentelemetry-demo which includes newly introduced semantic convention attribute `service.criticality`
 
 ### Summary

  - Add a new "Sample Configurations" section under the demo docs
  - Document a tail-based sampling example using the `service.criticality` resource attribute introduced in [SemConv 1.40.0](https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.40.0)
  - Include collector configuration with sampling policies based on service criticality levels (`critical`, `high`, `medium`, `low`)

  ### Context

  This documentation accompanies [open-telemetry/opentelemetry-demo#2950](https://github.com/open-telemetry/opentelemetry-demo/pull/2950), which adds `service.criticality` as a resource attribute to all demo services. The example was originally included in the
  demo's `otelcol-config-extras.yml` and moved here per reviewer feedback.
 
 
[semconv PR](https://github.com/open-telemetry/semantic-conventions/pull/3088)

 

<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---


