### PR TITLE
feat: add setup-new-localization skill

### DIFF
--- a/.claude/skills/setup-new-localization/SKILL.md
+++ b/.claude/skills/setup-new-localization/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   onboarding a localization team.
 argument-hint: '<kickoff-issue | lang-code>'
 allowed-tools: Bash Read Edit Write Grep Glob
-cSpell:ignore: endonym gitkeep nowrap unstaffed
+cSpell:ignore: endonym unstaffed
 ---
 
 # Set up a new localization
@@ -38,9 +38,10 @@ Either way, derive these; don't ask for them as separate arguments:
 
 > [!NOTE]
 >
-> All list entries below stay in **alphabetical order by `<lang>`** (English
-> `en` stays first as the default). Match the placement of an existing neighbor
-> (e.g. insert `ko` between `ja` and `pl`).
+> Most lists below are ordered alphabetically by `<lang>` (English `en` stays
+> first). Some aren't — `projects/localization.md`'s "Current language teams"
+> section is ordered by English name. At each insertion point, match the
+> ordering of the existing entries rather than assuming one global rule.
 
 ## Steps
 
@@ -97,7 +98,7 @@ Create it empty — git won't track an empty folder, so the `.gitkeep` is the
 tracked file:
 
 ```bash
-touch content/<lang>/.gitkeep
+mkdir -p content/<lang> && touch content/<lang>/.gitkeep
 ```
 
 **Do NOT copy the English homepage into the setup PR.** The translated homepage
@@ -126,12 +127,9 @@ published package names are inconsistent (`dict-es-es` with a hyphen vs
 `dict-pl_pl` with an underscore), but the [dictionary folders][cspell-dicts]
 follow one rule: `<lang>` (e.g. `bn`) or `<lang>_<REGION>` (e.g. `es_ES`,
 `pl_PL`, `pt_BR`, `uk_UA`). A matching folder means a dict exists; no folder (no
-`ko`, `ja`, `zh`) means there isn't one.
-
-```bash
-gh api repos/streetsidesoftware/cspell-dicts/contents/dictionaries \
-  --jq '.[].name' | grep -i '^<lang>'
-```
+`ko`, `ja`, `zh`) means there isn't one. Read the [dictionary
+folders][cspell-dicts] directly — a folder-name match is the source of truth,
+not a guessed npm name.
 
 The **dictionary id** is the folder name lowercased with `_` → `-` (`pl_PL` →
 `pl-pl`). For the exact **package name** and version, read them from npm
@@ -156,20 +154,22 @@ leave the `package.json` devDependencies unchanged.
 touch .cspell/<lang>-words.txt
 ```
 
-### f. `package.json` — Prettier nowrap group (ask a maintainer)
+### f. Prettier prose-wrapping — default: leave it alone
 
-Some locales break under Prettier's default prose wrapping; the
-`_check:format:nowrap` script runs those with `--prose-wrap preserve` instead.
-It currently lists `content/ja content/ko content/uk content/zh` (CJK plus
-Ukrainian), so there's no clean a-priori rule. **Confirm with a maintainer**
-whether `<lang>` belongs in this group. If it does, add `content/<lang>`
-(alphabetical) to the script:
+**Default: no Prettier changes for a new locale.** Per `localization.md`,
+prose-wrap exceptions exist only for languages Prettier mishandles; a locale
+opts in later, when its team hits the problem — not at setup time.
 
-```json
-"_check:format:nowrap": "npm run __check:format:nowrap -- content/ja content/<lang> content/uk content/zh"
-```
+If the team does opt in, it's **two coupled edits**, and one without the other
+is a silent no-op:
 
-Then run `npm run check:format` to confirm the locale's content passes.
+- a `/content/<lang>` line in `.prettierignore` (exempts the dir from the
+  default `proseWrap: always` pass), **and**
+- `content/<lang>` in the `_check:format:nowrap` script in `package.json`
+  (re-checks it with `--prose-wrap preserve`).
+
+Read `.prettierignore` and that script for the current members rather than
+trusting a snapshot here.
 
 ### g. `lang:<lang>` label — labeler config **and** the GitHub label
 
@@ -218,12 +218,13 @@ npm run check:codeowners   # must report "up to date"
 
 **Never hand-edit** the generated block in `.github/CODEOWNERS`.
 
-### j. `projects/localization.md` — 5 alphabetical insertions
+### j. `projects/localization.md` — 5 insertions (match neighbor ordering)
 
 1. Supported-languages list: `- [<native-label> - <Lang> (<lang>)][<lang>]`
    **and** its link ref `[<lang>]: https://opentelemetry.io/<lang>/`
 2. "Current language teams" section block (Website / Slack / Maintainers /
-   Approvers, mirroring a sibling)
+   Approvers, mirroring a sibling) — this section is ordered by **English
+   name**, not `<lang>`
 3. Labels list: `` - [`lang:<lang>`][issues-lang-<lang>] - <Lang> localization``
 4. Slack channel ref: `[otel-localization-<lang>]: <channel-url>`
 5. Issues label ref: `[issues-lang-<lang>]: <issues-search-url>`
