### PR TITLE
[ja] update translation of content/en/docs/languages/ruby/instrumentation.md

### DIFF
--- a/content/ja/docs/languages/ruby/instrumentation.md
+++ b/content/ja/docs/languages/ruby/instrumentation.md
@@ -7,8 +7,7 @@ aliases:
   - /docs/languages/ruby/context-propagation
 weight: 20
 description: OpenTelemetry Ruby計装
-default_lang_commit: c88a006471f039334aed7990736e089a62b33f94
-drifted_from_default: true
+default_lang_commit: d03483e1d5cc696a5541f8bcc8ff97170f2f2ca1
 cSpell:ignore: SIGHUP
 ---
 
@@ -103,6 +102,24 @@ require "opentelemetry/sdk"
 def do_work
   MyAppTracer.in_span("do_work") do |span|
     # `do_work`スパンが追跡する何らかの処理を実行
+  end
+end
+```
+
+`in_span` ブロックから例外がエスケープした場合、トレーサーはデフォルトでスパンに例外を記録し、スパンステータスを `Error` に設定して、例外を再度発生させます。
+`in_span` メソッドの引数として `record_exception: false` を渡すことで、自動例外記録を無効にできます。
+
+ブロック内で例外をレスキューし、再度発生させない場合は、必要に応じてスパンステータスの設定と例外の記録を手動で行います。
+
+```ruby
+MyAppTracer.in_span("do_work") do |span|
+  begin
+    # 例外を発生させる可能性のある処理を実行
+  rescue StandardError => e
+    span.status = OpenTelemetry::Trace::Status.error(e.message)
+    span.record_exception(e)
+
+    # フォールバックを返すなど、再度発生させずに例外を処理する
   end
 end
 ```


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/ruby/instrumentation.md` to match the latest English source at
`content/en/docs/languages/ruby/instrumentation.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff added documentation about exception handling behavior in `in_span` blocks:
- How the tracer records exceptions by default when they escape the block
- How to disable automatic exception recording with `record_exception: false`
- A code example showing manual exception handling inside an `in_span` block

Note: PR #10758 ("Add Do11y script") also touches this file but only to add `drifted_from_default: true` — it is not a competing drift fix. This PR supersedes that flag change.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10789--opentelemetry.netlify.app/ja/docs/languages/ruby/instrumentation/
- **English (canonical):** https://opentelemetry.io/docs/languages/ruby/instrumentation/

_(deploy preview status: pending. The URLs will work once Netlify finishes building.)_
<!-- preview-section-end -->
