### PR TITLE
[ja] update translation of content/en/docs/languages/python/mypy.md

### DIFF
--- a/content/ja/docs/languages/python/mypy.md
+++ b/content/ja/docs/languages/python/mypy.md
@@ -1,8 +1,7 @@
 ---
 title: mypyの使用
 weight: 120
-default_lang_commit: c3365f297f394baf10f5dba3473e13621ade4461 # patched
-drifted_from_default: true
+default_lang_commit: b7589cf40b05480bc7a2022cf2dd36cc299904fa
 cSpell:ignore: mypy
 ---
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/python/mypy.md` to match the latest English source at
`content/en/docs/languages/python/mypy.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff since the previous `default_lang_commit` was a single link target fix
(`#cmdoption-mypy-namespace-packages` → `#cmdoption-mypy-no-namespace-packages`), which
had already been applied to the Japanese file via a targeted `# patched` update. This PR
completes the sync by updating `default_lang_commit` to current HEAD and removing the
drift marker.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11004--opentelemetry.netlify.app/ja/docs/languages/python/mypy/
- **English (canonical):** https://opentelemetry.io/docs/languages/python/mypy/

<!-- preview-section-end -->
