### PR TITLE
fix: update endpoint default warning

### DIFF
--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -106,8 +106,7 @@ configuration with a receiver, a processor, an exporter, and three extensions.
 >
 > While it is generally preferable to bind endpoints to `localhost` when all
 > clients are local, our example configurations use the "unspecified" address
-> `0.0.0.0` as a convenience. The Collector currently defaults to `0.0.0.0`, but
-> the default will be changed to `localhost` in the near future. For details
+> `0.0.0.0` as a convenience. The Collector defaults to `localhost`. For details
 > concerning either of these choices as endpoint configuration value, see
 > [Safeguards against denial of service attacks][].
 


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
---
## Summary
- Update the Collector docs warning about binding endpoints to clarify that the Collector **defaults to `localhost`**.
- Remove outdated text stating the default is `0.0.0.0` and would change “in the near future”.

Fixes #9404.

## Test plan
- [x] Confirm the updated warning renders correctly on the Collector configuration page.
- [x] Spot-check the “Safeguards against denial of service attacks” link still resolves.