### PR TITLE
ci(pr-actions): acknowledge /fix directives with a progress comment; harden pipeline

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -26,9 +26,10 @@ jobs:
   ack:
     name: Acknowledge request (trusted)
     runs-on: ubuntu-latest
-    # Same broad gate as report (PR state included): every directive that gets
-    # an outcome comment first gets an in-progress acknowledgement, which the
-    # report job then updates in place with the outcome.
+    # Same broad /fix PR-comment gate as generate-patch, including the open-PR
+    # check; closed PRs skip the ack and get a fresh outcome comment from the
+    # report job. The report job updates the ack comment in place with the
+    # outcome.
     if: |
       github.event.issue.pull_request &&
       github.event.issue.state == 'open' &&

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -189,8 +189,10 @@ jobs:
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
           LABEL: ${{ needs.generate-patch.outputs.action_name }}
           # Updates the ack comment in place when one was posted; otherwise
-          # (e.g. directive on a closed PR, or the ack job failed) the
-          # outcome is posted as a new comment.
+          # (e.g. directive on a closed PR, the ack job failed, or the run
+          # was cancelled before the ack posted its comment id) the outcome
+          # is posted as a new comment — in the cancelled case a stale 🔄
+          # comment may remain.
           ACK_COMMENT_ID: ${{ needs.ack.outputs.comment_id }}
           DIRECTIVE_URL: ${{ github.event.comment.html_url }}
           # 'open' or 'closed'; merged PRs are 'closed' with a merged_at time.

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -23,6 +23,52 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.event.comment.body, '/fix') }}
 
 jobs:
+  ack:
+    name: Acknowledge request (trusted)
+    runs-on: ubuntu-latest
+    # Same broad gate as report (PR state included): every directive that gets
+    # an outcome comment first gets an in-progress acknowledgement, which the
+    # report job then updates in place with the outcome.
+    if: |
+      github.event.issue.pull_request &&
+      github.event.issue.state == 'open' &&
+      startsWith(github.event.comment.body, '/fix')
+    permissions:
+      contents: read # checkout
+    outputs:
+      comment_id: ${{ steps.ack.outputs.comment_id }}
+
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with: { fetch-depth: 1, persist-credentials: false }
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: otelbot-token
+        with:
+          client-id: ${{ vars.OTELBOT_APP_ID }}
+          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          # PR comments authorize via the pull-requests permission (even
+          # though they're posted through the issues API endpoint).
+          permission-pull-requests: write # post the acknowledgement comment
+
+      - name: Post acknowledgement comment
+        id: ack
+        env:
+          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+          DIRECTIVE_URL: ${{ github.event.comment.html_url }}
+        run: |
+          node scripts/gh/patch-report/cli.mjs --ack \
+            --pr "$PR_NUM" \
+            --directive-url "$DIRECTIVE_URL"
+
   generate-patch:
     name: Run PR action and generate patch (untrusted)
     runs-on: ubuntu-latest
@@ -102,7 +148,7 @@ jobs:
   report:
     name: Report outcome (trusted)
     runs-on: ubuntu-latest
-    needs: [generate-patch, apply-patch]
+    needs: [ack, generate-patch, apply-patch]
     # Always tell the requestor what happened, for every comment that enters
     # the pipeline (same broad gate as generate-patch, minus the PR-state
     # check): invalid directives, failures, and directives on closed PRs.
@@ -141,6 +187,11 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
           LABEL: ${{ needs.generate-patch.outputs.action_name }}
+          # Updates the ack comment in place when one was posted; otherwise
+          # (e.g. directive on a closed PR, or the ack job failed) the
+          # outcome is posted as a new comment.
+          ACK_COMMENT_ID: ${{ needs.ack.outputs.comment_id }}
+          DIRECTIVE_URL: ${{ github.event.comment.html_url }}
           # 'open' or 'closed'; merged PRs are 'closed' with a merged_at time.
           PR_STATE: ${{ github.event.issue.state }}
           PR_MERGED: ${{ github.event.issue.pull_request.merged_at != null }}
@@ -156,6 +207,8 @@ jobs:
           hint=$(node -e 'import("./scripts/gh/pr-fix/index.mjs").then((m) => console.log(m.DIRECTIVE_HINT))')
           node scripts/gh/patch-report/cli.mjs \
             --pr "$PR_NUM" \
+            --comment-id "$ACK_COMMENT_ID" \
+            --directive-url "$DIRECTIVE_URL" \
             --label "$LABEL" \
             --pr-state "$PR_STATE" \
             --pr-merged "$PR_MERGED" \

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -26,6 +26,7 @@ jobs:
   ack:
     name: Acknowledge request (trusted)
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     # Same broad /fix PR-comment gate as generate-patch, including the open-PR
     # check; closed PRs skip the ack and get a fresh outcome comment from the
     # report job. The report job updates the ack comment in place with the
@@ -75,6 +76,8 @@ jobs:
   generate-patch:
     name: Run PR action and generate patch (untrusted)
     runs-on: ubuntu-latest
+    # Bounds runner usage by hostile or runaway fix scripts.
+    timeout-minutes: 15
     # Broad prefix gate; exact (first-line) parsing happens in the extract
     # step below. Closed (including merged) PRs are gated out here; the report
     # job still explains why nothing ran.
@@ -110,7 +113,7 @@ jobs:
         # usage hint) on the PR.
         run: node scripts/gh/pr-fix/cli.mjs --comment "$COMMENT"
 
-      - run: gh pr checkout $PR_NUM -b "pr-action-${RANDOM}"
+      - run: gh pr checkout "$PR_NUM" -b "pr-action-${RANDOM}"
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -119,6 +122,9 @@ jobs:
         # Untrusted: runs the resolved npm script and captures any changes as a
         # patch artifact. Has no write permissions or secrets. The `_refcache:prune`
         # post-command drops 404 entries so refcache updates stay clean.
+        # NOTE: after `gh pr checkout` above, this local action's definition
+        # resolves from the PR branch — treat the action itself as untrusted;
+        # never add secrets or write permissions to this job.
         uses: ./.github/actions/npm-script-patch
         with:
           command: ${{ steps.extract.outputs.command }}
@@ -152,6 +158,7 @@ jobs:
   report:
     name: Report outcome (trusted)
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: [ack, generate-patch, apply-patch]
     # Always tell the requestor what happened, for every comment that enters
     # the pipeline (same broad gate as generate-patch, minus the PR-state

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -29,8 +29,10 @@ jobs:
     # Same broad /fix PR-comment gate as generate-patch, including the open-PR
     # check; closed PRs skip the ack and get a fresh outcome comment from the
     # report job. The report job updates the ack comment in place with the
-    # outcome.
+    # outcome. The repository-owner check keeps the pipeline from failing in
+    # forks, which lack the bot app variables and secrets.
     if: |
+      github.repository_owner == 'open-telemetry' &&
       github.event.issue.pull_request &&
       github.event.issue.state == 'open' &&
       startsWith(github.event.comment.body, '/fix')
@@ -77,6 +79,7 @@ jobs:
     # step below. Closed (including merged) PRs are gated out here; the report
     # job still explains why nothing ran.
     if: |
+      github.repository_owner == 'open-telemetry' &&
       github.event.issue.pull_request &&
       github.event.issue.state == 'open' &&
       startsWith(github.event.comment.body, '/fix')
@@ -155,6 +158,7 @@ jobs:
     # check): invalid directives, failures, and directives on closed PRs.
     if: |
       always() &&
+      github.repository_owner == 'open-telemetry' &&
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/fix')
     # The outcome comment is posted with the app token below, not GITHUB_TOKEN.

--- a/.github/workflows/reusable-apply-patch.yml
+++ b/.github/workflows/reusable-apply-patch.yml
@@ -69,6 +69,7 @@ jobs:
   apply:
     name: Apply and push patch
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     # NOTE: the steps below authenticate with the app token, not GITHUB_TOKEN,
     # so these GITHUB_TOKEN grants may be trimmable. Verify in a live run
     # (e.g. the artifact download) before tightening.

