### PR TITLE
[demo] Add docs for agent, chatbot, mcp, opamp-server, and telemetry-docs

### DIFF
--- a/.lycheecache
+++ b/.lycheecache
@@ -791,6 +791,7 @@ https://explorer.opentelemetry.io/java-agent/instrumentation/latest,206,17843556
 https://expressjs.com/,206,1784442359
 https://failsafe.dev/,200,1784701475
 https://farfetch.github.io/kafkaflow/docs/guides/open-telemetry,206,1784285133
+https://fastapi.tiangolo.com/,200,1784749298
 https://fastapi.tiangolo.com/tutorial/handling-errors/#use-httpexception,200,1784356048
 https://firebase.google.com/docs/projects/manage-installations,200,1784701516
 https://flagd.dev/,206,1784269623
@@ -1498,6 +1499,7 @@ https://github.com/jjatria/perl-opentelemetry-exporter-otlp,206,1784285131
 https://github.com/jjatria/perl-opentelemetry-sdk,206,1784285219
 https://github.com/jkoronaAtCisco,200,1784625650
 https://github.com/jkwatson,206,1784284910
+https://github.com/jlowin/fastmcp,200,1784749298
 https://github.com/jmacd,206,1784355596
 https://github.com/jmw51798,206,1784284914
 https://github.com/joaopgrassi,206,1784284917
@@ -2611,7 +2613,9 @@ https://github.com/open-telemetry/opentelemetry-demo,206,1784442353
 https://github.com/open-telemetry/opentelemetry-demo/blob/main/README.md?plain=1,206,1784442357
 https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/accounting/,206,1784442349
 https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/ad/,206,1784284638
+https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/agent/,200,1784749298
 https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/cart/,206,1784269443
+https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/chatbot/,200,1784749298
 https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/checkout/,206,1784442350
 https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/currency/,206,1784284638
 https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/email/,206,1784284640
@@ -2623,6 +2627,8 @@ https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/frontend/,206
 https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/image-provider/,206,1784284647
 https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/kafka/,200,1784701477
 https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/load-generator/,206,1784284638
+https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/mcp/,200,1784749298
+https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/opamp-server/,200,1784749298
 https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/otel-collector/otelcol-config-extras.yml,206,1784442395
 https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/otel-collector/otelcol-config.yml,200,1784701477
 https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/payment/,206,1784442353
@@ -2631,6 +2637,7 @@ https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/quote/,206,17
 https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/react-native-app/,206,1784442352
 https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/recommendation/,206,1784269447
 https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/shipping/,206,1784442350
+https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/telemetry-docs/,200,1784749298
 https://github.com/open-telemetry/opentelemetry-demo/tree/db0d981326ee0161d706c949061686d7823d99a2/src/product-reviews,200,1784701477
 https://github.com/open-telemetry/opentelemetry-demo/tree/main/test,206,1784442358
 https://github.com/open-telemetry/opentelemetry-dotnet,206,1784269452
@@ -5800,6 +5807,7 @@ https://www.flipt.io/docs/configuration/observability#tracing,200,1784701494
 https://www.freedesktop.org/software/systemd/man/latest/machine-id.html,206,1784284997
 https://www.fulcrumapp.com/,200,1784269455
 https://www.gnupg.org/gph/en/manual/x135.html#AEN160,200,1784701520
+https://www.gradio.app/,200,1784749298
 https://www.graphql-java.com/,200,1784284835
 https://www.gwtproject.org/,206,1784442405
 https://www.heroku.com/,200,1784701493
@@ -5923,6 +5931,7 @@ https://www.keycloak.org/observability/telemetry,200,1784701493
 https://www.konghq.com/,206,1784355883
 https://www.krakend.io/,206,1784183252
 https://www.krakend.io/docs/telemetry/opentelemetry/,200,1784270078
