### PR TITLE
docs: remove redundant "metrics" from data sources

### DIFF
--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -371,7 +371,7 @@ processors:
       - key: email
         action: hash
 
-  # Data sources: metrics, metrics, logs
+  # Data sources: traces, metrics, logs
   filter:
     error_mode: ignore
     traces:


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

Fixes a minor documentation line code comment. The code comment had duplicate word ("metrics").
