### PR TITLE
ci: Add reusable workflow failure reporting, and more

### DIFF
--- a/.github/workflows/auto-update-community-members.yml
+++ b/.github/workflows/auto-update-community-members.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  auto-update-versions:
+  auto-update:
     name: Auto-update community members page
     runs-on: ubuntu-latest
     # Remove the if statement below when testing against a fork
@@ -64,3 +64,11 @@ jobs:
           title: Update community members
           body: |
             This pull request contains automated updates to files by the GitHub Action.
+
+  report-failure:
+    needs: auto-update
+    if: failure() && github.repository == 'open-telemetry/opentelemetry.io'
+    uses: ./.github/workflows/reusable-report-failure.yml
+    permissions:
+      issues: write
+      contents: read

--- a/.github/workflows/auto-update-community-members.yml
+++ b/.github/workflows/auto-update-community-members.yml
@@ -70,5 +70,5 @@ jobs:
     if: failure() && github.repository == 'open-telemetry/opentelemetry.io'
     uses: ./.github/workflows/reusable-report-failure.yml
     permissions:
-      issues: write
+      issues: write # Pass through for failure tracking issues
       contents: read

--- a/.github/workflows/auto-update-registry.yml
+++ b/.github/workflows/auto-update-registry.yml
@@ -10,7 +10,7 @@ on:
 permissions: read-all
 
 jobs:
-  auto-update-versions:
+  auto-update:
     name: Auto-update registry versions
     runs-on: ubuntu-latest
     permissions:
@@ -38,3 +38,11 @@ jobs:
         env:
           # change to ${{ secrets.GITHUB_TOKEN }} and comment out the step above when testing against a fork
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+
+  report-failure:
+    needs: auto-update
+    if: failure() && github.repository == 'open-telemetry/opentelemetry.io'
+    uses: ./.github/workflows/reusable-report-failure.yml
+    permissions:
+      issues: write
+      contents: read

--- a/.github/workflows/auto-update-registry.yml
+++ b/.github/workflows/auto-update-registry.yml
@@ -44,5 +44,5 @@ jobs:
     if: failure() && github.repository == 'open-telemetry/opentelemetry.io'
     uses: ./.github/workflows/reusable-report-failure.yml
     permissions:
-      issues: write
+      issues: write # Pass through for failure tracking issues
       contents: read

--- a/.github/workflows/auto-update-versions.yml
+++ b/.github/workflows/auto-update-versions.yml
@@ -9,7 +9,7 @@ on:
 permissions: read-all
 
 jobs:
-  auto-update-versions:
+  auto-update:
     name: Auto-update versions
     runs-on: ubuntu-latest
     permissions:
@@ -36,3 +36,11 @@ jobs:
         env:
           # change to ${{ secrets.GITHUB_TOKEN }} and comment out the step above when testing against a fork
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+
+  report-failure:
+    needs: auto-update
+    if: failure() && github.repository == 'open-telemetry/opentelemetry.io'
+    uses: ./.github/workflows/reusable-report-failure.yml
+    permissions:
+      issues: write
+      contents: read

--- a/.github/workflows/auto-update-versions.yml
+++ b/.github/workflows/auto-update-versions.yml
@@ -42,5 +42,5 @@ jobs:
     if: failure() && github.repository == 'open-telemetry/opentelemetry.io'
     uses: ./.github/workflows/reusable-report-failure.yml
     permissions:
-      issues: write
+      issues: write # Pass through for failure tracking issues
       contents: read

--- a/.github/workflows/reusable-report-failure.yml
+++ b/.github/workflows/reusable-report-failure.yml
@@ -1,0 +1,60 @@
+name: Reusable - report workflow failure
+
+# Reusable workflow that opens (or comments on an existing) GitHub issue when a
+# caller workflow fails. Call it as a final job gated with `if: failure()`:
+#
+#   report-failure:
+#     needs: [my-job]
+#     if: failure() && github.repository == 'open-telemetry/opentelemetry.io'
+#     uses: ./.github/workflows/reusable-report-failure.yml
+#     permissions:
+#       issues: write
+#       contents: read
+#
+# In a called workflow the `github` context refers to the caller, so the
+# workflow name, branch, commit, and run URL are derived automatically and don't
+# need to be passed in. The issue logic lives in
+# scripts/gh/report-failure/ (with unit tests).
+
+on:
+  workflow_call:
+    inputs:
+      label:
+        required: false
+        type: string
+        default: CI/infra
+      issue-type: # Must match an issue type defined for the org (Task, Bug, Feature).
+        required: false
+        type: string
+        default: Bug
+      issue-prefix:
+        required: false
+        type: string
+        default: Workflow failed
+
+permissions:
+  contents: read
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Create or update issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          WORKFLOW_URL:
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{
+            github.run_id }}
+          HEAD_BRANCH: ${{ github.ref_name }}
+          HEAD_SHA: ${{ github.sha }}
+          LABEL: ${{ inputs.label }}
+          ISSUE_TYPE: ${{ inputs.issue-type }}
+          ISSUE_PREFIX: ${{ inputs.issue-prefix }}
+        run: node scripts/gh/report-failure/cli.mjs