+https://www.langchain.com/,200,1784749298
 https://www.langchain.com/langgraph,200,1784701474
 https://www.lfasiallc.com/kubecon-cloudnativecon-openinfra-summit-pytorch-conference-china/?utm_source=opentelemetry&utm_medium=website&utm_content=blog,200,1784269630
 https://www.linkedin.com/company/opentelemetry/,200,1784355604
@@ -5946,6 +5955,7 @@ https://www.meetup.com/opentelemetry-in-practice-meetup-group/,200,1784701489
 https://www.metricshub.com/docs/latest/,206,1784183224
 https://www.microsoft.com/,206,1784356185
 https://www.microsoft.com/sql-server,200,1784285360
+https://www.mkdocs.org/,200,1784749298
 https://www.mongodb.com/,200,1784701516
 https://www.mongodb.com/docs/manual/reference/command/,200,1784285004
 https://www.mongodb.com/docs/manual/reference/error-codes/,200,1784701518
@@ -6118,6 +6128,7 @@ https://www.thousandeyes.com/,200,1784285383
 https://www.tinybird.co/,200,1784183361
 https://www.tinybird.co/docs/api-reference/events-api,200,1784183365
 https://www.traceloop.com/,200,1784284874
+https://www.traceloop.com/docs/openllmetry,200,1784749298
 https://www.typescriptlang.org/download,206,1784284659
 https://www.uber.com/blog/flipr/,200,1784285385
 https://www.velodb.io/solutions/use-cases/observability,200,1784269683

--- a/content/en/docs/demo/_index.md
+++ b/content/en/docs/demo/_index.md
@@ -4,6 +4,7 @@ linkTitle: Demo
 cascade:
   repo: https://github.com/open-telemetry/opentelemetry-demo
 weight: 180
+cSpell:ignore: mcp
 ---
 
 Welcome to the [OpenTelemetry Demo](/ecosystem/demo/) documentation, which
@@ -22,20 +23,20 @@ Want to deploy the demo and see it in action? Start here.
 Want to understand how a particular language's instrumentation works? Start
 here.
 
