### PR TITLE
Add type annotations for registerLiveChecks imports

### DIFF
--- a/tests/live-check.test.mjs
+++ b/tests/live-check.test.mjs
@@ -2,8 +2,10 @@ import test from 'node:test';
 
 process.env.SITE_LIVE_CHECK_GROUPED = '1';
 
+/** @type {(testFn: Function) => void} */
 const { registerLiveChecks: registerEdgeFunctionLiveChecks } =
   await import('../netlify/edge-functions/tests/live-check.test.mjs');
+/** @type {(testFn: Function) => void} */
 const { registerLiveChecks: registerRedirectLiveChecks } =
   await import('./redirects/live-check.test.mjs');
 


### PR DESCRIPTION
## Problem
The `registerLiveChecks` functions imported in the test file lacked explicit type definitions, which could lead to type unsafety and reduced IDE support, such as incorrect autocompletion or error detection.

## Changes
Added JSDoc type annotations to the two `registerLiveChecks` imports. The annotations specify that each function accepts a `testFn` parameter of type `Function` and returns `void`, improving type safety and developer experience without altering functionality.

## Verification
These changes are minimal and non-breaking. They can be verified by reviewing the annotations for correctness, ensuring the code passes existing tests, and confirming improved IDE behavior (e.g., better type inference).

---

**Note from the maintainers**: this description was submitted without our [PR template](https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/PULL_REQUEST_TEMPLATE.md)'s checklist, which asks you to confirm:

- [ ] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [ ] I have the experience and knowledge necessary to understand, review, and validate all content in this PR. (Yes, I can answer maintainer questions about the content of this PR, without using AI.)

Per our [first-time contributor policy](https://github.com/open-telemetry/opentelemetry.io/issues/11243), answer these questions by ticking each box that applies.
