### PR TITLE
[ja] update translation of content/en/docs/languages/js/context.md

### DIFF
--- a/content/ja/docs/languages/js/context.md
+++ b/content/ja/docs/languages/js/context.md
@@ -3,8 +3,7 @@ title: コンテキスト
 description: OpenTelemetry JavaScript Context API ドキュメント
 aliases: [api/context]
 weight: 60
-default_lang_commit: 68e94a4555606e74c27182b79789d46faf84ec25
-drifted_from_default: true
+default_lang_commit: 6751402db060c25800bb41c270dcaebb48aa7acb
 ---
 
 OpenTelemetryが動作するためには、重要なテレメトリーデータを保存し、伝搬する必要があります。
@@ -102,7 +101,7 @@ const ctx = api.ROOT_CONTEXT;
 const ctx2 = ctx.setValue(key, 'context 2');
 
 // エントリを削除
-const ctx3 = ctx.deleteValue(key);
+const ctx3 = ctx2.deleteValue(key);
 
 // ctx3にはエントリが含まれない
 console.log(ctx3.getValue(key)); // undefined


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/js/context.md` to match the latest English source at
`content/en/docs/languages/js/context.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The only change in the English source was a one-line bug fix in a code example:
`ctx.deleteValue(key)` → `ctx2.deleteValue(key)` (using the correct variable).

## Checks

- [x] Followed the [localization guide](https://opentelemetry.io/docs/contributing/localization/)
- [x] `npm run fix:all` ran cleanly
- [x] `npm run check:i18n` reports no missing or stale `default_lang_commit`
- [x] `npm run check:links` passes