### PR TITLE
Upgrade Hugo to 0.163.2 and Docsy theme to latest

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	path = themes/docsy
 	url = https://github.com/google/docsy.git
   # cSpell:disable-next-line
-	docsy-pin = v0.15.0-17-gf5167068
+	docsy-pin = v0.15.0-20-g6fdfd21b
 	docsy-note = "2024-04-01 Switching to google/docsy.git from cncf/docsy.git since we don't have any CNCF customizations."
 	docsy-reminder = "Ensure that any tag referenced by `docsy-pin` is present in the remote repo (url), otherwise add (push) the tags to the repo."
 [submodule "content-modules/opentelemetry-specification"]

--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "code-excerpter": "0.2.0",
     "cspell": "10.0.1",
     "gulp": "5.0.1",
-    "hugo-extended": "0.163.1",
+    "hugo-extended": "0.163.2",
     "js-yaml": "4.2.0",
     "markdown-it": "14.2.0",
     "markdown-link-check": "3.14.2",


### PR DESCRIPTION
- Docsy theme:
  - Bumps the `themes/docsy` submodule to `v0.15.0-20-g6fdfd21b` (google/docsy main), picking up the favicon-discovery rework and Russian i18n updates. Done via the `update-git-submodule` skill.
  - The only theme change affecting this site is the favicon partial: the `favicon.ico` link is now emitted without the hard-coded `sizes` attribute (`<link rel="icon" href="/favicon.ico" />`). This site overrides neither changed theme file, so no override port is needed.
- Hugo:
  - Bumps `hugo-extended` from 0.163.1 to 0.163.2 (latest), a patch release that hardens the 0.161 Node-permission model (PostCSS/Netlify `ERR_ACCESS_DENIED` fix) and standardizes behavior when external markup converters are  neither affects this site's build.missing 
- Verifies a clean build (Hugo 0.163.2, no deprecation notices) and a green `npm test`.

```console
$ (cd public && git diff -bw --ignore-blank-lines -I 'favicon.ico|0\.163\.' -- ':(exclude)*.xml')         
```
```diff        
diff --git a/site/index.html b/site/index.html
index b2ed728eb2..4a53901206 100644
--- a/site/index.html
+++ b/site/index.html
@@ -448,7 +448,7 @@ design/implementation decisions.</li>
 <script>
 document.addEventListener("DOMContentLoaded", function() {
   var options = { hour: '2-digit', hour12: false, minute: '2-digit', timeZoneName: 'short' };
-  var buildDate = new Date("2026-06-16T13:16:30-04:00");
+  var buildDate = new Date("2026-06-16T16:02:38-04:00");
   document.getElementById("local-time").innerText = buildDate.toLocaleString(undefined, options);
 });
 </script>
diff --git a/site/index.md b/site/index.md
index 37d03503e0..abc9ea9c80 100644
--- a/site/index.md
+++ b/site/index.md
@@ -62,7 +62,7 @@ Deploy context | local
 <script>
 document.addEventListener("DOMContentLoaded", function() {
   var options = { hour: '2-digit', hour12: false, minute: '2-digit', timeZoneName: 'short' };
-  var buildDate = new Date("2026-06-16T13:16:30-04:00");
+  var buildDate = new Date("2026-06-16T16:02:38-04:00");
   document.getElementById("local-time").innerText = buildDate.toLocaleString(undefined, options);
 });
 </script>
 ```