### PR TITLE
[ja] update translation of content/en/docs/zero-code/obi/configure/internal-metrics-reporter.md

### DIFF
--- a/content/ja/docs/zero-code/obi/configure/internal-metrics-reporter.md
+++ b/content/ja/docs/zero-code/obi/configure/internal-metrics-reporter.md
@@ -61,11 +61,11 @@ Prometheus メトリクスを取得するための HTTP クエリパスを設定
 
 [`prometheus_export.port`](../export-data/#prometheus-exporter-component) と `internal_metrics.prometheus.port` が同じ値を使用する場合、`internal_metrics.prometheus.path` を `prometheus_export.path` とは異なる値に設定してメトリクスファミリーを分離するか、同じ値を使用して両方のメトリクスファミリーを同じスクレイプエンドポイントにまとめることができます。
 
-## avoided-services のカーディナリティー {#avoided-services-cardinality}
+## avoided-services のカーディナリティ {#avoided-services-cardinality}
 
 `obi.avoided.services` OTLP メトリクス(Prometheus では `obi_avoided_services`)は、サービスが直接 OpenTelemetry データをエクスポートしていることを検出した後、OBI がテレメトリーの重複を回避したサービスをレポートします。
-系列にはサービス名、サービス名前空間、回避したシグナル(`metrics` または `traces`)が含まれますが、高カーディナリティーのサービスインスタンス ID は含まれません。
+系列にはサービス名、サービス名前空間、回避したシグナル(`metrics` または `traces`)が含まれますが、高カーディナリティのサービスインスタンス ID は含まれません。
 
 `avoided_services.limit` は系列数の上限を設定します。
 上限を超えたサービスは `otel.metric.overflow=true`(Prometheus: `otel_metric_overflow="true"`) の系列にまとめられます。
-OpenTelemetry SDK のデフォルトのメトリクスカーディナリティー制限を使用するには `0` に設定し、このメトリクスを省略するには `disabled: true` に設定します。
+OpenTelemetry SDK のデフォルトのメトリクスカーディナリティ制限を使用するには `0` に設定し、このメトリクスを省略するには `disabled: true` に設定します。

--- a/content/ja/docs/zero-code/obi/configure/internal-metrics-reporter.md
+++ b/content/ja/docs/zero-code/obi/configure/internal-metrics-reporter.md
@@ -3,8 +3,7 @@ title: OBI 内部メトリクスレポーターを設定する
 linkTitle: 内部メトリクスレポーター
 description: オプションの内部メトリクスレポーターコンポーネントが、自動計装ツールの内部動作に関するメトリクスを Prometheus 形式でレポートする方法を設定する
 weight: 80
-default_lang_commit: f7dab5cfc4d44a8c788b7e02d07ec1e1d84e3845
-drifted_from_default: true
+default_lang_commit: 4c8d57fea0147ce76633951315c40a27c55fad2e
 ---
 
 YAML セクション: `internal_metrics`
@@ -30,11 +29,13 @@ internal_metrics:
 
 ## 設定の概要 {#configuration-summary}
 
-| YAML              | 環境変数                                     | 型     | デフォルト          | 概要                                                                       |
-| ----------------- | -------------------------------------------- | ------ | ------------------- | -------------------------------------------------------------------------- |
-| `exporter`        | `OTEL_EBPF_INTERNAL_METRICS_EXPORTER`        | string | `disabled`          | [内部メトリクスのエクスポーターを選択します。](#internal-metrics-exporter) |
-| `prometheus.port` | `OTEL_EBPF_INTERNAL_METRICS_PROMETHEUS_PORT` | int    | (未設定)            | [Prometheus スクレイプエンドポイントの HTTP ポート。](#prometheus-port)    |
-| `prometheus.path` | `OTEL_EBPF_INTERNAL_METRICS_PROMETHEUS_PATH` | string | `/internal/metrics` | [Prometheus メトリクスの HTTP クエリパス。](#prometheus-path)              |
+| YAML                        | 環境変数                                               | 型      | デフォルト          | 概要                                                                       |
+| --------------------------- | ------------------------------------------------------ | ------- | ------------------- | -------------------------------------------------------------------------- |
+| `exporter`                  | `OTEL_EBPF_INTERNAL_METRICS_EXPORTER`                  | string  | `disabled`          | [内部メトリクスのエクスポーターを選択します。](#internal-metrics-exporter) |
+| `prometheus.port`           | `OTEL_EBPF_INTERNAL_METRICS_PROMETHEUS_PORT`           | int     | (未設定)            | [Prometheus スクレイプエンドポイントの HTTP ポート。](#prometheus-port)    |
+| `prometheus.path`           | `OTEL_EBPF_INTERNAL_METRICS_PROMETHEUS_PATH`           | string  | `/internal/metrics` | [Prometheus メトリクスの HTTP クエリパス。](#prometheus-path)              |
+| `avoided_services.disabled` | `OTEL_EBPF_INTERNAL_METRICS_AVOIDED_SERVICES_DISABLED` | boolean | `false`             | avoided-services メトリクスを無効にします。                                |
+| `avoided_services.limit`    | `OTEL_EBPF_INTERNAL_METRICS_AVOIDED_SERVICES_LIMIT`    | int     | `2000`              | overflow 系列を含む avoided-services の系列数を制限します。                |
 
 ---
 
@@ -59,3 +60,12 @@ Prometheus スクレイプエンドポイントの HTTP ポートを設定しま
 Prometheus メトリクスを取得するための HTTP クエリパスを設定します。
 
 [`prometheus_export.port`](../export-data/#prometheus-exporter-component) と `internal_metrics.prometheus.port` が同じ値を使用する場合、`internal_metrics.prometheus.path` を `prometheus_export.path` とは異なる値に設定してメトリクスファミリーを分離するか、同じ値を使用して両方のメトリクスファミリーを同じスクレイプエンドポイントにまとめることができます。
+
+## avoided-services のカーディナリティー {#avoided-services-cardinality}
+
+`obi.avoided.services` OTLP メトリクス(Prometheus では `obi_avoided_services`)は、サービスが直接 OpenTelemetry データをエクスポートしていることを検出した後、OBI がテレメトリーの重複を回避したサービスをレポートします。
+系列にはサービス名、サービス名前空間、回避したシグナル(`metrics` または `traces`)が含まれますが、高カーディナリティーのサービスインスタンス ID は含まれません。
+
+`avoided_services.limit` は系列数の上限を設定します。
+上限を超えたサービスは `otel.metric.overflow=true`(Prometheus: `otel_metric_overflow="true"`) の系列にまとめられます。
+OpenTelemetry SDK のデフォルトのメトリクスカーディナリティー制限を使用するには `0` に設定し、このメトリクスを省略するには `disabled: true` に設定します。


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/obi/configure/internal-metrics-reporter.md` to match the latest English source at
`content/en/docs/zero-code/obi/configure/internal-metrics-reporter.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

Changes:
- Updated the configuration summary table with wider columns and added two new rows for `avoided_services.disabled` and `avoided_services.limit`
- Added new "avoided-services のカーディナリティー" section translating the new "Avoided-services cardinality" section

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10947--opentelemetry.netlify.app/ja/docs/zero-code/obi/configure/internal-metrics-reporter/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/obi/configure/internal-metrics-reporter/

_(deploy preview will be available once Netlify finishes building.)_
<!-- preview-section-end -->
