### PR TITLE
Move Go compile-time "how-to" from blog into docs

### DIFF
--- a/content/en/blog/2026/go-compile-time-instrumentation-v1/index.md
+++ b/content/en/blog/2026/go-compile-time-instrumentation-v1/index.md
@@ -7,7 +7,7 @@ author: '[Kemal Akkoyun](https://github.com/kakkoyun) (Datadog)'
 issue: 10670
 sig: Go Compile-Time Instrumentation
 # prettier-ignore
-cSpell:ignore: Akkoyun Azhar Cabify Castañé Dario GOFLAGS Haibin Martinez Momin otelc toolexec Xabier
+cSpell:ignore: Akkoyun Azhar Cabify Castañé Dario Haibin Martinez Momin otelc toolexec Xabier
 ---
 
 If you write Java, Python, Node.js, or .NET, you have been able to add
@@ -73,35 +73,15 @@ don't own.
 The project ships a command-line tool called `otelc` that wraps the standard Go
 toolchain. The change to your build is a single line: run `otelc go build` where
 you used to run `go build`. Everything after `go` is forwarded to the toolchain,
-so the rest of your build stays the same.
+so the rest of your build stays the same, and the same swap works in a container
+build. By default, `otelc` discovers the supported libraries in your module and
+instruments them automatically, with no configuration and no code changes.
 
-Install it with `go install`:
-
-```sh
-go install go.opentelemetry.io/otelc/tool/cmd/otelc@latest
-```
-
-Then build your application through it:
-
-```sh
-otelc go build -o myapp .
-```
-
-If you'd rather not change your build command, run `otelc setup` once to prepare
-the module, then point the Go toolchain at `otelc` through `GOFLAGS` and keep
-running `go build` as usual:
-
-```sh
-otelc setup
-export GOFLAGS="${GOFLAGS} '-toolexec=otelc toolexec'"
-go build -o myapp .
-```
-
-By default, `otelc` discovers the supported libraries in your module and
-instruments them automatically, with no configuration and no code changes. The
-same swap works in a container build: install `otelc` in your build stage and
-replace the `go build` line in your `Dockerfile` with `otelc go build`. For the
-full walkthrough, see the
+To install `otelc`, build your application through it, and see the telemetry it
+produces, follow the
+[getting-started guide](/docs/zero-code/go/compile-time/getting-started/). For
+everything else — configuration, supported libraries, and troubleshooting — see
+the
 [compile-time instrumentation documentation](/docs/zero-code/go/compile-time/).
 
 ## When should you use it?

--- a/content/en/docs/zero-code/go/compile-time/getting-started.md
+++ b/content/en/docs/zero-code/go/compile-time/getting-started.md
@@ -4,7 +4,7 @@ description:
   Capture telemetry from a Go application without writing any instrumentation
   code.
 weight: 5
-cSpell:ignore: otelc
+cSpell:ignore: GOFLAGS otelc toolexec
 ---
 
 This page shows you how to build a Go application with compile-time
