### PR TITLE
KubeCon Japan announcement: shorten with a Details link

### DIFF
--- a/content/en/announcements/kubecon-japan.md
+++ b/content/en/announcements/kubecon-japan.md
@@ -13,7 +13,7 @@ params:
 ---
 
 [**{{% param title %}}**][LF], **<span class="text-nowrap">July 28–30,</span>
-Yokohama**. [Details][blog].
+Yokohama**. [Details][blog]
 
 [blog]: <{{% param blogPostURL %}}>
 [LF]: <{{% param eventUrl %}}register/?{{% _param utmParam %}}>

--- a/content/en/announcements/kubecon-japan.md
+++ b/content/en/announcements/kubecon-japan.md
@@ -13,9 +13,7 @@ params:
 ---
 
 [**{{% param title %}}**][LF], **<span class="text-nowrap">July 28–30,</span>
-Yokohama**. <span class="d-none d-md-inline"><br></span> Come [collaborate,
-learn, and share][blog]<span class="d-none d-sm-inline"> with the Cloud Native
-community</span>!
+Yokohama**. [Details][blog].
 
 [blog]: <{{% param blogPostURL %}}>
 [LF]: <{{% param eventUrl %}}register/?{{% _param utmParam %}}>


### PR DESCRIPTION
- Shortens the KubeCon Japan banner: replaces the second sentence ("Come collaborate, learn, and share with the Cloud Native community!") with a short **Details** link, and drops the forced-line-break spans along with it.
- Keeps the link target (`blogPostURL`): currently the event page, to be swapped to the KubeCon blog post when it's ready.
- Precedent for a short second part with no forced break: `open-observability-summit-na.md`.
- Leaves the sibling kubecon announcements untouched (expired or expiring).
- **Preview**: https://deploy-preview-10971--opentelemetry.netlify.app/
