### PR TITLE
Add script for synchronizing Configuration schema data

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -16,6 +16,7 @@ ignorePaths:
   - content/{ja,zh}
   - data/community/members.yaml
   - data/ecosystem/vendors.yaml
+  - data/opentelemetry/configurationTypes.json
   - data/collector
   - public/_redirects
   - static/refcache.json

--- a/data/opentelemetry/configurationTypes.json
+++ b/data/opentelemetry/configurationTypes.json
@@ -1,0 +1,2747 @@
+{
+  "types": [
+    {
+      "id": "aggregation",
+      "name": "Aggregation",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "default",
+          "type": "DefaultAggregation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configures the stream to use the instrument kind to select an aggregation and advisory parameters to influence aggregation configuration parameters. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#default-aggregation for details. If omitted, ignore."
+        },
+        {
+          "name": "drop",
+          "type": "DropAggregation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configures the stream to ignore/drop all instrument measurements. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#drop-aggregation for details. If omitted, ignore."
+        },
+        {
+          "name": "explicit_bucket_histogram",
+          "type": "ExplicitBucketHistogramAggregation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configures the stream to collect data for the histogram metric point using a set of explicit boundary values for histogram bucketing. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#explicit-bucket-histogram-aggregation for details If omitted, ignore."
+        },
+        {
+          "name": "base2_exponential_bucket_histogram",
+          "type": "Base2ExponentialBucketHistogramAggregation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configures the stream to collect data for the exponential histogram metric point, which uses a base-2 exponential formula to determine bucket boundaries and an integer scale parameter to control resolution. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#base2-exponential-bucket-histogram-aggregation for details. If omitted, ignore."
+        },
+        {
+          "name": "last_value",
+          "type": "LastValueAggregation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configures the stream to collect data using the last measurement. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#last-value-aggregation for details. If omitted, ignore."
+        },
+        {
+          "name": "sum",
+          "type": "SumAggregation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configures the stream to collect the arithmetic sum of measurement values. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#sum-aggregation for details. If omitted, ignore."
+        }
+      ],
+      "constraints": "additionalProperties: false. minProperties: 1. maxProperties: 1."
+    },
+    {
+      "id": "alwaysoffsampler",
+      "name": "AlwaysOffSampler",
+      "isExperimental": false,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "alwaysonsampler",
+      "name": "AlwaysOnSampler",
+      "isExperimental": false,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "attributelimits",
+      "name": "AttributeLimits",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "attribute_value_length_limit",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: 0",
+          "description": "Configure max attribute value size. Value must be non-negative. If omitted or null, there is no limit."
+        },
+        {
+          "name": "attribute_count_limit",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: 0",
+          "description": "Configure max attribute count. Value must be non-negative. If omitted or null, 128 is used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "attributenamevalue",
+      "name": "AttributeNameValue",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "type": "string",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "The attribute name. Property is required and must be non-null."
+        },
+        {
+          "name": "value",
+          "type": "object",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "The attribute value. The type of value must match .type. Property is required and must be non-null."
+        },
+        {
+          "name": "type",
+          "type": "AttributeType",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "The attribute type. Values include: * bool: Boolean attribute value. * bool_array: Boolean array attribute value. * double: Double attribute value. * double_array: Double array attribute value. * int: Integer attribute value. * int_array: Integer array attribute value. * string: String attribute value. * string_array: String array attribute value. If omitted, string is used."
+        }
+      ],
+      "constraints": "additionalProperties: false. Required properties: name, value."
+    },
+    {
+      "id": "attributetype",
+      "name": "AttributeType",
+      "isExperimental": false,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": ""
+    },
+    {
+      "id": "b3multipropagator",
+      "name": "B3MultiPropagator",
+      "isExperimental": false,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "b3propagator",
+      "name": "B3Propagator",
+      "isExperimental": false,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "baggagepropagator",
+      "name": "BaggagePropagator",
+      "isExperimental": false,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "base2exponentialbuckethistogramaggregation",
+      "name": "Base2ExponentialBucketHistogramAggregation",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "max_scale",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: -10, maximum: 20",
+          "description": "Configure the max scale factor. If omitted or null, 20 is used."
+        },
+        {
+          "name": "max_size",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: 2",
+          "description": "Configure the maximum number of buckets in each of the positive and negative ranges, not counting the special zero bucket. If omitted or null, 160 is used."
+        },
+        {
+          "name": "record_min_max",
+          "type": "boolean, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure whether or not to record min and max. If omitted or null, true is used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "batchlogrecordprocessor",
+      "name": "BatchLogRecordProcessor",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "schedule_delay",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: 0",
+          "description": "Configure delay interval (in milliseconds) between two consecutive exports. Value must be non-negative. If omitted or null, 1000 is used."
+        },
+        {
+          "name": "export_timeout",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: 0",
+          "description": "Configure maximum allowed time (in milliseconds) to export data. Value must be non-negative. A value of 0 indicates no limit (infinity). If omitted or null, 30000 is used."
+        },
+        {
+          "name": "max_queue_size",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure maximum queue size. Value must be positive. If omitted or null, 2048 is used."
+        },
+        {
+          "name": "max_export_batch_size",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure maximum batch size. Value must be positive. If omitted or null, 512 is used."
+        },
+        {
+          "name": "exporter",
+          "type": "LogRecordExporter",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure exporter. Property is required and must be non-null."
+        }
+      ],
+      "constraints": "additionalProperties: false. Required properties: exporter."
+    },
+    {
+      "id": "batchspanprocessor",
+      "name": "BatchSpanProcessor",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "schedule_delay",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: 0",
+          "description": "Configure delay interval (in milliseconds) between two consecutive exports. Value must be non-negative. If omitted or null, 5000 is used."
+        },
+        {
+          "name": "export_timeout",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: 0",
+          "description": "Configure maximum allowed time (in milliseconds) to export data. Value must be non-negative. A value of 0 indicates no limit (infinity). If omitted or null, 30000 is used."
+        },
+        {
+          "name": "max_queue_size",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure maximum queue size. Value must be positive. If omitted or null, 2048 is used."
+        },
+        {
+          "name": "max_export_batch_size",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure maximum batch size. Value must be positive. If omitted or null, 512 is used."
+        },
+        {
+          "name": "exporter",
+          "type": "SpanExporter",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure exporter. Property is required and must be non-null."
+        }
+      ],
+      "constraints": "additionalProperties: false. Required properties: exporter."
+    },
+    {
+      "id": "cardinalitylimits",
+      "name": "CardinalityLimits",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "default",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure default cardinality limit for all instrument types. Instrument-specific cardinality limits take priority. If omitted or null, 2000 is used."
+        },
+        {
+          "name": "counter",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure default cardinality limit for counter instruments. If omitted or null, the value from .default is used."
+        },
+        {
+          "name": "gauge",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure default cardinality limit for gauge instruments. If omitted or null, the value from .default is used."
+        },
+        {
+          "name": "histogram",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure default cardinality limit for histogram instruments. If omitted or null, the value from .default is used."
+        },
+        {
+          "name": "observable_counter",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure default cardinality limit for observable_counter instruments. If omitted or null, the value from .default is used."
+        },
+        {
+          "name": "observable_gauge",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure default cardinality limit for observable_gauge instruments. If omitted or null, the value from .default is used."
+        },
+        {
+          "name": "observable_up_down_counter",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure default cardinality limit for observable_up_down_counter instruments. If omitted or null, the value from .default is used."
+        },
+        {
+          "name": "up_down_counter",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure default cardinality limit for up_down_counter instruments. If omitted or null, the value from .default is used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "consoleexporter",
+      "name": "ConsoleExporter",
+      "isExperimental": false,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "consolemetricexporter",
+      "name": "ConsoleMetricExporter",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "temporality_preference",
+          "type": "ExporterTemporalityPreference",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure temporality preference. Values include: * cumulative: Use cumulative aggregation temporality for all instrument types. * delta: Use delta aggregation for all instrument types except up down counter and asynchronous up down counter. * low_memory: Use delta aggregation temporality for counter and histogram instrument types. Use cumulative aggregation temporality for all other instrument types. If omitted, cumulative is used."
+        },
+        {
+          "name": "default_histogram_aggregation",
+          "type": "ExporterDefaultHistogramAggregation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure default histogram aggregation. Values include: * base2_exponential_bucket_histogram: Use base2 exponential histogram as the default aggregation for histogram instruments. * explicit_bucket_histogram: Use explicit bucket histogram as the default aggregation for histogram instruments. If omitted, explicit_bucket_histogram is used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "defaultaggregation",
+      "name": "DefaultAggregation",
+      "isExperimental": false,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "distribution",
+      "name": "Distribution",
+      "isExperimental": false,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": "minProperties: 1."
+    },
+    {
+      "id": "dropaggregation",
+      "name": "DropAggregation",
+      "isExperimental": false,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "exemplarfilter",
+      "name": "ExemplarFilter",
+      "isExperimental": false,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": ""
+    },
+    {
+      "id": "experimentalcodeinstrumentation",
+      "name": "ExperimentalCodeInstrumentation",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "semconv",
+          "type": "ExperimentalSemconvConfig",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure code semantic convention version and migration behavior. This property takes precedence over the .instrumentation/development.general.stability_opt_in_list setting. See code semantic conventions: https://opentelemetry.io/docs/specs/semconv/registry/attributes/code/ If omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalcomposablealwaysoffsampler",
+      "name": "ExperimentalComposableAlwaysOffSampler",
+      "isExperimental": true,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalcomposablealwaysonsampler",
+      "name": "ExperimentalComposableAlwaysOnSampler",
+      "isExperimental": true,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalcomposableparentthresholdsampler",
+      "name": "ExperimentalComposableParentThresholdSampler",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "root",
+          "type": "ExperimentalComposableSampler",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Sampler to use when there is no parent. Property is required and must be non-null."
+        }
+      ],
+      "constraints": "additionalProperties: false. Required properties: root."
+    },
+    {
+      "id": "experimentalcomposableprobabilitysampler",
+      "name": "ExperimentalComposableProbabilitySampler",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "ratio",
+          "type": "number, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: 0, maximum: 1",
+          "description": "Configure ratio. If omitted or null, 1.0 is used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalcomposablerulebasedsampler",
+      "name": "ExperimentalComposableRuleBasedSampler",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "rules",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "The rules for the sampler, matched in order. Each rule can have multiple match conditions. All conditions must match for the rule to match. If no conditions are specified, the rule matches all spans that reach it. If no rules match, the span is not sampled. If omitted, no span is sampled."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalcomposablerulebasedsamplerrule",
+      "name": "ExperimentalComposableRuleBasedSamplerRule",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "attribute_values",
+          "type": "ExperimentalComposableRuleBasedSamplerRuleAttributeValues",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Values to match against a single attribute. Non-string attributes are matched using their string representation: for example, a value of \"404\" would match the http.response.status_code 404. For array attributes, if any item matches, it is considered a match. If omitted, ignore."
+        },
+        {
+          "name": "attribute_patterns",
+          "type": "ExperimentalComposableRuleBasedSamplerRuleAttributePatterns",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Patterns to match against a single attribute. Non-string attributes are matched using their string representation: for example, a pattern of \"4*\" would match any http.response.status_code in 400-499. For array attributes, if any item matches, it is considered a match. If omitted, ignore."
+        },
+        {
+          "name": "span_kinds",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "The span kinds to match. If the span's kind matches any of these, it matches. Values include: * client: client, a client span. * consumer: consumer, a consumer span. * internal: internal, an internal span. * producer: producer, a producer span. * server: server, a server span. If omitted, ignore."
+        },
+        {
+          "name": "parent",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "The parent span types to match. Values include: * local: local, a local parent. * none: none, no parent, i.e., the trace root. * remote: remote, a remote parent. If omitted, ignore."
+        },
+        {
+          "name": "sampler",
+          "type": "ExperimentalComposableSampler",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "The sampler to use for matching spans. Property is required and must be non-null."
+        }
+      ],
+      "constraints": "additionalProperties: false. Required properties: sampler."
+    },
+    {
+      "id": "experimentalcomposablerulebasedsamplerruleattributepatterns",
+      "name": "ExperimentalComposableRuleBasedSamplerRuleAttributePatterns",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "key",
+          "type": "string",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "The attribute key to match against. Property is required and must be non-null."
+        },
+        {
+          "name": "included",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "Configure list of value patterns to include. Values are evaluated to match as follows: * If the value exactly matches. * If the value matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none. If omitted, all values are included."
+        },
+        {
+          "name": "excluded",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "Configure list of value patterns to exclude. Applies after .included (i.e. excluded has higher priority than included). Values are evaluated to match as follows: * If the value exactly matches. * If the value matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none. If omitted, .included attributes are included."
+        }
+      ],
+      "constraints": "additionalProperties: false. Required properties: key."
+    },
+    {
+      "id": "experimentalcomposablerulebasedsamplerruleattributevalues",
+      "name": "ExperimentalComposableRuleBasedSamplerRuleAttributeValues",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "key",
+          "type": "string",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "The attribute key to match against. Property is required and must be non-null."
+        },
+        {
+          "name": "values",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "The attribute values to match against. If the attribute's value matches any of these, it matches. Property is required and must be non-null."
+        }
+      ],
+      "constraints": "additionalProperties: false. Required properties: key, values."
+    },
+    {
+      "id": "experimentalcomposablesampler",
+      "name": "ExperimentalComposableSampler",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "always_off",
+          "type": "ExperimentalComposableAlwaysOffSampler",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure sampler to be always_off. If omitted, ignore."
+        },
+        {
+          "name": "always_on",
+          "type": "ExperimentalComposableAlwaysOnSampler",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure sampler to be always_on. If omitted, ignore."
+        },
+        {
+          "name": "parent_threshold",
+          "type": "ExperimentalComposableParentThresholdSampler",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure sampler to be parent_threshold. If omitted, ignore."
+        },
+        {
+          "name": "probability",
+          "type": "ExperimentalComposableProbabilitySampler",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure sampler to be probability. If omitted, ignore."
+        },
+        {
+          "name": "rule_based",
+          "type": "ExperimentalComposableRuleBasedSampler",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure sampler to be rule_based. If omitted, ignore."
+        }
+      ],
+      "constraints": "minProperties: 1. maxProperties: 1."
+    },
+    {
+      "id": "experimentalcontainerresourcedetector",
+      "name": "ExperimentalContainerResourceDetector",
+      "isExperimental": true,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentaldbinstrumentation",
+      "name": "ExperimentalDbInstrumentation",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "semconv",
+          "type": "ExperimentalSemconvConfig",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure database semantic convention version and migration behavior. This property takes precedence over the .instrumentation/development.general.stability_opt_in_list setting. See database migration: https://opentelemetry.io/docs/specs/semconv/database/ If omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalgenaiinstrumentation",
+      "name": "ExperimentalGenAiInstrumentation",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "semconv",
+          "type": "ExperimentalSemconvConfig",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure GenAI semantic convention version and migration behavior. This property takes precedence over the .instrumentation/development.general.stability_opt_in_list setting. See GenAI semantic conventions: https://opentelemetry.io/docs/specs/semconv/gen-ai/ If omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalgeneralinstrumentation",
+      "name": "ExperimentalGeneralInstrumentation",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "http",
+          "type": "ExperimentalHttpInstrumentation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure instrumentations following the http semantic conventions. See http semantic conventions: https://opentelemetry.io/docs/specs/semconv/http/ If omitted, defaults as described in ExperimentalHttpInstrumentation are used."
+        },
+        {
+          "name": "code",
+          "type": "ExperimentalCodeInstrumentation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure instrumentations following the code semantic conventions. See code semantic conventions: https://opentelemetry.io/docs/specs/semconv/registry/attributes/code/ If omitted, defaults as described in ExperimentalCodeInstrumentation are used."
+        },
+        {
+          "name": "db",
+          "type": "ExperimentalDbInstrumentation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure instrumentations following the database semantic conventions. See database semantic conventions: https://opentelemetry.io/docs/specs/semconv/database/ If omitted, defaults as described in ExperimentalDbInstrumentation are used."
+        },
+        {
+          "name": "gen_ai",
+          "type": "ExperimentalGenAiInstrumentation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure instrumentations following the GenAI semantic conventions. See GenAI semantic conventions: https://opentelemetry.io/docs/specs/semconv/gen-ai/ If omitted, defaults as described in ExperimentalGenAiInstrumentation are used."
+        },
+        {
+          "name": "messaging",
+          "type": "ExperimentalMessagingInstrumentation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure instrumentations following the messaging semantic conventions. See messaging semantic conventions: https://opentelemetry.io/docs/specs/semconv/messaging/ If omitted, defaults as described in ExperimentalMessagingInstrumentation are used."
+        },
+        {
+          "name": "rpc",
+          "type": "ExperimentalRpcInstrumentation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure instrumentations following the RPC semantic conventions. See RPC semantic conventions: https://opentelemetry.io/docs/specs/semconv/rpc/ If omitted, defaults as described in ExperimentalRpcInstrumentation are used."
+        },
+        {
+          "name": "sanitization",
+          "type": "ExperimentalSanitization",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure general sanitization options. If omitted, defaults as described in ExperimentalSanitization are used."
+        },
+        {
+          "name": "stability_opt_in_list",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure semantic convention stability opt-in as a comma-separated list. This property follows the format and semantics of the OTEL_SEMCONV_STABILITY_OPT_IN environment variable. Controls the emission of stable vs. experimental semantic conventions for instrumentation. This setting is only intended for migrating from experimental to stable semantic conventions. Known values include: - http: Emit stable HTTP and networking conventions only - http/dup: Emit both old and stable HTTP and networking conventions (for phased migration) - database: Emit stable database conventions only - database/dup: Emit both old and stable database conventions (for phased migration) - rpc: Emit stable RPC conventions only - rpc/dup: Emit both experimental and stable RPC conventions (for phased migration) - messaging: Emit stable messaging conventions only - messaging/dup: Emit both old and stable messaging conventions (for phased migration) - code: Emit stable code conventions only - code/dup: Emit both old and stable code conventions (for phased migration) Multiple values can be specified as a comma-separated list (e.g., \"http,database/dup\"). Additional signal types may be supported in future versions. Domain-specific semconv properties (e.g., .instrumentation/development.general.db.semconv) take precedence over this general setting. See: - HTTP migration: https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/ - Database migration: https://opentelemetry.io/docs/specs/semconv/database/ - RPC: https://opentelemetry.io/docs/specs/semconv/rpc/ - Messaging: https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/ If omitted or null, no opt-in is configured and instrumentations continue emitting their default semantic convention version."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalhostresourcedetector",
+      "name": "ExperimentalHostResourceDetector",
+      "isExperimental": true,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalhttpclientinstrumentation",
+      "name": "ExperimentalHttpClientInstrumentation",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "request_captured_headers",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "Configure headers to capture for outbound http requests. If omitted, no outbound request headers are captured."
+        },
+        {
+          "name": "response_captured_headers",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "Configure headers to capture for inbound http responses. If omitted, no inbound response headers are captured."
+        },
+        {
+          "name": "known_methods",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 0",
+          "description": "Override the default list of known HTTP methods. Known methods are case-sensitive. This is a full override of the default known methods, not a list of known methods in addition to the defaults. If omitted, HTTP methods GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH are known."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalhttpinstrumentation",
+      "name": "ExperimentalHttpInstrumentation",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "semconv",
+          "type": "ExperimentalSemconvConfig",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure HTTP semantic convention version and migration behavior. This property takes precedence over the .instrumentation/development.general.stability_opt_in_list setting. See HTTP migration: https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/ If omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set."
+        },
+        {
+          "name": "client",
+          "type": "ExperimentalHttpClientInstrumentation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure instrumentations following the http client semantic conventions. If omitted, defaults as described in ExperimentalHttpClientInstrumentation are used."
+        },
+        {
+          "name": "server",
+          "type": "ExperimentalHttpServerInstrumentation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure instrumentations following the http server semantic conventions. If omitted, defaults as described in ExperimentalHttpServerInstrumentation are used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalhttpserverinstrumentation",
+      "name": "ExperimentalHttpServerInstrumentation",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "request_captured_headers",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "Configure headers to capture for inbound http requests. If omitted, no request headers are captured."
+        },
+        {
+          "name": "response_captured_headers",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "Configure headers to capture for outbound http responses. If omitted, no response headers are captures."
+        },
+        {
+          "name": "known_methods",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 0",
+          "description": "Override the default list of known HTTP methods. Known methods are case-sensitive. This is a full override of the default known methods, not a list of known methods in addition to the defaults. If omitted, HTTP methods GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH are known."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalinstrumentation",
+      "name": "ExperimentalInstrumentation",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "general",
+          "type": "ExperimentalGeneralInstrumentation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure general SemConv options that may apply to multiple languages and instrumentations. Instrumenation may merge general config options with the language specific configuration at .instrumentation.<language>. If omitted, default values as described in ExperimentalGeneralInstrumentation are used."
+        },
+        {
+          "name": "cpp",
+          "type": "ExperimentalLanguageSpecificInstrumentation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure C++ language-specific instrumentation libraries. If omitted, instrumentation defaults are used."
+        },
+        {
+          "name": "dotnet",
+          "type": "ExperimentalLanguageSpecificInstrumentation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure .NET language-specific instrumentation libraries. Each entry's key identifies a particular instrumentation library. The corresponding value configures it. If omitted, instrumentation defaults are used."
+        },
+        {
+          "name": "erlang",
+          "type": "ExperimentalLanguageSpecificInstrumentation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure Erlang language-specific instrumentation libraries. Each entry's key identifies a particular instrumentation library. The corresponding value configures it. If omitted, instrumentation defaults are used."
+        },
+        {
+          "name": "go",
+          "type": "ExperimentalLanguageSpecificInstrumentation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure Go language-specific instrumentation libraries. Each entry's key identifies a particular instrumentation library. The corresponding value configures it. If omitted, instrumentation defaults are used."
+        },
+        {
+          "name": "java",
+          "type": "ExperimentalLanguageSpecificInstrumentation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure Java language-specific instrumentation libraries. Each entry's key identifies a particular instrumentation library. The corresponding value configures it. If omitted, instrumentation defaults are used."
+        },
+        {
+          "name": "js",
+          "type": "ExperimentalLanguageSpecificInstrumentation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure JavaScript language-specific instrumentation libraries. Each entry's key identifies a particular instrumentation library. The corresponding value configures it. If omitted, instrumentation defaults are used."
+        },
+        {
+          "name": "php",
+          "type": "ExperimentalLanguageSpecificInstrumentation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure PHP language-specific instrumentation libraries. Each entry's key identifies a particular instrumentation library. The corresponding value configures it. If omitted, instrumentation defaults are used."
+        },
+        {
+          "name": "python",
+          "type": "ExperimentalLanguageSpecificInstrumentation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure Python language-specific instrumentation libraries. Each entry's key identifies a particular instrumentation library. The corresponding value configures it. If omitted, instrumentation defaults are used."
+        },
+        {
+          "name": "ruby",
+          "type": "ExperimentalLanguageSpecificInstrumentation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure Ruby language-specific instrumentation libraries. Each entry's key identifies a particular instrumentation library. The corresponding value configures it. If omitted, instrumentation defaults are used."
+        },
+        {
+          "name": "rust",
+          "type": "ExperimentalLanguageSpecificInstrumentation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure Rust language-specific instrumentation libraries. Each entry's key identifies a particular instrumentation library. The corresponding value configures it. If omitted, instrumentation defaults are used."
+        },
+        {
+          "name": "swift",
+          "type": "ExperimentalLanguageSpecificInstrumentation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure Swift language-specific instrumentation libraries. Each entry's key identifies a particular instrumentation library. The corresponding value configures it. If omitted, instrumentation defaults are used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentaljaegerremotesampler",
+      "name": "ExperimentalJaegerRemoteSampler",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "endpoint",
+          "type": "string",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure the endpoint of the jaeger remote sampling service. Property is required and must be non-null."
+        },
+        {
+          "name": "interval",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: 0",
+          "description": "Configure the polling interval (in milliseconds) to fetch from the remote sampling service. If omitted or null, 60000 is used."
+        },
+        {
+          "name": "initial_sampler",
+          "type": "Sampler",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure the initial sampler used before first configuration is fetched. Property is required and must be non-null."
+        }
+      ],
+      "constraints": "additionalProperties: false. Required properties: endpoint, initial_sampler."
+    },
+    {
+      "id": "experimentallanguagespecificinstrumentation",
+      "name": "ExperimentalLanguageSpecificInstrumentation",
+      "isExperimental": true,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": ""
+    },
+    {
+      "id": "experimentalloggerconfig",
+      "name": "ExperimentalLoggerConfig",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "enabled",
+          "type": "boolean, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure if the logger is enabled or not. If omitted or null, true is used."
+        },
+        {
+          "name": "minimum_severity",
+          "type": "SeverityNumber",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure severity filtering. Log records with an non-zero (i.e. unspecified) severity number which is less than minimum_severity are not processed. Values include: * debug: debug, severity number 5. * debug2: debug2, severity number 6. * debug3: debug3, severity number 7. * debug4: debug4, severity number 8. * error: error, severity number 17. * error2: error2, severity number 18. * error3: error3, severity number 19. * error4: error4, severity number 20. * fatal: fatal, severity number 21. * fatal2: fatal2, severity number 22. * fatal3: fatal3, severity number 23. * fatal4: fatal4, severity number 24. * info: info, severity number 9. * info2: info2, severity number 10. * info3: info3, severity number 11. * info4: info4, severity number 12. * trace: trace, severity number 1. * trace2: trace2, severity number 2. * trace3: trace3, severity number 3. * trace4: trace4, severity number 4. * warn: warn, severity number 13. * warn2: warn2, severity number 14. * warn3: warn3, severity number 15. * warn4: warn4, severity number 16. If omitted, severity filtering is not applied."
+        },
+        {
+          "name": "trace_based",
+          "type": "boolean, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure trace based filtering. If true, log records associated with unsampled trace contexts traces are not processed. If false, or if a log record is not associated with a trace context, trace based filtering is not applied. If omitted or null, trace based filtering is not applied."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalloggerconfigurator",
+      "name": "ExperimentalLoggerConfigurator",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "default_config",
+          "type": "ExperimentalLoggerConfig",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure the default logger config used there is no matching entry in .logger_configurator/development.loggers. If omitted, unmatched .loggers use default values as described in ExperimentalLoggerConfig."
+        },
+        {
+          "name": "loggers",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "Configure loggers. If omitted, all loggers use .default_config."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalloggermatcherandconfig",
+      "name": "ExperimentalLoggerMatcherAndConfig",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "type": "string",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure logger names to match, evaluated as follows: * If the logger name exactly matches. * If the logger name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none. Property is required and must be non-null."
+        },
+        {
+          "name": "config",
+          "type": "ExperimentalLoggerConfig",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "The logger config. Property is required and must be non-null."
+        }
+      ],
+      "constraints": "additionalProperties: false. Required properties: name, config."
+    },
+    {
+      "id": "experimentalmessaginginstrumentation",
+      "name": "ExperimentalMessagingInstrumentation",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "semconv",
+          "type": "ExperimentalSemconvConfig",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure messaging semantic convention version and migration behavior. This property takes precedence over the .instrumentation/development.general.stability_opt_in_list setting. See messaging semantic conventions: https://opentelemetry.io/docs/specs/semconv/messaging/ If omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalmeterconfig",
+      "name": "ExperimentalMeterConfig",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "enabled",
+          "type": "boolean",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure if the meter is enabled or not. If omitted, true is used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalmeterconfigurator",
+      "name": "ExperimentalMeterConfigurator",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "default_config",
+          "type": "ExperimentalMeterConfig",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure the default meter config used there is no matching entry in .meter_configurator/development.meters. If omitted, unmatched .meters use default values as described in ExperimentalMeterConfig."
+        },
+        {
+          "name": "meters",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "Configure meters. If omitted, all meters used .default_config."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalmetermatcherandconfig",
+      "name": "ExperimentalMeterMatcherAndConfig",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "type": "string",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure meter names to match, evaluated as follows: * If the meter name exactly matches. * If the meter name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none. Property is required and must be non-null."
+        },
+        {
+          "name": "config",
+          "type": "ExperimentalMeterConfig",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "The meter config. Property is required and must be non-null."
+        }
+      ],
+      "constraints": "additionalProperties: false. Required properties: name, config."
+    },
+    {
+      "id": "experimentalotlpfileexporter",
+      "name": "ExperimentalOtlpFileExporter",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "output_stream",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure output stream. Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl. If omitted or null, stdout is used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalotlpfilemetricexporter",
+      "name": "ExperimentalOtlpFileMetricExporter",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "output_stream",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure output stream. Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl. If omitted or null, stdout is used."
+        },
+        {
+          "name": "temporality_preference",
+          "type": "ExporterTemporalityPreference",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure temporality preference. Values include: * cumulative: Use cumulative aggregation temporality for all instrument types. * delta: Use delta aggregation for all instrument types except up down counter and asynchronous up down counter. * low_memory: Use delta aggregation temporality for counter and histogram instrument types. Use cumulative aggregation temporality for all other instrument types. If omitted, cumulative is used."
+        },
+        {
+          "name": "default_histogram_aggregation",
+          "type": "ExporterDefaultHistogramAggregation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure default histogram aggregation. Values include: * base2_exponential_bucket_histogram: Use base2 exponential histogram as the default aggregation for histogram instruments. * explicit_bucket_histogram: Use explicit bucket histogram as the default aggregation for histogram instruments. If omitted, explicit_bucket_histogram is used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalprobabilitysampler",
+      "name": "ExperimentalProbabilitySampler",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "ratio",
+          "type": "number, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: 0, maximum: 1",
+          "description": "Configure ratio. If omitted or null, 1.0 is used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalprocessresourcedetector",
+      "name": "ExperimentalProcessResourceDetector",
+      "isExperimental": true,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalprometheusmetricexporter",
+      "name": "ExperimentalPrometheusMetricExporter",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "host",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure host. If omitted or null, localhost is used."
+        },
+        {
+          "name": "port",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure port. If omitted or null, 9464 is used."
+        },
+        {
+          "name": "without_scope_info",
+          "type": "boolean, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure Prometheus Exporter to produce metrics without scope labels. If omitted or null, false is used."
+        },
+        {
+          "name": "without_target_info/development",
+          "type": "boolean, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure Prometheus Exporter to produce metrics without a target info metric for the resource. If omitted or null, false is used."
+        },
+        {
+          "name": "with_resource_constant_labels",
+          "type": "IncludeExclude",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure Prometheus Exporter to add resource attributes as metrics attributes, where the resource attribute keys match the patterns. If omitted, no resource attributes are added."
+        },
+        {
+          "name": "translation_strategy",
+          "type": "ExperimentalPrometheusTranslationStrategy",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure how metric names are translated to Prometheus metric names. Values include: * no_translation/development: Special character escaping is disabled. Type and unit suffixes are disabled. Metric names are unaltered. * no_utf8_escaping_with_suffixes/development: Special character escaping is disabled. Type and unit suffixes are enabled. * underscore_escaping_with_suffixes: Special character escaping is enabled. Type and unit suffixes are enabled. * underscore_escaping_without_suffixes/development: Special character escaping is enabled. Type and unit suffixes are disabled. This represents classic Prometheus metric name compatibility. If omitted, underscore_escaping_with_suffixes is used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalprometheustranslationstrategy",
+      "name": "ExperimentalPrometheusTranslationStrategy",
+      "isExperimental": true,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": ""
+    },
+    {
+      "id": "experimentalresourcedetection",
+      "name": "ExperimentalResourceDetection",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "attributes",
+          "type": "IncludeExclude",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure attributes provided by resource detectors. If omitted, all attributes from resource detectors are added."
+        },
+        {
+          "name": "detectors",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "Configure resource detectors. Resource detector names are dependent on the SDK language ecosystem. Please consult documentation for each respective language. If omitted, no resource detectors are enabled."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalresourcedetector",
+      "name": "ExperimentalResourceDetector",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "container",
+          "type": "ExperimentalContainerResourceDetector",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Enable the container resource detector, which populates container.* attributes. If omitted, ignore."
+        },
+        {
+          "name": "host",
+          "type": "ExperimentalHostResourceDetector",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Enable the host resource detector, which populates host.* and os.* attributes. If omitted, ignore."
+        },
+        {
+          "name": "process",
+          "type": "ExperimentalProcessResourceDetector",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Enable the process resource detector, which populates process.* attributes. If omitted, ignore."
+        },
+        {
+          "name": "service",
+          "type": "ExperimentalServiceResourceDetector",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Enable the service detector, which populates service.name based on the OTEL_SERVICE_NAME environment variable and service.instance.id. If omitted, ignore."
+        }
+      ],
+      "constraints": "minProperties: 1. maxProperties: 1."
+    },
+    {
+      "id": "experimentalrpcinstrumentation",
+      "name": "ExperimentalRpcInstrumentation",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "semconv",
+          "type": "ExperimentalSemconvConfig",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure RPC semantic convention version and migration behavior. This property takes precedence over the .instrumentation/development.general.stability_opt_in_list setting. See RPC semantic conventions: https://opentelemetry.io/docs/specs/semconv/rpc/ If omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalsanitization",
+      "name": "ExperimentalSanitization",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "url",
+          "type": "ExperimentalUrlSanitization",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure URL sanitization options. If omitted, defaults as described in ExperimentalUrlSanitization are used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalsemconvconfig",
+      "name": "ExperimentalSemconvConfig",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "version",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: 0",
+          "description": "The target semantic convention version for this domain (e.g., 1). If omitted or null, the latest stable version is used, or if no stable version is available and .experimental is true then the latest experimental version is used."
+        },
+        {
+          "name": "experimental",
+          "type": "boolean, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Use latest experimental semantic conventions (before stable is available or to enable experimental features on top of stable conventions). If omitted or null, false is used."
+        },
+        {
+          "name": "dual_emit",
+          "type": "boolean, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "When true, also emit the previous major version alongside the target version. For version=1, the previous version refers to the pre-stable conventions that the instrumentation emitted before the first stable semantic convention version was defined. For version=2 and above, the previous version is the prior stable major version (e.g., version=2, dual_emit=true emits both v2 and v1). Enables dual-emit for phased migration between versions. If omitted or null, false is used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalserviceresourcedetector",
+      "name": "ExperimentalServiceResourceDetector",
+      "isExperimental": true,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentalspanparent",
+      "name": "ExperimentalSpanParent",
+      "isExperimental": true,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": ""
+    },
+    {
+      "id": "experimentaltracerconfig",
+      "name": "ExperimentalTracerConfig",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "enabled",
+          "type": "boolean",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure if the tracer is enabled or not. If omitted, true is used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentaltracerconfigurator",
+      "name": "ExperimentalTracerConfigurator",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "default_config",
+          "type": "ExperimentalTracerConfig",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure the default tracer config used there is no matching entry in .tracer_configurator/development.tracers. If omitted, unmatched .tracers use default values as described in ExperimentalTracerConfig."
+        },
+        {
+          "name": "tracers",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "Configure tracers. If omitted, all tracers use .default_config."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "experimentaltracermatcherandconfig",
+      "name": "ExperimentalTracerMatcherAndConfig",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "type": "string",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure tracer names to match, evaluated as follows: * If the tracer name exactly matches. * If the tracer name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none. Property is required and must be non-null."
+        },
+        {
+          "name": "config",
+          "type": "ExperimentalTracerConfig",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "The tracer config. Property is required and must be non-null."
+        }
+      ],
+      "constraints": "additionalProperties: false. Required properties: name, config."
+    },
+    {
+      "id": "experimentalurlsanitization",
+      "name": "ExperimentalUrlSanitization",
+      "isExperimental": true,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "sensitive_query_parameters",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 0",
+          "description": "List of query parameter names whose values should be redacted from URLs. Query parameter names are case-sensitive. This is a full override of the default sensitive query parameter keys, it is not a list of keys in addition to the defaults. Set to an empty array to disable query parameter redaction. If omitted, the default sensitive query parameter list as defined by the url semantic conventions (https://github.com/open-telemetry/semantic-conventions/blob/main/docs/registry/attributes/url.md) is used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "explicitbuckethistogramaggregation",
+      "name": "ExplicitBucketHistogramAggregation",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "boundaries",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 0",
+          "description": "Configure bucket boundaries. If omitted, [0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000] is used."
+        },
+        {
+          "name": "record_min_max",
+          "type": "boolean, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure record min and max. If omitted or null, true is used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "exporterdefaulthistogramaggregation",
+      "name": "ExporterDefaultHistogramAggregation",
+      "isExperimental": false,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": ""
+    },
+    {
+      "id": "exportertemporalitypreference",
+      "name": "ExporterTemporalityPreference",
+      "isExperimental": false,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": ""
+    },
+    {
+      "id": "grpctls",
+      "name": "GrpcTls",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "ca_file",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure certificate used to verify a server's TLS credentials. Absolute path to certificate file in PEM format. If omitted or null, system default certificate verification is used for secure connections."
+        },
+        {
+          "name": "key_file",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure mTLS private client key. Absolute path to client key file in PEM format. If set, .client_certificate must also be set. If omitted or null, mTLS is not used."
+        },
+        {
+          "name": "cert_file",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure mTLS client certificate. Absolute path to client certificate file in PEM format. If set, .client_key must also be set. If omitted or null, mTLS is not used."
+        },
+        {
+          "name": "insecure",
+          "type": "boolean, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure client transport security for the exporter's connection. Only applicable when .endpoint is provided without http or https scheme. Implementations may choose to ignore .insecure. If omitted or null, false is used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "httptls",
+      "name": "HttpTls",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "ca_file",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure certificate used to verify a server's TLS credentials. Absolute path to certificate file in PEM format. If omitted or null, system default certificate verification is used for secure connections."
+        },
+        {
+          "name": "key_file",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure mTLS private client key. Absolute path to client key file in PEM format. If set, .client_certificate must also be set. If omitted or null, mTLS is not used."
+        },
+        {
+          "name": "cert_file",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure mTLS client certificate. Absolute path to client certificate file in PEM format. If set, .client_key must also be set. If omitted or null, mTLS is not used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "includeexclude",
+      "name": "IncludeExclude",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "included",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "Configure list of value patterns to include. Values are evaluated to match as follows: * If the value exactly matches. * If the value matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none. If omitted, all values are included."
+        },
+        {
+          "name": "excluded",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "Configure list of value patterns to exclude. Applies after .included (i.e. excluded has higher priority than included). Values are evaluated to match as follows: * If the value exactly matches. * If the value matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none. If omitted, .included attributes are included."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "instrumenttype",
+      "name": "InstrumentType",
+      "isExperimental": false,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": ""
+    },
+    {
+      "id": "lastvalueaggregation",
+      "name": "LastValueAggregation",
+      "isExperimental": false,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "loggerprovider",
+      "name": "LoggerProvider",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "processors",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "Configure log record processors. Property is required and must be non-null."
+        },
+        {
+          "name": "limits",
+          "type": "LogRecordLimits",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure log record limits. See also attribute_limits. If omitted, default values as described in LogRecordLimits are used."
+        },
+        {
+          "name": "logger_configurator/development",
+          "type": "ExperimentalLoggerConfigurator",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure loggers. If omitted, all loggers use default values as described in ExperimentalLoggerConfig."
+        }
+      ],
+      "constraints": "additionalProperties: false. Required properties: processors."
+    },
+    {
+      "id": "logrecordexporter",
+      "name": "LogRecordExporter",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "otlp_http",
+          "type": "OtlpHttpExporter",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure exporter to be OTLP with HTTP transport. If omitted, ignore."
+        },
+        {
+          "name": "otlp_grpc",
+          "type": "OtlpGrpcExporter",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure exporter to be OTLP with gRPC transport. If omitted, ignore."
+        },
+        {
+          "name": "otlp_file/development",
+          "type": "ExperimentalOtlpFileExporter",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure exporter to be OTLP with file transport. If omitted, ignore."
+        },
+        {
+          "name": "console",
+          "type": "ConsoleExporter",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure exporter to be console. If omitted, ignore."
+        }
+      ],
+      "constraints": "minProperties: 1. maxProperties: 1."
+    },
+    {
+      "id": "logrecordlimits",
+      "name": "LogRecordLimits",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "attribute_value_length_limit",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: 0",
+          "description": "Configure max attribute value size. Overrides .attribute_limits.attribute_value_length_limit. Value must be non-negative. If omitted or null, there is no limit."
+        },
+        {
+          "name": "attribute_count_limit",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: 0",
+          "description": "Configure max attribute count. Overrides .attribute_limits.attribute_count_limit. Value must be non-negative. If omitted or null, 128 is used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "logrecordprocessor",
+      "name": "LogRecordProcessor",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "batch",
+          "type": "BatchLogRecordProcessor",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure a batch log record processor. If omitted, ignore."
+        },
+        {
+          "name": "simple",
+          "type": "SimpleLogRecordProcessor",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure a simple log record processor. If omitted, ignore."
+        }
+      ],
+      "constraints": "minProperties: 1. maxProperties: 1."
+    },
+    {
+      "id": "meterprovider",
+      "name": "MeterProvider",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "readers",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "Configure metric readers. Property is required and must be non-null."
+        },
+        {
+          "name": "views",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "Configure views. Each view has a selector which determines the instrument(s) it applies to, and a configuration for the resulting stream(s). If omitted, no views are registered."
+        },
+        {
+          "name": "exemplar_filter",
+          "type": "ExemplarFilter",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure the exemplar filter. Values include: * always_off: ExemplarFilter which makes no measurements eligible for being an Exemplar. * always_on: ExemplarFilter which makes all measurements eligible for being an Exemplar. * trace_based: ExemplarFilter which makes measurements recorded in the context of a sampled parent span eligible for being an Exemplar. If omitted, trace_based is used."
+        },
+        {
+          "name": "meter_configurator/development",
+          "type": "ExperimentalMeterConfigurator",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure meters. If omitted, all meters use default values as described in ExperimentalMeterConfig."
+        }
+      ],
+      "constraints": "additionalProperties: false. Required properties: readers."
+    },
+    {
+      "id": "metricproducer",
+      "name": "MetricProducer",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "opencensus",
+          "type": "OpenCensusMetricProducer",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure metric producer to be opencensus. If omitted, ignore."
+        }
+      ],
+      "constraints": "minProperties: 1. maxProperties: 1."
+    },
+    {
+      "id": "metricreader",
+      "name": "MetricReader",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "periodic",
+          "type": "PeriodicMetricReader",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure a periodic metric reader. If omitted, ignore."
+        },
+        {
+          "name": "pull",
+          "type": "PullMetricReader",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure a pull based metric reader. If omitted, ignore."
+        }
+      ],
+      "constraints": "additionalProperties: false. minProperties: 1. maxProperties: 1."
+    },
+    {
+      "id": "namestringvaluepair",
+      "name": "NameStringValuePair",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "type": "string",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "The name of the pair. Property is required and must be non-null."
+        },
+        {
+          "name": "value",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "The value of the pair. Property must be present, but if null the behavior is dependent on usage context."
+        }
+      ],
+      "constraints": "additionalProperties: false. Required properties: name, value."
+    },
+    {
+      "id": "opencensusmetricproducer",
+      "name": "OpenCensusMetricProducer",
+      "isExperimental": false,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "otlpgrpcexporter",
+      "name": "OtlpGrpcExporter",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "endpoint",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure endpoint. If omitted or null, http://localhost:4317 is used."
+        },
+        {
+          "name": "tls",
+          "type": "GrpcTls",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure TLS settings for the exporter. If omitted, system default TLS settings are used."
+        },
+        {
+          "name": "headers",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "Configure headers. Entries have higher priority than entries from .headers_list. If an entry's .value is null, the entry is ignored. If omitted, no headers are added."
+        },
+        {
+          "name": "headers_list",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure headers. Entries have lower priority than entries from .headers. The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details. If omitted or null, no headers are added."
+        },
+        {
+          "name": "compression",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure compression. Known values include: gzip, none. Implementations may support other compression algorithms. If omitted or null, none is used."
+        },
+        {
+          "name": "timeout",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: 0",
+          "description": "Configure max time (in milliseconds) to wait for each export. Value must be non-negative. A value of 0 indicates no limit (infinity). If omitted or null, 10000 is used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "otlpgrpcmetricexporter",
+      "name": "OtlpGrpcMetricExporter",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "endpoint",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure endpoint. If omitted or null, http://localhost:4317 is used."
+        },
+        {
+          "name": "tls",
+          "type": "GrpcTls",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure TLS settings for the exporter. If omitted, system default TLS settings are used."
+        },
+        {
+          "name": "headers",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "Configure headers. Entries have higher priority than entries from .headers_list. If an entry's .value is null, the entry is ignored. If omitted, no headers are added."
+        },
+        {
+          "name": "headers_list",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure headers. Entries have lower priority than entries from .headers. The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details. If omitted or null, no headers are added."
+        },
+        {
+          "name": "compression",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure compression. Known values include: gzip, none. Implementations may support other compression algorithms. If omitted or null, none is used."
+        },
+        {
+          "name": "timeout",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: 0",
+          "description": "Configure max time (in milliseconds) to wait for each export. Value must be non-negative. A value of 0 indicates no limit (infinity). If omitted or null, 10000 is used."
+        },
+        {
+          "name": "temporality_preference",
+          "type": "ExporterTemporalityPreference",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure temporality preference. Values include: * cumulative: Use cumulative aggregation temporality for all instrument types. * delta: Use delta aggregation for all instrument types except up down counter and asynchronous up down counter. * low_memory: Use delta aggregation temporality for counter and histogram instrument types. Use cumulative aggregation temporality for all other instrument types. If omitted, cumulative is used."
+        },
+        {
+          "name": "default_histogram_aggregation",
+          "type": "ExporterDefaultHistogramAggregation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure default histogram aggregation. Values include: * base2_exponential_bucket_histogram: Use base2 exponential histogram as the default aggregation for histogram instruments. * explicit_bucket_histogram: Use explicit bucket histogram as the default aggregation for histogram instruments. If omitted, explicit_bucket_histogram is used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "otlphttpencoding",
+      "name": "OtlpHttpEncoding",
+      "isExperimental": false,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": ""
+    },
+    {
+      "id": "otlphttpexporter",
+      "name": "OtlpHttpExporter",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "endpoint",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure endpoint, including the signal specific path. If omitted or null, the http://localhost:4318/v1/{signal} (where signal is 'traces', 'logs', or 'metrics') is used."
+        },
+        {
+          "name": "tls",
+          "type": "HttpTls",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure TLS settings for the exporter. If omitted, system default TLS settings are used."
+        },
+        {
+          "name": "headers",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "Configure headers. Entries have higher priority than entries from .headers_list. If an entry's .value is null, the entry is ignored. If omitted, no headers are added."
+        },
+        {
+          "name": "headers_list",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure headers. Entries have lower priority than entries from .headers. The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details. If omitted or null, no headers are added."
+        },
+        {
+          "name": "compression",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure compression. Known values include: gzip, none. Implementations may support other compression algorithms. If omitted or null, none is used."
+        },
+        {
+          "name": "timeout",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: 0",
+          "description": "Configure max time (in milliseconds) to wait for each export. Value must be non-negative. A value of 0 indicates no limit (infinity). If omitted or null, 10000 is used."
+        },
+        {
+          "name": "encoding",
+          "type": "OtlpHttpEncoding",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure the encoding used for messages. Implementations may not support json. Values include: * json: Protobuf JSON encoding. * protobuf: Protobuf binary encoding. If omitted, protobuf is used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "otlphttpmetricexporter",
+      "name": "OtlpHttpMetricExporter",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "endpoint",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure endpoint. If omitted or null, http://localhost:4318/v1/metrics is used."
+        },
+        {
+          "name": "tls",
+          "type": "HttpTls",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure TLS settings for the exporter. If omitted, system default TLS settings are used."
+        },
+        {
+          "name": "headers",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "Configure headers. Entries have higher priority than entries from .headers_list. If an entry's .value is null, the entry is ignored. If omitted, no headers are added."
+        },
+        {
+          "name": "headers_list",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure headers. Entries have lower priority than entries from .headers. The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details. If omitted or null, no headers are added."
+        },
+        {
+          "name": "compression",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure compression. Known values include: gzip, none. Implementations may support other compression algorithms. If omitted or null, none is used."
+        },
+        {
+          "name": "timeout",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: 0",
+          "description": "Configure max time (in milliseconds) to wait for each export. Value must be non-negative. A value of 0 indicates no limit (infinity). If omitted or null, 10000 is used."
+        },
+        {
+          "name": "encoding",
+          "type": "OtlpHttpEncoding",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure the encoding used for messages. Implementations may not support json. Values include: * json: Protobuf JSON encoding. * protobuf: Protobuf binary encoding. If omitted, protobuf is used."
+        },
+        {
+          "name": "temporality_preference",
+          "type": "ExporterTemporalityPreference",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure temporality preference. Values include: * cumulative: Use cumulative aggregation temporality for all instrument types. * delta: Use delta aggregation for all instrument types except up down counter and asynchronous up down counter. * low_memory: Use delta aggregation temporality for counter and histogram instrument types. Use cumulative aggregation temporality for all other instrument types. If omitted, cumulative is used."
+        },
+        {
+          "name": "default_histogram_aggregation",
+          "type": "ExporterDefaultHistogramAggregation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure default histogram aggregation. Values include: * base2_exponential_bucket_histogram: Use base2 exponential histogram as the default aggregation for histogram instruments. * explicit_bucket_histogram: Use explicit bucket histogram as the default aggregation for histogram instruments. If omitted, explicit_bucket_histogram is used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "parentbasedsampler",
+      "name": "ParentBasedSampler",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "root",
+          "type": "Sampler",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure root sampler. If omitted, always_on is used."
+        },
+        {
+          "name": "remote_parent_sampled",
+          "type": "Sampler",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure remote_parent_sampled sampler. If omitted, always_on is used."
+        },
+        {
+          "name": "remote_parent_not_sampled",
+          "type": "Sampler",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure remote_parent_not_sampled sampler. If omitted, always_off is used."
+        },
+        {
+          "name": "local_parent_sampled",
+          "type": "Sampler",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure local_parent_sampled sampler. If omitted, always_on is used."
+        },
+        {
+          "name": "local_parent_not_sampled",
+          "type": "Sampler",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure local_parent_not_sampled sampler. If omitted, always_off is used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "periodicmetricreader",
+      "name": "PeriodicMetricReader",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "interval",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: 0",
+          "description": "Configure delay interval (in milliseconds) between start of two consecutive exports. Value must be non-negative. If omitted or null, 60000 is used."
+        },
+        {
+          "name": "timeout",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: 0",
+          "description": "Configure maximum allowed time (in milliseconds) to export data. Value must be non-negative. A value of 0 indicates no limit (infinity). If omitted or null, 30000 is used."
+        },
+        {
+          "name": "exporter",
+          "type": "PushMetricExporter",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure exporter. Property is required and must be non-null."
+        },
+        {
+          "name": "producers",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "Configure metric producers. If omitted, no metric producers are added."
+        },
+        {
+          "name": "cardinality_limits",
+          "type": "CardinalityLimits",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure cardinality limits. If omitted, default values as described in CardinalityLimits are used."
+        }
+      ],
+      "constraints": "additionalProperties: false. Required properties: exporter."
+    },
+    {
+      "id": "propagator",
+      "name": "Propagator",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "composite",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "Configure the propagators in the composite text map propagator. Entries from .composite_list are appended to the list here with duplicates filtered out. Built-in propagator keys include: tracecontext, baggage, b3, b3multi. Known third party keys include: xray. If omitted, and .composite_list is omitted or null, a noop propagator is used."
+        },
+        {
+          "name": "composite_list",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure the propagators in the composite text map propagator. Entries are appended to .composite with duplicates filtered out. The value is a comma separated list of propagator identifiers matching the format of OTEL_PROPAGATORS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration for details. Built-in propagator identifiers include: tracecontext, baggage, b3, b3multi. Known third party identifiers include: xray. If omitted or null, and .composite is omitted or null, a noop propagator is used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "pullmetricexporter",
+      "name": "PullMetricExporter",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "prometheus/development",
+          "type": "ExperimentalPrometheusMetricExporter",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure exporter to be prometheus. If omitted, ignore."
+        }
+      ],
+      "constraints": "minProperties: 1. maxProperties: 1."
+    },
+    {
+      "id": "pullmetricreader",
+      "name": "PullMetricReader",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "exporter",
+          "type": "PullMetricExporter",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure exporter. Property is required and must be non-null."
+        },
+        {
+          "name": "producers",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "Configure metric producers. If omitted, no metric producers are added."
+        },
+        {
+          "name": "cardinality_limits",
+          "type": "CardinalityLimits",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure cardinality limits. If omitted, default values as described in CardinalityLimits are used."
+        }
+      ],
+      "constraints": "additionalProperties: false. Required properties: exporter."
+    },
+    {
+      "id": "pushmetricexporter",
+      "name": "PushMetricExporter",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "otlp_http",
+          "type": "OtlpHttpMetricExporter",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure exporter to be OTLP with HTTP transport. If omitted, ignore."
+        },
+        {
+          "name": "otlp_grpc",
+          "type": "OtlpGrpcMetricExporter",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure exporter to be OTLP with gRPC transport. If omitted, ignore."
+        },
+        {
+          "name": "otlp_file/development",
+          "type": "ExperimentalOtlpFileMetricExporter",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure exporter to be OTLP with file transport. If omitted, ignore."
+        },
+        {
+          "name": "console",
+          "type": "ConsoleMetricExporter",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure exporter to be console. If omitted, ignore."
+        }
+      ],
+      "constraints": "minProperties: 1. maxProperties: 1."
+    },
+    {
+      "id": "resource",
+      "name": "Resource",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "attributes",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "Configure resource attributes. Entries have higher priority than entries from .resource.attributes_list. If omitted, no resource attributes are added."
+        },
+        {
+          "name": "detection/development",
+          "type": "ExperimentalResourceDetection",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure resource detection. If omitted, resource detection is disabled."
+        },
+        {
+          "name": "schema_url",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure resource schema URL. If omitted or null, no schema URL is used."
+        },
+        {
+          "name": "attributes_list",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure resource attributes. Entries have lower priority than entries from .resource.attributes. The value is a list of comma separated key-value pairs matching the format of OTEL_RESOURCE_ATTRIBUTES. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration for details. If omitted or null, no resource attributes are added."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "sampler",
+      "name": "Sampler",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "always_off",
+          "type": "AlwaysOffSampler",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure sampler to be always_off. If omitted, ignore."
+        },
+        {
+          "name": "always_on",
+          "type": "AlwaysOnSampler",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure sampler to be always_on. If omitted, ignore."
+        },
+        {
+          "name": "composite/development",
+          "type": "ExperimentalComposableSampler",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure sampler to be composite. If omitted, ignore."
+        },
+        {
+          "name": "jaeger_remote/development",
+          "type": "ExperimentalJaegerRemoteSampler",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure sampler to be jaeger_remote. If omitted, ignore."
+        },
+        {
+          "name": "parent_based",
+          "type": "ParentBasedSampler",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure sampler to be parent_based. If omitted, ignore."
+        },
+        {
+          "name": "probability/development",
+          "type": "ExperimentalProbabilitySampler",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure sampler to be probability. If omitted, ignore."
+        },
+        {
+          "name": "trace_id_ratio_based",
+          "type": "TraceIdRatioBasedSampler",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure sampler to be trace_id_ratio_based. If omitted, ignore."
+        }
+      ],
+      "constraints": "minProperties: 1. maxProperties: 1."
+    },
+    {
+      "id": "severitynumber",
+      "name": "SeverityNumber",
+      "isExperimental": false,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": ""
+    },
+    {
+      "id": "simplelogrecordprocessor",
+      "name": "SimpleLogRecordProcessor",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "exporter",
+          "type": "LogRecordExporter",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure exporter. Property is required and must be non-null."
+        }
+      ],
+      "constraints": "additionalProperties: false. Required properties: exporter."
+    },
+    {
+      "id": "simplespanprocessor",
+      "name": "SimpleSpanProcessor",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "exporter",
+          "type": "SpanExporter",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure exporter. Property is required and must be non-null."
+        }
+      ],
+      "constraints": "additionalProperties: false. Required properties: exporter."
+    },
+    {
+      "id": "spanexporter",
+      "name": "SpanExporter",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "otlp_http",
+          "type": "OtlpHttpExporter",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure exporter to be OTLP with HTTP transport. If omitted, ignore."
+        },
+        {
+          "name": "otlp_grpc",
+          "type": "OtlpGrpcExporter",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure exporter to be OTLP with gRPC transport. If omitted, ignore."
+        },
+        {
+          "name": "otlp_file/development",
+          "type": "ExperimentalOtlpFileExporter",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure exporter to be OTLP with file transport. If omitted, ignore."
+        },
+        {
+          "name": "console",
+          "type": "ConsoleExporter",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure exporter to be console. If omitted, ignore."
+        }
+      ],
+      "constraints": "minProperties: 1. maxProperties: 1."
+    },
+    {
+      "id": "spankind",
+      "name": "SpanKind",
+      "isExperimental": false,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": ""
+    },
+    {
+      "id": "spanlimits",
+      "name": "SpanLimits",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "attribute_value_length_limit",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: 0",
+          "description": "Configure max attribute value size. Overrides .attribute_limits.attribute_value_length_limit. Value must be non-negative. If omitted or null, there is no limit."
+        },
+        {
+          "name": "attribute_count_limit",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: 0",
+          "description": "Configure max attribute count. Overrides .attribute_limits.attribute_count_limit. Value must be non-negative. If omitted or null, 128 is used."
+        },
+        {
+          "name": "event_count_limit",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: 0",
+          "description": "Configure max span event count. Value must be non-negative. If omitted or null, 128 is used."
+        },
+        {
+          "name": "link_count_limit",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: 0",
+          "description": "Configure max span link count. Value must be non-negative. If omitted or null, 128 is used."
+        },
+        {
+          "name": "event_attribute_count_limit",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: 0",
+          "description": "Configure max attributes per span event. Value must be non-negative. If omitted or null, 128 is used."
+        },
+        {
+          "name": "link_attribute_count_limit",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: 0",
+          "description": "Configure max attributes per span link. Value must be non-negative. If omitted or null, 128 is used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "spanprocessor",
+      "name": "SpanProcessor",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "batch",
+          "type": "BatchSpanProcessor",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure a batch span processor. If omitted, ignore."
+        },
+        {
+          "name": "simple",
+          "type": "SimpleSpanProcessor",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure a simple span processor. If omitted, ignore."
+        }
+      ],
+      "constraints": "minProperties: 1. maxProperties: 1."
+    },
+    {
+      "id": "sumaggregation",
+      "name": "SumAggregation",
+      "isExperimental": false,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "textmappropagator",
+      "name": "TextMapPropagator",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "tracecontext",
+          "type": "TraceContextPropagator",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Include the w3c trace context propagator. If omitted, ignore."
+        },
+        {
+          "name": "baggage",
+          "type": "BaggagePropagator",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Include the w3c baggage propagator. If omitted, ignore."
+        },
+        {
+          "name": "b3",
+          "type": "B3Propagator",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Include the zipkin b3 propagator. If omitted, ignore."
+        },
+        {
+          "name": "b3multi",
+          "type": "B3MultiPropagator",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Include the zipkin b3 multi propagator. If omitted, ignore."
+        }
+      ],
+      "constraints": "minProperties: 1. maxProperties: 1."
+    },
+    {
+      "id": "tracecontextpropagator",
+      "name": "TraceContextPropagator",
+      "isExperimental": false,
+      "hasNoProperties": true,
+      "properties": [],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "traceidratiobasedsampler",
+      "name": "TraceIdRatioBasedSampler",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "ratio",
+          "type": "number, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "minimum: 0, maximum: 1",
+          "description": "Configure trace_id_ratio. If omitted or null, 1.0 is used."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "tracerprovider",
+      "name": "TracerProvider",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "processors",
+          "type": "array",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "minItems: 1",
+          "description": "Configure span processors. Property is required and must be non-null."
+        },
+        {
+          "name": "limits",
+          "type": "SpanLimits",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure span limits. See also attribute_limits. If omitted, default values as described in SpanLimits are used."
+        },
+        {
+          "name": "sampler",
+          "type": "Sampler",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure the sampler. If omitted, parent based sampler with a root of always_on is used."
+        },
+        {
+          "name": "tracer_configurator/development",
+          "type": "ExperimentalTracerConfigurator",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure tracers. If omitted, all tracers use default values as described in ExperimentalTracerConfig."
+        }
+      ],
+      "constraints": "additionalProperties: false. Required properties: processors."
+    },
+    {
+      "id": "view",
+      "name": "View",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "selector",
+          "type": "ViewSelector",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure view selector. Selection criteria is additive as described in https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-selection-criteria. Property is required and must be non-null."
+        },
+        {
+          "name": "stream",
+          "type": "ViewStream",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure view stream. Property is required and must be non-null."
+        }
+      ],
+      "constraints": "additionalProperties: false. Required properties: selector, stream."
+    },
+    {
+      "id": "viewselector",
+      "name": "ViewSelector",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "instrument_name",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure instrument name selection criteria. If omitted or null, all instrument names match."
+        },
+        {
+          "name": "instrument_type",
+          "type": "InstrumentType",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure instrument type selection criteria. Values include: * counter: Synchronous counter instruments. * gauge: Synchronous gauge instruments. * histogram: Synchronous histogram instruments. * observable_counter: Asynchronous counter instruments. * observable_gauge: Asynchronous gauge instruments. * observable_up_down_counter: Asynchronous up down counter instruments. * up_down_counter: Synchronous up down counter instruments. If omitted, all instrument types match."
+        },
+        {
+          "name": "unit",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure the instrument unit selection criteria. If omitted or null, all instrument units match."
+        },
+        {
+          "name": "meter_name",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure meter name selection criteria. If omitted or null, all meter names match."
+        },
+        {
+          "name": "meter_version",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure meter version selection criteria. If omitted or null, all meter versions match."
+        },
+        {
+          "name": "meter_schema_url",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure meter schema url selection criteria. If omitted or null, all meter schema URLs match."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    },
+    {
+      "id": "viewstream",
+      "name": "ViewStream",
+      "isExperimental": false,
+      "hasNoProperties": false,
+      "properties": [
+        {
+          "name": "name",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure metric name of the resulting stream(s). If omitted or null, the instrument's original name is used."
+        },
+        {
+          "name": "description",
+          "type": "string, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure metric description of the resulting stream(s). If omitted or null, the instrument's origin description is used."
+        },
+        {
+          "name": "aggregation",
+          "type": "Aggregation",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure aggregation of the resulting stream(s). If omitted, default is used."
+        },
+        {
+          "name": "aggregation_cardinality_limit",
+          "type": "integer, null",
+          "default": "If omitted or null, default behavior applies.",
+          "constraints": "",
+          "description": "Configure the aggregation cardinality limit. If omitted or null, the metric reader's default cardinality limit is used."
+        },
+        {
+          "name": "attribute_keys",
+          "type": "IncludeExclude",
+          "default": "If omitted, default behavior applies.",
+          "constraints": "",
+          "description": "Configure attribute keys retained in the resulting stream(s). If omitted, all attribute keys are retained."
+        }
+      ],
+      "constraints": "additionalProperties: false."
+    }
+  ]
+}

