### PR TITLE
fix(docs): split helm install code block to fix clipboard copy

### DIFF
--- a/content/en/docs/platforms/kubernetes/helm/operator.md
+++ b/content/en/docs/platforms/kubernetes/helm/operator.md
@@ -22,7 +22,7 @@ following commands:
 ```console
 helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 ```
-```console
+```shell
 helm install my-opentelemetry-operator open-telemetry/opentelemetry-operator \
   --set "manager.collectorImage.repository=otel/opentelemetry-collector-k8s" \
   --set admissionWebhooks.certManager.enabled=false \

--- a/content/en/docs/platforms/kubernetes/helm/operator.md
+++ b/content/en/docs/platforms/kubernetes/helm/operator.md
@@ -19,7 +19,7 @@ For detailed use of the OpenTelemetry Operator visit its
 To install the chart with the release name `my-opentelemetry-operator`, run the
 following commands:
 
-```console
+```shell
 helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 ```
 ```shell

--- a/content/en/docs/platforms/kubernetes/helm/operator.md
+++ b/content/en/docs/platforms/kubernetes/helm/operator.md
@@ -21,6 +21,8 @@ following commands:
 
 ```console
 helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+```
+```console
 helm install my-opentelemetry-operator open-telemetry/opentelemetry-operator \
   --set "manager.collectorImage.repository=otel/opentelemetry-collector-k8s" \
   --set admissionWebhooks.certManager.enabled=false \

--- a/content/en/docs/platforms/kubernetes/helm/operator.md
+++ b/content/en/docs/platforms/kubernetes/helm/operator.md
@@ -22,6 +22,7 @@ following commands:
 ```shell
 helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 ```
+
 ```shell
 helm install my-opentelemetry-operator open-telemetry/opentelemetry-operator \
   --set "manager.collectorImage.repository=otel/opentelemetry-collector-k8s" \


### PR DESCRIPTION
The helm commands were in a single console code block, causing the clipboard copy button to copy an empty string. Split into two separate code blocks so each command can be copied independently.

<!-- MAINTAINER NOTE: each list item should be on a single line. -->
- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]
[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.