### PR TITLE
Locale auto-merge: recognize directive on first or last comment line

### DIFF
--- a/.github/workflows/locale-auto-merge.yml
+++ b/.github/workflows/locale-auto-merge.yml
@@ -2,7 +2,8 @@ name: Locale auto-merge
 
 # Lets a locale team member enable (or disable) GitHub-native auto-merge on a
 # locale-only PR by commenting `/auto-merge` (or `/auto-merge:enable` /
-# `:disable`) on its own line, as the first or last line of the comment. The
+# `:disable`) on its own line, as the first or last non-blank line of the
+# comment. The
 # DOCS bot (which has the permissions needed to enable auto-merge) performs
 # the action;
 # branch protection + CODEOWNERS remain the hard gate — the PR still won't
@@ -23,8 +24,10 @@ jobs:
     concurrency:
       group: locale-auto-merge-${{ github.event.issue.number }}
       cancel-in-progress: false
-    # Only a broad substring match on the comment body here. The helper does
-    # the exact (line-anchored) parsing and posts "Unrecognized command" when
+    # Only a broad substring match on the comment body here (intentional: the
+    # directive may sit below review text, so a prefix match is not enough; an
+    # incidental mention just costs one short no-op job). The helper does the
+    # exact (line-anchored) parsing and posts "Unrecognized command" when
     # the comment looks like an attempt but is malformed.
     if: |
       github.repository_owner == 'open-telemetry' &&

--- a/.github/workflows/locale-auto-merge.yml
+++ b/.github/workflows/locale-auto-merge.yml
@@ -2,8 +2,9 @@ name: Locale auto-merge
 
 # Lets a locale team member enable (or disable) GitHub-native auto-merge on a
 # locale-only PR by commenting `/auto-merge` (or `/auto-merge:enable` /
-# `:disable`). The DOCS bot (which has the permissions needed to enable
-# auto-merge) performs the action;
+# `:disable`) on its own line, as the first or last line of the comment. The
+# DOCS bot (which has the permissions needed to enable auto-merge) performs
+# the action;
 # branch protection + CODEOWNERS remain the hard gate — the PR still won't
 # merge until all required reviews and checks pass. The eligibility and
 # locale-team authorization logic lives in scripts/gh/locale-auto-merge/.
@@ -22,13 +23,13 @@ jobs:
     concurrency:
       group: locale-auto-merge-${{ github.event.issue.number }}
       cancel-in-progress: false
-    # Only a broad prefix match on the comment body here. The helper does the
-    # exact parsing and posts "Unrecognized command" when the comment is
-    # malformed.
+    # Only a broad substring match on the comment body here. The helper does
+    # the exact (line-anchored) parsing and posts "Unrecognized command" when
+    # the comment looks like an attempt but is malformed.
     if: |
       github.repository_owner == 'open-telemetry' &&
       github.event.issue.pull_request != null &&
-      startsWith(github.event.comment.body, '/auto-merge')
+      contains(github.event.comment.body, '/auto-merge')
 
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/locale-auto-merge.yml
+++ b/.github/workflows/locale-auto-merge.yml
@@ -3,9 +3,8 @@ name: Locale auto-merge
 # Lets a locale team member enable (or disable) GitHub-native auto-merge on a
 # locale-only PR by commenting `/auto-merge` (or `/auto-merge:enable` /
 # `:disable`) on its own line, as the first or last non-blank line of the
-# comment. The
-# DOCS bot (which has the permissions needed to enable auto-merge) performs
-# the action;
+# comment. The DOCS bot (which has the permissions needed to enable
+# auto-merge) performs the action;
 # branch protection + CODEOWNERS remain the hard gate — the PR still won't
 # merge until all required reviews and checks pass. The eligibility and
 # locale-team authorization logic lives in scripts/gh/locale-auto-merge/.

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -487,8 +487,8 @@ when **Spelling** has no natural-language dictionary to add.
 Members of a locale's maintainers team can enable [GitHub auto-merge][] on a
 locale-only PR by commenting `/auto-merge` (or `/auto-merge:enable`; use
 `/auto-merge:disable` to turn it off). The directive must be on its own line —
