### PR TITLE
Announce KubeCon Japan 2026

### DIFF
--- a/.lycheecache
+++ b/.lycheecache
@@ -771,8 +771,11 @@ https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/co-located-even
 https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/features-add-ons/maintainer-summit/,200,1784355599
 https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/register/,200,1784269413
 https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/register/?utm_source=opentelemetry&amp;utm_medium=website&amp;utm_content=blog,200,1784269415
+https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/,200,1784656945
 https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/?utm_source=opentelemetry&utm_medium=website&utm_content=blog,200,1784269408
 https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/register/?utm_source=opentelemetry&utm_medium=website&utm_content=blog,200,1784269413
+https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/register/?utm_source=opentelemetry&utm_medium=website&utm_content=community-events,200,1784656948
+https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/register/?utm_source=opentelemetry&utm_medium=website&utm_content=slim-banner,200,1784656946
 https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/?utm_source=opentelemetry&amp;utm_medium=website&amp;utm_content=blog,200,1784183203
 https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/co-located-events/observability-day/?utm_source=opentelemetry&amp;utm_medium=website&amp;utm_content=blog,200,1784284617
 https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/features-add-ons/maintainer-summit/?utm_source=opentelemetry&amp;utm_medium=website&amp;utm_content=blog,200,1784284615

--- a/content/en/announcements/kubecon-japan.md
+++ b/content/en/announcements/kubecon-japan.md
@@ -1,18 +1,20 @@
 ---
-title: KubeCon + CloudNativeCon Japan 2025
-linkTitle: KubeCon Japan 2025
-date: 2025-06-12
-expiryDate: 2025-06-17 # keep
-weight: 20250617
+title: KubeCon + CloudNativeCon Japan 2026
+linkTitle: KubeCon Japan 2026
+date: 2026-07-21
+expiryDate: 2026-07-30 # keep
+weight: 20260730
 params:
   eventUrl: &eventUrl >-
     https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/
-  blogPostURL: /blog/2025/kubecon-japan/
+  # Use this when the blog post is ready:
+  # blogPostURL: /blog/2026/kubecon-japan/
+  blogPostURL: *eventUrl
 ---
 
-[**{{% param title %}}**][LF], **<span class="text-nowrap">June 16-17,</span>
-Tokyo**. <span class="d-none d-md-inline"><br></span> [Come collaborate, learn,
-and share][blog]<span class="d-none d-sm-inline"> with the Cloud Native
+[**{{% param title %}}**][LF], **<span class="text-nowrap">July 28–30,</span>
+Yokohama**. <span class="d-none d-md-inline"><br></span> Come [collaborate,
+learn, and share][blog]<span class="d-none d-sm-inline"> with the Cloud Native
 community</span>!
 
 [blog]: <{{% param blogPostURL %}}>


### PR DESCRIPTION
- Revives the kept `kubecon-japan` announcement for its 2026 edition (**July 28–30, Yokohama**), matching the banner other CNCF sites show via the shared CNCF [hello-bar script][] — banner text and event link mirror the current [hello-bar content][].
- No 2026 blog post yet, so `blogPostURL` points at the event page for now, with a comment to swap in `/blog/2026/kubecon-japan/` once published (same pattern as `kubecon-india.md`).
- Leaves `content/ja/announcements/kubecon-japan.md` to the ja team per our locale-PR practice. Note that until it's synced, the expired ja override shadows this banner on `/ja/` pages — cc @open-telemetry/docs-ja-approvers, in case you'd like the banner up before the event.
- **Preview(s)**:
  - [Homepage banner](https://deploy-preview-10933--opentelemetry.netlify.app/)

[hello-bar content]: https://www.cncf.io/wp-json/lf/v1/get_hello
[hello-bar script]: https://www.cncf.io/wp-content/themes/cncf-twenty-two/source/js/on-demand/hello-bar-embed.js
