### PR TITLE
ci: Remove static/refcache.json from component label map

### DIFF
--- a/.github/component-label-map.yml
+++ b/.github/component-label-map.yml
@@ -166,7 +166,6 @@ CI/infra: # including config
           - netlify.toml
           - prh/**
           - scripts/**
-          - static/refcache.json
           - tests/**
 
 dependencies:


### PR DESCRIPTION
(Otherwise almost all PRs will have a `CI/infra` label :)