### PR TITLE
feat: Add openai-go and kafka-go compile time instrumentation registry entries

### DIFF
--- a/.lycheecache
+++ b/.lycheecache
@@ -3083,7 +3083,9 @@ https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tree/
 https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tree/main/instrumentation/database/sql,206,1784442929
 https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tree/main/instrumentation/github.com/anthropics/anthropic-sdk-go,200,1784625647
 https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tree/main/instrumentation/github.com/gin-gonic/gin,206,1784442921
+https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tree/main/instrumentation/github.com/openai/openai-go,200,1784791245
 https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tree/main/instrumentation/github.com/redis/go-redis/v9,206,1784442922
+https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tree/main/instrumentation/github.com/segmentio/kafka-go,200,1784791245
 https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tree/main/instrumentation/github.com/sirupsen/logrus,206,1784442927
 https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tree/main/instrumentation/go.mongodb.org/mongo-driver/mongo,206,1784442928
 https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tree/main/instrumentation/google.golang.org/grpc,206,1784442926
@@ -5588,6 +5590,7 @@ https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/rec
 https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/yanggrpcreceiver,200,1784356178
 https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver,200,1784442867
 https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver,200,1784442867
+https://pkg.go.dev/github.com/openai/openai-go,200,1784791245
 https://pkg.go.dev/github.com/openclarity/apiclarity/plugins/otel-collector/apiclarityexporter,200,1784285061
 https://pkg.go.dev/github.com/opencontainers/cgroups@v0.0.6#CpuUsage,200,1784701518
 https://pkg.go.dev/github.com/r0mdau/fluentforwardexporter,200,1784960540

--- a/data/registry/instrumentation-go-compile-time-kafka-go.yml
+++ b/data/registry/instrumentation-go-compile-time-kafka-go.yml
@@ -1,0 +1,20 @@
+# cSpell:ignore segmentio
+title:
+  OpenTelemetry Go Compile-Time Auto-Instrumentation for `segmentio/kafka-go`
+registryType: instrumentation
+language: go
+tags:
+  - go
+  - instrumentation
+  - compile-time
+  - auto-instrumentation
+  - kafka
+license: Apache 2.0
+description: >
+  Go compile-time auto-instrumentation plugin for the [`segmentio/kafka-go`
+  package](https://pkg.go.dev/github.com/segmentio/kafka-go).
+authors:
+  - name: OpenTelemetry Authors
+urls:
+  repo: https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tree/main/instrumentation/github.com/segmentio/kafka-go
+createdAt: 2026-07-08

--- a/data/registry/instrumentation-go-compile-time-openai-go.yml
+++ b/data/registry/instrumentation-go-compile-time-openai-go.yml
@@ -1,0 +1,19 @@
+# cSpell:ignore openai
+title: OpenTelemetry Go Compile-Time Auto-Instrumentation for `openai/openai-go`
+registryType: instrumentation
+language: go
+tags:
+  - go
+  - instrumentation
+  - compile-time
+  - auto-instrumentation
+  - openai
+license: Apache 2.0
+description: >
+  Go compile-time auto-instrumentation plugin for the [`openai/openai-go`
+  package](https://pkg.go.dev/github.com/openai/openai-go).
+authors:
+  - name: OpenTelemetry Authors
+urls:
+  repo: https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tree/main/instrumentation/github.com/openai/openai-go
+createdAt: 2026-07-08


### PR DESCRIPTION
- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

Adds two new OpenTelemetry Go compile-time instrumentation entries to the OpenTelemetry Registry:

* [`github.com/openai/openai-go`](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tree/main/instrumentation/github.com/openai/openai-go)
* [`github.com/segmentio/kafka-go`](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tree/main/instrumentation/github.com/segmentio/kafka-go)
