### PR TITLE
ci(renovate): group all non-major dependency updates into one PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,7 @@
     'config:best-practices',
     'docker:pinDigests',
     'helpers:pinGitHubActionDigestsToSemver',
+    'group:allNonMajor',
   ],
   minimumReleaseAge: '7 days',
   internalChecksFilter: 'strict',
@@ -17,11 +18,6 @@
       // hugo-extended is intentionally pinned; updated manually via `npm run update:hugo`.
       matchPackageNames: ['hugo-extended'],
       enabled: false,
-    },
-    {
-      matchDepTypes: ['devDependencies'],
-      matchUpdateTypes: ['patch', 'minor'],
-      groupName: 'npm devDependencies (non-major)',
     },
   ],
 }


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

- Adds the `group:allNonMajor` preset so all minor and patch updates collect into a single weekly PR
- Removes the `npm devDependencies (non-major)` group rule, which would override the preset and split devDependencies back into their own PR

/cc @chalin 