### PR TITLE
Install link-cache from the npm registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "gulp": "5.0.1",
     "hugo-extended": "0.164.0",
     "js-yaml": "5.2.1",
-    "link-cache": "github:chalin/link-cache#semver:^0.2.1",
+    "link-cache": "0.3.0",
     "markdown-it": "14.3.0",
     "markdown-link-check": "3.14.2",
     "markdownlint": "0.41.1",


### PR DESCRIPTION
- Follow-up to #10955: switches the `link-cache` devDependency from the GitHub pin (`github:chalin/link-cache#semver:^0.2.1`) to the package's first npm registry release, published with the registry's strictest settings (trusted publishing, 2FA required, tokens disallowed).
- Registry installs are faster (no git clone) and immutable — a published version's tarball can't change, which matters here since this repo doesn't commit a lockfile.
- Verified: `npm install` resolves `link-cache@0.3.0` from the registry, and the `lychee-norm-cache` / `refcache` bins run from `node_modules/.bin`.