### PR TITLE
Add update-submodule skill and upgrade Docsy to main HEAD

### DIFF
--- a/.claude/skills/update-git-submodule/SKILL.md
+++ b/.claude/skills/update-git-submodule/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: update-git-submodule
+description: >-
+  Update one or more of the repository's git submodules to a target version (a
+  specific tag or commit, the latest release, or HEAD), adjusting the pins in
+  .gitmodules and re-syncing the submodule gitlinks. Follows the procedure in
+  update-git-submodule.md.
+argument-hint: '<submodule>... <version|latest|HEAD>'
+cSpell:ignore: gitlinks
+---
+
+# Update git submodules
+
+## Arguments
+
+See the arguments specified in [update-git-submodule.md][], though briefly:
+
+1. One or more submodules to update.
+2. Target version: a specific tag or commit; `latest`; or `HEAD`
+
+## Usage
+
+Read and follow [update-git-submodule.md][]. If either argument is missing, ask
+the user before applying.
+
+[update-git-submodule.md]:
+  ../../../content/en/site/skills/update-git-submodule.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# cSpell:ignore worktrees venv
+# cSpell:ignore worktrees venv mypy pytest
 
 /.claude/worktrees
 /.claude/settings.local.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	path = themes/docsy
 	url = https://github.com/google/docsy.git
   # cSpell:disable-next-line
-	docsy-pin = v0.15.0
+	docsy-pin = v0.15.0-8-gcfc90204
 	docsy-note = "2024-04-01 Switching to google/docsy.git from cncf/docsy.git since we don't have any CNCF customizations."
 	docsy-reminder = "Ensure that any tag referenced by `docsy-pin` is present in the remote repo (url), otherwise add (push) the tags to the repo."
 [submodule "content-modules/opentelemetry-specification"]

--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -2,7 +2,7 @@
 baseURL: https://opentelemetry.io
 title: OpenTelemetry
 disableKinds: [taxonomy]
-theme: [docsy]
+theme: [docsy/theme]
 disableAliases: true # We do redirects via Netlify's _redirects file
 enableGitInfo: true
 enableRobotsTXT: true

--- a/content/en/site/skills/_index.md
+++ b/content/en/site/skills/_index.md
@@ -39,6 +39,8 @@ As mentioned above, skills are defined in [`.claude/skills/`][], they are:
   open a PR automatically.
 - [`/update-old-blog-ignores`][update-old-blog-ignores]: advance the year range
   of old blog posts excluded from lint/format checks and fix scripts.
+- [`/update-git-submodule <submodule>... <version|latest|HEAD>`][update-git-submodule]:
+  update one or more git submodules to a target version.
 
 Some agent chats let you invoke a skill by typing `/` followed by its name.
 
@@ -78,6 +80,8 @@ See the section index below.
   https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/update-i18n-drift-status/SKILL.md
 [update-old-blog-ignores]:
   https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/update-old-blog-ignores/SKILL.md
+[update-git-submodule]:
+  https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/update-git-submodule/SKILL.md
 [hooks]: https://docs.claude.com/en/docs/claude-code/hooks
 [hooks-json]:
   https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/hooks/hooks.json

