### PR TITLE
[ja] update translation of content/en/docs/languages/_includes/index-intro.md

### DIFF
--- a/content/ja/docs/languages/_includes/index-intro.md
+++ b/content/ja/docs/languages/_includes/index-intro.md
@@ -1,11 +1,11 @@
 ---
-default_lang_commit: 3c38c3392fc74f8f071a7a0179fbd141faa7dc40
-drifted_from_default: true
+default_lang_commit: c88a006471f039334aed7990736e089a62b33f94
 ---
 
-これはOpenTelemetry{{ $name }}のドキュメントです。
-OpenTelemetryはオブザーバビリティのためのフレームワークであり、メトリクス、ログ、トレースといったアプリケーションのテレメトリーデータの生成および収集を支援するように設計された API、SDK、およびツール群で構成されています。
-このドキュメントは、OpenTelemetry {{ $name }}の使い方を理解し、利用を開始するための手助けとなるように作られています。
+OpenTelemetry {{ $name }} のドキュメントへようこそ。
+このセクションでは、OpenTelemetry の API と SDK を使い、{{ $name }} でメトリクス、ログ、トレースなどのテレメトリーデータを生成・収集する方法を紹介します。
+
+これらのページは、OpenTelemetry {{ $name }} の利用を開始し、現在の機能とステータスを理解するための手助けとなるように作られています。
 
 ## ステータスとリリース {#status-and-releases}
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/_includes/index-intro.md` to match the latest English source at
`content/en/docs/languages/_includes/index-intro.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

### Changes

- Rewrote the intro paragraph to match the new English wording ("Welcome to..." structure with a separate paragraph about getting started and understanding capabilities/status).
- Reference link definitions reformatted by Prettier (cosmetic, no functional change).

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
<!-- preview-section-start -->

## Preview

This file is a partial (`_includes`) used by language-specific index pages. Preview it via any language page that includes it:

- **Japanese (this PR):** https://deploy-preview-10184--opentelemetry.netlify.app/ja/docs/languages/go/
- **English (canonical):** https://opentelemetry.io/docs/languages/go/

<!-- preview-section-end -->
