### PR TITLE
Announce Observability Summit North America 2026

### DIFF
--- a/content/en/announcements/kubecon-india.md
+++ b/content/en/announcements/kubecon-india.md
@@ -1,7 +1,7 @@
 ---
 title: KubeCon + CloudNativeCon India 2026
 linkTitle: KubeCon India 2026
-date: 2026-04-06
+date: 2026-05-23
 expiryDate: 2026-06-19 # keep
 weight: 20260619
 params:

--- a/content/en/announcements/open-observability-summit-na.md
+++ b/content/en/announcements/open-observability-summit-na.md
@@ -1,6 +1,6 @@
 ---
-title: Observability Summit North America 2026
-linkTitle: Observability Summit NA 2026
+title: Observability Summit NA 2026
+linkTitle: Observability Summit NA '26
 date: 2026-04-22
 expiryDate: 2026-05-23 # keep
 weight: 20260522
@@ -12,10 +12,9 @@ params:
 
 <i class="fas fa-bullhorn"></i> [**{{% param title %}}**][event],
 **<span class="text-nowrap">May 21–22,</span> Minneapolis**.
-<span class="d-none d-md-inline"><br></span>
-[Register][register]<span class="d-none d-sm-inline"> now</span> or [view the
-schedule][schedule]!
+<span class="d-none DISABLE-d-md-inline"><br></span> [Register][] now or view
+the [schedule][]!
 
 [event]: <{{% param eventUrl %}}?{{% param queryParams %}}>
-[register]: <{{% param eventUrl %}}register/?{{% param queryParams %}}>
+[Register]: <{{% param eventUrl %}}register/?{{% param queryParams %}}>
 [schedule]: <{{% param eventUrl %}}program/schedule/?{{% param queryParams %}}>

--- a/content/en/announcements/open-observability-summit-na.md
+++ b/content/en/announcements/open-observability-summit-na.md
@@ -13,10 +13,9 @@ params:
 <i class="fas fa-bullhorn"></i> [**{{% param title %}}**][event],
 **<span class="text-nowrap">May 21–22,</span> Minneapolis**.
 <span class="d-none d-md-inline"><br></span>
-[Register][register]<span class="d-none d-sm-inline"> now</span> or
-[view the schedule][schedule]!
+[Register][register]<span class="d-none d-sm-inline"> now</span> or [view the
+schedule][schedule]!
 
 [event]: <{{% param eventUrl %}}?{{% param queryParams %}}>
 [register]: <{{% param eventUrl %}}register/?{{% param queryParams %}}>
-[schedule]:
-  <{{% param eventUrl %}}program/schedule/?{{% param queryParams %}}>
+[schedule]: <{{% param eventUrl %}}program/schedule/?{{% param queryParams %}}>

--- a/content/en/announcements/open-observability-summit-na.md
+++ b/content/en/announcements/open-observability-summit-na.md
@@ -1,19 +1,22 @@
 ---
-title: Open Observability Summit NA 2025
-linkTitle: Open Observability Summit '25
-date: 2025-05-21
-expiryDate: 2025-06-26 # keep
-weight: 20250624
+title: Observability Summit North America 2026
+linkTitle: Observability Summit NA 2026
+date: 2026-04-22
+expiryDate: 2026-05-23 # keep
+weight: 20260522
+params:
+  eventUrl: >-
+    https://events.linuxfoundation.org/observability-summit-north-america/
+  queryParams: utm_source=opentelemetry&utm_medium=website&utm_content=slim-banner
 ---
 
-<i class="fas fa-bullhorn"></i> <span class="d-none d-sm-inline">[Get
-ready][blog] for the inaugural</span> [**{{% param title %}}**][oss] and
+<i class="fas fa-bullhorn"></i> [**{{% param title %}}**][event],
+**<span class="text-nowrap">May 21–22,</span> Minneapolis**.
 <span class="d-none d-md-inline"><br></span>
-<span class="d-none d-sm-inline">co-located </span>[**OTel Community
-Day**][ocd], **Denver CO, <span class="text-nowrap">June 24-26</span>**
+[Register][register]<span class="d-none d-sm-inline"> now</span> or
+[view the schedule][schedule]!
 
-[blog]: /blog/2025/otel-day/
-[oss]:
-  https://events.linuxfoundation.org/open-source-summit-north-america/?utm_source=opentelemetry&utm_medium=website&utm_content=slim-banner
-[ocd]:
-  https://events.linuxfoundation.org/open-observability-summit-otel-community-day/?utm_source=opentelemetry&utm_medium=website&utm_content=slim-banner
+[event]: <{{% param eventUrl %}}?{{% param queryParams %}}>
+[register]: <{{% param eventUrl %}}register/?{{% param queryParams %}}>
+[schedule]:
+  <{{% param eventUrl %}}program/schedule/?{{% param queryParams %}}>

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -3219,6 +3219,18 @@
     "StatusCode": 206,
     "LastSeen": "2026-04-22T12:11:22.406404285Z"
   },
+  "https://events.linuxfoundation.org/observability-summit-north-america/?utm_source=opentelemetry&amp;utm_medium=website&amp;utm_content=slim-banner": {
+    "StatusCode": 206,
+    "LastSeen": "2026-04-22T17:12:31.913673484Z"
+  },
+  "https://events.linuxfoundation.org/observability-summit-north-america/program/schedule/?utm_source=opentelemetry&amp;utm_medium=website&amp;utm_content=slim-banner": {
+    "StatusCode": 206,
+    "LastSeen": "2026-04-22T17:12:34.930569593Z"
+  },
+  "https://events.linuxfoundation.org/observability-summit-north-america/register/?utm_source=opentelemetry&amp;utm_medium=website&amp;utm_content=slim-banner": {
+    "StatusCode": 206,
+    "LastSeen": "2026-04-22T17:12:33.425565683Z"
+  },
   "https://events.linuxfoundation.org/open-observability-summit-otel-community-day/": {
     "StatusCode": 200,
     "LastSeen": "2026-04-22T14:16:31.92558023Z"


### PR DESCRIPTION
## Summary

- Adds a banner for Observability Summit North America 2026 (May 21–22, Minneapolis) with CTAs to register and view the schedule.
- Defers the KubeCon India banner (`date: 2026-05-23`) so it only appears after Observability Summit NA wraps; its existing `expiryDate: 2026-06-19` still governs its end.

## Test plan

- [x] Preview deploy: verify the Observability Summit NA banner renders on pages with `show_banner: true`
- [ ] Confirm the KubeCon India banner is not rendered (date in the future)
- [ ] Click through Register and Schedule CTAs to confirm they resolve to the correct LF URLs