--- a/data/opentelemetry/configurationTypes.json
+++ b/data/opentelemetry/configurationTypes.json
@@ -9,42 +9,36 @@
         {
           "name": "default",
           "type": "DefaultAggregation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configures the stream to use the instrument kind to select an aggregation and advisory parameters to influence aggregation configuration parameters. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#default-aggregation for details. If omitted, ignore."
         },
         {
           "name": "drop",
           "type": "DropAggregation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configures the stream to ignore/drop all instrument measurements. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#drop-aggregation for details. If omitted, ignore."
         },
         {
           "name": "explicit_bucket_histogram",
           "type": "ExplicitBucketHistogramAggregation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configures the stream to collect data for the histogram metric point using a set of explicit boundary values for histogram bucketing. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#explicit-bucket-histogram-aggregation for details If omitted, ignore."
         },
         {
           "name": "base2_exponential_bucket_histogram",
           "type": "Base2ExponentialBucketHistogramAggregation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configures the stream to collect data for the exponential histogram metric point, which uses a base-2 exponential formula to determine bucket boundaries and an integer scale parameter to control resolution. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#base2-exponential-bucket-histogram-aggregation for details. If omitted, ignore."
         },
         {
           "name": "last_value",
           "type": "LastValueAggregation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configures the stream to collect data using the last measurement. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#last-value-aggregation for details. If omitted, ignore."
         },
         {
           "name": "sum",
           "type": "SumAggregation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configures the stream to collect the arithmetic sum of measurement values. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#sum-aggregation for details. If omitted, ignore."
         }