-| Language   | Automatic Instrumentation                                                                                | Instrumentation Libraries                                                                    | Manual Instrumentation                                                                                   |
-| ---------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| .NET       | [Accounting Service](services/accounting/)                                                               | [Cart Service](services/cart/)                                                               | [Cart Service](services/cart/)                                                                           |
-| C++        |                                                                                                          |                                                                                              | [Currency Service](services/currency/)                                                                   |
-| Elixir     |                                                                                                          | [Flagd-UI Service](services/flagd-ui/)                                                       |                                                                                                          |
-| Go         |                                                                                                          | [Checkout Service](services/checkout/), [Product Catalog Service](services/product-catalog/) | [Checkout Service](services/checkout/), [Product Catalog Service](services/product-catalog/)             |
-| Java       | [Ad Service](services/ad/)                                                                               |                                                                                              | [Ad Service](services/ad/)                                                                               |
-| JavaScript | [Payment Service](services/payment/)                                                                     |                                                                                              | [Payment Service](services/payment/)                                                                     |
-| TypeScript |                                                                                                          | [Frontend](services/frontend/), [React Native App](services/react-native-app/)               | [Frontend](services/frontend/)                                                                           |
-| Kotlin     |                                                                                                          | [Fraud Detection Service](services/fraud-detection/)                                         |                                                                                                          |
-| PHP        |                                                                                                          | [Quote Service](services/quote/)                                                             | [Quote Service](services/quote/)                                                                         |
-| Python     | [Recommendation Service](services/recommendation/), [Product Reviews Service](services/product-reviews/) |                                                                                              | [Recommendation Service](services/recommendation/), [Product Reviews Service](services/product-reviews/) |
-| Ruby       |                                                                                                          | [Email Service](services/email/)                                                             | [Email Service](services/email/)                                                                         |
-| Rust       |                                                                                                          | [Shipping Service](services/shipping/)                                                       | [Shipping Service](services/shipping/)                                                                   |
+| Language   | Automatic Instrumentation                                                                                | Instrumentation Libraries                                                                            | Manual Instrumentation                                                                                   |
+| ---------- | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| .NET       | [Accounting Service](services/accounting/)                                                               | [Cart Service](services/cart/)                                                                       | [Cart Service](services/cart/)                                                                           |
+| C++        |                                                                                                          |                                                                                                      | [Currency Service](services/currency/)                                                                   |
+| Elixir     |                                                                                                          | [Flagd-UI Service](services/flagd-ui/)                                                               |                                                                                                          |
+| Go         |                                                                                                          | [Checkout Service](services/checkout/), [Product Catalog Service](services/product-catalog/)         | [Checkout Service](services/checkout/), [Product Catalog Service](services/product-catalog/)             |
+| Java       | [Ad Service](services/ad/)                                                                               |                                                                                                      | [Ad Service](services/ad/)                                                                               |
+| JavaScript | [Payment Service](services/payment/)                                                                     |                                                                                                      | [Payment Service](services/payment/)                                                                     |
+| TypeScript |                                                                                                          | [Frontend](services/frontend/), [React Native App](services/react-native-app/)                       | [Frontend](services/frontend/)                                                                           |
+| Kotlin     |                                                                                                          | [Fraud Detection Service](services/fraud-detection/)                                                 |                                                                                                          |
+| PHP        |                                                                                                          | [Quote Service](services/quote/)                                                                     | [Quote Service](services/quote/)                                                                         |
+| Python     | [Recommendation Service](services/recommendation/), [Product Reviews Service](services/product-reviews/) | [Agent Service](services/agent/), [Chatbot Service](services/chatbot/), [MCP Service](services/mcp/) | [Recommendation Service](services/recommendation/), [Product Reviews Service](services/product-reviews/) |
+| Ruby       |                                                                                                          | [Email Service](services/email/)                                                                     | [Email Service](services/email/)                                                                         |
+| Rust       |                                                                                                          | [Shipping Service](services/shipping/)                                                               | [Shipping Service](services/shipping/)                                                                   |
 
 ## Service Documentation
 
@@ -57,6 +58,11 @@ found here:
 - [Shipping Service](services/shipping/)
 - [Image Provider Service](services/image-provider/)
 - [React Native App](services/react-native-app/)
+- [Agent Service](services/agent/)
+- [Chatbot Service](services/chatbot/)
+- [MCP Service](services/mcp/)
+- [OpAMP Server](services/opamp-server/)
+- [Telemetry Docs Service](services/telemetry-docs/)
 
 ## Feature Flag Scenarios
 

--- a/content/en/docs/demo/architecture.md
+++ b/content/en/docs/demo/architecture.md
@@ -14,8 +14,10 @@ graph TD
 subgraph Service Diagram
 accounting(Accounting):::dotnet
 ad(Ad):::java
