### PR TITLE
[ja] update translation of content/en/docs/demo/sample-configurations/tail-sampling-service-criticality.md

### DIFF
--- a/content/ja/docs/demo/sample-configurations/tail-sampling-service-criticality.md
+++ b/content/ja/docs/demo/sample-configurations/tail-sampling-service-criticality.md
@@ -1,8 +1,7 @@
 ---
 title: service.criticality を使用したテイルベースサンプリング
 linkTitle: テイルサンプリング
-default_lang_commit: d503571bbd711e05b9e6f85966fed6f0e00ba910
-drifted_from_default: true
+default_lang_commit: 8fd99e125e5510385b18b541d97c283e28f76ef2
 ---
 
 この例では、OpenTelemetry Collector においてインテリジェントなテイルベースのサンプリング決定を行うために、リソース属性 [`service.criticality`](/docs/specs/semconv/resource/service/#service) を使用する方法を示します。
@@ -13,7 +12,7 @@ drifted_from_default: true
 | ---------- | ------------------ | ---------------------------------------------------------------------------- |
 | `critical` | 100%               | 支払い、チェックアウト、フロントエンド、フロントエンドプロキシ               |
 | `high`     | 50%                | カート、商品カタログ、通貨換算、配送                                         |
-| `medium`   | 10%                | レコメンデーション、広告、商品レビュー、メール                               |
+| `medium`   | 10%                | レコメンデーション、広告、メール                                             |
 | `low`      | 1%                 | 会計、不正検知、画像プロバイダー、負荷生成、見積もり、flagd、flagd-ui、Kafka |
 
 ## コレクター設定 {#collector-configuration}


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/demo/sample-configurations/tail-sampling-service-criticality.md` to match the latest English source at
`content/en/docs/demo/sample-configurations/tail-sampling-service-criticality.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff removed `product-reviews` from the medium-criticality services table row.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.


<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11032--opentelemetry.netlify.app/ja/docs/demo/sample-configurations/tail-sampling-service-criticality/
- **English (canonical):** https://opentelemetry.io/docs/demo/sample-configurations/tail-sampling-service-criticality/

<!-- preview-section-end -->