--- a/content/en/docs/contributing/pull-requests.md
+++ b/content/en/docs/contributing/pull-requests.md
@@ -162,9 +162,11 @@ Add the following comment to your PR:
 /fix
 ```
 
-This will trigger the OpenTelemetry bot to try to fix build issues, and reply
-with the outcome. Or you can issue one of the following fix commands to address
-a specific failure:
+This will trigger the OpenTelemetry bot to try to fix build issues. The bot
+replies with a progress comment that links back to your fix command, then
+updates that same comment with the result — so each fix command you issue gets
+its own bot comment. Or you can issue one of the following fix commands to
+address a specific failure:
 
 ```text
 /fix:code-excerpts
@@ -182,7 +184,8 @@ a specific failure:
 
 The fix command must be the first line of your comment; you can add explanatory
 text on the lines that follow. Issuing a new fix command while one is already
-running cancels the in-progress run so that the latest command wins.
+running cancels the in-progress run so that the latest command wins; the
+cancelled run's bot comment is updated to note the cancellation.
 
 > [!TIP] Pro tip
 >

--- a/content/en/docs/contributing/pull-requests.md
+++ b/content/en/docs/contributing/pull-requests.md
@@ -184,8 +184,8 @@ address a specific failure:
 
 The fix command must be the first line of your comment; you can add explanatory
 text on the lines that follow. Issuing a new fix command while one is already
-running cancels the in-progress run so that the latest command wins; the
-cancelled run's bot comment is updated to note the cancellation.
+running cancels the in-progress run so that the latest command wins; when
+possible, the cancelled run's bot comment is updated to note the cancellation.
 
 > [!TIP] Pro tip
 >

--- a/content/en/site/build/ci-workflows.md
+++ b/content/en/site/build/ci-workflows.md
@@ -279,6 +279,10 @@ Directives only run against open PRs (draft PRs included): on a closed or merged
 PR the fix command never runs and the report job explains why. The PR state
 comes from the trigger payload, so no runner is spent on the fix itself.
 
+The pipeline only runs in the canonical `open-telemetry` repository, where the
+bot app credentials exist. Fork PRs work normally — `issue_comment` events fire
+in the base repository — but the workflow skips itself inside forks.
+
 Directives follow latest-wins semantics: a new `/fix` comment on a PR cancels
 that PR's in-flight run (which still reports a ⚠️ outcome), since concurrent fix
 runs on the same branch serve no purpose — the second push would fail anyway

--- a/content/en/site/build/ci-workflows.md
+++ b/content/en/site/build/ci-workflows.md
@@ -256,20 +256,24 @@ all).
 
 [#9291]: https://github.com/open-telemetry/opentelemetry.io/pull/9291
 
-It runs as a three-stage pipeline:
+It runs as a four-stage pipeline:
 
-1. **`generate-patch`** (untrusted): checks out the PR branch, runs the fix
+1. **`ack`** (trusted): immediately replies with a 🔄 in-progress comment that
+   links the directive comment and the run.
+2. **`generate-patch`** (untrusted): checks out the PR branch, runs the fix
    command, prunes the link refcache, and uploads a patch artifact
    (`site.patch`), up to 1024 KB.
-2. **`apply-patch`** (trusted): calls the [`reusable-apply-patch.yml`][]
+3. **`apply-patch`** (trusted): calls the [`reusable-apply-patch.yml`][]
    workflow — resolved from the default branch, never from the PR — which
    applies the patch with a GitHub App token and pushes a commit to the PR
    branch. Skipped when the command produced no changes.
-3. **`report`** (trusted): always comments the outcome back on the PR — with a
-   link to the run that produced it — so the requestor learns the result of
-   every directive that triggers the workflow, including invalid directives
-   (such as `/fixup` or `/fix please`), no-op runs, and failures that happen
-   before any patch is produced.
+4. **`report`** (trusted): updates the ack comment in place with the outcome (or
+   posts a new comment when there is no ack, such as on a closed PR), so each
+   directive maps to a single progress-then-outcome comment that links back to
+   the directive and to the run that produced it. This covers every directive
+   that triggers the workflow, including invalid directives (such as `/fixup` or
+   `/fix please`), no-op runs, and failures that happen before any patch is
+   produced.
 
 Directives only run against open PRs (draft PRs included): on a closed or merged
 PR the fix command never runs and the report job explains why. The PR state

--- a/content/en/site/build/ci-workflows.md
+++ b/content/en/site/build/ci-workflows.md
@@ -285,8 +285,8 @@ runs on the same branch serve no purpose — the second push would fail anyway
 once the branch has moved.
 
 The directive parser lives in [scripts/gh/pr-fix/][], patch generation is the
-[npm-script-patch][] action, and the outcome comment is composed by
-[scripts/gh/patch-report/][]; all are unit tested via
+[npm-script-patch][] action, and the acknowledgement and outcome comments are
+composed by [scripts/gh/patch-report/][]; all are unit tested via
 `npm run test:local-tools`.
 
 [pr-actions]:

--- a/content/en/site/build/ci-workflows.md
+++ b/content/en/site/build/ci-workflows.md
@@ -267,13 +267,13 @@ It runs as a four-stage pipeline:
    workflow — resolved from the default branch, never from the PR — which
    applies the patch with a GitHub App token and pushes a commit to the PR
    branch. Skipped when the command produced no changes.
-4. **`report`** (trusted): updates the ack comment in place with the outcome (or
-   posts a new comment when there is no ack, such as on a closed PR), so each
-   directive maps to a single progress-then-outcome comment that links back to
-   the directive and to the run that produced it. This covers every directive
-   that triggers the workflow, including invalid directives (such as `/fixup` or
-   `/fix please`), no-op runs, and failures that happen before any patch is
-   produced.
+4. **`report`** (trusted): replaces the acknowledgement with the final outcome
+   when possible, or posts a new outcome comment when no acknowledgement exists,
+   such as for closed PRs. Each directive thus maps to a single comment that
+   links back to the directive and to the run that produced it. This covers
+   every directive that triggers the workflow, including invalid directives
+   (such as `/fixup` or `/fix please`), no-op runs, and failures that happen
+   before any patch is produced.
 
 Directives only run against open PRs (draft PRs included): on a closed or merged
 PR the fix command never runs and the report job explains why. The PR state

--- a/content/en/site/build/ci-workflows.md
+++ b/content/en/site/build/ci-workflows.md
@@ -258,8 +258,8 @@ all).
 
 It runs as a four-stage pipeline:
 
-1. **`ack`** (trusted): immediately replies with a 🔄 in-progress comment that
-   links the directive comment and the run.
+1. **`ack`** (trusted): as soon as a directive is received, replies with a 🔄
+   in-progress comment that links to the directive comment and to the run.
 2. **`generate-patch`** (untrusted): checks out the PR branch, runs the fix
    command, prunes the link refcache, and uploads a patch artifact
    (`site.patch`), up to 1024 KB.
@@ -269,8 +269,8 @@ It runs as a four-stage pipeline:
    branch. Skipped when the command produced no changes.
 4. **`report`** (trusted): replaces the acknowledgement with the final outcome
    when possible, or posts a new outcome comment when no acknowledgement exists,
-   such as for closed PRs. Each directive thus maps to a single comment that
-   links back to the directive and to the run that produced it. This covers
+   such as for closed PRs. Each directive thus normally maps to a single comment
+   that links back to the directive and to the run that produced it. This covers
    every directive that triggers the workflow, including invalid directives
    (such as `/fixup` or `/fix please`), no-op runs, and failures that happen
    before any patch is produced.

--- a/projects/2026/pr-fix-reusable-actions.plan.md
+++ b/projects/2026/pr-fix-reusable-actions.plan.md
@@ -79,9 +79,12 @@ once the shared patch path has proven stable.
   i18n caller comes later.
 - The trusted publication path is a reusable workflow rather than a composite
   action, so that no PR-controlled code can run with write credentials.
