### PR TITLE
Fix Azure SDK integration: use vendor-neutral docs link

### DIFF
--- a/data/registry/instrumentation-dotnet-azure-sdk.yml
+++ b/data/registry/instrumentation-dotnet-azure-sdk.yml
@@ -10,9 +10,8 @@ tags:
   - azure
 license: MIT
 description:
-  Azure SDK for .NET (Track 2 libraries) natively emits distributed traces
-  using System.Diagnostics APIs, which is the official OpenTelemetry API for
-  .NET.
+  Azure SDK for .NET (Track 2 libraries) natively emits distributed traces using
+  System.Diagnostics APIs, which is the official OpenTelemetry API for .NET.
 authors:
   - name: Microsoft Azure Authors
     url: https://github.com/Azure

--- a/data/registry/instrumentation-dotnet-azure-sdk.yml
+++ b/data/registry/instrumentation-dotnet-azure-sdk.yml
@@ -9,13 +9,16 @@ tags:
   - azure-sdk
   - azure
 license: MIT
-description: Instrumentation for Azure SDK for .NET (Track 2 libraries).
+description:
+  Azure SDK for .NET (Track 2 libraries) natively emits distributed traces
+  using System.Diagnostics APIs, which is the official OpenTelemetry API for
+  .NET.
 authors:
   - name: Microsoft Azure Authors
     url: https://github.com/Azure
 urls:
   website: https://github.com/Azure/azure-sdk-for-net # to work on the integrations page as well
-  docs: https://learn.microsoft.com/en-us/azure/azure-monitor/app/opentelemetry-enable
+  docs: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/Diagnostics.md#opentelemetry-configuration
   repo: https://github.com/Azure/azure-sdk-for-net
 createdAt: 2021-12-16
 isNative: true

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -3387,6 +3387,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-06-16T11:25:28.84591838Z"
   },
+  "https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/Diagnostics.md#opentelemetry-configuration": {
+    "StatusCode": 206,
+    "LastSeen": "2026-06-20T10:55:57.110913913Z"
+  },
   "https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore": {
     "StatusCode": 206,
     "LastSeen": "2026-06-14T10:43:10.528403957Z"


### PR DESCRIPTION
The existing docs link points to Azure Monitor setup (vendor-specific). Replace with the Azure SDK's own vendor-neutral OpenTelemetry configuration docs, and clarify the description to reflect that it emits distributed traces (not metrics).