@@ -76,14 +70,12 @@
         {
           "name": "attribute_value_length_limit",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: 0",
           "description": "Configure max attribute value size. Value must be non-negative. If omitted or null, there is no limit."
         },
         {
           "name": "attribute_count_limit",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: 0",
           "description": "Configure max attribute count. Value must be non-negative. If omitted or null, 128 is used."
         }
@@ -99,21 +91,18 @@
         {
           "name": "name",
           "type": "string",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "The attribute name. Property is required and must be non-null."
         },
         {
           "name": "value",
           "type": "object",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "The attribute value. The type of value must match .type. Property is required and must be non-null."
         },
         {
           "name": "type",
           "type": "AttributeType",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "The attribute type. Values include: * bool: Boolean attribute value. * bool_array: Boolean array attribute value. * double: Double attribute value. * double_array: Double array attribute value. * int: Integer attribute value. * int_array: Integer array attribute value. * string: String attribute value. * string_array: String array attribute value. If omitted, string is used."
         }
@@ -161,21 +150,18 @@
         {
           "name": "max_scale",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: -10, maximum: 20",
           "description": "Configure the max scale factor. If omitted or null, 20 is used."
         },
         {
           "name": "max_size",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: 2",
           "description": "Configure the maximum number of buckets in each of the positive and negative ranges, not counting the special zero bucket. If omitted or null, 160 is used."
         },
         {
           "name": "record_min_max",
           "type": "boolean, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure whether or not to record min and max. If omitted or null, true is used."
         }
