### PR TITLE
[ja] update translation of content/en/docs/contributing/pull-requests.md

### DIFF
--- a/content/ja/docs/contributing/pull-requests.md
+++ b/content/ja/docs/contributing/pull-requests.md
@@ -3,8 +3,7 @@ title: コンテンツの提出
 description: GitHub UI 利用して、またはローカルのフォークから、新しいコンテンツまたはコンテンツの変更を提出する方法を学びます
 aliases: [new-content]
 weight: 15
-default_lang_commit: 8013aa5f0aae284fa343311981625be6dbb25e5b
-drifted_from_default: true
+default_lang_commit: e76ca67d0f5b6906f7a9c90cde82380fc31e6e85
 ---
 
 新しいドキュメントの内容を追加や改善するには、[プルリクエスト][PR] （PR）を提出してください。
@@ -154,8 +153,8 @@ bot は修正コマンドへのリンクを含む進捗コメントで応答し�
 /fix:format
 /fix:i18n
 /fix:l10n
+/fix:link-cache
 /fix:markdown
-/fix:refcache
 /fix:submodule
 /fix:text
 ```


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/contributing/pull-requests.md` to match the latest English source at
`content/en/docs/contributing/pull-requests.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff renamed `/fix:refcache` to `/fix:link-cache` in the list of fix commands.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.


<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11070--opentelemetry.netlify.app/ja/docs/contributing/pull-requests/
- **English (canonical):** https://opentelemetry.io/docs/contributing/pull-requests/

_(deploy preview may take a few minutes to build.)_
<!-- preview-section-end -->
