### PR TITLE
Refresh traceway/opentelemetry-symfony registry entry

### DIFF
--- a/data/registry/instrumentation-php-symfony-traceway.yml
+++ b/data/registry/instrumentation-php-symfony-traceway.yml
@@ -26,11 +26,11 @@ urls:
 license: MIT
 description:
   Pure-PHP OpenTelemetry instrumentation for Symfony — automatic tracing for
-  HTTP, Console, HttpClient, Messenger, Mailer, Scheduler, Doctrine DBAL,
-  Cache, and Twig; Monolog log-trace correlation; opt-in OTel log export;
-  opt-in metrics for Messenger/DBAL/HTTP/Mailer; and native AWS X-Ray
-  propagator and ID generator. Ships a traceway:doctor command for
-  diagnostics. No C extension required. PHP 8.1+, Symfony 6.4 LTS / 7.x / 8.x.
+  HTTP, Console, HttpClient, Messenger, Mailer, Scheduler, Doctrine DBAL, Cache,
+  and Twig; Monolog log-trace correlation; opt-in OTel log export; opt-in
+  metrics for Messenger/DBAL/HTTP/Mailer; and native AWS X-Ray propagator and ID
+  generator. Ships a traceway:doctor command for diagnostics. No C extension
+  required. PHP 8.1+, Symfony 6.4 LTS / 7.x / 8.x.
 authors:
   - name: Traceway
     url: https://github.com/tracewayapp

--- a/data/registry/instrumentation-php-symfony-traceway.yml
+++ b/data/registry/instrumentation-php-symfony-traceway.yml
@@ -7,20 +7,30 @@ tags:
   - php
   - instrumentation
   - tracing
+  - metrics
+  - logs
   - doctrine
   - twig
   - cache
   - messenger
+  - mailer
+  - scheduler
+  - monolog
   - http-client
   - console
+  - otlp
+  - aws-xray
 urls:
   repo: https://github.com/tracewayapp/opentelemetry-symfony-bundle
   docs: https://github.com/tracewayapp/opentelemetry-symfony-bundle#readme
 license: MIT
 description:
-  Pure-PHP OpenTelemetry tracing for Symfony — automatic instrumentation for
-  HTTP, Console, Doctrine DBAL, Cache, Twig, Messenger, and HttpClient. No C
-  extension required. Supports PHP 8.1+ and Symfony 6.4/7.x/8.x.
+  Pure-PHP OpenTelemetry instrumentation for Symfony — automatic tracing for
+  HTTP, Console, HttpClient, Messenger, Mailer, Scheduler, Doctrine DBAL,
+  Cache, and Twig; Monolog log-trace correlation; opt-in OTel log export;
+  opt-in metrics for Messenger/DBAL/HTTP/Mailer; and native AWS X-Ray
+  propagator and ID generator. Ships a traceway:doctor command for
+  diagnostics. No C extension required. PHP 8.1+, Symfony 6.4 LTS / 7.x / 8.x.
 authors:
   - name: Traceway
     url: https://github.com/tracewayapp


### PR DESCRIPTION
Refreshes the registry entry for traceway/opentelemetry-symfony to cover the instrumentation it has shipped since the
initial entry was added.

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

