### PR TITLE
Add kapa.ai hosted MCP server

### DIFF
--- a/layouts/_partials/hooks/head-end.html
+++ b/layouts/_partials/hooks/head-end.html
@@ -45,6 +45,8 @@
   xx-DOES-NOT-WORK-data-launcher-button-font-size="1rem"
   data-font-size-lg="1rem"
   data-color-scheme-selector="[data-bs-theme='dark']"
+  data-mcp-enabled="true"
+  data-mcp-server-url="https://opentelemetry.mcp.kapa.ai"
 >
 </script>
 {{/* */ -}}

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -15227,6 +15227,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-06-05T14:12:09.947836205Z"
   },
+  "https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/update-git-submodule/SKILL.md": {
+    "StatusCode": 206,
+    "LastSeen": "2026-06-11T08:05:03.493683-04:00"
+  },
   "https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/update-i18n-drift-status/SKILL.md": {
     "StatusCode": 206,
     "LastSeen": "2026-06-05T14:12:13.799462878Z"
@@ -15234,10 +15238,6 @@
   "https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/update-old-blog-ignores/SKILL.md": {
     "StatusCode": 206,
     "LastSeen": "2026-06-10T22:49:27.563612-04:00"
-  },
-  "https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/update-git-submodule/SKILL.md": {
-    "StatusCode": 206,
-    "LastSeen": "2026-06-11T08:05:03.493683-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry.io/blob/main/.cspell.yml": {
     "StatusCode": 206,


### PR DESCRIPTION
## Summary
- Enable the kapa.ai hosted MCP server by adding `data-mcp-enabled` and `data-mcp-server-url` attributes to the kapa widget configuration.
<img width="1710" height="950" alt="otelmcp" src="https://github.com/user-attachments/assets/c52aa257-fd9a-4478-b431-8f56f424b1b6" />

## Test plan
- [x] Verify the kapa widget loads correctly with MCP enabled
- [x] Confirm the MCP server URL resolves and responds