### PR TITLE
[ja] update translation of content/en/docs/contributing/sig-practices.md

### DIFF
--- a/content/ja/docs/contributing/sig-practices.md
+++ b/content/ja/docs/contributing/sig-practices.md
@@ -3,8 +3,7 @@ title: 承認者およびメンテナーのための SIG のプラクティス
 linkTitle: SIG のプラクティス
 description: 承認者およびメンテナーがどのようにイシューやコントリビューションを管理するかを学びます。
 weight: 999
-default_lang_commit: bb20a7fb593782fea0e05e988d1478831726f9f5
-drifted_from_default: true
+default_lang_commit: 94f3816a5eadb63c7ac0309fe5aac6552abec12a
 cSpell:ignore: Comms contribfest
 ---
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/contributing/sig-practices.md` to match the latest English source at
`content/en/docs/contributing/sig-practices.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff since the last sync was a single typo fix (`move an the issue` → `move the issue`).
The existing Japanese translation already conveyed the correct meaning (`イシューを "discussions" に移動します`),
so no prose changes were needed — only the frontmatter bookkeeping was updated.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10403--opentelemetry.netlify.app/ja/docs/contributing/sig-practices/
- **English (canonical):** https://opentelemetry.io/docs/contributing/sig-practices/

<!-- preview-section-end -->
