### PR TITLE
[ja] update translation of content/en/docs/guidance/reference-implementations/skyscanner/index.md

### DIFF
--- a/content/ja/docs/guidance/reference-implementations/skyscanner/index.md
+++ b/content/ja/docs/guidance/reference-implementations/skyscanner/index.md
@@ -1,14 +1,7 @@
 ---
 title: 'Skyscanner: 24 の本番クラスターにまたがる OpenTelemetry Collector の管理'
 linkTitle: Skyscanner
-author: >-
-  [Johanna Öjeling](https://github.com/johannaojeling) (Grafana Labs), [Juliano
-  Costa](https://github.com/julianocosta89) (Datadog), [Tristan
-  Sloughter](https://github.com/tsloughter) (community), [Neil
-  Fordyce](https://github.com/neilfordyce) (Skyscanner)
-sig: End-User
-default_lang_commit: ce5058cd71a2fc6be2f9b90d4704520fff981dfe
-drifted_from_default: true
+default_lang_commit: d88ab6df454cbc6de0b0ae5a4de4684e1154cea4
 cSpell:ignore: Fordyce kube kubelet rollouts Skyscanner Sloughter Öjeling
 ---
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/guidance/reference-implementations/skyscanner/index.md` to match the latest English source at
`content/en/docs/guidance/reference-implementations/skyscanner/index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff was frontmatter-only: removed `author` and `sig` fields, added `# prettier-ignore` comment, and added `unsets` to `cSpell:ignore`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10867--opentelemetry.netlify.app/ja/docs/guidance/reference-implementations/skyscanner/index/
- **English (canonical):** https://opentelemetry.io/docs/guidance/reference-implementations/skyscanner/index/

<!-- preview-section-end -->
