### PR TITLE
Clarify status levels and semconv stability on Languages page

### DIFF
--- a/content/en/docs/languages/_index.md
+++ b/content/en/docs/languages/_index.md
@@ -25,15 +25,19 @@ application.
 
 ## Status and Releases
 
-The current status of the major functional components for OpenTelemetry is as
-follows:
+The current [status][spec-status] of the major functional components for
+OpenTelemetry is as follows. For definitions of status levels such as
+Experimental, Stable, and Deprecated, see
+[Component Lifecycle][spec-status-lifecycle].
 
 > [!WARNING]
 >
 > Regardless of an API/SDK's status, if your instrumentation relies on [semantic
 > conventions][semconv] that are marked as [Experimental][] in the [semantic
 > conventions specification][semconv-spec], your data flow might be subject to
-> **breaking changes**.
+> **breaking changes**. Each page in the [semantic conventions
+> specification][semconv-spec] lists its status at the top, so you can check
+> whether the conventions you depend on are Experimental or Stable.
 >
 > [semconv]: /docs/concepts/semantic-conventions/
 > [Experimental]: /docs/specs/otel/document-status/
@@ -56,3 +60,5 @@ references are available:
 [zero-code]: /docs/platforms/kubernetes/operator/automatic/
 [instrumentation]: /docs/concepts/instrumentation/
 [otel-op]: /docs/platforms/kubernetes/operator/
+[spec-status]: /docs/specs/status/
+[spec-status-lifecycle]: /docs/specs/status/#component-lifecycle


### PR DESCRIPTION
## What

On the Languages index page (`content/en/docs/languages/_index.md`):

- Link the word "status" on each instrumentation row to the [Specification Status](/docs/specs/status/) page and its [Component Lifecycle](/docs/specs/status/#component-lifecycle) section, so readers know what Experimental, Stable, and Deprecated actually mean.
- Expand the semantic conventions warning to point out that each convention page shows its own status, so readers can check stability before depending on a convention.

## Why

Fixes #6673. Readers frequently ask what "Experimental" or "Stable" means in the context of OTel instrumentation vs. semantic conventions. The existing columns show the status but don't link out to the definitions, and the semconv warning doesn't tell readers they can look up per-convention stability. This adds the missing wayfinding without changing any of the status data itself.

## Scope

One file changed: `content/en/docs/languages/_index.md` (+9 / -3).

---

**Note from the maintainers**: this description was submitted without our [PR template](https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/PULL_REQUEST_TEMPLATE.md)'s checklist, which asks you to confirm:

- [ ] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [ ] I have the experience and knowledge necessary to understand, review, and validate all content in this PR. (Yes, I can answer maintainer questions about the content of this PR, without using AI.)

Per our [first-time contributor policy](https://github.com/open-telemetry/opentelemetry.io/issues/11243), answer these questions by ticking each box that applies.
