### PR TITLE
[ja] docs(i18n): sync content/ja/docs/zero-code/java/spring-boot-starter/_…

### DIFF
--- a/content/ja/docs/zero-code/java/spring-boot-starter/_index.md
+++ b/content/ja/docs/zero-code/java/spring-boot-starter/_index.md
@@ -5,7 +5,7 @@ aliases:
   - /docs/languages/java/automatic/spring-boot
   - /docs/zero-code/java/agent/spring-boot
   - /docs/zero-code/java/spring-boot
-default_lang_commit: 68e94a4555606e74c27182b79789d46faf84ec25
+default_lang_commit: 68c29178b21e7ace970d27c5817a4edcff3ea9fb
 ---
 
 [Spring Boot](https://spring.io/projects/spring-boot) アプリケーションを OpenTelemetry で計装するには、2つのオプションを使用できます。
@@ -17,3 +17,4 @@ default_lang_commit: 68e94a4555606e74c27182b79789d46faf84ec25
    - OpenTelemetry Javaエージェントの**起動オーバーヘッド**が要件を超えている場合
    - OpenTelemetry Javaエージェントが他のエージェントと動作しない可能性があるため、Java 監視エージェントがすでに使用されている場合
    - OpenTelemetry Javaエージェントでは動作しないOpenTelemetry Spring Bootスターターを設定するための**Spring Boot 設定ファイル**(`application.properties`、`application.yml`)
+   - `application.yaml` 内の構造化された YAML 形式を用いた **[宣言的設定](declarative-configuration/)**


### PR DESCRIPTION
…index.md

<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

# Summary

This PR updates `content/ja/docs/zero-code/java/spring-boot-starter/_index.md` to match with the current English version.

- [Spring Boot starter](https://opentelemetry.io/docs/zero-code/java/spring-boot-starter/)
  - https://github.com/open-telemetry/opentelemetry.io/compare/68e94a4555606e74c27182b79789d46faf84ec25...68c29178b#diff-2dc9e4adbb9ae779253ec3bffb7cb5b3fac1bb7af6fd46a58018d709a6ddd77a

# Preview

- https://deploy-preview-9954--opentelemetry.netlify.app/ja/docs/zero-code/java/spring-boot-starter/