### PR TITLE
Widen RocketMQ patch version range for semconv pins

### DIFF
--- a/scripts/content-modules/adjust-pages.pl
+++ b/scripts/content-modules/adjust-pages.pl
@@ -69,7 +69,8 @@ my @patches = (
     # cSpell:ignore rocketmq
     id      => '2026-06-05-rocketmq-consumer-group-url',
     module  => 'semconv',
-    minVers => '1.41.1',
+    minVers => '1.41.0',
+    maxVers => '1.42.0',
     file    => qr|^tmp/semconv/docs/messaging/rocketmq\.md$|,
     apply   => sub {
       s{


### PR DESCRIPTION
- Fix in support of #10157
- Ensures that the RocketMQ consumer-group URL patch in `adjust-pages.pl` applies to semconv pins between `1.41.0` and `1.42.0`, including git-describe forms such as `1.41.0-42-g*`
