### PR TITLE
Harden link-check tooling: blank patterns, Git failures, no-owner drift

### DIFF
--- a/scripts/gh/locale-auto-merge/README.md
+++ b/scripts/gh/locale-auto-merge/README.md
@@ -18,8 +18,9 @@ required code owner has approved and all checks pass.
 The helper adds two guards of its own:
 
 1. **Eligibility** — every changed file must be locale-owned (`content/<loc>/`,
-   `.cspell/<loc>-*.txt`, `prh/<loc>.yml`) or a recognized no-owner file
-   (`.lycheecache`). A PR may touch more than one locale.
+   `.cspell/<loc>-*.txt`, `prh/<loc>.yml`) or one of the no-owner paths declared
+   in `.github/CODEOWNERS` (e.g. `.lycheecache`). A PR may touch more than one
+   locale.
 2. **Authorization** — the commenter must be a member of
    `@open-telemetry/docs-<loc>-maintainers` for **every** locale the PR touches.
 

--- a/scripts/gh/locale-auto-merge/index.mjs
+++ b/scripts/gh/locale-auto-merge/index.mjs
@@ -8,9 +8,11 @@
 
 import { readdirSync } from 'node:fs';
 
-// Files with no code owner (see .github/CODEOWNERS) that may appear in an
-// otherwise locale-only PR without making it ineligible.
-const NO_OWNER_PATHS = new Set(['.lycheecache']);
+// Files with no code owner that may appear in an otherwise locale-only PR
+// without making it ineligible. Canonical home: the no-owner block of
+// .github/CODEOWNERS (patterns listed without an owner); the agreement is
+// guarded by a test.
+export const NO_OWNER_PATHS = new Set(['.lycheecache']);
 
 // The default content language. `content/en/` is the source English content,
 // owned by docs maintainers — not a translation locale — so it is excluded from

--- a/scripts/gh/locale-auto-merge/index.test.mjs
+++ b/scripts/gh/locale-auto-merge/index.test.mjs
@@ -1,5 +1,6 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 
 // cspell:ignore mallory
 
@@ -11,6 +12,7 @@ import {
   authorizeForLocales,
   resolveVerdict,
   runAutoMergeCommand,
+  NO_OWNER_PATHS,
 } from './index.mjs';
 
 const LOCALES = discoverLocales();
