### PR TITLE
[demo] Link Grafana to its open source project instead of vendor homepage

### DIFF
--- a/content/en/docs/demo/telemetry-features/_index.md
+++ b/content/en/docs/demo/telemetry-features/_index.md
@@ -21,7 +21,7 @@ aliases: [demo_features, features]
 
 ## Observability Solutions
 
-- **[Grafana](https://grafana.com/)**: all metric dashboards are stored in
+- **[Grafana](https://github.com/grafana/grafana)**: all metric dashboards are stored in
   Grafana.
 - **[Jaeger](https://www.jaegertracing.io/)**: all generated traces are being
   sent to Jaeger.

--- a/content/en/docs/demo/telemetry-features/_index.md
+++ b/content/en/docs/demo/telemetry-features/_index.md
@@ -21,8 +21,8 @@ aliases: [demo_features, features]
 
 ## Observability Solutions
 
-- **[Grafana](https://github.com/grafana/grafana)**: all metric dashboards are stored in
-  Grafana.
+- **[Grafana](https://github.com/grafana/grafana)**: all metric dashboards are
+  stored in Grafana.
 - **[Jaeger](https://www.jaegertracing.io/)**: all generated traces are being
   sent to Jaeger.
 - **[OpenSearch](https://opensearch.org/)**: all generated logs are sent to Data

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -5487,6 +5487,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-06-29T15:32:37.4750834Z"
   },
+  "https://github.com/grafana/grafana": {
+    "StatusCode": 206,
+    "LastSeen": "2026-06-29T15:32:32.611634515Z"
+  },
   "https://github.com/grafana/grafana-ansible-collection/tree/main/roles/opentelemetry_collector": {
     "StatusCode": 206,
     "LastSeen": "2026-06-29T15:32:32.086007388Z"


### PR DESCRIPTION
On the [Telemetry Features](https://opentelemetry.io/docs/demo/telemetry-features/) page, the Grafana entry linked to the Grafana company homepage (`https://grafana.com/`), while the neighboring entries (Jaeger, OpenSearch, Prometheus) all link to their open source project sites.

In keeping with OpenTelemetry's vendor-neutral stance, this updates the Grafana link to point to the open source project repository at `https://github.com/grafana/grafana` rather than the commercial vendor's homepage.