### PR TITLE
[ja] update translation of content/en/docs/platforms/kubernetes/helm/collector.md

### DIFF
--- a/content/ja/docs/platforms/kubernetes/helm/collector.md
+++ b/content/ja/docs/platforms/kubernetes/helm/collector.md
@@ -1,10 +1,9 @@
 ---
 title: OpenTelemetryコレクターチャート
 linkTitle: コレクターチャート
-default_lang_commit: 276d7eb3f936deef6487cdd2b1d89822951da6c8 # patched
-drifted_from_default: true
+default_lang_commit: f7dab5cfc4d44a8c788b7e02d07ec1e1d84e3845
 # prettier-ignore
-cSpell:ignore: debugexporter filelog filelogreceiver hostmetricsreceiver kubelet kubeletstats kubeletstatsreceiver otlphttp sattributesprocessor sclusterreceiver sobjectsreceiver statefulset
+cSpell:ignore: filelog filelogreceiver hostmetricsreceiver kubelet kubeletstats kubeletstatsreceiver otlp_http sattributesprocessor sclusterreceiver sobjectsreceiver statefulset
 ---
 
 ## はじめに {#introduction}
@@ -173,13 +172,13 @@ presets:
     enabled: true
 ```
 
-チャートのデフォルトのログパイプラインは `debugexporter` を使用します。
+チャートのデフォルトのログパイプラインは `debug` エクスポーターを使用します。
 `logsCollection` プリセットの `filelogreceiver` と組み合わせると、エクスポートしたログを誤ってコレクターに戻してしまい、「ログの爆発」を引き起こす可能性があります。
 
 ループを防止するために、レシーバーのデフォルト設定ではコレクター自身のログを除外しています。
 コレクターのログを含めたい場合は、 `debug` エクスポーターをコレクターの標準出力にログを送信しないエクスポーターに置き換えてください。
 
-以下は `values.yaml` の例で、`logs` パイプラインのデフォルトの `debug` エクスポーターを、コンテナのログを `https://example.com:55681` エンドポイントに送信する `otlphttp` エクスポーターに置き換えたものです。
+以下は `values.yaml` の例で、`logs` パイプラインのデフォルトの `debug` エクスポーターを、コンテナのログを `https://example.com:55681` エンドポイントに送信する `otlp_http` エクスポーターに置き換えたものです。
 また、`presets.logsCollection.includeCollectorLogs` を使用して、コレクターのログの収集を有効にするようにプリセットに指示します。
 
 ```yaml
@@ -198,7 +197,7 @@ config:
     pipelines:
       logs:
         exporters:
-          - otlphttp
+          - otlp_http
 ```
 
 #### Kubernetes属性プリセット {#kubernetes-attributes-preset}


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/platforms/kubernetes/helm/collector.md` to match the
latest English source: refreshes the cSpell ignore list (drop `debugexporter`,
rename `otlphttp` → `otlp_http`), renames `debugexporter` → `debug` exporter
in prose, and renames the example exporter key to `otlp_http`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.