### PR TITLE
[ja] Announce KubeCon Japan 2026

### DIFF
--- a/content/ja/announcements/kubecon-japan.md
+++ b/content/ja/announcements/kubecon-japan.md
@@ -1,17 +1,19 @@
 ---
-title: KubeCon + CloudNativeCon Japan 2025
-linkTitle: KubeCon Japan 2025
-date: 2025-06-12
-expiryDate: 2025-06-17 # keep
-weight: 20250617
+title: KubeCon + CloudNativeCon Japan 2026
+linkTitle: KubeCon Japan 2026
+date: 2026-07-21
+expiryDate: 2026-07-30 # keep
+weight: 20260730
 params:
   eventUrl: &eventUrl >-
     https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/
-  blogPostURL: /blog/2025/kubecon-japan/
-default_lang_commit: 1f686d5f7b6bbdfaa30dafdc6ca0214c6f2308db
+  # Use this when the blog post is ready:
+  # blogPostURL: /blog/2026/kubecon-japan/
+  blogPostURL: *eventUrl
+default_lang_commit: f34ea47f2795ab7823c24968f7e6874ee9381cf6
 ---
 
-[**{{% param title %}}**][LF]が **6月16・17日に東京で開催**
+[**{{% param title %}}**][LF]が **7月28日から30日に横浜で開催**
 <span class="d-none d-md-inline"><br></span>
 <span class="d-none d-sm-inline"> Cloud Nativeコミュニティと一緒に</span>、[協力し、学び、共有しましょう][blog]！
 


### PR DESCRIPTION
- Revives the ja `kubecon-japan` announcement for the 2026 edition (**July 28–30, Yokohama**), in sync with its en counterpart from #10933 — until now the expired ja override was shadowing the en banner on `/ja/` pages.
- Follows the 2025 ja translation's phrasing with dates/city updated; front matter mirrors en (`# keep`, `blogPostURL: *eventUrl` placeholder until a 2026 blog post exists) and `default_lang_commit` points at the merged en commit.
- **Preview(s)**:
  - [ja homepage banner](https://deploy-preview-10935--opentelemetry.netlify.app/ja/)
