### PR TITLE
[ja] update translation of content/en/docs/security/_index.md

### DIFF
--- a/content/ja/docs/security/_index.md
+++ b/content/ja/docs/security/_index.md
@@ -3,8 +3,7 @@ title: セキュリティ
 cascade:
   collector_vers: 0.151.0
 weight: 970
-default_lang_commit: 68e94a4555606e74c27182b79789d46faf84ec25
-drifted_from_default: true
+default_lang_commit: 6751402db060c25800bb41c270dcaebb48aa7acb
 ---
 
 このセクションでは、OpenTelemetryプロジェクトがどのように脆弱性を公開し、インシデントに対応しているかを学び、あなたがテレメトリーを安全に収集し、送信するために何ができるかを知ることができます。


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/security/_index.md` to match the latest English source at
`content/en/docs/security/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The only English-side change was a frontmatter update (`cascade.collector_vers: 0.137.0 → 0.151.0`);
the Japanese file already had the correct value, so no body edits were needed.

## Checks

- [x] Followed the [localization guide](https://opentelemetry.io/docs/contributing/localization/)
- [x] `npm run fix:all` ran cleanly
- [x] `npm run check:i18n` reports no missing or stale `default_lang_commit`
- [ ] `npm run check:links` passes