### PR TITLE
[ja] update translation of content/en/docs/guidance/blueprints/instrumenting-applications-and-processes-on-nonk8s-environments.md

### DIFF
--- a/content/ja/docs/guidance/blueprints/instrumenting-applications-and-processes-on-nonk8s-environments.md
+++ b/content/ja/docs/guidance/blueprints/instrumenting-applications-and-processes-on-nonk8s-environments.md
@@ -1,10 +1,6 @@
 ---
 title: 非 Kubernetes 環境におけるインフラストラクチャとプロセス
-date: 2026-06-03
-author: Lukasz Ciukaj (Splunk)
-default_lang_commit: a481099dea6e789033d52a3238c0d9bcabcdc167
-drifted_from_default: true
-cSpell:ignore: ciukaj lukasz
+default_lang_commit: 87b4cea0e74dccab17d61601c4bd80e15dc95d08
 ---
 
 ## 概要 {#summary}


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/guidance/blueprints/instrumenting-applications-and-processes-on-nonk8s-environments.md` to match the latest English source at
`content/en/docs/guidance/blueprints/instrumenting-applications-and-processes-on-nonk8s-environments.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

Changes from the English side (frontmatter only):
- Removed `date` field
- Removed `author` field
- Removed `ciukaj lukasz` from `cSpell:ignore` (no longer needed after `author` removal)

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10859--opentelemetry.netlify.app/ja/docs/guidance/blueprints/instrumenting-applications-and-processes-on-nonk8s-environments/
- **English (canonical):** https://opentelemetry.io/docs/guidance/blueprints/instrumenting-applications-and-processes-on-nonk8s-environments/

<!-- preview-section-end -->
