### PR TITLE
[ja] update translation of content/en/docs/collector/internal-telemetry.md

### DIFF
--- a/content/ja/docs/collector/internal-telemetry.md
+++ b/content/ja/docs/collector/internal-telemetry.md
@@ -1,9 +1,8 @@
 ---
 title: 内部テレメトリー
 weight: 25
-default_lang_commit: 548ae50123bba6fd70cb0b080c68294b8239769a
-drifted_from_default: true
-cSpell:ignore: alloc batchprocessor journalctl
+default_lang_commit: 74ba66cadfe96161b3fa03fdf3d8ea4067b00849
+cSpell:ignore: alloc batchprocessor journalctl otelgrpc
 ---
 
 インスタンス自身の内部テレメトリーを確認することで、任意の OpenTelemetry コレクターのインスタンスの健全性を詳しく調べることができます。
@@ -320,7 +319,7 @@ service:
 コレクター v0.120.0 より前では、Prometheus で公開される内部メトリクスは、Prometheus の命名規則に合わせるためにドット（`.`）をアンダースコア（`_`）に変更していました。その結果、`rpc_server_duration`のようなメトリクス名になっていました。
 
 コレクターの 0.120.0 以降のバージョンでは Prometheus 3.0 スクレーパーを使用するため、ドットを含む元の `http*` および `rpc*` メトリクス名が保持されます。
