### PR TITLE
Update otelbot token workflows to use client IDs

### DIFF
--- a/.github/workflows/ai-content-detection.yml
+++ b/.github/workflows/ai-content-detection.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          client-id: ${{ vars.OTELBOT_APP_ID }}
+          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
 
       - name: Checkout

--- a/.github/workflows/auto-update-community-members.yml
+++ b/.github/workflows/auto-update-community-members.yml
@@ -33,7 +33,7 @@ jobs:
         id: otelbot-token
         with:
           # the higher privileged docs token is needed to push commits to an existing PR
-          client-id: ${{ vars.OTELBOT_DOCS_APP_ID }}
+          client-id: ${{ vars.OTELBOT_DOCS_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_DOCS_PRIVATE_KEY }}
 
       - name: Run script

--- a/.github/workflows/auto-update-registry.yml
+++ b/.github/workflows/auto-update-registry.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          client-id: ${{ vars.OTELBOT_APP_ID }}
+          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
 
       - name: Auto-update

--- a/.github/workflows/auto-update-versions.yml
+++ b/.github/workflows/auto-update-versions.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          client-id: ${{ vars.OTELBOT_APP_ID }}
+          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
 
       - run: ./scripts/auto-update/all-versions.sh

--- a/.github/workflows/blog-publish-labels.yml
+++ b/.github/workflows/blog-publish-labels.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          client-id: ${{ vars.OTELBOT_DOCS_APP_ID }}
+          client-id: ${{ vars.OTELBOT_DOCS_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_DOCS_PRIVATE_KEY }}
 
       - name: Update blog publish labels

--- a/.github/workflows/collector-sync.yml
+++ b/.github/workflows/collector-sync.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          client-id: ${{ vars.OTELBOT_DOCS_APP_ID }}
+          client-id: ${{ vars.OTELBOT_DOCS_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_DOCS_PRIVATE_KEY }}
 
       - name: Sync collector documentation

--- a/.github/workflows/component-owners.yml
+++ b/.github/workflows/component-owners.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          client-id: ${{ vars.OTELBOT_DOCS_APP_ID }}
+          client-id: ${{ vars.OTELBOT_DOCS_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_DOCS_PRIVATE_KEY }}
       - uses: dyladan/component-owners@7ff2b343629407c4dbe1c28ae66f55f723543d2b # v0.2.0
         with:

--- a/.github/workflows/first-timer-response.yml
+++ b/.github/workflows/first-timer-response.yml
@@ -59,7 +59,7 @@ jobs:
         id: otelbot-token
         if: steps.check-trigger.outputs.match == 'true'
         with:
-          client-id: ${{ vars.OTELBOT_APP_ID }}
+          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
 
       - name: Check if commenter is an org member

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -117,7 +117,7 @@ jobs:
       user-name: otelbot
       user-email: 197425009+otelbot@users.noreply.github.com
       # the higher privileged docs app is needed to push branches and open PRs
-      app-id: ${{ vars.OTELBOT_DOCS_APP_ID }}
+      client-id: ${{ vars.OTELBOT_DOCS_CLIENT_ID }}
     secrets:
       app-private-key: ${{ secrets.OTELBOT_DOCS_PRIVATE_KEY }}
 

--- a/.github/workflows/label-manager.yml
+++ b/.github/workflows/label-manager.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          client-id: ${{ vars.OTELBOT_DOCS_APP_ID }}
+          client-id: ${{ vars.OTELBOT_DOCS_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_DOCS_PRIVATE_KEY }}
 
       - name: Update approval labels

--- a/.github/workflows/locale-auto-merge.yml
+++ b/.github/workflows/locale-auto-merge.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          client-id: ${{ vars.OTELBOT_DOCS_APP_ID }}
+          client-id: ${{ vars.OTELBOT_DOCS_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_DOCS_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          client-id: ${{ vars.OTELBOT_APP_ID }}
+          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
           # PR comments authorize via the pull-requests permission (even
           # though they're posted through the issues API endpoint).
@@ -151,7 +151,7 @@ jobs:
       user-name: otelbot
       user-email: 197425009+otelbot@users.noreply.github.com
       # the higher privileged docs app is needed to push commits to an existing PR
-      app-id: ${{ vars.OTELBOT_DOCS_APP_ID }}
+      client-id: ${{ vars.OTELBOT_DOCS_CLIENT_ID }}
     secrets:
       app-private-key: ${{ secrets.OTELBOT_DOCS_PRIVATE_KEY }}
 
@@ -187,7 +187,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          client-id: ${{ vars.OTELBOT_APP_ID }}
+          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
           # PR comments authorize via the pull-requests permission (even
           # though they're posted through the issues API endpoint). The

--- a/.github/workflows/refcache-refresh.yml
+++ b/.github/workflows/refcache-refresh.yml
@@ -48,7 +48,7 @@ jobs:
         id: otelbot-token
         with:
           # the higher privileged docs token is needed to push commits to an existing PR
-          client-id: ${{ vars.OTELBOT_DOCS_APP_ID }}
+          client-id: ${{ vars.OTELBOT_DOCS_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_DOCS_PRIVATE_KEY }}
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/reusable-apply-patch.yml
+++ b/.github/workflows/reusable-apply-patch.yml
@@ -17,7 +17,7 @@ name: Reusable - apply patch to PR
 #       commit-message: Apply patch
 #       user-name: otelbot
 #       user-email: 197425009+otelbot@users.noreply.github.com
-#       app-id: ${{ vars.MY_APP_ID }}
+#       client-id: ${{ vars.MY_CLIENT_ID }}
 #     secrets:
 #       app-private-key: ${{ secrets.MY_APP_PRIVATE_KEY }}
 
@@ -47,7 +47,7 @@ on:
         description: Git user email for the commit.
         required: true
         type: string
-      app-id:
+      client-id:
         description: >-
           Client ID of the GitHub App used to push to the PR branch. The app
           needs write access to this repository's contents.
@@ -55,7 +55,7 @@ on:
         type: string
     secrets:
       app-private-key:
-        description: Private key of the GitHub App identified by `app-id`.
+        description: Private key of the GitHub App.
         required: true
     outputs:
       committed:
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ inputs.app-id }}
+          client-id: ${{ inputs.client-id }}
           private-key: ${{ secrets.app-private-key }}
           permission-contents: write # apply/push the patch commit
           permission-pull-requests: read # gh pr checkout

