### PR TITLE
[ja] update translation of content/en/docs/zero-code/java/_index.md

### DIFF
--- a/content/ja/docs/zero-code/java/_index.md
+++ b/content/ja/docs/zero-code/java/_index.md
@@ -7,10 +7,9 @@ aliases:
 cascade:
   vers:
     instrumentation: 2.28.1
-    otel: 1.62.0
+    otel: 1.63.0
     contrib: 1.54.0
-default_lang_commit: c1e141558ab36cc1ab9f864728e4665e272ac131
-drifted_from_default: true
+default_lang_commit: 8530cdc7afd7f1432fb1749af74f46686fc5c40a
 ---
 
 Javaでゼロコード計装を行う一般的なオプションには、Java エージェント JAR、Spring Boot Starter、Quarkus OpenTelemetry Extension があります。


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/java/_index.md` to match the latest English source at
`content/en/docs/zero-code/java/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English change was a single version bump in `cascade.vers.otel` from `1.62.0` to `1.63.0`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10397--opentelemetry.netlify.app/ja/docs/zero-code/java/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/java/

<!-- preview-section-end -->
