### PR TITLE
Docs: Modify Prometheus exporters section under Language APIs & SDKs

### DIFF
--- a/content/en/docs/languages/_includes/exporters/prometheus-setup.md
+++ b/content/en/docs/languages/_includes/exporters/prometheus-setup.md
@@ -19,8 +19,10 @@ For pushing to a metrics endpoint directly:
 
 Once you have Prometheus set up, you can set up the OTLP Exporter, Prometheus exporter, or push to a metrics endpoint directly.
 
-### Push To Metrics Endpoint {#push-metrics-directly}
-#### Step 1: Using Environment Variables
+### Push to metrics endpoint {#push-metrics-directly}
+This section explains how to configure your application to send metrics directly to a Prometheus endpoint.
+
+#### Use environment variables
 OpenTelemetry SDKs and instrumentation libraries can usually be configured via [standard environment variables](/docs/languages/sdk-configuration/). Set the environment variables before starting your application by:
 - exporting them directly from your terminal,
 - adding them to your shell config file (e.g., `.bashrc`, `.zshrc`), 

--- a/content/en/docs/languages/_includes/exporters/prometheus-setup.md
+++ b/content/en/docs/languages/_includes/exporters/prometheus-setup.md
@@ -29,8 +29,6 @@ You can configure OpenTelemetry SDKs and instrumentation libraries with [standar
 export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=http://localhost:9090/api/v1/otlp
 ```
-Note:
-
 The OTEL_EXPORTER_OTLP_METRICS_ENDPOINT environment variable is treated as a base URL. The `/v1/metrics` path is appended as defined by the [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.50.0/specification/protocol/exporter.md#endpoint-urls-for-otlphttp).
 
 Turn off traces and logs when using Prometheus if you only need metrics:

--- a/content/en/docs/languages/_includes/exporters/prometheus-setup.md
+++ b/content/en/docs/languages/_includes/exporters/prometheus-setup.md
@@ -31,8 +31,7 @@ export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=http://localhost:9090/api/v1/otlp
 ```
 Note:
 
-- The [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.50.0/specification/protocol/exporter.md#endpoint-urls-for-otlphttp) states that the OTEL_EXPORTER_OTLP_METRICS_ENDPOINT env var must be used as a base URL. The signal `/v1/metrics` is automatically appended
-- See also: [opentelemetry-python #2443](https://github.com/open-telemetry/opentelemetry-python/issues/2443) 
+The OTEL_EXPORTER_OTLP_METRICS_ENDPOINT environment variable is treated as a base URL. The `/v1/metrics` path is appended as defined by the [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.50.0/specification/protocol/exporter.md#endpoint-urls-for-otlphttp).
 
 Turn off traces and logs:
 

--- a/content/en/docs/languages/_includes/exporters/prometheus-setup.md
+++ b/content/en/docs/languages/_includes/exporters/prometheus-setup.md
@@ -33,20 +33,20 @@ Note:
 
 The OTEL_EXPORTER_OTLP_METRICS_ENDPOINT environment variable is treated as a base URL. The `/v1/metrics` path is appended as defined by the [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.50.0/specification/protocol/exporter.md#endpoint-urls-for-otlphttp).
 
-Turn off traces and logs:
+Turn off traces and logs when using Prometheus if you only need metrics:
 
 ```bash
 export OTEL_TRACES_EXPORTER=none
 export OTEL_LOGS_EXPORTER=none
 ```
 
-The default push interval for OpenTelemetry metrics is 60 seconds. The following will set a 15-second push interval:
+The default push interval for OpenTelemetry metrics is 60 seconds. The following sets a 15-second interval for more responsive monitoring and faster alerting speed. Shorter intervals may increase network and processing overhead.
 
 ```bash
 export OTEL_METRIC_EXPORT_INTERVAL=15000
 ```
 
-If your instrumentation library does not provide `service.name` and `service.instance.id` out-of-the-box, it is highly recommended to set them. The example below assumes that the `uuidgen` command is available on your system.
+If your instrumentation library does not provide `service.name` and `service.instance.id` out-of-the-box, it is highly recommended to set them. Without these attributes, it becomes difficult to reliably identify services or distinguish between instances, making debugging and aggregation significantly harder. The example below assumes that the `uuidgen` command is available on your system.
 
 ```bash
 export OTEL_SERVICE_NAME="my-example-service"

--- a/content/en/docs/languages/_includes/exporters/prometheus-setup.md
+++ b/content/en/docs/languages/_includes/exporters/prometheus-setup.md
@@ -23,7 +23,7 @@ Once you have Prometheus set up, you can set up the OTLP Exporter, Prometheus ex
 This section explains how to configure your application to send metrics directly to a Prometheus endpoint.
 
 #### Use environment variables
-You can configure OpenTelemetry SDKs and instrumentation libraries with [standard environment variables](/docs/languages/sdk-configuration/). Set the environment variables before starting your application. Below are the OpenTelemetry variables needed to send OpenTelemetry metrics to a Prometheus server on localhost:
+You can configure OpenTelemetry SDKs and instrumentation libraries with [standard environment variables](/docs/languages/sdk-configuration/). Set the environment variables before starting your application. The following OpenTelemetry variables are needed to send OpenTelemetry metrics to a Prometheus server on localhost:
 
 ```bash
 export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf

--- a/content/en/docs/languages/_includes/exporters/prometheus-setup.md
+++ b/content/en/docs/languages/_includes/exporters/prometheus-setup.md
@@ -23,17 +23,11 @@ Once you have Prometheus set up, you can set up the OTLP Exporter, Prometheus ex
 This section explains how to configure your application to send metrics directly to a Prometheus endpoint.
 
 #### Use environment variables
-OpenTelemetry SDKs and instrumentation libraries can usually be configured via [standard environment variables](/docs/languages/sdk-configuration/). Set the environment variables before starting your application by:
-- exporting them directly from your terminal,
-- adding them to your shell config file (e.g., `.bashrc`, `.zshrc`), 
-- or loading them from a `.env` file. 
-
-Below are the OpenTelemetry variables needed to send OpenTelemetry metrics to a Prometheus server on localhost:
+You can configure OpenTelemetry SDKs and instrumentation libraries with [standard environment variables](/docs/languages/sdk-configuration/). Set the environment variables before starting your application. Below are the OpenTelemetry variables needed to send OpenTelemetry metrics to a Prometheus server on localhost:
 
 ```bash
 export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=http://localhost:9090/api/v1/otlp
-
 ```
 Note:
 
@@ -53,14 +47,18 @@ The default push interval for OpenTelemetry metrics is 60 seconds. The following
 export OTEL_METRIC_EXPORT_INTERVAL=15000
 ```
 
-If your instrumentation library does not provide `service.name` and `service.instance.id` out-of-the-box, it is highly recommended to set them.
+If your instrumentation library does not provide `service.name` and `service.instance.id` out-of-the-box, it is highly recommended to set them. The example below assumes that the `uuidgen` command is available on your system.
 
 ```bash
 export OTEL_SERVICE_NAME="my-example-service"
 export OTEL_RESOURCE_ATTRIBUTES="service.instance.id=$(uuidgen)"
 ```
 
-The above assumes that the `uuidgen` command is available on your system. Make sure that `service.instance.id` is unique for each instance, and that a new `service.instance.id` is generated whenever a resource attribute changes. The [recommended way](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource) is to generate a new UUID on each startup of an instance.
+> [!NOTE]
+> Make sure that `service.instance.id` is unique for each instance, 
+> and that a new `service.instance.id` is generated whenever a resource attribute changes.
+> The [recommended way](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource) 
+> is to generate a new UUID on each startup of an instance.
 
-#### Step 2: Configuring Telemetry
+#### Configure telemetry
 Update your OpenTelemetry Configuration to use the same `exporter` and `reader` from the [OTLP](#otlp-dependencies) setup. If the environment variables are set up and loaded correctly, the OpenTelemetry SDK reads them automatically. 

--- a/content/en/docs/languages/_includes/exporters/prometheus-setup.md
+++ b/content/en/docs/languages/_includes/exporters/prometheus-setup.md
@@ -1,62 +1,17 @@
 ## Prometheus
 
-To send your metric data to [Prometheus](https://prometheus.io/), you can either:
+To send your metric data to [Prometheus](https://prometheus.io/), you can
+either:
+
 - [Enable Prometheus' OTLP Receiver](https://prometheus.io/docs/guides/opentelemetry/#enable-the-otlp-receiver)
-and use the [OTLP exporter](#otlp) (best practice),
-- [Enable Prometheus' OTLP Receiver](https://prometheus.io/docs/guides/opentelemetry/#enable-the-otlp-receiver)
-and [push Prometheus to the metrics endpoint directly](#push-metrics-directly) (for development or testing purposes), or
-- Use the Prometheus exporter, a `MetricReader` that starts an HTTP server that collects metrics and serializes to Prometheus text format on request.
+  and use the [OTLP exporter](#otlp) (best practice), or
+- Use the Prometheus exporter, a `MetricReader` that starts an HTTP server that
+  collects metrics and serializes to Prometheus text format on request.
 
 ### Backend setup {#prometheus-setup}
 
-For [OTLP Exporter](#otlp-dependencies) or [Prometheus exporter](#prometheus-dependencies):
+To run a Prometheus server backend and begin scraping metrics, see the
+[Prometheus getting started guide](https://prometheus.io/docs/prometheus/latest/getting_started/).
 
-  To run a Prometheus server backend and begin scraping metrics, see the [Prometheus getting started guide](https://prometheus.io/docs/prometheus/latest/getting_started/). To enable the OTLP Receiver, see the [Prometheus guide for enabling the OTLP Receiver](https://prometheus.io/docs/guides/opentelemetry/#enable-the-otlp-receiver).
-
-For pushing to a metrics endpoint directly:
-  
-  Follow the [example prometheus.yml configuration in this Prometheus guide](https://prometheus.io/docs/guides/opentelemetry/#configuring-prometheus).
-
-Once you have Prometheus set up, you can set up the OTLP Exporter, Prometheus exporter, or push to a metrics endpoint directly.
-
-### Push to metrics endpoint {#push-metrics-directly}
-This section explains how to configure your application to send metrics directly to a Prometheus endpoint.
-
-#### Use environment variables
-You can configure OpenTelemetry SDKs and instrumentation libraries with [standard environment variables](/docs/languages/sdk-configuration/). Set the environment variables before starting your application. The following OpenTelemetry variables are needed to send OpenTelemetry metrics to a Prometheus server on localhost:
-
-```bash
-export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=http://localhost:9090/api/v1/otlp
-```
-The OTEL_EXPORTER_OTLP_METRICS_ENDPOINT environment variable is treated as a base URL. The `/v1/metrics` path is appended as defined by the [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.50.0/specification/protocol/exporter.md#endpoint-urls-for-otlphttp).
-
-Turn off traces and logs when using Prometheus if you only need metrics:
-
-```bash
-export OTEL_TRACES_EXPORTER=none
-export OTEL_LOGS_EXPORTER=none
-```
-
-The default push interval for OpenTelemetry metrics is 60 seconds. The following sets a 15-second interval for more responsive monitoring and faster alerting speed. Shorter intervals may increase network and processing overhead.
-
-```bash
-export OTEL_METRIC_EXPORT_INTERVAL=15000
-```
-
-If your instrumentation library does not provide `service.name` and `service.instance.id` out-of-the-box, it is highly recommended to set them. Without these attributes, it becomes difficult to reliably identify services or distinguish between instances, making debugging and aggregation significantly harder. The example below assumes that the `uuidgen` command is available on your system.
-
-```bash
-export OTEL_SERVICE_NAME="my-example-service"
-export OTEL_RESOURCE_ATTRIBUTES="service.instance.id=$(uuidgen)"
-```
-
-> [!NOTE]
->
-> Make sure that `service.instance.id` is unique for each instance, 
-> and that a new `service.instance.id` is generated whenever a resource attribute changes.
-> The [recommended way](/docs/specs/semconv/resource/service/#service-instance) 
-> is to generate a new UUID on each startup of an instance.
-
-#### Configure telemetry
-Update your OpenTelemetry Configuration to use the same `exporter` and `reader` from the [OTLP](#otlp-dependencies) setup. If the environment variables are set up and loaded correctly, the OpenTelemetry SDK reads them automatically. 
+To enable the OTLP Receiver, see the
+[Prometheus guide for enabling the OTLP Receiver](https://prometheus.io/docs/guides/opentelemetry/#enable-the-otlp-receiver).

--- a/content/en/docs/languages/_includes/exporters/prometheus-setup.md
+++ b/content/en/docs/languages/_includes/exporters/prometheus-setup.md
@@ -14,30 +14,6 @@ Prometheus text format on request.
 > can skip this section and setup the [Prometheus](#prometheus-dependencies) or
 > [OTLP](#otlp-dependencies) exporter dependencies for your application.
 
-You can run [Prometheus](https://prometheus.io) in a docker container,
-accessible on port `9090` by following these instructions:
+To run a Prometheus server backend and begin scraping metrics, see the [Prometheus getting started guide](https://prometheus.io/docs/prometheus/latest/getting_started/).
 
-Create a file called `prometheus.yml` with the following content:
-
-```yaml
-scrape_configs:
-  - job_name: dice-service
-    scrape_interval: 5s
-    static_configs:
-      - targets: [host.docker.internal:9464]
-```
-
-Run Prometheus in a docker container with the UI accessible on port `9090`:
-
-```shell
-docker run --rm -v ${PWD}/prometheus.yml:/prometheus/prometheus.yml -p 9090:9090 prom/prometheus --web.enable-otlp-receiver
-```
-
-> [!NOTE]
->
-> When using Prometheus' OTLP Receiver, make sure that you set the OTLP endpoint
-> for metrics in your application to `http://localhost:9090/api/v1/otlp`.
->
-> Not all docker environments support `host.docker.internal`. In some cases you
-> may need to replace `host.docker.internal` with `localhost` or the IP address
-> of your machine.
+To enable the OTLP Receiver, see the [Prometheus guide for enabling the OTLP Receiver](https://prometheus.io/docs/guides/opentelemetry/#enable-the-otlp-receiver)

--- a/content/en/docs/languages/_includes/exporters/prometheus-setup.md
+++ b/content/en/docs/languages/_includes/exporters/prometheus-setup.md
@@ -1,19 +1,64 @@
 ## Prometheus
 
-To send your metric data to [Prometheus](https://prometheus.io/), you can either
-[enable Prometheus' OTLP Receiver](https://prometheus.io/docs/guides/opentelemetry/#enable-the-otlp-receiver)
-and use the [OTLP exporter](#otlp) or you can use the Prometheus exporter, a
-`MetricReader` that starts an HTTP server that collects metrics and serialize to
-Prometheus text format on request.
+To send your metric data to [Prometheus](https://prometheus.io/), you can either:
+- [enable Prometheus' OTLP Receiver](https://prometheus.io/docs/guides/opentelemetry/#enable-the-otlp-receiver)
+and use the [OTLP exporter](#otlp) (best practice),
+- [enable Prometheus' OTLP Receiver](https://prometheus.io/docs/guides/opentelemetry/#enable-the-otlp-receiver)
+and [push Prometheus to the metrics endpoint directly](#push-metrics-directly) (for development or testing purposes),
+- or you can use the Prometheus exporter, a `MetricReader` that starts an HTTP server that collects metrics and serialize to Prometheus text format on request.
 
 ### Backend Setup {#prometheus-setup}
 
-> [!NOTE]
->
-> If you have Prometheus or a Prometheus-compatible backend already set up, you
-> can skip this section and setup the [Prometheus](#prometheus-dependencies) or
-> [OTLP](#otlp-dependencies) exporter dependencies for your application.
+- For [OTLP Exporter](#otlp-dependencies) or [Prometheus exporter](#prometheus-dependencies):
 
-To run a Prometheus server backend and begin scraping metrics, see the [Prometheus getting started guide](https://prometheus.io/docs/prometheus/latest/getting_started/).
+  To run a Prometheus server backend and begin scraping metrics, see the [Prometheus getting started guide](https://prometheus.io/docs/prometheus/latest/getting_started/). To enable the OTLP Receiver, see the [Prometheus guide for enabling the OTLP Receiver](https://prometheus.io/docs/guides/opentelemetry/#enable-the-otlp-receiver).
 
-To enable the OTLP Receiver, see the [Prometheus guide for enabling the OTLP Receiver](https://prometheus.io/docs/guides/opentelemetry/#enable-the-otlp-receiver)
+- For pushing to a metrics endpoint directly:
+  
+  Follow this [guide for prometheus.yml configuration in this Prometheus guide](https://prometheus.io/docs/guides/opentelemetry/#configuring-prometheus).
+
+Once you have Prometheus set up, you can set up the OTLP Exporter, Prometheus exporter, or push to a metrics endpoint directly.
+
+### Push To Metrics Endpoint {#push-metrics-directly}
+#### Step 1: Using Environment Variables
+OpenTelemetry SDKs and instrumentation libraries can usually be configured via [standard environment variables](/docs/languages/sdk-configuration/). Set the environment variables before starting your application by:
+- exporting them directly from your terminal,
+- adding them to your shell config file (e.g., `.bashrc`, `.zshrc`), 
+- or loading them from a `.env` file. 
+
+Below are the OpenTelemetry variables needed to send OpenTelemetry metrics to a Prometheus server on localhost:
+
+```bash
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=http://localhost:9090/api/v1/otlp
+
+```
+Note:
+
+- The [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.50.0/specification/protocol/exporter.md#endpoint-urls-for-otlphttp) states that the OTEL_EXPORTER_OTLP_METRICS_ENDPOINT env var must be used as a base URL. The signal `/v1/metrics` is automatically appended
+- See also: [opentelemetry-python #2443](https://github.com/open-telemetry/opentelemetry-python/issues/2443) 
+
+Turn off traces and logs:
+
+```bash
+export OTEL_TRACES_EXPORTER=none
+export OTEL_LOGS_EXPORTER=none
+```
+
+The default push interval for OpenTelemetry metrics is 60 seconds. The following will set a 15-second push interval:
+
+```bash
+export OTEL_METRIC_EXPORT_INTERVAL=15000
+```
+
+If your instrumentation library does not provide `service.name` and `service.instance.id` out-of-the-box, it is highly recommended to set them.
+
+```bash
+export OTEL_SERVICE_NAME="my-example-service"
+export OTEL_RESOURCE_ATTRIBUTES="service.instance.id=$(uuidgen)"
+```
+
+The above assumes that the `uuidgen` command is available on your system. Make sure that `service.instance.id` is unique for each instance, and that a new `service.instance.id` is generated whenever a resource attribute changes. The [recommended way](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource) is to generate a new UUID on each startup of an instance.
+
+#### Step 2: Configuring Telemetry
+Update your OpenTelemetry Configuration to use the same `exporter` and `reader` from the [OTLP](#otlp-dependencies) setup. If the environment variables are set up and loaded correctly, the OpenTelemetry SDK will read them automatically. 

--- a/content/en/docs/languages/_includes/exporters/prometheus-setup.md
+++ b/content/en/docs/languages/_includes/exporters/prometheus-setup.md
@@ -7,15 +7,15 @@ and use the [OTLP exporter](#otlp) (best practice),
 and [push Prometheus to the metrics endpoint directly](#push-metrics-directly) (for development or testing purposes),
 - or you can use the Prometheus exporter, a `MetricReader` that starts an HTTP server that collects metrics and serialize to Prometheus text format on request.
 
-### Backend Setup {#prometheus-setup}
+### Backend setup {#prometheus-setup}
 
-- For [OTLP Exporter](#otlp-dependencies) or [Prometheus exporter](#prometheus-dependencies):
+For [OTLP Exporter](#otlp-dependencies) or [Prometheus exporter](#prometheus-dependencies):
 
   To run a Prometheus server backend and begin scraping metrics, see the [Prometheus getting started guide](https://prometheus.io/docs/prometheus/latest/getting_started/). To enable the OTLP Receiver, see the [Prometheus guide for enabling the OTLP Receiver](https://prometheus.io/docs/guides/opentelemetry/#enable-the-otlp-receiver).
 
-- For pushing to a metrics endpoint directly:
+For pushing to a metrics endpoint directly:
   
-  Follow this [guide for prometheus.yml configuration in this Prometheus guide](https://prometheus.io/docs/guides/opentelemetry/#configuring-prometheus).
+  Follow the [example prometheus.yml configuration in this Prometheus guide](https://prometheus.io/docs/guides/opentelemetry/#configuring-prometheus).
 
 Once you have Prometheus set up, you can set up the OTLP Exporter, Prometheus exporter, or push to a metrics endpoint directly.
 
@@ -61,4 +61,4 @@ export OTEL_RESOURCE_ATTRIBUTES="service.instance.id=$(uuidgen)"
 The above assumes that the `uuidgen` command is available on your system. Make sure that `service.instance.id` is unique for each instance, and that a new `service.instance.id` is generated whenever a resource attribute changes. The [recommended way](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource) is to generate a new UUID on each startup of an instance.
 
 #### Step 2: Configuring Telemetry
-Update your OpenTelemetry Configuration to use the same `exporter` and `reader` from the [OTLP](#otlp-dependencies) setup. If the environment variables are set up and loaded correctly, the OpenTelemetry SDK will read them automatically. 
+Update your OpenTelemetry Configuration to use the same `exporter` and `reader` from the [OTLP](#otlp-dependencies) setup. If the environment variables are set up and loaded correctly, the OpenTelemetry SDK reads them automatically. 

--- a/content/en/docs/languages/_includes/exporters/prometheus-setup.md
+++ b/content/en/docs/languages/_includes/exporters/prometheus-setup.md
@@ -54,9 +54,10 @@ export OTEL_RESOURCE_ATTRIBUTES="service.instance.id=$(uuidgen)"
 ```
 
 > [!NOTE]
+>
 > Make sure that `service.instance.id` is unique for each instance, 
 > and that a new `service.instance.id` is generated whenever a resource attribute changes.
-> The [recommended way](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource) 
+> The [recommended way](/docs/specs/semconv/resource/service/#service-instance) 
 > is to generate a new UUID on each startup of an instance.
 
 #### Configure telemetry

--- a/content/en/docs/languages/_includes/exporters/prometheus-setup.md
+++ b/content/en/docs/languages/_includes/exporters/prometheus-setup.md
@@ -1,11 +1,11 @@
 ## Prometheus
 
 To send your metric data to [Prometheus](https://prometheus.io/), you can either:
-- [enable Prometheus' OTLP Receiver](https://prometheus.io/docs/guides/opentelemetry/#enable-the-otlp-receiver)
+- [Enable Prometheus' OTLP Receiver](https://prometheus.io/docs/guides/opentelemetry/#enable-the-otlp-receiver)
 and use the [OTLP exporter](#otlp) (best practice),
-- [enable Prometheus' OTLP Receiver](https://prometheus.io/docs/guides/opentelemetry/#enable-the-otlp-receiver)
-and [push Prometheus to the metrics endpoint directly](#push-metrics-directly) (for development or testing purposes),
-- or you can use the Prometheus exporter, a `MetricReader` that starts an HTTP server that collects metrics and serialize to Prometheus text format on request.
+- [Enable Prometheus' OTLP Receiver](https://prometheus.io/docs/guides/opentelemetry/#enable-the-otlp-receiver)
+and [push Prometheus to the metrics endpoint directly](#push-metrics-directly) (for development or testing purposes), or
+- Use the Prometheus exporter, a `MetricReader` that starts an HTTP server that collects metrics and serializes to Prometheus text format on request.
 
 ### Backend setup {#prometheus-setup}
 

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -22903,6 +22903,10 @@
     "StatusCode": 200,
     "LastSeen": "2026-03-10T09:54:55.343309116Z"
   },
+  "https://prometheus.io/docs/prometheus/latest/getting_started/": {
+    "StatusCode": 200,
+    "LastSeen": "2026-04-20T20:35:35.466392978Z"
+  },
   "https://prometheus.io/docs/prometheus/latest/http_sd/": {
     "StatusCode": 200,
     "LastSeen": "2026-03-23T14:15:26.26619547Z"


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---
### Description

Related to #9520 

As discussed in the issue above, I have replaced the [configuration section found in the `_includes` page](https://github.com/open-telemetry/opentelemetry.io/blob/main/content/en/docs/languages/_includes/exporters/prometheus-setup.md) with a brief description and redirected users to the [Prometheus getting-started page](https://prometheus.io/docs/prometheus/latest/getting_started/) and [Prometheus page for enabling the OTLP receiver](https://prometheus.io/docs/guides/opentelemetry/#enable-the-otlp-receiver).

However, as I worked through the documentation some more, I found something else I would like your input on.

I noticed that the OpenTelemetry `_includes` page doesn't mention the OTLP → Prometheus push flow at all, even though the [Prometheus OpenTelemetry page](https://prometheus.io/docs/guides/opentelemetry/#send-opentelemetry-metrics-to-the-prometheus-server) — where users will be redirected — actually includes OTel-side config for it.

This led me to reason that, if this method exists and is acknowledged by Prometheus itself, then it is worth listing as a method of sending metrics in the OpenTelemetry documentation.

I think we can serve users better by:

1. Including this method in the OpenTelemetry docs with the relevant OTel-side config (moved from the Prometheus page), explicitly marked as 'development or testing only' since it's not production-recommended.
2. Still redirecting to the Prometheus getting-started page as originally proposed

I understand this is more than the original proposal, but I want to make sure the documentation across both projects tells a coherent story for users. I have included these changes in this PR so you can get a view of my thoughts. Please let me know what you think about this.