### PR TITLE
[ja] update translation of content/en/docs/security/_index.md

### DIFF
--- a/content/ja/docs/security/_index.md
+++ b/content/ja/docs/security/_index.md
@@ -1,10 +1,9 @@
 ---
 title: セキュリティ
 cascade:
-  collector_vers: 0.154.0
+  collector_vers: 0.155.0
 weight: 970
-default_lang_commit: db8337edbbac824aebbb330acea18a7042b38806
-drifted_from_default: true
+default_lang_commit: 1604e4a539552aea3cd5caff67e7c476d26ab7d6
 ---
 
 このセクションでは、OpenTelemetryプロジェクトがどのように脆弱性を公開し、インシデントに対応しているかを学び、あなたがテレメトリーを安全に収集し、送信するために何ができるかを知ることができます。


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/security/_index.md` to match the latest English source at
`content/en/docs/security/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The only English-side change was a `cascade.collector_vers` bump from `0.154.0` to `0.155.0`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10691--opentelemetry.netlify.app/ja/docs/security/
- **English (canonical):** https://opentelemetry.io/docs/security/

_(deploy preview may take a few minutes to build.)_
<!-- preview-section-end -->
