### PR TITLE
[ja] update translation of content/en/docs/languages/js/_includes/browser-instrumentation-warning.md

### DIFF
--- a/content/ja/docs/languages/js/_includes/browser-instrumentation-warning.md
+++ b/content/ja/docs/languages/js/_includes/browser-instrumentation-warning.md
@@ -1,12 +1,10 @@
 ---
-default_lang_commit: 6f3712c5cda4ea79f75fb410521880396ca30c91
-drifted_from_default: true
+default_lang_commit: 1f686d5f7b6bbdfaa30dafdc6ca0214c6f2308db
 ---
 
-{{% alert title=警告 color=warning %}}
+> [!WARNING]
+>
+> ブラウザ向けのクライアント計装は**実験的**であり、主に**未規定**です。
+> 協力に興味をお持ちの場合は、[Browser SIG][] までご連絡ください。
 
-ブラウザ向けのクライアント計装は**実験的**であり、主に**未規定**です。協力に興味をお持ちの場合は、[Client Instrumentation SIG][sig]までご連絡ください。
-
-[sig]: https://docs.google.com/document/d/16Vsdh-DM72AfMg_FIt9yT9ExEWF4A_vRbQ3jRNBe09w
-
-{{% /alert %}}
+[Browser SIG]: https://github.com/open-telemetry/community#sig-browser


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/js/_includes/browser-instrumentation-warning.md` to match the latest English source at
`content/en/docs/languages/js/_includes/browser-instrumentation-warning.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

Changes applied:
- Replaced Hugo `{{% alert %}}` shortcode with GitHub-flavored `> [!WARNING]` blockquote syntax
- Updated SIG name from "Client Instrumentation SIG" to "Browser SIG"
- Updated SIG link reference from Google Docs to GitHub community repo

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.


<!-- preview-section-start -->

## Preview

This file is an `_includes` partial; it renders as part of other pages. Preview it in context:

- **Japanese (this PR):** https://deploy-preview-10177--opentelemetry.netlify.app/ja/docs/languages/js/getting-started/browser/
- **English (canonical):** https://opentelemetry.io/docs/languages/js/getting-started/browser/

_(deploy preview will be available once Netlify finishes building.)_
<!-- preview-section-end -->
