### PR TITLE
Fix author line in Japanese survey blog post

### DIFF
--- a/content/en/blog/2026/japanese-survey/index.md
+++ b/content/en/blog/2026/japanese-survey/index.md
@@ -3,10 +3,10 @@ title: OpenTelemetry Japanese Community Survey
 linkTitle: OTel Japanese Survey
 date: 2026-04-28
 author: >-
-  "[Ernest Owojori](https://github.com/E-STAT), [Andrej
-  Kiripolsky](https://github.com/andrejkiri), [Yoshifumi
+  [Ernest Owojori](https://github.com/E-STAT), [Andrej
+  Kiripolsky](https://github.com/andrejkiri) (Grafana Labs), [Yoshifumi
   YAMAGUCHI](https://github.com/ymotongpoo) (Grafana Labs), [Austin
-  Parker](https://github.com/austinlparker) (Honeycomb.io)"
+  Parker](https://github.com/austinlparker) (Honeycomb.io)
 issue: 8985
 sig: End User
 # prettier-ignore


### PR DESCRIPTION
## Summary

- Remove stray double quotes wrapping the author block in [content/en/blog/2026/japanese-survey/index.md](https://github.com/open-telemetry/opentelemetry.io/blob/main/content/en/blog/2026/japanese-survey/index.md). The YAML folded scalar (`>-`) treats them as literal characters, so they would render as visible `"` around the author list.
- Add the missing `(Grafana Labs)` affiliation for Andrej Kiripolsky.

Follow-up to #9660.


## Disclaimers
- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "First-time contributing?" section.
- [x]  This PR has content that I did not fully write myself.
   - [x]  I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x]  I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[1](https://github.com/open-telemetry/opentelemetry.io/pull/9777#user-content-fn-I-know-my-stuff-1640b926f9e4e035c81c0b58eb30e75d)

1^ Yes, I can answer maintainer questions about the content of this PR, without using AI. [↩](https://github.com/open-telemetry/opentelemetry.io/pull/9777#user-content-fnref-I-know-my-stuff-1640b926f9e4e035c81c0b58eb30e75d)

