### PR TITLE
[ja] update translation of content/en/docs/platforms/kubernetes/collector/components.md

### DIFF
--- a/content/ja/docs/platforms/kubernetes/collector/components.md
+++ b/content/ja/docs/platforms/kubernetes/collector/components.md
@@ -1,8 +1,7 @@
 ---
 title: Kubernetesのための重要なコンポーネント
 linkTitle: コンポーネント
-default_lang_commit: 1f686d5f7b6bbdfaa30dafdc6ca0214c6f2308db
-drifted_from_default: true
+default_lang_commit: 77207ae357ec6a3296c28aae8bf4378181f25eb2
 # prettier-ignore
 cSpell:ignore: alertmanagers filelog horizontalpodautoscalers hostfs hostmetrics k8sattributes kubelet kubeletstats replicasets replicationcontrollers resourcequotas statefulsets varlibdockercontainers varlogpods
 ---
@@ -641,7 +640,7 @@ spec:
 
 ```yaml
 receivers:
-  hostmetrics:
+  host_metrics:
     root_path: /hostfs
     collection_interval: 10s
     scrapers:


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/platforms/kubernetes/collector/components.md` to match the latest English source at
`content/en/docs/platforms/kubernetes/collector/components.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English change was a single-line YAML key rename in a code block: `hostmetrics:` → `host_metrics:`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10888--opentelemetry.netlify.app/ja/docs/platforms/kubernetes/collector/components/
- **English (canonical):** https://opentelemetry.io/docs/platforms/kubernetes/collector/components/

_(deploy preview will be available once Netlify finishes building.)_
<!-- preview-section-end -->
