### PR TITLE
[ja] add translation of content/en/docs/demo/services/kafka.md

### DIFF
--- a/content/ja/docs/demo/services/kafka.md
+++ b/content/ja/docs/demo/services/kafka.md
@@ -1,0 +1,20 @@
+---
+title: Kafka
+default_lang_commit: 119208cc7b365e78d78be27a7c2d507650c73f7d
+cSpell:ignore: Dotel
+---
+
+これはチェックアウトサービスと会計サービスおよび不正検知サービスを接続するためのメッセージキューサービスとして使用されます。
+
+[Kafka サービスのソースコード](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/kafka/)
+
+## 自動計装 {#auto-instrumentation}
+
+このサービスは、OpenTelemetry Java エージェントと組み込みの [JMX Metric Insight Module](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/jmx-metrics/javaagent) を使用して、[Kafka ブローカーメトリクス](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/javaagent/kafka-broker.md)をキャプチャし、OTLP 経由で Collector に送信します。
+
+エージェントは `-javaagent` コマンドライン引数を使用してプロセスに渡されます。
+コマンドライン引数は `Dockerfile` 内の `KAFKA_OPTS` を通じて追加されます。
+
+```dockerfile
+ENV KAFKA_OPTS="-javaagent:/tmp/opentelemetry-javaagent.jar -Dotel.jmx.target.system=kafka-broker"
+```


### PR DESCRIPTION
## Summary

Translates `content/en/docs/demo/services/kafka.md` into Japanese as `content/ja/docs/demo/services/kafka.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10135--opentelemetry.netlify.app/ja/docs/demo/services/kafka/
- **English (canonical):** https://opentelemetry.io/docs/demo/services/kafka/

<!-- preview-section-end -->
