### PR TITLE
Link checking: authenticate housekeeping runs, guard refresh-count copies

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -76,6 +76,10 @@ jobs:
         # Default-branch only (trusted; cf. pr-actions). Non-zero exit is OK—
         # fixes still publish; residual failures fail in report-failure below.
         uses: ./.github/actions/npm-script-patch
+        env:
+          # Authenticated github.com link checks (rate limits) in fix:refcache;
+          # step-level env reaches the composite action's steps.
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           command: ${{ inputs.command || 'fix-and-test:all' }}
           patch-name: housekeeping-${{ github.run_id }}

--- a/scripts/lychee/refresh-count.test.mjs
+++ b/scripts/lychee/refresh-count.test.mjs
@@ -1,0 +1,31 @@
+// The default refcache refresh/prune count lives in two places that cannot
+// derive from each other: the `${PRUNE_N:-N}` fallback in the
+// `fix:refcache:refresh` npm script (shell), and the
+// `number_of_entries_to_refresh` workflow-dispatch input default in
+// refcache-refresh.yml (a YAML literal). This guard keeps the copies in
+// agreement.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const read = (relPath) =>
+  readFileSync(new URL(relPath, import.meta.url), 'utf8');
+
+test('default refresh count agrees across package.json and refcache-refresh.yml', () => {
+  const script = JSON.parse(read('../../package.json')).scripts[
+    'fix:refcache:refresh'
+  ];
+  const pkgMatch = script?.match(/\$\{PRUNE_N:-(\d+)\}/);
+  assert.ok(pkgMatch, 'fix:refcache:refresh has a ${PRUNE_N:-N} fallback');
+
+  const workflow = read('../../.github/workflows/refcache-refresh.yml');
+  const wfMatch = workflow.match(/^\s*default: &default_refresh_count (\d+)$/m);
+  assert.ok(wfMatch, 'refcache-refresh.yml has a default_refresh_count anchor');
+
+  assert.equal(
+    pkgMatch[1],
+    wfMatch[1],
+    'refresh counts agree across package.json and refcache-refresh.yml',
+  );
+});


### PR DESCRIPTION
Contributes to #10912. Two small follow-ups from the Lychee-switch review verification:

- Sets `GITHUB_TOKEN` on the housekeeping workflow's trusted `npm-script-patch` step, so scheduled `fix:refcache` link checks are authenticated (the untrusted `pr-actions.yml` caller stays secret-free).
- Adds a drift guard asserting that the default refcache refresh count agrees across its two copies: the `${PRUNE_N:-800}` fallback in `package.json` and the workflow-dispatch input default in `refcache-refresh.yml`.