### PR TITLE
[ja] add translation of content/en/docs/demo/services/fraud-detection.md

### DIFF
--- a/content/ja/docs/demo/services/fraud-detection.md
+++ b/content/ja/docs/demo/services/fraud-detection.md
@@ -1,0 +1,21 @@
+---
+title: 不正検知サービス
+linkTitle: 不正検知
+aliases: [frauddetectionservice]
+default_lang_commit: 147b494062edd35ab8900709a9f78e7fd086c3d3
+---
+
+このサービスは受信した注文を分析し、悪意のある顧客を検出します。
+これはモックのみであり、受信した注文が出力されます。
+
+[不正検知サービスのソースコード](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/fraud-detection/)
+
+## 自動計装 {#auto-instrumentation}
+
+このサービスは、Kafka などのライブラリを自動的に計装し、OpenTelemetry SDK を設定するために、OpenTelemetry Java エージェントに依存しています。
+エージェントは `-javaagent` コマンドライン引数を使用してプロセスに渡されます。
+コマンドライン引数は `Dockerfile` の `JAVA_TOOL_OPTIONS` を通じて追加され、自動生成された Gradle スタートアップスクリプトで利用されます。
+
+```dockerfile
+ENV JAVA_TOOL_OPTIONS=-javaagent:/app/opentelemetry-javaagent.jar
+```


### PR DESCRIPTION
## Summary

Translates `content/en/docs/demo/services/fraud-detection.md` into Japanese as `content/ja/docs/demo/services/fraud-detection.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.


<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10129--opentelemetry.netlify.app/ja/docs/demo/services/fraud-detection/
- **English (canonical):** https://opentelemetry.io/docs/demo/services/fraud-detection/

<!-- preview-section-end -->
