### PR TITLE
[ja] update translation of content/en/docs/languages/java/configuration.md

### DIFF
--- a/content/ja/docs/languages/java/configuration.md
+++ b/content/ja/docs/languages/java/configuration.md
@@ -3,8 +3,7 @@ title: SDKの設定
 linkTitle: SDKの設定
 weight: 13
 aliases: [config]
-default_lang_commit: 1f686d5f7b6bbdfaa30dafdc6ca0214c6f2308db
-drifted_from_default: true
+default_lang_commit: 906771a74807a998613527841d296e49d3609a9f
 # prettier-ignore
 cSpell:ignore: autoconfigured blrp Customizer Dotel ignore LOWMEMORY ottrace PKCS
 ---
@@ -608,6 +607,6 @@ public class CustomTextMapPropagatorProvider implements ConfigurablePropagatorPr
 
 詳細については、以下のリソースを参照してください。
 
-- [使用ドキュメント](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/incubator#declarative-configuration)
-- [Javaエージェントでの例](https://github.com/open-telemetry/opentelemetry-java-examples/tree/main/javaagent#declarative-configuration)
+- [使用ドキュメント](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/declarative-config)
+- [Javaエージェントでの例](https://github.com/open-telemetry/opentelemetry-java-examples/tree/main/javaagent-declarative-configuration)
 - [Javaエージェントなしでの例](https://github.com/open-telemetry/opentelemetry-java-examples/tree/main/declarative-configuration)


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/java/configuration.md` to match the latest English source at
`content/en/docs/languages/java/configuration.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff consists of two link target changes in the "Declarative configuration" section:
- `sdk-extensions/incubator#declarative-configuration` → `sdk-extensions/declarative-config`
- `javaagent#declarative-configuration` → `javaagent-declarative-configuration`

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10592--opentelemetry.netlify.app/ja/docs/languages/java/configuration/
- **English (canonical):** https://opentelemetry.io/docs/languages/java/configuration/

<!-- preview-section-end -->
