### PR TITLE
[ja] update translation of content/en/site/build/npm-scripts.md

### DIFF
--- a/content/ja/site/build/npm-scripts.md
+++ b/content/ja/site/build/npm-scripts.md
@@ -4,8 +4,7 @@ description: >-
   OpenTelemetry ウェブサイトのビルド、配信、検証、メンテナンスのための NPM スクリプト。
 weight: 20
 todo: Keep table entries sorted
-default_lang_commit: e87b1c4543d287bc4509225d102588c0f2670eae
-drifted_from_default: true
+default_lang_commit: b7589cf40b05480bc7a2022cf2dd36cc299904fa
 ---
 
 スクリプトの定義はリポジトリルートの [`package.json`](https://github.com/open-telemetry/opentelemetry.io/blob/main/package.json) にあります。
@@ -37,27 +36,26 @@ drifted_from_default: true
 
 ## チェック {#checking}
 
-| スクリプト             | 説明                                                                     |
-| ---------------------- | ------------------------------------------------------------------------ |
-| `check:all`            | すべてのチェックスクリプトを順番に実行します。                           |
-| `check:code-excerpts`  | コード抜粋をチェックし、更新が必要な場合は失敗します。                   |
-| `check:codeowners`     | CODEOWNERS のロケールセクションがレジストリと一致することを検証します。  |
-| `check:collector-sync` | collector-sync チェックを実行します。                                    |
-| `check:expired`        | 期限切れのコンテンツ（フロントマターに基づく）をリストします。           |
-| `check:filenames`      | [ファイル名の検証と廃止されたファイル/フォルダの検出][fn]。              |
-| `check:format`         | Prettier と prose-wrap のチェック。                                      |
-| `check:i18n`           | ローカリゼーションフロントマター（`default_lang_commit`）を検証します。  |
-| `check:l10n`           | ローカリゼーションチェックを実行します。                                 |
-| `check:links:diff`     | 変更されたファイルのみの Lychee リンクチェック（パイロット）。           |
-| `check:links:htmltest` | htmltest でサイト全体をリンクチェックします。最初にリーンビルドを実行。  |
-| `check:links:lychee`   | Lychee でサイト全体をリンクチェックします。最初にリーンビルドを実行。    |
-| `check:links`          | サイト全体をリンクチェック（htmltest、デフォルト）。最初にリーンビルド。 |
-| `check:markdown:specs` | `tmp/` 内の仕様フラグメントの Markdown lint。                            |
-| `check:markdown`       | Markdown lint（コンテンツおよびプロジェクト）。                          |
-| `check:registry`       | `data/registry/` 配下のレジストリ YAML を検証します。                    |
-| `check:spelling`       | コンテンツ、データ、レイアウト Markdown に対する cspell。                |
-| `check:text`           | コンテンツとデータに対する textlint。                                    |
-| `check`                | もっとも一般的に必要なチェックスクリプトを順番に実行します。             |
+| スクリプト             | 説明                                                                    |
+| ---------------------- | ----------------------------------------------------------------------- |
+| `check:all`            | すべてのチェックスクリプトを順番に実行します。                          |
+| `check:code-excerpts`  | コード抜粋をチェックし、更新が必要な場合は失敗します。                  |
+| `check:codeowners`     | CODEOWNERS のロケールセクションがレジストリと一致することを検証します。 |
+| `check:collector-sync` | collector-sync チェックを実行します。                                   |
+| `check:expired`        | 期限切れのコンテンツ（フロントマターに基づく）をリストします。          |
+| `check:filenames`      | [ファイル名の検証と廃止されたファイル/フォルダの検出][fn]。             |
+| `check:format`         | Prettier と prose-wrap のチェック。                                     |
+| `check:i18n`           | ローカリゼーションフロントマター（`default_lang_commit`）を検証します。 |
+| `check:l10n`           | ローカリゼーションチェックを実行します。                                |
+| `check:links:diff`     | 変更されたファイルのみの Lychee リンクチェック。                        |
+| `check:links:internal` | オフラインリンクチェック（内部リンクのみ）。最初にリーンビルドを実行。  |
+| `check:links`          | Lychee でサイト全体をリンクチェックします。最初にリーンビルドを実行。   |
+| `check:markdown:specs` | `tmp/` 内の仕様フラグメントの Markdown lint。                           |
+| `check:markdown`       | Markdown lint（コンテンツおよびプロジェクト）。                         |
+| `check:registry`       | `data/registry/` 配下のレジストリ YAML を検証します。                   |
+| `check:spelling`       | コンテンツ、データ、レイアウト Markdown に対する cspell。               |
+| `check:text`           | コンテンツとデータに対する textlint。                                   |
+| `check`                | もっとも一般的に必要なチェックスクリプトを順番に実行します。            |
 
 ## 修正 {#fixing}
 
@@ -72,8 +70,8 @@ drifted_from_default: true
 | `fix:i18n`                | i18n フロントマターを追加/修正します（`fix:i18n:new`、`fix:i18n:status`）。 |
 | `fix:l10n`                | ローカリゼーションの修正を適用します。                                      |
 | `fix:markdown`            | Markdown lint の問題と末尾の空白を修正します。                              |
-| `fix:refcache`            | refcache をプルーンし、リンクチェックを再実行します（refcache を更新）。    |
-| `fix:refcache:refresh`    | カウントに基づいて refcache をプルーンします。                              |
+| `fix:refcache`            | リンクチェックを実行し、コミット済みの `.lycheecache` を更新します。        |
+| `fix:refcache:refresh`    | もっとも古いキャッシュエントリをプルーンし、`fix:refcache` を実行します。   |
 | `fix:submodule`           | サブモジュールのリビジョンをピンします（`pin:submodule` と同じ）。          |
 | `fix:filenames`           | [ファイルのリネームと廃止されたファイル/フォルダの削除][fn]。               |
 | `fix:dict`                | cspell ワードリストをソートし、フロントマターを正規化します。               |
@@ -119,40 +117,37 @@ drifted_from_default: true
     [テストカテゴリ](/site/testing/#test-categories)を参照してください。
 
 [^fat]:
-    ハウスキーピングのデフォルト: コンテンツ修正の後に `fix:refcache`（プルーンしてからリンクチェック）を実行します。
+    ハウスキーピングのデフォルト: コンテンツ修正の後に `fix:refcache`（リンクチェックを実行し、リンクキャッシュを更新）を実行します。
     keep-going `all` ランナーを使用してすべての修正を記録します。
     チェックフェーズは `check:links`（`fix:refcache` がカバー）と `check:i18n`（`fix:i18n` がドリフトステータスを記録した後は冗長）を除外します。
     [ハウスキーピング](../ci-workflows/#housekeeping)を参照してください。
 
 ## ユーティリティ {#utilities}
 
-| スクリプト                     | 説明                                                                         |
-| ------------------------------ | ---------------------------------------------------------------------------- |
-| `seq`                          | 指定されたスクリプト名を順番に実行します。最初の失敗で終了。                 |
-| `all`                          | 指定されたすべてのスクリプトを実行し、いずれかが失敗した場合は失敗で終了。   |
-| `locale-auto-merge`            | [ロケール自動マージヘルパー CLI][locale-auto-merge]（`--help`）。            |
-| `prepare`                      | インストールステップ: `get:submodule` を実行し、Docsy テーマの npm install。 |
-| `prebuild:*`                   | `build*` の前に実行されるフック。各フックは `_prebuild` を実行。             |
-| `update:hugo`                  | 最新の hugo-extended をインストールします。                                  |
-| `update:packages`              | npm-check-updates を実行して依存関係を更新します。                           |
-| `generate:config:links`        | `.htmltest.base.yml` から git 無視の `.htmltest.yml` を生成します。          |
-| `generate:config:links:lychee` | `lychee.base.toml` から git 無視の `lychee.toml` を生成します。              |
-| `log:build`、`log:check:links` | 対応するスクリプトを実行し、出力を `tmp/` に tee します。                    |
+| スクリプト                     | 説明                                                                                  |
+| ------------------------------ | ------------------------------------------------------------------------------------- |
+| `seq`                          | 指定されたスクリプト名を順番に実行します。最初の失敗で終了。                          |
+| `all`                          | 指定されたすべてのスクリプトを実行し、いずれかが失敗した場合は失敗で終了。            |
+| `locale-auto-merge`            | [ロケール自動マージヘルパー CLI][locale-auto-merge]（`--help`）。                     |
+| `prepare`                      | インストールステップ: `get:submodule` を実行し、Docsy テーマの `postinstall` を実行。 |
+| `prebuild:*`                   | `build*` の前に実行されるフック。各フックは `_prebuild` を実行。                      |
+| `update:hugo`                  | 最新の hugo-extended をインストールします。                                           |
+| `update:packages`              | npm-check-updates を実行して依存関係を更新します。                                    |
+| `generate:config:links`        | `lychee.base.toml` とページフロントマターから git 無視の `lychee.toml` を生成します。 |
+| `log:build`、`log:check:links` | 対応するスクリプトを実行し、出力を `tmp/` に tee します。                             |
 
 ## 注記 {#notes}
 
-- **refcache のメンテナンス**は htmltest 固有です。
-  詳細は [Refcache](/site/build/link-checking/#refcache) を参照してください。
-- **Lychee リンクチェック（パイロット）。**
-  `:lychee` と `:diff` スクリプトは、htmltest のより高速な代替として [Lychee](https://github.com/lycheeverse/lychee) を実行し、そのカバレッジを反映します。
-  `lychee.toml` を生成し、refcache から `.lycheecache` を自動的に（再）シードします。
-  Lychee は [#10449](https://github.com/open-telemetry/opentelemetry.io/issues/10449) で評価される間、非ブロッキングの [CI パイロット](../ci-workflows/#other-workflows)として実行されます。
+- **リンクキャッシュ。**
+  リンクチェックスクリプトはコミット済みの `.lycheecache` を読み書きします。
+  `fix:refcache*` スクリプトは歴史的な名前を維持しています。
+  詳細は[リンクチェック](../link-checking/)を参照してください。
 - **`test:local-tools:lychee`** は `test:local-tools` のうち `lychee` バイナリを必要とするサブセット（動作フラグメントおよび設定チェックテスト）です。
   バイナリが存在しない場合はそれらのテストはスキップされるため、`test:local-tools` は一般的なテストジョブですでにカバーしています。
   末尾の `:lychee` はこのスクリプトを `test:compound-tests`（`test:*-*` にマッチ）から除外し、スイートが2回実行されないようにします。
   リンクチェック CI ジョブは lychee をインストールし、このスクリプトを実行して実際にテストを実行します。
 - **`all`** はリスト内のスクリプトを1つが失敗してもすべて実行し、いずれかが失敗した場合は非ゼロステータスで終了します。
 
-[build kinds]: /site/build/#build-kinds
+[build kinds]: ../#build-kinds
 [fn]: /docs/contributing/pr-checks/#filename-check
 [locale-auto-merge]: ../ci-workflows/#locale-auto-merge

--- a/content/ja/site/build/npm-scripts.md
+++ b/content/ja/site/build/npm-scripts.md
@@ -4,7 +4,7 @@ description: >-
   OpenTelemetry ウェブサイトのビルド、配信、検証、メンテナンスのための NPM スクリプト。
 weight: 20
 todo: Keep table entries sorted
-default_lang_commit: 1ff7122fa7e1fd78714d7540b93ec70a3e72d84c
+default_lang_commit: 0aff0aab149003b5592edfe186c193047e40c766
 ---
 
 スクリプトの定義はリポジトリルートの [`package.json`](https://github.com/open-telemetry/opentelemetry.io/blob/main/package.json) にあります。
@@ -126,17 +126,17 @@ default_lang_commit: 1ff7122fa7e1fd78714d7540b93ec70a3e72d84c
 
 ## ユーティリティ {#utilities}
 
-| スクリプト                     | 説明                                                                                  |
-| ------------------------------ | ------------------------------------------------------------------------------------- |
-| `seq`                          | 指定されたスクリプト名を順番に実行します。最初の失敗で終了。                          |
-| `all`                          | 指定されたすべてのスクリプトを実行し、いずれかが失敗した場合は失敗で終了。            |
-| `locale-auto-merge`            | [ロケール自動マージヘルパー CLI][locale-auto-merge]（`--help`）。                     |
-| `prepare`                      | インストールステップ: `get:submodule` を実行し、Docsy テーマの `postinstall` を実行。 |
-| `prebuild:*`                   | `build*` の前に実行されるフック。各フックは `_prebuild` を実行。                      |
-| `update:hugo`                  | 最新の hugo-extended をインストールします。                                           |
-| `update:packages`              | npm-check-updates を実行して依存関係を更新します。                                    |
-| `generate:config:links`        | `lychee.base.toml` とページフロントマターから git 無視の `lychee.toml` を生成します。 |
-| `log:build`、`log:check:links` | 対応するスクリプトを実行し、出力を `tmp/` に tee します。                             |
+| スクリプト                     | 説明                                                                                      |
+| ------------------------------ | ----------------------------------------------------------------------------------------- |
+| `seq`                          | 指定されたスクリプト名を順番に実行します。最初の失敗で終了。                              |
+| `all`                          | 指定されたすべてのスクリプトを実行し、いずれかが失敗した場合は失敗で終了。                |
+| `locale-auto-merge`            | [ロケール自動マージヘルパー CLI][locale-auto-merge]（`--help`）。                         |
+| `prepare`                      | インストールステップ: `get:submodule` を実行し、Docsy テーマの `postinstall` を実行。     |
+| `prebuild:*`                   | `build*` の前に実行されるフック。各フックは `_prebuild` を実行。                          |
+| `update:hugo`                  | 最新の hugo-extended をインストールします。                                               |
+| `update:packages`              | npm-check-updates を実行して依存関係を更新します。                                        |
+| `generate:config:links`        | `lychee.base.toml` とページフロントマターから git 無視の `lychee.toml` を生成します。     |
+| `log:build`、`log:check:links` | 対応するスクリプトを実行し、出力を `tmp/` に tee し、スクリプトの終了コードを伝播します。 |
 
 ## 注記 {#notes}
 

--- a/content/ja/site/build/npm-scripts.md
+++ b/content/ja/site/build/npm-scripts.md
@@ -59,27 +59,27 @@ default_lang_commit: 1ff7122fa7e1fd78714d7540b93ec70a3e72d84c
 
 ## 修正 {#fixing}
 
-| スクリプト                | 説明                                                                        |
-| ------------------------- | --------------------------------------------------------------------------- |
-| `fix`                     | もっとも一般的に必要な修正スクリプトを実行します。                          |
-| `fix:code-excerpts`       | コード抜粋を更新します。                                                    |
-| `fix:codeowners`          | レジストリから CODEOWNERS ロケールセクションを再生成します。                |
-| `fix:all`                 | すべての修正スクリプトを実行します。                                        |
-| `fix:format`              | Prettier を適用し、末尾の空白を削除します。                                 |
-| `fix:format:staged`       | ステージングされたファイルのみをフォーマットします。                        |
-| `fix:i18n`                | i18n フロントマターを追加/修正します（`fix:i18n:new`、`fix:i18n:status`）。 |
-| `fix:l10n`                | ローカリゼーションの修正を適用します。                                      |
-| `fix:link-cache`          | リンクチェックを実行し、コミット済みの `.lycheecache` を更新します。        |
-| `fix:link-cache:double-check` | [ブラウザプローブで失敗したリンクを再検証します][dc]。                  |
-| `fix:link-cache:refresh`  | もっとも古いキャッシュエントリをプルーンし、`fix:link-cache` を実行します。 |
-| `fix:markdown`            | Markdown lint の問題と末尾の空白を修正します。                              |
-| `fix:submodule`           | サブモジュールのリビジョンをピンします（`pin:submodule` と同じ）。          |
-| `fix:filenames`           | [ファイルのリネームと廃止されたファイル/フォルダの削除][fn]。               |
-| `fix:dict`                | cspell ワードリストをソートし、フロントマターを正規化します。               |
-| `fix:expired`             | `check:expired` で報告されたファイルを削除します。                          |
-| `fix:text`                | --fix 付きで textlint を実行します。                                        |
-| `fix:collector-sync:lint` | --fix 付きで collector-sync 内の ruff を実行します。                        |
-| `format`                  | Prettier write のエイリアス（コンテンツおよび nowrap パス）。               |
+| スクリプト                    | 説明                                                                        |
+| ----------------------------- | --------------------------------------------------------------------------- |
+| `fix`                         | もっとも一般的に必要な修正スクリプトを実行します。                          |
+| `fix:code-excerpts`           | コード抜粋を更新します。                                                    |
+| `fix:codeowners`              | レジストリから CODEOWNERS ロケールセクションを再生成します。                |
+| `fix:all`                     | すべての修正スクリプトを実行します。                                        |
+| `fix:format`                  | Prettier を適用し、末尾の空白を削除します。                                 |
+| `fix:format:staged`           | ステージングされたファイルのみをフォーマットします。                        |
+| `fix:i18n`                    | i18n フロントマターを追加/修正します（`fix:i18n:new`、`fix:i18n:status`）。 |
+| `fix:l10n`                    | ローカリゼーションの修正を適用します。                                      |
+| `fix:link-cache`              | リンクチェックを実行し、コミット済みの `.lycheecache` を更新します。        |
+| `fix:link-cache:double-check` | [ブラウザプローブで失敗したリンクを再検証します][dc]。                      |
+| `fix:link-cache:refresh`      | もっとも古いキャッシュエントリをプルーンし、`fix:link-cache` を実行します。 |
+| `fix:markdown`                | Markdown lint の問題と末尾の空白を修正します。                              |
+| `fix:submodule`               | サブモジュールのリビジョンをピンします（`pin:submodule` と同じ）。          |
+| `fix:filenames`               | [ファイルのリネームと廃止されたファイル/フォルダの削除][fn]。               |
+| `fix:dict`                    | cspell ワードリストをソートし、フロントマターを正規化します。               |
+| `fix:expired`                 | `check:expired` で報告されたファイルを削除します。                          |
+| `fix:text`                    | --fix 付きで textlint を実行します。                                        |
+| `fix:collector-sync:lint`     | --fix 付きで collector-sync 内の ruff を実行します。                        |
+| `format`                      | Prettier write のエイリアス（コンテンツおよび nowrap パス）。               |
 
 ## サブモジュールとコンテンツ {#submodules-and-content}
 

--- a/content/ja/site/build/npm-scripts.md
+++ b/content/ja/site/build/npm-scripts.md
@@ -136,7 +136,7 @@ default_lang_commit: 0aff0aab149003b5592edfe186c193047e40c766
 | `update:hugo`                  | 最新の hugo-extended をインストールします。                                               |
 | `update:packages`              | npm-check-updates を実行して依存関係を更新します。                                        |
 | `generate:config:links`        | `lychee.base.toml` とページフロントマターから git 無視の `lychee.toml` を生成します。     |
-| `log:build`、`log:check:links` | 対応するスクリプトを実行し、出力を `tmp/` に tee し、スクリプトの終了コードを伝播します。 |
+| `log:build`、`log:check:links` | 対応するスクリプトを実行し、出力を `tmp/` に tee し、スクリプトの終了コードを伝搬します。 |
 
 ## 注記 {#notes}
 

--- a/content/ja/site/build/npm-scripts.md
+++ b/content/ja/site/build/npm-scripts.md
@@ -4,7 +4,7 @@ description: >-
   OpenTelemetry ウェブサイトのビルド、配信、検証、メンテナンスのための NPM スクリプト。
 weight: 20
 todo: Keep table entries sorted
-default_lang_commit: b7589cf40b05480bc7a2022cf2dd36cc299904fa
+default_lang_commit: 1ff7122fa7e1fd78714d7540b93ec70a3e72d84c
 ---
 
 スクリプトの定義はリポジトリルートの [`package.json`](https://github.com/open-telemetry/opentelemetry.io/blob/main/package.json) にあります。
@@ -69,9 +69,10 @@ default_lang_commit: b7589cf40b05480bc7a2022cf2dd36cc299904fa
 | `fix:format:staged`       | ステージングされたファイルのみをフォーマットします。                        |
 | `fix:i18n`                | i18n フロントマターを追加/修正します（`fix:i18n:new`、`fix:i18n:status`）。 |
 | `fix:l10n`                | ローカリゼーションの修正を適用します。                                      |
+| `fix:link-cache`          | リンクチェックを実行し、コミット済みの `.lycheecache` を更新します。        |
+| `fix:link-cache:double-check` | [ブラウザプローブで失敗したリンクを再検証します][dc]。                  |
+| `fix:link-cache:refresh`  | もっとも古いキャッシュエントリをプルーンし、`fix:link-cache` を実行します。 |
 | `fix:markdown`            | Markdown lint の問題と末尾の空白を修正します。                              |
-| `fix:refcache`            | リンクチェックを実行し、コミット済みの `.lycheecache` を更新します。        |
-| `fix:refcache:refresh`    | もっとも古いキャッシュエントリをプルーンし、`fix:refcache` を実行します。   |
 | `fix:submodule`           | サブモジュールのリビジョンをピンします（`pin:submodule` と同じ）。          |
 | `fix:filenames`           | [ファイルのリネームと廃止されたファイル/フォルダの削除][fn]。               |
 | `fix:dict`                | cspell ワードリストをソートし、フロントマターを正規化します。               |
@@ -100,11 +101,12 @@ default_lang_commit: b7589cf40b05480bc7a2022cf2dd36cc299904fa
 | `fix-and-test:all`         | すべての修正（i18n を含む）を実行し、その後チェック。リンクチェックは1回。[^fat] |
 | `netlify-build:preview`    | `build:preview` を実行し、その後 `diff:check`。                                  |
 | `netlify-build:production` | `build:production` を実行し、その後 `diff:check`。                               |
-| `test-and-fix`             | 修正スクリプト（i18n/refcache/submodule を除く）を実行し、その後チェック。       |
+| `test-and-fix`             | 修正スクリプト（i18n/link-cache/submodule を除く）を実行し、その後チェック。     |
 | `test:all`                 | `test:base` を実行し、その後 `test:compound-tests`。                             |
 | `test:base`                | 基本テスト（`check` と同じ）。                                                   |
 | `test:collector-sync`      | collector-sync テスト。                                                          |
 | `test:compound-tests`      | 複合 `test:*-*` スクリプトを実行します。[^categories]                            |
+| `test:double-check:live`   | [double-check プローブ][dc]のライブスモークチェック。                            |
 | `test:edge-functions:live` | 任意の `node:test` ライブスイート。`--help` をサポート。                         |
 | `test:edge-functions`      | `netlify/edge-functions/**/*.test.ts` に対する Node テストランナー。             |
 | `test:local-tools`         | `scripts/**/*.test.mjs` に対する Node テストランナー。[^categories]              |
@@ -117,9 +119,9 @@ default_lang_commit: b7589cf40b05480bc7a2022cf2dd36cc299904fa
     [テストカテゴリ](/site/testing/#test-categories)を参照してください。
 
 [^fat]:
-    ハウスキーピングのデフォルト: コンテンツ修正の後に `fix:refcache`（リンクチェックを実行し、リンクキャッシュを更新）を実行します。
+    ハウスキーピングのデフォルト: コンテンツ修正の後に `fix:link-cache`（リンクチェックを実行し、リンクキャッシュを更新）を実行します。
     keep-going `all` ランナーを使用してすべての修正を記録します。
-    チェックフェーズは `check:links`（`fix:refcache` がカバー）と `check:i18n`（`fix:i18n` がドリフトステータスを記録した後は冗長）を除外します。
+    チェックフェーズは `check:links`（`fix:link-cache` がカバー）と `check:i18n`（`fix:i18n` がドリフトステータスを記録した後は冗長）を除外します。
     [ハウスキーピング](../ci-workflows/#housekeeping)を参照してください。
 
 ## ユーティリティ {#utilities}
@@ -140,14 +142,14 @@ default_lang_commit: b7589cf40b05480bc7a2022cf2dd36cc299904fa
 
 - **リンクキャッシュ。**
   リンクチェックスクリプトはコミット済みの `.lycheecache` を読み書きします。
-  `fix:refcache*` スクリプトは歴史的な名前を維持しています。
-  詳細は[リンクチェック](../link-checking/)を参照してください。
-- **`test:local-tools:lychee`** は `test:local-tools` のうち `lychee` バイナリを必要とするサブセット（動作フラグメントおよび設定チェックテスト）です。
+  詳細は[リンクチェック](/site/build/link-checking/)を参照してください。
+- **`test:local-tools:lychee`** は `test:local-tools` のうち `lychee` バイナリを必要とするサブセット（動作フラグメントおよび設定チェックテスト、およびエンドツーエンドのドリフトオーバーレイシナリオ）です。
   バイナリが存在しない場合はそれらのテストはスキップされるため、`test:local-tools` は一般的なテストジョブですでにカバーしています。
   末尾の `:lychee` はこのスクリプトを `test:compound-tests`（`test:*-*` にマッチ）から除外し、スイートが2回実行されないようにします。
   リンクチェック CI ジョブは lychee をインストールし、このスクリプトを実行して実際にテストを実行します。
 - **`all`** はリスト内のスクリプトを1つが失敗してもすべて実行し、いずれかが失敗した場合は非ゼロステータスで終了します。
 
-[build kinds]: ../#build-kinds
+[build kinds]: /site/build/#build-kinds
+[dc]: /site/build/link-checking/#double-check
 [fn]: /docs/contributing/pr-checks/#filename-check
 [locale-auto-merge]: ../ci-workflows/#locale-auto-merge


### PR DESCRIPTION
## Summary

Updates `content/ja/site/build/npm-scripts.md` to match the latest English source at
`content/en/site/build/npm-scripts.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

Changes applied:
- **Checking table**: removed `check:links:htmltest` and `check:links:lychee` rows, added `check:links:internal`, updated `check:links:diff` (removed "(pilot)") and `check:links` descriptions
- **Fixing table**: updated `fix:refcache` and `fix:refcache:refresh` descriptions to reflect Lychee migration
- **Footnote [^fat]**: reworded to match updated English
- **Utilities table**: removed `generate:config:links:lychee` row, updated `prepare` and `generate:config:links` descriptions
- **Notes section**: replaced "refcache maintenance" and "Lychee link check (pilot)" bullets with single "Link cache" bullet
- **Reference link**: updated `[build kinds]` from `/site/build/#build-kinds` to `../#build-kinds`
- **Frontmatter**: removed `cSpell:ignore: lycheecache` (removed in EN)

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11006--opentelemetry.netlify.app/ja/site/build/npm-scripts/
- **English (canonical):** https://opentelemetry.io/site/build/npm-scripts/

_(deploy preview may take a few minutes to become available.)_
<!-- preview-section-end -->
