### PR TITLE
[ja] update translation of content/en/docs/collector/extend/custom-component/connector/index.md

### DIFF
--- a/content/ja/docs/collector/extend/custom-component/connector/index.md
+++ b/content/ja/docs/collector/extend/custom-component/connector/index.md
@@ -5,8 +5,7 @@ aliases:
   - /docs/collector/build-connector
   - /docs/collector/building/connector
 weight: 200
-default_lang_commit: 8013aa5f0aae284fa343311981625be6dbb25e5b # patched
-drifted_from_default: true
+default_lang_commit: ad6f8d1e5179464d22f7e9cdf9fe86bc53f550e5
 # prettier-ignore
 cSpell:ignore: debugexporter exampleconnector gomod gord Jaglowski mapstructure otlpreceiver pdata pmetric ptrace servicegraph spanmetrics struct uber
 ---


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/collector/extend/custom-component/connector/index.md` to match the latest English source at
`content/en/docs/collector/extend/custom-component/connector/index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The only English-side change since the previous `default_lang_commit` (`8013aa5f…`, patched) was a URL update
(`observiq.com/…` → `bindplane.com/…`) which was already applied by a prior targeted patch. This PR therefore
only updates the i18n bookkeeping: sets `default_lang_commit` to the current HEAD and removes the `drifted_from_default` line.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10724--opentelemetry.netlify.app/ja/docs/collector/extend/custom-component/connector/
- **English (canonical):** https://opentelemetry.io/docs/collector/extend/custom-component/connector/

_(deploy preview may still be building. The URLs will work once Netlify finishes.)_
<!-- preview-section-end -->