-with no leading text or spaces — as the first or last line of the comment, so
-you can write, for example:
+with no leading text or spaces — as the first or last non-blank line of the
+comment, and appear only once, so you can write, for example:
 
 ```text
 LGTM

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -486,10 +486,18 @@ when **Spelling** has no natural-language dictionary to add.
 
 Members of a locale's maintainers team can enable [GitHub auto-merge][] on a
 locale-only PR by commenting `/auto-merge` (or `/auto-merge:enable`; use
-`/auto-merge:disable` to turn it off). This lets established localization teams
-land their own PRs without waiting on a docs maintainer. GitHub, branch
-protection, and CODEOWNERS rules still gate the merge: the PR only merges once
-all required reviews are in and checks pass.
+`/auto-merge:disable` to turn it off). The directive must be on its own line —
+with no leading text or spaces — as the first or last line of the comment, so
+you can write, for example:
+
+```text
+LGTM
+/auto-merge
+```
+
+This lets established localization teams land their own PRs without waiting on a
+docs maintainer. GitHub, branch protection, and CODEOWNERS rules still gate the
+merge: the PR only merges once all required reviews are in and checks pass.
 
 An auto-merge comment is honored only when every changed file is owned by a
 locale you maintain, so it can't be used to make changes to shared or English

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -488,7 +488,7 @@ Members of a locale's maintainers team can enable [GitHub auto-merge][] on a
 locale-only PR by commenting `/auto-merge` (or `/auto-merge:enable`; use
 `/auto-merge:disable` to turn it off). The directive must be on its own line —
 with no leading text or spaces — as the first or last non-blank line of the
-comment, and appear only once, so you can write, for example:
+comment, and appear at most once, so you can write, for example:
 
 ```text
 LGTM

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -486,9 +486,9 @@ when **Spelling** has no natural-language dictionary to add.
 
 Members of a locale's maintainers team can enable [GitHub auto-merge][] on a
 locale-only PR by commenting `/auto-merge` (or `/auto-merge:enable`; use
-`/auto-merge:disable` to turn it off). The directive must be on its own line —
-with no leading text or spaces — as the first or last non-blank line of the
-comment, and appear at most once, so you can write, for example:
+`/auto-merge:disable` to turn it off). The directive must be on its own line,
+with no leading text or whitespace, as the first or last non-blank line of the
+comment. It may appear at most once. For example, you can write:
 
 ```text
 LGTM

--- a/content/en/site/build/ci-workflows.md
+++ b/content/en/site/build/ci-workflows.md
@@ -359,9 +359,10 @@ It runs as a three-stage pipeline:
 
 The [locale-auto-merge.yml][] workflow lets a locale's maintainers enable
 [GitHub auto-merge][] on a locale-only PR by commenting `/auto-merge` (or
-`/auto-merge:disable`). It runs as the DOCS bot, which holds the privileges
-needed to flip the "merge when ready" switch under branch protection; CODEOWNERS
-and required checks remain the hard merge gate.
+`/auto-merge:disable`) on its own line, as the first or last line of the
+comment. It runs as the DOCS bot, which holds the privileges needed to flip the
+"merge when ready" switch under branch protection; CODEOWNERS and required
+checks remain the hard merge gate.
 
 The thin workflow delegates to the testable helper in
 [scripts/gh/locale-auto-merge/][locale-auto-merge-script], which enforces two

--- a/content/en/site/build/ci-workflows.md
+++ b/content/en/site/build/ci-workflows.md
@@ -358,11 +358,12 @@ It runs as a three-stage pipeline:
 ## Locale auto-merge
 
 The [locale-auto-merge.yml][] workflow lets a locale's maintainers enable
-[GitHub auto-merge][] on a locale-only PR by commenting `/auto-merge` (or
-`/auto-merge:disable`) on its own line, as the first or last line of the
-comment. It runs as the DOCS bot, which holds the privileges needed to flip the
-"merge when ready" switch under branch protection; CODEOWNERS and required
-checks remain the hard merge gate.
+[GitHub auto-merge][] on a locale-only PR through an `/auto-merge` (or
+`/auto-merge:enable` / `/auto-merge:disable`) comment directive — for placement
+rules, see the helper [README][locale-auto-merge-script]. It runs as the DOCS
+bot, which holds the privileges needed to flip the "merge when ready" switch
+under branch protection; CODEOWNERS and required checks remain the hard merge
+gate.
 
 The thin workflow delegates to the testable helper in
 [scripts/gh/locale-auto-merge/][locale-auto-merge-script], which enforces two

--- a/scripts/gh/locale-auto-merge/README.md
+++ b/scripts/gh/locale-auto-merge/README.md
@@ -5,13 +5,13 @@ Logic + CLI behind the **Locale auto-merge** workflow
 
 A locale team member comments `/auto-merge` (or `/auto-merge:enable` /
 `/auto-merge:disable`) on a locale-only PR. The directive must be on its own
-line — no leading text or spaces — as the first or last non-blank line of the
-comment (so, e.g., `LGTM` followed by `/auto-merge` works), and appear at most
-once. Mis-indented, buried, or duplicated directives get an explanatory reply;
-blockquoted directives (`> /auto-merge`) are treated as citations and ignored
-silently. The workflow runs this helper as the **DOCS bot** (which has the
-permissions needed to enable auto-merge) to enable GitHub-native auto-merge. The
-bot only flips the "merge when ready" switch — **branch protection and
+line, with no leading text or whitespace, as the first or last non-blank line of
+the comment (so, e.g., `LGTM` followed by `/auto-merge` works). It may appear at
+most once. Mis-indented, buried, or duplicated directives get an explanatory
+reply; blockquoted directives (`> /auto-merge`) are treated as citations and
+ignored silently. The workflow runs this helper as the **DOCS bot** (which has
+the permissions needed to enable auto-merge) to enable GitHub-native auto-merge.
+The bot only flips the "merge when ready" switch — **branch protection and
 CODEOWNERS remain the hard gate**, so the PR still won't merge until every
 required code owner has approved and all checks pass.
 

--- a/scripts/gh/locale-auto-merge/README.md
+++ b/scripts/gh/locale-auto-merge/README.md
@@ -5,13 +5,15 @@ Logic + CLI behind the **Locale auto-merge** workflow
 
 A locale team member comments `/auto-merge` (or `/auto-merge:enable` /
 `/auto-merge:disable`) on a locale-only PR. The directive must be on its own
-line — no leading text or spaces — as the first or last line of the comment (so,
-e.g., `LGTM` followed by `/auto-merge` works), and appear at most once. The
-workflow runs this helper as the **DOCS bot** (which has the permissions needed
-to enable auto-merge) to enable GitHub-native auto-merge. The bot only flips the
-"merge when ready" switch — **branch protection and CODEOWNERS remain the hard
-gate**, so the PR still won't merge until every required code owner has approved
-and all checks pass.
+line — no leading text or spaces — as the first or last non-blank line of the
+comment (so, e.g., `LGTM` followed by `/auto-merge` works), and appear at most
+once. Mis-indented, buried, or duplicated directives get an explanatory reply;
+blockquoted directives (`> /auto-merge`) are treated as citations and ignored
+silently. The workflow runs this helper as the **DOCS bot** (which has the
+permissions needed to enable auto-merge) to enable GitHub-native auto-merge. The
+bot only flips the "merge when ready" switch — **branch protection and
+CODEOWNERS remain the hard gate**, so the PR still won't merge until every
+required code owner has approved and all checks pass.
 
 The helper adds two guards of its own:
 
@@ -62,13 +64,13 @@ like `unauthorized`, `ineligible`, `too-many-files`, and `not-open` — exit `0`
 since they're reported via the PR comment rather than as a failed run. Only an
 infrastructure failure (`mutation-failed`, or a failed `gh` read) exits `1`.
 
-| Outcome           | Exit | Meaning                                                                                                    |
-| ----------------- | ---- | ---------------------------------------------------------------------------------------------------------- |
-| `apply`           | 0    | Auto-merge was enabled or disabled.                                                                        |
-| `noop`            | 0    | Already in the requested state; nothing to do.                                                             |
-| `no-command`      | 0    | The comment was not a recognized `/auto-merge` command (a malformed `/auto-merge …` variant gets a reply). |
-| `not-open`        | 0    | The PR is not open, so auto-merge can't be changed.                                                        |
-| `too-many-files`  | 0    | The PR changes more files than `gh` can return, so eligibility can't be verified (fails closed).           |
-| `ineligible`      | 0    | A changed file is outside the locale-owned set.                                                            |
-| `unauthorized`    | 0    | The commenter isn't on the maintainer team for every touched locale.                                       |
-| `mutation-failed` | 1    | The `gh pr merge` call itself failed.                                                                      |
+| Outcome           | Exit | Meaning                                                                                                                 |
+| ----------------- | ---- | ----------------------------------------------------------------------------------------------------------------------- |
+| `apply`           | 0    | Auto-merge was enabled or disabled.                                                                                     |
+| `noop`            | 0    | Already in the requested state; nothing to do.                                                                          |
+| `no-command`      | 0    | The comment was not a recognized `/auto-merge` command (a malformed, mis-placed, or duplicated directive gets a reply). |
+| `not-open`        | 0    | The PR is not open, so auto-merge can't be changed.                                                                     |
+| `too-many-files`  | 0    | The PR changes more files than `gh` can return, so eligibility can't be verified (fails closed).                        |
+| `ineligible`      | 0    | A changed file is outside the locale-owned set.                                                                         |
+| `unauthorized`    | 0    | The commenter isn't on the maintainer team for every touched locale.                                                    |
+| `mutation-failed` | 1    | The `gh pr merge` call itself failed.                                                                                   |

--- a/scripts/gh/locale-auto-merge/README.md
+++ b/scripts/gh/locale-auto-merge/README.md
@@ -4,11 +4,14 @@ Logic + CLI behind the **Locale auto-merge** workflow
 ([`.github/workflows/locale-auto-merge.yml`](../../../.github/workflows/locale-auto-merge.yml)).
 
 A locale team member comments `/auto-merge` (or `/auto-merge:enable` /
-`/auto-merge:disable`) on a locale-only PR. The workflow runs this helper as the
-**DOCS bot** (which has the permissions needed to enable auto-merge) to enable
-GitHub-native auto-merge. The bot only flips the "merge when ready" switch —
-**branch protection and CODEOWNERS remain the hard gate**, so the PR still won't
-merge until every required code owner has approved and all checks pass.
+`/auto-merge:disable`) on a locale-only PR. The directive must be on its own
+line — no leading text or spaces — as the first or last line of the comment (so,
+e.g., `LGTM` followed by `/auto-merge` works), and appear at most once. The
+workflow runs this helper as the **DOCS bot** (which has the permissions needed
+to enable auto-merge) to enable GitHub-native auto-merge. The bot only flips the
+"merge when ready" switch — **branch protection and CODEOWNERS remain the hard
+gate**, so the PR still won't merge until every required code owner has approved
+and all checks pass.
 
 The helper adds two guards of its own:
 

--- a/scripts/gh/locale-auto-merge/index.mjs
+++ b/scripts/gh/locale-auto-merge/index.mjs
@@ -474,9 +474,9 @@ export function runAutoMergeCommand({
     const message =
       `❓ Unrecognized auto-merge command. Use \`/auto-merge\` (or ` +
       `\`/auto-merge:enable\`) to enable auto-merge, or \`/auto-merge:disable\` ` +
