### PR TITLE
Update Go compile-time docs for v1.0.0

### DIFF
--- a/content/en/docs/zero-code/go/compile-time/_index.md
+++ b/content/en/docs/zero-code/go/compile-time/_index.md
@@ -15,8 +15,8 @@ required.
 
 > [!NOTE]
 >
-> This project is under active development and is not yet ready for production
-> use. To follow progress or get involved, visit the
+> This project is stable and ready for production use as of v1.0.0. To follow
+> development or get involved, visit the
 > [opentelemetry-go-compile-instrumentation repository](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation).
 
 ## How it works

--- a/content/en/docs/zero-code/go/compile-time/configuration.md
+++ b/content/en/docs/zero-code/go/compile-time/configuration.md
@@ -16,12 +16,13 @@ application produces.
 
 `otelc` wraps the Go toolchain. Its subcommands:
 
-| Command         | Purpose                                                              |
-| --------------- | -------------------------------------------------------------------- |
-| `otelc go …`    | Run a `go` command (such as `go build`) with instrumentation applied |
-| `otelc setup`   | Set up the environment for instrumentation                           |
-| `otelc cleanup` | Remove all artifacts created by the setup and build phases           |
-| `otelc version` | Print the tool version                                               |
+| Command         | Purpose                                                                                             |
+| --------------- | --------------------------------------------------------------------------------------------------- |
+| `otelc go …`    | Run a `go` command (such as `go build`) with instrumentation applied                                |
+| `otelc setup`   | Set up the environment for instrumentation                                                          |
+| `otelc pin`     | Generate or update `otel.instrumentation.go` to pin instrumentation packages for the current module |
+| `otelc cleanup` | Remove all artifacts created by the setup and build phases                                          |
+| `otelc version` | Print the tool version                                                                              |
 
 Flags are passed before the subcommand:
 


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [X] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [X] This PR has content that I did not fully write myself.
  - [X] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [X] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

Updates the Go compile-time instrumentation docs for the v1.0.0 GA release of
opentelemetry-go-compile-instrumentation, published today:
https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/releases/tag/v1.0.0

- Update the production-readiness note: the project is stable as of v1.0.0,
  mirroring the wording from the repository's own release preparation
  (open-telemetry/opentelemetry-go-compile-instrumentation#687).
- Add the new `otelc pin` subcommand to the configuration page.

Checked against the v1.0.0 tag: the install flow, flags, environment
variables, and the supported-libraries table are unchanged and remain
accurate.

Part of #10578

