### PR TITLE
[ja] add translation of content/en/_includes/page-drifted-msg.md

### DIFF
--- a/content/ja/_includes/page-drifted-msg.md
+++ b/content/ja/_includes/page-drifted-msg.md
@@ -1,0 +1,29 @@
+---
+default_lang_commit: e76ca67d0f5b6906f7a9c90cde82380fc31e6e85
+---
+
+<i class="fa-solid fa-triangle-exclamation" style="margin-left: -1.9rem; padding-right: 0.5rem;"></i>
+このページの内容は<b>古くなっている</b>可能性があり、一部のリンクが無効になっている場合があります。
+
+{{ if $show_details }}
+
+このページの<b>より新しいバージョン</b>が
+<a href="{{$default_lang_page_url}}">英語版</a>にあります。
+
+<details class="mt-2">
+  <summary>詳細情報 ...</summary>
+  <p>
+    このページが最後に更新されてからの英語ページの変更を確認するには、
+    <a href="{{$compare_url}}" class="external-link" target="_blank" rel="noopener" data-proofer-ignore>
+      GitHub compare {{$default_lang_commit_short}}..{{$default_lang_hash_short}}
+    </a>
+    にアクセスし、<code>{{$def_lang_path}}</code> を検索してください。
+  </p>
+</details>
+{{ end }}
+
+{{ if $no_default_lang_page }}
+
+このページに対応する英語ページはもう存在しません。
+
+{{ end }}


### PR DESCRIPTION
## Summary

Translates `content/en/_includes/page-drifted-msg.md` into Japanese as `content/ja/_includes/page-drifted-msg.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
<!-- preview-section-start -->

## Preview

This file is a Hugo partial included in other pages' layouts (the drift-warning banner). It is not directly browsable at a standalone URL. To verify the translation, check any drifted Japanese page that renders this banner in the deploy preview:

- **Deploy preview base:** https://deploy-preview-11073--opentelemetry.netlify.app/ja/
- **English source (canonical):** https://opentelemetry.io/

<!-- preview-section-end -->
