### PR TITLE
Fix typos in contributing, getting-started, and Swift docs

### DIFF
--- a/content/en/docs/contributing/sig-practices.md
+++ b/content/en/docs/contributing/sig-practices.md
@@ -103,7 +103,7 @@ Additional valuable resources to review are
     - issue type `enhancement` for feature requests
     - label `type:question` for questions
     - label `type:copyedit` for copy edits
-    - move an the issue to "discussions" if it seems to be a non workable
+    - move the issue to "discussions" if it seems to be a non workable
       open-ended conversation
   - Optional: An estimate label if applicable:
     - `e0-minutes`

--- a/content/en/docs/getting-started/dev.md
+++ b/content/en/docs/getting-started/dev.md
@@ -25,7 +25,7 @@ natively:
 If you are looking for a set of applications to try things out, you will find
 our official [OpenTelemetry demo](/ecosystem/demo/) useful.
 
-Next, you can deep dive into the documentations for the
+Next, you can deep dive into the documentation for the
 [language](../../languages/) you are using:
 
 - [C++](../../languages/cpp/)

--- a/content/en/docs/languages/swift/libraries.md
+++ b/content/en/docs/languages/swift/libraries.md
@@ -116,18 +116,18 @@ defined in `URLSessionInstrumentationConfiguration`:
 
 - `createdRequest: ((URLRequest, Span) -> Void)?`
 
-  Called after request is created, it allows to add extra information to the
+  Called after request is created, it allows you to add extra information to the
   Span.
 
 - `receivedResponse: ((URLResponse, DataOrFile?, Span) -> Void)?`
 
-  Called after response is received, it allows to add extra information to the
-  Span.
+  Called after response is received, it allows you to add extra information to
+  the Span.
 
 - `receivedError: ((Error, DataOrFile?, HTTPStatus, Span) -> Void)?`
 
-  Called after an error is received, it allows to add extra information to the
-  Span.
+  Called after an error is received, it allows you to add extra information to
+  the Span.
 
 Below is an example of initialization.
 `URLSessionInstrumentationConfiguration`'s construction can be passed the


### PR DESCRIPTION
## Description

While reading through the docs I spotted a few small wording slips and cleaned them up:

- In the SIG practices guide there's a doubled article — "move an the issue" — which I trimmed to "move the issue".

- The getting-started dev page said "documentations"; changed it to "documentation".

- On the Swift libraries page, "it allows to add extra information..." reads a little off in English, so I made it "it allows you to add" (it appears three times).

All wording-only — none of the actual content changed. The extra line-wrap changes you'll see are just Prettier re-flowing those paragraphs to 80 columns after my edits.