### PR TITLE
[ja] docs(i18n): sync content/ja/announcements/_index.md

### DIFF
--- a/content/ja/announcements/_index.md
+++ b/content/ja/announcements/_index.md
@@ -1,6 +1,6 @@
 ---
 title: お知らせ
 # cascade is omitted because it is for the en locale only.
-redirects: [{ from: '*', to: '?' }]
-default_lang_commit: 86cff3e582771d0b035c14bc85266c34ebc6b2d4 # patched
+redirects: [{ from: '*', to: '? 302' }]
+default_lang_commit: b51a1db58883aa963c461d34356aa86ac18d94b7
 ---


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

# Description

This PR updates the front matter in `content/ja/announcements/_index.md` to align with the latest English version.
Since the `cascade` front matter block is omitted in non-en files, just update the `redirects` and `default_lang_commit`.

[View diffs in the English source](https://github.com/open-telemetry/opentelemetry.io/compare/86cff3e582771d0b035c14bc85266c34ebc6b2d4...b51a1db58)

# Preview

- https://deploy-preview-9858--opentelemetry.netlify.app/ja/announcements/

