### PR TITLE
[ja] update translation of content/en/docs/collector/configuration.md

### DIFF
--- a/content/ja/docs/collector/configuration.md
+++ b/content/ja/docs/collector/configuration.md
@@ -2,10 +2,9 @@
 title: 設定
 weight: 20
 description: ニーズに合わせてコレクターを設定する方法を確認してください
-default_lang_commit: ad6f8d1e5179464d22f7e9cdf9fe86bc53f550e5
-drifted_from_default: true
+default_lang_commit: 77207ae357ec6a3296c28aae8bf4378181f25eb2
 # prettier-ignore
-cSpell:ignore: cfssl cfssljson configtls fluentforward gencert genkey hostmetrics initca oidc pprof prodevent prometheusremotewrite spanevents unredacted upsert zpages
+cSpell:ignore: cfssl cfssljson configtls fluentforward gencert genkey initca oidc pprof prodevent prometheusremotewrite spanevents unredacted upsert zpages
 ---
 
 <!-- markdownlint-disable link-fragments -->
@@ -259,7 +258,7 @@ receivers:
     endpoint: 0.0.0.0:8006
 
   # データソース: メトリクス
-  hostmetrics:
+  host_metrics:
     scrapers:
       cpu:
       disk:


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/collector/configuration.md` to match the latest English source at
`content/en/docs/collector/configuration.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

English-side changes:
- `cSpell:ignore` frontmatter: removed `hostmetrics` (no longer used)
- Code block: renamed `hostmetrics:` to `host_metrics:` in the receivers YAML example

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10887--opentelemetry.netlify.app/ja/docs/collector/configuration/
- **English (canonical):** https://opentelemetry.io/docs/collector/configuration/

_(deploy preview status: pending. The URLs will work once Netlify finishes building.)_
<!-- preview-section-end -->
