### PR TITLE
Update docker-compose.yaml to canonical compose.yaml terminology

### DIFF
--- a/content/en/docs/collector/install/docker.md
+++ b/content/en/docs/collector/install/docker.md
@@ -43,7 +43,7 @@ docker run -v $(pwd)/config.yaml:/etc/otelcol/config.yaml ghcr.io/open-telemetry
 ## Docker Compose
 
 You can also add the OpenTelemetry Collector to your existing
-`docker-compose.yaml` file:
+`compose.yaml` file:
 
 ```yaml
 otel-collector:


### PR DESCRIPTION
🖖

Very minor update to use `compose.yaml` over `docker-compose.yaml`. Docker supports both, but `compose.yaml` is canonical/preferred. [See docs](https://docs.docker.com/compose/intro/compose-application-model/). Cheers! :) 

---

**Note from the maintainers**: this description was submitted without our [PR template](https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/PULL_REQUEST_TEMPLATE.md)'s checklist, which asks you to confirm:

- [ ] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [ ] I have the experience and knowledge necessary to understand, review, and validate all content in this PR. (Yes, I can answer maintainer questions about the content of this PR, without using AI.)

Per our [first-time contributor policy](https://github.com/open-telemetry/opentelemetry.io/issues/11243), answer these questions by ticking each box that applies.
