### PR TITLE
[ja] update translation of content/en/docs/zero-code/java/agent/supported-libraries.md

### DIFF
--- a/content/ja/docs/zero-code/java/agent/supported-libraries.md
+++ b/content/ja/docs/zero-code/java/agent/supported-libraries.md
@@ -2,14 +2,17 @@
 title: サポートされているライブラリ
 linkTitle: サポートされているライブラリ
 weight: 11
-default_lang_commit: c6ba3e413b9c48ff4f4dc44b4e4f8e1eae1f330b
-drifted_from_default: true
+default_lang_commit: 6ef946a85afe66ba52174df13dad8345a3566d20
 # prettier-ignore
 cSpell:ignore: activej akka armeria avaje clickhouse couchbase dbcp dropwizard dubbo finatra helidon hikari hikaricp httpasyncclient httpclient hystrix javalin jedis jodd ktor logmanager mojarra mybatis myfaces nats okhttp openai oshi payara pekko rabbitmq ratpack rediscala redisson resteasy restlet rocketmq shenyu spymemcached twilio vaadin vertx vibur webflux webmvc
 ---
 
 Java エージェントは、多くのライブラリ、フレームワーク、アプリケーションサーバーをすぐに自動計装します。
 お探しのフレームワークやテクノロジーが見つからない場合は、[イシューの作成](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues)を検討してください。
+
+> [!TIP]
+>
+> 個々の計装ライブラリの詳細情報やその機能、出力されるテレメトリーについては、[Ecosystem Explorer](https://explorer.opentelemetry.io/java-agent/instrumentation) を確認してください。
 
 ## ライブラリとフレームワーク {#libraries-and-frameworks}
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/java/agent/supported-libraries.md` to match the latest English source at
`content/en/docs/zero-code/java/agent/supported-libraries.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff added a TIP callout pointing to the Ecosystem Explorer for more detailed information about individual instrumentation libraries.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10674--opentelemetry.netlify.app/ja/docs/zero-code/java/agent/supported-libraries/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/java/agent/supported-libraries/

_(deploy preview may still be building. The URLs will work once Netlify finishes.)_
<!-- preview-section-end -->
