### PR TITLE
Update OBI docs for v0.9.0 release

### DIFF
--- a/content/en/docs/zero-code/obi/_index.md
+++ b/content/en/docs/zero-code/obi/_index.md
@@ -39,13 +39,13 @@ OBI offers the following features:
 - **Visibility into encrypted communications**: Capture transactions over
   TLS/SSL without decryption
 - **Context propagation**: Propagate trace context across services automatically
-- **Protocol support**: HTTP/S, gRPC, gRPC-Web, JSON-RPC, MQTT, Memcached, and
-  more
+- **Protocol support**: HTTP/S, gRPC, gRPC-Web, JSON-RPC, MQTT, NATS, AMQP
+  1.0, Memcached, and more
 - **Database instrumentation**: PostgreSQL (including pgx driver), MySQL,
-  MongoDB, Redis, Couchbase (N1QL/SQL++ and KV protocol)
+  MSSQL, MongoDB, Redis, Couchbase (N1QL/SQL++ and KV protocol)
 - **GenAI instrumentation**: Trace and metrics for OpenAI, Anthropic Claude,
-  Google AI Studio (Gemini), and AWS Bedrock API calls with automatic payload
-  extraction
+  Google AI Studio (Gemini), AWS Bedrock, Qwen (DashScope), MCP over JSON-RPC,
+  and embedding and rerank APIs for Voyage AI, Cohere, and Jina AI
 - **Low cardinality metrics**: Prometheus-compatible metrics with low
   cardinality for cost reduction
 - **Network observability**: Capture network flows between services with
@@ -55,32 +55,33 @@ OBI offers the following features:
 - **Collector integration**: Run OBI as an OpenTelemetry Collector receiver
   component
 
-## Recent highlights (v0.8.0)
+## Recent highlights (v0.9.0)
 
-OBI v0.8.0 expands protocol coverage, payload extraction, and deployment
-documentation:
+OBI v0.9.0 expands protocol coverage, emitted telemetry, and GenAI
+instrumentation:
 
-- **Generic Go tracing improvements**: Added generic Go protocol support,
-  including context propagation for generic requests
-- **Expanded protocol coverage**: Added JSON-RPC support across all languages
-- **Deeper HTTP payload extraction**: Added full HTTP body extraction, with
-  bounded decompression for response bodies
-- **Broader GenAI coverage**: Added Google AI Studio (Gemini) and AWS Bedrock
-  payload extraction, and fixed Vertex AI Gemini support
-- **Named CIDR labels**: Network metrics can now label configured CIDR ranges
-  with human-readable names
-- **New example scenario**: Added an Apache HTTP Server example alongside the
-  existing NGINX walkthroughs
-- **Support documentation**: Added a project support matrix for release
-  artifacts and supported environments
+- **New messaging protocol support**: Added NATS and AMQP 1.0 tracing and
+  metrics
+- **Expanded database coverage**: Added MSSQL protocol support, including
+  prepared statement handling and error extraction
+- **Broader GenAI coverage**: Added Qwen (DashScope), MCP over JSON-RPC,
+  embedding providers (Voyage AI, Cohere, Jina AI), and rerank providers
+  (Cohere, Jina AI, Voyage AI, and Qwen)
+- **New stats metrics**: Added TCP failed connection metrics alongside the
+  existing TCP RTT metrics
+- **Telemetry schema registry**: Added a Weaver-compatible schema registry for
+  OBI-emitted metrics and attributes
+- **Span and service graph alignment**: OBI now documents and emits
+  span-metrics and service-graph telemetry aligned with the collector-contrib
+  connectors
 
 For a complete list of changes and upgrade notes, see the
-[release notes](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases/tag/v0.8.0).
+[release notes](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases/tag/v0.9.0).
 
 If you want to explore the upstream examples, see the
-[NGINX walkthrough](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/tree/v0.8.0/examples/nginx)
+[NGINX walkthrough](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/tree/v0.9.0/examples/nginx)
 and the
-[Apache walkthrough](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/tree/v0.8.0/examples/apache).
+[Apache walkthrough](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/tree/v0.9.0/examples/apache).
 
 ## How OBI works
 

--- a/content/en/docs/zero-code/obi/_index.md
+++ b/content/en/docs/zero-code/obi/_index.md
@@ -5,12 +5,11 @@ description:
   Learn how to use OpenTelemetry eBPF Instrumentation for automatic
   instrumentation.
 weight: 3
-# prettier-ignore
-cSpell:ignore: Qwen rerank
 cascade:
   OTEL_RESOURCE_ATTRIBUTES_APPLICATION: obi
   OTEL_RESOURCE_ATTRIBUTES_NAMESPACE: obi
   OTEL_RESOURCE_ATTRIBUTES_POD: obi
+cSpell:ignore: Qwen rerank
 ---
 
 OpenTelemetry libraries provide telemetry collection for popular programming

--- a/content/en/docs/zero-code/obi/_index.md
+++ b/content/en/docs/zero-code/obi/_index.md
@@ -39,10 +39,10 @@ OBI offers the following features:
 - **Visibility into encrypted communications**: Capture transactions over
   TLS/SSL without decryption
 - **Context propagation**: Propagate trace context across services automatically
-- **Protocol support**: HTTP/S, gRPC, gRPC-Web, JSON-RPC, MQTT, NATS, AMQP
-  1.0, Memcached, and more
-- **Database instrumentation**: PostgreSQL (including pgx driver), MySQL,
-  MSSQL, MongoDB, Redis, Couchbase (N1QL/SQL++ and KV protocol)
+- **Protocol support**: HTTP/S, gRPC, gRPC-Web, JSON-RPC, MQTT, NATS, AMQP 1.0,
+  Memcached, and more
+- **Database instrumentation**: PostgreSQL (including pgx driver), MySQL, MSSQL,
+  MongoDB, Redis, Couchbase (N1QL/SQL++ and KV protocol)
 - **GenAI instrumentation**: Trace and metrics for OpenAI, Anthropic Claude,
   Google AI Studio (Gemini), AWS Bedrock, Qwen (DashScope), MCP over JSON-RPC,
   and embedding and rerank APIs for Voyage AI, Cohere, and Jina AI
@@ -71,9 +71,8 @@ instrumentation:
   existing TCP RTT metrics
 - **Telemetry schema registry**: Added a Weaver-compatible schema registry for
   OBI-emitted metrics and attributes
-- **Span and service graph alignment**: OBI now documents and emits
-  span-metrics and service-graph telemetry aligned with the collector-contrib
-  connectors
+- **Span and service graph alignment**: OBI now documents and emits span-metrics
+  and service-graph telemetry aligned with the collector-contrib connectors
 
 For a complete list of changes and upgrade notes, see the
 [release notes](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases/tag/v0.9.0).

