### PR TITLE
[ja] update translation of content/en/docs/guidance/blueprints/_index.md

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -141,7 +141,6 @@ IgnoreDirs:
   - ^ja/docs/collector/troubleshooting/$
   - ^ja/docs/concepts/observability-primer/$
   - ^ja/docs/concepts/signals/baggage/$
-  - ^ja/docs/guidance/blueprints/$
   - ^ja/docs/languages/java/$
   - ^ja/docs/languages/java/configuration/$
   - ^ja/docs/languages/java/sdk/$

--- a/content/ja/docs/guidance/blueprints/_index.md
+++ b/content/ja/docs/guidance/blueprints/_index.md
@@ -1,8 +1,7 @@
 ---
 title: ブループリント
 description: 一般的な環境において OpenTelemetry を採用し実装する際のベストプラクティスのためのブループリント
-default_lang_commit: 68c29178b21e7ace970d27c5817a4edcff3ea9fb
-drifted_from_default: true
+default_lang_commit: c87c4cd1a007500700746c184918add6456175c3
 ---
 
 ブループリントは、所定の環境における OpenTelemetry の一般的な採用および実装の課題を解決するリビングドキュメントです。
@@ -11,5 +10,3 @@ drifted_from_default: true
 
 新しい環境における OpenTelemetry の採用について、ベストプラクティスを共有するブループリントを提案したい場合は、ぜひお知らせください！
 新しいブループリントを作成する手順を開始するには、[コントリビュートの方法](../#how-to-contribute)のガイダンスを参照してください。
-
-**近日公開！**


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/guidance/blueprints/_index.md` to match the latest English source at
`content/en/docs/guidance/blueprints/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff since the last sync removed the "Coming soon!" line — the corresponding
Japanese `**近日公開！**` line has been removed accordingly.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10237--opentelemetry.netlify.app/ja/docs/guidance/blueprints/
- **English (canonical):** https://opentelemetry.io/docs/guidance/blueprints/

<!-- preview-section-end -->

