### PR TITLE
docs: introduce agentic skills for OTel.io docs workflows (#9397)

### DIFF
--- a/.agents/skills/new-page-scaffold.md
+++ b/.agents/skills/new-page-scaffold.md
@@ -1,0 +1,25 @@
+# Skill: `new-page-scaffold`
+
+Scaffold a new documentation page with correct frontmatter and directory structure for `opentelemetry.io`.
+
+## Parameters
+
+- `title`: The title of the page.
+- `description`: A brief description for SEO and site search.
+- `path`: The target path relative to `content/en/docs/`.
+
+## Steps
+
+1.  **Validate path**: Ensure the target directory exists under `content/en/docs/`.
+2.  **Determine filename**: Use kebab-case for the filename. If it's a section landing page, use `_index.md`.
+3.  **Generate frontmatter**:
+    ```yaml
+    ---
+    title: <title>
+    description: <description>
+    weight: <calculated-weight>
+    ---
+    ```
+4.  **Calculate weight**: Check existing files in the directory to determine the next logical `weight` (increment by 10 or 5).
+5.  **Create file**: Write the scaffolding to the calculated path.
+6.  **Verify**: Run `npm run check:markdown` on the new file.

--- a/.agents/skills/new-page-scaffold.md
+++ b/.agents/skills/new-page-scaffold.md
@@ -1,6 +1,7 @@
 # Skill: `new-page-scaffold`
 
-Scaffold a new documentation page with correct frontmatter and directory structure for `opentelemetry.io`.
+Scaffold a new documentation page with correct frontmatter and directory
+structure for `opentelemetry.io`.
 
 ## Parameters
 
@@ -10,8 +11,10 @@ Scaffold a new documentation page with correct frontmatter and directory structu
 
 ## Steps
 
-1.  **Validate path**: Ensure the target directory exists under `content/en/docs/`.
-2.  **Determine filename**: Use kebab-case for the filename. If it's a section landing page, use `_index.md`.
+1.  **Validate path**: Ensure the target directory exists under
+    `content/en/docs/`.
+2.  **Determine filename**: Use kebab-case for the filename. If it's a section
+    landing page, use `_index.md`.
 3.  **Generate frontmatter**:
     ```yaml
     ---
@@ -20,6 +23,7 @@ Scaffold a new documentation page with correct frontmatter and directory structu
     weight: <calculated-weight>
     ---
     ```
-4.  **Calculate weight**: Check existing files in the directory to determine the next logical `weight` (increment by 10 or 5).
+4.  **Calculate weight**: Check existing files in the directory to determine the
+    next logical `weight` (increment by 10 or 5).
 5.  **Create file**: Write the scaffolding to the calculated path.
 6.  **Verify**: Run `npm run check:markdown` on the new file.

--- a/.agents/skills/review-content.md
+++ b/.agents/skills/review-content.md
@@ -1,0 +1,25 @@
+# Skill: `review-content`
+
+Review `opentelemetry.io` documentation content for compliance with the OTel style guide and markdown standards.
+
+## Parameters
+
+- `path`: The path to the markdown file to review.
+
+## Steps
+
+1.  **Format and lint check**:
+    - Run `npm run check:markdown -- <path>` to verify basic markdown formatting.
+    - Run `npm run check:text -- <path>` for terminology and textlint rules.
+2.  **Style guide alignment**:
+    - **Alerts**: Verify alert types use the standard `> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!WARNING]`, or `> [!CAUTION]` syntax.
+    - **Headings**: Ensure each page has exactly one `H1` and that heading levels follow a logical hierarchy.
+    - **Heading IDs**: Check if headings have explicit IDs (e.g., `## Heading {#id}`) as required by the site's Hugo configuration.
+    - **Inclusive language**: Ensure the content follows inclusive language principles (e.g., avoiding "master/slave", "whitelist/blacklist").
+3.  **Frontmatter validation**:
+    - Verify mandatory fields: `title`, `description`.
+    - Check for appropriate `weight` if the page is part of a sequence.
+4.  **Links and images**:
+    - Run `npm run check:links -- <path>` to verify all links are valid.
+    - For images, ensure they have descriptive alt text.
+5.  **Summarize results**: Provide a clear list of violations and suggested fixes.

--- a/.agents/skills/review-content.md
+++ b/.agents/skills/review-content.md
@@ -1,6 +1,7 @@
 # Skill: `review-content`
 
-Review `opentelemetry.io` documentation content for compliance with the OTel style guide and markdown standards.
+Review `opentelemetry.io` documentation content for compliance with the OTel
+style guide and markdown standards.
 
 ## Parameters
 
@@ -9,17 +10,23 @@ Review `opentelemetry.io` documentation content for compliance with the OTel sty
 ## Steps
 
 1.  **Format and lint check**:
-    - Run `npm run check:markdown -- <path>` to verify basic markdown formatting.
+    - Run `npm run check:markdown -- <path>` to verify basic markdown
+      formatting.
     - Run `npm run check:text -- <path>` for terminology and textlint rules.
 2.  **Style guide alignment**:
-    - **Alerts**: Verify alert types use the standard `> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!WARNING]`, or `> [!CAUTION]` syntax.
-    - **Headings**: Ensure each page has exactly one `H1` and that heading levels follow a logical hierarchy.
-    - **Heading IDs**: Check if headings have explicit IDs (e.g., `## Heading {#id}`) as required by the site's Hugo configuration.
-    - **Inclusive language**: Ensure the content follows inclusive language principles (e.g., avoiding "master/slave", "whitelist/blacklist").
+    - **Alerts**: Verify alert types use the standard `> [!NOTE]`, `> [!TIP]`,
+      `> [!IMPORTANT]`, `> [!WARNING]`, or `> [!CAUTION]` syntax.
+    - **Headings**: Ensure each page has exactly one `H1` and that heading
+      levels follow a logical hierarchy.
+    - **Heading IDs**: Check if headings have explicit IDs (e.g.,
+      `## Heading {#id}`) as required by the site's Hugo configuration.
+    - **Inclusive language**: Ensure the content follows inclusive language
+      principles (e.g., avoiding "master/slave", "whitelist/blacklist").
 3.  **Frontmatter validation**:
     - Verify mandatory fields: `title`, `description`.
     - Check for appropriate `weight` if the page is part of a sequence.
 4.  **Links and images**:
     - Run `npm run check:links -- <path>` to verify all links are valid.
     - For images, ensure they have descriptive alt text.
-5.  **Summarize results**: Provide a clear list of violations and suggested fixes.
+5.  **Summarize results**: Provide a clear list of violations and suggested
+    fixes.

--- a/.agents/skills/setup-localization.md
+++ b/.agents/skills/setup-localization.md
@@ -1,0 +1,30 @@
+# Skill: `setup-localization`
+
+Automate the "New localizations" onboarding process for `opentelemetry.io`.
+
+## Parameters
+
+- `language_name`: The name of the language (e.g., "Hindi").
+- `language_code`: ISO 639-1 language code (e.g., "hi").
+- `mentor_handle`: GitHub handle of the localization mentor.
+- `contributor_handles`: List of GitHub handles for initial contributors.
+
+## Steps
+
+1.  **Prepare Hugo config**:
+    - Update `config/_default/hugo.yaml`: Add the new language to the `languages` block.
+    - Update `config/_default/module-template.yaml`: Add a content mount for the new language.
+2.  **Setup spelling support**:
+    - Check for an available `@cspell/dict-<language_code>` NPM package.
+    - If available, install as a dev dependency (`npm install --save-dev @cspell/dict-<language_code>`).
+    - Create `.cspell/<language_code>-words.txt` for site-local words.
+    - Update `.cspell.yml` to import the new dictionary and define the local word file.
+3.  **Localize homepage**:
+    - Create `content/<language_code>/_index.md`.
+    - Scaffold the file with basic frontmatter including `title` and `description` in the target language.
+4.  **Draft initial localization issue**:
+    - Use the template from `content/en/docs/contributing/localization.md` section "Localization kickoff".
+    - Populate fields: Language info, Locale team info, and OTel maintainer checklist.
+5.  **Verify**:
+    - Build the site locally (`npm run build`) to ensure Hugo configuration is valid.
+    - Run `npm run check:i18n -- content/<language_code>` to check synchronization status.

--- a/.agents/skills/setup-localization.md
+++ b/.agents/skills/setup-localization.md
@@ -12,19 +12,28 @@ Automate the "New localizations" onboarding process for `opentelemetry.io`.
 ## Steps
 
 1.  **Prepare Hugo config**:
-    - Update `config/_default/hugo.yaml`: Add the new language to the `languages` block.
-    - Update `config/_default/module-template.yaml`: Add a content mount for the new language.
+    - Update `config/_default/hugo.yaml`: Add the new language to the
+      `languages` block.
+    - Update `config/_default/module-template.yaml`: Add a content mount for the
+      new language.
 2.  **Setup spelling support**:
     - Check for an available `@cspell/dict-<language_code>` NPM package.
-    - If available, install as a dev dependency (`npm install --save-dev @cspell/dict-<language_code>`).
+    - If available, install as a dev dependency
+      (`npm install --save-dev @cspell/dict-<language_code>`).
     - Create `.cspell/<language_code>-words.txt` for site-local words.
-    - Update `.cspell.yml` to import the new dictionary and define the local word file.
+    - Update `.cspell.yml` to import the new dictionary and define the local
+      word file.
 3.  **Localize homepage**:
     - Create `content/<language_code>/_index.md`.
-    - Scaffold the file with basic frontmatter including `title` and `description` in the target language.
+    - Scaffold the file with basic frontmatter including `title` and
+      `description` in the target language.
 4.  **Draft initial localization issue**:
-    - Use the template from `content/en/docs/contributing/localization.md` section "Localization kickoff".
-    - Populate fields: Language info, Locale team info, and OTel maintainer checklist.
+    - Use the template from `content/en/docs/contributing/localization.md`
+      section "Localization kickoff".
+    - Populate fields: Language info, Locale team info, and OTel maintainer
+      checklist.
 5.  **Verify**:
-    - Build the site locally (`npm run build`) to ensure Hugo configuration is valid.
-    - Run `npm run check:i18n -- content/<language_code>` to check synchronization status.
+    - Build the site locally (`npm run build`) to ensure Hugo configuration is
+      valid.
+    - Run `npm run check:i18n -- content/<language_code>` to check
+      synchronization status.


### PR DESCRIPTION
### PR Description

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

This PR introduces an agentic skills catalog in the `.agents/skills` directory, as proposed in #9397. These skills are structured Markdown files that enable AI coding agents to automate common documentation workflows within the `opentelemetry.io` repository.

**Initial Skills Added:**

1.  **`setup-localization.md`**: Automates the onboarding process for new localizations, including Hugo configuration updates and drafting the kickoff issue.
2.  **`review-content.md`**: Provides a standardized checklist and command set for reviewing content against the OTel style guide and site-wide linting rules.
3.  **`new-page-scaffold.md`**: Automates the creation of new documentation pages with correct frontmatter and weight calculations.

These skills are designed to improve the contributor experience for those using AI-assisted tools while maintaining compliance with project standards and automation requirements.

Fixes #9397