### PR TITLE
[ja] update translation of content/en/docs/languages/java/_index.md

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -142,7 +142,6 @@ IgnoreDirs:
   - ^ja/docs/concepts/observability-primer/$
   - ^ja/docs/concepts/signals/baggage/$
   - ^ja/docs/guidance/blueprints/$
-  - ^ja/docs/languages/java/$
   - ^ja/docs/languages/java/configuration/$
   - ^ja/docs/languages/java/sdk/$
   - ^ja/docs/languages/js/benchmarks/$

--- a/content/ja/docs/languages/java/_index.md
+++ b/content/ja/docs/languages/java/_index.md
@@ -12,10 +12,9 @@ cascade:
     instrumentation: 2.28.1
     otel: 1.62.0
     contrib: 1.57.0
-    semconv: 1.41.0
+    semconv: 1.41.1
 weight: 150
-default_lang_commit: a790e3cf91025305c683047b181120ab6bbae3de
-drifted_from_default: true
+default_lang_commit: c87c4cd1a007500700746c184918add6456175c3
 ---
 
 {{% docs/languages/index-intro java /%}}


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/java/_index.md` to match the latest English source at
`content/en/docs/languages/java/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff was a single frontmatter version bump (`cascade.vers.semconv: 1.41.0` → `1.41.1`).

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10241--opentelemetry.netlify.app/ja/docs/languages/java/
- **English (canonical):** https://opentelemetry.io/docs/languages/java/

<!-- preview-section-end -->
