### PR TITLE
Go: document that users should check Enabled when making sychronous metric API calls

### DIFF
--- a/content/en/docs/languages/go/instrumentation.md
+++ b/content/en/docs/languages/go/instrumentation.md
@@ -476,7 +476,9 @@ example).
 
 ### Performance Optimization for Synchronous Instruments
 
-For synchronous instruments, you can use the `Enabled` method to check if the instrument is enabled before performing expensive operations to compute attributes or values.
+For synchronous instruments, you can use the `Enabled` method to check if the
+instrument is enabled before performing expensive operations to compute
+attributes or values.
 
 ```go
 if apiCounter.Enabled(ctx) {
@@ -485,7 +487,8 @@ if apiCounter.Enabled(ctx) {
 }
 ```
 
-This ensures your instrumentation doesn't pay a performance penalty when no MeterProvider is configured, or when a view is configured to drop the metric.
+This ensures your instrumentation doesn't pay a performance penalty when no
+MeterProvider is configured, or when a view is configured to drop the metric.
 
 ### Using Counters
 

--- a/content/en/docs/languages/go/instrumentation.md
+++ b/content/en/docs/languages/go/instrumentation.md
@@ -474,6 +474,19 @@ In cases like these, it's often better to observe a cumulative value directly,
 rather than aggregate a series of deltas in post-processing (the synchronous
 example).
 
+### Performance Optimization for Synchronous Instruments
+
+For synchronous instruments, you can use the `Enabled` method to check if the instrument is enabled before performing expensive operations to compute attributes or values.
+
+```go
+if apiCounter.Enabled(ctx) {
+    // compute attributes or values
+    apiCounter.Add(ctx, 1, metric.WithAttributes(attributes...))
+}
+```
+
+This ensures your instrumentation doesn't pay a performance penalty when no MeterProvider is configured, or when a view is configured to drop the metric.
+
 ### Using Counters
 
 Counters can be used to measure a non-negative, increasing value.
@@ -497,7 +510,9 @@ func init() {
 		panic(err)
 	}
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		apiCounter.Add(r.Context(), 1)
+		if apiCounter.Enabled(r.Context()) {
+			apiCounter.Add(r.Context(), 1)
+		}
 
 		// do some work in an API call
 	})
@@ -535,13 +550,19 @@ func init() {
 func addItem() {
 	// code that adds an item to the collection
 
-	itemsCounter.Add(context.Background(), 1)
+	ctx := context.Background()
+	if itemsCounter.Enabled(ctx) {
+		itemsCounter.Add(ctx, 1)
+	}
 }
 
 func removeItem() {
 	// code that removes an item from the collection
 
-	itemsCounter.Add(context.Background(), -1)
+	ctx := context.Background()
+	if itemsCounter.Enabled(ctx) {
+		itemsCounter.Add(ctx, -1)
+	}
 }
 ```
 
@@ -597,7 +618,9 @@ func init() {
 func recordFanSpeed() {
 	ctx := context.Background()
 	for fanSpeed := range fanSpeedSubscription {
-		speedGauge.Record(ctx, fanSpeed)
+		if speedGauge.Enabled(ctx) {
+			speedGauge.Record(ctx, fanSpeed)
+		}
 	}
 }
 ```
@@ -632,7 +655,9 @@ func init() {
 		// do some work in an API call
 
 		duration := time.Since(start)
-		histogram.Record(r.Context(), duration.Seconds())
+		if histogram.Enabled(r.Context()) {
+			histogram.Record(r.Context(), duration.Seconds())
+		}
 	})
 }
 ```


### PR DESCRIPTION
- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

Part of https://github.com/open-telemetry/opentelemetry-go/issues/7800

The Performance Optimization for Synchronous Instruments section will be expanded later to include pooling, and precomputing attribute sets.

cc @open-telemetry/go-approvers 