### PR TITLE
[ja] update translation of content/en/docs/guidance/blueprints/managed-telemetry-platforms-for-k8s-workloads.md

### DIFF
--- a/content/ja/docs/guidance/blueprints/managed-telemetry-platforms-for-k8s-workloads.md
+++ b/content/ja/docs/guidance/blueprints/managed-telemetry-platforms-for-k8s-workloads.md
@@ -1,11 +1,7 @@
 ---
 title: 'Kubernetes ワークロード向けマネージドテレメトリープラットフォーム'
 linkTitle: 'K8s ワークロード向けマネージドテレメトリープラットフォーム'
-date: '2026-06-24'
-author: '[Dan Gomez Blanco](https://github.com/danielgblanco) (New Relic)'
-sig: End-User
-default_lang_commit: 8c95bffcf7243a916f79a0d525cf55b6a3d34ad7
-drifted_from_default: true
+default_lang_commit: 87b4cea0e74dccab17d61601c4bd80e15dc95d08
 cSpell:ignore: Autoscaler kube OTTL SDLC Skyscanner statefulset
 ---
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/guidance/blueprints/managed-telemetry-platforms-for-k8s-workloads.md` to match the latest English source at
`content/en/docs/guidance/blueprints/managed-telemetry-platforms-for-k8s-workloads.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff removed three frontmatter fields (`date`, `author`, `sig`) that are no longer present in the English source. This update removes the same fields from the Japanese frontmatter.

Note: PR #10831 also touches this file (a link reference fix), but that change is orthogonal to this frontmatter-only drift fix.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.


<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10860--opentelemetry.netlify.app/ja/docs/guidance/blueprints/managed-telemetry-platforms-for-k8s-workloads/
- **English (canonical):** https://opentelemetry.io/docs/guidance/blueprints/managed-telemetry-platforms-for-k8s-workloads/

<!-- preview-section-end -->
