### PR TITLE
Add Profiles endpoint to declarative config

### DIFF
--- a/content/en/docs/languages/sdk-configuration/declarative-configuration.md
+++ b/content/en/docs/languages/sdk-configuration/declarative-configuration.md
@@ -147,6 +147,7 @@ config when using `otlp_http`:
 | Traces             | `${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:-http://localhost:4318/v1/traces}`   |
 | Metrics            | `${OTEL_EXPORTER_OTLP_METRICS_ENDPOINT:-http://localhost:4318/v1/metrics}` |
 | Logs               | `${OTEL_EXPORTER_OTLP_LOGS_ENDPOINT:-http://localhost:4318/v1/logs}`       |
+| Profiles           | `${OTEL_EXPORTER_OTLP_LOGS_ENDPOINT:-http://localhost:4318/v1/profiles}`   |
 
 ## gRPC Exporter
 

--- a/content/en/docs/languages/sdk-configuration/declarative-configuration.md
+++ b/content/en/docs/languages/sdk-configuration/declarative-configuration.md
@@ -147,7 +147,7 @@ config when using `otlp_http`:
 | Traces             | `${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:-http://localhost:4318/v1/traces}`   |
 | Metrics            | `${OTEL_EXPORTER_OTLP_METRICS_ENDPOINT:-http://localhost:4318/v1/metrics}` |
 | Logs               | `${OTEL_EXPORTER_OTLP_LOGS_ENDPOINT:-http://localhost:4318/v1/logs}`       |
-| Profiles           | `${OTEL_EXPORTER_OTLP_LOGS_ENDPOINT:-http://localhost:4318/v1/profiles}`   |
+| Profiles           | `${OTEL_EXPORTER_OTLP_PROFILES_ENDPOINT:-http://localhost:4318/v1/profiles}`   |
 
 ## gRPC Exporter
 


### PR DESCRIPTION

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] ~~This PR has content that I did not fully write myself.~~
  - [ ] ~~I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).~~
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

Profiles is a signal in OTel, like Traces, Metrics and Logs. Therefore it should be named alongside these signals.
