### PR TITLE
[ja] update translation of content/en/docs/zero-code/java/spring-boot-starter/additional-instrumentations.md

### DIFF
--- a/content/ja/docs/zero-code/java/spring-boot-starter/additional-instrumentations.md
+++ b/content/ja/docs/zero-code/java/spring-boot-starter/additional-instrumentations.md
@@ -26,7 +26,7 @@ OpenTelemetry Spring Bootスターターは、追加の計装で拡張できる[
 
 OpenTelemetryアペンダーのその他の設定オプションは、[Log4j](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/log4j/log4j-appender-2.17/library/README.md)計装ライブラリで確認できます。
 
-{{< tabpane text=true >}} {{% tab "Properties" %}}
+{{< tabpane text=true >}} {{% tab "プロパティ" %}}
 
 `OpenTelemetry` インスタンスで Log4j OpenTelemetry アペンダーの設定を有効にします。
 
@@ -37,7 +37,7 @@ otel:
       enabled: true # default: true
 ```
 
-{{% /tab %}} {{% tab "Declarative Configuration" %}}
+{{% /tab %}} {{% tab "宣言的な設定" %}}
 
 [宣言的な設定](../declarative-configuration/)では、一元化された計装リストを使用して Log4j を有効または無効にします。
 

--- a/content/ja/docs/zero-code/java/spring-boot-starter/additional-instrumentations.md
+++ b/content/ja/docs/zero-code/java/spring-boot-starter/additional-instrumentations.md
@@ -1,8 +1,7 @@
 ---
 title: 追加の計装
 weight: 60
-default_lang_commit: 276d7eb3f936deef6487cdd2b1d89822951da6c8
-drifted_from_default: true
+default_lang_commit: 1f686d5f7b6bbdfaa30dafdc6ca0214c6f2308db
 ---
 
 OpenTelemetry Spring Bootスターターは、追加の計装で拡張できる[すぐに使える計装](../out-of-the-box-instrumentation)を提供します。
@@ -27,9 +26,31 @@ OpenTelemetry Spring Bootスターターは、追加の計装で拡張できる[
 
 OpenTelemetryアペンダーのその他の設定オプションは、[Log4j](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/log4j/log4j-appender-2.17/library/README.md)計装ライブラリで確認できます。
 
-| システムプロパティ                            | 型      | デフォルト | 説明                                                                              |
-| --------------------------------------------- | ------- | ---------- | --------------------------------------------------------------------------------- |
-| `otel.instrumentation.log4j-appender.enabled` | Boolean | true       | `OpenTelemetry` インスタンスでLog4j OpenTelemetryアペンダーの設定を有効にします。 |
+{{< tabpane text=true >}} {{% tab "Properties" %}}
+
+`OpenTelemetry` インスタンスで Log4j OpenTelemetry アペンダーの設定を有効にします。
+
+```yaml
+otel:
+  instrumentation:
+    log4j-appender:
+      enabled: true # default: true
+```
+
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+[宣言的な設定](../declarative-configuration/)では、一元化された計装リストを使用して Log4j を有効または無効にします。
+
+```yaml
+otel:
+  distribution:
+    spring_starter:
+      instrumentation:
+        disabled:
+          - log4j_appender
+```
+
+{{% /tab %}} {{< /tabpane >}}
 
 ## 計装ライブラリ {#instrumentation-libraries}
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/java/spring-boot-starter/additional-instrumentations.md` to match the latest English source at
`content/en/docs/zero-code/java/spring-boot-starter/additional-instrumentations.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

### Changes

The English source replaced the configuration table (system property / type / default / description) with a `tabpane` shortcode containing two tabs:

- **Properties** — YAML configuration for the Log4j appender
- **Declarative Configuration** — YAML for disabling Log4j via declarative configuration

The Japanese translation mirrors this structural change.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10182--opentelemetry.netlify.app/ja/docs/zero-code/java/spring-boot-starter/additional-instrumentations/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/java/spring-boot-starter/additional-instrumentations/

_(deploy preview may take a few minutes to build.)_
<!-- preview-section-end -->
