### PR TITLE
Hugo config housekeeping and prep

### DIFF
--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -90,7 +90,7 @@ mediaTypes:
   text/netlify: {}
 
 outputFormats:
-  REDIRECTS:
+  redirects:
     mediaType: text/netlify
     baseName: _redirects
     notAlternative: true
@@ -103,8 +103,8 @@ services:
   rss: { limit: 20 }
 
 cascade:
-  build: { list: never, publishResources: false, render: never }
-  _target: { path: '{,/**}/_includes{,/**}' }
+  - build: { list: never, publishResources: false, render: never }
+    target: { path: '{,/**}/_includes{,/**}' }
 
 params:
   copyright:


### PR DESCRIPTION
- Prep for #9449
- Contributes to #8933 by resolving this warning:
  ```text
  INFO  deprecated: cascade._target was deprecated in Hugo v0.156.0 and will be removed in a future release. Use cascade.target instead, see https://gohugo.io/content-management/front-matter/#target
  ```

No change to generated site files other than the build timestamp:

```console
$ (cd public && git diff) | grep ^diff 
diff --git a/site/index.html b/site/index.html
```