-このページの[内部メトリクス](#lists-of-internal-metrics) は、`rpc.server.duration` のような元の形式で一覧化されています。
+このページの[内部メトリクス](#lists-of-internal-metrics) は、`rpc.server.call.duration` のような元の形式で一覧化されています。
 詳細については、[コレクター v0.120.0 リリースノート](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CHANGELOG.md#v01200)を参照してください。
 
 ### 内部メトリクスの一覧 {#lists-of-internal-metrics}
@@ -342,35 +341,36 @@ service:
 
 #### `basic` レベルのメトリクス {#basic-level-metrics}
 
-| メトリクス名                                           | 説明                                                                                            | 種別    |
-| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------- | ------- |
-| `otelcol_exporter_enqueue_failed_`<br>`log_records`    | エクスポーターがキュー投入に失敗したログの数。                                                  | Counter |
-| `otelcol_exporter_enqueue_failed_`<br>`metric_points`  | エクスポーターがキュー投入に失敗したメトリクスポイントの数。                                    | Counter |
-| `otelcol_exporter_enqueue_failed_`<br>`spans`          | エクスポーターがキュー投入に失敗したスパンの数。                                                | Counter |
-| `otelcol_exporter_queue_capacity`                      | 送信キューの固定容量（バッチ単位）。                                                            | Gauge   |
-| `otelcol_exporter_queue_size`                          | 送信キューの現在サイズ（バッチ単位）。                                                          | Gauge   |
-| `otelcol_exporter_send_failed_`<br>`log_records`       | エクスポーターが宛先への送信に失敗したログの数。                                                | Counter |
-| `otelcol_exporter_send_failed_`<br>`metric_points`     | エクスポーターが宛先への送信に失敗したメトリクスポイントの数。                                  | Counter |
-| `otelcol_exporter_send_failed_`<br>`spans`             | エクスポーターが宛先への送信に失敗したスパンの数。                                              | Counter |
-| `otelcol_exporter_sent_log_records`                    | 宛先に正常に送信されたログの数。                                                                | Counter |
-| `otelcol_exporter_sent_metric_points`                  | 宛先に正常に送信されたメトリクスポイントの数。                                                  | Counter |
-| `otelcol_exporter_sent_spans`                          | 宛先に正常に送信されたスパンの数。                                                              | Counter |
-| `otelcol_process_cpu_seconds`                          | CPU のユーザー時間とシステム時間の合計（秒）。                                                  | Counter |
-| `otelcol_process_memory_rss`                           | 物理メモリーの合計（RSS: resident set size）（バイト）。                                        | Gauge   |
-| `otelcol_process_runtime_heap_`<br>`alloc_bytes`       | 割り当て済みヒープオブジェクトのバイト数（`go doc runtime.MemStats.HeapAlloc` を参照）。        | Gauge   |
-| `otelcol_process_runtime_total_`<br>`alloc_bytes`      | ヒープオブジェクトに割り当てられた累積バイト数（`go doc runtime.MemStats.TotalAlloc` を参照）。 | Counter |
-| `otelcol_process_runtime_total_`<br>`sys_memory_bytes` | OS から取得したメモリー総バイト数（`go doc runtime.MemStats.Sys` を参照）。                     | Gauge   |
-| `otelcol_process_uptime`                               | プロセスの稼働時間（秒）。                                                                      | Counter |
-| `otelcol_processor_incoming_items`                     | processor に渡された項目数。                                                                    | Counter |
-| `otelcol_processor_outgoing_items`                     | processor から出力された項目数。                                                                | Counter |
-| `otelcol_receiver_accepted_`<br>`log_records`          | 正常に取り込まれ、パイプラインへプッシュされたログの数。                                        | Counter |
-| `otelcol_receiver_accepted_`<br>`metric_points`        | 正常に取り込まれ、パイプラインへプッシュされたメトリクスポイントの数。                          | Counter |
-| `otelcol_receiver_accepted_spans`                      | 正常に取り込まれ、パイプラインへプッシュされたスパンの数。                                      | Counter |
-| `otelcol_receiver_refused_`<br>`log_records`           | パイプラインへプッシュできなかったログの数。                                                    | Counter |
-| `otelcol_receiver_refused_`<br>`metric_points`         | パイプラインへプッシュできなかったメトリクスポイントの数。                                      | Counter |
-| `otelcol_receiver_refused_spans`                       | パイプラインへプッシュできなかったスパンの数。                                                  | Counter |
-| `otelcol_scraper_errored_`<br>`metric_points`          | コレクターがスクレイプに失敗したメトリクスポイントの数。                                        | Counter |
-| `otelcol_scraper_scraped_`<br>`metric_points`          | コレクターがスクレイプしたメトリクスポイントの数。                                              | Counter |
+| メトリクス名                                           | 説明                                                                                            | 種別          |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------- | ------------- |
+| `otelcol_exporter_enqueue_failed_`<br>`log_records`    | エクスポーターがキュー投入に失敗したログの数。                                                  | Counter       |
+| `otelcol_exporter_enqueue_failed_`<br>`metric_points`  | エクスポーターがキュー投入に失敗したメトリクスポイントの数。                                    | Counter       |
+| `otelcol_exporter_enqueue_failed_`<br>`spans`          | エクスポーターがキュー投入に失敗したスパンの数。                                                | Counter       |
+| `otelcol_exporter_in_flight_requests`                  | 再試行バックオフを含む、現在処理中のエクスポートリクエスト数。                                  | UpDownCounter |
+| `otelcol_exporter_queue_capacity`                      | 送信キューの固定容量（バッチ単位）。                                                            | Gauge         |
+| `otelcol_exporter_queue_size`                          | 送信キューの現在サイズ（バッチ単位）。                                                          | Gauge         |
+| `otelcol_exporter_send_failed_`<br>`log_records`       | エクスポーターが宛先への送信に失敗したログの数。                                                | Counter       |
+| `otelcol_exporter_send_failed_`<br>`metric_points`     | エクスポーターが宛先への送信に失敗したメトリクスポイントの数。                                  | Counter       |
+| `otelcol_exporter_send_failed_`<br>`spans`             | エクスポーターが宛先への送信に失敗したスパンの数。                                              | Counter       |
+| `otelcol_exporter_sent_log_records`                    | 宛先に正常に送信されたログの数。                                                                | Counter       |
+| `otelcol_exporter_sent_metric_points`                  | 宛先に正常に送信されたメトリクスポイントの数。                                                  | Counter       |
+| `otelcol_exporter_sent_spans`                          | 宛先に正常に送信されたスパンの数。                                                              | Counter       |
+| `otelcol_process_cpu_seconds`                          | CPU のユーザー時間とシステム時間の合計（秒）。                                                  | Counter       |
+| `otelcol_process_memory_rss`                           | 物理メモリーの合計（RSS: resident set size）（バイト）。                                        | Gauge         |
+| `otelcol_process_runtime_heap_`<br>`alloc_bytes`       | 割り当て済みヒープオブジェクトのバイト数（`go doc runtime.MemStats.HeapAlloc` を参照）。        | Gauge         |
+| `otelcol_process_runtime_total_`<br>`alloc_bytes`      | ヒープオブジェクトに割り当てられた累積バイト数（`go doc runtime.MemStats.TotalAlloc` を参照）。 | Counter       |
+| `otelcol_process_runtime_total_`<br>`sys_memory_bytes` | OS から取得したメモリー総バイト数（`go doc runtime.MemStats.Sys` を参照）。                     | Gauge         |
+| `otelcol_process_uptime`                               | プロセスの稼働時間（秒）。                                                                      | Counter       |
+| `otelcol_processor_incoming_items`                     | processor に渡された項目数。                                                                    | Counter       |
+| `otelcol_processor_outgoing_items`                     | processor から出力された項目数。                                                                | Counter       |
+| `otelcol_receiver_accepted_`<br>`log_records`          | 正常に取り込まれ、パイプラインへプッシュされたログの数。                                        | Counter       |
+| `otelcol_receiver_accepted_`<br>`metric_points`        | 正常に取り込まれ、パイプラインへプッシュされたメトリクスポイントの数。                          | Counter       |
+| `otelcol_receiver_accepted_spans`                      | 正常に取り込まれ、パイプラインへプッシュされたスパンの数。                                      | Counter       |
+| `otelcol_receiver_refused_`<br>`log_records`           | パイプラインへプッシュできなかったログの数。                                                    | Counter       |
+| `otelcol_receiver_refused_`<br>`metric_points`         | パイプラインへプッシュできなかったメトリクスポイントの数。                                      | Counter       |
+| `otelcol_receiver_refused_spans`                       | パイプラインへプッシュできなかったスパンの数。                                                  | Counter       |
+| `otelcol_scraper_errored_`<br>`metric_points`          | コレクターがスクレイプに失敗したメトリクスポイントの数。                                        | Counter       |
+| `otelcol_scraper_scraped_`<br>`metric_points`          | コレクターがスクレイプしたメトリクスポイントの数。                                              | Counter       |
 
 #### 追加の `normal` レベルのメトリクス {#additional-normal-level-metrics}
 
@@ -390,33 +390,47 @@ service:
 
 #### 追加の `detailed` レベルのメトリクス {#additional-detailed-level-metrics}
 
-| メトリクス名                                          | 説明                                                                                                     | 種別      |
-| ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | --------- |
-| `http.client.request.body.size`                       | HTTP クライアントリクエストボディーのサイズを測定します。                                                | Counter   |
-| `http.client.request.duration`                        | HTTP クライアントリクエストの継続時間を測定します。                                                      | Histogram |
-| `http.server.request.body.size`                       | HTTP サーバーリクエストボディーのサイズを測定します。                                                    | Counter   |
-| `http.server.request.duration`                        | HTTP サーバーリクエストの継続時間を測定します。                                                          | Histogram |
-| `http.server.response.body.size`                      | HTTP サーバーレスポンスボディーのサイズを測定します。                                                    | Counter   |
-| `otelcol_processor_batch_batch_`<br>`send_size_bytes` | 送信されたバッチ内のバイト数。                                                                           | Histogram |
-| `rpc.client.duration`                                 | アウトバウンド RPC の継続時間を測定します。                                                              | Histogram |
-| `rpc.client.request.size`                             | RPC リクエストメッセージ（非圧縮）のサイズを測定します。                                                 | Histogram |
-| `rpc.client.requests_per_rpc`                         | RPC ごとに受信されたメッセージ数を測定します。すべての非ストリーミング RPC では 1 になる必要があります。 | Histogram |
-| `rpc.client.response.size`                            | RPC レスポンスメッセージ（非圧縮）のサイズを測定します。                                                 | Histogram |
-| `rpc.client.responses_per_rpc`                        | RPC ごとに送信されたメッセージ数を測定します。すべての非ストリーミング RPC では 1 になる必要があります。 | Histogram |
-| `rpc.server.duration`                                 | インバウンド RPC の継続時間を測定します。                                                                | Histogram |
-| `rpc.server.request.size`                             | RPC リクエストメッセージ（非圧縮）のサイズを測定します。                                                 | Histogram |
-| `rpc.server.requests_per_rpc`                         | RPC ごとに受信されたメッセージ数を測定します。すべての非ストリーミング RPC では 1 になる必要があります。 | Histogram |
-| `rpc.server.response.size`                            | RPC レスポンスメッセージ（非圧縮）のサイズを測定します。                                                 | Histogram |
-| `rpc.server.responses_per_rpc`                        | RPC ごとに送信されたメッセージ数を測定します。すべての非ストリーミング RPC では 1 になる必要があります。 | Histogram |
+| メトリクス名                                          | 説明                                                      | 種別      |
+| ----------------------------------------------------- | --------------------------------------------------------- | --------- |
+| `http.client.request.body.size`                       | HTTP クライアントリクエストボディーのサイズを測定します。 | Counter   |
+| `http.client.request.duration`                        | HTTP クライアントリクエストの継続時間を測定します。       | Histogram |
+| `http.server.request.body.size`                       | HTTP サーバーリクエストボディーのサイズを測定します。     | Counter   |
+| `http.server.request.duration`                        | HTTP サーバーリクエストの継続時間を測定します。           | Histogram |
+| `http.server.response.body.size`                      | HTTP サーバーレスポンスボディーのサイズを測定します。     | Counter   |
+| `otelcol_processor_batch_batch_`<br>`send_size_bytes` | 送信されたバッチ内のバイト数。                            | Histogram |
+| `rpc.client.call.duration`                            | アウトバウンド RPC の継続時間を測定します。               | Histogram |
+| `rpc.server.call.duration`                            | インバウンド RPC の継続時間を測定します。                 | Histogram |
 
-> [!NOTE]
->
-> `http*` と `rpc*` のメトリクスは、コレクター SIG の管理下にないため、以下の成熟度レベルの対象外になります。
->
-> `otelcol_processor_batch_` メトリクスは `batchprocessor` 固有です。
->
-> `otelcol_receiver_`、`otelcol_scraper_`、`otelcol_processor_`、および `otelcol_exporter_` のメトリクスは、それぞれ対応する `helper` パッケージに由来します。
-> そのため、これらのパッケージを使用していないいくつかのコンポーネントは、それらを出力しない可能性があります。
+#### 出力されるメトリクスのオーナーシップ {#ownership-of-emitted-metrics}
+
+一部のメトリクスはコレクター SIG が管理しておらず、また一部は特定のコンポーネントに限定されています。
+
+**`http*` および `rpc` メトリクス**
+
+これらのメトリクスはコレクター SIG の管理下にないため、以下の成熟度レベルの対象外になります。
+
+**`rpc` メトリクス**
+
+コレクターの内部 RPC メトリクスは、上流の [`otelgrpc`](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/google.golang.org/grpc/otelgrpc) 計装から取得されており、[OpenTelemetry RPC セマンティック規約](/docs/specs/semconv/rpc/rpc-metrics/) を追跡しています。
+コレクターが出力する RPC メトリクスのセットは、リリースごとに変更されています。
+
+| コレクターバージョン | 出力される RPC メトリクス                                                                                                                                         |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| v0.146.x 以前        | `rpc.client.duration`, `rpc.server.duration`, `rpc.*.request.size`, `rpc.*.response.size`, `rpc.*.requests_per_rpc`, `rpc.*.responses_per_rpc`                    |
+| v0.147.0             | `rpc.client.call.duration`, `rpc.server.call.duration`, `rpc.*.request.size`, `rpc.*.response.size`（`*_per_rpc` メトリクスは非推奨となり出力されなくなりました） |
+| v0.148.0 以降        | `rpc.client.call.duration`, `rpc.server.call.duration` のみ                                                                                                       |
+
+RPC サイズメトリクスはコレクター v0.148.0 以降では出力されません。
+[RPC セマンティック規約 v1.40.0](https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.40.0) は、定義の曖昧さと実装の不整合を理由にそれらを非推奨としました。
+
+**`otelcol_processor_batch_*` メトリクス**
+
+これらのメトリクスは `batchprocessor` 固有です。
+
+**`helper` パッケージのメトリクス**
+
+`otelcol_receiver_`、`otelcol_scraper_`、`otelcol_processor_`、および `otelcol_exporter_` のメトリクスは、それぞれ対応する `helper` パッケージに由来します。
+そのため、これらのパッケージを使用していないいくつかのコンポーネントは、それらを出力しない可能性があります。
 
 ### 内部ログで観測可能なイベント {#events-observable-with-internal-logs}
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/collector/internal-telemetry.md` to match the latest English source at
`content/en/docs/collector/internal-telemetry.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

Changes applied:
- Added `otelgrpc` to `cSpell:ignore` frontmatter
- Updated `rpc.server.duration` → `rpc.server.call.duration` in the dots-v-underscores section
- Added new metric `otelcol_exporter_in_flight_requests` (UpDownCounter) to the basic-level metrics table
- Widened the Type column in the basic-level metrics table to accommodate `UpDownCounter`
- Replaced the old detailed-level RPC metrics (10 rows) with `rpc.client.call.duration` and `rpc.server.call.duration` (2 rows)
- Replaced the NOTE blockquote about metric ownership with a new `#### Ownership of emitted metrics` section including sub-sections on `http*`/`rpc`, `rpc`, `otelcol_processor_batch_*`, and `helper` package metrics

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10472--opentelemetry.netlify.app/ja/docs/collector/internal-telemetry/
- **English (canonical):** https://opentelemetry.io/docs/collector/internal-telemetry/

_(deploy preview may take a few minutes to build.)_
<!-- preview-section-end -->
