### PR TITLE
Add Go compile-time Anthropic instrumentation to registry

### DIFF
--- a/content/en/docs/zero-code/go/compile-time/supported-libraries.md
+++ b/content/en/docs/zero-code/go/compile-time/supported-libraries.md
@@ -2,26 +2,28 @@
 title: Supported libraries
 description: Libraries and frameworks instrumented out of the box.
 weight: 10
-cSpell:ignore: gonic logrus openai runtimemetrics segmentio sirupsen
+# prettier-ignore
+cSpell:ignore: anthropics gonic logrus openai runtimemetrics segmentio sirupsen
 ---
 
 The tool ships instrumentation packages for the following libraries and
 frameworks. When your application or its dependencies use one of them, the
 matching instrumentation is injected automatically at build time.
 
-| Library or framework    | Import path                             | Instrumented operations        |
-| ----------------------- | --------------------------------------- | ------------------------------ |
-| HTTP (standard library) | `net/http`                              | Client and server requests     |
-| gRPC                    | `google.golang.org/grpc`                | Client and server calls        |
-| SQL databases           | `database/sql`                          | Database calls                 |
-| Gin                     | `github.com/gin-gonic/gin`              | Server requests                |
-| Redis                   | `github.com/redis/go-redis/v9`          | Client commands                |
-| MongoDB                 | `go.mongodb.org/mongo-driver/mongo`     | Client commands                |
-| Kafka                   | `github.com/segmentio/kafka-go`         | Produced and consumed messages |
-| OpenAI                  | `github.com/openai/openai-go` (v1 – v3) | Client calls                   |
-| Kubernetes client       | `k8s.io/client-go/tools/cache`          | Informer cache operations      |
-| slog (standard library) | `log/slog`                              | Log records                    |
-| Logrus                  | `github.com/sirupsen/logrus`            | Log records                    |
+| Library or framework    | Import path                              | Instrumented operations        |
+| ----------------------- | ---------------------------------------- | ------------------------------ |
+| HTTP (standard library) | `net/http`                               | Client and server requests     |
+| gRPC                    | `google.golang.org/grpc`                 | Client and server calls        |
+| SQL databases           | `database/sql`                           | Database calls                 |
+| Gin                     | `github.com/gin-gonic/gin`               | Server requests                |
+| Redis                   | `github.com/redis/go-redis/v9`           | Client commands                |
+| MongoDB                 | `go.mongodb.org/mongo-driver/mongo`      | Client commands                |
+| Kafka                   | `github.com/segmentio/kafka-go`          | Produced and consumed messages |
+| OpenAI                  | `github.com/openai/openai-go` (v1 – v3)  | Client calls                   |
+| Anthropic               | `github.com/anthropics/anthropic-sdk-go` | Client calls                   |
+| Kubernetes client       | `k8s.io/client-go/tools/cache`           | Informer cache operations      |
+| slog (standard library) | `log/slog`                               | Log records                    |
+| Logrus                  | `github.com/sirupsen/logrus`             | Log records                    |
 
 HTTP and gRPC instrumentation produce spans and metrics, including automatic
 [context propagation](/docs/concepts/context-propagation/) between services.

--- a/data/registry/instrumentation-go-compile-time-anthropic.yml
+++ b/data/registry/instrumentation-go-compile-time-anthropic.yml
@@ -1,0 +1,24 @@
+# cSpell:ignore anthropics genai
+title:
+  OpenTelemetry Go Compile-Time Auto-Instrumentation for
+  `anthropics/anthropic-sdk-go`
+registryType: instrumentation
+language: go
+tags:
+  - go
+  - instrumentation
+  - compile-time
+  - auto-instrumentation
+  - genai
+  - llm
+  - anthropic
+license: Apache 2.0
+description: >
+  Go compile-time auto-instrumentation plugin for the [`anthropic-sdk-go`
+  package](https://pkg.go.dev/github.com/anthropics/anthropic-sdk-go), producing
+  GenAI client spans that follow the `gen_ai.*` semantic conventions.
+authors:
+  - name: OpenTelemetry Authors
+urls:
+  repo: https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tree/main/instrumentation/github.com/anthropics/anthropic-sdk-go
+createdAt: 2026-07-20

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -11015,6 +11015,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-07-19T06:35:29.638199127Z"
   },
+  "https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tree/main/instrumentation/github.com/anthropics/anthropic-sdk-go": {
+    "StatusCode": 206,
+    "LastSeen": "2026-07-20T18:48:35.801588565Z"
+  },
   "https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tree/main/instrumentation/github.com/gin-gonic/gin": {
     "StatusCode": 206,
     "LastSeen": "2026-07-19T06:35:21.313573385Z"
@@ -19686,6 +19690,10 @@
   "https://pkg.go.dev/github.com/XSAM/otelsql": {
     "StatusCode": 200,
     "LastSeen": "2026-07-16T06:32:54.148786222Z"
+  },
+  "https://pkg.go.dev/github.com/anthropics/anthropic-sdk-go": {
+    "StatusCode": 200,
+    "LastSeen": "2026-07-20T18:48:36.060900084Z"
   },
   "https://pkg.go.dev/github.com/dnwe/otelsarama": {
     "StatusCode": 200,


### PR DESCRIPTION
Adds a registry entry for the Go compile-time auto-instrumentation of
[`anthropic-sdk-go`](https://github.com/anthropics/anthropic-sdk-go), which was merged upstream in
open-telemetry/opentelemetry-go-compile-instrumentation#689.

The instrumentation produces GenAI client spans following the `gen_ai.*` semantic conventions
(request/response model, token usage including prompt-cache tokens, finish reasons, provider name)
with no application code changes.

Also adds Anthropic to the compile-time supported-libraries page, since it was listed alongside the
other instrumented libraries but the row was missing.
