### PR TITLE
[ja] update translation of content/en/docs/demo/_index.md

### DIFF
--- a/content/ja/docs/demo/_index.md
+++ b/content/ja/docs/demo/_index.md
@@ -4,8 +4,7 @@ linkTitle: デモ
 cascade:
   repo: https://github.com/open-telemetry/opentelemetry-demo
 weight: 180
-default_lang_commit: 906771a74807a998613527841d296e49d3609a9f # patched
-drifted_from_default: true
+default_lang_commit: 0916db501b8b2562b21e2fb56dea97aab38d3266
 ---
 
 [OpenTelemetryデモ](/ecosystem/demo/)のドキュメンテーションへようこそ。
@@ -22,20 +21,20 @@ drifted_from_default: true
 
 特定の言語の計装がどのように機能するかを理解したい場合は、ここから始めてください。
 
-| 言語       | 自動計装                                                                                                  | 計装ライブラリ                                                                         | 手動計装                                                                                                  |
-| ---------- | --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| .NET       | [会計サービス](services/accounting/)                                                                      | [カートサービス](services/cart/)                                                       | [カートサービス](services/cart/)                                                                          |
-| C++        |                                                                                                           |                                                                                        | [通貨サービス](services/currency/)                                                                        |
-| Elixir     |                                                                                                           | [Flagd-UIサービス](services/flagd-ui/)                                                 |                                                                                                           |
-| Go         |                                                                                                           | [決済サービス](services/checkout/), [商品カタログサービス](services/product-catalog/)  | [決済サービス](services/checkout/), [商品カタログサービス](services/product-catalog/)                     |
-| Java       | [広告サービス](services/ad/)                                                                              |                                                                                        | [広告サービス](services/ad/)                                                                              |
-| JavaScript | [支払いサービス](services/payment/)                                                                       |                                                                                        | [支払いサービス](services/payment/)                                                                       |
-| TypeScript |                                                                                                           | [フロントエンド](services/frontend/), [React Nativeアプリ](services/react-native-app/) | [フロントエンド](services/frontend/)                                                                      |
-| Kotlin     |                                                                                                           | [不正検知サービス](services/fraud-detection/)                                          |                                                                                                           |
-| PHP        |                                                                                                           | [見積サービス](services/quote/)                                                        | [見積サービス](services/quote/)                                                                           |
-| Python     | [レコメンデーションサービス](services/recommendation/)、[商品レビューサービス](services/product-reviews/) |                                                                                        | [レコメンデーションサービス](services/recommendation/)、[商品レビューサービス](services/product-reviews/) |
-| Ruby       |                                                                                                           | [メールサービス](services/email/)                                                      | [メールサービス](services/email/)                                                                         |
-| Rust       |                                                                                                           | [配送サービス](services/shipping/)                                                     | [配送サービス](services/shipping/)                                                                        |
+| 言語       | 自動計装                                               | 計装ライブラリ                                                                         | 手動計装                                                                              |
+| ---------- | ------------------------------------------------------ | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| .NET       | [会計サービス](services/accounting/)                   | [カートサービス](services/cart/)                                                       | [カートサービス](services/cart/)                                                      |
+| C++        |                                                        |                                                                                        | [通貨サービス](services/currency/)                                                    |
+| Elixir     |                                                        | [Flagd-UIサービス](services/flagd-ui/)                                                 |                                                                                       |
+| Go         |                                                        | [決済サービス](services/checkout/), [商品カタログサービス](services/product-catalog/)  | [決済サービス](services/checkout/), [商品カタログサービス](services/product-catalog/) |
+| Java       | [広告サービス](services/ad/)                           |                                                                                        | [広告サービス](services/ad/)                                                          |
+| JavaScript | [支払いサービス](services/payment/)                    |                                                                                        | [支払いサービス](services/payment/)                                                   |
+| TypeScript |                                                        | [フロントエンド](services/frontend/), [React Nativeアプリ](services/react-native-app/) | [フロントエンド](services/frontend/)                                                  |
+| Kotlin     |                                                        | [不正検知サービス](services/fraud-detection/)                                          |                                                                                       |
+| PHP        |                                                        | [見積サービス](services/quote/)                                                        | [見積サービス](services/quote/)                                                       |
+| Python     | [レコメンデーションサービス](services/recommendation/) |                                                                                        | [レコメンデーションサービス](services/recommendation/)                                |
+| Ruby       |                                                        | [メールサービス](services/email/)                                                      | [メールサービス](services/email/)                                                     |
+| Rust       |                                                        | [配送サービス](services/shipping/)                                                     | [配送サービス](services/shipping/)                                                    |
 
 ## サービスドキュメント {#service-documentation}
 
@@ -50,7 +49,6 @@ drifted_from_default: true
 - [負荷生成ツール](services/load-generator/)
 - [支払いサービス](services/payment/)
 - [商品カタログサービス](services/product-catalog/)
-- [商品レビューサービス](services/product-reviews/)
 - [見積サービス](services/quote/)
 - [レコメンデーションサービス](services/recommendation/)
 - [配送サービス](services/shipping/)


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/demo/_index.md` to match the latest English source at
`content/en/docs/demo/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

### Changes applied

- **Table (Language Feature Reference):** Removed Product Reviews Service from
  the Python row (both Automatic Instrumentation and Manual Instrumentation
  columns), matching the English source change. Adjusted table column widths.
- **Service Documentation list:** Removed the Product Reviews Service entry.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11019--opentelemetry.netlify.app/ja/docs/demo/
- **English (canonical):** https://opentelemetry.io/docs/demo/

_(deploy preview may still be building — the URLs will work once Netlify finishes.)_
<!-- preview-section-end -->
