### PR TITLE
Upgrade to Hugo 0.158.0 and Docsy @ HEAD; fix deprecated Hugo API usage

### DIFF
--- a/.cspell/en-words.txt
+++ b/.cspell/en-words.txt
@@ -53,6 +53,7 @@ servlet
 shippingservice
 stdoutmetric
 subresponse
+subtag
 sunsetting
 tabpane
 timeframe

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	path = themes/docsy
 	url = https://github.com/google/docsy.git
   # cSpell:disable-next-line
-	docsy-pin = v0.15.0-8-gcfc90204
+	docsy-pin = v0.15.0-9-g5c5733de
 	docsy-note = "2024-04-01 Switching to google/docsy.git from cncf/docsy.git since we don't have any CNCF customizations."
 	docsy-reminder = "Ensure that any tag referenced by `docsy-pin` is present in the remote repo (url), otherwise add (push) the tags to the repo."
 [submodule "content-modules/opentelemetry-specification"]

--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -13,24 +13,24 @@ defaultContentLanguage: en
 
 languages:
   en:
-    languageName: English
-    languageCode: en-US
+    label: English
+    locale: en-US
     params:
       description: The OpenTelemetry Project Site
   bn:
-    languageName: বাংলা
+    label: বাংলা
     params:
       description: ওপেনটেলিমেট্রি প্রকল্পের সাইট
   es:
-    languageName: Español
+    label: Español
     params:
       description: Sitio del proyecto OpenTelemetry
   fr:
-    languageName: Français
+    label: Français
     params:
       description: Site du projet OpenTelemetry
   ja:
-    languageName: 日本語
+    label: 日本語
     params:
       description: OpenTelemetryプロジェクト公式サイト
       notes:
