### PR TITLE
[ja] update translation of content/en/docs/zero-code/obi/troubleshooting.md

### DIFF
--- a/content/ja/docs/zero-code/obi/troubleshooting.md
+++ b/content/ja/docs/zero-code/obi/troubleshooting.md
@@ -2,8 +2,7 @@
 title: トラブルシューティング
 description: OBI の一般的な問題やエラーのトラブルシューティング
 weight: 22
-default_lang_commit: 94498a7529f6d456201faebba59716baccf79bf8
-drifted_from_default: true
+default_lang_commit: 4c8d57fea0147ce76633951315c40a27c55fad2e
 cSpell:ignore: Clickhouse uprobe userland
 ---
 
@@ -90,8 +89,8 @@ Span #0
     Status message :
 Attributes:
      -> rpc.method: Str(/opentelemetry.proto.collector.metrics.v1.MetricsService/Export)
-     -> rpc.system: Str(grpc)
-     -> rpc.grpc.status_code: Int(0)
+     -> rpc.system.name: Str(grpc)
+     -> rpc.response.status_code: Str(OK)
      -> server.address: Str(otel-collector.default)
      -> peer.service: Str(otel-collector.default)
      -> server.port: Int(4317)


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/obi/troubleshooting.md` to match the latest English source at
`content/en/docs/zero-code/obi/troubleshooting.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff updated two semantic convention attribute names in the debug traces exporter code example:
- `rpc.system` → `rpc.system.name`
- `rpc.grpc.status_code: Int(0)` → `rpc.response.status_code: Str(OK)`

These are inside a fenced code block and are preserved byte-identical to the English source.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.


<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10936--opentelemetry.netlify.app/ja/docs/zero-code/obi/troubleshooting/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/obi/troubleshooting/

<!-- preview-section-end -->
