### PR TITLE
docs: add OpAMP UI and SDK self-observability dashboard to demo docs

### DIFF
--- a/content/en/docs/demo/architecture.md
+++ b/content/en/docs/demo/architecture.md
@@ -175,11 +175,26 @@ subgraph tdf[Telemetry Data Flow]
             oc-proc --> oc-spanmetrics
             oc-spanmetrics --> oc-prom
 
+            oc-opamp[/"OpAMP Extension"/]
+
         end
 
         oc-prom -->|"localhost:9090/api/v1/otlp"| pr-sc
         oc-otlp -->|gRPC| ja-col
         oc-opensearch -->|HTTP| os-http
+
+        subgraph op[OpAMP Server]
+            style op fill:#a6ce39,color:black;
+            op-srv["OpAMP Server"]
+            op-http[/"OpAMP HTTP<br/>listening on<br/>localhost:8080/opamp/"/]
+
+            op-srv --> op-http
+        end
+
+        oc-opamp -->|"reports status<br/>over WebSocket"| op-srv
+
+        op-b{{"Browser<br/>OpAMP UI"}}
+        op-http -->|"localhost:8080/opamp/"| op-b
 
         subgraph pr[Prometheus]
             style pr fill:#e75128,color:black;

--- a/content/en/docs/demo/architecture.md
+++ b/content/en/docs/demo/architecture.md
@@ -136,6 +136,13 @@ The collector is configured in
 [otelcol-config.yml](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/otel-collector/otelcol-config.yml),
 alternative exporters can be configured here.
 
