### PR TITLE
[CI,specs] pick-branch: directly executable command, dry-run-agnostic issue outcome

### DIFF
--- a/.github/workflows/update-semconv-integration-branch.yml
+++ b/.github/workflows/update-semconv-integration-branch.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Pick integration branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node scripts/gh/specs/pick-branch/cli.mjs --spec semconv
+        run: scripts/gh/specs/pick-branch.mjs --spec semconv
 
       - name: Checkout or create branch
         run: |

--- a/.github/workflows/update-spec-integration-branch.yml
+++ b/.github/workflows/update-spec-integration-branch.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Pick integration branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node scripts/gh/specs/pick-branch/cli.mjs --spec otel
+        run: scripts/gh/specs/pick-branch.mjs --spec otel
 
       - name: Checkout or create branch
         run: |

--- a/content/en/site/build/ci-workflows.md
+++ b/content/en/site/build/ci-workflows.md
@@ -400,7 +400,7 @@ into the release PR.
   https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/workflows/update-semconv-integration-branch.yml
 
 Both workflows delegate the "pick the mode, version and branch" step to a shared
-Node helper, [scripts/gh/specs/pick-branch/cli.mjs][]. The helper:
+Node helper, [scripts/gh/specs/pick-branch.mjs][]. The helper:
 
 - Selects the run's `MODE`: `dev` while the version pinned on main is the latest
   upstream release, `release` once a newer release exists.
@@ -408,8 +408,8 @@ Node helper, [scripts/gh/specs/pick-branch/cli.mjs][]. The helper:
 - Opens a tracking issue (label `<slug>-integration-warning`, deduplicated) when
   it detects problems such as multiple stale integration branches.
 
-[scripts/gh/specs/pick-branch/cli.mjs]:
-  https://github.com/open-telemetry/opentelemetry.io/tree/main/scripts/gh/specs/pick-branch
+[scripts/gh/specs/pick-branch.mjs]:
+  https://github.com/open-telemetry/opentelemetry.io/blob/main/scripts/gh/specs/pick-branch.mjs
 
 The final step, [scripts/gh/specs/create-or-finalize-pr.mjs][], creates or
 finalizes the PR as `MODE` calls for: in dev mode it opens the draft integration
@@ -437,8 +437,8 @@ use your local `gh` credentials; if `GITHUB_ENV` is unset, pick-branch prints
 create-or-finalize-pr run. Try it:
 
 ```sh
-node scripts/gh/specs/pick-branch/cli.mjs --spec otel
-node scripts/gh/specs/pick-branch/cli.mjs --spec semconv --no-dry-run
+scripts/gh/specs/pick-branch.mjs --spec otel
+scripts/gh/specs/pick-branch.mjs --spec semconv --no-dry-run
 scripts/gh/specs/create-or-finalize-pr.mjs --help
 ```
 

--- a/scripts/gh/specs/pick-branch.mjs
+++ b/scripts/gh/specs/pick-branch.mjs
@@ -40,14 +40,14 @@ function main() {
     );
   } else {
     console.log(
-      '  Will append VERSION/BRANCH to $GITHUB_ENV (if set) and may create a tracking issue via `gh`. Pass --dry-run to skip writes.',
+      '  Will append MODE/VERSION/BRANCH to $GITHUB_ENV (if set) and may create a tracking issue via `gh`. Pass --dry-run to skip writes.',
     );
   }
 
   const githubEnv = dryRun ? null : process.env.GITHUB_ENV || null;
   if (!dryRun && !githubEnv) {
     console.log(
-      '[note] GITHUB_ENV is unset; VERSION/BRANCH will be printed to stdout only.',
+      '[note] GITHUB_ENV is unset; MODE/VERSION/BRANCH will be printed to stdout only.',
     );
   }
 

--- a/scripts/gh/specs/pick-branch.mjs
+++ b/scripts/gh/specs/pick-branch.mjs
@@ -1,39 +1,18 @@
 #!/usr/bin/env node
