### PR TITLE
[adjust-pages.pl] clarify patch field semantics, and other changes

### DIFF
--- a/content/en/site/build/content-module-patches.md
+++ b/content/en/site/build/content-module-patches.md
@@ -3,7 +3,6 @@ title: Content module patches
 description: >-
   Creating and managing temporary patches for content modules between releases.
 weight: 15
-cSpell:ignore: frontmatter
 ---
 
 Spec pages published on this site (OTel specification, OTLP, semantic
@@ -25,14 +24,19 @@ matter, their links point to GitHub URLs, and image paths assume the repository
 layout. The [`adjust-pages.pl`][script] script bridges this gap by applying the
 following transformations to each file:
 
-| Transformation             | Description                                                                                                                                                            |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Front matter injection** | Extracts the first `# Heading` as `title`, generates `linkTitle`, and emits Hugo front matter. Supports front matter embedded in `<!--- Hugo ... --->` comment blocks. |
-| **Version stamping**       | Appends spec version numbers (e.g., `1.54.0`) to titles and linkTitles for OTel spec, OTLP, and semconv landing pages.                                                 |
-| **URL rewriting**          | Converts absolute GitHub URLs for spec repositories into local `/docs/specs/...` paths so cross-spec links work on the site.                                           |
-| **Image path adjustment**  | Rewrites relative image paths so they resolve correctly from the Hugo page location.                                                                                   |
-| **Content stripping**      | Removes `<details>` blocks and `<!-- toc -->` sections that are not needed on the site.                                                                                |
-| **Temporary patches**      | Applies regex-based patches for spec issues that have not yet been fixed in a release (see below).                                                                     |
+- **Front matter injection** — Extracts the first `# Heading` as `title`,
+  generates `linkTitle`, and emits Hugo front matter. Supports front matter
+  embedded in `<!--- Hugo ... --->` comment blocks.
+- **Version stamping** — Appends spec version numbers (e.g., `1.54.0`) to titles
+  and linkTitles for OTel spec, OTLP, and semconv landing pages.
+- **URL rewriting** — Converts absolute GitHub URLs for spec repositories into
+  local `/docs/specs/...` paths so cross-spec links work on the site.
+- **Image path adjustment** — Rewrites relative image paths so they resolve
+  correctly from the Hugo page location.
+- **Content stripping** — Removes `<details>` blocks and `<!-- toc -->` sections
+  that are not needed on the site.
+- **Temporary patches** — Applies regex-based patches for spec issues that have
+  not yet been fixed in a release (see below).
 
 Spec versions are declared at the top of the script in the `%versionsRaw` hash
 and are updated automatically by the version-update workflow.
@@ -48,8 +52,8 @@ PRs that check every external link on the site.
 To unblock CI without waiting for an upstream release, you can add a temporary
 patch to [`adjust-pages.pl`][script]. Patches are regex-based rewrites that run
 at build time and include built-in version tracking: once the spec advances past
-the target version, `cp:spec` prints a warning that the patch is obsolete and
-can be removed.
+the patch's version range, `cp:spec` prints a warning that the patch is obsolete
+and can be removed.
 
 ### 1. Add a patch entry
 
@@ -82,15 +86,25 @@ my @patches = (
 
 The fields for each patch entry are:
 
-| Field     | Description                                                                                                                                                                                         |
-| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`      | A unique ID (date + short description) printed in log messages.                                                                                                                                     |
-| `module`  | One of `spec`, `otlp`, or `semconv`.                                                                                                                                                                |
-| `minVers` | The spec version the patch applies to. The patch runs while the submodule is at this version and becomes obsolete once the spec advances past it.                                                   |
-| `maxVers` | Optional upper bound version. Set to `undef` if not needed. When set, the patch won't apply if the submodule version exceeds this value.                                                            |
-| `file`    | A compiled regular expression matching the file paths the patch should apply to, for example `qr\|^tmp/semconv/docs/\|`.                                                                            |
-| `context` | Optional. Set to `'frontmatter'` for patches that modify front matter. Defaults to `'body'` (patches that modify page content).                                                                     |
-| `apply`   | An anonymous subroutine containing the regular expression substitution. For body patches, it operates on `$_`. For front-matter patches, it operates on `$frontMatterFromFile` (via `$_` aliasing). |
+- **`id`** — A unique ID (date + short description) printed in log messages.
+- **`module`** — One of `spec`, `otlp`, or `semconv`.
+- **`minVers`** — Inclusive lower bound. The patch applies while the submodule
+  version is at or above this version, and becomes obsolete once the spec
+  advances past the patch's version range.
+- **`maxVers`** — Optional exclusive upper bound. If omitted or set to `undef`,
+  it defaults to `minVers` with its patch number incremented (for example,
+  `1.55.0` implies `maxVers = 1.55.1`), which matches the original prefix-match
+  behavior. When set explicitly, the patch is skipped once the submodule version
+  reaches `maxVers` (that is, it applies only while the version is `< maxVers`).
+- **`file`** — Optional compiled regular expression matching the file paths the
+  patch should apply to, for example `qr|^tmp/semconv/docs/|`. If omitted,
+  defaults to the module's spec/docs tree: `^tmp/otel/specification/` for
+  `spec`, `^tmp/otlp/docs/` for `otlp`, and `^tmp/semconv/docs/` for `semconv`.
+- **`context`** — Optional: `body|front matter` (default: `body`). Set to
+  `front matter` for patches that modify front matter.
+- **`apply`** — An anonymous subroutine containing the regular expression
+  substitution. For body patches, it operates on `$_`. For front-matter patches,
+  it operates on `$frontMatterFromFile` (via `$_` aliasing).
 
 No separate registration step is needed — the `applyPatches` dispatcher
 automatically iterates over all entries in `@patches` during the build.

--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -39,49 +39,66 @@ my %versFromSubmod = %versions; # Actual version of submodules. Updated by getVe
 
 # =================================================================================
 # Patches: data-driven list of spec patches.
+#
+# For patch details, see content/en/site/build/content-module-patches.md.
+#
 # To add a new patch, append an entry to this array:
 #
 #  {
 #    id      => '2026-01-01-some-unique-id',   # unique patch identifier
 #    module    => 'semconv',                   # module name: 'spec', 'otlp', 'semconv'
-#    minVers => '1.39.0',                      # target version (patch applies at this version)
-#    maxVers => '1.40.0',                      # optional upper bound (undef if none)
-#    file    => qr|^tmp/semconv/docs/|,        # regex matching file path
+#    minVers => '1.39.0',                      # inclusive lower bound (patch applies when
+#                                              # submodule version starts with, or is >=, minVers)
+#    maxVers => '1.40.0',                      # optional exclusive upper bound.
+#    file    => qr|^tmp/semconv/docs/|,        # optional regex matching file path; defaults
+#                                              # to the module's default spec/docs path
 #    context => 'body',                        # 'body' (default, operates on $_) or
-#                                              # 'frontmatter' (operates on $frontMatterFromFile)
+#                                              # 'front matter' (operates on $frontMatterFromFile)
 #    apply   => sub { s{old}{new}gx; },        # regex substitution to apply
 #  },
 # =================================================================================
 
 my @patches = (
-  {
-    # For the problematic links, see:
-    # https://github.com/open-telemetry/opentelemetry-specification/issues/4958
-    #
-    # Update migration links to new compatibility/migration paths:
-    # https://github.com/open-telemetry/opentelemetry-specification/pull/4958
-    id      => '2026-03-18-opentracing-migration-links',
-    module    => 'spec',
-    minVers => '1.55.0',
-    maxVers => undef,
-    file    => qr|^tmp/otel/specification/compatibility/opentracing\.md$|,
-    apply   => sub {
-      s{
-        (https://opentelemetry\.io/docs)/migration/(opentracing/)
-      }{$1/compatibility/migration/$2}gx;
-    },
-  },
+  # {
+  #   # For the problematic links, see:
+  #   # https://github.com/open-telemetry/opentelemetry-specification/issues/4958
+  #   #
+  #   # Update migration links to new compatibility/migration paths:
+  #   # https://github.com/open-telemetry/opentelemetry-specification/pull/4958
+  #   id      => '2026-03-18-opentracing-migration-links',
+  #   module    => 'spec',
+  #   minVers => '1.55.0',
+  #   file    => qr|^tmp/otel/specification/compatibility/opentracing\.md$|,
+  #   apply   => sub {
+  #     s{
+  #       (https://opentelemetry\.io/docs)/migration/(opentracing/)
+  #     }{$1/compatibility/migration/$2}gx;
+  #   },
+  # },
+);
+
+# Default `file` regex per module, used when a patch entry omits `file`.
+# Each regex matches Markdown files under the module's spec/docs tree.
+my %moduleFileDefaults = (
+  spec    => qr|^tmp/otel/specification/|,
+  otlp    => qr|^tmp/otlp/docs/|,
+  semconv => qr|^tmp/semconv/docs/|,
 );
 
 sub applyPatches($) {
   my ($context) = @_;
   for my $patch (@patches) {
     next unless ($patch->{context} // 'body') eq $context;
-    next unless $ARGV =~ $patch->{file};
+    my $fileRe = $patch->{file} // $moduleFileDefaults{$patch->{module}};
+    if (!defined $fileRe) {
+      warn "WARNING: patch '$patch->{id}' has unknown module '$patch->{module}' and no file regex; skipping";
+      next;
+    }
+    next unless $ARGV =~ $fileRe;
     next unless applyPatchOrPrintMsgIf(
       $patch->{id}, $patch->{module}, $patch->{minVers}, $patch->{maxVers}
     );
-    if ($context eq 'frontmatter') {
+    if ($context eq 'front matter') {
       local $_ = $frontMatterFromFile;
       $patch->{apply}->();
       $frontMatterFromFile = $_;
@@ -141,7 +158,7 @@ sub printFrontMatter() {
     # $frontMatterFromFile =~ s/cascade:\n/$&  draft: true\n/;
   }
 
-  applyPatches('frontmatter');
+  applyPatches('front matter');
 
   my $titleMaybeQuoted = ($title =~ ':') ? "\"$title\"" : $title;
   print "title: $titleMaybeQuoted\n" if $frontMatterFromFile !~ /title: /;
@@ -183,40 +200,65 @@ sub getVersFromGitmodules($) {
   return $_gitmodulesCache{$specName};
 }
 
+sub _defaultMaxVers($) {
+  # Returns $minVers with its patch (last) number incremented, e.g.,
+  # '1.39.0' -> '1.39.1', '1.55.2' -> '1.55.3'. This preserves the original
+  # prefix-match semantics, where a patch targeting '1.55.0' applied to
+  # '1.55.0' and '1.55.0-N-gHASH' but not to '1.55.1' or later.
+  my ($minVers) = @_;
+  my $v = $minVers;
+  $v =~ s/^v//;
+  if ($v =~ /^(\d+)\.(\d+)\.(\d+)/) {
+    return "$1.$2." . ($3 + 1);
+  }
+  warn "WARNING: cannot derive default maxVers from '$minVers'";
+  return undef;
+}
+
 sub applyPatchOrPrintMsgIf($$$;$) {
   # Returns truthy if patch should be applied, otherwise prints message (once) as to why not.
-  # The patch is applied if $submoduleVers starts with $targetVers and is <= $maxVers (if provided).
+  # Version-range semantics: $minVers is inclusive; $maxVers is exclusive.
+  # If $maxVers is undef, it defaults to $minVers with its patch number incremented
+  # (e.g., '1.55.0' -> '1.55.1'), matching the original prefix-match behavior.
+  # The patch is applied while $submoduleVers is in the range [$minVers, $maxVers).
 
-  my ($patchID, $specName, $targetVers, $maxVers) = @_;
+  my ($patchID, $specName, $minVers, $maxVers) = @_;
+  $maxVers //= _defaultMaxVers($minVers);
   my $vers = $versions{$specName};
   my $submoduleVers = getVersFromGitmodules($specName);
   my $key = $specName . $patchID;
 
   return 0 if $patchMsgCount{$key} && $patchMsgCount{$key} ne 'Apply the patch';
 
-  if ($maxVers && $submoduleVers && semverCmp($submoduleVers, $maxVers) > 0) {
+  # maxVers is exclusive: skip once submodule has reached it.
+  if ($maxVers && $submoduleVers && semverCmp($submoduleVers, $maxVers) >= 0) {
     print STDOUT "INFO: $0: skipping patch '$patchID' since spec '$specName' " .
-      "submodule is at version '$submoduleVers' > '$maxVers' (patch max version); " .
+      "submodule is at version '$submoduleVers' >= '$maxVers' (patch max version, exclusive); " .
       "the fix is likely in upstream now\n" unless $patchMsgCount{$key};
     $patchMsgCount{$key}++;
     return 0;
   }
 
-  if ($submoduleVers && $submoduleVers =~ /^\Q$targetVers\E/) {
+  if ($submoduleVers && semverCmp($submoduleVers, $minVers) >= 0) {
     print STDOUT "INFO: $0: applying patch '$patchID' since spec '$specName' " .
-      "submodule is at version '$submoduleVers', and it starts with the patch target '$targetVers'" .
+      "submodule is at version '$submoduleVers' >= '$minVers' (patch min version, inclusive)" .
+      ($maxVers ? " and < '$maxVers' (patch max version, exclusive)" : "") .
       "\n" unless $patchMsgCount{$key};
     return $patchMsgCount{$key} = 'Apply the patch';
-  } elsif (($maxVers && semverCmp($vers, $maxVers) > 0) || semverCmp($vers, $targetVers) >= 0) {
+  } elsif ($maxVers && semverCmp($vers, $maxVers) >= 0) {
     print STDOUT "INFO: $0: patch '$patchID' is probably obsolete now that " .
-      "spec '$specName' is at version '$vers' >= '$targetVers' (patch target version); " .
+      "spec '$specName' is at version '$vers' >= '$maxVers' (patch max version, exclusive); " .
+      "if so, remove the patch\n";
+  } elsif (semverCmp($vers, $minVers) >= 0) {
+    print STDOUT "INFO: $0: patch '$patchID' is probably obsolete now that " .
+      "spec '$specName' is at version '$vers' >= '$minVers' (patch min version, inclusive); " .
       "if so, remove the patch\n";
   } else {
     my $submodInfo = $submoduleVers
-      ? "and submodule version '$submoduleVers' doesn't start with the patch target '$targetVers'"
+      ? "and submodule version '$submoduleVers' < '$minVers' (patch min version, inclusive)"
       : "and submodule version is unknown";
     print STDOUT "INFO: $0: skipping patch '$patchID' since spec '$specName' " .
-      "submodule is at version '$vers' < '$targetVers' (patch target version); " .
+      "submodule is at version '$vers' < '$minVers' (patch min version, inclusive); " .
       "$submodInfo\n";
   }
   $patchMsgCount{$key}++;


### PR DESCRIPTION
- Adopt inclusive `minVers` / exclusive `maxVers` semantics, comparing via `semverCmp` instead of a prefix match
- Default `maxVers` to `minVers` with its patch segment incremented (for example, `1.55.0` → `1.55.1`), preserving the original prefix-match behavior
- Make `file` optional, defaulting to the module's spec/docs tree (`^tmp/otel/specification/`, `^tmp/otlp/docs/`, `^tmp/semconv/docs/`)
- Warn and skip when a patch's `module` is unknown and no `file` is provided
- Rename the `context` value `frontmatter` to `front matter` and drop the now-unneeded `cSpell:ignore` entry
- Clarify apply/skip/obsolete log messages to reference the triggering bound (min vs. max)
- Rewrite content-module-patches.md field descriptions to match and convert the reference tables to bulleted lists
- No changes to the generated site pages other than the updated site doc page (and sitemaps and build timestamps)