### PR TITLE
fix: prevent stacked banners from covering hero section

### DIFF
--- a/assets/scss/_homepage.scss
+++ b/assets/scss/_homepage.scss
@@ -42,12 +42,11 @@
   }
 
   // When 2+ banners are stacked, the fixed overlay grows beyond what the hero's
-  // default padding-top covers. Compensate with :has() so the hero content stays visible.
+  // default padding-top covers. .td-below-navbar sets padding-top with !important,
+  // so we must do the same to override it.
   @include media-breakpoint-up(md) {
-    &:has(.o-banner > div:nth-child(2)) main > section:first-of-type {
-      padding-top: calc(
-        #{$td-navbar-min-height} + #{$td-block-space-top-base} + 5rem
-      );
+    &:has(.o-banner > div:nth-child(2)) .td-cover-block.td-below-navbar {
+      padding-top: calc(#{$td-block-space-top-base} + 3rem) !important;
     }
   }
 

--- a/assets/scss/_homepage.scss
+++ b/assets/scss/_homepage.scss
@@ -41,6 +41,16 @@
     }
   }
 
+  // When 2+ banners are stacked, the fixed overlay grows beyond what the hero's
+  // default padding-top covers. Compensate with :has() so the hero content stays visible.
+  @include media-breakpoint-up(md) {
+    &:has(.o-banner > div:nth-child(2)) main > section:first-of-type {
+      padding-top: calc(
+        #{$td-navbar-min-height} + #{$td-block-space-top-base} + 5rem
+      );
+    }
+  }
+
   // =============================================================================
   // HERO SEARCH - Search bar section below compact hero
   // =============================================================================


### PR DESCRIPTION
## Summary

When two announcement banners are active simultaneously, the combined
fixed-position overlay covers the hero logo and headline.

The root cause: `.td-below-navbar` (a Docsy class on the cover block)
sets `padding-top: $td-block-space-top-base !important`, which overrides
any plain padding rule. The fix uses `:has()` to detect a second banner
child and overrides the padding with `!important`, giving the logo enough
clearance below the two-banner stack.

**Calculation:** `padding-top: 7rem` → logo lands at section-top (4rem) +
padding (7rem) + h1 margin (3rem) = **14rem** from viewport top; two
banners reach **12rem**. 2rem buffer.

Single-banner and no-banner behaviour is unchanged.

## Test plan

- [ ] Homepage with two active announcements: hero logo fully visible below both banners
- [ ] Homepage with one announcement: no change
- [ ] Homepage with no announcements: no change
- [ ] md+ breakpoint (≥768px) where banners are `position: fixed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)