@@ -191,35 +177,30 @@
         {
           "name": "schedule_delay",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: 0",
           "description": "Configure delay interval (in milliseconds) between two consecutive exports. Value must be non-negative. If omitted or null, 1000 is used."
         },
         {
           "name": "export_timeout",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: 0",
           "description": "Configure maximum allowed time (in milliseconds) to export data. Value must be non-negative. A value of 0 indicates no limit (infinity). If omitted or null, 30000 is used."
         },
         {
           "name": "max_queue_size",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure maximum queue size. Value must be positive. If omitted or null, 2048 is used."
         },
         {
           "name": "max_export_batch_size",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure maximum batch size. Value must be positive. If omitted or null, 512 is used."
         },
         {
           "name": "exporter",
           "type": "LogRecordExporter",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure exporter. Property is required and must be non-null."
         }
@@ -235,35 +216,30 @@
         {
           "name": "schedule_delay",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: 0",
           "description": "Configure delay interval (in milliseconds) between two consecutive exports. Value must be non-negative. If omitted or null, 5000 is used."
         },
         {
           "name": "export_timeout",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: 0",
           "description": "Configure maximum allowed time (in milliseconds) to export data. Value must be non-negative. A value of 0 indicates no limit (infinity). If omitted or null, 30000 is used."
         },
         {
           "name": "max_queue_size",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure maximum queue size. Value must be positive. If omitted or null, 2048 is used."
         },
         {
           "name": "max_export_batch_size",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure maximum batch size. Value must be positive. If omitted or null, 512 is used."
         },
         {
           "name": "exporter",
           "type": "SpanExporter",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure exporter. Property is required and must be non-null."
         }
