### PR TITLE
Add AgentMark to the vendors list

### DIFF
--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -4,6 +4,12 @@
   contact:
   oss: false
   commercial: true
+- name: AgentMark
+  nativeOTLP: true
+  url: https://docs.agentmark.co/observe/overview
+  contact: ryan@agentmark.co
+  oss: false
+  commercial: true
 - name: AppDynamics (Cisco)
   nativeOTLP: true
   url: https://docs.appdynamics.com/latest/en/application-monitoring/splunk-appdynamics-for-opentelemetry


### PR DESCRIPTION
Adds **AgentMark** to the vendors list. AgentMark is an observability platform for AI agents that natively ingests OpenTelemetry traces via OTLP.

Per the checklist in [Adding your organization](https://opentelemetry.io/ecosystem/vendors/#how-to-add):

- **Native OTLP ingestion docs:** https://docs.agentmark.co/integrations/tracing/opentelemetry — point any OTLP exporter at `https://api.agentmark.co/v1/traces`. AgentMark also normalizes OpenInference and OpenLLMetry spans into the OTel GenAI (`gen_ai.*`) model.
- **Distribution:** n/a (no custom OpenTelemetry distribution).
- **Open source:** `oss: false` — the AgentMark backend is a hosted service; the open-source `@agentmark-ai/*` SDK/CLI is instrumentation, which per the guidelines does not by itself qualify the offering as open source.
- **Point of contact:** ryan@agentmark.co