### PR TITLE
Upgrade Hugo to 0.163.1 and bump Docsy theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	path = themes/docsy
 	url = https://github.com/google/docsy.git
   # cSpell:disable-next-line
-	docsy-pin = v0.15.0-9-g5c5733de
+	docsy-pin = v0.15.0-11-gf22a352d
 	docsy-note = "2024-04-01 Switching to google/docsy.git from cncf/docsy.git since we don't have any CNCF customizations."
 	docsy-reminder = "Ensure that any tag referenced by `docsy-pin` is present in the remote repo (url), otherwise add (push) the tags to the repo."
 [submodule "content-modules/opentelemetry-specification"]

--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -67,8 +67,6 @@ enableEmoji: true
 
 imaging:
   resampleFilter: CatmullRom # cspell:disable-line
-  quality: 75
-  anchor: smart
 
 markup:
   tableOfContents:

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "code-excerpter": "0.2.0",
     "cspell": "10.0.1",
     "gulp": "5.0.1",
-    "hugo-extended": "0.158.0",
+    "hugo-extended": "0.163.1",
     "js-yaml": "4.2.0",
     "markdown-it": "14.2.0",
     "markdown-link-check": "3.14.2",


### PR DESCRIPTION
- Fixes #10372.
- Relates to #8933.
- Pins hugo-extended to 0.163.1 (from 0.158.0).
- Bumps the Docsy theme submodule to v0.15.0-11-gf22a352d (per the update-git-submodule skill), picking up the theme's Hugo 0.160.1 and 0.163.x upgrades, including a regenerated Chroma style for the new OperatorReserved token class.
- Drops the imaging quality (75) and anchor (smart) settings, which match Hugo defaults; the global imaging.quality option is deprecated as of 0.163.0. Keeps resampleFilter CatmullRom, which affects generated-image output. Theme-override port check: no overridden layout files changed in the submodule range.
- Build reports zero deprecation notices; npm run test passes.
- **Preview**: https://deploy-preview-10379--opentelemetry.netlify.app/
