### PR TITLE
Add GA headers to HTTP responses, add live-check fixtures as site test pages

### DIFF
--- a/content/en/site/_index.md
+++ b/content/en/site/_index.md
@@ -32,8 +32,8 @@ Tentatively planned content organization:
 - [**Build**](./build/) — Tooling, local development setup, CI/CD workflows,
   deployment environments, and automation details.
 - **Deployment** — Deployment-specific behavior for the OpenTelemetry website.
-- **Quality** — Link checking, accessibility standards, tests, review practices,
-  and other quality-related processes.
+- [**Testing**](./testing/) — Link checking, accessibility standards, tests,
+  review practices, and other quality-related processes.
 - **Roadmap** — Milestones, backlog, priorities, technical debt, and
   design/implementation decisions.
 

--- a/content/en/site/testing/_index.md
+++ b/content/en/site/testing/_index.md
@@ -7,3 +7,42 @@ This section contains testing strategies, processes, and test pages used by
 website tests and deployed live checks.
 
 > This section is under construction.
+
+## Test assertions
+
+### Goal
+
+When a test fails, the output should make it obvious what was being checked and
+show a clear diff between actual and expected values, without long hand-written
+messages.
+
+For example, avoid:
+
+```js
+assert.ok(a === b, `expected ${a} to be ${b}`);
+```
+
+Instead favor:
+
+```js
+assert.strictEqual(status, expectedStatus, 'HTTP status');
+```
+
+### Guidance
+
+The points below use Node's built-in `node:test` runner and `assert` API because
+that is what several of our test suites use. The same ideas apply in other test
+frameworks: prefer assertions that produce tight diffs, keep failure context
+short and specific, and extract shared helpers when the same check repeats.
+
+1. Prefer `assert.strictEqual` over `assert.equal` for primitive checks where
+   strictness and diff quality matter.
+2. Add a short third argument as context, for example `HTTP status`,
+   `Content-Type`, `Location`, `Request body`.
+3. Use `assert.match` when a regex expresses the intent more clearly than
+   `includes` or chained `ok` logic.
+4. Put shared assertion helpers in a module imported by the test suites that use
+   them, colocated with those tests instead of copy-pasted across files. Other
+   small, test-only utilities can live in the same module when it stays focused
+   (for example `assertVaryIncludesAccept` in
+   `netlify/edge-functions/lib/test-helpers.ts`).

--- a/content/en/site/testing/_index.md
+++ b/content/en/site/testing/_index.md
@@ -1,0 +1,9 @@
+---
+title: Testing
+description: Testing strategies, processes, and test pages.
+---
+
+This section contains testing strategies, processes, and test pages used by
+website tests and deployed live checks.
+
+> This section is under construction.

--- a/content/en/site/testing/_index.md
+++ b/content/en/site/testing/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Testing
-description: Testing strategies, processes, and test pages.
+description: Checking and testing strategies, processes, and test pages.
 ---
 
-This section contains testing strategies, processes, and test pages used by
-website tests and deployed live checks.
+This section contains checking and testing strategies, processes, and test pages
+used by website tests and deployed live checks.
 
 > This section is under construction.
 
@@ -39,8 +39,8 @@ short and specific, and extract shared helpers when the same check repeats.
    strictness and diff quality matter.
 2. Add a short third argument as context, for example `HTTP status`,
    `Content-Type`, `Location`, `Request body`.
-3. Use `assert.match` when a regex expresses the intent more clearly than
-   `includes` or chained `ok` logic.
+3. Use `assert.match` when a regular expression can capture the intent more
+   clearly than `includes` or chained `ok` logic.
 4. Put shared assertion helpers in a module imported by the test suites that use
    them, colocated with those tests instead of copy-pasted across files. Other
    small, test-only utilities can live in the same module when it stays focused

--- a/content/en/site/testing/tests/_index.md
+++ b/content/en/site/testing/tests/_index.md
@@ -1,0 +1,5 @@
+---
+title: Test pages
+---
+
+This section contains low-impact pages reserved for deployed live checks.

--- a/content/en/site/testing/tests/no-md.md
+++ b/content/en/site/testing/tests/no-md.md
@@ -1,0 +1,6 @@
+---
+title: HTML-only test page
+outputs: [HTML]
+---
+
+This is a test page.

--- a/content/en/site/testing/tests/regular.md
+++ b/content/en/site/testing/tests/regular.md
@@ -1,0 +1,5 @@
+---
+title: Regular test page
+---
+
+This is a test page.

--- a/netlify/edge-functions/asset-tracking/README.md
+++ b/netlify/edge-functions/asset-tracking/README.md
@@ -5,7 +5,8 @@ tests.
 
 It tracks explicit asset-path requests by extension using `context.next()`
 (currently `*.md` and `*.txt`) and emits GA4 `asset_fetch` events for tracked
-`GET` requests regardless of response status.
+`GET` requests regardless of response status. Emitted events set `event_emitter`
+to `tracking`.
 
 If the request includes `X-Asset-Fetch-Ga-Info`, the function treats it as an
 internal subrequest and skips tracking. This prevents duplicate events when

--- a/netlify/edge-functions/asset-tracking/README.md
+++ b/netlify/edge-functions/asset-tracking/README.md
@@ -12,6 +12,9 @@ If the request includes `X-Asset-Fetch-Ga-Info`, the function treats it as an
 internal subrequest and skips tracking. This prevents duplicate events when
 `markdown-negotiation` fetches sibling `index.md` assets internally.
 
+Responses also include `X-Asset-Fetch-Ga-Info` for coarse sanity-checking of the
+derived GA path and local trackability/config state.
+
 ### Live tests
 
 To run the live checks over a server:

--- a/netlify/edge-functions/asset-tracking/README.md
+++ b/netlify/edge-functions/asset-tracking/README.md
@@ -13,7 +13,7 @@ internal subrequest and skips tracking. This prevents duplicate events when
 `markdown-negotiation` fetches sibling `index.md` assets internally.
 
 Responses also include `X-Asset-Fetch-Ga-Info` for coarse sanity-checking of the
-derived GA path and local trackability/config state.
+derived GA path and local GA-event candidate/config state.
 
 ### Live tests
 

--- a/netlify/edge-functions/asset-tracking/index.test.ts
+++ b/netlify/edge-functions/asset-tracking/index.test.ts
@@ -15,7 +15,9 @@ import {
   INTERNAL_ASSET_FETCH_GA_INFO_VALUE,
 } from '../lib/ga4-asset-fetch.ts';
 import {
+  assertAssetFetchGa4Event,
   createWaitUntilSpy,
+  firstAssetFetchEvent,
   setupGa4CapturingFetchMock,
   setupNetlifyEnv,
 } from '../lib/test-helpers.ts';
@@ -161,30 +163,22 @@ test('handler emits asset_fetch for explicit .md requests', async (t) => {
   await spy.flush();
 
   assert.strictEqual(response.status, 200, 'HTTP status');
-  assert.strictEqual(ga4Bodies.length, 1, 'GA4 body count');
   assert.strictEqual(
     response.headers.get('x-asset-fetch-ga-info'),
     '/docs/concepts/resources/index.md;ga-event-candidate,config-present',
     'X-Asset-Fetch-Ga-Info',
   );
 
-  const event = (
-    ga4Bodies[0].events as { name: string; params: Record<string, string> }[]
-  )[0];
-  assert.strictEqual(event.name, 'asset_fetch', 'event name');
-  assert.strictEqual(
-    event.params.asset_path,
-    '/docs/concepts/resources/index.md',
-    'asset_path',
+  assertAssetFetchGa4Event(
+    firstAssetFetchEvent(ga4Bodies),
+    {
+      asset_path: '/docs/concepts/resources/index.md',
+      content_type: 'text/markdown',
+      status_code: '200',
+      event_emitter: 'tracking',
+    },
+    { expectOriginalPathAbsent: true },
   );
-  assert.strictEqual(
-    event.params.content_type,
-    'text/markdown',
-    'content_type',
-  );
-  assert.strictEqual(event.params.status_code, '200', 'status_code');
-  assert.ok(!('original_path' in event.params));
-  assert.strictEqual(event.params.event_emitter, 'tracking', 'event_emitter');
 });
 
 test('handler emits asset_fetch for explicit .txt requests', async (t) => {
@@ -207,17 +201,17 @@ test('handler emits asset_fetch for explicit .txt requests', async (t) => {
   await spy.flush();
 
   assert.strictEqual(response.status, 200, 'HTTP status');
-  assert.strictEqual(ga4Bodies.length, 1, 'GA4 body count');
 
-  const event = (
-    ga4Bodies[0].events as { name: string; params: Record<string, string> }[]
-  )[0];
-  assert.strictEqual(event.name, 'asset_fetch', 'event name');
-  assert.strictEqual(event.params.asset_path, '/llms.txt', 'asset_path');
-  assert.strictEqual(event.params.content_type, 'text/plain', 'content_type');
-  assert.strictEqual(event.params.status_code, '200', 'status_code');
-  assert.ok(!('original_path' in event.params));
-  assert.strictEqual(event.params.event_emitter, 'tracking', 'event_emitter');
+  assertAssetFetchGa4Event(
+    firstAssetFetchEvent(ga4Bodies),
+    {
+      asset_path: '/llms.txt',
+      content_type: 'text/plain',
+      status_code: '200',
+      event_emitter: 'tracking',
+    },
+    { expectOriginalPathAbsent: true },
+  );
 });
 
 test('handler skips asset_fetch for internal marked explicit .md requests', async (t) => {
@@ -272,18 +266,11 @@ test('handler emits asset_fetch for explicit .md requests regardless of response
   await spy.flush();
 
   assert.strictEqual(response.status, 404, 'HTTP status');
-  assert.strictEqual(ga4Bodies.length, 1, 'GA4 body count');
 
-  const event = (
-    ga4Bodies[0].events as { name: string; params: Record<string, string> }[]
-  )[0];
-  assert.strictEqual(event.name, 'asset_fetch', 'event name');
-  assert.strictEqual(
-    event.params.asset_path,
-    '/docs/concepts/resources/index.md',
-    'asset_path',
-  );
-  assert.strictEqual(event.params.content_type, 'text/plain', 'content_type');
-  assert.strictEqual(event.params.status_code, '404', 'status_code');
-  assert.strictEqual(event.params.event_emitter, 'tracking', 'event_emitter');
+  assertAssetFetchGa4Event(firstAssetFetchEvent(ga4Bodies), {
+    asset_path: '/docs/concepts/resources/index.md',
+    content_type: 'text/plain',
+    status_code: '404',
+    event_emitter: 'tracking',
+  });
 });

--- a/netlify/edge-functions/asset-tracking/index.test.ts
+++ b/netlify/edge-functions/asset-tracking/index.test.ts
@@ -195,6 +195,7 @@ test('handler emits asset_fetch for explicit .md requests', async (t) => {
   assert.equal(event.params.content_type, 'text/markdown');
   assert.equal(event.params.status_code, '200');
   assert.ok(!('original_path' in event.params));
+  assert.equal(event.params.event_emitter, 'tracking');
 });
 
 test('handler emits asset_fetch for explicit .txt requests', async (t) => {
@@ -227,6 +228,7 @@ test('handler emits asset_fetch for explicit .txt requests', async (t) => {
   assert.equal(event.params.content_type, 'text/plain');
   assert.equal(event.params.status_code, '200');
   assert.ok(!('original_path' in event.params));
+  assert.equal(event.params.event_emitter, 'tracking');
 });
 
 test('handler skips asset_fetch for internal marked explicit .md requests', async (t) => {
@@ -285,4 +287,5 @@ test('handler emits asset_fetch for explicit .md requests regardless of response
   assert.equal(event.params.asset_path, '/docs/concepts/resources/index.md');
   assert.equal(event.params.content_type, 'text/plain');
   assert.equal(event.params.status_code, '404');
+  assert.equal(event.params.event_emitter, 'tracking');
 });

--- a/netlify/edge-functions/asset-tracking/index.test.ts
+++ b/netlify/edge-functions/asset-tracking/index.test.ts
@@ -191,9 +191,7 @@ test('handler emits asset_fetch for explicit .md requests', async (t) => {
     ga4Bodies[0].events as { name: string; params: Record<string, string> }[]
   )[0];
   assert.equal(event.name, 'asset_fetch');
-  assert.equal(event.params.asset_group, 'markdown');
   assert.equal(event.params.asset_path, '/docs/concepts/resources/index.md');
-  assert.equal(event.params.asset_ext, 'md');
   assert.equal(event.params.content_type, 'text/markdown');
   assert.equal(event.params.status_code, '200');
   assert.ok(!('original_path' in event.params));
@@ -225,9 +223,7 @@ test('handler emits asset_fetch for explicit .txt requests', async (t) => {
     ga4Bodies[0].events as { name: string; params: Record<string, string> }[]
   )[0];
   assert.equal(event.name, 'asset_fetch');
-  assert.equal(event.params.asset_group, 'text');
   assert.equal(event.params.asset_path, '/llms.txt');
-  assert.equal(event.params.asset_ext, 'txt');
   assert.equal(event.params.content_type, 'text/plain');
   assert.equal(event.params.status_code, '200');
   assert.ok(!('original_path' in event.params));
@@ -286,9 +282,7 @@ test('handler emits asset_fetch for explicit .md requests regardless of response
     ga4Bodies[0].events as { name: string; params: Record<string, string> }[]
   )[0];
   assert.equal(event.name, 'asset_fetch');
-  assert.equal(event.params.asset_group, 'markdown');
   assert.equal(event.params.asset_path, '/docs/concepts/resources/index.md');
-  assert.equal(event.params.asset_ext, 'md');
   assert.equal(event.params.content_type, 'text/plain');
   assert.equal(event.params.status_code, '404');
 });

--- a/netlify/edge-functions/asset-tracking/index.test.ts
+++ b/netlify/edge-functions/asset-tracking/index.test.ts
@@ -14,64 +14,12 @@ import {
   ASSET_FETCH_GA_INFO_HEADER,
   INTERNAL_ASSET_FETCH_GA_INFO_VALUE,
 } from '../lib/ga4-asset-fetch.ts';
+import {
+  createWaitUntilSpy,
+  setupGa4CapturingFetchMock,
+  setupNetlifyEnv,
+} from '../lib/test-helpers.ts';
 import assetTracking, { shouldTrackAssetFetch } from './index.ts';
-
-function setupNetlifyEnv(t: { after: (fn: () => void) => void }) {
-  const g = globalThis as Record<string, unknown>;
-  const originalNetlify = g.Netlify;
-  t.after(() => {
-    g.Netlify = originalNetlify;
-  });
-
-  g.Netlify = {
-    env: {
-      get: (name: string) => {
-        if (name === 'HUGO_SERVICES_GOOGLEANALYTICS_ID') return 'G-TEST';
-        if (name === 'GA4_API_SECRET') return 'secret';
-        return undefined;
-      },
-    },
-  };
-}
-
-function setupFetchMock(t: { after: (fn: () => void) => void }) {
-  const originalFetch = globalThis.fetch;
-  t.after(() => {
-    globalThis.fetch = originalFetch;
-  });
-
-  const ga4Bodies: Record<string, unknown>[] = [];
-
-  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-    const url =
-      input instanceof URL
-        ? input.toString()
-        : typeof input === 'string'
-          ? input
-          : input.url;
-
-    if (url.includes('google-analytics.com')) {
-      if (init?.body) {
-        ga4Bodies.push(JSON.parse(init.body as string));
-      }
-      return new Response('', { status: 200 });
-    }
-
-    return new Response('unexpected fetch', { status: 500 });
-  }) as typeof fetch;
-
-  return ga4Bodies;
-}
-
-function createWaitUntilSpy() {
-  const promises: Promise<unknown>[] = [];
-  return {
-    waitUntil: (p: Promise<unknown>) => {
-      promises.push(p);
-    },
-    flush: () => Promise.all(promises),
-  };
-}
 
 test('shouldTrackAssetFetch accepts GET .md requests', () => {
   const request = new Request(
@@ -82,7 +30,11 @@ test('shouldTrackAssetFetch accepts GET .md requests', () => {
     status: 200,
   });
 
-  assert.equal(shouldTrackAssetFetch(request, response), true);
+  assert.strictEqual(
+    shouldTrackAssetFetch(request, response),
+    true,
+    'shouldTrackAssetFetch',
+  );
 });
 
 test('shouldTrackAssetFetch accepts GET .txt requests', () => {
@@ -92,7 +44,11 @@ test('shouldTrackAssetFetch accepts GET .txt requests', () => {
     status: 200,
   });
 
-  assert.equal(shouldTrackAssetFetch(request, response), true);
+  assert.strictEqual(
+    shouldTrackAssetFetch(request, response),
+    true,
+    'shouldTrackAssetFetch',
+  );
 });
 
 test('shouldTrackAssetFetch returns false for internal marked requests', () => {
@@ -109,7 +65,11 @@ test('shouldTrackAssetFetch returns false for internal marked requests', () => {
     status: 200,
   });
 
-  assert.equal(shouldTrackAssetFetch(request, response), false);
+  assert.strictEqual(
+    shouldTrackAssetFetch(request, response),
+    false,
+    'shouldTrackAssetFetch',
+  );
 });
 
 test('shouldTrackAssetFetch returns false for non-GET methods', () => {
@@ -123,7 +83,11 @@ test('shouldTrackAssetFetch returns false for non-GET methods', () => {
       status: 200,
     });
 
-    assert.equal(shouldTrackAssetFetch(request, response), false);
+    assert.strictEqual(
+      shouldTrackAssetFetch(request, response),
+      false,
+      'shouldTrackAssetFetch',
+    );
   }
 });
 
@@ -137,7 +101,11 @@ test('shouldTrackAssetFetch accepts non-2xx responses for tracked assets', () =>
       status,
     });
 
-    assert.equal(shouldTrackAssetFetch(request, response), true);
+    assert.strictEqual(
+      shouldTrackAssetFetch(request, response),
+      true,
+      'shouldTrackAssetFetch',
+    );
   }
 });
 
@@ -150,7 +118,11 @@ test('shouldTrackAssetFetch accepts non-markdown content type for tracked assets
     status: 200,
   });
 
