### PR TITLE
docs(js): update browser SIG reference

### DIFF
--- a/content/en/docs/languages/js/_includes/browser-instrumentation-warning.md
+++ b/content/en/docs/languages/js/_includes/browser-instrumentation-warning.md
@@ -5,7 +5,7 @@
 >
 > Client instrumentation for the browser is **experimental** and mostly
 > **unspecified**. If you are interested in helping out, get in touch with the
-> [Client Instrumentation SIG][].
+> [Browser SIG][].
 
-[Client Instrumentation SIG]:
-  https://docs.google.com/document/d/16Vsdh-DM72AfMg_FIt9yT9ExEWF4A_vRbQ3jRNBe09w
+[Browser SIG]:
+  https://github.com/open-telemetry/community?tab=readme-ov-file#implementation-sigs


### PR DESCRIPTION
## Summary
- rename the browser warning reference from Client Instrumentation SIG to Browser SIG
- replace the editable meeting notes link with the OpenTelemetry community implementation SIGs page

Closes #9537

## Test Plan
- verified the include now references Browser SIG
- checked the diff only updates the warning include used by the browser getting started page
