### PR TITLE
Clean up compatibility docs metadata and rename Prometheus clients page

### DIFF
--- a/.cspell/en-words.txt
+++ b/.cspell/en-words.txt
@@ -51,6 +51,7 @@ servlet
 shippingservice
 stdoutmetric
 subresponse
+sunsetting
 tabpane
 timeframe
 uids

--- a/content/en/blog/2023/sunsetting-opencensus.md
+++ b/content/en/blog/2023/sunsetting-opencensus.md
@@ -3,7 +3,6 @@ title: Sunsetting OpenCensus
 linkTitle: Sunsetting OpenCensus
 date: 2023-05-01
 author: '[Aaron Abbott](https://github.com/aabmass) (Google)'
-cSpell:ignore: sunsetting
 ---
 
 In 2019, we announced that OpenTracing and OpenCensus would be merging to form

--- a/content/en/blog/2025/ux-research-prometheus-otel/index.md
+++ b/content/en/blog/2025/ux-research-prometheus-otel/index.md
@@ -8,7 +8,7 @@ author: >-
   [Victoria Nduka](https://github.com/nwanduka)
 sig: End User
 # prettier-ignore
-cSpell:ignore: Beorn explorative Kiripolsky Nduka negotiables Rabestein Suereth sunsetting Volz
+cSpell:ignore: Beorn explorative Kiripolsky Nduka negotiables Rabestein Suereth Volz
 ---
 
 <!-- markdownlint-configure-file {"no-shortcut-ref-link": {"ignore_pattern": "^[Ww]ith$"}} -->

--- a/content/en/docs/compatibility/migration/_index.md
+++ b/content/en/docs/compatibility/migration/_index.md
@@ -1,9 +1,8 @@
 ---
 title: Migration
 description: How to migrate to OpenTelemetry
-aliases:
-  - /docs/migration/
-weight: 800
+aliases: [/docs/migration/]
+weight: -10
 ---
 
 ## OpenTracing and OpenCensus

--- a/content/en/docs/compatibility/migration/opencensus.md
+++ b/content/en/docs/compatibility/migration/opencensus.md
@@ -3,8 +3,5 @@ title: Migrating from OpenCensus
 linkTitle: OpenCensus
 redirect: /blog/2023/sunsetting-opencensus/#how-to-migrate-to-opentelemetry
 build: { render: link }
-aliases:
-  - /docs/migration/opencensus/
-weight: 3
-cSpell:ignore: sunsetting
+aliases: [/docs/migration/opencensus/]
 ---

--- a/content/en/docs/compatibility/migration/opentracing.md
+++ b/content/en/docs/compatibility/migration/opentracing.md
@@ -1,10 +1,7 @@
 ---
 title: Migrating from OpenTracing
 linkTitle: OpenTracing
-weight: 2
-aliases:
-  - /docs/migration/opentracing/
-cSpell:ignore: codebases
+aliases: [/docs/migration/opentracing/]
 ---
 
 Backward compatibility with [OpenTracing][] has been a priority for the

--- a/content/en/docs/compatibility/prometheus/_index.md
+++ b/content/en/docs/compatibility/prometheus/_index.md
@@ -1,7 +1,6 @@
 ---
 title: Prometheus
 description: Learn about OpenTelemetry and Prometheus interoperability
-weight: 5
 ---
 
 This section includes resources and guides on interoperability between

--- a/content/en/docs/compatibility/prometheus/client-libraries.md
+++ b/content/en/docs/compatibility/prometheus/client-libraries.md
@@ -1,10 +1,7 @@
 ---
-title: Prometheus Client Libraries vs. OpenTelemetry
-linkTitle: Prometheus Clients
-aliases: [/docs/compatibility/prometheus/]
-weight: 5
-# prettier-ignore
-cSpell:ignore: AggregationBase2ExponentialHistogram base2ExponentialBucketHistogram bedroomTemperatureCelsius buildAndStart buildWithCallback classicUpperBounds connectedDeviceCount CounterValue defaultAggregation deviceCommandDuration devicesConnected errcheck gaugeBuilder GaugeFunc GaugeValue GaugeWithCallback hvac hvacOnTime initLabelValues InstrumentKindHistogram InstrumentSelector InstrumentType labelValues livingRoomTemperatureCelsius LongUpDownCounter MustNewConstMetric NativeHistogramBucketFactor nativeOnly nolint OtelHistogramAsSummary otlpmetrichttp PrometheusHistogramNative PrometheusRegistry PrometheusSummary promhttp sdkmetric setDefaultAggregationSelector setExplicitBucketBoundariesAdvice thermostatSetpoint totalEnergyJoules upDownCounterBuilder
+title: Prometheus client libraries vs. OpenTelemetry
+linkTitle: Client libraries
+cSpell:ignore: hvac
 ---
 
 <?code-excerpt path-base="examples/java/prometheus-compatibility"?>

--- a/tools/content/compatibility
+++ b/tools/content/compatibility
@@ -1,1 +1,0 @@
-../../content/en/docs/compatibility


### PR DESCRIPTION
- Followup to #9712, etc
- Renames the Prometheus compatibility guide file to a leaner slug that avoids the prometheus stutter
- Normalizes front matter metadata in compatibility and migration pages.
- Removes obsolete local cSpell ignores and adds shared dictionary coverage.
- Removes unused `tools/content/compatibility` path alias.
- Removes no-op alias

/cc @tiffany76 @Wineshuga