### PR TITLE
[ja] add translation of content/en/docs/demo/services/flagd-ui.md

### DIFF
--- a/content/ja/docs/demo/services/flagd-ui.md
+++ b/content/ja/docs/demo/services/flagd-ui.md
@@ -1,0 +1,47 @@
+---
+title: Flagd-UI サービス
+linkTitle: Flagd-UI
+aliases: [flagd-uiservice]
+default_lang_commit: c5406fb091b81c0d8e55aa36d0215c3f987e2aef
+cSpell:ignore: uiservice
+---
+
+このサービスは、ユーザーがフィーチャーフラグを切り替えたり編集したりして、デモ環境の動作を変更できるフロントエンドとして機能します。
+
+[Flagd-UI サービスのソースコード](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/flagd-ui/)
+
+## トレーシングの初期化 {#initializing-tracing}
+
+Phoenix エンドポイントとリクエストの自動計装に必要な依存関係をインストールした後、[公式ドキュメント](/docs/languages/erlang/getting-started/)に従って `config/runtime.exs` ファイルを編集し、設定を行います。
+
+```elixir
+otel_endpoint =
+  System.get_env("OTEL_EXPORTER_OTLP_ENDPOINT") ||
+    raise """
+    environment variable OTEL_EXPORTER_OTLP_ENDPOINT is missing.
+    """
+
+config :opentelemetry, :processors,
+    otel_batch_processor: %{
+      exporter: {:opentelemetry_exporter, %{endpoints: [otel_endpoint]}}
+    }
+```
+
+また、[`lib/flagd_ui/application.ex`](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/flagd-ui/lib/flagd_ui/application.ex) 内で OpenTelemetry Bandit アダプターと Phoenix ライブラリも初期化します。
+
+```elixir
+OpentelemetryBandit.setup()
+OpentelemetryPhoenix.setup(adapter: :bandit)
+```
+
+## トレース {#traces}
+
+Phoenix と Bandit は専用のライブラリを通じて自動計装されます。
+
+## メトリクス {#metrics}
+
+TBD
+
+## ログ {#logs}
+
+TBD


### PR DESCRIPTION
## Summary

Translates `content/en/docs/demo/services/flagd-ui.md` into Japanese as `content/ja/docs/demo/services/flagd-ui.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10137--opentelemetry.netlify.app/ja/docs/demo/services/flagd-ui/
- **English (canonical):** https://opentelemetry.io/docs/demo/services/flagd-ui/

<!-- preview-section-end -->
