### PR TITLE
Auto update excerpts when updating submodules

### DIFF
--- a/scripts/auto-update/version-in-file.sh
+++ b/scripts/auto-update/version-in-file.sh
@@ -118,6 +118,10 @@ if [[ "$repo" == "opentelemetry-specification"
   )
 fi
 
+# Sync any code-excerpt directives that embed upstream files, so the build
+# doesn't fail if the new version changed an excerpted file.
+npm run fix:code-excerpts
+
 $GIT checkout -b "$branch"
 $GIT commit -a -m "$message"
 $GIT push --set-upstream origin "$branch"


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

In #10546, I added opentelemetry-configuration to the list of submodules to auto update.

Unfortunately, the first [auto PR](https://github.com/open-telemetry/opentelemetry.io/pull/10550) had a build failure because a code excerpt failed to update.

I _think_ the solution is to update code excerpts as a part of the auto update process.