### PR TITLE
Generalize refresh-refcache-pr-fix skill and create refcache PRs as non-draft

### DIFF
--- a/.claude/skills/refresh-refcache-pr-fix/SKILL.md
+++ b/.claude/skills/refresh-refcache-pr-fix/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: refresh-refcache-pr-fix
 description: >-
-  Fetch, review, and attempt to fix non-2XX `static/refcache.json` URLs on an
-  otelbot PR — by default `otelbot/refcache-refresh`, or a collector-docs
-  branch, or a spec/semconv integration branch when so instructed. Use when a
-  bot branch is red, refcache still lists 4XX/fragment errors after retries, or
-  you want a guided pass over the refcache fix loop.
+  Fetch, review, and attempt to fix non-2XX `static/refcache.json` URLs on
+  otelbot PRs. By default, sweeps all open `otelbot/*` PRs and processes those
+  with failing link checks; targets a specific branch or group of branches when
+  so instructed. Use when a bot branch is red, refcache still lists 4XX/fragment
+  errors after retries, or you want a guided pass over the refcache fix loop.
 disable-model-invocation: true
 ---
 

--- a/.claude/skills/refresh-refcache-pr-fix/SKILL.md
+++ b/.claude/skills/refresh-refcache-pr-fix/SKILL.md
@@ -2,10 +2,10 @@
 name: refresh-refcache-pr-fix
 description: >-
   Fetch, review, and attempt to fix non-2XX `static/refcache.json` URLs on an
-  otelbot PR — by default `otelbot/refcache-refresh`, or a spec/semconv
-  integration branch when so instructed. Use when a bot branch is red, refcache
-  still lists 4XX/fragment errors after retries, or you want a guided pass over
-  the refcache fix loop.
+  otelbot PR — by default `otelbot/refcache-refresh`, or a collector-docs or
+  spec/semconv integration branch when so instructed. Use when a bot branch is
+  red, refcache still lists 4XX/fragment errors after retries, or you want a
+  guided pass over the refcache fix loop.
 disable-model-invocation: true
 ---
 

--- a/.claude/skills/refresh-refcache-pr-fix/SKILL.md
+++ b/.claude/skills/refresh-refcache-pr-fix/SKILL.md
@@ -2,10 +2,10 @@
 name: refresh-refcache-pr-fix
 description: >-
   Fetch, review, and attempt to fix non-2XX `static/refcache.json` URLs on an
-  otelbot PR — by default `otelbot/refcache-refresh`, or a collector-docs or
-  spec/semconv integration branch when so instructed. Use when a bot branch is
-  red, refcache still lists 4XX/fragment errors after retries, or you want a
-  guided pass over the refcache fix loop.
+  otelbot PR — by default `otelbot/refcache-refresh`, or a collector-docs
+  branch, or a spec/semconv integration branch when so instructed. Use when a
+  bot branch is red, refcache still lists 4XX/fragment errors after retries, or
+  you want a guided pass over the refcache fix loop.
 disable-model-invocation: true
 ---
 

--- a/.github/workflows/refcache-refresh.yml
+++ b/.github/workflows/refcache-refresh.yml
@@ -199,7 +199,7 @@ jobs:
           fi
 
           if gh pr create --title "Refresh refcache" \
-              --body "$PR_BODY" --draft;
+              --body "$PR_BODY";
           then
             PR_URL=$(gh pr view --json url --jq '.url')
             printf "PR created: %s\n" "$PR_URL"

--- a/content/en/site/skills/_index.md
+++ b/content/en/site/skills/_index.md
@@ -29,8 +29,8 @@ As mentioned above, skills are defined in [`.claude/skills/`][], they are:
   guidelines, and the label taxonomy.
 - [`/refresh-refcache-pr-fix`][refresh-refcache-pr-fix]: fetch, review and
   attempt to fix non-2XX URLs on an otelbot PR (by default
-  `otelbot/refcache-refresh`, or a spec/semconv integration branch when so
-  instructed).
+  `otelbot/refcache-refresh`, or a collector-docs or spec/semconv integration
+  branch when so instructed).
 - [`/resolve-refcache-conflicts <optional-pr-number>`][resolve-refcache-conflicts]:
   resolve `static/refcache.json` merge/rebase conflicts.
 - [`/review-blog-post <blog-post-path-or-pr-number>`][review-blog-post]: review

