### PR TITLE
Add Guance to OpenTelemetry vendors

### DIFF
--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -185,6 +185,12 @@
   contact: https://github.com/jpkrohling/
   oss: true
   commercial: true
+- name: Guance
+  nativeOTLP: true
+  url: https://docs.guance.com/en/integrations/opentelemetry/
+  contact: 
+  oss: false
+  commercial: true
 - name: Heroku
   nativeOTLP: true
   url: https://devcenter.heroku.com/articles/heroku-telemetry

--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -188,7 +188,7 @@
 - name: Guance
   nativeOTLP: true
   url: https://docs.guance.com/en/integrations/opentelemetry/
-  contact: 
+  contact:
   oss: false
   commercial: true
 - name: Heroku

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -1967,6 +1967,10 @@
     "StatusCode": 200,
     "LastSeen": "2026-07-11T06:26:51.852473075Z"
   },
+  "https://docs.guance.com/en/integrations/opentelemetry/": {
+    "StatusCode": 200,
+    "LastSeen": "2026-07-15T04:32:05.153718774Z"
+  },
   "https://docs.helixops.ai/bin/view/IT-Operations-Management/Operations-Management/BMC-Helix-AIOps/aiops254/Administering/Enabling-BMC-Helix-applications-to-collect-service-traces-from-OpenTelemetry/": {
     "StatusCode": 200,
     "LastSeen": "2026-07-10T11:54:33.503553-04:00"


### PR DESCRIPTION
Adds Guance to the OpenTelemetry vendors list with native OTLP support.

The entry links to Guance's OpenTelemetry integration documentation and marks the offering as commercial.

Validation:
- `npm run build:lean`
- `npx prettier --check data/ecosystem/vendors.yaml static/refcache.json`