### PR TITLE
[ja] update translation of content/en/docs/demo/architecture.md

### DIFF
--- a/content/ja/docs/demo/architecture.md
+++ b/content/ja/docs/demo/architecture.md
@@ -3,8 +3,7 @@ title: デモのアーキテクチャ
 linkTitle: アーキテクチャ
 aliases: [current_architecture]
 body_class: otel-mermaid-max-width
-default_lang_commit: c1e141558ab36cc1ab9f864728e4665e272ac131
-drifted_from_default: true
+default_lang_commit: 867f1ba6a44275ce3bc7d8708765a78baaa0287f
 ---
 
 **OpenTelemetryデモ** は、異なるプログラミング言語で書かれた複数のマイクロサービスから構成されており、gRPCとHTTPを使って相互に通信を行います。
@@ -26,11 +25,9 @@ fraud-detection(不正検知):::kotlin
 frontend(フロントエンド):::typescript
 frontend-proxy(フロントエンドプロキシ <br/>&#40Envoy&#41):::cpp
 image-provider(画像プロバイダー <br/>&#40nginx&#41):::cpp
-llm(LLM):::python
 load-generator([負荷生成ツール]):::python
 payment(支払い):::javascript
 product-catalog(商品カタログ):::golang
-product-reviews(商品レビュー):::python
 quoteservice(見積サービス):::php
 recommendation(レコメンデーション):::python
 shipping(配送):::rust
@@ -63,22 +60,13 @@ frontend -->|gRPC| checkout
 frontend -->|HTTP| shipping
 frontend ---->|gRPC| recommendation
 frontend -->|gRPC| product-catalog
-frontend -->|gRPC| product-reviews
 
 frontend-proxy -->|gRPC| flagd
 frontend-proxy -->|HTTP| frontend
 frontend-proxy -->|HTTP| flagd-ui
 frontend-proxy -->|HTTP| image-provider
 
-llm -->|gRPC| flagd
-llm ---> product-reviews
-
 payment -->|gRPC| flagd
-
-product-reviews -->|gRPC| flagd
-product-reviews -->|gRPC| product-catalog
-product-reviews -->|gRPC| llm
-product-reviews ---> postgresql
 
 queue -->|TCP| accounting
 queue -->|TCP| fraud-detection


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/demo/architecture.md` to match the latest English source at
`content/en/docs/demo/architecture.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff removed the `llm` (LLM) and `product-reviews` (Product Reviews)
services from the mermaid service diagram, along with all their edge connections.
This update applies the same deletions to the Japanese file.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11038--opentelemetry.netlify.app/ja/docs/demo/architecture/
- **English (canonical):** https://opentelemetry.io/docs/demo/architecture/

_(deploy preview may still be building)_
<!-- preview-section-end -->
