### PR TITLE
Site skills: generalize refresh-refcache-pr-fix to any otelbot PR

### DIFF
--- a/.claude/skills/refresh-refcache-pr-fix/SKILL.md
+++ b/.claude/skills/refresh-refcache-pr-fix/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: refresh-refcache-pr-fix
 description: >-
-  Fetch, review, and attempt to fix non-2XX `static/refcache.json` URLs on the
-  upstream `otelbot/refcache-refresh` PR. Use when that bot branch is red,
-  refcache still lists 4XX/fragment errors after retries, or you want a guided
-  pass over the refcache-refresh fix loop.
+  Fetch, review, and attempt to fix non-2XX `static/refcache.json` URLs on an
+  otelbot PR — by default `otelbot/refcache-refresh`, or a spec/semconv
+  integration branch when so instructed. Use when a bot branch is red, refcache
+  still lists 4XX/fragment errors after retries, or you want a guided pass over
+  the refcache fix loop.
 disable-model-invocation: true
 ---
 

--- a/content/en/site/skills/_index.md
+++ b/content/en/site/skills/_index.md
@@ -28,7 +28,9 @@ As mentioned above, skills are defined in [`.claude/skills/`][], they are:
   `opentelemetry.io` repository following issue templates, contributing
   guidelines, and the label taxonomy.
 - [`/refresh-refcache-pr-fix`][refresh-refcache-pr-fix]: fetch, review and
-  attempt to fix non-2XX URLs on the upstream `otelbot/refcache-refresh` PR.
+  attempt to fix non-2XX URLs on an otelbot PR (by default
+  `otelbot/refcache-refresh`, or a spec/semconv integration branch when so
+  instructed).
 - [`/resolve-refcache-conflicts <optional-pr-number>`][resolve-refcache-conflicts]:
   resolve `static/refcache.json` merge/rebase conflicts.
 - [`/review-blog-post <blog-post-path-or-pr-number>`][review-blog-post]: review

--- a/content/en/site/skills/refresh-refcache-pr-fix.md
+++ b/content/en/site/skills/refresh-refcache-pr-fix.md
@@ -14,8 +14,9 @@ entries remain.
 Unless instructed otherwise, target the PR for the upstream
 `otelbot/refcache-refresh` branch. When asked to fix a **spec or semconv
 integration branch**, target the open PR whose head branch matches
-`otelbot/spec-integration-*` or `otelbot/semconv-integration-*`, respectively —
-at most one such PR is open at a time. To list open otelbot PRs:
+`otelbot/spec-integration-*` or `otelbot/semconv-integration-*`, respectively.
+If more than one PR matches, ask which one is intended. To list open otelbot
+PRs:
 
 ```sh
 gh pr list --search head:otelbot/
@@ -100,6 +101,8 @@ multiple runs over time and you have confirmed the URL is not otherwise healthy.
    - Where it originates from: provide links to files or pages.
    - A recommendation. For links into github.com, recommend a replacement link
      based on the last commit that contains the named resource.
+   - For an **integration branch**: where the fix belongs — in-branch, a
+     separate PR against `main`, or upstream in the spec repository.
 
    Pause for feedback from a reviewer.
 
@@ -110,14 +113,6 @@ multiple runs over time and you have confirmed the URL is not otherwise healthy.
    - If any touched page is outside `content/en/`, follow
      [Localization](/docs/contributing/localization/#link-fixes-and-resource-updates)
      for that edit (e.g. `# patched` on `default_lang_commit`).
-
-   On an **integration branch**, only refcache changes belong in-branch:
-
-   - Link fixes to pages that exist on `main` go in a separate PR against
-     `main`; the integration branch picks them up at its next scheduled merge
-     from main.
-   - Broken links within the imported spec pages are fixed upstream in the spec
-     repository, not by editing the generated pages.
 
 7. Run `npm run fix:refcache` to refresh `static/refcache.json` after those
    source-link changes, then repeat the steps in this section (from step 1)

--- a/content/en/site/skills/refresh-refcache-pr-fix.md
+++ b/content/en/site/skills/refresh-refcache-pr-fix.md
@@ -1,13 +1,27 @@
 ---
 title: Refresh-refcache PR fix
 description: >-
-  How to resolve outstanding non-2XX entries on the otelbot refcache-refresh PR.
+  How to resolve outstanding non-2XX refcache entries on an otelbot PR.
 ---
 
