### PR TITLE
Fix the post title to use the official signal name.

### DIFF
--- a/content/en/blog/2026/profiles-alpha/index.md
+++ b/content/en/blog/2026/profiles-alpha/index.md
@@ -1,6 +1,6 @@
 ---
-title: OpenTelemetry Profiling Enters Public Alpha
-linkTitle: Profiling Public Alpha
+title: OpenTelemetry Profiles Enters Public Alpha
+linkTitle: Profiles Public Alpha
 date: 2026-03-26
 author: >-
   [Alexey Alexandrov](https://github.com/aalexand) (Google) [Ivo


### PR DESCRIPTION
Looks like in #9430 we fixed it everywhere except the title.

I decided to leave it as "enters" as opposed to "enter". Despite "Profiles" is plural, I think there is "Profiles signal" that is implied.

- [X] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [X] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
