### PR TITLE
[ja] update translation of content/en/docs/languages/java/_index.md

### DIFF
--- a/content/ja/docs/languages/java/_index.md
+++ b/content/ja/docs/languages/java/_index.md
@@ -9,13 +9,12 @@ redirects:
   - { from: /docs/java/*, to: ':splat' }
 cascade:
   vers:
-    instrumentation: 2.28.1
+    instrumentation: 2.29.0
     otel: 1.63.0
-    contrib: 1.57.0
+    contrib: 1.58.0
     semconv: 1.42.0
 weight: 150
-default_lang_commit: 74ba66cadfe96161b3fa03fdf3d8ea4067b00849
-drifted_from_default: true
+default_lang_commit: b291d077d4c7aba2b43ec5a1648c02bb5c43f870
 ---
 
 {{% docs/languages/index-intro java /%}}


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/java/_index.md` to match the latest English source at
`content/en/docs/languages/java/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

Changes are frontmatter-only: `cascade.vers.instrumentation` 2.28.1 → 2.29.0 and
`cascade.vers.contrib` 1.57.0 → 1.58.0.

Note: PR #10503 ("Make images zoomable") also touches this file but only to add
`drifted_from_default: true` as part of a cross-cutting site-wide change — no content overlap.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10529--opentelemetry.netlify.app/ja/docs/languages/java/
- **English (canonical):** https://opentelemetry.io/docs/languages/java/

_(deploy preview may take a few minutes to build.)_
<!-- preview-section-end -->
