### PR TITLE
Housekeeping: apply patch with 3-way merge to tolerate mid-run merges

### DIFF
--- a/.github/workflows/reusable-patch-pr.yml
+++ b/.github/workflows/reusable-patch-pr.yml
@@ -135,6 +135,10 @@ jobs:
         with:
           ref: main
           persist-credentials: false
+          # Enough history to cover commits that land on main while the
+          # caller's run is in flight: the 3-way apply below needs the
+          # pre-image blobs of the main that the patch was generated against.
+          fetch-depth: 50
 
       # Let git resolve credentials through the gh CLI (which reads GH_TOKEN
       # from each step's env) instead of persisting the token in .git/config.
@@ -152,7 +156,10 @@ jobs:
           BRANCH: ${{ inputs.branch }}
         run: |
           git checkout -b "$BRANCH"
-          if ! git apply --verbose site.patch; then
+          # Main may have moved since the patch was generated. Fall back to a
+          # 3-way merge (--3way) so that context drift and already-applied
+          # hunks don't fail the apply; a true conflict still fails loudly.
+          if ! git apply --3way --verbose site.patch; then
             echo "Patch failed to apply. For details, see output above. To debug this locally,"
             echo "get the patch file from the workflow summary artifact section."
             exit 1

--- a/.github/workflows/reusable-patch-pr.yml
+++ b/.github/workflows/reusable-patch-pr.yml
@@ -135,10 +135,10 @@ jobs:
         with:
           ref: main
           persist-credentials: false
-          # Enough history to cover commits that land on main while the
-          # caller's run is in flight: the 3-way apply below needs the
-          # pre-image blobs of the main that the patch was generated against.
-          fetch-depth: 50
+          # Full history so that the 3-way apply below always has the
+          # pre-image blobs of the main that the patch was generated against,
+          # even when commits land on main while the caller's run is in flight.
+          fetch-depth: 0
 
       # Let git resolve credentials through the gh CLI (which reads GH_TOKEN
       # from each step's env) instead of persisting the token in .git/config.

--- a/.github/workflows/reusable-patch-pr.yml
+++ b/.github/workflows/reusable-patch-pr.yml
@@ -136,8 +136,7 @@ jobs:
           ref: main
           persist-credentials: false
           # Full history so that the 3-way apply below always has the
-          # pre-image blobs of the main that the patch was generated against,
-          # even when commits land on main while the caller's run is in flight.
+          # pre-image blobs of the main that the patch was generated against.
           fetch-depth: 0
 
       # Let git resolve credentials through the gh CLI (which reads GH_TOKEN
@@ -156,9 +155,8 @@ jobs:
           BRANCH: ${{ inputs.branch }}
         run: |
           git checkout -b "$BRANCH"
-          # Main may have moved since the patch was generated. Fall back to a
-          # 3-way merge (--3way) so that context drift and already-applied
-          # hunks don't fail the apply; a true conflict still fails loudly.
+          # 3-way so that the patch still applies when commits land on main
+          # while the caller's run is in flight.
           if ! git apply --3way --verbose site.patch; then
             echo "Patch failed to apply. For details, see output above. To debug this locally,"
             echo "get the patch file from the workflow summary artifact section."


### PR DESCRIPTION
- Fixes #10745
- Switches the publish job of `reusable-patch-pr.yml` to `git apply --3way`: the patch is applied to a fresh checkout of `main`, which may have moved past the `main` it was generated against (both Housekeeping failures — 07-09 and 07-21 — were this race; the 07-21 run lost to the #10935 merge landing mid-run). With `--3way`, context drift and already-applied hunks merge through, while a true conflict still fails loudly (conflict markers, non-zero exit).
- Switches the job's checkout to full history (`fetch-depth: 0`): the 3-way fallback needs the pre-image blobs of the patch's base commit, which the previous depth-1 checkout lacks in exactly the racing case. Full history removes any "deep enough?" doubt, and is cheap for this workflow's sole caller (Housekeeping, one nightly run). Verified locally by simulation: plain apply on drift-in-context fails (the observed failure mode); `--3way` on a depth-1 clone still fails (missing blob); `--3way` with history applies cleanly, and a genuine overlapping edit still errors out.