### PR TITLE
l10n: restrict multi-locale PRs to keeping build and checks green

### DIFF
--- a/.claude/skills/review-pull-request/SKILL.md
+++ b/.claude/skills/review-pull-request/SKILL.md
@@ -82,10 +82,9 @@ validates and the local fix command. Caveats:
 
 - Submodules: non-maintainer PRs should not touch them; a maintainer fixes
   before merge — [`sig-practices.md#general`][general].
-- Locale span: semantic changes are per-locale; editorial cross-locale edits are
-  OK and append `# patched` to `default_lang_commit` —
-  [`localization.md#prs-should-not-span-locales`][locale-span] and
-  [`#patch-locale-links`][patch-locale].
+- Locale span: semantic changes are per-locale; a PR may span locales only to
+  keep checks green (link fixes append `# patched` to `default_lang_commit`) —
+  [`localization.md#prs-should-not-span-locales`][locale-span].
 
 **Branch state**
 
@@ -123,8 +122,8 @@ Walk this checklist before writing the review:
 - [ ] Netlify preview builds.
 - [ ] Each failing `check-*` assessed against [`pr-checks.md#checks`][checks].
 - [ ] Linked issue is `triage:accepted` (or this is an auto/hotfix PR).
-- [ ] Does not span locales with semantic changes — or uses `# patched` for
-      editorial cross-locale edits.
+- [ ] Does not span locales — or does so only to keep checks green (link fixes
+      use `# patched`).
 - [ ] First-time-contributor AI checklist in the PR description is filled in and
       looks human-written.
 - [ ] No unrelated changes bundled.
@@ -205,5 +204,3 @@ Source-of-truth files — read on demand:
 [general]: ../../../content/en/docs/contributing/sig-practices.md#general
 [locale-span]:
   ../../../content/en/docs/contributing/localization.md#prs-should-not-span-locales
-[patch-locale]:
-  ../../../content/en/docs/contributing/localization.md#patch-locale-links

--- a/.claude/skills/review-pull-request/SKILL.md
+++ b/.claude/skills/review-pull-request/SKILL.md
@@ -83,7 +83,7 @@ validates and the local fix command. Caveats:
 - Submodules: non-maintainer PRs should not touch them; a maintainer fixes
   before merge — [`sig-practices.md#general`][general].
 - Locale span: semantic changes are per-locale; a PR may span locales only to
-  keep checks green (link fixes append `# patched` to `default_lang_commit`) —
+  keep checks green (such fixes append `# patched` to `default_lang_commit`) —
   [`localization.md#prs-should-not-span-locales`][locale-span].
 
 **Branch state**
@@ -122,7 +122,7 @@ Walk this checklist before writing the review:
 - [ ] Netlify preview builds.
 - [ ] Each failing `check-*` assessed against [`pr-checks.md#checks`][checks].
 - [ ] Linked issue is `triage:accepted` (or this is an auto/hotfix PR).
-- [ ] Does not span locales — or does so only to keep checks green (link fixes
+- [ ] Does not span locales — or does so only to keep checks green (such fixes
       use `# patched`).
 - [ ] First-time-contributor AI checklist in the PR description is filled in and
       looks human-written.

--- a/.claude/skills/review-pull-request/SKILL.md
+++ b/.claude/skills/review-pull-request/SKILL.md
@@ -82,8 +82,9 @@ validates and the local fix command. Caveats:
 
 - Submodules: non-maintainer PRs should not touch them; a maintainer fixes
   before merge — [`sig-practices.md#general`][general].
-- Locale span: semantic changes are per-locale; a PR may span locales only to
-  keep checks green (such fixes append `# patched` to `default_lang_commit`) —
+- Locale span: semantic changes are per-locale; page-content changes may span
+  locales only to keep checks green (such fixes append `# patched` to
+  `default_lang_commit`); content-neutral maintenance is exempt —
   [`localization.md#prs-should-not-span-locales`][locale-span].
 
 **Branch state**
@@ -122,8 +123,8 @@ Walk this checklist before writing the review:
 - [ ] Netlify preview builds.
 - [ ] Each failing `check-*` assessed against [`pr-checks.md#checks`][checks].
 - [ ] Linked issue is `triage:accepted` (or this is an auto/hotfix PR).
-- [ ] Does not span locales — or does so only to keep checks green (such fixes
-      use `# patched`).
+- [ ] Does not span locales — or does so only for checks-green fixes (marked
+      `# patched`) or content-neutral maintenance.
 - [ ] First-time-contributor AI checklist in the PR description is filled in and
       looks human-written.
 - [ ] No unrelated changes bundled.

--- a/.github/localization.instructions.md
+++ b/.github/localization.instructions.md
@@ -140,9 +140,13 @@ default_lang_commit: <commit-hash-of-english-page>
   fixes, build fixes) may edit localized pages without syncing them
 - Make only the edits the fix requires, and add the `# patched` comment to the
   `default_lang_commit` line in front matter
