### PR TITLE
Add AGENTS.md, skills page, and refcache skill

### DIFF
--- a/.claude/skills/resolve-refcache-conflicts/SKILL.md
+++ b/.claude/skills/resolve-refcache-conflicts/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: resolve-refcache-conflicts
+description:
+  Skill for resolving static/refcache.json merge or rebase conflicts in the
+  current branch or a specified PR.
+argument-hint: '[optional-pr-number]'
+---
+
+`static/refcache.json` is an auto-generated file. Resolving conflicts requires
+first taking the integration branch's side, finishing the merge/rebase, then
+running `npm run fix:refcache` to restore any URLs unique to the active branch.
+
+## Prerequisites
+
+If the current branch has a merge or rebase in progress, then skip the rest of
+this section and jump to **Preparation**.
+
+The current branch must be clean (`git status --short`). If not clean, offer to
+run `git stash` or `git commit` to clean it up, or stop.
+
+If `$ARGUMENTS` is a PR number, then check out the PR branch with:
+`gh pr checkout $ARGUMENTS`.
+
+## Preparation
+
+At this point, we are ready to resolve the conflicts in the active branch:
+
+1. Determine the integration reference (`$BASE_BRANCH`): run `git remote -v`; if
+   an `upstream` remote exists, use `upstream/main`, otherwise use `main`.
+
+2. If merge or rebase is in progress (`git status`), skip this step. Otherwise,
+   ask the user whether to run `git merge $BASE_BRANCH` or
+   `git rebase $BASE_BRANCH`, then run it.
+
+3. If there are no conflicts: stop, we are done.
+
+4. Conflicts other than `static/refcache.json`: resolve them with the user.
+
+5. If no `static/refcache.json` conflict remains: stop, we are done. Otherwise,
+   proceed to **Resolve**.
+
+## Resolve
+
+1. Check out the `$BASE_BRANCH` version of `static/refcache.json`. The correct
+   command depends on the operation in progress (assumes the active branch is
+   being rebased/merged from `$BASE_BRANCH`, not the other way around):
+   - Rebase: `git checkout --ours static/refcache.json`
+   - Merge: `git checkout --theirs static/refcache.json`
+
+2. Run: `git add static/refcache.json`
+3. Stage all resolved files, then `git rebase --continue` or `git commit` for
+   merge.
+4. Rebase only: for each subsequent rebase stop that conflicts on
+   `static/refcache.json`, repeat Resolve steps 1–3. If other paths are also
+   conflicted on that stop, run Preparation step 4 first.
+5. Run: `npm run fix:refcache` (requires network and installed dependencies; can
+   be slow)
+6. Commit the changes, if any:
+
+   ```sh
+   git add static/refcache.json
+   git diff --cached --quiet static/refcache.json || \
+      git commit -m "Refresh refcache after resolving conflicts"
+   ```
+
+7. Push:
+   - Merge: `git push`
+   - Rebase: `git push --force-with-lease`

--- a/.claude/skills/resolve-refcache-conflicts/SKILL.md
+++ b/.claude/skills/resolve-refcache-conflicts/SKILL.md
@@ -51,17 +51,20 @@ At this point, we are ready to resolve the conflicts in the active branch:
    | Rebase of active branch onto `$BASE_BRANCH` | `git checkout --ours static/refcache.json`   |
    | Merge of `$BASE_BRANCH` into active branch  | `git checkout --theirs static/refcache.json` |
 
-2. Stage `static/refcache.json` and any other resolved files, then continue:
-   - Rebase: `git add -u && git rebase --continue`
-   - Merge: `git add -u && git commit --no-edit`
+2. Stage the resolved files, then continue:
+   - Rebase: `git add static/refcache.json && git rebase --continue`
+   - Merge: `git add static/refcache.json && git commit --no-edit`
+   - If other files were resolved in Preparation step 4, `git add` those too
+     before continuing.
 
 3. Rebase only: for each subsequent rebase stop that conflicts on
    `static/refcache.json`, repeat Resolve steps 1–2. If other paths are also
    conflicted on that stop, run Preparation step 4 first.
 
