### PR TITLE
Link checking: move config guide into site docs, slim script headers

### DIFF
--- a/content/en/site/build/link-checking.md
+++ b/content/en/site/build/link-checking.md
@@ -41,9 +41,17 @@ For details, see [Build kinds: full and lean][].
 Lychee runs over the built site (`public/`) using the generated, git-ignored
 `lychee.toml`. The `generate:config:links` script derives it from
 [`lychee.base.toml`][] plus an `exclude_path` block computed from page front
-matter: pages marked `drifted_from_default: true`, and path patterns listed
-under the `link_check_exclude_path` front-matter key (see, for example,
-[`content/en/blog/_index.md`][blog-index]).
+matter, which has two sources:
+
+- **`link_check_exclude_path`** — a list of site-relative path regexes for pages
+  the link checker must skip, such as blog pagination and old blog posts; see
+  [`content/en/blog/_index.md`][blog-index]. Start a pattern with `^(../)?` to
+  have it cover every locale: the optional `../` matches a two-letter locale
+  path segment such as `ja/`.
+- **`drifted_from_default: true`** — [drifted localized pages][drifted]. Links
+  _from_ a drifted page aren't checked, since they may be stale, but the page
+  remains a valid link target: inbound links from in-sync pages, including
+  fragments, are still validated.
 
 ## Link cache {#refcache}
 
@@ -85,6 +93,7 @@ The job fails if any link check fails, or if the run leaves the committed
 [blog-index]:
   https://github.com/open-telemetry/opentelemetry.io/blob/main/content/en/blog/_index.md
 [ci]: ../ci-workflows/
+[drifted]: /docs/contributing/localization/#track-changes
 [housekeeping]: ../ci-workflows/#housekeeping
 [Lychee]: https://lychee.cli.rs/
 [`lychee.base.toml`]:

--- a/scripts/lychee/changed-html/index.mjs
+++ b/scripts/lychee/changed-html/index.mjs
@@ -90,8 +90,7 @@ export function confineToPublic(rel, root = process.cwd()) {
   return abs === pubRoot || abs.startsWith(pubRoot + path.sep) ? abs : null;
 }
 
