### PR TITLE
[ja] update translation of content/en/docs/demo/docker-deployment.md

### DIFF
--- a/content/ja/docs/demo/docker-deployment.md
+++ b/content/ja/docs/demo/docker-deployment.md
@@ -2,8 +2,7 @@
 title: Docker デプロイ
 linkTitle: Docker
 aliases: [docker_deployment]
-default_lang_commit: c1e141558ab36cc1ab9f864728e4665e272ac131
-drifted_from_default: true
+default_lang_commit: 953ac190ae2ae3a67f19f85ca7ce5f9efb990deb
 cSpell:ignore: otlphttp spanmetrics tracetest tracetesting
 ---
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/demo/docker-deployment.md` to match the latest English source at
`content/en/docs/demo/docker-deployment.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff was a trivial whitespace-only change (extra space in a numbered list item),
so the Japanese content required no translation changes — only frontmatter bookkeeping.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.


<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10714--opentelemetry.netlify.app/ja/docs/demo/docker-deployment/
- **English (canonical):** https://opentelemetry.io/docs/demo/docker-deployment/

_(deploy preview may take a few minutes to build.)_
<!-- preview-section-end -->
