### PR TITLE
Add link-check sanity guard: exclusions hold through a symlinked public/

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "gulp": "5.0.1",
     "hugo-extended": "0.164.0",
     "js-yaml": "5.2.1",
-    "link-cache": "github:chalin/link-cache#semver:^0.2.0",
+    "link-cache": "github:chalin/link-cache#semver:^0.2.1",
     "markdown-it": "14.3.0",
     "markdown-link-check": "3.14.2",
     "markdownlint": "0.41.1",

--- a/scripts/lychee/sanity/norm-cache.test.mjs
+++ b/scripts/lychee/sanity/norm-cache.test.mjs
@@ -1,0 +1,87 @@
+// Regression guard for the lychee-norm-cache helper (link-cache package): the
+// `/public/`-anchored `exclude_path` patterns that ../config/index.mjs
+// generates only match when the helper hands lychee the lexical `<cwd>/public`
+// path. When `public` is a symlink -- the diffable-public layout -- resolving
+// it to its target would strip the `/public/` path component and silently
+// disable every exclusion (fixed in chalin/link-cache v0.2.1).
+//
+// Skips cleanly when the `lychee` binary or the link-cache package is absent.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  writeFileSync,
+  mkdirSync,
+  rmSync,
+  symlinkSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+
+import { lycheeAvailable } from './run-lychee.mjs';
+
+const require = createRequire(import.meta.url);
+
+function normCacheBin() {
+  try {
+    return require.resolve('link-cache/check/index.mjs');
+  } catch {
+    return null;
+  }
+}
+
+const bin = normCacheBin();
+const skip = !lycheeAvailable()
+  ? 'lychee binary is not on PATH'
+  : !bin
+    ? 'link-cache package is not installed'
+    : process.platform === 'win32'
+      ? 'directory symlinks need elevation on Windows'
+      : false;
+
+describe(
+  'lychee-norm-cache exclusions through a symlinked public/',
+  { skip },
+  () => {
+    test('a dead link under an excluded path stays excluded', () => {
+      const root = mkdtempSync(join(tmpdir(), 'lychee-norm-cache-'));
+      try {
+        // Mirror the diffable-public layout: `public` is a symlink to a
+        // sibling directory holding the built site.
+        const built = join(root, 'site.g');
+        mkdirSync(join(built, 'blog', '2022'), { recursive: true });
+        writeFileSync(
+          join(built, 'index.html'),
+          '<!doctype html><html><body><a href="present.html">ok</a></body></html>',
+        );
+        writeFileSync(join(built, 'present.html'), 'x');
+        writeFileSync(
+          join(built, 'blog', '2022', 'index.html'),
+          '<!doctype html><html><body><a href="missing.html">dead</a></body></html>',
+        );
+        const site = join(root, 'site');
+        mkdirSync(site);
+        symlinkSync(join('..', 'site.g'), join(site, 'public'));
+        writeFileSync(
+          join(site, 'lychee.toml'),
+          'extensions = ["html"]\nexclude_path = ["/public/blog/2022/"]\n',
+        );
+
+        const result = spawnSync('node', [bin, '--offline'], {
+          cwd: site,
+          encoding: 'utf8',
+        });
+        assert.equal(
+          result.status,
+          0,
+          `the excluded dead link is skipped, so the check passes:\n${result.stdout}${result.stderr}`,
+        );
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+  },
+);


### PR DESCRIPTION
- Contributes to #10912 (follow-up to #10911).
- Adds a sanity test asserting that the generated `exclude_path` patterns hold when `public/` is a symlink (the diffable-public layout). Until [link-cache v0.2.1][], `lychee-norm-cache` resolved the symlink, stripping the `/public/` anchor from every pattern and silently disabling all exclusions; the fix arrives through the existing `^0.2.0` semver range.

[link-cache v0.2.1]: https://github.com/chalin/link-cache/releases/tag/v0.2.1