-// CLI entry point: pick the integration branch / version for a spec workflow.
-//
-// Usage:
-//   node scripts/gh/specs/pick-branch/cli.mjs [--spec <id>] [--[no-]dry-run]
-//
-// Flags:
-//   -s, --spec <id>   One of the keys defined in SPECS (e.g. `otel`,
-//                     `semconv`). Defaults to `otel`. Determines the upstream
-//                     repo and branch slug.
-//       --dry-run     Skip side-effecting operations: do NOT write to
-//                     $GITHUB_ENV, do NOT call `gh label create`/`gh issue
-//                     create`. Read-only `git`/`gh` calls still run.
-//       --no-dry-run  Force writes even when running locally.
-//                     Default: dry-run is ON unless GITHUB_ACTIONS=true.
-//   -h, --help        Print usage and exit.
-//
-// Outputs MODE (dev|release), VERSION and BRANCH; see cliUsage() in index.mjs.
-//
-// Required environment when writes are enabled:
-//   GH_TOKEN          Used by `gh`; needs `issues: write` for issue creation.
-//   GITHUB_ENV        Path written by GitHub Actions. Optional locally; if
-//                     unset, MODE/VERSION/BRANCH are written to stdout only.
+// Pick the integration branch, version, and MODE (dev vs release) for a spec
+// workflow run, and write them to $GITHUB_ENV. Run with --help for usage.
 
 import { execFileSync, spawnSync } from 'node:child_process';
 import { appendFileSync } from 'node:fs';
 
 import {
   buildIssueBody,
-  cliUsage,
   computeIntegrationVersion,
   ensureWarningIssueOpen,
   formatGithubEnv,
   parseCliArgs,
   SPECS,
-} from './index.mjs';
+} from './pick-branch/index.mjs';
 
 main();
 