@@ -104,6 +106,43 @@ describe('locale-auto-merge: localeForPath', () => {
     assert.equal(localeForPath('layouts/partials/head.html', LOCALES), null);
     assert.equal(localeForPath('.lycheecache', LOCALES), null);
     assert.equal(localeForPath('content/ja', LOCALES), null);
+  });
+});
+
+describe('locale-auto-merge: no-owner paths agree with CODEOWNERS', () => {
+  // .github/CODEOWNERS is the canonical home of the no-owner policy: a
+  // pattern listed without an owner team. NO_OWNER_PATHS is the runtime copy.
+  const codeownersNoOwnerPaths = () => {
+    const text = readFileSync(
+      new URL('../../../.github/CODEOWNERS', import.meta.url),
+      'utf8',
+    );
+    return new Set(
+      text
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line && !line.startsWith('#'))
+        .filter((line) => !line.includes('@'))
+        .map((pattern) => pattern.replace(/^\//, '')),
+    );
+  };
+
+  test('NO_OWNER_PATHS matches the ownerless CODEOWNERS entries', () => {
+    assert.deepEqual(NO_OWNER_PATHS, codeownersNoOwnerPaths());
+  });
+
+  test('each no-owner path has a component-owners.yml fallback entry', () => {
+    const text = readFileSync(
+      new URL('../../../.github/component-owners.yml', import.meta.url),
+      'utf8',
+    );
+    for (const p of NO_OWNER_PATHS) {
+      assert.match(
+        text,
+        new RegExp(`^ {2}${p.replaceAll('.', '\\.')}:$`, 'm'),
+        `component-owners.yml assigns a fallback team to ${p}`,
+      );
+    }
   });
 });
 

--- a/scripts/lychee/changed-html/index.mjs
+++ b/scripts/lychee/changed-html/index.mjs
@@ -18,14 +18,19 @@ import path from 'node:path';
 
 const DEFAULT_BRANCH = 'main';
 
-function git(...args) {
+// Run a git command and return its stdout. Strict by default: a failure
+// throws (naming the command), since misreading it as empty output would
+// silently shrink the diff scope. Pass `{ mayFail: true }` only where failure
+// legitimately means "no result" (e.g. no merge base).
+function git(args, { mayFail = false } = {}) {
   try {
     return execFileSync('git', args, {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
     });
-  } catch {
-    return '';
+  } catch (err) {
+    if (mayFail) return '';
+    throw new Error(`git ${args.join(' ')} failed`, { cause: err });
   }
 }
 
@@ -42,7 +47,7 @@ function splitLines(out) {
 // mistyped LYCHEE_DIFF_BASE): a silent empty diff would false-green the check.
 export function changedFiles() {
   const baseRef = process.env.LYCHEE_DIFF_BASE || DEFAULT_BRANCH;
-  const base = git('merge-base', baseRef, 'HEAD').trim();
+  const base = git(['merge-base', baseRef, 'HEAD'], { mayFail: true }).trim();
   if (!base) {
     throw new Error(
       `cannot resolve the diff base '${baseRef}': ensure that it exists ` +
@@ -51,12 +56,12 @@ export function changedFiles() {
     );
   }
   const files = new Set();
-  splitLines(git('diff', '--name-only', base)).forEach((f) => files.add(f));
-  splitLines(git('diff', '--name-only')).forEach((f) => files.add(f));
-  splitLines(git('diff', '--name-only', '--cached')).forEach((f) =>
+  splitLines(git(['diff', '--name-only', base])).forEach((f) => files.add(f));
+  splitLines(git(['diff', '--name-only'])).forEach((f) => files.add(f));
+  splitLines(git(['diff', '--name-only', '--cached'])).forEach((f) =>
     files.add(f),
   );
-  splitLines(git('ls-files', '--others', '--exclude-standard')).forEach((f) =>
+  splitLines(git(['ls-files', '--others', '--exclude-standard'])).forEach((f) =>
     files.add(f),
   );
   return [...files];

--- a/scripts/lychee/changed-html/index.test.mjs
+++ b/scripts/lychee/changed-html/index.test.mjs
@@ -4,6 +4,9 @@
 
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, delimiter } from 'node:path';
 
 import { contentToPublic, confineToPublic, changedFiles } from './index.mjs';
 
@@ -95,4 +98,27 @@ describe('changedFiles()', () => {
       delete process.env.LYCHEE_DIFF_BASE;
     }
   });
+
+  test(
+    'a required git command failing after a valid merge base is an error',
+    { skip: process.platform === 'win32' && 'the git shim is a POSIX script' },
+    () => {
+      // Shim git so merge-base succeeds but diff fails: the failure must
+      // propagate rather than read as "no changed files" (a false green).
+      const dir = mkdtempSync(join(tmpdir(), 'changed-html-'));
+      const origPath = process.env.PATH;
+      try {
+        writeFileSync(
+          join(dir, 'git'),
+          '#!/bin/sh\ncase "$1" in merge-base) echo abc123;; *) exit 1;; esac\n',
+          { mode: 0o755 },
+        );
+        process.env.PATH = `${dir}${delimiter}${origPath}`;
+        assert.throws(() => changedFiles(), /git diff/);
+      } finally {
+        process.env.PATH = origPath;
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/scripts/lychee/config/index.mjs
+++ b/scripts/lychee/config/index.mjs
@@ -55,10 +55,10 @@ export function excludePathPatternsOf(frontMatter, filePath) {
   if (
     !Array.isArray(patterns) ||
     patterns.length === 0 ||
-    !patterns.every((p) => typeof p === 'string')
+    !patterns.every((p) => typeof p === 'string' && /\S/.test(p))
   ) {
     throw new Error(
-      `${filePath}: front-matter '${FRONT_MATTER_KEY}' must be a non-empty list of regex strings`,
+      `${filePath}: front-matter '${FRONT_MATTER_KEY}' must be a non-empty list of non-blank regex strings`,
     );
   }
   return patterns;

--- a/scripts/lychee/config/index.test.mjs
+++ b/scripts/lychee/config/index.test.mjs
@@ -65,6 +65,22 @@ describe('excludePathPatternsOf()', () => {
       /f\.md.*non-empty list/,
     );
   });
+
+  // A blank pattern would translate to `/public/`, excluding every page and
+  // false-greening the whole check.
+  test('throws on an empty-string pattern', () => {
+    assert.throws(
+      () => excludePathPatternsOf(`${FRONT_MATTER_KEY}: ['']`, 'f.md'),
+      /f\.md.*non-blank/,
+    );
+  });
+
+  test('throws on a whitespace-only pattern', () => {
+    assert.throws(
+      () => excludePathPatternsOf(`${FRONT_MATTER_KEY}: ['  ']`, 'f.md'),
+      /f\.md.*non-blank/,
+    );
+  });
 });
 
 describe('driftedIgnoreDirOf()', () => {


### PR DESCRIPTION
- Contributes to #10912: hardens the link-check toolchain per the non-gating findings of the switch's branch review.
- Rejects blank `link_check_exclude_path` patterns — a blank entry translates to `/public/`, excluding every page and false-greening the check.
- Propagates required Git-command failures in `changed-html` — a failing `git diff`/`git ls-files` no longer reads as "no changed files".
- Guards the locale-auto-merge no-owner paths against their canonical home, the no-owner block of `.github/CODEOWNERS` (agreement test + `component-owners.yml` fallback check).