### PR TITLE
[fr] Update Spring Boot starter pages to match English

### DIFF
--- a/content/fr/docs/zero-code/java/spring-boot-starter/_index.md
+++ b/content/fr/docs/zero-code/java/spring-boot-starter/_index.md
@@ -1,11 +1,11 @@
 ---
 title: Spring Boot starter
 aliases:
+  - /docs/languages/java/spring-boot
   - /docs/languages/java/automatic/spring-boot
   - /docs/zero-code/java/agent/spring-boot
   - /docs/zero-code/java/spring-boot
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649
-drifted_from_default: true
+default_lang_commit: 2d89b60b2e09d42ba96757b0afdbc31f54a2b0e7
 ---
 
 Vous pouvez utiliser deux options pour instrumenter les applications
@@ -27,3 +27,5 @@ Vous pouvez utiliser deux options pour instrumenter les applications
    - Les **fichiers de configuration Spring Boot** pour configurer le Spring
      Boot starter OpenTelemetry (`application.properties`, `application.yml`)
      qui ne fonctionne pas avec l'agent Java OpenTelemetry
+   - La **[configuration déclarative](declarative-configuration/)**, qui utilise
+     un format YAML structuré au sein d'`application.yaml`

--- a/content/fr/docs/zero-code/java/spring-boot-starter/additional-instrumentations.md
+++ b/content/fr/docs/zero-code/java/spring-boot-starter/additional-instrumentations.md
@@ -1,8 +1,7 @@
 ---
 title: Instrumentation supplémentaire
 weight: 60
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649
-drifted_from_default: true
+default_lang_commit: 2d89b60b2e09d42ba96757b0afdbc31f54a2b0e7
 ---
 
 Le Spring Boot starter OpenTelemetry fournit une
@@ -31,9 +30,33 @@ Vous pouvez trouver plus d'options de configuration pour l'appender
 OpenTelemetry dans la bibliothèque d'instrumentation
 [Log4j](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/log4j/log4j-appender-2.17/library/README.md).
 
-| Propriété système                             | Type    | Défaut | Description                                                                                  |
-| --------------------------------------------- | ------- | ------ | -------------------------------------------------------------------------------------------- |
-| `otel.instrumentation.log4j-appender.enabled` | Boolean | true   | Active la configuration de l'appender Log4j OpenTelemetry avec une instance `OpenTelemetry`. |
+{{< tabpane text=true >}} {{% tab "Properties" %}}
+
+Active la configuration de l'appender Log4j OpenTelemetry avec une instance
+`OpenTelemetry` :
+
+```yaml
+otel:
+  instrumentation:
+    log4j-appender:
+      enabled: true # défaut : true
+```
+
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+En [configuration déclarative](../declarative-configuration/), utilisez les
+listes d'instrumentations centralisées pour activer ou désactiver Log4j :
+
+```yaml
+otel:
+  distribution:
+    spring_starter:
+      instrumentation:
+        disabled:
+          - log4j_appender
+```
+
+{{% /tab %}} {{< /tabpane >}}
 
 ## Bibliothèques d'instrumentation {#instrumentation-libraries}
 

--- a/content/fr/docs/zero-code/java/spring-boot-starter/annotations.md
+++ b/content/fr/docs/zero-code/java/spring-boot-starter/annotations.md
@@ -1,8 +1,7 @@
 ---
 title: Annotations
 weight: 50
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649
-drifted_from_default: true
+default_lang_commit: 2d89b60b2e09d42ba96757b0afdbc31f54a2b0e7
 ---
 
 <!-- markdownlint-disable blanks-around-fences -->