@@ -170,4 +149,29 @@ function actionsRunUrl() {
 function fatal(msg) {
   process.stderr.write(`${msg}\n`);
   process.exit(1);
+}
+
+/** Help text for `--help`. */
+function cliUsage() {
+  return [
+    'Pick the integration-branch MODE, VERSION, and BRANCH for a spec',
+    'workflow run and write them to $GITHUB_ENV (or stdout when GITHUB_ENV',
+    'is unset). MODE is `release` when the latest upstream release is newer',
+    'than the version pinned on main, else `dev`. Opens a tracking issue on',
+    'warnings.',
+    '',
+    'Usage: scripts/gh/specs/pick-branch.mjs \\',
+    '         [--spec <otel|semconv>] [--[no-]dry-run]',
+    '',
+    'Options:',
+    '  -s, --spec <otel|semconv>  Selects the upstream spec (default: otel).',
+    '      --dry-run              Skip writes (default when run locally).',
+    '      --no-dry-run           Perform writes (default under GitHub Actions).',
+    '  -h, --help                 Show this help.',
+    '',
+    'Environment:',
+    '  GH_TOKEN    Used by `gh`; needs `issues: write` when writes are enabled.',
+    '  GITHUB_ENV  Output path (set by GitHub Actions). Optional locally; if',
+    '              unset, MODE/VERSION/BRANCH are written to stdout only.',
+  ].join('\n');
 }

--- a/scripts/gh/specs/pick-branch/cli-args.test.mjs
+++ b/scripts/gh/specs/pick-branch/cli-args.test.mjs
@@ -1,7 +1,7 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { parseCliArgs, cliUsage } from './index.mjs';
+import { parseCliArgs } from './index.mjs';
 
 describe('pick-branch: CLI args', () => {
   test('defaults: spec=otel, dry-run on when not in Actions', () => {
@@ -71,12 +71,5 @@ describe('pick-branch: CLI args', () => {
 
   test('--spec without value throws', () => {
     assert.throws(() => parseCliArgs(['--spec'], {}), /Missing value/);
-  });
-
-  test('cliUsage mentions both specs and the dry-run flags', () => {
-    const text = cliUsage();
-    assert.match(text, /otel\|semconv/);
-    assert.match(text, /--dry-run/);
-    assert.match(text, /--no-dry-run/);
   });
 });

--- a/scripts/gh/specs/pick-branch/index.mjs
+++ b/scripts/gh/specs/pick-branch/index.mjs
@@ -235,11 +235,12 @@ export function buildIssueBody({ warnings, repo, abbr, runUrl = null }) {
  */
 
 /**
- * @typedef {Object} EnsureIssueResult
- * @property {'skipped-existing' | 'created' | 'would-create'} action
- *   - `skipped-existing`: an open issue with the label already exists.
- *   - `created`: a new issue was created.
- *   - `would-create`: dry-run; no issue created.
+ * Outcome of an {@link ensureWarningIssueOpen} run. In dry-run mode, the
+ * outcome that a write run would have produced.
+ *
+ * @typedef {'created' | 'unchanged'} IssueOutcome
+ *   - `created`: a new issue was opened (with its label ensured first).
+ *   - `unchanged`: an open issue with the label already exists.
  */
 
 /**
@@ -257,7 +258,7 @@ export function buildIssueBody({ warnings, repo, abbr, runUrl = null }) {
  *   Synchronous `gh` runner. Receives the argv (without `gh`) and returns
  *   `{ stdout, status }`.
  * @param {(msg: string) => void} [input.log]
- * @returns {EnsureIssueResult}
+ * @returns {IssueOutcome}
  */
 export function ensureWarningIssueOpen({
   title,
@@ -285,17 +286,15 @@ export function ensureWarningIssueOpen({
     );
   }
   if (JSON.parse(list.stdout || '[]').length > 0) {
-    log(`Warning issue with label "${label}" already open; skipping.`);
-    return { action: 'skipped-existing' };
+    log(`Warning issue with label "${label}" is already open; nothing to do.`);
+    return 'unchanged';
   }
 
+  const prefix = dryRun ? '[dry-run] ' : '';
+  log(`${prefix}Opening an issue titled "${title}".`);
   if (dryRun) {
-    log(
-      `[dry-run] Would open an issue with label "${label}" (no existing open issue found).`,
-    );
-    log(`[dry-run] Title: ${title}`);
     log(`[dry-run] Body:\n${body}`);
-    return { action: 'would-create' };
+    return 'created';
   }
 
   // Make sure the label exists; ignore failure if it already does.
@@ -324,7 +323,9 @@ export function ensureWarningIssueOpen({
       `gh issue create failed (status ${create.status}): ${create.stdout}`,
     );
   }
-  return { action: 'created' };
+  const url = create.stdout.trim();
+  if (url) log(url);
+  return 'created';
 }
 
 /**

--- a/scripts/gh/specs/pick-branch/index.mjs
+++ b/scripts/gh/specs/pick-branch/index.mjs
@@ -1,8 +1,8 @@
-// Pure library for computing the VERSION and BRANCH env vars for the
+// Pure library for computing the MODE, VERSION, and BRANCH env vars for the
 // "Update <repo> integration branch" family of workflows.
 //
-// Side-effecting concerns (subprocess invocation, $GITHUB_ENV writes, opening
-// issues, argv parsing) live in ./cli.mjs.
+// Side-effecting concerns (subprocess invocation, argv/env handling) live in
+// the command file, ../pick-branch.mjs.
 //
 // cSpell:ignore dedup
 
@@ -329,9 +329,9 @@ export function ensureWarningIssueOpen({
 }
 
 /**
- * Parse the CLI argv for `cli.mjs`. Pure: throws on invalid input rather than
- * calling `process.exit`, and reads the GitHub Actions signal from an injected
- * env object.
+ * Parse the CLI argv for the spec workflow commands. Pure: throws on invalid
+ * input rather than calling `process.exit`, and reads the GitHub Actions
+ * signal from an injected env object.
  *
  * @param {string[]} argv  Argv tail (i.e. without `node` and the script path).
  * @param {Record<string, string|undefined>} [env]  Defaults to `process.env`.
@@ -400,29 +400,4 @@ export function parseCliArgs(argv, env = process.env) {
   }
 
   return { spec, dryRun, dryRunReason, help };
-}
-
-/**
- * Help text for `cli.mjs --help`.
- *
- * @returns {string}
- */
-export function cliUsage() {
-  const allowed = Object.keys(SPECS).join('|');
-  return [
-    'Pick the integration-branch version and mode for a spec workflow and',
-    'write MODE/VERSION/BRANCH to $GITHUB_ENV (or stdout when GITHUB_ENV is',
-    'unset). MODE is `release` when the latest upstream release is newer than',
-    'the version pinned on main, else `dev`. Opens a tracking issue on',
-    'warnings.',
-    '',
-    'Usage: node scripts/gh/specs/pick-branch/cli.mjs \\',
-    `         [--spec <${allowed}>] [--[no-]dry-run]`,
-    '',
-    'Options:',
-    `  -s, --spec <${allowed}>  Selects the upstream spec (default: otel).`,
-    '      --dry-run            Skip writes (default when run locally).',
-    '      --no-dry-run         Perform writes (default under GitHub Actions).',
-    '  -h, --help               Show this help.',
-  ].join('\n');
 }

--- a/scripts/gh/specs/pick-branch/issue.test.mjs
+++ b/scripts/gh/specs/pick-branch/issue.test.mjs
@@ -87,7 +87,7 @@ describe('pick-branch: ensureWarningIssueOpen', () => {
     );
     assert.ok(
       logs.some((m) => m.includes(ISSUE_URL)),
-      'the created issue URL is logged',
+      'created issue URL is logged',
     );
   });
 
@@ -103,15 +103,11 @@ describe('pick-branch: ensureWarningIssueOpen', () => {
       log: (m) => logs.push(m),
     });
     assert.equal(outcome, 'created');
-    assert.equal(
-      calls.length,
-      1,
-      'the read-only issue-list is the sole gh call',
-    );
+    assert.equal(calls.length, 1, 'read-only issue-list is the sole gh call');
     assert.deepEqual(calls[0].slice(0, 2), ['issue', 'list']);
     assert.ok(
       logs.some((m) => /\[dry-run\] Opening an issue/.test(m)),
-      'the dry-run log announces the issue that a write run would open',
+      'dry-run log announces the issue that a write run would open',
     );
   });
 
@@ -128,7 +124,7 @@ describe('pick-branch: ensureWarningIssueOpen', () => {
     });
     assert.equal(outcome, 'unchanged');
     assert.equal(calls.length, 1);
-    assert.equal(logs.length, 1, 'the no-op message is the sole log line');
+    assert.equal(logs.length, 1, 'no-op message is the sole log line');
     assert.match(logs[0], /already open; nothing to do/);
   });
 

--- a/scripts/gh/specs/pick-branch/issue.test.mjs
+++ b/scripts/gh/specs/pick-branch/issue.test.mjs
@@ -45,7 +45,7 @@ describe('pick-branch: ensureWarningIssueOpen', () => {
       log: (m) => logs.push(m),
     });
     assert.equal(outcome, 'unchanged');
-    assert.equal(calls.length, 1, 'only the issue-list call is made');
+    assert.equal(calls.length, 1, 'issue-list is the sole gh call');
     assert.deepEqual(calls[0].slice(0, 2), ['issue', 'list']);
     assert.match(logs[0], /already open; nothing to do/);
   });