--- a/content/en/site/skills/_index.md
+++ b/content/en/site/skills/_index.md
@@ -16,6 +16,11 @@ procedure) a set of steps that an agent or maintainer can follow to accomplish a
 specific task. Agent skills are defined in [`.claude/skills/`][]. Maintainer
 procedures are defined in this section.
 
+In skill and procedure steps, the prose states the intent of each action; a
+command given in parentheses is a suggested way to fulfill the step, not the
+only valid one. Skills written before this convention was adopted might not yet
+follow it.
+
 ## Agent skills
 
 As mentioned above, skills are defined in [`.claude/skills/`][], they are:
@@ -28,9 +33,8 @@ As mentioned above, skills are defined in [`.claude/skills/`][], they are:
   `opentelemetry.io` repository following issue templates, contributing
   guidelines, and the label taxonomy.
 - [`/refresh-refcache-pr-fix`][refresh-refcache-pr-fix]: fetch, review and
-  attempt to fix non-2XX URLs on an otelbot PR (by default
-  `otelbot/refcache-refresh`, or a collector-docs branch, or a spec/semconv
-  integration branch when so instructed).
+  attempt to fix non-2XX URLs on otelbot PRs (by default, all open `otelbot/*`
+  PRs with failing link checks, or specific branches when so instructed).
 - [`/resolve-refcache-conflicts <optional-pr-number>`][resolve-refcache-conflicts]:
   resolve `static/refcache.json` merge/rebase conflicts.
 - [`/review-blog-post <blog-post-path-or-pr-number>`][review-blog-post]: review

--- a/content/en/site/skills/_index.md
+++ b/content/en/site/skills/_index.md
@@ -29,8 +29,8 @@ As mentioned above, skills are defined in [`.claude/skills/`][], they are:
   guidelines, and the label taxonomy.
 - [`/refresh-refcache-pr-fix`][refresh-refcache-pr-fix]: fetch, review and
   attempt to fix non-2XX URLs on an otelbot PR (by default
-  `otelbot/refcache-refresh`, or a collector-docs or spec/semconv integration
-  branch when so instructed).
+  `otelbot/refcache-refresh`, or a collector-docs branch, or a spec/semconv
+  integration branch when so instructed).
 - [`/resolve-refcache-conflicts <optional-pr-number>`][resolve-refcache-conflicts]:
   resolve `static/refcache.json` merge/rebase conflicts.
 - [`/review-blog-post <blog-post-path-or-pr-number>`][review-blog-post]: review

--- a/content/en/site/skills/refresh-refcache-pr-fix.md
+++ b/content/en/site/skills/refresh-refcache-pr-fix.md
@@ -74,7 +74,8 @@ multiple runs over time and you have confirmed the URL is not otherwise healthy.
      _`TARGET_BRANCH`_ (as of this step).
    - For all target branches, add an evidence / activity-log comment to the PR —
      skip this only when the skill invocation asks for no comment (e.g., it
-     includes “no comment” or “silent”). The comment consists of:
+     includes “no comment” or “silent”). Post it with
+     `gh pr comment <num> --body '…'`; the comment consists of:
      - The skill invocation command, as inline code.
      - A terse, one-or-two-line summary of the run.
 

--- a/content/en/site/skills/refresh-refcache-pr-fix.md
+++ b/content/en/site/skills/refresh-refcache-pr-fix.md
@@ -1,47 +1,42 @@
 ---
 title: Refresh-refcache PR fix
 description: >-
-  How to resolve outstanding non-2XX refcache entries on an otelbot PR.
+  How to resolve outstanding non-2XX refcache entries on otelbot PRs.
 ---
 
 Follow these steps to resolve non-2XX `static/refcache.json` entries on the
