### PR TITLE
docs(obi): document trace attribute selection

### DIFF
--- a/content/en/docs/zero-code/obi/configure/metrics-traces-attributes.md
+++ b/content/en/docs/zero-code/obi/configure/metrics-traces-attributes.md
@@ -79,8 +79,7 @@ take precedence over wildcard matches.
 
 For exported OpenTelemetry traces, use the `traces` key (not a metric name)
 under `attributes.select`. It controls optional trace decoration such as
-`db.query.text`, `url.query`, GenAI payload attributes, and
-`db.response.error`.
+`db.query.text`, `url.query`, GenAI payload attributes, and `db.response.error`.
 
 ```yaml
 attributes:
@@ -96,19 +95,19 @@ attributes:
 `db.response.error` is not part of the OpenTelemetry semantic conventions. OBI
 uses this string only as a configuration flag under `attributes.select.traces`.
 
-| Condition | Behavior |
-| --------- | -------- |
+| Condition              | Behavior                                                                                                                                                                                                                                                               |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Not included (default) | On failed database-related spans (SQL, Redis, MongoDB, Couchbase, Memcached, SQL++ over HTTP), `span.status.message` is left empty. This is consistent with how other optional attributes (for example, `db.query.text`) behave — when not selected, they are omitted. |
-| Included | On those same spans, `span.status.message` is set to the actual error description parsed from the protocol response. |
+| Included               | On those same spans, `span.status.message` is set to the actual error description parsed from the protocol response.                                                                                                                                                   |
 
-`db.response.error` is never attached as a span attribute on OTLP traces.
-During export, OBI uses the gated value only to build `span.status.message` for
+`db.response.error` is never attached as a span attribute on OTLP traces. During
+export, OBI uses the gated value only to build `span.status.message` for
 database spans, then drops the attribute from the exported span. Enabling this
 option changes the status description, not a separate `db.response.error` field
 on the span.
 
-The opt-in exists because error strings may contain sensitive or high-cardinality
-detail (schema names, fragments of queries, or data values).
+The opt-in exists because error strings may contain sensitive or
+high-cardinality detail (schema names, fragments of queries, or data values).
 
 ## Distributed traces and context propagation
 

--- a/content/en/docs/zero-code/obi/configure/metrics-traces-attributes.md
+++ b/content/en/docs/zero-code/obi/configure/metrics-traces-attributes.md
@@ -75,6 +75,41 @@ client metrics and `http_route` for HTTP server metrics.
 When a metric name matches multiple definitions using wildcards, exact matches
 take precedence over wildcard matches.
 
+## Trace selection {#trace-selection}
+
+For exported OpenTelemetry traces, use the `traces` key (not a metric name)
+under `attributes.select`. It controls optional trace decoration such as
+`db.query.text`, `url.query`, GenAI payload attributes, and
+`db.response.error`.
+
+```yaml
+attributes:
+  select:
+    traces:
+      include:
+        - db.query.text
+        - db.response.error
+```
+
+### `db.response.error` {#db-response-error}
+
+`db.response.error` is not part of the OpenTelemetry semantic conventions. OBI
+uses this string only as a configuration flag under `attributes.select.traces`.
+
+| Condition | Behavior |
+| --------- | -------- |
+| Not included (default) | On failed database-related spans (SQL, Redis, MongoDB, Couchbase, Memcached, SQL++ over HTTP), `span.status.message` is left empty. This is consistent with how other optional attributes (for example, `db.query.text`) behave — when not selected, they are omitted. |
+| Included | On those same spans, `span.status.message` is set to the actual error description parsed from the protocol response. |
+
+`db.response.error` is never attached as a span attribute on OTLP traces.
+During export, OBI uses the gated value only to build `span.status.message` for
+database spans, then drops the attribute from the exported span. Enabling this
+option changes the status description, not a separate `db.response.error` field
+on the span.
+
+The opt-in exists because error strings may contain sensitive or high-cardinality
+detail (schema names, fragments of queries, or data values).
+
 ## Distributed traces and context propagation
 
 YAML section: `ebpf`


### PR DESCRIPTION
## Description

Document the `traces` key under `attributes.select` and specifically the `db.response.error` configuration flag for OBI.

This user-facing documentation was originally proposed in [open-telemetry/opentelemetry-ebpf-instrumentation#2086](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2086) but per reviewer feedback, it belongs in the official OBI documentation here rather than in the project's internal devdocs.

## Changes

- Added "Trace selection" section to the metrics-traces-attributes configuration page
- Documented `db.response.error` behavior (default vs enabled)
- Explained that enabling this option affects `span.status.message`, not a separate attribute

## Related

- Fixes: open-telemetry/opentelemetry-ebpf-instrumentation#2076
- Related PR: open-telemetry/opentelemetry-ebpf-instrumentation#2086