### PR TITLE
Improve declarative config usage link experience with full JSONPath

### DIFF
--- a/assets/js/configTypesAccordion.js
+++ b/assets/js/configTypesAccordion.js
@@ -310,7 +310,7 @@ function renderUsages(type, i18n, usagePathMap) {
         <button type="button"
                 class="ct-usage-copy"
                 data-usage-copy="${escapeAttr(plainPath)}"
-                aria-label="${escapeAttr(i18n.copy)} ${escapeHtml(plainPath)}">${escapeHtml(i18n.copy)}</button>
+                aria-label="${escapeAttr(i18n.copy)} ${escapeAttr(plainPath)}">${escapeHtml(i18n.copy)}</button>
       </li>`;
     })
     .join('');
@@ -436,11 +436,19 @@ function wireControls(container, types, i18n) {
 
   // Copy buttons (delegated, since the accordion is built in one innerHTML pass).
   // Handles both snippet copy buttons and inline usage-path copy buttons.
+  // WeakMap so rapid re-clicks don't capture a stale "Copied!" as the original
+  // label, which would leave the button stuck in the copied state.
+  const copyTimers = new WeakMap();
   function flashCopied(btn) {
-    const original = btn.textContent;
+    if (!copyTimers.has(btn)) {
+      copyTimers.set(btn, { original: btn.textContent.trim(), timer: null });
+    }
+    const state = copyTimers.get(btn);
+    clearTimeout(state.timer);
     btn.textContent = i18n.copied;
-    setTimeout(() => {
-      btn.textContent = original;
+    state.timer = setTimeout(() => {
+      btn.textContent = state.original;
+      copyTimers.delete(btn);
     }, 2000);
   }
 

--- a/assets/js/configTypesAccordion.js
+++ b/assets/js/configTypesAccordion.js
@@ -36,6 +36,58 @@ function readI18n(container) {
   };
 }
 
+// ── JSON path computation ───────────────────────────────────────────────────────
+
+// BFS from the root type to compute the JSON path chain for each usage edge.
+// Uses per-type expansion (each type expanded once, at its shortest path) so
+// cycles in the schema (e.g. Sampler ↔ ParentBasedSampler) cannot loop.
+//
+// Returns a Map keyed by "childTypeName|parentTypeName|propertyName" whose
+// value is a chain array of { text, typeId } segments, e.g.
+//   "SpanProcessor|TracerProvider|processors" →
+//     [ {text:'$', typeId:'opentelemetryconfiguration'},
+//       {text:'tracer_provider', typeId:'tracerprovider'},
+//       {text:'processors[*]', typeId:'spanprocessor'} ]
+//
+// Each segment's typeId is the type *referenced by* that segment, so links
+// navigate to the type a user would expect to land on when clicking that step.
+function computeUsageJsonPaths(types) {
+  const typesByName = new Map(types.map((t) => [t.name, t]));
+  const rootType = types.find((t) => t.isRoot);
+  if (!rootType) return new Map();
+
+  const usagePathMap = new Map();
+  const expandedTypes = new Set();
+  const rootChain = [{ text: '$', typeId: rootType.id }];
+  const queue = [[rootType.name, rootChain]];
+
+  while (queue.length > 0) {
+    const [typeName, chain] = queue.shift();
+    if (expandedTypes.has(typeName)) continue;
+    expandedTypes.add(typeName);
+
+    const type = typesByName.get(typeName);
+    if (!type) continue;
+
+    for (const prop of type.properties ?? []) {
+      if (!prop.typeRef) continue;
+      const childType = typesByName.get(prop.typeRef);
+      const childTypeId = childType?.id ?? prop.typeRef.toLowerCase();
+      const isArray = prop.type === 'array';
+      const segmentText = isArray ? `${prop.name}[*]` : prop.name;
+      const childChain = [...chain, { text: segmentText, typeId: childTypeId }];
+
+      usagePathMap.set(`${prop.typeRef}|${typeName}|${prop.name}`, childChain);
+
+      if (!expandedTypes.has(prop.typeRef)) {
+        queue.push([prop.typeRef, childChain]);
+      }
+    }
+  }
+
+  return usagePathMap;
+}
+
 // ── Rendering ─────────────────────────────────────────────────────────────────
 
 function escapeAttr(str) {
@@ -231,13 +283,36 @@ function renderSnippets(type, i18n) {
 </div>`;
 }
 