-[target otelbot PR](#target-pr). This process may involve updating or removing
+[target otelbot PRs](#target-prs). This process may involve updating or removing
 dead links on the site, then refreshing the refcache again until no non-2XX
 entries remain.
 
-## Target PR
+## Target PRs
 
-Unless instructed otherwise, target the PR for the upstream
-`otelbot/refcache-refresh` branch. When asked to fix one of the following kinds
-of branches instead, target the open PR whose head branch matches:
+By default, sweep all open otelbot PRs — those whose head branch matches
+`otelbot/*`. When instructed, narrow the sweep to the named branch or group of
+branches (for example, `otelbot/refcache-refresh`, or the spec/semconv
+integration branches); ask if the instruction is ambiguous.
 
-- **Collector docs branch**: `otelbot/collector-docs-*`
-- **Spec or semconv integration branch**: `otelbot/spec-integration-*` or
-  `otelbot/semconv-integration-*`, respectively
+1. List the open otelbot PRs:
 
-If more than one PR matches, ask which one is intended. To list open otelbot
-PRs:
+   ```sh
+   gh pr list --search head:otelbot/ --json number,title,headRefName,isDraft
+   ```
 
-```sh
-gh pr list --search head:otelbot/
-```
-
-In the steps below, _`TARGET_BRANCH`_ is the head branch of the target PR.
+2. Determine which of them have failing link checks — checks of the `Links`
+   workflow (`gh pr checks <num>`) — and report the full list: PR number, head
+   branch, draft status, and whether it will be processed.
+3. Process each PR that has link-check failures in turn, following the sections
+   below. In those steps, _`TARGET_BRANCH`_ is the head branch of the PR being
+   processed.
 
 ## Preparation
 
-These steps assume you have a local clone of the repository with the `upstream`
-remote configured to point to the main repository. Run these steps locally from
-the repository root.
+Run these steps from the root of a local clone with the `upstream` remote
+pointing at the main repository.
 
-1. Determine the PR associated with upstream _`TARGET_BRANCH`_.
-2. If none exists, stop.
-3. If a local _`TARGET_BRANCH`_ branch already exists and contains commits that
-   are not in the upstream branch, back them up or stop before resetting
-   anything.
-4. Check out the PR branch with `gh pr checkout <num>`. If that fails because
-   the local branch has diverged and you have already backed up any local-only
-   commits, realign it with upstream:
+1. Check out the PR branch: `gh pr checkout <num>`. If that fails because a
+   local _`TARGET_BRANCH`_ has diverged, back up any local-only commits (or
+   stop), then realign:
 
    ```sh
    git fetch upstream
@@ -49,7 +44,7 @@ the repository root.
    git reset --hard upstream/TARGET_BRANCH
    ```
 
-5. If any content modules are out of date, run `npm run get:submodule`.
+2. If any content modules are out of date, run `npm run get:submodule`.
 
 ## Handling 5XX responses
 
@@ -67,43 +62,8 @@ multiple runs over time and you have confirmed the URL is not otherwise healthy.
    still cached as 4XX and fragment URLs marked INVALID FRAGMENT, then update
    `static/refcache.json`. See LinkedIn note below.
 2. Scan `static/refcache.json` for remaining non-2XX statuses.
-3. If none remain, that is, the double-check script succeeds:
-   - Share the double-check summary in your reply (retried URLs, entries
-     updated, final HTTP status counts, and “Processed N URLs” when shown).
-   - If `static/refcache.json` changed, commit and push to upstream
-     _`TARGET_BRANCH`_ (as of this step). Use the double-check summary as the
-     commit-message body (plain text; if the retried-URL list is long, include
-     only the counts): it remains visible in the PR's commit history even after
-     a squash merge.
-   - For all target branches, add an evidence / activity-log comment to the PR —
-     skip this only when the skill invocation asks for no comment (e.g., it
-     includes “no comment” or “silent”). Post it with
-     `gh pr comment <num> --body '…'`; the comment consists of:
-     - The skill invocation, as inline code — reconstructed in minimal form
-       (skill name and target selection only). Never quote the surrounding
-       conversation, which may contain private or unrelated context.
-     - A terse, one-or-two-line summary of the run.
-
-     For example:
-
-     ```text
-     Refcache update done using: `/refresh-refcache-pr-fix for the otelbot collector-docs branch`
-
-     Re-checked 12 cached 4XX/fragment URLs; all now 2XX — no non-2XX entries remain.
-     ```
-
-   - For `otelbot/refcache-refresh` and `otelbot/collector-docs-*` PRs —
-     integration-branch PRs stay draft until their workflow finalizes them at
-     release time:
-     - Mark the PR ready for review: `gh pr ready <num>`.
-     - Enable auto-merge, so that the PR is merged once all approvals are in and
-       the checks pass: `gh pr merge <num> --auto`.
-     - **Remind a maintainer to approve** the PR so auto-merge can complete.
-       Provide a link to the PR:
-       `https://github.com/open-telemetry/opentelemetry.io/pull/<num>`.
-
-   Then stop unless you are also leaving notes for reviewers.
-
+3. If none remain, that is, the double-check script succeeds,
+   [wrap up the PR](#wrap-up).
 4. **Otherwise** (non-2XX still present after step 2), list remaining URLs and
    their statuses:
 
@@ -125,8 +85,9 @@ multiple runs over time and you have confirmed the URL is not otherwise healthy.
    - Where it originates from: provide links to files or pages.
    - A recommendation. For links into github.com, recommend a replacement link
      based on the last commit that contains the named resource.
-   - For an **integration branch**: where the fix belongs — in-branch, a
-     separate PR against `main`, or upstream in the spec repository.
+   - Where the fix belongs — in-branch; in a separate PR against `main` (for
+     example, when the same dead link also affects `main` or several target
+     PRs); or upstream in the source repository, for integration branches.
 
    Pause for feedback from a reviewer.
 
@@ -141,3 +102,38 @@ multiple runs over time and you have confirmed the URL is not otherwise healthy.
 7. Run `npm run fix:refcache` to refresh `static/refcache.json` after those
    source-link changes, then repeat the steps in this section (from step 1)
    until no non-2XX statuses remain.
+
+## Wrap up
+
+Once no non-2XX entries remain on the PR being processed:
+
+1. Share the double-check summary in your reply (retried URLs, entries updated,
+   final HTTP status counts, and “Processed N URLs” when shown).
+2. If `static/refcache.json` changed, commit and push to upstream
+   _`TARGET_BRANCH`_. Use the double-check summary as the commit-message body
+   (plain text; if the retried-URL list is long, include only the counts): it
+   remains visible in the PR's commit history even after a squash merge.
+3. Unless the skill invocation asks for no comment (e.g., it includes “no
+   comment” or “silent”), add a comment to the PR
+   (`gh pr comment <num> --body '…'`) consisting of:
+   - The skill invocation, as inline code — reconstructed in minimal form (skill
+     name and target selection only). Never quote the surrounding conversation,
+     which may contain private or unrelated context.
+   - A terse, one-or-two-line summary of the run.
+
+   For example:
+
+   ```text
+   Refcache update done using: `/refresh-refcache-pr-fix for the collector-docs branch`
+
+   Re-checked 12 cached 4XX/fragment URLs; all now 2XX — no non-2XX entries remain.
+   ```
+
+4. If the PR is **not** a draft and the link check was its only failing check,
+   enable auto-merge (`gh pr merge <num> --auto --squash`), and **remind a
+   maintainer to approve** the PR so that auto-merge can complete; include a
+   link to the PR. Otherwise, report why the PR was left as is: draft status
+   (for example, an integration PR that its own workflow finalizes at release
+   time), or other failing checks.
+
+Then continue with the next target PR, if any.

--- a/content/en/site/skills/refresh-refcache-pr-fix.md
+++ b/content/en/site/skills/refresh-refcache-pr-fix.md
@@ -12,9 +12,13 @@ entries remain.
 ## Target PR
 
 Unless instructed otherwise, target the PR for the upstream
-`otelbot/refcache-refresh` branch. When asked to fix a **spec or semconv
-integration branch**, target the open PR whose head branch matches
-`otelbot/spec-integration-*` or `otelbot/semconv-integration-*`, respectively.
+`otelbot/refcache-refresh` branch. When asked to fix one of the following kinds
+of branches instead, target the open PR whose head branch matches:
+
+- **Collector docs branch**: `otelbot/collector-docs-*`
+- **Spec or semconv integration branch**: `otelbot/spec-integration-*` or
+  `otelbot/semconv-integration-*`, respectively
+
 If more than one PR matches, ask which one is intended. To list open otelbot
 PRs:
 
@@ -64,13 +68,27 @@ multiple runs over time and you have confirmed the URL is not otherwise healthy.
    `static/refcache.json`. See LinkedIn note below.
 2. Scan `static/refcache.json` for remaining non-2XX statuses.
 3. If none remain, that is, the double-check script succeeds:
-   - Share the double-check summary: in your reply or PR comment (retried URLs,
-     entries updated, final HTTP status counts, and “Processed N URLs” when
-     shown).
+   - Share the double-check summary in your reply (retried URLs, entries
+     updated, final HTTP status counts, and “Processed N URLs” when shown).
    - If `static/refcache.json` changed, commit and push to upstream
      _`TARGET_BRANCH`_ (as of this step).
-   - For `otelbot/refcache-refresh` only — integration-branch PRs stay draft
-     until their workflow finalizes them at release time:
+   - For all target branches, add an evidence / activity-log comment to the PR —
+     skip this only when the skill invocation asks for no comment (e.g., it
+     includes “no comment” or “silent”). The comment consists of:
+     - The skill invocation command, as inline code.
+     - A terse, one-or-two-line summary of the run.
+
+     For example:
+
+     ```text
+     Refcache update done using: `/refresh-refcache-pr-fix for the otelbot collector-docs branch`
+
+     Re-checked 12 cached 4XX/fragment URLs; all now 2XX — no non-2XX entries remain.
+     ```
+
+   - For `otelbot/refcache-refresh` and `otelbot/collector-docs-*` PRs —
+     integration-branch PRs stay draft until their workflow finalizes them at
+     release time:
      - Mark the PR ready for review: `gh pr ready <num>`.
      - Enable auto-merge, so that the PR is merged once all approvals are in and
        the checks pass: `gh pr merge <num> --auto`.

--- a/content/en/site/skills/refresh-refcache-pr-fix.md
+++ b/content/en/site/skills/refresh-refcache-pr-fix.md
@@ -71,12 +71,17 @@ multiple runs over time and you have confirmed the URL is not otherwise healthy.
    - Share the double-check summary in your reply (retried URLs, entries
      updated, final HTTP status counts, and “Processed N URLs” when shown).
    - If `static/refcache.json` changed, commit and push to upstream
-     _`TARGET_BRANCH`_ (as of this step).
+     _`TARGET_BRANCH`_ (as of this step). Use the double-check summary as the
+     commit-message body (plain text; if the retried-URL list is long, include
+     only the counts): it remains visible in the PR's commit history even after
+     a squash merge.
    - For all target branches, add an evidence / activity-log comment to the PR —
      skip this only when the skill invocation asks for no comment (e.g., it
      includes “no comment” or “silent”). Post it with
      `gh pr comment <num> --body '…'`; the comment consists of:
-     - The skill invocation command, as inline code.
+     - The skill invocation, as inline code — reconstructed in minimal form
+       (skill name and target selection only). Never quote the surrounding
+       conversation, which may contain private or unrelated context.
      - A terse, one-or-two-line summary of the run.
 
      For example:


### PR DESCRIPTION
Reworks the `/refresh-refcache-pr-fix` site skill around a simple, general model, and adjusts the refcache-refresh workflow to match:

- **Sweeps all open `otelbot/*` PRs by default** — lists them, then processes those with failing link checks; explicit branch or branch-group targeting remains as an override.
- **Arms auto-merge and the approval reminder** only on a non-draft PR whose sole failing check was the link check; otherwise reports why the PR was left as is (draft status, or other failing checks).
- **Drops `--draft` in `refcache-refresh.yml`**: CI is the real merge gate; born-draft status only forced a manual ready step.
- **Leaves a run trail**: double-check diagnostics in the commit-message body (survives squash merge); a PII-safe, minimally reconstructed skill invocation plus terse summary as a PR comment (opt-out via "no comment"/"silent").

Other changes:

- Gathers the post-fix steps into a new "Wrap up" section.
- Generalizes fix-placement guidance: in-branch, separate PR against `main`, or upstream.
- Skills index: notes how to read step commands (prose states the intent; a parenthesized command is a suggestion).
- Tightens Preparation; updates the skill-wrapper description and skills-index blurb to match.

**Transition note**: if an `otelbot/refcache-refresh` draft PR is open when this lands, it needs a one-time manual `gh pr ready` (or close-and-regenerate); subsequent workflow runs create non-draft PRs.

Preview(s):

- https://deploy-preview-10780--opentelemetry.netlify.app/site/skills/refresh-refcache-pr-fix/
- https://deploy-preview-10780--opentelemetry.netlify.app/site/skills/