-  assert.equal(shouldTrackAssetFetch(request, response), true);
+  assert.strictEqual(
+    shouldTrackAssetFetch(request, response),
+    true,
+    'shouldTrackAssetFetch',
+  );
 });
 
 test('shouldTrackAssetFetch returns false for non-tracked extensions', () => {
@@ -162,12 +134,16 @@ test('shouldTrackAssetFetch returns false for non-tracked extensions', () => {
     status: 200,
   });
 
-  assert.equal(shouldTrackAssetFetch(request, response), false);
+  assert.strictEqual(
+    shouldTrackAssetFetch(request, response),
+    false,
+    'shouldTrackAssetFetch',
+  );
 });
 
 test('handler emits asset_fetch for explicit .md requests', async (t) => {
   setupNetlifyEnv(t);
-  const ga4Bodies = setupFetchMock(t);
+  const ga4Bodies = setupGa4CapturingFetchMock(t);
   const spy = createWaitUntilSpy();
 
   const response = await assetTracking(
@@ -184,27 +160,36 @@ test('handler emits asset_fetch for explicit .md requests', async (t) => {
 
   await spy.flush();
 
-  assert.equal(response.status, 200);
-  assert.equal(ga4Bodies.length, 1);
-  assert.equal(
+  assert.strictEqual(response.status, 200, 'HTTP status');
+  assert.strictEqual(ga4Bodies.length, 1, 'GA4 body count');
+  assert.strictEqual(
     response.headers.get('x-asset-fetch-ga-info'),
     '/docs/concepts/resources/index.md;ga-event-candidate,config-present',
+    'X-Asset-Fetch-Ga-Info',
   );
 
   const event = (
     ga4Bodies[0].events as { name: string; params: Record<string, string> }[]
   )[0];
-  assert.equal(event.name, 'asset_fetch');
-  assert.equal(event.params.asset_path, '/docs/concepts/resources/index.md');
-  assert.equal(event.params.content_type, 'text/markdown');
-  assert.equal(event.params.status_code, '200');
+  assert.strictEqual(event.name, 'asset_fetch', 'event name');
+  assert.strictEqual(
+    event.params.asset_path,
+    '/docs/concepts/resources/index.md',
+    'asset_path',
+  );
+  assert.strictEqual(
+    event.params.content_type,
+    'text/markdown',
+    'content_type',
+  );
+  assert.strictEqual(event.params.status_code, '200', 'status_code');
   assert.ok(!('original_path' in event.params));
-  assert.equal(event.params.event_emitter, 'tracking');
+  assert.strictEqual(event.params.event_emitter, 'tracking', 'event_emitter');
 });
 
 test('handler emits asset_fetch for explicit .txt requests', async (t) => {
   setupNetlifyEnv(t);
-  const ga4Bodies = setupFetchMock(t);
+  const ga4Bodies = setupGa4CapturingFetchMock(t);
   const spy = createWaitUntilSpy();
 
   const response = await assetTracking(
@@ -221,23 +206,23 @@ test('handler emits asset_fetch for explicit .txt requests', async (t) => {
 
   await spy.flush();
 
-  assert.equal(response.status, 200);
-  assert.equal(ga4Bodies.length, 1);
+  assert.strictEqual(response.status, 200, 'HTTP status');
+  assert.strictEqual(ga4Bodies.length, 1, 'GA4 body count');
 
   const event = (
     ga4Bodies[0].events as { name: string; params: Record<string, string> }[]
   )[0];
-  assert.equal(event.name, 'asset_fetch');
-  assert.equal(event.params.asset_path, '/llms.txt');
-  assert.equal(event.params.content_type, 'text/plain');
-  assert.equal(event.params.status_code, '200');
+  assert.strictEqual(event.name, 'asset_fetch', 'event name');
+  assert.strictEqual(event.params.asset_path, '/llms.txt', 'asset_path');
+  assert.strictEqual(event.params.content_type, 'text/plain', 'content_type');
+  assert.strictEqual(event.params.status_code, '200', 'status_code');
   assert.ok(!('original_path' in event.params));
-  assert.equal(event.params.event_emitter, 'tracking');
+  assert.strictEqual(event.params.event_emitter, 'tracking', 'event_emitter');
 });
 
 test('handler skips asset_fetch for internal marked explicit .md requests', async (t) => {
   setupNetlifyEnv(t);
-  const ga4Bodies = setupFetchMock(t);
+  const ga4Bodies = setupGa4CapturingFetchMock(t);
   const spy = createWaitUntilSpy();
 
   const response = await assetTracking(
@@ -258,17 +243,18 @@ test('handler skips asset_fetch for internal marked explicit .md requests', asyn
 
   await spy.flush();
 
-  assert.equal(response.status, 200);
-  assert.equal(ga4Bodies.length, 0);
-  assert.equal(
+  assert.strictEqual(response.status, 200, 'HTTP status');
+  assert.strictEqual(ga4Bodies.length, 0, 'GA4 body count');
+  assert.strictEqual(
     response.headers.get('x-asset-fetch-ga-info'),
     'none: internal subrequest',
+    'X-Asset-Fetch-Ga-Info',
   );
 });
 
 test('handler emits asset_fetch for explicit .md requests regardless of response status', async (t) => {
   setupNetlifyEnv(t);
-  const ga4Bodies = setupFetchMock(t);
+  const ga4Bodies = setupGa4CapturingFetchMock(t);
   const spy = createWaitUntilSpy();
 
   const response = await assetTracking(
@@ -285,15 +271,19 @@ test('handler emits asset_fetch for explicit .md requests regardless of response
 
   await spy.flush();
 
-  assert.equal(response.status, 404);
-  assert.equal(ga4Bodies.length, 1);
+  assert.strictEqual(response.status, 404, 'HTTP status');
+  assert.strictEqual(ga4Bodies.length, 1, 'GA4 body count');
 
   const event = (
     ga4Bodies[0].events as { name: string; params: Record<string, string> }[]
   )[0];
-  assert.equal(event.name, 'asset_fetch');
-  assert.equal(event.params.asset_path, '/docs/concepts/resources/index.md');
-  assert.equal(event.params.content_type, 'text/plain');
-  assert.equal(event.params.status_code, '404');
-  assert.equal(event.params.event_emitter, 'tracking');
+  assert.strictEqual(event.name, 'asset_fetch', 'event name');
+  assert.strictEqual(
+    event.params.asset_path,
+    '/docs/concepts/resources/index.md',
+    'asset_path',
+  );
+  assert.strictEqual(event.params.content_type, 'text/plain', 'content_type');
+  assert.strictEqual(event.params.status_code, '404', 'status_code');
+  assert.strictEqual(event.params.event_emitter, 'tracking', 'event_emitter');
 });

--- a/netlify/edge-functions/asset-tracking/index.test.ts
+++ b/netlify/edge-functions/asset-tracking/index.test.ts
@@ -186,6 +186,10 @@ test('handler emits asset_fetch for explicit .md requests', async (t) => {
 
   assert.equal(response.status, 200);
   assert.equal(ga4Bodies.length, 1);
+  assert.equal(
+    response.headers.get('x-asset-fetch-ga-info'),
+    '/docs/concepts/resources/index.md;ga-event-candidate,config-present',
+  );
 
   const event = (
     ga4Bodies[0].events as { name: string; params: Record<string, string> }[]
@@ -256,6 +260,10 @@ test('handler skips asset_fetch for internal marked explicit .md requests', asyn
 
   assert.equal(response.status, 200);
   assert.equal(ga4Bodies.length, 0);
+  assert.equal(
+    response.headers.get('x-asset-fetch-ga-info'),
+    'none: internal subrequest',
+  );
 });
 
 test('handler emits asset_fetch for explicit .md requests regardless of response status', async (t) => {

--- a/netlify/edge-functions/asset-tracking/index.ts
+++ b/netlify/edge-functions/asset-tracking/index.ts
@@ -23,6 +23,7 @@ export default async function assetTracking(
     asset_path: assetPath,
     content_type: normalizeContentType(response.headers.get('content-type')),
     status_code: String(response.status),
+    event_emitter: 'tracking',
   });
 
   return response;

--- a/netlify/edge-functions/asset-tracking/index.ts
+++ b/netlify/edge-functions/asset-tracking/index.ts
@@ -19,12 +19,8 @@ export default async function assetTracking(
 
   const requestUrl = new URL(request.url);
   const assetPath = requestUrl.pathname;
-  const assetExt = getPathExtension(assetPath);
-
   enqueueAssetFetchEvent(request, context, {
-    asset_group: classifyAssetGroup(assetExt),
     asset_path: assetPath,
-    asset_ext: assetExt.slice(1),
     content_type: normalizeContentType(response.headers.get('content-type')),
     status_code: String(response.status),
   });
@@ -55,19 +51,6 @@ export function shouldTrackAssetFetch(
 
   return true;
 }
-
-function classifyAssetGroup(extension: string): 'markdown' | 'text' | 'other' {
-  if (extension === '.md') {
-    return 'markdown';
-  }
-
-  if (extension === '.txt') {
-    return 'text';
-  }
-
-  return 'other';
-}
-
 function getPathExtension(pathname: string): string {
   const lastSegment = pathname.split('/').pop() ?? '';
   const match = /\.([^.]+)$/.exec(lastSegment);

--- a/netlify/edge-functions/asset-tracking/index.ts
+++ b/netlify/edge-functions/asset-tracking/index.ts
@@ -1,8 +1,11 @@
 import {
+  buildAssetFetchGaInfoHeaderValue,
+  hasAssetFetchConfig,
   isInternalAssetFetchRequest,
   type AssetFetchContext,
   enqueueAssetFetchEvent,
   normalizeContentType,
+  withAssetFetchGaInfoHeader,
 } from '../lib/ga4-asset-fetch.ts';
 
 const TRACKED_EXTENSIONS = new Set(['.md', '.txt']);
@@ -12,21 +15,34 @@ export default async function assetTracking(
   context: AssetFetchContext & { next: () => Promise<Response> },
 ) {
   const response = await context.next();
+  const requestUrl = new URL(request.url);
+  const trackable = shouldTrackAssetFetch(request, response);
+  const responseWithGaInfo = withAssetFetchGaInfoHeader(
+    response,
+    buildAssetFetchGaInfoHeaderValue({
+      assetPath: trackable ? requestUrl.pathname : undefined,
+      configPresent: hasAssetFetchConfig(),
+      noneReason: trackable
+        ? undefined
+        : getAssetTrackingGaInfoNoneReason(request),
+      gaEventCandidate: trackable,
+    }),
+  );
 
-  if (!shouldTrackAssetFetch(request, response)) {
-    return response;
+  if (!trackable) {
+    return responseWithGaInfo;
   }
 
-  const requestUrl = new URL(request.url);
-  const assetPath = requestUrl.pathname;
   enqueueAssetFetchEvent(request, context, {
-    asset_path: assetPath,
-    content_type: normalizeContentType(response.headers.get('content-type')),
-    status_code: String(response.status),
+    asset_path: requestUrl.pathname,
+    content_type: normalizeContentType(
+      responseWithGaInfo.headers.get('content-type'),
+    ),
+    status_code: String(responseWithGaInfo.status),
     event_emitter: 'tracking',
   });
 
-  return response;
+  return responseWithGaInfo;
 }
 
 export function shouldTrackAssetFetch(
@@ -52,6 +68,28 @@ export function shouldTrackAssetFetch(
 
   return true;
 }
+
+function getAssetTrackingGaInfoNoneReason(
+  request: Request,
+): string | undefined {
+  if (request.method !== 'GET') {
+    return `request method ${request.method} is not currently tracked`;
+  }
+
+  if (isInternalAssetFetchRequest(request)) {
+    return 'internal subrequest';
+  }
+
+  const requestUrl = new URL(request.url);
+  const extension = getPathExtension(requestUrl.pathname);
+
+  if (!TRACKED_EXTENSIONS.has(extension)) {
+    return 'request path does not match a tracked route';
+  }
+
+  return undefined;
+}
+
 function getPathExtension(pathname: string): string {
   const lastSegment = pathname.split('/').pop() ?? '';
   const match = /\.([^.]+)$/.exec(lastSegment);

--- a/netlify/edge-functions/asset-tracking/live-check.test.mjs
+++ b/netlify/edge-functions/asset-tracking/live-check.test.mjs
@@ -32,8 +32,20 @@ function baseRef() {
   return resolveBaseRef(raw);
 }
 
+function expectedConfigTag(baseRef) {
+  return (
+    'config-' +
+    (baseRef.hostname === 'opentelemetry.io' ? 'present' : 'missing')
+  );
+}
+
 const markdownPath = '/site/testing/tests/regular/index.md';
 const textPath = '/llms.txt';
+const expectedMarkdownContentType = 'text/markdown; charset=UTF-8';
+const expectedPlainTextContentType = 'text/plain; charset=UTF-8';
+
+const regularPageMarkdownHeading = /^# Regular test page/;
+const llmsTxtHeading = /^# OpenTelemetry/;
 
 test('GET explicit .md path → markdown response', async () => {
   const ref = baseRef();
@@ -42,15 +54,9 @@ test('GET explicit .md path → markdown response', async () => {
   const ct = res.headers.get('content-type') ?? '';
   const text = await res.text();
 
-  assert.equal(res.status, 200, `expected 200 for ${url}`);
-  assert.ok(
-    ct.toLowerCase().includes('text/markdown'),
-    `expected text/markdown content-type, got ${JSON.stringify(ct)}`,
-  );
-  assert.ok(
-    text.includes('# Regular edge function test page'),
-    'body should contain "# Regular edge function test page"',
-  );
+  assert.strictEqual(res.status, 200, 'HTTP status');
+  assert.strictEqual(ct, expectedMarkdownContentType, 'Content-Type');
+  assert.match(text, regularPageMarkdownHeading, 'Request body');
 });
 
 test('GET explicit .md path → X-Asset-Fetch-Ga-Info header', async () => {
@@ -58,9 +64,10 @@ test('GET explicit .md path → X-Asset-Fetch-Ga-Info header', async () => {
   const url = absUrl(markdownPath, ref);
   const res = await fetch(url);
 
-  assert.equal(
+  assert.strictEqual(
     res.headers.get(ASSET_FETCH_GA_INFO_HEADER),
-    `${markdownPath};ga-event-candidate,config-present`,
+    `${markdownPath};ga-event-candidate,${expectedConfigTag(ref)}`,
+    'X-Asset-Fetch-Ga-Info',
   );
 });
 
@@ -71,12 +78,9 @@ test('HEAD explicit .md path → success with empty body', async () => {
   const ct = res.headers.get('content-type') ?? '';
   const buf = await res.arrayBuffer();
 
-  assert.equal(res.status, 200, `expected 200 for ${url}`);
-  assert.ok(
-    ct.toLowerCase().includes('text/markdown'),
-    `expected text/markdown content-type, got ${JSON.stringify(ct)}`,
-  );
-  assert.equal(buf.byteLength, 0, 'expected empty body');
+  assert.strictEqual(res.status, 200, 'HTTP status');
+  assert.strictEqual(ct, expectedMarkdownContentType, 'Content-Type');
+  assert.strictEqual(buf.byteLength, 0, 'Response body');
 });
 
 test('GET explicit .md path with internal marker → same markdown response', async () => {
@@ -90,15 +94,9 @@ test('GET explicit .md path with internal marker → same markdown response', as
   const ct = res.headers.get('content-type') ?? '';
   const text = await res.text();
 
-  assert.equal(res.status, 200, `expected 200 for ${url}`);
-  assert.ok(
-    ct.toLowerCase().includes('text/markdown'),
-    `expected text/markdown content-type, got ${JSON.stringify(ct)}`,
-  );
-  assert.ok(
-    text.includes('# Regular edge function test page'),
-    'body should contain "# Regular edge function test page"',
-  );
+  assert.strictEqual(res.status, 200, 'HTTP status');
+  assert.strictEqual(ct, expectedMarkdownContentType, 'Content-Type');
+  assert.match(text, regularPageMarkdownHeading, 'Request body');
 });
 
 test('GET explicit .txt path → text response', async () => {
@@ -108,15 +106,9 @@ test('GET explicit .txt path → text response', async () => {
   const ct = res.headers.get('content-type') ?? '';
   const text = await res.text();
 
-  assert.equal(res.status, 200, `expected 200 for ${url}`);
-  assert.ok(
-    ct.toLowerCase().includes('text/plain'),
-    `expected text/plain content-type, got ${JSON.stringify(ct)}`,
-  );
-  assert.ok(
-    text.includes('# OpenTelemetry'),
-    'body should contain "# OpenTelemetry" (llms.txt heading)',
-  );
+  assert.strictEqual(res.status, 200, 'HTTP status');
+  assert.strictEqual(ct, expectedPlainTextContentType, 'Content-Type');
+  assert.match(text, llmsTxtHeading, 'Request body');
 });
 
 test('GET explicit .txt path with internal marker → same text response', async () => {
@@ -130,13 +122,7 @@ test('GET explicit .txt path with internal marker → same text response', async
   const ct = res.headers.get('content-type') ?? '';
   const text = await res.text();
 
-  assert.equal(res.status, 200, `expected 200 for ${url}`);
-  assert.ok(
-    ct.toLowerCase().includes('text/plain'),
-    `expected text/plain content-type, got ${JSON.stringify(ct)}`,
-  );
-  assert.ok(
-    text.includes('# OpenTelemetry'),
-    'body should contain "# OpenTelemetry" (llms.txt heading)',
-  );
+  assert.strictEqual(res.status, 200, 'HTTP status');
+  assert.strictEqual(ct, expectedPlainTextContentType, 'Content-Type');
+  assert.match(text, llmsTxtHeading, 'Request body');
 });

--- a/netlify/edge-functions/asset-tracking/live-check.test.mjs
+++ b/netlify/edge-functions/asset-tracking/live-check.test.mjs
@@ -32,7 +32,7 @@ function baseRef() {
   return resolveBaseRef(raw);
 }
 
-const markdownPath = '/docs/concepts/resources/index.md';
+const markdownPath = '/site/testing/tests/regular/index.md';
 const textPath = '/llms.txt';
 
 test('GET explicit .md path → markdown response', async () => {
@@ -48,8 +48,19 @@ test('GET explicit .md path → markdown response', async () => {
     `expected text/markdown content-type, got ${JSON.stringify(ct)}`,
   );
   assert.ok(
-    text.includes('# Resources'),
-    'body should contain "# Resources" (English docs index heading)',
+    text.includes('# Regular edge function test page'),
+    'body should contain "# Regular edge function test page"',
+  );
+});
+
+test('GET explicit .md path → X-Asset-Fetch-Ga-Info header', async () => {
+  const ref = baseRef();
+  const url = absUrl(markdownPath, ref);
+  const res = await fetch(url);
+
+  assert.equal(
+    res.headers.get(ASSET_FETCH_GA_INFO_HEADER),
+    `${markdownPath};ga-event-candidate,config-present`,
   );
 });
 
@@ -85,8 +96,8 @@ test('GET explicit .md path with internal marker → same markdown response', as
     `expected text/markdown content-type, got ${JSON.stringify(ct)}`,
   );
   assert.ok(
-    text.includes('# Resources'),
-    'body should contain "# Resources" (English docs index heading)',
+    text.includes('# Regular edge function test page'),
+    'body should contain "# Regular edge function test page"',
   );
 });
 

--- a/netlify/edge-functions/asset-tracking/live-check.test.mjs
+++ b/netlify/edge-functions/asset-tracking/live-check.test.mjs
@@ -13,31 +13,11 @@ import {
   ASSET_FETCH_GA_INFO_HEADER,
   INTERNAL_ASSET_FETCH_GA_INFO_VALUE,
 } from '../lib/ga4-asset-fetch.ts';
-
-/** Must match the key set in `live-check.mjs` before spawning `node --test`. */
-const LIVE_CHECK_BASE_URL_ENV = 'LIVE_CHECK_BASE_URL';
-
-function resolveBaseRef(raw) {
-  const withScheme = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
-  return new URL(withScheme.endsWith('/') ? withScheme : `${withScheme}/`);
-}
-
-function absUrl(path, baseRef) {
-  return new URL(path, baseRef).href;
-}
-
-function baseRef() {
-  const raw = process.env[LIVE_CHECK_BASE_URL_ENV]?.trim();
-  assert.ok(raw, 'Run live checks via: node .../live-check.mjs [-h] [BASE]');
-  return resolveBaseRef(raw);
-}
-
-function expectedConfigTag(baseRef) {
-  return (
-    'config-' +
-    (baseRef.hostname === 'opentelemetry.io' ? 'present' : 'missing')
-  );
-}
+import {
+  absUrl,
+  baseRef,
+  expectedConfigTag,
+} from '../lib/live-check-test-base.mjs';
 
 const markdownPath = '/site/testing/tests/regular/index.md';
 const textPath = '/llms.txt';

--- a/netlify/edge-functions/integration/index.test.ts
+++ b/netlify/edge-functions/integration/index.test.ts
@@ -12,35 +12,8 @@ import {
   ASSET_FETCH_GA_INFO_HEADER,
   INTERNAL_ASSET_FETCH_GA_INFO_VALUE,
 } from '../lib/ga4-asset-fetch.ts';
+import { createWaitUntilSpy, setupNetlifyEnv } from '../lib/test-helpers.ts';
 import markdownNegotiation from '../markdown-negotiation/index.ts';
-
-function setupNetlifyEnv(t: { after: (fn: () => void) => void }) {
-  const g = globalThis as Record<string, unknown>;
-  const originalNetlify = g.Netlify;
-  t.after(() => {
-    g.Netlify = originalNetlify;
-  });
-
-  g.Netlify = {
-    env: {
-      get: (name: string) => {
-        if (name === 'HUGO_SERVICES_GOOGLEANALYTICS_ID') return 'G-TEST';
-        if (name === 'GA4_API_SECRET') return 'secret';
-        return undefined;
-      },
-    },
-  };
-}
-
-function createWaitUntilSpy() {
-  const promises: Promise<unknown>[] = [];
-  return {
-    waitUntil: (p: Promise<unknown>) => {
-      promises.push(p);
-    },
-    flush: () => Promise.all(promises),
-  };
-}
 
 test('markdown negotiation internal .md fetch does not double-count asset_fetch', async (t) => {
   setupNetlifyEnv(t);
@@ -70,12 +43,17 @@ test('markdown negotiation internal .md fetch does not double-count asset_fetch'
     }
 
     const url = new URL(request.url);
-    assert.equal(url.pathname, '/docs/index.md');
-    assert.equal(request.method, 'GET');
-    assert.equal(request.headers.get('accept'), 'text/markdown');
-    assert.equal(
+    assert.strictEqual(url.pathname, '/docs/index.md', 'Subrequest pathname');
+    assert.strictEqual(request.method, 'GET', 'Subrequest method');
+    assert.strictEqual(
+      request.headers.get('accept'),
+      'text/markdown',
+      'Accept header',
+    );
+    assert.strictEqual(
       request.headers.get(ASSET_FETCH_GA_INFO_HEADER),
       INTERNAL_ASSET_FETCH_GA_INFO_VALUE,
+      'X-Asset-Fetch-Ga-Info',
     );
 
     return assetTracking(request, {
@@ -104,27 +82,37 @@ test('markdown negotiation internal .md fetch does not double-count asset_fetch'
 
   await spy.flush();
 
-  assert.equal(response.status, 200);
-  assert.equal(
+  assert.strictEqual(response.status, 200, 'HTTP status');
+  assert.strictEqual(
     response.headers.get('content-type'),
     'text/markdown; charset=utf-8',
+    'Content-Type',
   );
-  assert.equal(
+  assert.strictEqual(
     response.headers.get('x-asset-fetch-ga-info'),
     '/docs/index.md;ga-event-candidate,config-present',
+    'X-Asset-Fetch-Ga-Info',
   );
-  assert.equal(await response.text(), '# Docs');
-  assert.equal(ga4Bodies.length, 1);
+  assert.strictEqual(await response.text(), '# Docs', 'Response body');
+  assert.strictEqual(ga4Bodies.length, 1, 'GA4 body count');
 
   const event = (
     ga4Bodies[0].events as { name: string; params: Record<string, string> }[]
   )[0];
-  assert.equal(event.name, 'asset_fetch');
-  assert.equal(event.params.asset_path, '/docs/index.md');
-  assert.equal(event.params.content_type, 'text/markdown');
-  assert.equal(event.params.status_code, '200');
-  assert.equal(event.params.original_path, '/docs/');
-  assert.equal(event.params.event_emitter, 'negotiation');
+  assert.strictEqual(event.name, 'asset_fetch', 'event name');
+  assert.strictEqual(event.params.asset_path, '/docs/index.md', 'asset_path');
+  assert.strictEqual(
+    event.params.content_type,
+    'text/markdown',
+    'content_type',
+  );
+  assert.strictEqual(event.params.status_code, '200', 'status_code');
+  assert.strictEqual(event.params.original_path, '/docs/', 'original_path');
+  assert.strictEqual(
+    event.params.event_emitter,
+    'negotiation',
+    'event_emitter',
+  );
 });
 
 test('direct .md request passes through markdown negotiation and emits one asset_fetch', async (t) => {
@@ -173,25 +161,31 @@ test('direct .md request passes through markdown negotiation and emits one asset
 
   await spy.flush();
 
-  assert.equal(response.status, 200);
-  assert.equal(
+  assert.strictEqual(response.status, 200, 'HTTP status');
+  assert.strictEqual(
     response.headers.get('content-type'),
     'text/markdown; charset=utf-8',
+    'Content-Type',
   );
-  assert.equal(
+  assert.strictEqual(
     response.headers.get('x-asset-fetch-ga-info'),
     '/docs/index.md;ga-event-candidate,config-present',
+    'X-Asset-Fetch-Ga-Info',
   );
-  assert.equal(await response.text(), '# Docs');
-  assert.equal(ga4Bodies.length, 1);
+  assert.strictEqual(await response.text(), '# Docs', 'Response body');
+  assert.strictEqual(ga4Bodies.length, 1, 'GA4 body count');
 
   const event = (
     ga4Bodies[0].events as { name: string; params: Record<string, string> }[]
   )[0];
-  assert.equal(event.name, 'asset_fetch');
-  assert.equal(event.params.asset_path, '/docs/index.md');
-  assert.equal(event.params.content_type, 'text/markdown');
-  assert.equal(event.params.status_code, '200');
+  assert.strictEqual(event.name, 'asset_fetch', 'event name');
+  assert.strictEqual(event.params.asset_path, '/docs/index.md', 'asset_path');
+  assert.strictEqual(
+    event.params.content_type,
+    'text/markdown',
+    'content_type',
+  );
+  assert.strictEqual(event.params.status_code, '200', 'status_code');
   assert.ok(!('original_path' in event.params));
-  assert.equal(event.params.event_emitter, 'tracking');
+  assert.strictEqual(event.params.event_emitter, 'tracking', 'event_emitter');
 });

--- a/netlify/edge-functions/integration/index.test.ts
+++ b/netlify/edge-functions/integration/index.test.ts
@@ -16,6 +16,7 @@ import {
   assertAssetFetchGa4Event,
   createWaitUntilSpy,
   firstAssetFetchEvent,
+  setupGa4CapturingFetchMock,
   setupNetlifyEnv,
 } from '../lib/test-helpers.ts';
 import markdownNegotiation from '../markdown-negotiation/index.ts';
@@ -23,30 +24,8 @@ import markdownNegotiation from '../markdown-negotiation/index.ts';
 test('markdown negotiation internal .md fetch does not double-count asset_fetch', async (t) => {
   setupNetlifyEnv(t);
 
-  const originalFetch = globalThis.fetch;
-  t.after(() => {
-    globalThis.fetch = originalFetch;
-  });
-
   const spy = createWaitUntilSpy();
-  const ga4Bodies: Record<string, unknown>[] = [];
-
-  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-    const request =
-      input instanceof Request
-        ? input
-        : new Request(
-            input instanceof URL ? input.toString() : String(input),
-            init,
-          );
-
-    if (request.url.includes('google-analytics.com')) {
-      if (init?.body) {
-        ga4Bodies.push(JSON.parse(init.body as string));
-      }
-      return new Response('', { status: 200 });
-    }
-
+  const ga4Bodies = setupGa4CapturingFetchMock(t, async (request) => {
     const url = new URL(request.url);
     assert.strictEqual(url.pathname, '/docs/index.md', 'Subrequest pathname');
     assert.strictEqual(request.method, 'GET', 'Subrequest method');
@@ -69,7 +48,7 @@ test('markdown negotiation internal .md fetch does not double-count asset_fetch'
         }),
       ...spy,
     });
-  }) as typeof fetch;
+  });
 
   const response = await markdownNegotiation(
     new Request('https://example.com/docs/', {
@@ -112,31 +91,8 @@ test('markdown negotiation internal .md fetch does not double-count asset_fetch'
 test('direct .md request passes through markdown negotiation and emits one asset_fetch', async (t) => {
   setupNetlifyEnv(t);
 
-  const originalFetch = globalThis.fetch;
-  t.after(() => {
-    globalThis.fetch = originalFetch;
-  });
-
   const spy = createWaitUntilSpy();
-  const ga4Bodies: Record<string, unknown>[] = [];
-
-  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-    const url =
-      input instanceof URL
-        ? input.toString()
-        : typeof input === 'string'
-          ? input
-          : input.url;
-
-    if (url.includes('google-analytics.com')) {
-      if (init?.body) {
-        ga4Bodies.push(JSON.parse(init.body as string));
-      }
-      return new Response('', { status: 200 });
-    }
-
-    return new Response('unexpected fetch', { status: 500 });
-  }) as typeof fetch;
+  const ga4Bodies = setupGa4CapturingFetchMock(t);
 
   const request = new Request('https://example.com/docs/index.md');
 

--- a/netlify/edge-functions/integration/index.test.ts
+++ b/netlify/edge-functions/integration/index.test.ts
@@ -109,6 +109,10 @@ test('markdown negotiation internal .md fetch does not double-count asset_fetch'
     response.headers.get('content-type'),
     'text/markdown; charset=utf-8',
   );
+  assert.equal(
+    response.headers.get('x-asset-fetch-ga-info'),
+    '/docs/index.md;ga-event-candidate,config-present',
+  );
   assert.equal(await response.text(), '# Docs');
   assert.equal(ga4Bodies.length, 1);
 
@@ -173,6 +177,10 @@ test('direct .md request passes through markdown negotiation and emits one asset
   assert.equal(
     response.headers.get('content-type'),
     'text/markdown; charset=utf-8',
+  );
+  assert.equal(
+    response.headers.get('x-asset-fetch-ga-info'),
+    '/docs/index.md;ga-event-candidate,config-present',
   );
   assert.equal(await response.text(), '# Docs');
   assert.equal(ga4Bodies.length, 1);

--- a/netlify/edge-functions/integration/index.test.ts
+++ b/netlify/edge-functions/integration/index.test.ts
@@ -120,6 +120,7 @@ test('markdown negotiation internal .md fetch does not double-count asset_fetch'
   assert.equal(event.params.content_type, 'text/markdown');
   assert.equal(event.params.status_code, '200');
   assert.equal(event.params.original_path, '/docs/');
+  assert.equal(event.params.event_emitter, 'negotiation');
 });
 
 test('direct .md request passes through markdown negotiation and emits one asset_fetch', async (t) => {
@@ -184,4 +185,5 @@ test('direct .md request passes through markdown negotiation and emits one asset
   assert.equal(event.params.content_type, 'text/markdown');
   assert.equal(event.params.status_code, '200');
   assert.ok(!('original_path' in event.params));
+  assert.equal(event.params.event_emitter, 'tracking');
 });

--- a/netlify/edge-functions/integration/index.test.ts
+++ b/netlify/edge-functions/integration/index.test.ts
@@ -116,9 +116,7 @@ test('markdown negotiation internal .md fetch does not double-count asset_fetch'
     ga4Bodies[0].events as { name: string; params: Record<string, string> }[]
   )[0];
   assert.equal(event.name, 'asset_fetch');
-  assert.equal(event.params.asset_group, 'markdown');
   assert.equal(event.params.asset_path, '/docs/index.md');
-  assert.equal(event.params.asset_ext, 'md');
   assert.equal(event.params.content_type, 'text/markdown');
   assert.equal(event.params.status_code, '200');
   assert.equal(event.params.original_path, '/docs/');
@@ -182,9 +180,7 @@ test('direct .md request passes through markdown negotiation and emits one asset
     ga4Bodies[0].events as { name: string; params: Record<string, string> }[]
   )[0];
   assert.equal(event.name, 'asset_fetch');
-  assert.equal(event.params.asset_group, 'markdown');
   assert.equal(event.params.asset_path, '/docs/index.md');
-  assert.equal(event.params.asset_ext, 'md');
   assert.equal(event.params.content_type, 'text/markdown');
   assert.equal(event.params.status_code, '200');
   assert.ok(!('original_path' in event.params));

--- a/netlify/edge-functions/integration/index.test.ts
+++ b/netlify/edge-functions/integration/index.test.ts
@@ -12,7 +12,12 @@ import {
   ASSET_FETCH_GA_INFO_HEADER,
   INTERNAL_ASSET_FETCH_GA_INFO_VALUE,
 } from '../lib/ga4-asset-fetch.ts';
-import { createWaitUntilSpy, setupNetlifyEnv } from '../lib/test-helpers.ts';
+import {
+  assertAssetFetchGa4Event,
+  createWaitUntilSpy,
+  firstAssetFetchEvent,
+  setupNetlifyEnv,
+} from '../lib/test-helpers.ts';
 import markdownNegotiation from '../markdown-negotiation/index.ts';
 
 test('markdown negotiation internal .md fetch does not double-count asset_fetch', async (t) => {
@@ -94,25 +99,14 @@ test('markdown negotiation internal .md fetch does not double-count asset_fetch'
     'X-Asset-Fetch-Ga-Info',
   );
   assert.strictEqual(await response.text(), '# Docs', 'Response body');
-  assert.strictEqual(ga4Bodies.length, 1, 'GA4 body count');
 
-  const event = (
-    ga4Bodies[0].events as { name: string; params: Record<string, string> }[]
-  )[0];
-  assert.strictEqual(event.name, 'asset_fetch', 'event name');
-  assert.strictEqual(event.params.asset_path, '/docs/index.md', 'asset_path');
-  assert.strictEqual(
-    event.params.content_type,
-    'text/markdown',
-    'content_type',
-  );
-  assert.strictEqual(event.params.status_code, '200', 'status_code');
-  assert.strictEqual(event.params.original_path, '/docs/', 'original_path');
-  assert.strictEqual(
-    event.params.event_emitter,
-    'negotiation',
-    'event_emitter',
-  );
+  assertAssetFetchGa4Event(firstAssetFetchEvent(ga4Bodies), {
+    asset_path: '/docs/index.md',
+    content_type: 'text/markdown',
+    status_code: '200',
+    original_path: '/docs/',
+    event_emitter: 'negotiation',
+  });
 });
 
 test('direct .md request passes through markdown negotiation and emits one asset_fetch', async (t) => {
@@ -173,19 +167,15 @@ test('direct .md request passes through markdown negotiation and emits one asset
     'X-Asset-Fetch-Ga-Info',
   );
   assert.strictEqual(await response.text(), '# Docs', 'Response body');
-  assert.strictEqual(ga4Bodies.length, 1, 'GA4 body count');
 
-  const event = (
-    ga4Bodies[0].events as { name: string; params: Record<string, string> }[]
-  )[0];
-  assert.strictEqual(event.name, 'asset_fetch', 'event name');
-  assert.strictEqual(event.params.asset_path, '/docs/index.md', 'asset_path');
-  assert.strictEqual(
-    event.params.content_type,
-    'text/markdown',
-    'content_type',
+  assertAssetFetchGa4Event(
+    firstAssetFetchEvent(ga4Bodies),
+    {
+      asset_path: '/docs/index.md',
+      content_type: 'text/markdown',
+      status_code: '200',
+      event_emitter: 'tracking',
+    },
+    { expectOriginalPathAbsent: true },
   );
-  assert.strictEqual(event.params.status_code, '200', 'status_code');
-  assert.ok(!('original_path' in event.params));
-  assert.strictEqual(event.params.event_emitter, 'tracking', 'event_emitter');
 });

--- a/netlify/edge-functions/lib/ga4-asset-fetch.test.ts
+++ b/netlify/edge-functions/lib/ga4-asset-fetch.test.ts
@@ -55,9 +55,7 @@ test('enqueueAssetFetchEvent no-ops without waitUntil', () => {
     request,
     {},
     {
-      asset_group: 'schema',
       asset_path: '/schemas/1.40.0',
-      asset_ext: 'yaml',
       content_type: 'application/yaml',
       status_code: '200',
     },
@@ -110,9 +108,7 @@ test('enqueueAssetFetchEvent calls waitUntil with GA4 payload', async (t) => {
   const request = new Request('https://example.com/schemas/1.40.0');
 
   enqueueAssetFetchEvent(request, context, {
-    asset_group: 'schema',
     asset_path: '/schemas/1.40.0',
-    asset_ext: 'yaml',
     content_type: 'application/yaml',
     status_code: '200',
   });
@@ -134,9 +130,7 @@ test('enqueueAssetFetchEvent calls waitUntil with GA4 payload', async (t) => {
   }>;
   assert.equal(events.length, 1);
   assert.equal(events[0].name, 'asset_fetch');
-  assert.equal(events[0].params.asset_group, 'schema');
   assert.equal(events[0].params.asset_path, '/schemas/1.40.0');
-  assert.equal(events[0].params.asset_ext, 'yaml');
   assert.equal(events[0].params.content_type, 'application/yaml');
   assert.equal(events[0].params.status_code, '200');
   assert.equal(

--- a/netlify/edge-functions/lib/ga4-asset-fetch.test.ts
+++ b/netlify/edge-functions/lib/ga4-asset-fetch.test.ts
@@ -11,34 +11,49 @@ import {
 } from './ga4-asset-fetch.ts';
 
 test('normalizeContentType extracts media type', () => {
-  assert.equal(normalizeContentType('application/yaml'), 'application/yaml');
-  assert.equal(normalizeContentType('text/html; charset=utf-8'), 'text/html');
-  assert.equal(
+  assert.strictEqual(
+    normalizeContentType('application/yaml'),
+    'application/yaml',
+    'normalizeContentType',
+  );
+  assert.strictEqual(
+    normalizeContentType('text/html; charset=utf-8'),
+    'text/html',
+    'normalizeContentType',
+  );
+  assert.strictEqual(
     normalizeContentType('  Application/JSON ; q=0.9'),
     'application/json',
+    'normalizeContentType',
   );
-  assert.equal(normalizeContentType(null), 'none');
-  assert.equal(normalizeContentType(''), 'none');
+  assert.strictEqual(
+    normalizeContentType(null),
+    'none',
+    'normalizeContentType',
+  );
+  assert.strictEqual(normalizeContentType(''), 'none', 'normalizeContentType');
 });
 
 test('buildAssetFetchGaInfoHeaderValue formats GA event candidate path with tags', () => {
-  assert.equal(
+  assert.strictEqual(
     buildAssetFetchGaInfoHeaderValue({
       assetPath: '/schemas/1.40.0',
       configPresent: true,
       gaEventCandidate: true,
     }),
     '/schemas/1.40.0;ga-event-candidate,config-present',
+    'buildAssetFetchGaInfoHeaderValue',
   );
 });
 
 test('buildAssetFetchGaInfoHeaderValue formats none reason', () => {
-  assert.equal(
+  assert.strictEqual(
     buildAssetFetchGaInfoHeaderValue({
       noneReason: 'internal subrequest',
       gaEventCandidate: false,
     }),
     'none: internal subrequest',
+    'buildAssetFetchGaInfoHeaderValue',
   );
 });
 
@@ -46,28 +61,40 @@ test('resolveClientId returns fallback when no GA cookie is present', () => {
   const request = new Request('https://example.com/', {
     headers: {},
   });
-  assert.equal(resolveClientId(request), 'asset_fetch.anonymous');
+  assert.strictEqual(
+    resolveClientId(request),
+    'asset_fetch.anonymous',
+    'resolveClientId',
+  );
 });
 
 test('resolveClientId extracts client id from GA cookie', () => {
   const request = new Request('https://example.com/', {
     headers: { cookie: '_ga=GA1.1.123456789.1234567890' },
   });
-  assert.equal(resolveClientId(request), '123456789.1234567890');
+  assert.strictEqual(
+    resolveClientId(request),
+    '123456789.1234567890',
+    'resolveClientId',
+  );
 });
 
 test('resolveClientId returns raw value for non-standard GA cookie', () => {
   const request = new Request('https://example.com/', {
     headers: { cookie: '_ga=custom-value' },
   });
-  assert.equal(resolveClientId(request), 'custom-value');
+  assert.strictEqual(
+    resolveClientId(request),
+    'custom-value',
+    'resolveClientId',
+  );
 });
 
 test('resolveClientId finds GA cookie among multiple cookies', () => {
   const request = new Request('https://example.com/', {
     headers: { cookie: 'session=abc; _ga=GA1.2.111.222; other=xyz' },
   });
-  assert.equal(resolveClientId(request), '111.222');
+  assert.strictEqual(resolveClientId(request), '111.222', 'resolveClientId');
 });
 
 test('enqueueAssetFetchEvent no-ops without waitUntil', () => {
@@ -142,25 +169,45 @@ test('enqueueAssetFetchEvent calls waitUntil with GA4 payload', async (t) => {
 
   assert.ok(capturedUrl, 'fetch should have been called');
   const url = new URL(capturedUrl!);
-  assert.equal(url.searchParams.get('api_secret'), 'secret-test');
-  assert.equal(url.searchParams.get('measurement_id'), 'G-TEST123');
+  assert.strictEqual(
+    url.searchParams.get('api_secret'),
+    'secret-test',
+    'api_secret',
+  );
+  assert.strictEqual(
+    url.searchParams.get('measurement_id'),
+    'G-TEST123',
+    'measurement_id',
+  );
 
-  assert.ok(capturedBody);
-  assert.equal(capturedBody!.client_id, 'asset_fetch.anonymous');
+  assert.ok(capturedBody, 'Body exists');
+  assert.strictEqual(
+    capturedBody!.client_id,
+    'asset_fetch.anonymous',
+    'client_id',
+  );
 
   const events = capturedBody!.events as Array<{
     name: string;
     params: Record<string, string>;
   }>;
-  assert.equal(events.length, 1);
-  assert.equal(events[0].name, 'asset_fetch');
-  assert.equal(events[0].params.asset_path, '/schemas/1.40.0');
-  assert.equal(events[0].params.content_type, 'application/yaml');
-  assert.equal(events[0].params.status_code, '200');
-  assert.equal(events[0].params.event_emitter, 'schema');
-  assert.equal(
+  assert.strictEqual(events.length, 1, 'events length');
+  assert.strictEqual(events[0].name, 'asset_fetch', 'event name');
+  assert.strictEqual(
+    events[0].params.asset_path,
+    '/schemas/1.40.0',
+    'asset_path',
+  );
+  assert.strictEqual(
+    events[0].params.content_type,
+    'application/yaml',
+    'content_type',
+  );
+  assert.strictEqual(events[0].params.status_code, '200', 'status_code');
+  assert.strictEqual(events[0].params.event_emitter, 'schema', 'event_emitter');
+  assert.strictEqual(
     events[0].params.original_path,
     undefined,
-    'undefined params should be stripped',
+    'original_path',
   );
 });

--- a/netlify/edge-functions/lib/ga4-asset-fetch.test.ts
+++ b/netlify/edge-functions/lib/ga4-asset-fetch.test.ts
@@ -58,6 +58,7 @@ test('enqueueAssetFetchEvent no-ops without waitUntil', () => {
       asset_path: '/schemas/1.40.0',
       content_type: 'application/yaml',
       status_code: '200',
+      event_emitter: 'schema',
     },
   );
 });
@@ -111,6 +112,7 @@ test('enqueueAssetFetchEvent calls waitUntil with GA4 payload', async (t) => {
     asset_path: '/schemas/1.40.0',
     content_type: 'application/yaml',
     status_code: '200',
+    event_emitter: 'schema',
   });
 
   assert.ok(waitUntilPromise, 'waitUntil should have been called');
@@ -133,6 +135,7 @@ test('enqueueAssetFetchEvent calls waitUntil with GA4 payload', async (t) => {
   assert.equal(events[0].params.asset_path, '/schemas/1.40.0');
   assert.equal(events[0].params.content_type, 'application/yaml');
   assert.equal(events[0].params.status_code, '200');
+  assert.equal(events[0].params.event_emitter, 'schema');
   assert.equal(
     events[0].params.original_path,
     undefined,

--- a/netlify/edge-functions/lib/ga4-asset-fetch.test.ts
+++ b/netlify/edge-functions/lib/ga4-asset-fetch.test.ts
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  buildAssetFetchGaInfoHeaderValue,
   enqueueAssetFetchEvent,
   normalizeContentType,
   resolveClientId,
@@ -18,6 +19,27 @@ test('normalizeContentType extracts media type', () => {
   );
   assert.equal(normalizeContentType(null), 'none');
   assert.equal(normalizeContentType(''), 'none');
+});
+
+test('buildAssetFetchGaInfoHeaderValue formats GA event candidate path with tags', () => {
+  assert.equal(
+    buildAssetFetchGaInfoHeaderValue({
+      assetPath: '/schemas/1.40.0',
+      configPresent: true,
+      gaEventCandidate: true,
+    }),
+    '/schemas/1.40.0;ga-event-candidate,config-present',
+  );
+});
+
+test('buildAssetFetchGaInfoHeaderValue formats none reason', () => {
+  assert.equal(
+    buildAssetFetchGaInfoHeaderValue({
+      noneReason: 'internal subrequest',
+      gaEventCandidate: false,
+    }),
+    'none: internal subrequest',
+  );
 });
 
 test('resolveClientId returns fallback when no GA cookie is present', () => {

--- a/netlify/edge-functions/lib/ga4-asset-fetch.ts
+++ b/netlify/edge-functions/lib/ga4-asset-fetch.ts
@@ -2,7 +2,7 @@
  * GA4 Measurement Protocol helpers for `asset_fetch` events.
  * Event shape matches projects/2026/asset-fetch-analytics.plan.md.
  *
- * cSpell:ignore GOOGLEANALYTICS
+ * cSpell:ignore GOOGLEANALYTICS replayable
  */
 
 const GA4_COLLECT_URL = 'https://www.google-analytics.com/mp/collect';
@@ -96,6 +96,10 @@ export type AssetFetchContext = {
 };
 
 export function isInternalAssetFetchRequest(request: Request): boolean {
+  // We deliberately use a publicly visible and replayable marker. In this
+  // project GA4 asset analytics are a convenience surface, not the source of
+  // truth; Netlify Observability remains the cross-check for request counts and
+  // anomalies.
   return request.headers.has(ASSET_FETCH_GA_INFO_HEADER);
 }
 

--- a/netlify/edge-functions/lib/ga4-asset-fetch.ts
+++ b/netlify/edge-functions/lib/ga4-asset-fetch.ts
@@ -92,6 +92,9 @@ export function isInternalAssetFetchRequest(request: Request): boolean {
   return request.headers.has(ASSET_FETCH_GA_INFO_HEADER);
 }
 
+/** Canonical `event_emitter` values; see projects/2026/asset-fetch-analytics.plan.md */
+export type AssetFetchEventEmitter = 'negotiation' | 'tracking' | 'schema';
+
 /**
  * GA4 `asset_fetch` event parameters (custom dimensions). Required fields match
  * the plan; optional fields are omitted from the payload when unset.
@@ -100,6 +103,7 @@ export type AssetFetchEventParams = {
   asset_path: string;
   content_type: string;
   status_code: string;
+  event_emitter: AssetFetchEventEmitter;
   original_path?: string;
   referrer_host?: string;
   ua_category?: string;

--- a/netlify/edge-functions/lib/ga4-asset-fetch.ts
+++ b/netlify/edge-functions/lib/ga4-asset-fetch.ts
@@ -44,6 +44,13 @@ export function getEnvValue(names: string[]): string | null {
   return null;
 }
 
+export function hasAssetFetchConfig(): boolean {
+  return !!(
+    netlifyEnvGet(MEASUREMENT_ID_ENV_NAME)?.trim() &&
+    getEnvValue(API_SECRET_ENV_NAMES)
+  );
+}
+
 export function normalizeContentType(contentTypeHeader: string | null): string {
   if (!contentTypeHeader) {
     return 'none';
@@ -115,6 +122,48 @@ function compactStringParams(
   return Object.fromEntries(
     Object.entries(eventParams).filter(([, v]) => v !== undefined),
   ) as Record<string, string>;
+}
+
+export function buildAssetFetchGaInfoHeaderValue({
+  assetPath,
+  gaEventCandidate,
+  configPresent,
+  noneReason,
+}: {
+  assetPath?: string;
+  gaEventCandidate: boolean;
+  configPresent?: boolean;
+  noneReason?: string;
+}): string {
+  if (!gaEventCandidate || !assetPath) {
+    return noneReason ? `none: ${noneReason}` : 'none';
+  }
+
+  const tags = [
+    'ga-event-candidate',
+    configPresent ? 'config-present' : 'config-missing',
+  ];
+  return `${assetPath};${tags.join(',')}`;
+}
+
+export function withAssetFetchGaInfoHeader(
+  response: Response,
+  value: string,
+  { overwrite = true }: { overwrite?: boolean } = {},
+): Response {
+  const headers = new Headers(response.headers);
+
+  if (!overwrite && headers.has(ASSET_FETCH_GA_INFO_HEADER)) {
+    return response;
+  }
+
+  headers.set(ASSET_FETCH_GA_INFO_HEADER, value);
+
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
 }
 
 /**

--- a/netlify/edge-functions/lib/ga4-asset-fetch.ts
+++ b/netlify/edge-functions/lib/ga4-asset-fetch.ts
@@ -92,17 +92,12 @@ export function isInternalAssetFetchRequest(request: Request): boolean {
   return request.headers.has(ASSET_FETCH_GA_INFO_HEADER);
 }
 
-/** `asset_group` values from the analytics plan. */
-export type AssetFetchEventGroup = 'schema' | 'markdown' | 'other';
-
 /**
  * GA4 `asset_fetch` event parameters (custom dimensions). Required fields match
  * the plan; optional fields are omitted from the payload when unset.
  */
 export type AssetFetchEventParams = {
-  asset_group: AssetFetchEventGroup;
   asset_path: string;
-  asset_ext: string;
   content_type: string;
   status_code: string;
   original_path?: string;

--- a/netlify/edge-functions/lib/live-check-test-base.mjs
+++ b/netlify/edge-functions/lib/live-check-test-base.mjs
@@ -1,0 +1,34 @@
+/**
+ * Shared helpers for `live-check.test.mjs` files (plain ESM so `node --test`
+ * does not need to load this module from TypeScript).
+ *
+ * `LIVE_CHECK_BASE_URL` must match the key set in each edge function's
+ * `live-check.mjs` before spawning `node --test`.
+ */
+
+import assert from 'node:assert/strict';
+
+/** Must match the key set in `live-check.mjs` before spawning `node --test`. */
+export const LIVE_CHECK_BASE_URL_ENV = 'LIVE_CHECK_BASE_URL';
+
+export function resolveBaseRef(raw) {
+  const withScheme = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+  return new URL(withScheme.endsWith('/') ? withScheme : `${withScheme}/`);
+}
+
+export function absUrl(path, baseRef) {
+  return new URL(path, baseRef).href;
+}
+
+export function baseRef() {
+  const raw = process.env[LIVE_CHECK_BASE_URL_ENV]?.trim();
+  assert.ok(raw, 'Run live checks via: node .../live-check.mjs [-h] [BASE]');
+  return resolveBaseRef(raw);
+}
+
+export function expectedConfigTag(baseRef) {
+  return (
+    'config-' +
+    (baseRef.hostname === 'opentelemetry.io' ? 'present' : 'missing')
+  );
+}

--- a/netlify/edge-functions/lib/test-helpers.ts
+++ b/netlify/edge-functions/lib/test-helpers.ts
@@ -129,11 +129,7 @@ export function firstAssetFetchEvent(
   ga4Bodies: Record<string, unknown>[],
   expectedBodyCount = 1,
 ): AssetFetchGa4Event {
-  assert.strictEqual(
-    ga4Bodies.length,
-    expectedBodyCount,
-    'GA4 body count',
-  );
+  assert.strictEqual(ga4Bodies.length, expectedBodyCount, 'GA4 body count');
   const events = parseGa4EventsArray(ga4Bodies[0] as Record<string, unknown>);
   assert.ok(events.length > 0, 'GA4 events length');
   return events[0]!;

--- a/netlify/edge-functions/lib/test-helpers.ts
+++ b/netlify/edge-functions/lib/test-helpers.ts
@@ -80,6 +80,102 @@ export function setupGa4CapturingFetchMock(
   return ga4Bodies;
 }
 
+/**
+ * Replaces `globalThis.fetch` for the duration of the test; restores the
+ * previous implementation in `t.after`.
+ */
+export function withMockFetch(
+  t: TestLifecycle,
+  implementation: typeof fetch,
+): void {
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+  globalThis.fetch = implementation;
+}
+
+/** One GA4 Measurement Protocol `events[]` entry used in `asset_fetch` tests. */
+export type AssetFetchGa4Event = {
+  name: string;
+  params: Record<string, string>;
+};
+
+const ASSET_FETCH_PARAM_KEYS = [
+  'asset_path',
+  'content_type',
+  'status_code',
+  'original_path',
+  'event_emitter',
+] as const;
+
+export type AssetFetchParamsExpected = Partial<
+  Record<(typeof ASSET_FETCH_PARAM_KEYS)[number], string>
+>;
+
+function parseGa4EventsArray(
+  body: Record<string, unknown>,
+): AssetFetchGa4Event[] {
+  const events = body.events;
+  assert.ok(Array.isArray(events), 'GA4 body.events');
+  return events as AssetFetchGa4Event[];
+}
+
+/**
+ * Asserts `ga4Bodies.length` and returns the first event from the first captured
+ * GA4 POST JSON body.
+ */
+export function firstAssetFetchEvent(
+  ga4Bodies: Record<string, unknown>[],
+  expectedBodyCount = 1,
+): AssetFetchGa4Event {
+  assert.strictEqual(
+    ga4Bodies.length,
+    expectedBodyCount,
+    'GA4 body count',
+  );
+  const events = parseGa4EventsArray(ga4Bodies[0] as Record<string, unknown>);
+  assert.ok(events.length > 0, 'GA4 events length');
+  return events[0]!;
+}
+
+/** Like {@link firstAssetFetchEvent} but returns only `params` (no `name` check). */
+export function firstAssetFetchParams(
+  ga4Bodies: Record<string, unknown>[],
+  expectedBodyCount = 1,
+): Record<string, string> {
+  return firstAssetFetchEvent(ga4Bodies, expectedBodyCount).params;
+}
+
+export function assertAssetFetchGa4Event(
+  event: AssetFetchGa4Event,
+  expectedParams: AssetFetchParamsExpected,
+  options?: { expectOriginalPathAbsent?: boolean },
+): void {
+  assert.strictEqual(event.name, 'asset_fetch', 'event name');
+  assertAssetFetchParams(event.params, expectedParams, options);
+}
+
+/**
+ * Asserts selected `asset_fetch` params. Only keys present on `expected` are
+ * checked. When `expectOriginalPathAbsent` is true, asserts `original_path` is
+ * not present on `params` (same as `assert.ok(!('original_path' in params))`).
+ */
+export function assertAssetFetchParams(
+  params: Record<string, string>,
+  expected: AssetFetchParamsExpected,
+  options?: { expectOriginalPathAbsent?: boolean },
+): void {
+  if (options?.expectOriginalPathAbsent) {
+    assert.ok(!('original_path' in params));
+  }
+  for (const k of ASSET_FETCH_PARAM_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(expected, k)) {
+      assert.strictEqual(params[k], expected[k], k);
+    }
+  }
+}
+
 export function varyIncludesAccept(
   varyHeader: string | null | undefined,
 ): boolean {

--- a/netlify/edge-functions/lib/test-helpers.ts
+++ b/netlify/edge-functions/lib/test-helpers.ts
@@ -1,0 +1,103 @@
+/** Shared helpers for edge-function tests (unit and live-check). */
+
+import assert from 'node:assert/strict';
+
+/** `node:test` context (or any object with `after`). */
+export type TestLifecycle = { after: (fn: () => void) => void };
+
+/**
+ * Minimal Netlify globals so GA4 enqueue paths see measurement id + API secret.
+ * Values match across handler / integration tests (`G-TEST`, `secret`).
+ */
+export function setupNetlifyEnv(t: TestLifecycle): void {
+  const g = globalThis as Record<string, unknown>;
+  const originalNetlify = g.Netlify;
+  t.after(() => {
+    g.Netlify = originalNetlify;
+  });
+
+  g.Netlify = {
+    env: {
+      get: (name: string) => {
+        if (name === 'HUGO_SERVICES_GOOGLEANALYTICS_ID') return 'G-TEST';
+        if (name === 'GA4_API_SECRET') return 'secret';
+        return undefined;
+      },
+    },
+  };
+}
+
+/** Collects `context.waitUntil` promises for `await flush()` in tests. */
+export function createWaitUntilSpy(): {
+  waitUntil: (p: Promise<unknown>) => void;
+  flush: () => Promise<unknown[]>;
+} {
+  const promises: Promise<unknown>[] = [];
+  return {
+    waitUntil: (p: Promise<unknown>) => {
+      promises.push(p);
+    },
+    flush: () => Promise.all(promises),
+  };
+}
+
+const defaultNonGa4Fetch: (input: Request) => Promise<Response> = async () =>
+  new Response('unexpected fetch', { status: 500 });
+
+/**
+ * Stubs `globalThis.fetch`: records GA4 Measurement Protocol POST bodies and
+ * delegates other requests to `nonGa4Handler` (default: 500 "unexpected fetch").
+ */
+export function setupGa4CapturingFetchMock(
+  t: TestLifecycle,
+  nonGa4Handler: (input: Request) => Promise<Response> = defaultNonGa4Fetch,
+): Record<string, unknown>[] {
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const ga4Bodies: Record<string, unknown>[] = [];
+
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      input instanceof URL
+        ? input.toString()
+        : typeof input === 'string'
+          ? input
+          : input.url;
+
+    if (url.includes('google-analytics.com')) {
+      if (init?.body) {
+        ga4Bodies.push(JSON.parse(init.body as string));
+      }
+      return new Response('', { status: 200 });
+    }
+
+    return nonGa4Handler(input as Request);
+  }) as typeof fetch;
+
+  return ga4Bodies;
+}
+
+export function varyIncludesAccept(
+  varyHeader: string | null | undefined,
+): boolean {
+  if (!varyHeader) {
+    return false;
+  }
+  return varyHeader
+    .split(',')
+    .some((part) => part.trim().toLowerCase() === 'accept');
+}
+
+export function assertVaryIncludesAccept(
+  res: Response,
+  label = 'Vary header',
+): void {
+  const vary = res.headers.get('vary');
+  assert.ok(
+    varyIncludesAccept(vary),
+    `${label}: expected Accept token, got ${JSON.stringify(vary)}`,
+  );
+}

--- a/netlify/edge-functions/markdown-negotiation/README.md
+++ b/netlify/edge-functions/markdown-negotiation/README.md
@@ -17,7 +17,7 @@ so the asset-tracking Edge Function can detect and skip those subrequests,
 avoiding duplicate `asset_fetch` events.
 
 Responses also include `X-Asset-Fetch-Ga-Info` for coarse sanity-checking of the
-derived GA path and local trackability/config state.
+derived GA path and local request-path/config state.
 
 Explicit `GET` requests to a `*.md` URL pass straight through and do **not**
 emit `asset_fetch` here.

--- a/netlify/edge-functions/markdown-negotiation/README.md
+++ b/netlify/edge-functions/markdown-negotiation/README.md
@@ -7,9 +7,10 @@ Successful `2xx` Markdown responses enqueue a GA4 `asset_fetch` event (GET only)
 when `GA4_API_SECRET` and `HUGO_SERVICES_GOOGLEANALYTICS_ID` are set (see
 `../lib/ga4-asset-fetch.ts` and `projects/2026/asset-fetch-analytics.plan.md`).
 `asset_path` is the resolved `*.md` path; `original_path` is included only when
-it differs from `asset_path`; `content_type` is read from the response headers.
-Non-2xx results fall back to the normal HTML page, which is covered by the
-site's client-side GA `page_view` instrumentation.
+it differs from `asset_path`; `content_type` is read from the response headers;
+and `event_emitter` is `negotiation`. Non-2xx results fall back to the
+normal HTML page, which is covered by the site's client-side GA `page_view`
+instrumentation.
 
 Internal fetches for sibling `index.md` assets include `X-Asset-Fetch-Ga-Info`
 so the asset-tracking Edge Function can detect and skip those subrequests,

--- a/netlify/edge-functions/markdown-negotiation/README.md
+++ b/netlify/edge-functions/markdown-negotiation/README.md
@@ -8,13 +8,16 @@ when `GA4_API_SECRET` and `HUGO_SERVICES_GOOGLEANALYTICS_ID` are set (see
 `../lib/ga4-asset-fetch.ts` and `projects/2026/asset-fetch-analytics.plan.md`).
 `asset_path` is the resolved `*.md` path; `original_path` is included only when
 it differs from `asset_path`; `content_type` is read from the response headers;
-and `event_emitter` is `negotiation`. Non-2xx results fall back to the
-normal HTML page, which is covered by the site's client-side GA `page_view`
+and `event_emitter` is `negotiation`. Non-2xx results fall back to the normal
+HTML page, which is covered by the site's client-side GA `page_view`
 instrumentation.
 
 Internal fetches for sibling `index.md` assets include `X-Asset-Fetch-Ga-Info`
 so the asset-tracking Edge Function can detect and skip those subrequests,
 avoiding duplicate `asset_fetch` events.
+
+Responses also include `X-Asset-Fetch-Ga-Info` for coarse sanity-checking of the
+derived GA path and local trackability/config state.
 
 Explicit `GET` requests to a `*.md` URL pass straight through and do **not**
 emit `asset_fetch` here.

--- a/netlify/edge-functions/markdown-negotiation/analytics.test.ts
+++ b/netlify/edge-functions/markdown-negotiation/analytics.test.ts
@@ -114,9 +114,7 @@ test('GET markdown emits asset_fetch with original_path when path differs', asyn
     ga4Bodies[0].events as { name: string; params: Record<string, string> }[]
   )[0];
   assert.equal(event.name, 'asset_fetch');
-  assert.equal(event.params.asset_group, 'markdown');
   assert.equal(event.params.asset_path, '/docs/index.md');
-  assert.equal(event.params.asset_ext, 'md');
   assert.equal(event.params.content_type, 'text/markdown');
   assert.equal(event.params.status_code, '200');
   assert.equal(event.params.original_path, '/docs/');

--- a/netlify/edge-functions/markdown-negotiation/analytics.test.ts
+++ b/netlify/edge-functions/markdown-negotiation/analytics.test.ts
@@ -109,6 +109,10 @@ test('GET markdown emits asset_fetch with original_path when path differs', asyn
     'text/markdown; charset=utf-8',
   );
   assert.equal(ga4Bodies.length, 1);
+  assert.equal(
+    response.headers.get('x-asset-fetch-ga-info'),
+    '/docs/index.md;ga-event-candidate,config-present',
+  );
 
   const event = (
     ga4Bodies[0].events as { name: string; params: Record<string, string> }[]
@@ -231,7 +235,7 @@ test('markdown unavailable does not emit asset_fetch', async (t) => {
 
   const spy = createWaitUntilSpy();
 
-  await markdownNegotiation(
+  const response = await markdownNegotiation(
     new Request('https://example.com/search/', {
       headers: { accept: 'text/markdown' },
     }),
@@ -251,5 +255,9 @@ test('markdown unavailable does not emit asset_fetch', async (t) => {
     ga4Bodies.length,
     0,
     'failed markdown fetch should not emit GA4 events',
+  );
+  assert.equal(
+    response.headers.get('x-asset-fetch-ga-info'),
+    'none: response does not meet route-specific gating',
   );
 });

--- a/netlify/edge-functions/markdown-negotiation/analytics.test.ts
+++ b/netlify/edge-functions/markdown-negotiation/analytics.test.ts
@@ -13,71 +13,16 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import {
+  createWaitUntilSpy,
+  setupGa4CapturingFetchMock,
+  setupNetlifyEnv,
+} from '../lib/test-helpers.ts';
 import markdownNegotiation from './index.ts';
-
-function setupNetlifyEnv(t: { after: (fn: () => void) => void }) {
-  const g = globalThis as Record<string, unknown>;
-  const originalNetlify = g.Netlify;
-  t.after(() => {
-    g.Netlify = originalNetlify;
-  });
-
-  g.Netlify = {
-    env: {
-      get: (name: string) => {
-        if (name === 'HUGO_SERVICES_GOOGLEANALYTICS_ID') return 'G-TEST';
-        if (name === 'GA4_API_SECRET') return 'secret';
-        return undefined;
-      },
-    },
-  };
-}
-
-function setupFetchMock(
-  t: { after: (fn: () => void) => void },
-  handler: (input: Request) => Promise<Response>,
-) {
-  const originalFetch = globalThis.fetch;
-  t.after(() => {
-    globalThis.fetch = originalFetch;
-  });
-
-  const ga4Bodies: Record<string, unknown>[] = [];
-
-  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-    const url =
-      input instanceof URL
-        ? input.toString()
-        : typeof input === 'string'
-          ? input
-          : input.url;
-
-    if (url.includes('google-analytics.com')) {
-      if (init?.body) {
-        ga4Bodies.push(JSON.parse(init.body as string));
-      }
-      return new Response('', { status: 200 });
-    }
-
-    return handler(input as Request);
-  }) as typeof fetch;
-
-  return ga4Bodies;
-}
-
-function createWaitUntilSpy() {
-  const promises: Promise<unknown>[] = [];
-  return {
-    waitUntil: (p: Promise<unknown>) => {
-      promises.push(p);
-    },
-    flush: () => Promise.all(promises),
-  };
-}
 
 test('GET markdown emits asset_fetch with original_path when path differs', async (t) => {
   setupNetlifyEnv(t);
-  const ga4Bodies = setupFetchMock(
+  const ga4Bodies = setupGa4CapturingFetchMock(
     t,
     async () =>
       new Response('# Docs', {
@@ -104,30 +49,40 @@ test('GET markdown emits asset_fetch with original_path when path differs', asyn
 
   await spy.flush();
 
-  assert.equal(
+  assert.strictEqual(
     response.headers.get('content-type'),
     'text/markdown; charset=utf-8',
+    'Content-Type',
   );
-  assert.equal(ga4Bodies.length, 1);
-  assert.equal(
+  assert.strictEqual(ga4Bodies.length, 1, 'GA4 body count');
+  assert.strictEqual(
     response.headers.get('x-asset-fetch-ga-info'),
     '/docs/index.md;ga-event-candidate,config-present',
+    'X-Asset-Fetch-Ga-Info',
   );
 
   const event = (
     ga4Bodies[0].events as { name: string; params: Record<string, string> }[]
   )[0];
-  assert.equal(event.name, 'asset_fetch');
-  assert.equal(event.params.asset_path, '/docs/index.md');
-  assert.equal(event.params.content_type, 'text/markdown');
-  assert.equal(event.params.status_code, '200');
-  assert.equal(event.params.original_path, '/docs/');
-  assert.equal(event.params.event_emitter, 'negotiation');
+  assert.strictEqual(event.name, 'asset_fetch', 'event name');
+  assert.strictEqual(event.params.asset_path, '/docs/index.md', 'asset_path');
+  assert.strictEqual(
+    event.params.content_type,
+    'text/markdown',
+    'content_type',
+  );
+  assert.strictEqual(event.params.status_code, '200', 'status_code');
+  assert.strictEqual(event.params.original_path, '/docs/', 'original_path');
+  assert.strictEqual(
+    event.params.event_emitter,
+    'negotiation',
+    'event_emitter',
+  );
 });
 
 test('GET markdown includes original_path when request path differs from resolved md', async (t) => {
   setupNetlifyEnv(t);
-  const ga4Bodies = setupFetchMock(
+  const ga4Bodies = setupGa4CapturingFetchMock(
     t,
     async () =>
       new Response('# Page', {
@@ -154,18 +109,18 @@ test('GET markdown includes original_path when request path differs from resolve
 
   await spy.flush();
 
-  assert.equal(ga4Bodies.length, 1);
+  assert.strictEqual(ga4Bodies.length, 1, 'GA4 body count');
   const params = (
     ga4Bodies[0].events as { params: Record<string, string> }[]
   )[0].params;
-  assert.equal(params.asset_path, '/docs/index.md');
-  assert.equal(params.original_path, '/docs/index.html');
-  assert.equal(params.event_emitter, 'negotiation');
+  assert.strictEqual(params.asset_path, '/docs/index.md', 'asset_path');
+  assert.strictEqual(params.original_path, '/docs/index.html', 'original_path');
+  assert.strictEqual(params.event_emitter, 'negotiation', 'event_emitter');
 });
 
 test('GET direct .md URL currently passes through without asset_fetch', async (t) => {
   setupNetlifyEnv(t);
-  const ga4Bodies = setupFetchMock(
+  const ga4Bodies = setupGa4CapturingFetchMock(
     t,
     async () =>
       new Response('unexpected: fetch should not run for pass-through .md', {
@@ -189,17 +144,18 @@ test('GET direct .md URL currently passes through without asset_fetch', async (t
 
   await spy.flush();
 
-  assert.equal(response.status, 200);
-  assert.equal(
+  assert.strictEqual(response.status, 200, 'HTTP status');
+  assert.strictEqual(
     response.headers.get('content-type'),
     'text/markdown; charset=utf-8',
+    'Content-Type',
   );
-  assert.equal(ga4Bodies.length, 0);
+  assert.strictEqual(ga4Bodies.length, 0, 'GA4 body count');
 });
 
 test('HEAD markdown does not emit asset_fetch', async (t) => {
   setupNetlifyEnv(t);
-  const ga4Bodies = setupFetchMock(
+  const ga4Bodies = setupGa4CapturingFetchMock(
     t,
     async () =>
       new Response('ignored', {
@@ -223,12 +179,12 @@ test('HEAD markdown does not emit asset_fetch', async (t) => {
 
   await spy.flush();
 
-  assert.equal(ga4Bodies.length, 0, 'HEAD should not emit GA4 events');
+  assert.strictEqual(ga4Bodies.length, 0, 'GA4 body count');
 });
 
 test('markdown unavailable does not emit asset_fetch', async (t) => {
   setupNetlifyEnv(t);
-  const ga4Bodies = setupFetchMock(
+  const ga4Bodies = setupGa4CapturingFetchMock(
     t,
     async () => new Response('not found', { status: 404 }),
   );
@@ -251,13 +207,10 @@ test('markdown unavailable does not emit asset_fetch', async (t) => {
 
   await spy.flush();
 
-  assert.equal(
-    ga4Bodies.length,
-    0,
-    'failed markdown fetch should not emit GA4 events',
-  );
-  assert.equal(
+  assert.strictEqual(ga4Bodies.length, 0, 'GA4 body count');
+  assert.strictEqual(
     response.headers.get('x-asset-fetch-ga-info'),
     'none: response does not meet route-specific gating',
+    'X-Asset-Fetch-Ga-Info',
   );
 });

--- a/netlify/edge-functions/markdown-negotiation/analytics.test.ts
+++ b/netlify/edge-functions/markdown-negotiation/analytics.test.ts
@@ -118,6 +118,7 @@ test('GET markdown emits asset_fetch with original_path when path differs', asyn
   assert.equal(event.params.content_type, 'text/markdown');
   assert.equal(event.params.status_code, '200');
   assert.equal(event.params.original_path, '/docs/');
+  assert.equal(event.params.event_emitter, 'negotiation');
 });
 
 test('GET markdown includes original_path when request path differs from resolved md', async (t) => {
@@ -155,6 +156,7 @@ test('GET markdown includes original_path when request path differs from resolve
   )[0].params;
   assert.equal(params.asset_path, '/docs/index.md');
   assert.equal(params.original_path, '/docs/index.html');
+  assert.equal(params.event_emitter, 'negotiation');
 });
 
 test('GET direct .md URL currently passes through without asset_fetch', async (t) => {

--- a/netlify/edge-functions/markdown-negotiation/analytics.test.ts
+++ b/netlify/edge-functions/markdown-negotiation/analytics.test.ts
@@ -14,7 +14,11 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  assertAssetFetchGa4Event,
+  assertAssetFetchParams,
   createWaitUntilSpy,
+  firstAssetFetchEvent,
+  firstAssetFetchParams,
   setupGa4CapturingFetchMock,
   setupNetlifyEnv,
 } from '../lib/test-helpers.ts';
@@ -54,30 +58,19 @@ test('GET markdown emits asset_fetch with original_path when path differs', asyn
     'text/markdown; charset=utf-8',
     'Content-Type',
   );
-  assert.strictEqual(ga4Bodies.length, 1, 'GA4 body count');
   assert.strictEqual(
     response.headers.get('x-asset-fetch-ga-info'),
     '/docs/index.md;ga-event-candidate,config-present',
     'X-Asset-Fetch-Ga-Info',
   );
 
-  const event = (
-    ga4Bodies[0].events as { name: string; params: Record<string, string> }[]
-  )[0];
-  assert.strictEqual(event.name, 'asset_fetch', 'event name');
-  assert.strictEqual(event.params.asset_path, '/docs/index.md', 'asset_path');
-  assert.strictEqual(
-    event.params.content_type,
-    'text/markdown',
-    'content_type',
-  );
-  assert.strictEqual(event.params.status_code, '200', 'status_code');
-  assert.strictEqual(event.params.original_path, '/docs/', 'original_path');
-  assert.strictEqual(
-    event.params.event_emitter,
-    'negotiation',
-    'event_emitter',
-  );
+  assertAssetFetchGa4Event(firstAssetFetchEvent(ga4Bodies), {
+    asset_path: '/docs/index.md',
+    content_type: 'text/markdown',
+    status_code: '200',
+    original_path: '/docs/',
+    event_emitter: 'negotiation',
+  });
 });
 
 test('GET markdown includes original_path when request path differs from resolved md', async (t) => {
@@ -109,13 +102,11 @@ test('GET markdown includes original_path when request path differs from resolve
 
   await spy.flush();
 
-  assert.strictEqual(ga4Bodies.length, 1, 'GA4 body count');
-  const params = (
-    ga4Bodies[0].events as { params: Record<string, string> }[]
-  )[0].params;
-  assert.strictEqual(params.asset_path, '/docs/index.md', 'asset_path');
-  assert.strictEqual(params.original_path, '/docs/index.html', 'original_path');
-  assert.strictEqual(params.event_emitter, 'negotiation', 'event_emitter');
+  assertAssetFetchParams(firstAssetFetchParams(ga4Bodies), {
+    asset_path: '/docs/index.md',
+    original_path: '/docs/index.html',
+    event_emitter: 'negotiation',
+  });
 });
 
 test('GET direct .md URL currently passes through without asset_fetch', async (t) => {

--- a/netlify/edge-functions/markdown-negotiation/handler.test.ts
+++ b/netlify/edge-functions/markdown-negotiation/handler.test.ts
@@ -12,34 +12,35 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { assertVaryIncludesAccept } from '../lib/test-helpers.ts';
+import {
+  assertVaryIncludesAccept,
+  withMockFetch,
+} from '../lib/test-helpers.ts';
 import markdownNegotiation from './index.ts';
 
 test('handler serves markdown when preferred and available', async (t) => {
-  const originalFetch = globalThis.fetch;
-  t.after(() => {
-    globalThis.fetch = originalFetch;
-  });
+  withMockFetch(
+    t,
+    (async (input) => {
+      const request = input as Request;
+      assert.strictEqual(
+        request.url,
+        'https://example.com/docs/index.md',
+        'Subrequest URL',
+      );
+      assert.strictEqual(request.method, 'GET', 'Subrequest method');
+      assert.strictEqual(
+        request.headers.get('accept'),
+        'text/markdown',
+        'Accept header',
+      );
 
-  globalThis.fetch = (async (input) => {
-    const request = input as Request;
-    assert.strictEqual(
-      request.url,
-      'https://example.com/docs/index.md',
-      'Subrequest URL',
-    );
-    assert.strictEqual(request.method, 'GET', 'Subrequest method');
-    assert.strictEqual(
-      request.headers.get('accept'),
-      'text/markdown',
-      'Accept header',
-    );
-
-    return new Response('# Docs', {
-      headers: { 'content-type': 'text/plain; charset=utf-8' },
-      status: 200,
-    });
-  }) as typeof fetch;
+      return new Response('# Docs', {
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+        status: 200,
+      });
+    }) as typeof fetch,
+  );
 
   const response = await markdownNegotiation(
     new Request('https://example.com/docs/', {
@@ -64,25 +65,23 @@ test('handler serves markdown when preferred and available', async (t) => {
 });
 
 test('handler serves markdown for the site root', async (t) => {
-  const originalFetch = globalThis.fetch;
-  t.after(() => {
-    globalThis.fetch = originalFetch;
-  });
+  withMockFetch(
+    t,
+    (async (input) => {
+      const request = input as Request;
+      assert.strictEqual(
+        request.url,
+        'https://example.com/index.md',
+        'Subrequest URL',
+      );
+      assert.strictEqual(request.method, 'GET', 'Subrequest method');
 
-  globalThis.fetch = (async (input) => {
-    const request = input as Request;
-    assert.strictEqual(
-      request.url,
-      'https://example.com/index.md',
-      'Subrequest URL',
-    );
-    assert.strictEqual(request.method, 'GET', 'Subrequest method');
-
-    return new Response('# Home', {
-      headers: { 'content-type': 'text/plain; charset=utf-8' },
-      status: 200,
-    });
-  }) as typeof fetch;
+      return new Response('# Home', {
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+        status: 200,
+      });
+    }) as typeof fetch,
+  );
 
   const response = await markdownNegotiation(
     new Request('https://example.com/', {
@@ -102,25 +101,23 @@ test('handler serves markdown for the site root', async (t) => {
 });
 
 test('handler serves markdown for explicit html page requests', async (t) => {
-  const originalFetch = globalThis.fetch;
-  t.after(() => {
-    globalThis.fetch = originalFetch;
-  });
+  withMockFetch(
+    t,
+    (async (input) => {
+      const request = input as Request;
+      assert.strictEqual(
+        request.url,
+        'https://example.com/docs/index.md',
+        'Subrequest URL',
+      );
+      assert.strictEqual(request.method, 'GET', 'Subrequest method');
 
-  globalThis.fetch = (async (input) => {
-    const request = input as Request;
-    assert.strictEqual(
-      request.url,
-      'https://example.com/docs/index.md',
-      'Subrequest URL',
-    );
-    assert.strictEqual(request.method, 'GET', 'Subrequest method');
-
-    return new Response('# Html page mapped to markdown', {
-      headers: { 'content-type': 'text/plain; charset=utf-8' },
-      status: 200,
-    });
-  }) as typeof fetch;
+      return new Response('# Html page mapped to markdown', {
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+        status: 200,
+      });
+    }) as typeof fetch,
+  );
 
   const response = await markdownNegotiation(
     new Request('https://example.com/docs/index.html', {
@@ -144,16 +141,14 @@ test('handler serves markdown for explicit html page requests', async (t) => {
 });
 
 test('handler bypasses negotiation for non-index html paths', async (t) => {
-  const originalFetch = globalThis.fetch;
-  t.after(() => {
-    globalThis.fetch = originalFetch;
-  });
-
   let fetched = false;
-  globalThis.fetch = (async () => {
-    fetched = true;
-    return new Response('unexpected', { status: 200 });
-  }) as typeof fetch;
+  withMockFetch(
+    t,
+    (async () => {
+      fetched = true;
+      return new Response('unexpected', { status: 200 });
+    }) as typeof fetch,
+  );
 
   const docsHtmlResponse = await markdownNegotiation(
     new Request('https://example.com/docs.html', {
@@ -219,16 +214,14 @@ test('handler bypasses negotiation for non-index html paths', async (t) => {
 });
 
 test('handler bypasses markdown fetch when html is preferred', async (t) => {
-  const originalFetch = globalThis.fetch;
-  t.after(() => {
-    globalThis.fetch = originalFetch;
-  });
-
   let fetched = false;
-  globalThis.fetch = (async () => {
-    fetched = true;
-    return new Response('unexpected', { status: 200 });
-  }) as typeof fetch;
+  withMockFetch(
+    t,
+    (async () => {
+      fetched = true;
+      return new Response('unexpected', { status: 200 });
+    }) as typeof fetch,
+  );
 
   const response = await markdownNegotiation(
     new Request('https://example.com/docs/', {
@@ -257,16 +250,14 @@ test('handler bypasses markdown fetch when html is preferred', async (t) => {
 });
 
 test('handler bypasses markdown fetch when Accept is missing', async (t) => {
-  const originalFetch = globalThis.fetch;
-  t.after(() => {
-    globalThis.fetch = originalFetch;
-  });
-
   let fetched = false;
-  globalThis.fetch = (async () => {
-    fetched = true;
-    return new Response('unexpected', { status: 200 });
-  }) as typeof fetch;
+  withMockFetch(
+    t,
+    (async () => {
+      fetched = true;
+      return new Response('unexpected', { status: 200 });
+    }) as typeof fetch,
+  );
 
   const response = await markdownNegotiation(
     new Request('https://example.com/docs/'),
@@ -293,16 +284,14 @@ test('handler bypasses markdown fetch when Accept is missing', async (t) => {
 });
 
 test('handler bypasses markdown fetch for unsupported methods', async (t) => {
-  const originalFetch = globalThis.fetch;
-  t.after(() => {
-    globalThis.fetch = originalFetch;
-  });
-
   let fetched = false;
-  globalThis.fetch = (async () => {
-    fetched = true;
-    return new Response('unexpected', { status: 200 });
-  }) as typeof fetch;
+  withMockFetch(
+    t,
+    (async () => {
+      fetched = true;
+      return new Response('unexpected', { status: 200 });
+    }) as typeof fetch,
+  );
 
   const response = await markdownNegotiation(
     new Request('https://example.com/docs/', {
@@ -332,26 +321,24 @@ test('handler bypasses markdown fetch for unsupported methods', async (t) => {
 });
 
 test('handler serves HEAD markdown responses without a body', async (t) => {
-  const originalFetch = globalThis.fetch;
-  t.after(() => {
-    globalThis.fetch = originalFetch;
-  });
+  withMockFetch(
+    t,
+    (async (input) => {
+      const request = input as Request;
+      assert.strictEqual(
+        request.url,
+        'https://example.com/docs/index.md',
+        'Subrequest URL',
+      );
+      assert.strictEqual(request.method, 'HEAD', 'Subrequest method');
 
-  globalThis.fetch = (async (input) => {
-    const request = input as Request;
-    assert.strictEqual(
-      request.url,
-      'https://example.com/docs/index.md',
-      'Subrequest URL',
-    );
-    assert.strictEqual(request.method, 'HEAD', 'Subrequest method');
-
-    return new Response('ignored', {
-      headers: { 'content-type': 'text/plain; charset=utf-8' },
-      status: 200,
-      statusText: 'OK',
-    });
-  }) as typeof fetch;
+      return new Response('ignored', {
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+        status: 200,
+        statusText: 'OK',
+      });
+    }) as typeof fetch,
+  );
 
   const response = await markdownNegotiation(
     new Request('https://example.com/docs/', {
@@ -375,34 +362,32 @@ test('handler serves HEAD markdown responses without a body', async (t) => {
 });
 
 test('handler falls back from HEAD to GET when HEAD is not supported', async (t) => {
-  const originalFetch = globalThis.fetch;
-  t.after(() => {
-    globalThis.fetch = originalFetch;
-  });
-
   const methods: string[] = [];
-  globalThis.fetch = (async (input) => {
-    const request = input as Request;
-    methods.push(request.method);
-    assert.strictEqual(
-      request.url,
-      'https://example.com/docs/index.md',
-      'Subrequest URL',
-    );
+  withMockFetch(
+    t,
+    (async (input) => {
+      const request = input as Request;
+      methods.push(request.method);
+      assert.strictEqual(
+        request.url,
+        'https://example.com/docs/index.md',
+        'Subrequest URL',
+      );
 
-    if (request.method === 'HEAD') {
-      return new Response(null, {
-        status: 405,
-        statusText: 'Method Not Allowed',
+      if (request.method === 'HEAD') {
+        return new Response(null, {
+          status: 405,
+          statusText: 'Method Not Allowed',
+        });
+      }
+
+      return new Response('# Docs', {
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+        status: 200,
+        statusText: 'OK',
       });
-    }
-
-    return new Response('# Docs', {
-      headers: { 'content-type': 'text/plain; charset=utf-8' },
-      status: 200,
-      statusText: 'OK',
-    });
-  }) as typeof fetch;
+    }) as typeof fetch,
+  );
 
   const response = await markdownNegotiation(
     new Request('https://example.com/docs/', {
@@ -427,13 +412,10 @@ test('handler falls back from HEAD to GET when HEAD is not supported', async (t)
 });
 
 test('handler falls back to html and varies on Accept when markdown is missing', async (t) => {
-  const originalFetch = globalThis.fetch;
-  t.after(() => {
-    globalThis.fetch = originalFetch;
-  });
-
-  globalThis.fetch = (async () =>
-    new Response('missing', { status: 404 })) as typeof fetch;
+  withMockFetch(
+    t,
+    (async () => new Response('missing', { status: 404 })) as typeof fetch,
+  );
 
   const response = await markdownNegotiation(
     new Request('https://example.com/search/', {

--- a/netlify/edge-functions/markdown-negotiation/handler.test.ts
+++ b/netlify/edge-functions/markdown-negotiation/handler.test.ts
@@ -19,28 +19,25 @@ import {
 import markdownNegotiation from './index.ts';
 
 test('handler serves markdown when preferred and available', async (t) => {
-  withMockFetch(
-    t,
-    (async (input) => {
-      const request = input as Request;
-      assert.strictEqual(
-        request.url,
-        'https://example.com/docs/index.md',
-        'Subrequest URL',
-      );
-      assert.strictEqual(request.method, 'GET', 'Subrequest method');
-      assert.strictEqual(
-        request.headers.get('accept'),
-        'text/markdown',
-        'Accept header',
-      );
+  withMockFetch(t, (async (input) => {
+    const request = input as Request;
+    assert.strictEqual(
+      request.url,
+      'https://example.com/docs/index.md',
+      'Subrequest URL',
+    );
+    assert.strictEqual(request.method, 'GET', 'Subrequest method');
+    assert.strictEqual(
+      request.headers.get('accept'),
+      'text/markdown',
+      'Accept header',
+    );
 
-      return new Response('# Docs', {
-        headers: { 'content-type': 'text/plain; charset=utf-8' },
-        status: 200,
-      });
-    }) as typeof fetch,
-  );
+    return new Response('# Docs', {
+      headers: { 'content-type': 'text/plain; charset=utf-8' },
+      status: 200,
+    });
+  }) as typeof fetch);
 
   const response = await markdownNegotiation(
     new Request('https://example.com/docs/', {
@@ -65,23 +62,20 @@ test('handler serves markdown when preferred and available', async (t) => {
 });
 
 test('handler serves markdown for the site root', async (t) => {
-  withMockFetch(
-    t,
-    (async (input) => {
-      const request = input as Request;
-      assert.strictEqual(
-        request.url,
-        'https://example.com/index.md',
-        'Subrequest URL',
-      );
-      assert.strictEqual(request.method, 'GET', 'Subrequest method');
+  withMockFetch(t, (async (input) => {
+    const request = input as Request;
+    assert.strictEqual(
+      request.url,
+      'https://example.com/index.md',
+      'Subrequest URL',
+    );
+    assert.strictEqual(request.method, 'GET', 'Subrequest method');
 
-      return new Response('# Home', {
-        headers: { 'content-type': 'text/plain; charset=utf-8' },
-        status: 200,
-      });
-    }) as typeof fetch,
-  );
+    return new Response('# Home', {
+      headers: { 'content-type': 'text/plain; charset=utf-8' },
+      status: 200,
+    });
+  }) as typeof fetch);
 
   const response = await markdownNegotiation(
     new Request('https://example.com/', {
@@ -101,23 +95,20 @@ test('handler serves markdown for the site root', async (t) => {
 });
 
 test('handler serves markdown for explicit html page requests', async (t) => {
-  withMockFetch(
-    t,
-    (async (input) => {
-      const request = input as Request;
-      assert.strictEqual(
-        request.url,
-        'https://example.com/docs/index.md',
-        'Subrequest URL',
-      );
-      assert.strictEqual(request.method, 'GET', 'Subrequest method');
+  withMockFetch(t, (async (input) => {
+    const request = input as Request;
+    assert.strictEqual(
+      request.url,
+      'https://example.com/docs/index.md',
+      'Subrequest URL',
+    );
+    assert.strictEqual(request.method, 'GET', 'Subrequest method');
 
-      return new Response('# Html page mapped to markdown', {
-        headers: { 'content-type': 'text/plain; charset=utf-8' },
-        status: 200,
-      });
-    }) as typeof fetch,
-  );
+    return new Response('# Html page mapped to markdown', {
+      headers: { 'content-type': 'text/plain; charset=utf-8' },
+      status: 200,
+    });
+  }) as typeof fetch);
 
   const response = await markdownNegotiation(
     new Request('https://example.com/docs/index.html', {
@@ -142,13 +133,10 @@ test('handler serves markdown for explicit html page requests', async (t) => {
 
 test('handler bypasses negotiation for non-index html paths', async (t) => {
   let fetched = false;
-  withMockFetch(
-    t,
-    (async () => {
-      fetched = true;
-      return new Response('unexpected', { status: 200 });
-    }) as typeof fetch,
-  );
+  withMockFetch(t, (async () => {
+    fetched = true;
+    return new Response('unexpected', { status: 200 });
+  }) as typeof fetch);
 
   const docsHtmlResponse = await markdownNegotiation(
     new Request('https://example.com/docs.html', {
@@ -215,13 +203,10 @@ test('handler bypasses negotiation for non-index html paths', async (t) => {
 
 test('handler bypasses markdown fetch when html is preferred', async (t) => {
   let fetched = false;
-  withMockFetch(
-    t,
-    (async () => {
-      fetched = true;
-      return new Response('unexpected', { status: 200 });
-    }) as typeof fetch,
-  );
+  withMockFetch(t, (async () => {
+    fetched = true;
+    return new Response('unexpected', { status: 200 });
+  }) as typeof fetch);
 
   const response = await markdownNegotiation(
     new Request('https://example.com/docs/', {
@@ -251,13 +236,10 @@ test('handler bypasses markdown fetch when html is preferred', async (t) => {
 
 test('handler bypasses markdown fetch when Accept is missing', async (t) => {
   let fetched = false;
-  withMockFetch(
-    t,
-    (async () => {
-      fetched = true;
-      return new Response('unexpected', { status: 200 });
-    }) as typeof fetch,
-  );
+  withMockFetch(t, (async () => {
+    fetched = true;
+    return new Response('unexpected', { status: 200 });
+  }) as typeof fetch);
 
   const response = await markdownNegotiation(
     new Request('https://example.com/docs/'),
@@ -285,13 +267,10 @@ test('handler bypasses markdown fetch when Accept is missing', async (t) => {
 
 test('handler bypasses markdown fetch for unsupported methods', async (t) => {
   let fetched = false;
-  withMockFetch(
-    t,
-    (async () => {
-      fetched = true;
-      return new Response('unexpected', { status: 200 });
-    }) as typeof fetch,
-  );
+  withMockFetch(t, (async () => {
+    fetched = true;
+    return new Response('unexpected', { status: 200 });
+  }) as typeof fetch);
 
   const response = await markdownNegotiation(
     new Request('https://example.com/docs/', {
@@ -321,24 +300,21 @@ test('handler bypasses markdown fetch for unsupported methods', async (t) => {
 });
 
 test('handler serves HEAD markdown responses without a body', async (t) => {
-  withMockFetch(
-    t,
-    (async (input) => {
-      const request = input as Request;
-      assert.strictEqual(
-        request.url,
-        'https://example.com/docs/index.md',
-        'Subrequest URL',
-      );
-      assert.strictEqual(request.method, 'HEAD', 'Subrequest method');
+  withMockFetch(t, (async (input) => {
+    const request = input as Request;
+    assert.strictEqual(
+      request.url,
+      'https://example.com/docs/index.md',
+      'Subrequest URL',
+    );
+    assert.strictEqual(request.method, 'HEAD', 'Subrequest method');
 
-      return new Response('ignored', {
-        headers: { 'content-type': 'text/plain; charset=utf-8' },
-        status: 200,
-        statusText: 'OK',
-      });
-    }) as typeof fetch,
-  );
+    return new Response('ignored', {
+      headers: { 'content-type': 'text/plain; charset=utf-8' },
+      status: 200,
+      statusText: 'OK',
+    });
+  }) as typeof fetch);
 
   const response = await markdownNegotiation(
     new Request('https://example.com/docs/', {
@@ -363,31 +339,28 @@ test('handler serves HEAD markdown responses without a body', async (t) => {
 
 test('handler falls back from HEAD to GET when HEAD is not supported', async (t) => {
   const methods: string[] = [];
-  withMockFetch(
-    t,
-    (async (input) => {
-      const request = input as Request;
-      methods.push(request.method);
-      assert.strictEqual(
-        request.url,
-        'https://example.com/docs/index.md',
-        'Subrequest URL',
-      );
+  withMockFetch(t, (async (input) => {
+    const request = input as Request;
+    methods.push(request.method);
+    assert.strictEqual(
+      request.url,
+      'https://example.com/docs/index.md',
+      'Subrequest URL',
+    );
 
-      if (request.method === 'HEAD') {
-        return new Response(null, {
-          status: 405,
-          statusText: 'Method Not Allowed',
-        });
-      }
-
-      return new Response('# Docs', {
-        headers: { 'content-type': 'text/plain; charset=utf-8' },
-        status: 200,
-        statusText: 'OK',
+    if (request.method === 'HEAD') {
+      return new Response(null, {
+        status: 405,
+        statusText: 'Method Not Allowed',
       });
-    }) as typeof fetch,
-  );
+    }
+
+    return new Response('# Docs', {
+      headers: { 'content-type': 'text/plain; charset=utf-8' },
+      status: 200,
+      statusText: 'OK',
+    });
+  }) as typeof fetch);
 
   const response = await markdownNegotiation(
     new Request('https://example.com/docs/', {

--- a/netlify/edge-functions/markdown-negotiation/handler.test.ts
+++ b/netlify/edge-functions/markdown-negotiation/handler.test.ts
@@ -12,6 +12,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import { assertVaryIncludesAccept } from '../lib/test-helpers.ts';
 import markdownNegotiation from './index.ts';
 
 test('handler serves markdown when preferred and available', async (t) => {
@@ -22,9 +23,17 @@ test('handler serves markdown when preferred and available', async (t) => {
 
   globalThis.fetch = (async (input) => {
     const request = input as Request;
-    assert.equal(request.url, 'https://example.com/docs/index.md');
-    assert.equal(request.method, 'GET');
-    assert.equal(request.headers.get('accept'), 'text/markdown');
+    assert.strictEqual(
+      request.url,
+      'https://example.com/docs/index.md',
+      'Subrequest URL',
+    );
+    assert.strictEqual(request.method, 'GET', 'Subrequest method');
+    assert.strictEqual(
+      request.headers.get('accept'),
+      'text/markdown',
+      'Accept header',
+    );
 
     return new Response('# Docs', {
       headers: { 'content-type': 'text/plain; charset=utf-8' },
@@ -45,12 +54,13 @@ test('handler serves markdown when preferred and available', async (t) => {
     },
   );
 
-  assert.equal(await response.text(), '# Docs');
-  assert.equal(
+  assert.strictEqual(await response.text(), '# Docs', 'Response body');
+  assert.strictEqual(
     response.headers.get('content-type'),
     'text/markdown; charset=utf-8',
+    'Content-Type',
   );
-  assert.match(response.headers.get('vary') ?? '', /(^|,\s*)Accept(,|$)/);
+  assertVaryIncludesAccept(response);
 });
 
 test('handler serves markdown for the site root', async (t) => {
@@ -61,8 +71,12 @@ test('handler serves markdown for the site root', async (t) => {
 
   globalThis.fetch = (async (input) => {
     const request = input as Request;
-    assert.equal(request.url, 'https://example.com/index.md');
-    assert.equal(request.method, 'GET');
+    assert.strictEqual(
+      request.url,
+      'https://example.com/index.md',
+      'Subrequest URL',
+    );
+    assert.strictEqual(request.method, 'GET', 'Subrequest method');
 
     return new Response('# Home', {
       headers: { 'content-type': 'text/plain; charset=utf-8' },
@@ -79,10 +93,11 @@ test('handler serves markdown for the site root', async (t) => {
     },
   );
 
-  assert.equal(await response.text(), '# Home');
-  assert.equal(
+  assert.strictEqual(await response.text(), '# Home', 'Response body');
+  assert.strictEqual(
     response.headers.get('content-type'),
     'text/markdown; charset=utf-8',
+    'Content-Type',
   );
 });
 
@@ -94,8 +109,12 @@ test('handler serves markdown for explicit html page requests', async (t) => {
 
   globalThis.fetch = (async (input) => {
     const request = input as Request;
-    assert.equal(request.url, 'https://example.com/docs/index.md');
-    assert.equal(request.method, 'GET');
+    assert.strictEqual(
+      request.url,
+      'https://example.com/docs/index.md',
+      'Subrequest URL',
+    );
+    assert.strictEqual(request.method, 'GET', 'Subrequest method');
 
     return new Response('# Html page mapped to markdown', {
       headers: { 'content-type': 'text/plain; charset=utf-8' },
@@ -112,10 +131,15 @@ test('handler serves markdown for explicit html page requests', async (t) => {
     },
   );
 
-  assert.equal(await response.text(), '# Html page mapped to markdown');
-  assert.equal(
+  assert.strictEqual(
+    await response.text(),
+    '# Html page mapped to markdown',
+    'Response body',
+  );
+  assert.strictEqual(
     response.headers.get('content-type'),
     'text/markdown; charset=utf-8',
+    'Content-Type',
   );
 });
 
@@ -144,9 +168,13 @@ test('handler bypasses negotiation for non-index html paths', async (t) => {
     },
   );
 
-  assert.equal(fetched, false);
-  assert.equal(docsHtmlResponse.status, 301);
-  assert.equal(docsHtmlResponse.headers.get('location'), '/docs/');
+  assert.strictEqual(fetched, false, 'Markdown subrequest');
+  assert.strictEqual(docsHtmlResponse.status, 301, 'HTTP status');
+  assert.strictEqual(
+    docsHtmlResponse.headers.get('location'),
+    '/docs/',
+    'Location',
+  );
 
   const uppercaseIndexHtmlResponse = await markdownNegotiation(
     new Request('https://example.com/docs/index.HTML', {
@@ -161,10 +189,11 @@ test('handler bypasses negotiation for non-index html paths', async (t) => {
     },
   );
 
-  assert.equal(fetched, false);
-  assert.equal(
+  assert.strictEqual(fetched, false, 'Markdown subrequest');
+  assert.strictEqual(
     await uppercaseIndexHtmlResponse.text(),
     '<html>uppercase</html>',
+    'Response body',
   );
 
   const fourOhFourResponse = await markdownNegotiation(
@@ -180,9 +209,13 @@ test('handler bypasses negotiation for non-index html paths', async (t) => {
     },
   );
 
-  assert.equal(fetched, false);
-  assert.equal(fourOhFourResponse.status, 404);
-  assert.equal(await fourOhFourResponse.text(), '<html>not found</html>');
+  assert.strictEqual(fetched, false, 'Markdown subrequest');
+  assert.strictEqual(fourOhFourResponse.status, 404, 'HTTP status');
+  assert.strictEqual(
+    await fourOhFourResponse.text(),
+    '<html>not found</html>',
+    'Response body',
+  );
 });
 
 test('handler bypasses markdown fetch when html is preferred', async (t) => {
@@ -210,11 +243,16 @@ test('handler bypasses markdown fetch when html is preferred', async (t) => {
     },
   );
 
-  assert.equal(fetched, false);
-  assert.equal(await response.text(), '<html>docs</html>');
-  assert.equal(
+  assert.strictEqual(fetched, false, 'Markdown subrequest');
+  assert.strictEqual(
+    await response.text(),
+    '<html>docs</html>',
+    'Response body',
+  );
+  assert.strictEqual(
     response.headers.get('content-type'),
     'text/html; charset=utf-8',
+    'Content-Type',
   );
 });
 
@@ -241,11 +279,16 @@ test('handler bypasses markdown fetch when Accept is missing', async (t) => {
     },
   );
 
-  assert.equal(fetched, false);
-  assert.equal(await response.text(), '<html>docs</html>');
-  assert.equal(
+  assert.strictEqual(fetched, false, 'Markdown subrequest');
+  assert.strictEqual(
+    await response.text(),
+    '<html>docs</html>',
+    'Response body',
+  );
+  assert.strictEqual(
     response.headers.get('content-type'),
     'text/html; charset=utf-8',
+    'Content-Type',
   );
 });
 
@@ -275,11 +318,16 @@ test('handler bypasses markdown fetch for unsupported methods', async (t) => {
     },
   );
 
-  assert.equal(fetched, false);
-  assert.equal(await response.text(), '<html>post passthrough</html>');
-  assert.equal(
+  assert.strictEqual(fetched, false, 'Markdown subrequest');
+  assert.strictEqual(
+    await response.text(),
+    '<html>post passthrough</html>',
+    'Response body',
+  );
+  assert.strictEqual(
     response.headers.get('content-type'),
     'text/html; charset=utf-8',
+    'Content-Type',
   );
 });
 
@@ -291,8 +339,12 @@ test('handler serves HEAD markdown responses without a body', async (t) => {
 
   globalThis.fetch = (async (input) => {
     const request = input as Request;
-    assert.equal(request.url, 'https://example.com/docs/index.md');
-    assert.equal(request.method, 'HEAD');
+    assert.strictEqual(
+      request.url,
+      'https://example.com/docs/index.md',
+      'Subrequest URL',
+    );
+    assert.strictEqual(request.method, 'HEAD', 'Subrequest method');
 
     return new Response('ignored', {
       headers: { 'content-type': 'text/plain; charset=utf-8' },
@@ -311,14 +363,15 @@ test('handler serves HEAD markdown responses without a body', async (t) => {
     },
   );
 
-  assert.equal(response.status, 200);
-  assert.equal(response.statusText, 'OK');
-  assert.equal(await response.text(), '');
-  assert.equal(
+  assert.strictEqual(response.status, 200, 'HTTP status');
+  assert.strictEqual(response.statusText, 'OK', 'HTTP statusText');
+  assert.strictEqual(await response.text(), '', 'Response body');
+  assert.strictEqual(
     response.headers.get('content-type'),
     'text/markdown; charset=utf-8',
+    'Content-Type',
   );
-  assert.match(response.headers.get('vary') ?? '', /(^|,\s*)Accept(,|$)/);
+  assertVaryIncludesAccept(response);
 });
 
 test('handler falls back from HEAD to GET when HEAD is not supported', async (t) => {
@@ -331,7 +384,11 @@ test('handler falls back from HEAD to GET when HEAD is not supported', async (t)
   globalThis.fetch = (async (input) => {
     const request = input as Request;
     methods.push(request.method);
-    assert.equal(request.url, 'https://example.com/docs/index.md');
+    assert.strictEqual(
+      request.url,
+      'https://example.com/docs/index.md',
+      'Subrequest URL',
+    );
 
     if (request.method === 'HEAD') {
       return new Response(null, {
@@ -357,15 +414,16 @@ test('handler falls back from HEAD to GET when HEAD is not supported', async (t)
     },
   );
 
-  assert.deepEqual(methods, ['HEAD', 'GET']);
-  assert.equal(response.status, 200);
-  assert.equal(response.statusText, 'OK');
-  assert.equal(await response.text(), '');
-  assert.equal(
+  assert.deepStrictEqual(methods, ['HEAD', 'GET'], 'Subrequest methods');
+  assert.strictEqual(response.status, 200, 'HTTP status');
+  assert.strictEqual(response.statusText, 'OK', 'HTTP statusText');
+  assert.strictEqual(await response.text(), '', 'Response body');
+  assert.strictEqual(
     response.headers.get('content-type'),
     'text/markdown; charset=utf-8',
+    'Content-Type',
   );
-  assert.match(response.headers.get('vary') ?? '', /(^|,\s*)Accept(,|$)/);
+  assertVaryIncludesAccept(response);
 });
 
 test('handler falls back to html and varies on Accept when markdown is missing', async (t) => {
@@ -390,10 +448,15 @@ test('handler falls back to html and varies on Accept when markdown is missing',
     },
   );
 
-  assert.equal(await response.text(), '<html>search</html>');
-  assert.equal(
+  assert.strictEqual(
+    await response.text(),
+    '<html>search</html>',
+    'Response body',
+  );
+  assert.strictEqual(
     response.headers.get('content-type'),
     'text/html; charset=utf-8',
+    'Content-Type',
   );
-  assert.match(response.headers.get('vary') ?? '', /(^|,\s*)Accept(,|$)/);
+  assertVaryIncludesAccept(response);
 });

--- a/netlify/edge-functions/markdown-negotiation/index.ts
+++ b/netlify/edge-functions/markdown-negotiation/index.ts
@@ -67,6 +67,7 @@ export default async function markdownNegotiation(
       asset_path: assetPath,
       content_type: normalizeContentType(headers.get('content-type') ?? ''),
       status_code: String(markdownResponse.status),
+      event_emitter: 'negotiation',
       ...(url.pathname !== assetPath ? { original_path: url.pathname } : {}),
     };
     enqueueAssetFetchEvent(request, context, eventParams);

--- a/netlify/edge-functions/markdown-negotiation/index.ts
+++ b/netlify/edge-functions/markdown-negotiation/index.ts
@@ -64,9 +64,7 @@ export default async function markdownNegotiation(
   if (request.method === 'GET') {
     const assetPath = resolveMarkdownPath(url.pathname);
     const eventParams: AssetFetchEventParams = {
-      asset_group: 'markdown',
       asset_path: assetPath,
-      asset_ext: 'md',
       content_type: normalizeContentType(headers.get('content-type') ?? ''),
       status_code: String(markdownResponse.status),
       ...(url.pathname !== assetPath ? { original_path: url.pathname } : {}),

--- a/netlify/edge-functions/markdown-negotiation/index.ts
+++ b/netlify/edge-functions/markdown-negotiation/index.ts
@@ -19,10 +19,13 @@
 
 import {
   ASSET_FETCH_GA_INFO_HEADER,
+  buildAssetFetchGaInfoHeaderValue,
+  hasAssetFetchConfig,
   INTERNAL_ASSET_FETCH_GA_INFO_VALUE,
   type AssetFetchEventParams,
   enqueueAssetFetchEvent,
   normalizeContentType,
+  withAssetFetchGaInfoHeader,
 } from '../lib/ga4-asset-fetch.ts';
 
 const HTML_TYPES = new Set(['text/html', 'application/xhtml+xml']);
@@ -38,12 +41,26 @@ export default async function markdownNegotiation(
   const url = new URL(request.url);
 
   if (!shouldConsiderRequest(request.method, url.pathname)) {
-    return context.next();
+    return withAssetFetchGaInfoHeader(
+      await context.next(),
+      buildAssetFetchGaInfoHeaderValue({
+        noneReason: getMarkdownNegotiationPathOrMethodNoneReason(
+          request.method,
+          url.pathname,
+        ),
+        gaEventCandidate: false,
+      }),
+      { overwrite: false },
+    );
   }
 
   const acceptHeader = request.headers.get('accept');
   if (!acceptHeader || !prefersMarkdownOverHtml(acceptHeader)) {
-    return context.next();
+    return withAssetFetchGaInfoHeader(
+      await context.next(),
+      buildAssetFetchGaInfoHeaderValue({ gaEventCandidate: false }),
+      { overwrite: false },
+    );
   }
 
   const markdownResponse = await fetchMarkdownVariant(
@@ -52,7 +69,17 @@ export default async function markdownNegotiation(
   );
 
   if (!isSuccessfulMarkdownResponse(markdownResponse)) {
-    return withVaryAccept(await context.next());
+    return withAssetFetchGaInfoHeader(
+      withVaryAccept(await context.next()),
+      buildAssetFetchGaInfoHeaderValue({
+        noneReason:
+          request.method === 'GET'
+            ? 'response does not meet route-specific gating'
+            : `request method ${request.method} is not currently tracked`,
+        gaEventCandidate: false,
+      }),
+      { overwrite: false },
+    );
   }
 
   const headers = new Headers(markdownResponse.headers);
@@ -73,23 +100,41 @@ export default async function markdownNegotiation(
     enqueueAssetFetchEvent(request, context, eventParams);
   }
 
+  const gaInfoValue =
+    request.method === 'GET'
+      ? buildAssetFetchGaInfoHeaderValue({
+          assetPath: resolveMarkdownPath(url.pathname),
+          configPresent: hasAssetFetchConfig(),
+          gaEventCandidate: true,
+        })
+      : buildAssetFetchGaInfoHeaderValue({
+          noneReason: `request method ${request.method} is not currently tracked`,
+          gaEventCandidate: false,
+        });
+
   if (request.method === 'HEAD') {
     if (markdownResponse.body) {
       void markdownResponse.body.cancel();
     }
 
-    return new Response(null, {
+    return withAssetFetchGaInfoHeader(
+      new Response(null, {
+        headers,
+        status: markdownResponse.status,
+        statusText: markdownResponse.statusText,
+      }),
+      gaInfoValue,
+    );
+  }
+
+  return withAssetFetchGaInfoHeader(
+    new Response(markdownResponse.body, {
       headers,
       status: markdownResponse.status,
       statusText: markdownResponse.statusText,
-    });
-  }
-
-  return new Response(markdownResponse.body, {
-    headers,
-    status: markdownResponse.status,
-    statusText: markdownResponse.statusText,
-  });
+    }),
+    gaInfoValue,
+  );
 }
 
 export function shouldConsiderRequest(
@@ -177,6 +222,21 @@ async function fetchMarkdownVariant(
 
 function isSuccessfulMarkdownResponse(response: Response): boolean {
   return response.status >= 200 && response.status < 300;
+}
+
+function getMarkdownNegotiationPathOrMethodNoneReason(
+  method: string,
+  pathname: string,
+): string | undefined {
+  if (method !== 'GET' && method !== 'HEAD') {
+    return `request method ${method} is not currently tracked`;
+  }
+
+  if (!shouldConsiderRequest(method, pathname)) {
+    return 'request path does not match a tracked route';
+  }
+
+  return undefined;
 }
 
 export function prefersMarkdownOverHtml(acceptHeader: string): boolean {

--- a/netlify/edge-functions/markdown-negotiation/live-check.test.mjs
+++ b/netlify/edge-functions/markdown-negotiation/live-check.test.mjs
@@ -9,6 +9,8 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import { ASSET_FETCH_GA_INFO_HEADER } from '../lib/ga4-asset-fetch.ts';
+
 /** Must match the key set in `live-check.mjs` before spawning `node --test`. */
 const LIVE_CHECK_BASE_URL_ENV = 'LIVE_CHECK_BASE_URL';
 
@@ -36,11 +38,12 @@ function baseRef() {
   return resolveBaseRef(raw);
 }
 
-const docsPath = '/docs/concepts/resources/';
-const docsIndexHtmlPath = '/docs/concepts/resources/index.html';
-const docsUppercaseIndexHtmlPath = '/docs/concepts/resources/index.HTML';
+const docsPath = '/site/testing/tests/regular/';
+const docsIndexHtmlPath = '/site/testing/tests/regular/index.html';
+const docsUppercaseIndexHtmlPath = '/site/testing/tests/regular/index.HTML';
+const noMarkdownPath = '/site/testing/tests/no-md/';
 
-test('GET /docs/concepts/resources/ with Accept: text/markdown → markdown + Vary: Accept', async () => {
+test('GET /site/testing/tests/regular/ with Accept: text/markdown → markdown + Vary: Accept', async () => {
   const ref = baseRef();
   const url = absUrl(docsPath, ref);
   const res = await fetch(url, {
@@ -54,12 +57,25 @@ test('GET /docs/concepts/resources/ with Accept: text/markdown → markdown + Va
     `expected text/markdown content-type, got ${JSON.stringify(ct)}`,
   );
   assert.ok(
-    text.includes('# Resources'),
-    'body should contain "# Resources" (English docs index heading)',
+    text.includes('# Regular edge function test page'),
+    'body should contain "# Regular edge function test page"',
   );
   assert.ok(
     varyIncludesAccept(res.headers.get('vary')),
     `Vary should include Accept, got ${JSON.stringify(res.headers.get('vary'))}`,
+  );
+});
+
+test('GET /site/testing/tests/regular/ with Accept: text/markdown → X-Asset-Fetch-Ga-Info header', async () => {
+  const ref = baseRef();
+  const url = absUrl(docsPath, ref);
+  const res = await fetch(url, {
+    headers: { accept: 'text/markdown' },
+  });
+
+  assert.equal(
+    res.headers.get(ASSET_FETCH_GA_INFO_HEADER),
+    '/site/testing/tests/regular/index.md;ga-event-candidate,config-present',
   );
 });
 
@@ -82,7 +98,7 @@ test('GET same URL with HTML preferred → HTML', async () => {
   );
 });
 
-test('GET /docs/concepts/resources/index.html with Accept: text/markdown → markdown + Vary: Accept', async () => {
+test('GET /site/testing/tests/regular/index.html with Accept: text/markdown → markdown + Vary: Accept', async () => {
   const ref = baseRef();
   const url = absUrl(docsIndexHtmlPath, ref);
   const res = await fetch(url, {
@@ -96,8 +112,8 @@ test('GET /docs/concepts/resources/index.html with Accept: text/markdown → mar
     `expected text/markdown content-type, got ${JSON.stringify(ct)}`,
   );
   assert.ok(
-    text.includes('# Resources'),
-    'body should contain "# Resources" (English docs index heading)',
+    text.includes('# Regular edge function test page'),
+    'body should contain "# Regular edge function test page"',
   );
   assert.ok(
     varyIncludesAccept(res.headers.get('vary')),
@@ -106,7 +122,7 @@ test('GET /docs/concepts/resources/index.html with Accept: text/markdown → mar
 });
 
 test(
-  'GET /docs/concepts/resources/index.HTML with Accept: text/markdown → redirect',
+  'GET /site/testing/tests/regular/index.HTML with Accept: text/markdown → redirect',
   {
     // Deployed behavior for uppercase `index.HTML` is inconsistent across
     // paths and environments on Netlify. Skip this edge case for now.
@@ -126,7 +142,7 @@ test(
     const loc = res.headers.get('location');
     assert.ok(loc, 'missing Location header');
     const target = new URL(loc, url).href;
-    const expected = '/docs/concepts/resources/';
+    const expected = '/site/testing/tests/regular/';
     assert.ok(
       target.endsWith(expected),
       `Location should end with ${expected} (or without trailing slash), got ${JSON.stringify(loc)} → ${target}`,
@@ -134,9 +150,9 @@ test(
   },
 );
 
-test('GET /search/ with Accept: text/markdown → HTML fallback + Vary: Accept', async () => {
+test('GET /site/testing/tests/no-md/ with Accept: text/markdown → HTML fallback + Vary: Accept', async () => {
   const ref = baseRef();
-  const url = absUrl('/search/', ref);
+  const url = absUrl(noMarkdownPath, ref);
   const res = await fetch(url, {
     headers: { accept: 'text/markdown' },
   });
@@ -157,7 +173,7 @@ test('GET /search/ with Accept: text/markdown → HTML fallback + Vary: Accept',
   );
 });
 
-test('HEAD /docs/concepts/resources/ with Accept: text/markdown → empty body', async () => {
+test('HEAD /site/testing/tests/regular/ with Accept: text/markdown → empty body', async () => {
   const ref = baseRef();
   const url = absUrl(docsPath, ref);
   const res = await fetch(url, {

--- a/netlify/edge-functions/markdown-negotiation/live-check.test.mjs
+++ b/netlify/edge-functions/markdown-negotiation/live-check.test.mjs
@@ -10,6 +10,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { ASSET_FETCH_GA_INFO_HEADER } from '../lib/ga4-asset-fetch.ts';
+import { assertVaryIncludesAccept } from '../lib/test-helpers.ts';
 
 /** Must match the key set in `live-check.mjs` before spawning `node --test`. */
 const LIVE_CHECK_BASE_URL_ENV = 'LIVE_CHECK_BASE_URL';
@@ -23,25 +24,31 @@ function absUrl(path, baseRef) {
   return new URL(path, baseRef).href;
 }
 
-function varyIncludesAccept(varyHeader) {
-  if (!varyHeader) {
-    return false;
-  }
-  return varyHeader
-    .split(',')
-    .some((part) => part.trim().toLowerCase() === 'accept');
-}
-
 function baseRef() {
   const raw = process.env[LIVE_CHECK_BASE_URL_ENV]?.trim();
   assert.ok(raw, 'Run live checks via: node .../live-check.mjs [-h] [BASE]');
   return resolveBaseRef(raw);
 }
 
+function expectedConfigTag(baseRef) {
+  return (
+    'config-' +
+    (baseRef.hostname === 'opentelemetry.io' ? 'present' : 'missing')
+  );
+}
+
 const docsPath = '/site/testing/tests/regular/';
 const docsIndexHtmlPath = '/site/testing/tests/regular/index.html';
 const docsUppercaseIndexHtmlPath = '/site/testing/tests/regular/index.HTML';
 const noMarkdownPath = '/site/testing/tests/no-md/';
+
+/** Negotiated Markdown responses set this in `markdown-negotiation/index.ts`. */
+const expectedNegotiatedMarkdownContentType = 'text/markdown; charset=utf-8';
+/** Static HTML from `context.next()` (typical Netlify / Hugo). */
+const expectedHtmlContentType = 'text/html; charset=UTF-8';
+
+const regularPageMarkdownHeading = /^# Regular test page/;
+const htmlDocumentPattern = /<!DOCTYPE html|<html[\s>]/i;
 
 test('GET /site/testing/tests/regular/ with Accept: text/markdown → markdown + Vary: Accept', async () => {
   const ref = baseRef();
@@ -51,19 +58,10 @@ test('GET /site/testing/tests/regular/ with Accept: text/markdown → markdown +
   });
   const ct = res.headers.get('content-type') ?? '';
   const text = await res.text();
-  assert.equal(res.status, 200, `expected 200 for ${url}`);
-  assert.ok(
-    ct.toLowerCase().includes('text/markdown'),
-    `expected text/markdown content-type, got ${JSON.stringify(ct)}`,
-  );
-  assert.ok(
-    text.includes('# Regular edge function test page'),
-    'body should contain "# Regular edge function test page"',
-  );
-  assert.ok(
-    varyIncludesAccept(res.headers.get('vary')),
-    `Vary should include Accept, got ${JSON.stringify(res.headers.get('vary'))}`,
-  );
+  assert.strictEqual(res.status, 200, 'HTTP status');
+  assert.strictEqual(ct, expectedNegotiatedMarkdownContentType, 'Content-Type');
+  assert.match(text, regularPageMarkdownHeading, 'Request body');
+  assertVaryIncludesAccept(res);
 });
 
 test('GET /site/testing/tests/regular/ with Accept: text/markdown → X-Asset-Fetch-Ga-Info header', async () => {
@@ -73,9 +71,10 @@ test('GET /site/testing/tests/regular/ with Accept: text/markdown → X-Asset-Fe
     headers: { accept: 'text/markdown' },
   });
 
-  assert.equal(
+  assert.strictEqual(
     res.headers.get(ASSET_FETCH_GA_INFO_HEADER),
-    '/site/testing/tests/regular/index.md;ga-event-candidate,config-present',
+    `/site/testing/tests/regular/index.md;ga-event-candidate,${expectedConfigTag(ref)}`,
+    'X-Asset-Fetch-Ga-Info',
   );
 });
 
@@ -87,15 +86,9 @@ test('GET same URL with HTML preferred → HTML', async () => {
   });
   const ct = res.headers.get('content-type') ?? '';
   const text = await res.text();
-  assert.equal(res.status, 200, `expected 200 for ${url}`);
-  assert.ok(
-    ct.toLowerCase().includes('text/html'),
-    `expected text/html content-type, got ${JSON.stringify(ct)}`,
-  );
-  assert.ok(
-    text.includes('<!DOCTYPE html') || text.includes('<html'),
-    'body should look like HTML',
-  );
+  assert.strictEqual(res.status, 200, 'HTTP status');
+  assert.strictEqual(ct, expectedHtmlContentType, 'Content-Type');
+  assert.match(text, htmlDocumentPattern, 'Request body');
 });
 
 test('GET /site/testing/tests/regular/index.html with Accept: text/markdown → markdown + Vary: Accept', async () => {
@@ -106,19 +99,10 @@ test('GET /site/testing/tests/regular/index.html with Accept: text/markdown → 
   });
   const ct = res.headers.get('content-type') ?? '';
   const text = await res.text();
-  assert.equal(res.status, 200, `expected 200 for ${url}`);
-  assert.ok(
-    ct.toLowerCase().includes('text/markdown'),
-    `expected text/markdown content-type, got ${JSON.stringify(ct)}`,
-  );
-  assert.ok(
-    text.includes('# Regular edge function test page'),
-    'body should contain "# Regular edge function test page"',
-  );
-  assert.ok(
-    varyIncludesAccept(res.headers.get('vary')),
-    `Vary should include Accept, got ${JSON.stringify(res.headers.get('vary'))}`,
-  );
+  assert.strictEqual(res.status, 200, 'HTTP status');
+  assert.strictEqual(ct, expectedNegotiatedMarkdownContentType, 'Content-Type');
+  assert.match(text, regularPageMarkdownHeading, 'Request body');
+  assertVaryIncludesAccept(res);
 });
 
 test(
@@ -135,18 +119,12 @@ test(
       headers: { accept: 'text/markdown' },
       redirect: 'manual',
     });
-    assert.ok(
-      300 <= res.status && res.status <= 399,
-      `expected redirect (3xx), got ${res.status} for ${url}`,
-    );
+    assert.match(String(res.status), /^3\d\d$/, 'HTTP status');
     const loc = res.headers.get('location');
-    assert.ok(loc, 'missing Location header');
-    const target = new URL(loc, url).href;
-    const expected = '/site/testing/tests/regular/';
-    assert.ok(
-      target.endsWith(expected),
-      `Location should end with ${expected} (or without trailing slash), got ${JSON.stringify(loc)} → ${target}`,
-    );
+    assert.ok(loc, 'Location');
+    const expectedPathname = '/site/testing/tests/regular/';
+    const locUrl = new URL(loc, url);
+    assert.strictEqual(locUrl.pathname, expectedPathname, 'Location');
   },
 );
 
@@ -158,19 +136,10 @@ test('GET /site/testing/tests/no-md/ with Accept: text/markdown → HTML fallbac
   });
   const ct = res.headers.get('content-type') ?? '';
   const text = await res.text();
-  assert.equal(res.status, 200, `expected 200 for ${url}`);
-  assert.ok(
-    ct.toLowerCase().includes('text/html'),
-    `expected text/html, got ${JSON.stringify(ct)}`,
-  );
-  assert.ok(
-    varyIncludesAccept(res.headers.get('vary')),
-    `Vary should include Accept, got ${JSON.stringify(res.headers.get('vary'))}`,
-  );
-  assert.ok(
-    text.includes('<!DOCTYPE html') || text.includes('<html'),
-    'body should look like HTML',
-  );
+  assert.strictEqual(res.status, 200, 'HTTP status');
+  assert.strictEqual(ct, expectedHtmlContentType, 'Content-Type');
+  assertVaryIncludesAccept(res);
+  assert.match(text, htmlDocumentPattern, 'Request body');
 });
 
 test('HEAD /site/testing/tests/regular/ with Accept: text/markdown → empty body', async () => {
@@ -182,12 +151,9 @@ test('HEAD /site/testing/tests/regular/ with Accept: text/markdown → empty bod
   });
   const ct = res.headers.get('content-type') ?? '';
   const buf = await res.arrayBuffer();
-  assert.equal(res.status, 200, `expected 200 for ${url}`);
-  assert.ok(
-    ct.toLowerCase().includes('text/markdown'),
-    `expected text/markdown, got ${JSON.stringify(ct)}`,
-  );
-  assert.equal(buf.byteLength, 0, 'expected empty body');
+  assert.strictEqual(res.status, 200, 'HTTP status');
+  assert.strictEqual(ct, expectedNegotiatedMarkdownContentType, 'Content-Type');
+  assert.strictEqual(buf.byteLength, 0, 'Response body');
 });
 
 test('GET /docs.html → redirect toward /docs/', async () => {
@@ -197,18 +163,9 @@ test('GET /docs.html → redirect toward /docs/', async () => {
     headers: { accept: 'text/markdown' },
     redirect: 'manual',
   });
-  assert.ok(
-    res.status === 301 ||
-      res.status === 302 ||
-      res.status === 307 ||
-      res.status === 308,
-    `expected redirect (3xx), got ${res.status} for ${url}`,
-  );
+  assert.match(String(res.status), /^30[1278]$/, 'HTTP status');
   const loc = res.headers.get('location');
-  assert.ok(loc, 'missing Location header');
-  const target = new URL(loc, url).href;
-  assert.ok(
-    target.replace(/\/+$/, '').endsWith('/docs'),
-    `Location should end with /docs/ (or /docs), got ${JSON.stringify(loc)} → ${target}`,
-  );
+  assert.ok(loc, 'Location');
+  const docsLocUrl = new URL(loc, url);
+  assert.match(docsLocUrl.pathname, /^\/docs\/?$/, 'Location');
 });

--- a/netlify/edge-functions/markdown-negotiation/live-check.test.mjs
+++ b/netlify/edge-functions/markdown-negotiation/live-check.test.mjs
@@ -10,32 +10,12 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { ASSET_FETCH_GA_INFO_HEADER } from '../lib/ga4-asset-fetch.ts';
+import {
+  absUrl,
+  baseRef,
+  expectedConfigTag,
+} from '../lib/live-check-test-base.mjs';
 import { assertVaryIncludesAccept } from '../lib/test-helpers.ts';
-
-/** Must match the key set in `live-check.mjs` before spawning `node --test`. */
-const LIVE_CHECK_BASE_URL_ENV = 'LIVE_CHECK_BASE_URL';
-
-function resolveBaseRef(raw) {
-  const withScheme = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
-  return new URL(withScheme.endsWith('/') ? withScheme : `${withScheme}/`);
-}
-
-function absUrl(path, baseRef) {
-  return new URL(path, baseRef).href;
-}
-
-function baseRef() {
-  const raw = process.env[LIVE_CHECK_BASE_URL_ENV]?.trim();
-  assert.ok(raw, 'Run live checks via: node .../live-check.mjs [-h] [BASE]');
-  return resolveBaseRef(raw);
-}
-
-function expectedConfigTag(baseRef) {
-  return (
-    'config-' +
-    (baseRef.hostname === 'opentelemetry.io' ? 'present' : 'missing')
-  );
-}
 
 const docsPath = '/site/testing/tests/regular/';
 const docsIndexHtmlPath = '/site/testing/tests/regular/index.html';

--- a/netlify/edge-functions/markdown-negotiation/negotiation.test.ts
+++ b/netlify/edge-functions/markdown-negotiation/negotiation.test.ts
@@ -8,29 +8,50 @@ import test from 'node:test';
 import { prefersMarkdownOverHtml } from './index.ts';
 
 test('prefersMarkdownOverHtml honors explicit markdown preference', () => {
-  assert.equal(prefersMarkdownOverHtml('text/markdown'), true);
-  assert.equal(prefersMarkdownOverHtml('text/markdown, text/html;q=0.8'), true);
-  assert.equal(
+  assert.strictEqual(
+    prefersMarkdownOverHtml('text/markdown'),
+    true,
+    'prefersMarkdownOverHtml',
+  );
+  assert.strictEqual(
+    prefersMarkdownOverHtml('text/markdown, text/html;q=0.8'),
+    true,
+    'prefersMarkdownOverHtml',
+  );
+  assert.strictEqual(
     prefersMarkdownOverHtml('text/html, text/markdown;q=0.8'),
     false,
+    'prefersMarkdownOverHtml',
   );
-  assert.equal(
+  assert.strictEqual(
     prefersMarkdownOverHtml('text/html;q=0.8, text/markdown;q=0.8'),
     true,
+    'prefersMarkdownOverHtml',
   );
-  assert.equal(
+  assert.strictEqual(
     prefersMarkdownOverHtml('text/html;q=0.5, text/markdown;q=0.8'),
     true,
+    'prefersMarkdownOverHtml',
   );
-  assert.equal(
+  assert.strictEqual(
     prefersMarkdownOverHtml('application/xhtml+xml, text/markdown;q=0.8'),
     false,
+    'prefersMarkdownOverHtml',
   );
-  assert.equal(
+  assert.strictEqual(
     prefersMarkdownOverHtml('application/xhtml+xml;q=0.5, text/markdown;q=0.8'),
     true,
+    'prefersMarkdownOverHtml',
   );
   // Wildcards are ignored by design: explicit markdown still wins here.
-  assert.equal(prefersMarkdownOverHtml('text/markdown;q=0.5, */*'), true);
-  assert.equal(prefersMarkdownOverHtml('text/html, */*;q=0.8'), false);
+  assert.strictEqual(
+    prefersMarkdownOverHtml('text/markdown;q=0.5, */*'),
+    true,
+    'prefersMarkdownOverHtml',
+  );
+  assert.strictEqual(
+    prefersMarkdownOverHtml('text/html, */*;q=0.8'),
+    false,
+    'prefersMarkdownOverHtml',
+  );
 });

--- a/netlify/edge-functions/markdown-negotiation/pathing.test.ts
+++ b/netlify/edge-functions/markdown-negotiation/pathing.test.ts
@@ -11,26 +11,98 @@ import test from 'node:test';
 import { resolveMarkdownPath, shouldConsiderRequest } from './index.ts';
 
 test('shouldConsiderRequest only accepts page-like GET/HEAD requests', () => {
-  assert.equal(shouldConsiderRequest('GET', '/docs/'), true);
-  assert.equal(shouldConsiderRequest('HEAD', '/docs'), true);
-  assert.equal(shouldConsiderRequest('GET', '/docs/index.html'), true);
-  assert.equal(shouldConsiderRequest('GET', '/docs/index.HTML'), false);
-  assert.equal(shouldConsiderRequest('GET', '/docs.html'), false);
-  assert.equal(shouldConsiderRequest('GET', '/404.html'), false);
-  assert.equal(shouldConsiderRequest('POST', '/docs/'), false);
-  assert.equal(shouldConsiderRequest('GET', '/docs/index.md'), false);
-  assert.equal(shouldConsiderRequest('GET', '/data/search.json'), false);
-  assert.equal(shouldConsiderRequest('GET', '/styles/site.css'), false);
-  assert.equal(shouldConsiderRequest('GET', '/img/logo.svg'), false);
-  assert.equal(shouldConsiderRequest('GET', '/.well-known/test'), false);
+  assert.strictEqual(
+    shouldConsiderRequest('GET', '/docs/'),
+    true,
+    'shouldConsiderRequest',
+  );
+  assert.strictEqual(
+    shouldConsiderRequest('HEAD', '/docs'),
+    true,
+    'shouldConsiderRequest',
+  );
+  assert.strictEqual(
+    shouldConsiderRequest('GET', '/docs/index.html'),
+    true,
+    'shouldConsiderRequest',
+  );
+  assert.strictEqual(
+    shouldConsiderRequest('GET', '/docs/index.HTML'),
+    false,
+    'shouldConsiderRequest',
+  );
+  assert.strictEqual(
+    shouldConsiderRequest('GET', '/docs.html'),
+    false,
+    'shouldConsiderRequest',
+  );
+  assert.strictEqual(
+    shouldConsiderRequest('GET', '/404.html'),
+    false,
+    'shouldConsiderRequest',
+  );
+  assert.strictEqual(
+    shouldConsiderRequest('POST', '/docs/'),
+    false,
+    'shouldConsiderRequest',
+  );
+  assert.strictEqual(
+    shouldConsiderRequest('GET', '/docs/index.md'),
+    false,
+    'shouldConsiderRequest',
+  );
+  assert.strictEqual(
+    shouldConsiderRequest('GET', '/data/search.json'),
+    false,
+    'shouldConsiderRequest',
+  );
+  assert.strictEqual(
+    shouldConsiderRequest('GET', '/styles/site.css'),
+    false,
+    'shouldConsiderRequest',
+  );
+  assert.strictEqual(
+    shouldConsiderRequest('GET', '/img/logo.svg'),
+    false,
+    'shouldConsiderRequest',
+  );
+  assert.strictEqual(
+    shouldConsiderRequest('GET', '/.well-known/test'),
+    false,
+    'shouldConsiderRequest',
+  );
   // Last segment matches `\\.([^.]+)$` as `.0` — not extensionless, not index.html.
-  assert.equal(shouldConsiderRequest('GET', '/schemas/1.40.0'), false);
+  assert.strictEqual(
+    shouldConsiderRequest('GET', '/schemas/1.40.0'),
+    false,
+    'shouldConsiderRequest',
+  );
 });
 
 test('resolveMarkdownPath maps page requests to markdown artifacts', () => {
-  assert.equal(resolveMarkdownPath('/'), '/index.md');
-  assert.equal(resolveMarkdownPath('/docs/'), '/docs/index.md');
-  assert.equal(resolveMarkdownPath('/docs'), '/docs/index.md');
-  assert.equal(resolveMarkdownPath('/index.html'), '/index.md');
-  assert.equal(resolveMarkdownPath('/docs/index.html'), '/docs/index.md');
+  assert.strictEqual(
+    resolveMarkdownPath('/'),
+    '/index.md',
+    'resolveMarkdownPath',
+  );
+  assert.strictEqual(
+    resolveMarkdownPath('/docs/'),
+    '/docs/index.md',
+    'resolveMarkdownPath',
+  );
+  assert.strictEqual(
+    resolveMarkdownPath('/docs'),
+    '/docs/index.md',
+    'resolveMarkdownPath',
+  );
+  assert.strictEqual(
+    resolveMarkdownPath('/index.html'),
+    '/index.md',
+    'resolveMarkdownPath',
+  );
+  assert.strictEqual(
+    resolveMarkdownPath('/docs/index.html'),
+    '/docs/index.md',
+    'resolveMarkdownPath',
+  );
 });

--- a/netlify/edge-functions/schema-analytics/index.test.ts
+++ b/netlify/edge-functions/schema-analytics/index.test.ts
@@ -4,6 +4,8 @@
  * - content-type fixup (ensureSchemaContentType)
  * - tracking gate (shouldTrackSchemaFetch)
  * - handler integration (schemaAnalytics default export)
+ *
+ * cSpell:ignore GOOGLEANALYTICS
  */
 
 import assert from 'node:assert/strict';

--- a/netlify/edge-functions/schema-analytics/index.test.ts
+++ b/netlify/edge-functions/schema-analytics/index.test.ts
@@ -14,6 +14,24 @@ import schemaAnalytics, {
   shouldTrackSchemaFetch,
 } from './index.ts';
 
+function setupNetlifyEnv(t: { after: (fn: () => void) => void }) {
+  const g = globalThis as Record<string, unknown>;
+  const originalNetlify = g.Netlify;
+  t.after(() => {
+    g.Netlify = originalNetlify;
+  });
+
+  g.Netlify = {
+    env: {
+      get: (name: string) => {
+        if (name === 'HUGO_SERVICES_GOOGLEANALYTICS_ID') return 'G-TEST';
+        if (name === 'GA4_API_SECRET') return 'secret';
+        return undefined;
+      },
+    },
+  };
+}
+
 // --- ensureSchemaContentType ---
 
 test('ensureSchemaContentType sets application/yaml for 2xx /schemas/ responses', () => {
@@ -169,6 +187,25 @@ test('handler returns response with yaml content type for /schemas/ GET', async 
   assert.equal(response.status, 200);
   assert.equal(response.headers.get('content-type'), 'application/yaml');
   assert.equal(await response.text(), 'opentelemetry: 1.40.0');
+});
+
+test('handler adds X-Asset-Fetch-Ga-Info for GA event candidate schema responses when config is present', async (t) => {
+  setupNetlifyEnv(t);
+
+  const request = new Request('https://example.com/schemas/1.40.0');
+  const context = {
+    next: async () =>
+      new Response('opentelemetry: 1.40.0', {
+        headers: { 'content-type': 'text/plain' },
+        status: 200,
+      }),
+  };
+
+  const response = await schemaAnalytics(request, context);
+  assert.equal(
+    response.headers.get('x-asset-fetch-ga-info'),
+    '/schemas/1.40.0;ga-event-candidate,config-present',
+  );
 });
 
 test('handler passes through non-/schemas/ requests unchanged', async () => {

--- a/netlify/edge-functions/schema-analytics/index.test.ts
+++ b/netlify/edge-functions/schema-analytics/index.test.ts
@@ -11,28 +11,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import { setupNetlifyEnv } from '../lib/test-helpers.ts';
 import schemaAnalytics, {
   ensureSchemaContentType,
   shouldTrackSchemaFetch,
 } from './index.ts';
-
-function setupNetlifyEnv(t: { after: (fn: () => void) => void }) {
-  const g = globalThis as Record<string, unknown>;
-  const originalNetlify = g.Netlify;
-  t.after(() => {
-    g.Netlify = originalNetlify;
-  });
-
-  g.Netlify = {
-    env: {
-      get: (name: string) => {
-        if (name === 'HUGO_SERVICES_GOOGLEANALYTICS_ID') return 'G-TEST';
-        if (name === 'GA4_API_SECRET') return 'secret';
-        return undefined;
-      },
-    },
-  };
-}
 
 // --- ensureSchemaContentType ---
 
@@ -44,8 +27,12 @@ test('ensureSchemaContentType sets application/yaml for 2xx /schemas/ responses'
   });
 
   const result = ensureSchemaContentType(request, response);
-  assert.equal(result.headers.get('content-type'), 'application/yaml');
-  assert.equal(result.status, 200);
+  assert.strictEqual(
+    result.headers.get('content-type'),
+    'application/yaml',
+    'Content-Type',
+  );
+  assert.strictEqual(result.status, 200, 'HTTP status');
 });
 
 test('ensureSchemaContentType does not alter non-/schemas/ responses', () => {
@@ -56,7 +43,11 @@ test('ensureSchemaContentType does not alter non-/schemas/ responses', () => {
   });
 
   const result = ensureSchemaContentType(request, response);
-  assert.equal(result.headers.get('content-type'), 'text/html');
+  assert.strictEqual(
+    result.headers.get('content-type'),
+    'text/html',
+    'Content-Type',
+  );
 });
 
 test('ensureSchemaContentType passes through non-2xx /schemas/ responses', () => {
@@ -64,8 +55,12 @@ test('ensureSchemaContentType passes through non-2xx /schemas/ responses', () =>
   const response = new Response('Not Found', { status: 404 });
 
   const result = ensureSchemaContentType(request, response);
-  assert.equal(result.status, 404);
-  assert.notEqual(result.headers.get('content-type'), 'application/yaml');
+  assert.strictEqual(result.status, 404, 'HTTP status');
+  assert.notStrictEqual(
+    result.headers.get('content-type'),
+    'application/yaml',
+    'Content-Type',
+  );
 });
 
 test('ensureSchemaContentType passes through 3xx /schemas/ responses', () => {
@@ -76,8 +71,12 @@ test('ensureSchemaContentType passes through 3xx /schemas/ responses', () => {
   });
 
   const result = ensureSchemaContentType(request, response);
-  assert.equal(result.status, 302);
-  assert.notEqual(result.headers.get('content-type'), 'application/yaml');
+  assert.strictEqual(result.status, 302, 'HTTP status');
+  assert.notStrictEqual(
+    result.headers.get('content-type'),
+    'application/yaml',
+    'Content-Type',
+  );
 });
 
 // --- shouldTrackSchemaFetch ---
@@ -88,14 +87,22 @@ test('shouldTrackSchemaFetch accepts GET /schemas/ with yaml content type', () =
     headers: { 'content-type': 'application/yaml' },
     status: 200,
   });
-  assert.equal(shouldTrackSchemaFetch(request, response), true);
+  assert.strictEqual(
+    shouldTrackSchemaFetch(request, response),
+    true,
+    'shouldTrackSchemaFetch',
+  );
 });
 
 test('shouldTrackSchemaFetch accepts GET /schemas/ with no content type', () => {
   const request = new Request('https://example.com/schemas/1.40.0');
   const response = new Response(null, { status: 200 });
   response.headers.delete('content-type');
-  assert.equal(shouldTrackSchemaFetch(request, response), true);
+  assert.strictEqual(
+    shouldTrackSchemaFetch(request, response),
+    true,
+    'shouldTrackSchemaFetch',
+  );
 });
 
 test('shouldTrackSchemaFetch accepts various yaml content types', () => {
@@ -110,7 +117,11 @@ test('shouldTrackSchemaFetch accepts various yaml content types', () => {
       headers: { 'content-type': ct },
       status: 200,
     });
-    assert.equal(shouldTrackSchemaFetch(request, response), true, `${ct}`);
+    assert.strictEqual(
+      shouldTrackSchemaFetch(request, response),
+      true,
+      'shouldTrackSchemaFetch',
+    );
   }
 });
 
@@ -123,10 +134,10 @@ test('shouldTrackSchemaFetch returns false for non-GET methods', () => {
       headers: { 'content-type': 'application/yaml' },
       status: 200,
     });
-    assert.equal(
+    assert.strictEqual(
       shouldTrackSchemaFetch(request, response),
       false,
-      `method ${method}`,
+      'shouldTrackSchemaFetch',
     );
   }
 });
@@ -137,7 +148,11 @@ test('shouldTrackSchemaFetch returns false for non-/schemas/ paths', () => {
     headers: { 'content-type': 'application/yaml' },
     status: 200,
   });
-  assert.equal(shouldTrackSchemaFetch(request, response), false);
+  assert.strictEqual(
+    shouldTrackSchemaFetch(request, response),
+    false,
+    'shouldTrackSchemaFetch',
+  );
 });
 
 test('shouldTrackSchemaFetch returns false for 4xx and 5xx responses', () => {
@@ -147,10 +162,10 @@ test('shouldTrackSchemaFetch returns false for 4xx and 5xx responses', () => {
       headers: { 'content-type': 'application/yaml' },
       status,
     });
-    assert.equal(
+    assert.strictEqual(
       shouldTrackSchemaFetch(request, response),
       false,
-      `status ${status}`,
+      'shouldTrackSchemaFetch',
     );
   }
 });
@@ -161,7 +176,11 @@ test('shouldTrackSchemaFetch accepts 3xx redirects', () => {
     status: 302,
     headers: { location: '/schemas/1.40.0' },
   });
-  assert.equal(shouldTrackSchemaFetch(request, response), true);
+  assert.strictEqual(
+    shouldTrackSchemaFetch(request, response),
+    true,
+    'shouldTrackSchemaFetch',
+  );
 });
 
 test('shouldTrackSchemaFetch returns false for 2xx with non-yaml content type', () => {
@@ -170,7 +189,11 @@ test('shouldTrackSchemaFetch returns false for 2xx with non-yaml content type', 
     headers: { 'content-type': 'text/html' },
     status: 200,
   });
-  assert.equal(shouldTrackSchemaFetch(request, response), false);
+  assert.strictEqual(
+    shouldTrackSchemaFetch(request, response),
+    false,
+    'shouldTrackSchemaFetch',
+  );
 });
 
 // --- handler integration ---
@@ -186,9 +209,17 @@ test('handler returns response with yaml content type for /schemas/ GET', async 
   };
 
   const response = await schemaAnalytics(request, context);
-  assert.equal(response.status, 200);
-  assert.equal(response.headers.get('content-type'), 'application/yaml');
-  assert.equal(await response.text(), 'opentelemetry: 1.40.0');
+  assert.strictEqual(response.status, 200, 'HTTP status');
+  assert.strictEqual(
+    response.headers.get('content-type'),
+    'application/yaml',
+    'Content-Type',
+  );
+  assert.strictEqual(
+    await response.text(),
+    'opentelemetry: 1.40.0',
+    'Response body',
+  );
 });
 
 test('handler adds X-Asset-Fetch-Ga-Info for GA event candidate schema responses when config is present', async (t) => {
@@ -204,9 +235,10 @@ test('handler adds X-Asset-Fetch-Ga-Info for GA event candidate schema responses
   };
 
   const response = await schemaAnalytics(request, context);
-  assert.equal(
+  assert.strictEqual(
     response.headers.get('x-asset-fetch-ga-info'),
     '/schemas/1.40.0;ga-event-candidate,config-present',
+    'X-Asset-Fetch-Ga-Info',
   );
 });
 
@@ -221,7 +253,11 @@ test('handler passes through non-/schemas/ requests unchanged', async () => {
   };
 
   const response = await schemaAnalytics(request, context);
-  assert.equal(response.headers.get('content-type'), 'text/html');
+  assert.strictEqual(
+    response.headers.get('content-type'),
+    'text/html',
+    'Content-Type',
+  );
 });
 
 test('handler passes through 404 /schemas/ responses', async () => {
@@ -231,7 +267,7 @@ test('handler passes through 404 /schemas/ responses', async () => {
   };
 
   const response = await schemaAnalytics(request, context);
-  assert.equal(response.status, 404);
+  assert.strictEqual(response.status, 404, 'HTTP status');
 });
 
 test('handler skips tracking for HEAD requests', async () => {
@@ -247,5 +283,5 @@ test('handler skips tracking for HEAD requests', async () => {
   };
 
   const response = await schemaAnalytics(request, context);
-  assert.equal(response.status, 200);
+  assert.strictEqual(response.status, 200, 'HTTP status');
 });

--- a/netlify/edge-functions/schema-analytics/index.ts
+++ b/netlify/edge-functions/schema-analytics/index.ts
@@ -1,7 +1,10 @@
 import {
+  buildAssetFetchGaInfoHeaderValue,
+  hasAssetFetchConfig,
   type AssetFetchContext,
   enqueueAssetFetchEvent,
   normalizeContentType,
+  withAssetFetchGaInfoHeader,
 } from '../lib/ga4-asset-fetch.ts';
 
 export default async function schemaAnalytics(
@@ -10,24 +13,37 @@ export default async function schemaAnalytics(
 ) {
   const response = await context.next();
   const normalizedResponse = ensureSchemaContentType(request, response);
+  const requestUrl = new URL(request.url);
+  const trackable = shouldTrackSchemaFetch(request, normalizedResponse);
+  const gaInfoValue = buildAssetFetchGaInfoHeaderValue({
+    assetPath: trackable ? requestUrl.pathname : undefined,
+    configPresent: hasAssetFetchConfig(),
+    noneReason: trackable
+      ? undefined
+      : getSchemaGaInfoNoneReason(request, normalizedResponse),
+    gaEventCandidate: trackable,
+  });
+  const responseWithGaInfo = withAssetFetchGaInfoHeader(
+    normalizedResponse,
+    gaInfoValue,
+  );
 
-  if (!shouldTrackSchemaFetch(request, normalizedResponse)) {
-    return normalizedResponse;
+  if (!trackable) {
+    return responseWithGaInfo;
   }
 
-  const requestUrl = new URL(request.url);
   const contentType = normalizeContentType(
-    normalizedResponse.headers.get('content-type'),
+    responseWithGaInfo.headers.get('content-type'),
   );
 
   enqueueAssetFetchEvent(request, context, {
     asset_path: requestUrl.pathname,
     content_type: contentType,
-    status_code: String(normalizedResponse.status),
+    status_code: String(responseWithGaInfo.status),
     event_emitter: 'schema',
   });
 
-  return normalizedResponse;
+  return responseWithGaInfo;
 }
 
 // Netlify custom headers from netlify.toml do not reliably apply once an Edge
@@ -86,4 +102,24 @@ export function shouldTrackSchemaFetch(request: Request, response: Response) {
   const contentType = response.headers.get('content-type');
 
   return !contentType || isSchemaContentType(contentType);
+}
+
+function getSchemaGaInfoNoneReason(
+  request: Request,
+  response: Response,
+): string | undefined {
+  if (request.method !== 'GET') {
+    return `request method ${request.method} is not currently tracked`;
+  }
+
+  const requestUrl = new URL(request.url);
+  if (!requestUrl.pathname.startsWith('/schemas/')) {
+    return 'request path does not match a tracked route';
+  }
+
+  if (!shouldTrackSchemaFetch(request, response)) {
+    return 'response does not meet route-specific gating';
+  }
+
+  return undefined;
 }

--- a/netlify/edge-functions/schema-analytics/index.ts
+++ b/netlify/edge-functions/schema-analytics/index.ts
@@ -24,6 +24,7 @@ export default async function schemaAnalytics(
     asset_path: requestUrl.pathname,
     content_type: contentType,
     status_code: String(normalizedResponse.status),
+    event_emitter: 'schema',
   });
 
   return normalizedResponse;

--- a/netlify/edge-functions/schema-analytics/index.ts
+++ b/netlify/edge-functions/schema-analytics/index.ts
@@ -21,9 +21,7 @@ export default async function schemaAnalytics(
   );
 
   enqueueAssetFetchEvent(request, context, {
-    asset_group: 'schema',
     asset_path: requestUrl.pathname,
-    asset_ext: 'yaml',
     content_type: contentType,
     status_code: String(normalizedResponse.status),
   });

--- a/netlify/edge-functions/schema-analytics/live-check.test.mjs
+++ b/netlify/edge-functions/schema-analytics/live-check.test.mjs
@@ -10,31 +10,11 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { ASSET_FETCH_GA_INFO_HEADER } from '../lib/ga4-asset-fetch.ts';
-
-/** Must match the key set in `live-check.mjs` before spawning `node --test`. */
-const LIVE_CHECK_BASE_URL_ENV = 'LIVE_CHECK_BASE_URL';
-
-function resolveBaseRef(raw) {
-  const withScheme = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
-  return new URL(withScheme.endsWith('/') ? withScheme : `${withScheme}/`);
-}
-
-function absUrl(path, baseRef) {
-  return new URL(path, baseRef).href;
-}
-
-function baseRef() {
-  const raw = process.env[LIVE_CHECK_BASE_URL_ENV]?.trim();
-  assert.ok(raw, 'Run live checks via: node .../live-check.mjs [-h] [BASE]');
-  return resolveBaseRef(raw);
-}
-
-function expectedConfigTag(baseRef) {
-  return (
-    'config-' +
-    (baseRef.hostname === 'opentelemetry.io' ? 'present' : 'missing')
-  );
-}
+import {
+  absUrl,
+  baseRef,
+  expectedConfigTag,
+} from '../lib/live-check-test-base.mjs';
 
 const schemaVersionPath = '/schemas/1.40.0';
 const latestSchemaPath = '/schemas/latest';

--- a/netlify/edge-functions/schema-analytics/live-check.test.mjs
+++ b/netlify/edge-functions/schema-analytics/live-check.test.mjs
@@ -29,9 +29,19 @@ function baseRef() {
   return resolveBaseRef(raw);
 }
 
+function expectedConfigTag(baseRef) {
+  return (
+    'config-' +
+    (baseRef.hostname === 'opentelemetry.io' ? 'present' : 'missing')
+  );
+}
+
 const schemaVersionPath = '/schemas/1.40.0';
 const latestSchemaPath = '/schemas/latest';
 const missingSchemaPath = '/schemas/does-not-exist';
+
+/** Set on successful `/schemas/*` responses in `schema-analytics/index.ts`. */
+const expectedSchemaYamlContentType = 'application/yaml';
 
 test('GET /schemas/1.40.0 → YAML response', async () => {
   const ref = baseRef();
@@ -40,16 +50,9 @@ test('GET /schemas/1.40.0 → YAML response', async () => {
   const ct = res.headers.get('content-type') ?? '';
   const text = await res.text();
 
-  assert.equal(res.status, 200, `expected 200 for ${url}`);
-  assert.equal(
-    ct.toLowerCase(),
-    'application/yaml',
-    `expected application/yaml content-type, got ${JSON.stringify(ct)}`,
-  );
-  assert.ok(
-    text.includes('schema_url:'),
-    'body should look like a schema YAML document',
-  );
+  assert.strictEqual(res.status, 200, 'HTTP status');
+  assert.strictEqual(ct, expectedSchemaYamlContentType, 'Content-Type');
+  assert.match(text, /schema_url:/, 'Request body');
 });
 
 test('GET /schemas/1.40.0 → X-Asset-Fetch-Ga-Info header', async () => {
@@ -57,9 +60,10 @@ test('GET /schemas/1.40.0 → X-Asset-Fetch-Ga-Info header', async () => {
   const url = absUrl(schemaVersionPath, ref);
   const res = await fetch(url);
 
-  assert.equal(
+  assert.strictEqual(
     res.headers.get(ASSET_FETCH_GA_INFO_HEADER),
-    `${schemaVersionPath};ga-event-candidate,config-present`,
+    `${schemaVersionPath};ga-event-candidate,${expectedConfigTag(ref)}`,
+    'X-Asset-Fetch-Ga-Info',
   );
 });
 
@@ -70,13 +74,9 @@ test('HEAD /schemas/1.40.0 → success with empty body', async () => {
   const ct = res.headers.get('content-type') ?? '';
   const buf = await res.arrayBuffer();
 
-  assert.equal(res.status, 200, `expected 200 for ${url}`);
-  assert.equal(
-    ct.toLowerCase(),
-    'application/yaml',
-    `expected application/yaml content-type, got ${JSON.stringify(ct)}`,
-  );
-  assert.equal(buf.byteLength, 0, 'expected empty body');
+  assert.strictEqual(res.status, 200, 'HTTP status');
+  assert.strictEqual(ct, expectedSchemaYamlContentType, 'Content-Type');
+  assert.strictEqual(buf.byteLength, 0, 'Response body');
 });
 
 test('GET /schemas/latest → redirect', async () => {
@@ -84,15 +84,12 @@ test('GET /schemas/latest → redirect', async () => {
   const url = absUrl(latestSchemaPath, ref);
   const res = await fetch(url, { redirect: 'manual' });
 
-  assert.ok(300 <= res.status && res.status <= 399, `status for ${url}`);
+  assert.match(String(res.status), /^3\d\d$/, 'HTTP status');
 
   const loc = res.headers.get('location');
-  assert.ok(loc, 'missing Location header');
-  const target = new URL(loc, url).href;
-  assert.ok(
-    target.includes('/schemas/'),
-    `Location should stay under /schemas/, got ${JSON.stringify(loc)} → ${target}`,
-  );
+  assert.ok(loc, 'Location');
+  const latestLocUrl = new URL(loc, url);
+  assert.match(latestLocUrl.pathname, /^\/schemas\/.+$/, 'Location');
 });
 
 test('GET /schemas/does-not-exist → not found', async () => {
@@ -100,11 +97,7 @@ test('GET /schemas/does-not-exist → not found', async () => {
   const url = absUrl(missingSchemaPath, ref);
   const res = await fetch(url, { redirect: 'manual' });
 
-  assert.equal(res.status, 404, `status for ${url}`);
+  assert.strictEqual(res.status, 404, 'HTTP status');
   const ct = res.headers.get('content-type') ?? '';
-  assert.notEqual(
-    ct,
-    'application/yaml',
-    `non-YAML content-type for missing schema, got ${JSON.stringify(ct)}`,
-  );
+  assert.notStrictEqual(ct, 'application/yaml', 'Content-Type');
 });

--- a/netlify/edge-functions/schema-analytics/live-check.test.mjs
+++ b/netlify/edge-functions/schema-analytics/live-check.test.mjs
@@ -9,6 +9,8 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import { ASSET_FETCH_GA_INFO_HEADER } from '../lib/ga4-asset-fetch.ts';
+
 /** Must match the key set in `live-check.mjs` before spawning `node --test`. */
 const LIVE_CHECK_BASE_URL_ENV = 'LIVE_CHECK_BASE_URL';
 
@@ -47,6 +49,17 @@ test('GET /schemas/1.40.0 → YAML response', async () => {
   assert.ok(
     text.includes('schema_url:'),
     'body should look like a schema YAML document',
+  );
+});
+
+test('GET /schemas/1.40.0 → X-Asset-Fetch-Ga-Info header', async () => {
+  const ref = baseRef();
+  const url = absUrl(schemaVersionPath, ref);
+  const res = await fetch(url);
+
+  assert.equal(
+    res.headers.get(ASSET_FETCH_GA_INFO_HEADER),
+    `${schemaVersionPath};ga-event-candidate,config-present`,
   );
 });
 

--- a/projects/2026/asset-fetch-analytics.plan.md
+++ b/projects/2026/asset-fetch-analytics.plan.md
@@ -414,6 +414,35 @@ the event. The header might be dropped in the future.
 Edge Function design should ensure that at most one `asset_fetch` event is sent
 for each request.
 
+### Test assertions (edge functions)
+
+**Goal:** When a test fails, the output should make it obvious _what_ was being
+checked and show a clear **actual vs expected** diff, without long hand-written
+messages.
+
+**Guidance for writing tests** (unit tests under
+`netlify/edge-functions/**/*.test.ts` and live checks under
+`**/live-check.test.mjs`):
+
+1. Prefer **`assert.strictEqual`** over **`assert.equal`** for primitive checks
+   where strictness and diff quality matter.
+2. Add a **short third argument** as context: e.g. `'HTTP status'`,
+   `'Content-Type'`, `'Location'`, `'Request body'`, `'Response body'`,
+   `'X-Asset-Fetch-Ga-Info'`, or `'Subrequest URL'` / `'Subrequest method'` for
+   mocked `fetch` expectations. Let Node print values; avoid long interpolated
+   strings unless the case is truly one-off.
+3. Use **`assert.match`** when a regex expresses the intent more clearly than
+   `includes` or chained `ok` logic (especially for bodies and redirect status
+   classes).
+4. For **`Content-Type`**, compare to a **fixed full string** when the
+   implementation sets a stable value; avoid `toLowerCase()` unless the
+   environment is inconsistent.
+5. For **redirects**, resolve **`Location`** with `new URL(loc, baseUrl)` and
+   assert on **pathname** (or a tight pathname regex) with label
+   **`'Location'`**.
+6. **DRY** repeated checks into **`netlify/edge-functions/lib/test-helpers.ts`**
+   (or similar), e.g. shared **`assertVaryIncludesAccept`**.
+
 ## Identity and privacy
 
 ### Client identity

--- a/projects/2026/asset-fetch-analytics.plan.md
+++ b/projects/2026/asset-fetch-analytics.plan.md
@@ -142,9 +142,13 @@ Event parameters correspond to the following GA4 custom dimensions:
 - Dimension name: `Event emitter`
   - Scope: `Event`
   - Event parameter: `event_emitter`
-  - Description: Instrumentation scope that emitted the `asset_fetch` event. One
-    of `markdown-negotiation`, `schema-analytics`, and `asset-tracking`. These
-    correspond to the corresponding Edge Function names.
+  - Description: Short stable id for the instrumentation scope that emitted the
+    `asset_fetch` event.
+  - Canonical values:
+    - `negotiation` — Accept-negotiated page Markdown (`markdown-negotiation`)
+    - `tracking` — direct `.md` / `.txt` paths (`asset-tracking`)
+    - `schema` — `/schemas/*` responses (`schema-analytics`). **Note:** this
+      value may be deprecated in the future.
 
 Deprecated dimensions:
 
@@ -549,7 +553,10 @@ Reverse chronological: prepend a `### v…` section for each plan-changing PR; u
 
 ### v0.4-dev - TBD (not merged yet)
 
-- ...
+- Added `event_emitter` with canonical values `negotiation`, `tracking`, and
+  `schema`, and updated the implementation/tests to emit and validate it.
+- Deprecated `asset_group` and `asset_ext`, and removed them from the emitted
+  GA4 payloads and related test assertions.
 
 ### v0.3 - 2026-04-10
 

--- a/projects/2026/asset-fetch-analytics.plan.md
+++ b/projects/2026/asset-fetch-analytics.plan.md
@@ -139,6 +139,12 @@ Event parameters correspond to the following GA4 custom dimensions:
   - Scope: `Event`
   - Event parameter: `status_code`
   - Description: HTTP response status code returned when serving the asset
+- Dimension name: `Event emitter`
+  - Scope: `Event`
+  - Event parameter: `event_emitter`
+  - Description: Instrumentation scope that emitted the `asset_fetch` event. One
+    of `markdown-negotiation`, `schema-analytics`, and `asset-tracking`. These
+    correspond to the corresponding Edge Function names.
 
 Deprecated dimensions:
 
@@ -155,9 +161,7 @@ Deprecated dimensions:
   - Description: Broad category for fetched non-HTML assets, such as `schema` or
     `markdown`
 
-Possible future optional event parameters:
-
-### Optional event parameters
+Possible future event parameters:
 
 - `referrer_host`
 - `ua_category`: coarse user-agent class such as `browser`, `ai-agent`,
@@ -241,6 +245,7 @@ Register these event-scoped custom dimensions in GA4:
 - `asset_path`
 - `content_type`
 - `status_code`
+- `event_emitter`
 - `original_path` (phase 2)
 - `referrer_host` if used
 - `ua_category` if used

--- a/projects/2026/asset-fetch-analytics.plan.md
+++ b/projects/2026/asset-fetch-analytics.plan.md
@@ -3,7 +3,7 @@ title: GA4 asset fetch analytics plan
 date: 2026-04-10
 version: 0.4-dev
 custodian: Patrice Chalin
-cSpell:ignore: GOOGLEANALYTICS trackability
+cSpell:ignore: GOOGLEANALYTICS
 ---
 
 ## Goal
@@ -505,13 +505,19 @@ Steps:
    `X-Asset-Fetch-Ga-Info`; the direct-asset handler should treat the presence
    of that request header as an internal subrequest marker and skip tracking to
    avoid double-counting negotiated page requests. The same header can also
-   expose compact debug info on responses, which keeps the mechanism simple and
+   expose compact GA-info on responses, which keeps the mechanism simple and
    live-testable.
 
-3. **Debug response header** — add `X-Asset-Fetch-Ga-Info` to responses using
-   the format described in [Debug response header](#debug-response-header).
-   Purpose: validate derived GA path plus coarse trackability/config state in
-   production without implying GA ingestion.
+3. **GA-info response header** — `X-Asset-Fetch-Ga-Info` responses use the
+   format described in [Response header](#response-header). Purpose: validate
+   derived GA path plus coarse GA event candidate/config state in production
+   without implying GA ingestion.
+
+   The same header is also used as the internal-subrequest marker for
+   deduplication. External callers can emulate it and therefore it is not a
+   security boundary. That tradeoff is accepted: GA4 asset analytics are a
+   convenience surface, while Netlify Observability remains the source of truth
+   for request counts and cross-checking.
 
 4. (optional) Add `ua_category` if the classification is stable and
    low-cardinality.
@@ -570,7 +576,7 @@ This section broadly tracks the tasks for the implementation plan.
 
 ### In progress
 
-Add support for `X-Asset-Fetch-Ga-Info` header.
+None.
 
 ### Other tasks
 
@@ -626,8 +632,8 @@ plan-changing PR; use `-dev` on the version until that change set is merged.
 - Captured implementation/testing work: README notes, unit-test rationale,
   negotiated Markdown live checks, and schema delivery live checks.
 - Updated deployment/config notes: removed the fallback `/schemas/:version`
-  header rule from `netlify.toml` and added a follow-up task for a temporary
-  debug response header.
+  header rule from `netlify.toml` and recorded a later GA-info response header
+  follow-up.
 
 ### v0.1 - 2026-04-03
 

--- a/projects/2026/asset-fetch-analytics.plan.md
+++ b/projects/2026/asset-fetch-analytics.plan.md
@@ -372,6 +372,43 @@ These rule help avoid emitting non-essential events to GA. Consult the site's
 [Netlify Observability][] page for responses with other status codes such as
 `4xx` or `5xx`, and other HTTP methods.
 
+### Response header
+
+For rollout and sanity-checking, add a response header:
+
+- `X-Asset-Fetch-Ga-Info: <asset_path>[; <info-tag>[,<info-tag>]*]`
+- `X-Asset-Fetch-Ga-Info: none[: <info-tag> [,<info-tag>]*]`
+
+Where:
+
+- `<asset_path>` is the derived GA `asset_path` that would be sent for the
+  request; or `none` when there is no derived GA path
+
+When `<asset_path>` is `none`, the info-tag offers a reason:
+
+- `request method X is not currently tracked` (where X is the request method)
+- `request path does not match a tracked route`
+- `internal subrequest`
+  - Request is an internal subrequest already marked with
+    `X-Asset-Fetch-Ga-Info`.
+- `response does not meet route-specific gating`
+  - Request path matches, but the response does not meet route-specific gating.
+
+When there is a path, possible info-tags include:
+
+- `config-missing`
+  - GA credentials are not present, so the request is only a local GA event
+    candidate.
+- `config-present`
+  - GA credentials are present, so event enqueue will be attempted.
+- `ga-event-candidate`
+  - The request matches the current route/method/response gating and is a
+    candidate to emit `asset_fetch`.
+
+This header is for validating path derivation and coarse GA event
+candidate/config state only. It does not indicate that GA accepted or reported
+the event. The header might be dropped in the future.
+
 ### Deduplication policy
 
 Edge Function design should ensure that at most one `asset_fetch` event is sent
@@ -471,7 +508,12 @@ Steps:
    expose compact debug info on responses, which keeps the mechanism simple and
    live-testable.
 
-3. (optional) Add `ua_category` if the classification is stable and
+3. **Debug response header** — add `X-Asset-Fetch-Ga-Info` to responses using
+   the format described in [Debug response header](#debug-response-header).
+   Purpose: validate derived GA path plus coarse trackability/config state in
+   production without implying GA ingestion.
+
+4. (optional) Add `ua_category` if the classification is stable and
    low-cardinality.
 
 ### Phase 3
@@ -528,7 +570,7 @@ This section broadly tracks the tasks for the implementation plan.
 
 ### In progress
 
-All done for this iteration.
+Add support for `X-Asset-Fetch-Ga-Info` header.
 
 ### Other tasks
 
@@ -536,20 +578,13 @@ In no particular order:
 
 - Add `ua_category` if the classification is stable and low-cardinality.
 - Build a shared GA4 exploration or Looker Studio report for the team.
-- Add a temporary compiled-const debug response header for post-merge production
-  sanity checks, for example
-  `X-Asset-Fetch-Ga-Info: /schemas/1.40.0;trackable,config-present` or
-  `none:<reason>`. Use it only to confirm the derived GA path and basic
-  trackability/config state, not GA ingestion. In phase 2.2, the presence of the
-  same header on internal subrequests will also act as the duplicate-suppression
-  marker.
 - Report non-2XX and non-3XX responses from internal markdown-negotiation
   subrequests.
 
 ## Edit history
 
-Reverse chronological: prepend a `### v…` section for each plan-changing PR; use
-`-dev` on the version until that change set is merged.
+Plan changes in reverse chronological order. Prepend a `### v…` section for each
+plan-changing PR; use `-dev` on the version until that change set is merged.
 
 ### v0.4-dev - TBD (not merged yet)
 
@@ -557,6 +592,13 @@ Reverse chronological: prepend a `### v…` section for each plan-changing PR; u
   `schema`, and updated the implementation/tests to emit and validate it.
 - Deprecated `asset_group` and `asset_ext`, and removed them from the emitted
   GA4 payloads and related test assertions.
+- Added support for `X-Asset-Fetch-Ga-Info` response headers using
+  `<asset_path>[;<info-tag>[,<info-tag>]*]` or
+  `none[: <info-tag> [,<info-tag>]*]`, and updated tests to validate the initial
+  GA event candidate and non-candidate cases, including integration tests and
+  deployed-host live checks.
+- Added dedicated `/site/testing/tests/` content fixtures for live checks,
+  including a regular page and an HTML-only page that does not publish Markdown.
 
 ### v0.3 - 2026-04-10
 

--- a/projects/2026/asset-fetch-analytics.plan.md
+++ b/projects/2026/asset-fetch-analytics.plan.md
@@ -415,35 +415,6 @@ the event. The header might be dropped in the future.
 Edge Function design should ensure that at most one `asset_fetch` event is sent
 for each request.
 
-### Test assertions (edge functions)
-
-**Goal:** When a test fails, the output should make it obvious _what_ was being
-checked and show a clear **actual vs expected** diff, without long hand-written
-messages.
-
-**Guidance for writing tests** (unit tests under
-`netlify/edge-functions/**/*.test.ts` and live checks under
-`**/live-check.test.mjs`):
-
-1. Prefer **`assert.strictEqual`** over **`assert.equal`** for primitive checks
-   where strictness and diff quality matter.
-2. Add a **short third argument** as context: e.g. `'HTTP status'`,
-   `'Content-Type'`, `'Location'`, `'Request body'`, `'Response body'`,
-   `'X-Asset-Fetch-Ga-Info'`, or `'Subrequest URL'` / `'Subrequest method'` for
-   mocked `fetch` expectations. Let Node print values; avoid long interpolated
-   strings unless the case is truly one-off.
-3. Use **`assert.match`** when a regex expresses the intent more clearly than
-   `includes` or chained `ok` logic (especially for bodies and redirect status
-   classes).
-4. For **`Content-Type`**, compare to a **fixed full string** when the
-   implementation sets a stable value; avoid `toLowerCase()` unless the
-   environment is inconsistent.
-5. For **redirects**, resolve **`Location`** with `new URL(loc, baseUrl)` and
-   assert on **pathname** (or a tight pathname regex) with label
-   **`'Location'`**.
-6. **DRY** repeated checks into **`netlify/edge-functions/lib/test-helpers.ts`**
-   (or similar), e.g. shared **`assertVaryIncludesAccept`**.
-
 ## Identity and privacy
 
 ### Client identity

--- a/projects/2026/asset-fetch-analytics.plan.md
+++ b/projects/2026/asset-fetch-analytics.plan.md
@@ -1,7 +1,8 @@
 ---
 title: GA4 asset fetch analytics plan
-date: 2026-04-10
-version: 0.4-dev
+date: 2026-04-03
+lastmod: 2026-04-11
+version: 0.4
 custodian: Patrice Chalin
 cSpell:ignore: GOOGLEANALYTICS
 ---
@@ -621,7 +622,7 @@ In no particular order:
 Plan changes in reverse chronological order. Prepend a `### v…` section for each
 plan-changing PR; use `-dev` on the version until that change set is merged.
 
-### v0.4-dev - TBD (not merged yet)
+### v0.4 - 2026-04-11
 
 - Added `event_emitter` with canonical values `negotiation`, `tracking`, and
   `schema`, and updated the implementation/tests to emit and validate it.
@@ -632,8 +633,12 @@ plan-changing PR; use `-dev` on the version until that change set is merged.
   `none[: <info-tag> [,<info-tag>]*]`, and updated tests to validate the initial
   GA event candidate and non-candidate cases, including integration tests and
   deployed-host live checks.
+- Made deployed-host GA-info header checks environment-aware so production
+  expects `config-present` while preview/local expects `config-missing`.
 - Added dedicated `/site/testing/tests/` content fixtures for live checks,
   including a regular page and an HTML-only page that does not publish Markdown.
+- Added edge-function test assertion guidance to this plan and refactored
+  repeated helper logic so the test suites stay DRY without changing coverage.
 
 ### v0.3 - 2026-04-10
 

--- a/projects/2026/asset-fetch-analytics.plan.md
+++ b/projects/2026/asset-fetch-analytics.plan.md
@@ -1,14 +1,14 @@
 ---
 title: GA4 asset fetch analytics plan
 date: 2026-04-10
-version: 0.2
+version: 0.4-dev
 custodian: Patrice Chalin
 cSpell:ignore: GOOGLEANALYTICS trackability
 ---
 
 ## Goal
 
-Support analytics/observability for non-HTML assets served from
+Support essential GA4 analytics for non-HTML assets served from
 `opentelemetry.io`, including:
 
 - Schema files under `/schemas/*`
@@ -17,6 +17,9 @@ Support analytics/observability for non-HTML assets served from
 
 The chosen design keeps reporting accessible to the existing team through Google
 Analytics while preserving a reliable operational view in Netlify.
+
+[Netlify Observability][] remains the operational backstop for request-level
+validation and debugging.
 
 ## Summary
 
@@ -110,32 +113,49 @@ flowchart LR
 
 ### Event name
 
-Use one custom event:
+Use a single custom event: `asset_fetch`
 
-`asset_fetch`
+### Event parameters
 
-This keeps reporting simple and avoids proliferating many event names.
+Event parameters correspond to the following GA4 custom dimensions:
 
-### Required event parameters
+- Dimension name: `Asset path`
+  - Scope: `Event`
+  - Event parameter: `asset_path`
+  - Description: Path of the resource returned for the fetch (after Path
+    resolution), such as `/schemas/1.40.0`
+- Dimension name: `Original path`
+  - Scope: `Event`
+  - Event parameter: `original_path`
+  - Description: Unmodified request path when it differs from `asset_path`.
+    Register for Markdown negotiation; omit when unused (for example schemas do
+    not send this parameter).
+- Dimension name: `Content type`
+  - Scope: `Event`
+  - Event parameter: `content_type`
+  - Description: Response content type returned for the fetched asset, such as
+    `application/yaml`
+- Dimension name: `Status code`
+  - Scope: `Event`
+  - Event parameter: `status_code`
+  - Description: HTTP response status code returned when serving the asset
 
-Send the following GA4 event parameters for every tracked asset request:
+Deprecated dimensions:
 
-- `asset_group`: one of: `schema`, `markdown`, `text`, `other`
-- `asset_path`: path of the resource returned in the response, after Path
-  resolution (for example `/schemas/1.40.0` or
-  `/docs/concepts/context/index.md`)
-- `asset_ext`: extension from `asset_path` when present; always `yaml` for
-  schemas
-- `content_type`: stable response content type, for example `application/yaml`
-- `status_code`: response status as a string, for example `200`
+- Dimension name: `Asset extension`
+  - Status: **DEPRECATED** since v0.4
+  - Scope: `Event`
+  - Event parameter: `asset_ext`
+  - Description: Extension from `asset_path` when present. Always `yaml` for
+    schemas.
+- Dimension name: `Asset group`
+  - Status: **DEPRECATED** since v0.4
+  - Scope: `Event`
+  - Event parameter: `asset_group`
+  - Description: Broad category for fetched non-HTML assets, such as `schema` or
+    `markdown`
 
-### Markdown negotiation: `original_path`
-
-- `original_path`: unmodified request path when it differs from `asset_path`,
-  for example `/docs/concepts/context/` when the resolved `asset_path` is
-  `/docs/concepts/context/index.md` (omit when request and resolution match).
-  The `markdown-negotiation` Edge Function sends this today; other asset types
-  may add it later.
+Possible future optional event parameters:
 
 ### Optional event parameters
 
@@ -218,153 +238,38 @@ property.
 
 Register these event-scoped custom dimensions in GA4:
 
-- `asset_group`
 - `asset_path`
-- `asset_ext`
 - `content_type`
 - `status_code`
 - `original_path` (phase 2)
 - `referrer_host` if used
 - `ua_category` if used
 
-### Reporting model
-
-The primary GA4 metric is:
-
-- `Event count`
-
-The main report slices are:
-
-- event count by `asset_path`
-- event count by `asset_group`
-- event count by `asset_ext`
-- event count by `status_code`
-- event count by `ua_category` if implemented
-
 ### Retention and history
 
 GA4 aggregated reports remain available in the GA UI, but event-level retention
-used by Explorations is limited by GA4 retention settings. If exact long-term
-path-level history matters, enable BigQuery export.
+used by Explorations is limited by GA4 retention settings, which is set to 14
+months (as of 2026-04-03).
 
-## Reporting examples
+## Reporting
 
-### Schema access counts
-
-Example question:
-
-How many times was `/schemas/1.40.0` fetched in the last 30 days?
-
-GA4 answer shape:
-
-- filter `event_name = asset_fetch`
-- filter `asset_group = schema`
-- breakdown by `asset_path`
-- metric `Event count`
-
-### Markdown asset access counts
-
-Example question:
-
-Which Markdown-rendered page assets were fetched most often this month?
-
-GA4 answer shape:
-
-- filter `event_name = asset_fetch`
-- filter `asset_group = markdown`
-- breakdown by `asset_path`
-- metric `Event count`
-
-For negotiated Markdown delivery, the `markdown-negotiation` Edge Function sets
-`asset_path` to the path of the returned resource and sends `original_path` when
-the request path differs.
-
-### Bot and AI traffic split
-
-Example question:
-
-How much of Markdown asset traffic comes from AI agents vs browsers?
-
-Two options:
-
-1. In GA4, if `ua_category` is sent as an event parameter.
-2. In Netlify Observability, which already classifies user agents and is better
-   suited for validation and operational analysis.
-
-## Looker Studio reporting
-
-Use the existing GA4-backed Looker Studio reporting approach for asset
-analytics. This should work well for the current goals:
-
-- access counts
-- top-accessed schema files
-- top-accessed Markdown assets
-
-### Top 10 schemas in the last 30 days
-
-Recommended chart configuration:
-
-- data source: GA4 property or dedicated asset stream
-- chart type: table
-- dimension: `asset_path`
-- metric: `Event count`
-- filters:
-  - `event_name = asset_fetch`
-  - `asset_group = schema`
-- sort: `Event count` descending
-- row limit: top `10`
-- date range: last `30` days
-
-### Top Markdown assets in the last 30 days
-
-Recommended chart configuration:
-
-- data source: GA4 property or dedicated asset stream
-- chart type: table
-- dimension: `asset_path`
-- metric: `Event count`
-- filters:
-  - `event_name = asset_fetch`
-  - `asset_group = markdown`
-- sort: `Event count` descending
-- row limit: top `10`
-- date range: last `30` days
-
-### Publishing and sharing
-
-This reporting can be added to the existing public Looker Studio dashboard,
-assuming:
-
-- the report uses owner credentials for the GA4 data source
-- the GA4 custom dimensions have been registered
-- the new fields have propagated and the Looker data source fields have been
-  refreshed
-
-### Limits
-
-This approach is a good fit for top-N reporting. If `asset_path` eventually
-becomes too high-cardinality and GA4 starts collapsing values into `(other)`,
-move the public path-level report to Looker Studio on top of GA4 BigQuery
-export.
+- Google Analytics console:
+  - Engagement > Events report. Select `asset_fetch` to view details of all
+    asset fetch events.
+- Looker Studio
+  - Asset fetch event reporting can be added to the existing public Looker
+    Studio dashboard.
+    - For an example, see the Schema table (added around 2026-04-09)
+  - Note: You may have to refresh the data source to see new custom dimensions.
+  - Limits:
+    - This approach is a good fit for top-N reporting. If `asset_path`
+      eventually becomes too high-cardinality and GA4 starts collapsing values
+      into `(other)`, move the public path-level report to Looker Studio on top
+      of GA4 BigQuery export.
 
 ## Phase 1 runtime configuration (completed)
 
-Configure the Netlify site with:
-
-- `HUGO_SERVICES_GOOGLEANALYTICS_ID`
-  - existing GA4 measurement ID for the site's current web stream
-- `GA4_API_SECRET`
-  - new GA4 Measurement Protocol API secret for `asset_fetch` events
-
-Phase 1 should reuse the existing web stream and should not introduce a second
-measurement ID.
-
-Phase 1 should rely on environment-variable scoping rather than host-based
-checks inside the Edge Function. If `GA4_API_SECRET` is only configured for
-production, local and preview environments will not send GA4 events unless the
-secret is intentionally provided there as well.
-
-### Create the GA4 Measurement Protocol API secret
+### Create a GA4 Measurement Protocol API secret
 
 In GA4:
 
@@ -376,16 +281,16 @@ In GA4:
 
 Operational notes:
 
-- keep the secret private
-- store it only in Netlify site settings
-- rotate it if there is any reason to suspect exposure
+- Keep the secret private
+- Store it only in Netlify site settings
+- Rotate it if there is any reason to suspect exposure
 
-### Set the Netlify environment variable
+### Set `GA4_API_SECRET`
 
-In Netlify site settings:
+In Netlify site Environment Variables settings:
 
 1. Open the site's environment variable settings.
-2. Add `GA4_API_SECRET`.
+2. Add `GA4_API_SECRET` for **production only**.
 3. Paste the Measurement Protocol API secret value.
 4. Redeploy after the variable is added or updated.
 
@@ -399,43 +304,12 @@ In GA4:
 1. Open `Admin`.
 2. Under `Data display`, open `Custom definitions`.
 3. Open the `Custom dimensions` tab.
-4. Create event-scoped custom dimensions for the `asset_fetch` parameters.
+4. Create event-scoped custom dimensions for each of the `asset_fetch`
+   parameters listed in [Event parameters](#event-parameters).
 
-Suggested GA4 dimension definitions:
-
-- Dimension name: `Asset group`
-  - Scope: `Event`
-  - Event parameter: `asset_group`
-  - Description: Broad category for fetched non-HTML assets, such as `schema` or
-    `markdown`
-- Dimension name: `Asset path`
-  - Scope: `Event`
-  - Event parameter: `asset_path`
-  - Description: Path of the resource returned for the fetch (after Path
-    resolution), such as `/schemas/1.40.0`
-- Dimension name: `Asset extension`
-  - Scope: `Event`
-  - Event parameter: `asset_ext`
-  - Description: Extension from `asset_path` when present. Always `yaml` for
-    schemas.
-- Dimension name: `Content type`
-  - Scope: `Event`
-  - Event parameter: `content_type`
-  - Description: Response content type returned for the fetched asset, such as
-    `application/yaml`
-- Dimension name: `Status code`
-  - Scope: `Event`
-  - Event parameter: `status_code`
-  - Description: HTTP response status code returned when serving the asset
-- Dimension name: `Original path`
-  - Scope: `Event`
-  - Event parameter: `original_path`
-  - Description: Unmodified request path when it differs from `asset_path`.
-    Register for Markdown negotiation; omit when unused (for example schemas do
-    not send this parameter).
-
-GA4 custom dimensions typically become available in reports and explorations 24
-to 48 hours after the event data is sent and the custom dimension is created.
+> **Note:** GA4 custom dimensions typically become available in reports and
+> explorations 24 to 48 hours after the event data is sent and the custom
+> dimension is created.
 
 ### Validate phase 1 after deploy
 
@@ -444,8 +318,8 @@ After deploying:
 1. Fetch a known schema URL such as `/schemas/1.40.0`.
 2. Confirm the response still returns YAML.
 3. Check GA4 Realtime for the `asset_fetch` event.
-4. After custom dimensions propagate, confirm `asset_group = schema` and the
-   expected `asset_path` appear in GA4 and Looker Studio.
+4. After custom dimensions propagate, confirm the expected `asset_path`,
+   `content_type`, and `status_code` appear in GA4 and Looker Studio.
 
 Validation note:
 
@@ -458,15 +332,14 @@ Validation note:
 
 ### Tracked paths
 
-Initial scope:
-
 - `/schemas/*`
-- Negotiated Markdown responses
-- Explicit `.md` and `.txt` requests
+- Request paths ending in `.md` or `.txt`
+- Any path with content negotiation for Markdown
 
-Future optional scope:
+> **Note:** More extensions may be added in the future in support of [Download
+> URLs #4079][#4079].
 
-- Other machine-readable non-HTML assets that warrant analytics
+[#4079]: https://github.com/open-telemetry/opentelemetry.io/issues/4079
 
 ### Response gating
 
@@ -478,29 +351,22 @@ Only send GA4 events when all of the following are true:
 
 Current route-specific rules:
 
-- Schemas: track `GET /schemas/*` for successful `2xx` YAML responses and
-  successful `3xx` redirects under `/schemas/*`
 - Negotiated Markdown: track only successful negotiated Markdown `GET 2xx`
   responses
 - Explicit `.md` and `.txt`: track direct `GET` requests to tracked asset URLs
   regardless of response status, and skip any request marked with
   `X-Asset-Fetch-Ga-Info`
+- Schemas: track `GET /schemas/*` for successful `2xx` YAML responses and
+  successful `3xx` redirects under `/schemas/*`.
 
-This avoids inflating counts with irrelevant methods or internal subrequests.
-
-In the future we might broaden tracking to other HTTP methods, and for other
-response status codes.
+These rule help avoid emitting non-essential events to GA. Consult the site's
+[Netlify Observability][] page for responses with other status codes such as
+`4xx` or `5xx`, and other HTTP methods.
 
 ### Deduplication policy
 
-Do not attempt request deduplication in the Edge Function. Count each served
-request as one `asset_fetch` event.
-
-Reason:
-
-- request count is the simplest and most defensible metric
-- GA4 user/session semantics are weak for server-side asset fetches anyway
-- deduplication would add ambiguity and operational complexity
+Edge Function design should ensure that at most one `asset_fetch` event is sent
+for each request.
 
 ## Identity and privacy
 
@@ -550,11 +416,11 @@ assets are generated for many pages.
 
 ### Mitigations
 
-- use one event name only
-- use a small set of categorical parameters
-- keep `asset_path` stable (Path resolution)
-- do not send query strings
-- use BigQuery export for exact long-term analysis
+- Use one event name only
+- Use a small set of categorical parameters
+- Keep `asset_path` stable (path resolution)
+- Do not send query strings
+- Use BigQuery export for exact long-term analysis
 
 ### When to move beyond GA4 UI
 
@@ -562,21 +428,6 @@ If the GA4 UI starts collapsing rows into `(other)` for `asset_path`, use:
 
 - GA4 for high-level grouped reporting
 - BigQuery for exact path-level analysis
-
-## Netlify Observability role
-
-Netlify Observability should remain enabled even after GA4 asset tracking is
-added.
-
-Use it for:
-
-- sanity-checking request volumes
-- short-term incident analysis
-- debugging status-code spikes
-- identifying traffic classes such as AI agents and crawlers
-
-Do not treat it as the primary shared reporting surface for this initiative. It
-is better suited to internal operational use than broad publishing.
 
 ## Implementation plan
 
@@ -588,6 +439,8 @@ is better suited to internal operational use than broad publishing.
 4. Validate counts against Netlify Observability.
 
 ### Phase 2
+
+**Status:** In progress. Completed steps: 1, 2.
 
 Steps:
 
@@ -609,55 +462,20 @@ Steps:
    expose compact debug info on responses, which keeps the mechanism simple and
    live-testable.
 
-3. Add `ua_category` if the classification is stable and low-cardinality.
-4. Build a shared GA4 exploration or Looker Studio report for the team.
+3. (optional) Add `ua_category` if the classification is stable and
+   low-cardinality.
 
 ### Phase 3
 
+This phase is optional.
+
+1. Build a shared GA4 exploration or Looker Studio report for the team.
 1. Enable GA4 BigQuery export if exact long-term path-level reporting becomes
    important.
-2. Add grouped dashboards for:
+1. Add grouped dashboards for:
    - schema usage by version
    - Markdown asset usage by section
    - asset traffic by status code
-
-## Open decisions
-
-### Stream vs property
-
-Default recommendation: use the existing web stream in the existing property.
-
-Decision triggers for a separate property:
-
-- stricter access control
-- a need for stronger isolation than a separate event name provides
-- desire to isolate machine traffic completely
-- concern that asset events will confuse non-technical GA users
-
-### Whether to send `ua_category`
-
-Recommended default: not in phase 1.
-
-Reason:
-
-- Netlify already provides agent classification operationally
-- it can be added later if needed
-
-### Whether to count redirects
-
-Recommended default: yes, if the request is a successful redirect for a tracked
-asset route such as `/schemas/latest`.
-
-If reports should reflect only terminal asset responses, change the gating rule
-to only count `2xx`.
-
-## Proposed dashboard questions
-
-- Which schema versions are fetched most often?
-- How often is `/schemas/latest` used compared to pinned schema versions?
-- Which Markdown asset routes are fetched most often?
-- Which documentation sections receive the most Markdown asset traffic?
-- What share of asset traffic is non-`200`?
 
 ## Prior art
 
@@ -724,6 +542,10 @@ In no particular order:
 Reverse chronological: prepend a `### v…` section for each plan-changing PR; use
 `-dev` on the version until that change set is merged.
 
+### v0.4-dev - TBD (not merged yet)
+
+- ...
+
 ### v0.3 - 2026-04-10
 
 - Implemented phase 2.2/2.3 with a generic `asset-tracking` Edge Function for
@@ -756,3 +578,6 @@ Reverse chronological: prepend a `### v…` section for each plan-changing PR; u
 ### v0.1 - 2026-04-03
 
 - First version.
+
+[Netlify Observability]:
+  https://app.netlify.com/projects/opentelemetry/logs-and-metrics/observability


### PR DESCRIPTION
- Contributes to #9559
- Adds `X-Asset-Fetch-Ga-Info` response headers to schema, negotiated Markdown, and direct asset responses
- Updates the asset-fetch analytics plan and edit history to match the current implementation
- Uses `ga-event-candidate` with `config-present` or `config-missing` to expose derived GA path and coarse emission state
- Keeps non-candidate cases readable with `none: <reason>` header values
- Extends unit and cross-function integration tests to validate the new header behavior
- Splits deployed-host live checks so delivery assertions and header assertions stay separate
- Adds shared edge-function test helpers and makes the test suites more DRY without changing coverage
- Splits deployed-host live checks so delivery assertions and GA-info header assertions stay separate
- Adds isolated `/site/testing/tests/` fixtures, including a regular page and an HTML-only page, for low-impact live checks

---

All unit, integration, and live tests are passing.

New response header is being generated, e.g.:

```console
$ curl -sI  -H 'Accept: text/markdown' https://deploy-preview-9630--opentelemetry.netlify.app/site/testing/tests/regular/
HTTP/2 200 
...
x-asset-fetch-ga-info: /site/testing/tests/regular/index.md;ga-event-candidate,config-missing
...
```