--- a/content/en/site/skills/update-git-submodule.md
+++ b/content/en/site/skills/update-git-submodule.md
@@ -1,0 +1,74 @@
+---
+title: Update git submodules
+description: >-
+  How to update one or more of the repository's git submodules to a target
+  version.
+cSpell:ignore: gitlink gitlinks
+---
+
+Each submodule is pinned to a tag or commit via a `*-pin` field in
+[.gitmodules][]. Follow the process below to update one or more submodules to
+target version(s).
+
+## Arguments
+
+1. One or more submodules to update (path or name). Submodules available for
+   update are declared in [.gitmodules][], and include:
+   - `themes/docsy`, the Docsy theme
+   - `content-modules/*`, OpenTelemetry submodules
+
+2. Target version specifier (for each submodule or all):
+   - A specific tag or commit
+   - `latest` for the latest tagged release
+   - `HEAD` for the default branch head
+
+## Process
+
+1. Run `npm run update:submodule`.
+
+   > Fetches tags and switches each submodule to its remote default-branch head,
+   > so pin values can be determined locally in the next step.
+
+2. For each submodule, determine the new pin value from the target version,
+   running git commands from within the submodule:
+   - **A specific tag or commit**: use it as given, after validating that it
+     exists via `git rev-parse --verify <tag-or-commit>`, which prints the
+     corresponding SHA when valid.
+
+     > To see the list of valid tags, run `git tag --list`.
+
+   - **Latest release**: `git describe --tags --abbrev=0`
+   - **HEAD**: the SHA[^sha] of `HEAD`
+
+   For commit pins, including `HEAD`:
+   - If [`git describe --tags`][git-describe] `<commit>` succeeds, use its
+     output as the pin since it conveys the nearest release -- for example,
+     `v1.23.0-11-gca090204` vs `ca090204`.
+   - Otherwise, use the SHA[^sha] of `<commit>`.
+
+3. Edit the submodule's `*-pin` value in [.gitmodules][].
+4. Run `npm run pin:submodule` to switch the submodules to their new pins, and
+   verify that the reported revisions (also available via `git submodule`) match
+   the pins.
+5. Commit the changes to `.gitmodules` and the submodule gitlink(s). Use a
+   commit message such as "Update `<submodule>` to `<version>`" for
+   single-module updates, or something similar otherwise. Committing now
+   prevents the next step from resetting the submodules to their previously
+   committed gitlinks.
+6. Run `npm run prepare` to refresh submodule dependencies. Commit any resulting
+   changes, amending the previous commit if desired.
+
+Validation:
+
+- For quick validation, run `npm run build` and ensure it succeeds without
+  errors or (unexpected) warnings.
+- For comprehensive validation, run `npm run test` and ensure it passes without
+  errors.
+
+[^sha]:
+    The full SHA is sometimes necessary, but the short SHA is typically
+    sufficient.
+
+[.gitmodules]:
+  https://github.com/open-telemetry/opentelemetry.io/blob/main/.gitmodules
+[git-describe]: https://git-scm.com/docs/git-describe

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "prepare": "npm run seq -- get:submodule _prepare:docsy",
     "preserve:hugo": "npm run _prebuild",
     "preserve:netlify": "npm run seq -- _prebuild _install:netlify-cli",
-    "schemas:update": "npm run update:submodule content-modules/opentelemetry-specification",
+    "schemas:update": "npm run update:submodule -- content-modules/opentelemetry-specification",
     "seq": "bash -c 'for cmd in \"$@\"; do npm run $cmd || exit 1; done' - ",
     "serve:hugo": "npm run _serve:hugo -- --renderToMemory",
     "serve:netlify": "npm run _serve:netlify",

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -3399,6 +3399,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-06-05T14:07:28.057439202Z"
   },
+  "https://git-scm.com/docs/git-describe": {
+    "StatusCode": 206,
+    "LastSeen": "2026-06-11T08:05:04.448833-04:00"
+  },
   "https://git-scm.com/docs/git-merge#_how_conflicts_are_presented": {
     "StatusCode": 206,
     "LastSeen": "2026-06-07T10:26:50.214177156Z"
@@ -15231,6 +15235,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-06-10T22:49:27.563612-04:00"
   },
+  "https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/update-git-submodule/SKILL.md": {
+    "StatusCode": 206,
+    "LastSeen": "2026-06-11T08:05:03.493683-04:00"
+  },
   "https://github.com/open-telemetry/opentelemetry.io/blob/main/.cspell.yml": {
     "StatusCode": 206,
     "LastSeen": "2026-06-07T10:27:46.615550932Z"
@@ -15318,6 +15326,10 @@
   "https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/workflows/update-spec-integration-branch.yml": {
     "StatusCode": 206,
     "LastSeen": "2026-06-05T14:11:30.099814835Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry.io/blob/main/.gitmodules": {
+    "StatusCode": 206,
+    "LastSeen": "2026-06-11T08:05:03.739911-04:00"
   },
   "https://github.com/open-telemetry/opentelemetry.io/blob/main/.markdownlint-cli2.yaml": {
     "StatusCode": 206,


### PR DESCRIPTION
- **Submodule-update skill**: adds the `/update-git-submodule` agent skill and maintainer procedure so submodule bumps follow a repeatable, documented workflow
- **Updates Docsy** (using the skill) to `v0.15.0-8-gcfc90204`, which includes Docsy's monorepo reorg: the theme now lives in the `theme/` subfolder, hence the `theme: [docsy/theme]` config adjustment
- Drive-by fixes:
  - `schemas:update` npm script argument passing
  - Adds `mypy pytest` to the `.gitignore` cSpell ignore list