### PR TITLE
[ja] update translation of content/en/docs/zero-code/obi/configure/metrics-traces-attributes.md

### DIFF
--- a/content/ja/docs/zero-code/obi/configure/metrics-traces-attributes.md
+++ b/content/ja/docs/zero-code/obi/configure/metrics-traces-attributes.md
@@ -3,8 +3,7 @@ title: OBI のメトリクスとトレースの属性を設定する
 linkTitle: メトリクス属性
 description: 計装された Kubernetes Pod のインスタンス ID デコレーションとメタデータを含む、報告される属性を制御するメトリクスとトレースの属性コンポーネントを設定します。
 weight: 30
-default_lang_commit: fc509b751d6882b99824ea78a1dd8e638dd9055a
-drifted_from_default: true
+default_lang_commit: 1c5c4de33671bca46cb2ad38c082933284c53739
 cSpell:ignore: kube kubecache kubeconfig replicaset statefulset
 ---
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/obi/configure/metrics-traces-attributes.md` to match the latest English source at
`content/en/docs/zero-code/obi/configure/metrics-traces-attributes.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English-side change was trivial: removal of a duplicate `### HTTP header and body enrichment for spans` heading (the duplicate lacked the `{#id}` suffix). The Japanese translation already omitted the duplicate, so no content changes were needed — only the frontmatter bookkeeping (`default_lang_commit` update + `drifted_from_default` removal).

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10322--opentelemetry.netlify.app/ja/docs/zero-code/obi/configure/metrics-traces-attributes/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/obi/configure/metrics-traces-attributes/

<!-- preview-section-end -->
