### PR TITLE
[ja] update translation of content/en/docs/languages/js/resources.md

### DIFF
--- a/content/ja/docs/languages/js/resources.md
+++ b/content/ja/docs/languages/js/resources.md
@@ -2,8 +2,7 @@
 title: リソース
 weight: 70
 description: アプリケーションの環境に関する詳細情報をテレメトリに追加する
-default_lang_commit: 68e94a4555606e74c27182b79789d46faf84ec25
-drifted_from_default: true
+default_lang_commit: 39d3d2ef243d968e6a434fd9d2690c8070c3d7ea
 cSpell:ignore: myhost SIGINT uuidgen WORKDIR
 ---
 
@@ -13,12 +12,14 @@ cSpell:ignore: myhost SIGINT uuidgen WORKDIR
 
 ## セットアップ {#setup}
 
-[Getting Started - Node.js][]の手順に従って、`package.json`、`app.js`、`tracing.js`ファイルを用意してください。
+[Getting Started - Node.js][]の手順に従って、`package.json`、`app.js`（または `app.ts`）、`instrumentation.mjs`（または `instrumentation.ts`）ファイルを用意してください。
+
+{{% include esm-support-note.md %}}
 
 ## プロセスおよび環境リソースの検出 {#process--environment-resource-detection}
 
 Node.js SDKは、初期設定で[プロセスとプロセスランタイムリソース][process and process runtime resources]を検出し、環境変数`OTEL_RESOURCE_ATTRIBUTES`から属性を取得します。
-`tracing.js`で診断ログを有効にすることで、何が検出されているかを確認できます。
+計装ファイルで診断ログを有効にすることで、何が検出されているかを確認できます。
 
 ```javascript
 // トラブルシューティングのため、ログレベルをDiagLogLevel.DEBUGに設定
@@ -30,7 +31,7 @@ diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
 
 ```console
 $ env OTEL_RESOURCE_ATTRIBUTES="host.name=localhost" \
-  node --require ./tracing.js app.js
+  node --import ./instrumentation.mjs app.js
 @opentelemetry/api: Registered a global for diag v1.2.0.
 ...
 Listening for requests on http://localhost:8080
@@ -61,7 +62,7 @@ ProcessDetector found resource. Resource {
 
 ```console
 $ env OTEL_SERVICE_NAME="app.js" OTEL_RESOURCE_ATTRIBUTES="service.namespace=tutorial,service.version=1.0,service.instance.id=`uuidgen`,host.name=${HOSTNAME},host.type=`uname -m`,os.name=`uname -s`,os.version=`uname -r`" \
-  node --require ./tracing.js app.js
+  node --import ./instrumentation.mjs app.js
 ...
 EnvDetector found resource. Resource {
   attributes: {
@@ -82,7 +83,7 @@ EnvDetector found resource. Resource {
 
 カスタムリソースはコードでも設定できます。
 `NodeSDK`では設定オプションが提供されており、ここでリソースを設定できます。
-たとえば、以下のように`tracing.js`を更新して`service.*`属性を設定できます。
+たとえば、以下のように計装ファイルを更新して`service.*`属性を設定できます。
 
 ```javascript
 ...
@@ -100,15 +101,13 @@ const sdk = new opentelemetry.NodeSDK({
 ...
 ```
 
-{{% alert title="注意" class="info" %}}
-
-環境変数とコードの両方でリソース属性を設定した場合、環境変数で設定された値が優先されます。
-
-{{% /alert %}}
+> [!NOTE]
+>
+> 環境変数とコードの両方でリソース属性を設定した場合、環境変数で設定された値が優先されます。
 
 ## コンテナリソースの検出 {#container-resource-detection}
 
-同じセットアップ（`package.json`、`app.js`、デバッグを有効にした`tracing.js`）を使用し、同じディレクトリに以下の内容の`Dockerfile`を作成します。
+同じセットアップ（`package.json`、`app.js`、デバッグを有効にした`instrumentation.mjs`）を使用し、同じディレクトリに以下の内容の`Dockerfile`を作成します。
 
 ```Dockerfile
 FROM node:latest
@@ -117,7 +116,7 @@ COPY package.json ./
 RUN npm install
 COPY . .
 EXPOSE 8080
-CMD [ "node", "--require", "./tracing.js", "app.js" ]
+CMD [ "node", "--import", "./instrumentation.mjs", "app.js" ]
 ```
 
 <kbd>Ctrl + C</kbd>（`SIGINT`）でDockerコンテナを停止できるようにするため、`app.js`の最後に以下を追加します。
@@ -134,7 +133,7 @@ process.on('SIGINT', function () {
 npm install @opentelemetry/resource-detector-container
 ```
 
-次に、`tracing.js`を以下のように更新します。
+次に、`instrumentation.mjs`を以下のように更新します。
 
 ```javascript
 const opentelemetry = require('@opentelemetry/sdk-node');


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/js/resources.md` to match the latest English source. Refreshes `default_lang_commit` and removes the `drifted_from_default` flag.

The English diff migrated the page from CommonJS `tracing.js` (`node --require`) to ESM `instrumentation.mjs` (`node --import`) and converted a Docsy alert to a GFM `> [!NOTE]` callout. Specifically:

- Setup section: file list now includes `app.js`（または `app.ts`）and `instrumentation.mjs`（または `instrumentation.ts`）, with the `{{% include esm-support-note.md %}}` reference. The JA `_includes/esm-support-note.md` is not yet created in this PR; it is being added by #10017 and #10028 and will resolve via the EN fallback in the meantime.
- All `node --require ./tracing.js app.js` invocations updated to `node --import ./instrumentation.mjs app.js` (including the Dockerfile `CMD`).
- Prose references like 「`tracing.js` で診断ログを…」 changed to 「計装ファイルで…」 to match the EN simplification.
- Docsy `{{% alert title="Note" %}}` block in the "コードでリソースを追加" section converted to the GFM `> [!NOTE]` form.
- "Container Resource Detection" intro updated to reference `instrumentation.mjs` instead of `tracing.js`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.