### PR TITLE
Fix duplicate section header in metrics-traces-attributes.md

### DIFF
--- a/content/en/docs/zero-code/obi/configure/metrics-traces-attributes.md
+++ b/content/en/docs/zero-code/obi/configure/metrics-traces-attributes.md
@@ -194,8 +194,6 @@ PostgreSQL, MySQL, and MSSQL binary protocols.
 
 ### HTTP header and body enrichment for spans {#http-header-enrichment-for-spans}
 
-### HTTP header and body enrichment for spans
-
 OBI can attach selected HTTP headers and selected HTTP body fields to spans
 through the `ebpf.payload_extraction.http.enrichment` configuration section.
 This is useful when you want to carry business or routing headers into traces


### PR DESCRIPTION
Removed duplicate section header for HTTP header and body enrichment.
I believe that explicitly stating the link is the correct approach.

---

<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

