### PR TITLE
Harden refresh-refcache-pr-fix skill after first live run

### DIFF
--- a/content/en/site/skills/refresh-refcache-pr-fix.md
+++ b/content/en/site/skills/refresh-refcache-pr-fix.md
@@ -96,10 +96,8 @@ multiple runs over time and you have confirmed the URL is not otherwise healthy.
    Stop and wait for reviewer approval -- never self-approve recommendations.
 
 6. **Apply approved fixes.** Perform the maintainer-approved fix and follow-up
-   actions — and only those. If any touched page is outside `content/en/`,
-   follow
-   [Localization](/docs/contributing/localization/#link-fixes-and-resource-updates)
-   for that edit (e.g. `# patched` on `default_lang_commit`).
+   actions, and only those. Follow [Localization][] for gating requirements on
+   any edits outside `content/en/`, and conventions (e.g. `# patched` tags).
 
 7. Run `npm run fix:refcache` to refresh `static/refcache.json` after those
    source-link changes, then repeat the steps in this section (from step 1)
@@ -169,3 +167,7 @@ archive is slow.
 
 Remove the entry, and cc the entry's original submitter in the PR comment, per
 [Keeping registry and list information current](/ecosystem/registry/updating/).
+
+<!-- prettier-ignore-start -->
+[Localization]: /docs/contributing/localization/#link-fixes-and-resource-updates
+<!-- prettier-ignore-end -->

--- a/content/en/site/skills/refresh-refcache-pr-fix.md
+++ b/content/en/site/skills/refresh-refcache-pr-fix.md
@@ -14,7 +14,8 @@ entries remain.
 By default, sweep all open otelbot PRs — those whose head branch matches
 `otelbot/*`. When instructed, narrow the sweep to the named branch or group of
 branches (for example, `otelbot/refcache-refresh`, or the spec/semconv
-integration branches); ask if the instruction is ambiguous.
+integration branches); ask if the instruction is ambiguous. This skill operates
+on PRs: if a named branch has no open PR, report that and stop.
 
 1. List the open otelbot PRs:
 
@@ -81,23 +82,17 @@ multiple runs over time and you have confirmed the URL is not otherwise healthy.
    > 4XX links, instead let a maintainer manually run
    > `./scripts/double-check-refcache-4XX.mjs --retry-404` locally first.
 
-5. **Analyze and recommend**. For each URL from the previous step, produce a
-   numbered or bulleted list that includes at least:
+5. **Analyze and recommend**. For each URL from the previous step, report:
    - The URL and HTTP status.
    - Where it originates from: provide links to files or pages.
-   - A recommendation, with **evidence** that any replacement URL is a proper
-     replacement: the fetched page must name or otherwise match the resource
-     being linked — a 2XX status alone proves nothing, since SPA catch-alls and
-     login pages return 200 for any path. For links into github.com, base the
-     replacement on the last commit that contains the named resource.
-   - When the linked project appears defunct, absorbed, or otherwise no longer
-     meets its listing criteria, recommend retiring the registry or ecosystem
-     entry instead of updating its links — see
-     [Keeping registry and list information current](/ecosystem/registry/updating/)
-     — and cc the entry's original submitter in the PR comment.
-   - Where the fix belongs — in-branch; in a separate PR against `main` (for
-     example, when the same dead link also affects `main` or several target
-     PRs); or upstream in the source repository, for integration branches.
+   - A recommendation — update or remove the link, or retire the entry — with
+     supporting evidence; see
+     [Recommendation guidance](#recommendation-guidance).
+   - Where the fix belongs, for example:
+     - In-branch
+     - In a separate PR against `main`, when the same dead link also affects
+       `main` or several target PRs
+     - Upstream in the source repository, for integration branches
 
    Stop and wait for reviewer approval — never self-approve recommendations.
 
@@ -147,3 +142,17 @@ Once no non-2XX entries remain on the PR being processed:
    time), or other failing checks.
 
 Then continue with the next target PR, if any.
+
+## Recommendation guidance
+
+Ground each recommendation in evidence:
+
+- **Replacement URL** — show that the fetched page names or otherwise matches
+  the linked resource: a 2XX status alone proves nothing, since SPA catch-alls
+  and login pages return 200 for any path. For links into github.com, base the
+  replacement on the last commit that contains the named resource.
+- **Entry retirement** — when the linked project appears defunct, absorbed, or
+  otherwise no longer meets its listing criteria, retire the registry or
+  ecosystem entry instead of updating its links, and cc the entry's original
+  submitter in the PR comment. For the policy, see
+  [Keeping registry and list information current](/ecosystem/registry/updating/).

