### PR TITLE
[ja] fix expression of "observability" in title

### DIFF
--- a/content/ja/docs/concepts/observability-primer.md
+++ b/content/ja/docs/concepts/observability-primer.md
@@ -1,5 +1,5 @@
 ---
-title: Observability入門
+title: オブザーバビリティ入門
 description: 重要なオブザーバビリティに関する概念
 weight: 9
 default_lang_commit: 1f686d5f7b6bbdfaa30dafdc6ca0214c6f2308db


### PR DESCRIPTION
## Changes

Fix the title of the Japanese observability primer page.

Changed the title from `Observability入門` (mixing English and Japanese) to `オブザーバビリティ入門` (fully in Japanese katakana), which is consistent with how "observability" is expressed throughout the rest of the page.

## Target page

`content/ja/docs/concepts/observability-primer.md`

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]