### PR TITLE
[ja] update translation of content/en/docs/concepts/signals/baggage.md

### DIFF
--- a/content/ja/docs/concepts/signals/baggage.md
+++ b/content/ja/docs/concepts/signals/baggage.md
@@ -2,8 +2,7 @@
 title: バゲッジ
 weight: 4
 description: シグナル間でやり取りされるコンテキスト情報
-default_lang_commit: 458f7c58d64f19b075332989bcbf5bff1a343b82
-drifted_from_default: true
+default_lang_commit: 1f686d5f7b6bbdfaa30dafdc6ca0214c6f2308db
 ---
 
 OpenTelemetryでは、バゲッジ（Baggage）はコンテキストの隣にあるコンテキスト情報です。


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/concepts/signals/baggage.md` to match the latest English source at
`content/en/docs/concepts/signals/baggage.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The only English-side change since the last sync was a reference link syntax update
(`[baggage specification]` → `[baggage specification][]`). The Japanese file already uses
the explicit label form (`[バゲッジ仕様][baggage specification]`), so no content changes
were needed — only the frontmatter bookkeeping.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10186--opentelemetry.netlify.app/ja/docs/concepts/signals/baggage/
- **English (canonical):** https://opentelemetry.io/docs/concepts/signals/baggage/

_(deploy preview may take a few minutes to build.)_
<!-- preview-section-end -->
