### PR TITLE
Improve refcache-fix skill and add double-check --retry-404

### DIFF
--- a/content/en/site/skills/refresh-refcache-pr-fix.md
+++ b/content/en/site/skills/refresh-refcache-pr-fix.md
@@ -32,6 +32,16 @@ the repository root.
 
 5. If any content modules are out of date, run `npm run get:submodule`.
 
+## Handling 5XX responses
+
+Status 5XX responses are usually transient. If `static/refcache.json` or
+`./scripts/double-check-refcache-4XX.mjs` (below) reports status 5XX for a URL,
+treat it as likely temporary (origin down, gateway errors, overload). **Do not**
+change site content or links solely to work around a 5XX; prefer re-running the
+double-check script or `npm run fix:refcache` later. Only investigate a 5XX like
+a real defect if it **keeps** failing across multiple runs over time and you
+have confirmed the URL is not otherwise healthy.
+
 ## Resolve non-2XX entries
 
 1. Run `./scripts/double-check-refcache-4XX.mjs` to retry transient 4XX failures
@@ -47,11 +57,20 @@ the repository root.
      static/refcache.json
    ```
 
-5. For each remaining status, fix or remove the source link that produced it:
-   - For a 404, identify the site pages that refer to the dead URL and update or
-     remove that link.
-   - For any other non-2XX status, inspect it manually and update or remove the
-     source link as needed before continuing.
-6. Run `npm run fix:refcache` to refresh `static/refcache.json` after those
-   source-link changes, then repeat the steps in this section until no non-2XX
-   statuses remain.
+5. **Analyze and recommend**. For each URL from the previous step, produce a
+   numbered or bulleted list that includes at least:
+   - The URL and HTTP status.
+   - Where it originates from: provide links to files or pages.
+   - A recommendation. For links into github.com, recommend a replacement link
+     based on the last commit that contains the named resource.
+
+   Pause for feedback from a reviewer.
+
+6. **Apply approved fixes.** After approval, edit the suggested sources:
+   - For a **404**, update or remove the referring link where you identified it.
+   - For **other non-2XX** statuses, apply the reviewed recommendation (manual
+     inspection may still be required for ambiguous cases).
+
+7. Run `npm run fix:refcache` to refresh `static/refcache.json` after those
+   source-link changes, then repeat the steps in this section (from step 1)
+   until no non-2XX statuses remain.

--- a/scripts/double-check-refcache-4XX.mjs
+++ b/scripts/double-check-refcache-4XX.mjs
@@ -15,6 +15,8 @@ const DEFAULT_MAX_NUM_TO_UPDATE = null; // no max
 
 let verbose = false;
 let checkForFragments = false;
+/** When true, re-fetch URLs cached as 404 instead of skipping them. */
+let retry404 = false;
 let maxNumEntriesToUpdate = DEFAULT_MAX_NUM_TO_UPDATE;
 
 // Magic numbers that we use to determine if a URL with a fragment has been
@@ -65,9 +67,13 @@ async function writeRefcache(cache) {
   console.log(`Wrote updated ${CACHE_FILE}.`);
 }
 
-// Retry HTTP status check for refcache URLs with non-200s and not 404
+// Retry HTTP status check for refcache URLs with non-2XX (normally skips cached 404).
 async function retry400sAndUpdateCache() {
-  console.log(`Checking ${CACHE_FILE} for 4XX status URLs ...`);
+  console.log(
+    `Checking ${CACHE_FILE} for 4XX status URLs` +
+      (retry404 ? ' (retry-404 enabled)' : '') +
+      ` ...`,
+  );
   const cache = await readRefcache();
   let updatedCount = 0;
   let entriesCount = 0;
@@ -103,16 +109,21 @@ async function retry400sAndUpdateCache() {
       continue;
     }
 
-    if (
-      isStatusNotFound(StatusCode, url) ||
-      (parsedUrl.hash && is4XXForFragments(StatusCode, lastSeenDate))
-    ) {
+    // Invalid fragment sentinel: always skipped here (handled with --check-fragments flow).
+    if (parsedUrl.hash && is4XXForFragments(StatusCode, lastSeenDate)) {
       console.log(
-        `Skipping ${StatusCode}: ${url} (last seen ${lastSeenDate.toLocaleDateString()})${
-          is4XXForFragments(StatusCode, lastSeenDate) ? ' INVALID FRAGMENT' : ''
-        }`,
+        `Skipping ${StatusCode}: ${url} (last seen ${lastSeenDate.toLocaleDateString()}) INVALID FRAGMENT`,
       );
-      if (parsedUrl.hash) urlWithInvalidFragCount++;
+      urlWithInvalidFragCount++;
+      continue;
+    }
+
+    // Cached 404: skip unless --retry-404 (still-404 responses still do not
+    // update the cache non-hash path unless the new status is 2XX).
+    if (isStatusNotFound(StatusCode, url) && !retry404) {
+      console.log(
+        `Skipping ${StatusCode}: ${url} (last seen ${lastSeenDate.toLocaleDateString()})`,
+      );
       continue;
     }
 
@@ -226,6 +237,8 @@ Options:
                              Use 0 to have file scanned and checked for updates.
   --check-fragments, -f      Also check URLs with fragments for validity,
                              which htmltest doesn't do.
+  --retry-404, -4            Re-fetch URLs that are cached with status 404
+                             instead of skipping them (default: skip cached 404s).
   --verbose, -v              Show verbose output.
 `);
   exit(exitCode);
@@ -245,6 +258,11 @@ function parseCliArgs() {
     'check-fragments': {
       type: 'boolean',
       short: 'f',
+      default: false,
+    },
+    'retry-404': {
+      type: 'boolean',
+      short: '4',
       default: false,
     },
     verbose: {
@@ -282,6 +300,7 @@ function parseCliArgs() {
   return {
     maxNumEntriesToUpdate: maxNumValue,
     checkForFragments: args.values['check-fragments'],
+    retry404: args.values['retry-404'],
     verbose: args.values['verbose'],
   };
 }
@@ -296,6 +315,7 @@ async function main() {
   // Set global configuration variables
   maxNumEntriesToUpdate = config.maxNumEntriesToUpdate;
   checkForFragments = config.checkForFragments;
+  retry404 = config.retry404;
   verbose = config.verbose;
 
   await retry400sAndUpdateCache();


### PR DESCRIPTION
- Document transient 5XX handling and split analysis from applying fixes.
- Add --retry-404/-4 to re-fetch cached 404 URLs; separate fragment skip logic.