### PR TITLE
docs: fix broken opentelemetry-operator compatibility link

### DIFF
--- a/content/en/docs/guidance/blueprints/managed-telemetry-platforms-for-k8s-workloads.md
+++ b/content/en/docs/guidance/blueprints/managed-telemetry-platforms-for-k8s-workloads.md
@@ -1216,7 +1216,7 @@ scaling considerations][62].
 [31]:
   https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/redactionprocessor/README.md
 [32]:
-  https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/compatibility.md#compatibility-matrix
+  https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/getting-started/compatibility.md#compatibility-matrix
 [33]:
   https://github.com/open-telemetry/opentelemetry-operator#opentelemetry-auto-instrumentation-injection
 [34]: /docs/platforms/kubernetes/operator/

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -12687,6 +12687,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-07-09T06:53:53.51199562Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/getting-started/compatibility.md#compatibility-matrix": {
+    "StatusCode": 206,
+    "LastSeen": "2026-07-13T05:50:12.712255544Z"
+  },
   "https://github.com/open-telemetry/opentelemetry-operator/issues/1393": {
     "StatusCode": 206,
     "LastSeen": "2026-07-05T06:51:45.697578784Z"


### PR DESCRIPTION
Several documentation links return HTTP 404. This updates each to its current working location:

- `content/en/docs/guidance/blueprints/managed-telemetry-platforms-for-k8s-workloads.md` (1 link)

Docs-only change. Each replacement URL was verified to return HTTP 200.