### PR TITLE
[ja] update translation of content/en/docs/collector/components/connector.md

### DIFF
--- a/content/ja/docs/collector/components/connector.md
+++ b/content/ja/docs/collector/components/connector.md
@@ -2,35 +2,10 @@
 title: コネクター
 description: OpenTelemetry Collectorで利用可能なコネクターの一覧
 weight: 340
-default_lang_commit: 1c2b0563e8e66ef0952c442e3662e4bec18a8762 # patched
-drifted_from_default: true
-# prettier-ignore
-cSpell:ignore: countconnector datadogconnector exceptionsconnector failoverconnector forwardconnector grafanacloudconnector otlpjsonconnector roundrobinconnector routingconnector servicegraphconnector signaltometricsconnector slowsqlconnector spanmetricsconnector sumconnector
+default_lang_commit: f7dab5cfc4d44a8c788b7e02d07ec1e1d84e3845
 ---
 
 コネクターは、2つのパイプラインを接続し、エクスポーターとレシーバーの両方として機能します。
 コネクターの詳細な設定方法については、[Collectorの設定ドキュメント](/docs/collector/configuration/#connectors)を参照してください。
 
-<!-- BEGIN GENERATED: connector-table SOURCE: scripts/collector-sync -->
-
-| 名前                                                                                   | ディストリビューション[^1] |
-| -------------------------------------------------------------------------------------- | -------------------------- |
-| {{< component-link name="countconnector" type="connector" repo="contrib" >}}           | contrib, K8s               |
-| {{< component-link name="datadogconnector" type="connector" repo="contrib" >}}         | contrib                    |
-| {{< component-link name="exceptionsconnector" type="connector" repo="contrib" >}}      | contrib, K8s               |
-| {{< component-link name="failoverconnector" type="connector" repo="contrib" >}}        | contrib, K8s               |
-| {{< component-link name="forwardconnector" type="connector" repo="core" >}}            | contrib, core, K8s         |
-| {{< component-link name="grafanacloudconnector" type="connector" repo="contrib" >}}    | contrib                    |
-| {{< component-link name="metricsaslogsconnector" type="connector" repo="contrib" >}}   | contrib                    |
-| {{< component-link name="otlpjsonconnector" type="connector" repo="contrib" >}}        | contrib, K8s               |
-| {{< component-link name="roundrobinconnector" type="connector" repo="contrib" >}}      | contrib, K8s               |
-| {{< component-link name="routingconnector" type="connector" repo="contrib" >}}         | contrib, K8s               |
-| {{< component-link name="servicegraphconnector" type="connector" repo="contrib" >}}    | contrib, K8s               |
-| {{< component-link name="signaltometricsconnector" type="connector" repo="contrib" >}} | contrib                    |
-| {{< component-link name="slowsqlconnector" type="connector" repo="contrib" >}}         | contrib                    |
-| {{< component-link name="spanmetricsconnector" type="connector" repo="contrib" >}}     | contrib                    |
-| {{< component-link name="sumconnector" type="connector" repo="contrib" >}}             | contrib                    |
-
-[^1]: このコンポーネントが含まれている[ディストリビューション](/docs/collector/distributions/)（core、contrib、K8sなど）を示します。
-
-<!-- END GENERATED: connector-table SOURCE: scripts/collector-sync -->
+{{< collector-component-rows type="connector" >}}


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/collector/components/connector.md` to match the
latest English source: replaces the hand-maintained connector table with
the `{{< collector-component-rows type="connector" >}}` shortcode and drops
the now-unused `cSpell:ignore` frontmatter.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.