### PR TITLE
fix: prevent stacked banners from covering hero section

### DIFF
--- a/assets/scss/_homepage.scss
+++ b/assets/scss/_homepage.scss
@@ -41,6 +41,16 @@
     }
   }
 
+  // When 2+ banners are stacked, the fixed overlay grows beyond what the hero's
+  // default padding-top covers. Compensate with :has() so the hero content stays visible.
+  @include media-breakpoint-up(md) {
+    &:has(.o-banner > div:nth-child(2)) main > section:first-of-type {
+      padding-top: calc(
+        #{$td-navbar-min-height} + #{$td-block-space-top-base} + 5rem
+      );
+    }
+  }
+
   // =============================================================================
   // HERO SEARCH - Search bar section below compact hero
   // =============================================================================


### PR DESCRIPTION
## Summary

- When two announcement banners are active simultaneously, the combined fixed-position overlay height exceeds the hero section's default `padding-top`, causing the logo and headline to be hidden behind the banners.
- Added a CSS `:has()` rule in `_homepage.scss` that detects when the `.o-banner` contains a second child `<div>` and increases the first section's `padding-top` to `calc($td-navbar-min-height + $td-block-space-top-base + 5rem)` (~13rem), enough to clear the two-banner stack.
- Single-banner behaviour is unchanged.

## Test plan

- [ ] Verify homepage with two active announcements: hero logo and headline should be fully visible below the banners
- [ ] Verify homepage with one active announcement: layout unchanged
- [ ] Verify homepage with no banners: layout unchanged
- [ ] Check at md+ breakpoint (≥768px) where the banners are `position: fixed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)