### PR TITLE
fix(auto-update): fetch tags from remote before switching

### DIFF
--- a/scripts/auto-update/version-in-file.sh
+++ b/scripts/auto-update/version-in-file.sh
@@ -137,7 +137,8 @@ if [[ "$repo" == "opentelemetry-specification"
     npm run get:submodule -- content-modules/$repo &&
     cd content-modules/$repo &&
     git fetch &&
-    git fetch $(git remote | tail -1) --tags &&
+    remote=$(git remote | grep -qx upstream && echo upstream || echo origin) &&
+    git fetch "$remote" --tags &&
     git switch --detach $latest_version
   )
 fi

--- a/scripts/auto-update/version-in-file.sh
+++ b/scripts/auto-update/version-in-file.sh
@@ -137,6 +137,7 @@ if [[ "$repo" == "opentelemetry-specification"
     npm run get:submodule -- content-modules/$repo &&
     cd content-modules/$repo &&
     git fetch &&
+    git fetch $(git remote | tail -1) --tags &&
     git switch --detach $latest_version
   )
 fi


### PR DESCRIPTION
- Fixes #10117 by fetching tags first
- Contributes to #10118
- Notes:
  - Use of `$(git remote | tail -1)` is a heuristic that should work in all of the cases in this repo
  - We won't be able to test this until it lands