-- Outcome reporting is a third, always-run trusted job: the requestor is
+- Outcome reporting is an always-run trusted `report` job: the requestor is
   notified of every directive outcome, improving on the original workflow's
-  silent failure modes.
+  silent failure modes. A trusted `ack` job posts an immediate in-progress
+  comment that `report` then updates in place. The ack deliberately says "your
+  request" (with a link to the directive comment) rather than naming the
+  command, so the trusted ack job never parses the directive.
 - Push policy lives inside the trusted reusable workflow (the cost of the
   security fix above). Phase 3 (maintenance fixes published as a new PR) should
   be a _sibling_ trusted workflow (patch → branch → `gh pr create`) rather than
@@ -108,28 +111,31 @@ As of 2026-06-10 (continued work tracked in [#10320][]):
   - [ ] same flow from a fork PR
 - Follow-up: trim the `GITHUB_TOKEN` grants forwarded to the reusable workflow
   once live runs confirm the minimum required.
-- Feature candidates (improve directive↔outcome association when a PR has
-  several directives):
-  - [x] Immediate acknowledgement: a trusted `ack` job posts a 🔄 in-progress
-        comment (linking the directive comment and the run) as soon as a
-        directive is received; the report job then edits that same comment with
-        the final outcome (1:1 comment per directive, no mutation of user
-        content). Outcome messages link back to the directive comment.
-        Alternative considered: editing the originating comment's first line —
-        rejected as invasive (alters user content).
-  - [x] Include the run link in every outcome, in a uniform format: each outcome
-        message ends with "See the logs of [run ID](url)."
-  - [x] Latest directive wins: per-PR workflow-level concurrency with
-        cancel-in-progress, so concurrent runs don't waste resources. Non-`/fix`
-        comments get a unique group so they can't cancel a `/fix` run.
-  - [x] Directives on closed or merged PRs are gated out (from the trigger
-        payload, before any runner does fix work) and reported as ❌ with the
-        reason. Draft PRs still work; deleted-branch sub-cases are moot since
-        nothing is checked out.
-  - [x] Locked PRs need no special handling: locking restricts commenting to
-        users with write access, so any directive author is privileged by
-        construction, and the bot (a GitHub App with write permission) can still
-        post and edit its comments on a locked conversation.
+- Follow-up: the trusted `ack` and `report` jobs share ~40 lines of setup
+  boilerplate (harden-runner, checkout, setup-node, app token); factor out a
+  composite action if a third trusted comment job appears.
+- Directive↔outcome improvements (all shipped):
+  - A trusted `ack` job posts a 🔄 in-progress comment (linking the directive
+    comment and the run) as soon as a directive is received; the report job then
+    edits that same comment with the final outcome (1:1 comment per directive,
+    no mutation of user content). Outcome messages link back to the directive
+    comment. Alternative considered: editing the originating comment's first
+    line — rejected as invasive (alters user content).
+  - Every outcome message ends with the run link in a uniform format: "See
+    [run ID](url)."
+  - Latest directive wins: per-PR workflow-level concurrency with
+    cancel-in-progress, so concurrent runs don't waste resources. Non-`/fix`
+    comments get a unique group so they can't cancel a `/fix` run. Edge case: if
+    a run is cancelled after its ack posted but before the outcome update, its
+    🔄 comment is updated to ⚠️ by its own always-run report job.
+  - Directives on closed or merged PRs are gated out (from the trigger payload,
+    before any runner does fix work) and reported as ❌ with the reason. Draft
+    PRs still work; deleted-branch sub-cases are moot since nothing is checked
+    out.
+  - Locked PRs need no special handling: locking restricts commenting to users
+    with write access, so any directive author is privileged by construction,
+    and the bot (a GitHub App with write permission) can still post and edit its
+    comments on a locked conversation.
 - Phases 2 (i18n caller) and 3 (scheduled maintenance) not started.
 
 <!-- prettier-ignore-start -->

--- a/projects/2026/pr-fix-reusable-actions.plan.md
+++ b/projects/2026/pr-fix-reusable-actions.plan.md
@@ -110,12 +110,13 @@ As of 2026-06-10 (continued work tracked in [#10320][]):
   once live runs confirm the minimum required.
 - Feature candidates (improve directive↔outcome association when a PR has
   several directives):
-  - [ ] Immediate acknowledgement: a trusted "ack" job posts a progress comment
-        (e.g. "🔄 Running `/fix:format` — [run](link)") as soon as a directive
-        is received; the report job then edits that same comment with the final
-        outcome (1:1 comment per directive, no mutation of user content).
-        Alternative considered: editing the originating comment's first line —
-        rejected as invasive (alters user content).
+  - [x] Immediate acknowledgement: a trusted `ack` job posts a 🔄 in-progress
+        comment (linking the directive comment and the run) as soon as a
+        directive is received; the report job then edits that same comment with
+        the final outcome (1:1 comment per directive, no mutation of user
+        content). Outcome labels link back to the directive comment. Alternative
+        considered: editing the originating comment's first line — rejected as
+        invasive (alters user content).
   - [x] Include the run link in every outcome, in a uniform format: each outcome
         message ends with "See the logs of [run ID](url)."
   - [x] Latest directive wins: per-PR workflow-level concurrency with

--- a/projects/2026/pr-fix-reusable-actions.plan.md
+++ b/projects/2026/pr-fix-reusable-actions.plan.md
@@ -114,9 +114,9 @@ As of 2026-06-10 (continued work tracked in [#10320][]):
         comment (linking the directive comment and the run) as soon as a
         directive is received; the report job then edits that same comment with
         the final outcome (1:1 comment per directive, no mutation of user
-        content). Outcome labels link back to the directive comment. Alternative
-        considered: editing the originating comment's first line — rejected as
-        invasive (alters user content).
+        content). Outcome messages link back to the directive comment.
+        Alternative considered: editing the originating comment's first line —
+        rejected as invasive (alters user content).
   - [x] Include the run link in every outcome, in a uniform format: each outcome
         message ends with "See the logs of [run ID](url)."
   - [x] Latest directive wins: per-PR workflow-level concurrency with
@@ -126,6 +126,10 @@ As of 2026-06-10 (continued work tracked in [#10320][]):
         payload, before any runner does fix work) and reported as ❌ with the
         reason. Draft PRs still work; deleted-branch sub-cases are moot since
         nothing is checked out.
+  - [x] Locked PRs need no special handling: locking restricts commenting to
+        users with write access, so any directive author is privileged by
+        construction, and the bot (a GitHub App with write permission) can still
+        post and edit its comments on a locked conversation.
 - Phases 2 (i18n caller) and 3 (scheduled maintenance) not started.
 
 <!-- prettier-ignore-start -->

--- a/projects/2026/pr-fix-reusable-actions.plan.md
+++ b/projects/2026/pr-fix-reusable-actions.plan.md
@@ -123,6 +123,15 @@ As of 2026-06-10 (continued work tracked in [#10320][]):
 - Follow-up: the trusted `ack` and `report` jobs share ~40 lines of setup
   boilerplate (harden-runner, checkout, setup-node, app token); factor out a
   composite action if a third trusted comment job appears.
+- Follow-up (security pass): decide who may trigger `/fix` — currently anyone
+  who can comment; tracked as its own issue since it is a policy decision.
+- Follow-up (security pass): consider `egress-policy: block` + allowlist for the
+  trusted jobs' harden-runner steps (their egress set is small and known); keep
+  `audit` on the untrusted job, which needs broad egress for npm install.
+- Follow-up (security pass): a patch may touch `.github/workflows/**`; the push
+  then succeeds only if the bot app holds the Workflows permission. If not, the
+  push fails closed and reports ❌ — the desired default. Verify the app
+  permission once and record the intended behavior.
 - Directive↔outcome improvements (all shipped):
   - A trusted `ack` job posts a 🔄 in-progress comment (linking the directive
     comment and the run) as soon as a directive is received; the report job then

--- a/projects/2026/pr-fix-reusable-actions.plan.md
+++ b/projects/2026/pr-fix-reusable-actions.plan.md
@@ -107,6 +107,8 @@ As of 2026-06-10 (continued work tracked in [#10320][]):
         changed to latest-wins: a new directive cancels the PR's in-flight run,
         which still reports a ⚠️ outcome.
   - [ ] `/fix` followed by explanatory lines → treated as `/fix`
+  - [x] directive on a closed PR → ❌ "only apply to open PRs" comment, no fix
+        work run
   - [ ] failing command → ❌/⚠️ comment
   - [ ] same flow from a fork PR
 - Follow-up: trim the `GITHUB_TOKEN` grants forwarded to the reusable workflow

--- a/projects/2026/pr-fix-reusable-actions.plan.md
+++ b/projects/2026/pr-fix-reusable-actions.plan.md
@@ -106,7 +106,8 @@ As of 2026-06-10 (continued work tracked in [#10320][]):
         second failed loudly (stale duplicate patch). Since then, semantics
         changed to latest-wins: a new directive cancels the PR's in-flight run,
         which still reports a ⚠️ outcome.
-  - [ ] `/fix` followed by explanatory lines → treated as `/fix`
+  - [ ] `/fix` followed by explanatory lines → treated as `/fix` (first-line
+        parsing has unit coverage in `pr-fix`; live check pending)
   - [x] directive on a closed PR → ❌ "only apply to open PRs" comment, no fix
         work run
   - [x] failing command → ❌ "could not be run, or its changes could not be
@@ -133,9 +134,11 @@ As of 2026-06-10 (continued work tracked in [#10320][]):
     [run ID](url)."
   - Latest directive wins: per-PR workflow-level concurrency with
     cancel-in-progress, so concurrent runs don't waste resources. Non-`/fix`
-    comments get a unique group so they can't cancel a `/fix` run. Edge case: if
-    a run is cancelled after its ack posted but before the outcome update, its
-    🔄 comment is updated to ⚠️ by its own always-run report job.
+    comments get a unique group so they can't cancel a `/fix` run. Edge cases:
+    if a run is cancelled after its ack posted but before the outcome update,
+    its 🔄 comment is updated to ⚠️ by its own always-run report job; if it is
+    cancelled before the ack posts its comment id, the outcome lands in a new
+    comment and a stale 🔄 comment may remain.
   - Directives on closed or merged PRs are gated out (from the trigger payload,
     before any runner does fix work) and reported as ❌ with the reason. Draft
     PRs still work; deleted-branch sub-cases are moot since nothing is checked

--- a/projects/2026/pr-fix-reusable-actions.plan.md
+++ b/projects/2026/pr-fix-reusable-actions.plan.md
@@ -23,8 +23,9 @@ infrastructure.
   a patch.
 - A reusable trusted path to publish those patch changes without running
   untrusted code with write credentials.
-- A foundation that can support `/fix`, i18n fixes, and scheduled maintenance
-  fixes without duplicating workflow logic.
+- A foundation that can support `/fix` and scheduled housekeeping fixes (and
+  potentially other callers, such as i18n fixes) without duplicating workflow
+  logic.
 - Clear separation between reusable mechanics and caller-specific policy.
 
 ## Goals
@@ -32,8 +33,8 @@ infrastructure.
 - Preserve the current `/fix` behavior and security posture.
 - Make the untrusted/trusted split explicit and reusable.
 - Keep future maintenance workflows thin and easier to review.
-- Support incremental rollout: first refactor existing behavior, then add i18n
-  or scheduled maintenance callers.
+- Support incremental rollout: first refactor existing behavior, then add the
+  scheduled housekeeping caller.
 
 ## Non-goals
 
@@ -63,20 +64,29 @@ The shared actions should provide mechanics, not hidden policy.
 
 ### Strategy 3: Roll out in phases
 
-Start by refactoring `/fix` with no intended behavior change. Then add the next
-caller, likely i18n fixes. After that, add scheduled maintenance PR creation
-once the shared patch path has proven stable.
+Start by refactoring `/fix` with no intended behavior change. Then add a
+scheduled **housekeeping** caller — run the approved fix scripts (e.g.
+`test-and-fix` or `test:all`) on a schedule and publish the results as a new PR
+— once the shared patch path has proven stable. This is the second caller that
+proves the actions are reusable: it has no PR context, so it exercises the patch
+mechanics decoupled from the `issue_comment` trigger.
 
 ## Open decisions
 
-- Whether scheduled maintenance should use one stable branch per fix family or a
-  shared generated-fixes branch.
-- Whether `fix:i18n` should be available by PR comment, schedule, or both.
+- Housekeeping workflow: one PR for all fixes (matching `test-and-fix` semantics
+  — simplest, the starting point) vs. one PR per fix script (independently
+  reviewable/mergeable; adopt later if single-PR review proves painful).
+- Housekeeping workflow: when a previous housekeeping PR is still open, skip the
+  new run or update the existing PR's branch?
+- Whether scheduled housekeeping should use one stable branch per fix family or
+  a shared generated-fixes branch.
+- Whether an i18n caller (e.g. `fix:i18n` by PR comment, schedule, or both) is
+  wanted as a third caller.
 
 ## Resolved decisions
 
 - The first implementation PR includes only the `/fix` refactor (phase 1); the
-  i18n caller comes later.
+  scheduled housekeeping caller comes later.
 - The trusted publication path is a reusable workflow rather than a composite
   action, so that no PR-controlled code can run with write credentials.
 - Outcome reporting is an always-run trusted `report` job: the requestor is
@@ -86,9 +96,12 @@ once the shared patch path has proven stable.
   request" (with a link to the directive comment) rather than naming the
   command, so the trusted ack job never parses the directive.
 - Push policy lives inside the trusted reusable workflow (the cost of the
-  security fix above). Phase 3 (maintenance fixes published as a new PR) should
+  security fix above). Phase 2 (housekeeping fixes published as a new PR) should
   be a _sibling_ trusted workflow (patch → branch → `gh pr create`) rather than
   evolving this one into a multi-mode publisher.
+- Phase 2 is a scheduled housekeeping workflow rather than an i18n caller: it is
+  what the founding issue ([#6592][]) asked for, and its lack of PR context best
+  demonstrates that the patch actions are trigger-agnostic.
 
 ## Status details
 
@@ -106,8 +119,8 @@ As of 2026-06-10 (continued work tracked in [#10320][]):
         second failed loudly (stale duplicate patch). Since then, semantics
         changed to latest-wins: a new directive cancels the PR's in-flight run,
         which still reports a ⚠️ outcome.
-  - [ ] `/fix` followed by explanatory lines → treated as `/fix` (first-line
-        parsing has unit coverage in `pr-fix`; live check pending)
+  - [x] `/fix` followed by explanatory lines → treated as `/fix` (first-line
+        parsing; also has unit coverage in `pr-fix`)
   - [x] directive on a closed PR → ❌ "only apply to open PRs" comment, no fix
         work run
   - [x] failing command → ❌ "could not be run, or its changes could not be
@@ -156,7 +169,7 @@ As of 2026-06-10 (continued work tracked in [#10320][]):
     with write access, so any directive author is privileged by construction,
     and the bot (a GitHub App with write permission) can still post and edit its
     comments on a locked conversation.
-- Phases 2 (i18n caller) and 3 (scheduled maintenance) not started.
+- Phase 2 (scheduled housekeeping caller) not started.
 
 <!-- prettier-ignore-start -->
 [#10309]: https://github.com/open-telemetry/opentelemetry.io/pull/10309
@@ -165,4 +178,5 @@ As of 2026-06-10 (continued work tracked in [#10320][]):
 [#10319]: https://github.com/open-telemetry/opentelemetry.io/pull/10319
 [#10320]: https://github.com/open-telemetry/opentelemetry.io/issues/10320
 [#10329]: https://github.com/open-telemetry/opentelemetry.io/issues/10329
+[#6592]: https://github.com/open-telemetry/opentelemetry.io/issues/6592
 <!-- prettier-ignore-end -->

--- a/projects/2026/pr-fix-reusable-actions.plan.md
+++ b/projects/2026/pr-fix-reusable-actions.plan.md
@@ -124,7 +124,7 @@ As of 2026-06-10 (continued work tracked in [#10320][]):
   boilerplate (harden-runner, checkout, setup-node, app token); factor out a
   composite action if a third trusted comment job appears.
 - Follow-up (security pass): decide who may trigger `/fix` — currently anyone
-  who can comment; tracked as its own issue since it is a policy decision.
+  who can comment; tracked as [#10329][] since it is a policy decision.
 - Follow-up (security pass): consider `egress-policy: block` + allowlist for the
   trusted jobs' harden-runner steps (their egress set is small and known); keep
   `audit` on the untrusted job, which needs broad egress for npm install.
@@ -164,4 +164,5 @@ As of 2026-06-10 (continued work tracked in [#10320][]):
 [#10318]: https://github.com/open-telemetry/opentelemetry.io/pull/10318
 [#10319]: https://github.com/open-telemetry/opentelemetry.io/pull/10319
 [#10320]: https://github.com/open-telemetry/opentelemetry.io/issues/10320
+[#10329]: https://github.com/open-telemetry/opentelemetry.io/issues/10329
 <!-- prettier-ignore-end -->

--- a/projects/2026/pr-fix-reusable-actions.plan.md
+++ b/projects/2026/pr-fix-reusable-actions.plan.md
@@ -109,8 +109,14 @@ As of 2026-06-10 (continued work tracked in [#10320][]):
   - [ ] `/fix` followed by explanatory lines → treated as `/fix`
   - [x] directive on a closed PR → ❌ "only apply to open PRs" comment, no fix
         work run
-  - [ ] failing command → ❌/⚠️ comment
-  - [ ] same flow from a fork PR
+  - [x] failing command → ❌ "could not be run, or its changes could not be
+        captured" comment
+  - [x] same flow from a fork PR: all of the above were exercised from fork PRs
+        targeting the canonical repo (`issue_comment` runs in the base
+        repository, where the bot credentials exist)
+  - [x] PR opened within a fork → pipeline skips (repository-owner gate);
+        previously the trusted jobs failed at the app-token mint for lack of the
+        bot app variables and secrets
 - Follow-up: trim the `GITHUB_TOKEN` grants forwarded to the reusable workflow
   once live runs confirm the minimum required.
 - Follow-up: the trusted `ack` and `report` jobs share ~40 lines of setup

--- a/scripts/gh/patch-report/cli.mjs
+++ b/scripts/gh/patch-report/cli.mjs
@@ -24,6 +24,7 @@ Options:
                                an outcome, and emit its comment id.
       --comment-id <id>        Update this existing comment instead of
                                creating a new one (e.g. the ack comment).
+                               Mutually exclusive with --ack.
       --directive-url <url>    URL of the comment that requested the action;
                                linked from the posted comment.
       --label <name>           The action as requested (e.g. the command).
@@ -135,8 +136,8 @@ if (res.status !== 0) {
 
 const id = (res.stdout ?? '').trim();
 console.log(`Comment id: ${id}`);
-// Only the ack invocation's comment id is a meaningful output (the report
-// invocation consumes ids, it doesn't produce them).
+// Only the ack invocation's comment id is a meaningful output (on the
+// report invocation's fallback create, the new comment's id has no consumer).
 const githubOutput = process.env.GITHUB_OUTPUT;
 if (values.ack && githubOutput) {
   appendFileSync(githubOutput, `comment_id=${id}\n`);

--- a/scripts/gh/patch-report/cli.mjs
+++ b/scripts/gh/patch-report/cli.mjs
@@ -1,21 +1,31 @@
 #!/usr/bin/env node
-// CLI entry point: post the single outcome comment for a patch-pipeline run.
-// Runs in a trusted job so the requestor always learns the result, even when
-// the patch could not be generated or applied. All pure logic (message
+// CLI entry point: post or update the comment that tracks a patch-pipeline
+// run. Runs in trusted jobs so the requestor always learns the result, even
+// when the patch could not be generated or applied. All pure logic (message
 // selection) lives in ./index.mjs.
 
+import { appendFileSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { parseArgs } from 'node:util';
 
-import { buildOutcomeComment } from './index.mjs';
+import { buildAckComment, buildOutcomeComment } from './index.mjs';
 
 const HELP = `Usage: cli.mjs --pr <num> [options]
 
-Compose the outcome comment for a patch-pipeline run and post it to the PR
-with \`gh pr comment\` (which authenticates via $GH_TOKEN).
+Compose the comment that tracks a patch-pipeline run and post it to the PR
+via the GitHub API (authenticating with $GH_TOKEN). With --ack, posts an
+acknowledgement that the run is in progress and emits the comment id (as a
+\`comment_id\` step output under GitHub Actions); the outcome invocation can
+then pass that id as --comment-id to update the same comment in place.
 
 Options:
   -p, --pr <num>               Pull request number to comment on. Required.
+  -a, --ack                    Post the in-progress acknowledgement instead of
+                               an outcome, and emit its comment id.
+      --comment-id <id>        Update this existing comment instead of
+                               creating a new one (e.g. the ack comment).
+      --directive-url <url>    URL of the comment that requested the action;
+                               linked from the posted comment.
       --label <name>           The action as requested (e.g. the command).
       --pr-state <state>       PR state: 'open' or 'closed' ('' acts as open).
       --pr-merged <bool>       'true' when the PR is merged.
@@ -35,6 +45,9 @@ $GITHUB_RUN_ID (provided by GitHub Actions).
 const { values } = parseArgs({
   options: {
     pr: { type: 'string', short: 'p' },
+    ack: { type: 'boolean', short: 'a', default: false },
+    'comment-id': { type: 'string', default: '' },
+    'directive-url': { type: 'string', default: '' },
     label: { type: 'string', default: '' },
     'pr-state': { type: 'string', default: '' },
     'pr-merged': { type: 'string', default: '' },
@@ -61,26 +74,58 @@ if (!values.pr) {
 
 const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } = process.env;
 const runUrl = `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`;
+const runId = GITHUB_RUN_ID || '';
+const directiveUrl = values['directive-url'];
 
-const body = buildOutcomeComment({
-  label: values.label,
-  prState: values['pr-state'],
-  prMerged: values['pr-merged'],
-  generateResult: values['generate-result'],
-  patchSkipped: values['patch-skipped'],
-  commandExitStatus: values['command-exit-status'],
-  applyResult: values['apply-result'],
-  runId: GITHUB_RUN_ID || '',
-  runUrl,
-  hint: values.hint,
-});
+const body = values.ack
+  ? buildAckComment({ directiveUrl, runId, runUrl })
+  : buildOutcomeComment({
+      label: values.label,
+      prState: values['pr-state'],
+      prMerged: values['pr-merged'],
+      generateResult: values['generate-result'],
+      patchSkipped: values['patch-skipped'],
+      commandExitStatus: values['command-exit-status'],
+      applyResult: values['apply-result'],
+      runId,
+      runUrl,
+      directiveUrl,
+      hint: values.hint,
+    });
 
-console.log(`Posting outcome comment to PR #${values.pr}:`);
+const commentId = values['comment-id'];
+const action = commentId
+  ? `Updating comment ${commentId} on`
+  : 'Posting comment to';
+console.log(`${action} PR #${values.pr}:`);
 console.log(body);
 
 if (values['dry-run']) process.exit(0);
 
-const res = spawnSync('gh', ['pr', 'comment', values.pr, '--body', body], {
-  stdio: 'inherit',
-});
-process.exit(res.status ?? 1);
+// Use the REST API directly (rather than `gh pr comment`) so that we can
+// capture the comment id on create, and update an existing comment in place.
+const endpoint = commentId
+  ? `repos/${GITHUB_REPOSITORY}/issues/comments/${commentId}`
+  : `repos/${GITHUB_REPOSITORY}/issues/${values.pr}/comments`;
+const res = spawnSync(
+  'gh',
+  [
+    'api',
+    ...(commentId ? ['-X', 'PATCH'] : []),
+    endpoint,
+    '-f',
+    `body=${body}`,
+    '--jq',
+    '.id',
+  ],
+  { encoding: 'utf8' },
+);
+process.stderr.write(res.stderr ?? '');
+if (res.status !== 0) process.exit(res.status ?? 1);
+
+const id = (res.stdout ?? '').trim();
+console.log(`Comment id: ${id}`);
+const githubOutput = process.env.GITHUB_OUTPUT;
+if (githubOutput) {
+  appendFileSync(githubOutput, `comment_id=${id}\n`);
+}

--- a/scripts/gh/patch-report/cli.mjs
+++ b/scripts/gh/patch-report/cli.mjs
@@ -72,6 +72,12 @@ if (!values.pr) {
   process.exit(1);
 }
 
+if (values.ack && values['comment-id']) {
+  console.error('--ack and --comment-id are mutually exclusive\n');
+  console.error(HELP);
+  process.exit(1);
+}
+
 const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } = process.env;
 const runUrl = `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`;
 const runId = GITHUB_RUN_ID || '';
@@ -121,11 +127,17 @@ const res = spawnSync(
   { encoding: 'utf8' },
 );
 process.stderr.write(res.stderr ?? '');
-if (res.status !== 0) process.exit(res.status ?? 1);
+if (res.status !== 0) {
+  // Surface any captured API error body, which gh writes to stdout.
+  process.stdout.write(res.stdout ?? '');
+  process.exit(res.status ?? 1);
+}
 
 const id = (res.stdout ?? '').trim();
 console.log(`Comment id: ${id}`);
+// Only the ack invocation's comment id is a meaningful output (the report
+// invocation consumes ids, it doesn't produce them).
 const githubOutput = process.env.GITHUB_OUTPUT;
-if (githubOutput) {
+if (values.ack && githubOutput) {
   appendFileSync(githubOutput, `comment_id=${id}\n`);
 }

--- a/scripts/gh/patch-report/cli.test.mjs
+++ b/scripts/gh/patch-report/cli.test.mjs
@@ -4,7 +4,7 @@
 
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -12,20 +12,23 @@ import { join } from 'node:path';
 const CLI = new URL('./cli.mjs', import.meta.url).pathname;
 
 // Runs the CLI with a stubbed `gh` and returns the args that the stub
-// received plus the contents written to $GITHUB_OUTPUT.
-function runCli(cliArgs) {
+// received plus the contents written to $GITHUB_OUTPUT. The stub exits with
+// $GH_STUB_EXIT (default 0) so failure propagation can be tested.
+function runCli(cliArgs, { ghExit = 0 } = {}) {
   const dir = mkdtempSync(join(tmpdir(), 'patch-report-cli-'));
   const argsFile = join(dir, 'gh-args.txt');
+  writeFileSync(argsFile, ''); // remains empty if the CLI exits before gh runs
   const outputFile = join(dir, 'github-output.txt');
   writeFileSync(outputFile, '');
   const stub = join(dir, 'gh');
+  // NUL-separated argv so multi-line comment bodies can't break parsing.
   writeFileSync(
     stub,
-    `#!/bin/sh\nprintf '%s\\n' "$@" > '${argsFile}'\necho 314159\n`,
+    `#!/bin/sh\nprintf '%s\\0' "$@" > '${argsFile}'\necho 314159\nexit ${ghExit}\n`,
   );
   chmodSync(stub, 0o755);
 
-  const stdout = execFileSync(process.execPath, [CLI, ...cliArgs], {
+  const res = spawnSync(process.execPath, [CLI, ...cliArgs], {
     encoding: 'utf8',
     env: {
       ...process.env,
@@ -37,22 +40,26 @@ function runCli(cliArgs) {
     },
   });
 
+  const rawArgs = readFileSync(argsFile, 'utf8');
   return {
-    stdout,
-    ghArgs: readFileSync(argsFile, 'utf8').trim().split('\n'),
+    status: res.status,
+    stdout: res.stdout,
+    stderr: res.stderr,
+    ghArgs: rawArgs ? rawArgs.split('\0').slice(0, -1) : [],
     githubOutput: readFileSync(outputFile, 'utf8'),
   };
 }
 
 describe('patch-report CLI', () => {
   test('--ack creates a comment and emits its id as a step output', () => {
-    const { ghArgs, githubOutput } = runCli([
+    const { ghArgs, githubOutput, status } = runCli([
       '--ack',
       '--pr',
       '42',
       '--directive-url',
       'https://example.test/c/7',
     ]);
+    assert.equal(status, 0);
     assert.equal(ghArgs[0], 'api');
     assert.ok(ghArgs.includes('repos/org/repo/issues/42/comments'));
     assert.ok(!ghArgs.includes('PATCH'), 'create must not PATCH');
@@ -62,7 +69,7 @@ describe('patch-report CLI', () => {
   });
 
   test('--comment-id updates the given comment in place', () => {
-    const { ghArgs } = runCli([
+    const { ghArgs, githubOutput, status } = runCli([
       '--pr',
       '42',
       '--comment-id',
@@ -78,6 +85,7 @@ describe('patch-report CLI', () => {
       '--apply-result',
       'success',
     ]);
+    assert.equal(status, 0);
     assert.deepEqual(ghArgs.slice(0, 3), ['api', '-X', 'PATCH']);
     assert.ok(ghArgs.includes('repos/org/repo/issues/comments/314159'));
     const body = ghArgs.find((a) => a.startsWith('body='));
@@ -85,6 +93,25 @@ describe('patch-report CLI', () => {
       body,
       /^body=✅ \[`fix:format`\]\(https:\/\/example\.test\/c\/7\) applied successfully/,
     );
+    assert.equal(githubOutput, '', 'update path must not emit comment_id');
+  });
+
+  test('--ack and --comment-id are mutually exclusive', () => {
+    const { status, stderr } = runCli([
+      '--ack',
+      '--pr',
+      '42',
+      '--comment-id',
+      '314159',
+    ]);
+    assert.equal(status, 1);
+    assert.match(stderr, /mutually exclusive/);
+  });
+
+  test('gh failure propagates its exit code and surfaces output', () => {
+    const { status, stdout } = runCli(['--ack', '--pr', '42'], { ghExit: 3 });
+    assert.equal(status, 3);
+    assert.match(stdout, /314159/, 'gh stdout (API error body) is surfaced');
   });
 
   test('empty --comment-id creates a new comment (ack fallback path)', () => {

--- a/scripts/gh/patch-report/cli.test.mjs
+++ b/scripts/gh/patch-report/cli.test.mjs
@@ -13,7 +13,7 @@ const CLI = new URL('./cli.mjs', import.meta.url).pathname;
 
 // Runs the CLI with a stubbed `gh` and returns the args that the stub
 // received plus the contents written to $GITHUB_OUTPUT. The stub exits with
-// $GH_STUB_EXIT (default 0) so failure propagation can be tested.
+// the `ghExit` option (default 0) so failure propagation can be tested.
 function runCli(cliArgs, { ghExit = 0 } = {}) {
   const dir = mkdtempSync(join(tmpdir(), 'patch-report-cli-'));
   const argsFile = join(dir, 'gh-args.txt');

--- a/scripts/gh/patch-report/cli.test.mjs
+++ b/scripts/gh/patch-report/cli.test.mjs
@@ -67,6 +67,8 @@ describe('patch-report CLI', () => {
       '42',
       '--comment-id',
       '314159',
+      '--directive-url',
+      'https://example.test/c/7',
       '--label',
       'fix:format',
       '--generate-result',
@@ -79,7 +81,27 @@ describe('patch-report CLI', () => {
     assert.deepEqual(ghArgs.slice(0, 3), ['api', '-X', 'PATCH']);
     assert.ok(ghArgs.includes('repos/org/repo/issues/comments/314159'));
     const body = ghArgs.find((a) => a.startsWith('body='));
-    assert.match(body, /^body=✅ `fix:format` applied successfully/);
+    assert.match(
+      body,
+      /^body=✅ \[`fix:format`\]\(https:\/\/example\.test\/c\/7\) applied successfully/,
+    );
+  });
+
+  test('empty --comment-id creates a new comment (ack fallback path)', () => {
+    const { ghArgs } = runCli([
+      '--pr',
+      '42',
+      '--comment-id',
+      '',
+      '--label',
+      'fix:format',
+      '--generate-result',
+      'success',
+      '--patch-skipped',
+      'true',
+    ]);
+    assert.ok(!ghArgs.includes('PATCH'), 'fallback must create, not PATCH');
+    assert.ok(ghArgs.includes('repos/org/repo/issues/42/comments'));
   });
 
   test('--dry-run prints the comment without invoking gh', () => {

--- a/scripts/gh/patch-report/cli.test.mjs
+++ b/scripts/gh/patch-report/cli.test.mjs
@@ -1,0 +1,107 @@
+// Tests for the CLI wiring: gh-api invocation (create vs update) and
+// comment_id step-output emission. A stub `gh` on PATH records its argv and
+// returns a canned comment id, so no live GitHub API is involved.
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const CLI = new URL('./cli.mjs', import.meta.url).pathname;
+
+// Runs the CLI with a stubbed `gh` and returns the args that the stub
+// received plus the contents written to $GITHUB_OUTPUT.
+function runCli(cliArgs) {
+  const dir = mkdtempSync(join(tmpdir(), 'patch-report-cli-'));
+  const argsFile = join(dir, 'gh-args.txt');
+  const outputFile = join(dir, 'github-output.txt');
+  writeFileSync(outputFile, '');
+  const stub = join(dir, 'gh');
+  writeFileSync(
+    stub,
+    `#!/bin/sh\nprintf '%s\\n' "$@" > '${argsFile}'\necho 314159\n`,
+  );
+  chmodSync(stub, 0o755);
+
+  const stdout = execFileSync(process.execPath, [CLI, ...cliArgs], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${dir}:${process.env.PATH}`,
+      GITHUB_SERVER_URL: 'https://example.test',
+      GITHUB_REPOSITORY: 'org/repo',
+      GITHUB_RUN_ID: '123',
+      GITHUB_OUTPUT: outputFile,
+    },
+  });
+
+  return {
+    stdout,
+    ghArgs: readFileSync(argsFile, 'utf8').trim().split('\n'),
+    githubOutput: readFileSync(outputFile, 'utf8'),
+  };
+}
+
+describe('patch-report CLI', () => {
+  test('--ack creates a comment and emits its id as a step output', () => {
+    const { ghArgs, githubOutput } = runCli([
+      '--ack',
+      '--pr',
+      '42',
+      '--directive-url',
+      'https://example.test/c/7',
+    ]);
+    assert.equal(ghArgs[0], 'api');
+    assert.ok(ghArgs.includes('repos/org/repo/issues/42/comments'));
+    assert.ok(!ghArgs.includes('PATCH'), 'create must not PATCH');
+    const body = ghArgs.find((a) => a.startsWith('body='));
+    assert.match(body, /^body=🔄 Processing \[your request\]/);
+    assert.equal(githubOutput, 'comment_id=314159\n');
+  });
+
+  test('--comment-id updates the given comment in place', () => {
+    const { ghArgs } = runCli([
+      '--pr',
+      '42',
+      '--comment-id',
+      '314159',
+      '--label',
+      'fix:format',
+      '--generate-result',
+      'success',
+      '--patch-skipped',
+      'false',
+      '--apply-result',
+      'success',
+    ]);
+    assert.deepEqual(ghArgs.slice(0, 3), ['api', '-X', 'PATCH']);
+    assert.ok(ghArgs.includes('repos/org/repo/issues/comments/314159'));
+    const body = ghArgs.find((a) => a.startsWith('body='));
+    assert.match(body, /^body=✅ `fix:format` applied successfully/);
+  });
+
+  test('--dry-run prints the comment without invoking gh', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'patch-report-dry-'));
+    const outputFile = join(dir, 'github-output.txt');
+    writeFileSync(outputFile, '');
+    const stdout = execFileSync(
+      process.execPath,
+      [CLI, '--ack', '--pr', '42', '--dry-run'],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: dir, // no gh available: must not be needed
+          GITHUB_SERVER_URL: 'https://example.test',
+          GITHUB_REPOSITORY: 'org/repo',
+          GITHUB_RUN_ID: '123',
+          GITHUB_OUTPUT: outputFile,
+        },
+      },
+    );
+    assert.match(stdout, /🔄 Processing your request/);
+    assert.equal(readFileSync(outputFile, 'utf8'), '');
+  });
+});

--- a/scripts/gh/patch-report/index.mjs
+++ b/scripts/gh/patch-report/index.mjs
@@ -67,8 +67,9 @@ export function buildAckComment({ directiveUrl, runId, runUrl }) {
  * Build the final outcome comment that tells the requestor how their run
  * turned out (replacing the acknowledgement comment when one was posted),
  * for every outcome including failures that happen before any patch is produced
- * (unidentifiable request, oversized patch, setup errors). This is the one
- * message the workflow posts, so it must cover all paths.
+ * (unidentifiable request, oversized patch, setup errors). This is the final
+ * message posted for a run (replacing the ack when present), so it must cover
+ * all paths.
  *
  * @param {OutcomeInput} input
  * @returns {string} The comment body.

--- a/scripts/gh/patch-report/index.mjs
+++ b/scripts/gh/patch-report/index.mjs
@@ -1,4 +1,5 @@
-// Pure library for composing the comment that reports a patch-pipeline outcome.
+// Pure library for composing the comments that track a patch-pipeline run:
+// an in-progress acknowledgement and the final outcome.
 //
 // A workflow that generates a patch and applies it can funnel every outcome
 // through this builder so the requestor always learns the result, even when the

--- a/scripts/gh/patch-report/index.mjs
+++ b/scripts/gh/patch-report/index.mjs
@@ -42,10 +42,13 @@
 
 /**
  * Render the action label, linked back to the requesting comment when its URL
- * is known.
+ * is known. The label can originate from an untrusted (forgeable) job output,
+ * so strip Markdown code/link metacharacters before wrapping it in trusted
+ * link syntax.
  */
 function renderWhat(label, directiveUrl, fallback = 'the requested action') {
-  const text = label ? `\`${label}\`` : fallback;
+  const safeLabel = label ? label.replace(/[`[\]()]/g, '') : '';
+  const text = safeLabel ? `\`${safeLabel}\`` : fallback;
   return directiveUrl ? `[${text}](${directiveUrl})` : text;
 }
 

--- a/scripts/gh/patch-report/index.mjs
+++ b/scripts/gh/patch-report/index.mjs
@@ -64,7 +64,8 @@ export function buildAckComment({ directiveUrl, runId, runUrl }) {
 }
 
 /**
- * Build the single comment that tells the requestor how their run turned out,
+ * Build the final outcome comment that tells the requestor how their run
+ * turned out (replacing the acknowledgement comment when one was posted),
  * for every outcome including failures that happen before any patch is produced
  * (unidentifiable request, oversized patch, setup errors). This is the one
  * message the workflow posts, so it must cover all paths.

--- a/scripts/gh/patch-report/index.mjs
+++ b/scripts/gh/patch-report/index.mjs
@@ -30,10 +30,37 @@
  *                                       'failure' | 'cancelled' | 'skipped'.
  * @property {string} runId              GitHub Actions run id.
  * @property {string} runUrl             URL of the workflow run.
+ * @property {string} [directiveUrl]     URL of the comment that requested the
+ *                                       action; when given, the action label
+ *                                       links back to it so the outcome can be
+ *                                       traced to its request.
  * @property {string} [hint]             Optional caller-supplied guidance shown
  *                                       when the request could not be identified
  *                                       (e.g. how to phrase it correctly).
  */
+
+/**
+ * Render the action label, linked back to the requesting comment when its URL
+ * is known.
+ */
+function renderWhat(label, directiveUrl, fallback = 'the requested action') {
+  const text = label ? `\`${label}\`` : fallback;
+  return directiveUrl ? `[${text}](${directiveUrl})` : text;
+}
+
+/**
+ * Build the comment acknowledging that a request is being processed. A
+ * trusted job posts it as soon as a request enters the pipeline; the outcome
+ * comment later replaces it (same comment, edited) so each request maps to a
+ * single progress-then-outcome comment.
+ *
+ * @param {{directiveUrl?: string, runId: string, runUrl: string}} input
+ * @returns {string} The comment body.
+ */
+export function buildAckComment({ directiveUrl, runId, runUrl }) {
+  const what = renderWhat('', directiveUrl, 'your request');
+  return `🔄 Processing ${what}… See [run ${runId}](${runUrl}).`;
+}
 
 /**
  * Build the single comment that tells the requestor how their run turned out,
@@ -54,9 +81,10 @@ export function buildOutcomeComment({
   applyResult,
   runId,
   runUrl,
+  directiveUrl,
   hint,
 }) {
-  const what = label ? `\`${label}\`` : 'the requested action';
+  const what = renderWhat(label, directiveUrl);
   const logs = `See [run ${runId}](${runUrl}).`;
 
   // 0. The PR isn't open: nothing ran (the pipeline gates on PR state).
@@ -72,7 +100,8 @@ export function buildOutcomeComment({
   if (generateResult !== 'success') {
     if (!label) {
       const guidance = hint ? ` ${hint}` : '';
-      return `❌ The request could not be processed.${guidance} ${logs}`;
+      const req = renderWhat('', directiveUrl, 'The request');
+      return `❌ ${req} could not be processed.${guidance} ${logs}`;
     }
     return `❌ ${what} could not be run, or its changes could not be captured. ${logs}`;
   }

--- a/scripts/gh/patch-report/index.test.mjs
+++ b/scripts/gh/patch-report/index.test.mjs
@@ -165,6 +165,12 @@ describe('buildOutcomeComment', () => {
                       body.endsWith('See [run 1](u).'),
                       `comment should end with the run link: ${body}`,
                     );
+                    if (directiveUrl) {
+                      assert.ok(
+                        body.includes('](d)'),
+                        `comment should link the directive: ${body}`,
+                      );
+                    }
                   }
                 }
               }

--- a/scripts/gh/patch-report/index.test.mjs
+++ b/scripts/gh/patch-report/index.test.mjs
@@ -25,6 +25,18 @@ describe('buildOutcomeComment', () => {
     assert.match(body, /^✅ `fix:refcache` applied successfully/);
   });
 
+  test('strips Markdown metacharacters from a forgeable label', () => {
+    // cspell:ignore xhttps exampley
+    const body = build({
+      label: 'x`](https://evil.example)[`y',
+      directiveUrl: 'https://example.test/c/7',
+    });
+    assert.match(
+      body,
+      /^✅ \[`xhttps:\/\/evil\.exampley`\]\(https:\/\/example\.test\/c\/7\)/,
+    );
+  });
+
   test('no-op: generation produced no changes', () => {
     assert.equal(
       build({ patchSkipped: 'true' }),

--- a/scripts/gh/patch-report/index.test.mjs
+++ b/scripts/gh/patch-report/index.test.mjs
@@ -3,7 +3,7 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { buildOutcomeComment } from './index.mjs';
+import { buildAckComment, buildOutcomeComment } from './index.mjs';
 
 describe('buildOutcomeComment', () => {
   const BASE = {
@@ -111,6 +111,26 @@ describe('buildOutcomeComment', () => {
     assert.equal(build({ prState: 'open' }), build({}));
   });
 
+  test('label links to the directive comment when its URL is given', () => {
+    const body = build({ directiveUrl: 'https://example.test/c/1' });
+    assert.match(
+      body,
+      /^✅ \[`fix:refcache`\]\(https:\/\/example\.test\/c\/1\) applied successfully/,
+    );
+  });
+
+  test('unidentified request links to the directive comment', () => {
+    const body = build({
+      generateResult: 'failure',
+      label: '',
+      directiveUrl: 'https://example.test/c/1',
+    });
+    assert.match(
+      body,
+      /^❌ \[The request\]\(https:\/\/example\.test\/c\/1\) could not be processed\./,
+    );
+  });
+
   test('every outcome produces a non-empty comment ending with the run link', () => {
     for (const generateResult of ['success', 'failure', 'cancelled']) {
       for (const patchSkipped of ['true', 'false']) {
@@ -124,25 +144,28 @@ describe('buildOutcomeComment', () => {
             for (const label of ['fix', '']) {
               for (const hint of ['Any hint text.', '']) {
                 for (const prState of ['open', 'closed', '']) {
-                  const body = buildOutcomeComment({
-                    label,
-                    prState,
-                    generateResult,
-                    patchSkipped,
-                    commandExitStatus,
-                    applyResult,
-                    runId: '1',
-                    runUrl: 'u',
-                    hint,
-                  });
-                  assert.ok(
-                    typeof body === 'string' && body.length > 0,
-                    'comment should be a non-empty string',
-                  );
-                  assert.ok(
-                    body.endsWith('See [run 1](u).'),
-                    `comment should end with the run link: ${body}`,
-                  );
+                  for (const directiveUrl of ['d', '']) {
+                    const body = buildOutcomeComment({
+                      label,
+                      prState,
+                      generateResult,
+                      patchSkipped,
+                      commandExitStatus,
+                      applyResult,
+                      runId: '1',
+                      runUrl: 'u',
+                      directiveUrl,
+                      hint,
+                    });
+                    assert.ok(
+                      typeof body === 'string' && body.length > 0,
+                      'comment should be a non-empty string',
+                    );
+                    assert.ok(
+                      body.endsWith('See [run 1](u).'),
+                      `comment should end with the run link: ${body}`,
+                    );
+                  }
                 }
               }
             }
@@ -150,5 +173,25 @@ describe('buildOutcomeComment', () => {
         }
       }
     }
+  });
+});
+
+describe('buildAckComment', () => {
+  test('links the directive comment and the run', () => {
+    assert.equal(
+      buildAckComment({
+        directiveUrl: 'https://example.test/c/1',
+        runId: '123',
+        runUrl: 'https://example.test/run/123',
+      }),
+      '🔄 Processing [your request](https://example.test/c/1)… See [run 123](https://example.test/run/123).',
+    );
+  });
+
+  test('omits the directive link when the URL is unknown', () => {
+    assert.equal(
+      buildAckComment({ directiveUrl: '', runId: '1', runUrl: 'u' }),
+      '🔄 Processing your request… See [run 1](u).',
+    );
   });
 });


### PR DESCRIPTION
- Contributes to #10320; related follow-up: #10329
- Progress reporting
  - Adds a trusted `ack` job that immediately replies with a 🔄 in-progress comment, so the requestor knows the directive was received and which run is handling it
  - Edits the ack comment in place with the final outcome, giving each directive a single progress-then-outcome comment; falls back to a new comment when there is no ack (e.g. directive on a closed PR)
- Directive-to-outcome association
  - Links the ack and outcome messages back to the directive comment, so results can be traced to their requests when a PR has several directives
- Hardening (from review and security passes)
  - Gates all jobs on the canonical repository owner, so fork-internal runs skip instead of failing at the app-token mint
  - Adds `timeout-minutes` to all pipeline jobs to bound runner usage
  - Sanitizes the forgeable action label before rendering it in trusted link syntax
  - Rejects the mutually exclusive `--ack`/`--comment-id` CLI combination, emits the `comment_id` step output only for acks, and surfaces the API error body on failure
  - Warns that the local `npm-script-patch` action definition resolves from the PR branch and must remain untrusted
- Implementation
  - Switches comment posting from `gh pr comment` to the REST API, so the comment id can be captured on create and used to update in place
  - Extends the CLI and library tests (27 cases), with a stubbed `gh` covering create-vs-update wiring, failure propagation, and step-output emission
  - Documents the four-stage pipeline in the maintainer and contributor docs, and records the shipped improvements and security-pass follow-ups in the project plan