### PR TITLE
[ja] add translation of content/en/search.md

### DIFF
--- a/content/ja/search.md
+++ b/content/ja/search.md
@@ -1,0 +1,5 @@
+---
+title: 検索結果
+layout: search
+default_lang_commit: 7cded84e3bd5923350bc541714655e12401a59cf
+---


### PR DESCRIPTION
## Summary

Translates `content/en/search.md` into Japanese as `content/ja/search.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11055--opentelemetry.netlify.app/ja/search/
- **English (canonical):** https://opentelemetry.io/search/

<!-- preview-section-end -->
