### PR TITLE
platforms/kubernetes: update logging documentation for Python SDK bump

### DIFF
--- a/content/en/docs/platforms/kubernetes/operator/automatic.md
+++ b/content/en/docs/platforms/kubernetes/operator/automatic.md
@@ -459,11 +459,10 @@ in the previous step.
 
 #### Auto-instrumenting Python logs
 
-By default, Python logs auto-instrumentation is enabled by the `opentelemetry-instrumentation-logging` package.
-If you would like to
-disable this feature, you must to set
-`OTEL_PYTHON_LOG_AUTO_INSTRUMENTATION` environment variable as
-follows:
+By default, Python logs auto-instrumentation is enabled by the
+`opentelemetry-instrumentation-logging` package. If you would like to disable
+this feature, you must to set `OTEL_PYTHON_LOG_AUTO_INSTRUMENTATION` environment
+variable as follows:
 
 ```yaml
 apiVersion: opentelemetry.io/v1alpha1
@@ -484,8 +483,9 @@ spec:
         value: 'false'
 ```
 
-> Before operator v0.148.0 this was handled by `OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED`
-> that was set to `false` by default
+> Before operator v0.148.0 this was handled by
+> `OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED` that was set to `false` by
+> default
 
 #### Excluding auto-instrumentation {#python-excluding-auto-instrumentation}
 

--- a/content/en/docs/platforms/kubernetes/operator/automatic.md
+++ b/content/en/docs/platforms/kubernetes/operator/automatic.md
@@ -459,9 +459,10 @@ in the previous step.
 
 #### Auto-instrumenting Python logs
 
-By default, Python logs auto-instrumentation is disabled. If you would like to
-enable this feature, you must to set
-`OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED` environment variable as
+By default, Python logs auto-instrumentation is enabled by the `opentelemetry-instrumentation-logging` package.
+If you would like to
+disable this feature, you must to set
+`OTEL_PYTHON_LOG_AUTO_INSTRUMENTATION` environment variable as
 follows:
 
 ```yaml
@@ -479,12 +480,12 @@ spec:
     - baggage
   python:
     env:
-      - name: OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED
-        value: 'true'
+      - name: OTEL_PYTHON_LOG_AUTO_INSTRUMENTATION
+        value: 'false'
 ```
 
-> As of operator v0.111.0 setting `OTEL_LOGS_EXPORTER` to `otlp` is not required
-> anymore.
+> Before operator v0.148.0 this was handled by `OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED`
+> that was set to `false` by default
 
 #### Excluding auto-instrumentation {#python-excluding-auto-instrumentation}
 

--- a/content/en/docs/platforms/kubernetes/operator/automatic.md
+++ b/content/en/docs/platforms/kubernetes/operator/automatic.md
@@ -483,7 +483,7 @@ spec:
         value: 'false'
 ```
 
-> Before operator v0.148.0 this was handled by
+> Before operator v0.149.0 this was handled by
 > `OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED` that was set to `false` by
 > default
 


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

Since 1.40.0 logging autoinstrumentation is handled by opentelemetry-instrumentation-logging and it is enabled by default.