### PR TITLE
fix(blog): remove duplicate "the" in blog/2026/dart-flutter-opentelemetry.md

### DIFF
--- a/content/en/blog/2026/dart-flutter-opentelemetry.md
+++ b/content/en/blog/2026/dart-flutter-opentelemetry.md
@@ -23,7 +23,7 @@ leaving Dart and Flutter developers without a supported path to capture
 telemetry from their servers and apps.
 
 An actively developed implementation of the OpenTelemetry specification for Dart
-already exists that is in the process of being donated to the the OpenTelemetry
+already exists that is in the process of being donated to the OpenTelemetry
 project:
 [dartastic_opentelemetry](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry)
 and its standalone API package


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

Follow-up to #10773. Thanks to @unusdon for catching this and opening the original fix.
