### PR TITLE
[ja] add translation of content/en/docs/platforms/client-apps/web/_index.md

### DIFF
--- a/content/ja/docs/platforms/client-apps/web/_index.md
+++ b/content/ja/docs/platforms/client-apps/web/_index.md
@@ -1,0 +1,8 @@
+---
+title: Web
+description: >-
+  ウェブブラウザ上で動作するアプリで OpenTelemetry を使う
+default_lang_commit: 147b494062edd35ab8900709a9f78e7fd086c3d3
+---
+
+コンテンツは近日公開予定です！


### PR DESCRIPTION
## Summary

Translates `content/en/docs/platforms/client-apps/web/_index.md` into Japanese as `content/ja/docs/platforms/client-apps/web/_index.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10127--opentelemetry.netlify.app/ja/docs/platforms/client-apps/web/
- **English (canonical):** https://opentelemetry.io/docs/platforms/client-apps/web/

<!-- preview-section-end -->
