### PR TITLE
[ja] docs(i18n): sync content/ja/docs/platforms/faas/_index.md

### DIFF
--- a/content/ja/docs/platforms/faas/_index.md
+++ b/content/ja/docs/platforms/faas/_index.md
@@ -4,8 +4,7 @@ linkTitle: FaaS
 description: >-
   OpenTelemetryは、さまざまなクラウドベンダーが提供するFaaSを監視するさまざまな方法をサポートしています。
 redirects: [{ from: /docs/faas/*, to: ':splat' }] # cSpell:disable-line
-default_lang_commit: 9ba98f4fded66ec78bfafa189ab2d15d66df2309 # patched
-drifted_from_default: true
+default_lang_commit: 49dff58cfe83650455e67611a6d72ae89a39e0f8
 ---
 
 Functions as a Service（FaaS）は、[クラウドネイティブアプリ][cloud native apps]にとって重要なサーバーレスコンピュートプラットフォームです。


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

# Description

This PR updates the `default_lang_commit` and removes `drifted_from_default` in `content/ja/platforms/faas/_index.md` to match the latest English version.
The English file (`content/en/platforms/faas/_index.md`) only changed in minor ways-heading levels and reference-style links.
There was no substantive drift in the Japanese body text, so only `default_lang_commit` was refreshed (and `drifted_from_defautl` dropped).

- [Function as a Service](https://opentelemetry.io/ja/docs/platforms/faas/)

[View diffs in the English file](https://github.com/open-telemetry/opentelemetry.io/compare/9ba98f4fded66ec78bfafa189ab2d15d66df2309...49dff58cf)

# Preview

- https://deploy-preview-9867--opentelemetry.netlify.app/ja/docs/platforms/faas/