@@ -279,56 +255,48 @@
         {
           "name": "default",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure default cardinality limit for all instrument types. Instrument-specific cardinality limits take priority. If omitted or null, 2000 is used."
         },
         {
           "name": "counter",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure default cardinality limit for counter instruments. If omitted or null, the value from .default is used."
         },
         {
           "name": "gauge",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure default cardinality limit for gauge instruments. If omitted or null, the value from .default is used."
         },
         {
           "name": "histogram",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure default cardinality limit for histogram instruments. If omitted or null, the value from .default is used."
         },
         {
           "name": "observable_counter",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure default cardinality limit for observable_counter instruments. If omitted or null, the value from .default is used."
         },
         {
           "name": "observable_gauge",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure default cardinality limit for observable_gauge instruments. If omitted or null, the value from .default is used."
         },
         {
           "name": "observable_up_down_counter",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure default cardinality limit for observable_up_down_counter instruments. If omitted or null, the value from .default is used."
         },
         {
           "name": "up_down_counter",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure default cardinality limit for up_down_counter instruments. If omitted or null, the value from .default is used."
         }
@@ -352,14 +320,12 @@
         {
           "name": "temporality_preference",
           "type": "ExporterTemporalityPreference",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure temporality preference. Values include: * cumulative: Use cumulative aggregation temporality for all instrument types. * delta: Use delta aggregation for all instrument types except up down counter and asynchronous up down counter. * low_memory: Use delta aggregation temporality for counter and histogram instrument types. Use cumulative aggregation temporality for all other instrument types. If omitted, cumulative is used."
         },
         {
           "name": "default_histogram_aggregation",
           "type": "ExporterDefaultHistogramAggregation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure default histogram aggregation. Values include: * base2_exponential_bucket_histogram: Use base2 exponential histogram as the default aggregation for histogram instruments. * explicit_bucket_histogram: Use explicit bucket histogram as the default aggregation for histogram instruments. If omitted, explicit_bucket_histogram is used."
         }
@@ -407,7 +373,6 @@
         {
           "name": "semconv",
           "type": "ExperimentalSemconvConfig",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure code semantic convention version and migration behavior. This property takes precedence over the .instrumentation/development.general.stability_opt_in_list setting. See code semantic conventions: https://opentelemetry.io/docs/specs/semconv/registry/attributes/code/ If omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set."
         }
@@ -439,7 +404,6 @@
         {
           "name": "root",
           "type": "ExperimentalComposableSampler",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Sampler to use when there is no parent. Property is required and must be non-null."
         }
@@ -455,7 +419,6 @@
         {
           "name": "ratio",
           "type": "number, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: 0, maximum: 1",
           "description": "Configure ratio. If omitted or null, 1.0 is used."
         }
@@ -471,7 +434,6 @@
         {
           "name": "rules",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "The rules for the sampler, matched in order. Each rule can have multiple match conditions. All conditions must match for the rule to match. If no conditions are specified, the rule matches all spans that reach it. If no rules match, the span is not sampled. If omitted, no span is sampled."
         }
@@ -487,35 +449,30 @@
         {
           "name": "attribute_values",
           "type": "ExperimentalComposableRuleBasedSamplerRuleAttributeValues",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Values to match against a single attribute. Non-string attributes are matched using their string representation: for example, a value of \"404\" would match the http.response.status_code 404. For array attributes, if any item matches, it is considered a match. If omitted, ignore."
         },
         {
           "name": "attribute_patterns",
           "type": "ExperimentalComposableRuleBasedSamplerRuleAttributePatterns",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Patterns to match against a single attribute. Non-string attributes are matched using their string representation: for example, a pattern of \"4*\" would match any http.response.status_code in 400-499. For array attributes, if any item matches, it is considered a match. If omitted, ignore."
         },
         {
           "name": "span_kinds",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "The span kinds to match. If the span's kind matches any of these, it matches. Values include: * client: client, a client span. * consumer: consumer, a consumer span. * internal: internal, an internal span. * producer: producer, a producer span. * server: server, a server span. If omitted, ignore."
         },
         {
           "name": "parent",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "The parent span types to match. Values include: * local: local, a local parent. * none: none, no parent, i.e., the trace root. * remote: remote, a remote parent. If omitted, ignore."
         },
         {
           "name": "sampler",
           "type": "ExperimentalComposableSampler",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "The sampler to use for matching spans. Property is required and must be non-null."
         }
@@ -531,21 +488,18 @@
         {
           "name": "key",
           "type": "string",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "The attribute key to match against. Property is required and must be non-null."
         },
         {
           "name": "included",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "Configure list of value patterns to include. Values are evaluated to match as follows: * If the value exactly matches. * If the value matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none. If omitted, all values are included."
         },
         {
           "name": "excluded",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "Configure list of value patterns to exclude. Applies after .included (i.e. excluded has higher priority than included). Values are evaluated to match as follows: * If the value exactly matches. * If the value matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none. If omitted, .included attributes are included."
         }
@@ -561,14 +515,12 @@
         {
           "name": "key",
           "type": "string",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "The attribute key to match against. Property is required and must be non-null."
         },
         {
           "name": "values",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "The attribute values to match against. If the attribute's value matches any of these, it matches. Property is required and must be non-null."
         }
@@ -584,35 +536,30 @@
         {
           "name": "always_off",
           "type": "ExperimentalComposableAlwaysOffSampler",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure sampler to be always_off. If omitted, ignore."
         },
         {
           "name": "always_on",
           "type": "ExperimentalComposableAlwaysOnSampler",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure sampler to be always_on. If omitted, ignore."
         },
         {
           "name": "parent_threshold",
           "type": "ExperimentalComposableParentThresholdSampler",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure sampler to be parent_threshold. If omitted, ignore."
         },
         {
           "name": "probability",
           "type": "ExperimentalComposableProbabilitySampler",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure sampler to be probability. If omitted, ignore."
         },
         {
           "name": "rule_based",
           "type": "ExperimentalComposableRuleBasedSampler",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure sampler to be rule_based. If omitted, ignore."
         }
@@ -636,7 +583,6 @@
         {
           "name": "semconv",
           "type": "ExperimentalSemconvConfig",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure database semantic convention version and migration behavior. This property takes precedence over the .instrumentation/development.general.stability_opt_in_list setting. See database migration: https://opentelemetry.io/docs/specs/semconv/database/ If omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set."
         }
@@ -652,7 +598,6 @@
         {
           "name": "semconv",
           "type": "ExperimentalSemconvConfig",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure GenAI semantic convention version and migration behavior. This property takes precedence over the .instrumentation/development.general.stability_opt_in_list setting. See GenAI semantic conventions: https://opentelemetry.io/docs/specs/semconv/gen-ai/ If omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set."
         }
