### PR TITLE
Use registry versions for OCB confmap providers

### DIFF
--- a/content/en/docs/collector/extend/ocb.md
+++ b/content/en/docs/collector/extend/ocb.md
@@ -4,8 +4,6 @@ linkTitle: Build a custom Collector
 description: Assemble your own distribution of the OpenTelemetry Collector
 weight: 200
 aliases: [/docs/collector/custom-collector]
-params:
-  providers-vers: v1.48.0
 # prettier-ignore
 cSpell:ignore: chipset darwin debugexporter gomod otlpexporter otlpreceiver wyrtw
 ---
@@ -169,20 +167,20 @@ To configure `ocb`, follow these steps:
 
    providers:
      - gomod:
-         go.opentelemetry.io/collector/confmap/provider/envprovider {{% param
-         providers-vers %}}
+         go.opentelemetry.io/collector/confmap/provider/envprovider {{%
+         version-from-registry collector-confmap-provider-envprovider %}}
      - gomod:
-         go.opentelemetry.io/collector/confmap/provider/fileprovider {{% param
-         providers-vers %}}
+         go.opentelemetry.io/collector/confmap/provider/fileprovider {{%
+         version-from-registry collector-confmap-provider-fileprovider %}}
      - gomod:
-         go.opentelemetry.io/collector/confmap/provider/httpprovider {{% param
-         providers-vers %}}
+         go.opentelemetry.io/collector/confmap/provider/httpprovider {{%
+         version-from-registry collector-confmap-provider-httpprovider %}}
      - gomod:
-         go.opentelemetry.io/collector/confmap/provider/httpsprovider {{% param
-         providers-vers %}}
+         go.opentelemetry.io/collector/confmap/provider/httpsprovider {{%
+         version-from-registry collector-confmap-provider-httpsprovider %}}
      - gomod:
-         go.opentelemetry.io/collector/confmap/provider/yamlprovider {{% param
-         providers-vers %}}
+         go.opentelemetry.io/collector/confmap/provider/yamlprovider {{%
+         version-from-registry collector-confmap-provider-yamlprovider %}}
    ```
 
 > [!TIP]

--- a/content/ja/docs/collector/extend/ocb.md
+++ b/content/ja/docs/collector/extend/ocb.md
@@ -6,7 +6,8 @@ weight: 200
 aliases: [/docs/collector/custom-collector]
 params:
   providers-vers: v1.48.0
-default_lang_commit: 331c76c3500213c83ace2e30a407218ddedda628
+default_lang_commit: c2343a16d205913e724abb7a959ec87ff7e80f89 # patched
+drifted_from_default: true
 cSpell:ignore: darwin debugexporter gomod otlpexporter otlpreceiver wyrtw
 ---
 
@@ -148,21 +149,16 @@ YAMLマニフェストファイルで、`ocb`を構成します。
          version-from-registry collector-receiver-otlp %}}
 
    providers:
-     - gomod:
-         go.opentelemetry.io/collector/confmap/provider/envprovider {{% param
-         providers-vers %}}
-     - gomod:
-         go.opentelemetry.io/collector/confmap/provider/fileprovider {{% param
-         providers-vers %}}
-     - gomod:
-         go.opentelemetry.io/collector/confmap/provider/httpprovider {{% param
-         providers-vers %}}
-     - gomod:
-         go.opentelemetry.io/collector/confmap/provider/httpsprovider {{% param
-         providers-vers %}}
-     - gomod:
-         go.opentelemetry.io/collector/confmap/provider/yamlprovider {{% param
-         providers-vers %}}
+     - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider {{%
+         version-from-registry collector-confmap-provider-envprovider %}}
+     - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider {{%
+         version-from-registry collector-confmap-provider-fileprovider %}}
+     - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider {{%
+         version-from-registry collector-confmap-provider-httpprovider %}}
+     - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider {{%
+         version-from-registry collector-confmap-provider-httpsprovider %}}
+     - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider {{%
+         version-from-registry collector-confmap-provider-yamlprovider %}}
    ```
 
 > [!TIP]

--- a/content/pt/docs/collector/extend/ocb.md
+++ b/content/pt/docs/collector/extend/ocb.md
@@ -3,9 +3,7 @@ title: Compilar um Collector personalizado com o OpenTelemetry Collector Builder
 linkTitle: Compilar um Collector personalizado
 description: Monte sua própria distribuição do OpenTelemetry Collector
 weight: 200
-params:
-  providers-vers: v1.48.0
-default_lang_commit: 150fe5a5c5f0914cd067d4632ab26e529e7b9167
+default_lang_commit: 150fe5a5c5f0914cd067d4632ab26e529e7b9167 # patched
 # prettier-ignore
 cSpell:ignore: Conteinerizar darwin debugexporter gomod otlpexporter otlpreceiver wyrtw
 ---
@@ -171,20 +169,20 @@ Para configurar o `ocb`, siga estas etapas:
 
    providers:
      - gomod:
-         go.opentelemetry.io/collector/confmap/provider/envprovider {{% param
-         providers-vers %}}
+         go.opentelemetry.io/collector/confmap/provider/envprovider {{%
+         version-from-registry collector-confmap-provider-envprovider %}}
      - gomod:
-         go.opentelemetry.io/collector/confmap/provider/fileprovider {{% param
-         providers-vers %}}
+         go.opentelemetry.io/collector/confmap/provider/fileprovider {{%
+         version-from-registry collector-confmap-provider-fileprovider %}}
      - gomod:
-         go.opentelemetry.io/collector/confmap/provider/httpprovider {{% param
-         providers-vers %}}
+         go.opentelemetry.io/collector/confmap/provider/httpprovider {{%
+         version-from-registry collector-confmap-provider-httpprovider %}}
      - gomod:
-         go.opentelemetry.io/collector/confmap/provider/httpsprovider {{% param
-         providers-vers %}}
+         go.opentelemetry.io/collector/confmap/provider/httpsprovider {{%
+         version-from-registry collector-confmap-provider-httpsprovider %}}
      - gomod:
-         go.opentelemetry.io/collector/confmap/provider/yamlprovider {{% param
-         providers-vers %}}
+         go.opentelemetry.io/collector/confmap/provider/yamlprovider {{%
+         version-from-registry collector-confmap-provider-yamlprovider %}}
    ```
 
 > [!TIP]


### PR DESCRIPTION
- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

Hi maintainers, this is a small docs correction for OCB confmap provider versions.

Currently these OCB docs were using one page-level `providers-vers` value for the confmap provider modules. This PR changes those snippets to use `version-from-registry`, so the provider versions come from the registry data itself.

Updated providers:

- `collector-confmap-provider-envprovider`
- `collector-confmap-provider-fileprovider`
- `collector-confmap-provider-httpprovider`
- `collector-confmap-provider-httpsprovider`
- `collector-confmap-provider-yamlprovider`

Validation done locally:

- `git diff --check origin/main..HEAD`
- `markdownlint-cli2` on the three changed OCB pages
- `npm run -s check:format`
- `npm run -s check:filenames`
- `perl scripts/ensure-default-lang-commit-patched.pl --dry-run`
- `npm run -s check:registry`
- `npm run -s test:config-schema-tests`
- `scripts/check-i18n.sh -v content/ja/docs/collector/extend/ocb.md content/pt/docs/collector/extend/ocb.md`
- `npm run -s build`

Confirmed generated English, Portuguese, and Japanese OCB pages render these provider modules with the current registry version.
