### PR TITLE
[ja] update translation of content/en/blog/2025/kubecon-japan.md

### DIFF
--- a/content/ja/blog/2025/kubecon-japan.md
+++ b/content/ja/blog/2025/kubecon-japan.md
@@ -4,8 +4,7 @@ title: KubeCon + CloudNativeCon Japan 2025で、
 linkTitle: KubeCon Japan '25
 date: 2025-05-29
 author: '[Tiffany Hrabusa](https://github.com/tiffany76) (Grafana Labs)'
-default_lang_commit: 1f686d5f7b6bbdfaa30dafdc6ca0214c6f2308db
-drifted_from_default: true
+default_lang_commit: 3ec94f5792017e362e35b772e882525bcb7a032a
 # prettier-ignore
 cSpell:ignore: Baazi Chauhan Kang Kasper Mostafa Nissen Radwan Shivay Siddharth Vijay
 ---


### PR DESCRIPTION
## Summary

Updates `content/ja/blog/2025/kubecon-japan.md` to match the latest English source at
`content/en/blog/2025/kubecon-japan.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The only English-side change since the last sync was the removal of `Hrabusa` from the
`cSpell:ignore` frontmatter list; the Japanese file already did not include that word, so
the sole edit in this PR is the i18n bookkeeping update (`default_lang_commit` + removal of
`drifted_from_default: true`).

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10424--opentelemetry.netlify.app/ja/blog/2025/kubecon-japan/
- **English (canonical):** https://opentelemetry.io/blog/2025/kubecon-japan/

_(deploy preview may still be building)_
<!-- preview-section-end -->
