### PR TITLE
[ja] update translation of content/en/docs/demo/docker-deployment.md

### DIFF
--- a/content/ja/docs/demo/docker-deployment.md
+++ b/content/ja/docs/demo/docker-deployment.md
@@ -2,8 +2,7 @@
 title: Docker デプロイ
 linkTitle: Docker
 aliases: [docker_deployment]
-default_lang_commit: d0a90db560d4f15934bdb43d994eabcfd91c515a
-drifted_from_default: true
+default_lang_commit: b51a1db58883aa963c461d34356aa86ac18d94b7
 cSpell:ignore: otlphttp spanmetrics tracetest tracetesting
 ---
 
@@ -15,7 +14,8 @@ cSpell:ignore: otlphttp spanmetrics tracetest tracetesting
 - [Docker Compose](https://docs.docker.com/compose/install/)
   v2.0.0+
 - Make (オプション)
-- アプリケーション用に 6 GB の RAM
+- アプリケーション用に 6 GB の RAM（または[最小モード](#run-in-minimal-mode)を使う場合は約 3 GB）
+- 14 GB のディスク容量
 
 ## デモの取得と実行 {#get-and-run-the-demo}
 
@@ -46,6 +46,31 @@ docker compose up --force-recreate --remove-orphans --detach
 ```
 
     {{% /tab %}} {{< /tabpane >}}
+
+### 最小モードで実行する {#run-in-minimal-mode}
+
+リソースが限られている場合は、Kafka とそれに依存するサービスなしでデモを開始でき、メモリ使用量を約 3 GB の RAM に削減できます。
+
+    {{< tabpane text=true >}} {{% tab Make %}}
+
+```shell
+make start-minimal
+```
+
+    {{% /tab %}} {{% tab Docker %}}
+
+```shell
+docker compose -f docker-compose.minimal.yml up --force-recreate --remove-orphans --detach
+```
+
+    {{% /tab %}} {{< /tabpane >}}
+
+以下のサービスは最小モードには**含まれていません**。
+
+- `accounting`
+- `fraud-detection`
+- `flagd-ui`
+- `kafka`
 
 4. (オプション) API オブザーバビリティ駆動テストの有効化[^1]します。
 
@@ -124,11 +149,11 @@ OpenTelemetry コレクターはテレメトリーデータを複数のバック
         exporters: [spanmetrics, otlphttp/example]
   ```
 
-{{% alert title="Note" %}}
-YAML の値をコレクターとマージすると、オブジェクトはマージされて、配列は置き換えられます。
-`spanmetrics` エクスポーターを上書きする場合は、`traces` パイプラインのエクスポーターの配列に含める必要があります。
-このエクスポーターを含めないとエラーが発生します。
-{{% /alert %}}
+> [!NOTE]
+>
+> YAML の値をコレクターとマージすると、オブジェクトはマージされて、配列は置き換えられます。
+> `spanmetrics` エクスポーターを上書きする場合は、`traces` パイプラインのエクスポーターの配列に含める必要があります。
+> このエクスポーターを含めないとエラーが発生します。
 
 ベンダーのバックエンドは認証のために追加のパラメーターを必要とするかもしれません。ドキュメントを確認してください。
 一部のバックエンドは異なるエクスポーターが必要です。それらのエクスポーターとドキュメントについて[opentelemetry-collector-contrib/exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter) で入手できます。


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/demo/docker-deployment.md` to match the latest English
source at `content/en/docs/demo/docker-deployment.md`. Refreshes
`default_lang_commit` and removes the `drifted_from_default` flag.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
