### PR TITLE
chore: add front matter weights to fix Prometheus/Migration order

### DIFF
--- a/content/en/docs/compatibility/migration/_index.md
+++ b/content/en/docs/compatibility/migration/_index.md
@@ -2,7 +2,7 @@
 title: Migration
 description: How to migrate to OpenTelemetry
 aliases: [/docs/migration/]
-weight: -10
+weight: 300
 ---
 
 ## OpenTracing and OpenCensus

--- a/content/en/docs/compatibility/prometheus/_index.md
+++ b/content/en/docs/compatibility/prometheus/_index.md
@@ -1,6 +1,7 @@
 ---
 title: Prometheus
 description: Learn about OpenTelemetry and Prometheus interoperability
+weight: 100
 ---
 
 This section includes resources and guides on interoperability between


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR without using AI.

---

In the `docs/compatibility` section, fix alphabetical sorting issue by adding front matter weights:
- Prometheus: 100
- Migration: 300

Ensures Migration appears after Prometheus in the section.