### PR TITLE
[ja] update translation of content/en/docs/collector/scaling.md

### DIFF
--- a/content/ja/docs/collector/scaling.md
+++ b/content/ja/docs/collector/scaling.md
@@ -1,10 +1,8 @@
 ---
 title: コレクターのスケーリング
 weight: 26
-default_lang_commit: e14614722d84ee9dc8e66e3287afb1ca714f3819
-drifted_from_default: true
-# prettier-ignore
-cSpell:ignore: fluentd hostmetrics Linkerd loadbalancer loadbalancing statefulset
+default_lang_commit: 453013b113080a48166f412215176d345d2bf958
+cSpell:ignore: fluentd Linkerd loadbalancer loadbalancing statefulset
 ---
 
 OpenTelemetry Collectorを使用してオブザーバビリティパイプラインを計画する場合は、テレメトリー収集の増加に合わせてパイプラインをスケールする方法を検討する必要があります。
@@ -190,7 +188,7 @@ spec:
 
 ### スクレイパーのスケーリング {#scaling-the-scrapers}
 
-一部のレシーバーは、hostmetricsやprometheusレシーバーのように、パイプラインに配置するために積極的にテレメトリーデータを取得しています。
+一部のレシーバーは、host_metricsやprometheusレシーバーのように、パイプラインに配置するために積極的にテレメトリーデータを取得しています。
 ホストメトリクスの取得は通常スケールアップするものではありませんが、Prometheusレシーバーのために何千ものエンドポイントをスクレイプするジョブを分割する必要があるかもしれません。
 また、同じ構成でインスタンスを追加することもできません。
 なぜなら、各コレクターがクラスター内の他のすべてのコレクターと同じエンドポイントをスクレイプしようとし、サンプルの順序が乱れるなど、さらに多くの問題を引き起こすからです。


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/collector/scaling.md` to match the latest English source at
`content/en/docs/collector/scaling.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

Changes applied:
- Frontmatter: removed `# prettier-ignore` comment, updated `cSpell:ignore` to match EN (dropped `hostmetrics`)
- Body: updated receiver name `hostmetrics` → `host_metrics` to match EN rename

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10893--opentelemetry.netlify.app/ja/docs/collector/scaling/
- **English (canonical):** https://opentelemetry.io/docs/collector/scaling/

<!-- preview-section-end -->
