### PR TITLE
ci(pr-actions): latest-wins /fix concurrency, PR-state gating, uniform outcome links

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -12,6 +12,16 @@ env:
   PR_NUM: ${{ github.event.issue.number }}
   MAX_PATCH_SIZE_KB: 1024
 
+# Latest directive wins: a new /fix comment on a PR cancels that PR's
+# in-flight run (the cancelled run's report job still posts a ⚠️ outcome).
+# Non-/fix comments trigger this workflow too (all jobs skip), so they get a
+# unique group to keep them from cancelling a /fix run.
+concurrency:
+  group:
+    ${{ github.workflow }}-${{ startsWith(github.event.comment.body, '/fix') &&
+    github.event.issue.number || github.run_id }}
+  cancel-in-progress: ${{ startsWith(github.event.comment.body, '/fix') }}
+
 jobs:
   generate-patch:
     name: Run PR action and generate patch (untrusted)
@@ -71,11 +81,6 @@ jobs:
     # A reusable workflow (resolved from the default branch, never from the PR)
     # so that no PR-controlled code can run with write credentials.
     uses: ./.github/workflows/reusable-apply-patch.yml
-    # Serialize patch pushes per PR so that two rapid directives don't race.
-    # Job-level (not workflow-level) so that unrelated PR comments — which
-    # trigger this workflow but skip every job — can't evict a queued run.
-    concurrency:
-      group: ${{ github.workflow }}-apply-${{ github.event.issue.number }}
     # GITHUB_TOKEN grants forwarded to the reusable workflow (its jobs cannot
     # exceed these); see that workflow for how its steps authenticate.
     permissions:

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -27,9 +27,11 @@ jobs:
     name: Run PR action and generate patch (untrusted)
     runs-on: ubuntu-latest
     # Broad prefix gate; exact (first-line) parsing happens in the extract
-    # step below.
+    # step below. Closed (including merged) PRs are gated out here; the report
+    # job still explains why nothing ran.
     if: |
       github.event.issue.pull_request &&
+      github.event.issue.state == 'open' &&
       startsWith(github.event.comment.body, '/fix')
 
     # These outputs are produced by the untrusted job (PR-supplied code can
@@ -101,10 +103,13 @@ jobs:
     name: Report outcome (trusted)
     runs-on: ubuntu-latest
     needs: [generate-patch, apply-patch]
-    # Always tell the requestor what happened, including when patch generation
-    # failed before anything could be applied. Only skip when there was no /fix
-    # invocation to report on.
-    if: always() && needs.generate-patch.result != 'skipped'
+    # Always tell the requestor what happened, for every comment that enters
+    # the pipeline (same broad gate as generate-patch, minus the PR-state
+    # check): invalid directives, failures, and directives on closed PRs.
+    if: |
+      always() &&
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/fix')
     # The outcome comment is posted with the app token below, not GITHUB_TOKEN.
     permissions:
       contents: read # checkout
@@ -136,6 +141,9 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
           LABEL: ${{ needs.generate-patch.outputs.action_name }}
+          # 'open' or 'closed'; merged PRs are 'closed' with a merged_at time.
+          PR_STATE: ${{ github.event.issue.state }}
+          PR_MERGED: ${{ github.event.issue.pull_request.merged_at != null }}
           GENERATE_RESULT: ${{ needs.generate-patch.result }}
           PATCH_SKIPPED: ${{ needs.generate-patch.outputs.patch_skipped }}
           COMMAND_EXIT_STATUS:
@@ -149,6 +157,8 @@ jobs:
           node scripts/gh/patch-report/cli.mjs \
             --pr "$PR_NUM" \
             --label "$LABEL" \
+            --pr-state "$PR_STATE" \
+            --pr-merged "$PR_MERGED" \
             --generate-result "$GENERATE_RESULT" \
             --patch-skipped "$PATCH_SKIPPED" \
             --command-exit-status "$COMMAND_EXIT_STATUS" \

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -54,7 +54,8 @@ no-shortcut-ref-link:
   # - OTel spec informal footnotes like [1], [2]
   # - SemConf number ranges like [0..1], [0..n-1], [0.0, 1.0]
   # - Ellipsis like [...]
-  ignore_pattern: '^([-+,n\d\.\s]+)$|^\.\.\.$'
+  # - GFM task-list markers like [x] and unchecked [ ] (space matches \s)
+  ignore_pattern: '^([-+,n\d\.\s]+)$|^\.\.\.$|^x$'
 
 # -----------------------------------------------------------------------------
 # Link-validation rules (from scripts/_md-rules/link-rules.mjs)

