### PR TITLE
[ja] update translation of content/en/docs/getting-started/dev.md

### DIFF
--- a/content/ja/docs/getting-started/dev.md
+++ b/content/ja/docs/getting-started/dev.md
@@ -1,8 +1,7 @@
 ---
 title: 開発者のための入門
 linkTitle: Dev
-default_lang_commit: 548e5e29f574fddc3ca683989a458e9a6800242f
-drifted_from_default: true
+default_lang_commit: 94f3816a5eadb63c7ac0309fe5aac6552abec12a
 ---
 
 あなたが以下のいずれかに当てはまれば、このページはあなたのための[入門](..)ページです。


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/getting-started/dev.md` to match the latest English source at
`content/en/docs/getting-started/dev.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff was a single-word grammatical fix (`documentations` → `documentation`).
The existing Japanese translation already used `ドキュメント` (correct singular form),
so no body-text change was necessary — only the frontmatter bookkeeping is updated.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10402--opentelemetry.netlify.app/ja/docs/getting-started/dev/
- **English (canonical):** https://opentelemetry.io/docs/getting-started/dev/

_(deploy preview may take a few minutes to build.)_
<!-- preview-section-end -->
