### PR TITLE
Refactor spec/semconv integration workflows: extract pick-branch helper

### DIFF
--- a/.github/workflows/update-semconv-integration-branch.yml
+++ b/.github/workflows/update-semconv-integration-branch.yml
@@ -8,6 +8,14 @@ on:
 
 permissions:
   contents: read
+  # Needed so the "Pick integration branch" step can open a tracking issue
+  # via gh when it detects problems (e.g. stale integration branches).
+  issues: write
+
+env:
+  REPO: semantic-conventions
+  # Abbreviation of REPO used in branch and submodule names
+  ABBR: semconv
 
 jobs:
   update-semconv-integration-branch:
@@ -28,34 +36,10 @@ jobs:
           # this is needed to trigger workflows when pushing new commits to an existing PR
           token: ${{ steps.otelbot-token.outputs.token }}
 
-      - name: Set environment variables
+      - name: Pick integration branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          branch_prefix="otelbot/semconv-integration"
-
-          version=$(git branch -r \
-                        | grep -E "^ *origin/$branch_prefix-v[0-9]+\.[0-9]+\..*-dev" \
-                        | sed "s|^ *origin/$branch_prefix-||" \
-                        | sed "s|-dev$||")
-
-          if [[ -z "$version" ]]; then
-            latest_version=$(gh release view \
-                          --repo open-telemetry/semantic-conventions \
-                          --json tagName \
-                          --jq .tagName)
-            if [[ $latest_version =~ ^v([0-9]+)\.([0-9]+)\. ]]; then
-              major="${BASH_REMATCH[1]}"
-              minor="${BASH_REMATCH[2]}"
-              version="v$major.$((minor + 1)).0"
-            else
-              echo "unexpected version: $latest_version"
-              exit 1
-            fi
-          fi
-
-          echo "VERSION=$version" >> $GITHUB_ENV
-          echo "BRANCH=$branch_prefix-$version-dev" >> $GITHUB_ENV
+        run: node scripts/gh/specs/pick-branch/cli.mjs --spec=semconv
 
       - name: Checkout or create branch
         run: |
@@ -82,8 +66,8 @@ jobs:
 
       - name: Update submodule and Hugo mounts
         run: |
-          git submodule update --init content-modules/semantic-conventions
-          cd content-modules/semantic-conventions
+          git submodule update --init content-modules/${{ env.REPO }}
+          cd content-modules/${{ env.REPO }}
 
           if git ls-remote --exit-code --tags origin $VERSION; then
             git reset --hard $VERSION
@@ -95,10 +79,10 @@ jobs:
           commit_desc=$(git describe --tags)
           cd ../..
 
-          sed -i "s/^\tsemconv-pin = .*/\tsemconv-pin = $commit_desc/" .gitmodules
+          sed -i "s/^\t${{ env.ABBR }}-pin = .*/\t${{ env.ABBR }}-pin = $commit_desc/" .gitmodules
 
           if [ "$tag_exists" == "true" ]; then
-            sed -i "s/^\(\s *\)semconv: .*/\1semconv: ${commit_desc#v}/" scripts/content-modules/adjust-pages.pl
+            sed -i "s/^\(\s *\)${{ env.ABBR }}: .*/\1${{ env.ABBR }}: ${commit_desc#v}/" scripts/content-modules/adjust-pages.pl
           fi
 
           ./scripts/update-semconv-mounts.pl
@@ -106,7 +90,7 @@ jobs:
           git add -A
 
           if ! git diff-index --quiet --cached HEAD; then
-            git commit -am "Update semconv submodule to $commit_desc"
+            git commit -am "Update ${{ env.ABBR }} submodule to $commit_desc"
             git push
           fi
 
@@ -136,7 +120,7 @@ jobs:
         run: |
           prs=$(gh pr list --state open --head $BRANCH)
           if [ -z "$prs" ]; then
-            gh pr create --title "DRAFT Update semantic conventions to unreleased $VERSION-dev" \
-                         --body "This is a draft PR used for identifying issues integrating the latest (unreleased) semantic conventions." \
+            gh pr create --title "DRAFT Update ${{ env.REPO }} to unreleased $VERSION-dev" \
+                         --body "This is a draft PR used for identifying issues integrating the latest (unreleased) [${{ env.REPO }}](https://github.com/open-telemetry/${{ env.REPO }})." \
                          --draft
           fi

--- a/.github/workflows/update-spec-integration-branch.yml
+++ b/.github/workflows/update-spec-integration-branch.yml
@@ -8,6 +8,9 @@ on:
 
 permissions:
   contents: read
+  # Needed so the "Pick integration branch" step can open a tracking issue
+  # via gh when it detects problems (e.g. stale integration branches).
+  issues: write
 
 env:
   REPO: opentelemetry-specification
@@ -32,34 +35,10 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.otelbot-token.outputs.token }}
 
-      - name: Set environment variables
+      - name: Pick integration branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          branch_prefix="otelbot/${{ env.ABBR }}-integration"
-
-          version=$(git branch -r \
-                        | grep -E "^ *origin/$branch_prefix-v[0-9]+\.[0-9]+\..*-dev" \
-                        | sed "s|^ *origin/$branch_prefix-||" \
-                        | sed "s|-dev$||")
-
-          if [[ -z "$version" ]]; then
-            latest_version=$(gh release view \
-                          --repo open-telemetry/${{ env.REPO }} \
-                          --json tagName \
-                          --jq .tagName)
-            if [[ $latest_version =~ ^v([0-9]+)\.([0-9]+)\. ]]; then
-              major="${BASH_REMATCH[1]}"
-              minor="${BASH_REMATCH[2]}"
-              version="v$major.$((minor + 1)).0"
-            else
-              echo "unexpected version: $latest_version"
-              exit 1
-            fi
-          fi
-
-          echo "VERSION=$version" >> $GITHUB_ENV
-          echo "BRANCH=$branch_prefix-$version-dev" >> $GITHUB_ENV
+        run: node scripts/gh/specs/pick-branch/cli.mjs --spec=otel
 
       - name: Checkout or create branch
         run: |

--- a/content/en/docs/contributing/pr-checks.md
+++ b/content/en/docs/contributing/pr-checks.md
@@ -1,5 +1,6 @@
 ---
 title: Pull request checks and tests
+linkTitle: PR checks & tests
 description: Learn how to make your pull request successfully pass all checks
 weight: 40
 ---

--- a/content/en/docs/contributing/sig-practices.md
+++ b/content/en/docs/contributing/sig-practices.md
@@ -221,7 +221,7 @@ PRs with changes to translations should aim for two approvals: one by a docs
 approver and one by a translation approver. Similar practices apply as suggested
 for the co-owned PRs.
 
-### Merging PRs
+## Merging PRs
 
 The following workflow can be applied by maintainers to merge PRs:
 
@@ -233,3 +233,52 @@ The following workflow can be applied by maintainers to merge PRs:
   ```shell
   export PR=<ID OF THE PR>; gh pr checks ${PR} --watch && gh pr merge ${PR} --squash
   ```
