### PR TITLE
[ja] docs(i18n): update content/ja/docs/languages/java/_index.md

### DIFF
--- a/content/ja/docs/languages/java/_index.md
+++ b/content/ja/docs/languages/java/_index.md
@@ -14,7 +14,7 @@ cascade:
     contrib: 1.57.0
     semconv: 1.41.0
 weight: 150
-default_lang_commit: 68c29178b21e7ace970d27c5817a4edcff3ea9fb
+default_lang_commit: a790e3cf91025305c683047b181120ab6bbae3de
 ---
 
 {{% docs/languages/index-intro java /%}}


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

# Summary

This PR updates `content/ja/docs/languages/java/_index.md` to match the current English version.
Only `default_lang_commit` is updated as the version of `cascade.vers` has been up to date.

https://github.com/open-telemetry/opentelemetry.io/compare/68c29178b21e7ace970d27c5817a4edcff3ea9fb...a790e3cf9#diff-18b6c48e6322948ac6bd1248c2875151376975c23c88a5c85a8663d98365760e