### PR TITLE
Add Spanlens to vendors list

### DIFF
--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -443,6 +443,12 @@
   contact:
   oss: false
   commercial: true
+- name: Spanlens
+  nativeOTLP: true
+  url: https://www.spanlens.io/docs/otel
+  contact: support@spanlens.io
+  oss: true
+  commercial: true
 - name: Splunk
   nativeOTLP: true
   url: https://help.splunk.com/en/?resourceId=gdi_opentelemetry_opentelemetry


### PR DESCRIPTION
Adds Spanlens to the vendors list, per the criteria on the vendors page:

- **OTLP docs**: https://www.spanlens.io/docs/otel. Spanlens accepts OTLP/HTTP
  traces natively at its `/v1/traces` ingest endpoint.
- **Open source**: https://github.com/spanlens/Spanlens. The full product is MIT
  licensed (dashboard, server, SDKs), not just a distribution.
- **Commercial**: hosted SaaS at https://www.spanlens.io, with self-hosting supported.
- **Contact**: support@spanlens.io (or GitHub @maestro24).

Entry is placed alphabetically between SolarWinds and Splunk.

## Checklist

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR. (Yes, I can answer maintainer questions about the content of this PR, without using AI.)

I used an AI assistant to draft this description and the YAML entry. I build and
maintain Spanlens, so I can confirm each claim above and answer questions directly.