-4. Run: `npm run fix:refcache`. Note: this runs a full Hugo build and link
-   check, it requires network, installed npm dependencies, and populated
-   submodules, and can take several minutes.
+4. Run `npm run fix:refcache` once, after the entire rebase/merge completes.
+   Note: this runs a full Hugo build and link check — requires network,
+   installed npm dependencies, and populated submodules; can take several
+   minutes.
 
 5. Commit the changes, if any:
 

--- a/.claude/skills/resolve-refcache-conflicts/SKILL.md
+++ b/.claude/skills/resolve-refcache-conflicts/SKILL.md
@@ -25,8 +25,9 @@ If `$ARGUMENTS` is a PR number, then check out the PR branch with:
 
 At this point, we are ready to resolve the conflicts in the active branch:
 
-1. Determine the integration reference (`$BASE_BRANCH`): run `git remote -v`; if
-   an `upstream` remote exists, use `upstream/main`, otherwise use `main`.
+1. Determine the integration reference (`$BASE_BRANCH`) and fetch it:
+   - If an `upstream` remote exists: `git fetch upstream`, use `upstream/main`.
+   - Otherwise: `git fetch origin`, use `origin/main`.
 
 2. If merge or rebase is in progress (`git status`), skip this step. Otherwise,
    ask the user whether to run `git merge $BASE_BRANCH` or
@@ -41,21 +42,28 @@ At this point, we are ready to resolve the conflicts in the active branch:
 
 ## Resolve
 
-1. Check out the `$BASE_BRANCH` version of `static/refcache.json`. The correct
-   command depends on the operation in progress (assumes the active branch is
-   being rebased/merged from `$BASE_BRANCH`, not the other way around):
-   - Rebase: `git checkout --ours static/refcache.json`
-   - Merge: `git checkout --theirs static/refcache.json`
+1. Check out the `$BASE_BRANCH` version of `static/refcache.json`. Assumes the
+   active branch is being rebased/merged from `$BASE_BRANCH`, not the other way
+   around:
 
-2. Run: `git add static/refcache.json`
-3. Stage all resolved files, then `git rebase --continue` or `git commit` for
-   merge.
-4. Rebase only: for each subsequent rebase stop that conflicts on
-   `static/refcache.json`, repeat Resolve steps 1–3. If other paths are also
+   | Operation                                   | Command                                      |
+   | ------------------------------------------- | -------------------------------------------- |
+   | Rebase of active branch onto `$BASE_BRANCH` | `git checkout --ours static/refcache.json`   |
+   | Merge of `$BASE_BRANCH` into active branch  | `git checkout --theirs static/refcache.json` |
+
+2. Stage `static/refcache.json` and any other resolved files, then continue:
+   - Rebase: `git add -u && git rebase --continue`
+   - Merge: `git add -u && git commit --no-edit`
+
+3. Rebase only: for each subsequent rebase stop that conflicts on
+   `static/refcache.json`, repeat Resolve steps 1–2. If other paths are also
    conflicted on that stop, run Preparation step 4 first.
-5. Run: `npm run fix:refcache` (requires network and installed dependencies; can
-   be slow)
-6. Commit the changes, if any:
+
+4. Run: `npm run fix:refcache`. Note: this runs a full Hugo build and link
+   check, it requires network, installed npm dependencies, and populated
+   submodules, and can take several minutes.
+
+5. Commit the changes, if any:
 
    ```sh
    git add static/refcache.json
@@ -63,6 +71,6 @@ At this point, we are ready to resolve the conflicts in the active branch:
       git commit -m "Refresh refcache after resolving conflicts"
    ```
 
