### PR TITLE
Update draft-issue skill: do not hard-wrap issue body prose

### DIFF
--- a/.claude/skills/draft-issue/SKILL.md
+++ b/.claude/skills/draft-issue/SKILL.md
@@ -62,7 +62,11 @@ From `content/en/docs/contributing/issues.md`:
 - **Reference related issues and PRs** with `#1234` for the same repo, or the
   full URL for cross-repo references.
 - **Concise, actionable** descriptions; no filler.
-- Wrap body prose at 80 characters (convention, not enforced).
+
+Other guidance:
+
+- Format: do **not** hard line-wrap (prettify) issue body prose, instead let
+  GitHub flow paragraph text naturally.
 
 ## Labels {#labels}
 


### PR DESCRIPTION
- Replaces the "wrap body prose at 80 characters" drafting rule with a do-not-hard-wrap rule