### PR TITLE
Add `/approve-registry-update` helper skill

### DIFF
--- a/.claude/skills/approve-registry-update/SKILL.md
+++ b/.claude/skills/approve-registry-update/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: approve-registry-update
+description: >-
+  Verify that an otelbot "Auto-update registry versions" PR is a pure version
+  bump, then on confirmation, approve and add it to the merge queue. Use for
+  otelbot/auto-update-registry-* PRs in open-telemetry/opentelemetry.io.
+argument-hint: '[PR number or URL]'
+allowed-tools: Bash Read Grep Glob
+model: sonnet
+effort: medium
+---
+
+# Approve Registry Update
+
+Fast-path review for otelbot **Auto-update registry versions** PRs (for example
+[#10556][]), which bump the `package.version` field in `data/registry/*.yml`
+entries. Per [`sig-practices.md#prs-from-bots`][bots], these can be approved and
+merged immediately — but only after confirming the change is a clean version
+bump with **no other field changes** and **no added or changed URLs** (including
+no trailing comment on the version line).
+
+## Arguments
+
+- **No argument** (the happy path): discover the open registry auto-update PR(s)
+  and process each one through the workflow below, confirming and approving each
+  separately.
+
+  ```bash
+  gh pr list --state open --author app/otelbot \
+    --search "head:otelbot/auto-update-registry" --json number,headRefName,title
+  ```
+
+  If none are open, say so and stop.
+
+- **Argument given**: resolve `$ARGUMENTS` to a PR number — a bare number, a
+  `#`-prefixed number, or a GitHub URL with `/pull/<N>`. If unrecognizable, ask.
+
+## Scope
+
+Use this skill **only** for otelbot _registry_ auto-update PRs. Route other
+otelbot auto-update PRs (SDK, instrumentation, collector, spec) and any PR that
+turns out not to be a clean bump to the `review-pull-request` skill.
+
+## Workflow
+
+### 1. Confirm it's a registry auto-update PR
+
+Branch-discovered PRs already satisfy this; only re-check when a PR was passed
+as an argument:
+
+```bash
+gh pr view <N> --json author,headRefName,title,state
+```
+
+Require: `author.login` is `app/otelbot`, `headRefName` starts with
+`otelbot/auto-update-registry-`, `title` starts with
+`Auto-update registry versions`, and `state` is `OPEN`. If not, stop and say so.
+
+### 2. Analyze the diff
+
+These PRs touch 100+ files, so write the diff to a file and inspect it with
+`grep` — don't print it to the terminal. Prefer `./tmp` (gitignored) when it
+exists, else `/tmp`. Derive everything below from the diff, not from
+`gh pr view --json files` (that field caps at 100 files and under-reports large
+PRs).
+
+```bash
+gh pr diff <N> > ./tmp/registry-<N>.diff
+```
+
+A clean bump produces **no output** from any guard check below:
+
+```bash
+D=./tmp/registry-<N>.diff
+# a. Changed files outside data/registry/*.yml, or files added/deleted/renamed:
+grep -E '^\+\+\+ ' "$D" | sed 's#^+++ b/##' | grep -vE '^data/registry/.*\.ya?ml$'
+grep -E '^(new file|deleted file|rename|copy) ' "$D"
+# b. Changed content lines that aren't a bare `version:` bump
+#    (catches trailing comments, URLs, and any other field change):
+grep -E '^[+-]' "$D" | grep -vE '^(\+\+\+|---) ' | grep -vE '^[+-][[:space:]]+version: [^#]*$'
+```
+
+Summarize the bumps grouped by old → new version (useful for the report and the
+approval comment):
+
+```bash
+python3 - "$D" <<'PY'
+import sys, re, collections
+diff = open(sys.argv[1]).read()
+bumps = collections.Counter(); n = 0
+for f in re.split(r'(?m)^diff --git ', diff):
+    old = re.search(r'(?m)^-\s+version:\s*(\S+)', f)
+    new = re.search(r'(?m)^\+\s+version:\s*(\S+)', f)
+    if old and new:
+        n += 1; bumps[(old.group(1), new.group(1))] += 1
+print(f"{n} files bumped")
+for (o, nw), c in bumps.most_common():
+    print(f"  {o} -> {nw}  ({c})")
+PY
+```
+
+### 3. Report
+
+- **Clean** (all guard checks empty): report "Version bumps only — N files, no
+  other field changes, no added or changed URLs," followed by the grouped old →
+  new summary.
+- **Not clean**: report what each non-empty check found and point at what to
+  inspect — a non-`version` line means another field changed; a `#` or `http` on
+  a changed line means a trailing comment or URL was added; a non-registry path
+  or add/delete/rename means the PR is doing more than a bump. **Do not
+  approve** — recommend `/review-pull-request`, then ask whether to post the
+  summary as a PR comment.
+
+### 4. Approve and enqueue
+
+Only when the verdict is clean, ask: **Approve #N and add it to the merge
+queue?** On yes, approve with the summary in the comment body (not just LGTM),
+then enqueue:
+
+```bash
+gh pr review <N> --approve --body "Version bumps only — no other field changes, no added or changed URLs. Per sig-practices.md (PRs from bots).
+
+<grouped old → new summary>"
+gh pr merge <N>
+```
+
+The repo uses a squash merge queue, so `gh pr merge <N>` needs no strategy: it
+enqueues the PR (or enables auto-merge until checks pass). On no, stop.
+
+## References
+
+- [`sig-practices.md#prs-from-bots`][bots] — merge practices for bot PRs.
+- `review-pull-request` skill — full review for non-clean or non-registry PRs.
+
+[#10556]: https://github.com/open-telemetry/opentelemetry.io/pull/10556
+[bots]: ../../../content/en/docs/contributing/sig-practices.md#prs-from-bots

--- a/content/en/site/skills/_index.md
+++ b/content/en/site/skills/_index.md
@@ -20,6 +20,10 @@ procedures are defined in this section.
 
 As mentioned above, skills are defined in [`.claude/skills/`][], they are:
 
+- [`/approve-registry-update [pr-number-or-url]`][approve-registry-update]:
+  verify that an otelbot registry version-bump PR is a clean bump, then approve
+  it and add it to the merge queue. With no argument, processes open registry
+  auto-update PRs.
 - [`/draft-issue <issue-description>`][draft-issue]: draft a GitHub issue in the
   `opentelemetry.io` repository following issue templates, contributing
   guidelines, and the label taxonomy.
@@ -66,6 +70,8 @@ See the section index below.
 [`.claude/skills/`]:
   https://github.com/open-telemetry/opentelemetry.io/tree/main/.claude/skills
 [agentskills.io]: https://agentskills.io
+[approve-registry-update]:
+  https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/approve-registry-update/SKILL.md
 [draft-issue]:
   https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/draft-issue/SKILL.md
 [refresh-refcache-pr-fix]:

--- a/content/en/site/skills/_index.md
+++ b/content/en/site/skills/_index.md
@@ -21,9 +21,9 @@ procedures are defined in this section.
 As mentioned above, skills are defined in [`.claude/skills/`][], they are:
 
 - [`/approve-registry-update [pr-number-or-url]`][approve-registry-update]:
-  verify that an otelbot registry version-bump PR is a clean bump, then approve
-  it and add it to the merge queue. With no argument, processes open registry
-  auto-update PRs.
+  assist reviewers deciding whether to merge an otelbot registry version-bump
+  PR; verify it's a clean bump and, on confirmation, approve it and add it to
+  the merge queue. With no argument, processes open registry auto-update PRs.
 - [`/draft-issue <issue-description>`][draft-issue]: draft a GitHub issue in the
   `opentelemetry.io` repository following issue templates, contributing
   guidelines, and the label taxonomy.

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -15427,6 +15427,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-06-18T11:10:37.537854Z"
   },
+  "https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/approve-registry-update/SKILL.md": {
+    "StatusCode": 206,
+    "LastSeen": "2026-06-26T15:17:37.958271-04:00"
+  },
   "https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/draft-issue/SKILL.md": {
     "StatusCode": 206,
     "LastSeen": "2026-06-18T11:10:10.685307114Z"


### PR DESCRIPTION
- Adds a `/approve-registry-update` skill that verifies an otelbot registry auto-update PR is a clean version bump (no other field changes, no added or changed URLs) before approving it and adding it to the merge queue.
  - Defaults to discovering open `otelbot/auto-update-registry-*` PRs when no argument is given; also accepts an explicit PR number or URL.
  - Documents the skill in the site Skills index.
- Validated end-to-end against #10556 (the registry auto-update PR used for the test run): the skill discovered it, confirmed a clean 261-file version bump, then approved and added it to the merge queue.
- **Preview(s)**: [Skills index](https://deploy-preview-10582--opentelemetry.netlify.app/site/skills/)