### PR TITLE
[ja] update translation of content/en/docs/collector/troubleshooting.md

### DIFF
--- a/content/ja/docs/collector/troubleshooting.md
+++ b/content/ja/docs/collector/troubleshooting.md
@@ -2,8 +2,7 @@
 title: トラブルシューティング
 description: コレクターのトラブルシューティングに関する推奨事項
 weight: 25
-default_lang_commit: 974cdea55c03089f4e86d6068ec133b04e2653da
-drifted_from_default: true
+default_lang_commit: f7dab5cfc4d44a8c788b7e02d07ec1e1d84e3845
 cSpell:ignore: confmap pprof tracez zpages
 ---
 
@@ -249,6 +248,10 @@ extensions:
 - 次のホップはどのように設定されていますか？
 - データの出入りを妨げるネットワークポリシーはありますか？
 
+## Kubernetes 環境でのトラブルシューティング {#troubleshooting-in-kubernetes-environments}
+
+Kubernetes 上で OpenTelemetry Collector を実行している場合、[エフェメラルなデバッグコンテナ](https://kubernetes.io/docs/tasks/debug/debug-application/debug-running-pod/#ephemeral-container)を使用して Collector 関連の問題を調査できます。
+
 ## 一般的なコレクターの問題 {#common-collector-issues}
 
 このセクションでは、一般的なコレクターの問題を解決する方法について説明します。
@@ -264,8 +267,7 @@ extensions:
 - コレクターのサイジングが不適切で、受信したデータを処理してエクスポートする速度が追いつかない。
 - エクスポーターの宛先が利用できないか、データの受け入れが遅すぎる。
 
-ドロップを軽減するには、[`batch` プロセッサー](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md)を設定します。
-さらに、有効化されているエクスポーターで[キューリトライオプション](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/exporterhelper#configuration)を設定する必要があるかもしれません。
+ドロップを軽減するには、有効化されているエクスポーターで[キューリトライオプション](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/exporterhelper#configuration)、特に [Sending queue batch settings](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/exporterhelper#sending-queue-batch-settings)を設定します。
 
 #### コレクターがデータを受信していない {#collector-is-not-receiving-data}
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/collector/troubleshooting.md` to match the latest
English source. Adds the new "Troubleshooting in Kubernetes environments"
section and refreshes the data-drop mitigation paragraph (removes the
`batch` processor reference, adds the Sending queue batch settings link).

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.