### PR TITLE
[chore] Document /fix:refcache hint for new-link CI failures

### DIFF
--- a/content/en/docs/contributing/pr-checks.md
+++ b/content/en/docs/contributing/pr-checks.md
@@ -133,10 +133,11 @@ updates the reference cache. Push any changes to the refcache in a new commit.
 
 If you added or changed an external link, the link checker records it in the
 reference cache (`static/refcache.json`), and this check will fail until that
-cache is updated. If you're editing from the GitHub web UI or don't have a local
-setup, you don't need to update the cache by hand: comment
-[`/fix:refcache`](../pull-requests/#fixing-prs-in-github) on your PR and the
-OpenTelemetry bot will update it for you.
+cache is updated. The easiest way to update it is to comment
+[`/fix:refcache`](../pull-requests/#fixing-prs-in-github) on your PR — the
+OpenTelemetry bot updates `static/refcache.json` for you. This is usually
+simpler than running `npm run check:links` and committing the result yourself,
+even if you have a local clone.
 
 > [!NOTE]
 >

--- a/content/en/docs/contributing/pr-checks.md
+++ b/content/en/docs/contributing/pr-checks.md
@@ -131,6 +131,13 @@ These two checks build the website and verify that all links are valid.
 To build and check links locally, run `npm run check:links`. This command also
 updates the reference cache. Push any changes to the refcache in a new commit.
 
+If you added or changed an external link, the link checker records it in the
+reference cache (`static/refcache.json`), and this check will fail until that
+cache is updated. If you're editing from the GitHub web UI or don't have a local
+setup, you don't need to update the cache by hand: comment
+[`/fix:refcache`](../pull-requests/#fixing-prs-in-github) on your PR and the
+OpenTelemetry bot will update it for you.
+
 > [!NOTE]
 >
 > For information on warnings about site-local links, see

--- a/content/en/docs/contributing/pr-checks.md
+++ b/content/en/docs/contributing/pr-checks.md
@@ -128,16 +128,17 @@ path obsolete.
 
 These two checks build the website and verify that all links are valid.
 
-To build and check links locally, run `npm run check:links`. This command also
-updates the reference cache. Push any changes to the refcache in a new commit.
-
 If you added or changed an external link, the link checker records it in the
 reference cache (`static/refcache.json`), and this check will fail until that
-cache is updated. The easiest way to update it is to comment
+cache is updated.
+
+The easiest way to update it is to comment
 [`/fix:refcache`](../pull-requests/#fixing-prs-in-github) on your PR — the
-OpenTelemetry bot updates `static/refcache.json` for you. This is usually
-simpler than running `npm run check:links` and committing the result yourself,
-even if you have a local clone.
+OpenTelemetry bot updates `static/refcache.json` for you.
+
+Alternatively, you can build and check links locally, by running
+`npm run check:links`. This command also updates the reference cache. Push any
+changes to the refcache in a new commit.
 
 > [!NOTE]
 >


### PR DESCRIPTION
New contributors are often surprised when fixing a single external link fails CI on the refcache checks. The existing docs only describe the local `npm run check:links` workflow.

This adds a short note to the PR-checks guide highlighting the `/fix:refcache` bot command as the easy way to update `static/refcache.json` — just comment on the PR and the bot does it for you. It's usually simpler than running and committing the refcache update locally, even when you have a local clone.