@@ -277,7 +278,7 @@ this PR, but you can't merge it.
 
 ```bash
 npm run check:codeowners                  # "up to date"
-npm run check:format                      # passes (incl. nowrap group, if joined)
+npm run check:format                      # passes
 git diff --name-only                      # exactly the files below, nothing more
 git diff --name-only | grep component-owners.yml && echo "BUG: do not touch" || echo OK
 gh label list -R open-telemetry/opentelemetry.io | grep "lang:<lang>"  # label exists
@@ -295,4 +296,3 @@ Expected changed/added paths:
 - `data/locale-teams.yaml`
 - `projects/localization.md`
 - `package.json` **only if** an upstream `@cspell/dict-*` was added (step d)
-  and/or `<lang>` was added to the nowrap group (step f)

--- a/.claude/skills/setup-new-localization/SKILL.md
+++ b/.claude/skills/setup-new-localization/SKILL.md
@@ -72,22 +72,22 @@ Then add the block under `languages:`, in alphabetical order:
 Copy the shape of an existing block (e.g. `## ja`), in alphabetical order:
 
 ```yaml
-  ## <lang>
-  - source: content/<lang>
-    target: content
-    sites: &<lang>-matrix
-      matrix: { languages: [<lang>] }
-  # fallback pages
-  - source: content/en/_includes
-    target: content/_includes
-    sites: *<lang>-matrix
-  - source: content/en/announcements
-    target: content/announcements
-    sites: *<lang>-matrix
-  - source: content/en/docs
-    target: content/docs
-    files: ['! specs/**']
-    sites: *<lang>-matrix
+## <lang>
+- source: content/<lang>
+  target: content
+  sites: &<lang>-matrix
+    matrix: { languages: [<lang>] }
+# fallback pages
+- source: content/en/_includes
+  target: content/_includes
+  sites: *<lang>-matrix
+- source: content/en/announcements
+  target: content/announcements
+  sites: *<lang>-matrix
+- source: content/en/docs
+  target: content/docs
+  files: ['! specs/**']
+  sites: *<lang>-matrix
 ```
 
 ### c. `content/<lang>/.gitkeep` — placeholder content dir

