### PR TITLE
[ja] update translation of content/en/docs/languages/_includes/native-lib-alert.md

### DIFF
--- a/content/ja/docs/languages/_includes/native-lib-alert.md
+++ b/content/ja/docs/languages/_includes/native-lib-alert.md
@@ -1,27 +1,22 @@
 ---
-default_lang_commit: 276d7eb3f936deef6487cdd2b1d89822951da6c8
-drifted_from_default: true
+default_lang_commit: c88a006471f039334aed7990736e089a62b33f94
 ---
 
 {{ if $noIntegrations }}
 
-{{% alert title="ヘルプ募集中！" color=secondary %}}
-
-現在のところ、OpenTelemetryがネイティブに統合された{{ $name }}ライブラリは把握していません。
-もしそのようなライブラリをご存知でしたら、[お知らせください][let us know]。
-
-{{% /alert %}}
+> [!IMPORTANT] ヘルプ募集中
+>
+> 現在のところ、OpenTelemetry がネイティブに統合された{{ $name }}ライブラリは把握していません。
+> もしそのようなライブラリをご存知でしたら、[お知らせください][new-issue]。
 
 {{ end }}
 
 {{ if not $noIntegrations }}
 
-{{% alert color=info %}}
-
-OpenTelemetryがネイティブに統合された{{ $name }}ライブラリをご存知でしたら、[お知らせください][let us know]。
-
-{{% /alert %}}
+> [!IMPORTANT] ヘルプ募集中
+>
+> OpenTelemetry がネイティブに統合された{{ $name }}ライブラリをご存知でしたら、[お知らせください][new-issue]。
 
 {{ end }}
 
-[let us know]: https://github.com/open-telemetry/opentelemetry.io/issues/new/choose
+[new-issue]: https://github.com/open-telemetry/opentelemetry.io/issues/new/choose


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/_includes/native-lib-alert.md` to match the latest English source at
`content/en/docs/languages/_includes/native-lib-alert.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

### Changes

- Replaced `{{% alert %}}` shortcode blocks with GitHub-style `> [!IMPORTANT]` blockquote syntax
- Updated link reference label from `[let us know]` to `[new-issue]`
- Added `> [!IMPORTANT] ヘルプ募集中` title to the second block (matching the EN source which now has the same title for both blocks)
- Removed trailing `!` from the first block's title (`ヘルプ募集中！` → `ヘルプ募集中`) to match the EN source (`Help wanted` without `!`)
- Fixed half-width spacing around `OpenTelemetry` per style guide

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

This file is a Hugo partial (`_includes/native-lib-alert.md`), so it doesn't have its own page.
It renders on every language-specific "Libraries" page, for example:

- **Japanese (this PR):** https://deploy-preview-10220--opentelemetry.netlify.app/ja/docs/languages/java/libraries/
- **English (canonical):** https://opentelemetry.io/docs/languages/java/libraries/

_(The deploy preview URL will work once Netlify finishes building.)_
<!-- preview-section-end -->