-7. Push:
+6. Push:
    - Merge: `git push`
    - Rebase: `git push --force-with-lease`

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# cSpell:ignore worktrees
+
+/.claude/worktrees
+
 # Hugo-generated assets
 .hugo_build.lock
 /public

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,20 +1,15 @@
 # AGENTS.md — OpenTelemetry.io guide for AI agents
 
-<!-- markdownlint-disable no-otel-io-external-urls -->
-
 Maintainer-focused documentation for **building, testing, and deploying this
-website** is the **Site** section:
-
-- **Published:** [opentelemetry.io/site/](https://opentelemetry.io/site/)
-- **Repository source (English):** [content/en/site/](content/en/site/)
+website** is the [**Site** section][content/en/site/].
 
 Treat that tree as the primary reference for site tooling, CI, and conventions.
-Start at [content/en/site/](content/en/site/_index.md). Useful subsections:
+Start at [content/en/site/][]. Useful subsections:
 
-- [**Build**][Build] — npm scripts, workflows, patches, localization
-- [**Testing**][Testing]
-- [**Design**][Design]
-- [**Skills**][Skills]
+- [Build][] — npm scripts, workflows, patches, localization
+- [Testing][]
+- [Design][]
+- [Skills][]
 
 The **Docsy** theme is a git submodule. For theme-specific agent notes, see
 [themes/docsy/AGENTS.md](themes/docsy/AGENTS.md).
@@ -22,7 +17,8 @@ The **Docsy** theme is a git submodule. For theme-specific agent notes, see
 Repo-wide contribution context: [CONTRIBUTING.md](CONTRIBUTING.md),
 [README.md](README.md).
 
-[Build]: content/en/site/build/
-[Testing]: content/en/site/testing/
-[Design]: content/en/site/design/
+[content/en/site/]: content/en/site/_index.md
+[Build]: content/en/site/build/_index.md
+[Testing]: content/en/site/testing/_index.md
+[Design]: content/en/site/design/_index.md
 [Skills]: content/en/site/skills.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md — OpenTelemetry.io guide for AI agents
+
+<!-- markdownlint-disable no-otel-io-external-urls -->
+
+Maintainer-focused documentation for **building, testing, and deploying this
+website** is the **Site** section:
+
+- **Published:** [opentelemetry.io/site/](https://opentelemetry.io/site/)
+- **Repository source (English):** [content/en/site/](content/en/site/)
+
+Treat that tree as the primary reference for site tooling, CI, and conventions.
+Start at [content/en/site/](content/en/site/_index.md). Useful subsections:
+
+- [**Build**][Build] — npm scripts, workflows, patches, localization
+- [**Testing**][Testing]
+- [**Design**][Design]
+- [**Skills**][Skills]
+
+The **Docsy** theme is a git submodule. For theme-specific agent notes, see
+[themes/docsy/AGENTS.md](themes/docsy/AGENTS.md).
+
+Repo-wide contribution context: [CONTRIBUTING.md](CONTRIBUTING.md),
+[README.md](README.md).
+
+[Build]: content/en/site/build/
+[Testing]: content/en/site/testing/
+[Design]: content/en/site/design/
+[Skills]: content/en/site/skills.md

--- a/content/en/site/_index.md
+++ b/content/en/site/_index.md
@@ -25,6 +25,8 @@ Tentatively planned content organization:
   purpose, ownership, and overall status.
 - **Needs, requirements, and features** — Stakeholder needs, requirements, and
   other relevant information broken down into features.
+- [**Skills**](./skills/) — Skills for agents and humans to use when maintaining
+  the site.
 - **Design** — Architectural design, Information Architecture (IA), layout, UX
   choices, theme related decisions, and other design-level artifacts.
 - **Implementation** — Code-level structure and conventions, Hugo/Docsy

--- a/content/en/site/skills.md
+++ b/content/en/site/skills.md
@@ -5,11 +5,14 @@ description: Skills for agents and maintainers to use when maintaining the site.
 weight: 22
 ---
 
-Source: [`.claude/skills/`][]. Links use the **upstream** repo and **`main`**;
-the same paths apply in any clone (including forks on another default branch).
+Source: [`.claude/skills/`][].[^1]
 
 - [`/resolve-refcache-conflicts <optional-pr-number>`][resolve-refcache-conflicts]:
   resolve `static/refcache.json` merge/rebase conflicts.
+
+[^1]:
+    Links use the **upstream** repository and **`main`**; the same paths apply
+    in any clone (including forks on another default branch).
 
 [`.claude/skills/`]:
   https://github.com/open-telemetry/opentelemetry.io/tree/main/.claude/skills

--- a/content/en/site/skills.md
+++ b/content/en/site/skills.md
@@ -5,14 +5,12 @@ description: Skills for agents and maintainers to use when maintaining the site.
 weight: 22
 ---
 
-Source: [`.claude/skills/`][].[^1]
+Source: [`.claude/skills/`][] - links use the **upstream** repository and
+**`main`**; the same paths apply in any clone (including forks on another
+default branch).
 
 - [`/resolve-refcache-conflicts <optional-pr-number>`][resolve-refcache-conflicts]:
   resolve `static/refcache.json` merge/rebase conflicts.
-
-[^1]:
-    Links use the **upstream** repository and **`main`**; the same paths apply
-    in any clone (including forks on another default branch).
 
 [`.claude/skills/`]:
   https://github.com/open-telemetry/opentelemetry.io/tree/main/.claude/skills

--- a/content/en/site/skills.md
+++ b/content/en/site/skills.md
@@ -1,0 +1,17 @@
+---
+title: Skills for agents and maintainers
+linkTitle: Skills
+description: Skills for agents and maintainers to use when maintaining the site.
+weight: 22
+---
+
+Source: [`.claude/skills/`][]. Links use the **upstream** repo and **`main`**;
+the same paths apply in any clone (including forks on another default branch).
+
+- [`/resolve-refcache-conflicts <optional-pr-number>`][resolve-refcache-conflicts]:
+  resolve `static/refcache.json` merge/rebase conflicts.
+
+[`.claude/skills/`]:
+  https://github.com/open-telemetry/opentelemetry.io/tree/main/.claude/skills
+[resolve-refcache-conflicts]:
+  https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/resolve-refcache-conflicts/SKILL.md

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -15287,6 +15287,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-04-10T10:01:49.139856918Z"
   },
+  "https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/resolve-refcache-conflicts/SKILL.md": {
+    "StatusCode": 206,
+    "LastSeen": "2026-04-20T20:54:18.265886-04:00"
+  },
   "https://github.com/open-telemetry/opentelemetry.io/blob/main/.cspell.yml": {
     "StatusCode": 206,
     "LastSeen": "2026-04-10T09:58:01.148862206Z"
@@ -15494,6 +15498,10 @@
   "https://github.com/open-telemetry/opentelemetry.io/security/policy": {
     "StatusCode": 206,
     "LastSeen": "2026-03-24T09:53:38.909114584Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry.io/tree/main/.claude/skills": {
+    "StatusCode": 206,
+    "LastSeen": "2026-04-20T20:54:16.690618-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry.io/tree/main/.github": {
     "StatusCode": 206,


### PR DESCRIPTION
- Adds root `AGENTS.md` that points AI agents at published Site docs and `content/en/site/` subsection links (Build, Testing, Design, Skills).
- Adds `content/en/site/skills.md` cataloging Claude skills and links it from the site docs index.
- Adds `.claude/skills/resolve-refcache-conflicts/SKILL.md` for resolving `static/refcache.json` merge/rebase conflicts (integration checkout, `fix:refcache`, conditional commit, push).
- Ignores `/.claude/worktrees` in `.gitignore` for local tooling.

/cc @vitorvasc @theletterf 