### PR TITLE
Add Dash0 Operator for Kubernetes to the distributions list

### DIFF
--- a/data/ecosystem/distributions.yaml
+++ b/data/ecosystem/distributions.yaml
@@ -1,4 +1,4 @@
-# cSpell:ignore Splunk AWS ADOT Grafana Bindplane RHOSDT RedHat Sumo Liatrio Lumigo Distro Dynatrace Datadog Contrib DDOT eBPF NRDOT
+# cSpell:ignore Splunk AWS ADOT Grafana Bindplane RHOSDT RedHat Sumo Liatrio Lumigo Distro Dynatrace Datadog Contrib DDOT eBPF NRDOT dash0
 - name: Splunk Distribution of OpenTelemetry Collector
   url: https://github.com/signalfx/splunk-otel-collector
   docsUrl: https://docs.splunk.com/observability/en/gdi/opentelemetry/opentelemetry.html
@@ -199,6 +199,10 @@
   url: https://github.com/honeycombio/honeycomb-collector-distro
   docsUrl: https://github.com/honeycombio/honeycomb-collector-distro/blob/main/README.md
   components: [Collector]
+- name: Dash0 Operator for Kubernetes
+  url: https://github.com/dash0hq/dash0-operator
+  docsUrl: https://www.dash0.com/hub/integrations/int_dash0_operator/overview
+  components: [Collector, Node, Java, .NET, Python]
 
 # OSS Collector Distros
 - name: OpenTelemetry Collector Core Distro

--- a/static/refcache.json
+++ b/static/refcache.json
@@ -4915,6 +4915,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-07-18T06:23:41.553860567Z"
   },
+  "https://github.com/dash0hq/dash0-operator": {
+    "StatusCode": 206,
+    "LastSeen": "2026-07-21T10:44:35.319227+02:00"
+  },
   "https://github.com/dash0hq/otelbin": {
     "StatusCode": 206,
     "LastSeen": "2026-07-17T10:47:12.436731108Z"
@@ -22522,6 +22526,10 @@
   "https://www.dash0.com/": {
     "StatusCode": 200,
     "LastSeen": "2026-07-17T10:40:04.521862887Z"
+  },
+  "https://www.dash0.com/hub/integrations/int_dash0_operator/overview": {
+    "StatusCode": 200,
+    "LastSeen": "2026-07-21T10:44:35.188033+02:00"
   },
   "https://www.docker.com/": {
     "StatusCode": 206,


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

Follow-up to #10918 (cc @svrnm): as suggested there, this adds the [Dash0 Operator for Kubernetes](https://github.com/dash0hq/dash0-operator) to the distributions list instead of the integrations registry.

Point of contact: @mmanciop (michele.mancioppi@dash0.com)
