### PR TITLE
[ja] update translation of content/en/docs/languages/dotnet/exporters.md

### DIFF
--- a/content/ja/docs/languages/dotnet/exporters.md
+++ b/content/ja/docs/languages/dotnet/exporters.md
@@ -1,8 +1,7 @@
 ---
 title: エクスポーター
 weight: 50
-default_lang_commit: bb23218b2ffc669eb538742e664dd7b52b55531e # patched
-drifted_from_default: true
+default_lang_commit: e76ca67d0f5b6906f7a9c90cde82380fc31e6e85
 ---
 
 {{% docs/languages/exporters/intro %}}


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/dotnet/exporters.md` to match the latest English source at
`content/en/docs/languages/dotnet/exporters.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The only English-side change since the last sync was a link URL update
(`prometheus.io/docs/prometheus/latest/...` → `.../2.55/...`) which was already
applied to the Japanese file via a previous `# patched` update. This PR
therefore only updates the i18n bookkeeping (`default_lang_commit` and
`drifted_from_default` removal).

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.


<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11072--opentelemetry.netlify.app/ja/docs/languages/dotnet/exporters/
- **English (canonical):** https://opentelemetry.io/docs/languages/dotnet/exporters/

<!-- preview-section-end -->
