### PR TITLE
Add DataBuff to vendors list

### DIFF
--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -138,6 +138,12 @@
   contact: hi@dash0.com
   oss: false
   commercial: true
+- name: DataBuff
+  nativeOTLP: true
+  url: https://github.com/databufflabs/databuff/blob/master/docs/opentelemetry-otlp-ingestion_en.md
+  contact: https://github.com/databufflabs
+  oss: true
+  commercial: false
 - name: DaoCloud
   nativeOTLP: true
   url: https://docs.daocloud.io/en/insight/quickstart/otel/otel/

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -4911,6 +4911,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-06-27T06:48:19.33153547Z"
   },
+  "https://github.com/databufflabs/databuff/blob/master/docs/opentelemetry-otlp-ingestion_en.md": {
+    "StatusCode": 206,
+    "LastSeen": "2026-06-30T09:54:23.168155418Z"
+  },
   "https://github.com/datadog/orchestrion": {
     "StatusCode": 206,
     "LastSeen": "2026-06-29T13:30:06.885234831Z"


### PR DESCRIPTION
DataBuff is an open-source (AGPL-3.0) AI-native OpenTelemetry APM backend that natively ingests OTLP traces and metrics on ports 4317 (gRPC) and 4318 (HTTP).

Documentation: https://github.com/databufflabs/databuff/blob/master/docs/opentelemetry-otlp-ingestion_en.md

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.