### PR TITLE
ci: Fix `/fix` report job app-token scope

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -121,8 +121,11 @@ jobs:
         with:
           client-id: ${{ vars.OTELBOT_APP_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
-          permission-issues: write # PR comments go through the issues API
-          permission-pull-requests: read # gh pr view/metadata lookups
+          # PR comments authorize via the pull-requests permission (even
+          # though they're posted through the issues API endpoint). The
+          # otelbot installation has no issues permission; requesting it
+          # makes the token mint fail (422).
+          permission-pull-requests: write # comment the run outcome on the PR
 
       - name: Comment run outcome
         env:


### PR DESCRIPTION
- Contributes to #6592 (fixes a post-merge issue found while validating #10309)
- Token scoping
  - Replaces the report job's `permission-issues: write` request with
    `permission-pull-requests: write`, since the otelbot installation has no
    issues permission and the scoped token mint fails with a 422
  - Documents why: PR comments are posted through the issues API endpoint but
    authorize via the pull-requests permission for GitHub Apps (matching the
    existing `locale-auto-merge.yml` usage)