### PR TITLE
CI: install npm deps in auto-update versions workflow

### DIFF
--- a/.github/workflows/auto-update-versions.yml
+++ b/.github/workflows/auto-update-versions.yml
@@ -21,6 +21,13 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+
+      # Don't --ignore-scripts: code-excerpter needs submodules
+      - run: npm install --omit=optional
+
       - name: Use CLA approved github bot
         run: |
           git config user.name otelbot


### PR DESCRIPTION
- Fixes #10671
- Adds Node setup and `npm install --omit=optional` to the auto-update versions workflow so `code-excerpter` is available when submodule updates run `fix:code-excerpts` ([#10565](https://github.com/open-telemetry/opentelemetry.io/pull/10565))
- Fixes the [2026-07-03 workflow failure](https://github.com/open-telemetry/opentelemetry.io/actions/runs/28688560454) (exit code 127: `code-excerpter: not found`) while creating the semantic-conventions v1.43.0 update PR