### PR TITLE
i18n: resolve shortcode URLs via render-link

### DIFF
--- a/layouts/_partials/func/render-link-href.html
+++ b/layouts/_partials/func/render-link-href.html
@@ -1,0 +1,2 @@
+{{- $anchor := partial "hooks/render-link.html" (dict "ctx" .) -}}
+{{- replaceRE `(?s).*href="([^"]+)".*` "$1" $anchor -}}

--- a/layouts/_shortcodes/homepage/adopters-showcase.html
+++ b/layouts/_shortcodes/homepage/adopters-showcase.html
@@ -18,7 +18,12 @@
       {{ end }}
       <div class="adopters-showcase__grid">
         {{- range first (int $limit) $sortedAdopters -}}
-        {{- $linkUrl := .reference | default .url -}}
+        {{ $linkUrl := .reference | default .url -}}
+        {{ $linkUrl = partial "func/render-link-href.html" (dict
+              "Destination" $linkUrl
+              "PageInner" $.Page
+              "Text" .name)
+        -}}
         <a href="{{ $linkUrl }}" class="adopters-showcase__item{{ if not .logo }} adopters-showcase__item--text{{ end }}" target="_blank" rel="noopener" title="{{ .name }}{{ if .reference }} - {{ .referenceTitle }}{{ end }}">
           {{- if .logo -}}
           <img src="{{ .logo }}" alt="{{ .name }} logo" loading="lazy">
@@ -30,10 +35,14 @@
       </div>
       {{- if $showCta }}
       <div class="adopters-showcase__cta">
+        {{ $ctaUrl = partial "func/render-link-href.html" (dict
+              "Destination" $ctaUrl
+              "PageInner" .Page
+              "Text" $ctaText)
+        -}}
         <a href="{{ $ctaUrl }}" class="btn btn-primary">{{ $ctaText }} →</a>
       </div>
       {{- end }}
     </div>
   </div>
 </section>
-

--- a/layouts/_shortcodes/homepage/ecosystem-stats.html
+++ b/layouts/_shortcodes/homepage/ecosystem-stats.html
@@ -12,4 +12,3 @@
     </div>
   </div>
 </section>
-

--- a/layouts/_shortcodes/homepage/hero-search.html
+++ b/layouts/_shortcodes/homepage/hero-search.html
@@ -24,4 +24,3 @@
     </div>
   </div>
 </section>
-

--- a/layouts/_shortcodes/homepage/otel-feature.html
+++ b/layouts/_shortcodes/homepage/otel-feature.html
@@ -3,6 +3,13 @@
 {{ $title := .Get "title" -}}
 {{ $url := .Get "url" -}}
 
+{{ $anchor := partial "hooks/render-link.html" (dict
+    "ctx" (dict
+      "Destination" $url
+      "PageInner" .Page
+      "Text" $title))
+-}}
+
 <div class="otel-feature">
   {{- if $image -}}
   <div class="otel-feature__icon">
@@ -21,12 +28,9 @@
   </div>
   {{- end -}}
   <h3 class="otel-feature__title">
-    {{- with $url }}<a href="{{ . }}">{{ end -}}
-    {{ $title }}
-    {{- with $url }}</a>{{ end -}}
+    {{- $anchor -}}
   </h3>
   <div class="otel-feature__description">
     {{ .Inner | .Page.RenderString }}
   </div>
 </div>
-

--- a/layouts/_shortcodes/homepage/otel-features.html
+++ b/layouts/_shortcodes/homepage/otel-features.html
@@ -16,4 +16,3 @@
     </div>
   </div>
 </section>
-

--- a/layouts/_shortcodes/homepage/signal.html
+++ b/layouts/_shortcodes/homepage/signal.html
@@ -3,6 +3,12 @@
 {{ $image := .Get "image" -}}
 {{ $url := .Get "url" -}}
 
+{{ $url = partial "func/render-link-href.html" (dict
+    "Destination" $url
+    "PageInner" .Page
+    "Text" $name)
+-}}
+
 <a href="{{ $url }}" class="signal-card">
   <div class="signal-card__icon">
     {{- if $image -}}

--- a/layouts/_shortcodes/homepage/stat.html
+++ b/layouts/_shortcodes/homepage/stat.html
@@ -30,12 +30,16 @@
   {{- end -}}
 {{- end -}}
 