--- a/content/en/site/skills/refresh-refcache-pr-fix.md
+++ b/content/en/site/skills/refresh-refcache-pr-fix.md
@@ -11,7 +11,7 @@ entries remain.
 
 ## Target PRs
 
-By default, sweep all open otelbot PRs — those whose head branch matches
+By default, sweep all open otelbot PRs -- those whose head branch matches
 `otelbot/*`. When instructed, narrow the sweep to the named branch or group of
 branches (for example, `otelbot/refcache-refresh`, or the spec/semconv
 integration branches); ask if the instruction is ambiguous. This skill operates
@@ -23,9 +23,9 @@ on PRs: if a named branch has no open PR, report that and stop.
    gh pr list --search head:otelbot/ --json number,title,headRefName,isDraft
    ```
 
-2. Determine which of them have failing link checks — checks of the `Links`
+2. Determine which of them have failing link checks -- checks of the `Links`
    workflow (`gh pr checks <num>`).
-3. Report the sweep assessment **before processing any PR**: one line per PR —
+3. Report the sweep assessment **before processing any PR**: one line per PR --
    number, head branch, draft status, and whether it will be processed (with the
    reason when skipped).
 4. Process each qualifying PR in turn, following the sections below, naming the
@@ -93,7 +93,7 @@ multiple runs over time and you have confirmed the URL is not otherwise healthy.
        `main` or several target PRs
      - Upstream in the source repository, for integration branches
 
-   Stop and wait for reviewer approval — never self-approve recommendations.
+   Stop and wait for reviewer approval -- never self-approve recommendations.
 
 6. **Apply approved fixes.** Perform the maintainer-approved fix and follow-up
    actions, and only those. For edits outside `content/en/`, follow
@@ -116,9 +116,9 @@ Once no non-2XX entries remain on the PR being processed:
 3. Unless the skill invocation asks for no comment (e.g., it includes “no
    comment” or “silent”), add a comment to the PR
    (`gh pr comment <num> --body '…'`) consisting of:
-   - The skill invocation, as inline code — reconstructed in minimal form (skill
-     name and target selection only). Never quote the surrounding conversation,
-     which may contain private or unrelated context.
+   - The skill invocation, as inline code -- reconstructed in minimal form
+     (skill name and target selection only). Never quote the surrounding
+     conversation, which may contain private or unrelated context.
    - A terse, one-or-two-line summary of the run.
 
    For example:
@@ -126,7 +126,7 @@ Once no non-2XX entries remain on the PR being processed:
    ```text
    Refcache update done using: `/refresh-refcache-pr-fix for the collector-docs branch`
 
-   Re-checked 12 cached 4XX/fragment URLs; all now 2XX — no non-2XX entries remain.
+   Re-checked 12 cached 4XX/fragment URLs; all now 2XX -- no non-2XX entries remain.
    ```
 
 4. If the PR is **not** a draft and the link check was its only failing check,
@@ -145,7 +145,7 @@ Ground every recommendation in evidence, and match the fix to the situation:
 - **Linked page moved**: update the link, with
   [evidence](#evidence-for-a-replacement-url) that the replacement matches.
 - **Entry subject gone**: when the link originates from a registry or
-  ecosystem-list entry — adopters, distributions, integrations, vendors — and
+  ecosystem-list entry -- adopters, distributions, integrations, vendors -- and
   the component, product, or company behind the entry is defunct, absorbed, or
   otherwise no longer actively supports OpenTelemetry,
   [retire the entry](#retiring-an-entry) instead of updating its links.
@@ -155,13 +155,13 @@ Ground every recommendation in evidence, and match the fix to the situation:
 
 ### Evidence for a replacement URL
 
-Show that the fetched page names or otherwise matches the linked resource — a
+Show that the fetched page names or otherwise matches the linked resource -- a
 2XX status alone proves nothing, since SPA catch-alls and login pages return 200
 for any path. For links into github.com, base the replacement on the last commit
 that contains the named resource. The
 [Wayback Machine](https://web.archive.org/) can reveal what a dead URL used to
-serve or where it moved; check it briefly, but don't dig deep unless asked — the
-archive is slow.
+serve or where it moved; check it briefly, but don't dig deep unless asked --
+the archive is slow.
 
 ### Retiring an entry
 

--- a/content/en/site/skills/refresh-refcache-pr-fix.md
+++ b/content/en/site/skills/refresh-refcache-pr-fix.md
@@ -93,11 +93,11 @@ multiple runs over time and you have confirmed the URL is not otherwise healthy.
        `main` or several target PRs
      - Upstream in the source repository, for integration branches
 
-   Stop and wait for reviewer approval -- never self-approve recommendations.
+   Stop and wait for reviewer approval — never self-approve recommendations.
 
 6. **Apply approved fixes.** Perform the maintainer-approved fix and follow-up
-   actions, and only those. Follow [Localization][] for gating requirements on
-   any edits outside `content/en/`, and conventions (e.g. `# patched` tags).
+   actions, and only those. For edits outside `content/en/`, follow
+   [Localization][] gating requirements and conventions (e.g. `# patched` tags).
 
 7. Run `npm run fix:refcache` to refresh `static/refcache.json` after those
    source-link changes, then repeat the steps in this section (from step 1)

