### PR TITLE
Enable Hugo's default robots.txt generation

### DIFF
--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -5,6 +5,7 @@ disableKinds: [taxonomy]
 theme: [docsy]
 disableAliases: true # We do redirects via Netlify's _redirects file
 enableGitInfo: true
+enableRobotsTXT: true
 ignoreLogs: []
 
 # Language settings


### PR DESCRIPTION
- Contributes to #9560
- While this isn't a meaningful 404, it does little harm to have the Hugo-default `robots.txt` file generated.
- The advantage is that those 404 won't "polute" our data collection.
- There is no change to the generated site files other than the added `robots.txt`, and the site-generation timestamp.

```console
$ cat public/robots.txt 
User-agent: *
```