### PR TITLE
docs(blog): remove duplicated 'the' in Dart/Flutter donation sentence

### DIFF
--- a/content/en/blog/2026/dart-flutter-opentelemetry.md
+++ b/content/en/blog/2026/dart-flutter-opentelemetry.md
@@ -23,7 +23,7 @@ leaving Dart and Flutter developers without a supported path to capture
 telemetry from their servers and apps.
 
 An actively developed implementation of the OpenTelemetry specification for Dart
-already exists that is in the process of being donated to the the OpenTelemetry
+already exists that is in the process of being donated to the OpenTelemetry
 project:
 [dartastic_opentelemetry](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry)
 and its standalone API package


### PR DESCRIPTION
## Summary

`content/en/blog/2026/dart-flutter-opentelemetry.md:26` has a duplicated article:

```diff
- already exists that is in the process of being donated to the the OpenTelemetry
+ already exists that is in the process of being donated to the OpenTelemetry
```

One-line diff, blog post only, no code samples affected.

## Compliance

- [x] Commit is signed off (`-s`) per CNCF DCO requirement.

## Verified

- [x] Grep for `\bthe the\b` on `main` — only hit is this line in the Dart/Flutter blog post.