--- a/.github/workflows/reusable-report-failure.yml
+++ b/.github/workflows/reusable-report-failure.yml
@@ -42,7 +42,7 @@ jobs:
       issues: write # Create or comment on failure tracking issues via gh
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Create or update issue
         env:

--- a/.github/workflows/reusable-report-failure.yml
+++ b/.github/workflows/reusable-report-failure.yml
@@ -37,12 +37,15 @@ permissions:
 
 jobs:
   report:
+    name: Report failure
     runs-on: ubuntu-latest
     permissions:
       issues: write # Create or comment on failure tracking issues via gh
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Create or update issue
         env:

--- a/.github/workflows/reusable-report-failure.yml
+++ b/.github/workflows/reusable-report-failure.yml
@@ -8,7 +8,7 @@ name: Reusable - report workflow failure
 #     if: failure() && github.repository == 'open-telemetry/opentelemetry.io'
 #     uses: ./.github/workflows/reusable-report-failure.yml
 #     permissions:
-#       issues: write
+#       issues: write  # Pass through for failure tracking issues
 #       contents: read
 #
 # In a called workflow the `github` context refers to the caller, so the
@@ -39,7 +39,7 @@ jobs:
   report:
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      issues: write # Create or comment on failure tracking issues via gh
       contents: read
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/update-semconv-integration-branch.yml
+++ b/.github/workflows/update-semconv-integration-branch.yml
@@ -130,5 +130,5 @@ jobs:
     if: failure() && github.repository == 'open-telemetry/opentelemetry.io'
     uses: ./.github/workflows/reusable-report-failure.yml
     permissions:
-      issues: write
+      issues: write # Pass through for failure tracking issues
       contents: read

--- a/.github/workflows/update-semconv-integration-branch.yml
+++ b/.github/workflows/update-semconv-integration-branch.yml
@@ -124,3 +124,11 @@ jobs:
                          --body "This is a draft PR used for identifying issues integrating the latest (unreleased) [${{ env.REPO }}](https://github.com/open-telemetry/${{ env.REPO }})." \
                          --draft
           fi
+
+  report-failure:
+    needs: update-semconv-integration-branch
+    if: failure() && github.repository == 'open-telemetry/opentelemetry.io'
+    uses: ./.github/workflows/reusable-report-failure.yml
+    permissions:
+      issues: write
+      contents: read

--- a/.github/workflows/update-spec-integration-branch.yml
+++ b/.github/workflows/update-spec-integration-branch.yml
@@ -127,5 +127,5 @@ jobs:
     if: failure() && github.repository == 'open-telemetry/opentelemetry.io'
     uses: ./.github/workflows/reusable-report-failure.yml
     permissions:
-      issues: write
+      issues: write # Pass through for failure tracking issues
       contents: read

--- a/.github/workflows/update-spec-integration-branch.yml
+++ b/.github/workflows/update-spec-integration-branch.yml
@@ -121,3 +121,11 @@ jobs:
                          --body "This is a draft PR used for identifying issues integrating the latest (unreleased) [${{ env.REPO }}](https://github.com/open-telemetry/${{ env.REPO }})." \
                          --draft
           fi
+
+  report-failure:
+    needs: update-integration-branch
+    if: failure() && github.repository == 'open-telemetry/opentelemetry.io'
+    uses: ./.github/workflows/reusable-report-failure.yml
+    permissions:
+      issues: write
+      contents: read

--- a/content/en/site/build/ci-workflows.md
+++ b/content/en/site/build/ci-workflows.md
@@ -319,9 +319,9 @@ Pure logic and CLI argument parsing live in `index.mjs` and are covered by
 ## Workflow failure reporting {#workflow-failure-reporting}
 
 [`reusable-report-failure.yml`][report-failure] opens (or comments on) a
