### PR TITLE
[ja] update translation of content/en/docs/languages/java/sdk.md

### DIFF
--- a/content/ja/docs/languages/java/sdk.md
+++ b/content/ja/docs/languages/java/sdk.md
@@ -2,8 +2,7 @@
 title: SDKによるテレメトリーの管理
 weight: 12
 aliases: [exporters]
-default_lang_commit: 25e82e1790ea1f673d11dee3ccc9094664d0ccd5 # patched
-drifted_from_default: true
+default_lang_commit: 4c8d57fea0147ce76633951315c40a27c55fad2e
 cSpell:ignore: Interceptable okhttp
 ---
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/java/sdk.md` to match the latest English source at
`content/en/docs/languages/java/sdk.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The only English change since the last sync was a URL update for OkHttp
(`square.github.io/okhttp/` → `lysine.dev/okhttp/`), which was already
patched in the Japanese file via the `# patched` mechanism. This PR
promotes the temporary patch to a full sync by updating
`default_lang_commit` to the current HEAD and removing the drift flag.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.


<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10938--opentelemetry.netlify.app/ja/docs/languages/java/sdk/
- **English (canonical):** https://opentelemetry.io/docs/languages/java/sdk/

_(deploy preview may take a few minutes to build)_
<!-- preview-section-end -->