-Follow these steps to resolve non-2XX `static/refcache.json` entries in the
-`otelbot/refcache-refresh` PR. This process may involve updating or removing
+Follow these steps to resolve non-2XX `static/refcache.json` entries on the
+[target otelbot PR](#target-pr). This process may involve updating or removing
 dead links on the site, then refreshing the refcache again until no non-2XX
 entries remain.
+
+## Target PR
+
+Unless instructed otherwise, target the PR for the upstream
+`otelbot/refcache-refresh` branch. When asked to fix a **spec or semconv
+integration branch**, target the open PR whose head branch matches
+`otelbot/spec-integration-*` or `otelbot/semconv-integration-*`, respectively —
+at most one such PR is open at a time. To list open otelbot PRs:
+
+```sh
+gh pr list --search head:otelbot/
+```
+
+In the steps below, _`TARGET_BRANCH`_ is the head branch of the target PR.
 
 ## Preparation
 
@@ -15,19 +29,19 @@ These steps assume you have a local clone of the repository with the `upstream`
 remote configured to point to the main repository. Run these steps locally from
 the repository root.
 
-1. Determine the PR associated with upstream `otelbot/refcache-refresh`.
+1. Determine the PR associated with upstream _`TARGET_BRANCH`_.
 2. If none exists, stop.
-3. If a local `otelbot/refcache-refresh` branch already exists and contains
-   commits that are not in `upstream/otelbot/refcache-refresh`, back them up or
-   stop before resetting anything.
+3. If a local _`TARGET_BRANCH`_ branch already exists and contains commits that
+   are not in the upstream branch, back them up or stop before resetting
+   anything.
 4. Check out the PR branch with `gh pr checkout <num>`. If that fails because
    the local branch has diverged and you have already backed up any local-only
    commits, realign it with upstream:
 
    ```sh
    git fetch upstream
-   git checkout otelbot/refcache-refresh
-   git reset --hard upstream/otelbot/refcache-refresh
+   git checkout TARGET_BRANCH
+   git reset --hard upstream/TARGET_BRANCH
    ```
 
 5. If any content modules are out of date, run `npm run get:submodule`.
@@ -52,14 +66,16 @@ multiple runs over time and you have confirmed the URL is not otherwise healthy.
    - Share the double-check summary: in your reply or PR comment (retried URLs,
      entries updated, final HTTP status counts, and “Processed N URLs” when
      shown).
-   - If `static/refcache.json` changed, commit and push to
-     `upstream/otelbot/refcache-refresh` (as of this step).
-   - Mark the PR ready for review: `gh pr ready <num>`.
-   - Enable auto-merge, so that the PR is merged once all approvals are in and
-     the checks pass: `gh pr merge <num> --auto`.
-   - **Remind a maintainer to approve** the PR so auto-merge can complete.
-     Provide a link to the PR:
-     `https://github.com/open-telemetry/opentelemetry.io/pull/<num>`.
+   - If `static/refcache.json` changed, commit and push to upstream
+     _`TARGET_BRANCH`_ (as of this step).
+   - For `otelbot/refcache-refresh` only — integration-branch PRs stay draft
+     until their workflow finalizes them at release time:
+     - Mark the PR ready for review: `gh pr ready <num>`.
+     - Enable auto-merge, so that the PR is merged once all approvals are in and
+       the checks pass: `gh pr merge <num> --auto`.
+     - **Remind a maintainer to approve** the PR so auto-merge can complete.
+       Provide a link to the PR:
+       `https://github.com/open-telemetry/opentelemetry.io/pull/<num>`.
 
    Then stop unless you are also leaving notes for reviewers.
 
@@ -94,6 +110,14 @@ multiple runs over time and you have confirmed the URL is not otherwise healthy.
    - If any touched page is outside `content/en/`, follow
      [Localization](/docs/contributing/localization/#link-fixes-and-resource-updates)
      for that edit (e.g. `# patched` on `default_lang_commit`).
+
+   On an **integration branch**, only refcache changes belong in-branch:
+
+   - Link fixes to pages that exist on `main` go in a separate PR against
+     `main`; the integration branch picks them up at its next scheduled merge
+     from main.
+   - Broken links within the imported spec pages are fixed upstream in the spec
+     repository, not by editing the generated pages.
 
 7. Run `npm run fix:refcache` to refresh `static/refcache.json` after those
    source-link changes, then repeat the steps in this section (from step 1)


### PR DESCRIPTION
- Long-lived spec/semconv integration branches hit the same bot-block/429 refcache failures as `otelbot/refcache-refresh` (see the v1.59.0-dev branch episode), so the fix loop applies to them too.
- **Skill page** (`site/skills/refresh-refcache-pr-fix`):
  - Adds a **Target PR** section: default remains `otelbot/refcache-refresh`; spec/semconv integration branches on request (at most one open per family).
  - Keys the endgame on branch type: ready + auto-merge stays refcache-refresh-only; integration PRs remain draft (their workflow finalizes them at release).
  - Notes where content-link fixes belong for integration branches (PRs against main, or the upstream spec repo — not in-branch).
- **Cross-references**: aligns the `.claude` SKILL.md wrapper and skills-index descriptions.
- **Preview(s)**:
  - https://deploy-preview-10762--opentelemetry.netlify.app/site/skills/refresh-refcache-pr-fix/