+{{ $anchor := partial "hooks/render-link.html" (dict
+    "ctx" (dict
+      "Destination" $url
+      "PageInner" .Page
+      "Text" $number))
+-}}
+
 <div class="ecosystem-stat">
   <div class="ecosystem-stat__number">
-    {{- with $url }}<a href="{{ . }}">{{ end -}}
-    {{ $number }}
-    {{- with $url }}</a>{{ end -}}
+    {{- $anchor -}}
   </div>
   <div class="ecosystem-stat__label">{{ $label }}</div>
 </div>
-


### PR DESCRIPTION
- Fixes #10411
- Updates `signal`, `otel-feature`, `stat`, and `adopters-showcase` shortcodes to use render-link (or the new partial) for link targets.
- Ensures absolute `url`/`ctaUrl` params on localized homepages resolve to locale-aware targets instead of raw paths.
- Adds `render-link-href` partial to extract an `href` from the shared render-link hook.

---

Fixes links look like this:

```console
$ (cd public && git diff -bw --ignore-blank-lines -- ':(exclude)*.xml')  
```
```diff
diff --git a/es/index.html b/es/index.html
index 287b99a830..e212d69893 100644
--- a/es/index.html
+++ b/es/index.html
@@ -372,7 +372,7 @@ donde sea más conveniente.</p>
       
       <div class="signals-showcase__grid">
         
-<a href="/docs/concepts/signals/traces/" class="signal-card">
+<a href="/es/docs/concepts/signals/traces/" class="signal-card">
   <div class="signal-card__icon"><img src="/img/homepage/signal-traces.svg" alt="Trazas" class="signal-card__img"></div>
   <div class="signal-card__name">Trazas</div>
   
@@ -380,7 +380,7 @@ donde sea más conveniente.</p>
   
 </a>
 
-<a href="/docs/concepts/signals/metrics/" class="signal-card">
+<a href="/es/docs/concepts/signals/metrics/" class="signal-card">
   <div class="signal-card__icon"><img src="/img/homepage/signal-metrics.svg" alt="Métricas" class="signal-card__img"></div>
   <div class="signal-card__name">Métricas</div>
   
@@ -388,7 +388,7 @@ donde sea más conveniente.</p>
   
 </a>
 
-<a href="/docs/concepts/signals/logs/" class="signal-card">
+<a href="/es/docs/concepts/signals/logs/" class="signal-card">
   <div class="signal-card__icon"><img src="/img/homepage/signal-logs.svg" alt="Logs" class="signal-card__img"></div>
   <div class="signal-card__name">Logs</div>
   
@@ -396,7 +396,7 @@ donde sea más conveniente.</p>
   
 </a>
...
```

If we ignore the path fixes, nothing else has changed, and link checking passes:

```console
$ npm run check:links
...
htmltest started at 06:35:58 on public
========================================================================
running in concurrent mode, this is experimental
✔✔✔ passed in 1m33.05771375s
tested 4521 documents
...
$ (cd public && git diff -bw --ignore-blank-lines -I 'href="(/..)?/(docs|ecosystem|status)/' -- ':(exclude)*.xml')
```
```diff
diff --git a/site/index.html b/site/index.html
index 659310c624..3367af7148 100644
--- a/site/index.html
+++ b/site/index.html
@@ -453,7 +453,7 @@ design/implementation decisions.</li>
 <script>
 document.addEventListener("DOMContentLoaded", function() {
   var options = { hour: '2-digit', hour12: false, minute: '2-digit', timeZoneName: 'short' };
-  var buildDate = new Date("2026-06-14T09:39:13-04:00");
+  var buildDate = new Date("2026-06-14T18:35:51-04:00");
   document.getElementById("local-time").innerText = buildDate.toLocaleString(undefined, options);
 });
 </script>
diff --git a/site/index.md b/site/index.md
index 58cb27612b..1f5c310f95 100644
--- a/site/index.md
+++ b/site/index.md
@@ -62,7 +62,7 @@ Deploy context | local
 <script>
 document.addEventListener("DOMContentLoaded", function() {
   var options = { hour: '2-digit', hour12: false, minute: '2-digit', timeZoneName: 'short' };
-  var buildDate = new Date("2026-06-14T09:39:14-04:00");
+  var buildDate = new Date("2026-06-14T18:35:52-04:00");
   document.getElementById("local-time").innerText = buildDate.toLocaleString(undefined, options);
 });
 </script>
```

