### PR TITLE
[ja] docs(i18n): Update admonition labels ( `> **NOTE**` )

### DIFF
--- a/content/ja/docs/contributing/development.md
+++ b/content/ja/docs/contributing/development.md
@@ -29,7 +29,7 @@ cSpell:ignore: TOCSS
     また、次の形式のリンクを開くこともできます。
     `https://gitpod.io#https://github.com/YOUR_GITHUB_ID/opentelemetry.io`
 
-    > **注記**: このリポジトリで作業するための権限がある場合や、単に内容を確認したい場合は、
+    > **Note**: このリポジトリで作業するための権限がある場合や、単に内容を確認したい場合は、
     > <https://gitpod.io/#https://github.com/open-telemetry/opentelemetry.io> を開いてください。
 
 Gitpod はリポジトリ固有のパッケージを自動的にインストールします。

--- a/content/ja/docs/platforms/kubernetes/operator/automatic.md
+++ b/content/ja/docs/platforms/kubernetes/operator/automatic.md
@@ -556,7 +556,7 @@ spec:
 
 上記の場合、`myapp` と `myapp2` のコンテナが計装され、`myapp3` は計装されません。
 
-> **注記**: Goの自動計装は、マルチコンテナのPodを**サポートしていません**。
+> **NOTE**: Goの自動計装は、マルチコンテナのPodを**サポートしていません**。
 > Goの自動計装をインジェクトする場合、計装したいコンテナを最初のコンテナとして配置する必要があります。
 
 ### initコンテナの計装 {#instrumenting-init-containers}
@@ -655,9 +655,9 @@ spec:
 
 上記の場合、`myapp` と `myapp2` は Java で、`myapp3` は Python で計装されます。
 
-> **注記**: Goの自動計装は、マルチコンテナのPodを**サポートしていません**。
-> **注記**: 1つのコンテナを複数言語の計装で計装することはできません。
-> **注記**: `instrumentation.opentelemetry.io/container-names` アノテーションはこの機能では使用されません。
+> **NOTE**: Goの自動計装は、マルチコンテナのPodを**サポートしていません**。
+> **NOTE**: 1つのコンテナを複数言語の計装で計装することはできません。
+> **NOTE**: `instrumentation.opentelemetry.io/container-names` アノテーションはこの機能では使用されません。
 
 ## カスタマイズ済みまたはベンダー製の計装を使う {#using-customized-or-vendor-instrumentation}
 

--- a/content/ja/docs/zero-code/python/example.md
+++ b/content/ja/docs/zero-code/python/example.md
@@ -104,7 +104,7 @@ opentelemetry-bootstrap -a install
 この後の例では、計装結果をコンソールに送信します。
 コレクターのような他の送信先にテレメトリーを送信するための [OpenTelemetry Distro](/docs/languages/python/distro) のインストールと設定については、こちらを参照してください。
 
-> **注**: `opentelemetry-instrument` による自動計装を使用するには、
+> **Note**: `opentelemetry-instrument` による自動計装を使用するには、
 > 環境変数またはコマンドラインで設定する必要があります。
 > エージェントはテレメトリーパイプラインを作成するので、
 > これらの手段以外では変更できません。

--- a/content/ja/docs/zero-code/python/logs-example.md
+++ b/content/ja/docs/zero-code/python/logs-example.md
@@ -72,7 +72,7 @@ pip install opentelemetry-instrumentation-logging
 この後の例では、計装結果をコンソールに送信します。
 コレクターのような他の送信先にテレメトリーを送信するための [OpenTelemetry Distro](/docs/languages/python/distro) のインストールと設定については、ドキュメントを参照してください。
 
-> **注**: `opentelemetry-instrument`による自動計装を使用するには、
+> **Note**: `opentelemetry-instrument`による自動計装を使用するには、
 > 環境変数またはコマンドラインで設定する必要があります。
 > エージェントはテレメトリーパイプラインを作成するので、これらの手段以外では変更できません。
 > テレメトリーパイプラインのカスタマイズが必要な場合は、エージェントを使用せず、 OpenTelemetry SDK と計装ライブラリをコードにインポートし、そこで設定する必要があります。


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

Update Japanese admonition labels to match the English source text.

This change standardizes admonition labels that were mixed between Japanese and English, using `Note or NOTE` where the corresponding English source uses those labels.
NOTE is also commonly used in Japanese technical documentation, so keeping the English label is natural and consistent here.

---

## English page

https://opentelemetry.io/docs/platforms/kubernetes/operator/automatic/
https://opentelemetry.io/docs/zero-code/python/example/
https://opentelemetry.io/docs/zero-code/python/logs-example/

### File with SHA

https://github.com/open-telemetry/opentelemetry.io/blob/869b2bb90ca9e54d8d98e7815e66111b577165eb/content/en/docs/platforms/kubernetes/operator/automatic.md
https://github.com/open-telemetry/opentelemetry.io/blob/39d3d2ef243d968e6a434fd9d2690c8070c3d7ea/content/en/docs/zero-code/python/example.md
https://github.com/open-telemetry/opentelemetry.io/blob/4ed6dc80de862696701831ebc0ad3defbea70e31/content/en/docs/zero-code/python/logs-example.md

## Preview

https://deploy-preview-10501--opentelemetry.netlify.app/ja/docs/platforms/kubernetes/operator/automatic/
https://deploy-preview-10501--opentelemetry.netlify.app/ja/docs/zero-code/python/example/
https://deploy-preview-10501--opentelemetry.netlify.app/ja/docs/zero-code/python/logs-example/