@@ -46,37 +45,45 @@ public class TracedClass {
   @WithSpan(kind = SpanKind.CLIENT)
   public void tracedClientSpan() {}
 
+  @WithSpan
   public void tracedMethodWithAttribute(@SpanAttribute("attributeName") String parameter) {}
 }
 ```
 <!-- prettier-ignore-end -->
 
-{{% alert title="Note" %}} Les annotations OpenTelemetry utilisent Spring AOP
-basé sur des proxys.
+> [!NOTE]
+>
+> Les annotations OpenTelemetry utilisent Spring AOP basé sur des proxys.
+>
+> Ces annotations ne fonctionnent que pour les méthodes du proxy. Vous pouvez en
+> apprendre plus dans la
+> [documentation Spring](https://docs.spring.io/spring-framework/reference/core/aop/proxying.html).
+>
+> Dans l'exemple suivant, l'annotation `WithSpan` ne fera rien lorsque le point
+> de terminaison GET est appelé :
+>
+> ```java
+> @RestController
+> public class MyControllerManagedBySpring {
+>
+>     @GetMapping("/ping")
+>     public void aMethod() {
+>         anotherMethod();
+>     }
+>
+>     @WithSpan
+>     public void anotherMethod() {
+>     }
+> }
+> ```
 
-Ces annotations ne fonctionnent que pour les méthodes du proxy. Vous pouvez en
-apprendre plus dans la
-[documentation Spring](https://docs.spring.io/spring-framework/reference/core/aop/proxying.html).
+{{< comment >}} Note that we have to use the alert shortcode because it contains
+tab panes.
 
-Dans l'exemple suivant, l'annotation `WithSpan` ne fera rien lorsque le point de
-terminaison GET est appelé :
+<!-- markdownlint-capture -->
+<!-- markdownlint-disable prefer-blockquote-vs-docsy-alerts -->
 
-```java
-@RestController
-public class MyControllerManagedBySpring {
-
-    @GetMapping("/ping")
-    public void aMethod() {
-        anotherMethod();
-    }
-
-    @WithSpan
-    public void anotherMethod() {
-    }
-}
-```
-
-{{% /alert %}}
+{{< /comment >}}
 
 {{% alert title="Note" %}}
 
@@ -106,8 +113,22 @@ dependencies {
 
 {{% /alert %}}
 
+<!-- markdownlint-restore -->
+
 Vous pouvez désactiver les annotations OpenTelemetry en définissant la propriété
 `otel.instrumentation.annotations.enabled` à `false`.
+
+En [configuration déclarative](../declarative-configuration/), utilisez plutôt
+les listes d'instrumentations centralisées :
+
+```yaml
+otel:
+  distribution:
+    spring_starter:
+      instrumentation:
+        disabled:
+          - annotations
+```
 
 Vous pouvez personnaliser le span en utilisant les éléments de l'annotation
 `WithSpan` :

--- a/content/fr/docs/zero-code/java/spring-boot-starter/api.md
+++ b/content/fr/docs/zero-code/java/spring-boot-starter/api.md
@@ -6,8 +6,7 @@ description:
   étendre la télémétrie générée automatiquement avec des spans et des métriques
   personnalisés
 weight: 21
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649 # patched
-drifted_from_default: true
+default_lang_commit: 4b5381a2e9f129651ab8658357ab846bd4c965f2
 ---
 
 ## Introduction {#introduction}
@@ -29,13 +28,11 @@ composants Spring.
 
 ## Span {#span}
 
-{{% alert title="Note" %}}
-
-Pour les cas d'usage les plus courants, utilisez l'annotation `@WithSpan` au
-lieu de l'instrumentation manuelle. Consultez [Annotations](../annotations) pour
-plus d'informations.
-
-{{% /alert %}}
+> [!NOTE]
+>
+> Pour les cas d'usage les plus courants, utilisez l'annotation `@WithSpan` au
+> lieu de l'instrumentation manuelle. Consultez
+> [Annotations](../annotations) pour plus d'informations.
 
 ```java
 import io.opentelemetry.api.OpenTelemetry;

--- a/content/fr/docs/zero-code/java/spring-boot-starter/getting-started.md
+++ b/content/fr/docs/zero-code/java/spring-boot-starter/getting-started.md
@@ -1,18 +1,15 @@
 ---
 title: Démarrage rapide
 weight: 20
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649 # patched
-drifted_from_default: true
+default_lang_commit: 6bf06ddb9fc057dd6e8092f26d988ffe7b1af5ed
 cSpell:ignore: springboot
 ---
 
-{{% alert title="Note" %}}
-
-Vous pouvez également utiliser l'[agent Java](../../agent) pour instrumenter
-votre application Spring Boot. Pour les avantages et les inconvénients,
-consultez [Instrumentation Java Zero-code](..).
-
-{{% /alert %}}
+> [!NOTE]
+>
+> Vous pouvez également utiliser l'[agent Java](../../agent) pour instrumenter
+> votre application Spring Boot. Pour les avantages et les inconvénients,
+> consultez [Instrumentation Java Zero-code](..).
 
 ## Compatibilité {#compatibility}
 
@@ -33,19 +30,17 @@ OpenTelemetry, vous devez importer la nomenclature
 `opentelemetry-instrumentation-bom` lors de l'utilisation du starter
 OpenTelemetry.
 