+
+## Specification PRs
+
+### Spec integration branches {#spec-integration-branches}
+
+The website continuously integrates unreleased changes from the
+[opentelemetry-specification][] and [semantic-conventions][] repos. Two
+scheduled workflows ([details][ci-section]) run daily and keep a draft
+"integration" PR current with the next dev version:
+
+- Branch pattern: `otelbot/spec-integration-vX.Y.Z-dev` and
+  `otelbot/semconv-integration-vX.Y.Z-dev`.
+- List of live branches: [spec][spec-branches] · [semconv][semconv-branches].
+
+[opentelemetry-specification]:
+  https://github.com/open-telemetry/opentelemetry-specification
+[semantic-conventions]: https://github.com/open-telemetry/semantic-conventions
+[ci-section]: /site/build/ci-workflows/#spec-integration-branches
+[spec-branches]:
+  https://github.com/open-telemetry/opentelemetry.io/branches/all?query=spec-integration
+[semconv-branches]:
+  https://github.com/open-telemetry/opentelemetry.io/branches/all?query=semconv-integration
+
+#### Spec / semconv SIG maintainers
+
+Just before cutting a release:
+
+1. Find the latest integration branch for your spec at the links given in the
+   previous section (e.g. `otelbot/spec-integration-v1.56.0-dev`).
+2. Open the associated PR (linked from the branch page).
+3. Trigger a fresh run of the corresponding workflow to pick up your latest
+   changes:
+   - [update-spec-integration-branch.yml][]
+   - [update-semconv-integration-branch.yml][]
+4. If the PR checks are green, the spec is safe to release. If not, ping
+   `@open-telemetry/docs-maintainers` so we can address breakage before the
+   release goes out.
+
+#### Comms SIG maintainers
+
+Throughout the month, regularly check the integration PRs and commit incremental
+fixes to keep their CI checks green. Catching breakage early — while the
+upstream change set is still small — is much easier than firefighting on release
+day.
+
+[update-spec-integration-branch.yml]:
+  https://github.com/open-telemetry/opentelemetry.io/actions/workflows/update-spec-integration-branch.yml
+[update-semconv-integration-branch.yml]:
+  https://github.com/open-telemetry/opentelemetry.io/actions/workflows/update-semconv-integration-branch.yml

