### PR TITLE
chore(deps): drop through2 in favor of node:stream.Transform

### DIFF
--- a/gulp-src/validate-registry.js
+++ b/gulp-src/validate-registry.js
@@ -1,6 +1,6 @@
 const gulp = require('gulp');
+const { Transform } = require('node:stream');
 const { taskArgs } = require('./_util');
-const through2 = require('through2');
 const yaml = require('js-yaml');
 const Ajv = require('ajv');
 const addFormats = require('ajv-formats');
@@ -21,8 +21,12 @@ addFormats(ajv);
 addErrors(ajv);
 const validate = ajv.compile(schema);
 
+function objTransform(fn) {
+  return new Transform({ objectMode: true, transform: fn });
+}
+
 function logFiles(debug) {
-  return through2.obj(function (file, enc, cb) {
+  return objTransform(function (file, enc, cb) {
     if (debug) {
       console.log('Processing file:', file.path);
     }
@@ -165,7 +169,7 @@ function validateRegistry() {
   return gulp
     .src(globs, { followSymlinks: false })
     .pipe(logFiles(argv.debug))
-    .pipe(through2.obj(validateRegistryEntry))
+    .pipe(objTransform(validateRegistryEntry))
     .on('end', () => {
       const fileOrFiles = 'file' + (numFilesProcessed == 1 ? '' : 's');
       const msg = `Processed ${numFilesProcessed} ${fileOrFiles}, ${numFilesWithIssues} had issues.`;

--- a/package.json
+++ b/package.json
@@ -184,7 +184,6 @@
     "textlint-filter-rule-comments": "^1.3.0",
     "textlint-rule-prh": "^6.1.0",
     "textlint-rule-terminology": "^5.2.16",
-    "through2": "^4.0.2",
     "yargs": "^18.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
## Description

Dependabot opened #9879 and #9935 to bump `through2` from 4.0.2 to 5.0.x. This PR replaces `through2` with Node's built-in `node:stream.Transform`. 

Supersedes and closes #9935. 

- Replaces `through2.obj(...)` calls in `gulp-src/validate-registry.js` with a small local `objTransform(fn)` helper that returns `new Transform({ objectMode: true, transform: fn })`
- Removes `through2` from `devDependencies` in `package.json`

## Verification

- `npx gulp validate-registry` runs clean: `Processed N files, 0 had issues.`
- `npx gulp validate-registry --debug` still logs `Processing file: ...` for every entry, exercising the `logFiles` transform.
- `git grep through2` returns no source references after the change.