### PR TITLE
Registry: run validation on all PRs

### DIFF
--- a/.github/workflows/check-registry.yml
+++ b/.github/workflows/check-registry.yml
@@ -3,9 +3,6 @@ name: Registry Validation
 on:
   merge_group:
   pull_request:
-    # Make sure this only runs when registry entries are touched.
-    paths:
-      - 'data/registry/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
- Contributes to #10616
- Removes the `data/registry/**` path filter so `REGISTRY validation` reports a status on every PR, not only registry-data PRs.
- Closes the gap where a dependency bump that invalidates existing entries (e.g. the js-yaml v5 upgrade, #10603) merges without the check running, leaving `main` broken until an unrelated registry PR surfaces it.
- Costs little: the gulp validation task runs in well under a second.
- Pairs with an open-telemetry/admin change to make `REGISTRY validation` a required check.

cc @vitorvasc @svrnm
