### PR TITLE
fix(docs-redirects): don't force announcements redirects

### DIFF
--- a/content/en/announcements/_index.md
+++ b/content/en/announcements/_index.md
@@ -10,5 +10,5 @@ cascade:
       utm_source=opentelemetry&utm_medium=website&utm_content=slim-banner
   target:
     sites: { matrix: { languages: ['**'] } }
-redirects: [{ from: '*', to: '? 302!' }]
+redirects: [{ from: '*', to: '? 302' }]
 ---


### PR DESCRIPTION
Hopefully this will resolve the current 302 loop for paths below announcements. Yes, that was enough:

```console
$ curl -sI https://deploy-preview-9793--opentelemetry.netlify.app/announcements/ | grep -E '^H|loc'
HTTP/2 200 
$ curl -sI https://deploy-preview-9793--opentelemetry.netlify.app/announcements/abc | grep -E '^H|loc'
HTTP/2 302 
location: /announcements/
$ curl -sI https://deploy-preview-9793--opentelemetry.netlify.app/announcements/kubecon-india/ | grep -E '^H|loc'
HTTP/2 200 
```

**Preview**:

- https://deploy-preview-9793--opentelemetry.netlify.app/announcements/
- https://deploy-preview-9793--opentelemetry.netlify.app/announcements/abc
- https://deploy-preview-9793--opentelemetry.netlify.app/announcements/kubecon-india/