### PR TITLE
feat(registry): add otelc Go compile-time instrumentation

### DIFF
--- a/data/registry/tools-go-otelc.yml
+++ b/data/registry/tools-go-otelc.yml
@@ -1,0 +1,19 @@
+title: otelc - OpenTelemetry Go Compile-Time Instrumentation
+registryType: core
+language: go
+tags:
+  - go
+  - instrumentation
+  - compile-time
+  - auto-instrumentation
+license: Apache 2.0
+description: >-
+  otelc is a compile-time auto-instrumentation tool for Go applications.
+  It injects OpenTelemetry instrumentation during the Go build process
+  without requiring manual source-code changes in the target application.
+authors:
+  - name: OpenTelemetry Authors
+urls:
+  repo: https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation
+createdAt: 2024-06-01
+isFirstParty: true


### PR DESCRIPTION
## Description

Adds `opentelemetry-go-compile-instrumentation` (`otelc`) to the OpenTelemetry registry.

`otelc` is a compile-time auto-instrumentation tool for Go applications. It injects OpenTelemetry instrumentation during the Go build process without requiring manual source-code changes in the target application. It is an official first-party OpenTelemetry project under the `open-telemetry` GitHub organization.

This was requested in open-telemetry/opentelemetry-go-compile-instrumentation#503.

## Checklist

- [x] Entry uses `registryType: core` (first-party OpenTelemetry project)
- [x] License is Apache 2.0
- [x] `isFirstParty: true`
- [x] Repository URL points to the official GitHub repo
- [x] Tags reflect the tool's purpose: Go, instrumentation, compile-time, auto-instrumentation