### PR TITLE
docs(demo): fix formatting in Run in minimal mode section

### DIFF
--- a/content/en/docs/demo/docker-deployment.md
+++ b/content/en/docs/demo/docker-deployment.md
@@ -46,10 +46,10 @@ docker compose up --force-recreate --remove-orphans --detach
 
     {{% /tab %}} {{< /tabpane >}}
 
-### Run in minimal mode
+    ### Run in minimal mode
 
-If you have limited resources, you can start the demo without Kafka and its
-dependent services, reducing memory usage to approximately 3 GB of RAM:
+    If you have limited resources, you can start the demo without Kafka and its
+    dependent services, reducing memory usage to approximately 3 GB of RAM:
 
     {{< tabpane text=true >}} {{% tab Make %}}
 
@@ -65,12 +65,12 @@ docker compose -f docker-compose.minimal.yml up --force-recreate --remove-orphan
 
     {{% /tab %}} {{< /tabpane >}}
 
-The following services are **not** included in minimal mode:
+    The following services are **not** included in minimal mode:
 
-- `accounting`
-- `fraud-detection`
-- `flagd-ui`
-- `kafka`
+    - `accounting`
+    - `fraud-detection`
+    - `flagd-ui`
+    - `kafka`
 
 4.  (Optional) Enable API observability-driven testing[^1]:
 


### PR DESCRIPTION
- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

Fixes #9914

The `### Run in minimal mode` heading was placed between steps 3 and 4 of the numbered list in the Docker deployment guide, breaking the list continuation and surrounding layout.

**Changes:**
- Indent the `### Run in minimal mode` heading 4 spaces to align it with the rest of list item 3, keeping the H3 and its Table of Contents entry intact.
- Reduce the `{{< tabpane >}}` shortcode indentation from 8 spaces to 4 spaces so Hugo's Goldmark renderer processes it as a tab pane instead of a fenced code block.

This brings the formatting in line with the rest of the numbered procedure and prevents the broken list rendering on the published page.