### PR TITLE
[ja] update translation of content/en/docs/zero-code/python/troubleshooting.md

### DIFF
--- a/content/ja/docs/zero-code/python/troubleshooting.md
+++ b/content/ja/docs/zero-code/python/troubleshooting.md
@@ -2,8 +2,7 @@
 title: Pythonの自動計装に関する問題のトラブルシューティング
 linkTitle: Troubleshooting
 weight: 40
-default_lang_commit: 276d7eb3f936deef6487cdd2b1d89822951da6c8 # patched
-drifted_from_default: true
+default_lang_commit: 1f686d5f7b6bbdfaa30dafdc6ca0214c6f2308db
 cSpell:ignore: ASGI gunicorn uvicorn
 ---
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/python/troubleshooting.md` to match the latest English source at
`content/en/docs/zero-code/python/troubleshooting.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff (`276d7eb..1f686d5`) contained only two code-block changes
(`uv pip install` → `uv add`), both of which were already applied via a prior
`# patched` update. This PR completes the sync by updating the frontmatter
bookkeeping.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10196--opentelemetry.netlify.app/ja/docs/zero-code/python/troubleshooting/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/python/troubleshooting/

_(deploy preview status: pending. The URLs will work once Netlify finishes building.)_
<!-- preview-section-end -->
