### PR TITLE
Labeler: exclude word lists and locale prose rules from CI/infra

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,9 +19,8 @@
 
 # CI/infra resources are owned by docs-maintainers, except for cspell files.
 # Keep this list in sync with the `CI/infra` label list in
-# .github/component-label-map.yml -- except for the cspell word lists
-# (/.cspell/) and locale prose rules (/prh/), which are content-adjacent and
-# intentionally excluded from that label. cSpell:ignore gulpfile
+# .github/component-label-map.yml (which notes intentional omissions).
+# cSpell:ignore gulpfile
 /.claude/**                     @open-telemetry/docs-maintainers
 /.cspell/**                     @open-telemetry/docs-approvers
 /.cspell.yml                    @open-telemetry/docs-approvers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,9 @@
 
 # CI/infra resources are owned by docs-maintainers, except for cspell files.
 # Keep this list in sync with the `CI/infra` label list in
-# .github/component-label-map.yml. cSpell:ignore gulpfile
+# .github/component-label-map.yml -- except for the cspell word lists
+# (/.cspell/) and locale prose rules (/prh/), which are content-adjacent and
+# intentionally excluded from that label. cSpell:ignore gulpfile
 /.claude/**                     @open-telemetry/docs-maintainers
 /.cspell/**                     @open-telemetry/docs-approvers
 /.cspell.yml                    @open-telemetry/docs-approvers

--- a/.github/component-label-map.yml
+++ b/.github/component-label-map.yml
@@ -147,9 +147,8 @@ CI/infra: # including config
       - any-glob-to-any-file:
           # Maintainer note: keep .github/CODEOWNERS in sync with this list.
           # Entries are maintainer-owned unless indicated otherwise. Word lists
-          # (.cspell/) and locale prose rules (prh/) are content-adjacent, so
-          # they are deliberately excluded from this list; the base checker
-          # config (.cspell.yml) is not.
+          # (.cspell/) and prose rules (prh/) are content, not infra, so they
+          # are deliberately omitted.
           # cSpell:ignore gulpfile
           - .claude/**
           - .cspell.yml # owned by docs-approvers

--- a/.github/component-label-map.yml
+++ b/.github/component-label-map.yml
@@ -146,10 +146,12 @@ CI/infra: # including config
   - changed-files:
       - any-glob-to-any-file:
           # Maintainer note: keep .github/CODEOWNERS in sync with this list.
-          # Entries are maintainer-owned unless indicated otherwise.
+          # Entries are maintainer-owned unless indicated otherwise. Word lists
+          # (.cspell/) and locale prose rules (prh/) are content-adjacent, so
+          # they are deliberately excluded from this list; the base checker
+          # config (.cspell.yml) is not.
           # cSpell:ignore gulpfile
           - .claude/**
-          - .cspell/** # owned by docs-approvers
           - .cspell.yml # owned by docs-approvers
           - .devcontainer/**
           - .editorconfig
@@ -171,7 +173,6 @@ CI/infra: # including config
           - Makefile
           - netlify/**
           - netlify.toml
-          - prh/**
           - scripts/**
           - tests/**
 


### PR DESCRIPTION
- Drops `.cspell/**` word lists and `prh/**` locale prose rules from the `CI/infra` label globs: they are content-adjacent files routinely touched by ordinary docs, blog, registry, and i18n PRs just to keep checks green, so labeling those PRs `CI/infra` dilutes the label's triage value (e.g. #10704 got labeled `CI/infra` from a since-reverted `.cspell/en-words.txt` touch).
- Keeps `.cspell.yml` under the label, since it configures how the spell check runs repo-wide.
- Updates the sync comments in the label map and CODEOWNERS to document the intentional divergence; ownership entries are unchanged.