### PR TITLE
fix(Japanse): Typo in context propagation documentation

### DIFF
--- a/content/ja/docs/concepts/context-propagation/index.md
+++ b/content/ja/docs/concepts/context-propagation/index.md
@@ -83,7 +83,7 @@ OpenTelemetry SDKは、ログをトレースと自動的に関連づけること
 - 送信側では、コンテキストはキャリアに[注入](/docs/specs/otel/context/api-propagators/#inject)されます。
   たとえば、HTTPリクエストのヘッダーに注入されます。
   それ以外の場合では、リクエストのメタデータを保存できる場所を見つける必要があります。
-- 受診側では、コンテキストはキャリアから[抽出](/docs/specs/otel/context/api-propagators/#extract)されます。
+- 受信側では、コンテキストはキャリアから[抽出](/docs/specs/otel/context/api-propagators/#extract)されます。
   HTTPの場合は、ヘッダーから取得されます。
   それ以外の場合は、送信側でコンテキストを保存するために選択した場所を選択します。
 


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

<!-- DELETE THIS COMMENT BEFORE SUBMITTING YOUR PR

Provide a meaningful description of what your changes will do. Bonus points for including links to related issues, other PRs, or technical references.

A detailed description helps reviewers understand the context of your change and reduces
the time needed to review.

Please make sure to follow the [contribution guidelines](https://opentelemetry.io/docs/contributing/).

We run checks on all PRs, to ensure that your contribution follows our [style guide](https://opentelemetry.io/docs/contributing/style-guide/).

Many requirements of that guide can be enforced by running `npm run fix:all` locally and committing the changes.

Note, that although those checks need to be green before we can merge your PR, do not
worry about their status after submitting your PR. We will provide you with guidance, when and how to
address them.

Similarly, do not worry about your PR being out-of-date with the base branch and do not continuously
update or rebase your branch. We will let you know when it is necessary.

If you have any questions, feel free to ask.
-->

### Content
Fixed an incorrect Japanese term in the context propagation section.

```diff
Changed:
- 受診側では、コンテキストはキャリアから[抽出]されます
+ 受信側では、コンテキストはキャリアから[抽出]されます
```

### Reason:
The correct term is "受信側" (receiving side / extraction side), not "受診側" (medical examination side). The term appears in the section explaining how context is extracted from carriers.