-tracking issue when a caller workflow fails. How to wire it up, optional
-inputs, and caller context behavior are documented in the workflow file header;
-issue logic lives in [scripts/gh/report-failure/][report-failure-script]
+tracking issue when a caller workflow fails. How to wire it up, optional inputs,
+and caller context behavior are documented in the workflow file header; issue
+logic lives in [scripts/gh/report-failure/][report-failure-script]
 (`npm run test:local-tools`).
 
 [report-failure]:

--- a/content/en/site/build/ci-workflows.md
+++ b/content/en/site/build/ci-workflows.md
@@ -316,6 +316,19 @@ node scripts/gh/specs/pick-branch/cli.mjs --help
 Pure logic and CLI argument parsing live in `index.mjs` and are covered by
 `*.test.mjs` files in the same folder (`npm run test:local-tools` to run them).
 
+## Workflow failure reporting {#workflow-failure-reporting}
+
+[`reusable-report-failure.yml`][report-failure] opens (or comments on) a
+tracking issue when a caller workflow fails. How to wire it up, optional
+inputs, and caller context behavior are documented in the workflow file header;
+issue logic lives in [scripts/gh/report-failure/][report-failure-script]
+(`npm run test:local-tools`).
+
+[report-failure]:
+  https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/workflows/reusable-report-failure.yml
+[report-failure-script]:
+  https://github.com/open-telemetry/opentelemetry.io/tree/main/scripts/gh/report-failure
+
 ## Other workflows
 
 The repository includes several other workflows:

--- a/content/en/site/build/npm-scripts.md
+++ b/content/en/site/build/npm-scripts.md
@@ -96,12 +96,16 @@ are internal helpers and are not intended to be run directly.
 | `test:collector-sync`      | Collector-sync tests.                                             |
 | `test:edge-functions`      | Node test runner over `netlify/edge-functions/**/*.test.ts`.      |
 | `test:edge-functions:live` | Optional `node:test` live suite; supports `--help`.               |
-| `test:local-tools`         | Node test runner for `scripts/**/*.test.{mjs,js}`.                |
+| `test:local-tools`         | Node test runner for `scripts/**/*.test.mjs`.[^local-tools-note]  |
 | `test-and-fix`             | Run fix scripts (excluding i18n/refcache/submodule), then checks. |
 | `diff:check`               | Warn if working tree has uncommitted changes.                     |
 | `diff:fail`                | Fail if working tree has changes (e.g. after build).              |
 | `netlify-build:preview`    | `build:preview` then `diff:check`.                                |
 | `netlify-build:production` | `build:production` then `diff:check`.                             |
+
+[^local-tools-note]:
+    This script has a compound name, rather than being `test:tools`, so that it
+    gets picked up by `test:compound-tests`.
 
 ## Utilities
 

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "test:edge-functions:live": "npm run _test:ef:live --",
     "test:edge-functions": "node --test \"netlify/edge-functions/**/*.test.ts\"",
     "test:config-schema-tests": "node --test \"assets/js/**/*.test.mjs\"",
-    "test:local-tools": "find scripts -type f \\( -name '*.test.mjs' -o -name '*.test.js' \\) -print0 | xargs -0 node --test",
+    "test:local-tools": "node --test \"scripts/**/*.test.mjs\"",
     "test:redirects:live": "npm run _test:redirects:live --",
     "test": "CMD_SKIP=collector-sync npm run test:base",
     "update:hugo": "npm install --save-dev --save-exact hugo-extended@latest",

--- a/scripts/docsy-alerts-to-md/convert.test.mjs
+++ b/scripts/docsy-alerts-to-md/convert.test.mjs
@@ -1,14 +1,16 @@
 #!/usr/bin/env node
 /**
  * Sanity tests for convert.pl
- * Run: node test.js
+ * Run: npm run test:local-tools
  */
 
-const assert = require('assert');
-const { execSync } = require('child_process');
-const fs = require('fs');
-const path = require('path');
+import assert from 'node:assert/strict';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const scriptPath = path.join(__dirname, 'convert.pl');
 const tmpFile = path.join(__dirname, 'test-tmp.md');
 

