### PR TITLE
Add Ingero Fleet to the registry

### DIFF
--- a/data/registry/application-integration-collector-ingero-fleet.yml
+++ b/data/registry/application-integration-collector-ingero-fleet.yml
@@ -1,0 +1,25 @@
+# cSpell:ignore Ingero eBPF libnccl NCCL OTLP
+title: Ingero Fleet
+registryType: application integration
+language: collector
+tags:
+  - collector
+  - gpu
+  - nvidia
+  - cuda
+  - nccl
+  - ebpf
+license: Apache 2.0
+description:
+  A GPU-cluster OpenTelemetry Collector distribution. Receives OTLP from
+  Ingero eBPF agents and runs GPU-specific stream processing (MAD-based
+  straggler-threshold detection, per-rank NCCL collective skew, and
+  provider cost attribution), then forwards to any OTLP backend.
+authors:
+  - name: Ingero
+    url: https://github.com/ingero-io
+urls:
+  repo: https://github.com/ingero-io/ingero-fleet
+  website: https://ingero.io/
+createdAt: 2026-05-22
+isNative: false

--- a/data/registry/application-integration-collector-ingero-fleet.yml
+++ b/data/registry/application-integration-collector-ingero-fleet.yml
@@ -20,6 +20,7 @@ authors:
     url: https://github.com/ingero-io
 urls:
   repo: https://github.com/ingero-io/ingero-fleet
+  docs: https://github.com/ingero-io/ingero-fleet/tree/main/docs
   website: https://ingero.io/
 createdAt: '2026-05-22'
 isNative: false

--- a/data/registry/application-integration-collector-ingero-fleet.yml
+++ b/data/registry/application-integration-collector-ingero-fleet.yml
@@ -11,10 +11,10 @@ tags:
   - ebpf
 license: Apache 2.0
 description:
-  A GPU-cluster OpenTelemetry Collector distribution. Receives OTLP from
-  Ingero eBPF agents and runs GPU-specific stream processing (MAD-based
-  straggler-threshold detection, per-rank NCCL collective skew, and
-  provider cost attribution), then forwards to any OTLP backend.
+  A GPU-cluster OpenTelemetry Collector distribution. Receives OTLP from Ingero
+  eBPF agents and runs GPU-specific stream processing (MAD-based
+  straggler-threshold detection, per-rank NCCL collective skew, and provider
+  cost attribution), then forwards to any OTLP backend.
 authors:
   - name: Ingero
     url: https://github.com/ingero-io

--- a/data/registry/application-integration-collector-ingero-fleet.yml
+++ b/data/registry/application-integration-collector-ingero-fleet.yml
@@ -21,5 +21,5 @@ authors:
 urls:
   repo: https://github.com/ingero-io/ingero-fleet
   website: https://ingero.io/
-createdAt: 2026-05-22
+createdAt: '2026-05-22'
 isNative: false

--- a/data/registry/application-integration-collector-ingero-fleet.yml
+++ b/data/registry/application-integration-collector-ingero-fleet.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore Ingero eBPF libnccl NCCL OTLP
+# cSpell:ignore Ingero eBPF libnccl NCCL OTLP cuda nccl nvidia gpu
 title: Ingero Fleet
 registryType: application integration
 language: collector


### PR DESCRIPTION
Adds Ingero Fleet, a GPU-cluster OpenTelemetry Collector distribution, to the registry.

Fleet receives OTLP from eBPF-based GPU agents and runs GPU-specific stream processing (MAD-based straggler-threshold detection, per-rank NCCL collective skew, and provider cost attribution), then forwards to any OTLP backend. Apache 2.0.

- Repo: https://github.com/ingero-io/ingero-fleet

Filed as 'application integration' / language 'collector', following the existing collector-integration entries. Happy to adjust the registryType if maintainers prefer a different category.