### PR TITLE
[ja] update translation of content/en/docs/languages/python/_index.md

### DIFF
--- a/content/ja/docs/languages/python/_index.md
+++ b/content/ja/docs/languages/python/_index.md
@@ -5,8 +5,7 @@ description: >-
   src="/img/logos/32x32/Python_SDK.svg" alt="Python"> PythonにおけるOpenTelemetryの言語固有の実装。
 aliases: [/python, /python/metrics, /python/tracing]
 weight: 190
-default_lang_commit: 1143960b75c6faceb40eb64269e68390e3237671 # patched
-drifted_from_default: true
+default_lang_commit: b7589cf40b05480bc7a2022cf2dd36cc299904fa
 ---
 
 {{% docs/languages/index-intro python /%}}


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/python/_index.md` to match the latest English source at
`content/en/docs/languages/python/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The link URL for "editable install" was already patched to the current English value
(the previous `default_lang_commit` carried a `# patched` annotation), so this PR
only updates the frontmatter bookkeeping to clear the drift marker.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-10998--opentelemetry.netlify.app/ja/docs/languages/python/
- **English (canonical):** https://opentelemetry.io/docs/languages/python/

_(deploy preview status: pending. The URLs will work once Netlify finishes building.)_
<!-- preview-section-end -->
