### PR TITLE
[ja] Fix GenAI Client Metrics link in java agent supported libraries

### DIFF
--- a/content/ja/docs/zero-code/java/agent/supported-libraries.md
+++ b/content/ja/docs/zero-code/java/agent/supported-libraries.md
@@ -2,7 +2,7 @@
 title: サポートされているライブラリ
 linkTitle: サポートされているライブラリ
 weight: 11
-default_lang_commit: 9e05a7e681aebc70c29a149a7bfa4e4ff01df619
+default_lang_commit: c6ba3e413b9c48ff4f4dc44b4e4f8e1eae1f330b
 # prettier-ignore
 cSpell:ignore: activej akka armeria avaje clickhouse couchbase dbcp dropwizard dubbo finatra helidon hikari hikaricp httpasyncclient httpclient hystrix javalin jedis jodd ktor logmanager mojarra mybatis myfaces nats okhttp openai oshi payara pekko rabbitmq ratpack rediscala redisson resteasy restlet rocketmq shenyu spymemcached twilio vaadin vertx vibur webflux webmvc
 ---
@@ -202,7 +202,7 @@ Java エージェントは、多くのライブラリ、フレームワーク、
 [GraphQL Server Spans]: /docs/specs/semconv/graphql/graphql-spans/
 [FaaS Server Spans]: /docs/specs/semconv/faas/faas-spans/
 [GenAI Client Spans]: /docs/specs/semconv/gen-ai/gen-ai-spans/
-[GenAI Client Metrics]: /docs/specs/semconv/gen-ai/gen-ai-metrics/#generative-ai-client-metrics
+[GenAI Client Metrics]: /docs/specs/semconv/gen-ai/gen-ai-metrics/?link-check=no&see-issue=10153#generative-ai-client-metrics
 
 ## アプリケーションサーバー {#application-servers}
 


### PR DESCRIPTION
- Semconv integration branch has link-check failures: https://github.com/open-telemetry/opentelemetry.io/actions/runs/27090736085/job/79953893962?pr=10157
- Apply the same temporary fix as for other pages that was done via #10166
- Sync the localized page with the English link-check workaround and refresh default_lang_commit.

---

Drift context:

```console
$ npm run check:i18n -- -d content/ja/docs/zero-code/java/agent/supported-libraries.md

> check:i18n
> scripts/check-i18n.sh -d content/ja/docs/zero-code/java/agent/supported-libraries.md

Processing paths: content/ja/docs/zero-code/java/agent/supported-libraries.md
diff --git a/content/en/docs/zero-code/java/agent/supported-libraries.md b/content/en/docs/zero-code/java/agent/supported-libraries.md
index feba1f4f6..85fec7549 100644
--- a/content/en/docs/zero-code/java/agent/supported-libraries.md
+++ b/content/en/docs/zero-code/java/agent/supported-libraries.md
@@ -208,7 +208,7 @@ view execution. See
 [FaaS Server Spans]: /docs/specs/semconv/faas/faas-spans/
 [GenAI Client Spans]: /docs/specs/semconv/gen-ai/gen-ai-spans/
 [GenAI Client Metrics]:
-  /docs/specs/semconv/gen-ai/gen-ai-metrics/#generative-ai-client-metrics
+  /docs/specs/semconv/gen-ai/gen-ai-metrics/?link-check=no&see-issue=10153#generative-ai-client-metrics

 ## Application Servers

DRIFTED files: 1 out of 1
```