### PR TITLE
Upgrade Docsy to v0.15.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	path = themes/docsy
 	url = https://github.com/google/docsy.git
   # cSpell:disable-next-line
-	docsy-pin = v0.14.3-44-gc6834296
+	docsy-pin = v0.15.0
 	docsy-note = "2024-04-01 Switching to google/docsy.git from cncf/docsy.git since we don't have any CNCF customizations."
 	docsy-reminder = "Ensure that any tag referenced by `docsy-pin` is present in the remote repo (url), otherwise add (push) the tags to the repo."
 [submodule "content-modules/opentelemetry-specification"]


### PR DESCRIPTION
No unexpected changes to generated site files since we've been incrementally upgrading Docsy already, this is just an official version bump:

```console
$ (cd public && git diff -bw --ignore-blank-lines) | grep ^diff 
diff --git a/site/index.html b/site/index.html
diff --git a/site/index.md b/site/index.md
```

**Preview**: https://deploy-preview-9802--opentelemetry.netlify.app/