### PR TITLE
[ja] update translation of content/en/docs/demo/services/_index.md

### DIFF
--- a/content/ja/docs/demo/services/_index.md
+++ b/content/ja/docs/demo/services/_index.md
@@ -1,8 +1,7 @@
 ---
 title: サービス
 aliases: [service_table, service-table]
-default_lang_commit: 5b243d6b471ea2b384fa931e7ebfece074b1f2e5 # patched
-drifted_from_default: true
+default_lang_commit: 0916db501b8b2562b21e2fb56dea97aab38d3266
 ---
 
 リクエストフローを可視化するには、[サービスのダイアグラム](../architecture/)を確認してください。
@@ -21,7 +20,6 @@ drifted_from_default: true
 | [負荷生成](load-generator/)             | Python/Locust | 実際のユーザー購買フローを模したリクエストを、フロントエンドに継続的に送信します。                                                            |
 | [支払い](payment/)                      | JavaScript    | 指定されたクレジットカード情報（モック）に対して、指定された金額を請求し、トランザクションのIDを返却します。                                  |
 | [商品カタログ](product-catalog/)        | Go            | JSONファイルに基づく商品のカタログと、商品検索機能及び個別商品の取得機能を提供します。                                                        |
-| [商品レビュー](product-reviews/)        | Python        | 商品の説明とレビューに基づいて、商品のレビューを返却し、特定の商品に関する質問に回答します。                                                  |
 | [見積もり](quote/)                      | PHP           | 発送される商品の点数に基づいて、送料を計算します。                                                                                            |
 | [レコメンデーション](recommendation/)   | Python        | カートの内容に基づいて、他の商品をレコメンドします。                                                                                          |
 | [配送](shipping/)                       | Rust          | ショッピングカートに基づいて送料の見積もりを提示します。指定された住所に商品を配送します（モック）。                                          |


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/demo/services/_index.md` to match the latest English source at
`content/en/docs/demo/services/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff removed the `product-reviews` service row from the services table.
The corresponding Japanese row has been deleted.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11017--opentelemetry.netlify.app/ja/docs/demo/services/
- **English (canonical):** https://opentelemetry.io/docs/demo/services/

_(deploy preview will be available once Netlify finishes building.)_
<!-- preview-section-end -->
