### PR TITLE
fix(ja): normalize prh terminology

### DIFF
--- a/content/ja/docs/zero-code/obi/network/_index.md
+++ b/content/ja/docs/zero-code/obi/network/_index.md
@@ -8,7 +8,7 @@ cSpell:ignore: replicaset statefulset
 ---
 
 OpenTelemetry eBPF 計装は、異なるエンドポイント間のネットワークメトリクスを提供するように設定できます。
-たとえば、物理ノード、コンテナー、Kubernetes Pod、サービスなどの間です。
+たとえば、物理ノード、コンテナ、Kubernetes Pod、サービスなどの間です。
 
 ## はじめに {#get-started}
 


### PR DESCRIPTION
The `check:text` job started failing on `main` because two recent PRs landed in opposite order:

- #9834 (translation of `content/ja/docs/zero-code/obi/network/_index.md`) introduced the word `コンテナー`.
- #9854 (Japanese prh terminology normalization) added a new prh rule mapping `コンテナー` → `コンテナ`, but did not rewrite the existing occurrence.

This PR applies the rule to the leftover occurrence.

/cc @open-telemetry/docs-ja-approvers 