### PR TITLE
[ja] update translation of content/en/blog/2026/go-compile-time-instrumentation-v1/index.md

### DIFF
--- a/content/ja/blog/2026/go-compile-time-instrumentation-v1/index.md
+++ b/content/ja/blog/2026/go-compile-time-instrumentation-v1/index.md
@@ -5,10 +5,9 @@ date: 2026-07-16
 author: '[Kemal Akkoyun](https://github.com/kakkoyun) (Datadog)'
 issue: 10670
 sig: Go Compile-Time Instrumentation
-default_lang_commit: d88ab6df454cbc6de0b0ae5a4de4684e1154cea4
-drifted_from_default: true
+default_lang_commit: ec870712704ae037419e4e420b7fa3be04e10297
 # prettier-ignore
-cSpell:ignore: Akkoyun Azhar Cabify Castañé Dario GOFLAGS Haibin Martinez Momin otelc toolexec Xabier
+cSpell:ignore: Akkoyun Azhar Cabify Castañé Dario Haibin Martinez Momin otelc toolexec Xabier
 ---
 
 Java、Python、Node.js、.NETで開発している場合、コードを編集せずにOpenTelemetryをアプリケーションへ追加することが長年可能で、起動時にエージェントをアタッチすれば、テレメトリーの送信が始まります。
@@ -49,30 +48,11 @@ Goは単一の静的バイナリにコンパイルされるため、長い間、
 このプロジェクトは、標準のGoツールチェーンをラップする`otelc`というコマンドラインツールを提供します。
 ビルドの変更は1行だけで、以前 `go build` を実行していた場所で `otelc go build` を実行します。
 `go` の後に続くすべての引数はツールチェーンに転送されるため、ビルドの残りの部分は変わりません。
-
-`go install` でインストールします。
-
-```sh
-go install go.opentelemetry.io/otelc/tool/cmd/otelc@latest
-```
-
-次に、これを介してアプリケーションをビルドします。
-
-```sh
-otelc go build -o myapp .
-```
-
-ビルドコマンドを変更したくない場合は、モジュールを準備するために一度 `otelc setup` を実行し、続いて、`GOFLAGS`を通じてGoツールチェーンを`otelc`に向け、通常どおり`go build`を実行します。
-
-```sh
-otelc setup
-export GOFLAGS="${GOFLAGS} '-toolexec=otelc toolexec'"
-go build -o myapp .
-```
-
+同じ置き換えはコンテナビルドでも機能します。
 デフォルトでは、`otelc` はモジュール内のサポート対象ライブラリを検出し、設定やコード変更なしで自動的に計装します。
-同じ置き換えはコンテナビルドでも機能し、ビルドステージに `otelc` をインストールして、`Dockerfile` の `go build` 行を `otelc go build` に置き換えます。
-完全な手順は、[コンパイル時の計装のドキュメント](/docs/zero-code/go/compile-time/)を参照してください。
+
+`otelc` のインストール、アプリケーションのビルド、生成されるテレメトリーの確認については、[入門ガイド](/docs/zero-code/go/compile-time/getting-started/)に従ってください。
+設定、サポートされるライブラリ、トラブルシューティングなどについては、[コンパイル時の計装のドキュメント](/docs/zero-code/go/compile-time/)を参照してください。
 
 ## どのような場合に使うべきか {#when-should-you-use-it}
 


### PR DESCRIPTION
## Summary

Updates `content/ja/blog/2026/go-compile-time-instrumentation-v1/index.md` to match the latest English source at
`content/en/blog/2026/go-compile-time-instrumentation-v1/index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

### Changes applied

- **Frontmatter**: removed `GOFLAGS` from `cSpell:ignore` list (EN removed it).
- **Getting Started section**: removed detailed `go install`, code blocks, and `otelc setup`/`GOFLAGS` instructions. Replaced with a shorter paragraph pointing to the new [getting-started guide](/docs/zero-code/go/compile-time/getting-started/) and the existing [compile-time instrumentation documentation](/docs/zero-code/go/compile-time/). Moved the container-build mention into the intro paragraph, matching the EN restructuring.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11025--opentelemetry.netlify.app/ja/blog/2026/go-compile-time-instrumentation-v1/
- **English (canonical):** https://opentelemetry.io/blog/2026/go-compile-time-instrumentation-v1/

_(deploy preview status: pending. The URLs will work once Netlify finishes building.)_
<!-- preview-section-end -->