--- a/scripts/gh/report-failure/cli.mjs
+++ b/scripts/gh/report-failure/cli.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+// CLI entry point for the "Report workflow failure" reusable workflow.
+//
+// Reads the failing run's context from the environment (set by the workflow)
+// and opens or updates the tracking issue. All pure logic lives in ./index.mjs.
+//
+// Required environment:
+//   GH_TOKEN        Used by `gh`; needs `issues: write`.
+//   REPO            `owner/name` of the caller repository.
+//   WORKFLOW_NAME   Caller workflow name.
+//   WORKFLOW_URL    URL of the failing run.
+//   HEAD_BRANCH     Branch that failed.
+//   HEAD_SHA        Commit that failed.
+//
+// Optional environment (with defaults):
+//   LABEL           Existing label to apply. Default: `CI/infra`.
+//   ISSUE_TYPE      Org issue type name. Default: `Bug`.
+//   ISSUE_PREFIX    Title prefix. Default: `Workflow failed`.
+
+import { spawnSync } from 'node:child_process';
+
+import { reportFailure } from './index.mjs';
+
+/**
+ * Synchronous `gh` runner used by the orchestrator.
+ *
+ * @param {string[]} args
+ * @returns {{ stdout: string, status: number }}
+ */
+function runGh(args) {
+  const res = spawnSync('gh', args, { encoding: 'utf8' });
+  if (res.error) throw res.error;
+  if (res.stderr) process.stderr.write(res.stderr);
+  return { stdout: res.stdout ?? '', status: res.status ?? 1 };
+}
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`Missing required environment variable: ${name}`);
+    process.exit(1);
+  }
+  return value;
+}
+
+reportFailure({
+  repo: requireEnv('REPO'),
+  workflow: requireEnv('WORKFLOW_NAME'),
+  branch: requireEnv('HEAD_BRANCH'),
+  sha: requireEnv('HEAD_SHA'),
+  runUrl: requireEnv('WORKFLOW_URL'),
+  label: process.env.LABEL || 'CI/infra',
+  issueType: process.env.ISSUE_TYPE || 'Bug',
+  issuePrefix: process.env.ISSUE_PREFIX || 'Workflow failed',
+  runGh,
+});

