### PR TITLE
Add locale-team-cleanup helper script

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "generate:config:links": "scripts/htmltest-config.sh",
     "get:submodule": "npm run _get:${GET:-submodule} --",
     "locale-auto-merge": "node scripts/gh/locale-auto-merge/cli.mjs",
+    "locale-team-cleanup": "node scripts/gh/locale-team-cleanup/cli.mjs",
     "log:build": "npm run build 2>&1 | tee tmp/build-log.txt",
     "log:check:links": "npm run check:links 2>&1 | tee tmp/check-links-log.txt",
     "log:test-and-fix": "npm run test-and-fix 2>&1 | tee tmp/test-log.txt",

--- a/scripts/gh/locale-team-cleanup/README.md
+++ b/scripts/gh/locale-team-cleanup/README.md
@@ -33,10 +33,14 @@ occasionally stall indefinitely.
 
 ## Cautions
 
-- **Run as an org owner.** Team-membership writes need org-owner privileges (or
-  a maintainer role _on that very team_). Since the people being removed are the
-  ones holding team-maintainer roles, a non-owner runner can remove themselves
-  and then be unable to undo it (learned the hard way, 2026-06-12).
+- **Run as an org owner or a team maintainer of every targeted team.**
+  Team-membership writes need org-owner privileges or a maintainer role _on that
+  very team_. Round-trip (remove + re-add) verified live with a
+  team-maintainer-only runner on 2026-06-12.
+- **The runner is removed last from each team** (handled automatically):
+  removing yourself from a team destroys your team-maintainer role on it, so
+  removing yourself first would 403 the remaining removals — and you can't
+  re-add yourself afterwards either (learned the hard way, 2026-06-12).
 - **Child before parent.** `docs-<loc>-maintainers` is a child of
   `docs-<loc>-approvers` and GitHub rosters include child-team members, so the
   helper removes from the maintainers team first and treats a 404 (not a direct

--- a/scripts/gh/locale-team-cleanup/README.md
+++ b/scripts/gh/locale-team-cleanup/README.md
@@ -37,11 +37,11 @@ occasionally stall indefinitely.
   Team-membership writes need org-owner privileges or a maintainer role _on that
   very team_. Round-trip (remove + re-add) verified live with a
   team-maintainer-only runner on 2026-06-12.
-- **The runner is excluded by default; `--self-too` removes them last from each
-  team** (handled automatically): removing yourself from a team destroys your
-  team-maintainer role on it, so removing yourself first would 403 the remaining
-  removals — and you can't re-add yourself afterwards either (learned the hard
-  way, 2026-06-12).
+- **The runner's memberships are listed but skipped by default; `--self-too`
+  removes them too, last from each team**: removing yourself from a team
+  destroys your team-maintainer role on it, so removing yourself first would 403
+  the remaining removals — and you can't re-add yourself afterwards either
+  (learned the hard way, 2026-06-12).
 - **Child before parent.** `docs-<loc>-maintainers` is a child of
   `docs-<loc>-approvers` and GitHub rosters include child-team members, so the
   helper removes from the maintainers team first and treats a 404 (not a direct

--- a/scripts/gh/locale-team-cleanup/README.md
+++ b/scripts/gh/locale-team-cleanup/README.md
@@ -37,10 +37,11 @@ occasionally stall indefinitely.
   Team-membership writes need org-owner privileges or a maintainer role _on that
   very team_. Round-trip (remove + re-add) verified live with a
   team-maintainer-only runner on 2026-06-12.
-- **The runner is removed last from each team** (handled automatically):
-  removing yourself from a team destroys your team-maintainer role on it, so
-  removing yourself first would 403 the remaining removals — and you can't
-  re-add yourself afterwards either (learned the hard way, 2026-06-12).
+- **The runner is excluded by default; `--self-too` removes them last from each
+  team** (handled automatically): removing yourself from a team destroys your
+  team-maintainer role on it, so removing yourself first would 403 the remaining
+  removals — and you can't re-add yourself afterwards either (learned the hard
+  way, 2026-06-12).
 - **Child before parent.** `docs-<loc>-maintainers` is a child of
   `docs-<loc>-approvers` and GitHub rosters include child-team members, so the
   helper removes from the maintainers team first and treats a 404 (not a direct

--- a/scripts/gh/locale-team-cleanup/README.md
+++ b/scripts/gh/locale-team-cleanup/README.md
@@ -28,7 +28,7 @@ permissions smoke test), combine `-l <locale>`, `-u <user>`, and `--max <n>`:
 npm run locale-team-cleanup -- -f -l bn -u cartermp --max 1
 ```
 
-Every `gh` call has a timeout (default 30s, `--timeout <s>`) since `gh api` can
+Every `gh` call has a timeout (default 10s, `--timeout <s>`) since `gh api` can
 occasionally stall indefinitely.
 
 ## Cautions

--- a/scripts/gh/locale-team-cleanup/README.md
+++ b/scripts/gh/locale-team-cleanup/README.md
@@ -19,6 +19,18 @@ npm run locale-team-cleanup           # dry run
 npm run locale-team-cleanup -- -f     # actually remove (org owner only!)
 ```
 
