### PR TITLE
[ja] add translation of content/en/blog/2026/kubecon-eu.md

### DIFF
--- a/content/ja/blog/2026/kubecon-eu.md
+++ b/content/ja/blog/2026/kubecon-eu.md
@@ -1,0 +1,248 @@
+---
+title: KubeCon + CloudNativeCon Europe 2026
+linkTitle: KubeCon EU '26
+date: 2026-02-02
+author: '[Zhu Jiekun](https://github.com/jiekun) (VictoriaMetrics)'
+default_lang_commit: 66215f27a11cce93dc823a34713dc89cc5d96ca7
+# prettier-ignore
+cSpell:ignore: Altinity Amaechi Anoshin Aravena baeyens Benedetti Benedikt Bhatnagar Bongartz Bunino Cail Cijo Danielson Dapr Diagrid Dmitrii dyrmishi Ferri Geisendörfer Grcevski Guiton Haeussler Hantzaras helmuth Jernigan jiekun kasper Khavronenko Kluwer Kovalenko Kunju Kuntzer Lahouel Lehner Llinares Menderico Mikhailov Milind nissen Observablity Okorie Onyedikachi OTTL Pająk Perath Rabenhorst Roman Schrottner Skyscanner Spanimals Srivastava tacular Therrien Timelthaler Toulme Travaglini Ujuk Vamerlatti Wolters yash
+---
+
+OpenTelemetry プロジェクトのメンテナー、ガバナンス委員会メンバー、そして技術委員会メンバーは、2026年3月23日から26日にアムステルダムで開催される [KubeCon EU][] に参加します。
+ぜひ[登録][kubecon registration]して、一緒に参加しましょう！
+
+KubeCon 期間中の OpenTelemetry 関連イベントについて、以下をお読みください。
+
+## トークとメンテナーセッション {#talks-and-maintainer-sessions}
+
+- **[We Deleted Our Observability Stack and Rebuilt It With OTel: 12 Engineers to 4 at 20K+ Clusters](https://kccnceu2026.sched.com/event/2CVxh/we-deleted-our-observability-stack-and-rebuilt-it-with-otel-12-engineers-to-4-at-20k+-clusters-yash-sharma-kunju-perath-digitalocean)**<br>by
+  Yash Sharma, DigitalOcean; Kunju Perath, DigitalOcean<br> Tuesday March 24,
+  2026 11:15 - 11:45CET
+
+- **[When OTTL Goes Off the Rails: Debugging Transformations with Confidence](https://kccnceu2026.sched.com/event/2CVyH/when-ottl-goes-off-the-rails-debugging-transformations-with-confidence-edmo-vamerlatti-costa-elastic-tyler-helmuth-honeycomb)**<br>by
+  Edmo Vamerlatti Costa, Elastic; Tyler Helmuth, Honeycomb<br> Tuesday March 24,
+  2026 12:00 - 12:30CET
+
+- **[Schema Inference and Automation: A New Era for Telemetry Management](https://kccnceu2026.sched.com/event/2CVzR/schema-inference-and-automation-a-new-era-for-telemetry-management-nicolas-takashi-coralogix-arthur-silva-sens-grafana-labs)**<br>by
+  Arthur Silva Sens, Grafana Labs; Nicolas Takashi, Coralogix<br> Tuesday March
+  24, 2026 15:15 - 15:45CET
+
+- **[OpenTelemetry Collector SIG: Project Updates](https://kccnceu2026.sched.com/event/2EF6f/opentelemetry-collector-sig-project-updates-jade-guiton-datadog-dmitrii-anoshin-cisco-alex-boten-honeycomb-evan-bradley-dynatrace-llc-antoine-toulme-splunk)**<br>by
+  Dmitrii Anoshin, Cisco; Evan Bradley, Dynatrace LLC; Alex Boten, Honeycomb;
+  Antoine Toulme, Splunk; Jade Guiton, Datadog<br> Tuesday March 24, 2026
+  16:15 - 16:45CET
+
+- **[OpenTelemetry Logs Driving a Major Shift: Events, Richer Data, and Smarter Semantics](https://kccnceu2026.sched.com/event/2CVxk/opentelemetry-logs-driving-a-major-shift-events-richer-data-and-smarter-semantics-robert-pajak-splunk)**<br>by
+  Robert Pająk, Splunk, a Cisco company<br> Tuesday March 24, 2026 16:15 -
+  16:45CET
+
+- **[OpenTelemetry Project Update and AMA](https://kccnceu2026.sched.com/event/2EF6i/opentelemetry-project-update-and-ama-pablo-baeyens-datadog-juraci-paixao-krohling-ollygarden-marylia-gutierrez-grafana-labs-severin-neumann-causely)**<br>by
+  Juraci Paixão Kröhling, OllyGarden; Severin Neumann, Causely AI; Pablo
+  Baeyens, Datadog; Marylia Gutierrez, Grafana Labs<br> Tuesday March 24, 2026
+  17:00 - 17:30CET
+
+- **[Overcoming OpenTelemetry Adoption Challenges](https://kccnceu2026.sched.com/event/2CVyK/overcoming-opentelemetry-adoption-challenges-chris-weldon-wolters-kluwer)**<br>by
+  Chris Weldon, Wolters Kluwer<br> Tuesday March 24, 2026 17:00 - 17:30CET
+
+- **[Retroactive Sampling with OpenTelemetry: Cut 90% Distributed Tracing Bandwidth Usage](https://kccnceu2026.sched.com/event/2CW83/retroactive-sampling-with-opentelemetry-cut-90-distributed-tracing-bandwidth-usage-roman-khavronenko-zhu-jiekun-victoriametrics)**<br>by
+  Roman Khavronenko & Zhu Jiekun, VictoriaMetrics<br> Tuesday March 24, 2026
+  17:00 - 17:30CET
+
+- **[Hello World, Meet the Spanimals: Observability for Beginners](https://kccnceu2026.sched.com/event/2CW2F/hello-world-meet-the-spanimals-observability-for-beginners-tiffany-jernigan-grafana-labs-matthias-haeussler-cgi)**<br>by
+  Matthias Haeussler, CGI; Tiffany Jernigan, Grafana Labs<br> Wednesday March
+  25, 2026 14:15 - 14:45CET
+
+- **[Jaeger V2: The Maintainers' Guide To OpenTelemetry-Native Tracing](https://kccnceu2026.sched.com/event/2EF43/jaeger-v2-the-maintainers-guide-to-opentelemetry-native-tracing-pavol-loffay-red-hat)**<br>by
+  Pavol Loffay, Red Hat<br> Wednesday March 25, 2026 15:00 - 15:30CET
+
+- **[How Manual OTel Instrumentation Saves More Than Just Money](https://kccnceu2026.sched.com/event/2CW3A/how-manual-otel-instrumentation-saves-more-than-just-money-juliano-costa-datadog-yuri-oliveira-ollygarden)**<br>by
+  Juliano Costa, Datadog; Yuri Oliveira, OllyGarden<br> Wednesday March 25, 2026
+  15:00 - 15:30CET
+
+- **[📚 Tutorial: Full-Stack Observability on a Budget: A Guide to Strategic Sampling and Data Optimization](https://kccnceu2026.sched.com/event/2CW3t/tutorial-full-stack-observability-on-a-budget-a-guide-to-strategic-sampling-and-data-optimization-pavol-loffay-red-hat)**<br>by
+  Pavol Loffay, Red Hat<br> Wednesday March 25, 2026 16:00 - 17:15CET
+
+- **[⚡ Lightning Talk: "Naming Things Is Hard": A Guide to Naming Using Network Science](https://kccnceu2026.sched.com/event/2CW4Q/cl-lightning-talk-naming-things-is-hard-a-guide-to-naming-using-network-science-nick-travaglini-honeycombio)**<br>by
+  Nick Travaglini, Honeycomb.io<br> Wednesday March 25, 2026 16:45 - 16:50CET
+
+- **[Enriching Telemetry Signals Through Lookups in the OTel Collector](https://kccnceu2026.sched.com/event/2CW4H/enriching-telemetry-signals-through-lookups-in-the-otel-collector-joao-duarte-elastic)**<br>by
+  João Duarte, Elastic<br> Wednesday March 25, 2026 16:45 - 17:15CET
+
+- **[⚡ Lightning Talk: Going Global: Lessons From Internationalizing OpenTelemetry Docs](https://kccnceu2026.sched.com/event/2CW4f/cl-lightning-talk-going-global-lessons-from-internationalizing-opentelemetry-docs-severin-neumann-causely-ai-fabrizio-ferri-benedetti-elastic)**<br>by
+  Severin Neumann, Causely AI; Fabrizio Ferri-Benedetti, Elastic<br> Wednesday
+  March 25, 2026 17:20 - 17:25CET
+
+- **[DNS Tracing & Metrics Via eBPF in OpenTelemetry](https://kccnceu2026.sched.com/event/2CW5C/dns-tracing-metrics-via-ebpf-in-opentelemetry-endre-sara-causely-nikola-grcevski-grafana-labs)**<br>by
+  Endre Sara, Causely; Nikola Grcevski, Grafana Labs<br> Wednesday March 25,
+  2026 17:30 - 18:00CET
+
+- **[Observing Chaos: Real-Time Monitoring of AI-Driven Kubernetes Destruction](https://kccnceu2026.sched.com/event/2CW1T/observing-chaos-real-time-monitoring-of-ai-driven-kubernetes-destruction-josh-halley-cisco-ricardo-aravena-cncf)**<br>by
+  Ricardo Aravena, CNCF; Josh Halley, Cisco<br> Wednesday March 25, 2026 17:30 -
+  18:00CET
+
+- **[Cutting Metrics Traffic, Cutting Costs: The AZ-Aware Observability Blueprint](https://kccnceu2026.sched.com/event/2CW5m/cutting-metrics-traffic-cutting-costs-the-az-aware-observability-blueprint-iris-dyrmishi-rodrigo-fior-kuntzer-miro)**<br>by
+  Rodrigo Fior Kuntzer, Staff Site Reliability Engineer, Miro; Iris Dyrmishi,
+  Miro<br> Thursday March 26, 2026 11:00 - 11:30CET
+
+- **[Taming Complexity: Building Observable Workflows With Dapr and OpenTelemetry](https://kccnceu2026.sched.com/event/2CW6J/taming-complexity-building-observable-workflows-with-dapr-and-opentelemetry-mauricio-salaboy-salatino-diagrid-kasper-borg-nissen-dash0)**<br>by
+  Kasper Borg Nissen, Dash0; Mauricio Salatino, Diagrid<br> Thursday March 26,
+  2026 11:45 - 12:15CET
+
+- **[18 Bluetooth Controllers Walk into a Bar: Observability & Runtime Configuration with CNCF Tools](https://kccnceu2026.sched.com/event/2CW7W/18-bluetooth-controllers-walk-into-a-bar-observability-runtime-configuration-with-cncf-tools-simon-schrottner-dynatrace-manuel-timelthaler-tractive)**<br>by
+  Simon Schrottner, Dynatrace; Manuel Timelthaler, Tractive<br> Thursday March
+  26, 2026 14:30 - 15:00CET
+
+- **[Day-2 Reality Check: Taming Wasteful Telemetry](https://kccnceu2026.sched.com/event/2CW6M/day-2-reality-check-taming-wasteful-telemetry-juraci-paixao-krohling-ollygarden-elena-kovalenko-delivery-hero)**<br>by
+  Juraci Paixão Kröhling, OllyGarden; Elena Kovalenko, Delivery Hero<br>
+  Thursday March 26, 2026 15:15 - 15:45CET
+
+- **[The Fourth Pillar Arrives: OpenTelemetry Profiling Alpha in Action](https://kccnceu2026.sched.com/event/2CW0V/the-fourth-pillar-arrives-opentelemetry-profiling-alpha-in-action-felix-geisendorfer-datadog-florian-lehner-elastic)**<br>by
+  Felix Geisendörfer, Datadog; Florian Lehner, Elastic<br> Thursday March 26,
+  2026 15:15 - 15:45CET
+
+## Observability Day のトーク {#observability-day-talks}
+
+[Observability Day][] は、クラウドネイティブなオブザーバビリティプロジェクトに焦点を当てたコラボレーション、ディスカッション、知識共有を促進するイベントです。
+このイベントは2026年3月23日の 9:00 から 18:00 まで開催されます。
+オブザーバビリティと OpenTelemetry に関するお気に入りのトークを[スケジュール][obs-day-sched]からご覧ください。
+
+<details>
+
+- **[Observability Project Updates](https://colocatedeventseu2026.sched.com/event/2DYN7/observability-project-updates)**<br>by
+  Juraci Paixão Kröhling, OllyGarden; Austin Parker, honeycomb.io; Iris
+  Dyrmishi, Miro; Eduardo Silva, Chronosphere<br> Monday March 23, 2026 09:10 -
+  09:40CET
+
+- **[⚡Lightning Talk: The < Meta /> Trick: Connecting Page Load To Backend Traces](https://colocatedeventseu2026.sched.com/event/2DY1n/cllightning-talk-the-meta-trick-connecting-page-load-to-backend-traces-wolfgang-therrien-honeycomb)**<br>by
+  Wolfgang Therrien, Honeycomb<br> Monday March 23, 2026 09:45 - 09:55CET
+
+- **[A Practical Blueprint for Evolving Observability Schemas](https://colocatedeventseu2026.sched.com/event/2DY2Q/a-practical-blueprint-for-evolving-observability-schemas-benedikt-bongartz-red-hat-sebastian-rabenhorst-shopify)**<br>by
+  Sebastian Rabenhorst, Shopify; Benedikt Bongartz, Red Hat<br> Monday March 23,
+  2026 10:40 - 11:05CET
+
+- **[Unpacking Your OTel Baggage](https://colocatedeventseu2026.sched.com/event/2DY2T/unpacking-your-otel-baggage-dan-gomez-blanco-new-relic-john-clark-skyscanner)**<br>by
+  Dan Gomez Blanco, New Relic; John Clark, Skyscanner<br> Monday March 23, 2026
+  10:40 - 11:05CET
+
+- **[Beyond Dashboards: Cultivating the Observability Mindset That Makes Tools Work](https://colocatedeventseu2026.sched.com/event/2DY3F/beyond-dashboards-cultivating-the-observability-mindset-that-makes-tools-work-onyedikachi-hope-amaechi-okorie-json-schema)**<br>by
+  Onyedikachi Hope Amaechi-Okorie, JSON Schema<br> Monday March 23, 2026 11:15 -
+  11:40CET
+
+- **[Observability at the Edge: State of OpenTelemetry in Kubernetes Ingress Controllers](https://colocatedeventseu2026.sched.com/event/2DY3C/observability-at-the-edge-state-of-opentelemetry-in-kubernetes-ingress-controllers-kasper-borg-nissen-dash0)**<br>by
+  Kasper Borg Nissen, Dash0<br> Monday March 23, 2026 11:15 - 11:40CET
+
+- **[Panel: The Spec-tacular Game Show V2](https://colocatedeventseu2026.sched.com/event/2DY4M/panel-the-spec-tacular-game-show-v2-alex-boten-tyler-helmuth-honeycomb-adriana-villela-dynatrace-pablo-baeyens-datadog-marylia-gutierrez-grafana-labs)**<br>by
+  Adriana Villela, Dynatrace; Pablo Baeyens, Datadog; Alex Boten, Honeycomb;
+  Marylia Gutierrez, Grafana Labs; Tyler Helmuth, Honeycomb<br> Monday March 23,
+  2026 12:45 - 13:20CET
+
+- **[Scaling Telemetry To Terabytes: Applying Google's Principles To OpenTelemetry With OpAMP](https://colocatedeventseu2026.sched.com/event/2DY4Y/scaling-telemetry-to-terabytes-applying-googles-principles-to-opentelemetry-with-opamp-raphael-menderico-google)**<br>by
+  Raphael Menderico, Google<br> Monday March 23, 2026 12:55 - 13:20CET
+
+- **[Accelerating Science, Decelerating Carbon: Sustainable Computing at CERN](https://colocatedeventseu2026.sched.com/event/2DY4w/accelerating-science-decelerating-carbon-sustainable-computing-at-cern-laura-llinares-amine-lahouel-cern)**<br>by
+  Amine Lahouel, CERN; Laura Llinares, CERN<br> Monday March 23, 2026 13:30 -
+  13:55CET
+
+- **[To Make an SLO, First You Must Invent the Universe: OpenTelemetry Collection From Scratch](https://colocatedeventseu2026.sched.com/event/2DY4t/to-make-an-slo-first-you-must-invent-the-universe-opentelemetry-collection-from-scratch-cail-young-octopus-deploy)**<br>by
+  Cail Young, Octopus Deploy<br> Monday March 23, 2026 13:30 - 13:55CET
+
+- **[Observability in the Matrix: Choosing the Right AI Agent To Escape the Chaos](https://colocatedeventseu2026.sched.com/event/2DY5f/observability-in-the-matrix-choosing-the-right-ai-agent-to-escape-the-chaos-henrik-rexed-dynatrace)**<br>by
+  Henrik Rexed, Dynatrace<br> Monday March 23, 2026 14:05 - 14:30CET
+
+- **[Observability Through Users' Eyes and How To Fix the Knowledge Disconnect](https://colocatedeventseu2026.sched.com/event/2DY5i/observability-through-users-eyes-and-how-to-fix-the-knowledge-disconnect-iris-dyrmishi-miro-helia-barroso-five9)**<br>by
+  Iris Dyrmishi, Miro; Hélia Barroso, Five9<br> Monday March 23, 2026 14:05 -
+  14:30CET
+
+- **[From Pods To PUE: A Digital Twin Approach To Sustainable Kubernetes Infrastructure](https://colocatedeventseu2026.sched.com/event/2DY6U/from-pods-to-pue-a-digital-twin-approach-to-sustainable-kubernetes-infrastructure-matteo-bunino-cern)**<br>by
+  Matteo Bunino, CERN<br> Monday March 23, 2026 14:40 - 15:05CET
+
+- **[Parity in Observability Across Different Platforms](https://colocatedeventseu2026.sched.com/event/2DY6X/parity-in-observability-across-different-platforms-kirill-mikhailov-liam-harrington-riot-games)**<br>by
+  Kirill Mikhailov, Riot Games; Liam Harrington, Riot Games<br> Monday March 23,
+  2026 14:40 - 15:05CET
+
+- **[Designing for Observability](https://colocatedeventseu2026.sched.com/event/2DY7D/designing-for-observability-george-hantzaras-mongodb)**<br>by
+  George Peter Hantzaras, Core Platforms, MongoDB<br> Monday March 23, 2026
+  15:20 - 15:45CET
+
+- **[One YAML To Rule Them All: Declarative Config](https://colocatedeventseu2026.sched.com/event/2DY7A/one-yaml-to-rule-them-all-declarative-config-jamie-danielson-honeycombio)**<br>by
+  Jamie Danielson, Honeycomb.io<br> Monday March 23, 2026 15:20 - 15:45CET
+
+- **[Let Me Be Your OpenTelemetry Champ](https://colocatedeventseu2026.sched.com/event/2DY7w/let-me-be-your-opentelemetry-champ-pavol-loffay-red-hat)**<br>by
+  Pavol Loffay, Red Hat<br> Monday March 23, 2026 15:55 - 16:20CET
+
+- **[OpenTelemetry Gateways: Enforce, Transform, Route](https://colocatedeventseu2026.sched.com/event/2DY7t/opentelemetry-gateways-enforce-transform-route-juraci-paixao-krohling-ollygarden-natalie-ujuk-ig-group)**<br>by
+  Juraci Paixão Kröhling, OllyGarden; Natalie Ujuk, IG Group<br> Monday March
+  23, 2026 15:55 - 16:20CET
+
+- **[Observability Without Borders: The OpenTelemetry Collector in a WebAssembly World](https://colocatedeventseu2026.sched.com/event/2DY8f/observability-without-borders-the-opentelemetry-collector-in-a-webassembly-world-evan-bradley-dynatrace-pablo-baeyens-datadog)**<br>by
+  Evan Bradley, Dynatrace LLC; Pablo Baeyens, Datadog<br> Monday March 23, 2026
+  16:30 - 16:55CET
+
+- **[When the Codebase Starts Instrumenting Itself](https://colocatedeventseu2026.sched.com/event/2DY8i/when-the-codebase-starts-instrumenting-itself-whitney-lee-datadog)**<br>by
+  Whitney Lee, Datadog<br> Monday March 23, 2026 16:30 - 16:55CET
+
+- **[⚡Lightning Talk: A Drop-in System To Accelerate Metrics Observability by 100x Using Sketch-based Approximation](https://colocatedeventseu2026.sched.com/event/2DY9O/cllightning-talk-a-drop-in-system-to-accelerate-metrics-observability-by-100x-using-sketch-based-approximation-milind-srivastava-carnegie-mellon-university)**<br>by
+  Milind Srivastava, Carnegie Mellon University<br> Monday March 23, 2026
+  17:00 - 17:10CET
+
+- **[⚡Lightning Talk: Semantics Matter! Lessons From Stabilizing OpenTelemetry's System Conventions](https://colocatedeventseu2026.sched.com/event/2DY9R/cllightning-talk-semantics-matter-lessons-from-stabilizing-opentelemetrys-system-conventions-roger-coll-elastic)**<br>by
+  Roger Coll, Elastic<br> Monday March 23, 2026 17:00 - 17:10CET
+
+- **[⚡Lightning Talk: Grasp the Real Worth of Your Microservices by Brewing a Truth Potion of Observablity](https://colocatedeventseu2026.sched.com/event/2DYA1/cllightning-talk-grasp-the-real-worth-of-your-microservices-by-brewing-a-truth-potion-of-observablity-yash-bhatnagar-google)**<br>by
+  Yash Bhatnagar, Google<br> Monday March 23, 2026 17:15 - 17:25CET
+
+- **[⚡Lightning Talk: "Metrics That Lie": Understanding OpenTelemetry's Cardinality Capping and Its Implications](https://colocatedeventseu2026.sched.com/event/2DYA4/cllightning-talk-metrics-that-lie-understanding-opentelemetrys-cardinality-capping-and-its-implications-cijo-thomas-microsoft)**<br>by
+  Cijo Thomas, Microsoft<br> Monday March 23, 2026 17:15 - 17:25CET
+
+</details>
+
+> [!IMPORTANT] 重要なアクセスに関する注意
+>
+> **Observability Day** に参加するには _all-access_ パスが必要です。
+> 詳細は [KubeCon registration][] をご覧ください。
+
+## メンテナーサミット {#maintainer-summit}
+
+併設イベントとカンファレンスの前日にあたる3月22日に開催されるメンテナーサミットは、プロジェクトの担い手たちが直接顔を合わせる貴重な機会です。
+OpenTelemetry 組織の[メンバー][membership]が集まり、コラボレーション、学習、アイデアの共有、問題解決、そしてプロジェクトの充実を図ります。
+準備されたトーク、プロジェクトミーティング、アンカンファレンスセッションが 9:00 から 17:00 まで行われます。
+詳細は[フルスケジュール][summit schedule]をご覧ください。
+今すぐ[サインアップ][maintainer summit]しましょう！
+
+- **[Building Bridges: How the OTel End User SIG Helps Foster Community](https://maintainersummiteu2026.sched.com/event/2EWem/building-bridges-how-the-otel-end-user-sig-helps-foster-community-adriana-villela-dynatrace-josh-lee-altinity-reese-lee-new-relic)**<br>by
+  Adriana Villela, Dynatrace; Josh Lee, Altinity; Reese Lee, New Relic<br>
+  Sunday March 22, 2026 11:35 - 12:10GMT
+
+- **[Project Meeting | Prometheus & OpenTelemetry](https://maintainersummiteu2026.sched.com/event/2EWep/project-meeting-prometheus-opentelemetry)**
+  <br> Sunday March 22, 2026 11:35 - 12:10GMT
+
+> [!IMPORTANT] 重要なアクセスに関する注意
+>
+> **メンテナーサミット** に参加するには、KubeCon + CloudNativeCon への登録が必要です。
+> また、OpenTelemetry などの CNCF インキュベーティングプロジェクトのメンバーである必要があります。
+> 参加資格については [Maintainer Summit][] をご覧ください。
+
+{{< comment >}}
+
+## OpenTelemetry Observatory
+
+TODO
+
+## OpenTelemetry Community Awards
+
+TODO
+
+{{< /comment >}}
+
+## ぜひご参加ください {#join-us}
+
+OpenTelemetry のトークを聴き、学び、そしてプロジェクトに参加しましょう。
+アムステルダムでお会いしましょう！
+
+[kubecon eu]: https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/
+[Observability Day]: https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/co-located-events/observability-day/
+[kubecon registration]: https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/register/
+[summit schedule]: https://maintainersummiteu2026.sched.com/
+[maintainer summit]: https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/features-add-ons/maintainer-summit/
+[membership]: https://github.com/open-telemetry/community/blob/25f027532a6e9b503d6eb4dd3db0a98eb3b5f1cb/guides/contributor/membership.md#member?from_branch=main
+[obs-day-sched]: https://colocatedeventseu2026.sched.com/overview/type/Observability+Day


### PR DESCRIPTION
## Summary

Translates `content/en/blog/2026/kubecon-eu.md` into Japanese as `content/ja/blog/2026/kubecon-eu.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10513--opentelemetry.netlify.app/ja/blog/2026/kubecon-eu/
- **English (canonical):** https://opentelemetry.io/blog/2026/kubecon-eu/

<!-- preview-section-end -->
