### PR TITLE
[ja] add translation of content/en/api.md

### DIFF
--- a/content/ja/api.md
+++ b/content/ja/api.md
@@ -1,0 +1,9 @@
+---
+title: API リファレンス
+linkTitle: API
+redirect: /docs/languages/#api-references
+manualLinkTarget: _blank
+build: { render: link }
+aliases: [api-docs]
+default_lang_commit: 2c79639c8761264b6084f89827f34a3854d78da4
+---


### PR DESCRIPTION
## Summary

Translates `content/en/api.md` into Japanese as `content/ja/api.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11050--opentelemetry.netlify.app/ja/api/
- **English (canonical):** https://opentelemetry.io/api/

<!-- preview-section-end -->
