### PR TITLE
registry: add Runback — AI agent audit and governance (OTel-native)

### DIFF
--- a/data/registry/application-integration-runback.yml
+++ b/data/registry/application-integration-runback.yml
@@ -1,0 +1,26 @@
+title: Runback
+registryType: application integration
+language: js
+tags:
+  - ai-agents
+  - governance
+  - audit
+  - compliance
+  - replay
+  - llm
+license: proprietary
+description:
+  Runback is a system of record for AI agent decisions. It accepts OpenTelemetry
+  traces natively and adds deterministic re-execution, policy simulation against
+  historical decisions, and tamper-evident hash-chained audit cassettes
+  (runback.cassette/v1). Designed for EU AI Act Article 12 compliance and APRA
+  CPS 230. Self-hostable in your own VPC.
+authors:
+  - name: Runback
+    url: https://github.com/letsRunback
+urls:
+  website: https://runback.dev
+  docs: https://runback.dev/how-it-works
+  spec: https://runback.dev/spec
+createdAt: '2026-07-01'
+isNative: false


### PR DESCRIPTION
Adding [Runback](https://runback.dev) to the integration registry.

Runback is a system of record for AI agent decisions that accepts OpenTelemetry traces natively. It adds deterministic re-execution and tamper-evident audit cassettes on top of OTel trace capture — letting teams reproduce any agent failure from the exact captured context, simulate policies against historical decisions, and export hash-chained audit records for compliance.

**OTel integration:** Runback ingests OTel traces at `/api/otel/v1/traces` (standard OTLP/HTTP). No SDK change needed — point your existing OTel exporter at Runback.

**Registry entry:** `data/registry/application-integration-runback.yml`

**Relevant links:**
- Site: https://runback.dev
- How it works: https://runback.dev/how-it-works
- Open audit spec: https://runback.dev/spec (`runback.cassette/v1`)

---

**Note from the maintainers**: this description was submitted without our [PR template](https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/PULL_REQUEST_TEMPLATE.md)'s checklist, which asks you to confirm:

- [ ] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [ ] I have the experience and knowledge necessary to understand, review, and validate all content in this PR. (Yes, I can answer maintainer questions about the content of this PR, without using AI.)

Per our [first-time contributor policy](https://github.com/open-telemetry/opentelemetry.io/issues/11243), answer these questions by ticking each box that applies.
