### PR TITLE
[ja] update translation of content/en/docs/contributing/pr-checks.md

### DIFF
--- a/content/ja/docs/contributing/pr-checks.md
+++ b/content/ja/docs/contributing/pr-checks.md
@@ -3,8 +3,7 @@ title: プルリクエストのチェックとテスト
 linkTitle: PR チェック & テスト
 description: プルリクエストがすべてのチェックをパスする方法学ぶ
 weight: 40
-default_lang_commit: 1143960b75c6faceb40eb64269e68390e3237671
-drifted_from_default: true
+default_lang_commit: eb1e39f771d32be4756dc94885d1ac3940de6de7
 ---
 
 [opentelemetry.io リポジトリ](https://github.com/open-telemetry/opentelemetry.io)に[pull request](https://docs.github.com/en/get-started/learning-about-github/github-glossary#pull-request)（PR）を作成した際に、一連のチェックが実行されます。
@@ -182,7 +181,7 @@ OpenTelemetry ウェブサイト内のページをリンクする場合、外部
 - この警告を表示するレンダーリンクフック:
   [`layouts/_markup/render-link.html`](https://github.com/open-telemetry/opentelemetry.io/blob/main/layouts/_markup/render-link.html)
 - 完全な URL をローカルパスに自動的に変換するスクリプト:
-  [`scripts/content-modules/adjust-pages.pl`](https://github.com/open-telemetry/opentelemetry.io/blob/main/scripts/content-modules/adjust-pages.pl)
+  [`scripts/content-modules/adjust-pages/`](https://github.com/open-telemetry/opentelemetry.io/tree/main/scripts/content-modules/adjust-pages)
 
 </details>
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/contributing/pr-checks.md` to match the latest English source at
`content/en/docs/contributing/pr-checks.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English change was a single link update: the `adjust-pages.pl` script reference was updated
to `adjust-pages/` (directory), reflecting the upstream reorganization of that script.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10794--opentelemetry.netlify.app/ja/docs/contributing/pr-checks/
- **English (canonical):** https://opentelemetry.io/docs/contributing/pr-checks/

<!-- preview-section-end -->
