### PR TITLE
[ja] update translation of content/en/docs/languages/sdk-configuration/general.md

### DIFF
--- a/content/ja/docs/languages/sdk-configuration/general.md
+++ b/content/ja/docs/languages/sdk-configuration/general.md
@@ -3,66 +3,69 @@ title: 一般的なSDK設定
 linkTitle: 一般
 weight: 10
 aliases: [general-sdk-configuration]
-default_lang_commit: 276d7eb3f936deef6487cdd2b1d89822951da6c8 # patched
-drifted_from_default: true
+default_lang_commit: 813498074d85258c7180d137ace9e272d0149353
 cSpell:ignore: ottrace
 ---
 
-{{% alert title="Note" %}}
-
-環境変数のサポートはオプションです。
-各言語の実装がどの環境変数をサポートしているかの詳細については、[実装準拠マトリックス](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md#environment-variables)を参照してください。
-
-{{% /alert %}}
+{{% include "env-var-note.md" %}}
 
 ## `OTEL_SERVICE_NAME`
 
 [`service.name`](/docs/specs/semconv/resource/#service) リソース属性の値を設定します。
 
-**デフォルト値:** `"unknown_service"`
+**デフォルト値:** `unknown_service`
 
 `OTEL_RESOURCE_ATTRIBUTES` に `service.name` も指定されている場合は、`OTEL_SERVICE_NAME` が優先されます。
 
 **例:**
 
-`export OTEL_SERVICE_NAME="your-service-name"`
+```sh
+export OTEL_SERVICE_NAME="your-service-name"
+```
 
 ## `OTEL_RESOURCE_ATTRIBUTES`
 
 リソース属性として使用されるキーと値のペア。
-詳細は[リソースSDK](/docs/specs/otel/resource/sdk#specifying-resource-information-via-an-environment-variable)を参照してください。
 
 **デフォルト値:** 空
 
-一般的なリソースタイプで従うべきセマンティック規約については、[リソースのセマンティック規約](/docs/specs/semconv/resource/#semantic-attributes-with-sdk-provided-default-value)を参照してください。
-
 **例:**
 
-`export OTEL_RESOURCE_ATTRIBUTES="key1=value1,key2=value2"`
+```sh
+export OTEL_RESOURCE_ATTRIBUTES="key1=value1,key2=value2"
+```
+
+**参考資料:**
+
+- [リソースSDK](/docs/specs/otel/resource/sdk#specifying-resource-information-via-an-environment-variable)
+- [リソースのセマンティック規約](/docs/specs/semconv/resource/#semantic-attributes-with-sdk-provided-default-value)
+  — 一般的なリソースタイプで従うべきセマンティック規約
 
 ## `OTEL_TRACES_SAMPLER`
 
 SDKによるトレースのサンプリングに使用するサンプラーを指定します。
 
-**デフォルト値:** `"parentbased_always_on"`
+**デフォルト値:** `parentbased_always_on`
 
 **例:**
 
-`export OTEL_TRACES_SAMPLER="traceidratio"`
+```sh
+export OTEL_TRACES_SAMPLER="traceidratio"
+```
 
 `OTEL_TRACES_SAMPLER` に指定できる値の一覧は以下です。
 
-- `"always_on"`: `AlwaysOnSampler`
-- `"always_off"`: `AlwaysOffSampler`
-- `"traceidratio"`: `TraceIdRatioBased`
-- `"parentbased_always_on"`: `ParentBased(root=AlwaysOnSampler)`
-- `"parentbased_always_off"`: `ParentBased(root=AlwaysOffSampler)`
-- `"parentbased_traceidratio"`: `ParentBased(root=TraceIdRatioBased)`
-- `"parentbased_jaeger_remote"`: `ParentBased(root=JaegerRemoteSampler)`
-- `"jaeger_remote"`: `JaegerRemoteSampler`
-- `"xray"`:
-  [AWS X-Ray Centralized Sampling](https://docs.aws.amazon.com/xray/latest/devguide/xray-console-sampling.html)
-  (_サードパーティ_)
+- `always_on`: `AlwaysOnSampler`
+- `always_off`: `AlwaysOffSampler`
+- `traceidratio`: `TraceIdRatioBased`
+- `parentbased_always_on`: `ParentBased(root=AlwaysOnSampler)`
+- `parentbased_always_off`: `ParentBased(root=AlwaysOffSampler)`
+- `parentbased_traceidratio`: `ParentBased(root=TraceIdRatioBased)`
+- `parentbased_jaeger_remote`: `ParentBased(root=JaegerRemoteSampler)`
+- `jaeger_remote`: `JaegerRemoteSampler`
+- `xray`: [AWS X-Ray Centralized Sampling][] (_サードパーティ_)
+
+[AWS X-Ray Centralized Sampling]: https://docs.aws.amazon.com/xray/latest/devguide/xray-console-sampling.html
 
 ## `OTEL_TRACES_SAMPLER_ARG`
 
@@ -85,7 +88,7 @@ export OTEL_TRACES_SAMPLER_ARG="0.5"
 - `traceidratio` と `parentbased_traceidratio` サンプラーの場合: サンプリング確率。[0..1]の範囲で指定します。未設定の場合、デフォルトは1.0。
 - `jaeger_remote` と `parentbased_jaeger_remote` の場合: 値はカンマ区切りのリストです。
   - 例:
-    `"endpoint=http://localhost:14250,pollingIntervalMs=5000,initialSamplingRate=0.25"`
+    `endpoint=http://localhost:14250,pollingIntervalMs=5000,initialSamplingRate=0.25`
   - `endpoint`: サービスのサンプリング戦略を提供する gRPC サーバーの `scheme://host:port` 形式のエンドポイント ([sampling.proto](https://github.com/jaegertracing/jaeger-idl/blob/main/proto/api_v2/sampling.proto)).
   - `pollingIntervalMs`: サンプラーがサンプリング戦略の更新のためにバックエンドをポーリングする頻度をミリ秒単位で指定します。
   - `initialSamplingRate`: [0..1]の範囲で、サンプリング戦略を取得するためにバックエンドに到達できない場合のサンプリング確率として使用されます。サンプリング戦略の取得に成功すると、この値は意味を持たなくなり、新しいアップデートが取得されるまでリモート戦略が使用されるようになります。
@@ -94,34 +97,32 @@ export OTEL_TRACES_SAMPLER_ARG="0.5"
 
 カンマ区切りのリストで使用するプロパゲーターを指定します。
 
-**デフォルト値:** `"tracecontext,baggage"`
+**デフォルト値:** `tracecontext,baggage`
 
-**Example:**
+**例:**
 
 `export OTEL_PROPAGATORS="b3"`
 
 `OTEL_PROPAGATORS` に指定できる値の一覧は以下です。
 
-- `"tracecontext"`: [W3C Trace Context](https://www.w3.org/TR/trace-context/)
-- `"baggage"`: [W3C Baggage](https://www.w3.org/TR/baggage/)
-- `"b3"`: [B3 Single](/docs/specs/otel/context/api-propagators#configuration)
-- `"b3multi"`:
-  [B3 Multi](/docs/specs/otel/context/api-propagators#configuration)
-- `"jaeger"`:
-  [Jaeger](https://www.jaegertracing.io/sdk-migration/)
-- `"xray"`:
+- `tracecontext`: [W3C Trace Context](https://www.w3.org/TR/trace-context/)
+- `baggage`: [W3C Baggage](https://www.w3.org/TR/baggage/)
+- `b3`: [B3 Single](/docs/specs/otel/context/api-propagators#configuration)
+- `b3multi`: [B3 Multi](/docs/specs/otel/context/api-propagators#configuration)
+- `jaeger`: [Jaeger](https://www.jaegertracing.io/sdk-migration/)
+- `xray`:
   [AWS X-Ray](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader)
   (_サードパーティ_)
-- `"ottrace"`:
-  [OT Trace](https://github.com/opentracing?q=basic&type=&language=) (_サードパーティ_)
-- `"none"`: 自動設定されたプロパゲータがない。
+- `ottrace`: [OT Trace](https://github.com/opentracing?q=basic&type=&language=)
+  (_サードパーティ_)
+- `none`: 自動設定されたプロパゲータがない。
 
 ## `OTEL_TRACES_EXPORTER`
 
 トレースに使用するエクスポーターを指定します。
 実装によっては、カンマ区切りのリストになります。
 
-**デフォルト値:** `"otlp"`
+**デフォルト値:** `otlp`
 
 **例:**
 
@@ -129,18 +130,18 @@ export OTEL_TRACES_SAMPLER_ARG="0.5"
 
 指定できる値の一覧は以下です。
 
-- `"otlp"`: [OTLP][]
-- `"jaeger"`: Jaegerデータモデルでのエクスポート
-- `"zipkin"`: [Zipkin](https://zipkin.io/zipkin-api/)
-- `"console"`: [Standard Output](/docs/specs/otel/trace/sdk_exporters/stdout/)
-- `"none"`: トレース用に自動設定されたエクスポーターがない。
+- `otlp`: [OTLP][]
+- `jaeger`: Jaegerデータモデルでのエクスポート。
+- `zipkin`: [Zipkin](https://zipkin.io/zipkin-api/)
+- `console`: [Standard Output](/docs/specs/otel/trace/sdk_exporters/stdout/)
+- `none`: トレース用に自動設定されたエクスポーターがない。
 
 ## `OTEL_METRICS_EXPORTER`
 
 メトリクスに使用するエクスポーターを指定します。
 実装によっては、カンマ区切りのリストになります。
 
-**デフォルト値:** `"otlp"`
+**デフォルト値:** `otlp`
 
 **例:**
 
@@ -148,18 +149,18 @@ export OTEL_TRACES_SAMPLER_ARG="0.5"
 
 `OTEL_METRICS_EXPORTER` に指定できる値の一覧は以下です。
 
-- `"otlp"`: [OTLP][]
-- `"prometheus"`:
+- `otlp`: [OTLP][]
+- `prometheus`:
   [Prometheus](https://github.com/prometheus/docs/blob/main/docs/instrumenting/exposition_formats.md)
-- `"console"`: [標準出力](/docs/specs/otel/metrics/sdk_exporters/stdout/)
-- `"none"`: メトリクスのエクスポーターが自動的に設定されない。
+- `console`: [標準出力](/docs/specs/otel/metrics/sdk_exporters/stdout/)
+- `none`: メトリクスのエクスポーターが自動的に設定されない。
 
 ## `OTEL_LOGS_EXPORTER`
 
 ログにどのエクスポーターを使用するかを指定します。
 実装によっては、カンマ区切りのリストになります。
 
-**デフォルト値:** `"otlp"`
+**デフォルト値:** `otlp`
 
 **例:**
 
@@ -167,8 +168,8 @@ export OTEL_TRACES_SAMPLER_ARG="0.5"
 
 `OTEL_LOGS_EXPORTER` に指定できる値の一覧は以下です。
 
-- `"otlp"`: [OTLP][]
-- `"console"`: [標準出力](/docs/specs/otel/logs/sdk_exporters/stdout/)
-- `"none"`: ログのエクスポーターが自動的に設定されない。
+- `otlp`: [OTLP][]
+- `console`: [標準出力](/docs/specs/otel/logs/sdk_exporters/stdout/)
+- `none`: ログのエクスポーターが自動的に設定されない。
 
 [otlp]: /docs/specs/otlp/


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/sdk-configuration/general.md` to match the
latest English source at `content/en/docs/languages/sdk-configuration/general.md`.
Refreshes `default_lang_commit` and removes the `drifted_from_default` flag.

Notable upstream changes reflected:

- The legacy `{{% alert %}}` note was replaced by
  `{{% include "env-var-note.md" %}}`.
- The inner double quotes around literal values
  (`"unknown_service"` → `unknown_service`, `"always_on"` → `always_on`, etc.)
  were removed.
- Inline `` `export ...` `` examples were rewritten as fenced `sh` code blocks.
- `OTEL_RESOURCE_ATTRIBUTES` was reorganized with a new `References` section.
- The AWS X-Ray Centralized Sampling link uses a reference-style link.
- The `jaeger` propagator link was updated to
  `https://www.jaegertracing.io/sdk-migration/`.

## Typo fixes

While reviewing, I also fixed one unambiguous typo outside the English diff range:

- `content/ja/docs/languages/sdk-configuration/general.md`: the
  `OTEL_PROPAGATORS` Example label was `**Example:**` (untranslated). All other
  Example labels on this page use `**例:**`; updated for consistency.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.