### PR TITLE
[ja] update translation of content/en/docs/collector/management.md

### DIFF
--- a/content/ja/docs/collector/management.md
+++ b/content/ja/docs/collector/management.md
@@ -2,9 +2,8 @@
 title: 管理
 description: OpenTelemetry Collectorのデプロイメントを大規模に管理する方法
 weight: 23
-default_lang_commit: 1f686d5f7b6bbdfaa30dafdc6ca0214c6f2308db
-drifted_from_default: true
-cSpell:ignore: hostmetrics opampsupervisor
+default_lang_commit: 453013b113080a48166f412215176d345d2bf958
+cSpell:ignore: opampsupervisor
 ---
 
 このドキュメントでは、OpenTelemetry コレクターのデプロイを大規模に管理する方法について説明します。
@@ -199,7 +198,7 @@ $ ./opampsupervisor --config=./supervisor.yaml
 
 ```yaml
 receivers:
-  hostmetrics:
+  host_metrics:
     collection_interval: 10s
     scrapers:
       cpu:
@@ -212,7 +211,7 @@ exporters:
 service:
   pipelines:
     metrics:
-      receivers: [hostmetrics]
+      receivers: [host_metrics]
       exporters: [debug]
 ```
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/collector/management.md` to match the latest English source at
`content/en/docs/collector/management.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

Changes applied:
- Removed `hostmetrics` from `cSpell:ignore` (EN dropped the word)
- Renamed `hostmetrics` → `host_metrics` in the YAML code block (receiver name and pipeline config)

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10892--opentelemetry.netlify.app/ja/docs/collector/management/
- **English (canonical):** https://opentelemetry.io/docs/collector/management/

_(deploy preview is building; the Japanese URL will work once Netlify finishes.)_
<!-- preview-section-end -->
