### PR TITLE
Make announcements redirect with 302 for announcements that have expired

### DIFF
--- a/content/en/announcements/_index.md
+++ b/content/en/announcements/_index.md
@@ -4,5 +4,5 @@ cascade:
   type: docs
   params:
     hide_feedback: true
-redirects: [{ from: '*', to: '?' }]
+redirects: [{ from: '*', to: '? 302!' }]
 ---


### PR DESCRIPTION
- Fixes #6191
- Redirect rule change instructing Netlify to return 302 for announcement URLs that no longer exist. Of course this redirect rule catches any currently invalid announcements path.

```console
$ curl -sI https://deploy-preview-9733--opentelemetry.netlify.app/announcements/abc/
HTTP/2 302 
age: 0
cache-control: public,max-age=0,must-revalidate
cache-status: "Netlify Edge"; fwd=miss
content-type: text/plain
date: Thu, 23 Apr 2026 09:41:22 GMT
location: /announcements/
```