### PR TITLE
[ja] update translation of content/en/docs/security/_index.md

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -159,7 +159,6 @@ IgnoreDirs:
   - ^ja/docs/platforms/kubernetes/helm/operator/$
   - ^ja/docs/platforms/kubernetes/operator/horizontal-pod-autoscaling/$
   - ^ja/docs/platforms/kubernetes/operator/troubleshooting/automatic/$
-  - ^ja/docs/security/$
   - ^ja/docs/security/handling-sensitive-data/$
   - ^ja/docs/security/security-response/$
   - ^ja/docs/zero-code/java/agent/getting-started/$

--- a/content/ja/docs/security/_index.md
+++ b/content/ja/docs/security/_index.md
@@ -3,8 +3,7 @@ title: セキュリティ
 cascade:
   collector_vers: 0.153.0
 weight: 970
-default_lang_commit: 62c8cb2f4ea2e121cab3b4880f5cdf8c21aaea13
-drifted_from_default: true
+default_lang_commit: c87c4cd1a007500700746c184918add6456175c3
 ---
 
 このセクションでは、OpenTelemetryプロジェクトがどのように脆弱性を公開し、インシデントに対応しているかを学び、あなたがテレメトリーを安全に収集し、送信するために何ができるかを知ることができます。


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/security/_index.md` to match the latest English source at
`content/en/docs/security/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The only English-side change since the last sync was a `cascade.collector_vers` version
bump (`0.152.0` → `0.153.0`), which the Japanese file already had applied. This PR
therefore only updates the i18n bookkeeping (`default_lang_commit` refresh +
`drifted_from_default` removal).

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10238--opentelemetry.netlify.app/ja/docs/security/
- **English (canonical):** https://opentelemetry.io/docs/security/

_(deploy preview status: pending. The URLs will work once Netlify finishes building.)_
<!-- preview-section-end -->

