### PR TITLE
fix(registry): wrap badges on mobile

### DIFF
--- a/layouts/_partials/ecosystem/registry/entry.html
+++ b/layouts/_partials/ecosystem/registry/entry.html
@@ -108,11 +108,11 @@
     {{ end -}}
     <li class="card my-3 registry-entry {{ $highlightStyle }}" data-registry-id="{{ ._key }}" data-registrytype="{{ .registryType }}" data-registrylanguage="{{ .language }}"   data-registryflags="{{- range $index, $flag := $flags -}}{{ if $index }} {{ end }}{{ $flag }}{{- end }}">
         <div class="card-body container">
-        <h4 class="card-title mb-0 d-flex flex-row">
+        <h4 class="card-title mb-0 d-flex flex-column flex-sm-row align-items-start align-items-sm-center gap-2">
             <a {{ $primaryHref }} target="_blank" rel="noopener" class="me-auto">
             {{- .title | markdownify -}}
             </a>
-            <div class="ms-auto">
+            <div class="ms-sm-auto d-flex flex-wrap gap-1 justify-content-start justify-content-sm-end">
             {{ if $isNew -}}
             <span class="badge rounded-pill text-bg-info"><i class="fa-regular fa-star"></i> new</span>
             {{ end -}}

--- a/layouts/_partials/ecosystem/registry/entry.html
+++ b/layouts/_partials/ecosystem/registry/entry.html
@@ -112,7 +112,7 @@
             <a {{ $primaryHref }} target="_blank" rel="noopener" class="me-auto">
             {{- .title | markdownify -}}
             </a>
-            <div class="ms-sm-auto d-flex flex-wrap gap-1 justify-content-start justify-content-sm-end">
+            <div class="d-flex flex-wrap gap-1 justify-content-sm-end">
             {{ if $isNew -}}
             <span class="badge rounded-pill text-bg-info"><i class="fa-regular fa-star"></i> new</span>
             {{ end -}}


### PR DESCRIPTION
- Contributes to #5588

## Summary

This PR fixes the registry card layout on small screens by allowing badges to wrap instead of overflowing the viewport.

### Changes

- Stack the title and badges vertically on mobile.
- Preserve the existing horizontal layout on `sm` and larger screens.
- Allow badges to wrap using Bootstrap 5 utility classes.
- No custom CSS or JavaScript changes.

### Validation

- Prettier formatting passed.
- Markdown lint passed.
- Registry validation passed.
- Verified desktop layout remains unchanged.
- Verified badges wrap correctly on small screens.

---

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

Preview:

- [Registry](https://deploy-preview-10864--opentelemetry.netlify.app/ecosystem/registry/)
- Entries with title badges: [Envoy Proxy](https://deploy-preview-10864--opentelemetry.netlify.app/ecosystem/registry/?s=envoy), [OpenTelemetryProtocolCommon](https://deploy-preview-10864--opentelemetry.netlify.app/ecosystem/registry/?s=opentelemetryprotocolcommon)