### PR TITLE
Add Agent Audit Exporter to the registry

### DIFF
--- a/.lycheecache
+++ b/.lycheecache
@@ -4589,6 +4589,8 @@ https://github.com/sudarshan12s,200,1786028729
 https://github.com/sumo-drosiek,200,1785785935
 https://github.com/sunface,200,1785785935
 https://github.com/surbhiia,200,1786028730
+https://github.com/surpradhan,200,1786136225
+https://github.com/surpradhan/otel-agent-audit,200,1786136225
 https://github.com/sveltejs/,200,1786028705
 https://github.com/sveltejs/kit,200,1786028705
 https://github.com/svrnm,200,1785868505

--- a/data/registry/collector-exporter-agent-audit.yml
+++ b/data/registry/collector-exporter-agent-audit.yml
@@ -1,0 +1,30 @@
+# cSpell:ignore agentaudit ed25519 genai
+title: Agent Audit Exporter
+registryType: exporter
+language: collector
+tags:
+  - audit
+  - audit-log
+  - tamper-evident
+  - hash-chain
+  - ed25519
+  - signing
+  - genai
+  - agent
+  - guardrail
+  - governance
+urls:
+  repo: https://github.com/surpradhan/otel-agent-audit
+  docs: https://github.com/surpradhan/otel-agent-audit#readme
+license: MIT
+description: >-
+  An OpenTelemetry Collector exporter that consumes agent traces and emits a
+  per-trace, hash-chained, Ed25519-signed, independently verifiable audit log.
+  Records governance/guardrail decisions already present in spans and ships a
+  standalone verifier CLI. Observability only — it does not enforce or block.
+authors:
+  - name: Surabhi Pradhan
+    url: https://github.com/surpradhan
+createdAt: 2026-06-24
+isNative: false
+isFirstParty: false

--- a/data/registry/collector-exporter-agent-audit.yml
+++ b/data/registry/collector-exporter-agent-audit.yml
@@ -21,7 +21,7 @@ description: >-
   An OpenTelemetry Collector exporter that consumes agent traces and emits a
   per-trace, hash-chained, Ed25519-signed, independently verifiable audit log.
   Records governance/guardrail decisions already present in spans and ships a
-  standalone verifier CLI. Observability only — it does not enforce or block.
+  standalone verifier CLI.
 authors:
   - name: Surabhi Pradhan
     url: https://github.com/surpradhan

--- a/data/registry/collector-exporter-agent-audit.yml
+++ b/data/registry/collector-exporter-agent-audit.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore agentaudit ed25519 genai
+# cSpell:ignore agentaudit ed25519 genai Surabhi Pradhan
 title: Agent Audit Exporter
 registryType: exporter
 language: collector

--- a/data/registry/collector-exporter-agent-audit.yml
+++ b/data/registry/collector-exporter-agent-audit.yml
@@ -15,7 +15,6 @@ tags:
   - governance
 urls:
   repo: https://github.com/surpradhan/otel-agent-audit
-  docs: https://github.com/surpradhan/otel-agent-audit#readme
 license: MIT
 description: >-
   An OpenTelemetry Collector exporter that consumes agent traces and emits a


### PR DESCRIPTION
Agent Audit Exporter is a third-party MIT-licensed OpenTelemetry Collector exporter that consumes agent traces and emits a per-trace, hash-chained, Ed25519-signed audit log for AI agent governance: observability only, it does not enforce or block.

Repository: https://github.com/surpradhan/otel-agent-audit

---

**Note from the maintainers**: this description was submitted without our [PR template](https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/PULL_REQUEST_TEMPLATE.md)'s checklist, which asks you to confirm:

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR. (Yes, I can answer maintainer questions about the content of this PR, without using AI.)

Per our [first-time contributor policy](https://github.com/open-telemetry/opentelemetry.io/issues/11243), answer these questions by ticking each box that applies.
