### PR TITLE
Link check: ignore github.com/search URLs

### DIFF
--- a/.htmltest.base.yml
+++ b/.htmltest.base.yml
@@ -74,8 +74,8 @@ IgnoreURLs: # list of regexes of paths or URLs to be ignored
   - ^https://www\.intersystems\.com
 
   # Ignore issue, discussion, and search links with query parameters, e.g.:
-  - ^https://github\.com/open-telemetry/opentelemetry\.io/issues\?q=
-  - ^https://github\.com/open-telemetry/opentelemetry\.io/discussions\?discussions_q=
+  - ^https://github\.com/open-telemetry/opentelemetry\.io/issues/?\?q=
+  - ^https://github\.com/open-telemetry/opentelemetry\.io/discussions/?\?discussions_q=
   - ^https://github\.com/search/?\?
 
   # Ignore Docsy-generated GitHub links for now, until

--- a/.htmltest.base.yml
+++ b/.htmltest.base.yml
@@ -77,9 +77,7 @@ IgnoreURLs: # list of regexes of paths or URLs to be ignored
   - ^https://github\.com/open-telemetry/opentelemetry\.io/issues\?q=
   - ^https://github\.com/open-telemetry/opentelemetry\.io/discussions\?discussions_q=
 
-  # GitHub code/issue-search links: /search is effectively sign-in-gated (429
-  # Too Many Requests for anonymous clients), so results can't be link-checked.
-  # Upstream specs link message definitions etc. via such search queries.
+  # GitHub search is sign-in-gated (429 for anonymous clients)
   - ^https://github\.com/search\?
 
   # Ignore Docsy-generated GitHub links for now, until

--- a/.htmltest.base.yml
+++ b/.htmltest.base.yml
@@ -77,6 +77,11 @@ IgnoreURLs: # list of regexes of paths or URLs to be ignored
   - ^https://github\.com/open-telemetry/opentelemetry\.io/issues\?q=
   - ^https://github\.com/open-telemetry/opentelemetry\.io/discussions\?discussions_q=
 
+  # GitHub code/issue-search links: /search is effectively sign-in-gated (429
+  # Too Many Requests for anonymous clients), so results can't be link-checked.
+  # Upstream specs link message definitions etc. via such search queries.
+  - ^https://github\.com/search\?
+
   # Ignore Docsy-generated GitHub links for now, until
   # https://github.com/google/docsy/issues/1432 is fixed
   - ^https?://github\.com/.*?/.*?/(new/|edit/|issues/new\?) # view-page, edit-source etc

--- a/.htmltest.base.yml
+++ b/.htmltest.base.yml
@@ -73,12 +73,10 @@ IgnoreURLs: # list of regexes of paths or URLs to be ignored
   # https://github.com/open-telemetry/semantic-conventions/pull/2069
   - ^https://www\.intersystems\.com
 
-  # Ignore issues and discussions with query parameters, e.g.:
+  # Ignore issue, discussion, and search links with query parameters, e.g.:
   - ^https://github\.com/open-telemetry/opentelemetry\.io/issues\?q=
   - ^https://github\.com/open-telemetry/opentelemetry\.io/discussions\?discussions_q=
-
-  # GitHub search is sign-in-gated (429 for anonymous clients)
-  - ^https://github\.com/search\?
+  - ^https://github\.com/search/?\?
 
   # Ignore Docsy-generated GitHub links for now, until
   # https://github.com/google/docsy/issues/1432 is fixed

--- a/lychee.base.toml
+++ b/lychee.base.toml
@@ -63,8 +63,6 @@ exclude = [
   '^https://www\.intersystems\.com',
   '^https://github\.com/open-telemetry/opentelemetry\.io/issues\?q=',
   '^https://github\.com/open-telemetry/opentelemetry\.io/discussions\?discussions_q=',
-
-  # GitHub search is sign-in-gated (429 for anonymous clients)
   '^https://github\.com/search\?',
 
   # Docsy-generated GitHub edit/new/view-source links

--- a/lychee.base.toml
+++ b/lychee.base.toml
@@ -63,7 +63,7 @@ exclude = [
   '^https://www\.intersystems\.com',
   '^https://github\.com/open-telemetry/opentelemetry\.io/issues\?q=',
   '^https://github\.com/open-telemetry/opentelemetry\.io/discussions\?discussions_q=',
-  '^https://github\.com/search\?',
+  '^https://github\.com/search/?\?',
 
   # Docsy-generated GitHub edit/new/view-source links
   '^https?://github\.com/.*?/.*?/(new/|edit/|issues/new\?)',

--- a/lychee.base.toml
+++ b/lychee.base.toml
@@ -61,8 +61,8 @@ exclude = [
   '^https://hydrolix\.io/',
   '^https://oatpp\.io',
   '^https://www\.intersystems\.com',
-  '^https://github\.com/open-telemetry/opentelemetry\.io/issues\?q=',
-  '^https://github\.com/open-telemetry/opentelemetry\.io/discussions\?discussions_q=',
+  '^https://github\.com/open-telemetry/opentelemetry\.io/issues/?\?q=',
+  '^https://github\.com/open-telemetry/opentelemetry\.io/discussions/?\?discussions_q=',
   '^https://github\.com/search/?\?',
 
   # Docsy-generated GitHub edit/new/view-source links

--- a/lychee.base.toml
+++ b/lychee.base.toml
@@ -64,6 +64,9 @@ exclude = [
   '^https://github\.com/open-telemetry/opentelemetry\.io/issues\?q=',
   '^https://github\.com/open-telemetry/opentelemetry\.io/discussions\?discussions_q=',
 
+  # GitHub search is sign-in-gated (429 for anonymous clients)
+  '^https://github\.com/search\?',
+
   # Docsy-generated GitHub edit/new/view-source links
   '^https?://github\.com/.*?/.*?/(new/|edit/|issues/new\?)',
   '^https://github\.com/open-telemetry/opentelemetry\.io/tree/main/content/[^e]',

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -16191,10 +16191,6 @@
     "StatusCode": 206,
     "LastSeen": "2026-07-06T07:08:58.362977554Z"
   },
-  "https://github.com/search?q=is%3Aissue+is%3Aopen+org%3Aopen-telemetry+&type=issues": {
-    "StatusCode": 206,
-    "LastSeen": "2026-07-05T06:58:07.013320241Z"
-  },
   "https://github.com/secustor": {
     "StatusCode": 206,
     "LastSeen": "2026-07-09T07:01:30.083554332Z"


### PR DESCRIPTION
- GitHub aggressively rate-limits automated clients on `/search` (429 Too Many Requests), and the results page is client-side rendered, so search-result links can't be validated in CI. Most recent instance: the spec added 19 code-search links (`github.com/search?q=repo%3A…&type=code`) to its profiles data-format page, failing the spec-integration PR's (#10526) link checks until the refcache was hand-refreshed.
- Adds `^https://github\.com/search/?\?` to the htmltest `IgnoreURLs` (via `.htmltest.base.yml`) and mirrors the rule in `lychee.base.toml`, per the KEEP-IN-SYNC rule; also allows an optional slash before the query in the neighboring issue/discussion rules.
- Drops the one hand-seeded refcache entry for a `github.com/search` URL: ignored URLs are never looked up, so the entry is dead weight.
