### PR TITLE
docs(site): Add implementation style guide for Hugo templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Start at [content/en/site/][]. Useful subsections:
 - [Build][] — npm scripts, workflows, patches, localization
 - [Testing][]
 - [Design][]
+- [Implementation][] — Hugo template and code-level style conventions
 - [Skills][]
 
 The **Docsy** theme is a git submodule. For theme-specific agent notes, see
@@ -21,4 +22,5 @@ Repo-wide contribution context: [CONTRIBUTING.md](CONTRIBUTING.md),
 [Build]: content/en/site/build/_index.md
 [Testing]: content/en/site/testing/_index.md
 [Design]: content/en/site/design/_index.md
+[Implementation]: content/en/site/implementation/_index.md
 [Skills]: content/en/site/skills/_index.md

--- a/content/en/site/_index.md
+++ b/content/en/site/_index.md
@@ -27,10 +27,11 @@ Tentatively planned content organization:
   other relevant information broken down into features.
 - [**Skills**](./skills/) — Skills for agents and humans to use when maintaining
   the site.
-- **Design** — Architectural design, Information Architecture (IA), layout, UX
-  choices, theme related decisions, and other design-level artifacts.
-- **Implementation** — Code-level structure and conventions, Hugo/Docsy
-  templates, SCSS/JS customizations, patches, and internal shims.
+- [**Design**](./design/) — Architectural design, Information Architecture (IA),
+  layout, UX choices, theme related decisions, and other design-level artifacts.
+- [**Implementation**](./implementation/) — Code-level structure and
+  conventions, Hugo/Docsy templates, SCSS/JS customizations, patches, and
+  internal shims.
 - [**Build**](./build/) — Tooling, local development setup, CI/CD workflows,
   deployment environments, and automation details.
 - **Deployment** — Deployment-specific behavior for the OpenTelemetry website.

--- a/content/en/site/implementation/_index.md
+++ b/content/en/site/implementation/_index.md
@@ -1,0 +1,12 @@
+---
+title: Implementation
+description: >-
+  Code-level structure and conventions for the OpenTelemetry website, including
+  Hugo/Docsy templates, SCSS/JS customizations, patches, and internal shims.
+weight: 35
+---
+
+This section documents code-level structure and conventions for the
+OpenTelemetry website. It is the source of truth for how we write and organize
+template, style, and script code, as distinct from the design decisions recorded
+under [Design](../design/).

--- a/content/en/site/implementation/style-guide.md
+++ b/content/en/site/implementation/style-guide.md
@@ -1,0 +1,37 @@
+---
+title: Style guide
+description: Code-level style conventions for Hugo templates
+---
+
+This page records code-level style conventions for the OpenTelemetry website,
+currently covering Hugo templates. For prose and Markdown _content_ style, see
+the [Documentation style guide](/docs/contributing/style-guide/) instead.
+
+## Hugo templates
+
+### Indentation
+
+For code readability, use proper indentation for nested code blocks, including
+inside `{{ if }}`, `{{ range }}`, and `{{ with }}` actions.
+
+### Whitespace control
+
+Use Hugo's [whitespace control][] trim markers, `{{- ... }}` and `{{ ... -}}`,
+to keep generated output free of unnecessary blank lines and indentation, while
+keeping the template source readable.
+
+- **Default to right-trim only.** Write `{{ ... -}}`, which is generally enough
+  to keep generated output tidy.
+- Use a **left trim** (`{{- ... }}`) or a **double-sided trim** (`{{- ... -}}`)
+  only when justified, for example to collapse surrounding blank lines.
+- **Inline outputs inside markup** take no trim. For example, an action that
+  emits an attribute value, such as `class="{{ $class }}"`, needs no trim
+  markers.
+
+### Newlines in `range` blocks
+
+Inside `range` blocks, consider using `{{ "\n" -}}` or `{{- "\n" -}}` to control
+newlines between iterations, while avoiding leading and trailing blank lines in
+the generated output.
+
+[whitespace control]: https://gohugo.io/templates/introduction/#whitespace

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -16807,6 +16807,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-06-17T11:19:20.222759722Z"
   },
+  "https://gohugo.io/templates/introduction/#whitespace": {
+    "StatusCode": 206,
+    "LastSeen": "2026-06-16T17:06:58.173823-04:00"
+  },
   "https://google.aip.dev/122#full-resource-names": {
     "StatusCode": 206,
     "LastSeen": "2026-06-17T11:20:36.972332054Z"


### PR DESCRIPTION
- Adds an `Implementation` section under the site docs, filling the slot already reserved in the site index for code-level structure and conventions.
- Adds a `Style guide` page that documents Hugo template conventions:
  - Indentation for nested template actions.
  - Whitespace-control trim markers: default to right-trim, use left or double-sided trims only when justified, and no trim for inline markup outputs.
  - Newline control inside `range` blocks.
  - Scopes the intro to Hugo templates, the only topic covered so far.
- Wires up discovery of the new section:
  - Links it from the site index, alongside the now-linked `Design` section.
  - References it from the repo `AGENTS.md` Site subsection list.