-- Any other change to a localized page — including targeted content additions to
-  drifted pages, such as new glossary terms — is a semantic change for that
-  locale and belongs in a locale-specific PR
+- Any other change to localized page content — including targeted content
+  additions to drifted pages, such as new glossary terms — is a semantic change
+  for that locale and belongs in a locale-specific PR
+- Content-neutral maintenance (site-wide tooling, configuration, front-matter,
+  or markup updates, including drift-status bookkeeping) may also span locales;
+  for the full policy, see
+  `content/en/docs/contributing/localization.md#prs-should-not-span-locales`
 
 ### Starting New Localizations
 
@@ -219,12 +223,15 @@ default_lang_commit: <commit-hash-of-english-page>
 - Semantic changes should affect only one language per PR
 - Exception: changes strictly required to keep the site build and its checks
   green (link fixes, build fixes) can span locales
+- Exception: content-neutral maintenance (site-wide tooling, configuration,
+  front-matter, or markup updates) can span locales; for the full policy, see
+  `content/en/docs/contributing/localization.md#prs-should-not-span-locales`
 
 **PR Description Requirements:**
 
 - Specify which pages were translated/updated
 - Note any drift status changes
-- Document any targeted updates to drifted files
+- List any pages you patched (`# patched`) and why
 - Include screenshots for UI-affecting changes
 
 ### Maintenance Commands

--- a/.github/localization.instructions.md
+++ b/.github/localization.instructions.md
@@ -134,12 +134,15 @@ default_lang_commit: <commit-hash-of-english-page>
 3. Update `default_lang_commit` to latest hash:
    `npm run check:i18n -- -c HEAD content/xx/path/to/page`
 
-**Targeted Updates (Advanced):**
+**Patching (build and check fixes only):**
 
-- For small additions to drifted files, you can make targeted updates
-- Add `# patched` comment to `default_lang_commit` line in front matter
-- Document rationale in PR description
-- Example use cases: Adding new glossary terms, fixing broken links
+- Fixes strictly required to keep the site build and its checks green (link
+  fixes, build fixes) may edit localized pages without syncing them
+- Make only the edits the fix requires, and add the `# patched` comment to the
+  `default_lang_commit` line in front matter
+- Any other change to a localized page — including targeted content additions to
+  drifted pages, such as new glossary terms — is a semantic change for that
+  locale and belongs in a locale-specific PR
 
 ### Starting New Localizations
 

--- a/.github/localization.instructions.md
+++ b/.github/localization.instructions.md
@@ -214,8 +214,8 @@ default_lang_commit: <commit-hash-of-english-page>
 **Single-Language PRs:**
 
 - Semantic changes should affect only one language per PR
-- Exception: Pure editorial changes (link fixes, resource updates) can span
-  locales
+- Exception: changes strictly required to keep the site build and its checks
+  green (link fixes, build fixes) can span locales
 
 **PR Description Requirements:**
 

--- a/.lycheecache
+++ b/.lycheecache
@@ -4316,6 +4316,7 @@ https://gohugo.io/configuration/markup/#goldmark,206,1784284663
 https://gohugo.io/content-management/front-matter/,206,1784284638
 https://gohugo.io/content-management/multilingual/#page-bundles,206,1784183016
 https://gohugo.io/content-management/multilingual/,206,1784284632
+https://gohugo.io/content-management/urls/#aliases,200,1784649104
 https://gohugo.io/documentation/,206,1784284654
 https://gohugo.io/methods/page/regularpages/#default-sort-order,206,1784284876
 https://gohugo.io/methods/site/regularpages/,206,1784269432

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -532,11 +532,19 @@ the site build and its checks green:
   page's [drift status](#track-changes) only shields it from link checking, not
   from the Hugo build.
 
