### PR TITLE
Add EventName to log record top-level fields

### DIFF
--- a/content/en/docs/concepts/signals/logs.md
+++ b/content/en/docs/concepts/signals/logs.md
@@ -223,19 +223,20 @@ contains two kinds of fields:
 
 The top-level fields are:
 
-| Field Name           | Description                                  |
-| -------------------- | -------------------------------------------- |
-| Timestamp            | Time when the event occurred.                |
-| ObservedTimestamp    | Time when the event was observed.            |
-| TraceId              | Request trace ID.                            |
-| SpanId               | Request span ID.                             |
-| TraceFlags           | W3C trace flag.                              |
-| SeverityText         | The severity text (also known as log level). |
-| SeverityNumber       | Numerical value of the severity.             |
-| Body                 | The body of the log record.                  |
-| Resource             | Describes the source of the log.             |
-| InstrumentationScope | Describes the scope that emitted the log.    |
-| Attributes           | Additional information about the event.      |
+| Field Name           | Description                                          |
+| -------------------- | ---------------------------------------------------- |
+| Timestamp            | Time when the event occurred.                        |
+| ObservedTimestamp    | Time when the event was observed.                    |
+| TraceId              | Request trace ID.                                    |
+| SpanId               | Request span ID.                                     |
+| TraceFlags           | W3C trace flag.                                      |
+| SeverityText         | The severity text (also known as log level).         |
+| SeverityNumber       | Numerical value of the severity.                     |
+| Body                 | The body of the log record.                          |
+| Resource             | Describes the source of the log.                     |
+| InstrumentationScope | Describes the scope that emitted the log.            |
+| Attributes           | Additional information about the event.              |
+| EventName            | Name that identifies the class or type of the event. |
 
 For more details on log records and log fields, see
 [Logs Data Model](/docs/specs/otel/logs/data-model/).


### PR DESCRIPTION
The [log record concepts page](https://opentelemetry.io/docs/concepts/signals/logs/#log-record) was missing `EventName`, which is a top-level field in the [Logs Data Model](https://opentelemetry.io/docs/specs/otel/logs/data-model/). This adds it to the top-level fields table, matching the field name and description used in the specification.