### PR TITLE
[ja] docs(i18n): sync content/ja/docs/collector/extend/custom-component/_index.md

### DIFF
--- a/content/ja/docs/collector/extend/custom-component/_index.md
+++ b/content/ja/docs/collector/extend/custom-component/_index.md
@@ -3,7 +3,7 @@ title: カスタムコンポーネントのビルド
 description: 独自のコレクターコンポーネントをビルドする方法の説明
 aliases: [/docs/collector/building]
 weight: 300
-default_lang_commit: 6a7f17450ce3edc2e4363013551ee93ba7934a5d # patched
+default_lang_commit: 50b023ac3dcf1f780650d90152dbadc9bdc9dd8a
 ---
 
 OpenTelemetry Collectorは、既存のコンポーネントだけでなく、独自に開発・ビルドしたカスタムコンポーネントでも拡張できます。

--- a/content/ja/docs/collector/extend/custom-component/_index.md
+++ b/content/ja/docs/collector/extend/custom-component/_index.md
@@ -6,6 +6,7 @@ weight: 300
 default_lang_commit: 50b023ac3dcf1f780650d90152dbadc9bdc9dd8a
 ---
 
-OpenTelemetry Collectorは、既存のコンポーネントだけでなく、独自に開発・ビルドしたカスタムコンポーネントでも拡張できます。
-ここでは、これらのコンポーネントのビルド方法について説明します。
+OpenTelemetry Collector は、[コミュニティ](/docs/collector/components/)や[より広いエコシステム](/ecosystem/registry/)のコンポーネントを使用して構成できます。
+また、独自のカスタムコンポーネントを開発してビルドすることもできます。
+このセクションでは、そうしたコンポーネントのいくつかをビルドする方法について説明します。
 追加の詳細については、[opentelemetry-collector-contrib リポジトリ](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/README.md)内のドキュメントをご覧ください。


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

# Summary

This PR syncs `content/ja/docs/collector/extend/custom-component/_index.md` with the current English version.

- [Build custom components](https://opentelemetry.io/docs/collector/extend/custom-component/)

[View diffs in the English source](https://github.com/open-telemetry/opentelemetry.io/compare/6a7f17450ce3edc2e4363013551ee93ba7934a5d...50b023ac3#diff-4465a6152b68034d088455e3f7a5242ad5a8f1f79c4c03b4bcf47f10891b1394)

It seems that the Japanese intro was still based on the older text after the English page was updated (including path/alias changes). This PR also translates that part.

- https://github.com/open-telemetry/opentelemetry.io/commit/2e1d43493643bb0025d5a197751ac823b073e084#diff-86f38f3015955f6e2b7929b04df1e1735ab15aff17d717aec4c35e180ddfdee7
- https://github.com/open-telemetry/opentelemetry.io/commit/6a7f17450ce3edc2e4363013551ee93ba7934a5d#diff-4465a6152b68034d088455e3f7a5242ad5a8f1f79c4c03b4bcf47f10891b1394

# Preview

- https://deploy-preview-9921--opentelemetry.netlify.app/ja/docs/collector/extend/custom-component/