-{{% alert title="Note" %}}
-
-Lors de l'utilisation de Maven, importez les nomenclatures OpenTelemetry avant
-toute autre dans votre projet. Par exemple, si vous importez la nomenclature
-`spring-boot-dependencies`, vous devez la déclarer après les nomenclatures
-OpenTelemetry.
-
-Gradle sélectionne la
-[dernière version](https://docs.gradle.org/current/userguide/dependency_resolution.html#2_perform_conflict_resolution)
-d'une dépendance lorsque plusieurs nomenclatures sont utilisées, donc l'ordre
-des nomenclatures n'est pas important.
-
-{{% /alert %}}
+> [!NOTE]
+>
+> Lors de l'utilisation de Maven, importez les nomenclatures OpenTelemetry avant
+> toute autre dans votre projet. Par exemple, si vous importez la nomenclature
+> `spring-boot-dependencies`, vous devez la déclarer après les nomenclatures
+> OpenTelemetry.
+>
+> Gradle sélectionne la
+> [dernière version](https://docs.gradle.org/current/userguide/dependency_resolution.html#2_perform_conflict_resolution)
+> d'une dépendance lorsque plusieurs nomenclatures sont utilisées, donc l'ordre
+> des nomenclatures n'est pas important.
 
 L'exemple suivant montre comment importer les nomenclatures OpenTelemetry en
 utilisant Maven :
@@ -101,14 +96,12 @@ dependencyManagement {
 }
 ```
 
-{{% alert title="Note" %}}
-
-Faites attention à ne pas mélanger les différentes manières de configurer les
-choses avec Gradle. Par exemple, n'utilisez pas
-`implementation(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:{{% param vers.instrumentation %}}"))`
-avec le plugin `io.spring.dependency-management`.
-
-{{% /alert %}}
+> [!NOTE]
+>
+> Faites attention à ne pas mélanger les différentes manières de configurer les
+> choses avec Gradle. Par exemple, n'utilisez pas
+> `implementation(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:{{% param vers.instrumentation %}}"))`
+> avec le plugin `io.spring.dependency-management`.
 
 ### Dépendance du starter OpenTelemetry {#opentelemetry-starter-dependency}
 

--- a/content/fr/docs/zero-code/java/spring-boot-starter/other-spring-autoconfig.md
+++ b/content/fr/docs/zero-code/java/spring-boot-starter/other-spring-autoconfig.md
@@ -1,8 +1,7 @@
 ---
 title: Autre auto-configuration Spring
 weight: 70
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649
-drifted_from_default: true
+default_lang_commit: 2d89b60b2e09d42ba96757b0afdbc31f54a2b0e7
 cSpell:ignore: autoconfigurations
 ---
 
@@ -52,6 +51,32 @@ dependencies {
 
 ### Configurations {#configurations}
 
-| Propriété                      | Valeur par défaut | ConditionalOnClass   |
-| ------------------------------ | ----------------- | -------------------- |
-| `otel.exporter.zipkin.enabled` | true              | `ZipkinSpanExporter` |
+{{< tabpane text=true >}} {{% tab "Properties" %}}
+
+Active l'exportateur Zipkin (nécessite `ZipkinSpanExporter` dans le classpath) :
+
+```yaml
+otel:
+  exporter:
+    zipkin:
+      enabled: true # défaut : true
+```
+
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+Avec la [configuration déclarative](../declarative-configuration/),
+l'exportateur Zipkin se configure dans le
+[schéma standard de configuration déclarative](/docs/languages/sdk-configuration/declarative-configuration/),
+sous `tracer_provider.processors` :
+
+```yaml
+otel:
+  tracer_provider:
+    processors:
+      - batch:
+          exporter:
+            zipkin:
+              endpoint: http://localhost:9411/api/v2/spans
+```
+
+{{% /tab %}} {{< /tabpane >}}


### PR DESCRIPTION
Part of #8777. Fourth lot, after #11075 (Python), #11076 (Java agent) and #11077 (extensions).

Resyncs six French `spring-boot-starter` pages with their English sources and clears their `drifted_from_default` flags.

### Content changes, per upstream

- Converts the `alert` shortcodes to GitHub-style callouts, keeping the one in `annotations` that upstream deliberately retains because it contains tab panes (with the accompanying `markdownlint-capture` / `restore` guards).
- Replaces the Log4j appender and Zipkin exporter configuration **tables** with the new **Properties / Declarative Configuration** tab panes.
- Adds the declarative configuration entry to the `_index` option list and the new `/docs/languages/java/spring-boot` alias.
- Adds the centralized instrumentation list example for disabling annotations.
- Adds the missing `@WithSpan` annotation on `tracedMethodWithAttribute` in the annotations example, matching upstream.

### Scope

`out-of-the-box-instrumentation` and `sdk-configuration` are **not** in this PR. They are the two heaviest restructures of the lot (16 and 8 new tab panes, and `sdk-configuration` drops its whole *Programmatic configuration* section), so they get their own PR rather than being rushed in here.

### Note

I still cannot run `npm run fix:format` locally (no Node on this machine), so please flag any Prettier complaints from CI and I will push a fixup right away.

/cc @dmathieu