### PR TITLE
[ja] update translation of content/en/docs/specs/_index.md

### DIFF
--- a/content/ja/docs/specs/_index.md
+++ b/content/ja/docs/specs/_index.md
@@ -4,6 +4,5 @@ linkTitle: Specs ↗
 weight: 960
 build: { render: link }
 redirects: [{ from: '*', to: '/docs/specs/:splat' }]
-default_lang_commit: 3b44fbfa49ced919daea01123abfaed836d2d0ec
-drifted_from_default: true
+default_lang_commit: b51a1db58883aa963c461d34356aa86ac18d94b7
 ---


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/specs/_index.md` to match the latest English source at
`content/en/docs/specs/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
