### PR TITLE
[ja] update translation of content/en/docs/guidance/blueprints/_index.md

### DIFF
--- a/content/ja/docs/guidance/blueprints/_index.md
+++ b/content/ja/docs/guidance/blueprints/_index.md
@@ -1,8 +1,7 @@
 ---
 title: ブループリント
 description: 一般的な環境において OpenTelemetry を採用し実装する際のベストプラクティスのためのブループリント
-default_lang_commit: 68c29178b21e7ace970d27c5817a4edcff3ea9fb
-drifted_from_default: true
+default_lang_commit: 1f686d5f7b6bbdfaa30dafdc6ca0214c6f2308db
 ---
 
 ブループリントは、所定の環境における OpenTelemetry の一般的な採用および実装の課題を解決するリビングドキュメントです。
@@ -11,5 +10,3 @@ drifted_from_default: true
 
 新しい環境における OpenTelemetry の採用について、ベストプラクティスを共有するブループリントを提案したい場合は、ぜひお知らせください！
 新しいブループリントを作成する手順を開始するには、[コントリビュートの方法](../#how-to-contribute)のガイダンスを参照してください。
-
-**近日公開！**


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/guidance/blueprints/_index.md` to match the latest English source at
`content/en/docs/guidance/blueprints/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

### Changes

- Removed the "**近日公開！**" (`**Coming soon!**`) line that was deleted from the English source.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10185--opentelemetry.netlify.app/ja/docs/guidance/blueprints/
- **English (canonical):** https://opentelemetry.io/docs/guidance/blueprints/

_(deploy preview may still be building. The URLs will work once Netlify finishes.)_
<!-- preview-section-end -->
