### PR TITLE
[ja] update translation of content/en/docs/guidance/reference-implementations/mastodon/index.md

### DIFF
--- a/content/ja/docs/guidance/reference-implementations/mastodon/index.md
+++ b/content/ja/docs/guidance/reference-implementations/mastodon/index.md
@@ -1,15 +1,7 @@
 ---
 title: 'Mastodon: 小さなチームで本番環境の OpenTelemetry Collector を運用する'
 linkTitle: Mastodon
-author: >-
-  [Juliano Costa](https://github.com/julianocosta89) (Datadog), [Tristan
-  Sloughter](https://github.com/tsloughter) (community), [Johanna
-  Öjeling](https://github.com/johannaojeling) (Grafana Labs), [Damien
-  Mathieu](https://github.com/dmathieu) (Elastic), [Tim
-  Campbell](https://github.com/timetinytim) (Mastodon)
-sig: End-User
-default_lang_commit: 92dfdd7f60d865cdc9a73ae1a469f991b523670f
-drifted_from_default: true
+default_lang_commit: d88ab6df454cbc6de0b0ae5a4de4684e1154cea4
 cSpell:ignore: otelbin Sidekiq Sloughter Öjeling
 ---
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/guidance/reference-implementations/mastodon/index.md` to match the latest English source at
`content/en/docs/guidance/reference-implementations/mastodon/index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff removed the `author` and `sig` frontmatter fields. No body content changes.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10866--opentelemetry.netlify.app/ja/docs/guidance/reference-implementations/mastodon/
- **English (canonical):** https://opentelemetry.io/docs/guidance/reference-implementations/mastodon/

_(deploy preview status: pending. The URLs will work once Netlify finishes building.)_
<!-- preview-section-end -->
