### PR TITLE
chore: Compare refcache JSON canonically

### DIFF
--- a/.github/scripts/check-refcache.sh
+++ b/.github/scripts/check-refcache.sh
@@ -32,6 +32,17 @@ else
   echo "Compare shard refcache files against '$REFERENCE_FILE':"
 fi
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required to compare refcache JSON files"
+  exit 1
+fi
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+REFERENCE_NORMALIZED="$TMP_DIR/reference.json"
+jq --sort-keys . "$REFERENCE_FILE" >"$REFERENCE_NORMALIZED"
+
 # Find all refcache.json files in the directory
 REFCACHE_FILES=$(find "$DIRECTORY" -name "refcache.json" -type f | sort)
 
@@ -41,11 +52,16 @@ if [ -z "$REFCACHE_FILES" ]; then
 fi
 
 DIFFS_FOUND=0
+FILE_NUM=0
 for file in $REFCACHE_FILES; do
-  if ! diff -q "$REFERENCE_FILE" "$file" >/dev/null 2>&1; then
+  FILE_NUM=$((FILE_NUM + 1))
+  FILE_NORMALIZED="$TMP_DIR/shard-$FILE_NUM.json"
+  jq --sort-keys . "$file" >"$FILE_NORMALIZED"
+
+  if ! diff -q "$REFERENCE_NORMALIZED" "$FILE_NORMALIZED" >/dev/null 2>&1; then
     DIFFS_FOUND=1
     echo " - $file differs"
-    diff "$REFERENCE_FILE" "$file" | tail -n 100
+    diff "$REFERENCE_NORMALIZED" "$FILE_NORMALIZED" | tail -n 100
     echo ""
   else
     echo " - $file is identical"

--- a/scripts/check-refcache.test.mjs
+++ b/scripts/check-refcache.test.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import test from 'node:test';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const script = join(repoRoot, '.github/scripts/check-refcache.sh');
+
+function requireJq() {
+  try {
+    execFileSync('jq', ['--version'], { stdio: 'ignore' });
+  } catch {
+    return false;
+  }
+  return true;
+}
+
+function setupRefcachePair({ reference, shard }) {
+  const dir = mkdtempSync(join(tmpdir(), 'check-refcache-'));
+  mkdirSync(join(dir, 'static'), { recursive: true });
+  mkdirSync(join(dir, 'tmp/check-refcache/shard/static'), { recursive: true });
+  writeFileSync(
+    join(dir, 'static/refcache.json'),
+    JSON.stringify(reference, null, 2) + '\n',
+  );
+  writeFileSync(
+    join(dir, 'tmp/check-refcache/shard/static/refcache.json'),
+    JSON.stringify(shard, null, 2) + '\n',
+  );
+  return dir;
+}
+
+test(
+  'check-refcache ignores JSON object key order',
+  { skip: !requireJq() },
+  () => {
+    const cwd = setupRefcachePair({
+      reference: {
+        'https://example.test/b': {
+          StatusCode: 200,
+          LastSeen: '2026-01-02T00:00:00Z',
+        },
+        'https://example.test/a': {
+          StatusCode: 206,
+          LastSeen: '2026-01-01T00:00:00Z',
+        },
+      },
+      shard: {
+        'https://example.test/a': {
+          StatusCode: 206,
+          LastSeen: '2026-01-01T00:00:00Z',
+        },
+        'https://example.test/b': {
+          StatusCode: 200,
+          LastSeen: '2026-01-02T00:00:00Z',
+        },
+      },
+    });
+
+    const result = spawnSync(script, [], { cwd, encoding: 'utf8' });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /is identical/);
+  },
+);
+
+test(
+  'check-refcache still reports value differences',
+  { skip: !requireJq() },
+  () => {
+    const cwd = setupRefcachePair({
+      reference: {
+        'https://example.test/a': {
+          StatusCode: 200,
+          LastSeen: '2026-01-01T00:00:00Z',
+        },
+      },
+      shard: {
+        'https://example.test/a': {
+          StatusCode: 206,
+          LastSeen: '2026-01-01T00:00:00Z',
+        },
+      },
+    });
+
+    const result = spawnSync(script, [], { cwd, encoding: 'utf8' });
+
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, /differs/);
+    assert.match(result.stdout, /StatusCode/);
+  },
+);


### PR DESCRIPTION
## What changed

- Normalize `static/refcache.json` and each shard refcache with `jq --sort-keys` before comparing them in the refcache CI check.
- Add local-tool tests that cover order-only differences and real value differences.

## Why

The current check uses a raw file diff, so a PR merge commit can fail when Git orders JSON object keys differently from the shard-generated refcache even though the cached URL data is equivalent.

## Validation

- `node --test scripts/check-refcache.test.mjs`
- `bash -n .github/scripts/check-refcache.sh`