### PR TITLE
[ja] update translation of content/en/docs/zero-code/obi/setup/kubernetes-helm.md

### DIFF
--- a/content/ja/docs/zero-code/obi/setup/kubernetes-helm.md
+++ b/content/ja/docs/zero-code/obi/setup/kubernetes-helm.md
@@ -3,8 +3,7 @@ title: HelmでKubernetesにOBIをデプロイする
 linkTitle: Helm チャート
 description: KubernetesにHelmチャートとしてOBIをデプロイする方法を学ぶ
 weight: 2
-default_lang_commit: c88a006471f039334aed7990736e089a62b33f94
-drifted_from_default: true
+default_lang_commit: ad6f8d1e5179464d22f7e9cdf9fe86bc53f550e5
 ---
 
 > [!NOTE]


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/obi/setup/kubernetes-helm.md` to match the latest English source at
`content/en/docs/zero-code/obi/setup/kubernetes-helm.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff since the last sync was whitespace-only (a blank line addition in the TOC section), which the Japanese file already had. Only frontmatter bookkeeping was needed.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10722--opentelemetry.netlify.app/ja/docs/zero-code/obi/setup/kubernetes-helm/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/obi/setup/kubernetes-helm/

_(deploy preview status: pending. The URLs will work once Netlify finishes building.)_
<!-- preview-section-end -->
