### PR TITLE
Add raw json view of declarative config types

### DIFF
--- a/assets/js/configTypesAccordion.js
+++ b/assets/js/configTypesAccordion.js
@@ -31,6 +31,7 @@ function readI18n(container) {
     copy: d.i18nCopy,
     copied: d.i18nCopied,
     source: d.i18nSource,
+    viewSchema: d.i18nViewSchema,
   };
 }
 
@@ -240,6 +241,23 @@ function renderUsages(type) {
 </div>`;
 }
 
+function renderRawSchema(type, i18n) {
+  if (!type.rawDef) return '';
+  const json = JSON.stringify(type.rawDef, null, 2);
+  const sourceLink = type.sourceUrl
+    ? `<a class="ct-snippet-source" href="${escapeAttr(type.sourceUrl)}"
+          target="_blank" rel="noopener">${escapeHtml(i18n.source)}</a>`
+    : '';
+  return `
+<details class="ct-schema-details mt-3">
+  <summary class="ct-schema-summary">${escapeHtml(i18n.viewSchema)}</summary>
+  <div class="ct-snippet mt-1">
+    ${sourceLink ? `<div class="ct-snippet-toolbar">${sourceLink}</div>` : ''}
+    <pre class="ct-snippet-pre"><code>${escapeHtml(json)}</code></pre>
+  </div>
+</details>`;
+}
+
 function renderTypeItem(type, i18n, knownTypeIds) {
   const propCount = type.hasNoProperties ? 0 : (type.properties?.length ?? 0);
   const countText = propCount === 1 ? '1 property' : `${propCount} properties`;
@@ -269,6 +287,7 @@ function renderTypeItem(type, i18n, knownTypeIds) {
       ${renderSnippets(type, i18n)}
       ${constraintsHtml}
       ${renderUsages(type)}
+      ${renderRawSchema(type, i18n)}
     </div>
   </div>
 </div>`;

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -60,3 +60,4 @@ config_types_examples_heading: Examples
 config_types_copy: Copy
 config_types_copied: Copied!
 config_types_source: Source
+config_types_view_schema: View JSON schema

--- a/layouts/_shortcodes/config-types-accordion.html
+++ b/layouts/_shortcodes/config-types-accordion.html
@@ -16,7 +16,8 @@
   data-i18n-examples="{{ i18n "config_types_examples_heading" }}"
   data-i18n-copy="{{ i18n "config_types_copy" }}"
   data-i18n-copied="{{ i18n "config_types_copied" }}"
-  data-i18n-source="{{ i18n "config_types_source" }}">
+  data-i18n-source="{{ i18n "config_types_source" }}"
+  data-i18n-view-schema="{{ i18n "config_types_view_schema" }}">
 </div>
 
 {{ partial "script.html" (dict "src" "js/configTypesAccordion.js") -}}

--- a/scripts/generate-config-types.mjs
+++ b/scripts/generate-config-types.mjs
@@ -37,10 +37,56 @@ function resolveConfigRef() {
     return 'main';
   }
 }
-const snippetSourceBase = `https://github.com/${SNIPPET_REPO}/blob/${resolveConfigRef()}/snippets`;
+const configRef = resolveConfigRef();
+const snippetSourceBase = `https://github.com/${SNIPPET_REPO}/blob/${configRef}/snippets`;
 
-const rawSchema = JSON.parse(readFileSync(schemaPath, 'utf8'));
+const schemaRawText = readFileSync(schemaPath, 'utf8');
+const rawSchema = JSON.parse(schemaRawText);
 const result = transformSchema(rawSchema);
+
+// Scan the raw schema text for the 1-indexed line number of each $defs entry so
+// we can link directly to the right line on GitHub. Indentation is derived from
+// the file itself rather than assumed, so this works regardless of the JSON
+// formatting (2-space, 4-space, tabs). Direct $defs entries are the keys one
+// level deeper than `"$defs"`; nested keys (deeper still) are ignored, and the
+// scan stops when indentation returns to the $defs level (end of the block).
+function findDefLineNumbers(text) {
+  const lineNumbers = {};
+  const lines = text.split('\n');
+  let defsIndent = null; // leading whitespace of the `"$defs"` key
+  let entryIndent = null; // leading whitespace of a direct $defs entry
+  for (let i = 0; i < lines.length; i++) {
+    if (defsIndent === null) {
+      const m = lines[i].match(/^(\s*)"\$defs"\s*:/);
+      if (m) defsIndent = m[1];
+      continue;
+    }
+    const m = lines[i].match(/^(\s*)"([^"]+)"\s*:/);
+    if (!m) continue;
+    const indent = m[1];
+    if (indent.length <= defsIndent.length) break; // left the $defs block
+    if (entryIndent === null) entryIndent = indent; // first entry sets the depth
+    if (indent === entryIndent) lineNumbers[m[2]] = i + 1;
+  }
+  return lineNumbers;
+}
+
+const defLineNumbers = findDefLineNumbers(schemaRawText);
+const schemaGithubBase = `https://github.com/${SNIPPET_REPO}/blob/${configRef}/opentelemetry_configuration.json`;
+
+// Attach the raw $defs entry and a GitHub source link to each type.
+// The root type gets the schema minus $defs (which is enormous).
+for (const type of result.types) {
+  if (type.isRoot) {
+    const { $defs, ...rootDef } = rawSchema;
+    type.rawDef = rootDef;
+    type.sourceUrl = schemaGithubBase;
+  } else {
+    type.rawDef = rawSchema.$defs[type.name];
+    const line = defLineNumbers[type.name];
+    type.sourceUrl = line ? `${schemaGithubBase}#L${line}` : schemaGithubBase;
+  }
+}
 
 // Read example snippets and group them by the schema type they illustrate.
 // Snippet files are named `<JsonSchemaType>_<snake_case_description>.yaml`.


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

Extend declarative configuration types page to add a collapsible section containing the raw JSON schema to each type. This section contains a link to the original type definition in the source: https://github.com/open-telemetry/opentelemetry-configuration/blob/main/opentelemetry_configuration.json

The motivation is twofold:

1. Sometimes there will be parts of the JSON schema that aren't expressed in the rendered view of it. For these cases its useful to have a "just show me the source code" button.
2. This display of the raw JSON schema is the last meaningful difference between the opentelemetry.io rendering of the schema and the rendering at https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema-docs.md. With this change, I'd feel comfortable ripping out schema-docs.md and instead linking to https://opentelemetry.io/docs/specs/otel-config/types/

Example of how this looks:

<img width="982" height="1398" alt="Screenshot 2026-06-24 at 10 58 19 AM" src="https://github.com/user-attachments/assets/aedb4e4e-7a10-468c-8feb-8b1c315291da" />

cc @jaydeluca  