### PR TITLE
[ja] update translation of content/en/docs/languages/js/libraries.md

### DIFF
--- a/content/ja/docs/languages/js/_includes/esm-support-note.md
+++ b/content/ja/docs/languages/js/_includes/esm-support-note.md
@@ -1,4 +1,5 @@
 ---
+default_lang_commit: f7dab5cfc4d44a8c788b7e02d07ec1e1d84e3845
 ---
 
 > [!NOTE]

--- a/content/ja/docs/languages/js/_includes/esm-support-note.md
+++ b/content/ja/docs/languages/js/_includes/esm-support-note.md
@@ -1,0 +1,8 @@
+---
+---
+
+> [!NOTE]
+>
+> OpenTelemetryのドキュメントは、コンパイルされたアプリケーションが
+> [CommonJS](https://nodejs.org/api/modules.html#modules-commonjs-modules)として実行されることを前提としています。
+> アプリケーションをESMとして実行する場合は、[ESM Support Doc](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/esm-support.md)で指定されているローダーフックを追加してください。

--- a/content/ja/docs/languages/js/libraries.md
+++ b/content/ja/docs/languages/js/libraries.md
@@ -2,7 +2,7 @@
 title: 計装ライブラリの使用
 linkTitle: ライブラリ
 weight: 40
-description: アプリが依存するライブラリをインストルメントする方法
+description: アプリが依存するライブラリを計装する方法
 default_lang_commit: f7dab5cfc4d44a8c788b7e02d07ec1e1d84e3845
 ---
 

--- a/content/ja/docs/languages/js/libraries.md
+++ b/content/ja/docs/languages/js/libraries.md
@@ -3,8 +3,7 @@ title: 計装ライブラリの使用
 linkTitle: ライブラリ
 weight: 40
 description: アプリが依存するライブラリをインストルメントする方法
-default_lang_commit: 276d7eb3f936deef6487cdd2b1d89822951da6c8
-drifted_from_default: true
+default_lang_commit: f7dab5cfc4d44a8c788b7e02d07ec1e1d84e3845
 ---
 
 {{% docs/languages/libraries-intro "js" %}}
@@ -14,6 +13,8 @@ drifted_from_default: true
 ライブラリがOpenTelemetryを最初から組み込んでいない場合、ライブラリやフレームワークのテレメトリーデータを生成するために[計装ライブラリ](/docs/specs/otel/glossary/#instrumentation-library)を使用できます。
 
 たとえば、[Expressの計装ライブラリ](https://www.npmjs.com/package/@opentelemetry/instrumentation-express)は、インバウンドHTTPリクエストに基づいて自動的に[スパン](/docs/concepts/signals/traces/#spans)を作成します。
+
+{{% include esm-support-note.md %}}
 
 ### セットアップ {#setup}
 
@@ -198,8 +199,8 @@ const sdk = new NodeSDK({
 ```typescript
 import { Span } from '@opentelemetry/api';
 import {
-  SEMATTRS_HTTP_METHOD,
-  SEMATTRS_HTTP_URL,
+  ATTR_HTTP_REQUEST_METHOD,
+  ATTR_URL_FULL,
 } from '@opentelemetry/semantic-conventions';
 import {
   ExpressInstrumentation,
@@ -210,8 +211,8 @@ import {
 const expressInstrumentation = new ExpressInstrumentation({
   requestHook: function (span: Span, info: ExpressRequestInfo) {
     if (info.layerType === ExpressLayerType.REQUEST_HANDLER) {
-      span.setAttribute(SEMATTRS_HTTP_METHOD, info.request.method);
-      span.setAttribute(SEMATTRS_HTTP_URL, info.request.baseUrl);
+      span.setAttribute(ATTR_HTTP_REQUEST_METHOD, info.request.method);
+      span.setAttribute(ATTR_URL_FULL, info.request.baseUrl);
     }
   },
 });
@@ -224,8 +225,8 @@ const expressInstrumentation = new ExpressInstrumentation({
 ```javascript
 /*instrumentation.js*/
 const {
-  SEMATTRS_HTTP_METHOD,
-  SEMATTRS_HTTP_URL,
+  ATTR_HTTP_REQUEST_METHOD,
+  ATTR_URL_FULL,
 } = require('@opentelemetry/semantic-conventions');
 const {
   ExpressInstrumentation,
@@ -235,8 +236,8 @@ const {
 const expressInstrumentation = new ExpressInstrumentation({
   requestHook: function (span, info) {
     if (info.layerType === ExpressLayerType.REQUEST_HANDLER) {
-      span.setAttribute(SEMATTRS_HTTP_METHOD, info.request.method);
-      span.setAttribute(SEMATTRS_HTTP_URL, info.request.baseUrl);
+      span.setAttribute(ATTR_HTTP_REQUEST_METHOD, info.request.method);
+      span.setAttribute(ATTR_URL_FULL, info.request.baseUrl);
     }
   },
 });


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/js/libraries.md` to match the latest
English source at `content/en/docs/languages/js/libraries.md`:

- Adds the new `{{% include esm-support-note.md %}}` reference and ships
  a Japanese translation of the include at
  `content/ja/docs/languages/js/_includes/esm-support-note.md` (the
  include shortcode resolves per-locale, and no other locale has translated
  this file yet, so referencing it without a Japanese version would render
  `INTERNAL SITE ERROR` on the Japanese page).
- Renames `SEMATTRS_HTTP_METHOD` → `ATTR_HTTP_REQUEST_METHOD` and
  `SEMATTRS_HTTP_URL` → `ATTR_URL_FULL` in the Express instrumentation
  example code blocks (TypeScript and JavaScript variants), mirroring the
  upstream semantic-conventions API change.

Refreshes `default_lang_commit` and removes the `drifted_from_default` flag.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.