### PR TITLE
[fr] Update zero-code/python pages to match English

### DIFF
--- a/content/fr/docs/zero-code/python/_index.md
+++ b/content/fr/docs/zero-code/python/_index.md
@@ -3,8 +3,9 @@ title: Instrumentation sans code Python
 linkTitle: Python
 weight: 30
 aliases: [/docs/languages/python/automatic]
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649
-drifted_from_default: true
+cascade:
+  collector_vers: 0.157.0
+default_lang_commit: b4bfa8864292198d11860470a1ef22a539553845
 cSpell:ignore: distro
 ---
 
@@ -27,15 +28,13 @@ opentelemetry-bootstrap -a install
 Le paquet `opentelemetry-distro` installe l'API, le SDK, et les outils
 `opentelemetry-bootstrap` et `opentelemetry-instrument`.
 
-{{% alert title="Note" %}}
-
-Vous devez installer un paquet de distribution (distro) pour que
-l'instrumentation automatique fonctionne. Le paquet `opentelemetry-distro`
-contient la distribution par défaut pour configurer automatiquement certaines
-des options communes pour les utilisateurs. Pour plus d'informations, voir
-[Distribution OpenTelemetry](/docs/languages/python/distro/).
-
-{{% /alert %}}
+> [!NOTE]
+>
+> Vous devez installer un paquet de distribution (distro) pour que
+> l'instrumentation automatique fonctionne. Le paquet `opentelemetry-distro`
+> contient la distribution par défaut pour configurer automatiquement certaines
+> des options communes pour les utilisateurs. Pour plus d'informations, voir
+> [Distribution OpenTelemetry](/docs/languages/python/distro/).
 
 La commande `opentelemetry-bootstrap -a install` parcourt la liste des paquets
 installés dans votre dossier `site-packages` actif, et installe les
