### PR TITLE
[ja] add translation of content/en/blog/2025/kubecon-eu.md

### DIFF
--- a/content/ja/blog/2025/kubecon-eu.md
+++ b/content/ja/blog/2025/kubecon-eu.md
@@ -1,0 +1,191 @@
+---
+title: KubeCon + CloudNativeCon Europe 2025で、OpenTelemetryのトークとアクティビティに参加しよう
+linkTitle: KubeCon EU '25
+date: 2025-03-04
+author: '[Tiffany Hrabusa](https://github.com/tiffany76) (Grafana Labs)'
+eventUrl: &eventUrl >-
+  https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/
+queryParams: >-
+  utm_source=opentelemetry&utm_medium=website&utm_content=blog
+default_lang_commit: 06145168104b5054b4a2c0640a58c1fae022eb5b
+# prettier-ignore
+cSpell:ignore: Adevinta Aftab Arianna Baeyens Bartłomiej Boulineau Celalettin Cgroupv Chauhan codecentric Contribfest Cosmonic Geisendoerfer Guangya Hoeven Horovits Jiří Juraj Kalyanaraman Karemba Karthik Kasper Kathiresan kedify Keycloak Kimpel Kluwer Kokilavani Kovalenko Kowall Kremser Kruthika Liatrio Mancioppi Michálek MTTD Nilson Nissen Norimatsu Oberaigner observ Olly OTTL Paessler Pahlke Prasanna Płotka Querel Roubalik SCRM Simha Skyscanner Suereth Tanaka Vamerlatti Vespri Vijay Wolters Zbynek
+---
+
+OpenTelemetryのガバナンス委員会および技術委員会は、プロジェクトのメンテナーとともに、2025年4月1日から4日にかけてロンドンで開催される [KubeCon + CloudNativeCon Europe][]（[参加登録][registration]）および同時開催の [Observability Day][] に、OpenTelemetryコミュニティのメンバーと一緒に参加することを皆さんにご案内します。
+
+この記事では、KubeCon期間中に予定されているOpenTelemetry関連のすべてのアクティビティを紹介しています。
+カンファレンス開始前に、随時更新情報をチェックしてください！
+
+## OpenTelemetry Contribfest {#opentelemetry-contribfest}
+
+OpenTelemetryのメンテナーと一緒に [OpenTelemetry Contribfest](https://sched.co/1tcyB) に参加しましょう！
+このハンズオンセッションは、新しいコントリビューターに人気のイベントです。
+Collector、Go、Java、JavaScriptなど、さまざまなコントリビューションの機会から選ぶことができ、各プロジェクト領域のメンテナーがサポートとガイダンスを提供して、最初の一歩を後押しします。
+
+## KubeConトークとメンテナーセッション {#kubecon-talks-and-maintainer-sessions}
+
+- **[⚡ Lightning Talk: Quick Intro to CI/CD Observability with OpenTelemetry](https://sched.co/1tcwL)**（CI/CDオブザーバビリティとOpenTelemetryのクイック入門）<br>
+  Dotan Horovits（CNCF Ambassador）<br> 4月1日（火）• 14:50 - 14:55
+- **[Keynote: AI Enabled Observability Explainers - We Actually Did Something With AI!](https://sched.co/1txBX)**（AI活用オブザーバビリティ解説 - AIで実際に何かを成し遂げた！）<br>
+  Vijay Samuel（Principal MTS, Architect, eBay）<br> 4月2日（水）• 09:48 - 10:03
+- **[Keynote: The Observability Platform Engineering Advantage: From Zero-Code to Monitoring as Code](https://sched.co/1txBd)**（オブザーバビリティプラットフォームエンジニアリングの優位性：ゼロコードからMonitoring as Codeへ）<br>
+  Kasper Borg Nissen（Dash0）<br> 4月2日（水）• 10:26 -10:41
+- **[OpenTelemetry Project Update](https://sched.co/1tcxD)**（OpenTelemetryプロジェクトアップデート）<br>
+  Severin Neumann（Independent）、Daniel Gomez Blanco（Skyscanner）、Alolita Sharma（Apple）、Trask Stalnaker（Microsoft）、Pablo Baeyens（Datadog）<br> 4月2日（水）• 11:15 - 11:45
+- **[OpenFeature Update From the Maintainers](https://sched.co/1tcxA)**（メンテナーからのOpenFeatureアップデート）<br>
+  Thomas Poignant（Adevinta）、Lukas Reining（codecentric AG）、Alexandra Oberaigner（Dynatrace）<br> 4月2日（水）• 11:15 - 11:45
+- **[Standardizing CI/CD Observability with OpenTelemetry: Insights from the CI/CD Observability SIG](https://sched.co/1tcxP)**（OpenTelemetryによるCI/CDオブザーバビリティの標準化：CI/CD Observability SIGからの知見）<br>
+  Dotan Horovits（CNCF Ambassador）& Adriel Perkins（Liatrio）<br> 4月2日（水）• 12:00 - 12:30
+- **[From 0 to Production-Grade with Kubernetes Native Development](https://sched.co/1txGo)**（Kubernetesネイティブ開発で0からプロダクショングレードへ）<br>
+  Thomas Vitale（Systematic）& Kevin Dubois（Red Hat）<br> 4月2日（水）• 12:00 - 12:30
+- **[KEDA: Unlocking Advanced Event-Driven Scaling for Kubernetes](https://sched.co/1tcxY)**（KEDA：Kubernetesの高度なイベント駆動スケーリングを実現する）<br>
+  Zbynek Roubalik（Kedify）& Jorge Turrado（SCRM Lidl International Hub）<br> 4月2日（水）• 12:00 - 12:30
+- **[Enhancing Database Observability with OpenTelemetry](https://sched.co/1txE9)**（OpenTelemetryでデータベースのオブザーバビリティを強化する）<br>
+  Marylia Gutierrez（Grafana Labs）<br> 4月2日（水）• 14:30 - 15:00
+- **[What's New in gRPC](https://sched.co/1tcy8)**（gRPCの最新情報）<br>
+  Kevin Nilson（Google）<br> 4月2日（水）• 15:15 - 15:45
+- **[Deep Dive To AI Agent Observability](https://sched.co/1txEC)**（AIエージェントオブザーバビリティの深掘り）<br>
+  Guangya Liu（IBM）& Karthik Kalyanaraman（Langtrace AI）<br> 4月2日（水）• 15:15 - 15:45
+- **[More Data Please: Hands on Green Cloud Experiments](https://sched.co/1tx9z)**（もっとデータを：グリーンクラウド実験をハンズオンで）<br>
+  Leonard Pahlke（BWI GmbH）& Antonio Di Turi（Data Reply）<br> 4月2日（水）• 15:15 - 15:45
+- **[Asimov's Zeroth Law of Robotics: Observability for AI](https://sched.co/1txEF)**（アシモフのロボット工学第零法則：AIのためのオブザーバビリティ）<br>
+  Nicole van der Hoeven（Grafana Labs）<br> 4月2日（水）• 16:15 - 16:45
+- **[Jaeger V2: OpenTelemetry at the Core of Modern Distributed Tracing](https://sched.co/1tcyZ)**（Jaeger V2：モダンな分散トレーシングの中核としてのOpenTelemetry）<br>
+  Jonah Kowall（Paessler）<br> 4月2日（水）• 17:00 - 17:30
+- **[An Exemplary Path: Leveraging EBPFs and OpenTelemetry To Auto-instrument for Exemplars](https://sched.co/1txEI)**（模範的な道：eBPFとOpenTelemetryを活用してエグザンプラーを自動計装する）<br>
+  Charlie Le & Kruthika Prasanna Simha（Apple）<br> 4月2日（水）• 17:00 - 17:30
+- **[Logs, Metrics, Traces and Mayhem: An Interactive Observability Adventure Game](https://sched.co/1txG5)**（ログ、メトリクス、トレース、そして大混乱：インタラクティブなオブザーバビリティアドベンチャーゲーム）<br>
+  Jay Clifford & Tom Glenn（Grafana Labs）<br> 4月2日（水）• 17:45 - 18:15
+- **[How Green Is My OpenTelemetry Collector?](https://sched.co/1txEL)**（私のOpenTelemetry Collectorはどれだけグリーンか？）<br>
+  Nancy Chauhan（Student）& Adriana Villela（Dynatrace）<br> 4月2日（水）• 17:45 - 18:15
+- **[OTel Sucks (But Also Rocks!)](https://sched.co/1txHm)**（OTelのダメなところ（でも最高でもある！））<br>
+  Juraci Paixão Kröhling（OllyGarden）& Daniel Dyla（Dynatrace）<br> 4月3日（木）• 11:00 - 11:30
+- **[Wasm Whiplash: WasmCloud's Wild Ride To Standards](https://sched.co/1tcz9)**（Wasm Whiplash：WasmCloudの標準化への道のり）<br>
+  Brooks Townsend（Cosmonic）<br> 4月3日（木）• 11:45 - 12:15
+- **[How To Adopt OpenTelemetry in an Enterprise Where Incumbent Vendor Tools Reign Supreme](https://sched.co/1txHs)**（既存ベンダーツールが主流の企業でOpenTelemetryを導入する方法）<br>
+  Chris Weldon（Wolters Kluwer）<br> 4月3日（木）• 14:15 - 14:45
+- **[How To Rename Metrics Without Impacting Somebody's Observability](https://sched.co/1txHv)**（誰かのオブザーバビリティに影響を与えずにメトリクスをリネームする方法）<br>
+  Bartłomiej Płotka（Google）& Arianna Vespri（Independent）<br> 4月3日（木）• 15:00 - 15:30
+- **[OTel Me How To Get My Open Source Community Taken Seriously: Lessons Learned as an OTel Maintainer](https://sched.co/1txH6)**（OTelから学ぶ、オープンソースコミュニティを認めてもらう方法：OTelメンテナーとしての教訓）<br>
+  Reese Lee（New Relic）& Adriana Villela（Dynatrace）<br> 4月3日（木）• 16:45 - 17:15
+- **[⚡ Lightning Talk: Observability Diet: Your 5-Step Plan To Trim the Data Fat](https://sched.co/1txCq)**（オブザーバビリティダイエット：データの無駄をそぎ落とす5つのステップ）<br>
+  Pranay Prateek（SigNoz）<br> 4月3日（木）• 16:55 - 17:00
+- **[Optimizing Metrics Collection & Serving When Autoscaling LLM Workloads](https://sched.co/1txI4)**（LLMワークロードのオートスケーリング時のメトリクス収集と配信の最適化）<br>
+  Vincent Hou（Bloomberg）& Jiří Kremser（kedify.io）<br> 4月3日（木）• 17:30 - 18:00
+- **[The State of Prometheus and OpenTelemetry Interoperability](https://sched.co/1txIA)**（PrometheusとOpenTelemetryの相互運用性の現状）<br>
+  Arthur Sens（Grafana）& Juraj Michálek（Swiss RE）<br> 4月4日（金）• 11:45 - 12:15
+- **[Fluent Bit v4: A Decade of Innovation and What's Next](https://sched.co/1ue2s)**（Fluent Bit v4：10年のイノベーションとこれから）<br>
+  Eduardo Silva（Chronosphere）<br> 4月4日（金）• 13:45 - 14:15
+- **[Smooth Scaling With the OpAMP Supervisor: Managing Thousands of OpenTelemetry Collectors](https://sched.co/1txID)**（OpAMP Supervisorによるスムーズなスケーリング：数千のOpenTelemetry Collectorを管理する）<br>
+  Evan Bradley（Dynatrace）& Andy Keller（observIQ）<br> 4月4日（金）• 13:45 - 14:15
+- **[Evolving OpenID Connect and Observability in Keycloak](https://sched.co/1td1c)**（KeycloakにおけるOpenID Connectとオブザーバビリティの進化）<br>
+  Ryan Emerson（Red Hat）& Takashi Norimatsu（Hitachi）<br> 4月4日（金）• 14:30 - 15:00
+- **[How To Supercharge AI/ML Observability With OpenTelemetry and Fluent Bit](https://sched.co/1txAi)**（OpenTelemetryとFluent BitでAI/MLオブザーバビリティを強化する方法）<br>
+  Celalettin Calis（Chronosphere）<br> 4月4日（金）• 15:15 - 15:45
+
+## Observability Day {#observability-day}
+
+[Observability Day][] は、クラウドネイティブなオブザーバビリティプロジェクトにおける協業、議論、知識共有を促進するイベントです。
+このイベントは、2025年4月1日（火）の9:00から17:25まで開催されます。
+OpenTelemetryに関するセッションも複数予定されています。
+
+> [!IMPORTANT] 参加に関する重要な注意事項
+>
+> **Observability Day** に参加するには、_オールアクセス_ パスが必要です。
+> 詳細は [KubeConの参加登録][registration] をご覧ください。
+
+- **[Sponsored Keynote: The Future of Observability: Trends, AI, and New Relic's Vision for a Smarter Stack](https://sched.co/1u5jm)**（オブザーバビリティの未来：トレンド、AI、そしてNew Relicが描くよりスマートなスタック）<br>
+  Harry Kimpel（New Relic）<br> 4月1日（火）• 10:00 - 10:05
+- **[Sponsored Keynote: Fluent Bit vs. OpenTelemetry Collector - Why Not Both?](https://sched.co/1u5jp)**（Fluent Bit vs. OpenTelemetry Collector - 両方使えばいいのでは？）<br>
+  Paige Cruz（Chronosphere）<br> 4月1日（火）• 10:10 - 10:15
+- **[Observability by Design: Leveraging OpenTelemetry Weaver To Take Control of Your Observability](https://sched.co/1u5jy)**（設計からのオブザーバビリティ：OpenTelemetry Weaverを活用してオブザーバビリティを自在にコントロールする）<br>
+  Josh Suereth（Google）& Laurent Querel（F5）<br> 4月1日（火）• 11:20 - 11:45
+- **[Encrypted Telemetry in Transit](https://sched.co/1u5k4)**（転送中のテレメトリーの暗号化）<br>
+  Jason Plumb（Splunk）<br> 4月1日（火）• 12:55 - 13:20
+- **[From Sampling To Full Visibility: Scaling Tracing To Trillions of Spans](https://sched.co/1u5k7)**（サンプリングからフルビジビリティへ：数兆のスパンへとトレーシングをスケールする）<br>
+  Sonam Gupta（SigLens）<br> 4月1日（火）• 12:55 - 13:20
+- **[OpenTelemetry at Delivery Hero: The Good, the Bad and the Vendor-Agnostic](https://sched.co/1u5kD)**（Delivery HeroにおけるOpenTelemetry：良いところ、悪いところ、そしてベンダー非依存）<br>
+  Elena Kovalenko（Delivery Hero）<br> 4月1日（火）• 13:30 - 13:55
+- **[From Splunk To OTel: Scaling Observability at MSCI With a Four-Person Team](https://sched.co/1u5kP)**（SplunkからOTelへ：4人のチームでMSCIのオブザーバビリティをスケールする）<br>
+  Aftab Khan & Zach Arnold（MSCI）<br> 4月1日（火）• 14:40 - 15:05
+- **[Customize Your Own OpenTelemetry Collector: An Introduction To OCB](https://sched.co/1u5kV)**（自分だけのOpenTelemetry Collectorをカスタマイズ：OCB入門）<br>
+  Evan Bradley（Dynatrace）& Pablo Baeyens（Datadog）<br> 4月1日（火）• 15:20 - 15:45
+- **[The Art and Craft of No-touch Instrumentation](https://sched.co/1u5kS)**（ノータッチ計装の技法）<br>
+  Michele Mancioppi（Dash0）<br> 4月1日（火）• 15:20 - 15:45
+- **[OTel-y Oops: Learning From Our Observability Blunders](https://sched.co/1u5kY)**（OTelのしくじり：オブザーバビリティの失敗から学ぶ）<br>
+  Joe Stephenson & Rodney Karemba（Akamai Technologies）<br> 4月1日（火）• 15:55 - 16:20
+- **[Beyond the Ephemeral: Mastering Serverless Metrics at Scale With Shopify](https://sched.co/1u5kh)**（エフェメラルの先へ：Shopifyにおけるサーバーレスメトリクスの大規模運用）<br>
+  Pedro Tanaka（Shopify）<br> 4月1日（火）• 16:30 - 16:55
+- **[The State of OpenTelemetry Profiling](https://sched.co/1u5ke)**（OpenTelemetry Profilingの現状）<br>
+  Damien Mathieu（Elastic）& Felix Geisendoerfer（Datadog）<br> 4月1日（火）• 16:30 - 16:55
+- **[⚡ Lightning Talk: Unlocking Customer-Centric Observability: A Case Study of OpenTelemetry To Reduce MTTD < 3 Mins](https://sched.co/1u5kn)**（顧客中心のオブザーバビリティを実現する：MTTDを3分未満に短縮したOpenTelemetry事例）<br>
+  Kokilavani Kathiresan（Intuit）<br> 4月1日（火）• 17:00 - 17:10
+- **[⚡ Lightning Talk: Who Are You? Solving the Container ID Resolution With Cgroupv2](https://sched.co/1u5kk)**（あなたは誰？Cgroupv2によるコンテナID解決）<br>
+  Vincent Boulineau（Datadog）<br> 4月1日（火）• 17:00 - 17:10
+- **[⚡ Lightning Talk: Empowering OpenTelemetry Users With the OTTL Playground: Simplified Data Transformation and Testing](https://sched.co/1u5kt)**（OTTL Playgroundでユーザーを支援する：データ変換とテストの簡素化）<br>
+  Edmo Vamerlatti Costa（Elastic）<br> 4月1日（火）• 17:15 - 17:25
+- **[⚡ Lightning Talk: From HAR To OpenTelemetry Trace: Redefining Your Observability](https://sched.co/1u5kq)**（HARからOpenTelemetryトレースへ：オブザーバビリティを再定義する）<br>
+  Antonio Jimenez Martinez（Cisco ThousandEyes）<br> 4月1日（火）• 17:15 - 17:25
+
+## OpenTelemetry Observatoryブース {#opentelemetry-observatory}
+
+[Splunk][] の提供による **OpenTelemetry Observatoryブース**（Expo Hall内[^1]）に、ぜひお立ち寄りください。
+OpenTelemetryコミュニティのメンバーやメンテナーによる、気軽な会話やミートアップ、その他のディスカッションの場です。
+
+[^1]: Observatoryブースはイベントマップ上で「Splunk activation zone」と表示されている場合があります。
+
+**アクティビティスケジュール** については、[OTel Observatoryカレンダー][OTel Observatory Calendar] をご覧ください。
+ディスカッションや短いプレゼンテーションへの参加やリードをご希望の方は、[OpenTelemetry End User Working Group][] までご連絡ください。
+
+また、OpenTelemetryの導入、実装、利用に関するご意見やフィードバックを共有していただくことで、OTelの改善にご協力いただけます。
+いただいたコメントから適宜アクションアイテムを作成し、カンファレンス後に [#otel-sig-end-user][] で結果を公開します。
+
+{{< comment >}}
+
+<!-- To join a feedback session, book online below. All times in Central European
+Time (CET).
+
+- **March 20th, 11:45-12:45:**
+  [End User Feedback Session - .NET & .NET Auto-Instrumentation](https://calendly.com/euwg-user-feedback-session/end-user-feedback-session?month=2024-03)
+- **March 20th, 15:00-16:00:**
+  [End User Feedback Session - JavaScript](https://calendly.com/euwg-user-feedback-session/end-user-feedback-session-javascript?month=2024-03)
+- **March 21st, 11:00-12:00:**
+  [End User Feedback Session - Semantic Conventions](https://calendly.com/euwg-user-feedback-session/end-user-feedback-session-semantic-conventions?month=2024-03)
+- **March 21st, 14:30-15:30:**
+  [End User Feedback Session - Comms (website, docs)](https://calendly.com/euwg-user-feedback-session/end-user-feedback-session-comms?month=2024-03)
+- **March 21st, 15:00-16:00:**
+  [End User Feedback Session - Profiling](https://calendly.com/euwg-user-feedback-session/end-user-feedback-session-profiling?month=2024-03)
+- **March 21st, 15:30-16:30:**
+  [End User Feedback Session - Client-side](https://calendly.com/euwg-user-feedback-session/end-user-feedback-session-client-side)
+
+A maximum of 5 participants will join one SIG maintainer to provide feedback for
+that SIG. Sessions will be recorded and posted on the
+[OTel YouTube channel](https://youtube.com/@otel-official).
+-->
+
+{{< /comment >}}
+
+{{< comment >}}
+
+<!-- Back by popular demand! We'll be recording
+[Humans of OTel interviews](/blog/2023/humans-of-otel/) at the OTel Observatory.
+If you'd like to share your experiences as an OpenTelemetry practitioner or
+maintainer,
+[sign up for an interview session](https://calendly.com/otel-euwg/humans-of-otel).
+-->
+
+{{< /comment >}}
+
+## ご参加をお待ちしています {#join-us}
+
+OpenTelemetryの話を聞いて、学び、そして参加しましょう。
+ロンドンでお会いしましょう！
+
+[#otel-sig-end-user]: https://cloud-native.slack.com/archives/C01RT3MSWGZ
+[KubeCon + CloudNativeCon Europe]: <{{% param eventUrl %}}?{{% param queryParams %}}>
+[Observability Day]: <{{% param eventUrl %}}co-located-events/observability-day/>
+[OpenTelemetry End User Working Group]: https://cloud-native.slack.com/archives/C01RT3MSWGZ
+[OTel Observatory Calendar]: https://calendar.google.com/calendar/embed?src=c_6b6b343737cc9bbf0393ba40c101d6b017514751e66951c9890d089eedd78a37@group.calendar.google.com&mode=WEEK&dates=20250331/20250406
+[registration]: <{{% param eventUrl %}}register/?{{% param queryParams %}}>
+[Splunk]: https://www.splunk.com/


### PR DESCRIPTION
## Summary

Translates `content/en/blog/2025/kubecon-eu.md` into Japanese as `content/ja/blog/2025/kubecon-eu.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10700--opentelemetry.netlify.app/ja/blog/2025/kubecon-eu/
- **English (canonical):** https://opentelemetry.io/blog/2025/kubecon-eu/

<!-- preview-section-end -->