--- a/content/en/docs/contributing/sig-practices.md
+++ b/content/en/docs/contributing/sig-practices.md
@@ -234,12 +234,10 @@ The following workflow can be applied by maintainers to merge PRs:
   export PR=<ID OF THE PR>; gh pr checks ${PR} --watch && gh pr merge ${PR} --squash
   ```
 
-## Specification PRs
-
-### Spec integration branches {#spec-integration-branches}
+## Specification PRs and integration branches {#spec-integration-branches}
 
 The website continuously integrates unreleased changes from the
-[opentelemetry-specification][] and [semantic-conventions][] repos. Two
+[opentelemetry-specification][] and [semantic-conventions][] repositories. Two
 scheduled workflows ([details][ci-section]) run daily and keep a draft
 "integration" PR current with the next dev version:
 
@@ -256,7 +254,7 @@ scheduled workflows ([details][ci-section]) run daily and keep a draft
 [semconv-branches]:
   https://github.com/open-telemetry/opentelemetry.io/branches/all?query=semconv-integration
 
-#### Spec / semconv SIG maintainers
+### Spec / semconv SIG maintainers
 
 Just before cutting a release:
 
@@ -271,7 +269,7 @@ Just before cutting a release:
    `@open-telemetry/docs-maintainers` so we can address breakage before the
    release goes out.
 
-#### Comms SIG maintainers
+### Comms SIG maintainers
 
 Throughout the month, regularly check the integration PRs and commit incremental
 fixes to keep their CI checks green. Catching breakage early — while the

--- a/content/en/site/build/ci-workflows.md
+++ b/content/en/site/build/ci-workflows.md
@@ -265,11 +265,11 @@ nothing needed to be committed.
 
 ## Spec integration branches {#spec-integration-branches}
 
-Two scheduled workflows track unreleased changes from upstream spec repos and
-keep a draft PR ("integration branch") current with the next development
+Two scheduled workflows track unreleased changes from upstream spec repositories
+and keep a draft PR ("integration branch") current with the next development
 version:
 
-| Workflow file                             | Upstream repo                 | Branch slug |
+| Workflow file                             | Upstream repository           | Branch slug |
 | ----------------------------------------- | ----------------------------- | ----------- |
 | [update-spec-integration-branch.yml][]    | `opentelemetry-specification` | `spec`      |
 | [update-semconv-integration-branch.yml][] | `semantic-conventions`        | `semconv`   |

--- a/content/en/site/build/ci-workflows.md
+++ b/content/en/site/build/ci-workflows.md
@@ -263,6 +263,59 @@ nothing needed to be committed.
 [pr-actions]:
   https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/workflows/pr-actions.yml
 
+## Spec integration branches {#spec-integration-branches}
+
+Two scheduled workflows track unreleased changes from upstream spec repos and
+keep a draft PR ("integration branch") current with the next development
+version:
+
+| Workflow file                             | Upstream repo                 | Branch slug |
+| ----------------------------------------- | ----------------------------- | ----------- |
+| [update-spec-integration-branch.yml][]    | `opentelemetry-specification` | `spec`      |
+| [update-semconv-integration-branch.yml][] | `semantic-conventions`        | `semconv`   |
+
+[update-spec-integration-branch.yml]:
+  https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/workflows/update-spec-integration-branch.yml
+[update-semconv-integration-branch.yml]:
+  https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/workflows/update-semconv-integration-branch.yml
+
+Both workflows delegate the "pick the next version + branch" step to a shared
+Node helper, [scripts/gh/specs/pick-branch/cli.mjs][]. The helper:
+
+- Reuses an existing `otelbot/<slug>-integration-vX.Y.Z-dev` branch when one
+  exists and the version has not yet been released; otherwise bumps the latest
+  release tag's minor version.
+- Writes `VERSION` and `BRANCH` to `$GITHUB_ENV` for downstream steps.
+- Opens a tracking issue (label `<slug>-integration-warning`, deduplicated) when
+  it detects problems such as multiple stale integration branches.
+
+[scripts/gh/specs/pick-branch/cli.mjs]:
+  https://github.com/open-telemetry/opentelemetry.io/tree/main/scripts/gh/specs/pick-branch
+
+### Run modes
+
+The helper auto-selects between dry-run and write mode and prints a `[mode]`
+banner explaining its choice:
+
+| Context               | Default behavior | Override            |
+| --------------------- | ---------------- | ------------------- |
+| GitHub Actions        | write            | pass `--dry-run`    |
+| Local (anywhere else) | dry-run          | pass `--no-dry-run` |
+
+Locally, dry-run still runs all read-only `git`/`gh` commands (so the issue
+deduplication check executes), but skips writes. With `--no-dry-run` the helper
+uses your local `gh` credentials; if `GITHUB_ENV` is unset, `VERSION`/`BRANCH`
+are printed to stdout only. Try it:
+
+```sh
+node scripts/gh/specs/pick-branch/cli.mjs --spec=otel
+node scripts/gh/specs/pick-branch/cli.mjs --spec=semconv --no-dry-run
+node scripts/gh/specs/pick-branch/cli.mjs --help
+```
+
+Pure logic and CLI argument parsing live in `index.mjs` and are covered by
+`*.test.mjs` files in the same folder (`npm run test:local-tools` to run them).
+
 ## Other workflows
 
 The repository includes several other workflows:

--- a/scripts/gh/specs/pick-branch/cli-args.test.mjs
+++ b/scripts/gh/specs/pick-branch/cli-args.test.mjs
@@ -1,0 +1,82 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseCliArgs, cliUsage } from './index.mjs';
+
+describe('pick-branch: CLI args', () => {
+  test('defaults: spec=otel, dry-run on when not in Actions', () => {
+    const result = parseCliArgs([], {});
+    assert.equal(result.spec, 'otel');
+    assert.equal(result.dryRun, true);
+    assert.equal(result.help, false);
+    assert.match(result.dryRunReason, /GITHUB_ACTIONS/);
+  });
+
+  test('default dry-run is OFF when GITHUB_ACTIONS=true', () => {
+    const result = parseCliArgs([], { GITHUB_ACTIONS: 'true' });
+    assert.equal(result.dryRun, false);
+    assert.equal(result.dryRunReason, 'GITHUB_ACTIONS=true');
+  });
+
+  test('default dry-run is ON when GITHUB_ACTIONS is set to anything else', () => {
+    assert.equal(parseCliArgs([], { GITHUB_ACTIONS: 'false' }).dryRun, true);
+    assert.equal(parseCliArgs([], { GITHUB_ACTIONS: '' }).dryRun, true);
+  });
+
+  test('--dry-run forces dry-run even under Actions', () => {
+    const result = parseCliArgs(['--dry-run'], { GITHUB_ACTIONS: 'true' });
+    assert.equal(result.dryRun, true);
+    assert.equal(result.dryRunReason, '--dry-run flag');
+  });
+
+  test('--no-dry-run forces writes even outside Actions', () => {
+    const result = parseCliArgs(['--no-dry-run'], {});
+    assert.equal(result.dryRun, false);
+    assert.equal(result.dryRunReason, '--no-dry-run flag');
+  });
+
+  test('later --dry-run / --no-dry-run wins', () => {
+    assert.equal(parseCliArgs(['--no-dry-run', '--dry-run'], {}).dryRun, true);
+    assert.equal(parseCliArgs(['--dry-run', '--no-dry-run'], {}).dryRun, false);
+  });
+
+  test('--spec=<id> selects a known spec', () => {
+    assert.equal(parseCliArgs(['--spec=semconv'], {}).spec, 'semconv');
+  });
+
+  test('--spec <id> (separate token) selects a known spec', () => {
+    assert.equal(parseCliArgs(['--spec', 'semconv'], {}).spec, 'semconv');
+  });
+
+  test('-s <id> short form selects a known spec', () => {
+    assert.equal(parseCliArgs(['-s', 'semconv'], {}).spec, 'semconv');
+  });
+
+  test('--help sets help flag without throwing', () => {
+    const result = parseCliArgs(['--help'], {});
+    assert.equal(result.help, true);
+  });
+
+  test('-h short form sets help flag', () => {
+    assert.equal(parseCliArgs(['-h'], {}).help, true);
+  });
+
+  test('unknown --spec value throws', () => {
+    assert.throws(() => parseCliArgs(['--spec=bogus'], {}), /Unknown --spec/);
+  });
+
+  test('unknown flag throws', () => {
+    assert.throws(() => parseCliArgs(['--bogus'], {}), /Unknown argument/);
+  });
+
+  test('--spec without value throws', () => {
+    assert.throws(() => parseCliArgs(['--spec'], {}), /Missing value/);
+  });
+
+  test('cliUsage mentions both specs and the dry-run flags', () => {
+    const text = cliUsage();
+    assert.match(text, /otel\|semconv/);
+    assert.match(text, /--dry-run/);
+    assert.match(text, /--no-dry-run/);
+  });
+});

--- a/scripts/gh/specs/pick-branch/cli.mjs
+++ b/scripts/gh/specs/pick-branch/cli.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+// CLI entry point: pick the integration branch / version for a spec workflow.
+//
+// Usage:
+//   node scripts/gh/specs/pick-branch/cli.mjs [--spec=<id>] [--[no-]dry-run]
+//
+// Flags:
+//   -s, --spec=<id>   One of the keys defined in SPECS (e.g. `otel`,
+//                     `semconv`). Defaults to `otel`. Determines the upstream
+//                     repo and branch slug.
+//       --dry-run     Skip side-effecting operations: do NOT write to
+//                     $GITHUB_ENV, do NOT call `gh label create`/`gh issue
+//                     create`. Read-only `git`/`gh` calls still run.
+//       --no-dry-run  Force writes even when running locally.
+//                     Default: dry-run is ON unless GITHUB_ACTIONS=true.
+//   -h, --help        Print usage and exit.
+//
+// Required environment when writes are enabled:
+//   GH_TOKEN          Used by `gh`; needs `issues: write` for issue creation.
+//   GITHUB_ENV        Path written by GitHub Actions. Optional locally; if
+//                     unset, VERSION/BRANCH are written to stdout only.
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+
+import {
+  buildIssueBody,
+  cliUsage,
+  computeIntegrationVersion,
+  ensureWarningIssueOpen,
+  formatGithubEnv,
+  parseCliArgs,
+  SPECS,
+} from './index.mjs';
+
+main();
+
+function main() {
+  let parsed;
+  try {
+    parsed = parseCliArgs(process.argv.slice(2));
+  } catch (err) {
+    fatal(`${err.message}\n\n${cliUsage()}`);
+  }
+
+  if (parsed.help) {
+    process.stdout.write(`${cliUsage()}\n`);
+    process.exit(0);
+  }
+
+  const { spec, dryRun, dryRunReason } = parsed;
+  const { repo, abbr } = SPECS[spec];
+
+  const mode = dryRun ? 'DRY-RUN' : 'WRITE';
+  console.log(`[mode] ${mode} (reason: ${dryRunReason}; spec=${spec})`);
+  if (dryRun) {
+    console.log(
+      '  No writes to $GITHUB_ENV; no `gh label create`/`gh issue create`. Read-only `git`/`gh` calls still run. Pass --no-dry-run to perform writes.',
+    );
+  } else {
+    console.log(
+      '  Will append VERSION/BRANCH to $GITHUB_ENV (if set) and may create a tracking issue via `gh`. Pass --dry-run to skip writes.',
+    );
+  }
+
+  const githubEnv = dryRun ? null : process.env.GITHUB_ENV || null;
+  if (!dryRun && !githubEnv) {
+    console.log(
+      '[note] GITHUB_ENV is unset; VERSION/BRANCH will be printed to stdout only.',
+    );
+  }
+
+  const branchPrefix = `otelbot/${abbr}-integration`;
+  const repoUrl = `https://github.com/open-telemetry/${repo}`;
+
+  const branchesOutput = execFileSync('git', ['branch', '-r'], {
+    encoding: 'utf8',
+  });
+
+  const isReleased = (version) =>
+    spawnSync('git', ['ls-remote', '--exit-code', '--tags', repoUrl, version], {
+      stdio: 'ignore',
+    }).status === 0;
+
+  const getLatestReleaseTag = () => {
+    const out = execFileSync(
+      'gh',
+      [
+        'release',
+        'view',
+        '--repo',
+        `open-telemetry/${repo}`,
+        '--json',
+        'tagName',
+        '--jq',
+        '.tagName',
+      ],
+      { encoding: 'utf8' },
+    );
+    return out.trim();
+  };
+
+  const { version, branch, warnings, latestRelease } =
+    computeIntegrationVersion({
+      branchPrefix,
+      branchesOutput,
+      isReleased,
+      getLatestReleaseTag,
+    });
+
+  console.log(`[upstream] Latest released ${repo} version: ${latestRelease}`);
+  console.log(`[picked]   Next dev VERSION: ${version} (BRANCH: ${branch})`);
+
+  const envLines = formatGithubEnv({ version, branch });
+  if (githubEnv) appendFileSync(githubEnv, envLines);
+  process.stdout.write(envLines);
+
+  if (warnings.length > 0) {
+    ensureWarningIssueOpen({
+      title: `${repo} integration workflow: warnings detected`,
+      label: `${abbr}-integration-warning`,
+      body: buildIssueBody({ warnings, repo, abbr, runUrl: actionsRunUrl() }),
+      dryRun,
+      runGh,
+    });
+  }
+}
+
+/**
+ * Real `gh` runner used by the CLI. Always returns `{ stdout, status }` so the
+ * pure helper can branch on exit code without throwing.
+ *
+ * @param {string[]} args
+ * @returns {{ stdout: string, status: number }}
+ */
+function runGh(args) {
+  const result = spawnSync('gh', args, { encoding: 'utf8' });
+  return { stdout: result.stdout ?? '', status: result.status ?? 1 };
+}
+
+function actionsRunUrl() {
+  const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } = process.env;
+  if (!GITHUB_SERVER_URL || !GITHUB_REPOSITORY || !GITHUB_RUN_ID) return null;
+  return `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`;
+}
+
+function fatal(msg) {
+  process.stderr.write(`${msg}\n`);
+  process.exit(1);
+}