--- a/.github/workflows/reusable-patch-pr.yml
+++ b/.github/workflows/reusable-patch-pr.yml
@@ -16,7 +16,7 @@ name: Reusable - publish patch as PR
 #       commit-message: Apply housekeeping fixes
 #       user-name: otelbot
 #       user-email: 197425009+otelbot@users.noreply.github.com
-#       app-id: ${{ vars.MY_APP_ID }}
+#       client-id: ${{ vars.MY_CLIENT_ID }}
 #     secrets:
 #       app-private-key: ${{ secrets.MY_APP_PRIVATE_KEY }}
 #
@@ -76,7 +76,7 @@ on:
         description: Git user email for the commit.
         required: true
         type: string
-      app-id:
+      client-id:
         description: >-
           Client ID of the GitHub App used to push the branch and create the PR.
           The app needs write access to this repository's contents and pull
@@ -85,7 +85,7 @@ on:
         type: string
     secrets:
       app-private-key:
-        description: Private key of the GitHub App identified by `app-id`.
+        description: Private key of the GitHub App.
         required: true
     outputs:
       pr-url:
@@ -126,7 +126,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ inputs.app-id }}
+          client-id: ${{ inputs.client-id }}
           private-key: ${{ secrets.app-private-key }}
           permission-contents: write # push the patch branch
           permission-pull-requests: write # create the PR

--- a/.github/workflows/specs-integration.yml
+++ b/.github/workflows/specs-integration.yml
@@ -37,7 +37,7 @@ jobs:
         id: otelbot-token
         with:
           # the higher privileged docs token is needed to push commits to an existing PR
-          client-id: ${{ vars.OTELBOT_DOCS_APP_ID }}
+          client-id: ${{ vars.OTELBOT_DOCS_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_DOCS_PRIVATE_KEY }}
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/content/en/site/build/ci-workflows.md
+++ b/content/en/site/build/ci-workflows.md
@@ -137,7 +137,7 @@ sequenceDiagram
 - **`pr-review-trigger`**: intentionally minimal — no secrets, no privileged
   permissions. Ignores `review.state == "commented"` since comments don't affect
   approvals.
-- **`pr-approval-labels`**: runs with a GitHub App token (`OTELBOT_DOCS_APP_ID`
+- **`pr-approval-labels`**: runs with a GitHub App token (`OTELBOT_DOCS_CLIENT_ID`
   / `OTELBOT_DOCS_PRIVATE_KEY`) that has permissions to read org/team membership
   and edit PR labels. Uses `pull_request_target` and `workflow_run` to ensure it
   always executes in the trusted base repository context.

--- a/content/en/site/build/ci-workflows.md
+++ b/content/en/site/build/ci-workflows.md
@@ -137,10 +137,11 @@ sequenceDiagram
 - **`pr-review-trigger`**: intentionally minimal — no secrets, no privileged
   permissions. Ignores `review.state == "commented"` since comments don't affect
   approvals.
-- **`pr-approval-labels`**: runs with a GitHub App token (`OTELBOT_DOCS_CLIENT_ID`
-  / `OTELBOT_DOCS_PRIVATE_KEY`) that has permissions to read org/team membership
-  and edit PR labels. Uses `pull_request_target` and `workflow_run` to ensure it
-  always executes in the trusted base repository context.
+- **`pr-approval-labels`**: runs with a GitHub App token
+  (`OTELBOT_DOCS_CLIENT_ID` / `OTELBOT_DOCS_PRIVATE_KEY`) that has permissions
+  to read org/team membership and edit PR labels. Uses `pull_request_target` and
+  `workflow_run` to ensure it always executes in the trusted base repository
+  context.
 - **`blog-publish-labels`**: runs on a schedule with a GitHub App token and the
   `SLACK_WEBHOOK_URL` secret. Always executes in the trusted base repository
   context (schedule events have no fork variant).


### PR DESCRIPTION
Update otelbot token creation to use GitHub App client IDs.

The app-id input for `actions/create-github-app-token` is deprecated in favor of client-id. The matching `OTELBOT_*_CLIENT_ID` organization variables have been provisioned, so this updates direct token creation from `app-id / *_APP_ID` to `client-id / *_CLIENT_ID`.

Tracking issue: https://github.com/open-telemetry/admin/issues/744