### PR TITLE
[ja] add translation of content/en/status.md

### DIFF
--- a/content/ja/status.md
+++ b/content/ja/status.md
@@ -1,0 +1,39 @@
+---
+title: ステータス
+menu: { main: { weight: 30 } }
+aliases: [/project-status, /releases]
+description: 主要な OpenTelemetry コンポーネントの成熟度レベル
+type: docs
+body_class: td-no-left-sidebar
+default_lang_commit: 24784ba7f811b7517d9dfa0c2178a9a1e29c1949
+---
+
+OpenTelemetry は[いくつかのコンポーネント](/docs/concepts/components/)で構成されており、言語固有のものと言語に依存しないものがあります。
+[ステータス](/docs/specs/otel/versioning-and-stability/)を調べる際は、適切なコンポーネントのページからステータスを確認してください。
+たとえば、仕様におけるシグナルのステータスは、特定の言語 SDK でのシグナルのステータスとは異なる場合があります。
+
+## 言語 API と SDK {#language-apis--sdks}
+
+[言語 API または SDK](/docs/languages/) の開発ステータス、つまり成熟度レベルについては、以下の表を参照してください。
+
+{{% telemetry-support-table " " %}}
+
+実装ごとの仕様準拠の詳細については、[仕様準拠マトリクス](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md)を参照してください。
+
+## Collector {#collector}
+
+Collector のステータスは、コアの Collector コンポーネントが現在さまざまな[安定性レベル](https://github.com/open-telemetry/opentelemetry-collector#stability-levels)を持つため、[混合状態（mixed）](/docs/specs/otel/document-status/#mixed)です。
+
+**Collector コンポーネント**は成熟度が異なります。
+各コンポーネントの安定性はそれぞれの `README.md` に記載されています。
+利用可能な Collector コンポーネントの一覧は[レジストリ](/ecosystem/registry/?language=collector)にあります。
+
+## Kubernetes Operator {#kubernetes-operator}
+
+OpenTelemetry Operator のステータスは、異なるステータスのコンポーネントをデプロイするため、[混合状態（mixed）](/docs/specs/otel/document-status/#mixed)です。
+
+Operator 自体も `v1alpha1` と `v1beta1` のコンポーネントを持つ[混合状態（mixed）](/docs/specs/otel/document-status/#mixed)です。
+
+## 仕様 {#specifications}
+
+[仕様](/docs/specs/otel/)の開発ステータス、つまり成熟度レベルについては、[仕様ステータス概要](/docs/specs/status/)を参照してください。


### PR DESCRIPTION
## Summary

Translates `content/en/status.md` into Japanese as `content/ja/status.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11064--opentelemetry.netlify.app/ja/status/
- **English (canonical):** https://opentelemetry.io/status/

<!-- preview-section-end -->
