### PR TITLE
Add Dash0 Kubernetes Operator to registry

### DIFF
--- a/data/registry/application-integration-collector-dash0-operator.yml
+++ b/data/registry/application-integration-collector-dash0-operator.yml
@@ -1,0 +1,23 @@
+# cSpell:ignore dash0
+title: Dash0 Kubernetes Operator
+registryType: application integration
+language: collector
+tags:
+  - collector
+  - kubernetes
+  - operator
+  - instrumentation
+license: Apache-2.0
+description:
+  Kubernetes Operator that deploys and manages an OpenTelemetry Collector in
+  your cluster, providing auto-instrumentation for Node.js, Java, .NET, and
+  Python workloads, log collection, and infrastructure metrics export via OTLP.
+authors:
+  - name: Dash0 Inc.
+    url: https://github.com/dash0hq
+urls:
+  website: https://dash0.com
+  repo: https://github.com/dash0hq/dash0-operator
+  docs: https://www.dash0.com/hub/integrations/int_dash0_operator/overview
+createdAt: '2026-06-05'
+isNative: true


### PR DESCRIPTION
  - [x] I have read and followed the Contributing docs
  - [x] This PR has content that I did not fully write myself.
    - [x] I used AI and I have read and followed the Generative AI Contribution Policy.
  - [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.
  

### What this PR does:
This PR adds the Dash0 Kubernetes Operator to the OpenTelemetry Registry as an`application integration` entry.
  
The operator deploys and manages an OpenTelemetry Collector in Kubernetes clusters, providing auto-instrumentation for Node.js, Java, .NET, and Python workloads, log collection, and infrastructure metrics export via OTLP.
- Repo: https://github.com/dash0hq/dash0-operator