--- a/content/en/site/skills/refresh-refcache-pr-fix.md
+++ b/content/en/site/skills/refresh-refcache-pr-fix.md
@@ -23,11 +23,13 @@ integration branches); ask if the instruction is ambiguous.
    ```
 
 2. Determine which of them have failing link checks — checks of the `Links`
-   workflow (`gh pr checks <num>`) — and report the full list: PR number, head
-   branch, draft status, and whether it will be processed.
-3. Process each PR that has link-check failures in turn, following the sections
-   below. In those steps, _`TARGET_BRANCH`_ is the head branch of the PR being
-   processed.
+   workflow (`gh pr checks <num>`).
+3. Report the sweep assessment **before processing any PR**: one line per PR —
+   number, head branch, draft status, and whether it will be processed (with the
+   reason when skipped).
+4. Process each qualifying PR in turn, following the sections below, naming the
+   PR as you start on it. In those steps, _`TARGET_BRANCH`_ is the head branch
+   of the PR being processed.
 
 ## Preparation
 
@@ -83,13 +85,21 @@ multiple runs over time and you have confirmed the URL is not otherwise healthy.
    numbered or bulleted list that includes at least:
    - The URL and HTTP status.
    - Where it originates from: provide links to files or pages.
-   - A recommendation. For links into github.com, recommend a replacement link
-     based on the last commit that contains the named resource.
+   - A recommendation, with **evidence** that any replacement URL is a proper
+     replacement: the fetched page must name or otherwise match the resource
+     being linked — a 2XX status alone proves nothing, since SPA catch-alls and
+     login pages return 200 for any path. For links into github.com, base the
+     replacement on the last commit that contains the named resource.
+   - When the linked project appears defunct, absorbed, or otherwise no longer
+     meets its listing criteria, recommend retiring the registry or ecosystem
+     entry instead of updating its links — see
+     [Keeping registry and list information current](/ecosystem/registry/updating/)
+     — and cc the entry's original submitter in the PR comment.
    - Where the fix belongs — in-branch; in a separate PR against `main` (for
      example, when the same dead link also affects `main` or several target
      PRs); or upstream in the source repository, for integration branches.
 
-   Pause for feedback from a reviewer.
+   Stop and wait for reviewer approval — never self-approve recommendations.
 
 6. **Apply approved fixes.** After approval, edit the suggested sources:
    - For a **404**, update or remove the referring link where you identified it.

--- a/content/en/site/skills/refresh-refcache-pr-fix.md
+++ b/content/en/site/skills/refresh-refcache-pr-fix.md
@@ -155,13 +155,15 @@ Ground every recommendation in evidence, and match the fix to the situation:
 
 ### Evidence for a replacement URL
 
-Show that the fetched page names or otherwise matches the linked resource -- a
-2XX status alone proves nothing, since SPA catch-alls and login pages return 200
-for any path. For links into github.com, base the replacement on the last commit
-that contains the named resource. The
-[Wayback Machine](https://web.archive.org/) can reveal what a dead URL used to
-serve or where it moved; check it briefly, but don't dig deep unless asked --
-the archive is slow.
+Show that the fetched page names or otherwise matches the linked resource:
+
+- A 2XX status alone proves nothing: SPA catch-alls and login pages return 200
+  for any path.
+- For links into github.com, base the replacement on the last commit that
+  contains the named resource.
+- The [Wayback Machine](https://web.archive.org/) can reveal what a dead URL
+  used to serve or where it moved; check it briefly, but don't dig deep unless
+  asked -- the archive is slow.
 
 ### Retiring an entry
 

--- a/content/en/site/skills/refresh-refcache-pr-fix.md
+++ b/content/en/site/skills/refresh-refcache-pr-fix.md
@@ -144,14 +144,30 @@ Then continue with the next target PR, if any.
 
 ## Recommending a fix for non-2XX URLs
 
-Ground each recommendation in evidence:
+Ground every recommendation in evidence, and match the fix to the situation:
 
-- **Replacement URL** — show that the fetched page names or otherwise matches
-  the linked resource: a 2XX status alone proves nothing, since SPA catch-alls
-  and login pages return 200 for any path. For links into github.com, base the
-  replacement on the last commit that contains the named resource.
-- **Entry retirement** — when the linked project appears defunct, absorbed, or
-  otherwise no longer meets its listing criteria, retire the registry or
-  ecosystem entry instead of updating its links, and cc the entry's original
-  submitter in the PR comment. For the policy, see
-  [Keeping registry and list information current](/ecosystem/registry/updating/).
+- **Linked page moved**: update the link, with
+  [evidence](#evidence-for-a-replacement-url) that the replacement matches.
+- **Entry subject gone**: when the link originates from a registry or
+  ecosystem-list entry — adopters, distributions, integrations, vendors — and
+  the component, product, or company behind the entry is defunct, absorbed, or
+  otherwise no longer actively supports OpenTelemetry,
+  [retire the entry](#retiring-an-entry) instead of updating its links.
+- **Linked page gone, no equivalent**: as a last resort, a **maintainer** may
+  remove the link and rework the surrounding prose, flagging the appropriate SIG
+  approvers. Agents must not apply this fix; defer to a maintainer.
+
+### Evidence for a replacement URL
+
+Show that the fetched page names or otherwise matches the linked resource — a
+2XX status alone proves nothing, since SPA catch-alls and login pages return 200
+for any path. For links into github.com, base the replacement on the last commit
+that contains the named resource. The
+[Wayback Machine](https://web.archive.org/) can reveal what a dead URL used to
+serve or where it moved; check it briefly, but don't dig deep unless asked — the
+archive is slow.
+
+### Retiring an entry
+
+Remove the entry, and cc the entry's original submitter in the PR comment, per
+[Keeping registry and list information current](/ecosystem/registry/updating/).

--- a/content/en/site/skills/refresh-refcache-pr-fix.md
+++ b/content/en/site/skills/refresh-refcache-pr-fix.md
@@ -149,9 +149,12 @@ Ground every recommendation in evidence, and match the fix to the situation:
   the component, product, or company behind the entry is defunct, absorbed, or
   otherwise no longer actively supports OpenTelemetry,
   [retire the entry](#retiring-an-entry) instead of updating its links.
-- **Linked page gone, no equivalent**: as a last resort, a **maintainer** may
-  remove the link and rework the surrounding prose, flagging the appropriate SIG
-  approvers. Agents must not apply this fix; defer to a maintainer.
+- **Linked page gone, no equivalent**: Agents must not apply this fix; defer to
+  a maintainer. As a last resort, a **maintainer** may remove the link and
+  rework the surrounding prose. Cc the GitHub handles of the following as
+  appropriate:
+  - Authors of the PRs that introduced the content
+  - SIG docs approvers through their GitHub team handle
 
 ### Evidence for a replacement URL
 
@@ -167,8 +170,10 @@ Show that the fetched page names or otherwise matches the linked resource:
 
 ### Retiring an entry
 
-Remove the entry, and cc the entry's original submitter in the PR comment, per
-[Keeping registry and list information current](/ecosystem/registry/updating/).
+- Remove the entry
+- Cc in a PR comment the GitHub handles of the entry's original submitter and/or
+  any authors who updated the entry, per
+  [Keeping registry and list information current](/ecosystem/registry/updating/).
 
 <!-- prettier-ignore-start -->
 [Localization]: /docs/contributing/localization/#link-fixes-and-resource-updates

--- a/content/en/site/skills/refresh-refcache-pr-fix.md
+++ b/content/en/site/skills/refresh-refcache-pr-fix.md
@@ -85,9 +85,8 @@ multiple runs over time and you have confirmed the URL is not otherwise healthy.
 5. **Analyze and recommend**. For each URL from the previous step, report:
    - The URL and HTTP status.
    - Where it originates from: provide links to files or pages.
-   - A recommendation — update or remove the link, or retire the entry — with
-     supporting evidence; see
-     [Recommendation guidance](#recommendation-guidance).
+   - A recommended fix or follow-up action; see
+     [Recommending a fix for non-2XX URLs](#recommending-a-fix-for-non-2xx-urls).
    - Where the fix belongs, for example:
      - In-branch
      - In a separate PR against `main`, when the same dead link also affects
@@ -143,7 +142,7 @@ Once no non-2XX entries remain on the PR being processed:
 
 Then continue with the next target PR, if any.
 
-## Recommendation guidance
+## Recommending a fix for non-2XX URLs
 
 Ground each recommendation in evidence:
 

--- a/content/en/site/skills/refresh-refcache-pr-fix.md
+++ b/content/en/site/skills/refresh-refcache-pr-fix.md
@@ -93,15 +93,13 @@ multiple runs over time and you have confirmed the URL is not otherwise healthy.
        `main` or several target PRs
      - Upstream in the source repository, for integration branches
 
-   Stop and wait for reviewer approval — never self-approve recommendations.
+   Stop and wait for reviewer approval -- never self-approve recommendations.
 
-6. **Apply approved fixes.** After approval, edit the suggested sources:
-   - For a **404**, update or remove the referring link where you identified it.
-   - For **other non-2XX** statuses, apply the reviewed recommendation (manual
-     inspection may still be required for ambiguous cases).
-   - If any touched page is outside `content/en/`, follow
-     [Localization](/docs/contributing/localization/#link-fixes-and-resource-updates)
-     for that edit (e.g. `# patched` on `default_lang_commit`).
+6. **Apply approved fixes.** Perform the maintainer-approved fix and follow-up
+   actions — and only those. If any touched page is outside `content/en/`,
+   follow
+   [Localization](/docs/contributing/localization/#link-fixes-and-resource-updates)
+   for that edit (e.g. `# patched` on `default_lang_commit`).
 
 7. Run `npm run fix:refcache` to refresh `static/refcache.json` after those
    source-link changes, then repeat the steps in this section (from step 1)

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -22099,6 +22099,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-07-08T06:36:02.919392255Z"
   },