--- a/scripts/gh/report-failure/index.mjs
+++ b/scripts/gh/report-failure/index.mjs
@@ -1,0 +1,275 @@
+// Pure library for the "Report workflow failure" reusable workflow.
+//
+// On a caller-workflow failure this opens a tracking issue (or comments on the
+// already-open one), labels it, and sets its issue type. All side-effecting
+// `gh` calls are funneled through an injected `runGh` so the orchestration is
+// unit-testable; see ./cli.mjs for the real wiring and ./index.test.mjs for the
+// fakes.
+
+/**
+ * Result of an injected `gh` invocation.
+ *
+ * @typedef {Object} GhResult
+ * @property {string} stdout
+ * @property {number} status   Exit code (0 on success).
+ */
+
+/**
+ * Build the deduplication title used both to search for an existing issue and
+ * to create a new one.
+ *
+ * @param {{ prefix: string, workflow: string, branch: string }} input
+ * @returns {string}
+ */
+export function buildIssueTitle({ prefix, workflow, branch }) {
+  return `${prefix}: ${workflow} on ${branch}`;
+}
+
+/**
+ * Build the body of a newly created failure issue.
+ *
+ * @param {{ workflow: string, branch: string, sha: string, runUrl: string }} input
+ * @returns {string}
+ */
+export function buildIssueBody({ workflow, branch, sha, runUrl }) {
+  return [
+    'A workflow run failed.',
+    '',
+    `**Workflow:** ${workflow}`,
+    `**Branch:** ${branch}`,
+    `**Commit:** ${sha}`,
+    `**Run:** ${runUrl}`,
+    '',
+    'This issue was opened automatically; close it once the failure is resolved.',
+  ].join('\n');
+}
+
+/**
+ * Build the comment appended when a failure issue is already open.
+ *
+ * @param {{ sha: string, runUrl: string }} input
+ * @returns {string}
+ */
+export function buildCommentBody({ sha, runUrl }) {
+  return [
+    'Another failure occurred.',
+    '',
+    `**Run:** ${runUrl}`,
+    `**Commit:** ${sha}`,
+  ].join('\n');
+}
+
+/**
+ * GitHub issue search is fuzzy, so re-filter the candidates for an exact title
+ * match and return the first issue number (or `null`).
+ *
+ * @param {string} issuesJson   Raw stdout of `gh issue list --json number,title`.
+ * @param {string} title
+ * @returns {number|null}
+ */
+export function selectIssueNumberByExactTitle(issuesJson, title) {
+  let issues;
+  try {
+    issues = JSON.parse(issuesJson || '[]');
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(issues)) return null;
+  const match = issues.find((i) => i && i.title === title);
+  return match ? match.number : null;
+}
+
+/**
+ * Run `gh` and throw with context if it exits non-zero.
+ *
+ * @param {(args: string[]) => GhResult} runGh
+ * @param {string[]} args
+ * @returns {string} stdout
+ */
+function gh(runGh, args) {
+  const { stdout, status } = runGh(args);
+  if (status !== 0) {
+    throw new Error(`gh ${args.join(' ')} failed with exit code ${status}`);
+  }
+  return stdout;
+}
+
+/**
+ * Resolve the GraphQL node id of an org/repo issue type by name (e.g. `Bug`).
+ * Returns `null` if the type is not defined for the repository.
+ *
+ * @param {(args: string[]) => GhResult} runGh
+ * @param {{ owner: string, name: string, issueType: string }} input
+ * @returns {string|null}
+ */
+export function resolveIssueTypeId(runGh, { owner, name, issueType }) {
+  const query = `query($owner:String!,$name:String!){
+    repository(owner:$owner,name:$name){
+      issueTypes(first:20){ nodes{ id name } }
+    }
+  }`;
+  const stdout = gh(runGh, [
+    'api',
+    'graphql',
+    '-f',
+    `query=${query}`,
+    '-F',
+    `owner=${owner}`,
+    '-F',
+    `name=${name}`,
+  ]);
+  let nodes;
+  try {
+    nodes = JSON.parse(stdout).data.repository.issueTypes.nodes;
+  } catch {
+    return null;
+  }
+  const found = (nodes || []).find((n) => n && n.name === issueType);
+  return found ? found.id : null;
+}
+
+/**
+ * Set the issue type of an issue via GraphQL. No-op (returns false) when the
+ * requested type can't be resolved, so a missing type never fails the report.
+ *
+ * @param {(args: string[]) => GhResult} runGh
+ * @param {{ repo: string, issueNumber: number, issueType: string, log?: (m: string) => void }} input
+ * @returns {boolean} whether the type was set
+ */
+export function setIssueType(
+  runGh,
+  { repo, issueNumber, issueType, log = console.log },
+) {
+  const [owner, name] = repo.split('/');
+  const typeId = resolveIssueTypeId(runGh, { owner, name, issueType });
+  if (!typeId) {
+    log(`Issue type "${issueType}" is not defined for ${repo}; skipping.`);
+    return false;
+  }
+
+  const issueId = gh(runGh, [
+    'issue',
+    'view',
+    String(issueNumber),
+    '--repo',
+    repo,
+    '--json',
+    'id',
+    '--jq',
+    '.id',
+  ]).trim();
+  if (!issueId) {
+    log(`Could not resolve node id for issue #${issueNumber}; skipping type.`);
+    return false;
+  }
+
+  const mutation = `mutation($issueId:ID!,$typeId:ID!){
+    updateIssueIssueType(input:{issueId:$issueId, issueTypeId:$typeId}){
+      issue{ number }
+    }
+  }`;
+  gh(runGh, [
+    'api',
+    'graphql',
+    '-f',
+    `query=${mutation}`,
+    '-F',
+    `issueId=${issueId}`,
+    '-F',
+    `typeId=${typeId}`,
+  ]);
+  return true;
+}
+
+/**
+ * @typedef {Object} ReportResult
+ * @property {'commented' | 'created'} action
+ * @property {number} issueNumber
+ * @property {boolean} typeSet
+ */
+
+/**
+ * Open (or comment on) the failure tracking issue for the current run.
+ *
+ * @param {Object} input
+ * @param {string} input.repo        `owner/name`.
+ * @param {string} input.workflow    Caller workflow name.
+ * @param {string} input.branch
+ * @param {string} input.sha
+ * @param {string} input.runUrl
+ * @param {string} input.label       Existing label to apply / search by.
+ * @param {string} input.issueType   Org issue type name (e.g. `Bug`).
+ * @param {string} input.issuePrefix Title prefix (e.g. `Workflow failed`).
+ * @param {(args: string[]) => GhResult} input.runGh
+ * @param {(msg: string) => void} [input.log]
+ * @returns {ReportResult}
+ */
+export function reportFailure({
+  repo,
+  workflow,
+  branch,
+  sha,
+  runUrl,
+  label,
+  issueType,
+  issuePrefix,
+  runGh,
+  log = console.log,
+}) {
+  const title = buildIssueTitle({ prefix: issuePrefix, workflow, branch });
+
+  const listed = gh(runGh, [
+    'issue',
+    'list',
+    '--repo',
+    repo,
+    '--state',
+    'open',
+    '--label',
+    label,
+    '--search',
+    `${title} in:title`,
+    '--json',
+    'number,title',
+  ]);
+  const existing = selectIssueNumberByExactTitle(listed, title);
+
+  if (existing) {
+    gh(runGh, [
+      'issue',
+      'comment',
+      String(existing),
+      '--repo',
+      repo,
+      '--body',
+      buildCommentBody({ sha, runUrl }),
+    ]);
+    log(`Commented on existing issue #${existing}.`);
+    return { action: 'commented', issueNumber: existing, typeSet: false };
+  }
+
+  const createdUrl = gh(runGh, [
+    'issue',
+    'create',
+    '--repo',
+    repo,
+    '--title',
+    title,
+    '--label',
+    label,
+    '--body',
+    buildIssueBody({ workflow, branch, sha, runUrl }),
+  ]).trim();
+  const issueNumber = Number(createdUrl.split('/').pop());
+  log(`Created issue #${issueNumber}.`);
+
+  // gh has no flag to set an issue's type, so do it via GraphQL.
+  const typeSet = setIssueType(runGh, {
+    repo,
+    issueNumber,
+    issueType,
+    log,
+  });
+
+  return { action: 'created', issueNumber, typeSet };
+}

