### PR TITLE
docs: update Yoshi Yamaguchi's affiliation to Grafana Labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ These are the members of [@open-telemetry/docs-triagers][]:
 - [Ezzio Moreira](https://github.com/EzzioMoreira)
 - [Michael Yao](https://github.com/windsonsea), DaoCloud
 - [Pratik Mahalle](https://github.com/pratik-mahalle), DrDroid
-- [Yoshi Yamaguchi](https://github.com/ymotongpoo), AWS
+- [Yoshi Yamaguchi](https://github.com/ymotongpoo), Grafana Labs
 
 For more information about the triager role, see the
 [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#triager).


### PR DESCRIPTION
Updates my (Yoshi Yamaguchi) company affiliation in the triagers list from AWS to Grafana Labs, reflecting my current employer.