### PR TITLE
[ja] update translation of content/en/announcements/kubecon-japan.md

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -123,7 +123,6 @@ IgnoreDirs:
   - ^fr/docs/zero-code/python/logs-example/$
   - ^fr/docs/zero-code/python/operator/$
   - ^fr/docs/zero-code/python/troubleshooting/$
-  - ^ja/announcements/kubecon-japan/$
   - ^ja/docs/collector/$
   - ^ja/docs/collector/deploy/agent/$
   - ^ja/docs/collector/deploy/other/no-collector/$

--- a/content/ja/announcements/kubecon-japan.md
+++ b/content/ja/announcements/kubecon-japan.md
@@ -1,15 +1,14 @@
 ---
 title: KubeCon + CloudNativeCon Japan 2025
 linkTitle: KubeCon Japan 2025
-date: 2025-06-12 # Show once combined banner is hidden
-expiryDate: 2025-06-18 # keep
-build: { list: never, render: never } # Hide in favor of new Asia banner
-weight: 20250618
+date: 2025-06-12
+expiryDate: 2025-06-17 # keep
+weight: 20250617
 params:
-  eventUrl: https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/
+  eventUrl: &eventUrl >-
+    https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/
   blogPostURL: /blog/2025/kubecon-japan/
-default_lang_commit: 9bc3c40e6e637b3d776281eb946a60ebf79a4cd5 # patched
-drifted_from_default: true
+default_lang_commit: 1f686d5f7b6bbdfaa30dafdc6ca0214c6f2308db
 ---
 
 [**{{% param title %}}**][LF]が **6月16・17日に東京で開催**


### PR DESCRIPTION
## Summary

Updates `content/ja/announcements/kubecon-japan.md` to match the latest English source at
`content/en/announcements/kubecon-japan.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

### Changes applied

- Removed `build: { list: never, render: never }` (EN removed it)
- Updated `expiryDate` from `2025-06-18` to `2025-06-17`
- Updated `weight` from `20250618` to `20250617`
- Updated `params.eventUrl` to use YAML anchor `&eventUrl` with `>-` block scalar (matching EN format)
- Removed date comment `# Show once combined banner is hidden`
- Refreshed `default_lang_commit` and removed `drifted_from_default: true`

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10181--opentelemetry.netlify.app/ja/announcements/kubecon-japan/
- **English (canonical):** https://opentelemetry.io/announcements/kubecon-japan/

_(deploy preview status: pending. The URLs will work once Netlify finishes building.)_
<!-- preview-section-end -->