--- a/scripts/gh/report-failure/index.mjs
+++ b/scripts/gh/report-failure/index.mjs
@@ -261,15 +261,25 @@ export function reportFailure({
     buildIssueBody({ workflow, branch, sha, runUrl }),
   ]).trim();
   const issueNumber = Number(createdUrl.split('/').pop());
+  if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+    throw new Error(
+      `Could not parse issue number from gh issue create output: ${createdUrl}`,
+    );
+  }
   log(`Created issue #${issueNumber}.`);
 
   // gh has no flag to set an issue's type, so do it via GraphQL.
-  const typeSet = setIssueType(runGh, {
-    repo,
-    issueNumber,
-    issueType,
-    log,
-  });
+  let typeSet = false;
+  try {
+    typeSet = setIssueType(runGh, {
+      repo,
+      issueNumber,
+      issueType,
+      log,
+    });
+  } catch (err) {
+    log(`Could not set issue type "${issueType}"; skipping. ${err.message}`);
+  }
 
   return { action: 'created', issueNumber, typeSet };
 }

--- a/scripts/gh/report-failure/index.test.mjs
+++ b/scripts/gh/report-failure/index.test.mjs
@@ -1,0 +1,229 @@
+// Tests for the report-failure orchestration and helpers, driven by an injected
+// `gh` runner so no real GitHub calls are made.
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildIssueTitle,
+  buildIssueBody,
+  buildCommentBody,
+  selectIssueNumberByExactTitle,
+  resolveIssueTypeId,
+  reportFailure,
+} from './index.mjs';
+
+const noLog = () => {};
+
+/**
+ * Build a fake `gh` runner that records calls and serves canned responses keyed
+ * by the first two argv tokens (e.g. `issue list`, `issue create`,
+ * `api graphql`). Default response is `{ stdout: '', status: 0 }`.
+ */
+function makeFakeGh(responses = {}) {
+  const calls = [];
+  const runGh = (args) => {
+    calls.push(args);
+    const key = args.slice(0, 2).join(' ');
+    const r = responses[key];
+    const resolved = typeof r === 'function' ? r(args) : r;
+    return resolved ?? { stdout: '', status: 0 };
+  };
+  return { runGh, calls };
+}
+
+const TYPES_JSON = JSON.stringify({
+  data: {
+    repository: {
+      issueTypes: {
+        nodes: [
+          { id: 'IT_task', name: 'Task' },
+          { id: 'IT_bug', name: 'Bug' },
+        ],
+      },
+    },
+  },
+});
+
+const BASE = {
+  repo: 'open-telemetry/opentelemetry.io',
+  workflow: 'Auto-update versions',
+  branch: 'main',
+  sha: 'abc123',
+  runUrl: 'https://github.com/o/r/actions/runs/1',
+  label: 'CI/infra',
+  issueType: 'Bug',
+  issuePrefix: 'Workflow failed',
+};
+
+describe('report-failure: pure helpers', () => {
+  test('buildIssueTitle composes prefix, workflow, branch', () => {
+    assert.equal(
+      buildIssueTitle({
+        prefix: 'Workflow failed',
+        workflow: 'CI',
+        branch: 'main',
+      }),
+      'Workflow failed: CI on main',
+    );
+  });
+
+  test('buildIssueBody includes all fields', () => {
+    const body = buildIssueBody({
+      workflow: 'CI',
+      branch: 'main',
+      sha: 'deadbeef',
+      runUrl: 'https://example/run',
+    });
+    assert.match(body, /\*\*Workflow:\*\* CI/);
+    assert.match(body, /\*\*Branch:\*\* main/);
+    assert.match(body, /\*\*Commit:\*\* deadbeef/);
+    assert.match(body, /\*\*Run:\*\* https:\/\/example\/run/);
+  });
+
+  test('buildCommentBody includes run and commit', () => {
+    const body = buildCommentBody({
+      sha: 'feed',
+      runUrl: 'https://example/run2',
+    });
+    assert.match(body, /Another failure occurred/);
+    assert.match(body, /https:\/\/example\/run2/);
+    assert.match(body, /feed/);
+  });
+});
+
+describe('report-failure: selectIssueNumberByExactTitle', () => {
+  const title = 'Workflow failed: CI on main';
+
+  test('returns the exact-title match, ignoring fuzzy extras', () => {
+    const json = JSON.stringify([
+      { number: 7, title: 'Workflow failed: CI on main (was something else)' },
+      { number: 9, title },
+    ]);
+    assert.equal(selectIssueNumberByExactTitle(json, title), 9);
+  });
+
+  test('returns null when no exact match', () => {
+    const json = JSON.stringify([{ number: 7, title: 'unrelated' }]);
+    assert.equal(selectIssueNumberByExactTitle(json, title), null);
+  });
+
+  test('returns null on empty / invalid input', () => {
+    assert.equal(selectIssueNumberByExactTitle('', title), null);
+    assert.equal(selectIssueNumberByExactTitle('not json', title), null);
+  });
+});
+
+describe('report-failure: resolveIssueTypeId', () => {
+  test('resolves a known type by name', () => {
+    const { runGh } = makeFakeGh({
+      'api graphql': { stdout: TYPES_JSON, status: 0 },
+    });
+    const id = resolveIssueTypeId(runGh, {
+      owner: 'open-telemetry',
+      name: 'opentelemetry.io',
+      issueType: 'Bug',
+    });
+    assert.equal(id, 'IT_bug');
+  });
+
+  test('returns null for an unknown type', () => {
+    const { runGh } = makeFakeGh({
+      'api graphql': { stdout: TYPES_JSON, status: 0 },
+    });
+    const id = resolveIssueTypeId(runGh, {
+      owner: 'o',
+      name: 'r',
+      issueType: 'Nope',
+    });
+    assert.equal(id, null);
+  });
+});
+
+describe('report-failure: reportFailure', () => {
+  test('comments on an existing open issue and does not create', () => {
+    const title = buildIssueTitle({
+      prefix: BASE.issuePrefix,
+      workflow: BASE.workflow,
+      branch: BASE.branch,
+    });
+    const { runGh, calls } = makeFakeGh({
+      'issue list': {
+        stdout: JSON.stringify([{ number: 42, title }]),
+        status: 0,
+      },
+    });
+    const result = reportFailure({ ...BASE, runGh, log: noLog });
+
+    assert.deepEqual(result, {
+      action: 'commented',
+      issueNumber: 42,
+      typeSet: false,
+    });
+    const kinds = calls.map((a) => a.slice(0, 2).join(' '));
+    assert.deepEqual(kinds, ['issue list', 'issue comment']);
+  });
+
+  test('creates a new issue and sets its type when none exists', () => {
+    const { runGh, calls } = makeFakeGh({
+      'issue list': { stdout: '[]', status: 0 },
+      'issue create': {
+        stdout:
+          'https://github.com/open-telemetry/opentelemetry.io/issues/123\n',
+        status: 0,
+      },
+      'issue view': { stdout: 'I_node123', status: 0 },
+      'api graphql': (args) => {
+        // First graphql call resolves types; the mutation returns ok.
+        const q = args.find((a) => a.startsWith('query=')) ?? '';
+        if (q.includes('issueTypes')) return { stdout: TYPES_JSON, status: 0 };
+        return { stdout: '{"data":{}}', status: 0 };
+      },
+    });
+
+    const result = reportFailure({ ...BASE, runGh, log: noLog });
+
+    assert.equal(result.action, 'created');
+    assert.equal(result.issueNumber, 123);
+    assert.equal(result.typeSet, true);
+
+    const kinds = calls.map((a) => a.slice(0, 2).join(' '));
+    assert.deepEqual(kinds, [
+      'issue list',
+      'issue create',
+      'api graphql', // resolve type id
+      'issue view', // resolve issue node id
+      'api graphql', // set type mutation
+    ]);
+  });
+
+  test('still succeeds (typeSet=false) when the issue type is undefined', () => {
+    const { runGh } = makeFakeGh({
+      'issue list': { stdout: '[]', status: 0 },
+      'issue create': {
+        stdout: 'https://github.com/o/r/issues/5\n',
+        status: 0,
+      },
+      'api graphql': { stdout: TYPES_JSON, status: 0 },
+    });
+
+    const result = reportFailure({
+      ...BASE,
+      issueType: 'Nonexistent',
+      runGh,
+      log: noLog,
+    });
+    assert.equal(result.action, 'created');
+    assert.equal(result.typeSet, false);
+  });
+
+  test('throws when a gh call fails', () => {
+    const { runGh } = makeFakeGh({
+      'issue list': { stdout: '', status: 1 },
+    });
+    assert.throws(
+      () => reportFailure({ ...BASE, runGh, log: noLog }),
+      /gh issue list .* failed with exit code 1/,
+    );
+  });
+});