+  "https://web.archive.org/": {
+    "StatusCode": 200,
+    "LastSeen": "2026-07-15T09:34:16.445324-04:00"
+  },
   "https://web.archive.org/web/20180321091318/http://www.onlamp.com/pub/a/linux/2000/11/16/LinuxAdmin.html": {
     "StatusCode": 200,
     "LastSeen": "2026-07-09T06:55:58.093984438Z"


### PR DESCRIPTION
Hardens this maintainer skill based on findings from its first live run (see [#10804 recovery](https://github.com/open-telemetry/opentelemetry.io/pull/10804#issuecomment-4959584301)):

- Reports the sweep assessment before any PR is processed, and names each PR as processing starts
- Restructures the analyze step: one info item per bullet, with fix guidance moved to a new [Recommending a fix for non-2XX URLs][new-section] section — a condition→action map requiring evidence that a replacement URL matches the linked resource (a 2XX alone proves nothing), making entry retirement a first-class fix per the [registry updating policy], and reserving link removal for maintainers
- Strengthens the review gate: stop and wait for approval, apply only maintainer-approved actions
- **Preview**: [Refresh-refcache PR fix](https://deploy-preview-10847--opentelemetry.netlify.app/site/skills/refresh-refcache-pr-fix/)

[new-section]: https://deploy-preview-10847--opentelemetry.netlify.app/site/skills/refresh-refcache-pr-fix/#recommending-a-fix-for-non-2xx-urls
[registry updating policy]: https://opentelemetry.io/ecosystem/registry/updating/