### PR TITLE
Display declarative config schema version and link to full json schema

### DIFF
--- a/assets/js/configTypesAccordion.js
+++ b/assets/js/configTypesAccordion.js
@@ -32,6 +32,7 @@ function readI18n(container) {
     copied: d.i18nCopied,
     source: d.i18nSource,
     viewSchema: d.i18nViewSchema,
+    schemaVersion: d.i18nSchemaVersion,
   };
 }
 
@@ -52,7 +53,7 @@ function escapeHtml(str) {
     .replace(/>/g, '&gt;');
 }
 
-function renderControls(types, i18n) {
+function renderControls(types, i18n, schemaVersion, schemaSourceUrl) {
   const stableCount = types.filter((t) => !t.isExperimental).length;
   const expCount = types.filter((t) => t.isExperimental).length;
   const total = types.length;
@@ -60,9 +61,13 @@ function renderControls(types, i18n) {
   const rootLinkHtml = rootType
     ? `<p>The root schema type is <a href="#ct-item-${escapeAttr(rootType.id)}" data-ct-type-link="${escapeAttr(rootType.id)}">${escapeHtml(rootType.name)}</a>.</p>`
     : '';
+  const versionHtml =
+    schemaVersion && schemaSourceUrl
+      ? `<p>${escapeHtml(i18n.schemaVersion)}: <a href="${escapeAttr(schemaSourceUrl)}" target="_blank" rel="noopener">${escapeHtml(schemaVersion)}</a></p>`
+      : '';
 
   return `
-${rootLinkHtml}<div class="config-types-controls mb-3">
+${rootLinkHtml}${versionHtml}<div class="config-types-controls mb-3">
   <div class="row g-2 align-items-center">
     <div class="col-md-5">
       <input type="search"
@@ -477,11 +482,12 @@ async function init() {
     const res = await fetch(schemaUrl);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.json();
-    const types = data.types;
+    const { types, schemaVersion, schemaSourceUrl } = data;
     const knownTypeIds = new Set(types.map((t) => t.id));
 
     container.innerHTML =
-      renderControls(types, i18n) + renderAccordion(types, i18n, knownTypeIds);
+      renderControls(types, i18n, schemaVersion, schemaSourceUrl) +
+      renderAccordion(types, i18n, knownTypeIds);
     injectDescriptions(container, types);
     const resetControls = wireControls(container, types, i18n);
     wireTypeLinks(container, resetControls);

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -61,3 +61,4 @@ config_types_copy: Copy
 config_types_copied: Copied!
 config_types_source: Source
 config_types_view_schema: View JSON schema
+config_types_schema_version: Schema version

--- a/layouts/_shortcodes/config-types-accordion.html
+++ b/layouts/_shortcodes/config-types-accordion.html
@@ -17,7 +17,8 @@
   data-i18n-copy="{{ i18n "config_types_copy" }}"
   data-i18n-copied="{{ i18n "config_types_copied" }}"
   data-i18n-source="{{ i18n "config_types_source" }}"
-  data-i18n-view-schema="{{ i18n "config_types_view_schema" }}">
+  data-i18n-view-schema="{{ i18n "config_types_view_schema" }}"
+  data-i18n-schema-version="{{ i18n "config_types_schema_version" }}">
 </div>
 
 {{ partial "script.html" (dict "src" "js/configTypesAccordion.js") -}}

--- a/scripts/generate-config-types.mjs
+++ b/scripts/generate-config-types.mjs
@@ -88,6 +88,9 @@ for (const type of result.types) {
   }
 }
 
+result.schemaVersion = configRef;
+result.schemaSourceUrl = schemaGithubBase;
+
 // Read example snippets and group them by the schema type they illustrate.
 // Snippet files are named `<JsonSchemaType>_<snake_case_description>.yaml`.
 const snippetsByType = {};


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

The [declarative config types](https://opentelemetry.io/docs/specs/otel-config/types/) page lacks any sort of indication of the version of schema being rendered, or where the source code for it is defined. This PR adds a simple link to https://github.com/open-telemetry/opentelemetry-configuration/blob/main/opentelemetry_configuration.json corresponding to the version of the opentelemetry-configuration submodule. 

<img width="1021" height="542" alt="Screenshot 2026-06-24 at 1 14 12 PM" src="https://github.com/user-attachments/assets/c484ee7f-2865-4a8e-a952-accf7abe5d0e" />

cc @jaydeluca 