### PR TITLE
Add opentelemetry-configuration to list of submodules to automatically update

### DIFF
--- a/scripts/auto-update/all-versions.sh
+++ b/scripts/auto-update/all-versions.sh
@@ -32,6 +32,8 @@ function auto_update_versions() {
         semconv .gitmodules"
       "semantic-conventions-java
         semconv content/en/docs/languages/java/_index.md"
+      "opentelemetry-configuration
+        config .gitmodules"
   )
 
   for args in "${repo_and_files_to_update[@]}"; do

--- a/scripts/auto-update/version-in-file.sh
+++ b/scripts/auto-update/version-in-file.sh
@@ -105,7 +105,8 @@ fi
 
 if [[ "$repo" == "opentelemetry-specification"
   || "$repo" == "opentelemetry-proto"
-  || "$repo" == "semantic-conventions" ]]; then
+  || "$repo" == "semantic-conventions"
+  || "$repo" == "opentelemetry-configuration" ]]; then
   echo "Switching to $repo at tag $latest_version"
   ( set -x;
     npm run get:submodule -- content-modules/$repo &&


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [ ] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

I noticed that [declarative config types page](https://opentelemetry.io/docs/specs/otel-config/types/) is still generating from the old 1.0.0 schema rather than 1.1.0. 

Adding it to the list of auto-updating submodules so it stays in sync with latest release.

This shouldn't be a problem because there are no artifacts checked into version control that need to be regenerated after an update.