### PR TITLE
Drop inert ko Prettier-nowrap entry; fix supported-languages list

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "__find:md:not-old-blog": "sh -c 'find \"$@\" -name \"*.md\" -not -path \"content/en/blog/2019/*\" -not -path \"content/en/blog/202[0-4]/*\" -print0' --",
     "_build": "npm run _hugo -- --logLevel info -e dev --buildDrafts --buildFuture --baseURL \"${DEPLOY_PRIME_URL:-http://localhost}\"",
     "_check:format:any": "npm run __check:format -- --check --ignore-path ''",
-    "_check:format:nowrap": "npm run __check:format:nowrap -- content/ja content/ko content/uk content/zh",
+    "_check:format:nowrap": "npm run __check:format:nowrap -- content/ja content/uk content/zh",
     "_check:format": "npm run __check:format -- --check .",
     "_check:links--md": "npx markdown-link-check --config .markdown-link-check.json *.md",
     "_check:links--warn": "npm run _check:links || (echo; echo 'WARNING: see link-checker output for issues.'; echo)",

--- a/projects/localization.md
+++ b/projects/localization.md
@@ -20,8 +20,9 @@ The project currently supports the following languages in addition to English:
 - [বাংলা - Bengali (bn)][bn]
 - [Español - Spanish (es)][es]
 - [Français - French (fr)][fr]
-- [한국어 - Korean (ko)][ko]
 - [日本語 - Japanese (ja)][ja]
+- [한국어 - Korean (ko)][ko]
+- [Polski - Polish (pl)][pl]
 - [Português - Portuguese (pt)][pt]
 - [Română - Romanian (ro)][ro]
 - [Українська - Ukrainian (uk)][uk]
@@ -38,6 +39,7 @@ fostering broader adoption and contribution to the project.
 [fr]: https://opentelemetry.io/fr/
 [ja]: https://opentelemetry.io/ja/
 [ko]: https://opentelemetry.io/ko/
+[pl]: https://opentelemetry.io/pl/
 [pt]: https://opentelemetry.io/pt/
 [ro]: https://opentelemetry.io/ro/
 [uk]: https://opentelemetry.io/uk/


### PR DESCRIPTION
- Drops `content/ko` from the `_check:format:nowrap` script — the entry (added with the ko locale setup, #10440) was inert: the nowrap regime requires a matching `.prettierignore` entry to exempt the directory from the default `proseWrap: always` pass, and `content/ko` never had one. Korean pages are therefore already prose-wrapped, and the extra nowrap pass over `content/ko` checked nothing.
  - Leaving ko under the default `proseWrap: always` is safe: Prettier wraps Hangul at existing spaces only (verified empirically against Prettier 3.9.4, with round-trip check); the Korean-specific wrap bugs were fixed long ago (prettier/prettier#5028, prettier/prettier#6516), and the open CJK no-wrap issue (prettier/prettier#14936) scopes Han and Kana only.
  - If the ko localization team prefers unwrapped prose, the coupled pair (`.prettierignore` entry + nowrap-script entry) can be added, as uk did in #7445.
- Fixes the supported-languages list in `projects/localization.md`:
  - Restores lang-code ordering (moves ko after ja).
  - Adds Polish (pl) — live since March (#9389) but never listed.