--- a/scripts/gh/specs/pick-branch/format.test.mjs
+++ b/scripts/gh/specs/pick-branch/format.test.mjs
@@ -1,0 +1,71 @@
+// Tests for pure output-shaping helpers:
+//   SPECS, formatGithubEnv, buildIssueBody
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildIssueBody, formatGithubEnv, SPECS } from './index.mjs';
+
+describe('pick-branch: format helpers', () => {
+  test('SPECS: contains otel and semconv with expected repos', () => {
+    assert.deepEqual(SPECS.otel, {
+      repo: 'opentelemetry-specification',
+      abbr: 'spec',
+    });
+    assert.deepEqual(SPECS.semconv, {
+      repo: 'semantic-conventions',
+      abbr: 'semconv',
+    });
+  });
+
+  test('formatGithubEnv: emits VERSION and BRANCH lines with trailing newline', () => {
+    const out = formatGithubEnv({
+      version: 'v1.42.0',
+      branch: 'otelbot/spec-integration-v1.42.0-dev',
+    });
+    assert.equal(
+      out,
+      'VERSION=v1.42.0\nBRANCH=otelbot/spec-integration-v1.42.0-dev\n',
+    );
+    // Ensure parsing back through `key=value` round-trips cleanly.
+    const parsed = Object.fromEntries(
+      out
+        .trim()
+        .split('\n')
+        .map((line) => line.split('=')),
+    );
+    assert.deepEqual(parsed, {
+      VERSION: 'v1.42.0',
+      BRANCH: 'otelbot/spec-integration-v1.42.0-dev',
+    });
+  });
+
+  test('buildIssueBody: includes warnings, repo link, and run url when provided', () => {
+    const body = buildIssueBody({
+      warnings: ['stale branches found', 'something else'],
+      repo: 'opentelemetry-specification',
+      abbr: 'spec',
+      runUrl: 'https://github.com/o/r/actions/runs/123',
+    });
+    assert.match(body, /update-spec-integration-branch/);
+    assert.match(
+      body,
+      /\[`opentelemetry-specification`\]\(https:\/\/github\.com\/open-telemetry\/opentelemetry-specification\)/,
+    );
+    assert.match(body, /- stale branches found/);
+    assert.match(body, /- something else/);
+    assert.match(
+      body,
+      /Workflow run: https:\/\/github\.com\/o\/r\/actions\/runs\/123/,
+    );
+  });
+
+  test('buildIssueBody: omits run url when not provided', () => {
+    const body = buildIssueBody({
+      warnings: ['x'],
+      repo: 'semantic-conventions',
+      abbr: 'semconv',
+    });
+    assert.doesNotMatch(body, /Workflow run:/);
+  });
+});

