### PR TITLE
Fixes Kapa launcher overlap with site footer

### DIFF
--- a/.cspell/all-words.txt
+++ b/.cspell/all-words.txt
@@ -39,6 +39,7 @@ jboss
 jdbc
 jsonify
 Juraci
+kapa
 knative
 kotlin
 Kröhling

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # cSpell:ignore worktrees
 
 /.claude/worktrees
+/.claude/settings.local.json
 
 # Hugo-generated assets
 .hugo_build.lock

--- a/assets/js/kapa-footer-yield.js
+++ b/assets/js/kapa-footer-yield.js
@@ -1,0 +1,57 @@
+// Kapa preinitialization: queue API calls until the widget bundle loads.
+// https://docs.kapa.ai/integrations/website-widget/javascript-api/preinitialize
+(function () {
+  if (!window.Kapa) {
+    var i = function () {
+      i.c(arguments);
+    };
+    i.q = [];
+    i.c = function (args) {
+      i.q.push(args);
+    };
+    window.Kapa = i;
+  }
+})();
+
+// Set data-kapa-near-footer on <html> when the site footer is in view and
+// the Kapa modal is closed, so CSS can fade the launcher without doing so
+// while the modal is open. See #9676, #9689.
+(function () {
+  var root = document.documentElement;
+  var modalOpen = false;
+  var footerVisible = false;
+
+  function update() {
+    if (footerVisible && !modalOpen) {
+      root.setAttribute('data-kapa-near-footer', '');
+    } else {
+      root.removeAttribute('data-kapa-near-footer');
+    }
+  }
+
+  window.Kapa('onModalOpen', function () {
+    modalOpen = true;
+    update();
+  });
+  window.Kapa('onModalClose', function () {
+    modalOpen = false;
+    update();
+  });
+
+  function observeFooter() {
+    if (!('IntersectionObserver' in window)) return;
+    var footer = document.querySelector('footer.td-footer');
+    if (!footer) return;
+    var io = new IntersectionObserver(function (entries) {
+      footerVisible = entries[0].isIntersecting;
+      update();
+    });
+    io.observe(footer);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', observeFooter);
+  } else {
+    observeFooter();
+  }
+})();

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -65,9 +65,22 @@ body.td-page--draft .td-content {
 
 #kapa-widget-container {
   --modal-inner-align: flex-end !important;
+  transition:
+    opacity 2000ms ease,
+    transform 2000ms ease;
 }
 
 // Alternative to the above:
 // #kapa-widget-container::part(modal-inner) {
 //   align-items: flex-end !important;
 // }
+
+// Fade out the Kapa launcher when the site footer is in view, so it doesn't
+// cover the footer icons. The `data-kapa-near-footer` flag is toggled in JS
+// (see layouts/_partials/hooks/head-end.html) and is only set while the Kapa
+// modal is closed, so an open modal is unaffected. See #9676 and #9689.
+html[data-kapa-near-footer] #kapa-widget-container {
+  opacity: 0;
+  // transform: translateY(1rem);
+  pointer-events: none;
+}

--- a/layouts/_partials/hooks/head-end.html
+++ b/layouts/_partials/hooks/head-end.html
@@ -26,6 +26,7 @@
 
 {{- end -}}
 
+{{ partial "script.html" (dict "src" "js/kapa-footer-yield.js") }}
 <script
   async
   src="https://widget.kapa.ai/kapa-widget.bundle.js"


### PR DESCRIPTION
- Fixes #9676
- Prevents the Ask AI launcher from obscuring footer icons, improving access to footer links and reducing UI friction near the page bottom
- **Preview**: e.g., https://deploy-preview-9748--opentelemetry.netlify.app/ecosystem/

### Screenshots

<img width="1127" height="813" alt="image" src="https://github.com/user-attachments/assets/c46572f4-c203-4940-be5b-e8d618344dbe" />

---

<img width="1121" height="808" alt="image" src="https://github.com/user-attachments/assets/e7fe121c-54f0-4527-b716-347a3df98e33" />
