### PR TITLE
[fr] Update Java agent pages to match English

### DIFF
--- a/content/fr/docs/zero-code/java/_index.md
+++ b/content/fr/docs/zero-code/java/_index.md
@@ -6,10 +6,10 @@ aliases:
   - /docs/languages/java/automatic_instrumentation
 cascade:
   vers:
-    instrumentation: 2.28.1
-    otel: 1.62.0
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649
-drifted_from_default: true
+    instrumentation: 2.30.0
+    otel: 1.64.0
+    contrib: 1.54.0
+default_lang_commit: 775a743de4c13b03f631942893cb8466d0b888b6
 ---
 
 Les options les plus fréquentes pour l'instrumentation Zero-code avec Java sont

--- a/content/fr/docs/zero-code/java/agent/api.md
+++ b/content/fr/docs/zero-code/java/agent/api.md
@@ -5,8 +5,7 @@ description:
   Utilisez l'API OpenTelemetry en combinaison avec l'agent Java pour étendre la
   télémétrie générée automatiquement avec des spans et métriques personnalisés
 weight: 21
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649 # patched
-drifted_from_default: true
+default_lang_commit: 4b5381a2e9f129651ab8658357ab846bd4c965f2
 ---
 
 ## Introduction {#introduction}
@@ -45,18 +44,16 @@ dependencies {
 ## OpenTelemetry {#opentelemetry}
 
 L'agent Java est un cas particulier où `GlobalOpenTelemetry` est défini par l'
-agent. Appelez simplement `GlobalOpenTelemetry.get()` pour accéder à l'instance
-`OpenTelemetry`.
+agent. Appelez simplement `GlobalOpenTelemetry.getOrNoop()` pour accéder à
+l'instance `OpenTelemetry`.
 
 ## Span {#span}
 
-{{% alert title="Note" %}}
-
-Pour les cas d'usage les plus courants, utilisez l'annotation `@WithSpan` au
-lieu de l'instrumentation manuelle. Consultez [Annotations](../annotations) pour
-plus d'informations.
-
-{{% /alert %}}
+> [!NOTE]
+>
+> Pour les cas d'usage les plus courants, utilisez l'annotation `@WithSpan` au
+> lieu de l'instrumentation manuelle. Consultez
+> [Annotations](../annotations) pour plus d'informations.
 
 ```java
 import io.opentelemetry.api.GlobalOpenTelemetry;

--- a/content/fr/docs/zero-code/java/agent/configuration.md
+++ b/content/fr/docs/zero-code/java/agent/configuration.md
@@ -2,15 +2,16 @@
 title: Configuration
 weight: 10
 aliases: [agent-config]
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649
-drifted_from_default: true
+default_lang_commit: 5d68eec62bc16a5558678eae6d2f8c5083113823
 cSpell:ignore: classloader customizer
 ---
 
-{{% alert title="Pour plus d'informations" %}} Cette page décrit les différentes
-manières dont la configuration peut être fournie à l'agent Java. Pour des
-informations sur les options de configuration elles-mêmes, consultez
-[Configurer le SDK](/docs/languages/java/configuration). {{% /alert %}}
+> [!NOTE] Pour plus d'informations
+>
+> Cette page décrit les différentes manières dont la configuration peut être
+> fournie à l'agent Java. Pour des informations sur les options de configuration
+> elles-mêmes, consultez
+> [Configurer le SDK](/docs/languages/java/configuration).
 
 ## Configuration de l'agent {#agent-configuration}
 
@@ -94,13 +95,11 @@ de l'agent. Lisez la [documentation](/docs/languages/java/configuration) pour
 trouver des paramètres tels que la configuration de l'exportation ou de
 l'échantillonnage.
 
-{{% alert title="Important" color="warning" %}}
-
-Contrairement à l'autoconfiguration du SDK, les versions 2.0+ de l'agent Java et
-du Spring Boot Starter OpenTelemetry utilisent `http/protobuf` comme protocole
-par défaut, et non `grpc`.
-
-{{% /alert %}}
+> [!IMPORTANT]
+>
+> Contrairement à l'autoconfiguration du SDK, les versions 2.0+ de l'agent Java
+> et du Spring Boot Starter OpenTelemetry utilisent `http/protobuf` comme
+> protocole par défaut, et non `grpc`.
 
 ## Activer les fournisseurs de ressources qui sont désactivés par défaut {#enable-resource-providers-that-are-disabled-by-default}
 

--- a/content/fr/docs/zero-code/java/agent/disable.md
+++ b/content/fr/docs/zero-code/java/agent/disable.md
@@ -1,11 +1,10 @@
 ---
 title: Suppression d'instrumentation spécifique
 linkTitle: Suppression d'instrumentation
-weight: 11
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649 # patched
-drifted_from_default: true
+weight: 12
+default_lang_commit: 368f811f81c27798a031b4c92024ecdd65cddc19
 # prettier-ignore
-cSpell:ignore: akka armeria clickhouse couchbase datasource dbcp Dotel dropwizard dubbo finatra hikari hikaricp httpasyncclient httpclient hystrix javalin jaxrs jaxws jedis jodd kotlinx ktor logmanager mojarra mybatis myfaces okhttp oshi pekko rabbitmq ratpack rediscala redisson restlet rocketmq shenyu spymemcached twilio vaadin vertx vibur webflux webmvc
+cSpell:ignore: activej akka armeria avaje clickhouse couchbase datasource dbcp Dotel dropwizard dubbo elasticjob finatra helidon hikari hikaricp httpasyncclient httpclient hystrix javalin jaxrs jaxws jedis jfinal jodd kotlinx ktor logmanager mojarra mybatis myfaces nats okhttp openai oshi payara pekko powerjob rabbitmq ratpack rediscala redisson restlet rocketmq shenyu spymemcached twilio vaadin vertx vibur webflux webmvc
 ---
 
 ## Désactivation complète de l'agent {#disabling-the-agent-entirely}
@@ -31,12 +30,14 @@ Définissez à `false` pour désactiver toute l'instrumentation dans l'agent.
 `true` pour activer chaque instrumentation souhaitée individuellement.
 {{% /config_option %}}
 
-{{% alert title="Note" color="warning" %}} Certaines instrumentations dépendent
-d'autres instrumentations pour fonctionner correctement. Lors de l'activation
-sélective de l'instrumentation, assurez-vous d'activer également les dépendances
-transitives. La détermination de cette relation de dépendance est laissée à
-l'utilisateur. Ceci est considéré comme une utilisation avancée et n'est pas
-recommandé pour la plupart des utilisateurs. {{% /alert %}}
+> [!WARNING]
+>
+> Certaines instrumentations dépendent d'autres instrumentations pour
+> fonctionner correctement. Lors de l'activation sélective de l'instrumentation,
+> assurez-vous d'activer également les dépendances transitives. La détermination
+> de cette relation de dépendance est laissée à l'utilisateur. Ceci est
+> considéré comme une utilisation avancée et n'est pas recommandé pour la
+> plupart des utilisateurs.
 
 ## Activer uniquement l'instrumentation manuelle {#enable-manual-instrumentation-only}
 
@@ -59,17 +60,22 @@ spécifiques, où `[name]` est le nom d'instrumentation correspondant :
 | ------------------------------------------------ | ------------------------------------------- |
 | Traces de méthodes supplémentaires               | `methods`                                   |
 | Annotations supplémentaires des traces           | `external-annotations`                      |
+| Activej HTTP                                     | `activej-http`                              |
+| Avaje Jex                                        | `avaje-jex`                                 |
 | Akka Actor                                       | `akka-actor`                                |
 | Akka HTTP                                        | `akka-http`                                 |
+| Alibaba Druid                                    | `alibaba-druid`                             |
 | Apache Axis2                                     | `axis2`                                     |
 | Apache Camel                                     | `camel`                                     |
 | Apache Cassandra                                 | `cassandra`                                 |
 | Apache CXF                                       | `cxf`                                       |
 | Apache DBCP                                      | `apache-dbcp`                               |
 | Apache Dubbo                                     | `apache-dubbo`                              |
+| Apache ElasticJob                                | `apache-elasticjob`                         |
 | Apache Geode                                     | `geode`                                     |
 | Apache HttpAsyncClient                           | `apache-httpasyncclient`                    |
 | Apache HttpClient                                | `apache-httpclient`                         |
+| Apache Iceberg                                   | `iceberg`                                   |
 | Apache Kafka                                     | `kafka`                                     |
 | Apache MyFaces                                   | `jsf-myfaces`                               |
 | Apache Pekko Actor                               | `pekko-actor`                               |
@@ -103,8 +109,10 @@ spécifiques, où `[name]` est le nom d'instrumentation correspondant :
 | Eclipse Vert.x RxJava                            | `vertx-rx-java`                             |
 | Eclipse Vert.x SQL Client                        | `vertx-sql-client`                          |
 | Eclipse Vert.x Web                               | `vertx-web`                                 |
+| Elasticsearch API client                         | `elasticsearch-api-client`                  |
 | Elasticsearch client                             | `elasticsearch-transport`                   |
 | Elasticsearch REST client                        | `elasticsearch-rest`                        |
+| Failsafe                                         | `failsafe`                                  |
 | Finagle                                          | `finagle-http`                              |
 | Google Guava                                     | `guava`                                     |
 | Google HTTP client                               | `google-http-client`                        |
@@ -112,11 +120,13 @@ spécifiques, où `[name]` est le nom d'instrumentation correspondant :
 | Grails                                           | `grails`                                    |
 | GraphQL Java                                     | `graphql-java`                              |
 | GRPC                                             | `grpc`                                      |
+| Helidon                                          | `helidon`                                   |
 | Hibernate                                        | `hibernate`                                 |
 | Hibernate Reactive                               | `hibernate-reactive`                        |
 | HikariCP                                         | `hikaricp`                                  |
 | InfluxDB                                         | `influxdb`                                  |
 | Java HTTP Client                                 | `java-http-client`                          |
+| Java HTTP Server                                 | `java-http-server`                          |
 | Java `HttpURLConnection`                         | `http-url-connection`                       |
 | Java JDBC                                        | `jdbc`                                      |
 | Java JDBC `DataSource`                           | `jdbc-datasource`                           |
@@ -131,6 +141,7 @@ spécifiques, où `[name]` est le nom d'instrumentation correspondant :
 | JAX-WS                                           | `jaxws`                                     |
 | JBoss Logging Appender                           | `jboss-logmanager-appender`                 |
 | JBoss Logging MDC                                | `jboss-logmanager-mdc`                      |
+| JFinal                                           | `jfinal`                                    |
 | JMS                                              | `jms`                                       |
 | Jodd HTTP                                        | `jodd-http`                                 |
 | JSP                                              | `jsp`                                       |
@@ -145,17 +156,23 @@ spécifiques, où `[name]` est le nom d'instrumentation correspondant :
 | Micrometer                                       | `micrometer`                                |
 | MongoDB                                          | `mongo`                                     |
 | MyBatis                                          | `mybatis`                                   |
+| NATS Client                                      | `nats`                                      |
 | Netflix Hystrix                                  | `hystrix`                                   |
 | Netty                                            | `netty`                                     |
 | OkHttp                                           | `okhttp`                                    |
 | OpenLiberty                                      | `liberty`                                   |
-| Annotations de l'extension OpenTelemetry         | `opentelemetry-extension-annotations`       |
-| Annotations de l'instrumentation OpenTelemetry   | `opentelemetry-instrumentation-annotations` |
+| OpenAI                                           | `openai`                                    |
+| OpenSearch Java                                  | `opensearch-java`                           |
+| OpenSearch REST                                  | `opensearch-rest`                           |
+| OpenTelemetry Extension Annotations              | `opentelemetry-extension-annotations`       |
+| OpenTelemetry Instrumentation Annotations        | `opentelemetry-instrumentation-annotations` |
 | OpenTelemetry API                                | `opentelemetry-api`                         |
 | Oracle UCP                                       | `oracle-ucp`                                |
 | OSHI (Operating System and Hardware Information) | `oshi`                                      |
+| Payara                                           | `payara`                                    |
 | Play Framework                                   | `play`                                      |
 | Play WS HTTP Client                              | `play-ws`                                   |
+| Powerjob                                         | `powerjob`                                  |
 | Quarkus                                          | `quarkus`                                   |
 | Quartz                                           | `quartz`                                    |
 | R2DBC                                            | `r2dbc`                                     |
@@ -173,14 +190,19 @@ spécifiques, où `[name]` est le nom d'instrumentation correspondant :
 | Scala ForkJoinPool                               | `scala-fork-join`                           |
 | Spark Web Framework                              | `spark`                                     |
 | Spring Batch                                     | `spring-batch`                              |
+| Spring Boot Actuator Autoconfigure               | `spring-boot-actuator-autoconfigure`        |
+| Spring Cloud AWS                                 | `spring-cloud-aws`                          |
+| Spring Cloud Gateway                             | `spring-cloud-gateway`                      |
 | Spring Core                                      | `spring-core`                               |
 | Spring Data                                      | `spring-data`                               |
 | Spring JMS                                       | `spring-jms`                                |
 | Spring Integration                               | `spring-integration`                        |
 | Spring Kafka                                     | `spring-kafka`                              |
+| Spring Pulsar                                    | `spring-pulsar`                             |
 | Spring RabbitMQ                                  | `spring-rabbit`                             |
 | Spring RMI                                       | `spring-rmi`                                |
 | Spring Scheduling                                | `spring-scheduling`                         |
+| Spring Security Config                           | `spring-security-config`                    |
 | Spring Web                                       | `spring-web`                                |
 | Spring WebFlux                                   | `spring-webflux`                            |
 | Spring Web MVC                                   | `spring-webmvc`                             |

--- a/content/fr/docs/zero-code/java/agent/getting-started.md
+++ b/content/fr/docs/zero-code/java/agent/getting-started.md
@@ -1,8 +1,7 @@
 ---
 title: Démarrage rapide
 weight: 1
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649
-drifted_from_default: true
+default_lang_commit: 5d68eec62bc16a5558678eae6d2f8c5083113823
 cSpell:ignore: Dotel
 ---
 
@@ -28,6 +27,17 @@ cSpell:ignore: Dotel
       export OTEL_SERVICE_NAME="your-service-name"
       java -jar myapp.jar
       ```
+
+## Configuration déclarative {#declarative-configuration}
+
+La configuration déclarative utilise un fichier YAML plutôt que des variables
+d'environnement ou des propriétés système. C'est utile lorsque vous avez de
+nombreuses options de configuration à définir, ou si vous souhaitez utiliser des
+options qui ne sont pas disponibles sous forme de variables d'environnement ou
+de propriétés système.
+
+Consultez la page
+[Configuration déclarative](../declarative-configuration) pour plus de détails.
 
 ## Configuration de l'agent {#configuring-the-agent}
 

--- a/content/fr/docs/zero-code/java/agent/performance.md
+++ b/content/fr/docs/zero-code/java/agent/performance.md
@@ -3,8 +3,7 @@ title: Performance
 description: Informations sur la performance pour l'agent Java OpenTelemetry
 weight: 400
 aliases: [/docs/languages/java/performance]
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649 # patched
-drifted_from_default: true
+default_lang_commit: 6cebc46de450dd44481a8a6f17c9b3d6f04aa0f2
 cSpell:ignore: Dotel
 ---
 
@@ -103,14 +102,12 @@ Certaines instrumentations, par exemple JDBC ou Redis, produisent des volumes
 la façon de désactiver les instrumentations inutiles, voir
 [Désactiver des instrumentations spécifiques](#turn-off-specific-instrumentations).
 
-{{% alert title="Note" %}}
-
-Les fonctionnalités expérimentales de l'agent Java peuvent augmenter l'impact de
-l'agent en raison de l'accent mis sur le développement des fonctionnalités
-plutôt que sur les performances de celles-ci. Les fonctionnalités stables sont
-plus sûres en termes de performance de l'agent.
-
-{{% /alert %}}
+> [!NOTE]
+>
+> Les fonctionnalités expérimentales de l'agent Java peuvent augmenter l'impact
+> de l'agent en raison de l'accent mis sur le développement des fonctionnalités
+> plutôt que sur les performances de celles-ci. Les fonctionnalités stables sont
+> plus sûres en termes de performance de l'agent.
 
 ## Dépannage des problèmes de l'impact de l'agent {#troubleshooting-agent-overhead-issues}
 
@@ -198,14 +195,12 @@ représentatif. Incluez des scénarios d'erreur dans vos données de test. Simul
 un taux d'erreur similaire à celui d'une charge de travail normale, généralement
 entre 2 % et 10 %.
 
-{{% alert title="Note" %}}
-
-Les tests peuvent augmenter les coûts lorsqu'ils ciblent des backends
-d'observabilité et d'autres services commerciaux. Planifiez vos tests en
-conséquence ou envisagez d'utiliser des solutions alternatives, telles que des
-backends auto-hébergés ou exécutés localement.
-
-{{% /alert %}}
+> [!NOTE]
+>
+> Les tests peuvent augmenter les coûts lorsqu'ils ciblent des backends
+> d'observabilité et d'autres services commerciaux. Planifiez vos tests en
+> conséquence ou envisagez d'utiliser des solutions alternatives, telles que des
+> backends auto-hébergés ou exécutés localement.
 
 ### Collectez des mesures comparables {#collect-comparable-measurements}
 

--- a/content/fr/docs/zero-code/java/agent/server-config.md
+++ b/content/fr/docs/zero-code/java/agent/server-config.md
@@ -4,9 +4,8 @@ linkTitle: Configuration du serveur d'application
 description:
   Apprenez à définir les chemins d'agent pour les serveurs d'applications Java
 weight: 215
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649
-drifted_from_default: true
-cSpell:ignore: asadmin Glassfish Payara setenv
+default_lang_commit: 6bf06ddb9fc057dd6e8092f26d988ffe7b1af5ed
+cSpell:ignore: asadmin Glassfish Payara setenv wildfly
 ---
 
 Lors de l'instrumentation d'une application qui s'exécute sur un serveur
@@ -95,7 +94,18 @@ une entrée `<jmv-options>` pour l'agent.
 
 ## Tomcat / TomEE {#tomcat--tomee}
 
-Ajoutez le chemin vers l'agent Java à votre script de démarrage :
+Ajoutez le chemin vers l'agent Java à votre script de démarrage. La méthode de
+configuration dépend de votre installation :
+
+**Pour les installations gérées par paquets** (apt-get/yum), ajoutez dans
+`/etc/tomcat*/tomcat*.conf` :
+
+```sh
+JAVA_OPTS="$JAVA_OPTS -javaagent:/path/to/opentelemetry-javaagent.jar"
+```
+
+**Pour les installations téléchargées**, créez ou modifiez
+`<tomcat>/bin/setenv.sh` (Linux) ou `<tomcat>/bin/setenv.bat` (Windows) :
 
 {{< tabpane text=true persist=lang >}}
 
@@ -114,6 +124,11 @@ set CATALINA_OPTS=%CATALINA_OPTS% -javaagent:"<Drive>:\path\to\opentelemetry-jav
 ```
 
 {{% /tab %}} {{< /tabpane >}}
+
+**Pour les installations en service Windows**, utilisez
+`<tomcat>/bin/tomcat*w.exe` pour ajouter
+`-javaagent:<Drive>:\path\to\opentelemetry-javaagent.jar` aux options Java, sous
+l'onglet Java.
 
 ## WebLogic {#weblogic}
 
@@ -165,3 +180,33 @@ Ouvrez la console d'administration de WebSphere et suivez ces étapes :
 5.  Dans **Generic JVM arguments**, entrez le chemin vers l'agent :
     `-javaagent:/path/to/opentelemetry-javaagent.jar`.
 6.  Enregistrez la configuration et redémarrez le serveur.
+
+## Activer les métriques JMX prédéfinies {#enable-predefined-jmx-metrics}
+
+L'agent Java embarque des configurations de métriques JMX prédéfinies pour
+plusieurs serveurs d'applications répandus, mais elles ne sont pas activées par
+défaut. Pour activer la collecte de ces métriques, indiquez une liste de cibles
+comme valeur de la propriété système `otel.jmx.target.system`. Par exemple :
+
+```bash
+$ java -javaagent:path/to/opentelemetry-javaagent.jar \
+     -Dotel.jmx.target.system=jetty,tomcat \
+     ... \
+     -jar myapp.jar
+```
+
+Voici les valeurs connues de serveurs d'applications pour
+`otel.jmx.target.system` :
+
+- [`jetty`](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/library/jetty.md)
+- [`tomcat`](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/library/tomcat.md)
+- [`wildfly`](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/jmx-metrics/library/wildfly.md)
+
+> [!NOTE]
+>
+> Cette liste n'est pas exhaustive, et d'autres systèmes cibles JMX sont pris en
+> charge.
+
+Pour connaître la liste des métriques extraites de chaque serveur
+d'applications, sélectionnez le nom correspondant ci-dessus, ou consultez
+[Détails supplémentaires et possibilités de personnalisation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/jmx-metrics#predefined-metrics).

--- a/content/fr/docs/zero-code/java/quarkus.md
+++ b/content/fr/docs/zero-code/java/quarkus.md
@@ -1,8 +1,7 @@
 ---
 title: Instrumentation Quarkus
 linkTitle: Quarkus
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649
-drifted_from_default: true
+default_lang_commit: 6bf06ddb9fc057dd6e8092f26d988ffe7b1af5ed
 ---
 
 [Quarkus](https://quarkus.io/) est un framework open source conçu pour aider les
@@ -22,13 +21,11 @@ fournit :
 - Les mêmes instrumentations peuvent être utilisées avec les images natives
   Quarkus, qui ne sont pas supportées par l'agent Java OpenTelemetry.
 
-{{% alert title="Note" color="secondary" %}}
-
-L'instrumentation Quarkus OpenTelemetry est maintenue et supportée par Quarkus.
-Pour plus de détails, consultez
-[Support communautaire Quarkus](https://quarkus.io/support/).
-
-{{% /alert %}}
+> [!NOTE]
+>
+> L'instrumentation Quarkus OpenTelemetry est maintenue et supportée par
+> Quarkus. Pour plus de détails, consultez
+> [Support communautaire Quarkus](https://quarkus.io/support/).
 
 Quarkus peut également être instrumenté avec
 l'[agent Java OpenTelemetry](../agent/) si vous n'exécutez pas une application


### PR DESCRIPTION
Part of #8777. Second lot after #11075 (Python).

Resyncs eight French pages under `zero-code/java` with their English sources and clears their `drifted_from_default` flags.

### Content changes, per upstream

- Bumps the cascaded versions to instrumentation 2.30.0 / otel 1.64.0 and adds the new `contrib` version.
- `api`: `GlobalOpenTelemetry.get()` becomes `getOrNoop()`.
- `getting-started`: translates the new **Declarative configuration** section.
- `server-config`: translates the new Tomcat installation paths (package-managed, download, Windows service) and the new **Enable predefined JMX metrics** section.
- `disable`: refreshes the instrumentation table, which gained **21 entries** (Activej, Avaje Jex, Alibaba Druid, ElasticJob, Iceberg, Elasticsearch API client, Failsafe, Helidon, Java HTTP Server, JFinal, NATS, OpenAI, OpenSearch, Payara, Powerjob, Spring Boot Actuator Autoconfigure, Spring Cloud AWS, and others), bumps the page weight to 12, and extends the cSpell list accordingly.
- Converts the remaining `alert` shortcodes on these pages to GitHub-style callouts.

English heading anchors are preserved, per the French localization convention.

### Scope

The Java lot is split so it stays reviewable. Still to come: `agent/extensions.md` (large enough to deserve its own PR) and the `spring-boot-starter/` pages.

### Note

I still cannot run `npm run fix:format` locally (no Node on this machine), so please flag any Prettier complaints from CI and I will push a fixup right away. The `disable` table rows were regenerated from the English source at identical column widths, so they should be stable.

/cc @dmathieu