### PR TITLE
Auto-update community members: delete branch of obsolete PRs

### DIFF
--- a/.github/workflows/auto-update-community-members.yml
+++ b/.github/workflows/auto-update-community-members.yml
@@ -62,6 +62,7 @@ jobs:
           committer: otelbot <197425009+otelbot@users.noreply.github.com>
           token: ${{ steps.otelbot-token.outputs.token }}
           branch: otelbot/update-community-members
+          delete-branch: true
           title: Update community members
           body: |
             This pull request contains automated updates to files by the GitHub Action.


### PR DESCRIPTION
- Fixes #10797
- Sets `delete-branch: true` on the create-pull-request step: when a scheduled run finds no remaining diff with `main` while a previous run's PR is still open, the action now deletes the PR branch (which closes the PR) instead of force-pushing the branch to `main`'s HEAD and leaving it lingering after GitHub auto-closes the PR — see the [`delete-branch` docs](https://github.com/peter-evans/create-pull-request/blob/v8.1.1/README.md#delete-branch).
- Scope note: the `generate.js` spurious-removal guard also floated in the issue is intentionally **not** implemented — see the issue's [rescoping comment](https://github.com/open-telemetry/opentelemetry.io/issues/10797#issuecomment-4959550727) for the rationale.