+When running with the observability stack, the Collector also connects to the
+demo's OpAMP server through the
+[OpAMP extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/opampextension)
+and reports its health, version, attributes, and effective configuration. Open
+the OpAMP UI at <http://localhost:8080/opamp/> and select the Collector instance
+to view the reported status.
+
 ```mermaid
 graph TB
 subgraph tdf[Telemetry Data Flow]

--- a/content/en/docs/demo/docker-deployment.md
+++ b/content/en/docs/demo/docker-deployment.md
@@ -95,6 +95,7 @@ Once the images are built and containers are started you can access:
 - Web store: <http://localhost:8080/>
 - Grafana: <http://localhost:8080/grafana/>
 - Jaeger UI: <http://localhost:8080/jaeger/ui/>
+- OpAMP UI: <http://localhost:8080/opamp/>
 - Tracetest UI: <http://localhost:11633/>, only when using
   `make run-tracetesting`
 - Flagd configurator UI: <http://localhost:8080/feature>

--- a/content/en/docs/demo/self-observability-dashboard/index.md
+++ b/content/en/docs/demo/self-observability-dashboard/index.md
@@ -3,78 +3,24 @@ title: Self-Observability Dashboard
 linkTitle: Self-Observability Dashboard
 ---
 
-Operating an OpenTelemetry pipeline in production means the SDKs themselves
-become critical infrastructure: if a service's exporter is failing, its queue is
-saturated, or telemetry is being dropped, you want to see it. The OpenTelemetry
-SDKs can emit their own internal metrics (using the experimental
+The OpenTelemetry SDKs can emit their own internal metrics (using the
+experimental
 [`otel.sdk.*` semantic conventions](/docs/specs/semconv/otel/sdk-metrics/)) that
-describe how the SDK is behaving, and the demo's **Self-Observability**
-dashboard visualizes them.
-
-This dashboard demonstrates how to monitor the health of the OpenTelemetry SDKs
-running inside your instrumented services, so you can answer questions such as
-"is any service dropping spans?", "how long do exports take?", and "are the
-batch processor queues filling up?".
+describe how the SDK is behaving — for example whether a service is dropping
+telemetry, how long exports take, or whether processor queues are filling up.
+The demo's **Self-Observability** dashboard visualizes these metrics across the
+span, log, and metric pipelines.
 
 ## Enabling SDK self-observability
 
-SDK self-observability is opt-in and, at the time of writing, still
-experimental. Each SDK exposes its own switch:
-
-- **OpenTelemetry Java** services enable it by setting the environment variable
-  `OTEL_EXPERIMENTAL_SDK_TELEMETRY_VERSION=latest`.
-
+SDK self-observability is opt-in and still experimental. OpenTelemetry Java
+services enable it by setting `OTEL_EXPERIMENTAL_SDK_TELEMETRY_VERSION=latest`.
 In the demo, the Java services (`ad`, `fraud-detection`, and `kafka`) opt in
 this way. The dashboard is driven by a `Service` template variable, so any
-additional service that opts in appears automatically without any dashboard
-changes. As more SDKs add support for the `otel.sdk.*` conventions, they can be
-enabled and will show up here too.
+additional service that opts in appears automatically.
 
 ## Accessing the dashboard
 
 Once the demo is running, open the dashboard directly at
 <http://localhost:8080/grafana/d/self-observability>, or navigate to it from the
 Grafana dashboard list ("Self-Observability").
-
-## Dashboard sections
-
-The dashboard is organized into an overview followed by one section per signal
-pipeline.
-
-### Overview
-
-A high-level summary across all selected services: how many services are
-reporting self-observability metrics, the rate of spans, metric data points, and
-log records exported, export and processing error counts, and the number of
-items currently in flight. This is the fastest way to spot a service that is
-failing to export or dropping telemetry.
-
-### Span pipeline
-
-Focuses on the tracing SDK: the rate of spans started, live (in-progress) spans,
-span processor queue utilization (queue size versus capacity), spans exported
-and their error breakdown by `error.type`, spans in flight, and the average span
-export operation duration. Rising queue utilization or a growing error rate here
-indicates the exporter cannot keep up with the span volume.
-
-### Log pipeline
-
-The equivalent view for the logs SDK: log records created, processor queue
-utilization, exported log records with error breakdown, log records in flight,
-and the average log export operation duration.
-
-### Metric pipeline
-
-Focuses on the metrics SDK: metric data points exported and their error
-breakdown, data points in flight, the average metric collection duration (how
-long the metric reader takes to collect from all instruments), and the average
-metric export operation duration.
-
-## Extending the dashboard
-
-Because every panel is filtered by the `Service` template variable and keyed on
-the standardized `otel.sdk.*` metric names, this dashboard works for any service
-that opts in — regardless of language. It is intended as a starting point: you
-can add panels for additional `otel.sdk.*` metrics, or split the existing panels
-by attributes such as `otel.component.name` to drill into individual exporters
-and processors within a service.

--- a/content/en/docs/demo/self-observability-dashboard/index.md
+++ b/content/en/docs/demo/self-observability-dashboard/index.md
@@ -6,9 +6,10 @@ linkTitle: Self-Observability Dashboard
 Operating an OpenTelemetry pipeline in production means the SDKs themselves
 become critical infrastructure: if a service's exporter is failing, its queue is
 saturated, or telemetry is being dropped, you want to see it. The OpenTelemetry
-SDKs can emit their own internal metrics (using the experimental `otel.sdk.*`
-semantic conventions) that describe how the SDK is behaving, and the demo's
-**Self-Observability** dashboard visualizes them.
+SDKs can emit their own internal metrics (using the experimental
+[`otel.sdk.*` semantic conventions](/docs/specs/semconv/otel/sdk-metrics/)) that
+describe how the SDK is behaving, and the demo's **Self-Observability**
+dashboard visualizes them.
 
 This dashboard demonstrates how to monitor the health of the OpenTelemetry SDKs
 running inside your instrumented services, so you can answer questions such as

--- a/content/en/docs/demo/self-observability-dashboard/index.md
+++ b/content/en/docs/demo/self-observability-dashboard/index.md
@@ -1,0 +1,79 @@
+---
+title: Self-Observability Dashboard
+linkTitle: Self-Observability Dashboard
+---
+
+Operating an OpenTelemetry pipeline in production means the SDKs themselves
+become critical infrastructure: if a service's exporter is failing, its queue is
+saturated, or telemetry is being dropped, you want to see it. The OpenTelemetry
+SDKs can emit their own internal metrics (using the experimental `otel.sdk.*`
+semantic conventions) that describe how the SDK is behaving, and the demo's
+**Self-Observability** dashboard visualizes them.
+
+This dashboard demonstrates how to monitor the health of the OpenTelemetry SDKs
+running inside your instrumented services, so you can answer questions such as
+"is any service dropping spans?", "how long do exports take?", and "are the
+batch processor queues filling up?".
+
+## Enabling SDK self-observability
+
+SDK self-observability is opt-in and, at the time of writing, still
+experimental. Each SDK exposes its own switch:
+
+- **OpenTelemetry Java** services enable it by setting the environment variable
+  `OTEL_EXPERIMENTAL_SDK_TELEMETRY_VERSION=latest`.
+
+In the demo, the Java services (`ad`, `fraud-detection`, and `kafka`) opt in
+this way. The dashboard is driven by a `Service` template variable, so any
+additional service that opts in appears automatically without any dashboard
+changes. As more SDKs add support for the `otel.sdk.*` conventions, they can be
+enabled and will show up here too.
+
+## Accessing the dashboard
+
+Once the demo is running, open the dashboard directly at
+<http://localhost:8080/grafana/d/self-observability>, or navigate to it from the
+Grafana dashboard list ("Self-Observability").
+
+## Dashboard sections
+
+The dashboard is organized into an overview followed by one section per signal
+pipeline.
+
+### Overview
+
+A high-level summary across all selected services: how many services are
+reporting self-observability metrics, the rate of spans, metric data points, and
+log records exported, export and processing error counts, and the number of
+items currently in flight. This is the fastest way to spot a service that is
+failing to export or dropping telemetry.
+
+### Span pipeline
+
+Focuses on the tracing SDK: the rate of spans started, live (in-progress) spans,
+span processor queue utilization (queue size versus capacity), spans exported
+and their error breakdown by `error.type`, spans in flight, and the average span
+export operation duration. Rising queue utilization or a growing error rate here
+indicates the exporter cannot keep up with the span volume.
+
+### Log pipeline
+
+The equivalent view for the logs SDK: log records created, processor queue
+utilization, exported log records with error breakdown, log records in flight,
+and the average log export operation duration.
+
+### Metric pipeline
+
+Focuses on the metrics SDK: metric data points exported and their error
+breakdown, data points in flight, the average metric collection duration (how
+long the metric reader takes to collect from all instruments), and the average
+metric export operation duration.
+
+## Extending the dashboard
+
+Because every panel is filtered by the `Service` template variable and keyed on
+the standardized `otel.sdk.*` metric names, this dashboard works for any service
+that opts in — regardless of language. It is intended as a starting point: you
+can add panels for additional `otel.sdk.*` metrics, or split the existing panels
+by attributes such as `otel.component.name` to drill into individual exporters
+and processors within a service.

--- a/content/en/docs/demo/self-observability-dashboard/index.md
+++ b/content/en/docs/demo/self-observability-dashboard/index.md
@@ -13,11 +13,11 @@ span, log, and metric pipelines.
 
 ## Enabling SDK self-observability
 
-SDK self-observability is opt-in and still experimental. OpenTelemetry Java
-services enable it by setting `OTEL_EXPERIMENTAL_SDK_TELEMETRY_VERSION=latest`.
-In the demo, the Java services (`ad`, `fraud-detection`, and `kafka`) opt in
-this way. The dashboard is driven by a `Service` template variable, so any
-additional service that opts in appears automatically.
+SDK self-observability is opt-in and still experimental, and is enabled through
+SDK configuration on a per-service basis. In the demo, the `ad`,
+`fraud-detection`, and `kafka` services opt in. The dashboard is driven by a
+`Service` template variable, so any additional service that opts in appears
+automatically.
 
 ## Accessing the dashboard
 

--- a/content/en/docs/demo/self-observability-dashboard/index.md
+++ b/content/en/docs/demo/self-observability-dashboard/index.md
@@ -1,6 +1,5 @@
 ---
 title: Self-Observability Dashboard
-linkTitle: Self-Observability Dashboard
 ---
 
 The OpenTelemetry SDKs can emit their own internal metrics (using the

--- a/content/en/docs/demo/telemetry-features/_index.md
+++ b/content/en/docs/demo/telemetry-features/_index.md
@@ -18,6 +18,10 @@ aliases: [demo_features, features]
   and sending the generated traces and metrics to the OpenTelemetry Collector
   via gRPC. The received traces are then exported to the logs and to Jaeger;
   received metrics and exemplars are exported to logs and Prometheus.
+- **[OpAMP](/docs/specs/opamp/)**: the OpenTelemetry Collector reports health,
+  version, attributes, and effective configuration to the demo's OpAMP server.
+  You can view the reported status in the OpAMP UI at
+  <http://localhost:8080/opamp/>.
 
 ## Observability Solutions
 

--- a/content/en/docs/demo/telemetry-features/_index.md
+++ b/content/en/docs/demo/telemetry-features/_index.md
@@ -22,6 +22,10 @@ aliases: [demo_features, features]
   version, attributes, and effective configuration to the demo's OpAMP server.
   You can view the reported status in the OpAMP UI at
   <http://localhost:8080/opamp/>.
+- **SDK Self-Observability**: select services opt in to the experimental
+  `otel.sdk.*` internal metrics emitted by the OpenTelemetry SDKs themselves,
+  visualized in the
+  [Self-Observability dashboard](/docs/demo/self-observability-dashboard/).
 
 ## Observability Solutions
 


### PR DESCRIPTION
Documents the OpAMP UI added by open-telemetry/opentelemetry-demo#3566, and the SDK self-observability dashboard (`otel.sdk.*` metrics) for services that opt in.