### PR TITLE
[ja] docs(i18n): sync content/ja/docs/zero-code/js/_index.md

### DIFF
--- a/content/ja/docs/zero-code/js/_index.md
+++ b/content/ja/docs/zero-code/js/_index.md
@@ -3,7 +3,7 @@ title: JavaScriptのゼロコード計装
 linkTitle: JavaScript
 description: ソースコードの変更なしでアプリケーションからテレメトリーをキャプチャする
 aliases: [/docs/languages/js/automatic]
-default_lang_commit: 55f8de69ad3cf54f24243c200f70cd0b3a608ad4
+default_lang_commit: 68c29178b21e7ace970d27c5817a4edcff3ea9fb
 ---
 
 JavaScriptのゼロコード計装は、コードを変更することなく、任意のNode.jsアプリケーションを計装し、多くの人気のあるライブラリやフレームワークからテレメトリーデータをキャプチャする方法を提供します。
@@ -65,11 +65,9 @@ node app.js
 
 デフォルトのレベルは `info` です。
 
-{{% alert title="Notes" %}}
-
-- 本番環境では、 `OTEL_LOG_LEVEL` を `info` に設定することを推奨します。
-- ログは常に `console` に送信され、環境やデバッグレベルに関係なく送信されます。
-- デバッグログは、非常に冗長でありアプリケーションのパフォーマンスに悪影響を与える可能性があります。
-  必要な場合にのみデバッグログを有効にしてください。
-
-{{% /alert %}}
+> [!NOTE]
+>
+> - 本番環境では、 `OTEL_LOG_LEVEL` を `info` に設定することを推奨します。
+> - ログは常に `console` に送信され、環境やデバッグレベルに関係なく送信されます。
+> - デバッグログは、非常に冗長でありアプリケーションのパフォーマンスに悪影響を与える可能性があります。
+>   必要な場合にのみデバッグログを有効にしてください。


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

# Summary

This PR updates `content/ja/docs/zero-code/js/_index.md` to match the current English version.

- [JavaScript zero-code instrumentation](https://opentelemetry.io/docs/zero-code/js/)
  - https://github.com/open-telemetry/opentelemetry.io/compare/55f8de69ad3cf54f24243c200f70cd0b3a608ad4...68c29178b#diff-181946747976f2f57ecf5baff12a549053774825eaaed0af9e626f2d27fccc6e

# Preview

- https://deploy-preview-9952--opentelemetry.netlify.app/ja/docs/zero-code/js/