### PR TITLE
[ja] update translation of content/en/docs/languages/_includes/native-lib-alert.md

### DIFF
--- a/content/ja/docs/languages/_includes/native-lib-alert.md
+++ b/content/ja/docs/languages/_includes/native-lib-alert.md
@@ -1,27 +1,22 @@
 ---
-default_lang_commit: 276d7eb3f936deef6487cdd2b1d89822951da6c8
-drifted_from_default: true
+default_lang_commit: 1f686d5f7b6bbdfaa30dafdc6ca0214c6f2308db
 ---
 
 {{ if $noIntegrations }}
 
-{{% alert title="ヘルプ募集中！" color=secondary %}}
-
-現在のところ、OpenTelemetryがネイティブに統合された{{ $name }}ライブラリは把握していません。
-もしそのようなライブラリをご存知でしたら、[お知らせください][let us know]。
-
-{{% /alert %}}
+> [!IMPORTANT] Help wanted
+>
+> 現在のところ、OpenTelemetryがネイティブに統合された{{ $name }}ライブラリは把握していません。
+> もしそのようなライブラリをご存知でしたら、[お知らせください][new-issue]。
 
 {{ end }}
 
 {{ if not $noIntegrations }}
 
-{{% alert color=info %}}
-
-OpenTelemetryがネイティブに統合された{{ $name }}ライブラリをご存知でしたら、[お知らせください][let us know]。
-
-{{% /alert %}}
+> [!IMPORTANT] Help wanted
+>
+> OpenTelemetryがネイティブに統合された{{ $name }}ライブラリをご存知でしたら、[お知らせください][new-issue]。
 
 {{ end }}
 
-[let us know]: https://github.com/open-telemetry/opentelemetry.io/issues/new/choose
+[new-issue]: https://github.com/open-telemetry/opentelemetry.io/issues/new/choose


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/_includes/native-lib-alert.md` to match the latest English source at
`content/en/docs/languages/_includes/native-lib-alert.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

### Changes

- Converted `{{% alert %}}` shortcode blocks to GitHub-flavored `> [!IMPORTANT]` admonition syntax to match the updated English source.
- Updated the link reference label from `[let us know]` to `[new-issue]`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.


<!-- preview-section-start -->

## Preview

This file is a Hugo partial (`_includes/native-lib-alert.md`) included by language-specific pages. To preview, check any language page that uses it, for example:

- **Deploy preview (example):** https://deploy-preview-10189--opentelemetry.netlify.app/ja/docs/languages/go/libraries/
- **English (canonical):** https://opentelemetry.io/docs/languages/go/libraries/

<!-- preview-section-end -->