@@ -50,11 +49,12 @@ L'exécution de `opentelemetry-bootstrap` sans arguments liste les bibliothèque
 d'instrumentation recommandées à installer. Pour plus d'informations, voir
 [`opentelemetry-bootstrap`](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-instrumentation#opentelemetry-bootstrap).
 
-{{% alert title="Vous utilisez <code>uv</code> ?" color="warning" %}} Si vous
-utilisez le gestionnaire de paquets [uv](https://docs.astral.sh/uv/), vous
-pourriez rencontrer des difficultés lors de l'exécution de
-`opentelemetry-bootstrap -a install`. Pour plus de détails, voir
-[Bootstrap avec uv](troubleshooting/#bootstrap-using-uv). {{% /alert %}}
+> [!WARNING] Vous utilisez `uv` ?
+>
+> Si vous utilisez le gestionnaire de paquets [uv](https://docs.astral.sh/uv/),
+> vous pourriez rencontrer des difficultés lors de l'exécution de
+> `opentelemetry-bootstrap -a install`. Pour plus de détails, voir
+> [Bootstrap avec uv](troubleshooting/#bootstrap-using-uv).
 
 {#configuring-the-agent}
 

--- a/content/fr/docs/zero-code/python/configuration.md
+++ b/content/fr/docs/zero-code/python/configuration.md
@@ -5,9 +5,9 @@ weight: 10
 aliases:
   - /docs/languages/python/automatic/configuration
   - /docs/languages/python/automatic/agent-config
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649
-drifted_from_default: true
-cSpell:ignore: healthcheck instrumentor pyproject Starlette urllib
+default_lang_commit: 7a39e1b95f51cf97fe203ef98a1011d3be33d77e
+# prettier-ignore
+cSpell:ignore: gevent healthcheck instrumentor monkeypatch pyproject Starlette urllib
 ---
 
 L'agent est hautement configurable, soit par :
@@ -124,10 +124,13 @@ qui sont générés.
   format de journalisation personnalisé
 - `OTEL_PYTHON_LOG_LEVEL` : pour définir un niveau de journalisation
   personnalisé (info, error, debug, warning)
-- `OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED` : pour activer
-  l'auto-instrumentation des journaux. Attache le gestionnaire OTLP au logger
-  racine de Python. Pour un exemple, voir
-  [Auto-instrumentation des journaux](/docs/zero-code/python/logs-example/).
+- `OTEL_PYTHON_LOG_AUTO_INSTRUMENTATION` : contrôle si le gestionnaire de
+  journalisation est configuré automatiquement (true, false), activé par défaut.
+  Voir
+  [Auto-instrumentation des journaux](/docs/zero-code/python/logs-example/)
+- `OTEL_PYTHON_LOG_CODE_ATTRIBUTES` : pour activer l'ajout des attributs `code`
+  (`code.file.path`, `code.function.name`, `code.line.number`) aux journaux
+  (true, false)
 
 Exemples :
 
@@ -135,8 +138,14 @@ Exemples :
 export OTEL_PYTHON_LOG_CORRELATION=true
 export OTEL_PYTHON_LOG_FORMAT="%(msg)s [span_id=%(span_id)s]"
 export OTEL_PYTHON_LOG_LEVEL=debug
-export OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
+export OTEL_PYTHON_LOG_AUTO_INSTRUMENTATION=false
+export OTEL_PYTHON_LOG_CODE_ATTRIBUTES=true
 ```
+
+> Avant OpenTelemetry Python 1.40.0, l'auto-instrumentation des journaux était
+> désactivée par défaut et implémentée dans le paquet `opentelemetry-sdk`.
+> Mettre `OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED` à `true` l'aurait
+> activée.
 
 ### Autre {#other}
 
@@ -154,6 +163,9 @@ n'entrent pas dans une catégorie spécifique.
   le fournisseur global de traces
 - `OTEL_PYTHON_INSTRUMENTATION_SANITIZE_REDIS` : pour activer l'offuscation des
   valeurs dans les requêtes
+- `OTEL_PYTHON_AUTO_INSTRUMENTATION_EXPERIMENTAL_GEVENT_PATCH` : mettre à
+  `patch_all` pour appeler la méthode monkeypatch `patch_all` de gevent avant
+  d'initialiser le SDK
 
 Exemples :
 
@@ -163,6 +175,7 @@ export OTEL_PYTHON_ELASTICSEARCH_NAME_PREFIX=mon-prefixe-personnalise
 export OTEL_PYTHON_GRPC_EXCLUDED_SERVICES="GRPCTestServer,GRPCHealthServer"
 export OTEL_PYTHON_ID_GENERATOR=xray
 export OTEL_PYTHON_INSTRUMENTATION_SANITIZE_REDIS=true
+export OTEL_PYTHON_AUTO_INSTRUMENTATION_EXPERIMENTAL_GEVENT_PATCH=patch_all
 ```
 
 ## Désactivation d'instrumentations spécifiques {#disabling-specific-instrumentations}

--- a/content/fr/docs/zero-code/python/example.md
+++ b/content/fr/docs/zero-code/python/example.md
@@ -3,9 +3,9 @@ title: Exemple d'auto-instrumentation
 linkTitle: Exemple
 weight: 20
 aliases: [/docs/languages/python/automatic/example]
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649 # patched
-drifted_from_default: true
-cSpell:ignore: distro instrumentor mkdir MSIE Referer Starlette venv
+default_lang_commit: 6b9bf7eee2c4dc94f254e9a32909b58952f3f442
+# prettier-ignore
+cSpell:ignore: Aiohttp ASGI distro instrumentor mkdir MSIE Referer Starlette venv
 ---
 
 Cette page montre comment utiliser l'auto-instrumentation Python dans
@@ -147,7 +147,7 @@ python server_manual.py
 
 ```sh
 source ./venv/bin/activate
-python client.py testing
+python client.py
 ```
 
 La console exécutant `server_manual.py` affichera les spans générés par
@@ -203,7 +203,7 @@ Dans la console où vous avez précédemment exécuté `client.py`, exécutez à
 nouveau la commande suivante :
 
 ```sh
-python client.py testing
+python client.py
 ```
 
 La console exécutant `server_automatic.py` affichera les spans générés par
@@ -272,7 +272,7 @@ python server_programmatic.py
 
 ```sh
 source ./venv/bin/activate
-python client.py testing
+python client.py
 ```
 
 Les résultats devraient être les mêmes que lors de l'exécution avec
@@ -338,9 +338,12 @@ opentelemetry-instrument --traces_exporter console --metrics_exporter none --log
 Ces options de configuration sont prises en charge par les instrumentations HTTP
 suivantes :
 
+- Aiohttp-server
+- ASGI
 - Django
 - Falcon
 - FastAPI
+- Flask
 - Pyramid
 - Starlette
 - Tornado
@@ -360,6 +363,25 @@ Si ces en-têtes sont disponibles, ils seront inclus dans votre span :
   }
 }
 ```
+
+### Assainissement des en-têtes capturés {#sanitization-of-captured-headers}
+
+Afin d'éviter de stocker des données sensibles telles que des informations
+personnelles identifiables (PII), des clés de session, des mots de passe, etc.,
+définissez la variable d'environnement
+`OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS` avec une liste,
+séparée par des virgules, des noms d'en-têtes HTTP à assainir. Les expressions
+régulières sont acceptées, et tous les noms d'en-têtes sont comparés sans
+distinction de casse.
+
+Par exemple,
+
+```sh
+export OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS=".*session.*,set-cookie"
+```
+
+remplacera la valeur d'en-têtes tels que `session-id` et `set-cookie` par
+`[REDACTED]` dans le span.
 
 [convention sémantique]: /docs/specs/semconv/http/http-spans/
 [référence de l'API]:

--- a/content/fr/docs/zero-code/python/logs-example.md
+++ b/content/fr/docs/zero-code/python/logs-example.md
@@ -3,8 +3,7 @@ title: Exemple d'auto-instrumentation des journaux
 linkTitle: Exemple de journaux
 weight: 20
 aliases: [/docs/languages/python/automatic/logs-example]
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649
-drifted_from_default: true
+default_lang_commit: 7a39e1b95f51cf97fe203ef98a1011d3be33d77e
 cSpell:ignore: distro mkdir virtualenv
 ---
 
@@ -81,6 +80,7 @@ instrumenter automatiquement un programme.
 ```sh
 pip install opentelemetry-distro
 pip install opentelemetry-exporter-otlp
+pip install opentelemetry-instrumentation-logging
 ```
 
 Les exemples qui suivent envoient les résultats de l'instrumentation à la
@@ -107,9 +107,9 @@ Ouvrez une nouvelle fenêtre de terminal et démarrez le Collecteur OTel :
 
 ```sh
 docker run -it --rm -p 4317:4317 -p 4318:4318 \
-  -v $(pwd)/otel-collector-config.yml:/etc/otelcol-config.yml \
+  -v $(pwd)/otel-collector-config.yaml:/etc/otelcol-config.yml \
   --name otelcol \
-  otel/opentelemetry-collector-contrib:0.76.1 \
+  otel/opentelemetry-collector:{{% param collector_vers %}} \
   "--config=/etc/otelcol-config.yml"
 ```
 
@@ -118,7 +118,6 @@ Ouvrez un autre terminal et exécutez le programme Python :
 ```sh
 source python_logs_example/bin/activate
 
-export OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
 opentelemetry-instrument \
   --traces_exporter console,otlp \
   --metrics_exporter console,otlp \
@@ -126,6 +125,9 @@ opentelemetry-instrument \
   --service_name python-logs-example \
   python $(pwd)/example.py
 ```
+
+> Avant OpenTelemetry Python 1.40.0, il fallait activer l'instrumentation des
+> journaux avec `export OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true`
 
 Exemple de sortie :
 

--- a/content/fr/docs/zero-code/python/operator.md
+++ b/content/fr/docs/zero-code/python/operator.md
@@ -4,9 +4,8 @@ title:
 linkTitle: Opérateur
 aliases: [/docs/languages/python/automatic/operator]
 weight: 30
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649 # patched
-drifted_from_default: true
-cSpell:ignore: django-applications grpcio psutil PYTHONPATH
+default_lang_commit: 5d68eec62bc16a5558678eae6d2f8c5083113823
+cSpell:ignore: django-applications gevent grpcio monkeypatch psutil PYTHONPATH
 ---
 
 Si vous exécutez votre service Python dans Kubernetes, vous pouvez tirer parti
@@ -46,3 +45,11 @@ d'environnement :
   Django, par exemple "/app"
 - `DJANGO_SETTINGS_MODULE`, avec le nom du module de paramètres Django, par
   exemple "myapp.settings"
+
+### Applications gevent {#gevent-applications}
+
+Depuis la version 1.37.0/0.58b0 d'OpenTelemetry Python, si vous définissez dans
+votre fichier de déploiement la variable d'environnement
+`OTEL_PYTHON_AUTO_INSTRUMENTATION_EXPERIMENTAL_GEVENT_PATCH` à `patch_all`, le
+code d'auto-instrumentation appellera la méthode monkeypatch de gevent portant
+le même nom avant de s'initialiser.

--- a/content/fr/docs/zero-code/python/troubleshooting.md
+++ b/content/fr/docs/zero-code/python/troubleshooting.md
@@ -3,7 +3,7 @@ title: Dépannage des problèmes d'instrumentation automatique de Python
 linkTitle: Dépannage
 weight: 40
 default_lang_commit: 182bcc0bb62c5359157142153804d22f0ee60242
-cSpell:ignore: ASGI gunicorn uvicorn
+cSpell:ignore: ASGI gunicorn interblocages uvicorn
 ---
 
 ## Problèmes d'installation {#installation-issues}
@@ -122,8 +122,8 @@ chaque enfant. Voir également les forks et interblocages décrits dans le
 
 Il existe des contournements pour les serveurs pre-fork avec OpenTelemetry. Le
 tableau suivant résume la prise en charge actuelle de l'export des signaux par
-les différentes piles de passerelle web auto-instrumentées et pre-forkées avec
-plusieurs workers. Voir ci-dessous pour plus de détails et d'options :
+les différentes piles de passerelle web auto-instrumentées, lancées en pre-fork
+avec plusieurs workers. Voir ci-dessous pour plus de détails et d'options :
 
 | Pile avec plusieurs workers | Traces | Métriques | Journaux |
 | --------------------------- | ------ | --------- | -------- |

--- a/content/fr/docs/zero-code/python/troubleshooting.md
+++ b/content/fr/docs/zero-code/python/troubleshooting.md
@@ -2,8 +2,8 @@
 title: Dépannage des problèmes d'instrumentation automatique de Python
 linkTitle: Dépannage
 weight: 40
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649 # patched
-drifted_from_default: true
+default_lang_commit: 182bcc0bb62c5359157142153804d22f0ee60242
+cSpell:ignore: ASGI gunicorn uvicorn
 ---
 
 ## Problèmes d'installation {#installation-issues}
@@ -93,6 +93,114 @@ activé, définissez l'option `use_reloader` sur `False` :
 ```python
 if __name__ == "__main__":
     app.run(port=8082, debug=True, use_reloader=False)
+```
+
+### Problèmes avec les serveurs pre-fork {#pre-fork-server-issues}
+
+Un serveur pre-fork, comme Gunicorn avec plusieurs workers, peut être lancé
+ainsi :
+
+```sh
+gunicorn myapp.main:app --workers 4
+```
+
+Cependant, indiquer plus d'un `--workers` peut casser la génération des
+métriques lorsque l'auto-instrumentation est appliquée. En effet, le fork — la
+création des processus worker/enfants — introduit des incohérences dans chaque
+enfant au niveau des threads d'arrière-plan et des verrous que présupposent des
+composants clés du SDK OpenTelemetry. En particulier, le
+`PeriodicExportingMetricReader` crée son propre thread pour transmettre
+périodiquement les données à l'exporter. Voir aussi les tickets
+[#2767](https://github.com/open-telemetry/opentelemetry-python/issues/2767) et
+[#3307](https://github.com/open-telemetry/opentelemetry-python/issues/3307#issuecomment-1579101152).
+Après le fork, chaque enfant cherche en mémoire un objet thread qui n'est en
+réalité pas exécuté, et les verrous d'origine peuvent ne jamais se libérer pour
+chaque enfant. Voir également les forks et interblocages décrits dans le
+[ticket Python 6721](https://bugs.python.org/issue6721).
+
+#### Contournements {#workarounds}
+
+Il existe des contournements pour les serveurs pre-fork avec OpenTelemetry. Le
+tableau suivant résume la prise en charge actuelle de l'export des signaux par
+les différentes piles de passerelle web auto-instrumentées et pre-forkées avec
+plusieurs workers. Voir ci-dessous pour plus de détails et d'options :
+
+| Pile avec plusieurs workers | Traces | Métriques | Journaux |
+| --------------------------- | ------ | --------- | -------- |
+| Uvicorn                     | x      |           | x        |
+| Gunicorn                    | x      |           | x        |
+| Gunicorn + UvicornWorker    | x      | x         | x        |
+
+##### Déployer avec Gunicorn et UvicornWorker {#deploy-with-gunicorn-and-uvicornworker}
+
+Pour auto-instrumenter un serveur comportant plusieurs workers, il est
+recommandé de déployer avec Gunicorn et `uvicorn.workers.UvicornWorker` s'il
+s'agit d'une application ASGI (Asynchronous Server Gateway Interface) — FastAPI,
+Starlette, etc. La classe UvicornWorker est spécifiquement conçue pour gérer les
+forks en préservant les processus et threads d'arrière-plan. Par exemple :
+
+```sh
+opentelemetry-instrument gunicorn \
+  --workers 4 \
+  --worker-class uvicorn.workers.UvicornWorker \
+  --bind 0.0.0.0:8000 \
+  myapp.main:app
+```
+
+##### Utiliser l'auto-instrumentation programmatique {#use-programmatic-auto-instrumentation}
+
+Initialisez OpenTelemetry à l'intérieur du processus worker avec
+l'[auto-instrumentation programmatique](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/opentelemetry-instrumentation/README.rst#programmatic-auto-instrumentation)
+après le fork du serveur, plutôt qu'avec `opentelemetry-instrument`. Par
+exemple :
+
+```python
+from opentelemetry.instrumentation.auto_instrumentation import initialize
+initialize()
+
+from your_app import app
+```
+
+Si vous utilisez FastAPI, notez qu'`initialize()` doit être appelé avant
+d'importer `FastAPI`, en raison de la façon dont l'instrumentation est appliquée
+par patch. Par exemple :
+
+```python
+from opentelemetry.instrumentation.auto_instrumentation import initialize
+initialize()
+
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+async def root():
+    return {"message": "Hello World"}
+```
+
+Ensuite, lancez le serveur avec :
+
+```sh
+uvicorn main:app --workers 2
+```
+
+##### Utiliser Prometheus avec OTLP direct {#use-prometheus-with-direct-otlp}
+
+Envisagez d'utiliser une version récente de
+[Prometheus](/docs/languages/python/exporters/#prometheus-setup) pour recevoir
+directement les métriques OTLP. Mettez en place un
+`PeriodicExportingMetricReader` et un worker OTLP par processus pour pousser les
+données vers le serveur Prometheus. Nous recommandons de _ne pas_ utiliser
+`PrometheusMetricReader` avec le fork — voir le ticket
+[#3747](https://github.com/open-telemetry/opentelemetry-python/issues/3747).
+
+##### Utiliser un seul worker {#use-a-single-worker}
+
+Une autre solution consiste à n'utiliser qu'un seul worker en pre-fork avec
+l'instrumentation sans code :
+
+```sh
+opentelemetry-instrument gunicorn your_app:app --workers 1
 ```
 
 ## Problèmes de connectivité {#connectivity-issues}


### PR DESCRIPTION
Part of #8777.

Resyncs the six French `zero-code/python` pages with their English sources and clears their `drifted_from_default` flags.

### Content changes, per upstream

- **Logging config**: replaces `OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED` with `OTEL_PYTHON_LOG_AUTO_INSTRUMENTATION` and `OTEL_PYTHON_LOG_CODE_ATTRIBUTES`, keeping the pre-1.40.0 note.
- Adds `OTEL_PYTHON_AUTO_INSTRUMENTATION_EXPERIMENTAL_GEVENT_PATCH` and the new *gevent applications* section on the operator page.
- Translates the new **Pre-fork server issues** section, including the workarounds table and the Gunicorn/UvicornWorker, programmatic auto-instrumentation, Prometheus and single-worker options.
- Translates the new **Sanitization of captured headers** section and extends the list of supported HTTP instrumentations.
- Converts the two `alert` shortcodes to GitHub-style callouts.
- Adds the `collector_vers` cascade to `content/fr/docs/zero-code/python/_index.md` so `logs-example` can resolve the `param` shortcode, and pins the collector image accordingly.

### Drive-by fix

`logs-example` told readers to save the collector config as `otel-collector-config.yaml` but then mounted `otel-collector-config.yml`, so the documented `docker run` command could not work as written.

English heading anchors are preserved, per the French localization convention.

### Note

I could not run `npm run fix:format` locally (no Node on this machine), so please flag any Prettier complaints from CI and I will push a fixup right away.

/cc @dmathieu