### PR TITLE
Kapa modal dark-mode support

### DIFF
--- a/layouts/_partials/hooks/head-end.html
+++ b/layouts/_partials/hooks/head-end.html
@@ -43,6 +43,7 @@
   xx-DISABLED-data-launcher-button-text=""
   xx-DOES-NOT-WORK-data-launcher-button-font-size="1rem"
   data-font-size-lg="1rem"
+  data-color-scheme-selector="[data-bs-theme='dark']"
 >
 </script>
 {{/* */ -}}


### PR DESCRIPTION
- Contributes to #9662
- Followup to #9651
- Adds dark-mode support for the Kapa model dialog
- **Preview**: https://deploy-preview-9652--opentelemetry.netlify.app

### Screenshot

<img width="1023" height="1364" alt="image" src="https://github.com/user-attachments/assets/9263f58b-9787-4f93-a6ce-698fd18cee29" />
