### PR TITLE
[CI] Allow empty commit to bootstrap integration-branch PR creation

### DIFF
--- a/.github/workflows/update-semconv-integration-branch.yml
+++ b/.github/workflows/update-semconv-integration-branch.yml
@@ -120,6 +120,13 @@ jobs:
         run: |
           prs=$(gh pr list --state open --head $BRANCH)
           if [ -z "$prs" ]; then
+            if [ -z "$(git rev-list origin/main..HEAD)" ]; then
+              # Bootstrap this long-lived integration branch with an empty
+              # commit so that PR creation succeeds (gh pr create fails when
+              # there are no commits between main and the branch).
+              git commit --allow-empty -m "Trigger PR creation for $BRANCH"
+              git push
+            fi
             gh pr create --title "DRAFT Update ${{ env.REPO }} to unreleased $VERSION-dev" \
                          --body "This is a draft PR used for identifying issues integrating the latest (unreleased) [${{ env.REPO }}](https://github.com/open-telemetry/${{ env.REPO }})." \
                          --draft

--- a/.github/workflows/update-spec-integration-branch.yml
+++ b/.github/workflows/update-spec-integration-branch.yml
@@ -117,6 +117,13 @@ jobs:
         run: |
           prs=$(gh pr list --state open --head $BRANCH)
           if [ -z "$prs" ]; then
+            if [ -z "$(git rev-list origin/main..HEAD)" ]; then
+              # Bootstrap this long-lived integration branch with an empty
+              # commit so that PR creation succeeds (gh pr create fails when
+              # there are no commits between main and the branch).
+              git commit --allow-empty -m "Trigger PR creation for $BRANCH"
+              git push
+            fi
             gh pr create --title "DRAFT Update ${{ env.REPO }} to unreleased $VERSION-dev" \
                          --body "This is a draft PR used for identifying issues integrating the latest (unreleased) [${{ env.REPO }}](https://github.com/open-telemetry/${{ env.REPO }})." \
                          --draft


### PR DESCRIPTION
- Another integration workflow failure, see https://github.com/open-telemetry/opentelemetry.io/actions/runs/27448997445/job/81140164981
- Fixes #8167
- Closes #8872 by superseding it
- `gh pr create` fails with `No commits between main and <branch>` when an integration branch is in sync with `main`; this PR bootstraps the long-lived branch with an empty commit in that case, so PR creation always succeeds
- Applies the fix to both the spec and semconv integration-branch workflows