### PR TITLE
[ja] update translation of content/en/docs/concepts/signals/logs.md

### DIFF
--- a/content/ja/docs/concepts/signals/logs.md
+++ b/content/ja/docs/concepts/signals/logs.md
@@ -2,8 +2,7 @@
 title: ログ
 description: イベントの記録
 weight: 3
-default_lang_commit: 3b1656f719549d7c7081167ba6bdf98a4e45cf0c
-drifted_from_default: true
+default_lang_commit: 1143960b75c6faceb40eb64269e68390e3237671
 cSpell:ignore: filelogreceiver semistructured transformprocessor
 ---
 
@@ -180,19 +179,20 @@ OpenTelemetryでは、ログレコードには2種類のフィールドがあり
 
 トップレベルのフィールドは以下の通りです。
 
-| フィールド名         | 説明                                     |
-| -------------------- | ---------------------------------------- |
-| Timestamp            | イベントが発生した時刻                   |
-| ObservedTimestamp    | イベントが観測された時刻                 |
-| TraceId              | リクエストトレースID                     |
-| SpanId               | リクエストスパンID                       |
-| TraceFlags           | W3Cトレースフラグ                        |
-| SeverityText         | 重要度テキスト（ログレベルとも呼ばれる） |
-| SeverityNumber       | 重要度の数値                             |
-| Body                 | ログレコードの本文                       |
-| Resource             | ログのソース                             |
-| InstrumentationScope | ログを出力したスコープ                   |
-| Attributes           | イベントに関する追加情報                 |
+| フィールド名         | 説明                                       |
+| -------------------- | ------------------------------------------ |
+| Timestamp            | イベントが発生した時刻                     |
+| ObservedTimestamp    | イベントが観測された時刻                   |
+| TraceId              | リクエストトレースID                       |
+| SpanId               | リクエストスパンID                         |
+| TraceFlags           | W3Cトレースフラグ                          |
+| SeverityText         | 重要度テキスト（ログレベルとも呼ばれる）   |
+| SeverityNumber       | 重要度の数値                               |
+| Body                 | ログレコードの本文                         |
+| Resource             | ログのソース                               |
+| InstrumentationScope | ログを出力したスコープ                     |
+| Attributes           | イベントに関する追加情報                   |
+| EventName            | イベントのクラスまたはタイプを識別する名前 |
 
 ログレコードとログフィールドの詳細については、[ログデータモデル](/docs/specs/otel/logs/data-model/) を参照してください。
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/concepts/signals/logs.md` to match the latest English source at
`content/en/docs/concepts/signals/logs.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

Changes applied:
- Added new `EventName` row to the log record fields table
- Adjusted table column widths to match the updated English source

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10668--opentelemetry.netlify.app/ja/docs/concepts/signals/logs/
- **English (canonical):** https://opentelemetry.io/docs/concepts/signals/logs/

<!-- preview-section-end -->