@@ -668,56 +613,48 @@
         {
           "name": "http",
           "type": "ExperimentalHttpInstrumentation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure instrumentations following the http semantic conventions. See http semantic conventions: https://opentelemetry.io/docs/specs/semconv/http/ If omitted, defaults as described in ExperimentalHttpInstrumentation are used."
         },
         {
           "name": "code",
           "type": "ExperimentalCodeInstrumentation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure instrumentations following the code semantic conventions. See code semantic conventions: https://opentelemetry.io/docs/specs/semconv/registry/attributes/code/ If omitted, defaults as described in ExperimentalCodeInstrumentation are used."
         },
         {
           "name": "db",
           "type": "ExperimentalDbInstrumentation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure instrumentations following the database semantic conventions. See database semantic conventions: https://opentelemetry.io/docs/specs/semconv/database/ If omitted, defaults as described in ExperimentalDbInstrumentation are used."
         },
         {
           "name": "gen_ai",
           "type": "ExperimentalGenAiInstrumentation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure instrumentations following the GenAI semantic conventions. See GenAI semantic conventions: https://opentelemetry.io/docs/specs/semconv/gen-ai/ If omitted, defaults as described in ExperimentalGenAiInstrumentation are used."
         },
         {
           "name": "messaging",
           "type": "ExperimentalMessagingInstrumentation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure instrumentations following the messaging semantic conventions. See messaging semantic conventions: https://opentelemetry.io/docs/specs/semconv/messaging/ If omitted, defaults as described in ExperimentalMessagingInstrumentation are used."
         },
         {
           "name": "rpc",
           "type": "ExperimentalRpcInstrumentation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure instrumentations following the RPC semantic conventions. See RPC semantic conventions: https://opentelemetry.io/docs/specs/semconv/rpc/ If omitted, defaults as described in ExperimentalRpcInstrumentation are used."
         },
         {
           "name": "sanitization",
           "type": "ExperimentalSanitization",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure general sanitization options. If omitted, defaults as described in ExperimentalSanitization are used."
         },
         {
           "name": "stability_opt_in_list",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure semantic convention stability opt-in as a comma-separated list. This property follows the format and semantics of the OTEL_SEMCONV_STABILITY_OPT_IN environment variable. Controls the emission of stable vs. experimental semantic conventions for instrumentation. This setting is only intended for migrating from experimental to stable semantic conventions. Known values include: - http: Emit stable HTTP and networking conventions only - http/dup: Emit both old and stable HTTP and networking conventions (for phased migration) - database: Emit stable database conventions only - database/dup: Emit both old and stable database conventions (for phased migration) - rpc: Emit stable RPC conventions only - rpc/dup: Emit both experimental and stable RPC conventions (for phased migration) - messaging: Emit stable messaging conventions only - messaging/dup: Emit both old and stable messaging conventions (for phased migration) - code: Emit stable code conventions only - code/dup: Emit both old and stable code conventions (for phased migration) Multiple values can be specified as a comma-separated list (e.g., \"http,database/dup\"). Additional signal types may be supported in future versions. Domain-specific semconv properties (e.g., .instrumentation/development.general.db.semconv) take precedence over this general setting. See: - HTTP migration: https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/ - Database migration: https://opentelemetry.io/docs/specs/semconv/database/ - RPC: https://opentelemetry.io/docs/specs/semconv/rpc/ - Messaging: https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/ If omitted or null, no opt-in is configured and instrumentations continue emitting their default semantic convention version."
         }
@@ -741,21 +678,18 @@
         {
           "name": "request_captured_headers",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "Configure headers to capture for outbound http requests. If omitted, no outbound request headers are captured."
         },
         {
           "name": "response_captured_headers",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "Configure headers to capture for inbound http responses. If omitted, no inbound response headers are captured."
         },
         {
           "name": "known_methods",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 0",
           "description": "Override the default list of known HTTP methods. Known methods are case-sensitive. This is a full override of the default known methods, not a list of known methods in addition to the defaults. If omitted, HTTP methods GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH are known."
         }
@@ -771,21 +705,18 @@
         {
           "name": "semconv",
           "type": "ExperimentalSemconvConfig",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure HTTP semantic convention version and migration behavior. This property takes precedence over the .instrumentation/development.general.stability_opt_in_list setting. See HTTP migration: https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/ If omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set."
         },
         {
           "name": "client",
           "type": "ExperimentalHttpClientInstrumentation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure instrumentations following the http client semantic conventions. If omitted, defaults as described in ExperimentalHttpClientInstrumentation are used."
         },
         {
           "name": "server",
           "type": "ExperimentalHttpServerInstrumentation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure instrumentations following the http server semantic conventions. If omitted, defaults as described in ExperimentalHttpServerInstrumentation are used."
         }
@@ -801,21 +732,18 @@
         {
           "name": "request_captured_headers",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "Configure headers to capture for inbound http requests. If omitted, no request headers are captured."
         },
         {
           "name": "response_captured_headers",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "Configure headers to capture for outbound http responses. If omitted, no response headers are captures."
         },
         {
           "name": "known_methods",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 0",
           "description": "Override the default list of known HTTP methods. Known methods are case-sensitive. This is a full override of the default known methods, not a list of known methods in addition to the defaults. If omitted, HTTP methods GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH are known."
         }
@@ -831,84 +759,72 @@
         {
           "name": "general",
           "type": "ExperimentalGeneralInstrumentation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure general SemConv options that may apply to multiple languages and instrumentations. Instrumenation may merge general config options with the language specific configuration at .instrumentation.<language>. If omitted, default values as described in ExperimentalGeneralInstrumentation are used."
         },
         {
           "name": "cpp",
           "type": "ExperimentalLanguageSpecificInstrumentation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure C++ language-specific instrumentation libraries. If omitted, instrumentation defaults are used."
         },
         {
           "name": "dotnet",
           "type": "ExperimentalLanguageSpecificInstrumentation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure .NET language-specific instrumentation libraries. Each entry's key identifies a particular instrumentation library. The corresponding value configures it. If omitted, instrumentation defaults are used."
         },
         {
           "name": "erlang",
           "type": "ExperimentalLanguageSpecificInstrumentation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure Erlang language-specific instrumentation libraries. Each entry's key identifies a particular instrumentation library. The corresponding value configures it. If omitted, instrumentation defaults are used."
         },
         {
           "name": "go",
           "type": "ExperimentalLanguageSpecificInstrumentation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure Go language-specific instrumentation libraries. Each entry's key identifies a particular instrumentation library. The corresponding value configures it. If omitted, instrumentation defaults are used."
         },
         {
           "name": "java",
           "type": "ExperimentalLanguageSpecificInstrumentation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure Java language-specific instrumentation libraries. Each entry's key identifies a particular instrumentation library. The corresponding value configures it. If omitted, instrumentation defaults are used."
         },
         {
           "name": "js",
           "type": "ExperimentalLanguageSpecificInstrumentation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure JavaScript language-specific instrumentation libraries. Each entry's key identifies a particular instrumentation library. The corresponding value configures it. If omitted, instrumentation defaults are used."
         },
         {
           "name": "php",
           "type": "ExperimentalLanguageSpecificInstrumentation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure PHP language-specific instrumentation libraries. Each entry's key identifies a particular instrumentation library. The corresponding value configures it. If omitted, instrumentation defaults are used."
         },
         {
           "name": "python",
           "type": "ExperimentalLanguageSpecificInstrumentation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure Python language-specific instrumentation libraries. Each entry's key identifies a particular instrumentation library. The corresponding value configures it. If omitted, instrumentation defaults are used."
         },
         {
           "name": "ruby",
           "type": "ExperimentalLanguageSpecificInstrumentation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure Ruby language-specific instrumentation libraries. Each entry's key identifies a particular instrumentation library. The corresponding value configures it. If omitted, instrumentation defaults are used."
         },
         {
           "name": "rust",
           "type": "ExperimentalLanguageSpecificInstrumentation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure Rust language-specific instrumentation libraries. Each entry's key identifies a particular instrumentation library. The corresponding value configures it. If omitted, instrumentation defaults are used."
         },
         {
           "name": "swift",
           "type": "ExperimentalLanguageSpecificInstrumentation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure Swift language-specific instrumentation libraries. Each entry's key identifies a particular instrumentation library. The corresponding value configures it. If omitted, instrumentation defaults are used."
         }
@@ -924,21 +840,18 @@
         {
           "name": "endpoint",
           "type": "string",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure the endpoint of the jaeger remote sampling service. Property is required and must be non-null."
         },
         {
           "name": "interval",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: 0",
           "description": "Configure the polling interval (in milliseconds) to fetch from the remote sampling service. If omitted or null, 60000 is used."
         },
         {
           "name": "initial_sampler",
           "type": "Sampler",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure the initial sampler used before first configuration is fetched. Property is required and must be non-null."
         }
@@ -962,21 +875,18 @@
         {
           "name": "enabled",
           "type": "boolean, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure if the logger is enabled or not. If omitted or null, true is used."
         },
         {
           "name": "minimum_severity",
           "type": "SeverityNumber",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure severity filtering. Log records with an non-zero (i.e. unspecified) severity number which is less than minimum_severity are not processed. Values include: * debug: debug, severity number 5. * debug2: debug2, severity number 6. * debug3: debug3, severity number 7. * debug4: debug4, severity number 8. * error: error, severity number 17. * error2: error2, severity number 18. * error3: error3, severity number 19. * error4: error4, severity number 20. * fatal: fatal, severity number 21. * fatal2: fatal2, severity number 22. * fatal3: fatal3, severity number 23. * fatal4: fatal4, severity number 24. * info: info, severity number 9. * info2: info2, severity number 10. * info3: info3, severity number 11. * info4: info4, severity number 12. * trace: trace, severity number 1. * trace2: trace2, severity number 2. * trace3: trace3, severity number 3. * trace4: trace4, severity number 4. * warn: warn, severity number 13. * warn2: warn2, severity number 14. * warn3: warn3, severity number 15. * warn4: warn4, severity number 16. If omitted, severity filtering is not applied."
         },
         {
           "name": "trace_based",
           "type": "boolean, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure trace based filtering. If true, log records associated with unsampled trace contexts traces are not processed. If false, or if a log record is not associated with a trace context, trace based filtering is not applied. If omitted or null, trace based filtering is not applied."
         }
@@ -992,14 +902,12 @@
         {
           "name": "default_config",
           "type": "ExperimentalLoggerConfig",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure the default logger config used there is no matching entry in .logger_configurator/development.loggers. If omitted, unmatched .loggers use default values as described in ExperimentalLoggerConfig."
         },
         {
           "name": "loggers",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "Configure loggers. If omitted, all loggers use .default_config."
         }
@@ -1015,14 +923,12 @@
         {
           "name": "name",
           "type": "string",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure logger names to match, evaluated as follows: * If the logger name exactly matches. * If the logger name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none. Property is required and must be non-null."
         },
         {
           "name": "config",
           "type": "ExperimentalLoggerConfig",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "The logger config. Property is required and must be non-null."
         }
@@ -1038,7 +944,6 @@
         {
           "name": "semconv",
           "type": "ExperimentalSemconvConfig",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure messaging semantic convention version and migration behavior. This property takes precedence over the .instrumentation/development.general.stability_opt_in_list setting. See messaging semantic conventions: https://opentelemetry.io/docs/specs/semconv/messaging/ If omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set."
         }
@@ -1054,7 +959,6 @@
         {
           "name": "enabled",
           "type": "boolean",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure if the meter is enabled or not. If omitted, true is used."
         }
@@ -1070,14 +974,12 @@
         {
           "name": "default_config",
           "type": "ExperimentalMeterConfig",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure the default meter config used there is no matching entry in .meter_configurator/development.meters. If omitted, unmatched .meters use default values as described in ExperimentalMeterConfig."
         },
         {
           "name": "meters",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "Configure meters. If omitted, all meters used .default_config."
         }
@@ -1093,14 +995,12 @@
         {
           "name": "name",
           "type": "string",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure meter names to match, evaluated as follows: * If the meter name exactly matches. * If the meter name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none. Property is required and must be non-null."
         },
         {
           "name": "config",
           "type": "ExperimentalMeterConfig",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "The meter config. Property is required and must be non-null."
         }
@@ -1116,7 +1016,6 @@
         {
           "name": "output_stream",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure output stream. Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl. If omitted or null, stdout is used."
         }
@@ -1132,21 +1031,18 @@
         {
           "name": "output_stream",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure output stream. Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl. If omitted or null, stdout is used."
         },
         {
           "name": "temporality_preference",
           "type": "ExporterTemporalityPreference",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure temporality preference. Values include: * cumulative: Use cumulative aggregation temporality for all instrument types. * delta: Use delta aggregation for all instrument types except up down counter and asynchronous up down counter. * low_memory: Use delta aggregation temporality for counter and histogram instrument types. Use cumulative aggregation temporality for all other instrument types. If omitted, cumulative is used."
         },
         {
           "name": "default_histogram_aggregation",
           "type": "ExporterDefaultHistogramAggregation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure default histogram aggregation. Values include: * base2_exponential_bucket_histogram: Use base2 exponential histogram as the default aggregation for histogram instruments. * explicit_bucket_histogram: Use explicit bucket histogram as the default aggregation for histogram instruments. If omitted, explicit_bucket_histogram is used."
         }
@@ -1162,7 +1058,6 @@
         {
           "name": "ratio",
           "type": "number, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: 0, maximum: 1",
           "description": "Configure ratio. If omitted or null, 1.0 is used."
         }
@@ -1186,42 +1081,36 @@
         {
           "name": "host",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure host. If omitted or null, localhost is used."
         },
         {
           "name": "port",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure port. If omitted or null, 9464 is used."
         },
         {
           "name": "without_scope_info",
           "type": "boolean, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure Prometheus Exporter to produce metrics without scope labels. If omitted or null, false is used."
         },
         {
           "name": "without_target_info/development",
           "type": "boolean, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure Prometheus Exporter to produce metrics without a target info metric for the resource. If omitted or null, false is used."
         },
         {
           "name": "with_resource_constant_labels",
           "type": "IncludeExclude",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure Prometheus Exporter to add resource attributes as metrics attributes, where the resource attribute keys match the patterns. If omitted, no resource attributes are added."
         },
         {
           "name": "translation_strategy",
           "type": "ExperimentalPrometheusTranslationStrategy",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure how metric names are translated to Prometheus metric names. Values include: * no_translation/development: Special character escaping is disabled. Type and unit suffixes are disabled. Metric names are unaltered. * no_utf8_escaping_with_suffixes/development: Special character escaping is disabled. Type and unit suffixes are enabled. * underscore_escaping_with_suffixes: Special character escaping is enabled. Type and unit suffixes are enabled. * underscore_escaping_without_suffixes/development: Special character escaping is enabled. Type and unit suffixes are disabled. This represents classic Prometheus metric name compatibility. If omitted, underscore_escaping_with_suffixes is used."
         }
@@ -1245,14 +1134,12 @@
         {
           "name": "attributes",
           "type": "IncludeExclude",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure attributes provided by resource detectors. If omitted, all attributes from resource detectors are added."
         },
         {
           "name": "detectors",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "Configure resource detectors. Resource detector names are dependent on the SDK language ecosystem. Please consult documentation for each respective language. If omitted, no resource detectors are enabled."
         }
@@ -1268,28 +1155,24 @@
         {
           "name": "container",
           "type": "ExperimentalContainerResourceDetector",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Enable the container resource detector, which populates container.* attributes. If omitted, ignore."
         },
         {
           "name": "host",
           "type": "ExperimentalHostResourceDetector",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Enable the host resource detector, which populates host.* and os.* attributes. If omitted, ignore."
         },
         {
           "name": "process",
           "type": "ExperimentalProcessResourceDetector",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Enable the process resource detector, which populates process.* attributes. If omitted, ignore."
         },
         {
           "name": "service",
           "type": "ExperimentalServiceResourceDetector",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Enable the service detector, which populates service.name based on the OTEL_SERVICE_NAME environment variable and service.instance.id. If omitted, ignore."
         }
@@ -1305,7 +1188,6 @@
         {
           "name": "semconv",
           "type": "ExperimentalSemconvConfig",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure RPC semantic convention version and migration behavior. This property takes precedence over the .instrumentation/development.general.stability_opt_in_list setting. See RPC semantic conventions: https://opentelemetry.io/docs/specs/semconv/rpc/ If omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set."
         }
@@ -1321,7 +1203,6 @@
         {
           "name": "url",
           "type": "ExperimentalUrlSanitization",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure URL sanitization options. If omitted, defaults as described in ExperimentalUrlSanitization are used."
         }
@@ -1337,21 +1218,18 @@
         {
           "name": "version",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: 0",
           "description": "The target semantic convention version for this domain (e.g., 1). If omitted or null, the latest stable version is used, or if no stable version is available and .experimental is true then the latest experimental version is used."
         },
         {
           "name": "experimental",
           "type": "boolean, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Use latest experimental semantic conventions (before stable is available or to enable experimental features on top of stable conventions). If omitted or null, false is used."
         },
         {
           "name": "dual_emit",
           "type": "boolean, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "When true, also emit the previous major version alongside the target version. For version=1, the previous version refers to the pre-stable conventions that the instrumentation emitted before the first stable semantic convention version was defined. For version=2 and above, the previous version is the prior stable major version (e.g., version=2, dual_emit=true emits both v2 and v1). Enables dual-emit for phased migration between versions. If omitted or null, false is used."
         }
@@ -1383,7 +1261,6 @@
         {
           "name": "enabled",
           "type": "boolean",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure if the tracer is enabled or not. If omitted, true is used."
         }
@@ -1399,14 +1276,12 @@
         {
           "name": "default_config",
           "type": "ExperimentalTracerConfig",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure the default tracer config used there is no matching entry in .tracer_configurator/development.tracers. If omitted, unmatched .tracers use default values as described in ExperimentalTracerConfig."
         },
         {
           "name": "tracers",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "Configure tracers. If omitted, all tracers use .default_config."
         }
@@ -1422,14 +1297,12 @@
         {
           "name": "name",
           "type": "string",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure tracer names to match, evaluated as follows: * If the tracer name exactly matches. * If the tracer name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none. Property is required and must be non-null."
         },
         {
           "name": "config",
           "type": "ExperimentalTracerConfig",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "The tracer config. Property is required and must be non-null."
         }
@@ -1445,7 +1318,6 @@
         {
           "name": "sensitive_query_parameters",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 0",
           "description": "List of query parameter names whose values should be redacted from URLs. Query parameter names are case-sensitive. This is a full override of the default sensitive query parameter keys, it is not a list of keys in addition to the defaults. Set to an empty array to disable query parameter redaction. If omitted, the default sensitive query parameter list as defined by the url semantic conventions (https://github.com/open-telemetry/semantic-conventions/blob/main/docs/registry/attributes/url.md) is used."
         }
@@ -1461,14 +1333,12 @@
         {
           "name": "boundaries",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 0",
           "description": "Configure bucket boundaries. If omitted, [0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000] is used."
         },
         {
           "name": "record_min_max",
           "type": "boolean, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure record min and max. If omitted or null, true is used."
         }
@@ -1500,28 +1370,24 @@
         {
           "name": "ca_file",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure certificate used to verify a server's TLS credentials. Absolute path to certificate file in PEM format. If omitted or null, system default certificate verification is used for secure connections."
         },
         {
           "name": "key_file",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure mTLS private client key. Absolute path to client key file in PEM format. If set, .client_certificate must also be set. If omitted or null, mTLS is not used."
         },
         {
           "name": "cert_file",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure mTLS client certificate. Absolute path to client certificate file in PEM format. If set, .client_key must also be set. If omitted or null, mTLS is not used."
         },
         {
           "name": "insecure",
           "type": "boolean, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure client transport security for the exporter's connection. Only applicable when .endpoint is provided without http or https scheme. Implementations may choose to ignore .insecure. If omitted or null, false is used."
         }
@@ -1537,21 +1403,18 @@
         {
           "name": "ca_file",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure certificate used to verify a server's TLS credentials. Absolute path to certificate file in PEM format. If omitted or null, system default certificate verification is used for secure connections."
         },
         {
           "name": "key_file",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure mTLS private client key. Absolute path to client key file in PEM format. If set, .client_certificate must also be set. If omitted or null, mTLS is not used."
         },
         {
           "name": "cert_file",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure mTLS client certificate. Absolute path to client certificate file in PEM format. If set, .client_key must also be set. If omitted or null, mTLS is not used."
         }
@@ -1567,14 +1430,12 @@
         {
           "name": "included",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "Configure list of value patterns to include. Values are evaluated to match as follows: * If the value exactly matches. * If the value matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none. If omitted, all values are included."
         },
         {
           "name": "excluded",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "Configure list of value patterns to exclude. Applies after .included (i.e. excluded has higher priority than included). Values are evaluated to match as follows: * If the value exactly matches. * If the value matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none. If omitted, .included attributes are included."
         }
@@ -1606,21 +1467,18 @@
         {
           "name": "processors",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "Configure log record processors. Property is required and must be non-null."
         },
         {
           "name": "limits",
           "type": "LogRecordLimits",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure log record limits. See also attribute_limits. If omitted, default values as described in LogRecordLimits are used."
         },
         {
           "name": "logger_configurator/development",
           "type": "ExperimentalLoggerConfigurator",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure loggers. If omitted, all loggers use default values as described in ExperimentalLoggerConfig."
         }
@@ -1636,28 +1494,24 @@
         {
           "name": "otlp_http",
           "type": "OtlpHttpExporter",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure exporter to be OTLP with HTTP transport. If omitted, ignore."
         },
         {
           "name": "otlp_grpc",
           "type": "OtlpGrpcExporter",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure exporter to be OTLP with gRPC transport. If omitted, ignore."
         },
         {
           "name": "otlp_file/development",
           "type": "ExperimentalOtlpFileExporter",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure exporter to be OTLP with file transport. If omitted, ignore."
         },
         {
           "name": "console",
           "type": "ConsoleExporter",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure exporter to be console. If omitted, ignore."
         }
@@ -1673,14 +1527,12 @@
         {
           "name": "attribute_value_length_limit",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: 0",
           "description": "Configure max attribute value size. Overrides .attribute_limits.attribute_value_length_limit. Value must be non-negative. If omitted or null, there is no limit."
         },
         {
           "name": "attribute_count_limit",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: 0",
           "description": "Configure max attribute count. Overrides .attribute_limits.attribute_count_limit. Value must be non-negative. If omitted or null, 128 is used."
         }
@@ -1696,14 +1548,12 @@
         {
           "name": "batch",
           "type": "BatchLogRecordProcessor",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure a batch log record processor. If omitted, ignore."
         },
         {
           "name": "simple",
           "type": "SimpleLogRecordProcessor",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure a simple log record processor. If omitted, ignore."
         }
@@ -1719,28 +1569,24 @@
         {
           "name": "readers",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "Configure metric readers. Property is required and must be non-null."
         },
         {
           "name": "views",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "Configure views. Each view has a selector which determines the instrument(s) it applies to, and a configuration for the resulting stream(s). If omitted, no views are registered."
         },
         {
           "name": "exemplar_filter",
           "type": "ExemplarFilter",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure the exemplar filter. Values include: * always_off: ExemplarFilter which makes no measurements eligible for being an Exemplar. * always_on: ExemplarFilter which makes all measurements eligible for being an Exemplar. * trace_based: ExemplarFilter which makes measurements recorded in the context of a sampled parent span eligible for being an Exemplar. If omitted, trace_based is used."
         },
         {
           "name": "meter_configurator/development",
           "type": "ExperimentalMeterConfigurator",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure meters. If omitted, all meters use default values as described in ExperimentalMeterConfig."
         }
@@ -1756,7 +1602,6 @@
         {
           "name": "opencensus",
           "type": "OpenCensusMetricProducer",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure metric producer to be opencensus. If omitted, ignore."
         }
@@ -1772,14 +1617,12 @@
         {
           "name": "periodic",
           "type": "PeriodicMetricReader",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure a periodic metric reader. If omitted, ignore."
         },
         {
           "name": "pull",
           "type": "PullMetricReader",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure a pull based metric reader. If omitted, ignore."
         }
@@ -1795,14 +1638,12 @@
         {
           "name": "name",
           "type": "string",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "The name of the pair. Property is required and must be non-null."
         },
         {
           "name": "value",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "The value of the pair. Property must be present, but if null the behavior is dependent on usage context."
         }
@@ -1826,42 +1667,36 @@
         {
           "name": "endpoint",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure endpoint. If omitted or null, http://localhost:4317 is used."
         },
         {
           "name": "tls",
           "type": "GrpcTls",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure TLS settings for the exporter. If omitted, system default TLS settings are used."
         },
         {
           "name": "headers",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "Configure headers. Entries have higher priority than entries from .headers_list. If an entry's .value is null, the entry is ignored. If omitted, no headers are added."
         },
         {
           "name": "headers_list",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure headers. Entries have lower priority than entries from .headers. The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details. If omitted or null, no headers are added."
         },
         {
           "name": "compression",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure compression. Known values include: gzip, none. Implementations may support other compression algorithms. If omitted or null, none is used."
         },
         {
           "name": "timeout",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: 0",
           "description": "Configure max time (in milliseconds) to wait for each export. Value must be non-negative. A value of 0 indicates no limit (infinity). If omitted or null, 10000 is used."
         }
@@ -1877,56 +1712,48 @@
         {
           "name": "endpoint",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure endpoint. If omitted or null, http://localhost:4317 is used."
         },
         {
           "name": "tls",
           "type": "GrpcTls",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure TLS settings for the exporter. If omitted, system default TLS settings are used."
         },
         {
           "name": "headers",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "Configure headers. Entries have higher priority than entries from .headers_list. If an entry's .value is null, the entry is ignored. If omitted, no headers are added."
         },
         {
           "name": "headers_list",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure headers. Entries have lower priority than entries from .headers. The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details. If omitted or null, no headers are added."
         },
         {
           "name": "compression",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure compression. Known values include: gzip, none. Implementations may support other compression algorithms. If omitted or null, none is used."
         },
         {
           "name": "timeout",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: 0",
           "description": "Configure max time (in milliseconds) to wait for each export. Value must be non-negative. A value of 0 indicates no limit (infinity). If omitted or null, 10000 is used."
         },
         {
           "name": "temporality_preference",
           "type": "ExporterTemporalityPreference",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure temporality preference. Values include: * cumulative: Use cumulative aggregation temporality for all instrument types. * delta: Use delta aggregation for all instrument types except up down counter and asynchronous up down counter. * low_memory: Use delta aggregation temporality for counter and histogram instrument types. Use cumulative aggregation temporality for all other instrument types. If omitted, cumulative is used."
         },
         {
           "name": "default_histogram_aggregation",
           "type": "ExporterDefaultHistogramAggregation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure default histogram aggregation. Values include: * base2_exponential_bucket_histogram: Use base2 exponential histogram as the default aggregation for histogram instruments. * explicit_bucket_histogram: Use explicit bucket histogram as the default aggregation for histogram instruments. If omitted, explicit_bucket_histogram is used."
         }
@@ -1950,49 +1777,42 @@
         {
           "name": "endpoint",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure endpoint, including the signal specific path. If omitted or null, the http://localhost:4318/v1/{signal} (where signal is 'traces', 'logs', or 'metrics') is used."
         },
         {
           "name": "tls",
           "type": "HttpTls",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure TLS settings for the exporter. If omitted, system default TLS settings are used."
         },
         {
           "name": "headers",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "Configure headers. Entries have higher priority than entries from .headers_list. If an entry's .value is null, the entry is ignored. If omitted, no headers are added."
         },
         {
           "name": "headers_list",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure headers. Entries have lower priority than entries from .headers. The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details. If omitted or null, no headers are added."
         },
         {
           "name": "compression",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure compression. Known values include: gzip, none. Implementations may support other compression algorithms. If omitted or null, none is used."
         },
         {
           "name": "timeout",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: 0",
           "description": "Configure max time (in milliseconds) to wait for each export. Value must be non-negative. A value of 0 indicates no limit (infinity). If omitted or null, 10000 is used."
         },
         {
           "name": "encoding",
           "type": "OtlpHttpEncoding",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure the encoding used for messages. Implementations may not support json. Values include: * json: Protobuf JSON encoding. * protobuf: Protobuf binary encoding. If omitted, protobuf is used."
         }
@@ -2008,63 +1828,54 @@
         {
           "name": "endpoint",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure endpoint. If omitted or null, http://localhost:4318/v1/metrics is used."
         },
         {
           "name": "tls",
           "type": "HttpTls",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure TLS settings for the exporter. If omitted, system default TLS settings are used."
         },
         {
           "name": "headers",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "Configure headers. Entries have higher priority than entries from .headers_list. If an entry's .value is null, the entry is ignored. If omitted, no headers are added."
         },
         {
           "name": "headers_list",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure headers. Entries have lower priority than entries from .headers. The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details. If omitted or null, no headers are added."
         },
         {
           "name": "compression",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure compression. Known values include: gzip, none. Implementations may support other compression algorithms. If omitted or null, none is used."
         },
         {
           "name": "timeout",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: 0",
           "description": "Configure max time (in milliseconds) to wait for each export. Value must be non-negative. A value of 0 indicates no limit (infinity). If omitted or null, 10000 is used."
         },
         {
           "name": "encoding",
           "type": "OtlpHttpEncoding",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure the encoding used for messages. Implementations may not support json. Values include: * json: Protobuf JSON encoding. * protobuf: Protobuf binary encoding. If omitted, protobuf is used."
         },
         {
           "name": "temporality_preference",
           "type": "ExporterTemporalityPreference",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure temporality preference. Values include: * cumulative: Use cumulative aggregation temporality for all instrument types. * delta: Use delta aggregation for all instrument types except up down counter and asynchronous up down counter. * low_memory: Use delta aggregation temporality for counter and histogram instrument types. Use cumulative aggregation temporality for all other instrument types. If omitted, cumulative is used."
         },
         {
           "name": "default_histogram_aggregation",
           "type": "ExporterDefaultHistogramAggregation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure default histogram aggregation. Values include: * base2_exponential_bucket_histogram: Use base2 exponential histogram as the default aggregation for histogram instruments. * explicit_bucket_histogram: Use explicit bucket histogram as the default aggregation for histogram instruments. If omitted, explicit_bucket_histogram is used."
         }
@@ -2080,35 +1891,30 @@
         {
           "name": "root",
           "type": "Sampler",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure root sampler. If omitted, always_on is used."
         },
         {
           "name": "remote_parent_sampled",
           "type": "Sampler",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure remote_parent_sampled sampler. If omitted, always_on is used."
         },
         {
           "name": "remote_parent_not_sampled",
           "type": "Sampler",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure remote_parent_not_sampled sampler. If omitted, always_off is used."
         },
         {
           "name": "local_parent_sampled",
           "type": "Sampler",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure local_parent_sampled sampler. If omitted, always_on is used."
         },
         {
           "name": "local_parent_not_sampled",
           "type": "Sampler",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure local_parent_not_sampled sampler. If omitted, always_off is used."
         }
@@ -2124,35 +1930,30 @@
         {
           "name": "interval",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: 0",
           "description": "Configure delay interval (in milliseconds) between start of two consecutive exports. Value must be non-negative. If omitted or null, 60000 is used."
         },
         {
           "name": "timeout",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: 0",
           "description": "Configure maximum allowed time (in milliseconds) to export data. Value must be non-negative. A value of 0 indicates no limit (infinity). If omitted or null, 30000 is used."
         },
         {
           "name": "exporter",
           "type": "PushMetricExporter",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure exporter. Property is required and must be non-null."
         },
         {
           "name": "producers",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "Configure metric producers. If omitted, no metric producers are added."
         },
         {
           "name": "cardinality_limits",
           "type": "CardinalityLimits",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure cardinality limits. If omitted, default values as described in CardinalityLimits are used."
         }
@@ -2168,14 +1969,12 @@
         {
           "name": "composite",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "Configure the propagators in the composite text map propagator. Entries from .composite_list are appended to the list here with duplicates filtered out. Built-in propagator keys include: tracecontext, baggage, b3, b3multi. Known third party keys include: xray. If omitted, and .composite_list is omitted or null, a noop propagator is used."
         },
         {
           "name": "composite_list",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure the propagators in the composite text map propagator. Entries are appended to .composite with duplicates filtered out. The value is a comma separated list of propagator identifiers matching the format of OTEL_PROPAGATORS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration for details. Built-in propagator identifiers include: tracecontext, baggage, b3, b3multi. Known third party identifiers include: xray. If omitted or null, and .composite is omitted or null, a noop propagator is used."
         }
@@ -2191,7 +1990,6 @@
         {
           "name": "prometheus/development",
           "type": "ExperimentalPrometheusMetricExporter",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure exporter to be prometheus. If omitted, ignore."
         }
@@ -2207,21 +2005,18 @@
         {
           "name": "exporter",
           "type": "PullMetricExporter",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure exporter. Property is required and must be non-null."
         },
         {
           "name": "producers",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "Configure metric producers. If omitted, no metric producers are added."
         },
         {
           "name": "cardinality_limits",
           "type": "CardinalityLimits",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure cardinality limits. If omitted, default values as described in CardinalityLimits are used."
         }
@@ -2237,28 +2032,24 @@
         {
           "name": "otlp_http",
           "type": "OtlpHttpMetricExporter",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure exporter to be OTLP with HTTP transport. If omitted, ignore."
         },
         {
           "name": "otlp_grpc",
           "type": "OtlpGrpcMetricExporter",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure exporter to be OTLP with gRPC transport. If omitted, ignore."
         },
         {
           "name": "otlp_file/development",
           "type": "ExperimentalOtlpFileMetricExporter",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure exporter to be OTLP with file transport. If omitted, ignore."
         },
         {
           "name": "console",
           "type": "ConsoleMetricExporter",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure exporter to be console. If omitted, ignore."
         }
@@ -2274,28 +2065,24 @@
         {
           "name": "attributes",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "Configure resource attributes. Entries have higher priority than entries from .resource.attributes_list. If omitted, no resource attributes are added."
         },
         {
           "name": "detection/development",
           "type": "ExperimentalResourceDetection",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure resource detection. If omitted, resource detection is disabled."
         },
         {
           "name": "schema_url",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure resource schema URL. If omitted or null, no schema URL is used."
         },
         {
           "name": "attributes_list",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure resource attributes. Entries have lower priority than entries from .resource.attributes. The value is a list of comma separated key-value pairs matching the format of OTEL_RESOURCE_ATTRIBUTES. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration for details. If omitted or null, no resource attributes are added."
         }
@@ -2311,49 +2098,42 @@
         {
           "name": "always_off",
           "type": "AlwaysOffSampler",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure sampler to be always_off. If omitted, ignore."
         },
         {
           "name": "always_on",
           "type": "AlwaysOnSampler",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure sampler to be always_on. If omitted, ignore."
         },
         {
           "name": "composite/development",
           "type": "ExperimentalComposableSampler",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure sampler to be composite. If omitted, ignore."
         },
         {
           "name": "jaeger_remote/development",
           "type": "ExperimentalJaegerRemoteSampler",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure sampler to be jaeger_remote. If omitted, ignore."
         },
         {
           "name": "parent_based",
           "type": "ParentBasedSampler",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure sampler to be parent_based. If omitted, ignore."
         },
         {
           "name": "probability/development",
           "type": "ExperimentalProbabilitySampler",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure sampler to be probability. If omitted, ignore."
         },
         {
           "name": "trace_id_ratio_based",
           "type": "TraceIdRatioBasedSampler",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure sampler to be trace_id_ratio_based. If omitted, ignore."
         }
@@ -2377,7 +2157,6 @@
         {
           "name": "exporter",
           "type": "LogRecordExporter",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure exporter. Property is required and must be non-null."
         }
@@ -2393,7 +2172,6 @@
         {
           "name": "exporter",
           "type": "SpanExporter",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure exporter. Property is required and must be non-null."
         }
@@ -2409,28 +2187,24 @@
         {
           "name": "otlp_http",
           "type": "OtlpHttpExporter",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure exporter to be OTLP with HTTP transport. If omitted, ignore."
         },
         {
           "name": "otlp_grpc",
           "type": "OtlpGrpcExporter",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure exporter to be OTLP with gRPC transport. If omitted, ignore."
         },
         {
           "name": "otlp_file/development",
           "type": "ExperimentalOtlpFileExporter",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure exporter to be OTLP with file transport. If omitted, ignore."
         },
         {
           "name": "console",
           "type": "ConsoleExporter",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure exporter to be console. If omitted, ignore."
         }
@@ -2454,42 +2228,36 @@
         {
           "name": "attribute_value_length_limit",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: 0",
           "description": "Configure max attribute value size. Overrides .attribute_limits.attribute_value_length_limit. Value must be non-negative. If omitted or null, there is no limit."
         },
         {
           "name": "attribute_count_limit",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: 0",
           "description": "Configure max attribute count. Overrides .attribute_limits.attribute_count_limit. Value must be non-negative. If omitted or null, 128 is used."
         },
         {
           "name": "event_count_limit",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: 0",
           "description": "Configure max span event count. Value must be non-negative. If omitted or null, 128 is used."
         },
         {
           "name": "link_count_limit",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: 0",
           "description": "Configure max span link count. Value must be non-negative. If omitted or null, 128 is used."
         },
         {
           "name": "event_attribute_count_limit",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: 0",
           "description": "Configure max attributes per span event. Value must be non-negative. If omitted or null, 128 is used."
         },
         {
           "name": "link_attribute_count_limit",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: 0",
           "description": "Configure max attributes per span link. Value must be non-negative. If omitted or null, 128 is used."
         }
@@ -2505,14 +2273,12 @@
         {
           "name": "batch",
           "type": "BatchSpanProcessor",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure a batch span processor. If omitted, ignore."
         },
         {
           "name": "simple",
           "type": "SimpleSpanProcessor",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure a simple span processor. If omitted, ignore."
         }
@@ -2536,28 +2302,24 @@
         {
           "name": "tracecontext",
           "type": "TraceContextPropagator",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Include the w3c trace context propagator. If omitted, ignore."
         },
         {
           "name": "baggage",
           "type": "BaggagePropagator",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Include the w3c baggage propagator. If omitted, ignore."
         },
         {
           "name": "b3",
           "type": "B3Propagator",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Include the zipkin b3 propagator. If omitted, ignore."
         },
         {
           "name": "b3multi",
           "type": "B3MultiPropagator",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Include the zipkin b3 multi propagator. If omitted, ignore."
         }
@@ -2581,7 +2343,6 @@
         {
           "name": "ratio",
           "type": "number, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "minimum: 0, maximum: 1",
           "description": "Configure trace_id_ratio. If omitted or null, 1.0 is used."
         }
@@ -2597,28 +2358,24 @@
         {
           "name": "processors",
           "type": "array",
-          "default": "If omitted, default behavior applies.",
           "constraints": "minItems: 1",
           "description": "Configure span processors. Property is required and must be non-null."
         },
         {
           "name": "limits",
           "type": "SpanLimits",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure span limits. See also attribute_limits. If omitted, default values as described in SpanLimits are used."
         },
         {
           "name": "sampler",
           "type": "Sampler",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure the sampler. If omitted, parent based sampler with a root of always_on is used."
         },
         {
           "name": "tracer_configurator/development",
           "type": "ExperimentalTracerConfigurator",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure tracers. If omitted, all tracers use default values as described in ExperimentalTracerConfig."
         }
@@ -2634,14 +2391,12 @@
         {
           "name": "selector",
           "type": "ViewSelector",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure view selector. Selection criteria is additive as described in https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-selection-criteria. Property is required and must be non-null."
         },
         {
           "name": "stream",
           "type": "ViewStream",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure view stream. Property is required and must be non-null."
         }
@@ -2657,42 +2412,36 @@
         {
           "name": "instrument_name",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure instrument name selection criteria. If omitted or null, all instrument names match."
         },
         {
           "name": "instrument_type",
           "type": "InstrumentType",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure instrument type selection criteria. Values include: * counter: Synchronous counter instruments. * gauge: Synchronous gauge instruments. * histogram: Synchronous histogram instruments. * observable_counter: Asynchronous counter instruments. * observable_gauge: Asynchronous gauge instruments. * observable_up_down_counter: Asynchronous up down counter instruments. * up_down_counter: Synchronous up down counter instruments. If omitted, all instrument types match."
         },
         {
           "name": "unit",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure the instrument unit selection criteria. If omitted or null, all instrument units match."
         },
         {
           "name": "meter_name",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure meter name selection criteria. If omitted or null, all meter names match."
         },
         {
           "name": "meter_version",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure meter version selection criteria. If omitted or null, all meter versions match."
         },
         {
           "name": "meter_schema_url",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure meter schema url selection criteria. If omitted or null, all meter schema URLs match."
         }
@@ -2708,35 +2457,30 @@
         {
           "name": "name",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure metric name of the resulting stream(s). If omitted or null, the instrument's original name is used."
         },
         {
           "name": "description",
           "type": "string, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure metric description of the resulting stream(s). If omitted or null, the instrument's origin description is used."
         },
         {
           "name": "aggregation",
           "type": "Aggregation",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure aggregation of the resulting stream(s). If omitted, default is used."
         },
         {
           "name": "aggregation_cardinality_limit",
           "type": "integer, null",
-          "default": "If omitted or null, default behavior applies.",
           "constraints": "",
           "description": "Configure the aggregation cardinality limit. If omitted or null, the metric reader's default cardinality limit is used."
         },
         {
           "name": "attribute_keys",
           "type": "IncludeExclude",
-          "default": "If omitted, default behavior applies.",
           "constraints": "",
           "description": "Configure attribute keys retained in the resulting stream(s). If omitted, all attribute keys are retained."
         }

--- a/scripts/update-configuration-data.js
+++ b/scripts/update-configuration-data.js
@@ -1,0 +1,313 @@
+#!/usr/bin/env node
+
+/**
+ * Update Configuration Data
+ *
+ * Downloads and transforms the raw OpenTelemetry configuration JSON Schema into
+ * a simplified format optimized for the configuration types accordion UI.
+ *
+ * Source: https://github.com/open-telemetry/opentelemetry-configuration
+ * Output: data/opentelemetry/configurationTypes.json (simplified structure)
+ *
+ * This script downloads the schema, extracts type definitions, processes properties,
+ * resolves constraints, and generates human-readable default text.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+
+const SCHEMA_URL =
+  'https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/main/opentelemetry_configuration.json';
+const OUTPUT_FILE = 'data/opentelemetry/configurationTypes.json';
+
+/**
+ * Resolve type information from a property definition
+ * Handles arrays, single values, and $ref pointers
+ * @param {Object} propDef - Property definition from JSON Schema
+ * @returns {string} Comma-delimited type string
+ */
+function resolveType(propDef) {
+  let types;
+
+  if (Array.isArray(propDef.type)) {
+    types = propDef.type;
+  } else if (propDef.type) {
+    types = [propDef.type];
+  } else if (propDef.$ref) {
+    // Extract type name from reference like "#/$defs/TypeName"
+    const refParts = propDef.$ref.split('/');
+    types = [refParts[refParts.length - 1]];
+  } else {
+    types = ['object'];
+  }
+
+  return types.join(', ');
+}
+
+/**
+ * Build constraints string from property definition
+ * Extracts validation rules like minimum, maximum, pattern, enum, etc.
+ * @param {Object} propDef - Property definition from JSON Schema
+ * @returns {string} Comma-delimited constraints string
+ */
+function buildConstraints(propDef) {
+  const parts = [];
+
+  if (propDef.minimum !== undefined) {
+    parts.push(`minimum: ${propDef.minimum}`);
+  }
+  if (propDef.maximum !== undefined) {
+    parts.push(`maximum: ${propDef.maximum}`);
+  }
+
+  if (propDef.minLength !== undefined) {
+    parts.push(`minLength: ${propDef.minLength}`);
+  }
+  if (propDef.maxLength !== undefined) {
+    parts.push(`maxLength: ${propDef.maxLength}`);
+  }
+  if (propDef.pattern) {
+    parts.push(`pattern: ${propDef.pattern}`);
+  }
+
+  if (propDef.enum) {
+    const enumVals = propDef.enum.join(', ');
+    parts.push(`enum: [${enumVals}]`);
+  }
+
+  if (propDef.minProperties !== undefined) {
+    parts.push(`minProperties: ${propDef.minProperties}`);
+  }
+  if (propDef.maxProperties !== undefined) {
+    parts.push(`maxProperties: ${propDef.maxProperties}`);
+  }
+
+  if (propDef.minItems !== undefined) {
+    parts.push(`minItems: ${propDef.minItems}`);
+  }
+  if (propDef.maxItems !== undefined) {
+    parts.push(`maxItems: ${propDef.maxItems}`);
+  }
+
+  return parts.join(', ');
+}
+
+/**
+ * Generate human-readable default behavior text
+ * @param {Object} propDef - Property definition from JSON Schema
+ * @returns {string} Default behavior description
+ */
+function generateDefaultText(propDef) {
+  if (propDef.default !== undefined) {
+    return `If omitted, ${propDef.default} is used.`;
+  }
+
+  const types = Array.isArray(propDef.type) ? propDef.type : [propDef.type];
+  if (types.includes('null')) {
+    return 'If omitted or null, default behavior applies.';
+  }
+
+  return 'If omitted, default behavior applies.';
+}
+
+/**
+ * Clean description text
+ * Normalizes whitespace and trims
+ * @param {string} description - Raw description text
+ * @returns {string} Cleaned description
+ */
+function cleanDescription(description) {
+  if (!description) return '';
+
+  // Replace multiple whitespace characters with single space
+  return description.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Process a single property definition
+ * @param {string} propName - Property name
+ * @param {Object} propDef - Property definition from JSON Schema
+ * @returns {Object} Simplified property object
+ */
+function processProperty(propName, propDef) {
+  return {
+    name: propName,
+    type: resolveType(propDef),
+    default: generateDefaultText(propDef),
+    constraints: buildConstraints(propDef),
+    description: cleanDescription(propDef.description),
+  };
+}
+
+/**
+ * Build type-level constraints string
+ * @param {Object} typeDef - Type definition from JSON Schema
+ * @returns {string} Formatted constraints string
+ */
+function buildTypeConstraints(typeDef) {
+  const parts = [];
+
+  if (typeDef.additionalProperties === false) {
+    parts.push('additionalProperties: false');
+  }
+
+  if (typeDef.minProperties !== undefined) {
+    parts.push(`minProperties: ${typeDef.minProperties}`);
+  }
+
+  if (typeDef.maxProperties !== undefined) {
+    parts.push(`maxProperties: ${typeDef.maxProperties}`);
+  }
+
+  if (typeDef.required && typeDef.required.length > 0) {
+    const requiredProps = typeDef.required.join(', ');
+    parts.push(`Required properties: ${requiredProps}`);
+  }
+
+  if (parts.length === 0) return '';
+  return parts.join('. ') + '.';
+}
+
+/**
+ * Process a single type definition
+ * @param {string} typeName - Type name
+ * @param {Object} typeDef - Type definition from JSON Schema
+ * @returns {Object} Simplified type object
+ */
+function processType(typeName, typeDef) {
+  const properties = [];
+
+  if (typeDef.properties) {
+    for (const [propName, propDef] of Object.entries(typeDef.properties)) {
+      properties.push(processProperty(propName, propDef));
+    }
+  }
+
+  return {
+    id: typeName.toLowerCase(),
+    name: typeName,
+    isExperimental: typeName.startsWith('Experimental'),
+    hasNoProperties: properties.length === 0,
+    properties,
+    constraints: buildTypeConstraints(typeDef),
+  };
+}
+
+/**
+ * Fetch JSON from a URL
+ * @param {string} url - URL to fetch from
+ * @returns {Promise<Object>} Parsed JSON object
+ */
+function fetchJson(url) {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, (res) => {
+        if (res.statusCode !== 200) {
+          reject(
+            new Error(
+              `Failed to download schema: HTTP ${res.statusCode} ${res.statusMessage}`,
+            ),
+          );
+          res.resume();
+          return;
+        }
+
+        let data = '';
+        res.on('data', (chunk) => {
+          data += chunk;
+        });
+        res.on('end', () => {
+          try {
+            resolve(JSON.parse(data));
+          } catch (error) {
+            reject(new Error(`Failed to parse JSON: ${error.message}`));
+          }
+        });
+      })
+      .on('error', (error) => {
+        reject(new Error(`Network error: ${error.message}`));
+      });
+  });
+}
+
+/**
+ * Extract and process all type definitions from JSON Schema
+ * @param {Object} schema - Complete JSON Schema object
+ * @returns {Array} Array of processed type objects
+ */
+function extractTypes(schema) {
+  if (!schema.$defs) {
+    throw new Error('No $defs found in schema');
+  }
+
+  const types = [];
+
+  for (const [typeName, typeDef] of Object.entries(schema.$defs)) {
+    // Skip private types (those starting with underscore)
+    if (typeName.startsWith('_')) {
+      continue;
+    }
+
+    types.push(processType(typeName, typeDef));
+  }
+
+  types.sort((a, b) => a.name.localeCompare(b.name));
+
+  return types;
+}
+
+/**
+ * Main transformation function
+ * Downloads JSON Schema from URL, transforms it, and writes simplified output
+ */
+async function run() {
+  try {
+    const projectRoot = path.resolve(__dirname, '..');
+    const outputPath = path.join(projectRoot, OUTPUT_FILE);
+
+    console.log(`Downloading schema from: ${SCHEMA_URL}`);
+    const schema = await fetchJson(SCHEMA_URL);
+
+    console.log('Extracting and processing type definitions...');
+    const types = extractTypes(schema);
+
+    console.log(`Processed ${types.length} type definitions`);
+
+    const outputDir = path.dirname(outputPath);
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true });
+    }
+
+    const output = { types };
+    console.log(`Writing formatted data to: ${outputPath}`);
+    fs.writeFileSync(
+      outputPath,
+      JSON.stringify(output, null, 2) + '\n',
+      'utf8',
+    );
+
+    console.log('Transformation complete!');
+    console.log(`  Source: ${SCHEMA_URL}`);
+    console.log(`  Output: ${OUTPUT_FILE}`);
+  } catch (error) {
+    console.error('Error during transformation:');
+    console.error(error.message);
+    if (error.stack) {
+      console.error(error.stack);
+    }
+    process.exit(1);
+  }
+}
+
+// Run transformation if executed directly
+if (require.main === module) {
+  run().catch((error) => {
+    console.error('Unhandled error:', error);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  transform: run,
+};

--- a/scripts/update-configuration-data.js
+++ b/scripts/update-configuration-data.js
@@ -94,24 +94,6 @@ function buildConstraints(propDef) {
 }
 
 /**
- * Generate human-readable default behavior text
- * @param {Object} propDef - Property definition from JSON Schema
- * @returns {string} Default behavior description
- */
-function generateDefaultText(propDef) {
-  if (propDef.default !== undefined) {
-    return `If omitted, ${propDef.default} is used.`;
-  }
-
-  const types = Array.isArray(propDef.type) ? propDef.type : [propDef.type];
-  if (types.includes('null')) {
-    return 'If omitted or null, default behavior applies.';
-  }
-
-  return 'If omitted, default behavior applies.';
-}
-
-/**
  * Clean description text
  * Normalizes whitespace and trims
  * @param {string} description - Raw description text
@@ -134,7 +116,6 @@ function processProperty(propName, propDef) {
   return {
     name: propName,
     type: resolveType(propDef),
-    default: generateDefaultText(propDef),
     constraints: buildConstraints(propDef),
     description: cleanDescription(propDef.description),
   };


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

This is the first part of #9521 

This script pulls the schema from the [configuration repo](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/opentelemetry_configuration.json), and then converts it into a simplified structure for us to use in a new page for displaying the information. 

The page itself will come in a followup PR, but you can see the latest [draft preview here](https://deploy-preview-9383--opentelemetry.netlify.app/docs/specs/declarative-configuration/) to get an idea of how this will be used

cc @jack-berg 