### PR TITLE
Remove 'Coming soon!' note from blueprints index

### DIFF
--- a/content/en/docs/guidance/blueprints/_index.md
+++ b/content/en/docs/guidance/blueprints/_index.md
@@ -15,5 +15,3 @@ If you want to propose a blueprint to share best practices for adopting
 OpenTelemetry in a new environment, let us know! Please see our guidance on
 [how to contribute](../#how-to-contribute) to start the process towards crafting
 a new blueprint.
-
-**Coming soon!**


### PR DESCRIPTION
Now that we've published our first blueprint, I've removed the 'Coming soon!' note from the landing page.

<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---
