### PR TITLE
Revert "Guard against pre-Lychee-switch PR branches using `/fix:*` (#10970)"

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -96,7 +96,6 @@ jobs:
       action_exit_status: ${{ steps.patch.outputs.action_exit_status }}
       patch_name: pr-fix-${{ github.run_id }}
       patch_skipped: ${{ steps.patch.outputs.patch_skipped }}
-      stale_branch: ${{ steps.stale-branch-guard.outputs.stale_branch }}
 
     steps:
       - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -118,26 +117,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Guard against pre-Lychee-switch branches
-        id: stale-branch-guard
-        # PR branches cut before the Lychee link-checker switch (#10911) still
-        # carry the old refcache wiring, and the patch step runs the head's fix
-        # scripts — which would update the deleted `static/refcache.json`
-        # instead of `.lycheecache`, leaving link checks red.
-        # TODO(2026-08): remove this guard (and the report job's stale-branch
-        # handling) once pre-switch branches (cut before 2026-07-21) have aged
-        # out.
-        run: |
-          if [[ -f static/refcache.json ]]; then
-            echo "stale_branch=true" >> "$GITHUB_OUTPUT"
-            echo "::notice title=Stale PR branch::Head predates the Lychee switch (#10911); skipping fix scripts."
-          else
-            echo "stale_branch=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Run PR action and generate patch
         id: patch
-        if: steps.stale-branch-guard.outputs.stale_branch != 'true'
         # Untrusted: runs the resolved npm script and captures any changes as a
         # patch artifact. Has no write permissions or secrets.
         # NOTE: after `gh pr checkout` above, this local action's definition
@@ -228,13 +209,6 @@ jobs:
           PR_MERGED: ${{ github.event.issue.pull_request.merged_at != null }}
           GENERATE_RESULT: ${{ needs.generate-patch.result }}
           PATCH_SKIPPED: ${{ needs.generate-patch.outputs.patch_skipped }}
