### PR TITLE
[ja] update translation of content/en/docs/platforms/faas/lambda-auto-instrument.md

### DIFF
--- a/content/ja/docs/platforms/faas/lambda-auto-instrument.md
+++ b/content/ja/docs/platforms/faas/lambda-auto-instrument.md
@@ -2,8 +2,7 @@
 title: Lambda 自動計装
 weight: 11
 description: あなたのLambdaをOpenTelemetryで自動的に計装する
-default_lang_commit: 9b427bf25703c33a2c6e05c2a7b58e0f768f7bad # patched
-drifted_from_default: true
+default_lang_commit: 39d3d2ef243d968e6a434fd9d2690c8070c3d7ea
 cSpell:ignore: Corretto
 ---
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/platforms/faas/lambda-auto-instrument.md` to match the latest English source. Refreshes `default_lang_commit` and removes the `drifted_from_default` flag.

The English diff for this file was:

- A structural change promoting six `###` section headings to `##`. The Japanese page already used `##` for those headings, so no body changes are needed.
- A one-letter English typo fix (`use it's ARN` → `use its ARN`). The Japanese translation does not carry the apostrophe ambiguity — the corresponding sentence uses `そのARN`, which is already correct.

This PR therefore only updates the i18n bookkeeping fields and removes the stale `# patched` marker.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.