### PR TITLE
ci(renovate): split minor, and patch updates for automerge

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,16 +4,26 @@
     'config:best-practices',
     'docker:pinDigests',
     'helpers:pinGitHubActionDigestsToSemver',
-    'group:allNonMajor',
   ],
   minimumReleaseAge: '7 days',
   internalChecksFilter: 'strict',
   labels: ['dependencies'],
+  // Run once weekly as specified:
   schedule: ['before 9am on monday'],
   patch: {
     automerge: true,
   },
   packageRules: [
+    {
+      // Patch updates are typically non-breaking; one grouped PR can automerge.
+      groupName: 'all patch versions',
+      matchUpdateTypes: ['patch'],
+    },
+    {
+      // Consolidate minor updates into one PR for review.
+      groupName: 'all minor versions',
+      matchUpdateTypes: ['minor'],
+    },
     {
       // hugo-extended is intentionally pinned; updated manually via `npm run update:hugo`.
       matchPackageNames: ['hugo-extended'],


### PR DESCRIPTION
## Summary

- Follow-up to #10462
- Drops `group:allNonMajor`, which grouped patch and minor updates into one PR and prevented patch automerge from applying
- Groups patch updates into a dedicated PR that can use the existing `patch.automerge` setting
- Groups minor updates into a separate weekly PR for manual review

## Test plan

- [ ] Renovate config validates (next scheduled run or manual Renovate debug)

/cc @chalin @vitorvasc