-          STALE_BRANCH: ${{ needs.generate-patch.outputs.stale_branch }}
-          # Why the stale-branch guard declined to run the fix scripts; see the
-          # guard step in the generate-patch job, and remove along with it.
-          STALE_BRANCH_MESSAGE: >-
-            This PR branch predates the Lychee link-checker switch (#10911), so
-            its fix scripts would update the old link cache. Update the branch
-            from `main`, then re-run `/fix`.
           COMMAND_EXIT_STATUS:
             ${{ needs.generate-patch.outputs.action_exit_status }}
           APPLY_RESULT: ${{ needs.apply-patch.result }}
@@ -243,10 +217,6 @@ jobs:
         # branch, so the imported text is trusted.
         run: |
           hint=$(node -e 'import("./scripts/gh/pr-fix/index.mjs").then((m) => console.log(m.DIRECTIVE_HINT))')
-          not_run_reason=''
-          if [[ "$STALE_BRANCH" == 'true' ]]; then
-            not_run_reason="$STALE_BRANCH_MESSAGE"
-          fi
           node scripts/gh/patch-report/cli.mjs \
             --pr "$PR_NUM" \
             --comment-id "$ACK_COMMENT_ID" \
@@ -254,7 +224,6 @@ jobs:
             --label "$LABEL" \
             --pr-state "$PR_STATE" \
             --pr-merged "$PR_MERGED" \
-            --not-run-reason "$not_run_reason" \
             --generate-result "$GENERATE_RESULT" \
             --patch-skipped "$PATCH_SKIPPED" \
             --command-exit-status "$COMMAND_EXIT_STATUS" \

--- a/scripts/gh/patch-report/cli.mjs
+++ b/scripts/gh/patch-report/cli.mjs
@@ -30,10 +30,6 @@ Options:
       --label <name>           The action as requested (e.g. the command).
       --pr-state <state>       PR state: 'open' or 'closed' ('' acts as open).
       --pr-merged <bool>       'true' when the PR is merged.
-      --not-run-reason <text>  Reason the pipeline deliberately declined to
-                               run the action, as standalone sentence(s); when
-                               set, it is relayed instead of a generation/apply
-                               outcome.
       --generate-result <r>    Result of the patch-generation job.
       --patch-skipped <bool>   'true' when generation produced no changes.
       --command-exit-status <n> Exit status of the patch-producing command.
@@ -56,7 +52,6 @@ const { values } = parseArgs({
     label: { type: 'string', default: '' },
     'pr-state': { type: 'string', default: '' },
     'pr-merged': { type: 'string', default: '' },
-    'not-run-reason': { type: 'string', default: '' },
     'generate-result': { type: 'string', default: '' },
     'patch-skipped': { type: 'string', default: '' },
     'command-exit-status': { type: 'string', default: '' },
@@ -95,7 +90,6 @@ const body = values.ack
       label: values.label,
       prState: values['pr-state'],
       prMerged: values['pr-merged'],
-      notRunReason: values['not-run-reason'],
       generateResult: values['generate-result'],
       patchSkipped: values['patch-skipped'],
       commandExitStatus: values['command-exit-status'],

--- a/scripts/gh/patch-report/index.mjs
+++ b/scripts/gh/patch-report/index.mjs
@@ -21,10 +21,6 @@
  *                                       closed). '' is treated as open for
  *                                       callers that don't gate on state.
  * @property {string} [prMerged]         'true' when the PR is merged.
- * @property {string} [notRunReason]     When set, the pipeline deliberately
- *                                       declined to run the action; the reason
- *                                       to relay, as one or more standalone
- *                                       sentences.
  * @property {string} generateResult     Result of the patch-generation job:
  *                                       'success' | 'failure' | 'cancelled'.
  * @property {string} patchSkipped       'true' when generation produced no
@@ -85,7 +81,6 @@ export function buildOutcomeComment({
   label,
   prState,
   prMerged,
-  notRunReason,
   generateResult,
   patchSkipped,
   commandExitStatus,
@@ -104,12 +99,7 @@ export function buildOutcomeComment({
     return `❌ This PR ${why}, so ${what} was not run: such actions only apply to open PRs. ${logs}`;
   }
 
-  // 1. The pipeline deliberately declined to run the action.
-  if (notRunReason) {
-    return `⚠️ ${what} was not run. ${notRunReason} ${logs}`;
-  }
-
-  // 2. Patch generation did not succeed: no changes were ever captured.
+  // 1. Patch generation did not succeed: no changes were ever captured.
   if (generateResult === 'cancelled') {
     return `⚠️ ${what} was cancelled before any changes were generated. ${logs}`;
   }
@@ -122,7 +112,7 @@ export function buildOutcomeComment({
     return `❌ ${what} could not be run, or its changes could not be captured. ${logs}`;
   }
 
-  // 3. Generation succeeded but produced no changes.
+  // 2. Generation succeeded but produced no changes.
   if (patchSkipped === 'true') {
     if (commandExitStatus && commandExitStatus !== '0') {
       return (
@@ -133,7 +123,7 @@ export function buildOutcomeComment({
     return `ℹ️ ${what} made no changes; nothing to commit. ${logs}`;
   }
 
-  // 4. Changes were produced: report how applying them went.
+  // 3. Changes were produced: report how applying them went.
   if (applyResult === 'cancelled') {
     return `⚠️ ${what} produced changes, but applying them was cancelled. ${logs}`;
   }

--- a/scripts/gh/patch-report/index.test.mjs
+++ b/scripts/gh/patch-report/index.test.mjs
@@ -123,31 +123,6 @@ describe('buildOutcomeComment', () => {
     assert.equal(build({ prState: 'open' }), build({}));
   });
 
-  test('not-run reason: pipeline declined to run the action', () => {
-    const body = build({ notRunReason: 'The branch is stale.' });
-    assert.equal(
-      body,
-      `⚠️ \`fix:refcache\` was not run. The branch is stale. ${LOGS}`,
-    );
-  });
-
-  test('not-run reason takes precedence over generation and apply outcomes', () => {
-    const body = build({
-      notRunReason: 'The branch is stale.',
-      generateResult: 'failure',
-      applyResult: 'skipped',
-    });
-    assert.match(body, /was not run\. The branch is stale\./);
-  });
-
-  test('closed PR takes precedence over a not-run reason', () => {
-    const body = build({
-      prState: 'closed',
-      notRunReason: 'The branch is stale.',
-    });
-    assert.match(body, /^❌ This PR is closed/);
-  });
-
   test('label links to the directive comment when its URL is given', () => {
     const body = build({ directiveUrl: 'https://example.test/c/1' });
     assert.match(
@@ -182,34 +157,31 @@ describe('buildOutcomeComment', () => {
               for (const hint of ['Any hint text.', '']) {
                 for (const prState of ['open', 'closed', '']) {
                   for (const directiveUrl of ['d', '']) {
-                    for (const notRunReason of ['A reason.', '']) {
-                      const body = buildOutcomeComment({
-                        label,
-                        prState,
-                        notRunReason,
-                        generateResult,
-                        patchSkipped,
-                        commandExitStatus,
-                        applyResult,
-                        runId: '1',
-                        runUrl: 'u',
-                        directiveUrl,
-                        hint,
-                      });
+                    const body = buildOutcomeComment({
+                      label,
+                      prState,
+                      generateResult,
+                      patchSkipped,
+                      commandExitStatus,
+                      applyResult,
+                      runId: '1',
+                      runUrl: 'u',
+                      directiveUrl,
+                      hint,
+                    });
+                    assert.ok(
+                      typeof body === 'string' && body.length > 0,
+                      'comment should be a non-empty string',
+                    );
+                    assert.ok(
+                      body.endsWith('See [run 1](u).'),
+                      `comment should end with the run link: ${body}`,
+                    );
+                    if (directiveUrl) {
                       assert.ok(
-                        typeof body === 'string' && body.length > 0,
-                        'comment should be a non-empty string',
+                        body.includes('](d)'),
+                        `comment should link the directive: ${body}`,
                       );
-                      assert.ok(
-                        body.endsWith('See [run 1](u).'),
-                        `comment should end with the run link: ${body}`,
-                      );
-                      if (directiveUrl) {
-                        assert.ok(
-                          body.includes('](d)'),
-                          `comment should link the directive: ${body}`,
-                        );
-                      }
                     }
                   }
                 }


### PR DESCRIPTION
- Reverts #10970 (`git revert 2728c8fbf`): removes the `/fix` stale-branch guard, its patch-report plumbing, and tests.
- The guard never fired: 220 pr-actions runs and 6 real `/fix` executions since merge, zero declines.
- Coverage is already in place:
  - All affected PRs got recovery instructions in the #10990 sweep; the cohort is dormant and shrinking (91 → 51 open).
  - FILENAME (#10993) guards the re-add class, not this one: stale branches fail as merge conflicts, where checks don't run.
- Why now: the revert is still clean, and upcoming pr-actions work touches these files.
- Residual risk (`/fix` on a stale branch): recovery is documented in #10990; if it ever bites, the right shape is a branch-update action, not a guard.