### PR TITLE
Adds Tintri Receiver to the Registry

### DIFF
--- a/data/registry/collector-receiver-tintri.yml
+++ b/data/registry/collector-receiver-tintri.yml
@@ -1,0 +1,23 @@
+# cSpell:ignore vmstore tintri Tintri tgc VMstore
+title: Tintri Receiver
+registryType: receiver
+language: collector
+tags:
+  - go
+  - receiver
+  - collector
+license: Apache 2.0
+description:
+  This receiver collects metrics from Tintri VMstore appliances and Tintri
+  Global Center (TGC), covering datastore, virtual machine, and virtual disk
+  realtime, capacity, replication, and health telemetry.
+authors:
+  - name: IntegrationPlumbers
+    url: https://github.com/IntegrationPlumbers
+urls:
+  repo: https://github.com/IntegrationPlumbers/tintri
+createdAt: 2026-05-28
+package:
+  registry: go-collector
+  name: github.com/IntegrationPlumbers/tintri
+  version: v0.3.0


### PR DESCRIPTION
Adds Tintri TGC and VMStores as OTel-native observability application integrations leveraging existing REST API's available on Tintri appliances.

<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [X] This PR has content that I did not fully write myself.
  - [X] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.
- [x] I-know-my-stuff: Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

This PR adds the Tintri Reciever to the OpenTelemetry registry as First Party integration supported by Integration Plumbers.

**Project:** Extend existing Tintri API metrics support to OpenTelemetry.

**Why it belongs in the registry:** Tintri products have to this point not supported OpenTelemetry while facing increasing customer requests. The registry is a natural place for their customers to look for a solution. Integration Plumbers is seeking additional collaborators to expand and refine this collector, and the visibility provided by the registry would aid in this effort.

This is alpha level code, developed against a minimal footprint lab environment, with our initial efforts having been done in Python to expedite our initial debugging with access limitations. Our efforts continue, and we're interested in supporting anyone who is interested in using or contributing to this project directly.

- Repo: https://github.com/IntegrationPlumbers/tintri
- Website: https://www.integrationplumbers.io/
- License: Apache 2.0
- Language: Go Lang

I've followed the template at `templates/registry-entry.yml` and the marketing guidelines (no superlatives, factual description, all three URLs set).

<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [X] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [X] This PR has content that I did not fully write myself.
  - [X] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [X] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---
