### PR TITLE
[ja] update translation of content/en/_includes/otel-does-not-validate-3rd-pty-distros.md

### DIFF
--- a/content/ja/_includes/otel-does-not-validate-3rd-pty-distros.md
+++ b/content/ja/_includes/otel-does-not-validate-3rd-pty-distros.md
@@ -1,11 +1,8 @@
 ---
-default_lang_commit: dcd079d98e749febcefd4d7bb1da361770ec8ed3
-drifted_from_default: true
+default_lang_commit: 1f686d5f7b6bbdfaa30dafdc6ca0214c6f2308db
 ---
 
-{{% alert title="免責事項" color="warning" %}}
-
-OpenTelemetryは、以下に記載されているサードパーティディストリビューションを**検証または承認していません**。
-このリストはコミュニティの便宜のために提供されています。
-
-{{% /alert %}}
+> [!WARNING] 免責事項
+>
+> OpenTelemetryは、以下に記載されているサードパーティディストリビューションを**検証または承認していません**。
+> このリストはコミュニティの便宜のために提供されています。


### PR DESCRIPTION
## Summary

Updates `content/ja/_includes/otel-does-not-validate-3rd-pty-distros.md` to match the latest English source at
`content/en/_includes/otel-does-not-validate-3rd-pty-distros.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English change replaced the Hugo `{{% alert %}}` shortcode with a GitHub-flavored `> [!WARNING]` blockquote.
The Japanese translation mirrors this structural change while preserving the existing translated text.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

This file is an `_includes` snippet (not a standalone page), so there is no direct preview URL.
It is included by pages such as the distributions registry pages.

- **Deploy preview root:** https://deploy-preview-10179--opentelemetry.netlify.app/
<!-- preview-section-end -->
