### PR TITLE
[ja] update translation of content/en/docs/collector/_index.md

### DIFF
--- a/content/ja/docs/collector/_index.md
+++ b/content/ja/docs/collector/_index.md
@@ -6,8 +6,7 @@ sidebar_root_for: children
 cascade:
   vers: 0.153.0
 weight: 270
-default_lang_commit: 68c29178b21e7ace970d27c5817a4edcff3ea9fb
-drifted_from_default: true
+default_lang_commit: 1f686d5f7b6bbdfaa30dafdc6ca0214c6f2308db
 ---
 
 ![Jaeger、OTLP、Prometheusを統合したOpenTelemetryコレクターのダイアグラム](img/otel-collector.svg)


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/collector/_index.md` to match the latest English source at
`content/en/docs/collector/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff since the last sync was a single `cascade.vers` bump from `0.152.0` to `0.153.0`.
The Japanese file already had the updated version, so the only change is the frontmatter bookkeeping
(`default_lang_commit` updated, `drifted_from_default` removed).

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10178--opentelemetry.netlify.app/ja/docs/collector/
- **English (canonical):** https://opentelemetry.io/docs/collector/

_(deploy preview status: pending. The URLs will work once Netlify finishes building.)_
<!-- preview-section-end -->
