### PR TITLE
[ja] docs(i18n): update content/ja/docs/zero-code/_index.md

### DIFF
--- a/content/ja/docs/zero-code/_index.md
+++ b/content/ja/docs/zero-code/_index.md
@@ -2,7 +2,7 @@
 title: ゼロコード計装
 redirects: [{ from: 'net/*', to: 'dotnet/:splat' }]
 weight: 265
-default_lang_commit: d1ef521ee4a777881fb99c3ec2b506e068cdec4c # patched
+default_lang_commit: 68c29178b21e7ace970d27c5817a4edcff3ea9fb
 ---
 
 OpenTelemetryの[ゼロコード計装][zero-code instrumentation]は、以下のセクションインデックスに記載されている言語でサポートされています。


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

# Summary

This PR updates `content/ja/docs/zero-code/_index.md` to match the current English version.

- [Zero-code Instrumentation](https://opentelemetry.io/docs/zero-code/)
  - https://github.com/open-telemetry/opentelemetry.io/compare/d1ef521ee4a777881fb99c3ec2b506e068cdec4c...68c29178b#diff-bbf4c015c8f8ddff3daa5ef788d9875eb98f19c1866302a60b1bd1115cdf6a47

Only `default_lang_commit` is updated as `weight` has been up to date.

- https://github.com/open-telemetry/opentelemetry.io/commit/66c62cacd11ab7c921461b6d65ae31590c37e319#diff-bbf4c015c8f8ddff3daa5ef788d9875eb98f19c1866302a60b1bd1115cdf6a47

# Preview

- https://deploy-preview-9951--opentelemetry.netlify.app/ja/docs/zero-code/