### PR TITLE
[ja] update translation of content/en/docs/zero-code/java/agent/getting-started.md

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -139,7 +139,6 @@ IgnoreDirs:
   - ^ja/docs/languages/ruby/instrumentation/$
   - ^ja/docs/platforms/kubernetes/operator/horizontal-pod-autoscaling/$
   - ^ja/docs/platforms/kubernetes/operator/troubleshooting/automatic/$
-  - ^ja/docs/zero-code/java/agent/getting-started/$
   - ^ja/docs/zero-code/java/quarkus/$
   - ^ja/docs/zero-code/java/spring-boot-starter/additional-instrumentations/$
   - ^ja/docs/zero-code/java/spring-boot-starter/out-of-the-box-instrumentation/$

--- a/content/ja/docs/zero-code/java/agent/getting-started.md
+++ b/content/ja/docs/zero-code/java/agent/getting-started.md
@@ -1,8 +1,7 @@
 ---
 title: はじめに
 weight: 1
-default_lang_commit: dabd30226437f71ca1eca69f9e8f04926a042bae
-drifted_from_default: true
+default_lang_commit: 1f686d5f7b6bbdfaa30dafdc6ca0214c6f2308db
 cSpell:ignore: Dotel
 ---
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/java/agent/getting-started.md` to match the latest English source at
`content/en/docs/zero-code/java/agent/getting-started.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The only English change since the last sync was removing `myapp` from the `cSpell:ignore` frontmatter field.
The Japanese file already had the correct `cSpell:ignore` value, so only the i18n bookkeeping fields needed updating.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10205--opentelemetry.netlify.app/ja/docs/zero-code/java/agent/getting-started/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/java/agent/getting-started/

_(deploy preview may take a few minutes to become available)_
<!-- preview-section-end -->