-function renderUsages(type) {
+function renderUsages(type, i18n, usagePathMap) {
   if (!type.usages?.length) return '';
   const items = type.usages
-    .map(
-      (u) =>
-        `<li><a href="#type-${escapeAttr(u.typeId)}" data-ct-type-link="${escapeAttr(u.typeId)}">${escapeHtml(u.typeName)}</a>.<code>${escapeHtml(u.propertyName)}</code></li>`,
-    )
+    .map((u) => {
+      const chain = usagePathMap?.get(
+        `${type.name}|${u.typeName}|${u.propertyName}`,
+      );
+      if (!chain) return ''; // guarded at build time; should never happen
+
+      // Plain string for the copy button (standard JSONPath).
+      const plainPath = chain
+        .map((s, i) => (i === 0 ? s.text : `.${s.text}`))
+        .join('');
+
+      // Each segment is a link to the type it references.
+      const pathHtml = chain
+        .map((s, i) => {
+          const dot = i === 0 ? '' : '.';
+          return `${dot}<a href="#type-${escapeAttr(s.typeId)}" data-ct-type-link="${escapeAttr(s.typeId)}">${escapeHtml(s.text)}</a>`;
+        })
+        .join('');
+
+      return `<li class="ct-usage-item">
+        <code class="ct-usage-path">${pathHtml}</code>
+        <button type="button"
+                class="ct-usage-copy"
+                data-usage-copy="${escapeAttr(plainPath)}"
+                aria-label="${escapeAttr(i18n.copy)} ${escapeHtml(plainPath)}">${escapeHtml(i18n.copy)}</button>
+      </li>`;
+    })
     .join('');
   return `
 <div class="ct-usages mt-3">
@@ -263,7 +338,7 @@ function renderRawSchema(type, i18n) {
 </details>`;
 }
 
-function renderTypeItem(type, i18n, knownTypeIds) {
+function renderTypeItem(type, i18n, knownTypeIds, usagePathMap) {
   const propCount = type.hasNoProperties ? 0 : (type.properties?.length ?? 0);
   const countText = propCount === 1 ? '1 property' : `${propCount} properties`;
   const constraintsHtml = type.constraints
@@ -291,16 +366,16 @@ function renderTypeItem(type, i18n, knownTypeIds) {
       ${renderPropertiesTable(type, i18n, knownTypeIds)}
       ${renderSnippets(type, i18n)}
       ${constraintsHtml}
-      ${renderUsages(type)}
+      ${renderUsages(type, i18n, usagePathMap)}
       ${renderRawSchema(type, i18n)}
     </div>
   </div>
 </div>`;
 }
 
-function renderAccordion(types, i18n, knownTypeIds) {
+function renderAccordion(types, i18n, knownTypeIds, usagePathMap) {
   const items = types
-    .map((t) => renderTypeItem(t, i18n, knownTypeIds))
+    .map((t) => renderTypeItem(t, i18n, knownTypeIds, usagePathMap))
     .join('');
   return `
 <div id="${ACCORDION_ID}" class="accordion">
@@ -360,18 +435,32 @@ function wireControls(container, types, i18n) {
   let debounceTimer;
 
   // Copy buttons (delegated, since the accordion is built in one innerHTML pass).
+  // Handles both snippet copy buttons and inline usage-path copy buttons.
+  function flashCopied(btn) {
+    const original = btn.textContent;
+    btn.textContent = i18n.copied;
+    setTimeout(() => {
+      btn.textContent = original;
+    }, 2000);
+  }
+
   container.addEventListener('click', (e) => {
-    const btn = e.target.closest('[data-snippet-copy]');
-    if (!btn) return;
-    const code = btn.closest('.ct-snippet')?.querySelector('pre code');
-    if (!code) return;
-    navigator.clipboard.writeText(code.textContent).then(() => {
-      const original = btn.textContent;
-      btn.textContent = i18n.copied;
-      setTimeout(() => {
-        btn.textContent = original;
-      }, 2000);
-    });
+    const usageBtn = e.target.closest('[data-usage-copy]');
+    if (usageBtn) {
+      navigator.clipboard
+        .writeText(usageBtn.dataset.usageCopy)
+        .then(() => flashCopied(usageBtn));
+      return;
+    }
+
+    const snippetBtn = e.target.closest('[data-snippet-copy]');
+    if (snippetBtn) {
+      const code = snippetBtn.closest('.ct-snippet')?.querySelector('pre code');
+      if (!code) return;
+      navigator.clipboard
+        .writeText(code.textContent)
+        .then(() => flashCopied(snippetBtn));
+    }
   });
 
   // Search
@@ -402,7 +491,9 @@ function wireControls(container, types, i18n) {
   accordion.addEventListener('show.bs.collapse', (e) => {
     const item = e.target.closest('.accordion-item');
     if (!item?.dataset.typeId) return;
-    history.replaceState(null, '', `#type-${item.dataset.typeId}`);
+    const newHash = `#type-${item.dataset.typeId}`;
+    if (location.hash === newHash) return;
+    history.pushState(null, '', newHash);
   });
 
   // Expand / collapse all
@@ -441,6 +532,19 @@ function expandItem(item) {
 }
 
 function wireTypeLinks(container, resetControls) {
+  window.addEventListener('popstate', () => {
+    if (!location.hash) return;
+    let item;
+    try {
+      item = container.querySelector(location.hash);
+    } catch {
+      return;
+    }
+    if (!item || !item.classList.contains('accordion-item')) return;
+    expandItem(item);
+    item.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  });
+
   container.addEventListener('click', (e) => {
     const link = e.target.closest('a[data-ct-type-link]');
     if (!link) return;
@@ -451,8 +555,11 @@ function wireTypeLinks(container, resetControls) {
       `[data-type-id="${CSS.escape(typeId)}"]`,
     );
     if (item) {
+      const href = link.getAttribute('href');
       expandItem(item);
-      history.replaceState(null, '', link.getAttribute('href'));
+      // show.bs.collapse also pushes when the item wasn't already open; both
+      // sites dedupe on location.hash so we won't get a double entry.
+      if (location.hash !== href) history.pushState(null, '', href);
       item.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
   });
@@ -491,10 +598,11 @@ async function init() {
     const data = await res.json();
     const { types, schemaVersion, schemaSourceUrl } = data;
     const knownTypeIds = new Set(types.map((t) => t.id));
+    const usagePathMap = computeUsageJsonPaths(types);
 
     container.innerHTML =
       renderControls(types, i18n, schemaVersion, schemaSourceUrl) +
-      renderAccordion(types, i18n, knownTypeIds);
+      renderAccordion(types, i18n, knownTypeIds, usagePathMap);
     injectDescriptions(container, types);
     const resetControls = wireControls(container, types, i18n);
     wireTypeLinks(container, resetControls);

--- a/assets/scss/_config_types_accordion.scss
+++ b/assets/scss/_config_types_accordion.scss
@@ -140,6 +140,51 @@
     }
   }
 
+  // "Used by" usage entries: path + copy button on one line.
+  .ct-usage-item {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    margin-bottom: 0.25rem;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  // Linked JSONPath shown for each usage. Links inside use the standard link
+  // colour so they're clearly navigable, but inherit the monospace font.
+  .ct-usage-path {
+    font-size: 0.8125rem;
+
+    a {
+      color: var(--bs-link-color);
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+
+  // Inline copy button next to each usage path.
+  .ct-usage-copy {
+    flex-shrink: 0;
+    padding: 0;
+    font-size: 0.75rem;
+    line-height: 1.5;
+    color: var(--bs-tertiary-color);
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: color 0.15s ease;
+
+    &:hover {
+      color: var(--bs-secondary-color);
+    }
+  }
+
   // Type-level constraints note at the bottom of each accordion body.
   .ct-type-constraints {
     font-size: 0.8125rem;

--- a/scripts/generate-config-types.mjs
+++ b/scripts/generate-config-types.mjs
@@ -119,6 +119,46 @@ for (const type of result.types) {
   type.snippets = snippets;
 }
 
+// Guard against schema changes that would leave usage edges unreachable from
+// the root type. The accordion renders JSON paths for every usage, so any
+// missing edge would silently produce a broken entry at render time.
+function assertAllUsagesReachable(types) {
+  const typesByName = new Map(types.map((t) => [t.name, t]));
+  const rootType = types.find((t) => t.isRoot);
+  if (!rootType) throw new Error('No root type found in schema.');
+
+  const reachable = new Set();
+  const expanded = new Set();
+  const queue = [rootType.name];
+  while (queue.length > 0) {
+    const typeName = queue.shift();
+    if (expanded.has(typeName)) continue;
+    expanded.add(typeName);
+    const type = typesByName.get(typeName);
+    if (!type) continue;
+    for (const prop of type.properties ?? []) {
+      if (!prop.typeRef) continue;
+      reachable.add(`${prop.typeRef}|${typeName}|${prop.name}`);
+      if (!expanded.has(prop.typeRef)) queue.push(prop.typeRef);
+    }
+  }
+
+  const missing = [];
+  for (const type of types) {
+    for (const u of type.usages ?? []) {
+      const key = `${type.name}|${u.typeName}|${u.propertyName}`;
+      if (!reachable.has(key)) missing.push(key);
+    }
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      'Usage edge(s) not reachable from root — JSON paths cannot be computed:\n' +
+        missing.map((k) => `  ${k}`).join('\n'),
+    );
+  }
+}
+assertAllUsagesReachable(result.types);
+
 // Guard against a snippet whose filename prefix isn't a real schema type.
 const knownTypes = new Set(result.types.map((t) => t.name));
 const orphans = Object.keys(snippetsByType).filter((t) => !knownTypes.has(t));


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

I frequently need to reference the [JSONPath](https://en.wikipedia.org/wiki/JSONPath) of different parts of the declarative config schema.

I realized that existing "Used by:" section of the types page could be adapted to serve this purpose, and be more useful:

- Currently, we just link to the list of type / properties which use a given type
- With this PR, we list the JSONPaths which reference a given type
- Each segment in the JSON path links to its corresponding type
- There's a "Copy" button to copy the raw JSONPath 
- Navigation is updated so that each click on a type is added to the browser history so back / foward buttons work

Before:

<img width="1040" height="480" alt="Screenshot 2026-07-01 at 9 36 43 AM" src="https://github.com/user-attachments/assets/8dfa0f1f-00f8-4987-b829-9c000fd275b7" />

After:

<img width="1145" height="491" alt="Screenshot 2026-07-01 at 9 29 40 AM" src="https://github.com/user-attachments/assets/b071c799-9fe1-40d2-9ae4-9d99380c69b1" />

cc @jaydeluca 