+agent(Agent):::python
 cache[(Cache<br/>&#40Valkey&#41)]
 cart(Cart):::dotnet
+chatbot(Chatbot):::python
 checkout(Checkout):::golang
 currency(Currency):::cpp
 email(Email):::ruby
@@ -27,6 +29,7 @@ frontend-proxy(Frontend Proxy <br/>&#40Envoy&#41):::cpp
 image-provider(Image Provider <br/>&#40nginx&#41):::cpp
 llm(LLM):::python
 load-generator([Load Generator]):::python
+mcp(MCP):::python
 payment(Payment):::javascript
 product-catalog(Product Catalog):::golang
 product-reviews(Product Reviews):::python
@@ -68,6 +71,11 @@ frontend-proxy -->|gRPC| flagd
 frontend-proxy -->|HTTP| frontend
 frontend-proxy -->|HTTP| flagd-ui
 frontend-proxy -->|HTTP| image-provider
+frontend-proxy -->|HTTP| chatbot
+
+chatbot -->|HTTP| agent
+agent -->|HTTP| mcp
+mcp -->|HTTP| frontend
 
 llm -->|gRPC| flagd
 llm ---> product-reviews

--- a/content/en/docs/demo/services/_index.md
+++ b/content/en/docs/demo/services/_index.md
@@ -1,6 +1,7 @@
 ---
 title: Services
 aliases: [service_table, service-table]
+cSpell:ignore: Gradio LangGraph mcp MkDocs
 ---
 
 To visualize request flows, see the [Service Diagram](../architecture/).
@@ -9,7 +10,9 @@ To visualize request flows, see the [Service Diagram](../architecture/).
 | ------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | [accounting](accounting/)             | .NET          | Processes incoming orders and count the sum of all orders (mock/).                                                                   |
 | [ad](ad/)                             | Java          | Provides text ads based on given context words.                                                                                      |
+| [agent](agent/)                       | Python        | AI assistant that answers shop questions and performs actions using a LangGraph agent with built-in or MCP tools.                    |
 | [cart](cart/)                         | .NET          | Stores the items in the user's shopping cart in Valkey and retrieves it.                                                             |
+| [chatbot](chatbot/)                   | Python        | Browser-based chat UI (Gradio) that forwards user messages to the agent service.                                                     |
 | [checkout](checkout/)                 | Go            | Retrieves user cart, prepares order and orchestrates the payment, shipping and the email notification.                               |
 | [currency](currency/)                 | C++           | Converts one money amount to another currency. Uses real values fetched from European Central Bank. It's the highest QPS service.    |
 | [email](email/)                       | Ruby          | Sends users an order confirmation email (mock/).                                                                                     |
@@ -17,10 +20,13 @@ To visualize request flows, see the [Service Diagram](../architecture/).
 | [fraud-detection](fraud-detection/)   | Kotlin        | Analyzes incoming orders and detects fraud attempts (mock/).                                                                         |
 | [frontend](frontend/)                 | TypeScript    | Exposes an HTTP server to serve the website. Does not require sign up / login and generates session IDs for all users automatically. |
 | [load-generator](load-generator/)     | Python/Locust | Continuously sends requests imitating realistic user shopping flows to the frontend.                                                 |
+| [mcp](mcp/)                           | Python        | Exposes the shop's operations as tools over the Model Context Protocol for the agent service.                                        |
+| [opamp-server](opamp-server/)         | Go            | Reference OpAMP server that acts as a control plane for the OpenTelemetry Collector.                                                 |
 | [payment](payment/)                   | JavaScript    | Charges the given credit card info (mock/) with the given amount and returns a transaction ID.                                       |
 | [product-catalog](product-catalog/)   | Go            | Provides the list of products from a JSON file and ability to search products and get individual products.                           |
 | [product-reviews](product-reviews/)   | Python        | Returns product reviews and answers questions about a specific product based on the product description and reviews.                 |
 | [quote](quote/)                       | PHP           | Calculates the shipping costs, based on the number of items to be shipped.                                                           |
 | [recommendation](recommendation/)     | Python        | Recommends other products based on what's given in the cart.                                                                         |
 | [shipping](shipping/)                 | Rust          | Gives shipping cost estimates based on the shopping cart. Ships items to the given address (mock/).                                  |
+| [telemetry-docs](telemetry-docs/)     | NGINX         | Generates and hosts documentation of the demo's telemetry schema (Weaver + MkDocs).                                                  |
 | [react-native-app](react-native-app/) | TypeScript    | React Native mobile application that provides a UI on top of the shopping services.                                                  |

--- a/content/en/docs/demo/services/agent.md
+++ b/content/en/docs/demo/services/agent.md
@@ -1,0 +1,93 @@
+---
+title: Agent Service
+linkTitle: Agent
+aliases: [agentservice]
+cSpell:ignore: agentservice langchain openai Uvicorn
+---
+
+The Agent service provides an AI assistant for the Astronomy Shop. It exposes a
+[FastAPI](https://fastapi.tiangolo.com/) HTTP endpoint (`POST /prompt`) that
+routes user prompts through a [LangGraph](https://www.langchain.com/langgraph)
+agent, which answers questions and performs shop operations using either
+built-in tools or tools provided by the [MCP service](../mcp/).
+
+[Agent service source](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/agent/)
+
+The service is written in Python and uses:
+
+- FastAPI served by Uvicorn for the HTTP API
+- [LangChain](https://www.langchain.com/) and LangGraph for agent orchestration
+- `langchain_openai.ChatOpenAI` as the LLM client, with support for non-OpenAI
+  models through a LiteLLM-compatible endpoint
+
+It listens on port `8010` by default (`AGENT_PORT`).
+
+## Instrumentation
+
+Unlike most demo services, the Agent is instrumented with the
+[Traceloop SDK](https://www.traceloop.com/docs/openllmetry) (OpenLLMetry), which
+builds on OpenTelemetry to capture generative-AI spans — prompts, completions,
+token usage, and tool calls — following the OpenTelemetry
+[generative AI semantic conventions](/docs/specs/semconv/gen-ai/). Traceloop is
+initialized in `run.py` and exports over OTLP, and the outbound HTTP client is
+instrumented so calls to the LLM and MCP service are traced:
+
+```python
+Traceloop.init(
+    app_name=os.getenv("OTEL_SERVICE_NAME", "agent"),
+    api_endpoint=os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "localhost:4317"),
+)
+
+HTTPXClientInstrumentor().instrument()
+```
+
+Incoming requests are traced with the OpenTelemetry FastAPI instrumentation:
+
+```python
+FastAPIInstrumentor.instrument_app(agent.app)
+```
+
+### Traces
+
+The agent's top-level logic is wrapped in a Traceloop workflow, so each prompt
+produces a single, well-named trace:
+
+```python
+@workflow(name="astronomy_shop_agent_workflow")
+async def run_agent(self, input_prompt, history=None):
+    ...
+```
+
+Within a workflow, Traceloop automatically records the LangChain and LangGraph
+steps and the underlying LLM calls as child spans.
+
+## Tools
+
+The agent can operate in two modes:
+
+- **Built-in tools** (`MCP_ENABLED=False`): the agent calls the Astronomy Shop
+  tools defined in `src/shared/tools.py` directly.
+- **MCP tools** (`MCP_ENABLED=True`, the default in Docker Compose): the agent
+  loads its tools from the [MCP service](../mcp/) over the Model Context
+  Protocol, using `langchain_mcp_adapters`.
+
+Both modes reach the shop through the frontend API configured by
+`APPLICATION_ENDPOINT` (`frontend:8080` in Compose).
+
+## Configuration
+
+The service is configured through environment variables (see the
+[service source](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/agent/)
+for the full list). The most relevant ones are:
+
+| Variable               | Default                     | Description                                |
+| ---------------------- | --------------------------- | ------------------------------------------ |
+| `AGENT_PORT`           | `8010`                      | Port for the FastAPI/Uvicorn server.       |
+| `APPLICATION_ENDPOINT` | `frontend:8080`             | Frontend API used by the shop tools.       |
+| `LLM_BASE_URL`         | unset                       | Base URL of the OpenAI-compatible LLM API. |
+| `LLM_MODEL`            | `default`                   | Model name passed to the LLM client.       |
+| `API_KEY`              | unset                       | API key for the configured LLM provider.   |
+| `MCP_ENABLED`          | `False` (`True` in Compose) | Load tools from the MCP service.           |
+
+To avoid requiring live LLM access, the service ships canned responses for a
+small set of demo prompts, such as "Show all available products in the store".

--- a/content/en/docs/demo/services/chatbot.md
+++ b/content/en/docs/demo/services/chatbot.md
@@ -1,0 +1,47 @@
+---
+title: Chatbot Service
+linkTitle: Chatbot
+aliases: [chatbotservice]
+cSpell:ignore: chatbotservice Gradio httpx
+---
+
+The Chatbot service provides a browser-based chat UI for the Astronomy Shop. It
+is built with [Gradio](https://www.gradio.app/) and forwards user messages to
+the [Agent service](../agent/), displaying the agent's replies. When the demo is
+running, the chat UI is available through the frontend proxy at
+<http://localhost:8080/chatbot/>.
+
+[Chatbot service source](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/chatbot/)
+
+The service is written in Python, uses Gradio for the UI and the `requests`
+client to call the Agent service, and listens on port `7860` by default
+(`CHATBOT_PORT`).
+
+## Instrumentation
+
+The Chatbot configures the OpenTelemetry SDK manually in `run.py`: it creates a
+`TracerProvider` with the service name, exports spans over OTLP/gRPC with a
+`BatchSpanProcessor`, and enables the `requests` and `httpx` instrumentation
+libraries so outbound calls to the Agent service are traced automatically.
+
+```python
+provider = TracerProvider(resource=resource)
+provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+trace.set_tracer_provider(provider)
+
+RequestsInstrumentor().instrument()
+HTTPXClientInstrumentor().instrument()
+```
+
+Because the Agent and MCP services are also instrumented, a message typed into
+the chatbot produces a single distributed trace that spans the chatbot, the
+agent, its LLM calls, and the shop services the agent invokes.
+
+## Configuration
+
+| Variable            | Default    | Description                                           |
+| ------------------- | ---------- | ----------------------------------------------------- |
+| `CHATBOT_PORT`      | `7860`     | Port for the Gradio server.                           |
+| `CHATBOT_ROOT_PATH` | `/chatbot` | Root path used when served behind the frontend proxy. |
+| `AGENT_ENDPOINT`    | `agent`    | Hostname of the Agent service.                        |
+| `AGENT_PORT`        | `8010`     | Port of the Agent service.                            |

--- a/content/en/docs/demo/services/mcp.md
+++ b/content/en/docs/demo/services/mcp.md
@@ -1,0 +1,39 @@
+---
+title: MCP Service
+linkTitle: MCP
+aliases: [mcpservice]
+cSpell:ignore: HTTPX mcpservice
+---
+
+The MCP service exposes the Astronomy Shop's operations as tools over the
+[Model Context Protocol](https://modelcontextprotocol.io/), so the
+[Agent service](../agent/) — or any other MCP-compatible client — can discover
+and invoke them. It runs a [FastMCP](https://github.com/jlowin/fastmcp) server
+with an HTTP streamable transport at `/mcp`, on port `8011` by default
+(`MCP_PORT`).
+
+[MCP service source](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/mcp/)
+
+The tools it registers — listing products, fetching recommendations and ads,
+managing carts, checking out, and getting shipping quotes — are the shared shop
+tools in `src/shared/tools.py`. Each tool calls the frontend HTTP API configured
+by `APPLICATION_ENDPOINT` (`frontend:8080` in Compose).
+
+## Instrumentation
+
+Like the [Agent](../agent/), the MCP service is instrumented with the
+[Traceloop SDK](https://www.traceloop.com/docs/openllmetry) and exports over
+OTLP. It also enables the HTTPX instrumentation so the outbound calls its tools
+make to the frontend are captured as child spans:
+
+```python
+Traceloop.init(
+    app_name=os.getenv("OTEL_SERVICE_NAME", "mcp"),
+    api_endpoint=os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "localhost:4317"),
+)
+
+HTTPXClientInstrumentor().instrument()
+```
+
+When the agent runs with `MCP_ENABLED=True`, it loads its tools from this
+service instead of using its own built-in tools.

--- a/content/en/docs/demo/services/opamp-server.md
+++ b/content/en/docs/demo/services/opamp-server.md
@@ -1,0 +1,19 @@
+---
+title: OpAMP Server
+linkTitle: OpAMP Server
+aliases: [opampserver]
+cSpell:ignore: opampextension opampserver
+---
+
+This service runs the Go reference [OpAMP](/docs/specs/opamp/) server from
+[`open-telemetry/opamp-go`](https://github.com/open-telemetry/opamp-go). The
+OpenTelemetry Collector connects to it through the Collector `opampextension`
+and reports its health, version, attributes, and effective configuration,
+demonstrating how OpAMP can act as a Collector control plane.
+
+[OpAMP server source](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/opamp-server/)
+
+The server also exposes a minimal HTML UI — routed through the frontend proxy at
+<http://localhost:8080/opamp/> — that lists the connected agents (Collectors)
+and their reported status. The reference UI is patched during the Docker build
+so its links work under the demo's `/opamp/` proxy prefix.

--- a/content/en/docs/demo/services/telemetry-docs.md
+++ b/content/en/docs/demo/services/telemetry-docs.md
@@ -1,0 +1,38 @@
+---
+title: Telemetry Docs Service
+linkTitle: Telemetry Docs
+aliases: [telemetrydocs]
+cSpell:ignore: MkDocs telemetrydocs
+---
+
+The Telemetry Docs service generates and hosts documentation for the demo's
+telemetry schema — every custom attribute and metric used across the
+application. When the demo is running, it is available through the frontend
+proxy at <http://localhost:8080/telemetry>.
+
+[Telemetry Docs service source](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/telemetry-docs/)
+
+The documentation is generated from the YAML schema definitions in the
+`telemetry-schema/` directory using a three-stage Docker build:
+
+1. [OpenTelemetry Weaver](https://github.com/open-telemetry/weaver) resolves the
+   schema and generates Markdown.
+2. [MkDocs](https://www.mkdocs.org/) builds a static HTML site from that
+   Markdown.
+3. [NGINX with the OpenTelemetry module](https://github.com/nginxinc/nginx-otel)
+   serves the site, on port `8000` by default (`TELEMETRY_DOCS_PORT`).
+
+## Instrumentation
+
+The NGINX server is instrumented with the
+[nginx-otel module](https://github.com/nginxinc/nginx-otel), the same module
+used by the [Image Provider](../image-provider/) service. Its configuration
+demonstrates a few production-minded practices:
+
+- **Low-cardinality span names** through route parameters — for example,
+  `/services/*.html` is recorded as `GET /services/{service_name}` rather than
+  one span name per page.
+- **Tracing exclusions** for static assets, search indexes, and the `/status`
+  health-check endpoint, following the OpenTelemetry
+  [HTTP semantic conventions](/docs/specs/semconv/http/http-spans/).
+- **Batched export** every 5 seconds in batches of 256 spans.


### PR DESCRIPTION
## Description

Adds documentation for five services that exist in `opentelemetry-demo` `main`
but had no page under `content/en/docs/demo/services/`:

- **agent** — Python AI assistant (FastAPI + LangGraph) instrumented with the Traceloop SDK (open-telemetry/opentelemetry-demo#3455)
- **chatbot** — Python Gradio chat UI that forwards to the agent (open-telemetry/opentelemetry-demo#3455)
- **mcp** — Python FastMCP server exposing the shop tools over the Model Context Protocol (open-telemetry/opentelemetry-demo#3455)
- **opamp-server** — Go reference OpAMP server acting as a Collector control plane (open-telemetry/opentelemetry-demo#3566)
- **telemetry-docs** — Weaver + MkDocs + nginx-otel service that hosts the telemetry-schema docs (open-telemetry/opentelemetry-demo#2794)

Also wires the three AI services (`agent`, `chatbot`, `mcp`) into the
`architecture.md` service diagram, and lists all five in the docs landing page
(`_index.md`) and the service table (`services/_index.md`).

`opamp-server` and `telemetry-docs` are intentionally left out of the service
request-flow diagram, consistent with other support/infra services (Grafana,
Jaeger, Prometheus) that aren't shown there.

This PR is additive and English-only; it does not modify any translated content.

Part of #10962.

→ Assisted by [Claude Code](https://claude.com/claude-code)