-// Mapped, existing, absolute public HTML files for the current diff. Reports
-// unmappable / unbuilt changes on stderr.
+// Mapped, existing, absolute public HTML files for the current diff.
 export function mappedHtmlFiles(root = process.cwd()) {
   const mapped = [];
   const skipped = [];

--- a/scripts/lychee/changed-html/index.mjs
+++ b/scripts/lychee/changed-html/index.mjs
@@ -1,14 +1,8 @@
 #!/usr/bin/env node
 // Map changed content files to their built `public/` HTML, for a fast,
-// diff-scoped lychee run. "Changed" = everything since the merge-base with the
-// default branch (the PR's commits) plus staged, unstaged, and untracked files.
-//
-// Hugo builds `content/<lang>/<path>.md` into pretty-URL HTML under `public/`.
-// We replicate the common mapping (default-language strip, locale prefix,
-// `_index.md`/`index.md` -> `.../index.html`) and keep only paths that
-// actually exist in the build. This is best-effort: front-matter `url`/`slug`
-// overrides, aliases, and drafts may not map — those are reported on stderr, so
-// fall back to `npm run check:links` for guaranteed full coverage.
+// diff-scoped lychee run. Best-effort: front-matter `url`/`slug` overrides,
+// aliases, and drafts may not map — those are reported on stderr, so fall
+// back to `npm run check:links` for guaranteed full coverage.
 //
 // cSpell:ignore unmappable unbuilt
 
@@ -41,10 +35,11 @@ function splitLines(out) {
     .filter(Boolean);
 }
 
-// Changed files vs the merge-base with the default branch, union working-tree
-// (staged + unstaged) and untracked files. De-duplicated. Throws when the diff
-// base cannot be resolved (missing branch, shallow/single-branch clone, or a
-// mistyped LYCHEE_DIFF_BASE): a silent empty diff would false-green the check.
+// Changed files vs the merge-base with the default branch (the PR's commits),
+// union working-tree (staged + unstaged) and untracked files. De-duplicated.
+// Throws when the diff base cannot be resolved (missing branch,
+// shallow/single-branch clone, or a mistyped LYCHEE_DIFF_BASE): a silent empty
+// diff would false-green the check.
 export function changedFiles() {
   const baseRef = process.env.LYCHEE_DIFF_BASE || DEFAULT_BRANCH;
   const base = git(['merge-base', baseRef, 'HEAD'], { mayFail: true }).trim();
@@ -67,8 +62,10 @@ export function changedFiles() {
   return [...files];
 }
 
-// `content/<lang>/<rest>.md` -> built `public/[<lang>/]<pretty>/index.html`, or
-// `null` if the file isn't a mappable content page. Pure (no filesystem access).
+// `content/<lang>/<rest>.md` -> built `public/[<lang>/]<pretty>/index.html`
+// (default-language strip, `_index.md`/`index.md` -> `.../index.html`), or
+// `null` if the file isn't a mappable content page. Pure (no filesystem
+// access).
 export function contentToPublic(file) {
   const m = /^content\/([^/]+)\/(.+)\.md$/.exec(file);
   if (!m) return null;

--- a/scripts/lychee/check/index.sh
+++ b/scripts/lychee/check/index.sh
@@ -3,8 +3,8 @@
 # Run lychee over the built site (or over an explicit list of HTML files passed
 # as arguments, used by the diff-scoped check). Always passes an ABSOLUTE
 # `public/` path: lychee matches `exclude_path` against the input path as given,
-# and the IgnoreDirs port is anchored on `/public/...`, so a relative path would
-# silently disable every `exclude_path` entry.
+# and the generated `exclude_path` patterns are anchored on `/public/...`, so a
+# relative path would silently disable every `exclude_path` entry.
 #
 # Usage: scripts/lychee/check/index.sh [html-file ...]
 set -euo pipefail

--- a/scripts/lychee/config/index.mjs
+++ b/scripts/lychee/config/index.mjs
@@ -1,34 +1,20 @@
 #!/usr/bin/env node
-// Generate `lychee.toml` = `lychee.base.toml` + an `exclude_path` block derived
-// from content front matter. The base is hand-maintained and committed;
-// `lychee.toml` is generated and gitignored. Two front-matter sources feed the
-// block:
+// Generate `lychee.toml` = `lychee.base.toml` (hand-maintained, committed) +
+// an `exclude_path` block derived from page front matter
+// (`link_check_exclude_path` patterns and `drifted_from_default` pages). For
+// the configuration model and front-matter semantics, see:
+// https://opentelemetry.io/site/build/link-checking/#configuration
 //
-// - `link_check_exclude_path` — a list of site-relative regexes for pages the
-//   link checker must skip (e.g. blog pagination, old blog posts); see
-//   content/en/blog/_index.md.
-// - `drifted_from_default: true` — drifted localized pages. Link checking
-//   originating from drifted pages is skipped (their links may be stale), but
-//   the pages remain resolvable as anchor targets, so inbound links from
-//   non-drifted pages keep being validated.
-//
-// Both express paths relative to the site root (`public/`), while lychee's
+// Front matter expresses paths relative to the site root, while lychee's
 // `exclude_path` matches the absolute path of each input file it scans. So
-// every pattern is re-anchored onto the `/public/` path segment, accounting for
-// Hugo's pretty-URL `index.html` page files:
+// every pattern is re-anchored (verbatim — they are regexes) onto the
+// `/public/` path segment, accounting for Hugo's pretty-URL `index.html` page
+// files:
 //
-//   `^bn/docs/demo/$`             (a single page)   -> /public/bn/docs/demo/index\.html$
-//   `^(../)?blog/20(19|2.)/`      (a whole subtree) -> /public/(../)?blog/20(19|2.)/
-//   `^(../)?blog/(\d+/)?page/\d+` (substring)       -> /public/(../)?blog/(\d+/)?page/\d+
+//   `^bn/docs/demo/$`        (a single page)   -> /public/bn/docs/demo/index\.html$
+//   `^(../)?blog/20(19|2.)/` (a whole subtree) -> /public/(../)?blog/20(19|2.)/
 //
-// The `(../)?` prefix is regex (the `.`s are wildcards): it optionally matches
-// *any two characters + slash* — i.e. a 2-letter locale segment such as `ja/`,
-// `es/`, `pt/`. That is how a single pattern skips old blog posts in every
-// locale, not just EN. It is preserved verbatim; dropping it would only exclude
-// EN and leave localized old-blog externals to be (wrongly) scanned.
-//
-// Usage: node scripts/lychee/config/index.mjs
-// Run via `npm run generate:config:links`.
+// Usage: node scripts/lychee/config/index.mjs (npm run generate:config:links)
 
 import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';

--- a/scripts/lychee/config/index.test.mjs
+++ b/scripts/lychee/config/index.test.mjs
@@ -1,6 +1,6 @@
-// Unit tests for the front-matter -> lychee `exclude_path` generator. Guards
-// the key parity property: the `(../)?` locale prefix is preserved, so a single
-// pattern keeps excluding old blog posts in every locale, not just EN.
+// Unit tests for the front-matter -> lychee `exclude_path` generator
+// (./index.mjs), including preservation of the `(../)?` locale prefix that
+// lets a single pattern cover every locale.
 
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
@@ -40,8 +40,6 @@ describe('excludePathPatternsOf()', () => {
   });
 
   test('extracts a flow-style (one-line) list', () => {
-    // The htmltest-era extractor silently dropped this form; see the generator
-    // header comment.
     const fm = `${FRONT_MATTER_KEY}: [/en/docs/contributing/blog/]`;
     assert.deepEqual(excludePathPatternsOf(fm, 'f.md'), [
       '/en/docs/contributing/blog/',

--- a/scripts/lychee/diff-check/index.mjs
+++ b/scripts/lychee/diff-check/index.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 // Diff-scoped lychee check: run lychee only over the built HTML for content
-// files changed in this PR / working tree. No-op (exit 0) when nothing maps, so
-// it's cheap to run on docs-free changes. Delegates to scripts/lychee/check/index.sh
-// so the absolute `--root-dir public` handling stays in one place.
+// files changed in this PR / working tree; no-op (exit 0) when nothing maps.
+// Delegates to scripts/lychee/check/index.sh so the absolute
+// `--root-dir public` handling stays in one place.
 
 import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';

--- a/scripts/old-blog-lint-ignores.test.mjs
+++ b/scripts/old-blog-lint-ignores.test.mjs
@@ -2,9 +2,7 @@
 // file seeded with violations is created in an old blog folder (must be
 // ignored) and in a recent one (must be flagged). For the policy, tool list,
 // and config details, see:
-//
-// - https://opentelemetry.io/site/skills/update-old-blog-ignores/
-// - content/en/site/skills/update-old-blog-ignores.md
+// https://opentelemetry.io/site/skills/update-old-blog-ignores/
 //
 // Link checking is not covered (requires a site build); validate it manually
 // via `npm run check:links`.


### PR DESCRIPTION
- Contributes to #10912
- Moves the config generator's front-matter guide into [Link checking § Configuration][docs], making the docs page the canonical home for the exclusion model (`link_check_exclude_path`, drifted-page semantics, the `(../)?` all-locale idiom).
- Slims script and test file headers to must-know content; retains invariant comments such as the `/public/` re-anchoring. No behavior changes.
- **Preview(s)**:
  - [Link checking § Configuration][docs]

[docs]: https://deploy-preview-10929--opentelemetry.netlify.app/site/build/link-checking/#configuration