### PR TITLE
[ja] update translation of content/en/docs/zero-code/obi/setup/docker.md

### DIFF
--- a/content/ja/docs/zero-code/obi/setup/docker.md
+++ b/content/ja/docs/zero-code/obi/setup/docker.md
@@ -2,18 +2,24 @@
 title: DockerコンテナとしてOBIを実行する
 linkTitle: Docker
 description: OBIをDockerコンテナとしてセットアップして実行し、別のコンテナを計装する方法を学びます。
-weight: 2
-default_lang_commit: a4915a1d38456fa5abb367c96a23dd202bc856bf
-drifted_from_default: true
+weight: 3
+default_lang_commit: 331c76c3500213c83ace2e30a407218ddedda628
 cSpell:ignore: goblog
 ---
 
 OBIは、スタンドアロンのDockerコンテナとして実行し、別のコンテナで実行されているプロセスを計装できます。
 
-OBIの最新イメージは、[Docker Hub](https://hub.docker.com/r/otel/ebpf-instrument)で次の名前で見つけられます。
+OBIのコンテナイメージは、以下の両方のレジストリに公開されています。
+
+- [Docker Hub](https://hub.docker.com/r/otel/ebpf-instrument):
+  `otel/ebpf-instrument:v<version>`
+- [GHCR](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkgs/container/opentelemetry-ebpf-instrumentation%2Febpf-instrument):
+  `ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument:v<version>`
+
+開発タグは Docker Hub にも以下の名前で公開されています。
 
 ```text
-ebpf-instrument:main
+otel/ebpf-instrument:main
 ```
 
 OBIコンテナは、次のように構成する必要があります。
@@ -21,12 +27,49 @@ OBIコンテナは、次のように構成する必要があります。
 - **特権**コンテナとして実行するか、`SYS_ADMIN` ケーパビリティを持つコンテナとして実行します(ただし、この最後のオプションは一部のコンテナ環境では機能しない場合があります)。
 - `host` PID名前空間を使用して、他のコンテナ内のプロセスにアクセスできるようにします。
 
+## イメージの署名と検証 {#image-signing-and-verification}
+
+OBIコンテナイメージは、GitHub Actions の OIDC（OpenID Connect）プロトコルで認証されたエフェメラルキーを使用して、[Cosign](https://docs.sigstore.dev/cosign/signing/overview/) で署名されています。
+これにより、OpenTelemetry プロジェクトが公開したコンテナの真正性と完全性が保証されます。
+
+以下のコマンドを使用して、コンテナイメージの署名を検証できます。
+
+```sh
+export VERSION=v0.9.0
+
+# Docker Hub のリリースイメージを検証する
+cosign verify --certificate-identity-regexp 'https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' otel/ebpf-instrument:${VERSION}
+
+# GHCR の同じリリースを検証する
+cosign verify --certificate-identity-regexp 'https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument:${VERSION}
+```
+
+出力例を以下に示します。
+
+```log
+Verification for index.docker.io/otel/ebpf-instrument:main --
+The following checks were performed on each of these signatures:
+  - The cosign claims were validated
+  - Existence of the claims in the transparency log was verified offline
+  - The code-signing certificate was verified using trusted certificate authority certificates
+
+[{"critical":{"identity":{"docker-reference":"index.docker.io/otel/ebpf-instrument:main"},"image":{"docker-manifest-digest":"sha256:55426a2bbb8003573a961697888aa770a1f5f67fcda2276dc2187d1faf7181fe"},"type":"https://sigstore.dev/cosign/sign/v1"},"optional":{}}]
+```
+
+検証が成功すると、Cosign のクレームが検証されたことと署名されたイメージダイジェストが表示されます。
+検証が失敗した場合は、以下を確認してください。
+
+- クエリしたレジストリにタグが存在するか確認する
+- `main` だけでなく、公開されたリリースタグを検証していることを確認する
+- 上記に示された GitHub OIDC 発行者と ID 正規表現を使用していることを確認する
+
 ## Docker CLIの例 {#docker-cli-example}
 
 この例では、HTTP/SまたはgRPCサービスを実行しているコンテナが必要です。
 コンテナがない場合は、[Goで書かれたシンプルなブログエンジンサービス](https://macias.info)を使用できます。
 
 ```sh
+export VERSION=v0.9.0
 docker run -p 18443:8443 --name goblog mariomac/goblog:dev
 ```
 
@@ -51,7 +94,7 @@ docker run --rm \
   -e OTEL_EBPF_TRACE_PRINTER=text \
   --pid=host \
   --privileged \
-  docker.io/otel/ebpf-instrument:main
+  otel/ebpf-instrument:${VERSION}
 ```
 
 OBIの実行後、ブラウザで `https://localhost:18443` を開き、アプリを使用してテストデータを生成し、OBIが標準出力に次のようなトレースリクエストを出力することを確認します。
@@ -87,7 +130,7 @@ services:
       - '18443:8443'
 
   autoinstrumenter:
-    image: docker.io/otel/ebpf-instrument:main
+    image: otel/ebpf-instrument:main
     pid: 'host'
     privileged: true
     environment:


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/obi/setup/docker.md` to match the latest English source at
`content/en/docs/zero-code/obi/setup/docker.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

Changes synced from the English source:
- `weight` updated from 2 to 3
- Image registry section rewritten: now lists both Docker Hub and GHCR registries with versioned tags, plus a note about the development tag on Docker Hub
- Code block updated: `ebpf-instrument:main` → `otel/ebpf-instrument:main`
- New section added: "Image Signing and Verification" — describes Cosign-based image signing and verification commands
- Docker CLI example: added `export VERSION=v0.9.0` line, updated OBI image reference from `docker.io/otel/ebpf-instrument:main` to `otel/ebpf-instrument:${VERSION}`
- Docker Compose example: updated image from `docker.io/otel/ebpf-instrument:main` to `otel/ebpf-instrument:main`

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10442--opentelemetry.netlify.app/ja/docs/zero-code/obi/setup/docker/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/obi/setup/docker/

_(deploy preview may still be building. The URLs will work once Netlify finishes.)_
<!-- preview-section-end -->