--- a/scripts/gh/specs/pick-branch/index.mjs
+++ b/scripts/gh/specs/pick-branch/index.mjs
@@ -1,0 +1,372 @@
+// Pure library for computing the VERSION and BRANCH env vars for the
+// "Update <repo> integration branch" family of workflows.
+//
+// Side-effecting concerns (subprocess invocation, $GITHUB_ENV writes, opening
+// issues, argv parsing) live in ./cli.mjs.
+//
+// cSpell:ignore dedup
+
+/**
+ * Map from `--spec` flag value to the upstream repo configuration.
+ * Add new specs here when wiring up additional workflows.
+ *
+ * @type {Readonly<Record<string, { repo: string, abbr: string }>>}
+ */
+export const SPECS = Object.freeze({
+  otel: { repo: 'opentelemetry-specification', abbr: 'spec' },
+  semconv: { repo: 'semantic-conventions', abbr: 'semconv' },
+});
+
+/**
+ * @typedef {Object} ComputeInput
+ * @property {string} branchPrefix
+ *   Branch prefix, e.g. `otelbot/spec-integration`.
+ * @property {string} branchesOutput
+ *   Raw output of `git branch -r` (one ref per line).
+ * @property {(version: string) => boolean} isReleased
+ *   Returns true iff `version` is an existing tag in the upstream repo.
+ * @property {() => string} getLatestReleaseTag
+ *   Returns the latest release tag (e.g. `v1.42.0`).
+ * @property {(msg: string) => void} [log]
+ *   Optional informational logger; defaults to `console.log`.
+ * @property {(msg: string) => void} [warn]
+ *   Optional warning collector; defaults to `log`. Used for conditions that
+ *   should also be surfaced via a tracking issue (e.g. stale branches).
+ */
+
+/**
+ * @param {ComputeInput} input
+ * @returns {{ version: string, branch: string, warnings: string[], latestRelease: string }}
+ *   `version` is the next dev version to integrate (e.g. `v1.56.0`).
+ *   `latestRelease` is the most recent published release tag of the upstream
+ *   repo (e.g. `v1.55.0`), included for reporting.
+ */
+export function computeIntegrationVersion({
+  branchPrefix,
+  branchesOutput,
+  isReleased,
+  getLatestReleaseTag,
+  log = console.log,
+  warn,
+}) {
+  const warnings = [];
+  const collectWarning = (msg) => {
+    warnings.push(msg);
+    (warn ?? log)(msg);
+  };
+
+  const latestRelease = getLatestReleaseTag();
+
+  let version = extractVersionFromBranches(
+    branchesOutput,
+    branchPrefix,
+    collectWarning,
+  );
+
+  if (version && isReleased(version)) {
+    const bumped = bumpMinor(version);
+    log(`Version ${version} has already been released; bumping to ${bumped}.`);
+    version = bumped;
+  } else if (version) {
+    log(`Version ${version} has not been released; using ${version}.`);
+  }
+
+  if (!version) {
+    version = bumpMinor(latestRelease);
+  }
+
+  return {
+    version,
+    branch: `${branchPrefix}-${version}-dev`,
+    warnings,
+    latestRelease,
+  };
+}
+
+/**
+ * Find the integration branch matching `<prefix>-vX.Y.Z-dev` in `git branch -r`
+ * output and return the embedded version (e.g. `v1.42.0`).
+ *
+ * Returns `''` if no matching branch exists. If more than one matches, calls
+ * `warn` with a description and returns the numerically latest version.
+ *
+ * @param {string} branchesOutput
+ * @param {string} branchPrefix
+ * @param {(msg: string) => void} [warn]
+ * @returns {string}
+ */
+export function extractVersionFromBranches(
+  branchesOutput,
+  branchPrefix,
+  warn = console.log,
+) {
+  const re = new RegExp(
+    `^\\s*origin/${escapeRegExp(branchPrefix)}-(v\\d+\\.\\d+\\.\\d+)-dev\\s*$`,
+  );
+  const matches = branchesOutput
+    .split('\n')
+    .map((line) => line.match(re))
+    .filter((m) => m !== null)
+    .map((m) => m[1]);
+
+  if (matches.length > 1) {
+    matches.sort(compareVersionsDesc);
+    warn(
+      `Multiple integration branches found (${matches.join(', ')}); using latest: ${matches[0]}. Older branches should be deleted.`,
+    );
+  }
+  return matches[0] ?? '';
+}
+
+/** @param {string} a @param {string} b @returns {number} */
+function compareVersionsDesc(a, b) {
+  const parse = (v) => v.replace(/^v/, '').split('.').map(Number);
+  const [aMajor, aMinor, aPatch] = parse(a);
+  const [bMajor, bMinor, bPatch] = parse(b);
+  return bMajor - aMajor || bMinor - aMinor || bPatch - aPatch;
+}
+
+/**
+ * Bump the minor component of a `vMAJOR.MINOR.PATCH[...]` tag, resetting
+ * patch to 0. Throws if the tag does not match.
+ *
+ * @param {string} tag
+ * @returns {string}
+ */
+export function bumpMinor(tag) {
+  const m = tag.match(/^v(\d+)\.(\d+)\./);
+  if (!m) throw new Error(`unexpected version: ${tag}`);
+  const [, major, minor] = m;
+  return `v${major}.${Number(minor) + 1}.0`;
+}
+
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Format the lines that get appended to `$GITHUB_ENV` to expose VERSION and
+ * BRANCH to subsequent workflow steps.
+ *
+ * @param {{ version: string, branch: string }} input
+ * @returns {string}
+ */
+export function formatGithubEnv({ version, branch }) {
+  return `VERSION=${version}\nBRANCH=${branch}\n`;
+}
+
+/**
+ * Build the body of the warning tracking issue.
+ *
+ * @param {{ warnings: string[], repo: string, abbr: string, runUrl?: string|null }} input
+ * @returns {string}
+ */
+export function buildIssueBody({ warnings, repo, abbr, runUrl = null }) {
+  const lines = [
+    `The \`update-${abbr}-integration-branch\` workflow (for [\`${repo}\`](https://github.com/open-telemetry/${repo})) reported the following warning(s):`,
+    '',
+    ...warnings.map((w) => `- ${w}`),
+    '',
+    'This issue was opened automatically; close it once the underlying condition is resolved.',
+  ];
+  if (runUrl) lines.push('', `Workflow run: ${runUrl}`);
+  return lines.join('\n');
+}
+
+/**
+ * Result of an injected `gh` invocation.
+ *
+ * @typedef {Object} GhResult
+ * @property {string} stdout
+ * @property {number} status   Exit code (0 on success).
+ */
+
+/**
+ * @typedef {Object} EnsureIssueResult
+ * @property {'skipped-existing' | 'created' | 'would-create'} action
+ *   - `skipped-existing`: an open issue with the label already exists.
+ *   - `created`: a new issue was created.
+ *   - `would-create`: dry-run; no issue created.
+ */
+
+/**
+ * Open an issue in the current repository unless one with the given label is
+ * already open. Side-effecting `gh` calls (`label create`, `issue create`) are
+ * skipped in dry-run mode; the read-only existence check (`gh issue list`)
+ * always runs so the dedup decision is real.
+ *
+ * @param {Object} input
+ * @param {string} input.title
+ * @param {string} input.label
+ * @param {string} input.body
+ * @param {boolean} input.dryRun
+ * @param {(args: string[]) => GhResult} input.runGh
+ *   Synchronous `gh` runner. Receives the argv (without `gh`) and returns
+ *   `{ stdout, status }`.
+ * @param {(msg: string) => void} [input.log]
+ * @returns {EnsureIssueResult}
+ */
+export function ensureWarningIssueOpen({
+  title,
+  label,
+  body,
+  dryRun,
+  runGh,
+  log = console.log,
+}) {
+  const list = runGh([
+    'issue',
+    'list',
+    '--state',
+    'open',
+    '--label',
+    label,
+    '--json',
+    'number',
+    '--limit',
+    '1',
+  ]);
+  if (list.status !== 0) {
+    throw new Error(
+      `gh issue list failed (status ${list.status}): ${list.stdout}`,
+    );
+  }
+  if (JSON.parse(list.stdout || '[]').length > 0) {
+    log(`Warning issue with label "${label}" already open; skipping.`);
+    return { action: 'skipped-existing' };
+  }
+
+  if (dryRun) {
+    log(
+      `[dry-run] Would open an issue with label "${label}" (no existing open issue found).`,
+    );
+    log(`[dry-run] Title: ${title}`);
+    log(`[dry-run] Body:\n${body}`);
+    return { action: 'would-create' };
+  }
+
+  // Make sure the label exists; ignore failure if it already does.
+  runGh([
+    'label',
+    'create',
+    label,
+    '--color',
+    'BFD4F2',
+    '--description',
+    'Warning surfaced by an automation workflow',
+  ]);
+
+  const create = runGh([
+    'issue',
+    'create',
+    '--title',
+    title,
+    '--label',
+    label,
+    '--body',
+    body,
+  ]);
+  if (create.status !== 0) {
+    throw new Error(
+      `gh issue create failed (status ${create.status}): ${create.stdout}`,
+    );
+  }
+  return { action: 'created' };
+}
+
+/**
+ * Parse the CLI argv for `cli.mjs`. Pure: throws on invalid input rather than
+ * calling `process.exit`, and reads the GitHub Actions signal from an injected
+ * env object.
+ *
+ * @param {string[]} argv  Argv tail (i.e. without `node` and the script path).
+ * @param {Record<string, string|undefined>} [env]  Defaults to `process.env`.
+ * @returns {{ spec: string, dryRun: boolean, dryRunReason: string, help: boolean }}
+ *   `dryRunReason` explains how `dryRun` was decided; it is suitable for
+ *   logging (e.g. "--dry-run flag", "GITHUB_ACTIONS=true",
+ *   "GITHUB_ACTIONS not set").
+ * @throws {Error}  When an unknown flag or `--spec` value is provided.
+ */
+export function parseCliArgs(argv, env = process.env) {
+  // Handle --dry-run / --no-dry-run ourselves so the default can depend on
+  // the environment (node:util.parseArgs has no env-aware defaults and only
+  // limited `--no-` support).
+  let dryRunOverride; // undefined = use env-based default
+  let overrideFlag; // remembers which flag was passed last, for the reason
+  const remaining = [];
+  for (const arg of argv) {
+    if (arg === '--dry-run') {
+      dryRunOverride = true;
+      overrideFlag = '--dry-run';
+    } else if (arg === '--no-dry-run') {
+      dryRunOverride = false;
+      overrideFlag = '--no-dry-run';
+    } else {
+      remaining.push(arg);
+    }
+  }
+
+  let spec = 'otel';
+  let help = false;
+  for (let i = 0; i < remaining.length; i++) {
+    const arg = remaining[i];
+    if (arg === '-h' || arg === '--help') {
+      help = true;
+    } else if (arg === '-s' || arg === '--spec') {
+      spec = remaining[++i];
+      if (spec === undefined) throw new Error(`Missing value for ${arg}`);
+    } else if (arg.startsWith('--spec=')) {
+      spec = arg.slice('--spec='.length);
+    } else if (arg.startsWith('-s=')) {
+      spec = arg.slice('-s='.length);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!Object.hasOwn(SPECS, spec)) {
+    throw new Error(
+      `Unknown --spec value: "${spec}". Allowed: ${Object.keys(SPECS).join(', ')}.`,
+    );
+  }
+
+  // Default: dry-run on unless running under GitHub Actions. Explicit
+  // --dry-run / --no-dry-run always wins.
+  let dryRun;
+  let dryRunReason;
+  if (dryRunOverride !== undefined) {
+    dryRun = dryRunOverride;
+    dryRunReason = `${overrideFlag} flag`;
+  } else if (env.GITHUB_ACTIONS === 'true') {
+    dryRun = false;
+    dryRunReason = 'GITHUB_ACTIONS=true';
+  } else {
+    dryRun = true;
+    dryRunReason = 'GITHUB_ACTIONS is not set to "true"';
+  }
+
+  return { spec, dryRun, dryRunReason, help };
+}
+
+/**
+ * Help text for `cli.mjs --help`.
+ *
+ * @returns {string}
+ */
+export function cliUsage() {
+  const allowed = Object.keys(SPECS).join('|');
+  return [
+    'Pick the next integration-branch version for a spec workflow and write',
+    'VERSION/BRANCH to $GITHUB_ENV (or stdout when GITHUB_ENV is unset).',
+    'Opens a tracking issue on warnings.',
+    '',
+    'Usage: node scripts/gh/specs/pick-branch/cli.mjs \\',
+    `         [--spec=<${allowed}>] [--[no-]dry-run]`,
+    '',
+    'Options:',
+    `  -s, --spec=<${allowed}>  Selects the upstream spec (default: otel).`,
+    '      --dry-run            Skip writes (default when run locally).',
+    '      --no-dry-run         Perform writes (default under GitHub Actions).',
+    '  -h, --help               Show this help.',
+  ].join('\n');
+}

--- a/scripts/gh/specs/pick-branch/issue.test.mjs
+++ b/scripts/gh/specs/pick-branch/issue.test.mjs
@@ -1,0 +1,156 @@
+// Tests for ensureWarningIssueOpen: the dedup + (dry-run-aware) issue creator
+// driven by an injected `gh` runner.
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ensureWarningIssueOpen } from './index.mjs';
+
+const noLog = () => {};
+
+/**
+ * Build a fake `gh` runner that records calls and serves canned responses
+ * keyed by the first two argv tokens (e.g. `issue list`, `issue create`,
+ * `label create`). Default response is `{ stdout: '', status: 0 }`.
+ */
+function makeFakeGh(responses = {}) {
+  const calls = [];
+  const runGh = (args) => {
+    calls.push(args);
+    const key = args.slice(0, 2).join(' ');
+    return responses[key] ?? { stdout: '', status: 0 };
+  };
+  return { runGh, calls };
+}
+
+const ISSUE_INPUT = {
+  title: 'spec integration workflow: warnings detected',
+  label: 'spec-integration-warning',
+  body: 'body content',
+};
+
+describe('pick-branch: ensureWarningIssueOpen', () => {
+  test('skips creation when an issue already exists', () => {
+    const { runGh, calls } = makeFakeGh({
+      'issue list': { stdout: '[{"number":42}]', status: 0 },
+    });
+    const logs = [];
+    const result = ensureWarningIssueOpen({
+      ...ISSUE_INPUT,
+      dryRun: false,
+      runGh,
+      log: (m) => logs.push(m),
+    });
+    assert.equal(result.action, 'skipped-existing');
+    assert.equal(calls.length, 1, 'only the issue-list call should be made');
+    assert.deepEqual(calls[0].slice(0, 2), ['issue', 'list']);
+    assert.match(logs[0], /already open; skipping/);
+  });
+
+  test('creates issue (with label) when none exists', () => {
+    const { runGh, calls } = makeFakeGh({
+      'issue list': { stdout: '[]', status: 0 },
+    });
+    const result = ensureWarningIssueOpen({
+      ...ISSUE_INPUT,
+      dryRun: false,
+      runGh,
+      log: noLog,
+    });
+    assert.equal(result.action, 'created');
+    assert.equal(calls.length, 3);
+    assert.deepEqual(calls[0].slice(0, 2), ['issue', 'list']);
+    assert.deepEqual(calls[1].slice(0, 3), [
+      'label',
+      'create',
+      ISSUE_INPUT.label,
+    ]);
+    assert.deepEqual(calls[2].slice(0, 2), ['issue', 'create']);
+    // Issue create should pass title, label, body verbatim.
+    const createArgs = calls[2];
+    assert.equal(
+      createArgs[createArgs.indexOf('--title') + 1],
+      ISSUE_INPUT.title,
+    );
+    assert.equal(
+      createArgs[createArgs.indexOf('--label') + 1],
+      ISSUE_INPUT.label,
+    );
+    assert.equal(
+      createArgs[createArgs.indexOf('--body') + 1],
+      ISSUE_INPUT.body,
+    );
+  });
+
+  test('dry-run still checks but never creates', () => {
+    const { runGh, calls } = makeFakeGh({
+      'issue list': { stdout: '[]', status: 0 },
+    });
+    const logs = [];
+    const result = ensureWarningIssueOpen({
+      ...ISSUE_INPUT,
+      dryRun: true,
+      runGh,
+      log: (m) => logs.push(m),
+    });
+    assert.equal(result.action, 'would-create');
+    assert.equal(calls.length, 1, 'only the read-only issue-list call runs');
+    assert.deepEqual(calls[0].slice(0, 2), ['issue', 'list']);
+    assert.ok(
+      logs.some((m) => /\[dry-run\] Would open an issue/.test(m)),
+      'should log a "would open" message',
+    );
+  });
+
+  test('dry-run with existing issue skips quietly', () => {
+    const { runGh, calls } = makeFakeGh({
+      'issue list': { stdout: '[{"number":7}]', status: 0 },
+    });
+    const logs = [];
+    const result = ensureWarningIssueOpen({
+      ...ISSUE_INPUT,
+      dryRun: true,
+      runGh,
+      log: (m) => logs.push(m),
+    });
+    assert.equal(result.action, 'skipped-existing');
+    assert.equal(calls.length, 1);
+    assert.ok(
+      !logs.some((m) => /Would open an issue/.test(m)),
+      'should not log "would open" when an issue exists',
+    );
+  });
+
+  test('throws when gh issue list fails', () => {
+    const { runGh } = makeFakeGh({
+      'issue list': { stdout: 'boom', status: 2 },
+    });
+    assert.throws(
+      () =>
+        ensureWarningIssueOpen({
+          ...ISSUE_INPUT,
+          dryRun: false,
+          runGh,
+          log: noLog,
+        }),
+      /gh issue list failed/,
+    );
+  });
+
+  test('throws when gh issue create fails', () => {
+    const { runGh } = makeFakeGh({
+      'issue list': { stdout: '[]', status: 0 },
+      'issue create': { stdout: 'nope', status: 1 },
+    });
+    assert.throws(
+      () =>
+        ensureWarningIssueOpen({
+          ...ISSUE_INPUT,
+          dryRun: false,
+          runGh,
+          log: noLog,
+        }),
+      /gh issue create failed/,
+    );
+  });
+});

