### PR TITLE
[ja] update translation of content/en/docs/languages/python/_index.md

### DIFF
--- a/content/ja/docs/languages/python/_index.md
+++ b/content/ja/docs/languages/python/_index.md
@@ -5,15 +5,14 @@ description: >-
   src="/img/logos/32x32/Python_SDK.svg" alt="Python"> PythonにおけるOpenTelemetryの言語固有の実装。
 aliases: [/python, /python/metrics, /python/tracing]
 weight: 190
-default_lang_commit: d8f5ed285d009cc6baac6d7141bfde8d0956a756
-drifted_from_default: true
+default_lang_commit: 1143960b75c6faceb40eb64269e68390e3237671
 ---
 
 {{% docs/languages/index-intro python /%}}
 
 ## バージョンサポート {#version-support}
 
-OpenTelemetry-PythonはPython 3.9以上をサポートしています。
+OpenTelemetry-PythonはPython 3.10以上をサポートしています。
 
 ## インストール {#installation}
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/python/_index.md` to match the latest English source at
`content/en/docs/languages/python/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

Changes:
- Updated Python version support from 3.9 to 3.10

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10658--opentelemetry.netlify.app/ja/docs/languages/python/
- **English (canonical):** https://opentelemetry.io/docs/languages/python/

<!-- preview-section-end -->
