### PR TITLE
blog: The Voyage of a Small Environment Variable

### DIFF
--- a/content/en/blog/2026/spring-boot-declarative-config/index.md
+++ b/content/en/blog/2026/spring-boot-declarative-config/index.md
@@ -5,29 +5,32 @@ date: 2026-06-23
 author: >-
   [Gregor Zeitlinger](https://github.com/zeitlinger) (Grafana Labs)
 sig: Java
+issue: 10563
 cSpell:ignore: Customizer Dotel petclinic relaxed substituters zeitlinger
 ---
 
-The OpenTelemetry Spring Boot starter gained declarative-configuration support
-starting in version 2.26.0 — the same YAML schema
-[the Java agent introduced in late 2025](/blog/2025/declarative-config/), now
-embedded inside `application.yaml`. This post traces what one env var,
+The OpenTelemetry
+[Spring Boot starter](/docs/zero-code/java/spring-boot-starter/) gained
+declarative-configuration support starting in version 2.26.0 — the same YAML
+schema [the Java agent introduced in late 2025](/blog/2025/declarative-config/),
+now embedded inside `application.yaml`. This post traces what one env var,
 `OTEL_SERVICE_NAME=petclinic`, does in that new world, and where the seams are.
 
-_In a hurry? Jump straight to the
-[Spring Boot starter declarative-config docs](/docs/zero-code/java/spring-boot-starter/declarative-configuration/),
-paste your `application.properties` into the
-[interactive converter](/docs/zero-code/java/spring-boot-starter/declarative-configuration/#convert-your-existing-configuration),
-or pick your SDK setup in the [Ecosystem Explorer](/ecosystem/) with the Spring
-Boot starter target selected. Come back for the story when you have a coffee._
-
----
+> [!TIP] In a hurry?
+>
+> Jump straight to the
+> [Spring Boot starter declarative-config docs](/docs/zero-code/java/spring-boot-starter/declarative-configuration/),
+> paste your `application.properties` into the
+> [interactive converter](/docs/zero-code/java/spring-boot-starter/declarative-configuration/#convert-your-existing-configuration),
+> or pick your SDK setup in the [Ecosystem Explorer](/ecosystem/) with the
+> Spring Boot starter target selected. Come back for the story when you have a
+> coffee.
 
 For years, environment variables (and their JVM `-D` cousins) were the only way
 to configure the OpenTelemetry SDK: every exporter, every sampler, every
 captured header, expressed as a flat list of `OTEL_*` variables.
 
-Since starter 2.26.0, that list has a sibling. The SDK
+Since starter 2.26.0, that list has a new sibling. The SDK
 [declarative-configuration schema](/docs/languages/sdk-configuration/declarative-configuration/)
 is a YAML tree that can describe an entire telemetry pipeline (every processor,
 every exporter, every nested option) in the same shape the SDK actually runs.

--- a/content/en/blog/2026/spring-boot-declarative-config/index.md
+++ b/content/en/blog/2026/spring-boot-declarative-config/index.md
@@ -152,7 +152,7 @@ wiring. With declarative config, you do not.
 > the `composite/development` path still carries the `*/development` suffix
 > until the composable schema stabilizes. See a working
 > [example](https://github.com/open-telemetry/opentelemetry-configuration/blob/v1.0.0/snippets/Sampler_rule_based_kitchen_sink.yaml#L10-L53)
-> in the SDK config repo.
+> in the SDK config repository.
 
 So how does our small env var fit into a world where the SDK is configured by a
 tree?

--- a/content/en/blog/2026/spring-boot-declarative-config/index.md
+++ b/content/en/blog/2026/spring-boot-declarative-config/index.md
@@ -5,22 +5,22 @@ date: 2026-06-23
 author: >-
   [Gregor Zeitlinger](https://github.com/zeitlinger) (Grafana Labs)
 sig: Instrumentation
-cSpell:ignore: Customizer Dockerfiles Dotel petclinic relaxed sqlcommenter substituters zeitlinger
+# prettier-ignore
+cSpell:ignore: Customizer Dockerfiles Dotel petclinic relaxed substituters zeitlinger
 ---
 
 The OpenTelemetry Spring Boot starter 2.26.0 gained declarative-configuration
-support — the same YAML schema [the Java agent introduced in late
-2025](/blog/2025/declarative-config/), now embedded inside `application.yaml`.
-This post is the story of how that landed, told through the eyes of one
-small environment variable.
+support — the same YAML schema
+[the Java agent introduced in late 2025](/blog/2025/declarative-config/), now
+embedded inside `application.yaml`. This post is the story of how that landed,
+told through the eyes of one small environment variable.
 
-*In a hurry? Jump straight to the
+_In a hurry? Jump straight to the
 [Spring Boot starter declarative-config docs](/docs/zero-code/java/spring-boot-starter/declarative-configuration/),
 paste your `application.properties` into the
 [interactive converter](/docs/zero-code/java/spring-boot-starter/declarative-configuration/#convert-your-existing-configuration),
-or pick your SDK setup in the
-[Ecosystem Explorer](/ecosystem/) with the Spring Boot starter target
-selected. Come back for the story when you have a coffee.*
+or pick your SDK setup in the [Ecosystem Explorer](/ecosystem/) with the Spring
+Boot starter target selected. Come back for the story when you have a coffee._
 
 ---
 
@@ -37,27 +37,27 @@ thought twice about where she actually goes.
 She is older than you think.
 
 For years, environment variables (and their close cousin, the JVM `-D` system
-property) were the only way to configure the OpenTelemetry SDK. Every
-exporter, every sampler, every captured header — all expressed as a flat list
-of `OTEL_*` variables. Our small env var did the whole job, alone.
+property) were the only way to configure the OpenTelemetry SDK. Every exporter,
+every sampler, every captured header — all expressed as a flat list of `OTEL_*`
+variables. Our small env var did the whole job, alone.
 
 Recently, she got a sister.
 
-The OpenTelemetry SDK [declarative-configuration
-schema](/docs/languages/sdk-configuration/declarative-configuration/) is a YAML
-tree that can describe an entire telemetry pipeline — every processor, every
-exporter, every nested option — in the same shape the SDK actually runs.
-Things the env var could not say. Spring starter users wrote a `@Bean` for
-them. Java agent users had to write a full extension and package it in a
-separate jar to ship alongside the agent — almost prohibitive.
+The OpenTelemetry SDK
+[declarative-configuration schema](/docs/languages/sdk-configuration/declarative-configuration/)
+is a YAML tree that can describe an entire telemetry pipeline — every processor,
+every exporter, every nested option — in the same shape the SDK actually runs.
+Things the env var could not say. Spring starter users wrote a `@Bean` for them.
+Java agent users had to write a full extension and package it in a separate jar
+to ship alongside the agent — almost prohibitive.
 
 The two of them share a roof now. Since OpenTelemetry Spring Boot starter
-**2.26.0**, the YAML sister moves into your `application.yaml`, under a
-single `otel:` key. Our env var still has a place — but a narrower one.
+**2.26.0**, the YAML sister moves into your `application.yaml`, under a single
+`otel:` key. Our env var still has a place — but a narrower one.
 `OTEL_SERVICE_NAME` survives because a service-name resource detector goes
-hunting for her at boot. The new family rule is that most env vars don't
-flow into the SDK automatically anymore; if you want one to override a YAML
-leaf, you invite her in by name with `${VAR:default}`.
+hunting for her at boot. The new family rule is that most env vars don't flow
+into the SDK automatically anymore; if you want one to override a YAML leaf, you
+invite her in by name with `${VAR:default}`.
 
 This is the story of how they get along.
 
@@ -82,11 +82,11 @@ otel:
               endpoint: ${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:http://localhost:4318/v1/traces}
 ```
 
-That block under `otel:` is the OpenTelemetry SDK speaking its own native
-YAML — list of processors, each holding an exporter, each holding configuration
-— inside Spring's `application.yaml`. The presence of `otel.file_format` is
-the switch. Everything beneath it is parsed against the SDK schema. Spring
-does not need to know what any of it means.
+That block under `otel:` is the OpenTelemetry SDK speaking its own native YAML —
+list of processors, each holding an exporter, each holding configuration —
+inside Spring's `application.yaml`. The presence of `otel.file_format` is the
+switch. Everything beneath it is parsed against the SDK schema. Spring does not
+need to know what any of it means.
 
 ## The wall the env var alone could not climb
 
@@ -95,13 +95,12 @@ Env vars do cover a fixed list of built-in choices: a
 via `OTEL_TRACES_SAMPLER`, the standard OTLP exporters via
 `OTEL_EXPORTER_OTLP_*`, the usual signal-toggle flags. Anything outside that
 catalog — a custom rule-based sampler, a second OTLP exporter on a debug
-pipeline, a baggage processor, any nested option the SDK exposes — meant
-writing a `@Bean` (Spring starter) or shipping a separate extension jar
-(Java agent). The bigger sister is what unlocks the rest of the tree.
+pipeline, a baggage processor, any nested option the SDK exposes — meant writing
+a `@Bean` (Spring starter) or shipping a separate extension jar (Java agent).
+The bigger sister is what unlocks the rest of the tree.
 
-The docs page for the starter has a small example most teams need on day
-one: [exclude actuator endpoints from
-tracing](/docs/zero-code/java/spring-boot-starter/programmatic-configuration/#exclude-actuator-endpoints-from-tracing).
+The docs page for the starter has a small example most teams need on day one:
+[exclude actuator endpoints from tracing](/docs/zero-code/java/spring-boot-starter/programmatic-configuration/#exclude-actuator-endpoints-from-tracing).
 Yesterday that was a `@Configuration` class:
 
 ```java
@@ -137,28 +136,26 @@ otel:
                 pattern: /actuator.*
 ```
 
-It's the same Java code under the hood — both the agent and the starter
-already bundle the `opentelemetry-samplers` contrib jar. What changes is who
-writes the wiring. With declarative config, you do not.
+It's the same Java code under the hood — both the agent and the starter already
+bundle the `opentelemetry-samplers` contrib jar. What changes is who writes the
+wiring. With declarative config, you do not.
 
-So how does our small env var fit into a world where the SDK is configured by
-a tree?
+So how does our small env var fit into a world where the SDK is configured by a
+tree?
 
 She travels.
 
 ## Stage one: arriving at Spring's property stack
 
-When the application starts, our env var arrives at the front desk of a
-building she has known her entire life: the Spring property loader. She is
-not alone. Behind her is the JVM `-D`, in front of her is `application.yaml`,
-beside her is the active profile's overlay and the `--key=value` from the
-command line. Spring stacks them all into a single addressable property
-universe.
+When the application starts, our env var arrives at the front desk of a building
+she has known her entire life: the Spring property loader. She is not alone.
+Behind her is the JVM `-D`, in front of her is `application.yaml`, beside her is
+the active profile's overlay and the `--key=value` from the command line. Spring
+stacks them all into a single addressable property universe.
 
 She is one of many. `OTEL_SERVICE_NAME` rides the same Spring property bus as
-`SERVER_PORT` and `SPRING_PROFILES_ACTIVE`. Spring does not know which of
-these belong to OpenTelemetry; that is the starter's job, at the end of the
-line.
+`SERVER_PORT` and `SPRING_PROFILES_ACTIVE`. Spring does not know which of these
+belong to OpenTelemetry; that is the starter's job, at the end of the line.
 
 > [!NOTE] How Spring quietly aligns env vars with YAML keys
 >
@@ -166,22 +163,22 @@ line.
 > dot-separated name. The same property can come from many sources, written
 > differently in each:
 >
-> | Source        | Written as                       |
-> | ------------- | -------------------------------- |
-> | env var       | `OTEL_SERVICE_NAME=petclinic`    |
-> | system prop   | `-Dotel.service.name=petclinic`  |
-> | command line  | `--otel.service.name=petclinic`  |
-> | `application.yaml` | `otel.service.name: petclinic` |
+> | Source             | Written as                      |
+> | ------------------ | ------------------------------- |
+> | env var            | `OTEL_SERVICE_NAME=petclinic`   |
+> | system prop        | `-Dotel.service.name=petclinic` |
+> | command line       | `--otel.service.name=petclinic` |
+> | `application.yaml` | `otel.service.name: petclinic`  |
 >
-> Spring translates between them with rules like "lowercase, `_` becomes
-> `.`". The starter never has to know which one you used.
+> Spring translates between them with rules like "lowercase, `_` becomes `.`".
+> The starter never has to know which one you used.
 >
 > This is a Spring-only superpower. The OpenTelemetry SDK by itself does not
 > auto-map env vars onto YAML paths — that was discussed during the schema's
-> design and rejected as too complex. So inside the agent's standalone YAML,
-> you cannot set `OTEL_SERVICE_NAME` and have it land at `service.name` in
-> the tree. The starter gets this for free, because Spring is doing the
-> mapping, not the SDK.
+> design and rejected as too complex. So inside the agent's standalone YAML, you
+> cannot set `OTEL_SERVICE_NAME` and have it land at `service.name` in the tree.
+> The starter gets this for free, because Spring is doing the mapping, not the
+> SDK.
 
 ```mermaid
 flowchart LR
@@ -192,23 +189,22 @@ flowchart LR
   RE --> OUT
 ```
 
-*The starter walks every property Spring exposes, picks out the `otel.*`
-keys, and hands the assembled map to Jackson — once, for the whole tree, not
-per element. The diamond is the seam this post is about: an extra step for
-keys that sit under a list index, which the next stage explains.*
+_The starter walks every property Spring exposes, picks out the `otel._` keys,
+and hands the assembled map to Jackson — once, for the whole tree, not per
+element. The diamond is the seam this post is about: an extra step for keys that
+sit under a list index, which the next stage explains.\*
 
 ## Stage two: a cousin Spring almost lost
 
-Our protagonist is humble. But she has a gnarly cousin, the kind of relative
-who barely makes it past the front desk:
+Our protagonist is humble. But she has a gnarly cousin, the kind of relative who
+barely makes it past the front desk:
 
 ```bash
 OTEL_TRACER_PROVIDER_PROCESSORS_0_BATCH_EXPORTER_OTLP_HTTP_ENDPOINT=http://collector:4318/v1/traces
 ```
 
-She makes it past — but only because sixteen lines, deep inside the
-starter, go hunting for her by name. The diamond in the diagram above is
-where they live.
+She makes it past — but only because sixteen lines, deep inside the starter, go
+hunting for her by name. The diamond in the diagram above is where they live.
 
 > [!NOTE] How the cousin gets through (and why it takes work)
 >
@@ -218,46 +214,45 @@ where they live.
 >
 > The usual Spring move for "I have a tree of config" would be a
 > [`@ConfigurationProperties`](https://docs.spring.io/spring-boot/reference/features/external-config.html#features.external-config.typesafe-configuration-properties)
-> class: declare a Java POJO shaped like your config tree, annotate it with
-> the property prefix, and Spring binds every source onto it for you. The
-> OTel SDK schema is hundreds of properties across many polymorphic layers
-> (every exporter type, every sampler type, every processor type),
-> [generated](/docs/languages/sdk-configuration/declarative-configuration/)
-> from a YAML schema that is still evolving. A hand-written POJO tree to
-> mirror it would be a second source of truth, perpetually behind the
-> first. The gold-plated answer is to *generate* the POJOs from the schema
-> (the SDK's DC schema plus the not-yet-existing schemas for the
-> `distribution.*` and `instrumentation/development.*` subtrees) — that
-> same generated description could also drive the JSON metadata Spring uses
-> for IDE completion. The Java instrumentation team tracks that as a future
-> improvement in
+> class: declare a Java POJO shaped like your config tree, annotate it with the
+> property prefix, and Spring binds every source onto it for you. The OTel SDK
+> schema is hundreds of properties across many polymorphic layers (every
+> exporter type, every sampler type, every processor type),
+> [generated](/docs/languages/sdk-configuration/declarative-configuration/) from
+> a YAML schema that is still evolving. A hand-written POJO tree to mirror it
+> would be a second source of truth, perpetually behind the first. The
+> gold-plated answer is to _generate_ the POJOs from the schema (the SDK's DC
+> schema plus the not-yet-existing schemas for the `distribution.*` and
+> `instrumentation/development.*` subtrees) — that same generated description
+> could also drive the JSON metadata Spring uses for IDE completion. The Java
+> instrumentation team tracks that as a future improvement in
 > [opentelemetry-java-instrumentation#14083](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/14083).
 >
 > So the starter does something Spring rarely sees: it walks every
-> `PropertySource` directly and collects keys that begin with `otel.`. The
-> walk sees the YAML source's names with brackets
-> (`otel.tracer_provider.processors[0]...`), the env-var source's names
-> with underscores (`OTEL_TRACER_..._ENDPOINT`); Spring's rename only
-> happens when you *resolve* a property, not when you *list* one. Then
-> Jackson binds the collected keys onto the *generated* configuration
-> model, which always matches the live schema.
+> `PropertySource` directly and collects keys that begin with `otel.`. The walk
+> sees the YAML source's names with brackets
+> (`otel.tracer_provider.processors[0]...`), the env-var source's names with
+> underscores (`OTEL_TRACER_..._ENDPOINT`); Spring's rename only happens when
+> you _resolve_ a property, not when you _list_ one. Then Jackson binds the
+> collected keys onto the _generated_ configuration model, which always matches
+> the live schema.
 >
 > Sixteen lines in
-> [`EmbeddedConfigFile`](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/EmbeddedConfigFile.java#L66-L82)
-> close the gap between the two naming conventions. For every `otel.*`
-> key that contains a `[N]` bracket, the starter rebuilds the env-var name
-> from the property name and asks Spring directly. The cousin gets called.
+> [`EmbeddedConfigFile`](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/v2.29.0/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/EmbeddedConfigFile.java#L66-L82)
+> close the gap between the two naming conventions. For every `otel.*` key that
+> contains a `[N]` bracket, the starter rebuilds the env-var name from the
+> property name and asks Spring directly. The cousin gets called.
 
 ## Stage three: two substituters, one syntax
 
 Our env var can also speak in placeholders. So can her sister. They both use
-`${...}`. They mean almost — but not quite — the same thing. Spring will
-happily resolve a chained fallback like
+`${...}`. They mean almost — but not quite — the same thing. Spring will happily
+resolve a chained fallback like
 `${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}}/v1/traces`
 — chasing the outer placeholder into the inner so you can prefer a
 signal-specific override, fall back to a general one, and ultimately to a
-literal. The SDK's substituter is a single non-recursive regex pass; the
-same expression in `otel-config.yaml` would not parse.
+literal. The SDK's substituter is a single non-recursive regular-expression
+pass; the same expression in `otel-config.yaml` would not parse.
 
 ```mermaid
 flowchart LR
@@ -280,32 +275,28 @@ flowchart LR
 > Inside `application.yaml`, Spring resolves `${VAR:default}` (single colon)
 > from any property source it knows about — env vars, system properties,
 > profiles, command-line args, external config servers. The SDK's standalone
-> YAML uses `${VAR:-default}` (double colon, dash) and resolves from process
-> env vars and JVM system properties only. In the starter, the SDK
-> substituter never runs — Spring has already finished by the time the
-> starter reads the value.
+> YAML uses `${VAR:-default}` (double colon, dash) and resolves from process env
+> vars and JVM system properties only. In the starter, the SDK substituter never
+> runs — Spring has already finished by the time the starter reads the value.
 
 The dialects are close enough that mixing them up is easy. The reason the
 starter uses Spring's syntax is that Spring's resolver runs first, and by the
-time the starter retrieves a property the placeholder is already gone. The
-SDK never gets a chance to find one.
+time the starter retrieves a property the placeholder is already gone. The SDK
+never gets a chance to find one.
 
-That is also why all the Spring-native config tricks — profiles,
-command-line `--key=value`, `@Value`-style externalization, even external
-config servers — work transparently for OTel config. The starter never
-implemented any of them. Spring's resolver did, and the starter just reads
-properties.
+That is also why all the Spring-native config tricks — profiles, command-line
+`--key=value`, `@Value`-style externalization, even external config servers —
+work transparently for OTel config. The starter never implemented any of them.
+Spring's resolver did, and the starter just reads properties.
 
-The biggest practical consequence: in the starter, any env var named on the
-same canonical key path as a YAML leaf overrides it automatically — no
-extra wiring. The agent's standalone YAML cannot do that. There, an env-var
-override has to be wired into the YAML as a `${VAR}` placeholder ahead of
-time, or it does nothing.
+The biggest practical consequence: in the starter, any env var named on the same
+canonical key path as a YAML leaf overrides it automatically — no extra wiring.
+The agent's standalone YAML cannot do that. There, an env-var override has to be
+wired into the YAML as a `${VAR}` placeholder ahead of time, or it does nothing.
 
 > [!NOTE] Example: overriding a YAML leaf with an env var
 >
-> In the starter, this works at startup with nothing else changed in the
-> YAML:
+> In the starter, this works at startup with nothing else changed in the YAML:
 >
 > ```bash
 > OTEL_TRACER_PROVIDER_PROCESSORS_0_BATCH_EXPORTER_OTLP_HTTP_ENDPOINT=\
@@ -314,20 +305,20 @@ time, or it does nothing.
 >
 > Whatever the `application.yaml` said for that endpoint is replaced.
 >
-> In the agent, you would first have to write `${MY_ENDPOINT:-http://...}`
-> into the YAML, then set `MY_ENDPOINT` at startup. Containers in
-> production land softer in the starter.
+> In the agent, you would first have to write `${MY_ENDPOINT:-http://...}` into
+> the YAML, then set `MY_ENDPOINT` at startup. Containers in production land
+> softer in the starter.
 
 ## Arrival: the resolved tree the SDK actually boots from
 
 By the time our env var crosses the last boundary, she has been resolved,
-relaxed, normalized, and joined with every other `otel.*` key into a single
-flat map. The starter un-flattens that map back into the tree the SDK
-expects, hands it to Jackson, and Jackson produces the
-`OpenTelemetryConfigurationModel` the SDK boots from.
+relaxed, normalized, and joined with every other `otel.*` key into a single flat
+map. The starter un-flattens that map back into the tree the SDK expects, hands
+it to Jackson, and Jackson produces the `OpenTelemetryConfigurationModel` the
+SDK boots from.
 
-The env var and the YAML sister converge at the same door. Whoever wrote
-which value, the SDK only ever sees the resolved result.
+The env var and the YAML sister converge at the same door. Whoever wrote which
+value, the SDK only ever sees the resolved result.
 
 ```mermaid
 flowchart TD
@@ -342,24 +333,23 @@ flowchart TD
   J --> SDK[SDK runtime]
 ```
 
-*Spring owns the front door. The SDK never sees a raw `${VAR}`, a profile
-name, or a property file — only a fully-resolved tree, handed over once at
-boot.*
+_Spring owns the front door. The SDK never sees a raw `${VAR}`, a profile name,
+or a property file — only a fully-resolved tree, handed over once at boot._
 
 ## Why "experimental" is the best reason to try declarative config now
 
-Declarative configuration is the schema OpenTelemetry is converging on
-across every language. It is not finished. The Spring Boot starter's support
-for it is marked experimental, exactly because it has not seen enough real
-applications yet to know which corners to tighten.
+Declarative configuration is the schema OpenTelemetry is converging on across
+every language. It is not finished. The Spring Boot starter's support for it is
+marked experimental, exactly because it has not seen enough real applications
+yet to know which corners to tighten.
 
 That is not a warning. It is an invitation.
 
-Env-var configuration has been around long enough that all its rough edges
-have names. The YAML schema is younger — and pre-stable. Now, before it
-freezes, is the highest-leverage moment to put declarative config into a
-real `application.yaml` and see what breaks. Your friction is what shapes
-the schema that lands.
+Env-var configuration has been around long enough that all its rough edges have
+names. The YAML schema is younger — and pre-stable. Now, before it freezes, is
+the highest-leverage moment to put declarative config into a real
+`application.yaml` and see what breaks. Your friction is what shapes the schema
+that lands.
 
 ## Getting there in 60 seconds
 
@@ -368,40 +358,39 @@ Two starting points, both already there:
 - **You already have an `application.properties`?** Paste it into the
   [interactive converter](/docs/zero-code/java/spring-boot-starter/declarative-configuration/#convert-your-existing-configuration)
   on the doc page. Out comes the YAML, ready to drop into `application.yaml`.
-- **Greenfield?** The [OpenTelemetry Ecosystem
-  Explorer](https://opentelemetry.io/ecosystem/) generates declarative-config
-  YAML interactively — pick exporters, samplers, instrumentations, and copy
-  the result. A new Spring Boot starter target mode wraps the output under
-  `otel:` and uses the right `distribution.spring_starter.*` keys.
+- **Greenfield?** The [OpenTelemetry Ecosystem Explorer](/ecosystem/) generates
+  declarative-config YAML interactively — pick exporters, samplers,
+  instrumentations, and copy the result. A new Spring Boot starter target mode
+  wraps the output under `otel:` and uses the right
+  `distribution.spring_starter.*` keys.
 
 ## The fine print
 
 - **Dependency management is required on Spring Boot 3.5+.** Spring Boot 3.5
   ships its own OpenTelemetry version pin that conflicts with what the starter
-  needs. Import the OTel instrumentation BOM in `dependencyManagement` (see
-  the
+  needs. Import the OTel instrumentation BOM in `dependencyManagement` (see the
   [docs](/docs/zero-code/java/spring-boot-starter/getting-started/#dependency-management)).
   Skip it and you will see
   `NoClassDefFoundError: io/opentelemetry/common/ComponentLoader` at startup.
 - **Durations are milliseconds, as numbers.** Use `5000`, not `5s`.
 - **Programmatic customization changes shape.**
   `AutoConfigurationCustomizerProvider` is replaced by
-  `DeclarativeConfigurationCustomizerProvider`; SDK components plug in via
-  the `ComponentProvider` API. The
-  [agent extension API
-  docs](/docs/zero-code/java/agent/declarative-configuration/#extension-api)
+  `DeclarativeConfigurationCustomizerProvider`; SDK components plug in via the
+  `ComponentProvider` API. The
+  [agent extension API docs](/docs/zero-code/java/agent/declarative-configuration/#extension-api)
   apply to the starter unchanged.
 
 ## Two sisters under one roof
 
 The env var did the job alone for a long time. Her sister fills in what she
-could never quite say. They share a building, share a stack, share a door
-into the SDK. Spring is the building they both live in. OpenTelemetry is the
-work they both do.
+could never quite say. They share a building, share a stack, share a door into
+the SDK. Spring is the building they both live in. OpenTelemetry is the work
+they both do.
 
-If you migrate a real application onto this and hit something off, please
-file an issue —
+If you migrate a real application onto this and hit something off, please file
+an issue —
 [opentelemetry-java-instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues)
-for code, [opentelemetry.io](https://github.com/open-telemetry/opentelemetry.io/issues)
+for code,
+[opentelemetry.io](https://github.com/open-telemetry/opentelemetry.io/issues)
 for docs. That is how the docs got fixed last time, and how they will keep
 getting better.

--- a/content/en/blog/2026/spring-boot-declarative-config/index.md
+++ b/content/en/blog/2026/spring-boot-declarative-config/index.md
@@ -1,0 +1,383 @@
+---
+title: 'The Voyage of a Small Environment Variable'
+linkTitle: Spring Boot declarative config
+date: 2026-06-23
+author: >-
+  [Gregor Zeitlinger](https://github.com/zeitlinger) (Grafana Labs)
+sig: Instrumentation
+cSpell:ignore: Customizer Dockerfiles Dotel petclinic relaxed sqlcommenter substituters zeitlinger
+---
+
+The OpenTelemetry Spring Boot starter recently gained
+declarative-configuration support — the same YAML schema [the Java agent
+introduced in late 2025](/blog/2025/declarative-config/), now embedded inside
+`application.yaml`. This post is the story of how that landed, told through
+the eyes of one small environment variable.
+
+*In a hurry? Jump straight to the
+[Spring Boot starter declarative-config docs](/docs/zero-code/java/spring-boot-starter/declarative-configuration/),
+paste your `application.properties` into the
+[interactive converter](/docs/zero-code/java/spring-boot-starter/declarative-configuration/#convert-your-existing-configuration),
+or pick your SDK setup in the
+[Ecosystem Explorer](/ecosystem/) with the Spring Boot starter target
+selected. Come back for the story when you have a coffee.*
+
+---
+
+Meet a small environment variable.
+
+```bash
+OTEL_SERVICE_NAME=petclinic
+```
+
+You have set her hundreds of times. In CI files. In Dockerfiles. In your
+terminal, with a `&&` and a shrug. She is so familiar that you have never
+thought twice about where she actually goes.
+
+She is older than you think.
+
+For years, environment variables (and their close cousin, the JVM `-D` system
+property) were the only way to configure the OpenTelemetry SDK. Every
+exporter, every sampler, every captured header — all expressed as a flat list
+of `OTEL_*` variables. Our small env var did the whole job, alone.
+
+Recently, she got a sister.
+
+The OpenTelemetry SDK [declarative-configuration
+schema](/docs/languages/sdk-configuration/declarative-configuration/) is a YAML
+tree that can describe an entire telemetry pipeline — every processor, every
+exporter, every nested option — in the same shape the SDK actually runs.
+Things the env var could not say. Spring starter users wrote a `@Bean` for
+them. Java agent users had to write a full extension and package it in a
+separate jar to ship alongside the agent — almost prohibitive.
+
+The two of them share a roof now. Since OpenTelemetry Spring Boot starter
+**2.26.0**, the YAML sister moves into your `application.yaml`, under a
+single `otel:` key. Our env var still has a place — but a narrower one.
+`OTEL_SERVICE_NAME` survives because a service-name resource detector goes
+hunting for her at boot. The new family rule is that most env vars don't
+flow into the SDK automatically anymore; if you want one to override a YAML
+leaf, you invite her in by name with `${VAR:default}`.
+
+This is the story of how they get along.
+
+## A YAML file inside your YAML file
+
+Here is what living together looks like:
+
+```yaml
+otel:
+  file_format: '1.0'
+
+  resource:
+    attributes:
+      - name: service.name
+        value: petclinic
+
+  tracer_provider:
+    processors:
+      - batch:
+          exporter:
+            otlp_http:
+              endpoint: ${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:http://localhost:4318/v1/traces}
+```
+
+That block under `otel:` is the OpenTelemetry SDK speaking its own native
+YAML — list of processors, each holding an exporter, each holding configuration
+— inside Spring's `application.yaml`. The presence of `otel.file_format` is
+the switch. Everything beneath it is parsed against the SDK schema. Spring
+does not need to know what any of it means.
+
+## The wall the env var alone could not climb
+
+Env vars do cover a fixed list of built-in choices: a
+[fixed set of samplers](/docs/languages/sdk-configuration/general/#otel_traces_sampler)
+via `OTEL_TRACES_SAMPLER`, the standard OTLP exporters via
+`OTEL_EXPORTER_OTLP_*`, the usual signal-toggle flags. Anything outside that
+catalog — a custom rule-based sampler, a second OTLP exporter on a debug
+pipeline, a baggage processor, any nested option the SDK exposes — meant
+writing a `@Bean` (Spring starter) or shipping a separate extension jar
+(Java agent). The bigger sister is what unlocks the rest of the tree.
+
+The docs page for the starter has a small example most teams need on day
+one: [exclude actuator endpoints from
+tracing](/docs/zero-code/java/spring-boot-starter/programmatic-configuration/#exclude-actuator-endpoints-from-tracing).
+Yesterday that was a `@Configuration` class:
+
+```java
+@Configuration
+public class FilterPaths {
+  @Bean
+  public AutoConfigurationCustomizerProvider otelCustomizer() {
+    return p ->
+        p.addSamplerCustomizer(
+            (fallback, config) ->
+                RuleBasedRoutingSampler.builder(SpanKind.SERVER, fallback)
+                    .drop(UrlAttributes.URL_PATH, "^/actuator")
+                    .build());
+  }
+}
+```
+
+Today it is a YAML block in `application.yaml`:
+
+```yaml
+otel:
+  tracer_provider:
+    sampler:
+      parent_based:
+        root:
+          rule_based_routing:
+            fallback_sampler:
+              always_on:
+            span_kind: SERVER
+            rules:
+              - action: DROP
+                attribute: url.path
+                pattern: /actuator.*
+```
+
+It's the same Java code under the hood — both the agent and the starter
+already bundle the `opentelemetry-samplers` contrib jar. What changes is who
+writes the wiring. With declarative config, you do not.
+
+So how does our small env var fit into a world where the SDK is configured by
+a tree?
+
+She travels.
+
+## Stage one: arriving at Spring's property stack
+When the application starts, our env var arrives at the front desk of a
+building she has known her entire life: the Spring property loader. She is
+not alone. Behind her is the JVM `-D`, in front of her is `application.yaml`,
+beside her is the active profile's overlay and the `--key=value` from the
+command line. Spring stacks them all into a single addressable property
+universe.
+
+She is one of many. `OTEL_SERVICE_NAME` rides the same Spring property bus as
+`SERVER_PORT` and `SPRING_PROFILES_ACTIVE`. Spring does not know which of
+these belong to OpenTelemetry; that is the starter's job, at the end of the
+line.
+
+> [!NOTE] How Spring quietly aligns env vars with YAML keys
+>
+> Spring exposes every property under a single canonical, lowercased,
+> dot-separated name. The same property can come from many sources, written
+> differently in each:
+>
+> | Source        | Written as                       |
+> | ------------- | -------------------------------- |
+> | env var       | `OTEL_SERVICE_NAME=petclinic`    |
+> | system prop   | `-Dotel.service.name=petclinic`  |
+> | command line  | `--otel.service.name=petclinic`  |
+> | `application.yaml` | `otel.service.name: petclinic` |
+>
+> Spring translates between them with rules like "lowercase, `_` becomes
+> `.`". The starter never has to know which one you used.
+>
+> This is a Spring-only superpower. The OpenTelemetry SDK by itself does not
+> auto-map env vars onto YAML paths — that was discussed during the schema's
+> design and rejected as too complex. So inside the agent's standalone YAML,
+> you cannot set `OTEL_SERVICE_NAME` and have it land at `service.name` in
+> the tree. The starter gets this for free, because Spring is doing the
+> mapping, not the SDK.
+
+```mermaid
+flowchart LR
+  subgraph PS[Spring PropertySources]
+    direction TB
+    P1[JVM system properties]
+    P2[env vars]
+    P3[command-line args]
+    P4[application-prod.yaml]
+    P5[application.yaml]
+  end
+  PS --> W["starter walks every source<br/>collects every otel.* key"]
+  W --> SEAM{"key sits under a list index?"}
+  SEAM -- no --> OUT["un-flatten the whole map<br/>→ Jackson (once)<br/>→ SDK model"]
+  SEAM -- yes --> RE["recompute env-var name<br/>re-read environment"]
+  RE --> OUT
+```
+
+*The starter walks every property source, collects every `otel.*` key, and
+hands the assembled map to Jackson — once, for the whole tree, not per
+element. The diamond is the seam this post is about: an extra step for keys
+that sit under a list index, which the next stage explains.*
+
+## Stage two: a cousin Spring almost lost
+
+Our protagonist is humble. But she has a gnarly cousin, the kind of relative
+who barely makes it past the front desk:
+
+```bash
+OTEL_TRACER_PROVIDER_PROCESSORS_0_BATCH_EXPORTER_OTLP_HTTP_ENDPOINT=http://collector:4318/v1/traces
+```
+
+This one has a job to do — override one exporter's endpoint inside the YAML
+sister's tree — and she almost did not get heard.
+
+> [!NOTE] What Spring's binding does, with a worked example
+>
+> Setting `OTEL_SERVICE_NAME=petclinic` is the same as writing
+> `otel.service.name: petclinic` in `application.yaml`. Spring's binding
+> recognizes the env-var name as a different spelling of the same property.
+>
+> The rule extends to list indices: `OTEL_RESOURCE_ATTRIBUTES_0_NAME` becomes
+> `otel.resource.attributes[0].name`. So far, so good.
+>
+> The rule *stops* the moment a property with brackets in its name is already
+> in play. If `application.yaml` already declared `otel.tracer_provider.processors[0]....endpoint`,
+> Spring will *not* go looking for `OTEL_TRACER_PROVIDER_PROCESSORS_0_..._ENDPOINT`
+> as an override for that key. The bracket throws it off.
+
+That seam is where our cousin gets stuck. The starter notices and fixes it.
+For every `otel.*` key that sits under a list index, it reconstructs the
+env-var name from scratch — the same rule Spring would have used — and
+re-reads from the environment itself. Sixteen lines of code, deep inside
+[`EmbeddedConfigFile`][embed-link], that stitch the family back together so
+the cousin can reach into her sister's tree.
+
+[embed-link]: https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/EmbeddedConfigFile.java#L66-L82
+
+That seam is the diamond in the diagram above.
+
+## Stage three: two substituters, one syntax
+Our env var can also speak in placeholders. So can her sister. They both use
+`${...}`. They mean almost — but not quite — the same thing.
+
+```mermaid
+flowchart LR
+  subgraph STARTER["application.yaml — starter"]
+    direction TB
+    S1["&dollar;{VAR:default}<br/>&dollar;{VAR}"] --> S2[Spring resolver]
+    S2 --> S3["reads:<br/>env, sys props, args,<br/>profiles, all yaml"]
+  end
+  subgraph AGENT["otel-config.yaml — agent"]
+    direction TB
+    A1["&dollar;{VAR:-default}<br/>&dollar;{VAR}<br/>&dollar;{env:VAR:-default}<br/>&dollar;{sys:property:-default}"] --> A2[SDK resolver]
+    A2 --> A3["reads:<br/>env vars + system properties"]
+  end
+  STARTER --> MODEL[same SDK model]
+  AGENT --> MODEL
+```
+
+> [!NOTE] Same dollar-brace, two substituters
+>
+> Inside `application.yaml`, Spring resolves `${VAR:default}` (single colon)
+> from any property source it knows about — env vars, system properties,
+> profiles, command-line args, external config servers. The SDK's standalone
+> YAML uses `${VAR:-default}` (double colon, dash) and resolves from process
+> env vars and JVM system properties only. In the starter, the SDK
+> substituter never runs — Spring has already finished by the time the
+> starter reads the value.
+
+The dialects are close enough that mixing them up is easy. The reason the
+starter uses Spring's syntax is that Spring's resolver runs first, and by the
+time the starter retrieves a property the placeholder is already gone. The
+SDK never gets a chance to find one.
+
+That is also why all the Spring-native config tricks — profiles,
+command-line `--key=value`, `@Value`-style externalization, even external
+config servers — work transparently for OTel config. The starter never
+implemented any of them. Spring's resolver did, and the starter just reads
+properties.
+
+> [!NOTE] The biggest practical difference: env vars are first-class in the starter
+>
+> In the Spring starter, any env var named on the same canonical key path as
+> a YAML leaf overrides it automatically. Setting
+> `OTEL_TRACER_PROVIDER_PROCESSORS_0_BATCH_EXPORTER_OTLP_HTTP_ENDPOINT=http://prod-collector:4318/v1/traces`
+> at startup will replace whatever the YAML said. No extra wiring.
+>
+> In the Java agent's standalone YAML, the SDK substituter only resolves
+> `${VAR}` placeholders that *already exist in the YAML file*. If you want
+> an env var to override an agent-config value, you have to write
+> `${MY_VAR:-default}` into the YAML yourself ahead of time. Containers in
+> production land softer in the starter.
+
+## Arrival: the resolved tree the SDK actually boots from
+By the time our env var crosses the last boundary, she has been resolved,
+relaxed, normalized, and joined with every other `otel.*` key into a single
+flat map. The starter un-flattens that map back into the tree the SDK
+expects, hands it to Jackson, and Jackson produces the
+`OpenTelemetryConfigurationModel` the SDK boots from.
+
+The env var and the YAML sister converge at the same door. Whoever wrote
+which value, the SDK only ever sees the resolved result.
+
+```mermaid
+flowchart TD
+  A[application.yaml] --> S
+  B[application-prod.yaml] --> S
+  C[env vars] --> S
+  D[JVM system properties] --> S
+  E[command-line args] --> S
+  S["Spring property loader<br/>+ &dollar;{VAR} resolution"] --> F["flat property map<br/>otel.foo.bar[0].baz = ..."]
+  F --> X["starter: EmbeddedConfigFile<br/>walks otel.* keys, un-flattens"]
+  X --> J[Jackson → OpenTelemetryConfigurationModel]
+  J --> SDK[SDK runtime]
+```
+
+*Spring owns the front door. The SDK never sees a raw `${VAR}`, a profile
+name, or a property file — only a fully-resolved tree, handed over once at
+boot.*
+
+## Why "experimental" is the best reason to try declarative config now
+
+Declarative configuration is the schema OpenTelemetry is converging on
+across every language. It is not finished. The Spring Boot starter's support
+for it is marked experimental, exactly because it has not seen enough real
+applications yet to know which corners to tighten.
+
+That is not a warning. It is an invitation.
+
+Env-var configuration has been around long enough that all its rough edges
+have names. The YAML schema is younger — and pre-stable. Now, before it
+freezes, is the highest-leverage moment to put declarative config into a
+real `application.yaml` and see what breaks. Your friction is what shapes
+the schema that lands.
+
+## Getting there in 60 seconds
+
+Two starting points, both already there:
+
+- **You already have an `application.properties`?** Paste it into the
+  [interactive converter](/docs/zero-code/java/spring-boot-starter/declarative-configuration/#convert-your-existing-configuration)
+  on the doc page. Out comes the YAML, ready to drop into `application.yaml`.
+- **Greenfield?** The [OpenTelemetry Ecosystem
+  Explorer](https://opentelemetry.io/ecosystem/) generates declarative-config
+  YAML interactively — pick exporters, samplers, instrumentations, and copy
+  the result. A new Spring Boot starter target mode wraps the output under
+  `otel:` and uses the right `distribution.spring_starter.*` keys.
+
+## The fine print
+
+- **Dependency management is required on Spring Boot 3.5+.** Spring Boot 3.5
+  ships its own OpenTelemetry version pin that conflicts with what the starter
+  needs. Import the OTel instrumentation BOM in `dependencyManagement` (see
+  the
+  [docs](/docs/zero-code/java/spring-boot-starter/getting-started/#dependency-management)).
+  Skip it and you will see
+  `NoClassDefFoundError: io/opentelemetry/common/ComponentLoader` at startup.
+- **Durations are milliseconds, as numbers.** Use `5000`, not `5s`.
+- **Programmatic customization changes shape.**
+  `AutoConfigurationCustomizerProvider` is replaced by
+  `DeclarativeConfigurationCustomizerProvider`; SDK components plug in via
+  the `ComponentProvider` API. The
+  [agent extension API
+  docs](/docs/zero-code/java/agent/declarative-configuration/#extension-api)
+  apply to the starter unchanged.
+
+## Two sisters under one roof
+
+The env var did the job alone for a long time. Her sister fills in what she
+could never quite say. They share a building, share a stack, share a door
+into the SDK. Spring is the building they both live in. OpenTelemetry is the
+work they both do.
+
+If you migrate a real application onto this and hit something off, please
+file an issue —
+[opentelemetry-java-instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues)
+for code, [opentelemetry.io](https://github.com/open-telemetry/opentelemetry.io/issues)
+for docs. That is how the docs got fixed last time, and how they will keep
+getting better.

--- a/content/en/blog/2026/spring-boot-declarative-config/index.md
+++ b/content/en/blog/2026/spring-boot-declarative-config/index.md
@@ -150,8 +150,8 @@ wiring. With declarative config, you do not.
 > nested composition. The example above stays with `rule_based_routing`
 > because OTel Java has long recommended that sampler for this problem, and
 > the `composite/development` path still carries the `*/development` suffix
-> until the composable schema stabilizes. See a worked
-> [kitchen-sink example](https://github.com/open-telemetry/opentelemetry-configuration/blob/v1.0.0/snippets/Sampler_rule_based_kitchen_sink.yaml#L10-L53)
+> until the composable schema stabilizes. See a working
+> [example](https://github.com/open-telemetry/opentelemetry-configuration/blob/v1.0.0/snippets/Sampler_rule_based_kitchen_sink.yaml#L10-L53)
 > in the SDK config repo.
 
 So how does our small env var fit into a world where the SDK is configured by a

--- a/content/en/blog/2026/spring-boot-declarative-config/index.md
+++ b/content/en/blog/2026/spring-boot-declarative-config/index.md
@@ -224,7 +224,14 @@ where they live.
 > (every exporter type, every sampler type, every processor type),
 > [generated](/docs/languages/sdk-configuration/declarative-configuration/)
 > from a YAML schema that is still evolving. A hand-written POJO tree to
-> mirror it would be a second source of truth, perpetually behind the first.
+> mirror it would be a second source of truth, perpetually behind the
+> first. The gold-plated answer is to *generate* the POJOs from the schema
+> (the SDK's DC schema plus the not-yet-existing schemas for the
+> `distribution.*` and `instrumentation/development.*` subtrees) — that
+> same generated description could also drive the JSON metadata Spring uses
+> for IDE completion. The Java instrumentation team tracks that as a future
+> improvement in
+> [opentelemetry-java-instrumentation#14083](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/14083).
 >
 > So the starter does something Spring rarely sees: it walks every
 > `PropertySource` directly and collects keys that begin with `otel.`. The
@@ -244,7 +251,13 @@ where they live.
 ## Stage three: two substituters, one syntax
 
 Our env var can also speak in placeholders. So can her sister. They both use
-`${...}`. They mean almost — but not quite — the same thing.
+`${...}`. They mean almost — but not quite — the same thing. Spring will
+happily resolve a chained fallback like
+`${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}}/v1/traces`
+— chasing the outer placeholder into the inner so you can prefer a
+signal-specific override, fall back to a general one, and ultimately to a
+literal. The SDK's substituter is a single non-recursive regex pass; the
+same expression in `otel-config.yaml` would not parse.
 
 ```mermaid
 flowchart LR

--- a/content/en/blog/2026/spring-boot-declarative-config/index.md
+++ b/content/en/blog/2026/spring-boot-declarative-config/index.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Voyage of a Small Environment Variable'
 linkTitle: Spring Boot declarative config
-date: 2026-06-23
+date: 2026-07-13
 author: >-
   [Gregor Zeitlinger](https://github.com/zeitlinger) (Grafana Labs)
 sig: Java

--- a/content/en/blog/2026/spring-boot-declarative-config/index.md
+++ b/content/en/blog/2026/spring-boot-declarative-config/index.md
@@ -216,20 +216,30 @@ where they live.
 > Spring's relaxed binding has long understood that `OTEL_..._ENDPOINT` is
 > another spelling of `otel....endpoint`, brackets and all.
 >
-> But the starter is doing something unusual. The OTel schema is too big
-> and changes too often to bind to a configuration class, so the starter
-> does not ask Spring for known properties — it *enumerates* every
-> `PropertySource` and collects keys that begin with `otel.`. The walk
-> sees the YAML source's names with brackets
+> The usual Spring move for "I have a tree of config" would be a
+> [`@ConfigurationProperties`](https://docs.spring.io/spring-boot/reference/features/external-config.html#features.external-config.typesafe-configuration-properties)
+> class: declare a Java POJO shaped like your config tree, annotate it with
+> the property prefix, and Spring binds every source onto it for you. The
+> OTel SDK schema is hundreds of properties across many polymorphic layers
+> (every exporter type, every sampler type, every processor type),
+> [generated](/docs/languages/sdk-configuration/declarative-configuration/)
+> from a YAML schema that is still evolving. A hand-written POJO tree to
+> mirror it would be a second source of truth, perpetually behind the first.
+>
+> So the starter does something Spring rarely sees: it walks every
+> `PropertySource` directly and collects keys that begin with `otel.`. The
+> walk sees the YAML source's names with brackets
 > (`otel.tracer_provider.processors[0]...`), the env-var source's names
 > with underscores (`OTEL_TRACER_..._ENDPOINT`); Spring's rename only
-> happens when you *resolve* a property, not when you *list* one.
+> happens when you *resolve* a property, not when you *list* one. Then
+> Jackson binds the collected keys onto the *generated* configuration
+> model, which always matches the live schema.
 >
 > Sixteen lines in
 > [`EmbeddedConfigFile`](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/EmbeddedConfigFile.java#L66-L82)
-> close that gap. For every `otel.*` key that contains a `[N]` bracket,
-> the starter rebuilds the env-var name from the property name and asks
-> Spring directly. The cousin gets called.
+> close the gap between the two naming conventions. For every `otel.*`
+> key that contains a `[N]` bracket, the starter rebuilds the env-var name
+> from the property name and asks Spring directly. The cousin gets called.
 
 ## Stage three: two substituters, one syntax
 

--- a/content/en/blog/2026/spring-boot-declarative-config/index.md
+++ b/content/en/blog/2026/spring-boot-declarative-config/index.md
@@ -8,11 +8,11 @@ sig: Instrumentation
 cSpell:ignore: Customizer Dockerfiles Dotel petclinic relaxed sqlcommenter substituters zeitlinger
 ---
 
-The OpenTelemetry Spring Boot starter recently gained
-declarative-configuration support — the same YAML schema [the Java agent
-introduced in late 2025](/blog/2025/declarative-config/), now embedded inside
-`application.yaml`. This post is the story of how that landed, told through
-the eyes of one small environment variable.
+The OpenTelemetry Spring Boot starter 2.26.0 gained declarative-configuration
+support — the same YAML schema [the Java agent introduced in late
+2025](/blog/2025/declarative-config/), now embedded inside `application.yaml`.
+This post is the story of how that landed, told through the eyes of one
+small environment variable.
 
 *In a hurry? Jump straight to the
 [Spring Boot starter declarative-config docs](/docs/zero-code/java/spring-boot-starter/declarative-configuration/),
@@ -147,6 +147,7 @@ a tree?
 She travels.
 
 ## Stage one: arriving at Spring's property stack
+
 When the application starts, our env var arrives at the front desk of a
 building she has known her entire life: the Spring property loader. She is
 not alone. Behind her is the JVM `-D`, in front of her is `application.yaml`,
@@ -184,25 +185,17 @@ line.
 
 ```mermaid
 flowchart LR
-  subgraph PS[Spring PropertySources]
-    direction TB
-    P1[JVM system properties]
-    P2[env vars]
-    P3[command-line args]
-    P4[application-prod.yaml]
-    P5[application.yaml]
-  end
-  PS --> W["starter walks every source<br/>collects every otel.* key"]
-  W --> SEAM{"key sits under a list index?"}
+  S["Spring resolves<br/>all properties"] --> W["starter walks otel.* keys"]
+  W --> SEAM{"key sits under<br/>a list index?"}
   SEAM -- no --> OUT["un-flatten the whole map<br/>→ Jackson (once)<br/>→ SDK model"]
   SEAM -- yes --> RE["recompute env-var name<br/>re-read environment"]
   RE --> OUT
 ```
 
-*The starter walks every property source, collects every `otel.*` key, and
-hands the assembled map to Jackson — once, for the whole tree, not per
-element. The diamond is the seam this post is about: an extra step for keys
-that sit under a list index, which the next stage explains.*
+*The starter walks every property Spring exposes, picks out the `otel.*`
+keys, and hands the assembled map to Jackson — once, for the whole tree, not
+per element. The diamond is the seam this post is about: an extra step for
+keys that sit under a list index, which the next stage explains.*
 
 ## Stage two: a cousin Spring almost lost
 
@@ -214,9 +207,22 @@ OTEL_TRACER_PROVIDER_PROCESSORS_0_BATCH_EXPORTER_OTLP_HTTP_ENDPOINT=http://colle
 ```
 
 This one has a job to do — override one exporter's endpoint inside the YAML
-sister's tree — and she almost did not get heard.
+sister's tree — and Spring almost did not recognize her. Spring's relaxed
+binding renames env vars onto the dotted property tree for everything else,
+but it stops looking for env-var overrides the moment a key contains a `[0]`
+list bracket from the YAML. The cousin's name does not match anything Spring
+is searching for. She stands at the desk unread.
 
-> [!NOTE] What Spring's binding does, with a worked example
+The starter catches her there. For every `otel.*` key that sits under a list
+index, it reconstructs the env-var name from scratch — the same rule Spring
+would have used — and re-reads from the environment itself. Sixteen lines of
+code, deep inside [`EmbeddedConfigFile`][embed-link], that stitch the family
+back together so the cousin can reach into her sister's tree. The seam is
+the diamond in the diagram above.
+
+[embed-link]: https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/EmbeddedConfigFile.java#L66-L82
+
+> [!NOTE] What Spring's binding does, with a working example
 >
 > Setting `OTEL_SERVICE_NAME=petclinic` is the same as writing
 > `otel.service.name: petclinic` in `application.yaml`. Spring's binding
@@ -226,22 +232,17 @@ sister's tree — and she almost did not get heard.
 > `otel.resource.attributes[0].name`. So far, so good.
 >
 > The rule *stops* the moment a property with brackets in its name is already
-> in play. If `application.yaml` already declared `otel.tracer_provider.processors[0]....endpoint`,
-> Spring will *not* go looking for `OTEL_TRACER_PROVIDER_PROCESSORS_0_..._ENDPOINT`
-> as an override for that key. The bracket throws it off.
-
-That seam is where our cousin gets stuck. The starter notices and fixes it.
-For every `otel.*` key that sits under a list index, it reconstructs the
-env-var name from scratch — the same rule Spring would have used — and
-re-reads from the environment itself. Sixteen lines of code, deep inside
-[`EmbeddedConfigFile`][embed-link], that stitch the family back together so
-the cousin can reach into her sister's tree.
-
-[embed-link]: https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/EmbeddedConfigFile.java#L66-L82
-
-That seam is the diamond in the diagram above.
+> in play. If `application.yaml` already declared
+> `otel.tracer_provider.processors[0]....endpoint`, Spring will *not* go
+> looking for `OTEL_TRACER_PROVIDER_PROCESSORS_0_..._ENDPOINT` as an override
+> for that key. The bracket throws it off.
+>
+> That gap is exactly what the starter's 16-line patch closes: whenever it
+> sees an `otel.*` key with brackets in it, it rebuilds the env-var name
+> by the same rule and re-checks the environment itself.
 
 ## Stage three: two substituters, one syntax
+
 Our env var can also speak in placeholders. So can her sister. They both use
 `${...}`. They mean almost — but not quite — the same thing.
 
@@ -282,20 +283,30 @@ config servers — work transparently for OTel config. The starter never
 implemented any of them. Spring's resolver did, and the starter just reads
 properties.
 
-> [!NOTE] The biggest practical difference: env vars are first-class in the starter
+The biggest practical consequence: in the starter, any env var named on the
+same canonical key path as a YAML leaf overrides it automatically — no
+extra wiring. The agent's standalone YAML cannot do that. There, an env-var
+override has to be wired into the YAML as a `${VAR}` placeholder ahead of
+time, or it does nothing.
+
+> [!NOTE] Example: overriding a YAML leaf with an env var
 >
-> In the Spring starter, any env var named on the same canonical key path as
-> a YAML leaf overrides it automatically. Setting
-> `OTEL_TRACER_PROVIDER_PROCESSORS_0_BATCH_EXPORTER_OTLP_HTTP_ENDPOINT=http://prod-collector:4318/v1/traces`
-> at startup will replace whatever the YAML said. No extra wiring.
+> In the starter, this works at startup with nothing else changed in the
+> YAML:
 >
-> In the Java agent's standalone YAML, the SDK substituter only resolves
-> `${VAR}` placeholders that *already exist in the YAML file*. If you want
-> an env var to override an agent-config value, you have to write
-> `${MY_VAR:-default}` into the YAML yourself ahead of time. Containers in
+> ```bash
+> OTEL_TRACER_PROVIDER_PROCESSORS_0_BATCH_EXPORTER_OTLP_HTTP_ENDPOINT=\
+>   http://prod-collector:4318/v1/traces
+> ```
+>
+> Whatever the `application.yaml` said for that endpoint is replaced.
+>
+> In the agent, you would first have to write `${MY_ENDPOINT:-http://...}`
+> into the YAML, then set `MY_ENDPOINT` at startup. Containers in
 > production land softer in the starter.
 
 ## Arrival: the resolved tree the SDK actually boots from
+
 By the time our env var crosses the last boundary, she has been resolved,
 relaxed, normalized, and joined with every other `otel.*` key into a single
 flat map. The starter un-flattens that map back into the tree the SDK

--- a/content/en/blog/2026/spring-boot-declarative-config/index.md
+++ b/content/en/blog/2026/spring-boot-declarative-config/index.md
@@ -6,14 +6,14 @@ author: >-
   [Gregor Zeitlinger](https://github.com/zeitlinger) (Grafana Labs)
 sig: Instrumentation
 # prettier-ignore
-cSpell:ignore: Customizer Dockerfiles Dotel petclinic relaxed substituters zeitlinger
+cSpell:ignore: Customizer Dotel petclinic relaxed substituters zeitlinger
 ---
 
 The OpenTelemetry Spring Boot starter 2.26.0 gained declarative-configuration
 support — the same YAML schema
 [the Java agent introduced in late 2025](/blog/2025/declarative-config/), now
-embedded inside `application.yaml`. This post is the story of how that landed,
-told through the eyes of one small environment variable.
+embedded inside `application.yaml`. This post traces what one env var,
+`OTEL_SERVICE_NAME=petclinic`, does in that new world, and where the seams are.
 
 _In a hurry? Jump straight to the
 [Spring Boot starter declarative-config docs](/docs/zero-code/java/spring-boot-starter/declarative-configuration/),
@@ -24,46 +24,26 @@ Boot starter target selected. Come back for the story when you have a coffee._
 
 ---
 
-Meet a small environment variable.
+For years, environment variables (and their JVM `-D` cousins) were the only way
+to configure the OpenTelemetry SDK: every exporter, every sampler, every
+captured header, expressed as a flat list of `OTEL_*` variables.
 
-```bash
-OTEL_SERVICE_NAME=petclinic
-```
-
-You have set her hundreds of times. In CI files. In Dockerfiles. In your
-terminal, with a `&&` and a shrug. She is so familiar that you have never
-thought twice about where she actually goes.
-
-She is older than you think.
-
-For years, environment variables (and their close cousin, the JVM `-D` system
-property) were the only way to configure the OpenTelemetry SDK. Every exporter,
-every sampler, every captured header — all expressed as a flat list of `OTEL_*`
-variables. Our small env var did the whole job, alone.
-
-Recently, she got a sister.
-
-The OpenTelemetry SDK
+Since OpenTelemetry Spring Boot starter **2.26.0**, that list has a sibling. The
+SDK
 [declarative-configuration schema](/docs/languages/sdk-configuration/declarative-configuration/)
 is a YAML tree that can describe an entire telemetry pipeline (every processor,
 every exporter, every nested option) in the same shape the SDK actually runs.
-Things the env var could not say. Spring starter users wrote a `@Bean` for them.
-Java agent users had to write a full extension and package it in a separate jar
-to ship alongside the agent — almost prohibitive.
+Things the env var could not say. Spring starter users used to write a `@Bean`
+for them; Java agent users had to ship a full extension in a separate jar —
+almost prohibitive.
 
-The two of them share a roof now. Since OpenTelemetry Spring Boot starter
-**2.26.0**, the YAML sister moves into your `application.yaml`, under a single
-`otel:` key. Our env var still has a place, but a narrower one.
-`OTEL_SERVICE_NAME` survives because a service-name resource detector goes
-hunting for her at boot. The new family rule is that most env vars don't flow
-into the SDK automatically anymore; if you want one to override a YAML leaf, you
-invite her in by name with `${VAR:default}`.
-
-This is the story of how they get along.
+The schema moves into your `application.yaml`, under a single `otel:` key. Env
+vars still work, but in a narrower role: `OTEL_SERVICE_NAME` lands as a resource
+attribute because a service-name detector reads it at boot, and any
+`${VAR:default}` placeholder you write into the YAML pulls one in by name.
+Otherwise, the YAML is the source of truth.
 
 ## A YAML file inside your YAML file
-
-Here is what living together looks like:
 
 ```yaml
 otel:
@@ -82,22 +62,22 @@ otel:
               endpoint: ${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:http://localhost:4318/v1/traces}
 ```
 
-That block under `otel:` is the OpenTelemetry SDK speaking its own native YAML
-(list of processors, each holding an exporter, each holding configuration)
-inside Spring's `application.yaml`. The presence of `otel.file_format` is the
-switch. Everything beneath it is parsed against the SDK schema. Spring does not
-need to know what any of it means.
+The block under `otel:` is the OpenTelemetry SDK schema (list of processors,
+each holding an exporter, each holding configuration) inside Spring's
+`application.yaml`. The presence of `otel.file_format` is the switch. Everything
+beneath it is parsed against the SDK schema. Spring does not need to know what
+any of it means.
 
-## The wall the env var alone could not climb
+## The wall env vars alone could not climb
 
-Env vars do cover a fixed list of built-in choices: a
+Env vars cover a fixed list of built-in choices: a
 [fixed set of samplers](/docs/languages/sdk-configuration/general/#otel_traces_sampler)
 via `OTEL_TRACES_SAMPLER`, the standard OTLP exporters via
 `OTEL_EXPORTER_OTLP_*`, the usual signal-toggle flags. Anything outside that
 catalog (a custom rule-based sampler, a second OTLP exporter on a debug
 pipeline, a baggage processor, any nested option the SDK exposes) meant writing
 a `@Bean` (Spring starter) or shipping a separate extension jar (Java agent).
-The bigger sister is what unlocks the rest of the tree.
+Declarative config unlocks the rest of the tree.
 
 The docs page for the starter has a small example most teams need on day one:
 [exclude actuator endpoints from tracing](/docs/zero-code/java/spring-boot-starter/programmatic-configuration/#exclude-actuator-endpoints-from-tracing).
@@ -136,9 +116,8 @@ otel:
                 pattern: /actuator.*
 ```
 
-It's the same Java code under the hood: both the agent and the starter already
-bundle the `opentelemetry-samplers` contrib jar. What changes is who writes the
-wiring. With declarative config, you do not.
+Both versions run the same Java code — the agent and the starter already bundle
+the `opentelemetry-samplers` contrib jar. What changes is who writes the wiring.
 
 > [!NOTE] An alternative: the composable rule-based sampler
 >
@@ -154,22 +133,17 @@ wiring. With declarative config, you do not.
 > [example](https://github.com/open-telemetry/opentelemetry-configuration/blob/v1.0.0/snippets/Sampler_rule_based_kitchen_sink.yaml#L10-L53)
 > in the SDK config repository.
 
-So how does our small env var fit into a world where the SDK is configured by a
-tree?
-
-She travels.
+The rest of this post follows `OTEL_SERVICE_NAME` through three stages on its
+way into the SDK.
 
 ## Stage one: arriving at Spring's property stack
 
-When the application starts, our env var arrives at the front desk of a building
-she has known her entire life: the Spring property loader. She is not alone.
-Behind her is the JVM `-D`, in front of her is `application.yaml`, beside her is
-the active profile's overlay and the `--key=value` from the command line. Spring
-stacks them all into a single addressable property universe.
-
-She is one of many. `OTEL_SERVICE_NAME` rides the same Spring property bus as
-`SERVER_PORT` and `SPRING_PROFILES_ACTIVE`. Spring does not know which of these
-belong to OpenTelemetry; that is the starter's job, at the end of the line.
+Spring's property loader stacks every source the app sees — `application.yaml`,
+every active profile's overlay, the JVM `-D` flags, the `--key=value`
+command-line args, environment variables — into a single addressable property
+universe. `OTEL_SERVICE_NAME` lives in that stack alongside `SERVER_PORT` and
+`SPRING_PROFILES_ACTIVE`. Spring does not know which of these belong to
+OpenTelemetry; that is the starter's job, at the end of the line.
 
 > [!NOTE] How Spring quietly aligns env vars with YAML keys
 >
@@ -203,26 +177,25 @@ flowchart LR
   RE --> OUT
 ```
 
-_The starter walks every property Spring exposes, picks out the `otel._` keys,
+_The starter walks every property Spring exposes, picks out the `otel.*` keys,
 and hands the assembled map to Jackson — once, for the whole tree, not per
 element. The diamond is the seam this post is about: an extra step for keys that
-sit under a list index, which the next stage explains.\*
+sit under a list index, which the next stage explains._
 
-## Stage two: a cousin Spring almost lost
+## Stage two: the env var Spring almost lost
 
-Our protagonist is humble. But she has a gnarly cousin, the kind of relative who
-barely makes it past the front desk:
+Most `otel.*` env vars travel light. This one does not:
 
 ```bash
 OTEL_TRACER_PROVIDER_PROCESSORS_0_BATCH_EXPORTER_OTLP_HTTP_ENDPOINT=http://collector:4318/v1/traces
 ```
 
-She makes it past, but only because sixteen lines, deep inside the starter, go
-hunting for her by name. The diamond in the diagram above is where they live.
+It gets through, but only because sixteen lines deep inside the starter go
+hunting for it by name. The diamond in the diagram above is where they live.
 
-> [!NOTE] How the cousin gets through (and why it takes work)
+> [!NOTE] Why the starter walks every property source
 >
-> Asking Spring for the property by name would return her value just fine.
+> Asking Spring for the property by name would return this value just fine.
 > Spring's relaxed binding has long understood that `OTEL_..._ENDPOINT` is
 > another spelling of `otel....endpoint`, brackets and all.
 >
@@ -255,13 +228,13 @@ hunting for her by name. The diamond in the diagram above is where they live.
 > [`EmbeddedConfigFile`](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/v2.29.0/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/EmbeddedConfigFile.java#L66-L82)
 > close the gap between the two naming conventions. For every `otel.*` key that
 > contains a `[N]` bracket, the starter rebuilds the env-var name from the
-> property name and asks Spring directly. The cousin gets called.
+> property name and asks Spring directly.
 
 ## Stage three: two substituters, one syntax
 
-Our env var can also speak in placeholders. So can her sister. They both use
-`${...}`. They mean almost, but not quite, the same thing. Spring will happily
-resolve a chained fallback like
+Both `application.yaml` and the SDK's standalone YAML use `${...}` placeholders.
+They mean almost, but not quite, the same thing. Spring will happily resolve a
+chained fallback like
 `${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}}/v1/traces`,
 chasing the outer placeholder into the inner so you can prefer a signal-specific
 override, fall back to a general one, and ultimately to a literal. The SDK's
@@ -293,11 +266,6 @@ flowchart LR
 > vars and JVM system properties only. In the starter, the SDK substituter never
 > runs; Spring has already finished by the time the starter reads the value.
 
-The dialects are close enough that mixing them up is easy. The reason the
-starter uses Spring's syntax is that Spring's resolver runs first, and by the
-time the starter retrieves a property the placeholder is already gone. The SDK
-never gets a chance to find one.
-
 That is also why all the Spring-native config tricks (profiles, command-line
 `--key=value`, `@Value`-style externalization, even external config servers)
 work transparently for OTel config. The starter never implemented any of them.
@@ -325,14 +293,12 @@ wired into the YAML as a `${VAR}` placeholder ahead of time, or it does nothing.
 
 ## Arrival: the resolved tree the SDK actually boots from
 
-By the time our env var crosses the last boundary, she has been resolved,
-relaxed, normalized, and joined with every other `otel.*` key into a single flat
-map. The starter un-flattens that map back into the tree the SDK expects, hands
-it to Jackson, and Jackson produces the `OpenTelemetryConfigurationModel` the
-SDK boots from.
-
-The env var and the YAML sister converge at the same door. Whoever wrote which
-value, the SDK only ever sees the resolved result.
+By the time the SDK boots, every `otel.*` value has been resolved, relaxed,
+normalized, and joined with every other into a single flat map. The starter
+un-flattens that map back into the tree the SDK expects, hands it to Jackson,
+and Jackson produces the `OpenTelemetryConfigurationModel` the SDK boots from.
+Whatever wrote which value — yaml, env var, profile overlay, command-line arg —
+the SDK only ever sees the resolved result.
 
 ```mermaid
 flowchart TD
@@ -357,10 +323,7 @@ every language. It is not finished. The Spring Boot starter's support for it is
 marked experimental, exactly because it has not seen enough real applications
 yet to know which corners to tighten.
 
-That is not a warning. It is an invitation.
-
-Env-var configuration has been around long enough that all its rough edges have
-names. The YAML schema is younger, and pre-stable. Now, before it freezes, is
+That is not a warning. It is an invitation. Now, before the schema freezes, is
 the highest-leverage moment to put declarative config into a real
 `application.yaml` and see what breaks. Your friction is what shapes the schema
 that lands.
@@ -394,17 +357,9 @@ Two starting points, both already there:
   [agent extension API docs](/docs/zero-code/java/agent/declarative-configuration/#extension-api)
   apply to the starter unchanged.
 
-## Two sisters under one roof
-
-The env var did the job alone for a long time. Her sister fills in what she
-could never quite say. They share a building, share a stack, share a door into
-the SDK. Spring is the building they both live in. OpenTelemetry is the work
-they both do.
-
 If you migrate a real application onto this and hit something off, please file
 an issue:
 [opentelemetry-java-instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues)
 for code,
 [opentelemetry.io](https://github.com/open-telemetry/opentelemetry.io/issues)
-for docs. That is how the docs got fixed last time, and how they will keep
-getting better.
+for docs.

--- a/content/en/blog/2026/spring-boot-declarative-config/index.md
+++ b/content/en/blog/2026/spring-boot-declarative-config/index.md
@@ -4,13 +4,13 @@ linkTitle: Spring Boot declarative config
 date: 2026-06-23
 author: >-
   [Gregor Zeitlinger](https://github.com/zeitlinger) (Grafana Labs)
-sig: Instrumentation
+sig: Java
 # prettier-ignore
 cSpell:ignore: Customizer Dotel petclinic relaxed substituters zeitlinger
 ---
 
-The OpenTelemetry Spring Boot starter 2.26.0 gained declarative-configuration
-support — the same YAML schema
+The OpenTelemetry Spring Boot starter gained declarative-configuration support
+starting in version 2.26.0 — the same YAML schema
 [the Java agent introduced in late 2025](/blog/2025/declarative-config/), now
 embedded inside `application.yaml`. This post traces what one env var,
 `OTEL_SERVICE_NAME=petclinic`, does in that new world, and where the seams are.
@@ -28,14 +28,14 @@ For years, environment variables (and their JVM `-D` cousins) were the only way
 to configure the OpenTelemetry SDK: every exporter, every sampler, every
 captured header, expressed as a flat list of `OTEL_*` variables.
 
-Since OpenTelemetry Spring Boot starter **2.26.0**, that list has a sibling. The
-SDK
+Since starter 2.26.0, that list has a sibling. The SDK
 [declarative-configuration schema](/docs/languages/sdk-configuration/declarative-configuration/)
 is a YAML tree that can describe an entire telemetry pipeline (every processor,
 every exporter, every nested option) in the same shape the SDK actually runs.
-Things the env var could not say. Spring starter users used to write a `@Bean`
-for them; Java agent users had to ship a full extension in a separate jar —
-almost prohibitive.
+
+For things the env var could not say, Spring starter users needed to write a
+`@Bean`. Java agent users had to write a full extension and package it in a
+separate jar to ship alongside the agent — which can be prohibitive.
 
 The schema moves into your `application.yaml`, under a single `otel:` key. Env
 vars still work, but in a narrower role: `OTEL_SERVICE_NAME` lands as a resource

--- a/content/en/blog/2026/spring-boot-declarative-config/index.md
+++ b/content/en/blog/2026/spring-boot-declarative-config/index.md
@@ -5,7 +5,6 @@ date: 2026-06-23
 author: >-
   [Gregor Zeitlinger](https://github.com/zeitlinger) (Grafana Labs)
 sig: Java
-# prettier-ignore
 cSpell:ignore: Customizer Dotel petclinic relaxed substituters zeitlinger
 ---
 

--- a/content/en/blog/2026/spring-boot-declarative-config/index.md
+++ b/content/en/blog/2026/spring-boot-declarative-config/index.md
@@ -142,15 +142,15 @@ wiring. With declarative config, you do not.
 
 > [!NOTE] An alternative: the composable rule-based sampler
 >
-> The schema also has the
-> [composable rule-based sampler](/docs/specs/otel-config/types/#ct-item-experimentalcomposablerulebasedsampler)
-> (under `composite/development.rule_based`), which accomplishes the same
-> thing with a richer rule grammar: attribute patterns with includes/excludes,
-> multi-condition matches, span-kind filters, parent state, and arbitrary
-> nested composition. The example above stays with `rule_based_routing`
-> because OTel Java has long recommended that sampler for this problem, and
-> the `composite/development` path still carries the `*/development` suffix
-> until the composable schema stabilizes. See a working
+> The schema also has the composable rule-based sampler (under
+> `composite/development.rule_based` in the
+> [configuration types reference](/docs/specs/otel-config/types/)), which
+> accomplishes the same thing with a richer rule grammar: attribute patterns
+> with includes/excludes, multi-condition matches, span-kind filters, parent
+> state, and arbitrary nested composition. The example above stays with
+> `rule_based_routing` because OTel Java has long recommended that sampler for
+> this problem, and the `composite/development` path still carries the
+> `*/development` suffix until the composable schema stabilizes. See a working
 > [example](https://github.com/open-telemetry/opentelemetry-configuration/blob/v1.0.0/snippets/Sampler_rule_based_kitchen_sink.yaml#L10-L53)
 > in the SDK config repository.
 
@@ -263,10 +263,10 @@ Our env var can also speak in placeholders. So can her sister. They both use
 `${...}`. They mean almost, but not quite, the same thing. Spring will happily
 resolve a chained fallback like
 `${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}}/v1/traces`,
-chasing the outer placeholder into the inner so you can prefer a
-signal-specific override, fall back to a general one, and ultimately to a
-literal. The SDK's substituter is a single non-recursive regular-expression
-pass; the same expression in `otel-config.yaml` would not parse.
+chasing the outer placeholder into the inner so you can prefer a signal-specific
+override, fall back to a general one, and ultimately to a literal. The SDK's
+substituter is a single non-recursive regular-expression pass; the same
+expression in `otel-config.yaml` would not parse.
 
 ```mermaid
 flowchart LR

--- a/content/en/blog/2026/spring-boot-declarative-config/index.md
+++ b/content/en/blog/2026/spring-boot-declarative-config/index.md
@@ -206,40 +206,45 @@ who barely makes it past the front desk:
 OTEL_TRACER_PROVIDER_PROCESSORS_0_BATCH_EXPORTER_OTLP_HTTP_ENDPOINT=http://collector:4318/v1/traces
 ```
 
-This one has a job to do — override one exporter's endpoint inside the YAML
-sister's tree — and Spring almost did not recognize her. Spring's relaxed
-binding renames env vars onto the dotted property tree for everything else,
-but it stops looking for env-var overrides the moment a key contains a `[0]`
-list bracket from the YAML. The cousin's name does not match anything Spring
-is searching for. She stands at the desk unread.
+This one has a job to do: override one exporter's endpoint inside the YAML
+sister's tree. Asking Spring for the property by name would return her value
+just fine — Spring's relaxed binding has long understood that
+`OTEL_..._ENDPOINT` is another spelling of `otel....endpoint`, brackets and
+all.
 
-The starter catches her there. For every `otel.*` key that sits under a list
-index, it reconstructs the env-var name from scratch — the same rule Spring
-would have used — and re-reads from the environment itself. Sixteen lines of
-code, deep inside [`EmbeddedConfigFile`][embed-link], that stitch the family
-back together so the cousin can reach into her sister's tree. The seam is
-the diamond in the diagram above.
+But the starter is doing something unusual. The OTel schema is too big and
+changes too often to bind to a configuration class, so the starter does not
+ask Spring for known properties — it *enumerates* every `PropertySource`
+looking for keys that begin with `otel.`. The walk sees the YAML source's
+names (`otel.tracer_provider.processors[0]...`) but misses the env-var
+source's names (`OTEL_TRACER_..._ENDPOINT`); Spring's rename only happens
+when you *resolve* a property, not when you *list* one. The cousin's value
+is right there behind the front desk; the starter is simply not looking in
+the place where Spring filed her.
+
+Sixteen lines of code in [`EmbeddedConfigFile`][embed-link] close that gap.
+For every yaml-style `otel.*` key that contains a `[N]` bracket, the starter
+reconstructs the env-var name from the property name and asks Spring
+directly. The cousin gets called. The seam is the diamond in the diagram
+above.
 
 [embed-link]: https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/EmbeddedConfigFile.java#L66-L82
 
-> [!NOTE] What Spring's binding does, with a working example
+> [!NOTE] What Spring's binding does — and what it doesn't
 >
 > Setting `OTEL_SERVICE_NAME=petclinic` is the same as writing
-> `otel.service.name: petclinic` in `application.yaml`. Spring's binding
-> recognizes the env-var name as a different spelling of the same property.
+> `otel.service.name: petclinic` in `application.yaml` — Spring resolves
+> both spellings to the same property. The same rule extends to list
+> indices: `OTEL_RESOURCE_ATTRIBUTES_0_NAME` is another way of writing
+> `otel.resource.attributes[0].name`.
 >
-> The rule extends to list indices: `OTEL_RESOURCE_ATTRIBUTES_0_NAME` becomes
-> `otel.resource.attributes[0].name`. So far, so good.
->
-> The rule *stops* the moment a property with brackets in its name is already
-> in play. If `application.yaml` already declared
-> `otel.tracer_provider.processors[0]....endpoint`, Spring will *not* go
-> looking for `OTEL_TRACER_PROVIDER_PROCESSORS_0_..._ENDPOINT` as an override
-> for that key. The bracket throws it off.
->
-> That gap is exactly what the starter's 16-line patch closes: whenever it
-> sees an `otel.*` key with brackets in it, it rebuilds the env-var name
-> by the same rule and re-checks the environment itself.
+> But the renaming only happens when you *resolve* a property by name. If
+> you *enumerate* property names from the environment-variable source, you
+> see the raw `OTEL_..._NAME` form. The yaml source enumerates names with
+> brackets. A program that walks both lists — instead of binding to a
+> known set of keys — sees two parallel naming conventions and has to
+> align them itself. That alignment is what the starter's 16-line patch
+> does.
 
 ## Stage three: two substituters, one syntax
 

--- a/content/en/blog/2026/spring-boot-declarative-config/index.md
+++ b/content/en/blog/2026/spring-boot-declarative-config/index.md
@@ -22,28 +22,31 @@ now embedded inside `application.yaml`. This post traces what one env var,
 > [Spring Boot starter declarative-config docs](/docs/zero-code/java/spring-boot-starter/declarative-configuration/),
 > paste your `application.properties` into the
 > [interactive converter](/docs/zero-code/java/spring-boot-starter/declarative-configuration/#convert-your-existing-configuration),
-> or pick your SDK setup in the [Ecosystem Explorer](/ecosystem/) with the
-> Spring Boot starter target selected. Come back for the story when you have a
-> coffee.
+> or pick your SDK setup in the
+> [Ecosystem Explorer](https://explorer.opentelemetry.io/java-agent/configuration/builder)
+> with the Spring Boot starter target selected. Come back for the story when you
+> have a coffee.
 
 For years, environment variables (and their JVM `-D` cousins) were the only way
 to configure the OpenTelemetry SDK: every exporter, every sampler, every
 captured header, expressed as a flat list of `OTEL_*` variables.
 
-Since starter 2.26.0, that list has a new sibling. The SDK
+Since version 2.26.0 of the OpenTelemetry Spring Boot starter, that list has a
+new sibling. The SDK
 [declarative-configuration schema](/docs/languages/sdk-configuration/declarative-configuration/)
 is a YAML tree that can describe an entire telemetry pipeline (every processor,
 every exporter, every nested option) in the same shape the SDK actually runs.
 
 For things the env var could not say, Spring starter users needed to write a
-`@Bean`. Java agent users had to write a full extension and package it in a
-separate jar to ship alongside the agent — which can be prohibitive.
+`@Bean`. Java agent users had to write a full
+[extension](/docs/zero-code/java/agent/extensions/) and package it in a separate
+jar to ship alongside the agent — which can be prohibitive.
 
-The schema moves into your `application.yaml`, under a single `otel:` key. Env
-vars still work, but in a narrower role: `OTEL_SERVICE_NAME` lands as a resource
-attribute because a service-name detector reads it at boot, and any
-`${VAR:default}` placeholder you write into the YAML pulls one in by name.
-Otherwise, the YAML is the source of truth.
+With these new changes, the schema moves into your `application.yaml`, under a
+single `otel:` key. Env vars still work, but in a narrower role:
+`OTEL_SERVICE_NAME` lands as a resource attribute because a service-name
+detector reads it at boot, and any `${VAR:default}` placeholder you write into
+the YAML pulls one in by name. Otherwise, the YAML is the source of truth.
 
 ## A YAML file inside your YAML file
 
@@ -75,15 +78,14 @@ any of it means.
 Env vars cover a fixed list of built-in choices: a
 [fixed set of samplers](/docs/languages/sdk-configuration/general/#otel_traces_sampler)
 via `OTEL_TRACES_SAMPLER`, the standard OTLP exporters via
-`OTEL_EXPORTER_OTLP_*`, the usual signal-toggle flags. Anything outside that
+`OTEL_EXPORTER_OTLP_*`, and the usual signal-toggle flags. Anything outside that
 catalog (a custom rule-based sampler, a second OTLP exporter on a debug
-pipeline, a baggage processor, any nested option the SDK exposes) meant writing
-a `@Bean` (Spring starter) or shipping a separate extension jar (Java agent).
-Declarative config unlocks the rest of the tree.
+pipeline, a baggage processor, any nested option the SDK exposes) was outside
+the env-var model. Declarative config unlocks the rest of the tree.
 
 The docs page for the starter has a small example most teams need on day one:
 [exclude actuator endpoints from tracing](/docs/zero-code/java/spring-boot-starter/programmatic-configuration/#exclude-actuator-endpoints-from-tracing).
-Yesterday that was a `@Configuration` class:
+Previously, that was handled via a `@Configuration` class:
 
 ```java
 @Configuration
@@ -192,7 +194,7 @@ Most `otel.*` env vars travel light. This one does not:
 OTEL_TRACER_PROVIDER_PROCESSORS_0_BATCH_EXPORTER_OTLP_HTTP_ENDPOINT=http://collector:4318/v1/traces
 ```
 
-It gets through, but only because sixteen lines deep inside the starter go
+It gets through, but only because sixteen lines deep inside the starter we go
 hunting for it by name. The diamond in the diagram above is where they live.
 
 > [!NOTE] Why the starter walks every property source
@@ -337,8 +339,9 @@ Two starting points, both already there:
 - **You already have an `application.properties`?** Paste it into the
   [interactive converter](/docs/zero-code/java/spring-boot-starter/declarative-configuration/#convert-your-existing-configuration)
   on the doc page. Out comes the YAML, ready to drop into `application.yaml`.
-- **Greenfield?** The [OpenTelemetry Ecosystem Explorer](/ecosystem/) generates
-  declarative-config YAML interactively: pick exporters, samplers,
+- **Greenfield?** The
+  [OpenTelemetry Ecosystem Explorer](https://explorer.opentelemetry.io/java-agent/configuration/builder)
+  generates declarative-config YAML interactively: pick exporters, samplers,
   instrumentations, and copy the result. A new Spring Boot starter target mode
   wraps the output under `otel:` and uses the right
   `distribution.spring_starter.*` keys.

--- a/content/en/blog/2026/spring-boot-declarative-config/index.md
+++ b/content/en/blog/2026/spring-boot-declarative-config/index.md
@@ -1,7 +1,7 @@
 ---
 title: 'The Voyage of a Small Environment Variable'
 linkTitle: Spring Boot declarative config
-date: 2026-07-13
+date: 2026-07-14
 author: >-
   [Gregor Zeitlinger](https://github.com/zeitlinger) (Grafana Labs)
 sig: Java

--- a/content/en/blog/2026/spring-boot-declarative-config/index.md
+++ b/content/en/blog/2026/spring-boot-declarative-config/index.md
@@ -206,45 +206,30 @@ who barely makes it past the front desk:
 OTEL_TRACER_PROVIDER_PROCESSORS_0_BATCH_EXPORTER_OTLP_HTTP_ENDPOINT=http://collector:4318/v1/traces
 ```
 
-This one has a job to do: override one exporter's endpoint inside the YAML
-sister's tree. Asking Spring for the property by name would return her value
-just fine — Spring's relaxed binding has long understood that
-`OTEL_..._ENDPOINT` is another spelling of `otel....endpoint`, brackets and
-all.
+She makes it past — but only because sixteen lines, deep inside the
+starter, go hunting for her by name. The diamond in the diagram above is
+where they live.
 
-But the starter is doing something unusual. The OTel schema is too big and
-changes too often to bind to a configuration class, so the starter does not
-ask Spring for known properties — it *enumerates* every `PropertySource`
-looking for keys that begin with `otel.`. The walk sees the YAML source's
-names (`otel.tracer_provider.processors[0]...`) but misses the env-var
-source's names (`OTEL_TRACER_..._ENDPOINT`); Spring's rename only happens
-when you *resolve* a property, not when you *list* one. The cousin's value
-is right there behind the front desk; the starter is simply not looking in
-the place where Spring filed her.
-
-Sixteen lines of code in [`EmbeddedConfigFile`][embed-link] close that gap.
-For every yaml-style `otel.*` key that contains a `[N]` bracket, the starter
-reconstructs the env-var name from the property name and asks Spring
-directly. The cousin gets called. The seam is the diamond in the diagram
-above.
-
-[embed-link]: https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/EmbeddedConfigFile.java#L66-L82
-
-> [!NOTE] What Spring's binding does — and what it doesn't
+> [!NOTE] How the cousin gets through (and why it takes work)
 >
-> Setting `OTEL_SERVICE_NAME=petclinic` is the same as writing
-> `otel.service.name: petclinic` in `application.yaml` — Spring resolves
-> both spellings to the same property. The same rule extends to list
-> indices: `OTEL_RESOURCE_ATTRIBUTES_0_NAME` is another way of writing
-> `otel.resource.attributes[0].name`.
+> Asking Spring for the property by name would return her value just fine —
+> Spring's relaxed binding has long understood that `OTEL_..._ENDPOINT` is
+> another spelling of `otel....endpoint`, brackets and all.
 >
-> But the renaming only happens when you *resolve* a property by name. If
-> you *enumerate* property names from the environment-variable source, you
-> see the raw `OTEL_..._NAME` form. The yaml source enumerates names with
-> brackets. A program that walks both lists — instead of binding to a
-> known set of keys — sees two parallel naming conventions and has to
-> align them itself. That alignment is what the starter's 16-line patch
-> does.
+> But the starter is doing something unusual. The OTel schema is too big
+> and changes too often to bind to a configuration class, so the starter
+> does not ask Spring for known properties — it *enumerates* every
+> `PropertySource` and collects keys that begin with `otel.`. The walk
+> sees the YAML source's names with brackets
+> (`otel.tracer_provider.processors[0]...`), the env-var source's names
+> with underscores (`OTEL_TRACER_..._ENDPOINT`); Spring's rename only
+> happens when you *resolve* a property, not when you *list* one.
+>
+> Sixteen lines in
+> [`EmbeddedConfigFile`](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/EmbeddedConfigFile.java#L66-L82)
+> close that gap. For every `otel.*` key that contains a `[N]` bracket,
+> the starter rebuilds the env-var name from the property name and asks
+> Spring directly. The cousin gets called.
 
 ## Stage three: two substituters, one syntax
 

--- a/content/en/blog/2026/spring-boot-declarative-config/index.md
+++ b/content/en/blog/2026/spring-boot-declarative-config/index.md
@@ -45,15 +45,15 @@ Recently, she got a sister.
 
 The OpenTelemetry SDK
 [declarative-configuration schema](/docs/languages/sdk-configuration/declarative-configuration/)
-is a YAML tree that can describe an entire telemetry pipeline — every processor,
-every exporter, every nested option — in the same shape the SDK actually runs.
+is a YAML tree that can describe an entire telemetry pipeline (every processor,
+every exporter, every nested option) in the same shape the SDK actually runs.
 Things the env var could not say. Spring starter users wrote a `@Bean` for them.
 Java agent users had to write a full extension and package it in a separate jar
 to ship alongside the agent — almost prohibitive.
 
 The two of them share a roof now. Since OpenTelemetry Spring Boot starter
 **2.26.0**, the YAML sister moves into your `application.yaml`, under a single
-`otel:` key. Our env var still has a place — but a narrower one.
+`otel:` key. Our env var still has a place, but a narrower one.
 `OTEL_SERVICE_NAME` survives because a service-name resource detector goes
 hunting for her at boot. The new family rule is that most env vars don't flow
 into the SDK automatically anymore; if you want one to override a YAML leaf, you
@@ -82,8 +82,8 @@ otel:
               endpoint: ${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:http://localhost:4318/v1/traces}
 ```
 
-That block under `otel:` is the OpenTelemetry SDK speaking its own native YAML —
-list of processors, each holding an exporter, each holding configuration —
+That block under `otel:` is the OpenTelemetry SDK speaking its own native YAML
+(list of processors, each holding an exporter, each holding configuration)
 inside Spring's `application.yaml`. The presence of `otel.file_format` is the
 switch. Everything beneath it is parsed against the SDK schema. Spring does not
 need to know what any of it means.
@@ -94,8 +94,8 @@ Env vars do cover a fixed list of built-in choices: a
 [fixed set of samplers](/docs/languages/sdk-configuration/general/#otel_traces_sampler)
 via `OTEL_TRACES_SAMPLER`, the standard OTLP exporters via
 `OTEL_EXPORTER_OTLP_*`, the usual signal-toggle flags. Anything outside that
-catalog — a custom rule-based sampler, a second OTLP exporter on a debug
-pipeline, a baggage processor, any nested option the SDK exposes — meant writing
+catalog (a custom rule-based sampler, a second OTLP exporter on a debug
+pipeline, a baggage processor, any nested option the SDK exposes) meant writing
 a `@Bean` (Spring starter) or shipping a separate extension jar (Java agent).
 The bigger sister is what unlocks the rest of the tree.
 
@@ -136,9 +136,23 @@ otel:
                 pattern: /actuator.*
 ```
 
-It's the same Java code under the hood — both the agent and the starter already
+It's the same Java code under the hood: both the agent and the starter already
 bundle the `opentelemetry-samplers` contrib jar. What changes is who writes the
 wiring. With declarative config, you do not.
+
+> [!NOTE] An alternative: the composable rule-based sampler
+>
+> The schema also has the
+> [composable rule-based sampler](/docs/specs/otel-config/types/#ct-item-experimentalcomposablerulebasedsampler)
+> (under `composite/development.rule_based`), which accomplishes the same
+> thing with a richer rule grammar: attribute patterns with includes/excludes,
+> multi-condition matches, span-kind filters, parent state, and arbitrary
+> nested composition. The example above stays with `rule_based_routing`
+> because OTel Java has long recommended that sampler for this problem, and
+> the `composite/development` path still carries the `*/development` suffix
+> until the composable schema stabilizes. See a worked
+> [kitchen-sink example](https://github.com/open-telemetry/opentelemetry-configuration/blob/v1.0.0/snippets/Sampler_rule_based_kitchen_sink.yaml#L10-L53)
+> in the SDK config repo.
 
 So how does our small env var fit into a world where the SDK is configured by a
 tree?
@@ -174,7 +188,7 @@ belong to OpenTelemetry; that is the starter's job, at the end of the line.
 > The starter never has to know which one you used.
 >
 > This is a Spring-only superpower. The OpenTelemetry SDK by itself does not
-> auto-map env vars onto YAML paths — that was discussed during the schema's
+> auto-map env vars onto YAML paths; that was discussed during the schema's
 > design and rejected as too complex. So inside the agent's standalone YAML, you
 > cannot set `OTEL_SERVICE_NAME` and have it land at `service.name` in the tree.
 > The starter gets this for free, because Spring is doing the mapping, not the
@@ -203,12 +217,12 @@ barely makes it past the front desk:
 OTEL_TRACER_PROVIDER_PROCESSORS_0_BATCH_EXPORTER_OTLP_HTTP_ENDPOINT=http://collector:4318/v1/traces
 ```
 
-She makes it past — but only because sixteen lines, deep inside the starter, go
+She makes it past, but only because sixteen lines, deep inside the starter, go
 hunting for her by name. The diamond in the diagram above is where they live.
 
 > [!NOTE] How the cousin gets through (and why it takes work)
 >
-> Asking Spring for the property by name would return her value just fine —
+> Asking Spring for the property by name would return her value just fine.
 > Spring's relaxed binding has long understood that `OTEL_..._ENDPOINT` is
 > another spelling of `otel....endpoint`, brackets and all.
 >
@@ -223,7 +237,7 @@ hunting for her by name. The diamond in the diagram above is where they live.
 > would be a second source of truth, perpetually behind the first. The
 > gold-plated answer is to _generate_ the POJOs from the schema (the SDK's DC
 > schema plus the not-yet-existing schemas for the `distribution.*` and
-> `instrumentation/development.*` subtrees) — that same generated description
+> `instrumentation/development.*` subtrees); that same generated description
 > could also drive the JSON metadata Spring uses for IDE completion. The Java
 > instrumentation team tracks that as a future improvement in
 > [opentelemetry-java-instrumentation#14083](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/14083).
@@ -246,10 +260,10 @@ hunting for her by name. The diamond in the diagram above is where they live.
 ## Stage three: two substituters, one syntax
 
 Our env var can also speak in placeholders. So can her sister. They both use
-`${...}`. They mean almost — but not quite — the same thing. Spring will happily
+`${...}`. They mean almost, but not quite, the same thing. Spring will happily
 resolve a chained fallback like
-`${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}}/v1/traces`
-— chasing the outer placeholder into the inner so you can prefer a
+`${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318}}/v1/traces`,
+chasing the outer placeholder into the inner so you can prefer a
 signal-specific override, fall back to a general one, and ultimately to a
 literal. The SDK's substituter is a single non-recursive regular-expression
 pass; the same expression in `otel-config.yaml` would not parse.
@@ -273,19 +287,19 @@ flowchart LR
 > [!NOTE] Same dollar-brace, two substituters
 >
 > Inside `application.yaml`, Spring resolves `${VAR:default}` (single colon)
-> from any property source it knows about — env vars, system properties,
+> from any property source it knows about: env vars, system properties,
 > profiles, command-line args, external config servers. The SDK's standalone
 > YAML uses `${VAR:-default}` (double colon, dash) and resolves from process env
 > vars and JVM system properties only. In the starter, the SDK substituter never
-> runs — Spring has already finished by the time the starter reads the value.
+> runs; Spring has already finished by the time the starter reads the value.
 
 The dialects are close enough that mixing them up is easy. The reason the
 starter uses Spring's syntax is that Spring's resolver runs first, and by the
 time the starter retrieves a property the placeholder is already gone. The SDK
 never gets a chance to find one.
 
-That is also why all the Spring-native config tricks — profiles, command-line
-`--key=value`, `@Value`-style externalization, even external config servers —
+That is also why all the Spring-native config tricks (profiles, command-line
+`--key=value`, `@Value`-style externalization, even external config servers)
 work transparently for OTel config. The starter never implemented any of them.
 Spring's resolver did, and the starter just reads properties.
 
@@ -346,7 +360,7 @@ yet to know which corners to tighten.
 That is not a warning. It is an invitation.
 
 Env-var configuration has been around long enough that all its rough edges have
-names. The YAML schema is younger — and pre-stable. Now, before it freezes, is
+names. The YAML schema is younger, and pre-stable. Now, before it freezes, is
 the highest-leverage moment to put declarative config into a real
 `application.yaml` and see what breaks. Your friction is what shapes the schema
 that lands.
@@ -359,7 +373,7 @@ Two starting points, both already there:
   [interactive converter](/docs/zero-code/java/spring-boot-starter/declarative-configuration/#convert-your-existing-configuration)
   on the doc page. Out comes the YAML, ready to drop into `application.yaml`.
 - **Greenfield?** The [OpenTelemetry Ecosystem Explorer](/ecosystem/) generates
-  declarative-config YAML interactively — pick exporters, samplers,
+  declarative-config YAML interactively: pick exporters, samplers,
   instrumentations, and copy the result. A new Spring Boot starter target mode
   wraps the output under `otel:` and uses the right
   `distribution.spring_starter.*` keys.
@@ -388,7 +402,7 @@ the SDK. Spring is the building they both live in. OpenTelemetry is the work
 they both do.
 
 If you migrate a real application onto this and hit something off, please file
-an issue —
+an issue:
 [opentelemetry-java-instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues)
 for code,
 [opentelemetry.io](https://github.com/open-telemetry/opentelemetry.io/issues)

--- a/content/en/docs/zero-code/java/spring-boot-starter/declarative-configuration.md
+++ b/content/en/docs/zero-code/java/spring-boot-starter/declarative-configuration.md
@@ -20,6 +20,10 @@ This approach is useful when:
 >
 > Declarative configuration is experimental.
 
+For background on how declarative configuration fits into the Spring Boot
+starter, see the blog post
+[The Voyage of a Small Environment Variable](/blog/2026/spring-boot-declarative-config/).
+
 ## Supported versions
 
 Declarative configuration is supported in the **OpenTelemetry Spring Boot

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -3119,6 +3119,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-07-10T06:54:28.658360019Z"
   },
+  "https://explorer.opentelemetry.io/java-agent/configuration/builder": {
+    "StatusCode": 206,
+    "LastSeen": "2026-07-10T16:01:47.113443609Z"
+  },
   "https://explorer.opentelemetry.io/java-agent/instrumentation/latest": {
     "StatusCode": 206,
     "LastSeen": "2026-07-06T07:04:54.024913368Z"

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -10203,6 +10203,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-07-03T06:50:48.732083565Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-configuration/blob/v1.0.0/snippets/Sampler_rule_based_kitchen_sink.yaml#L10-L53": {
+    "StatusCode": 206,
+    "LastSeen": "2026-06-25T11:54:27.255083395Z"
+  },
   "https://github.com/open-telemetry/opentelemetry-configuration/issues/100": {
     "StatusCode": 206,
     "LastSeen": "2026-07-03T06:51:18.468739058Z"

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -2607,6 +2607,10 @@
     "StatusCode": 200,
     "LastSeen": "2026-07-07T06:54:08.234952311Z"
   },
+  "https://docs.spring.io/spring-boot/reference/features/external-config.html#features.external-config.typesafe-configuration-properties": {
+    "StatusCode": 200,
+    "LastSeen": "2026-06-24T16:36:56.212586683Z"
+  },
   "https://docs.spring.io/spring-boot/reference/using/auto-configuration.html": {
     "StatusCode": 200,
     "LastSeen": "2026-07-07T06:54:14.811827584Z"
@@ -11507,6 +11511,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-07-08T06:28:06.496184221Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/v2.29.0/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/EmbeddedConfigFile.java#L66-L82": {
+    "StatusCode": 206,
+    "LastSeen": "2026-06-24T16:36:58.797690147Z"
+  },
   "https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues": {
     "StatusCode": 206,
     "LastSeen": "2026-07-07T06:53:54.606016941Z"
@@ -11514,6 +11522,10 @@
   "https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1060": {
     "StatusCode": 206,
     "LastSeen": "2026-07-10T06:57:58.890535208Z"
+  },
+  "https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/14083": {
+    "StatusCode": 206,
+    "LastSeen": "2026-06-24T16:36:57.824117116Z"
   },
   "https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/7413": {
     "StatusCode": 206,

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -3115,13 +3115,13 @@
     "StatusCode": 206,
     "LastSeen": "2026-07-06T07:04:51.145834732Z"
   },
-  "https://explorer.opentelemetry.io/java-agent/instrumentation": {
-    "StatusCode": 206,
-    "LastSeen": "2026-07-10T06:54:28.658360019Z"
-  },
   "https://explorer.opentelemetry.io/java-agent/configuration/builder": {
     "StatusCode": 206,
     "LastSeen": "2026-07-10T16:01:47.113443609Z"
+  },
+  "https://explorer.opentelemetry.io/java-agent/instrumentation": {
+    "StatusCode": 206,
+    "LastSeen": "2026-07-10T06:54:28.658360019Z"
   },
   "https://explorer.opentelemetry.io/java-agent/instrumentation/latest": {
     "StatusCode": 206,


### PR DESCRIPTION
## Summary

A storytelling blog post about how the OpenTelemetry Spring Boot starter gained declarative-configuration support, told as the journey of one small environment variable through Spring's property loader into the SDK's YAML schema.

**Status: draft, not for review yet.** Opening as a draft so the Netlify preview renders the three Mermaid diagrams and four info-box callouts in their final form. Co-author Gregor is reviewing iteratively; will be marked ready once content + diagrams are confirmed and Jack Berg (declarative-config component owner) has done a technical review.

## Audience and arc

Greenfield Spring Boot developers who know Spring well but have not used OpenTelemetry beyond `OTEL_*` env vars. The post threads a family metaphor (env var + YAML sister) through the main narrative, with three Mermaid diagrams and four info boxes carrying technical depth for readers who want to dive in:

- **Stage one: arriving at Spring's property stack** — diagram of Spring's `PropertySource` stack and the env-var realignment seam; info box on Spring's relaxed binding (with the explicit note that the SDK by itself does not auto-map env vars onto YAML paths — a rejected design from the schema spec).
- **Stage two: a cousin Spring almost lost** — worked-example info box for the `[N]` bracket case, plus the [`EmbeddedConfigFile` fix](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/EmbeddedConfigFile.java#L66-L82).
- **Stage three: two substituters, one syntax** — diagram of starter vs. agent substitution paths; info box on the practical difference (env vars are first-class overrides in the starter, require explicit `${VAR}` placeholders in the agent).
- **Arrival: the resolved tree** — overview diagram of the full Spring → starter → Jackson → SDK handoff.

## Linked PRs

This blog references two parallel PRs that should land first so the links and claims hold:

- [opentelemetry.io#10509](https://github.com/open-telemetry/opentelemetry.io/pull/10509) — doc + converter fixes (BOM section, mapping table corrections, sqlcommenter row). Some of those fixes are referenced indirectly.
- [opentelemetry-ecosystem-explorer#722](https://github.com/open-telemetry/opentelemetry-ecosystem-explorer/pull/722) — adds the Spring Boot starter target mode the TL;DR mentions.

## Test plan

- [ ] Netlify preview renders all three Mermaid diagrams correctly
- [ ] Four info boxes (`> [!NOTE]` callouts) render with the docsy theme's intended styling
- [ ] All internal doc links resolve (`/docs/zero-code/...`, `/docs/languages/...`, `/ecosystem/`, `/blog/2025/declarative-config/`)
- [ ] External code link to `EmbeddedConfigFile.java#L66-L82` still points at the right lines on `main`
- [ ] Jack Berg technical review (declarative-config component owner)