### PR TITLE
[ja] update translation of content/en/docs/zero-code/java/spring-boot-starter/getting-started.md

### DIFF
--- a/content/ja/docs/zero-code/java/spring-boot-starter/getting-started.md
+++ b/content/ja/docs/zero-code/java/spring-boot-starter/getting-started.md
@@ -1,17 +1,14 @@
 ---
 title: はじめに
 weight: 20
-default_lang_commit: 276d7eb3f936deef6487cdd2b1d89822951da6c8 # patched
-drifted_from_default: true
+default_lang_commit: a790e3cf91025305c683047b181120ab6bbae3de
 cSpell:ignore: springboot
 ---
 
-{{% alert title="注意" %}}
-
-Spring Bootアプリケーションを計装するために、[Javaエージェント](../../agent)を使用することもできます。
-長所と短所については、[Javaゼロコード計装](..)を参照してください。
-
-{{% /alert %}}
+> [!NOTE]
+>
+> Spring Bootアプリケーションを計装するために、[Javaエージェント](../../agent)を使用することもできます。
+> 長所と短所については、[Javaゼロコード計装](..)を参照してください。
 
 ## 互換性 {#compatibility}
 
@@ -24,14 +21,12 @@ Bill of Material（[BOM](https://maven.apache.org/guides/introduction/introducti
 
 OpenTelemetryスターターを使用する際は、すべてのOpenTelemetry依存関係のバージョン整合性を確保するために、`opentelemetry-instrumentation-bom` BOMをインポートする必要があります。
 
-{{% alert title="注意" %}}
-
-Mavenを使用する場合は、プロジェクト内の他のBOMよりも前にOpenTelemetry BOMをインポートしてください。
-たとえば、`spring-boot-dependencies` BOMをインポートする場合は、OpenTelemetry BOMの後に宣言する必要があります。
-
-Gradleは依存関係の[最新バージョン](https://docs.gradle.org/current/userguide/dependency_resolution.html#2_perform_conflict_resolution)を選択するため、BOMの順序は重要ではありません。
-
-{{% /alert %}}
+> [!NOTE]
+>
+> Mavenを使用する場合は、プロジェクト内の他のBOMよりも前にOpenTelemetry BOMをインポートしてください。
+> たとえば、`spring-boot-dependencies` BOMをインポートする場合は、OpenTelemetry BOMの後に宣言する必要があります。
+>
+> Gradleは依存関係の[最新バージョン](https://docs.gradle.org/current/userguide/dependency_resolution.html#2_perform_conflict_resolution)を選択するため、BOMの順序は重要ではありません。
 
 以下の例は、Mavenを使用してOpenTelemetry BOMをインポートする方法を示しています。
 
@@ -83,12 +78,10 @@ dependencyManagement {
 }
 ```
 
-{{% alert title="注意" %}}
-
-Gradleで異なる設定方法を混在させないよう注意してください。
-たとえば、`io.spring.dependency-management`プラグインと一緒に`implementation(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:{{% param vers.instrumentation %}}"))`を使用しないでください。
-
-{{% /alert %}}
+> [!NOTE]
+>
+> Gradleで異なる設定方法を混在させないよう注意してください。
+> たとえば、`io.spring.dependency-management`プラグインと一緒に`implementation(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:{{% param vers.instrumentation %}}"))`を使用しないでください。
 
 ### OpenTelemetryスターターの依存関係 {#opentelemetry-starter-dependency}
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/java/spring-boot-starter/getting-started.md`
to match the latest English source. Refreshes `default_lang_commit` and
removes the `drifted_from_default` flag.

Notable upstream changes reflected:

- All three `{{% alert title="Note" %}}` callouts (Java-agent alternative
  pointer at the top, the Maven/Gradle BOM ordering note, and the
  "don't mix Gradle config styles" note) were rewritten as `> [!NOTE]`
  blockquote admonitions.

The previous heading-level promotion (`### Compatibility` → `## Compatibility`,
`### Dependency management` → `## Dependency management`, and
`#### OpenTelemetry Starter dependency` → `### OpenTelemetry Starter dependency`)
was already present in the JA file via an earlier `# patched` fix, so the
existing JA heading IDs (`#compatibility`, `#dependency-management`,
`#opentelemetry-starter-dependency`) already match the live page.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.