### PR TITLE
[ja] update translation of content/en/docs/languages/js/context.md

### DIFF
--- a/content/ja/docs/languages/js/context.md
+++ b/content/ja/docs/languages/js/context.md
@@ -3,8 +3,7 @@ title: コンテキスト
 description: OpenTelemetry JavaScript Context API ドキュメント
 aliases: [api/context]
 weight: 60
-default_lang_commit: 6751402db060c25800bb41c270dcaebb48aa7acb # patched
-drifted_from_default: true
+default_lang_commit: 1604e4a539552aea3cd5caff67e7c476d26ab7d6
 ---
 
 OpenTelemetryが動作するためには、重要なテレメトリーデータを保存し、伝搬する必要があります。


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/js/context.md` to match the latest English source at
`content/en/docs/languages/js/context.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff since the previous `default_lang_commit` (with `# patched`) was a single
link-target change (`classes/` → `interfaces/` in the Context API reference URL). That URL
was already patched in the Japanese file, so only the frontmatter bookkeeping needed updating.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10692--opentelemetry.netlify.app/ja/docs/languages/js/context/
- **English (canonical):** https://opentelemetry.io/docs/languages/js/context/

_(deploy preview may take a few minutes to become available.)_
<!-- preview-section-end -->
