### PR TITLE
[ja] add translation of content/en/docs/languages/rust/libraries.md

### DIFF
--- a/content/ja/docs/languages/rust/libraries.md
+++ b/content/ja/docs/languages/rust/libraries.md
@@ -1,0 +1,17 @@
+---
+title: 計装ライブラリの使用
+linkTitle: ライブラリ
+weight: 40
+description: アプリが依存するライブラリを計装する方法
+default_lang_commit: 147b494062edd35ab8900709a9f78e7fd086c3d3
+---
+
+{{% docs/languages/libraries-intro rust %}}
+
+## 計装ライブラリの使用 {#use-instrumentation-libraries}
+
+各計装ライブラリは [crate](https://crates.io/) です。
+
+たとえば、[Actix Web 用の計装ライブラリ](https://crates.io/crates/opentelemetry-instrumentation-actix-web)は、受信した HTTP リクエストに基づいて[スパン](/docs/concepts/signals/traces/#spans)と[メトリクス](/docs/concepts/signals/metrics/)を自動的に作成します。
+
+利用可能な計装ライブラリのリストは、[レジストリ](/ecosystem/registry/?language=rust&component=instrumentation)を参照してください。


### PR DESCRIPTION
## Summary

Translates `content/en/docs/languages/rust/libraries.md` into Japanese as `content/ja/docs/languages/rust/libraries.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10131--opentelemetry.netlify.app/ja/docs/languages/rust/libraries/
- **English (canonical):** https://opentelemetry.io/docs/languages/rust/libraries/

<!-- preview-section-end -->
