### PR TITLE
[ja] update translation of content/en/docs/languages/java/_index.md

### DIFF
--- a/content/ja/docs/languages/java/_index.md
+++ b/content/ja/docs/languages/java/_index.md
@@ -12,10 +12,9 @@ cascade:
     instrumentation: 2.28.1
     otel: 1.63.0
     contrib: 1.57.0
-    semconv: 1.41.1
+    semconv: 1.42.0
 weight: 150
-default_lang_commit: ce5058cd71a2fc6be2f9b90d4704520fff981dfe
-drifted_from_default: true
+default_lang_commit: 74ba66cadfe96161b3fa03fdf3d8ea4067b00849
 ---
 
 {{% docs/languages/index-intro java /%}}


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/java/_index.md` to match the latest English source at
`content/en/docs/languages/java/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The only English-side change was a version bump in `cascade.vers.semconv` from `1.41.1` to `1.42.0`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10471--opentelemetry.netlify.app/ja/docs/languages/java/
- **English (canonical):** https://opentelemetry.io/docs/languages/java/

<!-- preview-section-end -->
