### PR TITLE
[ja] docs(i18n): sync content/ja/docs/security/_index.md

### DIFF
--- a/content/ja/docs/security/_index.md
+++ b/content/ja/docs/security/_index.md
@@ -3,7 +3,7 @@ title: セキュリティ
 cascade:
   collector_vers: 0.152.0
 weight: 970
-default_lang_commit: 6751402db060c25800bb41c270dcaebb48aa7acb
+default_lang_commit: 62c8cb2f4ea2e121cab3b4880f5cdf8c21aaea13
 ---
 
 このセクションでは、OpenTelemetryプロジェクトがどのように脆弱性を公開し、インシデントに対応しているかを学び、あなたがテレメトリーを安全に収集し、送信するために何ができるかを知ることができます。


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

# Description

This PR syncs `content/ja/docs/security/_index.md` with the current English page.
`collector_vers` was already up to date; this change updates `default_lang_commit` only.

- [Security](https://opentelemetry.io/docs/security/)

[View diffs in the English source](https://github.com/open-telemetry/opentelemetry.io/compare/6751402db060c25800bb41c270dcaebb48aa7acb...62c8cb2f4)

# Preview

- https://deploy-preview-9904--opentelemetry.netlify.app/ja/docs/security/