### PR TITLE
[ja] docs(i18n): update translation of content/en/docs/languages/java/gett…

### DIFF
--- a/content/ja/docs/languages/java/getting-started.md
+++ b/content/ja/docs/languages/java/getting-started.md
@@ -2,10 +2,9 @@
 title: サンプルによる入門
 description: 5分以内にアプリのテレメトリーを取得しましょう！
 weight: 10
-default_lang_commit: 4b5381a2e9f129651ab8658357ab846bd4c965f2
+default_lang_commit: c2f1762937a709892f60dece2e238d35d8a4d103
 ---
 
-<!-- markdownlint-disable blanks-around-fences -->
 <?code-excerpt path-base="examples/java/getting-started"?>
 
 このページでは、JavaでOpenTelemetryを始める方法を紹介します。
@@ -58,8 +57,8 @@ dependencies {
 
 同じフォルダに、`DiceApplication.java`というファイルを作成し、次のコードをファイルに追加します。
 
-<!-- prettier-ignore-start -->
 <?code-excerpt "src/main/java/otel/DiceApplication.java"?>
+
 ```java
 package otel;
 
@@ -76,12 +75,11 @@ public class DiceApplication {
   }
 }
 ```
-<!-- prettier-ignore-end -->
 
 `RollController.java`という別のファイルを作成し、次のコードをファイルに追加します。
 
-<!-- prettier-ignore-start -->
 <?code-excerpt "src/main/java/otel/RollController.java"?>
+
 ```java
 package otel;
 
@@ -113,7 +111,6 @@ public class RollController {
   }
 }
 ```
-<!-- prettier-ignore-end -->
 
 次のコマンドでアプリケーションをビルドして実行し、Webブラウザで<http://localhost:8080/rolldice>を開いて動作していることを確認します。
 
@@ -139,9 +136,9 @@ java -jar ./build/libs/java-simple.jar
 
    ```sh
    export JAVA_TOOL_OPTIONS="-javaagent:PATH/TO/opentelemetry-javaagent.jar" \
-     OTEL_TRACES_EXPORTER=logging \
-     OTEL_METRICS_EXPORTER=logging \
-     OTEL_LOGS_EXPORTER=logging \
+     OTEL_TRACES_EXPORTER=console \
+     OTEL_METRICS_EXPORTER=console \
+     OTEL_LOGS_EXPORTER=console \
      OTEL_METRIC_EXPORT_INTERVAL=15000
    ```
 


### PR DESCRIPTION
…ing-started.md

<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

# Summary

This PR updates `content/ja/docs/languages/java/getting-started.md" to match the current English version.

- [Getting Started by Example](https://opentelemetry.io/docs/languages/java/getting-started/)
  - https://github.com/open-telemetry/opentelemetry.io/compare/4b5381a2e9f129651ab8658357ab846bd4c965f2...c2f176293#diff-29aa9658749dfe2bff391d4ffd82219b097ea0984102fb32aab379adcb16fbca

# Preview

- https://deploy-preview-10057--opentelemetry.netlify.app/ja/docs/languages/java/getting-started/
