### PR TITLE
Registry: fix capitalized boolean values

### DIFF
--- a/data/registry/application-integration-python-checkmk.yml
+++ b/data/registry/application-integration-python-checkmk.yml
@@ -19,4 +19,4 @@ authors:
   - name: Checkmk GmbH
     email: community@checkmk.com
 createdAt: 2024-08-22
-isNative: True
+isNative: true

--- a/data/registry/instrumentation-go-fiber.yml
+++ b/data/registry/instrumentation-go-fiber.yml
@@ -14,4 +14,4 @@ authors:
 urls:
   repo: https://github.com/gofiber/contrib/tree/main/v3/otel
 createdAt: 2022-01-14
-isFirstParty: True
+isFirstParty: true


### PR DESCRIPTION
- Fixes `check:registry`, which started failing on `main` after the js-yaml v5 upgrade (#10603): two registry entries set a boolean flag to `True` instead of `true`.
  - Corrects `isNative` in `application-integration-python-checkmk.yml`.
  - Corrects `isFirstParty` in `instrumentation-go-fiber.yml`.
- Roots out the cause: the validator parses entries with js-yaml `JSON_SCHEMA`. js-yaml v4 leniently parsed `True` as boolean `true`, but v5 tightened this so `True` parses as the string `"True"`, which fails the schema's `boolean` type.
