### PR TITLE
Add taleseal to the registry

### DIFF
--- a/data/registry/application-integration-taleseal.yml
+++ b/data/registry/application-integration-taleseal.yml
@@ -1,0 +1,21 @@
+# cSpell:ignore taleseal
+title: Taleseal
+registryType: application integration
+language: js
+tags:
+  - ai
+  - genai
+license: proprietary
+description:
+  Taleseal is an OTLP/HTTP sink for AI agent runs. Point an OpenTelemetry
+  exporter emitting GenAI (gen_ai.*) spans at it, and each run is composed into
+  a shareable narrative page — beats, tool receipts, token counts and a span
+  timeline — reachable at one short link.
+authors:
+  - name: Taleseal
+    url: https://taleseal.com
+urls:
+  website: https://taleseal.com
+  repo: https://github.com/Taleseal/taleseal
+createdAt: '2026-07-13'
+isNative: true


### PR DESCRIPTION
Adds an `application integration` registry entry for [taleseal](https://taleseal.com), an OTLP/HTTP sink for AI agent runs.

Point an OpenTelemetry exporter emitting GenAI (`gen_ai.*`) spans at `https://taleseal.com/v1/traces` and each run is composed into a shareable narrative page — beats, tool receipts, token counts and a span timeline — at one short link. It accepts both OTLP/HTTP encodings (protobuf and JSON).

New file: `data/registry/application-integration-taleseal.yml`, following the `registry-schema.json` and mirroring the existing `application-integration-claude-code.yml` entry. I'll sign the CNCF EasyCLA on this PR.

---

**Note from the maintainers**: this description was submitted without our [PR template](https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/PULL_REQUEST_TEMPLATE.md)'s checklist, which asks you to confirm:

- [ ] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [ ] I have the experience and knowledge necessary to understand, review, and validate all content in this PR. (Yes, I can answer maintainer questions about the content of this PR, without using AI.)

Per our [first-time contributor policy](https://github.com/open-telemetry/opentelemetry.io/issues/11243), answer these questions by ticking each box that applies.
