### PR TITLE
Guard against pre-Lychee-switch PR branches using `/fix:*`

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -96,6 +96,7 @@ jobs:
       action_exit_status: ${{ steps.patch.outputs.action_exit_status }}
       patch_name: pr-fix-${{ github.run_id }}
       patch_skipped: ${{ steps.patch.outputs.patch_skipped }}
+      stale_branch: ${{ steps.stale-branch-guard.outputs.stale_branch }}
 
     steps:
       - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -117,8 +118,27 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      - name: Guard against pre-Lychee-switch branches
+        id: stale-branch-guard
+        # PR branches cut before the Lychee link-checker switch (#10911) still
+        # carry the old refcache wiring, and the patch step runs the head's fix
+        # scripts — which would update the deleted `static/refcache.json`
+        # instead of `.lycheecache`, leaving link checks red. Detect such
+        # branches by the presence of the old cache file, skip the fix scripts,
+        # and let the report job tell the author to update from main.
+        # TODO(2026-08): remove this guard once pre-switch branches (cut before
+        # 2026-07-21) have aged out.
+        run: |
+          if [[ -f static/refcache.json ]]; then
+            echo "stale_branch=true" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Stale PR branch::Head predates the Lychee switch (#10911); skipping fix scripts."
+          else
+            echo "stale_branch=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run PR action and generate patch
         id: patch
+        if: steps.stale-branch-guard.outputs.stale_branch != 'true'
         # Untrusted: runs the resolved npm script and captures any changes as a
         # patch artifact. Has no write permissions or secrets.
         # NOTE: after `gh pr checkout` above, this local action's definition
@@ -209,14 +229,19 @@ jobs:
           PR_MERGED: ${{ github.event.issue.pull_request.merged_at != null }}
           GENERATE_RESULT: ${{ needs.generate-patch.result }}
           PATCH_SKIPPED: ${{ needs.generate-patch.outputs.patch_skipped }}
+          STALE_BRANCH: ${{ needs.generate-patch.outputs.stale_branch }}
           COMMAND_EXIT_STATUS:
             ${{ needs.generate-patch.outputs.action_exit_status }}
           APPLY_RESULT: ${{ needs.apply-patch.result }}
-        # The hint is owned by the directive parser (single source of truth
-        # with its invalid-directive message); this checkout is of the default
-        # branch, so the imported text is trusted.
+        # The hint and stale-branch reason are owned by the directive parser
+        # (single source of truth with its invalid-directive message); this
+        # checkout is of the default branch, so the imported text is trusted.
         run: |
           hint=$(node -e 'import("./scripts/gh/pr-fix/index.mjs").then((m) => console.log(m.DIRECTIVE_HINT))')
+          not_run_reason=''
+          if [[ "$STALE_BRANCH" == 'true' ]]; then
+            not_run_reason=$(node -e 'import("./scripts/gh/pr-fix/index.mjs").then((m) => console.log(m.STALE_BRANCH_MESSAGE))')
+          fi
           node scripts/gh/patch-report/cli.mjs \
             --pr "$PR_NUM" \
             --comment-id "$ACK_COMMENT_ID" \
@@ -224,6 +249,7 @@ jobs:
             --label "$LABEL" \
             --pr-state "$PR_STATE" \
             --pr-merged "$PR_MERGED" \
+            --not-run-reason "$not_run_reason" \
             --generate-result "$GENERATE_RESULT" \
             --patch-skipped "$PATCH_SKIPPED" \
             --command-exit-status "$COMMAND_EXIT_STATUS" \

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -123,11 +123,10 @@ jobs:
         # PR branches cut before the Lychee link-checker switch (#10911) still
         # carry the old refcache wiring, and the patch step runs the head's fix
         # scripts — which would update the deleted `static/refcache.json`
-        # instead of `.lycheecache`, leaving link checks red. Detect such
-        # branches by the presence of the old cache file, skip the fix scripts,
-        # and let the report job tell the author to update from main.
-        # TODO(2026-08): remove this guard once pre-switch branches (cut before
-        # 2026-07-21) have aged out.
+        # instead of `.lycheecache`, leaving link checks red.
+        # TODO(2026-08): remove this guard (and the report job's stale-branch
+        # handling) once pre-switch branches (cut before 2026-07-21) have aged
+        # out.
         run: |
           if [[ -f static/refcache.json ]]; then
             echo "stale_branch=true" >> "$GITHUB_OUTPUT"
@@ -230,17 +229,23 @@ jobs:
           GENERATE_RESULT: ${{ needs.generate-patch.result }}
           PATCH_SKIPPED: ${{ needs.generate-patch.outputs.patch_skipped }}
           STALE_BRANCH: ${{ needs.generate-patch.outputs.stale_branch }}
+          # Why the stale-branch guard declined to run the fix scripts; see the
+          # guard step in the generate-patch job, and remove along with it.
+          STALE_BRANCH_MESSAGE: >-
+            This PR branch predates the Lychee link-checker switch (#10911), so
+            its fix scripts would update the old link cache. Update the branch
+            from `main`, then re-run `/fix`.
           COMMAND_EXIT_STATUS:
             ${{ needs.generate-patch.outputs.action_exit_status }}
           APPLY_RESULT: ${{ needs.apply-patch.result }}
-        # The hint and stale-branch reason are owned by the directive parser
-        # (single source of truth with its invalid-directive message); this
-        # checkout is of the default branch, so the imported text is trusted.
+        # The hint is owned by the directive parser (single source of truth
+        # with its invalid-directive message); this checkout is of the default
+        # branch, so the imported text is trusted.
         run: |
           hint=$(node -e 'import("./scripts/gh/pr-fix/index.mjs").then((m) => console.log(m.DIRECTIVE_HINT))')
           not_run_reason=''
           if [[ "$STALE_BRANCH" == 'true' ]]; then
-            not_run_reason=$(node -e 'import("./scripts/gh/pr-fix/index.mjs").then((m) => console.log(m.STALE_BRANCH_MESSAGE))')
+            not_run_reason="$STALE_BRANCH_MESSAGE"
           fi
           node scripts/gh/patch-report/cli.mjs \
             --pr "$PR_NUM" \

--- a/scripts/gh/patch-report/cli.mjs
+++ b/scripts/gh/patch-report/cli.mjs
@@ -31,8 +31,9 @@ Options:
       --pr-state <state>       PR state: 'open' or 'closed' ('' acts as open).
       --pr-merged <bool>       'true' when the PR is merged.
       --not-run-reason <text>  Reason the pipeline deliberately declined to
-                               run the action; when set, it is relayed instead
-                               of a generation/apply outcome.
+                               run the action, as standalone sentence(s); when
+                               set, it is relayed instead of a generation/apply
+                               outcome.
       --generate-result <r>    Result of the patch-generation job.
       --patch-skipped <bool>   'true' when generation produced no changes.
       --command-exit-status <n> Exit status of the patch-producing command.

--- a/scripts/gh/patch-report/cli.mjs
+++ b/scripts/gh/patch-report/cli.mjs
@@ -30,6 +30,9 @@ Options:
       --label <name>           The action as requested (e.g. the command).
       --pr-state <state>       PR state: 'open' or 'closed' ('' acts as open).
       --pr-merged <bool>       'true' when the PR is merged.
+      --not-run-reason <text>  Reason the pipeline deliberately declined to
+                               run the action; when set, it is relayed instead
+                               of a generation/apply outcome.
       --generate-result <r>    Result of the patch-generation job.
       --patch-skipped <bool>   'true' when generation produced no changes.
       --command-exit-status <n> Exit status of the patch-producing command.
@@ -52,6 +55,7 @@ const { values } = parseArgs({
     label: { type: 'string', default: '' },
     'pr-state': { type: 'string', default: '' },
     'pr-merged': { type: 'string', default: '' },
+    'not-run-reason': { type: 'string', default: '' },
     'generate-result': { type: 'string', default: '' },
     'patch-skipped': { type: 'string', default: '' },
     'command-exit-status': { type: 'string', default: '' },
@@ -90,6 +94,7 @@ const body = values.ack
       label: values.label,
       prState: values['pr-state'],
       prMerged: values['pr-merged'],
+      notRunReason: values['not-run-reason'],
       generateResult: values['generate-result'],
       patchSkipped: values['patch-skipped'],
       commandExitStatus: values['command-exit-status'],

--- a/scripts/gh/patch-report/index.mjs
+++ b/scripts/gh/patch-report/index.mjs
@@ -21,6 +21,11 @@
  *                                       closed). '' is treated as open for
  *                                       callers that don't gate on state.
  * @property {string} [prMerged]         'true' when the PR is merged.
+ * @property {string} [notRunReason]     When set, the pipeline deliberately
+ *                                       declined to run the action; the reason
+ *                                       to relay. Spliced mid-sentence into the
+ *                                       composed message, so it should start
+ *                                       lowercase and end with a period.
  * @property {string} generateResult     Result of the patch-generation job:
  *                                       'success' | 'failure' | 'cancelled'.
  * @property {string} patchSkipped       'true' when generation produced no
@@ -81,6 +86,7 @@ export function buildOutcomeComment({
   label,
   prState,
   prMerged,
+  notRunReason,
   generateResult,
   patchSkipped,
   commandExitStatus,
@@ -99,7 +105,12 @@ export function buildOutcomeComment({
     return `❌ This PR ${why}, so ${what} was not run: such actions only apply to open PRs. ${logs}`;
   }
 
-  // 1. Patch generation did not succeed: no changes were ever captured.
+  // 1. The pipeline deliberately declined to run the action.
+  if (notRunReason) {
+    return `⚠️ ${what} was not run: ${notRunReason} ${logs}`;
+  }
+
+  // 2. Patch generation did not succeed: no changes were ever captured.
   if (generateResult === 'cancelled') {
     return `⚠️ ${what} was cancelled before any changes were generated. ${logs}`;
   }
@@ -112,7 +123,7 @@ export function buildOutcomeComment({
     return `❌ ${what} could not be run, or its changes could not be captured. ${logs}`;
   }
 
-  // 2. Generation succeeded but produced no changes.
+  // 3. Generation succeeded but produced no changes.
   if (patchSkipped === 'true') {
     if (commandExitStatus && commandExitStatus !== '0') {
       return (
@@ -123,7 +134,7 @@ export function buildOutcomeComment({
     return `ℹ️ ${what} made no changes; nothing to commit. ${logs}`;
   }
 
-  // 3. Changes were produced: report how applying them went.
+  // 4. Changes were produced: report how applying them went.
   if (applyResult === 'cancelled') {
     return `⚠️ ${what} produced changes, but applying them was cancelled. ${logs}`;
   }

--- a/scripts/gh/patch-report/index.mjs
+++ b/scripts/gh/patch-report/index.mjs
@@ -23,9 +23,8 @@
  * @property {string} [prMerged]         'true' when the PR is merged.
  * @property {string} [notRunReason]     When set, the pipeline deliberately
  *                                       declined to run the action; the reason
- *                                       to relay. Spliced mid-sentence into the
- *                                       composed message, so it should start
- *                                       lowercase and end with a period.
+ *                                       to relay, as one or more standalone
+ *                                       sentences.
  * @property {string} generateResult     Result of the patch-generation job:
  *                                       'success' | 'failure' | 'cancelled'.
  * @property {string} patchSkipped       'true' when generation produced no
@@ -107,7 +106,7 @@ export function buildOutcomeComment({
 
   // 1. The pipeline deliberately declined to run the action.
   if (notRunReason) {
-    return `⚠️ ${what} was not run: ${notRunReason} ${logs}`;
+    return `⚠️ ${what} was not run. ${notRunReason} ${logs}`;
   }
 
   // 2. Patch generation did not succeed: no changes were ever captured.

--- a/scripts/gh/patch-report/index.test.mjs
+++ b/scripts/gh/patch-report/index.test.mjs
@@ -123,6 +123,31 @@ describe('buildOutcomeComment', () => {
     assert.equal(build({ prState: 'open' }), build({}));
   });
 
+  test('not-run reason: pipeline declined to run the action', () => {
+    const body = build({ notRunReason: 'the branch is stale.' });
+    assert.equal(
+      body,
+      `⚠️ \`fix:refcache\` was not run: the branch is stale. ${LOGS}`,
+    );
+  });
+
+  test('not-run reason takes precedence over generation and apply outcomes', () => {
+    const body = build({
+      notRunReason: 'the branch is stale.',
+      generateResult: 'failure',
+      applyResult: 'skipped',
+    });
+    assert.match(body, /was not run: the branch is stale\./);
+  });
+
+  test('closed PR takes precedence over a not-run reason', () => {
+    const body = build({
+      prState: 'closed',
+      notRunReason: 'the branch is stale.',
+    });
+    assert.match(body, /^❌ This PR is closed/);
+  });
+
   test('label links to the directive comment when its URL is given', () => {
     const body = build({ directiveUrl: 'https://example.test/c/1' });
     assert.match(
@@ -157,31 +182,34 @@ describe('buildOutcomeComment', () => {
               for (const hint of ['Any hint text.', '']) {
                 for (const prState of ['open', 'closed', '']) {
                   for (const directiveUrl of ['d', '']) {
-                    const body = buildOutcomeComment({
-                      label,
-                      prState,
-                      generateResult,
-                      patchSkipped,
-                      commandExitStatus,
-                      applyResult,
-                      runId: '1',
-                      runUrl: 'u',
-                      directiveUrl,
-                      hint,
-                    });
-                    assert.ok(
-                      typeof body === 'string' && body.length > 0,
-                      'comment should be a non-empty string',
-                    );
-                    assert.ok(
-                      body.endsWith('See [run 1](u).'),
-                      `comment should end with the run link: ${body}`,
-                    );
-                    if (directiveUrl) {
+                    for (const notRunReason of ['a reason.', '']) {
+                      const body = buildOutcomeComment({
+                        label,
+                        prState,
+                        notRunReason,
+                        generateResult,
+                        patchSkipped,
+                        commandExitStatus,
+                        applyResult,
+                        runId: '1',
+                        runUrl: 'u',
+                        directiveUrl,
+                        hint,
+                      });
                       assert.ok(
-                        body.includes('](d)'),
-                        `comment should link the directive: ${body}`,
+                        typeof body === 'string' && body.length > 0,
+                        'comment should be a non-empty string',
                       );
+                      assert.ok(
+                        body.endsWith('See [run 1](u).'),
+                        `comment should end with the run link: ${body}`,
+                      );
+                      if (directiveUrl) {
+                        assert.ok(
+                          body.includes('](d)'),
+                          `comment should link the directive: ${body}`,
+                        );
+                      }
                     }
                   }
                 }

--- a/scripts/gh/patch-report/index.test.mjs
+++ b/scripts/gh/patch-report/index.test.mjs
@@ -124,26 +124,26 @@ describe('buildOutcomeComment', () => {
   });
 
   test('not-run reason: pipeline declined to run the action', () => {
-    const body = build({ notRunReason: 'the branch is stale.' });
+    const body = build({ notRunReason: 'The branch is stale.' });
     assert.equal(
       body,
-      `⚠️ \`fix:refcache\` was not run: the branch is stale. ${LOGS}`,
+      `⚠️ \`fix:refcache\` was not run. The branch is stale. ${LOGS}`,
     );
   });
 
   test('not-run reason takes precedence over generation and apply outcomes', () => {
     const body = build({
-      notRunReason: 'the branch is stale.',
+      notRunReason: 'The branch is stale.',
       generateResult: 'failure',
       applyResult: 'skipped',
     });
-    assert.match(body, /was not run: the branch is stale\./);
+    assert.match(body, /was not run\. The branch is stale\./);
   });
 
   test('closed PR takes precedence over a not-run reason', () => {
     const body = build({
       prState: 'closed',
-      notRunReason: 'the branch is stale.',
+      notRunReason: 'The branch is stale.',
     });
     assert.match(body, /^❌ This PR is closed/);
   });
@@ -182,7 +182,7 @@ describe('buildOutcomeComment', () => {
               for (const hint of ['Any hint text.', '']) {
                 for (const prState of ['open', 'closed', '']) {
                   for (const directiveUrl of ['d', '']) {
-                    for (const notRunReason of ['a reason.', '']) {
+                    for (const notRunReason of ['A reason.', '']) {
                       const body = buildOutcomeComment({
                         label,
                         prState,

--- a/scripts/gh/pr-fix/index.mjs
+++ b/scripts/gh/pr-fix/index.mjs
@@ -15,6 +15,17 @@ export const INVALID_DIRECTIVE_MESSAGE = `❌ Invalid fix directive. ${DIRECTIVE
 export const FIX_ALL_COMPAT_MESSAGE =
   'ℹ️ INFO: Running `/fix` for `/fix:all` (compat mode). Use `/fix` moving forward.';
 
+// Why the pipeline declines to run fix scripts on PR branches cut before the
+// Lychee link-checker switch (#10911): the scripts run from the PR head, so on
+// such branches they would update the deleted `static/refcache.json` instead
+// of `.lycheecache`, leaving link checks red. Surfaced by the report job when
+// the workflow's stale-branch guard fires; remove along with that guard once
+// pre-switch branches age out.
+export const STALE_BRANCH_MESSAGE =
+  'this PR branch predates the Lychee link-checker switch (#10911), so its ' +
+  'fix scripts would update the old link cache. Update the branch from ' +
+  '`main`, then re-run `/fix`.';
+
 // The first line of the comment must be exactly `/fix` optionally followed by
 // one or more `:segment` parts, where a segment is one or more of `-_0-9a-zA-Z`.
 // Any following lines are ignored.

--- a/scripts/gh/pr-fix/index.mjs
+++ b/scripts/gh/pr-fix/index.mjs
@@ -15,17 +15,6 @@ export const INVALID_DIRECTIVE_MESSAGE = `❌ Invalid fix directive. ${DIRECTIVE
 export const FIX_ALL_COMPAT_MESSAGE =
   'ℹ️ INFO: Running `/fix` for `/fix:all` (compat mode). Use `/fix` moving forward.';
 
-// Why the pipeline declines to run fix scripts on PR branches cut before the
-// Lychee link-checker switch (#10911): the scripts run from the PR head, so on
-// such branches they would update the deleted `static/refcache.json` instead
-// of `.lycheecache`, leaving link checks red. Surfaced by the report job when
-// the workflow's stale-branch guard fires; remove along with that guard once
-// pre-switch branches age out.
-export const STALE_BRANCH_MESSAGE =
-  'this PR branch predates the Lychee link-checker switch (#10911), so its ' +
-  'fix scripts would update the old link cache. Update the branch from ' +
-  '`main`, then re-run `/fix`.';
-
 // The first line of the comment must be exactly `/fix` optionally followed by
 // one or more `:segment` parts, where a segment is one or more of `-_0-9a-zA-Z`.
 // Any following lines are ignored.


### PR DESCRIPTION
- PR branches cut before the Lychee link-checker switch (#10911) still carry the old refcache wiring, and the fix pipeline runs the *head's* scripts — so `/fix` updates the deleted `static/refcache.json` instead of `.lycheecache`, and `CHECK LINKS` stays red (seen on #10946, which took two `/fix` rounds plus a merge-main to recover).
- Adds a guard step in `generate-patch` (the workflow runs from `main`, so it covers all stale heads): when the checked-out head still has `static/refcache.json`, skips the fix scripts.
- Relays the reason through a new generic `--not-run-reason` path in the patch-report composer; the stale-branch reason text lives in the workflow, with the guard that owns its lifecycle. Sample outcome comment: "⚠️ `fix:refcache` was not run. This PR branch predates the Lychee link-checker switch (#10911), so its fix scripts would update the old link cache. Update the branch from `main`, then re-run `/fix`."
- Marks the guard removable (`TODO(2026-08)`) once pre-switch branches age out.