--- a/content/en/docs/zero-code/obi/_index.md
+++ b/content/en/docs/zero-code/obi/_index.md
@@ -5,6 +5,8 @@ description:
   Learn how to use OpenTelemetry eBPF Instrumentation for automatic
   instrumentation.
 weight: 3
+# prettier-ignore
+cSpell:ignore: Qwen rerank
 cascade:
   OTEL_RESOURCE_ATTRIBUTES_APPLICATION: obi
   OTEL_RESOURCE_ATTRIBUTES_NAMESPACE: obi

--- a/content/en/docs/zero-code/obi/configure/export-data.md
+++ b/content/en/docs/zero-code/obi/configure/export-data.md
@@ -16,26 +16,29 @@ OBI can export OpenTelemetry metrics and traces to a OTLP endpoint.
 OBI supports the following protocol and feature versions for traces and metrics
 instrumentation:
 
-| Area          | Supported versions   | Notes                                                                                          |
-| :------------ | :------------------- | :--------------------------------------------------------------------------------------------- |
-| HTTP          | `1.0/1.1`            | Context propagation is supported.                                                              |
-| HTTP          | `2.0`                | Context propagation requires Go library-level instrumentation.                                 |
-| gRPC          | `1.0+`               | Long-lived connections started before OBI might use `*` for method names.                      |
-| MySQL         | All                  | Prepared statements created before OBI starts might not include query text.                    |
-| PostgreSQL    | All                  | Prepared statements created before OBI starts might not include query text.                    |
-| Redis         | All                  | Existing connections might not include database number or `db.namespace`.                      |
-| MongoDB       | `5.0+`               | Compressed payloads are not supported.                                                         |
-| Couchbase     | All                  | Bucket or collection names might be unavailable when negotiation completed before OBI started. |
-| Memcached     | All                  | Supports the ASCII text protocol subset, excluding `quit` and meta commands.                   |
-| Kafka         | All                  | Topic name lookup might fail for fetch API versions `13+`.                                     |
-| MQTT          | `3.1.1/5.0`          | Payloads are not captured.                                                                     |
-| GraphQL       | All                  | No additional documented version limits.                                                       |
-| Elasticsearch | `7.14+`              | No additional documented version limits.                                                       |
-| OpenSearch    | `3.0.0+`             | No additional documented version limits.                                                       |
-| AWS S3        | All                  | No additional documented version limits.                                                       |
-| AWS SQS       | All                  | No additional documented version limits.                                                       |
-| SQL++         | All                  | No additional documented version limits.                                                       |
-| GenAI         | OpenAI and Anthropic | No additional documented version limits.                                                       |
+| Area          | Supported versions                                                                  | Notes                                                                                          |
+| :------------ | :---------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------- |
+| HTTP          | `1.0/1.1`                                                                           | Context propagation is supported.                                                              |
+| HTTP          | `2.0`                                                                               | Context propagation requires Go library-level instrumentation.                                 |
+| gRPC          | `1.0+`                                                                              | Long-lived connections started before OBI might use `*` for method names.                      |
+| MySQL         | All                                                                                 | Prepared statements created before OBI starts might not include query text.                    |
+| PostgreSQL    | All                                                                                 | Prepared statements created before OBI starts might not include query text.                    |
+| MSSQL         | All                                                                                 | Prepared statements created before OBI starts might not include query text.                    |
+| Redis         | All                                                                                 | Existing connections might not include database number or `db.namespace`.                      |
+| MongoDB       | `5.0+`                                                                              | Compressed payloads are not supported.                                                         |
+| Couchbase     | All                                                                                 | Bucket or collection names might be unavailable when negotiation completed before OBI started. |
+| Memcached     | All                                                                                 | Supports the ASCII text protocol subset, excluding `quit` and meta commands.                   |
+| Kafka         | All                                                                                 | Topic name lookup might fail for fetch API versions `13+`.                                     |
+| MQTT          | `3.1.1/5.0`                                                                         | Payloads are not captured.                                                                     |
+| NATS          | All                                                                                 | No additional documented version limits.                                                       |
+| AMQP          | `1.0`                                                                               | Only transfer performatives create spans.                                                      |
+| GraphQL       | All                                                                                 | No additional documented version limits.                                                       |
+| Elasticsearch | `7.14+`                                                                             | No additional documented version limits.                                                       |
+| OpenSearch    | `3.0.0+`                                                                            | No additional documented version limits.                                                       |
+| AWS S3        | All                                                                                 | No additional documented version limits.                                                       |
+| AWS SQS       | All                                                                                 | No additional documented version limits.                                                       |
+| SQL++         | All                                                                                 | No additional documented version limits.                                                       |
+| GenAI         | OpenAI, Anthropic, Gemini, AWS Bedrock, Qwen, MCP, embedding APIs, and rerank APIs | Provider-specific payload extraction requires the matching `ebpf.payload_extraction.http` flag. |
 
 Some application-level instrumentation also depends on specific runtime,
 library, or server versions:
@@ -115,7 +118,7 @@ metrics:
 
 | YAML<br>environment variable               | Description                                                                                                                                                                                                                                                       | Type            | Default           |
 | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ----------------- |
