### PR TITLE
[ja] add translation of content/en/blog/2025/kubecon-na.md

### DIFF
--- a/content/ja/blog/2025/kubecon-na.md
+++ b/content/ja/blog/2025/kubecon-na.md
@@ -1,0 +1,151 @@
+---
+title: KubeCon NA 2025で、OpenTelemetryのトークとアクティビティに参加しよう
+linkTitle: KubeCon NA '25
+date: 2025-10-03
+author: '[Tiffany Hrabusa](https://github.com/tiffany76) (Grafana Labs)'
+eventUrl: &eventUrl >-
+  https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/
+queryParams: >-
+  utm_source=opentelemetry&utm_medium=website&utm_content=blog
+default_lang_commit: 62728c9080ad7538bb8472c10121ea8408188f92
+# prettier-ignore
+cSpell:ignore: Aditya Agno Alipio Amir Aronoff Artem Bagga Bodhish Caldwell Chauhan Chomiak CLDF Contribfest CopperPoint Cutsail Célestin Dixit Fairwinds Forrester Furst Grcevski Harshita Hodgson Hrittik Jakoby Jitendra Juspay Khallai Kubestronaut Kusha Mackie Macías Maharshi Mancioppi Markou Melamed Mohsine Nduka Nilson Octopus Olly Omlet Pająk Panos Pavlick Payal Pech Pyroscope Raveesh Reimagining Sandeep Sawmills Shiran Suereth Tkachuk Tsilopoulos Varma Veeam Verma Vijay Wijay Wrike Yahn Zscaler
+---
+
+OpenTelemetry のプロジェクトメンテナー、ガバナンス委員会メンバー、および技術委員会メンバーは、2025年11月10日から13日にかけてアトランタで開催される [KubeCon NA][] に参加します。
+ぜひ[参加登録][register]して、一緒に盛り上がりましょう！
+
+KubeCon 期間中に予定されている OpenTelemetry 関連のすべてのイベントをご紹介します。
+
+{{% comment %}}
+
+## OpenTelemetry Contribfest
+
+OpenTelemetry のメンテナーと一緒に [OpenTelemetry Contribfest](https://sched.co/1hoyF) に参加して、プロジェクトをより良いものにしましょう。
+さまざまなコントリビューションの機会から選ぶことができ、ドキュメント、Collector、Java、JS、Ruby、Python、.NET などの各プロジェクト領域のメンテナーが最初の一歩をサポートします。
+
+{{% /comment %}}
+
+## KubeCon トークとメンテナーセッション {#kubecon-talks-and-maintainer-sessions}
+
+- **[⚡ Project Lightning Talk: Fluent Bit](https://sched.co/27d5X)**<br>
+  Eduardo Silva（Maintainer）<br> 11月10日（月）• 15:00 - 15:05
+- **[Taming Telemetry at Scale: Platform Blueprints for Consistent Observability](https://sched.co/27FUv)**（大規模テレメトリーの制御：一貫性のあるオブザーバビリティのためのプラットフォームブループリント）<br>
+  Nancy Chauhan（Agno）、Marino Wijay（Kong Inc.）<br> 11月11日（火）• 11:15 – 11:45
+- **[Just Do It: OpAMP](https://sched.co/27FWT)**<br>
+  Panos Tsilopoulos & Bob Johnson（Nike, Inc.）<br> 11月11日（火）• 15:15 - 15:45
+- **[Reimagining Insurance Infrastructure: CopperPoint's Cloud Native Blueprint](https://sched.co/27FX0)**（保険インフラの再構築：CopperPoint のクラウドネイティブブループリント）<br>
+  Sid Dixit & Sham Rao（CopperPoint Insurance Companies）<br> 11月11日（火）• 16:15 - 16:45
+- **[Instrumentation Score: The Difference Between Telemetry and Good Telemetry](https://sched.co/27FWx)**（計装スコア：テレメトリーと優れたテレメトリーの違い）<br>
+  Juraci Paixão Kröhling（OllyGarden）& Michele Mancioppi（Dash0）<br> 11月11日（火）• 16:15 - 16:45
+- **[OpenTelemetry: Unpacking 2025, Charting 2026](https://sched.co/27Y2M)**（OpenTelemetry：2025年の振り返りと2026年の展望）<br>
+  Alolita Sharma、Trask Stalnaker、Josh Suereth、Austin Parker<br> 11月11日（火）• 17:00 – 17:30
+- **[Integrating Data Center Observability Into Cloud Native Environment](https://sched.co/27FXU)**（データセンターのオブザーバビリティをクラウドネイティブ環境に統合する）<br>
+  Pedro Célestin（CLDF）& Julia Furst Morgado（Veeam）<br> 11月11日（火）• 17:00 – 17:30
+- **[Sync or Swim: Building Platforms You Can See](https://sched.co/27FY4)**（泳ぐか沈むか：可視化できるプラットフォームの構築）<br>
+  Heather Lee & Mike Cutsail（Apple）<br> 11月11日（火）• 17:45 – 18:15
+- **[🪧 Poster Session (PS3): From Noise To Clarity: Humanizing Observability in Cloud Native Systems](https://sched.co/27FYM)**（ノイズから明確さへ：クラウドネイティブシステムのオブザーバビリティを人間中心にする）<br>
+  Nikita Verma（Zscaler）& Harshita Varma（Juspay）<br> 11月11日（火）• 18:15 – 19:45
+- **[Keynote: Cloud Native for Good](https://sched.co/27FUj)**（基調講演：Cloud Native for Good）<br>
+  Faseela K（Ericsson Software Technology）、Omar Mohsine（United Nations）、Roberto Machorro（Child Rescue Coalition）、Bodhish Thomas（Open Healthcare Network）、Jayson Workman（American Red Cross）<br> 11月12日（水）• 10:11 - 10:26
+- **[Models as Microservices, Platforms as Partners: Collaboratively Building ML Infra at Hinge](https://sched.co/27FYz)**（マイクロサービスとしてのモデル、パートナーとしてのプラットフォーム：Hinge における ML インフラの協同構築）<br>
+  Stephanie Pavlick（Hinge）<br> 11月12日（水）• 11:00 - 11:30
+- **[Retrofitting OTel Collectors & Prometheus: How to Overcome Scale/Design Limitations](https://sched.co/27FYq)**（OTel Collector と Prometheus の改良：スケールと設計の制約を克服する方法）<br>
+  Vijay Samuel & Sandeep Raveesh（eBay）<br> 11月12日（水）• 11:00 – 11:30
+- **[OTel+K8s= ❤️: An Introduction To OpenTelemetry for Kubernetes Users](https://sched.co/27FZN)**（OTel+K8s=❤️：Kubernetes ユーザーのための OpenTelemetry 入門）<br>
+  Christos Markou（Elastic）& Jacob Aronoff（Omlet）<br> 11月12日（水）• 11:45 - 12:15
+- **[Fluent Bit: Smarter Telemetry Routing, Faster Pipelines](https://sched.co/27Nmb)**（Fluent Bit：よりスマートなテレメトリールーティングと高速パイプライン）<br>
+  Eduardo Silva（Chronosphere）<br> 11月12日（水）• 11:45 - 12:15
+- **[What's New in gRPC](https://sched.co/27NnZ)**（gRPC の最新情報）<br>
+  Kevin Nilson（Google）& Israel Shapiro（Broadcom）<br> 11月12日（水）• 11:45 - 12:15
+- **[Beyond the Dashboard: Modern Observability for Platform Engineering at Scale](https://sched.co/27FaC)**（ダッシュボードの先へ：大規模プラットフォームエンジニアリングのためのモダンオブザーバビリティ）<br>
+  Danielle Cook（Independent）、Whitney Lee（Datadog）、Stevie Caldwell（Fairwinds）、Khallai Taylor（E.ON Digital Technology GmbH）、Payal Bagga（Intuit）<br> 11月12日（水）• 14:15 - 14:45
+- **[UX Research Report: Prometheus and OTel's Resource Attributes](https://sched.co/27FZr)**（UX リサーチレポート：Prometheus と OTel のリソース属性）<br>
+  Victoria Nduka（Independent）& Amy Super（Grafana Labs）<br> 11月12日（水）• 14:15 - 14:45
+- **[Building Scalable End-to-end Latency Metrics From Distributed Trace](https://sched.co/27Faj)**（分散トレースからのスケーラブルなエンドツーエンドレイテンシメトリクスの構築）<br>
+  Kusha Maharshi（Bloomberg）<br> 11月12日（水）• 15:00 - 15:30
+- **[Where's My Pod? End-to-End Tracing for Kubernetes With OpenTelemetry](https://sched.co/27FaO)**（Pod はどこ？OpenTelemetry による Kubernetes のエンドツーエンドトレーシング）<br>
+  Artem Tkachuk、JP Phillips（Netflix）<br> 11月12日（水）• 15:00 – 15:30
+- **[From Kubestronaut To Production Hero: Turning Study Paths Into Real-World Wins](https://sched.co/27Fav)**（Kubestronaut からプロダクションヒーローへ：学習パスを実践的な成功に変える）<br>
+  David Pech（Wrike）& Pedro Célestin（CLDF）<br> 11月12日（水）• 16:00 – 16:30
+- **[Debugging Your Cluster When It's on Fire](https://sched.co/27FbD)**（クラスターが炎上しているときのデバッグ）<br>
+  Nikola Grcevski（Grafana Labs）& Tyler Yahn（Splunk）<br> 11月12日（水）• 16:00 – 16:25
+- **[Zero-Downtime Telemetry: Hot Reloading OpenTelemetry Collector Pipelines](https://sched.co/27Fas)**（ゼロダウンタイムテレメトリー：OpenTelemetry Collector パイプラインのホットリロード）<br>
+  Amir Jakoby（Sawmills）、Shiran Melamed（JFrog）<br> 11月12日（水）• 16:00 – 16:30
+- **[⚡ Lightning Talk: Confidential Observability on Kubernetes: Protecting Telemetry End-to-End](https://sched.co/27Fbn)**（⚡ ライトニングトーク：Kubernetes での機密オブザーバビリティ：テレメトリーのエンドツーエンド保護）<br>
+  Jitendra Singh（IBM India Pvt. Ltd.）<br> 11月12日（水）• 16:45 – 16:50
+- **[Designing for Observability: From Noise To Insight](https://sched.co/27Fbk)**（オブザーバビリティのための設計：ノイズからインサイトへ）<br>
+  Andrea Chomiak（Dash0）<br> 11月12日（水）• 16:45 – 17:15
+- **[OpenTelemetry Logs Driving a Major Shift: Events, Richer Data, and Smarter Semantics](https://sched.co/27FbP)**（OpenTelemetry ログが促す大きな変革：イベント、よりリッチなデータ、よりスマートなセマンティクス）<br>
+  Robert Pająk（Splunk）<br> 11月12日（水）• 16:45 – 17:15
+- **[Diagnosing Application Performance With eBPF, Pyroscope, and Kubernetes](https://sched.co/27FcT)**（eBPF、Pyroscope、Kubernetes によるアプリケーションパフォーマンスの診断）<br>
+  Liam Mackie（Octopus Deploy）<br> 11月12日（水）• 17:30 – 18:00
+- **[Observing Dark Matter With OpenTelemetry](https://sched.co/27Fc8)**（OpenTelemetry でダークマターを観測する）<br>
+  Sam Alipio（Pasteur Labs）& Mario Macías（Grafana Labs）<br> 11月12日（水）• 17:30 – 18:00
+- **[⚡ Lightning Talk: Tracing the Untraceable: OpenTelemetry for 'Vibe-Coded' LLM Apps](https://sched.co/27Fcf)**（⚡ ライトニングトーク：追跡不可能なものを追跡する：「バイブコーディング」された LLM アプリのための OpenTelemetry）<br>
+  Pranay Prateek（SigNoz）<br> 11月12日（水）• 17:41 – 17:46
+- **[Feature Flags Suck! - The Problems With Feature Flagging and How To Avoid Them](https://sched.co/27FdI)**（フィーチャーフラグの問題点とその回避方法）<br>
+  Pete Hodgson（PH1）<br> 11月13日（木）• 11:00 - 11:30
+- **[Help! My LLM Is a Resource Hog: How We Tamed Inference With Kubernetes and Open Source Muscle](https://sched.co/27Feq)**（助けて！LLM がリソースを食いつぶす：Kubernetes とオープンソースの力で推論を制御した方法）<br>
+  Aditya Soni（Forrester Research）& Hrittik Roy（Loft Labs）<br> 11月13日（木）• 14:30 - 15:00
+
+## メンテナーサミット {#maintainer-summit}
+
+併設イベントとカンファレンスの前日にあたる11月9日に開催されるメンテナーサミットは、プロジェクトの担い手たちが直接顔を合わせる貴重な機会です。
+OpenTelemetry 組織の[メンバー][membership]が集まり、コラボレーション、学習、アイデアの共有、問題解決、そしてプロジェクトの充実を図ります。
+準備されたトーク、プロジェクトミーティング、アンカンファレンスセッションが 9:00 から 17:00 まで行われます。
+詳細は[フルスケジュール][summit schedule]をご覧ください。
+今すぐ[サインアップ][maintainer summit]しましょう！
+
+> [!IMPORTANT] 重要なアクセスに関する注意
+>
+> **メンテナーサミット** に参加するには、KubeCon + CloudNativeCon への登録が必要です。
+> また、OpenTelemetry などの CNCF インキュベーティングプロジェクトのメンバーである必要があります。
+> 参加資格については [Maintainer Summit][] をご覧ください。
+
+## Observability Day {#observability-day}
+
+[Observability Day][] は、クラウドネイティブなオブザーバビリティプロジェクトにおける協業、議論、知識共有を促進するイベントです。
+2025年11月10日の 9:00 から 18:00 まで開催されます。
+オブザーバビリティと OpenTelemetry に関するお気に入りのトークを[スケジュール][obs-day-sched]で探してみてください。
+
+> [!IMPORTANT] 重要なアクセスに関する注意
+>
+> **Observability Day** に参加するには、_オールアクセス_ パスが必要です。
+> 詳細は [KubeCon registration][register] をご覧ください。
+
+## OpenTelemetry Observatory {#opentelemetry-observatory}
+
+Expo Hall 内の Splunk 提供による OpenTelemetry Observatory に、ぜひお立ち寄りください。
+ここでは、OpenTelemetry コミュニティメンバーやメンテナーが主導する、カジュアルなチャット、ミートアップ、各種ディスカッションが行われます。
+
+- SIG オフィスアワー：プロジェクトの担い手たちに会い、活動内容を学び、質問し、フィードバックを共有し、コントリビューションの方法を知りましょう。
+- スペシャルトピックディスカッション：OTel コミュニティで最もホットなトピックについて学びましょう。
+
+ディスカッションのリードや、興味のあるディスカッショントピックがある場合は、[OpenTelemetry End User SIG][end user] までお知らせください。
+できる限り対応いたします。
+
+アクティビティの詳細については、[OTel Observatory Schedule][] をご覧ください。
+このスケジュールは随時更新中であり、イベント当日まで更新されます。
+最新情報を定期的にチェックしてください！
+
+## OpenTelemetry Community Awards {#opentelemetry-community-awards}
+
+OpenTelemetry はコミュニティ主導のプロジェクトであり、オブザーバビリティの分野に変革をもたらしている素晴らしい人々によって支えられています。
+コード、ドキュメント、プロジェクトマネジメント、アウトリーチ、導入、あるいは他の人を助けることなど、さまざまな形のコントリビューションとその担い手を表彰します。
+
+今年のアワードのノミネーション受付は近日中に開始され、KubeCon + CloudNativeCon North America で受賞者を発表します！
+
+OpenTelemetry のトークを聴き、学び、そしてプロジェクトに参加しましょう。
+
+アトランタでお会いしましょう！
+
+[kubecon na]: <{{% param eventUrl %}}?{{% param queryParams %}}>
+[Observability Day]: <{{% param eventUrl %}}co-located-events/observability-day/?{{% param queryParams %}}>
+[register]: <{{% param eventUrl %}}register/?{{% param queryParams %}}>
+[summit schedule]: https://maintainersummitna2025.sched.com/
+[maintainer summit]: <{{% param eventUrl %}}features-add-ons/maintainer-summit/?{{% param queryParams %}}>
+[membership]: https://github.com/open-telemetry/community/blob/25f027532a6e9b503d6eb4dd3db0a98eb3b5f1cb/guides/contributor/membership.md?from_branch=main#member
+[obs-day-sched]: https://colocatedeventsna2025.sched.com/overview/type/Observability+Day
+[end user]: https://cloud-native.slack.com/archives/C01RT3MSWGZ
+[otel observatory schedule]: https://docs.google.com/spreadsheets/d/1Kk6io9V6Q1nluq6H05zGjwvWlXwxh9IwjiThBGJP1Rw/edit?usp=sharing


### PR DESCRIPTION
## Summary

Translates `content/en/blog/2025/kubecon-na.md` into Japanese as `content/ja/blog/2025/kubecon-na.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10853--opentelemetry.netlify.app/ja/blog/2025/kubecon-na/
- **English (canonical):** https://opentelemetry.io/blog/2025/kubecon-na/

<!-- preview-section-end -->
