### PR TITLE
ci(housekeeping): ignore Python tool caches, add run-summary notes

### DIFF
--- a/.github/actions/npm-script-patch/action.yml
+++ b/.github/actions/npm-script-patch/action.yml
@@ -63,6 +63,8 @@ runs:
         echo "npm script exit status: $action_exit_status"
         if (( action_exit_status != 0 )); then
           echo "::warning title=npm script failed::npm run $INPUT_COMMAND exited with status $action_exit_status"
+          echo ":warning: \`npm run $INPUT_COMMAND\` exited with status $action_exit_status." \
+            >> "$GITHUB_STEP_SUMMARY"
         fi
 
         if [[ -n "$INPUT_POST_COMMAND" ]]; then
@@ -80,6 +82,8 @@ runs:
 
         if [ ! -s site.patch ]; then
           echo "No changes detected. Skipping patch."
+          echo ":information_source: No changes detected — nothing to publish." \
+            >> "$GITHUB_STEP_SUMMARY"
           echo "skipped=true" >> "$GITHUB_OUTPUT"
           exit 0
         fi
@@ -87,9 +91,13 @@ runs:
         actual_size_kb=$(du -k site.patch | cut -f1)
         if (( actual_size_kb > MAX_PATCH_SIZE_KB )); then
           echo "Patch too large: ${actual_size_kb} KB (limit: ${MAX_PATCH_SIZE_KB} KB)"
+          echo ":no_entry: Patch too large: ${actual_size_kb} KB (limit: ${MAX_PATCH_SIZE_KB} KB)." \
+            >> "$GITHUB_STEP_SUMMARY"
           exit 1
         fi
 
+        echo ":package: Patch generated (${actual_size_kb} KB); it will be published as a PR." \
+          >> "$GITHUB_STEP_SUMMARY"
         echo "skipped=false" >> "$GITHUB_OUTPUT"
 
     - name: Upload patch artifact

--- a/.github/workflows/reusable-patch-pr.yml
+++ b/.github/workflows/reusable-patch-pr.yml
@@ -227,3 +227,4 @@ jobs:
             echo "Updated $pr_url"
           fi
           echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
+          echo ":rocket: Patch published: $pr_url" >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ assets/jsconfig.json
 # WebStorm
 **/.idea/**
 
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
 .venv/
 *.pyc
 *uv.lock

--- a/projects/2026/pr-fix-reusable-actions.plan.md
+++ b/projects/2026/pr-fix-reusable-actions.plan.md
@@ -224,9 +224,9 @@ As of 2026-06-10 (continued work tracked in [#10320][]):
     side effect of the now-working pytest run: Prettier only honors the root
     `.gitignore`/`.prettierignore`, not the `.gitignore` pytest drops inside its
     cache directory. Root `.gitignore` now lists the cache dirs of all three
-    Python tools (`.pytest_cache/`, `.mypy_cache/`, `.ruff_cache/`) — each
-    drops a `*` `.gitignore` inside its own cache, and the mypy cache (JSON
-    files) was a latent identical failure.
+    Python tools (`.pytest_cache/`, `.mypy_cache/`, `.ruff_cache/`) — each drops
+    a `*` `.gitignore` inside its own cache, and the mypy cache (JSON files) was
+    a latent identical failure.
 
   Live validation status:
   - [x] dispatch run with changes → `otelbot/housekeeping` branch + PR created

--- a/projects/2026/pr-fix-reusable-actions.plan.md
+++ b/projects/2026/pr-fix-reusable-actions.plan.md
@@ -219,6 +219,15 @@ As of 2026-06-10 (continued work tracked in [#10320][]):
     `pyproject.toml`, which a fresh `uv run` does not install. The npm scripts
     now pass `--extra dev`, making them self-sufficient on clean checkouts.
 
+  Findings from the third live run:
+  - `check:format` failed on `scripts/collector-sync/.pytest_cache/README.md`, a
+    side effect of the now-working pytest run: Prettier only honors the root
+    `.gitignore`/`.prettierignore`, not the `.gitignore` pytest drops inside its
+    cache directory. Root `.gitignore` now lists the cache dirs of all three
+    Python tools (`.pytest_cache/`, `.mypy_cache/`, `.ruff_cache/`) — each
+    drops a `*` `.gitignore` inside its own cache, and the mypy cache (JSON
+    files) was a latent identical failure.
+
   Live validation status:
   - [x] dispatch run with changes → `otelbot/housekeeping` branch + PR created
         ([#10336][])

--- a/scripts/gh/report-failure/cli.mjs
+++ b/scripts/gh/report-failure/cli.mjs
@@ -17,7 +17,11 @@
 //   ISSUE_TYPE      Org issue type name. Default: `Bug`.
 //   ISSUE_PREFIX    Title prefix. Default: `Workflow failed`.
 //   PR_URL          URL of a related PR to link from the issue/comment.
+//
+// When GITHUB_STEP_SUMMARY is set, a one-line note pointing at the tracking
+// issue is appended to the run summary.
 
+import { appendFileSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 
 import { reportFailure } from './index.mjs';
@@ -44,8 +48,9 @@ function requireEnv(name) {
   return value;
 }
 
-reportFailure({
-  repo: requireEnv('REPO'),
+const repo = requireEnv('REPO');
+const { action, issueNumber } = reportFailure({
+  repo,
   workflow: requireEnv('WORKFLOW_NAME'),
   branch: requireEnv('HEAD_BRANCH'),
   sha: requireEnv('HEAD_SHA'),
@@ -56,3 +61,11 @@ reportFailure({
   prUrl: process.env.PR_URL || '',
   runGh,
 });
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  const verb = action === 'created' ? 'filed as' : 'tracked in';
+  appendFileSync(
+    process.env.GITHUB_STEP_SUMMARY,
+    `:beetle: Failure ${verb} https://github.com/${repo}/issues/${issueNumber}\n`,
+  );
+}


### PR DESCRIPTION
- Contributes to #6592
- Fixes the third live-run failure of #10337:
  - Adds `.pytest_cache/`, `.mypy_cache/`, and `.ruff_cache/` to the root `.gitignore` so Prettier (which only honors the root ignore files) skips the cache files that the collector-sync checks generate
- Improves run-page visibility:
  - Appends a one-line note to the run summary for each pipeline outcome: command failure, no changes, patch too large, patch generated, PR published, and failure-issue filed/updated
