### PR TITLE
[ja] update translation of content/en/docs/zero-code/python/example.md

### DIFF
--- a/content/ja/docs/zero-code/python/example.md
+++ b/content/ja/docs/zero-code/python/example.md
@@ -2,8 +2,9 @@
 title: 自動計装の例
 linkTitle: Example
 weight: 20
-default_lang_commit: 68e94a4555606e74c27182b79789d46faf84ec25
-drifted_from_default: true
+default_lang_commit: 39d3d2ef243d968e6a434fd9d2690c8070c3d7ea
+# prettier-ignore
+cSpell:ignore: Aiohttp ASGI distro instrumentor mkdir MSIE Referer Starlette venv
 ---
 
 このページでは、OpenTelemetry で Python 自動計装を使う方法を示します。
@@ -298,9 +299,12 @@ opentelemetry-instrument --traces_exporter console --metrics_exporter none --log
 
 これらの設定オプションは、以下のHTTP計装でサポートされています。
 
+- Aiohttp-server
+- ASGI
 - Django
 - Falcon
 - FastAPI
+- Flask
 - Pyramid
 - Starlette
 - Tornado
@@ -320,6 +324,19 @@ opentelemetry-instrument --traces_exporter console --metrics_exporter none --log
   }
 }
 ```
+
+### 取得したヘッダーのサニタイズ {#sanitization-of-captured-headers}
+
+個人を特定できる情報 (PII)、セッションキー、パスワードなどの機密データの保存を防ぐために、環境変数 `OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS` にサニタイズ対象とする HTTP ヘッダー名のカンマ区切りリストを設定してください。
+正規表現を使用でき、ヘッダー名はすべて大文字小文字を区別せずにマッチングされます。
+
+たとえば、次のように指定します。
+
+```sh
+export OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS=".*session.*,set-cookie"
+```
+
+すると、`session-id` や `set-cookie` などのヘッダーの値は、スパン内では `[REDACTED]` に置き換えられます。
 
 [semantic convention]: /docs/specs/semconv/http/http-spans/
 [api reference]: https://opentelemetry-python.readthedocs.io/en/latest/index.html


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/python/example.md` to match the latest English source. Refreshes `default_lang_commit` and removes the `drifted_from_default` flag.

EN diff hunks addressed:

- Frontmatter: synced the `# prettier-ignore` directive and `cSpell:ignore` field with the latest English (adds `Aiohttp`, `ASGI`). The Japanese page previously didn't carry `cSpell:ignore`; this brings it in line so the newly added bullets below pass spelling.
- HTTP instrumentations list: added `Aiohttp-server`, `ASGI`, and `Flask` in the same sorted positions as English.
- Added the new `### 取得したヘッダーのサニタイズ {#sanitization-of-captured-headers}` section, translated from the new "Sanitization of captured headers" block in English. Heading id was verified against the live page via `scripts/fetch_heading_ids.py`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.