### PR TITLE
docs: add "(members-only)" to team links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Here is a list of community roles with current and previous members:
 
 ### Maintainers
 
-These are the members of [@open-telemetry/docs-maintainers][]:
+These are the members of [@open-telemetry/docs-maintainers] (members-only):
 
 - [Austin Parker](https://github.com/austinlparker), Honeycomb
 - [Fabrizio Ferri-Benedetti](https://github.com/theletterf), Elastic
@@ -73,7 +73,7 @@ For more information about the maintainer role, see the
 
 ### Approvers
 
-These are the members of [@open-telemetry/docs-approvers][]:
+These are the members of [@open-telemetry/docs-approvers] (members-only):
 
 - [Jay DeLuca](https://github.com/jaydeluca), Grafana Labs
 - [Marylia Gutierrez](https://github.com/maryliag), Grafana Labs
@@ -83,7 +83,7 @@ For more information about the approver role, see the
 
 ### Triagers
 
-These are the members of [@open-telemetry/docs-triagers][]:
+These are the members of [@open-telemetry/docs-triagers] (members-only):
 
 - [Diana Todea](https://github.com/didiViking), VictoriaMetrics
 - [Emídio Neto](https://github.com/emdneto)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Here is a list of community roles with current and previous members:
 
 ### Maintainers
 
-These are the members of [@open-telemetry/docs-maintainers] (members-only):
+These are the members of [@open-telemetry/docs-maintainers][] (members-only):
 
 - [Austin Parker](https://github.com/austinlparker), Honeycomb
 - [Fabrizio Ferri-Benedetti](https://github.com/theletterf), Elastic
@@ -73,7 +73,7 @@ For more information about the maintainer role, see the
 
 ### Approvers
 
-These are the members of [@open-telemetry/docs-approvers] (members-only):
+These are the members of [@open-telemetry/docs-approvers][] (members-only):
 
 - [Jay DeLuca](https://github.com/jaydeluca), Grafana Labs
 - [Marylia Gutierrez](https://github.com/maryliag), Grafana Labs
@@ -83,7 +83,7 @@ For more information about the approver role, see the
 
 ### Triagers
 
-These are the members of [@open-telemetry/docs-triagers] (members-only):
+These are the members of [@open-telemetry/docs-triagers][] (members-only):
 
 - [Diana Todea](https://github.com/didiViking), VictoriaMetrics
 - [Emídio Neto](https://github.com/emdneto)


### PR DESCRIPTION
- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

Adds a `(members-only)` clarification label right after the `docs-maintainers`, `docs-approvers`, and `docs-triagers` team links in the README. 

This helps external contributors and the public avoid confusion when they encounter 404 errors on those restricted organization pages, as requested by @chalin.

Closes #10401