### PR TITLE
Add additional Ruby scans for other component types

### DIFF
--- a/data/registry-schema.json
+++ b/data/registry-schema.json
@@ -24,9 +24,11 @@
         "instrumentation",
         "log-bridge",
         "processor",
+        "propagator",
         "provider",
         "receiver",
         "resource-detector",
+        "sampler",
         "utilities"
       ]
     },

--- a/scripts/registry-scanner/index.mjs
+++ b/scripts/registry-scanner/index.mjs
@@ -100,6 +100,11 @@ const scanners = {
   ruby: () => {
     scanByLanguage('instrumentation', 'ruby');
     scanByLanguage('exporter', 'ruby', 'exporter', 'md', 'opentelemetry-ruby');
+    scanByLanguage('processor', 'ruby');
+    scanByLanguage('utilities', 'ruby', 'propagator');
+    scanByLanguage('resource-detector', 'ruby', 'resources');
+    scanByLanguage('utilities', 'ruby', 'sampler');
+    scanByLanguage('utilities', 'ruby', 'helpers');
   },
   erlang: () => {
     scanByLanguage('instrumentation', 'erlang', 'instrumentation');

--- a/scripts/registry-scanner/index.mjs
+++ b/scripts/registry-scanner/index.mjs
@@ -101,9 +101,9 @@ const scanners = {
     scanByLanguage('instrumentation', 'ruby');
     scanByLanguage('exporter', 'ruby', 'exporter', 'md', 'opentelemetry-ruby');
     scanByLanguage('processor', 'ruby');
-    scanByLanguage('utilities', 'ruby', 'propagator');
+    scanByLanguage('propagator', 'ruby');
     scanByLanguage('resource-detector', 'ruby', 'resources');
-    scanByLanguage('utilities', 'ruby', 'sampler');
+    scanByLanguage('sampler', 'ruby');
     scanByLanguage('utilities', 'ruby', 'helpers');
   },
   erlang: () => {


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

This adds more contrib directories to the registry scanner for ruby. Additional types have been added when no mapping existed. See repo here https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main

I based adding them on https://github.com/open-telemetry/opentelemetry.io/pull/9508

This should ensure ruby contrib components are listed.