### PR TITLE
feat(skills): add /review-registry-pr

### DIFF
--- a/.claude/skills/review-registry-pr/SKILL.md
+++ b/.claude/skills/review-registry-pr/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: review-registry-pr
+description: >-
+  Review PRs changing registry entries (data/registry/*.yml) or the ecosystem
+  lists (data/ecosystem/*.yaml). Validate schema gaps, registryType and license
+  rules, entry-vs-vendor placement, and common merge blockers. By default,
+  sweeps all open registry and ecosystem PRs; reviews a single PR when given a
+  number or URL.
+argument-hint: '[PR number or URL (optional)]'
+allowed-tools: Bash Read Grep Glob
+model: sonnet
+effort: medium
+disable-model-invocation: true
+---
+
+# Review Registry PR
+
+## Arguments
+
+- **No argument** (the default): sweep all open registry and ecosystem PRs
+  (those labeled `registry`, plus PRs touching `data/ecosystem/`), following the
+  Target PRs section of the procedure below.
+- **Argument given**: resolve `$ARGUMENTS` to a PR number (a bare number, a
+  `#`-prefixed number, or a GitHub URL with `/pull/<N>`). If unrecognizable,
+  ask.
+
+## Usage
+
+Read and follow
+[review-registry-pr.md](../../../content/en/site/skills/review-registry-pr.md).

--- a/.lycheecache
+++ b/.lycheecache
@@ -4089,6 +4089,7 @@ https://github.com/open-telemetry/opentelemetry.io/blob/main/.textlintrc.yml,206
 https://github.com/open-telemetry/opentelemetry.io/blob/main/config/_default/module-template.yaml,206,1784355595
 https://github.com/open-telemetry/opentelemetry.io/blob/main/content/en/_index.md,200,1784701477
 https://github.com/open-telemetry/opentelemetry.io/blob/main/content/en/blog/_index.md,200,1784583090
+https://github.com/open-telemetry/opentelemetry.io/blob/main/data/registry-schema.json,200,1785154173
 https://github.com/open-telemetry/opentelemetry.io/blob/main/data/spec-versions.yml,200,1784960537
 https://github.com/open-telemetry/opentelemetry.io/blob/main/layouts/_markup/render-link.html,200,1784701477
 https://github.com/open-telemetry/opentelemetry.io/blob/main/layouts/_shortcodes/collector-component-rows.html,206,1784355929
@@ -4101,6 +4102,7 @@ https://github.com/open-telemetry/opentelemetry.io/blob/main/scripts/content-mod
 https://github.com/open-telemetry/opentelemetry.io/blob/main/scripts/content-modules/cp-pages.sh,206,1784284877
 https://github.com/open-telemetry/opentelemetry.io/blob/main/scripts/gh/specs/create-or-finalize-pr.mjs,200,1785134667
 https://github.com/open-telemetry/opentelemetry.io/blob/main/scripts/gh/specs/pick-branch.mjs,200,1785134668
+https://github.com/open-telemetry/opentelemetry.io/blob/main/templates/registry-entry.yml,200,1785154173
 https://github.com/open-telemetry/opentelemetry.io/branches/all?query=semconv-integration,206,1784284695
 https://github.com/open-telemetry/opentelemetry.io/branches/all?query=spec-integration,206,1784284686
 https://github.com/open-telemetry/opentelemetry.io/commits/main/,200,1784701477

--- a/.lycheecache
+++ b/.lycheecache
@@ -4055,6 +4055,7 @@ https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/refr
 https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/resolve-link-cache-conflicts/SKILL.md,206,1784355937
 https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/review-blog-post/SKILL.md,206,1784355940
 https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/review-pull-request/SKILL.md,206,1784355943
+https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/review-registry-pr/SKILL.md,206,1784355947
 https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/setup-new-localization/SKILL.md,200,1784960537
 https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/update-git-submodule/SKILL.md,206,1784355951
 https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/update-i18n-drift-status/SKILL.md,206,1784355944

--- a/content/en/site/skills/_index.md
+++ b/content/en/site/skills/_index.md
@@ -43,6 +43,11 @@ As mentioned above, skills are defined in [`.claude/skills/`][], they are:
 - [`/review-pull-request <pr-number-or-url>`][review-pull-request]: review a
   pull request for CI check semantics, CLA and approval-label workflow,
   link-cache handling, locale rules, and content quality.
+- [`/review-registry-pr [pr-number-or-url]`][review-registry-pr]: review
+  registry entry (`data/registry/`) and ecosystem list (`data/ecosystem/`) PRs
+  for schema gaps that CI misses, placement, license and naming rules, and
+  common merge blockers. With no argument, sweeps all open registry and
+  ecosystem PRs.
 - [`/setup-new-localization <kickoff-issue | lang-code>`][setup-new-localization]:
   set up a new website localization end-to-end — Hugo language block, content
   mounts, cSpell word list, `lang:<lang>` labeler config and label,
@@ -93,6 +98,8 @@ See the section index below.
   https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/review-blog-post/SKILL.md
 [review-pull-request]:
   https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/review-pull-request/SKILL.md
+[review-registry-pr]:
+  https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/review-registry-pr/SKILL.md
 [setup-new-localization]:
   https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/setup-new-localization/SKILL.md
 [update-i18n-drift-status]:

--- a/content/en/site/skills/review-registry-pr.md
+++ b/content/en/site/skills/review-registry-pr.md
@@ -1,0 +1,160 @@
+---
+title: Review registry PR
+description: >-
+  How to review PRs that change registry entries or ecosystem lists.
+cSpell:ignore: BUSL SSPL
+---
+
+Follow these steps to review PRs that change [registry][] entries
+(`data/registry/*.yml`) or the ecosystem lists (`data/ecosystem/*.yaml`). This
+procedure covers the registry and ecosystem review layer only; for CI-check
+decoding, CLA and label mechanics, and general content quality, use the
+[review-pull-request][] skill. The [adding guide][adding], the [registry
+schema][], and the [entry template][template] are the authoritative sources.
+When this page drifts from them, trust them.
+
+This procedure is read-only: never approve, label, or merge.
+
+## Target PRs
+
+Review the single PR when given a number or URL. With no argument, sweep:
+
+1. List the open PRs labeled `registry`
+   (`gh pr list --label registry --state open --json number,title,author,isDraft`).
+2. Add open PRs that touch `data/ecosystem/`. Such PRs get no auto-applied
+   label, so find them through their changed files (for example,
+   `gh pr list --state open --json number,files` filtered locally).
+3. Route before reviewing:
+   - otelbot PRs on `otelbot/auto-update-registry-*` branches belong to the
+     [approve-registry-update][] skill.
+   - PRs that touch neither `data/registry/` nor `data/ecosystem/` belong to the
+     [review-pull-request][] skill.
+4. Report the sweep assessment before processing any PR: one line per PR with
+   number, title, and whether you will process it (and the reason when skipped).
+
+## Review a PR
+
+1. Gather the PR metadata, diff, and checks (`gh pr view`, `gh pr diff`,
+   `gh pr checks`). Classify each changed file: registry entry added, modified,
+   or deleted; ecosystem list; other.
+2. Confirm [placement](#placement). A misfiled submission is a blocking finding:
+   point the contributor to the right list and its how-to-add guide.
+3. Apply every applicable rule section below to every changed file.
+4. Check the [common merge blockers](#common-merge-blockers).
+5. Report with these headings: **CI status summary**, **Required changes
+   (blocking)**, **Suggested improvements (non-blocking)**, and **Positive
+   feedback**. The review is complete only when you have applied every rule
+   section to every changed file and reported each as pass, fail, or not
+   applicable.
+
+## Placement
+
+| Submission                                                                | Belongs in                                                                                                                                    |
+| ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Library, service, or app with native OTel support or a first-party plugin | `data/registry/*.yml`; the [Integrations](/ecosystem/integrations/) page is generated from registry data                                      |
+| Organization offering observability that consumes OTLP                    | [`data/ecosystem/vendors.yaml`][vendors]                                                                                                      |
+| End-user organization providing no OTel services                          | [`data/ecosystem/adopters.yaml`][adopters]                                                                                                    |
+| Customized non-collector OTel components                                  | [`data/ecosystem/distributions.yaml`][distributions]; Collector distributions go to [Collector distributions](/docs/collector/distributions/) |
+
+## Registry entries: what CI does not catch
+
+Schema validation (`npm run check:registry`) enforces less than the docs
+require. Check by hand:
+
+- `registryType` and `language` are optional to the schema. Verify both are
+  present and use values from the schema enums. The [adding guide][adding]
+  documents only 11 of the 19 `registryType` values; flag entries using an
+  undocumented type for a maintainer call.
+- The validator only globs `*.yml`: a `.yaml` file silently bypasses validation.
+  Require the `.yml` extension.
+- The license gate only rejects the literal string `Commercial`. `proprietary`,
+  `BUSL-1.1`, `SSPL`, or lowercase `commercial` pass CI, but only
+  `application integration` entries may be non-OSS; non-OSI licenses may be
+  rejected per the [template][].
+- Nothing resolves `package.name`. Verify the package exists on the named
+  package registry (npm, PyPI, pkg.go.dev).
+- URL liveness is not gated at submission time. Spot-check new `repo` and
+  `website` URLs.
+- No check enforces filenames. The naming rule is codified in
+  `scripts/registry-scanner/index.mjs`: `<registryType>-<language>-<name>.yml`,
+  inverted for collector components (`collector-<registryType>-<name>.yml`).
+  Also search `data/registry/` for an existing entry: a component may already be
+  listed under a different filename.
+
+## Registry entries: type and flag rules
+
+- `core` is for OpenTelemetry project components only. `exporter` and `receiver`
+  are not for third-party components that merely export or receive OTel data.
+  See [registry types][adding-types].
+- `application integration` entries and `isNative: true` instrumentation entries
+  land on the Integrations page, where the Hugo build hard-requires
+  `urls.website` and `urls.docs`; a missing one fails the `BUILD` job, not the
+  registry check.
+- Each author needs an email or an `https://` URL, and the name cannot contain
+  "OpenTelemetry" (except the exact `OpenTelemetry Authors`). Names and
+  descriptions must follow the [marketing guidelines][] and the Linux Foundation
+  trademark usage guidelines.
+- Deprecations need `deprecated.reason`, and the reason should name the
+  replacement. Entry removal follows the [updating policy][updating].
+
+## Ecosystem lists
+
+`data/ecosystem/` has no schema, no auto-label, and no component owner. This
+review is the only gate. The Hugo templates fail silently, so check field sets
+against current entries:
+
+- Adopters: `name`, `url`, `components`, `reference`, `referenceTitle`,
+  `contact`. A `reference` without a `referenceTitle` renders an empty link
+  label. Keep the list alphabetical.
+- Distributions: `name`, `url`, `docsUrl`, `components`. A missing `docsUrl`
+  renders an empty link. Sorted at render time.
+- Vendors: `name`, `nativeOTLP`, `url`, `contact`, `oss`, `commercial`. An
+  omitted boolean silently renders as "No". Sorted at render time.
+- Reject fields copied from old entries that no template reads: `distribution`
+  and `documentation`.
+- Vendor entries must link docs proving native OTLP consumption and, when
+  claiming open source, link proof; an open source distribution does not qualify
+  ([how to add a vendor][vendors]). Adopters are CNCF end-user organizations
+  with a reference link ([how to add an adopter][adopters]).
+- `vendors.yaml` is excluded from spell checking; `adopters.yaml` and
+  `distributions.yaml` need `# cSpell:ignore` header updates for unusual names.
+
+## Links and spelling
+
+- For link-cache mechanics, see [PR checks][pr-checks] and the
+  [review-pull-request][] skill. Never hand-edit `.lycheecache`. Append
+  `?link-check=no` only for URLs that block automated checkers.
+- For words unknown to the spell checker in registry YAML, add a
+  `# cSpell:ignore <word>` comment line above `title:` per the [style guide][].
+
+## Common merge blockers
+
+The most common reasons registry PRs stall; check them early:
+
+- A fork branch named `main` fails the `BRANCH NAME` check, and the contributor
+  must open a new PR from a different branch.
+- When maintainer edits are disabled or the fork is org-owned, `/fix:*` commands
+  cannot push; ask the contributor to run the fix locally (for example,
+  `npm run fix:link-cache`) and push.
+- The CLA check covers every commit author, including co-authors introduced by
+  applying suggestions.
+- The PR may duplicate an existing open PR or an existing entry.
+
+[adding]: /ecosystem/registry/adding/
+[adding-types]: /ecosystem/registry/adding/#registry-types
+[adopters]: /ecosystem/adopters/#how-to-add
+[approve-registry-update]:
+  https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/approve-registry-update/SKILL.md
+[distributions]: /ecosystem/distributions/#how-to-add
+[marketing guidelines]: /community/marketing-guidelines/
+[pr-checks]: /docs/contributing/pr-checks/
+[registry]: /ecosystem/registry/
+[registry schema]:
+  https://github.com/open-telemetry/opentelemetry.io/blob/main/data/registry-schema.json
+[review-pull-request]:
+  https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/review-pull-request/SKILL.md
+[style guide]: /docs/contributing/style-guide/
+[template]:
+  https://github.com/open-telemetry/opentelemetry.io/blob/main/templates/registry-entry.yml
+[updating]: /ecosystem/registry/updating/
+[vendors]: /ecosystem/vendors/#how-to-add


### PR DESCRIPTION
- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

Adds a `/review-registry-pr` skill to review PRs that modify registry entries (`data/registry/*.yml`) or ecosystem lists (`data/ecosystem/*.yaml`).

Using Claude, I retrieved the last 180 days of PRs labeled `registry` (180 PRs: 160 merged, 20 closed without merging) and every comment left during the review, grouping them into actionable categories:

| Rank | Category                                    | Count |
| ---- | ------------------------------------------- | ----- |
| 1    | ci-fix-command (+ lint asks)                | 34    |
| 2    | process-workflow                            | 21    |
| 3    | broken-link                                 | 14    |
| 4    | spelling-cspell                             | 14    |
| 5    | doc-content-accuracy                        | 13    |
| 6    | editorial-wording                           | 12    |
| 7    | registry-metadata                           | 11    |
| 8    | description-quality                         | 9     |
| 9    | duplicate-entry + pr-closure                | 8     |
| 10   | code-quality / registry-maintenance / other | 7     |

Two patterns stood out:

- On merged PRs, review effort concentrates on rules no CI check enforces: the schema leaves `registryType` and `language` optional, `.yaml` files skip validation entirely, the license gate only rejects the literal string `Commercial`, and nothing verifies that `package.name` exists.
- The PRs that never merged died on process: fork branches named `main`, unsigned CLAs, and org-owned forks where `/fix:*` cannot push.

`data/ecosystem/*.yaml` (vendors, adopters, distributions) has no schema, no auto-applied label, and no component owner, so maintainer review is the only gate there.

The skill is user-invoked and read-only: it never approves, labels, or merges.

The dataset behind the analysis (both CSVs plus a README describing the method and categories) is on my fork: https://github.com/vitorvasc/opentelemetry.io/tree/registry-review-analysis.

---

> Co-authored with Claude Fable 5.