### PR TITLE
Change logger.warn to logger.warning

### DIFF
--- a/content/en/docs/languages/python/getting-started.md
+++ b/content/en/docs/languages/python/getting-started.md
@@ -507,9 +507,9 @@ def roll_dice():
         # This adds 1 to the counter for the given roll value
         roll_counter.add(1, {"roll.value": result})
         if player:
-            logger.warn("%s is rolling the dice: %s", player, result)
+            logger.warning("%s is rolling the dice: %s", player, result)
         else:
-            logger.warn("Anonymous player is rolling the dice: %s", result)
+            logger.warning("Anonymous player is rolling the dice: %s", result)
         return result
 
 def roll():


### PR DESCRIPTION
Quick fix in the docs: I have replaced the deprecated `logger.warn` call with the `logger.warning`.

<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
