### PR TITLE
Fix Japanese sample code (Change mux.Handle to mux.HandleFunc for routes)

### DIFF
--- a/content/ja/docs/languages/go/getting-started.md
+++ b/content/ja/docs/languages/go/getting-started.md
@@ -337,8 +337,8 @@ func newHTTPHandler() http.Handler {
 	mux := http.NewServeMux()
 
 	// ハンドラーの登録。
-	mux.Handle("/rolldice/", rolldice)
-	mux.Handle("/rolldice/{player}", rolldice)
+	mux.HandleFunc("/rolldice/", rolldice)
+	mux.HandleFunc("/rolldice/{player}", rolldice)
 
 	// サーバー全体に対してHTTP計装を追加します。
 	handler := otelhttp.NewHandler(mux, "/")


### PR DESCRIPTION
The Japanese version of the source code is incorrect.

<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
