### PR TITLE
chore: change refcache refresh schedule to 7:33 CEST

### DIFF
--- a/.github/workflows/refcache-refresh.yml
+++ b/.github/workflows/refcache-refresh.yml
@@ -12,7 +12,7 @@ name: Refcache refresh
 #
 on:
   schedule:
-    - cron: '33 9 * * *' # daily at 9:33 UTC
+    - cron: '33 5 * * *' # daily at 5:33 UTC
   workflow_dispatch:
     inputs:
       number_of_entries_to_refresh:


### PR DESCRIPTION
Changes the cron schedule from `33 9 * * *` (9:33 UTC) to `33 5 * * *` (5:33 UTC).

| Timezone | Before | After |
|----------|--------|-------|
| UTC | 9:33 | 5:33 |
| EDT (Canada East) | 5:33 | 1:33 |
| BRT (Brasília) | 6:33 | 2:33 |
| CET (Berlin winter) | 10:33 | 6:33 |
| CEST (Berlin summer) | 11:33 | 7:33 ✓ |