### PR TITLE
[ja] update translation of content/en/docs/collector/extend/custom-component/extension/authenticator.md

### DIFF
--- a/content/ja/docs/collector/extend/custom-component/extension/authenticator.md
+++ b/content/ja/docs/collector/extend/custom-component/extension/authenticator.md
@@ -5,7 +5,7 @@ weight: 100
 aliases:
   - /docs/collector/custom-auth
   - /docs/collector/building/authenticator-extension
-default_lang_commit: e76ca67d0f5b6906f7a9c90cde82380fc31e6e85
+default_lang_commit: f304b22c356b4ad4046b8ce5550ddf503a510d69
 cSpell:ignore: configauth oidc
 ---
 
@@ -119,6 +119,6 @@ service:
 
 [authenticators]: https://pkg.go.dev/go.opentelemetry.io/collector/config/configauth
 [builder]: https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder
-[client authenticators]: https://pkg.go.dev/go.opentelemetry.io/collector/config/configauth#client-authenticators
+[client authenticators]: https://pkg.go.dev/go.opentelemetry.io/collector/config/configauth#readme-client-authenticators
 [extensions]: /docs/collector/configuration/#extensions
-[sa]: https://pkg.go.dev/go.opentelemetry.io/collector/config/configauth#server-authenticators
+[sa]: https://pkg.go.dev/go.opentelemetry.io/collector/config/configauth#readme-server-authenticators

--- a/content/ja/docs/collector/extend/custom-component/extension/authenticator.md
+++ b/content/ja/docs/collector/extend/custom-component/extension/authenticator.md
@@ -5,8 +5,7 @@ weight: 100
 aliases:
   - /docs/collector/custom-auth
   - /docs/collector/building/authenticator-extension
-default_lang_commit: 1f686d5f7b6bbdfaa30dafdc6ca0214c6f2308db # patched
-drifted_from_default: true
+default_lang_commit: e76ca67d0f5b6906f7a9c90cde82380fc31e6e85
 cSpell:ignore: configauth oidc
 ---
 
@@ -120,6 +119,6 @@ service:
 
 [authenticators]: https://pkg.go.dev/go.opentelemetry.io/collector/config/configauth
 [builder]: https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder
-[client authenticators]: https://pkg.go.dev/go.opentelemetry.io/collector/config/configauth#readme-client-authenticators
+[client authenticators]: https://pkg.go.dev/go.opentelemetry.io/collector/config/configauth#client-authenticators
 [extensions]: /docs/collector/configuration/#extensions
 [sa]: https://pkg.go.dev/go.opentelemetry.io/collector/config/configauth#server-authenticators


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/collector/extend/custom-component/extension/authenticator.md` to match the latest English source at
`content/en/docs/collector/extend/custom-component/extension/authenticator.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The only English-side change since the last sync was a link reference URL update
(`#client-authenticators` → `#readme-client-authenticators`), which had already been
applied via a prior `# patched` commit. This PR completes the bookkeeping by
advancing `default_lang_commit` to the current upstream HEAD.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11071--opentelemetry.netlify.app/ja/docs/collector/extend/custom-component/extension/authenticator/
- **English (canonical):** https://opentelemetry.io/docs/collector/extend/custom-component/extension/authenticator/

<!-- preview-section-end -->