-      `to turn it off. The directive must be on its own line — with no ` +
-      `leading text or spaces — as the first or last non-blank line of the ` +
-      `comment, and appear at most once.`;
+      `to turn it off. The directive must be on its own line, with no ` +
+      `leading text or whitespace, as the first or last non-blank line of ` +
+      `the comment. It may appear at most once.`;
     details.message = message;
     mutatingRunGh([
       'pr',

--- a/scripts/gh/locale-auto-merge/index.mjs
+++ b/scripts/gh/locale-auto-merge/index.mjs
@@ -41,18 +41,30 @@ export function discoverLocales(contentDir = 'content') {
 /**
  * Parse a PR comment body into an auto-merge action.
  *
- * Strict matcher: the trimmed comment must be exactly `/auto-merge`,
- * `/auto-merge:enable`, or `/auto-merge:disable` with no surrounding text.
- * Bare `/auto-merge` is shorthand for `enable`.
+ * Line-anchored matcher: the comment must contain exactly one directive line —
+ * `/auto-merge`, `/auto-merge:enable`, or `/auto-merge:disable` — with no
+ * leading text or whitespace (so indented code and `>` quotes can't trigger
+ * it), and that line must be the first or last non-blank line of the comment
+ * (which also rules out directives inside fenced code blocks, since a fence
+ * needs lines above and below). Bare `/auto-merge` is shorthand for `enable`.
  *
  * @param {unknown} body Raw comment body.
  * @returns {'enable'|'disable'|null}
  */
 export function parseCommand(body) {
   if (typeof body !== 'string') return null;
-  const match = body.trim().match(/^\/auto-merge(?::(enable|disable))?$/);
-  if (!match) return null;
-  return match[1] ?? 'enable';
+  const directiveRe = /^\/auto-merge(?::(enable|disable))?$/;
+  const lines = body.split('\n').map((line) => line.trimEnd());
+  const directiveIndices = lines.flatMap((line, i) =>
+    directiveRe.test(line) ? [i] : [],
+  );
+  if (directiveIndices.length !== 1) return null;
+
+  const [i] = directiveIndices;
+  const nonBlankIndices = lines.flatMap((line, j) => (line ? [j] : []));
+  if (i !== nonBlankIndices[0] && i !== nonBlankIndices.at(-1)) return null;
+
+  return lines[i].match(directiveRe)[1] ?? 'enable';
 }
 
 /**
@@ -443,12 +455,13 @@ export function runAutoMergeCommand({
   details.command = action;
   if (action === null) {
     // Stay a silent no-op for comments that aren't auto-merge attempts at all.
-    // But the workflow triggers on any `/auto-merge`-prefixed comment, so a
-    // malformed variant (e.g. `/auto-merge please` or `/auto-merge:foo`) should
-    // get feedback rather than a silent, seemingly-successful run.
+    // But the workflow triggers on any comment mentioning `/auto-merge`, so a
+    // failed attempt — a line starting with `/auto-merge` that is malformed
+    // (e.g. `/auto-merge please`, `/auto-merge:foo`), buried mid-comment, or
+    // duplicated — should get feedback rather than a silent run.
     const looksLikeAttempt =
       typeof commentBody === 'string' &&
-      commentBody.trim().startsWith('/auto-merge');
+      commentBody.split('\n').some((line) => line.startsWith('/auto-merge'));
     if (!looksLikeAttempt) {
       log('No recognized /auto-merge command; nothing to do.');
       return { outcome: 'no-command', exitCode: 0, details };
@@ -456,7 +469,9 @@ export function runAutoMergeCommand({
     const message =
       `❓ Unrecognized auto-merge command. Use \`/auto-merge\` (or ` +
       `\`/auto-merge:enable\`) to enable auto-merge, or \`/auto-merge:disable\` ` +
-      `to turn it off.`;
+      `to turn it off. The directive must be on its own line — with no ` +
+      `leading text or spaces — as the first or last line of the comment, ` +
+      `and appear at most once.`;
     details.message = message;
     mutatingRunGh([
       'pr',

--- a/scripts/gh/locale-auto-merge/index.mjs
+++ b/scripts/gh/locale-auto-merge/index.mjs
@@ -456,12 +456,17 @@ export function runAutoMergeCommand({
   if (action === null) {
     // Stay a silent no-op for comments that aren't auto-merge attempts at all.
     // But the workflow triggers on any comment mentioning `/auto-merge`, so a
-    // failed attempt — a line starting with `/auto-merge` that is malformed
-    // (e.g. `/auto-merge please`, `/auto-merge:foo`), buried mid-comment, or
-    // duplicated — should get feedback rather than a silent run.
+    // failed attempt — a line starting with `/auto-merge`, possibly indented,
+    // that is malformed (e.g. `/auto-merge please`, `/auto-merge:foo`,
+    // `  /auto-merge`), buried mid-comment, or duplicated — should get
+    // feedback rather than a silent run. Blockquoted directives
+    // (`> /auto-merge`) stay silent: quoting a command is a citation, not an
+    // attempt.
     const looksLikeAttempt =
       typeof commentBody === 'string' &&
-      commentBody.split('\n').some((line) => line.startsWith('/auto-merge'));
+      commentBody
+        .split('\n')
+        .some((line) => line.trimStart().startsWith('/auto-merge'));
     if (!looksLikeAttempt) {
       log('No recognized /auto-merge command; nothing to do.');
       return { outcome: 'no-command', exitCode: 0, details };
@@ -470,8 +475,8 @@ export function runAutoMergeCommand({
       `❓ Unrecognized auto-merge command. Use \`/auto-merge\` (or ` +
       `\`/auto-merge:enable\`) to enable auto-merge, or \`/auto-merge:disable\` ` +
       `to turn it off. The directive must be on its own line — with no ` +
-      `leading text or spaces — as the first or last line of the comment, ` +
-      `and appear at most once.`;
+      `leading text or spaces — as the first or last non-blank line of the ` +
+      `comment, and appear at most once.`;
     details.message = message;
     mutatingRunGh([
       'pr',

--- a/scripts/gh/locale-auto-merge/index.test.mjs
+++ b/scripts/gh/locale-auto-merge/index.test.mjs
@@ -26,7 +26,8 @@ describe('locale-auto-merge: discoverLocales', () => {
 describe('locale-auto-merge: parseCommand', () => {
   test('bare /auto-merge means enable', () => {
     assert.equal(parseCommand('/auto-merge'), 'enable');
-    assert.equal(parseCommand('  /auto-merge  '), 'enable');
+    assert.equal(parseCommand('/auto-merge  '), 'enable');
+    assert.equal(parseCommand('/auto-merge\r\n'), 'enable');
   });
 
   test('explicit enable/disable', () => {
@@ -34,8 +35,41 @@ describe('locale-auto-merge: parseCommand', () => {
     assert.equal(parseCommand('/auto-merge:disable'), 'disable');
   });
 
-  test('rejects surrounding text and unknown verbs', () => {
+  test('directive as last line after text', () => {
+    assert.equal(parseCommand('LGTM\n/auto-merge'), 'enable');
+    assert.equal(
+      parseCommand('LGTM!\nThanks.\n\n/auto-merge:disable\n'),
+      'disable',
+    );
+  });
+
+  test('directive as first line before text', () => {
+    assert.equal(parseCommand('/auto-merge\nLGTM, merging.'), 'enable');
+    assert.equal(parseCommand('\n/auto-merge\n\nLGTM.'), 'enable');
+  });
+
+  test('rejects a directive that is neither first nor last non-blank line', () => {
+    assert.equal(parseCommand('LGTM\n/auto-merge\nthanks'), null);
+    assert.equal(parseCommand('```\n/auto-merge\n```'), null);
+  });
+
+  test('rejects leading whitespace, quotes, and inline text', () => {
+    assert.equal(parseCommand('  /auto-merge'), null);
+    assert.equal(parseCommand('> /auto-merge'), null);
     assert.equal(parseCommand('please /auto-merge'), null);
+    assert.equal(parseCommand('LGTM\n  /auto-merge'), null);
+  });
+
+  test('rejects multiple directives', () => {
+    assert.equal(parseCommand('/auto-merge\n/auto-merge'), null);
+    assert.equal(
+      parseCommand('/auto-merge:enable\nhmm\n/auto-merge:disable'),
+      null,
+    );
+  });
+
+  test('stays silent on mid-sentence mentions and unknown verbs', () => {
+    assert.equal(parseCommand('Use /auto-merge to merge.'), null);
     assert.equal(parseCommand('/auto-merge now'), null);
     assert.equal(parseCommand('/auto-merge:later'), null);
     assert.equal(parseCommand('/automerge'), null);
@@ -392,6 +426,20 @@ describe('locale-auto-merge: runAutoMergeCommand', () => {
     assert.equal(calls.length, 0); // never even fetched the PR
   });
 
+  test('mid-sentence /auto-merge mention stays a silent no-op', () => {
+    const calls = [];
+    const r = runAutoMergeCommand({
+      repo: 'open-telemetry/opentelemetry.io',
+      prNum: 1,
+      commentAuthor: 'alice',
+      commentBody: 'You can use /auto-merge to merge locale PRs.',
+      knownLocales: KNOWN,
+      runGh: makeRunGh({ pr: {}, calls }),
+    });
+    assert.equal(r.outcome, 'no-command');
+    assert.equal(calls.length, 0); // no PR fetch, no feedback comment
+  });
+
   test('malformed /auto-merge attempt posts an unrecognized-command reply', () => {
     const calls = [];
     const r = runAutoMergeCommand({
@@ -410,6 +458,26 @@ describe('locale-auto-merge: runAutoMergeCommand', () => {
     assert.ok(comment, 'expected a feedback comment');
     const body = comment[comment.indexOf('--body') + 1];
     assert.match(body, /Unrecognized auto-merge command/);
+  });
+
+  test('mid-comment or duplicated directives get an unrecognized-command reply', () => {
+    for (const body of [
+      'LGTM\n/auto-merge\nthanks', // buried mid-comment
+      '/auto-merge\nhmm\n/auto-merge:disable', // more than one directive
+    ]) {
+      const calls = [];
+      const r = runAutoMergeCommand({
+        repo: 'open-telemetry/opentelemetry.io',
+        prNum: 5,
+        commentAuthor: 'alice',
+        commentBody: body,
+        knownLocales: KNOWN,
+        runGh: makeRunGh({ pr: {}, calls }),
+      });
+      assert.equal(r.outcome, 'no-command');
+      const comment = calls.find((a) => a[0] === 'pr' && a[1] === 'comment');
+      assert.ok(comment, `expected a feedback comment for: ${body}`);
+    }
   });
 
   test('eligible + authorized enable issues gh pr merge --auto', () => {

--- a/scripts/gh/locale-auto-merge/index.test.mjs
+++ b/scripts/gh/locale-auto-merge/index.test.mjs
@@ -464,6 +464,7 @@ describe('locale-auto-merge: runAutoMergeCommand', () => {
     for (const body of [
       'LGTM\n/auto-merge\nthanks', // buried mid-comment
       '/auto-merge\nhmm\n/auto-merge:disable', // more than one directive
+      'LGTM\n  /auto-merge', // mis-indented directive
     ]) {
       const calls = [];
       const r = runAutoMergeCommand({
@@ -477,7 +478,48 @@ describe('locale-auto-merge: runAutoMergeCommand', () => {
       assert.equal(r.outcome, 'no-command');
       const comment = calls.find((a) => a[0] === 'pr' && a[1] === 'comment');
       assert.ok(comment, `expected a feedback comment for: ${body}`);
+      const replyBody = comment[comment.indexOf('--body') + 1];
+      assert.match(replyBody, /first or last non-blank line/);
     }
+  });
+
+  test('blockquoted directive is a citation, not an attempt: silent no-op', () => {
+    const calls = [];
+    const r = runAutoMergeCommand({
+      repo: 'open-telemetry/opentelemetry.io',
+      prNum: 5,
+      commentAuthor: 'alice',
+      commentBody: '> /auto-merge\n\nWho ran this?',
+      knownLocales: KNOWN,
+      runGh: makeRunGh({ pr: {}, calls }),
+    });
+    assert.equal(r.outcome, 'no-command');
+    assert.equal(calls.length, 0);
+  });
+
+  test('LGTM followed by /auto-merge on the last line enables auto-merge', () => {
+    const calls = [];
+    const r = runAutoMergeCommand({
+      repo: 'open-telemetry/opentelemetry.io',
+      prNum: 43,
+      commentAuthor: 'alice',
+      commentBody: 'LGTM\n/auto-merge',
+      knownLocales: KNOWN,
+      runGh: makeRunGh({
+        pr: {
+          state: 'OPEN',
+          files: [{ path: 'content/ja/a.md' }],
+          autoMergeRequest: null,
+        },
+        teams: { 'docs-ja-maintainers': ['alice'] },
+        calls,
+      }),
+    });
+    assert.equal(r.outcome, 'apply');
+    assert.equal(r.exitCode, 0);
+    const merge = calls.find((a) => a[0] === 'pr' && a[1] === 'merge');
+    assert.ok(merge, 'expected a gh pr merge call');
+    assert.ok(merge.includes('--auto'));
   });
 
   test('eligible + authorized enable issues gh pr merge --auto', () => {


### PR DESCRIPTION
- Fixes #10375
- Contributes to #9219

- **Capability**
  - The `/auto-merge` directive (and `:enable` / `:disable`) no longer needs to be the entire comment: it is recognized on its own line, with no leading text or whitespace, as the first or last non-blank line of the comment. It may appear at most once. So the natural maintainer gesture works:

    ```
    LGTM
    /auto-merge
    ```

- **Semantics & safety**
  - No leading whitespace means indented code blocks and `> ` quotes can't trigger the command; the first-or-last-line rule also rules out directives inside fenced code blocks (a fence needs lines above and below).
  - Comments containing more than one directive, a directive buried mid-comment, or a mis-indented directive are rejected with an explanatory "unrecognized command" reply that includes placement guidance; mid-sentence mentions of `/auto-merge` and blockquoted directives (citations) stay silent.
  - The workflow prefilter widens from `startsWith(...)` to `contains(...)`; the helper remains the authoritative parser.

- **Implementation & docs**
  - `parseCommand` in `scripts/gh/locale-auto-merge/index.mjs` is now line-anchored (handles CRLF and trailing blank lines); the "looks like an attempt" check is per-line.
  - New unit and orchestrator tests cover directive-after-text, directive-before-text, leading-whitespace/quote rejection, mid-comment rejection, duplicate-directive rejection, mid-sentence silence, and the `LGTM` + `/auto-merge` happy path.
  - Command syntax updated in the helper README and the localization guide; the CI-workflows page stays lean and defers placement details to the README.

### Tests

- [x] `npm run test:local-tools`: 279 pass, 0 fail