--- a/scripts/gh/report-failure/index.test.mjs
+++ b/scripts/gh/report-failure/index.test.mjs
@@ -217,6 +217,38 @@ describe('report-failure: reportFailure', () => {
     assert.equal(result.typeSet, false);
   });
 
+  test('still succeeds (typeSet=false) when the issue-type mutation fails', () => {
+    const { runGh } = makeFakeGh({
+      'issue list': { stdout: '[]', status: 0 },
+      'issue create': {
+        stdout: 'https://github.com/o/r/issues/5\n',
+        status: 0,
+      },
+      'issue view': { stdout: 'I_node123', status: 0 },
+      'api graphql': (args) => {
+        const q = args.find((a) => a.startsWith('query=')) ?? '';
+        if (q.includes('issueTypes')) return { stdout: TYPES_JSON, status: 0 };
+        return { stdout: '', status: 1 };
+      },
+    });
+
+    const result = reportFailure({ ...BASE, runGh, log: noLog });
+    assert.equal(result.action, 'created');
+    assert.equal(result.issueNumber, 5);
+    assert.equal(result.typeSet, false);
+  });
+
+  test('throws when gh issue create output is not a parseable issue URL', () => {
+    const { runGh } = makeFakeGh({
+      'issue list': { stdout: '[]', status: 0 },
+      'issue create': { stdout: 'unexpected output\n', status: 0 },
+    });
+    assert.throws(
+      () => reportFailure({ ...BASE, runGh, log: noLog }),
+      /Could not parse issue number from gh issue create output/,
+    );
+  });
+
   test('throws when a gh call fails', () => {
     const { runGh } = makeFakeGh({
       'issue list': { stdout: '', status: 1 },

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -15427,6 +15427,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-05-03T10:05:48.345134942Z"
   },
+  "https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/workflows/reusable-report-failure.yml": {
+    "StatusCode": 206,
+    "LastSeen": "2026-06-03T15:27:42.601021-04:00"
+  },
   "https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/workflows/update-semconv-integration-branch.yml": {
     "StatusCode": 206,
     "LastSeen": "2026-05-21T10:49:36.93759165Z"
@@ -15662,6 +15666,10 @@
   "https://github.com/open-telemetry/opentelemetry.io/tree/main/layouts/_shortcodes/docs": {
     "StatusCode": 206,
     "LastSeen": "2026-05-03T09:59:21.01351518Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry.io/tree/main/scripts/gh/report-failure": {
+    "StatusCode": 206,
+    "LastSeen": "2026-06-03T15:27:44.206866-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry.io/tree/main/scripts/gh/specs/pick-branch": {
     "StatusCode": 206,


### PR DESCRIPTION
- Fixes #5762
- Addresses silent failures in scheduled auto-update and integration-branch workflows by opening or updating a tracking GitHub issue when a run fails
- Adds `reusable-report-failure.yml` as a reusable workflow callers invoke with `if: failure()`; usage details live in the workflow file header
- Adds `scripts/gh/report-failure/` (CLI, testable orchestration, unit tests) to create or comment on deduplicated `CI/infra` issues
- Wires a `report-failure` job into the auto-update and spec/semconv integration-branch workflows
- Renames `scripts/docsy-alerts-to-md/test.js` to `convert.test.mjs` so the Perl converter sanity tests run under `test:local-tools`
- Simplifies `test:local-tools` to `node --test "scripts/**/*.test.mjs"`
- Documents the failure-report workflow in `content/en/site/build/ci-workflows.md` and updates `npm-scripts.md`
- Codeveloped with Copilot and Cursor