### PR TITLE
ci/config(semconv gen-ai): skip selected refs when link checking

### DIFF
--- a/content/en/docs/zero-code/java/agent/supported-libraries.md
+++ b/content/en/docs/zero-code/java/agent/supported-libraries.md
@@ -208,7 +208,7 @@ view execution. See
 [FaaS Server Spans]: /docs/specs/semconv/faas/faas-spans/
 [GenAI Client Spans]: /docs/specs/semconv/gen-ai/gen-ai-spans/
 [GenAI Client Metrics]:
-  /docs/specs/semconv/gen-ai/gen-ai-metrics/#generative-ai-client-metrics
+  /docs/specs/semconv/gen-ai/gen-ai-metrics/?link-check=no&see-issue=10153#generative-ai-client-metrics
 
 ## Application Servers
 

--- a/content/zh/docs/zero-code/java/agent/supported-libraries.md
+++ b/content/zh/docs/zero-code/java/agent/supported-libraries.md
@@ -191,7 +191,7 @@ Java 代理开箱即用地对许多库、框架和应用服务器进行自动插
 [GraphQL Server Spans]: /docs/specs/semconv/graphql/graphql-spans/
 [FaaS Server Spans]: /docs/specs/semconv/faas/faas-spans/
 [GenAI Client Spans]: /docs/specs/semconv/gen-ai/gen-ai-spans/
-[GenAI Client Metrics]: /docs/specs/semconv/gen-ai/gen-ai-metrics/#generative-ai-client-metrics
+[GenAI Client Metrics]: /docs/specs/semconv/gen-ai/gen-ai-metrics/?link-check=no&see-issue=10153#generative-ai-client-metrics
 
 ## 应用服务器 {#application-servers}
 


### PR DESCRIPTION
- Contributes to #10153
- Marks `/docs/specs/semconv/gen-ai/gen-ai-metrics/#generative-ai-client-metrics` to be skipped from link checking for now because it fails with "hash not found". We'll restore the checking of the fragment ID once the gen-ai specs are published once again.