### PR TITLE
[ja] docs(i18n): sync content/ja/docs/languages/go/_index.md

### DIFF
--- a/content/ja/docs/languages/go/_index.md
+++ b/content/ja/docs/languages/go/_index.md
@@ -1,12 +1,14 @@
 ---
 title: Go
 description: >-
-  <img width="35" class="img-initial" src="/img/logos/32x32/Golang_SDK.svg"
-  alt="Go"> GoにおけるOpenTelemetryの言語固有の実装。
+  <img width="35" class="img-initial otel-icon"
+  src="/img/logos/32x32/Golang_SDK.svg" alt="Go"> GoにおけるOpenTelemetryの言語固有の実装。
 aliases: [/golang, /golang/metrics, /golang/tracing]
-weight: 16
-default_lang_commit: dc174c212e81fadbf8382bb54c54cff294954b1b
-drifted_from_default: true
+redirects:
+  - { from: /go/*, to: ':splat' }
+  - { from: /docs/go/*, to: ':splat' }
+weight: 140
+default_lang_commit: 68c29178b21e7ace970d27c5817a4edcff3ea9fb
 ---
 
 {{% docs/languages/index-intro go /%}}


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

# Summary

This PR updates `content/ja/docs/languages/go/_index.md` to match the current English version.

- [Go](https://opentelemetry.io/docs/languages/go/)
  - https://github.com/open-telemetry/opentelemetry.io/compare/dc174c212e81fadbf8382bb54c54cff294954b1b...68c29178b#diff-e55af9abf22ba489809f58f6ff4846bdfab5a8fef19f4181a399765eeeee5002

# Preview

- https://deploy-preview-9956--opentelemetry.netlify.app/ja/docs/languages/go/