### PR TITLE
[ja] add translation of content/en/blog/2019/_index.md

### DIFF
--- a/content/ja/blog/2019/_index.md
+++ b/content/ja/blog/2019/_index.md
@@ -1,0 +1,5 @@
+---
+title: 2019
+weight: -2019
+default_lang_commit: 9e05a7e681aebc70c29a149a7bfa4e4ff01df619
+---


### PR DESCRIPTION
## Summary

Translates `content/en/blog/2019/_index.md` into Japanese as `content/ja/blog/2019/_index.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.


<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10162--opentelemetry.netlify.app/ja/blog/2019/
- **English (canonical):** https://opentelemetry.io/blog/2019/

<!-- preview-section-end -->
