### PR TITLE
Add gocql compile-time auto-instrumentation to registry

### DIFF
--- a/data/registry/instrumentation-go-compile-time-gocql.yml
+++ b/data/registry/instrumentation-go-compile-time-gocql.yml
@@ -1,0 +1,20 @@
+title:
+  OpenTelemetry Go Compile-Time Auto-Instrumentation for `gocql/gocql`
+registryType: instrumentation
+language: go
+tags:
+  - go
+  - instrumentation
+  - compile-time
+  - auto-instrumentation
+  - cassandra
+  - database
+license: Apache 2.0
+description: >
+  Go compile-time auto-instrumentation plugin for the [`gocql/gocql` Cassandra
+  driver](https://pkg.go.dev/github.com/gocql/gocql).
+authors:
+  - name: OpenTelemetry Authors
+urls:
+  repo: https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/tree/main/instrumentation/github.com/gocql/gocql
+createdAt: 2026-07-27


### PR DESCRIPTION
Adds a registry entry for the `gocql/gocql` Cassandra driver compile-time auto-instrumentation in [opentelemetry-go-compile-instrumentation](https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation).

The instrumentation is added in open-telemetry/opentelemetry-go-compile-instrumentation#809. This entry follows the same shape as the existing `instrumentation-go-compile-time-*` entries (go-redis, mongo, gin, grpc, etc.).

---

**Note from the maintainers**: this description was submitted without our [PR template](https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/PULL_REQUEST_TEMPLATE.md)'s checklist, which asks you to confirm:

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR. (Yes, I can answer maintainer questions about the content of this PR, without using AI.)

Per our [first-time contributor policy](https://github.com/open-telemetry/opentelemetry.io/issues/11243), answer these questions by ticking each box that applies.