@@ -103,7 +103,11 @@ describe('pick-branch: ensureWarningIssueOpen', () => {
       log: (m) => logs.push(m),
     });
     assert.equal(outcome, 'created');
-    assert.equal(calls.length, 1, 'only the read-only issue-list call runs');
+    assert.equal(
+      calls.length,
+      1,
+      'the read-only issue-list is the sole gh call',
+    );
     assert.deepEqual(calls[0].slice(0, 2), ['issue', 'list']);
     assert.ok(
       logs.some((m) => /\[dry-run\] Opening an issue/.test(m)),
@@ -124,7 +128,7 @@ describe('pick-branch: ensureWarningIssueOpen', () => {
     });
     assert.equal(outcome, 'unchanged');
     assert.equal(calls.length, 1);
-    assert.equal(logs.length, 1, 'only the no-op message is logged');
+    assert.equal(logs.length, 1, 'the no-op message is the sole log line');
     assert.match(logs[0], /already open; nothing to do/);
   });
 

--- a/scripts/gh/specs/pick-branch/issue.test.mjs
+++ b/scripts/gh/specs/pick-branch/issue.test.mjs
@@ -29,35 +29,39 @@ const ISSUE_INPUT = {
   body: 'body content',
 };
 
+const ISSUE_URL = 'https://github.com/open-telemetry/opentelemetry.io/issues/123';
+
 describe('pick-branch: ensureWarningIssueOpen', () => {
-  test('skips creation when an issue already exists', () => {
+  test('is a no-op when an issue is already open', () => {
     const { runGh, calls } = makeFakeGh({
       'issue list': { stdout: '[{"number":42}]', status: 0 },
     });
     const logs = [];
-    const result = ensureWarningIssueOpen({
+    const outcome = ensureWarningIssueOpen({
       ...ISSUE_INPUT,
       dryRun: false,
       runGh,
       log: (m) => logs.push(m),
     });
-    assert.equal(result.action, 'skipped-existing');
-    assert.equal(calls.length, 1, 'only the issue-list call should be made');
+    assert.equal(outcome, 'unchanged');
+    assert.equal(calls.length, 1, 'only the issue-list call is made');
     assert.deepEqual(calls[0].slice(0, 2), ['issue', 'list']);
-    assert.match(logs[0], /already open; skipping/);
+    assert.match(logs[0], /already open; nothing to do/);
   });
 
   test('creates issue (with label) when none exists', () => {
     const { runGh, calls } = makeFakeGh({
       'issue list': { stdout: '[]', status: 0 },
+      'issue create': { stdout: `${ISSUE_URL}\n`, status: 0 },
     });
-    const result = ensureWarningIssueOpen({
+    const logs = [];
+    const outcome = ensureWarningIssueOpen({
       ...ISSUE_INPUT,
       dryRun: false,
       runGh,
-      log: noLog,
+      log: (m) => logs.push(m),
     });
-    assert.equal(result.action, 'created');
+    assert.equal(outcome, 'created');
     assert.equal(calls.length, 3);
     assert.deepEqual(calls[0].slice(0, 2), ['issue', 'list']);
     assert.deepEqual(calls[1].slice(0, 3), [
@@ -80,6 +84,10 @@ describe('pick-branch: ensureWarningIssueOpen', () => {
       createArgs[createArgs.indexOf('--body') + 1],
       ISSUE_INPUT.body,
     );
+    assert.ok(
+      logs.some((m) => m.includes(ISSUE_URL)),
+      'the created issue URL is logged',
+    );
   });
 
   test('dry-run still checks but never creates', () => {
@@ -87,18 +95,18 @@ describe('pick-branch: ensureWarningIssueOpen', () => {
       'issue list': { stdout: '[]', status: 0 },
     });
     const logs = [];
-    const result = ensureWarningIssueOpen({
+    const outcome = ensureWarningIssueOpen({
       ...ISSUE_INPUT,
       dryRun: true,
       runGh,
       log: (m) => logs.push(m),
     });
-    assert.equal(result.action, 'would-create');
+    assert.equal(outcome, 'created');
     assert.equal(calls.length, 1, 'only the read-only issue-list call runs');
     assert.deepEqual(calls[0].slice(0, 2), ['issue', 'list']);
     assert.ok(
-      logs.some((m) => /\[dry-run\] Would open an issue/.test(m)),
-      'should log a "would open" message',
+      logs.some((m) => /\[dry-run\] Opening an issue/.test(m)),
+      'the dry-run log announces the issue that a write run would open',
     );
   });
 
@@ -107,18 +115,16 @@ describe('pick-branch: ensureWarningIssueOpen', () => {
       'issue list': { stdout: '[{"number":7}]', status: 0 },
     });
     const logs = [];
-    const result = ensureWarningIssueOpen({
+    const outcome = ensureWarningIssueOpen({
       ...ISSUE_INPUT,
       dryRun: true,
       runGh,
       log: (m) => logs.push(m),
     });
-    assert.equal(result.action, 'skipped-existing');
+    assert.equal(outcome, 'unchanged');
     assert.equal(calls.length, 1);
-    assert.ok(
-      !logs.some((m) => /Would open an issue/.test(m)),
-      'should not log "would open" when an issue exists',
-    );
+    assert.equal(logs.length, 1, 'only the no-op message is logged');
+    assert.match(logs[0], /already open; nothing to do/);
   });
 
   test('throws when gh issue list fails', () => {

--- a/scripts/gh/specs/pick-branch/issue.test.mjs
+++ b/scripts/gh/specs/pick-branch/issue.test.mjs
@@ -29,7 +29,8 @@ const ISSUE_INPUT = {
   body: 'body content',
 };
 
-const ISSUE_URL = 'https://github.com/open-telemetry/opentelemetry.io/issues/123';
+const ISSUE_URL =
+  'https://github.com/open-telemetry/opentelemetry.io/issues/123';
 
 describe('pick-branch: ensureWarningIssueOpen', () => {
   test('is a no-op when an issue is already open', () => {

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -14683,6 +14683,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-07-09T13:00:00Z"
   },
+  "https://github.com/open-telemetry/opentelemetry.io/blob/main/scripts/gh/specs/pick-branch.mjs": {
+    "StatusCode": 206,
+    "LastSeen": "2026-07-09T12:43:01.609549-04:00"
+  },
   "https://github.com/open-telemetry/opentelemetry.io/branches/all?query=semconv-integration": {
     "StatusCode": 206,
     "LastSeen": "2026-07-05T06:52:17.295664434Z"


### PR DESCRIPTION
- Follow-up to #10738: gives `pick-branch` the same command surface and result vocabulary as its `create-or-finalize-pr` sibling.
- Makes the helper a directly executable command, `scripts/gh/specs/pick-branch.mjs --spec otel|semconv` (was `node scripts/gh/specs/pick-branch/cli.mjs`); the usage text moves out of the lib into the command file, whose header now just points to `--help`.
- The warning-issue helper returns a dry-run-agnostic `created | unchanged` outcome (drops `would-create` and the `{action}` wrapper) and logs the created issue's URL.
- Updates the workflows and the maintainer docs to the new invocation.
- **Preview**: [CI workflows » Spec integration branches](https://deploy-preview-10739--opentelemetry.netlify.app/site/build/ci-workflows/#spec-integration-branches)