--- a/content/en/docs/contributing/pull-requests.md
+++ b/content/en/docs/contributing/pull-requests.md
@@ -181,7 +181,8 @@ a specific failure:
 ```
 
 The fix command must be the first line of your comment; you can add explanatory
-text on the lines that follow.
+text on the lines that follow. Issuing a new fix command while one is already
+running cancels the in-progress run so that the latest command wins.
 
 > [!TIP] Pro tip
 >

--- a/content/en/site/build/ci-workflows.md
+++ b/content/en/site/build/ci-workflows.md
@@ -265,10 +265,16 @@ It runs as a three-stage pipeline:
    workflow — resolved from the default branch, never from the PR — which
    applies the patch with a GitHub App token and pushes a commit to the PR
    branch. Skipped when the command produced no changes.
-3. **`report`** (trusted): always comments the outcome back on the PR, so the
-   requestor learns the result of every directive that triggers the workflow —
-   including invalid directives (such as `/fixup` or `/fix please`), no-op runs,
-   and failures that happen before any patch is produced.
+3. **`report`** (trusted): always comments the outcome back on the PR — with a
+   link to the run that produced it — so the requestor learns the result of
+   every directive that triggers the workflow, including invalid directives
+   (such as `/fixup` or `/fix please`), no-op runs, and failures that happen
+   before any patch is produced.
+
+Directives follow latest-wins semantics: a new `/fix` comment on a PR cancels
+that PR's in-flight run (which still reports a ⚠️ outcome), since concurrent fix
+runs on the same branch serve no purpose — the second push would fail anyway
+once the branch has moved.
 
 The directive parser lives in [scripts/gh/pr-fix/][], patch generation is the
 [npm-script-patch][] action, and the outcome comment is composed by

--- a/content/en/site/build/ci-workflows.md
+++ b/content/en/site/build/ci-workflows.md
@@ -271,6 +271,10 @@ It runs as a three-stage pipeline:
    (such as `/fixup` or `/fix please`), no-op runs, and failures that happen
    before any patch is produced.
 
+Directives only run against open PRs (draft PRs included): on a closed or merged
+PR the fix command never runs and the report job explains why. The PR state
+comes from the trigger payload, so no runner is spent on the fix itself.
+
 Directives follow latest-wins semantics: a new `/fix` comment on a PR cancels
 that PR's in-flight run (which still reports a ⚠️ outcome), since concurrent fix
 runs on the same branch serve no purpose — the second push would fail anyway

--- a/projects/2026/pr-fix-reusable-actions.plan.md
+++ b/projects/2026/pr-fix-reusable-actions.plan.md
@@ -1,7 +1,7 @@
 ---
 title: Reusable patch actions for PR and maintenance fixes
 custodian: [Patrice Chalin](https://github.com/chalin)
-status: Phase 1 implemented; phases 2–3 pending.
+status: Phase 1 merged and partially live-validated; phases 2–3 pending.
 cSpell:ignore: otelbot test-and-fix
 ---
 
@@ -89,11 +89,19 @@ once the shared patch path has proven stable.
 
 ## Status details
 
-As of 2026-06-09:
+As of 2026-06-10:
 
-- Branch: `chalin-m24-pr-actions-refactor-2026-0609`.
-- Phase 1 implemented: `npm-script-patch` action (untrusted),
-  `reusable-apply-patch.yml` workflow (trusted), always-run outcome reporting,
-  unit-tested directive parsing and report composition, and a guard test for
-  workflow-to-file references.
+- Phase 1 merged ([#10309], plus app-token scope fix [#10318]):
+  `npm-script-patch` action (untrusted), `reusable-apply-patch.yml` workflow
+  (trusted), always-run outcome reporting, unit-tested directive parsing and
+  report composition, and a guard test for workflow-to-file references.
+- Live validation: happy path confirmed (`/fix:dict` on [#10317] — patch
+  generated, applied, pushed, ✅ outcome comment). Remaining checklist: invalid
+  directive, no-op, failing command, directive with trailing text, fork PR.
+- Follow-up: trim the `GITHUB_TOKEN` grants forwarded to the reusable workflow
+  once live runs confirm the minimum required.
 - Phases 2 (i18n caller) and 3 (scheduled maintenance) not started.
+
+[#10309]: https://github.com/open-telemetry/opentelemetry.io/pull/10309
+[#10317]: https://github.com/open-telemetry/opentelemetry.io/pull/10317
+[#10318]: https://github.com/open-telemetry/opentelemetry.io/pull/10318

--- a/projects/2026/pr-fix-reusable-actions.plan.md
+++ b/projects/2026/pr-fix-reusable-actions.plan.md
@@ -116,8 +116,8 @@ As of 2026-06-10 (continued work tracked in [#10320][]):
         outcome (1:1 comment per directive, no mutation of user content).
         Alternative considered: editing the originating comment's first line —
         rejected as invasive (alters user content).
-  - [x] Include the run link in the ℹ️ no-op outcome (the other outcomes already
-        link to the run or logs).
+  - [x] Include the run link in every outcome, in a uniform format: each outcome
+        message ends with "See the logs of [run ID](url)."
   - [x] Latest directive wins: per-PR workflow-level concurrency with
         cancel-in-progress, so concurrent runs don't waste resources. Non-`/fix`
         comments get a unique group so they can't cancel a `/fix` run.

--- a/projects/2026/pr-fix-reusable-actions.plan.md
+++ b/projects/2026/pr-fix-reusable-actions.plan.md
@@ -89,7 +89,7 @@ once the shared patch path has proven stable.
 
 ## Status details
 
-As of 2026-06-10:
+As of 2026-06-10 (continued work tracked in [#10320][]):
 
 - Phase 1 merged ([#10309][], plus app-token scope fix [#10318][]):
   `npm-script-patch` action (untrusted), `reusable-apply-patch.yml` workflow
@@ -99,8 +99,10 @@ As of 2026-06-10:
   - [x] `/fix:<name>` with changes pending → ✅ comment + pushed commit
   - [x] `/fixx` (invalid directive) → ❌ comment with usage hint
   - [x] `/fix:<name>` with no changes pending → ℹ️ no-op comment
-  - [x] two `/fix` directives in rapid succession → two independent runs
-        (applies serialize per-PR; a stale duplicate patch fails loudly)
+  - [x] two `/fix` directives in rapid succession → two independent runs; the
+        second failed loudly (stale duplicate patch). Since then, semantics
+        changed to latest-wins: a new directive cancels the PR's in-flight run,
+        which still reports a ⚠️ outcome.
   - [ ] `/fix` followed by explanatory lines → treated as `/fix`
   - [ ] failing command → ❌/⚠️ comment
   - [ ] same flow from a fork PR
@@ -116,6 +118,9 @@ As of 2026-06-10:
         rejected as invasive (alters user content).
   - [x] Include the run link in the ℹ️ no-op outcome (the other outcomes already
         link to the run or logs).
+  - [x] Latest directive wins: per-PR workflow-level concurrency with
+        cancel-in-progress, so concurrent runs don't waste resources. Non-`/fix`
+        comments get a unique group so they can't cancel a `/fix` run.
 - Phases 2 (i18n caller) and 3 (scheduled maintenance) not started.
 
 <!-- prettier-ignore-start -->
@@ -123,4 +128,5 @@ As of 2026-06-10:
 [#10317]: https://github.com/open-telemetry/opentelemetry.io/pull/10317
 [#10318]: https://github.com/open-telemetry/opentelemetry.io/pull/10318
 [#10319]: https://github.com/open-telemetry/opentelemetry.io/pull/10319
+[#10320]: https://github.com/open-telemetry/opentelemetry.io/issues/10320
 <!-- prettier-ignore-end -->

--- a/projects/2026/pr-fix-reusable-actions.plan.md
+++ b/projects/2026/pr-fix-reusable-actions.plan.md
@@ -121,6 +121,10 @@ As of 2026-06-10 (continued work tracked in [#10320][]):
   - [x] Latest directive wins: per-PR workflow-level concurrency with
         cancel-in-progress, so concurrent runs don't waste resources. Non-`/fix`
         comments get a unique group so they can't cancel a `/fix` run.
+  - [x] Directives on closed or merged PRs are gated out (from the trigger
+        payload, before any runner does fix work) and reported as ❌ with the
+        reason. Draft PRs still work; deleted-branch sub-cases are moot since
+        nothing is checked out.
 - Phases 2 (i18n caller) and 3 (scheduled maintenance) not started.
 
 <!-- prettier-ignore-start -->

--- a/projects/2026/pr-fix-reusable-actions.plan.md
+++ b/projects/2026/pr-fix-reusable-actions.plan.md
@@ -114,7 +114,7 @@ As of 2026-06-10:
         outcome (1:1 comment per directive, no mutation of user content).
         Alternative considered: editing the originating comment's first line —
         rejected as invasive (alters user content).
-  - [ ] Include the run link in the ℹ️ no-op outcome (the other outcomes already
+  - [x] Include the run link in the ℹ️ no-op outcome (the other outcomes already
         link to the run or logs).
 - Phases 2 (i18n caller) and 3 (scheduled maintenance) not started.
 

--- a/projects/2026/pr-fix-reusable-actions.plan.md
+++ b/projects/2026/pr-fix-reusable-actions.plan.md
@@ -1,6 +1,6 @@
 ---
 title: Reusable patch actions for PR and maintenance fixes
-custodian: [Patrice Chalin](https://github.com/chalin)
+custodian: '[Patrice Chalin](https://github.com/chalin)'
 status: Phase 1 merged and partially live-validated; phases 2–3 pending.
 cSpell:ignore: fixx otelbot test-and-fix
 ---
@@ -91,21 +91,36 @@ once the shared patch path has proven stable.
 
 As of 2026-06-10:
 
-- Phase 1 merged ([#10309], plus app-token scope fix [#10318]):
+- Phase 1 merged ([#10309][], plus app-token scope fix [#10318][]):
   `npm-script-patch` action (untrusted), `reusable-apply-patch.yml` workflow
   (trusted), always-run outcome reporting, unit-tested directive parsing and
   report composition, and a guard test for workflow-to-file references.
-- Live validation on [#10317]:
+- Live validation on [#10317][] and [#10319][]:
   - [x] `/fix:<name>` with changes pending → ✅ comment + pushed commit
   - [x] `/fixx` (invalid directive) → ❌ comment with usage hint
-  - [ ] `/fix:<name>` with no changes pending → ℹ️ no-op comment
+  - [x] `/fix:<name>` with no changes pending → ℹ️ no-op comment
+  - [x] two `/fix` directives in rapid succession → two independent runs
+        (applies serialize per-PR; a stale duplicate patch fails loudly)
   - [ ] `/fix` followed by explanatory lines → treated as `/fix`
   - [ ] failing command → ❌/⚠️ comment
   - [ ] same flow from a fork PR
 - Follow-up: trim the `GITHUB_TOKEN` grants forwarded to the reusable workflow
   once live runs confirm the minimum required.
+- Feature candidates (improve directive↔outcome association when a PR has
+  several directives):
+  - [ ] Immediate acknowledgement: a trusted "ack" job posts a progress comment
+        (e.g. "🔄 Running `/fix:format` — [run](link)") as soon as a directive
+        is received; the report job then edits that same comment with the final
+        outcome (1:1 comment per directive, no mutation of user content).
+        Alternative considered: editing the originating comment's first line —
+        rejected as invasive (alters user content).
+  - [ ] Include the run link in the ℹ️ no-op outcome (the other outcomes already
+        link to the run or logs).
 - Phases 2 (i18n caller) and 3 (scheduled maintenance) not started.
 
+<!-- prettier-ignore-start -->
 [#10309]: https://github.com/open-telemetry/opentelemetry.io/pull/10309
 [#10317]: https://github.com/open-telemetry/opentelemetry.io/pull/10317
 [#10318]: https://github.com/open-telemetry/opentelemetry.io/pull/10318
+[#10319]: https://github.com/open-telemetry/opentelemetry.io/pull/10319
+<!-- prettier-ignore-end -->

--- a/projects/2026/pr-fix-reusable-actions.plan.md
+++ b/projects/2026/pr-fix-reusable-actions.plan.md
@@ -2,7 +2,7 @@
 title: Reusable patch actions for PR and maintenance fixes
 custodian: [Patrice Chalin](https://github.com/chalin)
 status: Phase 1 merged and partially live-validated; phases 2–3 pending.
-cSpell:ignore: otelbot test-and-fix
+cSpell:ignore: fixx otelbot test-and-fix
 ---
 
 ## Context
@@ -95,9 +95,13 @@ As of 2026-06-10:
   `npm-script-patch` action (untrusted), `reusable-apply-patch.yml` workflow
   (trusted), always-run outcome reporting, unit-tested directive parsing and
   report composition, and a guard test for workflow-to-file references.
-- Live validation: happy path confirmed (`/fix:dict` on [#10317] — patch
-  generated, applied, pushed, ✅ outcome comment). Remaining checklist: invalid
-  directive, no-op, failing command, directive with trailing text, fork PR.
+- Live validation on [#10317]:
+  - [x] `/fix:<name>` with changes pending → ✅ comment + pushed commit
+  - [x] `/fixx` (invalid directive) → ❌ comment with usage hint
+  - [ ] `/fix:<name>` with no changes pending → ℹ️ no-op comment
+  - [ ] `/fix` followed by explanatory lines → treated as `/fix`
+  - [ ] failing command → ❌/⚠️ comment
+  - [ ] same flow from a fork PR
 - Follow-up: trim the `GITHUB_TOKEN` grants forwarded to the reusable workflow
   once live runs confirm the minimum required.
 - Phases 2 (i18n caller) and 3 (scheduled maintenance) not started.

--- a/scripts/gh/patch-report/cli.mjs
+++ b/scripts/gh/patch-report/cli.mjs
@@ -17,6 +17,8 @@ with \`gh pr comment\` (which authenticates via $GH_TOKEN).
 Options:
   -p, --pr <num>               Pull request number to comment on. Required.
       --label <name>           The action as requested (e.g. the command).
+      --pr-state <state>       PR state: 'open' or 'closed' ('' acts as open).
+      --pr-merged <bool>       'true' when the PR is merged.
       --generate-result <r>    Result of the patch-generation job.
       --patch-skipped <bool>   'true' when generation produced no changes.
       --command-exit-status <n> Exit status of the patch-producing command.
@@ -34,6 +36,8 @@ const { values } = parseArgs({
   options: {
     pr: { type: 'string', short: 'p' },
     label: { type: 'string', default: '' },
+    'pr-state': { type: 'string', default: '' },
+    'pr-merged': { type: 'string', default: '' },
     'generate-result': { type: 'string', default: '' },
     'patch-skipped': { type: 'string', default: '' },
     'command-exit-status': { type: 'string', default: '' },
@@ -60,6 +64,8 @@ const runUrl = `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_
 
 const body = buildOutcomeComment({
   label: values.label,
+  prState: values['pr-state'],
+  prMerged: values['pr-merged'],
   generateResult: values['generate-result'],
   patchSkipped: values['patch-skipped'],
   commandExitStatus: values['command-exit-status'],

--- a/scripts/gh/patch-report/index.mjs
+++ b/scripts/gh/patch-report/index.mjs
@@ -72,7 +72,7 @@ export function buildOutcomeComment({
         `and made no changes. ${logs}`
       );
     }
-    return `ℹ️ ${what} made no changes. Nothing to commit.`;
+    return `ℹ️ ${what} made no changes in [run ${runId}](${runUrl}). Nothing to commit.`;
   }
 
   // 3. Changes were produced: report how applying them went.

--- a/scripts/gh/patch-report/index.mjs
+++ b/scripts/gh/patch-report/index.mjs
@@ -15,6 +15,11 @@
  * @property {string} label              The action as requested (e.g. the
  *                                       command); '' when it could not be
  *                                       identified.
+ * @property {string} [prState]          PR state at the time of the request:
+ *                                       'open' or 'closed' (merged PRs are
+ *                                       closed). '' is treated as open for
+ *                                       callers that don't gate on state.
+ * @property {string} [prMerged]         'true' when the PR is merged.
  * @property {string} generateResult     Result of the patch-generation job:
  *                                       'success' | 'failure' | 'cancelled'.
  * @property {string} patchSkipped       'true' when generation produced no
@@ -41,6 +46,8 @@
  */
 export function buildOutcomeComment({
   label,
+  prState,
+  prMerged,
   generateResult,
   patchSkipped,
   commandExitStatus,
@@ -51,6 +58,12 @@ export function buildOutcomeComment({
 }) {
   const what = label ? `\`${label}\`` : 'the requested action';
   const logs = `See [run ${runId}](${runUrl}).`;
+
+  // 0. The PR isn't open: nothing ran (the pipeline gates on PR state).
+  if (prState && prState !== 'open') {
+    const why = prMerged === 'true' ? 'has already been merged' : 'is closed';
+    return `❌ This PR ${why}, so ${what} was not run: such actions only apply to open PRs. ${logs}`;
+  }
 
   // 1. Patch generation did not succeed: no changes were ever captured.
   if (generateResult === 'cancelled') {

--- a/scripts/gh/patch-report/index.mjs
+++ b/scripts/gh/patch-report/index.mjs
@@ -50,7 +50,9 @@ export function buildOutcomeComment({
   hint,
 }) {
   const what = label ? `\`${label}\`` : 'the requested action';
-  const logs = `See the [run logs](${runUrl}).`;
+  // Every outcome ends with this sentence so that outcomes can be traced back
+  // to the run that produced them, in a uniform format.
+  const logs = `See the logs of [run ${runId}](${runUrl}).`;
 
   // 1. Patch generation did not succeed: no changes were ever captured.
   if (generateResult === 'cancelled') {
@@ -72,7 +74,7 @@ export function buildOutcomeComment({
         `and made no changes. ${logs}`
       );
     }
-    return `ℹ️ ${what} made no changes in [run ${runId}](${runUrl}). Nothing to commit.`;
+    return `ℹ️ ${what} made no changes; nothing to commit. ${logs}`;
   }
 
   // 3. Changes were produced: report how applying them went.
@@ -88,5 +90,5 @@ export function buildOutcomeComment({
       `but the resulting changes were applied. ${logs}`
     );
   }
-  return `✅ ${what} applied successfully in [run ${runId}](${runUrl}).`;
+  return `✅ ${what} applied successfully. ${logs}`;
 }

--- a/scripts/gh/patch-report/index.mjs
+++ b/scripts/gh/patch-report/index.mjs
@@ -50,7 +50,7 @@ export function buildOutcomeComment({
   hint,
 }) {
   const what = label ? `\`${label}\`` : 'the requested action';
-  const logs = `See logs: ${runUrl}`;
+  const logs = `See the [run logs](${runUrl}).`;
 
   // 1. Patch generation did not succeed: no changes were ever captured.
   if (generateResult === 'cancelled') {

--- a/scripts/gh/patch-report/index.mjs
+++ b/scripts/gh/patch-report/index.mjs
@@ -50,9 +50,7 @@ export function buildOutcomeComment({
   hint,
 }) {
   const what = label ? `\`${label}\`` : 'the requested action';
-  // Every outcome ends with this sentence so that outcomes can be traced back
-  // to the run that produced them, in a uniform format.
-  const logs = `See the logs of [run ${runId}](${runUrl}).`;
+  const logs = `See [run ${runId}](${runUrl}).`;
 
   // 1. Patch generation did not succeed: no changes were ever captured.
   if (generateResult === 'cancelled') {

--- a/scripts/gh/patch-report/index.test.mjs
+++ b/scripts/gh/patch-report/index.test.mjs
@@ -27,14 +27,14 @@ describe('buildOutcomeComment', () => {
   test('no-op: generation produced no changes', () => {
     assert.equal(
       build({ patchSkipped: 'true' }),
-      'ℹ️ `fix:refcache` made no changes. Nothing to commit.',
+      'ℹ️ `fix:refcache` made no changes in [run 123](https://example.test/run/123). Nothing to commit.',
     );
   });
 
   test('no-op with unknown (empty) exit status is not reported as a failure', () => {
     assert.equal(
       build({ patchSkipped: 'true', commandExitStatus: '' }),
-      'ℹ️ `fix:refcache` made no changes. Nothing to commit.',
+      'ℹ️ `fix:refcache` made no changes in [run 123](https://example.test/run/123). Nothing to commit.',
     );
   });
 

--- a/scripts/gh/patch-report/index.test.mjs
+++ b/scripts/gh/patch-report/index.test.mjs
@@ -93,6 +93,24 @@ describe('buildOutcomeComment', () => {
     assert.match(body, /^✅ the requested action applied successfully/);
   });
 
+  test('closed PR: nothing ran', () => {
+    const body = build({ prState: 'closed' });
+    assert.match(body, /^❌ This PR is closed, so `fix:refcache` was not run/);
+    assert.match(body, /only apply to open PRs/);
+  });
+
+  test('merged PR: nothing ran', () => {
+    const body = build({ prState: 'closed', prMerged: 'true', label: '' });
+    assert.match(
+      body,
+      /^❌ This PR has already been merged, so the requested action was not run/,
+    );
+  });
+
+  test('open PR state does not short-circuit the outcome', () => {
+    assert.equal(build({ prState: 'open' }), build({}));
+  });
+
   test('every outcome produces a non-empty comment ending with the run link', () => {
     for (const generateResult of ['success', 'failure', 'cancelled']) {
       for (const patchSkipped of ['true', 'false']) {
@@ -105,24 +123,27 @@ describe('buildOutcomeComment', () => {
           for (const commandExitStatus of ['0', '1', '']) {
             for (const label of ['fix', '']) {
               for (const hint of ['Any hint text.', '']) {
-                const body = buildOutcomeComment({
-                  label,
-                  generateResult,
-                  patchSkipped,
-                  commandExitStatus,
-                  applyResult,
-                  runId: '1',
-                  runUrl: 'u',
-                  hint,
-                });
-                assert.ok(
-                  typeof body === 'string' && body.length > 0,
-                  'comment should be a non-empty string',
-                );
-                assert.ok(
-                  body.endsWith('See [run 1](u).'),
-                  `comment should end with the run link: ${body}`,
-                );
+                for (const prState of ['open', 'closed', '']) {
+                  const body = buildOutcomeComment({
+                    label,
+                    prState,
+                    generateResult,
+                    patchSkipped,
+                    commandExitStatus,
+                    applyResult,
+                    runId: '1',
+                    runUrl: 'u',
+                    hint,
+                  });
+                  assert.ok(
+                    typeof body === 'string' && body.length > 0,
+                    'comment should be a non-empty string',
+                  );
+                  assert.ok(
+                    body.endsWith('See [run 1](u).'),
+                    `comment should end with the run link: ${body}`,
+                  );
+                }
               }
             }
           }

--- a/scripts/gh/patch-report/index.test.mjs
+++ b/scripts/gh/patch-report/index.test.mjs
@@ -16,25 +16,26 @@ describe('buildOutcomeComment', () => {
     runUrl: 'https://example.test/run/123',
   };
 
+  const LOGS = 'See the logs of [run 123](https://example.test/run/123).';
+
   const build = (overrides) => buildOutcomeComment({ ...BASE, ...overrides });
 
   test('success: command applied cleanly', () => {
     const body = build({});
     assert.match(body, /^✅ `fix:refcache` applied successfully/);
-    assert.match(body, /\[run 123\]\(https:\/\/example\.test\/run\/123\)/);
   });
 
   test('no-op: generation produced no changes', () => {
     assert.equal(
       build({ patchSkipped: 'true' }),
-      'ℹ️ `fix:refcache` made no changes in [run 123](https://example.test/run/123). Nothing to commit.',
+      `ℹ️ \`fix:refcache\` made no changes; nothing to commit. ${LOGS}`,
     );
   });
 
   test('no-op with unknown (empty) exit status is not reported as a failure', () => {
     assert.equal(
       build({ patchSkipped: 'true', commandExitStatus: '' }),
-      'ℹ️ `fix:refcache` made no changes in [run 123](https://example.test/run/123). Nothing to commit.',
+      `ℹ️ \`fix:refcache\` made no changes; nothing to commit. ${LOGS}`,
     );
   });
 
@@ -42,10 +43,6 @@ describe('buildOutcomeComment', () => {
     const body = build({ patchSkipped: 'true', commandExitStatus: '2' });
     assert.match(body, /^❌ `fix:refcache` failed \(exit status 2\)/);
     assert.match(body, /made no changes/);
-    assert.match(
-      body,
-      /See the \[run logs\]\(https:\/\/example\.test\/run\/123\)\./,
-    );
   });
 
   test('command failed non-zero but changes were applied', () => {
@@ -60,10 +57,6 @@ describe('buildOutcomeComment', () => {
   test('unidentified request: generation failed with no label', () => {
     const body = build({ generateResult: 'failure', label: '' });
     assert.match(body, /^❌ The request could not be processed\./);
-    assert.match(
-      body,
-      /See the \[run logs\]\(https:\/\/example\.test\/run\/123\)\./,
-    );
   });
 
   test('unidentified request includes a caller-supplied hint', () => {
@@ -78,10 +71,6 @@ describe('buildOutcomeComment', () => {
   test('generation failed for a known command (e.g. oversized patch)', () => {
     const body = build({ generateResult: 'failure' });
     assert.match(body, /^❌ `fix:refcache` could not be run/);
-    assert.match(
-      body,
-      /See the \[run logs\]\(https:\/\/example\.test\/run\/123\)\./,
-    );
   });
 
   test('generation cancelled', () => {
@@ -104,7 +93,7 @@ describe('buildOutcomeComment', () => {
     assert.match(body, /^✅ the requested action applied successfully/);
   });
 
-  test('every outcome produces a non-empty comment', () => {
+  test('every outcome produces a non-empty comment ending with the run link', () => {
     for (const generateResult of ['success', 'failure', 'cancelled']) {
       for (const patchSkipped of ['true', 'false']) {
         for (const applyResult of [
@@ -129,6 +118,10 @@ describe('buildOutcomeComment', () => {
                 assert.ok(
                   typeof body === 'string' && body.length > 0,
                   'comment should be a non-empty string',
+                );
+                assert.ok(
+                  body.endsWith('See the logs of [run 1](u).'),
+                  `comment should end with the run link: ${body}`,
                 );
               }
             }

--- a/scripts/gh/patch-report/index.test.mjs
+++ b/scripts/gh/patch-report/index.test.mjs
@@ -42,7 +42,10 @@ describe('buildOutcomeComment', () => {
     const body = build({ patchSkipped: 'true', commandExitStatus: '2' });
     assert.match(body, /^❌ `fix:refcache` failed \(exit status 2\)/);
     assert.match(body, /made no changes/);
-    assert.match(body, /See logs: https:\/\/example\.test\/run\/123/);
+    assert.match(
+      body,
+      /See the \[run logs\]\(https:\/\/example\.test\/run\/123\)\./,
+    );
   });
 
   test('command failed non-zero but changes were applied', () => {
@@ -57,7 +60,10 @@ describe('buildOutcomeComment', () => {
   test('unidentified request: generation failed with no label', () => {
     const body = build({ generateResult: 'failure', label: '' });
     assert.match(body, /^❌ The request could not be processed\./);
-    assert.match(body, /See logs: https:\/\/example\.test\/run\/123/);
+    assert.match(
+      body,
+      /See the \[run logs\]\(https:\/\/example\.test\/run\/123\)\./,
+    );
   });
 
   test('unidentified request includes a caller-supplied hint', () => {
@@ -72,7 +78,10 @@ describe('buildOutcomeComment', () => {
   test('generation failed for a known command (e.g. oversized patch)', () => {
     const body = build({ generateResult: 'failure' });
     assert.match(body, /^❌ `fix:refcache` could not be run/);
-    assert.match(body, /See logs: https:\/\/example\.test\/run\/123/);
+    assert.match(
+      body,
+      /See the \[run logs\]\(https:\/\/example\.test\/run\/123\)\./,
+    );
   });
 
   test('generation cancelled', () => {

--- a/scripts/gh/patch-report/index.test.mjs
+++ b/scripts/gh/patch-report/index.test.mjs
@@ -16,7 +16,7 @@ describe('buildOutcomeComment', () => {
     runUrl: 'https://example.test/run/123',
   };
 
-  const LOGS = 'See the logs of [run 123](https://example.test/run/123).';
+  const LOGS = 'See [run 123](https://example.test/run/123).';
 
   const build = (overrides) => buildOutcomeComment({ ...BASE, ...overrides });
 
@@ -120,7 +120,7 @@ describe('buildOutcomeComment', () => {
                   'comment should be a non-empty string',
                 );
                 assert.ok(
-                  body.endsWith('See the logs of [run 1](u).'),
+                  body.endsWith('See [run 1](u).'),
                   `comment should end with the run link: ${body}`,
                 );
               }


### PR DESCRIPTION
- Contributes to #10320
- Concurrency
  - Adopts latest-wins semantics: a new `/fix` comment cancels the PR's in-flight run, since concurrent fix runs on the same branch serve no purpose; the cancelled run still reports a ⚠️ outcome
  - Gives non-`/fix` comments a unique concurrency group so they can't cancel a `/fix` run; removes the now-redundant job-level apply serialization
- PR-state gating
  - Skips the fix pipeline when the PR is closed or merged, using the trigger payload so no runner time is spent on a fix that could never be pushed
  - Reports the reason (closed vs merged) to the requestor via the report job, which now gates on the `/fix`-comment condition rather than on whether `generate-patch` ran
- Outcome messages
  - Ends every outcome with a uniform "See [run ID](url)." sentence so outcomes can be traced to their run; previously success/no-op embedded the link inline while failures used a raw URL without the run ID
  - Extends the exhaustive outcome test to assert the uniform suffix and the new PR-state axis
- Docs
  - Documents latest-wins cancellation and the open-PR requirement in the maintainer docs, and the cancellation behavior in the contributor docs
  - Updates the project plan: live-validation checklist, feature checklist, tracker issue