--- a/.claude/skills/setup-new-localization/SKILL.md
+++ b/.claude/skills/setup-new-localization/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: setup-new-localization
+description: >-
+  Set up a new website localization (language) for opentelemetry.io: Hugo
+  language config, content mounts, cSpell wiring, label map, CODEOWNERS via the
+  locale-teams registry, and the localization project page. Use when adding a
+  new language/locale, wiring a new `content/<lang>/` tree, or onboarding a
+  localization team.
+argument-hint: '<kickoff-issue | lang-code>'
+allowed-tools: Bash Read Edit Write Grep Glob
+cSpell:ignore: endonym unstaffed
+---
+
+# Set up a new localization
+
+Wire a new language into the site end-to-end. Start from one of:
+
+- **A kickoff issue (preferred)** — its number or URL, e.g.
+  [#9577][kickoff-example]. Read it with
+  `gh issue view <n> -R open-telemetry/opentelemetry.io` and pull out:
+  - ISO 639-1 code → `<lang>`
+  - Language name → `<native-label>`
+  - Locale mentor + Contributors → the **approvers** (`data/locale-teams.yaml`)
+- **A bare `<lang>` ISO 639-1 code** when there's no issue yet. You then gather
+  the team handles and native label yourself.
+
+Either way, derive these; don't ask for them as separate arguments:
+
+- **Hugo locale** — usually the bare code, so you **omit the `locale:` field**
+  (Hugo defaults it to `<lang>`, as `bn`, `es`, `fr`, and `ja` do). When
+  `<lang>` has several regional variants in real use, you must ask which one.
+  See step (a).
+- **`<native-label>`** — the endonym for that language (from the issue, or see
+  gotchas for picking the right one).
+- **`<country>`** — the language's primary country, for the Slack channel / team
+  naming and the label color (step (e)).
+
+[kickoff-example]:
+  https://github.com/open-telemetry/opentelemetry.io/issues/9577
+
+> [!NOTE]
+>
+> All list entries below stay in **alphabetical order by `<lang>`** (English
+> `en` stays first as the default). Match the placement of an existing neighbor
+> (e.g. insert `ko` between `ja` and `pl`).
+
+## Steps
+
+### a. `config/_default/hugo.yaml` — language block
+
+First decide the locale:
+
+- If `<lang>` maps to a single common locale, **omit `locale:`**. Hugo defaults
+  it to `<lang>` (the ISO 639-1 code), as `bn`, `es`, `fr`, and `ja` do.
+- If `<lang>` has several regional variants in real use (e.g. `pt` → `pt-BR` /
+  `pt-PT`, `zh` → `zh-CN` / `zh-TW`, `en` → `en-US` / `en-GB`), **ask the user
+  which locale** with the `AskUserQuestion` tool (if available; otherwise ask in
+  plain text), then set `locale:` to their answer.
+
+Then add the block under `languages:`, in alphabetical order:
+
+```yaml
+<lang>:
+  label: <native-label> # e.g. 한국어
+  locale: <LOCALE> # only when <lang> has multiple regional variants; else omit
+  params:
+    description: <translated site description>
+```
+
+### b. `config/_default/module-template.yaml` — content mounts
+
+Copy the shape of an existing block (e.g. `## ja`), in alphabetical order:
+
+```yaml
+  ## <lang>
+  - source: content/<lang>
+    target: content
+    sites: &<lang>-matrix
+      matrix: { languages: [<lang>] }
+  # fallback pages
+  - source: content/en/_includes
+    target: content/_includes
+    sites: *<lang>-matrix
+  - source: content/en/announcements
+    target: content/announcements
+    sites: *<lang>-matrix
+  - source: content/en/docs
+    target: content/docs
+    files: ['! specs/**']
+    sites: *<lang>-matrix
+```
+
+### c. `.cspell.yml` — custom word list
+
+Add the custom list in **both** sections (alphabetical):
+
+```yaml
+dictionaryDefinitions:
+  - name: <lang>-words
+    path: .cspell/<lang>-words.txt
+# ...
+dictionaries:
+  - <lang>-words
+```
+
+**Upstream dict: check the cspell-dicts repo, not a guessed npm name.** The
+published package names are inconsistent (`dict-es-es` with a hyphen vs
+`dict-pl_pl` with an underscore), but the [dictionary folders][cspell-dicts]
+follow one rule: `<lang>` (e.g. `bn`) or `<lang>_<REGION>` (e.g. `es_ES`,
+`pl_PL`, `pt_BR`, `uk_UA`). A matching folder means a dict exists; no folder (no
+`ko`, `ja`, `zh`) means there isn't one.
+
+```bash
+gh api repos/streetsidesoftware/cspell-dicts/contents/dictionaries \
+  --jq '.[].name' | grep -i '^<lang>'
+```
+
+The **dictionary id** is the folder name lowercased with `_` → `-` (`pl_PL` →
+`pl-pl`). For the exact **package name** and version, read them from npm
+(`npm view @cspell/dict-<id> name version`, falling back to the underscore form
+if the hyphen one 404s). Then wire it in three places:
+
+- `.cspell.yml` import: `'@cspell/dict-pl_pl/cspell-ext.json'` (exact package
+  name)
+- `.cspell.yml` `dictionaries:` id: `pl-pl` (hyphen, even though the package
+  uses `_`)
+- `package.json` devDependency: `"@cspell/dict-pl_pl": "<version>"`
+
+**Korean has no folder**, so for `ko` add only the custom `ko-words` list and
+leave `package.json` unchanged.
+
+[cspell-dicts]:
+  https://github.com/streetsidesoftware/cspell-dicts/tree/main/dictionaries
+
+### d. `.cspell/<lang>-words.txt` — empty custom list
+
+```bash
+touch .cspell/<lang>-words.txt
+```
+
+### e. `lang:<lang>` label — labeler config **and** the GitHub label
+
+Wire the auto-labeler in `.github/component-label-map.yml`:
+
+```yaml
+lang:<lang>:
+  - changed-files:
+      - any-glob-to-any-file:
+          - content/<lang>/**
+```
+
+The `lang:<lang>` GitHub label must also exist, or the labeler has nothing to
+apply. Create it with the country's **main flag color** (a maintainer action —
+needs repo triage/write):
+
+```bash
+gh label create "lang:<lang>" -R open-telemetry/opentelemetry.io --color <hex>
+# flag color, no leading '#', e.g. ko=0047A0  pl=DC143C  pt=009739  uk=ffdd00
+```
+
+### f. `data/locale-teams.yaml` — the CODEOWNERS source of truth
+
+Since #10295 this registry **generates** the locale section of CODEOWNERS. It
+records the expected membership of the `docs-<lang>-*` teams (created in the
+admin repo — see [Out-of-repo](#out-of-repo-create-the-org-teams)). Under the
+`locales:` map, in alphabetical order, add:
+
+```yaml
+<lang>:
+  maintainers: []
+  approvers: [<mentor-and-contribs>] # issue's "Locale mentor" + "Contributors"
+```
+
+Empty `maintainers` marks the locale **unstaffed**: its CODEOWNERS lines fall
+back to `@open-telemetry/docs-approvers`.
+
+### g. Regenerate CODEOWNERS
+
+```bash
+npm run fix:codeowners     # regenerates the BEGIN/END locale-owners block
+npm run check:codeowners   # must report "up to date"
+```
+
+**Never hand-edit** the generated block in `.github/CODEOWNERS`.
+
+### h. `projects/localization.md` — 5 alphabetical insertions
+
+1. Supported-languages list: `- [<native-label> - <Lang> (<lang>)][<lang>]`
+   **and** its link ref `[<lang>]: https://opentelemetry.io/<lang>/`
+2. "Current language teams" section block (Website / Slack / Maintainers /
+   Approvers, mirroring a sibling)
+3. Labels list: `` - [`lang:<lang>`][issues-lang-<lang>] - <Lang> localization``
+4. Slack channel ref: `[otel-localization-<lang>]: <channel-url>`
+5. Issues label ref: `[issues-lang-<lang>]: <issues-search-url>`
+
+## Do NOT (gotchas)
+
+- **Do NOT touch `.github/component-owners.yml`.** Pre-#10295 the old process
+  added a `content/<lang>:` block there; #10295 removed **all** locale teams
+  from that file. It now holds only non-locale component reviewers. Re-adding a
+  locale duplicates ownership.
+- **Do NOT hand-edit** the generated locale section of `.github/CODEOWNERS`.
+  Edit `data/locale-teams.yaml` and run `npm run fix:codeowners`.
+- **Pick the right endonym.** Korean is `한국어` (South Korea), not `조선말`
+  (North Korea). Choose the endonym matching the language's primary country.
+- **Never assume an upstream cSpell dict exists.** Check the cspell-dicts repo
+  folders (there is no `ko`, `ja`, or `zh`).
+
+## Out-of-repo: create the org teams {#out-of-repo-create-the-org-teams}
+
+The generated CODEOWNERS references `@open-telemetry/docs-<lang>-approvers`;
+GitHub flags it as invalid until that team exists. The two teams live in the
+[`open-telemetry/admin`][admin] repo's `teams.tf`, with
+`docs-<lang>-maintainers` as a **child** of `docs-<lang>-approvers`:
+
+```hcl
+resource "github_team" "docs-<lang>-approvers" {
+  name        = "docs-<lang>-approvers"
+  description = ""
+  privacy     = "closed"
+}
+
+resource "github_team" "docs-<lang>-maintainers" {
+  name           = "docs-<lang>-maintainers"
+  parent_team_id = github_team.docs-<lang>-approvers.id
+  description    = ""
+  privacy        = "closed"
+}
+```
+
+This is a **separate PR against `open-telemetry/admin`** (example:
+[admin#716][admin-716]) that an **org admin** must merge; the admin then applies
+team membership to match `data/locale-teams.yaml`. You can prepare and describe
+this PR, but you can't merge it.
+
+[admin]: https://github.com/open-telemetry/admin
+[admin-716]: https://github.com/open-telemetry/admin/pull/716
+
+## Validation checklist
+
+```bash
+npm run check:codeowners                  # "up to date"
+git diff --name-only                      # exactly the files below, nothing more
+git diff --name-only | grep component-owners.yml && echo "BUG: do not touch" || echo OK
+gh label list -R open-telemetry/opentelemetry.io | grep "lang:<lang>"  # label exists
+```
+
+Expected changed/added paths:
+
+- `config/_default/hugo.yaml`
+- `config/_default/module-template.yaml`
+- `.cspell.yml`
+- `.cspell/<lang>-words.txt` (new)
+- `.github/component-label-map.yml`
+- `.github/CODEOWNERS` (generated)
+- `data/locale-teams.yaml`
+- `projects/localization.md`
+- `package.json` **only if** an upstream `@cspell/dict-*` was added

--- a/.claude/skills/setup-new-localization/SKILL.md
+++ b/.claude/skills/setup-new-localization/SKILL.md
@@ -70,7 +70,10 @@ Then add the block under `languages:`, in alphabetical order:
 
 ### b. `config/_default/module-template.yaml` — content mounts
 
-Copy the shape of an existing block (e.g. `## ja`), in alphabetical order:
+Copy the `## <lang>` block from an existing language (e.g. `## ja`) into
+alphabetical position. The per-locale edits are just the language code and the
+YAML anchor name: the primary mount defines `&<lang>-matrix`, and the fallback
+mounts (`_includes`, `announcements`, `docs`) reference it as `*<lang>-matrix`.
 
 ```yaml
 ## <lang>
@@ -78,17 +81,7 @@ Copy the shape of an existing block (e.g. `## ja`), in alphabetical order:
   target: content
   sites: &<lang>-matrix
     matrix: { languages: [<lang>] }
-# fallback pages
-- source: content/en/_includes
-  target: content/_includes
-  sites: *<lang>-matrix
-- source: content/en/announcements
-  target: content/announcements
-  sites: *<lang>-matrix
-- source: content/en/docs
-  target: content/docs
-  files: ['! specs/**']
-  sites: *<lang>-matrix
+# …then the fallback mounts, identical to the sibling block
 ```
 
 ### c. `content/<lang>/.gitkeep` — placeholder content dir
@@ -127,9 +120,8 @@ published package names are inconsistent (`dict-es-es` with a hyphen vs
 `dict-pl_pl` with an underscore), but the [dictionary folders][cspell-dicts]
 follow one rule: `<lang>` (e.g. `bn`) or `<lang>_<REGION>` (e.g. `es_ES`,
 `pl_PL`, `pt_BR`, `uk_UA`). A matching folder means a dict exists; no folder (no
-`ko`, `ja`, `zh`) means there isn't one. Read the [dictionary
-folders][cspell-dicts] directly — a folder-name match is the source of truth,
-not a guessed npm name.
+`ko`, `ja`, `zh`) means there isn't one — the folder listing is the source of
+truth.
 
 The **dictionary id** is the folder name lowercased with `_` → `-` (`pl_PL` →
 `pl-pl`). For the exact **package name** and version, read them from npm

--- a/.claude/skills/setup-new-localization/SKILL.md
+++ b/.claude/skills/setup-new-localization/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   onboarding a localization team.
 argument-hint: '<kickoff-issue | lang-code>'
 allowed-tools: Bash Read Edit Write Grep Glob
-cSpell:ignore: endonym unstaffed
+cSpell:ignore: endonym gitkeep nowrap unstaffed
 ---
 
 # Set up a new localization
@@ -16,7 +16,9 @@ Wire a new language into the site end-to-end. Start from one of:
 - **A kickoff issue (preferred)** — its number or URL, e.g.
   [#9577][kickoff-example]. Read it with
   `gh issue view <n> -R open-telemetry/opentelemetry.io` and pull out:
-  - ISO 639-1 code → `<lang>`
+  - ISO 639-1 code → `<lang>` (required)
+  - Locale, if the issue specifies one → `<locale>` (optional), e.g. `pl-PL`,
+    `zh-CN` — otherwise decide in step (a)
   - Language name → `<native-label>`
   - Locale mentor + Contributors → the **approvers** (`data/locale-teams.yaml`)
 - **A bare `<lang>` ISO 639-1 code** when there's no issue yet. You then gather
@@ -24,11 +26,12 @@ Wire a new language into the site end-to-end. Start from one of:
 
 Either way, derive these; don't ask for them as separate arguments:
 
-- **Hugo locale** — derived in step (a).
+- **Hugo locale** — from the issue if it specifies one, otherwise decided in
+  step (a).
 - **`<native-label>`** — the endonym for that language (from the issue, or see
   gotchas for picking the right one).
 - **`<country>`** — the language's primary country, for the Slack channel / team
-  naming and the label color (step (e)).
+  naming and the label color (step (g)).
 
 [kickoff-example]:
   https://github.com/open-telemetry/opentelemetry.io/issues/9577
@@ -45,12 +48,14 @@ Either way, derive these; don't ask for them as separate arguments:
 
 First decide the locale:
 
-- If `<lang>` maps to a single common locale, **omit `locale:`**. Hugo defaults
-  it to `<lang>` (the ISO 639-1 code), as `bn`, `es`, `fr`, and `ja` do.
-- If `<lang>` has several regional variants in real use (e.g. `pt` → `pt-BR` /
-  `pt-PT`, `zh` → `zh-CN` / `zh-TW`, `en` → `en-US` / `en-GB`), **ask the user
-  which locale** with the `AskUserQuestion` tool (if available; otherwise ask in
-  plain text), then set `locale:` to their answer.
+- If the kickoff issue already specifies a `<locale>`, use it.
+- Otherwise, if `<lang>` maps to a single common locale, **omit `locale:`**.
+  Hugo defaults it to `<lang>` (the ISO 639-1 code), as `bn`, `es`, `fr`, and
+  `ja` do.
+- Otherwise, if `<lang>` has several regional variants in real use (e.g. `pt` →
+  `pt-BR` / `pt-PT`, `zh` → `zh-CN` / `zh-TW`, `en` → `en-US` / `en-GB`), **ask
+  the user which locale** with the `AskUserQuestion` tool (if available;
+  otherwise ask in plain text), then set `locale:` to their answer.
 
 Then add the block under `languages:`, in alphabetical order:
 
@@ -85,7 +90,25 @@ Copy the shape of an existing block (e.g. `## ja`), in alphabetical order:
     sites: *<lang>-matrix
 ```
 
-### c. `.cspell.yml` — custom word list
+### c. `content/<lang>/.gitkeep` — placeholder content dir
+
+The mount in step (b) points at `content/<lang>`, so the directory must exist.
+Create it empty — git won't track an empty folder, so the `.gitkeep` is the
+tracked file:
+
+```bash
+touch content/<lang>/.gitkeep
+```
+
+**Do NOT copy the English homepage into the setup PR.** The translated homepage
+lands in its own follow-up PR (e.g. [#10431][homepage-pr] for Korean). Copying
+`content/en/_index.md` here only creates merge conflicts with that PR and drags
+in a `default_lang_commit` you'd then have to manage. Keep the setup PR to the
+wiring; let `.gitkeep` hold the empty tree.
+
+[homepage-pr]: https://github.com/open-telemetry/opentelemetry.io/pull/10431
+
+### d. `.cspell.yml` — custom word list
 
 Add the custom list in **both** sections (alphabetical):
 
@@ -122,18 +145,33 @@ if the hyphen one 404s). Then wire it in three places:
 - `package.json` devDependency: `"@cspell/dict-pl_pl": "<version>"`
 
 **Korean has no folder**, so for `ko` add only the custom `ko-words` list and
-leave `package.json` unchanged.
+leave the `package.json` devDependencies unchanged.
 
 [cspell-dicts]:
   https://github.com/streetsidesoftware/cspell-dicts/tree/main/dictionaries
 
-### d. `.cspell/<lang>-words.txt` — empty custom list
+### e. `.cspell/<lang>-words.txt` — empty custom list
 
 ```bash
 touch .cspell/<lang>-words.txt
 ```
 
-### e. `lang:<lang>` label — labeler config **and** the GitHub label
+### f. `package.json` — Prettier nowrap group (ask a maintainer)
+
+Some locales break under Prettier's default prose wrapping; the
+`_check:format:nowrap` script runs those with `--prose-wrap preserve` instead.
+It currently lists `content/ja content/ko content/uk content/zh` (CJK plus
+Ukrainian), so there's no clean a-priori rule. **Confirm with a maintainer**
+whether `<lang>` belongs in this group. If it does, add `content/<lang>`
+(alphabetical) to the script:
+
+```json
+"_check:format:nowrap": "npm run __check:format:nowrap -- content/ja content/<lang> content/uk content/zh"
+```
+
+Then run `npm run check:format` to confirm the locale's content passes.
+
+### g. `lang:<lang>` label — labeler config **and** the GitHub label
 
 Wire the auto-labeler in `.github/component-label-map.yml`:
 
@@ -153,7 +191,7 @@ gh label create "lang:<lang>" -R open-telemetry/opentelemetry.io --color <hex>
 # flag color, no leading '#', e.g. ko=0047A0  pl=DC143C  pt=009739  uk=ffdd00
 ```
 
-### f. `data/locale-teams.yaml` — the CODEOWNERS source of truth
+### h. `data/locale-teams.yaml` — the CODEOWNERS source of truth
 
 Since #10295 this registry **generates** the locale section of CODEOWNERS. It
 records the expected membership of the `docs-<lang>-*` teams (created in the
@@ -166,10 +204,12 @@ admin repo — see [Out-of-repo](#out-of-repo-create-the-org-teams)). Under the
   approvers: [<mentor-and-contribs>] # issue's "Locale mentor" + "Contributors"
 ```
 
-Empty `maintainers` marks the locale **unstaffed**: its CODEOWNERS lines fall
-back to `@open-telemetry/docs-approvers`.
+Fill `approvers` with whatever roles are already known — even partial — rather
+than leaving it empty waiting to assess contributions. Empty `maintainers` marks
+the locale **unstaffed**: its CODEOWNERS lines fall back to
+`@open-telemetry/docs-approvers`.
 
-### g. Regenerate CODEOWNERS
+### i. Regenerate CODEOWNERS
 
 ```bash
 npm run fix:codeowners     # regenerates the BEGIN/END locale-owners block
@@ -178,7 +218,7 @@ npm run check:codeowners   # must report "up to date"
 
 **Never hand-edit** the generated block in `.github/CODEOWNERS`.
 
-### h. `projects/localization.md` — 5 alphabetical insertions
+### j. `projects/localization.md` — 5 alphabetical insertions
 
 1. Supported-languages list: `- [<native-label> - <Lang> (<lang>)][<lang>]`
    **and** its link ref `[<lang>]: https://opentelemetry.io/<lang>/`
@@ -194,11 +234,14 @@ npm run check:codeowners   # must report "up to date"
   added a `content/<lang>:` block there; #10295 removed **all** locale teams
   from that file. It now holds only non-locale component reviewers. Re-adding a
   locale duplicates ownership.
+- **Do NOT bundle the homepage.** The setup PR creates only
+  `content/<lang>/.gitkeep`; the translated `_index.md` is a separate PR — see
+  step (c).
 - **Do NOT hand-edit** the generated locale section of `.github/CODEOWNERS` —
-  see step (g).
+  see step (i).
 - **Pick the right endonym.** Korean is `한국어` (South Korea), not `조선말`
   (North Korea). Choose the endonym matching the language's primary country.
-- **Never assume an upstream cSpell dict exists** — see step (c).
+- **Never assume an upstream cSpell dict exists** — see step (d).
 
 ## Out-of-repo: create the org teams {#out-of-repo-create-the-org-teams}
 
@@ -234,6 +277,7 @@ this PR, but you can't merge it.
 
 ```bash
 npm run check:codeowners                  # "up to date"
+npm run check:format                      # passes (incl. nowrap group, if joined)
 git diff --name-only                      # exactly the files below, nothing more
 git diff --name-only | grep component-owners.yml && echo "BUG: do not touch" || echo OK
 gh label list -R open-telemetry/opentelemetry.io | grep "lang:<lang>"  # label exists
@@ -243,10 +287,12 @@ Expected changed/added paths:
 
 - `config/_default/hugo.yaml`
 - `config/_default/module-template.yaml`
+- `content/<lang>/.gitkeep` (new)
 - `.cspell.yml`
 - `.cspell/<lang>-words.txt` (new)
 - `.github/component-label-map.yml`
 - `.github/CODEOWNERS` (generated)
 - `data/locale-teams.yaml`
 - `projects/localization.md`
-- `package.json` **only if** an upstream `@cspell/dict-*` was added
+- `package.json` **only if** an upstream `@cspell/dict-*` was added (step d)
+  and/or `<lang>` was added to the nowrap group (step f)

--- a/.claude/skills/setup-new-localization/SKILL.md
+++ b/.claude/skills/setup-new-localization/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: setup-new-localization
 description: >-
-  Set up a new website localization (language) for opentelemetry.io: Hugo
-  language config, content mounts, cSpell wiring, label map, CODEOWNERS via the
-  locale-teams registry, and the localization project page. Use when adding a
-  new language/locale, wiring a new `content/<lang>/` tree, or onboarding a
-  localization team.
+  Set up a new website localization (language) for opentelemetry.io. Use when
+  adding a new language/locale, wiring a new `content/<lang>/` tree, or
+  onboarding a localization team.
 argument-hint: '<kickoff-issue | lang-code>'
 allowed-tools: Bash Read Edit Write Grep Glob
 cSpell:ignore: endonym unstaffed
@@ -26,10 +24,7 @@ Wire a new language into the site end-to-end. Start from one of:
 
 Either way, derive these; don't ask for them as separate arguments:
 
-- **Hugo locale** — usually the bare code, so you **omit the `locale:` field**
-  (Hugo defaults it to `<lang>`, as `bn`, `es`, `fr`, and `ja` do). When
-  `<lang>` has several regional variants in real use, you must ask which one.
-  See step (a).
+- **Hugo locale** — derived in step (a).
 - **`<native-label>`** — the endonym for that language (from the issue, or see
   gotchas for picking the right one).
 - **`<country>`** — the language's primary country, for the Slack channel / team
@@ -199,12 +194,11 @@ npm run check:codeowners   # must report "up to date"
   added a `content/<lang>:` block there; #10295 removed **all** locale teams
   from that file. It now holds only non-locale component reviewers. Re-adding a
   locale duplicates ownership.
-- **Do NOT hand-edit** the generated locale section of `.github/CODEOWNERS`.
-  Edit `data/locale-teams.yaml` and run `npm run fix:codeowners`.
+- **Do NOT hand-edit** the generated locale section of `.github/CODEOWNERS` —
+  see step (g).
 - **Pick the right endonym.** Korean is `한국어` (South Korea), not `조선말`
   (North Korea). Choose the endonym matching the language's primary country.
-- **Never assume an upstream cSpell dict exists.** Check the cspell-dicts repo
-  folders (there is no `ko`, `ja`, or `zh`).
+- **Never assume an upstream cSpell dict exists** — see step (c).
 
 ## Out-of-repo: create the org teams {#out-of-repo-create-the-org-teams}
 

--- a/content/en/site/skills/_index.md
+++ b/content/en/site/skills/_index.md
@@ -43,6 +43,11 @@ As mentioned above, skills are defined in [`.claude/skills/`][], they are:
 - [`/review-pull-request <pr-number-or-url>`][review-pull-request]: review a
   pull request for CI check semantics, CLA and approval-label workflow, refcache
   handling, locale rules, and content quality.
+- [`/setup-new-localization <kickoff-issue | lang-code>`][setup-new-localization]:
+  set up a new website localization end-to-end — Hugo language block, content
+  mounts, cSpell word list, `lang:<lang>` labeler config and label,
+  `locale-teams.yaml` with CODEOWNERS regeneration, and the `localization.md`
+  entries.
 - [`/update-i18n-drift-status [--locale locale,...] [--create-pr]`][update-i18n-drift-status]:
   update the `drifted_from_default` front matter field for localized content,
   with optional arguments to limit which locales are processed and whether to
@@ -88,6 +93,8 @@ See the section index below.
   https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/review-blog-post/SKILL.md
 [review-pull-request]:
   https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/review-pull-request/SKILL.md
+[setup-new-localization]:
+  https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/setup-new-localization/SKILL.md
 [update-i18n-drift-status]:
   https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/update-i18n-drift-status/SKILL.md
 [update-old-blog-ignores]:

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -14555,6 +14555,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-07-13T06:47:31.641532867Z"
   },
+  "https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/setup-new-localization/SKILL.md": {
+    "StatusCode": 206,
+    "LastSeen": "2026-07-15T06:33:20.173726585Z"
+  },
   "https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/update-git-submodule/SKILL.md": {
     "StatusCode": 206,
     "LastSeen": "2026-07-13T06:47:41.485235997Z"


### PR DESCRIPTION
- Adds `.claude/skills/setup-new-localization/SKILL.md` that wires a new locale end-to-end:
  - Hugo language block, content mounts, cSpell custom list with an upstream-dict lookup against the `cspell-dicts` repo, the `lang:<lang>` labeler config and GitHub label, `data/locale-teams.yaml` with CODEOWNERS regeneration, and the `projects/localization.md` entries
  - Takes a kickoff issue or a bare ISO 639-1 code as input
  - Documents the two maintainer/org-admin actions it can't do itself: creating the `lang:<lang>` label with the country's flag color, and the `docs-<lang>-*` org teams in `open-telemetry/admin` (example: admin#716)
  - Flags the pre-#10295 gotcha so contributors don't re-add locale owners to `component-owners.yml`

/cc @chalin 

---

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

> Co-authored with Claude Opus 4.8.