### PR TITLE
[ja] update translation of content/en/docs/contributing/pr-checks.md

### DIFF
--- a/content/ja/docs/contributing/pr-checks.md
+++ b/content/ja/docs/contributing/pr-checks.md
@@ -3,8 +3,7 @@ title: プルリクエストのチェックとテスト
 linkTitle: PR チェック & テスト
 description: プルリクエストがすべてのチェックをパスする方法学ぶ
 weight: 40
-default_lang_commit: 8013aa5f0aae284fa343311981625be6dbb25e5b
-drifted_from_default: true
+default_lang_commit: 1143960b75c6faceb40eb64269e68390e3237671
 ---
 
 [opentelemetry.io リポジトリ](https://github.com/open-telemetry/opentelemetry.io)に[pull request](https://docs.github.com/en/get-started/learning-about-github/github-glossary#pull-request)（PR）を作成した際に、一連のチェックが実行されます。
@@ -108,7 +107,13 @@ PR のチェックは次のことを検証します。
 
 これらの2つのチェックは、ウェブサイトをビルドしてすべてのリンクが有効であることを検証します。
 
-ローカルでビルドしてリンクをチェックするには、`npm run check:links` を実行してください。
+外部リンクを追加または変更した場合、リンクチェッカーはそのリンクを参照キャッシュ (`static/refcache.json`) に記録します。
+キャッシュが更新されるまでこのチェックは失敗します。
+
+キャッシュを更新する最も簡単な方法は、PR に [`/fix:refcache`](../pull-requests/#fixing-prs-in-github) とコメントすることです。
+OpenTelemetry ボットが `static/refcache.json` を更新してくれます。
+
+あるいは、`npm run check:links` を実行してローカルでビルドとリンクチェックを行うこともできます。
 このコマンドは参照キャッシュも更新します。
 refcache に変更があれば、新しいコミットでプッシュしてください。
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/contributing/pr-checks.md` to match the latest English source at
`content/en/docs/contributing/pr-checks.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10659--opentelemetry.netlify.app/ja/docs/contributing/pr-checks/
- **English (canonical):** https://opentelemetry.io/docs/contributing/pr-checks/

_(deploy preview status: pending. The URLs will work once Netlify finishes building.)_
<!-- preview-section-end -->
