### PR TITLE
Add TokenJam to registry

### DIFF
--- a/data/registry/application-integration-tokenjam.yml
+++ b/data/registry/application-integration-tokenjam.yml
@@ -1,0 +1,26 @@
+title: TokenJam
+registryType: application integration
+language: python
+tags:
+  - ai
+  - llm
+  - agents
+  - observability
+  - genai
+license: MIT
+description: |
+  TokenJam is an open-source, local-first, OTel-native observability and
+  token-economics platform for autonomous AI agents and coding agents. It
+  ingests OTLP traces, metrics, and logs into a local DuckDB store, captures
+  costs and token usage across providers, detects behavioral drift, surfaces
+  sensitive-action alerts, and exposes everything through a CLI, a local web
+  UI, and an MCP server. Native support for Claude Code, Codex CLI, and any
+  OTel-emitting agent framework. No signup, no proxy, no cloud dependency.
+authors:
+  - name: Metabuilder Labs
+    url: https://tokenjam.dev
+urls:
+  repo: https://github.com/Metabuilder-Labs/tokenjam
+  website: https://tokenjam.dev
+  docs: https://github.com/Metabuilder-Labs/tokenjam#readme
+createdAt: 2026-05-12

--- a/data/registry/application-integration-tokenjam.yml
+++ b/data/registry/application-integration-tokenjam.yml
@@ -9,7 +9,7 @@ tags:
   - genai
 license: MIT
 description: |
-  TokenJam is an open-source, local-first, OTel-native observability and
+  TokenJam is an open source, local-first, OTel-native observability and
   token-economics platform for autonomous AI agents and coding agents. It
   ingests OTLP traces, metrics, and logs into a local DuckDB store, captures
   costs and token usage across providers, detects behavioral drift, surfaces

--- a/data/registry/application-integration-tokenjam.yml
+++ b/data/registry/application-integration-tokenjam.yml
@@ -1,3 +1,4 @@
+# cSpell:ignore: genai metabuilder
 title: TokenJam
 registryType: application integration
 language: python


### PR DESCRIPTION
Adds TokenJam as an OTel-native local-first agent observability application integration.

<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.
- [x] I-know-my-stuff: Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

This PR adds TokenJam to the OpenTelemetry registry as an application integration.

**Project:** TokenJam — an open-source, local-first, OTel-native observability
and token-economics platform for autonomous AI agents and coding agents.

**Why it belongs in the registry:** TokenJam natively ingests OTLP traces,
metrics, and logs (via the OpenTelemetry GenAI semantic conventions) without
requiring a hosted backend. It has zero-config integrations with Claude Code
and Codex CLI's native OTel exporters, and works as a drop-in OTLP endpoint
for any OTel-emitting agent framework (Pydantic AI, LangChain, CrewAI,
LlamaIndex, OpenAI Agents SDK, Google ADK, AWS Strands, and others).

- Repo: https://github.com/Metabuilder-Labs/tokenjam
- Website: https://tokenjam.dev
- License: MIT / Apache 2.0 (dual)
- Language: Python (with a TypeScript SDK published as @tokenjam/sdk)

I've followed the template at `templates/registry-entry.yml` and the marketing
guidelines (no superlatives, factual description, all three URLs set).