-| `features`<br>`OTEL_EBPF_METRICS_FEATURES` | The list of metric groups OBI exports data for, refer to [metrics export features](#metrics-export-features). Accepted values `all`, `*`, `application`, `application_span`, `application_host`, `application_service_graph`, `network` and `network_inter_zone`. | list of strings | `["application"]` |
+| `features`<br>`OTEL_EBPF_METRICS_FEATURES` | The list of metric groups OBI exports data for, refer to [metrics export features](#metrics-export-features). Accepted values `all`, `*`, `application`, `application_span`, `application_span_otel`, `application_span_sizes`, `application_host`, `application_service_graph`, `network`, `network_inter_zone`, `stats`, `stats_tcp_rtt`, `stats_tcp_failed_connections`, and `ebpf`. | list of strings | `["application"]` |
 
 ### Metrics export features
 
@@ -140,6 +143,12 @@ processes matching entries in the [metrics discovery](./) configuration.
   [network metrics](../../network) configuration documentation to learn more.
 - `network_inter_zone`: Network inter-zone metrics, refer to the
   [network metrics](../../network/) configuration documentation to learn more.
+- `stats`: All TCP statistical metrics.
+- `stats_tcp_rtt`: TCP round-trip time histogram metrics.
+- `stats_tcp_failed_connections`: TCP failed connection counter metrics,
+  labeled by failure reason.
+- `ebpf`: eBPF runtime metrics for loaded probes and maps, exposed through the
+  Prometheus exporter and internal metrics reporter.
 
 ### Per-application metrics export features
 
@@ -242,9 +251,12 @@ The list of instrumentation areas OBI can collect data from:
 - `redis`: Redis client/server database metrics
 - `kafka`: Kafka client/server message queue metrics
 - `mqtt`: MQTT publish/subscribe message metrics (MQTT 3.1.1 and 5.0)
+- `nats`: NATS publish/subscribe message metrics
+- `amqp`: AMQP 1.0 publish/process message metrics
 - `couchbase`: Couchbase N1QL/SQL++ query metrics and KV (Key-Value) protocol
   metrics based on memcached protocol
-- `genai`: GenAI client metrics (OpenAI, Anthropic, Gemini, and AWS Bedrock)
+- `genai`: GenAI client metrics (OpenAI, Anthropic, Gemini, AWS Bedrock,
+  Qwen, MCP, and supported embedding and rerank APIs)
 - `gpu`: GPU performance metrics
 - `mongo`: MongoDB client call metrics
 - `dns`: DNS query metrics
@@ -302,9 +314,12 @@ The list of instrumentation areas OBI can collect data from:
 - `redis`: Redis client/server database traces
 - `kafka`: Kafka client/server message queue traces
 - `mqtt`: MQTT publish/subscribe message traces (MQTT 3.1.1 and 5.0)
+- `nats`: NATS publish/subscribe message traces
+- `amqp`: AMQP 1.0 publish/process message traces
 - `couchbase`: Couchbase N1QL/SQL++ query traces and KV (Key-Value) protocol
   traces, with query text and operation details
-- `genai`: GenAI client traces (OpenAI, Anthropic, Gemini, and AWS Bedrock)
+- `genai`: GenAI client traces (OpenAI, Anthropic, Gemini, AWS Bedrock,
+  Qwen, MCP, and supported embedding and rerank APIs)
 - `gpu`: GPU performance traces
 - `mongo`: MongoDB client call traces
 - `dns`: DNS query traces
@@ -557,8 +572,11 @@ The list of instrumentation areas OBI can collection data from:
 - `redis`: Redis client/server database metrics
 - `kafka`: Kafka client/server message queue metrics
 - `mqtt`: MQTT publish/subscribe message metrics
+- `nats`: NATS publish/subscribe message metrics
+- `amqp`: AMQP 1.0 publish/process message metrics
 - `couchbase`: Couchbase N1QL/SQL++ query metrics and KV protocol metrics
-- `genai`: GenAI client metrics (OpenAI, Anthropic, Gemini, and AWS Bedrock)
+- `genai`: GenAI client metrics (OpenAI, Anthropic, Gemini, AWS Bedrock,
+  Qwen, MCP, and supported embedding and rerank APIs)
 
 For example, setting the `instrumentations` option to: `http,grpc` enables the
 collection of `HTTP/HTTPS/HTTP2` and `gRPC` application metrics, and disables

--- a/content/en/docs/zero-code/obi/configure/export-data.md
+++ b/content/en/docs/zero-code/obi/configure/export-data.md
@@ -16,28 +16,28 @@ OBI can export OpenTelemetry metrics and traces to a OTLP endpoint.
 OBI supports the following protocol and feature versions for traces and metrics
 instrumentation:
 
-| Area          | Supported versions                                                                  | Notes                                                                                          |
-| :------------ | :---------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------- |
-| HTTP          | `1.0/1.1`                                                                           | Context propagation is supported.                                                              |
-| HTTP          | `2.0`                                                                               | Context propagation requires Go library-level instrumentation.                                 |
-| gRPC          | `1.0+`                                                                              | Long-lived connections started before OBI might use `*` for method names.                      |
-| MySQL         | All                                                                                 | Prepared statements created before OBI starts might not include query text.                    |
-| PostgreSQL    | All                                                                                 | Prepared statements created before OBI starts might not include query text.                    |
-| MSSQL         | All                                                                                 | Prepared statements created before OBI starts might not include query text.                    |
-| Redis         | All                                                                                 | Existing connections might not include database number or `db.namespace`.                      |
-| MongoDB       | `5.0+`                                                                              | Compressed payloads are not supported.                                                         |
-| Couchbase     | All                                                                                 | Bucket or collection names might be unavailable when negotiation completed before OBI started. |
-| Memcached     | All                                                                                 | Supports the ASCII text protocol subset, excluding `quit` and meta commands.                   |
-| Kafka         | All                                                                                 | Topic name lookup might fail for fetch API versions `13+`.                                     |
-| MQTT          | `3.1.1/5.0`                                                                         | Payloads are not captured.                                                                     |
-| NATS          | All                                                                                 | No additional documented version limits.                                                       |
-| AMQP          | `1.0`                                                                               | Only transfer performatives create spans.                                                      |
-| GraphQL       | All                                                                                 | No additional documented version limits.                                                       |
-| Elasticsearch | `7.14+`                                                                             | No additional documented version limits.                                                       |
-| OpenSearch    | `3.0.0+`                                                                            | No additional documented version limits.                                                       |
-| AWS S3        | All                                                                                 | No additional documented version limits.                                                       |
-| AWS SQS       | All                                                                                 | No additional documented version limits.                                                       |
-| SQL++         | All                                                                                 | No additional documented version limits.                                                       |
+| Area          | Supported versions                                                                 | Notes                                                                                           |
+| :------------ | :--------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------- |
+| HTTP          | `1.0/1.1`                                                                          | Context propagation is supported.                                                               |
+| HTTP          | `2.0`                                                                              | Context propagation requires Go library-level instrumentation.                                  |
+| gRPC          | `1.0+`                                                                             | Long-lived connections started before OBI might use `*` for method names.                       |
+| MySQL         | All                                                                                | Prepared statements created before OBI starts might not include query text.                     |
+| PostgreSQL    | All                                                                                | Prepared statements created before OBI starts might not include query text.                     |
+| MSSQL         | All                                                                                | Prepared statements created before OBI starts might not include query text.                     |
+| Redis         | All                                                                                | Existing connections might not include database number or `db.namespace`.                       |
+| MongoDB       | `5.0+`                                                                             | Compressed payloads are not supported.                                                          |
+| Couchbase     | All                                                                                | Bucket or collection names might be unavailable when negotiation completed before OBI started.  |
+| Memcached     | All                                                                                | Supports the ASCII text protocol subset, excluding `quit` and meta commands.                    |
+| Kafka         | All                                                                                | Topic name lookup might fail for fetch API versions `13+`.                                      |
+| MQTT          | `3.1.1/5.0`                                                                        | Payloads are not captured.                                                                      |
+| NATS          | All                                                                                | No additional documented version limits.                                                        |
+| AMQP          | `1.0`                                                                              | Only transfer performatives create spans.                                                       |
+| GraphQL       | All                                                                                | No additional documented version limits.                                                        |
+| Elasticsearch | `7.14+`                                                                            | No additional documented version limits.                                                        |
+| OpenSearch    | `3.0.0+`                                                                           | No additional documented version limits.                                                        |
+| AWS S3        | All                                                                                | No additional documented version limits.                                                        |
+| AWS SQS       | All                                                                                | No additional documented version limits.                                                        |
+| SQL++         | All                                                                                | No additional documented version limits.                                                        |
 | GenAI         | OpenAI, Anthropic, Gemini, AWS Bedrock, Qwen, MCP, embedding APIs, and rerank APIs | Provider-specific payload extraction requires the matching `ebpf.payload_extraction.http` flag. |
 
 Some application-level instrumentation also depends on specific runtime,
@@ -116,8 +116,8 @@ metrics:
   features: ['network', 'network_inter_zone']
 ```
 
-| YAML<br>environment variable               | Description                                                                                                                                                                                                                                                       | Type            | Default           |
-| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ----------------- |
+| YAML<br>environment variable               | Description                                                                                                                                                                                                                                                                                                                                                                             | Type            | Default           |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ----------------- |
 | `features`<br>`OTEL_EBPF_METRICS_FEATURES` | The list of metric groups OBI exports data for, refer to [metrics export features](#metrics-export-features). Accepted values `all`, `*`, `application`, `application_span`, `application_span_otel`, `application_span_sizes`, `application_host`, `application_service_graph`, `network`, `network_inter_zone`, `stats`, `stats_tcp_rtt`, `stats_tcp_failed_connections`, and `ebpf`. | list of strings | `["application"]` |
 
 ### Metrics export features
@@ -145,8 +145,8 @@ processes matching entries in the [metrics discovery](./) configuration.
   [network metrics](../../network/) configuration documentation to learn more.
 - `stats`: All TCP statistical metrics.
 - `stats_tcp_rtt`: TCP round-trip time histogram metrics.
-- `stats_tcp_failed_connections`: TCP failed connection counter metrics,
-  labeled by failure reason.
+- `stats_tcp_failed_connections`: TCP failed connection counter metrics, labeled
+  by failure reason.
 - `ebpf`: eBPF runtime metrics for loaded probes and maps, exposed through the
   Prometheus exporter and internal metrics reporter.
 
@@ -255,8 +255,8 @@ The list of instrumentation areas OBI can collect data from:
 - `amqp`: AMQP 1.0 publish/process message metrics
 - `couchbase`: Couchbase N1QL/SQL++ query metrics and KV (Key-Value) protocol
   metrics based on memcached protocol
-- `genai`: GenAI client metrics (OpenAI, Anthropic, Gemini, AWS Bedrock,
-  Qwen, MCP, and supported embedding and rerank APIs)
+- `genai`: GenAI client metrics (OpenAI, Anthropic, Gemini, AWS Bedrock, Qwen,
+  MCP, and supported embedding and rerank APIs)
 - `gpu`: GPU performance metrics
 - `mongo`: MongoDB client call metrics
 - `dns`: DNS query metrics
@@ -318,8 +318,8 @@ The list of instrumentation areas OBI can collect data from:
 - `amqp`: AMQP 1.0 publish/process message traces
 - `couchbase`: Couchbase N1QL/SQL++ query traces and KV (Key-Value) protocol
   traces, with query text and operation details
-- `genai`: GenAI client traces (OpenAI, Anthropic, Gemini, AWS Bedrock,
-  Qwen, MCP, and supported embedding and rerank APIs)
+- `genai`: GenAI client traces (OpenAI, Anthropic, Gemini, AWS Bedrock, Qwen,
+  MCP, and supported embedding and rerank APIs)
 - `gpu`: GPU performance traces
 - `mongo`: MongoDB client call traces
 - `dns`: DNS query traces
@@ -575,8 +575,8 @@ The list of instrumentation areas OBI can collection data from:
 - `nats`: NATS publish/subscribe message metrics
 - `amqp`: AMQP 1.0 publish/process message metrics
 - `couchbase`: Couchbase N1QL/SQL++ query metrics and KV protocol metrics
-- `genai`: GenAI client metrics (OpenAI, Anthropic, Gemini, AWS Bedrock,
-  Qwen, MCP, and supported embedding and rerank APIs)
+- `genai`: GenAI client metrics (OpenAI, Anthropic, Gemini, AWS Bedrock, Qwen,
+  MCP, and supported embedding and rerank APIs)
 
 For example, setting the `instrumentations` option to: `http,grpc` enables the
 collection of `HTTP/HTTPS/HTTP2` and `gRPC` application metrics, and disables

--- a/content/en/docs/zero-code/obi/configure/export-data.md
+++ b/content/en/docs/zero-code/obi/configure/export-data.md
@@ -6,7 +6,7 @@ description:
   and OpenTelemetry traces
 weight: 10
 # prettier-ignore
-cSpell:ignore: AsterixDB couchbase genai gonic jackc libcudart memcached pgxpool pyserver segmentio spanmetrics
+cSpell:ignore: AsterixDB couchbase genai gonic jackc libcudart memcached nats pgxpool pyserver Qwen rerank segmentio spanmetrics
 ---
 
 OBI can export OpenTelemetry metrics and traces to a OTLP endpoint.

--- a/content/en/docs/zero-code/obi/configure/metrics-traces-attributes.md
+++ b/content/en/docs/zero-code/obi/configure/metrics-traces-attributes.md
@@ -156,7 +156,7 @@ use a database technology not directly supported by OBI, you can enable this
 option to get database client telemetry. This option is not enabled by default,
 because it can create false positives, for example, if an application sends SQL
 text for logging through a TCP connection. Currently, OBI natively supports the
-PostgreSQL and MySQL binary protocols.
+PostgreSQL, MySQL, and MSSQL binary protocols.
 
 ### HTTP header and body enrichment for spans {#http-header-enrichment-for-spans}
 

--- a/content/en/docs/zero-code/obi/metrics.md
+++ b/content/en/docs/zero-code/obi/metrics.md
@@ -21,13 +21,14 @@ Prometheus format.
 | Application | `rpc.server.duration`              | `rpc_server_duration_seconds`              | Histogram | seconds | Duration of RPC service calls from the server side                                                                    |
 | Application | `sql.client.duration`              | `sql_client_duration_seconds`              | Histogram | seconds | Duration of SQL client operations (Experimental)                                                                      |
 | Application | `redis.client.duration`            | `redis_client_duration_seconds`            | Histogram | seconds | Duration of Redis client operations (Experimental)                                                                    |
-| Application | `messaging.publish.duration`       | `messaging_publish_duration`               | Histogram | seconds | Duration of Messaging (Kafka) publish operations (Experimental)                                                       |
-| Application | `messaging.process.duration`       | `messaging_process_duration`               | Histogram | seconds | Duration of Messaging (Kafka) process operations (Experimental)                                                       |
+| Application | `messaging.publish.duration`       | `messaging_publish_duration`               | Histogram | seconds | Duration of messaging publish operations across supported systems such as Kafka, MQTT, NATS, and AMQP (Experimental) |
+| Application | `messaging.process.duration`       | `messaging_process_duration`               | Histogram | seconds | Duration of messaging process operations across supported systems such as Kafka, MQTT, NATS, and AMQP (Experimental) |
 | Application | `gen_ai.client.operation.duration` | `gen_ai_client_operation_duration_seconds` | Histogram | seconds | Duration of GenAI client operations (Experimental)                                                                    |
 | Application | `gen_ai.client.token.usage`        | `gen_ai_client_token_usage`                | Histogram | 1       | Number of GenAI input/output tokens consumed, labeled by token type (Experimental)                                    |
 | Network     | `obi.network.flow.bytes`           | `obi_network_flow_bytes_total`             | Counter   | bytes   | Bytes submitted from a source network endpoint to a destination network endpoint                                      |
 | Network     | `obi.network.inter.zone.bytes`     | `obi_network_inter_zone_bytes_total`       | Counter   | bytes   | Bytes flowing between cloud availability zones in your cluster (Experimental, currently only available in Kubernetes) |
 | Network     | `obi.stat.tcp.rtt`                 | `obi_stat_tcp_rtt_seconds`                 | Histogram | seconds | TCP round-trip time (RTT) latency observed between network endpoints (StatsO11y)                                      |
+| Network     | `obi.stat.tcp.failed.connections`  | `obi_stat_tcp_failed_connections_total`    | Counter   | 1       | Failed TCP connection attempts between endpoints, labeled by failure reason (StatsO11y)                               |
 
 OBI can also export
 [Span metrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector)
@@ -128,6 +129,25 @@ check the `attributes`->`select` section in the
 | `obi.network.flow.bytes`       | `src.asn`                    | shown if the `geoip` configuration section exists |
 | `obi.network.flow.bytes`       | `dst.country`                | shown if the `geoip` configuration section exists |
 | `obi.network.flow.bytes`       | `dst.asn`                    | shown if the `geoip` configuration section exists |
+| `obi.stat.tcp.rtt`             | `obi.ip`                     | hidden                                            |
+| `obi.stat.tcp.rtt`             | `src.address`                | hidden                                            |
+| `obi.stat.tcp.rtt`             | `dst.address`                | hidden                                            |
+| `obi.stat.tcp.rtt`             | `src.port`                   | hidden                                            |
+| `obi.stat.tcp.rtt`             | `dst.port`                   | hidden                                            |
+| `obi.stat.tcp.rtt`             | `src.name`                   | hidden                                            |
+| `obi.stat.tcp.rtt`             | `dst.name`                   | hidden                                            |
+| `obi.stat.tcp.rtt`             | `src.zone`                   | hidden                                            |
+| `obi.stat.tcp.rtt`             | `dst.zone`                   | hidden                                            |
+| `obi.stat.tcp.failed.connections` | `obi.ip`                  | hidden                                            |
+| `obi.stat.tcp.failed.connections` | `src.address`             | hidden                                            |
+| `obi.stat.tcp.failed.connections` | `dst.address`             | hidden                                            |
+| `obi.stat.tcp.failed.connections` | `src.port`                | hidden                                            |
+| `obi.stat.tcp.failed.connections` | `dst.port`                | hidden                                            |
+| `obi.stat.tcp.failed.connections` | `src.name`                | hidden                                            |
+| `obi.stat.tcp.failed.connections` | `dst.name`                | hidden                                            |
+| `obi.stat.tcp.failed.connections` | `src.zone`                | hidden                                            |
+| `obi.stat.tcp.failed.connections` | `dst.zone`                | hidden                                            |
+| `obi.stat.tcp.failed.connections` | `reason`                  | hidden                                            |
 | Traces (SQL, Redis)            | `db.query.text`              | hidden                                            |
 
 > [!NOTE]

--- a/content/en/docs/zero-code/obi/metrics.md
+++ b/content/en/docs/zero-code/obi/metrics.md
@@ -21,8 +21,8 @@ Prometheus format.
 | Application | `rpc.server.duration`              | `rpc_server_duration_seconds`              | Histogram | seconds | Duration of RPC service calls from the server side                                                                    |
 | Application | `sql.client.duration`              | `sql_client_duration_seconds`              | Histogram | seconds | Duration of SQL client operations (Experimental)                                                                      |
 | Application | `redis.client.duration`            | `redis_client_duration_seconds`            | Histogram | seconds | Duration of Redis client operations (Experimental)                                                                    |
-| Application | `messaging.publish.duration`       | `messaging_publish_duration`               | Histogram | seconds | Duration of messaging publish operations across supported systems such as Kafka, MQTT, NATS, and AMQP (Experimental) |
-| Application | `messaging.process.duration`       | `messaging_process_duration`               | Histogram | seconds | Duration of messaging process operations across supported systems such as Kafka, MQTT, NATS, and AMQP (Experimental) |
+| Application | `messaging.publish.duration`       | `messaging_publish_duration`               | Histogram | seconds | Duration of messaging publish operations across supported systems such as Kafka, MQTT, NATS, and AMQP (Experimental)  |
+| Application | `messaging.process.duration`       | `messaging_process_duration`               | Histogram | seconds | Duration of messaging process operations across supported systems such as Kafka, MQTT, NATS, and AMQP (Experimental)  |
 | Application | `gen_ai.client.operation.duration` | `gen_ai_client_operation_duration_seconds` | Histogram | seconds | Duration of GenAI client operations (Experimental)                                                                    |
 | Application | `gen_ai.client.token.usage`        | `gen_ai_client_token_usage`                | Histogram | 1       | Number of GenAI input/output tokens consumed, labeled by token type (Experimental)                                    |
 | Network     | `obi.network.flow.bytes`           | `obi_network_flow_bytes_total`             | Counter   | bytes   | Bytes submitted from a source network endpoint to a destination network endpoint                                      |
@@ -47,108 +47,108 @@ In order to configure which attributes to show or which attributes to hide,
 check the `attributes`->`select` section in the
 [configuration documentation](../configure/options/).
 
-| Metrics                        | Name                         | Default                                           |
-| ------------------------------ | ---------------------------- | ------------------------------------------------- |
-| Application (all)              | `http.request.method`        | shown                                             |
-| Application (all)              | `http.response.status_code`  | shown                                             |
-| Application (all)              | `http.route`                 | shown if `routes` configuration section exists    |
-| Application (all)              | `k8s.daemonset.name`         | shown if Kubernetes metadata is enabled           |
-| Application (all)              | `k8s.deployment.name`        | shown if Kubernetes metadata is enabled           |
-| Application (all)              | `k8s.namespace.name`         | shown if Kubernetes metadata is enabled           |
-| Application (all)              | `k8s.node.name`              | shown if Kubernetes metadata is enabled           |
-| Application (all)              | `k8s.owner.name`             | shown if Kubernetes metadata is enabled           |
-| Application (all)              | `k8s.pod.name`               | shown if Kubernetes metadata is enabled           |
-| Application (all)              | `k8s.container.name`         | shown if Kubernetes metadata is enabled           |
-| Application (all)              | `k8s.pod.start_time`         | shown if Kubernetes metadata is enabled           |
-| Application (all)              | `k8s.pod.uid`                | shown if Kubernetes metadata is enabled           |
-| Application (all)              | `k8s.replicaset.name`        | shown if Kubernetes metadata is enabled           |
-| Application (all)              | `k8s.statefulset.name`       | shown if Kubernetes metadata is enabled           |
-| Application (all)              | `k8s.cluster.name`           | shown if Kubernetes metadata is enabled           |
-| Application (all)              | `container.id`               | shown if Docker metadata is enabled               |
-| Application (all)              | `container.name`             | shown if Docker metadata is enabled               |
-| Application (all)              | `cloud.provider`             | shown if cloud metadata is enabled                |
-| Application (all)              | `cloud.platform`             | shown if cloud metadata is enabled                |
-| Application (all)              | `cloud.region`               | shown if cloud metadata is enabled                |
-| Application (all)              | `cloud.account.id`           | shown if cloud metadata is enabled                |
-| Application (all)              | `cloud.availability_zone`    | shown if cloud metadata is enabled                |
-| Application (all)              | `cloud.resource_id`          | shown if cloud metadata is enabled (Azure only)   |
-| Application (all)              | `host.id`                    | shown if cloud metadata is enabled                |
-| Application (all)              | `host.type`                  | shown if cloud metadata is enabled                |
-| Application (all)              | `host.image.id`              | shown if cloud metadata is enabled (AWS only)     |
-| Application (all)              | `gcp.gce.instance.name`      | shown if cloud metadata is enabled (GCP only)     |
-| Application (all)              | `gcp.gce.instance.hostname`  | shown if cloud metadata is enabled (GCP only)     |
-| Application (all)              | `service.name`               | shown                                             |
-| Application (all)              | `service.namespace`          | shown                                             |
-| Application (all)              | `target.instance`            | shown                                             |
-| Application (all)              | `url.path`                   | hidden                                            |
-| Application (client)           | `server.address`             | hidden                                            |
-| Application (client)           | `server.port`                | hidden                                            |
-| Application `rpc.*`            | `rpc.grpc.status_code`       | shown                                             |
-| Application `rpc.*`            | `rpc.method`                 | shown                                             |
-| Application `rpc.*`            | `rpc.system`                 | shown                                             |
-| Application (server)           | `client.address`             | hidden                                            |
-| `obi.network.flow.bytes`       | `obi.ip`                     | hidden                                            |
-| `db.client.operation.duration` | `db.operation.name`          | shown                                             |
-| `db.client.operation.duration` | `db.collection.name`         | hidden                                            |
-| `messaging.publish.duration`   | `messaging.system`           | shown                                             |
-| `messaging.publish.duration`   | `messaging.destination.name` | shown                                             |
-| `messaging.process.duration`   | `messaging.system`           | shown                                             |
-| `messaging.process.duration`   | `messaging.destination.name` | shown                                             |
-| `obi.network.flow.bytes`       | `client.port`                | hidden                                            |
-| `obi.network.flow.bytes`       | `direction`                  | hidden                                            |
-| `obi.network.flow.bytes`       | `dst.address`                | hidden                                            |
-| `obi.network.flow.bytes`       | `dst.cidr`                   | shown if the `cidrs` configuration section exists |
-| `obi.network.flow.bytes`       | `dst.name`                   | hidden                                            |
-| `obi.network.flow.bytes`       | `dst.port`                   | hidden                                            |
-| `obi.network.flow.bytes`       | `dst.zone` (only Kubernetes) | hidden                                            |
-| `obi.network.flow.bytes`       | `iface`                      | hidden                                            |
-| `obi.network.flow.bytes`       | `k8s.cluster.name`           | shown if Kubernetes is enabled                    |
-| `obi.network.flow.bytes`       | `k8s.dst.name`               | hidden                                            |
-| `obi.network.flow.bytes`       | `k8s.dst.namespace`          | shown if Kubernetes is enabled                    |
-| `obi.network.flow.bytes`       | `k8s.dst.node.ip`            | hidden                                            |
-| `obi.network.flow.bytes`       | `k8s.dst.node.name`          | hidden                                            |
-| `obi.network.flow.bytes`       | `k8s.dst.owner.type`         | hidden                                            |
-| `obi.network.flow.bytes`       | `k8s.dst.type`               | hidden                                            |
-| `obi.network.flow.bytes`       | `k8s.dst.owner.name`         | shown if Kubernetes is enabled                    |
-| `obi.network.flow.bytes`       | `k8s.src.name`               | hidden                                            |
-| `obi.network.flow.bytes`       | `k8s.src.namespace`          | shown if Kubernetes is enabled                    |
-| `obi.network.flow.bytes`       | `k8s.src.node.ip`            | hidden                                            |
-| `obi.network.flow.bytes`       | `k8s.src.owner.name`         | shown if Kubernetes is enabled                    |
-| `obi.network.flow.bytes`       | `k8s.src.owner.type`         | hidden                                            |
-| `obi.network.flow.bytes`       | `k8s.src.type`               | hidden                                            |
-| `obi.network.flow.bytes`       | `server.port`                | hidden                                            |
-| `obi.network.flow.bytes`       | `src.address`                | hidden                                            |
-| `obi.network.flow.bytes`       | `src.cidr`                   | shown if the `cidrs` configuration section exists |
-| `obi.network.flow.bytes`       | `src.name`                   | hidden                                            |
-| `obi.network.flow.bytes`       | `src.port`                   | hidden                                            |
-| `obi.network.flow.bytes`       | `src.zone` (only Kubernetes) | hidden                                            |
-| `obi.network.flow.bytes`       | `transport`                  | hidden                                            |
-| `obi.network.flow.bytes`       | `network.type`               | hidden                                            |
-| `obi.network.flow.bytes`       | `network.protocol.name`      | hidden                                            |
-| `obi.network.flow.bytes`       | `src.country`                | shown if the `geoip` configuration section exists |
-| `obi.network.flow.bytes`       | `src.asn`                    | shown if the `geoip` configuration section exists |
-| `obi.network.flow.bytes`       | `dst.country`                | shown if the `geoip` configuration section exists |
-| `obi.network.flow.bytes`       | `dst.asn`                    | shown if the `geoip` configuration section exists |
-| `obi.stat.tcp.rtt`             | `obi.ip`                     | hidden                                            |
-| `obi.stat.tcp.rtt`             | `src.address`                | hidden                                            |
-| `obi.stat.tcp.rtt`             | `dst.address`                | hidden                                            |
-| `obi.stat.tcp.rtt`             | `src.port`                   | hidden                                            |
-| `obi.stat.tcp.rtt`             | `dst.port`                   | hidden                                            |
-| `obi.stat.tcp.rtt`             | `src.name`                   | hidden                                            |
-| `obi.stat.tcp.rtt`             | `dst.name`                   | hidden                                            |
-| `obi.stat.tcp.rtt`             | `src.zone`                   | hidden                                            |
-| `obi.stat.tcp.rtt`             | `dst.zone`                   | hidden                                            |
-| `obi.stat.tcp.failed.connections` | `obi.ip`                  | hidden                                            |
-| `obi.stat.tcp.failed.connections` | `src.address`             | hidden                                            |
-| `obi.stat.tcp.failed.connections` | `dst.address`             | hidden                                            |
-| `obi.stat.tcp.failed.connections` | `src.port`                | hidden                                            |
-| `obi.stat.tcp.failed.connections` | `dst.port`                | hidden                                            |
-| `obi.stat.tcp.failed.connections` | `src.name`                | hidden                                            |
-| `obi.stat.tcp.failed.connections` | `dst.name`                | hidden                                            |
-| `obi.stat.tcp.failed.connections` | `src.zone`                | hidden                                            |
-| `obi.stat.tcp.failed.connections` | `dst.zone`                | hidden                                            |
-| `obi.stat.tcp.failed.connections` | `reason`                  | hidden                                            |
-| Traces (SQL, Redis)            | `db.query.text`              | hidden                                            |
+| Metrics                           | Name                         | Default                                           |
+| --------------------------------- | ---------------------------- | ------------------------------------------------- |
+| Application (all)                 | `http.request.method`        | shown                                             |
+| Application (all)                 | `http.response.status_code`  | shown                                             |
+| Application (all)                 | `http.route`                 | shown if `routes` configuration section exists    |
+| Application (all)                 | `k8s.daemonset.name`         | shown if Kubernetes metadata is enabled           |
+| Application (all)                 | `k8s.deployment.name`        | shown if Kubernetes metadata is enabled           |
+| Application (all)                 | `k8s.namespace.name`         | shown if Kubernetes metadata is enabled           |
+| Application (all)                 | `k8s.node.name`              | shown if Kubernetes metadata is enabled           |
+| Application (all)                 | `k8s.owner.name`             | shown if Kubernetes metadata is enabled           |
+| Application (all)                 | `k8s.pod.name`               | shown if Kubernetes metadata is enabled           |
+| Application (all)                 | `k8s.container.name`         | shown if Kubernetes metadata is enabled           |
+| Application (all)                 | `k8s.pod.start_time`         | shown if Kubernetes metadata is enabled           |
+| Application (all)                 | `k8s.pod.uid`                | shown if Kubernetes metadata is enabled           |
+| Application (all)                 | `k8s.replicaset.name`        | shown if Kubernetes metadata is enabled           |
+| Application (all)                 | `k8s.statefulset.name`       | shown if Kubernetes metadata is enabled           |
+| Application (all)                 | `k8s.cluster.name`           | shown if Kubernetes metadata is enabled           |
+| Application (all)                 | `container.id`               | shown if Docker metadata is enabled               |
+| Application (all)                 | `container.name`             | shown if Docker metadata is enabled               |
+| Application (all)                 | `cloud.provider`             | shown if cloud metadata is enabled                |
+| Application (all)                 | `cloud.platform`             | shown if cloud metadata is enabled                |
+| Application (all)                 | `cloud.region`               | shown if cloud metadata is enabled                |
+| Application (all)                 | `cloud.account.id`           | shown if cloud metadata is enabled                |
+| Application (all)                 | `cloud.availability_zone`    | shown if cloud metadata is enabled                |
+| Application (all)                 | `cloud.resource_id`          | shown if cloud metadata is enabled (Azure only)   |
+| Application (all)                 | `host.id`                    | shown if cloud metadata is enabled                |
+| Application (all)                 | `host.type`                  | shown if cloud metadata is enabled                |
+| Application (all)                 | `host.image.id`              | shown if cloud metadata is enabled (AWS only)     |
+| Application (all)                 | `gcp.gce.instance.name`      | shown if cloud metadata is enabled (GCP only)     |
+| Application (all)                 | `gcp.gce.instance.hostname`  | shown if cloud metadata is enabled (GCP only)     |
+| Application (all)                 | `service.name`               | shown                                             |
+| Application (all)                 | `service.namespace`          | shown                                             |
+| Application (all)                 | `target.instance`            | shown                                             |
+| Application (all)                 | `url.path`                   | hidden                                            |
+| Application (client)              | `server.address`             | hidden                                            |
+| Application (client)              | `server.port`                | hidden                                            |
+| Application `rpc.*`               | `rpc.grpc.status_code`       | shown                                             |
+| Application `rpc.*`               | `rpc.method`                 | shown                                             |
+| Application `rpc.*`               | `rpc.system`                 | shown                                             |
+| Application (server)              | `client.address`             | hidden                                            |
+| `obi.network.flow.bytes`          | `obi.ip`                     | hidden                                            |
+| `db.client.operation.duration`    | `db.operation.name`          | shown                                             |
+| `db.client.operation.duration`    | `db.collection.name`         | hidden                                            |
+| `messaging.publish.duration`      | `messaging.system`           | shown                                             |
+| `messaging.publish.duration`      | `messaging.destination.name` | shown                                             |
+| `messaging.process.duration`      | `messaging.system`           | shown                                             |
+| `messaging.process.duration`      | `messaging.destination.name` | shown                                             |
+| `obi.network.flow.bytes`          | `client.port`                | hidden                                            |
+| `obi.network.flow.bytes`          | `direction`                  | hidden                                            |
+| `obi.network.flow.bytes`          | `dst.address`                | hidden                                            |
+| `obi.network.flow.bytes`          | `dst.cidr`                   | shown if the `cidrs` configuration section exists |
+| `obi.network.flow.bytes`          | `dst.name`                   | hidden                                            |
+| `obi.network.flow.bytes`          | `dst.port`                   | hidden                                            |
+| `obi.network.flow.bytes`          | `dst.zone` (only Kubernetes) | hidden                                            |
+| `obi.network.flow.bytes`          | `iface`                      | hidden                                            |
+| `obi.network.flow.bytes`          | `k8s.cluster.name`           | shown if Kubernetes is enabled                    |
+| `obi.network.flow.bytes`          | `k8s.dst.name`               | hidden                                            |
+| `obi.network.flow.bytes`          | `k8s.dst.namespace`          | shown if Kubernetes is enabled                    |
+| `obi.network.flow.bytes`          | `k8s.dst.node.ip`            | hidden                                            |
+| `obi.network.flow.bytes`          | `k8s.dst.node.name`          | hidden                                            |
+| `obi.network.flow.bytes`          | `k8s.dst.owner.type`         | hidden                                            |
+| `obi.network.flow.bytes`          | `k8s.dst.type`               | hidden                                            |
+| `obi.network.flow.bytes`          | `k8s.dst.owner.name`         | shown if Kubernetes is enabled                    |
+| `obi.network.flow.bytes`          | `k8s.src.name`               | hidden                                            |
+| `obi.network.flow.bytes`          | `k8s.src.namespace`          | shown if Kubernetes is enabled                    |
+| `obi.network.flow.bytes`          | `k8s.src.node.ip`            | hidden                                            |
+| `obi.network.flow.bytes`          | `k8s.src.owner.name`         | shown if Kubernetes is enabled                    |
+| `obi.network.flow.bytes`          | `k8s.src.owner.type`         | hidden                                            |
+| `obi.network.flow.bytes`          | `k8s.src.type`               | hidden                                            |
+| `obi.network.flow.bytes`          | `server.port`                | hidden                                            |
+| `obi.network.flow.bytes`          | `src.address`                | hidden                                            |
+| `obi.network.flow.bytes`          | `src.cidr`                   | shown if the `cidrs` configuration section exists |
+| `obi.network.flow.bytes`          | `src.name`                   | hidden                                            |
+| `obi.network.flow.bytes`          | `src.port`                   | hidden                                            |
+| `obi.network.flow.bytes`          | `src.zone` (only Kubernetes) | hidden                                            |
+| `obi.network.flow.bytes`          | `transport`                  | hidden                                            |
+| `obi.network.flow.bytes`          | `network.type`               | hidden                                            |
+| `obi.network.flow.bytes`          | `network.protocol.name`      | hidden                                            |
+| `obi.network.flow.bytes`          | `src.country`                | shown if the `geoip` configuration section exists |
+| `obi.network.flow.bytes`          | `src.asn`                    | shown if the `geoip` configuration section exists |
+| `obi.network.flow.bytes`          | `dst.country`                | shown if the `geoip` configuration section exists |
+| `obi.network.flow.bytes`          | `dst.asn`                    | shown if the `geoip` configuration section exists |
+| `obi.stat.tcp.rtt`                | `obi.ip`                     | hidden                                            |
+| `obi.stat.tcp.rtt`                | `src.address`                | hidden                                            |
+| `obi.stat.tcp.rtt`                | `dst.address`                | hidden                                            |
+| `obi.stat.tcp.rtt`                | `src.port`                   | hidden                                            |
+| `obi.stat.tcp.rtt`                | `dst.port`                   | hidden                                            |
+| `obi.stat.tcp.rtt`                | `src.name`                   | hidden                                            |
+| `obi.stat.tcp.rtt`                | `dst.name`                   | hidden                                            |
+| `obi.stat.tcp.rtt`                | `src.zone`                   | hidden                                            |
+| `obi.stat.tcp.rtt`                | `dst.zone`                   | hidden                                            |
+| `obi.stat.tcp.failed.connections` | `obi.ip`                     | hidden                                            |
+| `obi.stat.tcp.failed.connections` | `src.address`                | hidden                                            |
+| `obi.stat.tcp.failed.connections` | `dst.address`                | hidden                                            |
+| `obi.stat.tcp.failed.connections` | `src.port`                   | hidden                                            |
+| `obi.stat.tcp.failed.connections` | `dst.port`                   | hidden                                            |
+| `obi.stat.tcp.failed.connections` | `src.name`                   | hidden                                            |
+| `obi.stat.tcp.failed.connections` | `dst.name`                   | hidden                                            |
+| `obi.stat.tcp.failed.connections` | `src.zone`                   | hidden                                            |
+| `obi.stat.tcp.failed.connections` | `dst.zone`                   | hidden                                            |
+| `obi.stat.tcp.failed.connections` | `reason`                     | hidden                                            |
+| Traces (SQL, Redis)               | `db.query.text`              | hidden                                            |
 
 > [!NOTE]
 >

--- a/content/en/docs/zero-code/obi/setup/docker.md
+++ b/content/en/docs/zero-code/obi/setup/docker.md
@@ -44,7 +44,7 @@ You can verify the signature of the container image using the following
 commands:
 
 ```sh
-export VERSION=v0.8.0
+export VERSION=v0.9.0
 
 # Verify a release image from Docker Hub
 cosign verify --certificate-identity-regexp 'https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' otel/ebpf-instrument:${VERSION}
@@ -80,7 +80,7 @@ don't have one, you can use this
 [simple blog engine service written in Go](https://macias.info):
 
 ```sh
-export VERSION=v0.8.0
+export VERSION=v0.9.0
 docker run -p 18443:8443 --name goblog mariomac/goblog:dev
 ```
 

--- a/content/en/docs/zero-code/obi/setup/standalone.md
+++ b/content/en/docs/zero-code/obi/setup/standalone.md
@@ -38,7 +38,7 @@ Set your desired version and architecture:
 ```sh
 # Set your desired version (find latest at
 # https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases)
-VERSION=0.6.0
+VERSION=0.9.0
 
 # Determine your architecture
 # For Intel/AMD 64-bit: amd64

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -11503,6 +11503,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-04-29T13:17:41.363180144Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases/tag/v0.9.0": {
+    "StatusCode": 206,
+    "LastSeen": "2026-05-11T21:25:33.679333006Z"
+  },
   "https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/tree/2feaeb84ef7aeeb1e57e642b46c96b965ae4b804/internal/test/integration/k8s/manifests?from_branch=main": {
     "StatusCode": 206,
     "LastSeen": "2026-05-06T10:28:27.968959334Z"
@@ -11522,6 +11526,14 @@
   "https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/tree/v0.8.0/examples/nginx": {
     "StatusCode": 206,
     "LastSeen": "2026-04-29T13:17:43.267111366Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/tree/v0.9.0/examples/apache": {
+    "StatusCode": 206,
+    "LastSeen": "2026-05-11T21:25:43.748300573Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/tree/v0.9.0/examples/nginx": {
+    "StatusCode": 206,
+    "LastSeen": "2026-05-11T21:25:38.162147884Z"
   },
   "https://github.com/open-telemetry/opentelemetry-ebpf-profiler": {
     "StatusCode": 206,


### PR DESCRIPTION
## Summary
- update the OBI landing and setup docs for the v0.9.0 release
- align OBI export, compatibility, and metrics docs with the actual v0.9.0 code audited from `go.opentelemetry.io/obi`
- document newly added protocol, database, GenAI, and stats coverage introduced since v0.8.0

## What Changed
- refresh the OBI overview page to replace stale v0.8.0 highlights with v0.9.0 highlights and links
- update Docker and standalone setup examples to use v0.9.0 version examples
- update the instrumentation compatibility tables to include MSSQL, NATS, and AMQP 1.0 support
- update metrics and traces instrumentation docs to include NATS, AMQP, Qwen, MCP, and supported embedding and rerank APIs
- document the `stats`, `stats_tcp_rtt`, `stats_tcp_failed_connections`, and `ebpf` metrics feature groups
- add the new `obi.stat.tcp.failed.connections` metric and its attribute defaults
- correct the heuristic SQL detection docs to reflect PostgreSQL, MySQL, and MSSQL binary protocol support

## Validation
- reviewed the OBI docs diff locally
- ran `git diff --check`
- could not run a repo markdown lint target in this environment because `make lint-markdown` is not defined here and `htmltest` is unavailable

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.