+The run is **idempotent**: it plans from live rosters, so re-running after a
+(partial) cleanup only removes what is left. To limit a run (e.g. for a
+permissions smoke test), combine `-l <locale>`, `-u <user>`, and `--max <n>`:
+
+```sh
+# Test: can the runner remove a single membership? (child team first)
+npm run locale-team-cleanup -- -f -l bn -u cartermp --max 1
+```
+
+Every `gh` call has a timeout (default 30s, `--timeout <s>`) since `gh api` can
+occasionally stall indefinitely.
+
 ## Cautions
 
 - **Run as an org owner.** Team-membership writes need org-owner privileges (or

--- a/scripts/gh/locale-team-cleanup/README.md
+++ b/scripts/gh/locale-team-cleanup/README.md
@@ -1,0 +1,41 @@
+# Locale team cleanup helper
+
+One-time(ish) admin helper for [opentelemetry.io#10374][]: locale GitHub teams
+should contain only locale members, so that a locale-team approval honestly
+means a translation review. Unstaffed locales are gated by
+`@open-telemetry/docs-approvers` through the CODEOWNERS fallback instead.
+
+The helper removes interim docs-core members from every `docs-<loc>-*` team,
+**keeping** docs-core members who are genuine locale reviewers (see `KEEP` in
+`index.mjs`: chalin (fr); maryliag, vitorvasc (pt)).
+
+## Usage
+
+Dry-run is the default: it fetches live rosters and prints the removals it would
+perform, without changing anything.
+
+```sh
+npm run locale-team-cleanup           # dry run
+npm run locale-team-cleanup -- -f     # actually remove (org owner only!)
+```
+
+## Cautions
+
+- **Run as an org owner.** Team-membership writes need org-owner privileges (or
+  a maintainer role _on that very team_). Since the people being removed are the
+  ones holding team-maintainer roles, a non-owner runner can remove themselves
+  and then be unable to undo it (learned the hard way, 2026-06-12).
+- **Child before parent.** `docs-<loc>-maintainers` is a child of
+  `docs-<loc>-approvers` and GitHub rosters include child-team members, so the
+  helper removes from the maintainers team first and treats a 404 (not a direct
+  member) as a skip, not a failure.
+
+## Files
+
+- `index.mjs` — pure logic (`planRemovals`) + the `runCleanup` orchestrator (all
+  `gh` access is injected, so it is unit-testable).
+- `cli.mjs` — wires the real `gh`; run with `--help` for usage.
+- `index.test.mjs` — run with `npm run test:local-tools`.
+
+[opentelemetry.io#10374]:
+  https://github.com/open-telemetry/opentelemetry.io/issues/10374

--- a/scripts/gh/locale-team-cleanup/cli.mjs
+++ b/scripts/gh/locale-team-cleanup/cli.mjs
@@ -5,26 +5,47 @@
 import { spawnSync } from 'node:child_process';
 import { parseArgs } from 'node:util';
 
-import { runCleanup } from './index.mjs';
+import { DOCS_CORE, LOCALES, runCleanup } from './index.mjs';
+
+const DEFAULT_TIMEOUT_S = 30;
 
 const HELP = `Usage: cli.mjs [options]
 
 Remove interim docs-core members from docs-<loc>-* teams; see README.md and
 https://github.com/open-telemetry/opentelemetry.io/issues/10374.
 
+The run is idempotent: it plans from live rosters, so re-running after a
+(partial) cleanup only removes what is left.
+
 Options:
-  -n, --dry-run     Read-only: print planned removals (the default).
-  -f, --no-dry-run  Actually remove memberships. Requires org-owner
-                    privileges — see the README cautions.
-  -h, --help        Show this help.
+  -n, --dry-run        Read-only: print planned removals (the default).
+  -f, --no-dry-run     Actually remove memberships. Requires org-owner
+                       privileges -- see the README cautions.
+  -l, --locale <loc>   Restrict to this locale (repeatable), e.g. -l bn.
+  -u, --user <login>   Restrict to this user (repeatable), e.g. -u cartermp.
+      --max <n>        Remove at most <n> memberships.
+      --timeout <s>    Per-gh-call timeout in seconds (default: ${DEFAULT_TIMEOUT_S}).
+  -h, --help           Show this help.
 `;
 
-function runGh(args) {
-  const res = spawnSync('gh', args, { encoding: 'utf8' });
-  return {
-    stdout: res.stdout ?? '',
-    stderr: res.stderr ?? '',
-    status: res.status ?? 1,
+function makeRunGh(timeoutS) {
+  return (args) => {
+    const res = spawnSync('gh', args, {
+      encoding: 'utf8',
+      timeout: timeoutS * 1000,
+    });
+    if (res.error?.code === 'ETIMEDOUT') {
+      return {
+        stdout: '',
+        stderr: `gh timed out after ${timeoutS}s: gh ${args.join(' ')}`,
+        status: 1,
+      };
+    }
+    return {
+      stdout: res.stdout ?? '',
+      stderr: res.stderr ?? '',
+      status: res.status ?? 1,
+    };
   };
 }
 
@@ -35,6 +56,10 @@ function main() {
       options: {
         'dry-run': { type: 'boolean', short: 'n' },
         'no-dry-run': { type: 'boolean', short: 'f' },
+        locale: { type: 'string', short: 'l', multiple: true },
+        user: { type: 'string', short: 'u', multiple: true },
+        max: { type: 'string' },
+        timeout: { type: 'string' },
         help: { type: 'boolean', short: 'h' },
       },
     }));
@@ -47,14 +72,62 @@ function main() {
     console.log(HELP);
     return;
   }
-  if (values['dry-run'] && values['no-dry-run']) {
-    console.error(`Pass at most one of --dry-run and --no-dry-run.\n\n${HELP}`);
+  function usageError(msg) {
+    console.error(`${msg}\n\n${HELP}`);
     process.exit(2);
+  }
+
+  if (values['dry-run'] && values['no-dry-run']) {
+    usageError('Pass at most one of --dry-run and --no-dry-run.');
+  }
+
+  const locales = values.locale;
+  for (const loc of locales ?? []) {
+    if (!LOCALES.includes(loc)) {
+      usageError(
+        `Unknown locale: ${loc}. Expected one of: ${LOCALES.join(', ')}.`,
+      );
+    }
+  }
+
+  const users = values.user;
+  for (const user of users ?? []) {
+    if (!DOCS_CORE.includes(user)) {
+      usageError(
+        `Not a docs-core member: ${user}. ` +
+          `Expected one of: ${DOCS_CORE.join(', ')}.`,
+      );
+    }
+  }
+
+  let max;
+  if (values.max !== undefined) {
+    max = Number(values.max);
+    if (!Number.isInteger(max) || max < 1) {
+      usageError(`--max must be a positive integer, got: ${values.max}.`);
+    }
+  }
+
+  let timeoutS = DEFAULT_TIMEOUT_S;
+  if (values.timeout !== undefined) {
+    timeoutS = Number(values.timeout);
+    if (!Number.isFinite(timeoutS) || timeoutS <= 0) {
+      usageError(
+        `--timeout must be a positive number, got: ${values.timeout}.`,
+      );
+    }
   }
 
   const dryRun = !values['no-dry-run'];
   console.log(`== Locale team cleanup (${dryRun ? 'DRY RUN' : 'APPLY'}) ==\n`);
-  const { exitCode } = runCleanup({ runGh, dryRun, log: console.log });
+  const { exitCode } = runCleanup({
+    runGh: makeRunGh(timeoutS),
+    dryRun,
+    locales,
+    users,
+    max,
+    log: console.log,
+  });
   process.exit(exitCode);
 }
 

--- a/scripts/gh/locale-team-cleanup/cli.mjs
+++ b/scripts/gh/locale-team-cleanup/cli.mjs
@@ -119,13 +119,28 @@ function main() {
   }
 
   const dryRun = !values['no-dry-run'];
-  console.log(`== Locale team cleanup (${dryRun ? 'DRY RUN' : 'APPLY'}) ==\n`);
+
+  // Removing yourself from a team destroys your team-maintainer role on it,
+  // which the remaining removals may depend on — so the runner is removed
+  // last from each team. Detect who is running.
+  const runGh = makeRunGh(timeoutS);
+  const whoami = runGh(['api', 'user', '-q', '.login']);
+  if (whoami.status !== 0) {
+    console.error(`Could not determine current gh user: ${whoami.stderr}`);
+    process.exit(1);
+  }
+  const self = whoami.stdout.trim();
+
+  console.log(
+    `== Locale team cleanup (${dryRun ? 'DRY RUN' : 'APPLY'}; as ${self}) ==\n`,
+  );
   const { exitCode } = runCleanup({
-    runGh: makeRunGh(timeoutS),
+    runGh,
     dryRun,
     locales,
     users,
     max,
+    self,
     log: console.log,
   });
   process.exit(exitCode);

--- a/scripts/gh/locale-team-cleanup/cli.mjs
+++ b/scripts/gh/locale-team-cleanup/cli.mjs
@@ -7,7 +7,7 @@ import { parseArgs } from 'node:util';
 
 import { DOCS_CORE, LOCALES, runCleanup } from './index.mjs';
 
-const DEFAULT_TIMEOUT_S = 30;
+const DEFAULT_TIMEOUT_S = 10;
 
 const HELP = `Usage: cli.mjs [options]
 

--- a/scripts/gh/locale-team-cleanup/cli.mjs
+++ b/scripts/gh/locale-team-cleanup/cli.mjs
@@ -25,9 +25,10 @@ Options:
   -u, --user <login>   Restrict to this user (repeatable), e.g. -u cartermp.
       --max <n>        Remove at most <n> memberships.
       --self-too       Also remove the runner (last from each team). By
-                       default the runner is excluded, since self-removal
-                       destroys their team-maintainer role and cannot be
-                       undone by the runner.
+                       default the runner's memberships are listed but
+                       skipped, since self-removal destroys their
+                       team-maintainer role and cannot be undone by the
+                       runner.
       --timeout <s>    Per-gh-call timeout in seconds (default: ${DEFAULT_TIMEOUT_S}).
   -h, --help           Show this help.
 `;
@@ -127,9 +128,9 @@ function main() {
   const selfToo = values['self-too'] ?? false;
 
   // Removing yourself from a team destroys your team-maintainer role on it,
-  // which the remaining removals may depend on. So by default the runner is
-  // excluded from removals; with --self-too they are removed last from each
-  // team. Detect who is running.
+  // which the remaining removals may depend on. So by default the runner's
+  // memberships are listed but skipped; with --self-too they are removed
+  // last from each team. Detect who is running.
   const runGh = makeRunGh(timeoutS);
   const whoami = runGh(['api', 'user', '-q', '.login']);
   if (whoami.status !== 0) {
@@ -139,8 +140,7 @@ function main() {
   const self = whoami.stdout.trim();
 
   console.log(
-    `== Locale team cleanup (${dryRun ? 'DRY RUN' : 'APPLY'}; as ${self}` +
-      `${selfToo ? '' : ', excluded'}) ==\n`,
+    `== Locale team cleanup (${dryRun ? 'DRY RUN' : 'APPLY'}; as ${self}) ==\n`,
   );
   const { exitCode } = runCleanup({
     runGh,

--- a/scripts/gh/locale-team-cleanup/cli.mjs
+++ b/scripts/gh/locale-team-cleanup/cli.mjs
@@ -24,6 +24,10 @@ Options:
   -l, --locale <loc>   Restrict to this locale (repeatable), e.g. -l bn.
   -u, --user <login>   Restrict to this user (repeatable), e.g. -u cartermp.
       --max <n>        Remove at most <n> memberships.
+      --self-too       Also remove the runner (last from each team). By
+                       default the runner is excluded, since self-removal
+                       destroys their team-maintainer role and cannot be
+                       undone by the runner.
       --timeout <s>    Per-gh-call timeout in seconds (default: ${DEFAULT_TIMEOUT_S}).
   -h, --help           Show this help.
 `;
@@ -59,6 +63,7 @@ function main() {
         locale: { type: 'string', short: 'l', multiple: true },
         user: { type: 'string', short: 'u', multiple: true },
         max: { type: 'string' },
+        'self-too': { type: 'boolean' },
         timeout: { type: 'string' },
         help: { type: 'boolean', short: 'h' },
       },
@@ -119,10 +124,12 @@ function main() {
   }
 
   const dryRun = !values['no-dry-run'];
+  const selfToo = values['self-too'] ?? false;
 
   // Removing yourself from a team destroys your team-maintainer role on it,
-  // which the remaining removals may depend on — so the runner is removed
-  // last from each team. Detect who is running.
+  // which the remaining removals may depend on. So by default the runner is
+  // excluded from removals; with --self-too they are removed last from each
+  // team. Detect who is running.
   const runGh = makeRunGh(timeoutS);
   const whoami = runGh(['api', 'user', '-q', '.login']);
   if (whoami.status !== 0) {
@@ -132,7 +139,8 @@ function main() {
   const self = whoami.stdout.trim();
 
   console.log(
-    `== Locale team cleanup (${dryRun ? 'DRY RUN' : 'APPLY'}; as ${self}) ==\n`,
+    `== Locale team cleanup (${dryRun ? 'DRY RUN' : 'APPLY'}; as ${self}` +
+      `${selfToo ? '' : ', excluded'}) ==\n`,
   );
   const { exitCode } = runCleanup({
     runGh,
@@ -141,6 +149,7 @@ function main() {
     users,
     max,
     self,
+    selfToo,
     log: console.log,
   });
   process.exit(exitCode);

--- a/scripts/gh/locale-team-cleanup/cli.mjs
+++ b/scripts/gh/locale-team-cleanup/cli.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// CLI entry point for the locale team cleanup helper. Wires the real `gh`
+// runner and delegates all logic to `runCleanup` in ./index.mjs.
+
+import { spawnSync } from 'node:child_process';
+import { parseArgs } from 'node:util';
+
+import { runCleanup } from './index.mjs';
+
+const HELP = `Usage: cli.mjs [options]
+
+Remove interim docs-core members from docs-<loc>-* teams; see README.md and
+https://github.com/open-telemetry/opentelemetry.io/issues/10374.
+
+Options:
+  -n, --dry-run     Read-only: print planned removals (the default).
+  -f, --no-dry-run  Actually remove memberships. Requires org-owner
+                    privileges — see the README cautions.
+  -h, --help        Show this help.
+`;
+
+function runGh(args) {
+  const res = spawnSync('gh', args, { encoding: 'utf8' });
+  return {
+    stdout: res.stdout ?? '',
+    stderr: res.stderr ?? '',
+    status: res.status ?? 1,
+  };
+}
+
+function main() {
+  let values;
+  try {
+    ({ values } = parseArgs({
+      options: {
+        'dry-run': { type: 'boolean', short: 'n' },
+        'no-dry-run': { type: 'boolean', short: 'f' },
+        help: { type: 'boolean', short: 'h' },
+      },
+    }));
+  } catch (err) {
+    console.error(`${err.message}\n\n${HELP}`);
+    process.exit(2);
+  }
+
+  if (values.help) {
+    console.log(HELP);
+    return;
+  }
+  if (values['dry-run'] && values['no-dry-run']) {
+    console.error(`Pass at most one of --dry-run and --no-dry-run.\n\n${HELP}`);
+    process.exit(2);
+  }
+
+  const dryRun = !values['no-dry-run'];
+  console.log(`== Locale team cleanup (${dryRun ? 'DRY RUN' : 'APPLY'}) ==\n`);
+  const { exitCode } = runCleanup({ runGh, dryRun, log: console.log });
+  process.exit(exitCode);
+}
+
+main();

--- a/scripts/gh/locale-team-cleanup/index.mjs
+++ b/scripts/gh/locale-team-cleanup/index.mjs
@@ -51,22 +51,20 @@ export function teamsInRemovalOrder(locales = LOCALES) {
  * @param {string[]} [filters.locales] Restrict to these locales.
  * @param {string[]} [filters.users] Restrict to these users.
  * @param {number} [filters.max] Bound the number of removals.
- * @param {string} [filters.self] Login of the runner: excluded from removals
- *   unless selfToo is set, since self-removal destroys the runner's
- *   team-maintainer role on that team (which the other removals may depend
- *   on) and cannot be undone by the runner.
- * @param {boolean} [filters.selfToo] Also remove the runner — last from each
- *   team, so the other removals still succeed.
- * @returns {{ team: string, user: string }[]} In removal order.
+ * @param {string} [filters.self] Login of the runner: always planned last
+ *   from each team (whether the entry is acted on is up to the caller —
+ *   see selfToo in runCleanup).
+ * @returns {{ team: string, user: string, self: boolean }[]} In removal
+ *   order.
  */
 export function planRemovals(rosters, filters = {}) {
-  const { locales, users, max = Infinity, self, selfToo = false } = filters;
-  const candidates = (users ?? DOCS_CORE).filter(
-    (u) => DOCS_CORE.includes(u) && u !== self,
-  );
-  if (selfToo && self && (users ?? DOCS_CORE).includes(self)) {
-    candidates.push(self);
-  }
+  const { locales, users, max = Infinity, self } = filters;
+  const requested = (users ?? DOCS_CORE).filter((u) => DOCS_CORE.includes(u));
+  const others = requested.filter((u) => u !== self);
+  // The runner goes last per team: self-removal destroys their
+  // team-maintainer role, which the other removals may depend on.
+  const candidates =
+    requested.length > others.length ? [...others, self] : others;
   const removals = [];
   for (const team of teamsInRemovalOrder(locales)) {
     const roster = rosters.get(team);
@@ -75,7 +73,9 @@ export function planRemovals(rosters, filters = {}) {
     const keep = new Set(KEEP[locale] ?? []);
     for (const user of candidates) {
       if (removals.length >= max) return removals;
-      if (roster.has(user) && !keep.has(user)) removals.push({ team, user });
+      if (roster.has(user) && !keep.has(user)) {
+        removals.push({ team, user, self: user === self });
+      }
     }
   }
   return removals;
@@ -93,7 +93,8 @@ export function planRemovals(rosters, filters = {}) {
  * @param {string[]} [opts.locales] Restrict to these locales.
  * @param {string[]} [opts.users] Restrict to these users.
  * @param {number} [opts.max] Bound the number of removals.
- * @param {string} [opts.self] Login of the runner; excluded unless selfToo.
+ * @param {string} [opts.self] Login of the runner; listed but skipped
+ *   unless selfToo.
  * @param {boolean} [opts.selfToo] Also remove the runner, last per team.
  * @param {(msg: string) => void} [opts.log]
  * @returns {{ removals: { team: string, user: string, status: string }[],
@@ -125,18 +126,23 @@ export function runCleanup({
     rosters.set(team, new Set(res.stdout.split('\n').filter(Boolean)));
   }
 
-  const planned = planRemovals(rosters, { locales, users, max, self, selfToo });
+  const planned = planRemovals(rosters, { locales, users, max, self });
   if (planned.length === 0) {
     log('Nothing to remove; all locale teams are already clean.');
     return { removals: [], exitCode: 0 };
   }
 
   let failures = 0;
-  const removals = planned.map(({ team, user }) => {
+  let actionable = 0;
+  const removals = planned.map(({ team, user, self: isSelf }) => {
     let status;
-    if (dryRun) {
+    if (isSelf && !selfToo) {
+      status = 'skipped (runner; pass --self-too to remove)';
+    } else if (dryRun) {
+      actionable++;
       status = 'would remove';
     } else {
+      actionable++;
       const res = runGh([
         'api',
         '-X',
@@ -159,7 +165,7 @@ export function runCleanup({
 
   if (dryRun) {
     log(
-      `\nDry run only: ${planned.length} removal(s) planned. ` +
+      `\nDry run only: ${actionable} removal(s) planned. ` +
         `Pass --no-dry-run (-f) to perform them.`,
     );
   }

--- a/scripts/gh/locale-team-cleanup/index.mjs
+++ b/scripts/gh/locale-team-cleanup/index.mjs
@@ -51,17 +51,22 @@ export function teamsInRemovalOrder(locales = LOCALES) {
  * @param {string[]} [filters.locales] Restrict to these locales.
  * @param {string[]} [filters.users] Restrict to these users.
  * @param {number} [filters.max] Bound the number of removals.
- * @param {string} [filters.self] Login of the runner: removed last from each
- *   team, since self-removal destroys the runner's team-maintainer role on
- *   that team (which the other removals may depend on).
+ * @param {string} [filters.self] Login of the runner: excluded from removals
+ *   unless selfToo is set, since self-removal destroys the runner's
+ *   team-maintainer role on that team (which the other removals may depend
+ *   on) and cannot be undone by the runner.
+ * @param {boolean} [filters.selfToo] Also remove the runner — last from each
+ *   team, so the other removals still succeed.
  * @returns {{ team: string, user: string }[]} In removal order.
  */
 export function planRemovals(rosters, filters = {}) {
-  const { locales, users, max = Infinity, self } = filters;
+  const { locales, users, max = Infinity, self, selfToo = false } = filters;
   const candidates = (users ?? DOCS_CORE).filter(
     (u) => DOCS_CORE.includes(u) && u !== self,
   );
-  if (self && (users ?? DOCS_CORE).includes(self)) candidates.push(self);
+  if (selfToo && self && (users ?? DOCS_CORE).includes(self)) {
+    candidates.push(self);
+  }
   const removals = [];
   for (const team of teamsInRemovalOrder(locales)) {
     const roster = rosters.get(team);
@@ -88,7 +93,8 @@ export function planRemovals(rosters, filters = {}) {
  * @param {string[]} [opts.locales] Restrict to these locales.
  * @param {string[]} [opts.users] Restrict to these users.
  * @param {number} [opts.max] Bound the number of removals.
- * @param {string} [opts.self] Login of the runner; removed last per team.
+ * @param {string} [opts.self] Login of the runner; excluded unless selfToo.
+ * @param {boolean} [opts.selfToo] Also remove the runner, last per team.
  * @param {(msg: string) => void} [opts.log]
  * @returns {{ removals: { team: string, user: string, status: string }[],
  *   exitCode: number }}
@@ -100,6 +106,7 @@ export function runCleanup({
   users,
   max,
   self,
+  selfToo = false,
   log = () => {},
 }) {
   const rosters = new Map();
@@ -118,7 +125,7 @@ export function runCleanup({
     rosters.set(team, new Set(res.stdout.split('\n').filter(Boolean)));
   }
 
-  const planned = planRemovals(rosters, { locales, users, max, self });
+  const planned = planRemovals(rosters, { locales, users, max, self, selfToo });
   if (planned.length === 0) {
     log('Nothing to remove; all locale teams are already clean.');
     return { removals: [], exitCode: 0 };

--- a/scripts/gh/locale-team-cleanup/index.mjs
+++ b/scripts/gh/locale-team-cleanup/index.mjs
@@ -51,18 +51,24 @@ export function teamsInRemovalOrder(locales = LOCALES) {
  * @param {string[]} [filters.locales] Restrict to these locales.
  * @param {string[]} [filters.users] Restrict to these users.
  * @param {number} [filters.max] Bound the number of removals.
+ * @param {string} [filters.self] Login of the runner: removed last from each
+ *   team, since self-removal destroys the runner's team-maintainer role on
+ *   that team (which the other removals may depend on).
  * @returns {{ team: string, user: string }[]} In removal order.
  */
 export function planRemovals(rosters, filters = {}) {
-  const { locales, users, max = Infinity } = filters;
+  const { locales, users, max = Infinity, self } = filters;
+  const candidates = (users ?? DOCS_CORE).filter(
+    (u) => DOCS_CORE.includes(u) && u !== self,
+  );
+  if (self && (users ?? DOCS_CORE).includes(self)) candidates.push(self);
   const removals = [];
   for (const team of teamsInRemovalOrder(locales)) {
     const roster = rosters.get(team);
     if (!roster) continue;
     const locale = team.split('-')[1];
     const keep = new Set(KEEP[locale] ?? []);
-    for (const user of users ?? DOCS_CORE) {
-      if (!DOCS_CORE.includes(user)) continue;
+    for (const user of candidates) {
       if (removals.length >= max) return removals;
       if (roster.has(user) && !keep.has(user)) removals.push({ team, user });
     }
@@ -82,6 +88,7 @@ export function planRemovals(rosters, filters = {}) {
  * @param {string[]} [opts.locales] Restrict to these locales.
  * @param {string[]} [opts.users] Restrict to these users.
  * @param {number} [opts.max] Bound the number of removals.
+ * @param {string} [opts.self] Login of the runner; removed last per team.
  * @param {(msg: string) => void} [opts.log]
  * @returns {{ removals: { team: string, user: string, status: string }[],
  *   exitCode: number }}
@@ -92,6 +99,7 @@ export function runCleanup({
   locales,
   users,
   max,
+  self,
   log = () => {},
 }) {
   const rosters = new Map();
@@ -110,7 +118,7 @@ export function runCleanup({
     rosters.set(team, new Set(res.stdout.split('\n').filter(Boolean)));
   }
 
-  const planned = planRemovals(rosters, { locales, users, max });
+  const planned = planRemovals(rosters, { locales, users, max, self });
   if (planned.length === 0) {
     log('Nothing to remove; all locale teams are already clean.');
     return { removals: [], exitCode: 0 };

--- a/scripts/gh/locale-team-cleanup/index.mjs
+++ b/scripts/gh/locale-team-cleanup/index.mjs
@@ -1,0 +1,133 @@
+// Logic library for the locale team cleanup helper. See ./README.md for
+// context (opentelemetry.io#10374) and cautions. The orchestrator
+// (`runCleanup`) funnels every GitHub call through an injected `runGh` runner
+// so it stays unit-testable; ./cli.mjs wires in the real `gh`.
+
+export const ORG = 'open-telemetry';
+
+// Docs-core (docs-maintainers/approvers) members acting as interim locale
+// maintainers — the memberships to clean up.
+export const DOCS_CORE = [
+  'austinlparker',
+  'cartermp',
+  'chalin',
+  'jaydeluca',
+  'maryliag',
+  'svrnm',
+  'theletterf',
+  'tiffany76',
+  'vitorvasc',
+];
+
+// Locale -> docs-core members to KEEP: genuine locale reviewers (native
+// speakers) whose locale-team membership is honest, not interim.
+export const KEEP = {
+  fr: ['chalin'],
+  pt: ['maryliag', 'vitorvasc'],
+};
+
+export const LOCALES = ['bn', 'es', 'fr', 'ja', 'pl', 'pt', 'ro', 'uk', 'zh'];
+
+/**
+ * The teams to clean, in removal order: for each locale, the child team
+ * (maintainers) before its parent (approvers), since GitHub rosters include
+ * child-team members and removals must target the direct membership.
+ *
+ * @param {string[]} [locales]
+ * @returns {string[]} Team slugs.
+ */
+export function teamsInRemovalOrder(locales = LOCALES) {
+  return locales.flatMap((loc) => [
+    `docs-${loc}-maintainers`,
+    `docs-${loc}-approvers`,
+  ]);
+}
+
+/**
+ * Compute the memberships to remove, given live team rosters.
+ *
+ * @param {Map<string, Set<string>>} rosters Team slug -> member logins.
+ * @returns {{ team: string, user: string }[]} In removal order.
+ */
+export function planRemovals(rosters) {
+  const removals = [];
+  for (const team of teamsInRemovalOrder()) {
+    const roster = rosters.get(team);
+    if (!roster) continue;
+    const locale = team.split('-')[1];
+    const keep = new Set(KEEP[locale] ?? []);
+    for (const user of DOCS_CORE) {
+      if (roster.has(user) && !keep.has(user)) removals.push({ team, user });
+    }
+  }
+  return removals;
+}
+
+/**
+ * Fetch rosters, plan removals, and (unless dryRun) perform them.
+ *
+ * @param {Object} opts
+ * @param {(args: string[]) => { stdout: string, stderr?: string,
+ *   status: number }} opts.runGh Injected `gh` runner.
+ * @param {boolean} [opts.dryRun]
+ * @param {(msg: string) => void} [opts.log]
+ * @returns {{ removals: { team: string, user: string, status: string }[],
+ *   exitCode: number }}
+ */
+export function runCleanup({ runGh, dryRun = true, log = () => {} }) {
+  const rosters = new Map();
+  for (const team of teamsInRemovalOrder()) {
+    const res = runGh([
+      'api',
+      `/orgs/${ORG}/teams/${team}/members`,
+      '--paginate',
+      '-q',
+      '.[].login',
+    ]);
+    if (res.status !== 0) {
+      log(`ERROR: could not fetch roster for ${team}: ${res.stderr ?? ''}`);
+      return { removals: [], exitCode: 1 };
+    }
+    rosters.set(team, new Set(res.stdout.split('\n').filter(Boolean)));
+  }
+
+  const planned = planRemovals(rosters);
+  if (planned.length === 0) {
+    log('Nothing to remove; all locale teams are already clean.');
+    return { removals: [], exitCode: 0 };
+  }
+
+  let failures = 0;
+  const removals = planned.map(({ team, user }) => {
+    let status;
+    if (dryRun) {
+      status = 'would remove';
+    } else {
+      const res = runGh([
+        'api',
+        '-X',
+        'DELETE',
+        `/orgs/${ORG}/teams/${team}/memberships/${user}`,
+      ]);
+      if (res.status === 0) {
+        status = 'removed';
+      } else if ((res.stderr ?? '').includes('404')) {
+        // Not a direct member (e.g. only via the child team): skip.
+        status = 'skipped (not a direct member)';
+      } else {
+        status = `FAILED: ${(res.stderr ?? '').trim()}`;
+        failures++;
+      }
+    }
+    log(`${team}: ${user} — ${status}`);
+    return { team, user, status };
+  });
+
+  if (dryRun) {
+    log(
+      `\nDry run only: ${planned.length} removal(s) planned. ` +
+        `Pass --no-dry-run (-f) to perform them.`,
+    );
+  }
+  return { removals, exitCode: failures ? 1 : 0 };
+}

--- a/scripts/gh/locale-team-cleanup/index.mjs
+++ b/scripts/gh/locale-team-cleanup/index.mjs
@@ -47,16 +47,23 @@ export function teamsInRemovalOrder(locales = LOCALES) {
  * Compute the memberships to remove, given live team rosters.
  *
  * @param {Map<string, Set<string>>} rosters Team slug -> member logins.
+ * @param {Object} [filters]
+ * @param {string[]} [filters.locales] Restrict to these locales.
+ * @param {string[]} [filters.users] Restrict to these users.
+ * @param {number} [filters.max] Bound the number of removals.
  * @returns {{ team: string, user: string }[]} In removal order.
  */
-export function planRemovals(rosters) {
+export function planRemovals(rosters, filters = {}) {
+  const { locales, users, max = Infinity } = filters;
   const removals = [];
-  for (const team of teamsInRemovalOrder()) {
+  for (const team of teamsInRemovalOrder(locales)) {
     const roster = rosters.get(team);
     if (!roster) continue;
     const locale = team.split('-')[1];
     const keep = new Set(KEEP[locale] ?? []);
-    for (const user of DOCS_CORE) {
+    for (const user of users ?? DOCS_CORE) {
+      if (!DOCS_CORE.includes(user)) continue;
+      if (removals.length >= max) return removals;
       if (roster.has(user) && !keep.has(user)) removals.push({ team, user });
     }
   }
@@ -64,19 +71,31 @@ export function planRemovals(rosters) {
 }
 
 /**
- * Fetch rosters, plan removals, and (unless dryRun) perform them.
+ * Fetch rosters, plan removals, and (unless dryRun) perform them. The whole
+ * run is idempotent: it plans from live rosters, so re-running after a
+ * (partial) cleanup finds only what is still left to remove.
  *
  * @param {Object} opts
  * @param {(args: string[]) => { stdout: string, stderr?: string,
  *   status: number }} opts.runGh Injected `gh` runner.
  * @param {boolean} [opts.dryRun]
+ * @param {string[]} [opts.locales] Restrict to these locales.
+ * @param {string[]} [opts.users] Restrict to these users.
+ * @param {number} [opts.max] Bound the number of removals.
  * @param {(msg: string) => void} [opts.log]
  * @returns {{ removals: { team: string, user: string, status: string }[],
  *   exitCode: number }}
  */
-export function runCleanup({ runGh, dryRun = true, log = () => {} }) {
+export function runCleanup({
+  runGh,
+  dryRun = true,
+  locales,
+  users,
+  max,
+  log = () => {},
+}) {
   const rosters = new Map();
-  for (const team of teamsInRemovalOrder()) {
+  for (const team of teamsInRemovalOrder(locales)) {
     const res = runGh([
       'api',
       `/orgs/${ORG}/teams/${team}/members`,
@@ -91,7 +110,7 @@ export function runCleanup({ runGh, dryRun = true, log = () => {} }) {
     rosters.set(team, new Set(res.stdout.split('\n').filter(Boolean)));
   }
 
-  const planned = planRemovals(rosters);
+  const planned = planRemovals(rosters, { locales, users, max });
   if (planned.length === 0) {
     log('Nothing to remove; all locale teams are already clean.');
     return { removals: [], exitCode: 0 };

--- a/scripts/gh/locale-team-cleanup/index.test.mjs
+++ b/scripts/gh/locale-team-cleanup/index.test.mjs
@@ -24,8 +24,8 @@ describe('locale-team-cleanup: planRemovals', () => {
     ]);
     const removals = planRemovals(rosters);
     assert.deepEqual(removals, [
-      { team: 'docs-ja-maintainers', user: 'chalin' },
-      { team: 'docs-ja-maintainers', user: 'svrnm' },
+      { team: 'docs-ja-maintainers', user: 'chalin', self: false },
+      { team: 'docs-ja-maintainers', user: 'svrnm', self: false },
     ]);
   });
 
@@ -48,7 +48,7 @@ describe('locale-team-cleanup: planRemovals', () => {
       ['docs-ro-approvers', new Set(['chalin'])],
     ]);
     assert.deepEqual(planRemovals(rosters), [
-      { team: 'docs-ro-approvers', user: 'chalin' },
+      { team: 'docs-ro-approvers', user: 'chalin', self: false },
     ]);
   });
 
@@ -64,7 +64,7 @@ describe('locale-team-cleanup: planRemovals', () => {
       ['docs-ja-maintainers', new Set(['cartermp'])],
     ]);
     assert.deepEqual(planRemovals(rosters, { locales: ['bn'] }), [
-      { team: 'docs-bn-maintainers', user: 'cartermp' },
+      { team: 'docs-bn-maintainers', user: 'cartermp', self: false },
     ]);
   });
 
@@ -74,7 +74,7 @@ describe('locale-team-cleanup: planRemovals', () => {
     ]);
     assert.deepEqual(
       planRemovals(rosters, { users: ['cartermp', 'badhon495'] }),
-      [{ team: 'docs-bn-maintainers', user: 'cartermp' }],
+      [{ team: 'docs-bn-maintainers', user: 'cartermp', self: false }],
     );
   });
 
@@ -89,30 +89,20 @@ describe('locale-team-cleanup: planRemovals', () => {
     assert.deepEqual(removals[0].team, 'docs-bn-maintainers');
   });
 
-  test('self is excluded by default', () => {
-    const rosters = new Map([
-      ['docs-bn-maintainers', new Set(['chalin', 'svrnm'])],
-    ]);
-    assert.deepEqual(planRemovals(rosters, { self: 'chalin' }), [
-      { team: 'docs-bn-maintainers', user: 'svrnm' },
-    ]);
-  });
-
-  test('with selfToo, self is removed last from each team', () => {
+  test('self is planned last per team and flagged', () => {
     const rosters = new Map([
       ['docs-bn-maintainers', new Set(['chalin', 'svrnm', 'tiffany76'])],
       ['docs-bn-approvers', new Set(['chalin', 'austinlparker'])],
     ]);
-    const removals = planRemovals(rosters, {
-      self: 'chalin',
-      selfToo: true,
-    }).map((r) => `${r.team}:${r.user}`);
+    const removals = planRemovals(rosters, { self: 'chalin' }).map(
+      (r) => `${r.team}:${r.user}:${r.self}`,
+    );
     assert.deepEqual(removals, [
-      'docs-bn-maintainers:svrnm',
-      'docs-bn-maintainers:tiffany76',
-      'docs-bn-maintainers:chalin',
-      'docs-bn-approvers:austinlparker',
-      'docs-bn-approvers:chalin',
+      'docs-bn-maintainers:svrnm:false',
+      'docs-bn-maintainers:tiffany76:false',
+      'docs-bn-maintainers:chalin:true',
+      'docs-bn-approvers:austinlparker:false',
+      'docs-bn-approvers:chalin:true',
     ]);
   });
 });
@@ -191,6 +181,37 @@ describe('locale-team-cleanup: runCleanup', () => {
     });
     assert.equal(r.exitCode, 1);
     assert.deepEqual(r.removals, []);
+  });
+
+  test('self is listed but skipped by default; no DELETE issued', () => {
+    const calls = [];
+    const r = runCleanup({
+      runGh: makeRunGh({ rosters, calls }),
+      dryRun: false,
+      self: 'chalin',
+    });
+    assert.equal(r.exitCode, 0);
+    assert.deepEqual(
+      r.removals.map((x) => `${x.team}:${x.user}:${x.status}`),
+      [
+        'docs-ja-maintainers:chalin:skipped (runner; pass --self-too to remove)',
+        'docs-ja-approvers:chalin:skipped (runner; pass --self-too to remove)',
+      ],
+    );
+    assert.ok(!calls.some((a) => a.includes('DELETE')));
+  });
+
+  test('with selfToo, self is removed', () => {
+    const calls = [];
+    const r = runCleanup({
+      runGh: makeRunGh({ rosters, calls }),
+      dryRun: false,
+      self: 'chalin',
+      selfToo: true,
+    });
+    assert.equal(r.exitCode, 0);
+    assert.ok(r.removals.every((x) => x.status === 'removed'));
+    assert.equal(calls.filter((a) => a.includes('DELETE')).length, 2);
   });
 
   test('locales filter limits roster fetches and removals', () => {

--- a/scripts/gh/locale-team-cleanup/index.test.mjs
+++ b/scripts/gh/locale-team-cleanup/index.test.mjs
@@ -88,6 +88,23 @@ describe('locale-team-cleanup: planRemovals', () => {
     // Removal order is preserved: child team is exhausted first.
     assert.deepEqual(removals[0].team, 'docs-bn-maintainers');
   });
+
+  test('self is removed last from each team', () => {
+    const rosters = new Map([
+      ['docs-bn-maintainers', new Set(['chalin', 'svrnm', 'tiffany76'])],
+      ['docs-bn-approvers', new Set(['chalin', 'austinlparker'])],
+    ]);
+    const removals = planRemovals(rosters, { self: 'chalin' }).map(
+      (r) => `${r.team}:${r.user}`,
+    );
+    assert.deepEqual(removals, [
+      'docs-bn-maintainers:svrnm',
+      'docs-bn-maintainers:tiffany76',
+      'docs-bn-maintainers:chalin',
+      'docs-bn-approvers:austinlparker',
+      'docs-bn-approvers:chalin',
+    ]);
+  });
 });
 
 // Fake gh: returns canned rosters; records DELETE calls.

--- a/scripts/gh/locale-team-cleanup/index.test.mjs
+++ b/scripts/gh/locale-team-cleanup/index.test.mjs
@@ -89,14 +89,24 @@ describe('locale-team-cleanup: planRemovals', () => {
     assert.deepEqual(removals[0].team, 'docs-bn-maintainers');
   });
 
-  test('self is removed last from each team', () => {
+  test('self is excluded by default', () => {
+    const rosters = new Map([
+      ['docs-bn-maintainers', new Set(['chalin', 'svrnm'])],
+    ]);
+    assert.deepEqual(planRemovals(rosters, { self: 'chalin' }), [
+      { team: 'docs-bn-maintainers', user: 'svrnm' },
+    ]);
+  });
+
+  test('with selfToo, self is removed last from each team', () => {
     const rosters = new Map([
       ['docs-bn-maintainers', new Set(['chalin', 'svrnm', 'tiffany76'])],
       ['docs-bn-approvers', new Set(['chalin', 'austinlparker'])],
     ]);
-    const removals = planRemovals(rosters, { self: 'chalin' }).map(
-      (r) => `${r.team}:${r.user}`,
-    );
+    const removals = planRemovals(rosters, {
+      self: 'chalin',
+      selfToo: true,
+    }).map((r) => `${r.team}:${r.user}`);
     assert.deepEqual(removals, [
       'docs-bn-maintainers:svrnm',
       'docs-bn-maintainers:tiffany76',

--- a/scripts/gh/locale-team-cleanup/index.test.mjs
+++ b/scripts/gh/locale-team-cleanup/index.test.mjs
@@ -1,0 +1,147 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  DOCS_CORE,
+  KEEP,
+  ORG,
+  planRemovals,
+  runCleanup,
+  teamsInRemovalOrder,
+} from './index.mjs';
+
+describe('locale-team-cleanup: teamsInRemovalOrder', () => {
+  test('lists child (maintainers) before parent (approvers) per locale', () => {
+    const teams = teamsInRemovalOrder(['ja']);
+    assert.deepEqual(teams, ['docs-ja-maintainers', 'docs-ja-approvers']);
+  });
+});
+
+describe('locale-team-cleanup: planRemovals', () => {
+  test('removes docs-core members, keeps locale members', () => {
+    const rosters = new Map([
+      ['docs-ja-maintainers', new Set(['chalin', 'svrnm', 'katzchang'])],
+    ]);
+    const removals = planRemovals(rosters);
+    assert.deepEqual(removals, [
+      { team: 'docs-ja-maintainers', user: 'chalin' },
+      { team: 'docs-ja-maintainers', user: 'svrnm' },
+    ]);
+  });
+
+  test('honors per-locale KEEP exceptions', () => {
+    const rosters = new Map([
+      ['docs-fr-maintainers', new Set(['chalin', 'svrnm', 'marcalff'])],
+      ['docs-pt-approvers', new Set(['maryliag', 'vitorvasc', 'cartermp'])],
+    ]);
+    const users = planRemovals(rosters).map((r) => `${r.team}:${r.user}`);
+    assert.deepEqual(users, [
+      'docs-fr-maintainers:svrnm',
+      'docs-pt-approvers:cartermp',
+    ]);
+  });
+
+  test('keeps KEEP scoped to its locale', () => {
+    // chalin is kept in fr but still removed elsewhere.
+    const rosters = new Map([
+      ['docs-fr-approvers', new Set(['chalin'])],
+      ['docs-ro-approvers', new Set(['chalin'])],
+    ]);
+    assert.deepEqual(planRemovals(rosters), [
+      { team: 'docs-ro-approvers', user: 'chalin' },
+    ]);
+  });
+
+  test('skips teams with no roster and returns empty for clean rosters', () => {
+    assert.deepEqual(planRemovals(new Map()), []);
+    const clean = new Map([['docs-ja-maintainers', new Set(['katzchang'])]]);
+    assert.deepEqual(planRemovals(clean), []);
+  });
+});
+
+// Fake gh: returns canned rosters; records DELETE calls.
+function makeRunGh({ rosters, deleteStatus = () => 0, calls }) {
+  return (args) => {
+    calls.push(args);
+    if (args[0] === 'api' && args[1] === '-X' && args[2] === 'DELETE') {
+      const status = deleteStatus(args[3]);
+      return {
+        stdout: '',
+        stderr: status === 0 ? '' : 'HTTP 404: Not Found',
+        status,
+      };
+    }
+    const m = args[1]?.match(/teams\/([^/]+)\/members/);
+    const roster = (m && rosters[m[1]]) ?? [];
+    return { stdout: roster.join('\n'), stderr: '', status: 0 };
+  };
+}
+
+describe('locale-team-cleanup: runCleanup', () => {
+  const rosters = {
+    'docs-ja-maintainers': ['chalin', 'katzchang'],
+    'docs-ja-approvers': ['chalin', 'katzchang', 'kohbis'],
+  };
+
+  test('dry run plans removals but issues no DELETE', () => {
+    const calls = [];
+    const r = runCleanup({ runGh: makeRunGh({ rosters, calls }) });
+    assert.equal(r.exitCode, 0);
+    assert.deepEqual(
+      r.removals.map((x) => `${x.team}:${x.user}:${x.status}`),
+      [
+        'docs-ja-maintainers:chalin:would remove',
+        'docs-ja-approvers:chalin:would remove',
+      ],
+    );
+    assert.ok(!calls.some((a) => a.includes('DELETE')));
+  });
+
+  test('apply issues DELETE per planned removal, child team first', () => {
+    const calls = [];
+    const r = runCleanup({
+      runGh: makeRunGh({ rosters, calls }),
+      dryRun: false,
+    });
+    assert.equal(r.exitCode, 0);
+    const deletes = calls.filter((a) => a.includes('DELETE')).map((a) => a[3]);
+    assert.deepEqual(deletes, [
+      `/orgs/${ORG}/teams/docs-ja-maintainers/memberships/chalin`,
+      `/orgs/${ORG}/teams/docs-ja-approvers/memberships/chalin`,
+    ]);
+  });
+
+  test('404 on DELETE is a skip, not a failure', () => {
+    const calls = [];
+    const r = runCleanup({
+      runGh: makeRunGh({ rosters, deleteStatus: () => 1, calls }),
+      dryRun: false,
+    });
+    assert.equal(r.exitCode, 0);
+    assert.ok(
+      r.removals.every((x) => x.status === 'skipped (not a direct member)'),
+    );
+  });
+
+  test('roster fetch failure aborts with exit 1', () => {
+    const calls = [];
+    const r = runCleanup({
+      runGh: (args) => {
+        calls.push(args);
+        return { stdout: '', stderr: 'boom', status: 1 };
+      },
+    });
+    assert.equal(r.exitCode, 1);
+    assert.deepEqual(r.removals, []);
+  });
+});
+
+describe('locale-team-cleanup: config sanity', () => {
+  test('KEEP names are docs-core members', () => {
+    for (const users of Object.values(KEEP)) {
+      for (const u of users) {
+        assert.ok(DOCS_CORE.includes(u), `${u} should be in DOCS_CORE`);
+      }
+    }
+  });
+});

--- a/scripts/gh/locale-team-cleanup/index.test.mjs
+++ b/scripts/gh/locale-team-cleanup/index.test.mjs
@@ -57,6 +57,37 @@ describe('locale-team-cleanup: planRemovals', () => {
     const clean = new Map([['docs-ja-maintainers', new Set(['katzchang'])]]);
     assert.deepEqual(planRemovals(clean), []);
   });
+
+  test('locales filter restricts the teams considered', () => {
+    const rosters = new Map([
+      ['docs-bn-maintainers', new Set(['cartermp'])],
+      ['docs-ja-maintainers', new Set(['cartermp'])],
+    ]);
+    assert.deepEqual(planRemovals(rosters, { locales: ['bn'] }), [
+      { team: 'docs-bn-maintainers', user: 'cartermp' },
+    ]);
+  });
+
+  test('users filter restricts who is removed; non-docs-core ignored', () => {
+    const rosters = new Map([
+      ['docs-bn-maintainers', new Set(['cartermp', 'svrnm', 'badhon495'])],
+    ]);
+    assert.deepEqual(
+      planRemovals(rosters, { users: ['cartermp', 'badhon495'] }),
+      [{ team: 'docs-bn-maintainers', user: 'cartermp' }],
+    );
+  });
+
+  test('max bounds the number of planned removals', () => {
+    const rosters = new Map([
+      ['docs-bn-maintainers', new Set(['cartermp', 'svrnm'])],
+      ['docs-bn-approvers', new Set(['cartermp', 'svrnm'])],
+    ]);
+    const removals = planRemovals(rosters, { max: 3 });
+    assert.equal(removals.length, 3);
+    // Removal order is preserved: child team is exhausted first.
+    assert.deepEqual(removals[0].team, 'docs-bn-maintainers');
+  });
 });
 
 // Fake gh: returns canned rosters; records DELETE calls.
@@ -133,6 +164,25 @@ describe('locale-team-cleanup: runCleanup', () => {
     });
     assert.equal(r.exitCode, 1);
     assert.deepEqual(r.removals, []);
+  });
+
+  test('locales filter limits roster fetches and removals', () => {
+    const calls = [];
+    const r = runCleanup({
+      runGh: makeRunGh({ rosters, calls }),
+      dryRun: false,
+      locales: ['ja'],
+      users: ['chalin'],
+      max: 1,
+    });
+    assert.equal(r.exitCode, 0);
+    // Only the two ja teams fetched, single removal due to max.
+    const fetches = calls.filter((a) => !a.includes('DELETE'));
+    assert.equal(fetches.length, 2);
+    assert.deepEqual(
+      r.removals.map((x) => `${x.team}:${x.user}:${x.status}`),
+      ['docs-ja-maintainers:chalin:removed'],
+    );
   });
 });
 


### PR DESCRIPTION
- Contributes to #10374

**Locale team cleanup helper** (`scripts/gh/locale-team-cleanup/`):

- New admin helper that removes interim docs-core members from `docs-<loc>-*` locale teams, keeping genuine locale reviewers (chalin: fr; maryliag, vitorvasc: pt).
- Dry run by default; `--no-dry-run` (`-f`) performs the removals.
- Idempotent: plans from live rosters, so re-running after a (partial) cleanup only removes what is left.
- Scoping options for bounded or smoke-test runs: `-l/--locale`, `-u/--user` (repeatable, validated), `--max <n>`.
- Per-`gh`-call timeout (default 10s, `--timeout <s>`), since `gh api` can occasionally stall; typical calls complete in 0.2-0.4s.
- Removes from the child team (`-maintainers`) before its parent (`-approvers`); a DELETE 404 (not a direct member) is a skip, not a failure.
- The runner's own memberships are listed but skipped by default (`--self-too` opts in, removing them last from each team): self-removal destroys the runner's team-maintainer role, which the remaining removals depend on, and cannot be undone by the runner.
- Adds the `locale-team-cleanup` npm script.

**Permissions** (verified live, 2026-06-12): a runner who is a team maintainer of the targeted teams can both remove and re-add members (round-trip tested on `docs-bn-maintainers`); org-owner privileges are not required. README cautions document this.

### Tests

- [x] `node --test scripts/gh/locale-team-cleanup/*.test.mjs`: 17/17 pass
- [x] `npm run test:local-tools`: full suite passes
- [x] Live runs: cleanup applied to bn, es, ja, pl, pt, ro, zh (KEEPs honored; fr already clean); uk pending a team-maintainer role for the runner
