### PR TITLE
[ja] update translation of content/en/site/build/ci-workflows.md

### DIFF
--- a/content/ja/site/build/ci-workflows.md
+++ b/content/ja/site/build/ci-workflows.md
@@ -375,6 +375,6 @@ node scripts/gh/specs/pick-branch/cli.mjs --help
 | `component-owners.yml`     | コンポーネント所有権に基づくレビュアーの割り当て                                                  |
 
 <!-- prettier-ignore-start -->
-[lychee-pilot]: ../npm-scripts/#notes
+[lychee-pilot]: /site/build/npm-scripts/#notes
 [.github]: https://github.com/open-telemetry/opentelemetry.io/tree/main/.github
 <!-- prettier-ignore-end -->

--- a/content/ja/site/build/ci-workflows.md
+++ b/content/ja/site/build/ci-workflows.md
@@ -1,15 +1,12 @@
 ---
 title: CI ワークフロー
-linkTitle: CI ワークフロー
 description: >-
   PR のチェック、ラベル管理、その他の CI/CD プロセスを自動化する GitHub Actions ワークフロー。
 weight: 10
-default_lang_commit: 74ba66cadfe96161b3fa03fdf3d8ea4067b00849
-drifted_from_default: true
+default_lang_commit: b291d077d4c7aba2b43ec5a1648c02bb5c43f870
 ---
 
-すべてのワークフローファイルは
-[`.github/workflows/`](https://github.com/open-telemetry/opentelemetry.io/tree/main/.github/workflows) 配下にあります。
+ワークフローと（ほとんどの）ヘルパースクリプトについては、[.github][] 配下の `workflow` フォルダと `scripts` フォルダを参照してください。
 
 ## PR 承認ラベル {#pr-approval-labels}
 
@@ -377,4 +374,7 @@ node scripts/gh/specs/pick-branch/cli.mjs --help
 | `label-manager.yml`        | PR ラベル（コンポーネントラベルと承認フロー）                                                     |
 | `component-owners.yml`     | コンポーネント所有権に基づくレビュアーの割り当て                                                  |
 
-[lychee-pilot]: /site/build/npm-scripts/#notes
+<!-- prettier-ignore-start -->
+[lychee-pilot]: ../npm-scripts/#notes
+[.github]: https://github.com/open-telemetry/opentelemetry.io/tree/main/.github
+<!-- prettier-ignore-end -->


### PR DESCRIPTION
## Summary

Updates `content/ja/site/build/ci-workflows.md` to match the latest English source at
`content/en/site/build/ci-workflows.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

Note: PR #10503 ("Make images zoomable") also touches this file but only to add
the `drifted_from_default: true` flag as a housekeeping change. This PR is the
actual drift fix and does not conflict.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.


<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10530--opentelemetry.netlify.app/ja/site/build/ci-workflows/
- **English (canonical):** https://opentelemetry.io/site/build/ci-workflows/

_(deploy preview status: pending. The URLs will work once Netlify finishes building.)_
<!-- preview-section-end -->
