### PR TITLE
[ja] update translation of content/en/docs/security/config-best-practices.md

### DIFF
--- a/content/ja/docs/security/config-best-practices.md
+++ b/content/ja/docs/security/config-best-practices.md
@@ -2,8 +2,7 @@
 title: コレクターの設定のベストプラクティス
 linkTitle: コレクターの設定
 weight: 112
-default_lang_commit: 179f03bf118e1e8a3cc195ab56fc09d85c476394 # patched
-drifted_from_default: true
+default_lang_commit: dc2fb5771163265cb804a39b1dacc536b95bdb96
 cSpell:ignore: exporterhelper
 ---
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/security/config-best-practices.md` to match the latest English source at
`content/en/docs/security/config-best-practices.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English-side change was a link target update:
`/docs/collector/custom-collector` → `/docs/collector/extend/ocb/`

The Japanese file already had the correct link; only the i18n bookkeeping fields needed updating.

## Checks

- [x] Followed the [localization guide](https://opentelemetry.io/docs/contributing/localization/)
- [x] `npm run fix:format:diff` (Prettier on changed files) ran cleanly
- [x] `npm run check:i18n` reports no missing or stale `default_lang_commit`
- [x] `npm run check:links` passes