### PR TITLE
[ja] update translation of content/en/announcements/kubecon-japan.md

### DIFF
--- a/content/ja/announcements/kubecon-japan.md
+++ b/content/ja/announcements/kubecon-japan.md
@@ -7,16 +7,12 @@ weight: 20260730
 params:
   eventUrl: &eventUrl >-
     https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/
-  # Use this when the blog post is ready:
-  # blogPostURL: /blog/2026/kubecon-japan/
-  blogPostURL: *eventUrl
-default_lang_commit: f34ea47f2795ab7823c24968f7e6874ee9381cf6
-drifted_from_default: true
+  blogPostURL: /blog/2026/kubecon-japan/
+default_lang_commit: 7cded84e3bd5923350bc541714655e12401a59cf
 ---
 
-[**{{% param title %}}**][LF]が **7月28日から30日に横浜で開催**
-<span class="d-none d-md-inline"><br></span>
-<span class="d-none d-sm-inline"> Cloud Nativeコミュニティと一緒に</span>、[協力し、学び、共有しましょう][blog]！
+[**{{% param title %}}**][LF], **<span class="text-nowrap">July 28–30,</span>
+Yokohama**. [詳細][blog]
 
 [blog]: <{{% param blogPostURL %}}>
 [LF]: <{{% param eventUrl %}}register/?{{% _param utmParam %}}>


### PR DESCRIPTION
## Summary

Updates `content/ja/announcements/kubecon-japan.md` to match the latest English source at
`content/en/announcements/kubecon-japan.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

Changes applied:
- Updated `blogPostURL` from YAML anchor reference (`*eventUrl`) to the actual blog post URL (`/blog/2026/kubecon-japan/`), removing the comment-out placeholder lines.
- Simplified the body text to match the English source, which replaced the elaborate call-to-action with a concise `[Details][blog]` link (translated as `[詳細][blog]`).

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11043--opentelemetry.netlify.app/ja/announcements/kubecon-japan/
- **English (canonical):** https://opentelemetry.io/announcements/kubecon-japan/

_(deploy preview will be available once Netlify finishes building.)_
<!-- preview-section-end -->
