### PR TITLE
chore: .gitignore cleanup and tmp dir consolidation

### DIFF
--- a/.github/scripts/collector-sync.sh
+++ b/.github/scripts/collector-sync.sh
@@ -38,12 +38,12 @@ echo "Checking links..."
 npm run check:links || echo "Warning: Link check failed"
 
 # Get version info from cloned ecosystem-explorer registry
-if [ ! -d "tmp_repos/opentelemetry-ecosystem-explorer" ]; then
+if [ ! -d "tmp/repos/opentelemetry-ecosystem-explorer" ]; then
   echo "Error: ecosystem-explorer repository not found"
   exit 1
 fi
 
-VERSION=$(find tmp_repos/opentelemetry-ecosystem-explorer/ecosystem-registry/collector/core \
+VERSION=$(find tmp/repos/opentelemetry-ecosystem-explorer/ecosystem-registry/collector/core \
   -mindepth 1 -maxdepth 1 -type d -printf '%f\n' 2>/dev/null | \
   grep -v -i 'SNAPSHOT' | sort -V | tail -n 1)
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,6 @@
 node_modules/
 package-lock.json
 pnpm-lock.yaml
-
-# Link checker
 tmp/
 
 # macOS
@@ -32,11 +30,5 @@ assets/jsconfig.json
 # WebStorm
 **/.idea/**
 
-.dart_tool
-pubspec.lock
-
 *.pyc
-*tmp_repos/
 *uv.lock
-
-# cSpell:ignore pubspec

--- a/scripts/collector-sync/src/documentation_sync/explorer_repository_manager.py
+++ b/scripts/collector-sync/src/documentation_sync/explorer_repository_manager.py
@@ -13,14 +13,14 @@ class ExplorerRepositoryManager:
     """Manages cloning and updating the opentelemetry-ecosystem-explorer repository."""
 
     EXPLORER_REPO_URL = "https://github.com/open-telemetry/opentelemetry-ecosystem-explorer.git"
-    DEFAULT_CLONE_PATH = Path("tmp_repos/opentelemetry-ecosystem-explorer")
+    DEFAULT_CLONE_PATH = Path("tmp/repos/opentelemetry-ecosystem-explorer")
 
     def __init__(self, clone_path: Path | None = None):
         """Initialize the repository manager.
 
         Args:
             clone_path: Path where the repository should be cloned.
-                       Defaults to tmp_repos/opentelemetry-ecosystem-explorer
+                       Defaults to tmp/repos/opentelemetry-ecosystem-explorer
         """
         self.clone_path = clone_path or self.DEFAULT_CLONE_PATH
         self._repo: Repo | None = None


### PR DESCRIPTION
- Cleans out `.gitignore`, in particular dropping the Dart-related entries
- Consolidates tmp dirs, replacing `tmp_repose` by `tmp`
- As agreed via Slack with @jaydeluca 