@@ -13,11 +13,21 @@ instrumentation and see the telemetry it produces.
 ## Prerequisites
 
 - [Go](https://go.dev/) 1.25 or newer
-- `git` and `make`
 
-## Build the tool
+## Install otelc
 
-The `otelc` tool is built from the project repository:
+The project ships a command-line tool called `otelc` that wraps the standard Go
+toolchain. Install it with `go install`:
+
+```sh
+go install go.opentelemetry.io/otelc/tool/cmd/otelc@latest
+```
+
+This places the `otelc` binary in your Go bin directory (`$(go env GOPATH)/bin`
+by default). The following steps assume `otelc` is on your `PATH`.
+
+Alternatively, you can build the tool from source, for example to try unreleased
+changes. This requires `git` and `make`:
 
 ```sh
 git clone https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation.git
@@ -25,8 +35,8 @@ cd opentelemetry-go-compile-instrumentation
 make build
 ```
 
-This produces an `otelc` binary in the repository root. Add it to your `PATH`,
-or note its location — the following steps assume `otelc` is on your `PATH`:
+This produces an `otelc` binary in the repository root, which you can add to
+your `PATH`:
 
 ```sh
 export PATH=$PATH:$(pwd)
@@ -34,17 +44,58 @@ export PATH=$PATH:$(pwd)
 
 ## Instrument your application
 
-From your application's module directory, prefix your usual `go build` command
-with `otelc`:
+The change to your build is a single line: run `otelc go build` where you used
+to run `go build`. From your application's module directory:
 
 ```sh
 otelc go build -o myapp .
 ```
 
-The tool intercepts the build, applies the instrumentation rules that match your
-application and its dependencies, and produces an instrumented binary.
-Everything else about the build — flags, package arguments, output paths — works
-exactly as it does with plain `go build`.
+Everything after `go` is forwarded to the toolchain, so the rest of your build
+stays the same. The tool intercepts the build, applies the instrumentation rules
+that match your application and its dependencies, and produces an instrumented
+binary. Everything else about the build — flags, package arguments, output paths
+— works exactly as it does with plain `go build`.
+
+By default, `otelc` discovers the supported libraries in your module and
+instruments them automatically, with no configuration and no code changes.
+
+### Keep using go build
+
+If you'd rather not change your build command, run `otelc setup` once to prepare
+the module, then point the Go toolchain at `otelc` through `GOFLAGS` and keep
+running `go build` as usual:
+
+```sh
+otelc setup
+export GOFLAGS="${GOFLAGS} '-toolexec=otelc toolexec'"
+go build -o myapp .
+```
+
+This is a good fit when the `go build` command is fixed by an existing build
+system or script that you don't want to change.
+
+## Instrument a container build
+
+The same swap works in a container build: install `otelc` in your build stage
+and replace the `go build` line in your `Dockerfile` with `otelc go build`:
+
+```dockerfile
+# Build stage
+FROM golang:1.25 AS build
+WORKDIR /src
+COPY . .
+RUN go install go.opentelemetry.io/otelc/tool/cmd/otelc@latest
+RUN otelc go build -o /out/myapp .
+
+# Runtime stage
+FROM gcr.io/distroless/base-debian12
+COPY --from=build /out/myapp /myapp
+ENTRYPOINT ["/myapp"]
+```
+
+The instrumentation is compiled into the binary, so the runtime stage needs
+nothing extra — no agent to attach and no additional startup steps.
 
 ## Run the application and export telemetry
 


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

## Description

The Go compile-time instrumentation v1 announcement blog post (#10760) carried getting-started and usage content. As raised in Comms review, that how-to is reference material and belongs in the docs, where it stays discoverable and maintained after the announcement ages. This PR moves it into the existing compile-time docs and keeps the blog post focused on the announcement.

- `docs/zero-code/go/compile-time/getting-started.md` — add `go install` as the primary install method (keep build-from-source as an alternative), the `otelc setup` + `GOFLAGS` toolexec drop-in for keeping `go build`, and a container-build section
- `blog/2026/go-compile-time-instrumentation-v1/index.md` — trim the "Getting started" section to the one-line-change message and link to the docs; drop the now-migrated install/setup/container steps
- Keep `cSpell:ignore` lists accurate: add `GOFLAGS toolexec` to the docs page, remove the now-unused `GOFLAGS` from the blog

Related to #10760.

## Screenshots

<!-- before vs. after -->
### Before -
<img width="1512" height="982" alt="Screenshot 2026-07-22 at 10 49 18 PM" src="https://github.com/user-attachments/assets/86626492-b623-4650-b70d-faab0237e17b" />

### After -
<img width="1512" height="982" alt="Screenshot 2026-07-22 at 10 49 33 PM" src="https://github.com/user-attachments/assets/4613b04d-e20b-4662-a39e-0a04d205b8bc" />

→ Assisted by [Claude Code](https://claude.com/claude-code)

---

## Closes #10846 
(docs: migrate Go compile-time instrumentation how-to into /docs/zero-code/go/compile-time/)