-<a id="targeted-content-additions"></a> Any other change to a localized page is
-a **semantic** change for that locale. This includes targeted content additions
-to drifted pages, such as adding a new glossary term. As explained in the
-[previous section](#prs-should-not-span-locales), leave such changes to each
+<a id="targeted-content-additions"></a> Treat any other change to a localized
+page as a **semantic** change for that locale. This includes targeted content
+additions to drifted pages, such as adding a new glossary term. As explained in
+the [previous section](#prs-should-not-span-locales), leave such changes to each
 locale team to incorporate through its own locale-specific PRs.
+
+> [!NOTE] Content-neutral maintenance
+>
+> The rule above governs page **content**. Maintainers sometimes submit
+> content-neutral changes that necessarily span locales: site-wide tooling,
+> configuration, front-matter, or markup updates, including the automated
+> [drift-status](#track-changes) bookkeeping PRs. Such changes don't alter the
+> meaning of localized pages.
 
 #### Link fixes and resource updates {#link-fixes-and-resource-updates}
 

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -308,7 +308,9 @@ npm run check:i18n -- -c HEAD <PATH-TO-YOUR-NEW-FILES>
 Run `npm run fix:i18n:status` to set the `drifted_from_default` front-matter
 field on those target localization pages that have drifted. This field displays
 an "outdated" banner at the top of the page, and causes the link checker to skip
-the page, so that stale links on drifted pages don't fail CI.
+the page, so that stale links on drifted pages don't fail CI. For details about
+how the link checker handles drifted pages, see
+[Link checking](/site/build/link-checking/).
 
 ### Script help
 
@@ -548,7 +550,8 @@ adding a new glossary term.
 #### Link fixes and resource updates {#link-fixes-and-resource-updates}
 
 Changes to the English documentation can result in link-check failures for
-non-English locales. This happens when documentation pages are moved or deleted.
+non-English locales. This happens when documentation pages, or sections within
+them, are moved or deleted.
 
 When an English page is **moved**, first ensure that the page declares an
 [alias][aliases] for its old path. The alias keeps previously published links to
@@ -558,15 +561,25 @@ site's canonical page paths. Links to the old path therefore still need fixing.
 A moved or deleted page's localized copies themselves don't need to be touched:
 [drift tracking](#track-changes) flags them for their locale teams.
 
-Make the following updates to each non-English page that has a path that fails
-link checking (drifted pages are skipped by the link checker, so this typically
-applies to in-sync pages):
+When the link target was **moved**, make the following updates to each
+non-English page that has a path that fails link checking
+([drifted](#track-changes) pages are skipped by the link checker, so this
+typically applies to in-sync pages):
 
 - Update the link reference to the new page path.
 - Add the `# patched` YAML comment at the end of the line for the
   `default_lang_commit` front matter line.
 - Make no other changes to the file.
-- Rerun `npm run check:links` and ensure that no link failures remain.
+
+When the link target was **deleted** — the English page, or the section that the
+link points to, is gone — choosing a replacement or dropping the reference is a
+[semantic change](#prs-should-not-span-locales) for each affected locale, so
+don't patch such links. Instead, mark each affected localized page as
+[drifted](#track-changes) by setting `drifted_from_default: true` in its front
+matter, and leave the reconciliation to the page's locale team.
+
+In either case, rerun `npm run check:links` and ensure that no link failures
+remain.
 
 When an _external link_ to a **moved** (but otherwise semantically
 **unchanged**) resource (such as a GitHub file) results in a link-check failure,

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -513,11 +513,14 @@ README][].
 
 Approvers should ensure that [PRs][] making **semantic** changes to doc pages do
 not span multiple locales. A semantic change is one that impacts the _meaning_
-of the page content. Our docs [localization process](.) ensures that locale
-approvers will, in time, review the English-language edits to determine if the
-changes are appropriate for their locale, and how best to incorporate them into
-their locale. If changes are necessary, the locale approvers will make them via
-their own locale-specific PRs.
+of the page content — what readers understand and act on. Code blocks, commands,
+and configuration samples are part of that content: they aren't
+[translated](#do-not), but edits to them are semantic changes all the same. Our
+docs [localization process](.) ensures that locale approvers will, in time,
+review the English-language edits to determine if the changes are appropriate
+for their locale, and how best to incorporate them into their locale. If changes
+are necessary, the locale approvers will make them via their own locale-specific
+PRs.
 
 A PR may span multiple locales **only** when that is strictly required to keep
 the site build and its checks green:

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -586,7 +586,7 @@ be touched: [drift tracking](#track-changes) flags them for their locale teams.
 What may need fixing are the localized pages that **link** to such targets.
 Proceed according to the fate of the link target:
 
-- **A page or section was moved**:
+- **A page was moved**:
 
   1. Ensure that the moved English page declares an [alias][aliases] for its old
      path. The alias keeps previously published links to the page working, but
@@ -598,15 +598,25 @@ Proceed according to the fate of the link target:
      ([Drifted](#track-changes) pages are skipped by the link checker, so this
      typically applies to in-sync pages.)
 
+- **A section was moved**: aliases can't help in this case, since they redirect
+  page paths, not fragments. If the section moved within its page, preserve its
+  [heading ID](#headings) so that links to the section keep working. Otherwise,
+  update links to the section on each page that fails link checking, and mark
+  each edited localized page as [patched](#patched).
+
 - **A page or section was deleted**: choosing a replacement or dropping the
   reference is a [semantic change](#semantic-changes) for each affected locale,
-  so don't patch such links. Instead, mark each affected localized page as
-  [drifted](#track-changes) by setting `drifted_from_default: true` in its front
-  matter, and leave the reconciliation to the page's locale team.
+  so don't patch such links. Fixing the English pages that linked to the deleted
+  target makes their localized copies drift: once your English edits are
+  committed, run `npm run fix:i18n:status -- <PATHS-TO-LOCALIZED-COPIES>` to
+  refresh the [drift status](#drift-status) of those copies. The link checker
+  then skips those pages, and reconciliation is left to each page's locale team.
+  In the rare case where a failing link exists only in a localized page,
+  coordinate a fix with its locale team.
 
 - **An external resource was moved**, but is otherwise semantically unchanged
-  (such as a relocated GitHub file): update the link across all locales, marking
-  each edited localized page as [patched](#patched).
+  (such as a relocated GitHub file): update the link on each page that fails
+  link checking, marking each edited localized page as [patched](#patched).
 
 In all cases, rerun `npm run check:links` and confirm that no link failures
 remain.

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -303,6 +303,22 @@ npm run check:i18n -- -c HEAD <PATH-TO-YOUR-NEW-FILES>
 > `main` at HEAD in your **local environment**. Make sure that you fetch and
 > pull `main`, if you want HEAD to correspond to `main` in GitHub.
 
+### Patching localized pages {#patched}
+
+Some [locale-spanning fixes](#keep-checks-green) require editing a localized
+page without syncing it to its English counterpart — for example, retargeting a
+link after an English page was moved. Mark each localized page fixed in this way
+as **patched**:
+
+- Make only the edits that the fix requires — no other changes to the page.
+- Append the `# patched` YAML comment to the page's `default_lang_commit` line,
+  like this: `default_lang_commit: abc4567... # patched`.
+
+The marker tells the page's locale team that the page was mechanically fixed
+without being synced: the hash still records the last sync point. The marker is
+dropped the next time the page's hash is
+[updated](#updating-default_lang_commit-for-existing-pages).
+
 ### Drift status
 
 Run `npm run fix:i18n:status` to set the `drifted_from_default` front-matter
@@ -513,6 +529,11 @@ README][].
 
 ### PRs should not span locales {#prs-should-not-span-locales}
 
+As a general rule, a PR should not span locales, that is, it should change the
+pages of at most one locale. The only exceptions are described in this section.
+
+#### Semantic changes {#semantic-changes}
+
 Approvers should ensure that [PRs][] making **semantic** changes to doc pages do
 not span multiple locales. A semantic change is one that impacts the _meaning_
 of the page content — what readers understand and act on. Code blocks, commands,
@@ -523,6 +544,16 @@ review the English-language edits to determine if the changes are appropriate
 for their locale, and how best to incorporate them into their locale. If changes
 are necessary, the locale approvers will make them via their own locale-specific
 PRs.
+
+> [!NOTE] Content-neutral maintenance
+>
+> The locale-span rule governs page **content**. Maintainers sometimes submit
+> content-neutral changes that necessarily span locales: site-wide tooling,
+> configuration, front-matter, or markup updates, including the automated
+> [drift-status](#track-changes) bookkeeping PRs. Such changes don't alter the
+> meaning of localized pages.
+
+#### Keeping the build and checks green {#keep-checks-green}
 
 A PR may span multiple locales **only** when that is strictly required to keep
 the site build and its checks green:
@@ -535,17 +566,11 @@ the site build and its checks green:
   page's [drift status](#track-changes) only shields it from link checking, not
   from the Hugo build.
 
+In both cases, mark every localized page that you fix as [patched](#patched).
+
 Treat any other change to a localized page as a **semantic** change for that
 locale. This includes targeted content additions to drifted pages, such as
 adding a new glossary term.
-
-> [!NOTE] Content-neutral maintenance
->
-> The rule above governs page **content**. Maintainers sometimes submit
-> content-neutral changes that necessarily span locales: site-wide tooling,
-> configuration, front-matter, or markup updates, including the automated
-> [drift-status](#track-changes) bookkeeping PRs. Such changes don't alter the
-> meaning of localized pages.
 
 #### Link fixes and resource updates {#link-fixes-and-resource-updates}
 
@@ -561,20 +586,15 @@ site's canonical page paths. Links to the old path therefore still need fixing.
 A moved or deleted page's localized copies themselves don't need to be touched:
 [drift tracking](#track-changes) flags them for their locale teams.
 
-When the link target was **moved**, make the following updates to each
-non-English page that has a path that fails link checking
-([drifted](#track-changes) pages are skipped by the link checker, so this
-typically applies to in-sync pages):
-
-- Update the link reference to the new page path.
-- Add the `# patched` YAML comment at the end of the line for the
-  `default_lang_commit` front matter line.
-- Make no other changes to the file.
+When the link target was **moved**, update the link to the new page path on each
+non-English page that fails link checking, and mark each edited page as
+[patched](#patched). ([Drifted](#track-changes) pages are skipped by the link
+checker, so this typically applies to in-sync pages.)
 
 When the link target was **deleted** — the English page, or the section that the
 link points to, is gone — choosing a replacement or dropping the reference is a
-[semantic change](#prs-should-not-span-locales) for each affected locale, so
-don't patch such links. Instead, mark each affected localized page as
+[semantic change](#semantic-changes) for each affected locale, so don't patch
+such links. Instead, mark each affected localized page as
 [drifted](#track-changes) by setting `drifted_from_default: true` in its front
 matter, and leave the reconciliation to the page's locale team.
 

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -305,10 +305,10 @@ npm run check:i18n -- -c HEAD <PATH-TO-YOUR-NEW-FILES>
 
 ### Patching localized pages {#patched}
 
-Some [locale-spanning fixes](#keep-checks-green) require editing a localized
-page without syncing it to its English counterpart — for example, retargeting a
-link after an English page was moved. Mark each localized page fixed in this way
-as **patched**:
+[Build and check fixes](#keep-checks-green) sometimes require editing a
+localized page without syncing it to its English counterpart — for example,
+retargeting a link after an English page was moved. Mark each localized page
+fixed in this way as **patched**, whether or not the fix spans locales:
 
 - Make only the edits that the fix requires — no other changes to the page.
 - Append the `# patched` YAML comment to the page's `default_lang_commit` line:
@@ -317,9 +317,10 @@ as **patched**:
   default_lang_commit: abc4567... # patched
   ```
 
-The marker tells the page's locale team that the page was mechanically fixed
-without being synced: the hash still records the last sync point. The marker is
-dropped the next time the page's hash is
+The marker is reserved for such mechanical fixes —
+[semantic changes](#semantic-changes) never use it. The marker tells the page's
+locale team that the page was fixed without being synced: the hash still records
+the last sync point. The marker is dropped the next time the page's hash is
 [updated](#updating-default_lang_commit-for-existing-pages).
 
 ### Drift status
@@ -558,8 +559,8 @@ PRs.
 
 #### Keeping the build and checks green {#keep-checks-green}
 
-A PR may span multiple locales **only** when that is strictly required to keep
-the site build and its checks green:
+A PR that changes localized page **content** may span multiple locales only when
+that is strictly required to keep the site build and its checks green:
 
 - **Link fixes**: repairing link-check failures on localized pages after an
   English page is moved or deleted, or an external resource has moved. See
@@ -571,8 +572,8 @@ the site build and its checks green:
 
 In both cases, mark every localized page that you fix as [patched](#patched).
 
-Treat any other change to a localized page as a **semantic** change for that
-locale. This includes targeted content additions to drifted pages, such as
+Treat any other change to localized page content as a **semantic** change for
+that locale. This includes targeted content additions to drifted pages, such as
 adding a new glossary term.
 
 #### Link fixes and resource updates {#link-fixes-and-resource-updates}

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -519,26 +519,39 @@ changes are appropriate for their locale, and how best to incorporate them into
 their locale. If changes are necessary, the locale approvers will make them via
 their own locale-specific PRs.
 
-### Purely editorial changes across locales are OK {#patch-locale-links}
+### Multi-locale PRs are only for keeping checks green {#patch-locale-links}
 
-**Purely editorial** page updates are changes that **do not** affect the
-existing content and can span multiple locales. These include:
+A PR may span multiple locales **only** when that is strictly required to keep
+the site build and its checks green:
 
-- **Link maintenance**: Fixing broken link paths when pages are moved or
-  deleted.
-- **Resource updates**: Updating links to moved external resources.
-- **Targeted content additions**: Adding specific new definitions or sections to
-  files that have drifted, when updating the entire file isn't feasible.
+- **Link fixes**: repairing link-check failures on localized pages after an
+  English page is moved or deleted, or an external resource has moved. See
+  [Link fixes and resource updates](#link-fixes-and-resource-updates).
+- **Build fixes**: repairing site-build breakage on localized pages, for
+  example, after a shared shortcode, include file, or data source changes. A
+  page's [drift status](#track-changes) only shields it from link checking, not
+  from the Hugo build.
+
+<a id="targeted-content-additions"></a> Any other change to a localized page is
+a **semantic** change for that locale. This includes targeted content additions
+to drifted pages, such as adding a new glossary term. As explained in the
+[previous section](#prs-should-not-span-locales), leave such changes to each
+locale team to incorporate through its own locale-specific PRs.
 
 #### Link fixes and resource updates {#link-fixes-and-resource-updates}
 
-For example, sometimes changes to English language documentation can result in
-link-check failures for non-English locales. This happens when documentation
-pages are moved or deleted.
+Changes to the English documentation can result in link-check failures for
+non-English locales. This happens when documentation pages are moved or deleted.
 
-In such situations, make the following updates to each non-English page that has
-a path that fails link checking (drifted pages are skipped by the link checker,
-so this typically applies to in-sync pages):
+When an English page is **moved**, first ensure that the page declares an
+[alias][aliases] for its old path. The alias keeps previously published links to
+the page working, including those from localized pages, without any locale file
+needing to be touched.
+
+When an alias can't help (for example, the page was deleted), make the following
+updates to each non-English page that has a path that fails link checking
+(drifted pages are skipped by the link checker, so this typically applies to
+in-sync pages):
 
 - Update the link reference to the new page path.
 - Add the `# patched` YAML comment at the end of the line for the
@@ -551,31 +564,7 @@ When an _external link_ to a **moved** (but otherwise semantically
 update the link across all locales using the method described earlier in this
 section.
 
-#### Targeted content additions to drifted files {#targeted-content-additions}
-
-When adding specific new content to a localized file that has drifted from the
-English version, you may choose to make a targeted update rather than updating
-the entire file. For example, when a new glossary term such as "cardinality" is
-added to the English glossary, you can add just that term to the localized
-glossary without addressing other drifted content.
-
-Here's an example of the workflow for this targeted update:
-
-- Add only the "cardinality" definition block to the localized glossary file
-- Update the front matter by adding `# patched` as a comment at the end of the
-  `default_lang_commit` line
-- Leave all other existing content unchanged
-- In the PR description, clearly document:
-  - The specific content added ("cardinality" definition)
-  - That the file remains drifted for other content
-  - The rationale for the targeted update (e.g., "Providing critical new
-    terminology to localized readers without requiring full file
-    synchronization")
-
-This approach enables incremental improvements to localized content while
-maintaining awareness that the file still requires future attention for complete
-synchronization with the English version.
-
+[aliases]: https://gohugo.io/content-management/urls/#aliases
 [front matter]: https://gohugo.io/content-management/front-matter/
 [main]: https://github.com/open-telemetry/opentelemetry.io/commits/main/
 [maintainers]: https://github.com/orgs/open-telemetry/teams/docs-maintainers

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -311,8 +311,11 @@ link after an English page was moved. Mark each localized page fixed in this way
 as **patched**:
 
 - Make only the edits that the fix requires — no other changes to the page.
-- Append the `# patched` YAML comment to the page's `default_lang_commit` line,
-  like this: `default_lang_commit: abc4567... # patched`.
+- Append the `# patched` YAML comment to the page's `default_lang_commit` line:
+
+  ```yaml
+  default_lang_commit: abc4567... # patched
+  ```
 
 The marker tells the page's locale team that the page was mechanically fixed
 without being synced: the hash still records the last sync point. The marker is
@@ -576,35 +579,36 @@ adding a new glossary term.
 
 Changes to the English documentation can result in link-check failures for
 non-English locales. This happens when documentation pages, or sections within
-them, are moved or deleted.
+them, are moved or deleted; links to moved external resources can fail
+similarly. A moved or deleted page's localized copies themselves don't need to
+be touched: [drift tracking](#track-changes) flags them for their locale teams.
+What may need fixing are the localized pages that **link** to such targets.
+Proceed according to the fate of the link target:
 
-When an English page is **moved**, first ensure that the page declares an
-[alias][aliases] for its old path. The alias keeps previously published links to
-the page working, but only for site visitors: aliases are published as
-server-side redirects, and the link checker resolves links against the built
-site's canonical page paths. Links to the old path therefore still need fixing.
-A moved or deleted page's localized copies themselves don't need to be touched:
-[drift tracking](#track-changes) flags them for their locale teams.
+- **A page or section was moved**:
 
-When the link target was **moved**, update the link to the new page path on each
-non-English page that fails link checking, and mark each edited page as
-[patched](#patched). ([Drifted](#track-changes) pages are skipped by the link
-checker, so this typically applies to in-sync pages.)
+  1. Ensure that the moved English page declares an [alias][aliases] for its old
+     path. The alias keeps previously published links to the page working, but
+     only for site visitors: aliases are published as server-side redirects, and
+     the link checker resolves links against the built site's canonical page
+     paths. Links to the old path therefore still need fixing.
+  2. Update the link to the new path on each non-English page that fails link
+     checking, and mark each edited page as [patched](#patched).
+     ([Drifted](#track-changes) pages are skipped by the link checker, so this
+     typically applies to in-sync pages.)
 
-When the link target was **deleted** — the English page, or the section that the
-link points to, is gone — choosing a replacement or dropping the reference is a
-[semantic change](#semantic-changes) for each affected locale, so don't patch
-such links. Instead, mark each affected localized page as
-[drifted](#track-changes) by setting `drifted_from_default: true` in its front
-matter, and leave the reconciliation to the page's locale team.
+- **A page or section was deleted**: choosing a replacement or dropping the
+  reference is a [semantic change](#semantic-changes) for each affected locale,
+  so don't patch such links. Instead, mark each affected localized page as
+  [drifted](#track-changes) by setting `drifted_from_default: true` in its front
+  matter, and leave the reconciliation to the page's locale team.
 
-In either case, rerun `npm run check:links` and ensure that no link failures
+- **An external resource was moved**, but is otherwise semantically unchanged
+  (such as a relocated GitHub file): update the link across all locales, marking
+  each edited localized page as [patched](#patched).
+
+In all cases, rerun `npm run check:links` and confirm that no link failures
 remain.
-
-When an _external link_ to a **moved** (but otherwise semantically
-**unchanged**) resource (such as a GitHub file) results in a link-check failure,
-update the link across all locales using the method described earlier in this
-section.
 
 [aliases]: https://gohugo.io/content-management/urls/#aliases
 [front matter]: https://gohugo.io/content-management/front-matter/

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -552,13 +552,15 @@ non-English locales. This happens when documentation pages are moved or deleted.
 
 When an English page is **moved**, first ensure that the page declares an
 [alias][aliases] for its old path. The alias keeps previously published links to
-the page working, including those from localized pages, without any locale file
-needing to be touched.
+the page working, but only for site visitors: aliases are published as
+server-side redirects, and the link checker resolves links against the built
+site's canonical page paths. Links to the old path therefore still need fixing.
+A moved or deleted page's localized copies themselves don't need to be touched:
+[drift tracking](#track-changes) flags them for their locale teams.
 
-When an alias can't help (for example, the page was deleted), make the following
-updates to each non-English page that has a path that fails link checking
-(drifted pages are skipped by the link checker, so this typically applies to
-in-sync pages):
+Make the following updates to each non-English page that has a path that fails
+link checking (drifted pages are skipped by the link checker, so this typically
+applies to in-sync pages):
 
 - Update the link reference to the new page path.
 - Add the `# patched` YAML comment at the end of the line for the

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -509,7 +509,7 @@ README][].
 [helper README]:
   https://github.com/open-telemetry/opentelemetry.io/tree/main/scripts/gh/locale-auto-merge
 
-### PRs with semantic changes should not span locales {#prs-should-not-span-locales}
+### PRs should not span locales {#prs-should-not-span-locales}
 
 Approvers should ensure that [PRs][] making **semantic** changes to doc pages do
 not span multiple locales. A semantic change is one that impacts the _meaning_
@@ -518,8 +518,6 @@ approvers will, in time, review the English-language edits to determine if the
 changes are appropriate for their locale, and how best to incorporate them into
 their locale. If changes are necessary, the locale approvers will make them via
 their own locale-specific PRs.
-
-### Multi-locale PRs are only for keeping checks green {#patch-locale-links}
 
 A PR may span multiple locales **only** when that is strictly required to keep
 the site build and its checks green:
@@ -532,11 +530,9 @@ the site build and its checks green:
   page's [drift status](#track-changes) only shields it from link checking, not
   from the Hugo build.
 
-<a id="targeted-content-additions"></a> Treat any other change to a localized
-page as a **semantic** change for that locale. This includes targeted content
-additions to drifted pages, such as adding a new glossary term. As explained in
-the [previous section](#prs-should-not-span-locales), leave such changes to each
-locale team to incorporate through its own locale-specific PRs.
+Treat any other change to a localized page as a **semantic** change for that
+locale. This includes targeted content additions to drifted pages, such as
+adding a new glossary term.
 
 > [!NOTE] Content-neutral maintenance
 >

--- a/scripts/ensure-default-lang-commit-patched.pl
+++ b/scripts/ensure-default-lang-commit-patched.pl
@@ -1,12 +1,8 @@
 #!/usr/bin/env perl
 #
 # Ensures that each changed non-en locale file has its default_lang_commit front
-# matter field ending in "# patched".
-#
-# When making targeted changes to localized pages (e.g., link fixes, resource
-# updates, or content additions) without fully syncing with the English version,
-# add "# patched" as a YAML comment at the end of the default_lang_commit line.
-# See content/en/docs/contributing/localization.md for details.
+# matter field ending in "# patched". For when to mark a page as patched, see
+# content/en/docs/contributing/localization.md#patched.
 #
 # Usage:
 #   ./scripts/ensure-default-lang-commit-patched.pl [--dry-run]


### PR DESCRIPTION
- Contributes to #9219
- Tightens the locale-span policy: a PR that changes localized page **content** may span locales only when required to keep the site build and its checks green; any other content change — including additions to drifted pages — is a semantic change that belongs to the locale's team. Content-neutral maintenance is exempt.
- Gives the `# patched` marker its own section, "Patching localized pages": mechanical build and check fixes only, whether or not the fix spans locales; minimal-edit discipline and marker lifecycle.
- Restructures the cross-locale link-fix how-to as a case list by target fate: moved targets are patched, deleted targets have their drift status derived with `fix:i18n:status`, and aliases are clarified as serving site visitors only (page moves — fragments can't be redirected).
- Aligns the review-pull-request skill, the localization instructions, and the `ensure-default-lang-commit-patched` script header with the new policy.
- **Preview(s)**:
  - https://deploy-preview-10930--opentelemetry.netlify.app/docs/contributing/localization/#prs-should-not-span-locales
  - https://deploy-preview-10930--opentelemetry.netlify.app/docs/contributing/localization/#patched