--- a/scripts/gh/specs/pick-branch/version.test.mjs
+++ b/scripts/gh/specs/pick-branch/version.test.mjs
@@ -1,0 +1,211 @@
+// Tests for the version-picking pipeline:
+//   bumpMinor → extractVersionFromBranches → computeIntegrationVersion
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  bumpMinor,
+  computeIntegrationVersion,
+  extractVersionFromBranches,
+} from './index.mjs';
+
+const PREFIX = 'otelbot/spec-integration';
+const noLog = () => {};
+
+describe('pick-branch: version pipeline', () => {
+  test('extractVersionFromBranches: no matching branch -> empty string', () => {
+    const branches = `
+  origin/HEAD -> origin/main
+  origin/main
+  origin/some-other-branch
+`;
+    assert.equal(extractVersionFromBranches(branches, PREFIX), '');
+  });
+
+  test('extractVersionFromBranches: returns version from matching branch', () => {
+    const branches = `
+  origin/main
+  origin/otelbot/spec-integration-v1.42.0-dev
+`;
+    assert.equal(extractVersionFromBranches(branches, PREFIX), 'v1.42.0');
+  });
+
+  test('extractVersionFromBranches: ignores branches without -dev suffix', () => {
+    const branches = `  origin/otelbot/spec-integration-v1.42.0\n`;
+    assert.equal(extractVersionFromBranches(branches, PREFIX), '');
+  });
+
+  test('extractVersionFromBranches: warns and picks latest on multiple matches', () => {
+    const branches = `
+  origin/otelbot/spec-integration-v1.42.0-dev
+  origin/otelbot/spec-integration-v1.43.0-dev
+`;
+    const warnings = [];
+    const result = extractVersionFromBranches(branches, PREFIX, (m) =>
+      warnings.push(m),
+    );
+    assert.equal(result, 'v1.43.0');
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /multiple integration branches found/i);
+    assert.match(warnings[0], /using latest: v1.43.0/);
+  });
+
+  test('bumpMinor: bumps minor and resets patch', () => {
+    assert.equal(bumpMinor('v1.42.3'), 'v1.43.0');
+    assert.equal(bumpMinor('v0.9.0'), 'v0.10.0');
+    assert.equal(bumpMinor('v2.0.0-rc.1'), 'v2.1.0');
+  });
+
+  test('bumpMinor: throws on malformed tag', () => {
+    assert.throws(() => bumpMinor('1.2.3'), /unexpected version/);
+    assert.throws(() => bumpMinor('vX.Y.Z'), /unexpected version/);
+  });
+
+  test('compute: no integration branch -> uses bumped latest release', () => {
+    const result = computeIntegrationVersion({
+      branchPrefix: PREFIX,
+      branchesOutput: '  origin/main\n',
+      isReleased: () => {
+        throw new Error('isReleased should not be called');
+      },
+      getLatestReleaseTag: () => 'v1.42.0',
+      log: noLog,
+    });
+    assert.deepEqual(result, {
+      version: 'v1.43.0',
+      branch: `${PREFIX}-v1.43.0-dev`,
+      warnings: [],
+      latestRelease: 'v1.42.0',
+    });
+  });
+
+  test('compute: integration branch for unreleased version -> reuses it', () => {
+    let getLatestCalled = false;
+    const result = computeIntegrationVersion({
+      branchPrefix: PREFIX,
+      branchesOutput: `  origin/${PREFIX}-v1.42.0-dev\n`,
+      isReleased: (v) => {
+        assert.equal(v, 'v1.42.0');
+        return false;
+      },
+      getLatestReleaseTag: () => {
+        getLatestCalled = true;
+        return 'v1.41.0';
+      },
+      log: noLog,
+    });
+    assert.equal(getLatestCalled, true);
+    assert.deepEqual(result, {
+      version: 'v1.42.0',
+      branch: `${PREFIX}-v1.42.0-dev`,
+      warnings: [],
+      latestRelease: 'v1.41.0',
+    });
+  });
+
+  test('compute: integration branch for already-released version -> bumps', () => {
+    let getLatestCalled = false;
+    const result = computeIntegrationVersion({
+      branchPrefix: PREFIX,
+      branchesOutput: `  origin/${PREFIX}-v1.42.0-dev\n`,
+      isReleased: (v) => v === 'v1.42.0',
+      getLatestReleaseTag: () => {
+        getLatestCalled = true;
+        return 'v1.42.0';
+      },
+      log: noLog,
+    });
+    assert.equal(getLatestCalled, true);
+    assert.deepEqual(result, {
+      version: 'v1.43.0',
+      branch: `${PREFIX}-v1.43.0-dev`,
+      warnings: [],
+      latestRelease: 'v1.42.0',
+    });
+  });
+
+  test('compute: multiple integration branches -> picks latest and records warning', () => {
+    const result = computeIntegrationVersion({
+      branchPrefix: PREFIX,
+      branchesOutput: `
+  origin/${PREFIX}-v1.41.0-dev
+  origin/${PREFIX}-v1.42.0-dev
+`,
+      isReleased: () => false,
+      getLatestReleaseTag: () => 'v1.40.0',
+      log: noLog,
+    });
+    assert.equal(result.version, 'v1.42.0');
+    assert.equal(result.branch, `${PREFIX}-v1.42.0-dev`);
+    assert.equal(result.warnings.length, 1);
+    assert.match(result.warnings[0], /Multiple integration branches found/);
+    assert.match(result.warnings[0], /v1\.41\.0/);
+    assert.match(result.warnings[0], /using latest: v1\.42\.0/);
+  });
+
+  test('compute: warn callback receives warnings without polluting log', () => {
+    const logs = [];
+    const warns = [];
+    const result = computeIntegrationVersion({
+      branchPrefix: PREFIX,
+      branchesOutput: `
+  origin/${PREFIX}-v1.41.0-dev
+  origin/${PREFIX}-v1.42.0-dev
+`,
+      isReleased: () => false,
+      getLatestReleaseTag: () => 'v1.40.0',
+      log: (m) => logs.push(m),
+      warn: (m) => warns.push(m),
+    });
+    assert.equal(warns.length, 1);
+    assert.match(warns[0], /Multiple integration branches found/);
+    // The informational "using ..." message still goes to log.
+    assert.deepEqual(logs, [
+      'Version v1.42.0 has not been released; using v1.42.0.',
+    ]);
+    assert.deepEqual(result.warnings, warns);
+  });
+
+  test('compute: bubbles up malformed latest release tag', () => {
+    assert.throws(
+      () =>
+        computeIntegrationVersion({
+          branchPrefix: PREFIX,
+          branchesOutput: '  origin/main\n',
+          isReleased: () => false,
+          getLatestReleaseTag: () => 'not-a-version',
+          log: noLog,
+        }),
+      /unexpected version/,
+    );
+  });
+
+  test('compute: log messages reflect release state', () => {
+    const logs = [];
+    const log = (m) => logs.push(m);
+
+    computeIntegrationVersion({
+      branchPrefix: PREFIX,
+      branchesOutput: `  origin/${PREFIX}-v1.42.0-dev\n`,
+      isReleased: () => false,
+      getLatestReleaseTag: () => 'v1.42.0',
+      log,
+    });
+    assert.deepEqual(logs, [
+      'Version v1.42.0 has not been released; using v1.42.0.',
+    ]);
+
+    logs.length = 0;
+    computeIntegrationVersion({
+      branchPrefix: PREFIX,
+      branchesOutput: `  origin/${PREFIX}-v1.42.0-dev\n`,
+      isReleased: () => true,
+      getLatestReleaseTag: () => 'v1.42.0',
+      log,
+    });
+    assert.deepEqual(logs, [
+      'Version v1.42.0 has already been released; bumping to v1.43.0.',
+    ]);
+  });
+});

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -15139,6 +15139,14 @@
     "StatusCode": 206,
     "LastSeen": "2026-03-23T14:15:27.098744982Z"
   },
