### PR TITLE
docs: clarify OTLP/gRPC endpoint paths

### DIFF
--- a/content/en/docs/languages/sdk-configuration/otlp-exporter.md
+++ b/content/en/docs/languages/sdk-configuration/otlp-exporter.md
@@ -36,6 +36,11 @@ and logs, the following URLs are constructed from the example above:
 - Metrics: `"http://my-api-endpoint/v1/metrics"`
 - Logs: `"http://my-api-endpoint/v1/logs"`
 
+For OTLP/gRPC, endpoint values are gRPC targets. Do not append OTLP/HTTP signal
+paths such as `/v1/traces`, `/v1/metrics`, or `/v1/logs` to gRPC endpoint
+values; gRPC exporters use the OTLP protobuf service method for each signal
+after connecting to the configured target.
+
 ### `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
 
 Endpoint URL for trace data only, with an optionally-specified port number.


### PR DESCRIPTION
Summary:
- Clarify that OTLP/gRPC endpoint values are gRPC targets, not OTLP/HTTP URLs with signal paths.
- Note that `/v1/traces`, `/v1/metrics`, and `/v1/logs` should not be appended to gRPC endpoint values.

Fixes #4400

Validation:
- `npx prettier --check content/en/docs/languages/sdk-configuration/otlp-exporter.md` — passed
- `npx markdownlint-cli2 content/en/docs/languages/sdk-configuration/otlp-exporter.md` — passed
- `npx --yes -p node@24 node node_modules/cspell/bin.mjs --no-progress -c .cspell.yml content/en/docs/languages/sdk-configuration/otlp-exporter.md` — passed
- `git diff --check` — passed
