### PR TITLE
[ja] update translation of content/en/docs/platforms/faas/lambda-collector.md

### DIFF
--- a/content/ja/docs/platforms/faas/lambda-collector.md
+++ b/content/ja/docs/platforms/faas/lambda-collector.md
@@ -3,8 +3,7 @@ title: Lambdaコレクター設定
 linkTitle: Lambdaコレクター設定
 weight: 11
 description: コレクターLambdaレイヤーをあなたのLambdaに追加して設定する
-default_lang_commit: 9ba98f4fded66ec78bfafa189ab2d15d66df2309 # patched
-drifted_from_default: true
+default_lang_commit: 39d3d2ef243d968e6a434fd9d2690c8070c3d7ea
 cSpell:ignore: ADOT awsxray configmap confmap
 ---
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/platforms/faas/lambda-collector.md` to match the latest English source. Refreshes `default_lang_commit` and removes the `drifted_from_default` flag.

The English diff for this file was structural only — several headings were promoted (`### → ##`, `#### → ###`, `##### → ####`). The Japanese page already used the post-diff heading levels for every section, so no body changes are needed. This PR only updates the i18n bookkeeping fields and removes the stale `# patched` marker.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.