### PR TITLE
docs: document missing OTLP metrics exporter environment variables

### DIFF
--- a/content/en/docs/languages/sdk-configuration/otlp-exporter.md
+++ b/content/en/docs/languages/sdk-configuration/otlp-exporter.md
@@ -3,6 +3,7 @@ title: OTLP Exporter Configuration
 linkTitle: OTLP Exporter
 weight: 20
 aliases: [otlp-exporter-configuration]
+cSpell:ignore: lowmemory
 ---
 
 {{% include "env-var-note.md" %}}
@@ -283,3 +284,41 @@ Valid values are:
 - `grpc` to use OTLP/gRPC
 - `http/protobuf` to use OTLP/HTTP + protobuf
 - `http/json` to use OTLP/HTTP + JSON
+
+## Metrics configuration
+
+The following environment variables configure OTLP metrics exporter behaviors.
+
+### `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`
+
+Configures the exporter's aggregation temporality preference on the basis of
+instrument kind.
+
+**Default value:** `cumulative`
+
+**Example:** `export OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta`
+
+Valid values are:
+
+- `cumulative` to use cumulative aggregation temporality for all instrument
+  kinds.
+- `delta` to use delta aggregation temporality for Counter, Asynchronous
+  Counter, and Histogram, and cumulative for UpDownCounter and Asynchronous
+  UpDownCounter.
+- `lowmemory` to use delta aggregation temporality for Synchronous Counter and
+  Histogram, and cumulative for others.
+
+### `OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION`
+
+Configures the exporter's default aggregation for the Histogram instrument kind.
+
+**Default value:** `explicit_bucket_histogram`
+
+**Example:**
+`export OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION=base2_exponential_bucket_histogram`
+
+Valid values are:
+
+- `explicit_bucket_histogram` to use explicit bucket histogram aggregation.
+- `base2_exponential_bucket_histogram` to use base2 exponential bucket histogram
+  aggregation.


### PR DESCRIPTION
## Description

This PR documents two metrics-specific OTLP exporter environment variables that are defined in the OpenTelemetry Specification but were missing from the SDK configuration documentation.

### Added

- `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`
- `OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION`

The documentation includes:

- default values
- supported values
- usage examples

This change follows the repository localization policy by updating only the English source documentation.

Fixes #5095

---

**Note from the maintainers**: the required checklist below was missing from this PR description; we have re-added it. Please complete it -- see the comment on this PR.

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