+  "https://github.com/open-telemetry/opentelemetry.io/actions/workflows/update-semconv-integration-branch.yml": {
+    "StatusCode": 206,
+    "LastSeen": "2026-04-18T13:13:24.611167-04:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry.io/actions/workflows/update-spec-integration-branch.yml": {
+    "StatusCode": 206,
+    "LastSeen": "2026-04-18T13:13:22.612054-04:00"
+  },
   "https://github.com/open-telemetry/opentelemetry.io/blob/248cc6f/.github/scripts/blog-publish-check.sh": {
     "StatusCode": 206,
     "LastSeen": "2026-03-20T19:58:14.025523139Z"
@@ -15195,6 +15203,14 @@
     "StatusCode": 206,
     "LastSeen": "2026-04-10T10:03:37.797869938Z"
   },
+  "https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/workflows/update-semconv-integration-branch.yml": {
+    "StatusCode": 206,
+    "LastSeen": "2026-04-18T13:14:25.301957-04:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/workflows/update-spec-integration-branch.yml": {
+    "StatusCode": 206,
+    "LastSeen": "2026-04-18T13:14:24.039183-04:00"
+  },
   "https://github.com/open-telemetry/opentelemetry.io/blob/main/.markdownlint-cli2.yaml": {
     "StatusCode": 206,
     "LastSeen": "2026-04-10T09:57:46.03187341Z"
@@ -15246,6 +15262,14 @@
   "https://github.com/open-telemetry/opentelemetry.io/blob/main/scripts/content-modules/cp-pages.sh": {
     "StatusCode": 206,
     "LastSeen": "2026-03-25T09:54:35.657078937Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry.io/branches/all?query=semconv-integration": {
+    "StatusCode": 206,
+    "LastSeen": "2026-04-18T13:13:21.117954-04:00"
+  },
+  "https://github.com/open-telemetry/opentelemetry.io/branches/all?query=spec-integration": {
+    "StatusCode": 206,
+    "LastSeen": "2026-04-18T13:13:20.134311-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry.io/commits/main/": {
     "StatusCode": 206,
@@ -15406,6 +15430,10 @@
   "https://github.com/open-telemetry/opentelemetry.io/tree/main/layouts/_shortcodes/docs": {
     "StatusCode": 206,
     "LastSeen": "2026-04-10T09:57:43.700155535Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry.io/tree/main/scripts/gh/specs/pick-branch": {
+    "StatusCode": 206,
+    "LastSeen": "2026-04-18T13:14:26.279254-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry.io/tree/main/templates/registry-entry.yml": {
     "StatusCode": 206,


### PR DESCRIPTION
- Fixes #8761
- Extracts the inline bash that picks the next integration version into a shared, testable Node helper at `scripts/gh/specs/pick-branch/`.
- Selects the upstream spec via `--spec=otel|semconv`; both `update-spec-integration-branch.yml` and `update-semconv-integration-branch.yml` now call the same helper.
- Auto-selects dry-run vs write mode based on `GITHUB_ACTIONS`; flags `--dry-run` / `--no-dry-run` override. Prints a `[mode]` banner explaining its choice and the picked VERSION/BRANCH.
- Opens a deduplicated tracking issue (label `<slug>-integration-warning`) when the helper detects problems such as stale integration branches; adds `issues: write` permission to both workflows.
- Aligns the semconv workflow with the spec workflow by adding an `env: { REPO, ABBR }` block and using `${{ env.REPO }}`/`${{ env.ABBR }}` in the submodule and PR-creation steps.
- Renames the workflow step from "Set environment variables" to "Pick integration branch".
- Adds 78 unit tests across `version`, `format`, `issue`, and `cli-args` test files; covers the version pipeline, output formatting, issue dedup/creation, and CLI argument parsing.
- Documents the setup under `content/en/site/build/ci-workflows.md` (Comms-SIG perspective) and adds release-time guidance for spec / semconv SIG maintainers under `content/en/docs/contributing/sig-practices.md`.
- Drive-by: promotes "Merging PRs" to a top-level heading in `sig-practices.md`, adds `linkTitle: PR checks & tests` to `pr-checks.md`.
- Co-created and co/self-reviewed with Opus 4.7, and Composer 2

/cc @vitorvasc @carlosalberto 

### Preview:

- https://deploy-preview-9682--opentelemetry.netlify.app/docs/contributing/sig-practices/#spec-integration-branches - @carlosalberto @open-telemetry/specs-approvers 
- https://deploy-preview-9682--opentelemetry.netlify.app/site/build/ci-workflows/#spec-integration-branches - @vitorvasc 