### PR TITLE
[ja] update translation of content/en/docs/languages/java/_index.md

### DIFF
--- a/content/ja/docs/languages/java/_index.md
+++ b/content/ja/docs/languages/java/_index.md
@@ -10,12 +10,11 @@ redirects:
 cascade:
   vers:
     instrumentation: 2.29.0
-    otel: 1.63.0
+    otel: 1.64.0
     contrib: 1.58.0
     semconv: 1.43.0
 weight: 150
-default_lang_commit: 4d367048a304df51f35b33ca51cfb0d3703de230
-drifted_from_default: true
+default_lang_commit: 0b7375082d1799e37a3063aa2f918f2a8546c6ac
 ---
 
 {{% docs/languages/index-intro java /%}}


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/java/_index.md` to match the latest English source at
`content/en/docs/languages/java/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The only English-side change was a version bump in `cascade.vers.otel` from `1.63.0` to `1.64.0`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10851--opentelemetry.netlify.app/ja/docs/languages/java/
- **English (canonical):** https://opentelemetry.io/docs/languages/java/

<!-- preview-section-end -->