@@ -38,28 +38,28 @@ languages:
           `docker-compose` は非推奨です. 詳細は、
           [Migrate to Compose V2](https://docs.docker.com/compose/) を確認してください。
   pl:
-    languageName: Polski
-    languageCode: pl-PL
+    label: Polski
+    locale: pl-PL
     params:
       description: Strona projektu OpenTelemetry
   pt:
-    languageName: Português
-    languageCode: pt-BR
+    label: Português
+    locale: pt-BR
     params:
       description: Site do Projeto OpenTelemetry
   ro:
-    languageName: Română
-    languageCode: ro-RO
+    label: Română
+    locale: ro-RO
     params:
       description: Site-ul proiectului OpenTelemetry
   uk:
-    languageName: Українська
-    languageCode: uk-UA
+    label: Українська
+    locale: uk-UA
     params:
       description: Сайт проєкту OpenTelemetry
   zh:
-    languageName: 中文
-    languageCode: zh-CN
+    label: 中文
+    locale: zh-CN
     params:
       description: OpenTelemetry 项目网站
 

--- a/content/en/site/build/localization/_index.md
+++ b/content/en/site/build/localization/_index.md
@@ -44,9 +44,10 @@ LANG_ID:
     description: <site description translated into the new language>
 ```
 
-The `locale` is optional: provide it when the region tag matters (for example,
-for RSS feeds or Google Translate, as is the case for `zh-CN`); omit it
-otherwise.
+The `locale` field is optional: use it when the site should emit a regional
+language tag, such as `en-US`, `pl-PL`, or `zh-CN` — for example, in RSS feeds;
+otherwise the language ID is used. Google Translate needs the full `zh-CN` tag
+for Chinese, while most other languages use the primary subtag.
 
 For example, the Polish entry looks like:
 

--- a/content/en/site/build/localization/_index.md
+++ b/content/en/site/build/localization/_index.md
@@ -45,11 +45,11 @@ LANG_ID:
 ```
 
 The `locale` field is optional: use it when the site should emit a regional
-language tag, such as `en-US`, `pl-PL`, or `zh-CN` — for example, in RSS feeds;
+language tag, such as `en-US`, `pl-PL`, or `zh-CN`, in RSS feeds, for example;
 otherwise the language ID is used. Google Translate needs the full `zh-CN` tag
 for Chinese, while most other languages use the primary subtag.
 
-For example, the Polish entry looks like:
+As an example, the Polish entry looks like:
 
 ```yaml
 pl:

--- a/content/en/site/build/localization/_index.md
+++ b/content/en/site/build/localization/_index.md
@@ -38,18 +38,22 @@ Add an entry for the new language in `config/_default/hugo.yaml` under the
 
 ```yaml
 LANG_ID:
-  languageName: NativeName (English name)
-  languageCode: LANG_ID-REGION
+  label: NativeName
+  locale: LANG_ID-REGION
   params:
     description: <site description translated into the new language>
 ```
+
+The `locale` is optional: provide it when the region tag matters (for example,
+for RSS feeds or Google Translate, as is the case for `zh-CN`); omit it
+otherwise.
 
 For example, the Polish entry looks like:
 
 ```yaml
 pl:
-  languageName: Polski (Polish)
-  languageCode: pl-PL
+  label: Polski
+  locale: pl-PL
   params:
     description: Strona projektu OpenTelemetry
 ```

--- a/content/en/site/build/localization/_index.md
+++ b/content/en/site/build/localization/_index.md
@@ -39,7 +39,7 @@ Add an entry for the new language in `config/_default/hugo.yaml` under the
 ```yaml
 LANG_ID:
   label: NativeName
-  locale: LANG_ID-REGION
+  locale: LANG_ID-REGION # optional; see note below
   params:
     description: <site description translated into the new language>
 ```

--- a/layouts/_partials/docs/get-signal-status.html
+++ b/layouts/_partials/docs/get-signal-status.html
@@ -12,7 +12,7 @@
 {{ $status := "-" -}}
 {{ $signal := .signal -}}
 
-{{ with index site.Data.instrumentation .lang -}}
+{{ with index hugo.Data.instrumentation .lang -}}
   {{ with index .status $signal -}}
     {{ $statusWeCanLinkTo := "stable development" -}}
     {{ $status = cond (or (eq "experimental" .) (eq "in development" .)) "development" . -}}
@@ -25,7 +25,7 @@
     -}}
   {{ end -}}
 {{ else -}}
-  {{ errorf "The site.Data.instrumentation map has no language key '%s'." .lang -}}
+  {{ errorf "The hugo.Data.instrumentation map has no language key '%s'." .lang -}}
 {{ end -}}
 
 {{ return $status -}}

--- a/layouts/_partials/docs/native-libraries.md
+++ b/layouts/_partials/docs/native-libraries.md
@@ -5,10 +5,10 @@
 -}}
 {{ $howMany := .Get 1 | default 10 -}}
 
-{{ $langData := index $.Site.Data.instrumentation $langIndex -}}
+{{ $langData := index hugo.Data.instrumentation $langIndex -}}
 {{ $integrations := slice -}}
 
-{{ range $entry := $.Site.Data.registry -}}
+{{ range $entry := hugo.Data.registry -}}
   {{ if and (and (eq $entry.language $langIndex) (eq $entry.isNative true)) (eq $entry.registryType "instrumentation") -}}
     {{ $integrations = $integrations | append $entry -}}
   {{ end -}}

--- a/layouts/_partials/docs/propagation.md
+++ b/layouts/_partials/docs/propagation.md
@@ -4,7 +4,7 @@
     "componentName" "propagation.md")
 -}}
 
-{{ $langName := (index $.Site.Data.instrumentation $langIndex).name | default "" -}}
+{{ $langName := (index hugo.Data.instrumentation $langIndex).name | default "" -}}
 
 {{ $args := dict
     "_dot" .

--- a/layouts/_partials/func/locales-for-google-translate.html
+++ b/layouts/_partials/func/locales-for-google-translate.html
@@ -8,7 +8,7 @@
   seems to want only the primary subtag.
 
   References:
-  - https://gohugo.io/methods/site/language/
+  - https://gohugo.io/configuration/languages/
   - https://datatracker.ietf.org/doc/html/rfc5646
 
   */ -}}

--- a/layouts/_partials/func/locales-for-google-translate.html
+++ b/layouts/_partials/func/locales-for-google-translate.html
@@ -14,10 +14,10 @@
   */ -}}
 
 {{ $locales := slice -}}
-{{ range site.Languages -}}
-  {{ $langCode := .LanguageCode -}}
+{{ range hugo.Sites -}}
+  {{ $langCode := .Language.Locale -}}
   {{ $primaryTag := index (split $langCode "-") 0 -}}
-  {{ $localeTagForGT := cond (eq .Lang "zh") .LanguageCode $primaryTag -}}
+  {{ $localeTagForGT := cond (eq .Language.Lang "zh") $langCode $primaryTag -}}
   {{ $locales = $locales | append $localeTagForGT -}}
 {{ end -}}
 {{ return $locales -}}

--- a/layouts/_partials/i18n/fallback-page.html
+++ b/layouts/_partials/i18n/fallback-page.html
@@ -9,7 +9,7 @@
 {{ $result := false -}}
 
 {{ if and hugo.IsMultilingual .File -}}
-  {{ $defaultLang := .Site.Sites.Default.Language.Lang -}}
+  {{ $defaultLang := hugo.Sites.Default.Language.Lang -}}
 
   {{ $resultsArray := where .Translations "Lang" $defaultLang -}}
   {{ $defaultLangPage := index $resultsArray 0 -}}

--- a/layouts/_partials/redirects/localization.txt
+++ b/layouts/_partials/redirects/localization.txt
@@ -1,4 +1,4 @@
-{{/* Generate Netlify redirect rules for non-default .Site.Sites */ -}}
+{{/* Generate Netlify redirect rules for non-default hugo.Sites */ -}}
 {{/* cSpell:ignore cond */ -}}
 
 {{/*
@@ -9,7 +9,7 @@
   wildcard. */ -}}
 
 {{ $defaultLang := "" -}}
-{{ with .Site.Sites.Default -}}
+{{ with hugo.Sites.Default -}}
   {{ if eq .LanguagePrefix "" -}}
     {{ with .Language.Lang -}}
       {{ $defaultLang = . -}}
@@ -21,7 +21,7 @@
 
 {{/* Add redirect rules for non-default languages. */ -}}
 
-{{ range .Sites -}}
+{{ range hugo.Sites -}}
 
   {{ $siteLang := .Language.Lang -}}
 

--- a/layouts/_shortcodes/apidocs.md
+++ b/layouts/_shortcodes/apidocs.md
@@ -1,5 +1,5 @@
 {{ $pages := slice -}}
-{{ range $key,$value := $.Site.Data.instrumentation -}}
+{{ range $key,$value := hugo.Data.instrumentation -}}
     {{ if eq $key "dotnet" -}}
       {{ with $.Site.GetPage "/docs/languages/dotnet/traces-api" -}}
           {{ $pages = $pages | append (dict "lang" $value "page" .) -}}

--- a/layouts/_shortcodes/collector-component-rows.html
+++ b/layouts/_shortcodes/collector-component-rows.html
@@ -19,7 +19,7 @@ The shortcode reads from data/collector/{type}s.yml and uses i18n strings for he
 
 {{- $componentType := .Get "type" -}}
 {{- $dataFile := printf "%ss" $componentType -}}
-{{- $data := index .Site.Data.collector $dataFile -}}
+{{- $data := index hugo.Data.collector $dataFile -}}
 
 {{- if not $data -}}
   {{- errorf "No data found for component type '%s' (expected data/collector/%s.yml)" $componentType $dataFile -}}
@@ -84,7 +84,7 @@ The shortcode reads from data/collector/{type}s.yml and uses i18n strings for he
   {{- if $shouldRender -}}
     {{- /* Build GitHub URL */ -}}
     {{- $repoName := cond (eq $repo "core") "opentelemetry-collector" "opentelemetry-collector-contrib" -}}
-    {{- $version := index $.Site.Data "collector-versions" $repo -}}
+    {{- $version := index hugo.Data "collector-versions" $repo -}}
     {{- $path := "" -}}
     {{- if $itemSubtype -}}
       {{- $path = printf "%s/%s/%s" $componentType $itemSubtype $name -}}

--- a/layouts/_shortcodes/community/members-list.html
+++ b/layouts/_shortcodes/community/members-list.html
@@ -1,4 +1,4 @@
-{{ $data := $.Site.Data.community.members -}}
+{{ $data := hugo.Data.community.members -}}
 {{ $key := .Get 0 -}}
 {{ $group := index $data $key -}}
 {{ $lastIndex := 0 }}

--- a/layouts/_shortcodes/component-link.html
+++ b/layouts/_shortcodes/component-link.html
@@ -19,7 +19,7 @@ Versions are dynamically read from data/collector-versions.yml
 {{- $subtype := .Get "subtype" -}}
 
 {{- $repoName := cond (eq $repo "core") "opentelemetry-collector" "opentelemetry-collector-contrib" -}}
-{{- $version := index .Site.Data "collector-versions" $repo -}}
+{{- $version := index hugo.Data "collector-versions" $repo -}}
 
 {{- $path := "" -}}
 {{- if $subtype -}}

--- a/layouts/_shortcodes/docs/languages/exporters/intro.md
+++ b/layouts/_shortcodes/docs/languages/exporters/intro.md
@@ -37,7 +37,7 @@ it up from the language section index file.
 
 {{ $name := "" -}}
 {{ if $lang -}}
-  {{ $name = (index $.Site.Data.instrumentation $lang).name -}}
+  {{ $name = (index hugo.Data.instrumentation $lang).name -}}
   {{ if not $name -}}
     {{ warnf "No name for language '%s' in `instrumentation` data file." $lang -}}
   {{ end -}}

--- a/layouts/_shortcodes/docs/languages/index-adopters.md
+++ b/layouts/_shortcodes/docs/languages/index-adopters.md
@@ -1,7 +1,7 @@
 {{ $lang := .Get 0 -}}
 {{ $Lang := $lang | humanize -}}
 {{ $howMany := .Get 1 | default 10 -}}
-{{ $adopters := where $.Site.Data.ecosystem.adopters ".components" "intersect" (slice $Lang) -}}
+{{ $adopters := where hugo.Data.ecosystem.adopters ".components" "intersect" (slice $Lang) -}}
 
 ## Who's using OpenTelemetry {{ $Lang }}?
 

--- a/layouts/_shortcodes/docs/languages/index-intro.md
+++ b/layouts/_shortcodes/docs/languages/index-intro.md
@@ -1,5 +1,5 @@
 {{ $lang := .Get 0 -}}
-{{ $data := index $.Site.Data.instrumentation $lang }}
+{{ $data := index hugo.Data.instrumentation $lang }}
 {{ $name := $data.name -}}
 
 {{ $tracesStatus := partial "docs/get-signal-status.html" (dict "lang" $lang "signal" "traces") -}}

--- a/layouts/_shortcodes/ecosystem/adopters-table.md
+++ b/layouts/_shortcodes/ecosystem/adopters-table.md
@@ -1,4 +1,4 @@
-{{ $data := sort $.Site.Data.ecosystem.adopters "name" }}
+{{ $data := sort hugo.Data.ecosystem.adopters "name" }}
 Organization[^1] | Components |  Learn more
 ------------ | ---------- |  ----------
 {{- range $data }}

--- a/layouts/_shortcodes/ecosystem/distributions-table.md
+++ b/layouts/_shortcodes/ecosystem/distributions-table.md
@@ -1,6 +1,6 @@
 <!-- cSpell:ignore: cond -->
 {{/* Common variables */ -}}
-{{ $data := sort (sort $.Site.Data.ecosystem.distributions "components") "name" "asc" -}}
+{{ $data := sort (sort hugo.Data.ecosystem.distributions "components") "name" "asc" -}}
 {{ $filter := .Get "filter" -}}
 {{ $otelRepoUrl := "github.com/open-telemetry/opentelemetry-collector-releases" -}}
 

--- a/layouts/_shortcodes/ecosystem/integrations-table.md
+++ b/layouts/_shortcodes/ecosystem/integrations-table.md
@@ -1,13 +1,13 @@
 <!-- cSpell:ignore: cond isset -->
 {{ $integrations := slice -}}
-{{ range $entry := $.Site.Data.registry -}}
+{{ range $entry := hugo.Data.registry -}}
   {{ if or (and (eq ($.Get 0) "native libraries") (eq $entry.isNative true) (eq $entry.registryType "instrumentation")) (and (eq ($.Get 0) "application integrations") (eq $entry.registryType "application integration")) -}}
     {{ $entry = merge $entry (dict "oss" (ne .license "Commercial")) -}}
     {{ $integrations = $integrations | append $entry -}}
   {{ end -}}
 {{ end -}}
 
-{{ $languages := merge $.Site.Data.instrumentation (dict "collector" (dict "name" "collector") "lua" (dict "name" "Lua")) -}}
+{{ $languages := merge hugo.Data.instrumentation (dict "collector" (dict "name" "collector") "lua" (dict "name" "Lua")) -}}
 
 Name[^1]     | OSS | Component |  Learn more
 ------------ | --- | ---------- |  ----------
@@ -15,7 +15,7 @@ Name[^1]     | OSS | Component |  Learn more
 {{ $lang := cond
     (eq .language "collector")
     (dict "name" "Collector")
-    (index $.Site.Data.instrumentation .language)
+    (index hugo.Data.instrumentation .language)
 -}}
 {{ $cncfTag := cond
     (isset . "cncfProjectLevel")

--- a/layouts/_shortcodes/ecosystem/registry/search-form.html
+++ b/layouts/_shortcodes/ecosystem/registry/search-form.html
@@ -1,4 +1,4 @@
-{{ $registry := .Site.Data.registry -}}
+{{ $registry := hugo.Data.registry -}}
 {{ $registryUrl := .Page.RelPermalink -}}
 
 {{ $languageNames := newScratch -}}
@@ -36,7 +36,7 @@
 
 {{ $counter := 0 -}}
 {{ $entries := slice -}}
-{{ range $key, $entry := .Site.Data.registry -}}
+{{ range $key, $entry := hugo.Data.registry -}}
   {{ $flags := slice -}}
   {{ if .isNative -}}
     {{ $flags = $flags | append "native" -}}

--- a/layouts/_shortcodes/ecosystem/vendor-table.md
+++ b/layouts/_shortcodes/ecosystem/vendor-table.md
@@ -1,7 +1,7 @@
 {{/*
 cSpell:ignore: cial cond
 */ -}}
-{{ $data := sort (sort (sort $.Site.Data.ecosystem.vendors "name") "oss" "desc") "commercial" -}}
+{{ $data := sort (sort (sort hugo.Data.ecosystem.vendors "name") "oss" "desc") "commercial" -}}
 
 | Organization[^org] | OSS | Com&shy;mer&shy;cial | Native OTLP | Learn more  |
 | ----------- | ----------- | ---------- | ----------------- | ----------- | ----------- |

--- a/layouts/_shortcodes/homepage/adopters-showcase.html
+++ b/layouts/_shortcodes/homepage/adopters-showcase.html
@@ -5,8 +5,8 @@
 {{ $ctaText := .Get "ctaText" | default "View all adopters" -}}
 {{ $ctaUrl := .Get "ctaUrl" | default "/ecosystem/adopters/" -}}
 
-{{ $featuredAdopters := site.Data.ecosystem.featured_adopters -}}
-{{ $regularAdopters := site.Data.ecosystem.adopters -}}
+{{ $featuredAdopters := hugo.Data.ecosystem.featured_adopters -}}
+{{ $regularAdopters := hugo.Data.ecosystem.adopters -}}
 {{ $adopters := $featuredAdopters | default $regularAdopters -}}
 {{ $sortedAdopters := sort $adopters "name" -}}
 

--- a/layouts/_shortcodes/homepage/stat.html
+++ b/layouts/_shortcodes/homepage/stat.html
@@ -14,7 +14,7 @@
     {{- end -}}
     {{- $number = printf "%d+" $count -}}
   {{- else if eq $type "vendors" -}}
-    {{- $vendors := site.Data.ecosystem.vendors -}}
+    {{- $vendors := hugo.Data.ecosystem.vendors -}}
     {{- $number = printf "%d+" (len $vendors) -}}
   {{- else if eq $type "registry" -}}
     {{- $registryFiles := readDir "data/registry" -}}

--- a/layouts/_shortcodes/sampling-support-list.md
+++ b/layouts/_shortcodes/sampling-support-list.md
@@ -1,4 +1,4 @@
-{{- range $lang, $data := $.Site.Data.instrumentation }}
+{{- range $lang, $data := hugo.Data.instrumentation }}
   {{- $path := printf "/docs/languages/%s/sampling.md" $lang }}
   {{- with site.GetPage $path }}
     {{- template "list-item" (dict "name" $data.name "page" .) }}

--- a/layouts/_shortcodes/signal-support-table.md
+++ b/layouts/_shortcodes/signal-support-table.md
@@ -1,4 +1,4 @@
-{{ $data := $.Site.Data.instrumentation }}
+{{ $data := hugo.Data.instrumentation }}
 {{ $signal := .Get 0 -}}
 
 Language | {{ humanize $signal }} |

--- a/layouts/_shortcodes/spec_status.html
+++ b/layouts/_shortcodes/spec_status.html
@@ -4,7 +4,7 @@
 {{ if not (hasPrefix $pageRef "/") -}}
   {{ $pageRef = printf "/docs/specs/%s" $pageRef -}}
 {{ end -}}
-{{ $enSite := site.Sites.Default -}}
+{{ $enSite := hugo.Sites.Default -}}
 {{ $page := $enSite.GetPage $pageRef -}}
 {{ if not $page -}}
   {{ warnf "spec_status: Can't find page at '%s'." $pageRef -}}

--- a/layouts/_shortcodes/telemetry-support-table.md
+++ b/layouts/_shortcodes/telemetry-support-table.md
@@ -1,4 +1,4 @@
-{{ $data := $.Site.Data.instrumentation }}
+{{ $data := hugo.Data.instrumentation }}
 {{ $maturityLink := dict "stable" "https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/0232-maturity-of-otel.md#stable" "beta" "https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/0232-maturity-of-otel.md#beta" "development" "https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/0232-maturity-of-otel.md#development" }}
 
 Language | Traces | Metrics | Logs | Profiles |

--- a/layouts/_shortcodes/version-from-registry.md
+++ b/layouts/_shortcodes/version-from-registry.md
@@ -2,7 +2,7 @@
 {{ $noPrefix := default false (.Get 1) -}}
 
 {{ with $name -}}
-  {{ with index $.Site.Data.registry . -}}
+  {{ with index hugo.Data.registry . -}}
     {{ with .package.version -}}
       {{ if $noPrefix -}}
         {{ strings.TrimLeft "v" . -}}

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -1,7 +1,7 @@
 {{/* Docsy-delta */ -}}
 <!doctype html>
 <html itemscope itemtype="http://schema.org/WebPage"
-    {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
+    {{- with .Site.Language.Direction }} dir="{{ . }}" {{- end -}}
     {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
     class="no-js"
     {{- $darkMode := partialCached "dark-mode-config.html" "dark-mode-global" -}}

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -3,7 +3,7 @@
 
 <!doctype html>
 <html itemscope itemtype="http://schema.org/WebPage"
-    {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
+    {{- with .Site.Language.Direction }} dir="{{ . }}" {{- end -}}
     {{ with $lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
     class="no-js"
     {{- $darkMode := partialCached "dark-mode-config.html" "dark-mode-global" -}}

--- a/layouts/registry.json.json
+++ b/layouts/registry.json.json
@@ -1,6 +1,6 @@
 {{ $counter := 0 -}}
 {{ $entries := slice -}}
-{{ range $key, $entry := .Site.Data.registry -}}
+{{ range $key, $entry := hugo.Data.registry -}}
   {{ $flags := slice -}}
   {{ if .isNative -}}
     {{ $flags = $flags | append "native" -}}

--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -40,7 +40,7 @@
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne .Title .Site.Title }}{{ with .Title }}in {{ . }} {{ end }}{{ end }}on {{ .Site.Title }}</description>
     <generator>Hugo</generator>
-    <language>{{ site.Language.LanguageCode }}</language>{{ with $authorEmail }}
+    <language>{{ site.Language.Locale }}</language>{{ with $authorEmail }}
     <managingEditor>{{.}}{{ with $authorName }} ({{ . }}){{ end }}</managingEditor>{{ end }}{{ with $authorEmail }}
     <webMaster>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</webMaster>{{ end }}{{ with .Site.Copyright }}
     <copyright>{{ . }}</copyright>{{ end }}{{ if not .Date.IsZero }}

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "code-excerpter": "0.2.0",
     "cspell": "10.0.1",
     "gulp": "5.0.1",
-    "hugo-extended": "0.157.0",
+    "hugo-extended": "0.158.0",
     "js-yaml": "4.2.0",
     "markdown-it": "14.2.0",
     "markdown-link-check": "3.14.2",


### PR DESCRIPTION
- Fixes #10362; contributes to #8933
- Updates the Docsy submodule to `v0.15.0-9-g5c5733de`, which includes
  google/docsy#2647 (language-API deprecation fixes; raises the theme's min
  Hugo version to 0.158.0)
- Bumps Hugo to 0.158.0
- Migrates deprecated Hugo APIs in site config and layouts:
  - Language config keys: `languageName` -> `label` (x10), `languageCode` ->
    `locale` (x6)
  - `.Site.Language.LanguageDirection` -> `.Site.Language.Direction`
  - `.Site.Sites` / `site.Sites` -> `hugo.Sites`
  - `.Site.Data` / `site.Data` -> `hugo.Data` (x29 over 22 layout files)
  - `.Language.LanguageCode` -> `.Language.Locale`, and `site.Languages`
    range -> `hugo.Sites` (`rss.xml`, Google Translate locales partial)
- Updates the localization guide (`label` / `locale` config keys, optionality
  note) and the Google Translate partial's doc-comment reference

Validation:

- Production build succeeds with **zero** Hugo deprecation notices (baseline
  had 5 distinct notice kinds plus per-language config-key notices)
- Full `npm run test` passes
- Output-neutrality vs the live site: llms outputs (`llms.txt`, `index.md`,
  `docs/index.md`, `docs/languages/js/index.md`, `ja/index.md`) are
  byte-identical after base-URL normalization
- Spot checks over generated site:
  - `<html lang>` attribute correct for localized pages (`ja`, `bn`, etc.)
  - `_redirects` retains all 9 "Site localization" rule blocks
  - Google Translate locale list unchanged: `bn en es fr ja pl pt ro uk zh-CN`
    (zh keeps its full region tag)

