### PR TITLE
[ja] docs(i18n): update content/ja/docs/zero-code/java/_index.md

### DIFF
--- a/content/ja/docs/zero-code/java/_index.md
+++ b/content/ja/docs/zero-code/java/_index.md
@@ -9,7 +9,7 @@ cascade:
     instrumentation: 2.28.1
     otel: 1.62.0
     contrib: 1.54.0
-default_lang_commit: 68c29178b21e7ace970d27c5817a4edcff3ea9fb
+default_lang_commit: c1e141558ab36cc1ab9f864728e4665e272ac131
 ---
 
 Javaでゼロコード計装を行う一般的なオプションには、Java エージェント JAR、Spring Boot Starter、Quarkus OpenTelemetry Extension があります。


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

# Summary

This PR updates `content/ja/docs/zero-code/java/_index.md` to match the current English version.

- https://github.com/open-telemetry/opentelemetry.io/compare/68c29178b21e7ace970d27c5817a4edcff3ea9fb...c1e141558ab36cc1ab9f864728e4665e272ac131#diff-031bb089fb577a3142b95c718c3af038a69fefe76759c38591c3d6ccc2782126

Only the `default_lang_commit` is updated as the version of `instrumentation` in the front matter was already up to date.