### PR TITLE
Fixing a sentence in the helm collector docs

### DIFF
--- a/content/en/docs/platforms/kubernetes/helm/collector.md
+++ b/content/en/docs/platforms/kubernetes/helm/collector.md
@@ -9,8 +9,8 @@ cSpell:ignore: filelog filelogreceiver hostmetricsreceiver kubelet kubeletstats 
 
 The [OpenTelemetry Collector](/docs/collector) is an important tool for
 monitoring a Kubernetes cluster and all the services that operate within. To
-facilitate installation and management of a collector deployment in a Kubernetes cluster
-the OpenTelemetry community created the
+facilitate installation and management of a collector deployment in a Kubernetes
+cluster the OpenTelemetry community created the
 [OpenTelemetry Collector Helm Chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector).
 This helm chart can be used to install a collector as a Deployment, Daemonset,
 or Statefulset.


### PR DESCRIPTION
Fixing a sentence in the helm collector docs.

Decided for `...in a Kubernetes cluster...` although a shorter version `...in Kubernetes...` would also work out.