### PR TITLE
docs: add explicit project links to contributing index (#7278)

### DIFF
--- a/content/en/docs/contributing/_index.md
+++ b/content/en/docs/contributing/_index.md
@@ -56,20 +56,21 @@ What do you want to do?
 
 ## What can I contribute to?
 
-OpenTelemetry documentation contributors:
+If you want to contribute to the core OpenTelemetry projects, here is a list of the main repositories:
+
+- **[Specification](https://github.com/open-telemetry/opentelemetry-specification)** - Cross-language requirements and expectations for all implementations. ([Contributing Guide](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md))
+- **[Semantic Conventions](https://github.com/open-telemetry/semantic-conventions)** - Defines standard attribute names for telemetry data. ([Contributing Guide](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md))
+- **[Collector](https://github.com/open-telemetry/opentelemetry-collector)** - A vendor-agnostic proxy that can receive, process, and export telemetry data. ([Contributing Guide](https://github.com/open-telemetry/opentelemetry-collector/blob/main/CONTRIBUTING.md))
+- **Language SDKs**: Every [language implementation repository][org] contains its own project-specific contributing guide.
+
+For general guidance on contributing to the overall project, see the community [OpenTelemetry New Contributor Guide][].
+
+If you would like to contribute to OpenTelemetry **documentation**, you can:
 
 - Improve existing or create new content
 - [Submit a blog post](blog/) or case study
 - Add to or update the [OpenTelemetry Registry](/ecosystem/registry/)
 - Improve the code that builds the site
-
-The pages in this section describe how to contribute to OpenTelemetry
-**documentation**.
-
-For guidance on how to contribute to the OpenTelemetry project in general, see
-the community [OpenTelemetry New Contributor Guide][]. Every [OTel
-repository][org] for language implementations, the Collector, and conventions
-have their own project-specific contributing guides.
 
 [choose an issue]: issues/#fixing-an-existing-issue
 [issues]: issues/

--- a/content/en/docs/contributing/_index.md
+++ b/content/en/docs/contributing/_index.md
@@ -56,14 +56,23 @@ What do you want to do?
 
 ## What can I contribute to?
 
-If you want to contribute to the core OpenTelemetry projects, here is a list of the main repositories:
+If you want to contribute to the core OpenTelemetry projects, here is a list of
+the main repositories:
 
-- **[Specification](https://github.com/open-telemetry/opentelemetry-specification)** - Cross-language requirements and expectations for all implementations. ([Contributing Guide](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md))
-- **[Semantic Conventions](https://github.com/open-telemetry/semantic-conventions)** - Defines standard attribute names for telemetry data. ([Contributing Guide](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md))
-- **[Collector](https://github.com/open-telemetry/opentelemetry-collector)** - A vendor-agnostic proxy that can receive, process, and export telemetry data. ([Contributing Guide](https://github.com/open-telemetry/opentelemetry-collector/blob/main/CONTRIBUTING.md))
-- **Language SDKs**: Every [language implementation repository][org] contains its own project-specific contributing guide.
+- **[Specification](https://github.com/open-telemetry/opentelemetry-specification)** -
+  Cross-language requirements and expectations for all implementations.
+  ([Contributing Guide](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md))
+- **[Semantic Conventions](https://github.com/open-telemetry/semantic-conventions)** -
+  Defines standard attribute names for telemetry data.
+  ([Contributing Guide](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md))
+- **[Collector](https://github.com/open-telemetry/opentelemetry-collector)** - A
+  vendor-agnostic proxy that can receive, process, and export telemetry data.
+  ([Contributing Guide](https://github.com/open-telemetry/opentelemetry-collector/blob/main/CONTRIBUTING.md))
+- **Language SDKs**: Every [language implementation repository][org] contains
+  its own project-specific contributing guide.
 
-For general guidance on contributing to the overall project, see the community [OpenTelemetry New Contributor Guide][].
+For general guidance on contributing to the overall project, see the community
+[OpenTelemetry New Contributor Guide][].
 
 If you would like to contribute to OpenTelemetry **documentation**, you can:
 

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -9919,6 +9919,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-03-10T09:52:26.136939914Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-collector/blob/main/CONTRIBUTING.md": {
+    "StatusCode": 206,
+    "LastSeen": "2026-03-25T11:42:37.907496123Z"
+  },
   "https://github.com/open-telemetry/opentelemetry-collector/blob/main/README.md#compatibility": {
     "StatusCode": 206,
     "LastSeen": "2026-03-02T09:52:12.286462981Z"
@@ -13919,6 +13923,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-03-10T09:52:10.69562222Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md": {
+    "StatusCode": 206,
+    "LastSeen": "2026-03-25T11:42:32.722909875Z"
+  },
   "https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/profiles/0212-profiling-vision.md": {
     "StatusCode": 206,
     "LastSeen": "2026-03-18T09:54:14.113729735Z"
@@ -14982,6 +14990,10 @@
   "https://github.com/open-telemetry/semantic-conventions-java": {
     "StatusCode": 206,
     "LastSeen": "2026-03-03T09:51:55.962742991Z"
+  },
+  "https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md": {
+    "StatusCode": 206,
+    "LastSeen": "2026-03-25T11:42:36.318240912Z"
   },
   "https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/general/general-attributes.md#server-and-client-attributes": {
     "StatusCode": 206,


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

Fixes #7278

This PR updates the "What can I contribute to?" section in the contributing [_index.md](cci:7://file:///c:/Users/lovek/OneDrive/Desktop/OpenTelemetry/opentelemetry.io-1/content/en/community/_index.md:0:0-0:0) to directly list the main OpenTelemetry repositories (Specification, Semantic Conventions, Collector, and Language SDKs). 

Previously, users had to dig through the general community repo or specs to find where to contribute (like the `semconv` docs). This change surfaces the specific repository links right in the navigation, making them much easier to discover for new contributors.

