### PR TITLE
[fr] Update Spring Boot starter config pages to match English

### DIFF
--- a/content/fr/docs/zero-code/java/spring-boot-starter/out-of-the-box-instrumentation.md
+++ b/content/fr/docs/zero-code/java/spring-boot-starter/out-of-the-box-instrumentation.md
@@ -1,8 +1,7 @@
 ---
 title: Instrumentation prête à l'emploi
 weight: 40
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649 # patched
-drifted_from_default: true
+default_lang_commit: 2d89b60b2e09d42ba96757b0afdbc31f54a2b0e7
 cSpell:ignore: autoconfigurations webflux webmvc
 ---
 
@@ -11,6 +10,8 @@ cSpell:ignore: autoconfigurations webflux webmvc
 
 Une instrumentation prête à l'emploi par défaut est disponible pour plusieurs
 frameworks :
+
+{{< tabpane text=true >}} {{% tab "Properties" %}}
 
 | Fonctionnalité        | Propriété                                       | Valeur par défaut |
 | --------------------- | ----------------------------------------------- | ----------------- |
@@ -25,43 +26,199 @@ frameworks :
 | Micrometer            | `otel.instrumentation.micrometer.enabled`       | false             |
 | R2DBC (reactive JDBC) | `otel.instrumentation.r2dbc.enabled`            | true              |
 
+Pour désactiver une instrumentation précise :
+
+```yaml
+otel:
+  instrumentation:
+    logback-appender:
+      enabled: false
+```
+
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+En [configuration déclarative](../declarative-configuration/), l'activation et
+la désactivation des instrumentations passent par des listes centralisées, sous
+`otel.distribution.spring_starter.instrumentation`. Le nom de l'instrumentation
+s'écrit avec `_` (snake_case), et non `-` (kebab-case).
+
+| Fonctionnalité        | Nom                | Valeur par défaut |
+| --------------------- | ------------------ | ----------------- |
+| JDBC                  | `jdbc`             | activé            |
+| Logback               | `logback_appender` | activé            |
+| Logback MDC           | `logback_mdc`      | activé            |
+| Spring Web            | `spring_web`       | activé            |
+| Spring Web MVC        | `spring_webmvc`    | activé            |
+| Spring WebFlux        | `spring_webflux`   | activé            |
+| Kafka                 | `kafka`            | activé            |
+| MongoDB               | `mongo`            | activé            |
+| Micrometer            | `micrometer`       | désactivé         |
+| R2DBC (reactive JDBC) | `r2dbc`            | activé            |
+
+Pour désactiver une instrumentation précise :
+
+```yaml
+otel:
+  distribution:
+    spring_starter:
+      instrumentation:
+        disabled:
+          - logback_appender
+```
+
+{{% /tab %}} {{< /tabpane >}}
+
 ## Activer les instrumentations de manière sélective {#turn-on-instrumentations-selectively}
 
-Pour n'utiliser que des instrumentations spécifiques, désactivez d'abord toutes
-les instrumentations en définissant la propriété
-`otel.instrumentation.common.default-enabled` à `false`. Ensuite, activez les
-instrumentations une par une.
+{{< tabpane text=true >}} {{% tab "Properties" %}}
 
-Par exemple, si vous souhaitez uniquement activer l'instrumentation JDBC,
-définissez `otel.instrumentation.jdbc.enabled` à `true`.
+Pour n'utiliser que des instrumentations spécifiques, désactivez d'abord toutes
+les instrumentations, puis activez-les une par une :
+
+```yaml
+otel:
+  instrumentation:
+    common:
+      default-enabled: false
+    jdbc:
+      enabled: true
+```
+
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+En [configuration déclarative](../declarative-configuration/), mettez
+`default_enabled` à `false` et listez dans `enabled` les instrumentations
+souhaitées :
+
+```yaml
+otel:
+  distribution:
+    spring_starter:
+      instrumentation:
+        default_enabled: false
+        enabled:
+          - jdbc
+```
+
+{{% /tab %}} {{< /tabpane >}}
 
 ## Configuration commune de l'instrumentation {#common-instrumentation-configuration}
 
 Propriétés communes à toutes les instrumentations de base de données :
 
-| Propriété système                                            | Type    | Défaut | Description                                              |
-| ------------------------------------------------------------ | ------- | ------ | -------------------------------------------------------- |
-| `otel.instrumentation.common.db-statement-sanitizer.enabled` | Boolean | true   | Active le nettoyage des instructions de base de données. |
+{{< tabpane text=true >}} {{% tab "Properties" %}}
+
+Active le nettoyage des instructions pour toutes les instrumentations de base de
+données :
+
+```yaml
+otel:
+  instrumentation:
+    common:
+      db-statement-sanitizer:
+        enabled: true # défaut : true
+```
+
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+Active le nettoyage des instructions pour toutes les instrumentations de base de
+données :
+
+```yaml
+otel:
+  instrumentation/development:
+    java:
+      common:
+        database:
+          statement_sanitizer:
+            enabled: true
+```
+
+{{% /tab %}} {{< /tabpane >}}
 
 ## Instrumentation JDBC {#jdbc-instrumentation}
 
-| Propriété système                                       | Type    | Défaut | Description                                              |
-| ------------------------------------------------------- | ------- | ------ | -------------------------------------------------------- |
-| `otel.instrumentation.jdbc.statement-sanitizer.enabled` | Boolean | true   | Active le nettoyage des instructions de base de données. |
+{{< tabpane text=true >}} {{% tab "Properties" %}}
+
+Active le nettoyage des instructions de base de données pour JDBC :
+
+```yaml
+otel:
+  instrumentation:
+    jdbc:
+      statement-sanitizer:
+        enabled: true # défaut : true
+```
+
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+Active le nettoyage des instructions de base de données pour JDBC :
+
+```yaml
+otel:
+  instrumentation/development:
+    java:
+      jdbc:
+        statement_sanitizer:
+          enabled: true
+```
+
+{{% /tab %}} {{< /tabpane >}}
 
 ## Logback {#logback}
 
 Vous pouvez activer des fonctionnalités expérimentales à l'aide des propriétés
 système pour capturer des attributs :
 
-| Propriété système                                                                      | Type    | Défaut | Description                                                                                                                                                                      |
-| -------------------------------------------------------------------------------------- | ------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `otel.instrumentation.logback-appender.experimental-log-attributes`                    | Boolean | false  | Active la capture des attributs de log expérimentaux `thread.name` et `thread.id`.                                                                                               |
-| `otel.instrumentation.logback-appender.experimental.capture-code-attributes`           | Boolean | false  | Active la capture des [attributs de code source][]. Notez que la capture des attributs de code source sur les sites de journalisation peut ajouter une surcharge de performance. |
-| `otel.instrumentation.logback-appender.experimental.capture-marker-attribute`          | Boolean | false  | Active la capture des marqueurs Logback comme attributs.                                                                                                                         |
-| `otel.instrumentation.logback-appender.experimental.capture-key-value-pair-attributes` | Boolean | false  | Active la capture des paires clé-valeur Logback comme attributs.                                                                                                                 |
-| `otel.instrumentation.logback-appender.experimental.capture-logger-context-attributes` | Boolean | false  | Active la capture des propriétés de contexte du logger Logback comme attributs.                                                                                                  |
-| `otel.instrumentation.logback-appender.experimental.capture-mdc-attributes`            | String  |        | Liste séparée par des virgules des attributs MDC à capturer. Utilisez le caractère générique `*` pour capturer tous les attributs.                                               |
+{{< tabpane text=true >}} {{% tab "Properties" %}}
+
+| Propriété                                        | Type    | Défaut | Description                                                                                                                                                                      |
+| ------------------------------------------------ | ------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `experimental-log-attributes`                    | Boolean | false  | Active la capture des attributs de log expérimentaux `thread.name` et `thread.id`.                                                                                               |
+| `experimental.capture-code-attributes`           | Boolean | false  | Active la capture des [attributs de code source][]. Notez que la capture des attributs de code source sur les sites de journalisation peut ajouter une surcharge de performance. |
+| `experimental.capture-marker-attribute`          | Boolean | false  | Active la capture des marqueurs Logback comme attributs.                                                                                                                         |
+| `experimental.capture-key-value-pair-attributes` | Boolean | false  | Active la capture des paires clé-valeur Logback comme attributs.                                                                                                                 |
+| `experimental.capture-logger-context-attributes` | Boolean | false  | Active la capture des propriétés de contexte du logger Logback comme attributs.                                                                                                  |
+| `experimental.capture-mdc-attributes`            | String  |        | Liste séparée par des virgules des attributs MDC à capturer. Utilisez le caractère générique `*` pour capturer tous les attributs.                                               |
+
+```yaml
+otel:
+  instrumentation:
+    logback-appender:
+      experimental-log-attributes: false
+      experimental:
+        capture-code-attributes: false
+        capture-marker-attribute: false
+        capture-key-value-pair-attributes: false
+        capture-logger-context-attributes: false
+        capture-mdc-attributes: '*'
+```
+
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+| Propriété                                       | Type    | Défaut | Description                                                                                                                                                                      |
+| ----------------------------------------------- | ------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `experimental_log_attributes/development`       | Boolean | false  | Active la capture des attributs de log expérimentaux `thread.name` et `thread.id`.                                                                                               |
+| `capture_code_attributes/development`           | Boolean | false  | Active la capture des [attributs de code source][]. Notez que la capture des attributs de code source sur les sites de journalisation peut ajouter une surcharge de performance. |
+| `capture_marker_attribute/development`          | Boolean | false  | Active la capture des marqueurs Logback comme attributs.                                                                                                                         |
+| `capture_key_value_pair_attributes/development` | Boolean | false  | Active la capture des paires clé-valeur Logback comme attributs.                                                                                                                 |
+| `capture_logger_context_attributes/development` | Boolean | false  | Active la capture des propriétés de contexte du logger Logback comme attributs.                                                                                                  |
+| `capture_mdc_attributes/development`            | String  |        | Liste séparée par des virgules des attributs MDC à capturer. Utilisez le caractère générique `*` pour capturer tous les attributs.                                               |
+
+```yaml
+otel:
+  instrumentation/development:
+    java:
+      logback_appender:
+        experimental_log_attributes/development: false
+        capture_code_attributes/development: false
+        capture_marker_attribute/development: false
+        capture_key_value_pair_attributes/development: false
+        capture_logger_context_attributes/development: false
+        capture_mdc_attributes/development: '*'
+```
+
+{{% /tab %}} {{< /tabpane >}}
 
 [attributs de code source]:
   /docs/specs/semconv/general/attributes/#source-code-attributes
@@ -268,9 +425,30 @@ public class WebClientController {
 
 Fournit une autoconfiguration pour l'instrumentation du client Kafka.
 
-| Propriété système                                         | Type    | Défaut | Description                                            |
-| --------------------------------------------------------- | ------- | ------ | ------------------------------------------------------ |
-| `otel.instrumentation.kafka.experimental-span-attributes` | Boolean | false  | Active la capture des attributs de span expérimentaux. |
+{{< tabpane text=true >}} {{% tab "Properties" %}}
+
+Active la capture des attributs de span expérimentaux pour Kafka :
+
+```yaml
+otel:
+  instrumentation:
+    kafka:
+      experimental-span-attributes: false # défaut : false
+```
+
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+Active la capture des attributs de span expérimentaux pour Kafka :
+
+```yaml
+otel:
+  instrumentation/development:
+    java:
+      kafka:
+        experimental_span_attributes/development: false
+```
+
+{{% /tab %}} {{< /tabpane >}}
 
 ## Instrumentation Micrometer {#micrometer-instrumentation}
 
@@ -280,14 +458,60 @@ Fournit une autoconfiguration pour le pont Micrometer vers OpenTelemetry.
 
 Fournit une autoconfiguration pour l'instrumentation du client MongoDB.
 
-| Propriété système                                        | Type    | Défaut | Description                                              |
-| -------------------------------------------------------- | ------- | ------ | -------------------------------------------------------- |
-| `otel.instrumentation.mongo.statement-sanitizer.enabled` | Boolean | true   | Active le nettoyage des instructions de base de données. |
+{{< tabpane text=true >}} {{% tab "Properties" %}}
+
+Active le nettoyage des instructions de base de données pour MongoDB :
+
+```yaml
+otel:
+  instrumentation:
+    mongo:
+      statement-sanitizer:
+        enabled: true # défaut : true
+```
+
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+Active le nettoyage des instructions de base de données pour MongoDB :
+
+```yaml
+otel:
+  instrumentation/development:
+    java:
+      mongo:
+        statement_sanitizer:
+          enabled: true
+```
+
+{{% /tab %}} {{< /tabpane >}}
 
 ## Instrumentation R2DBC {#r2dbc-instrumentation}
 
 Fournit une autoconfiguration pour l'instrumentation R2DBC OpenTelemetry.
 
-| Propriété système                                        | Type    | Défaut | Description                                              |
-| -------------------------------------------------------- | ------- | ------ | -------------------------------------------------------- |
-| `otel.instrumentation.r2dbc.statement-sanitizer.enabled` | Boolean | true   | Active le nettoyage des instructions de base de données. |
+{{< tabpane text=true >}} {{% tab "Properties" %}}
+
+Active le nettoyage des instructions de base de données pour R2DBC :
+
+```yaml
+otel:
+  instrumentation:
+    r2dbc:
+      statement-sanitizer:
+        enabled: true # défaut : true
+```
+
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+Active le nettoyage des instructions de base de données pour R2DBC :
+
+```yaml
+otel:
+  instrumentation/development:
+    java:
+      r2dbc:
+        statement_sanitizer:
+          enabled: true
+```
+
+{{% /tab %}} {{< /tabpane >}}

--- a/content/fr/docs/zero-code/java/spring-boot-starter/sdk-configuration.md
+++ b/content/fr/docs/zero-code/java/spring-boot-starter/sdk-configuration.md
@@ -1,9 +1,8 @@
 ---
 title: Configuration du SDK
 weight: 30
-default_lang_commit: 3d179dbe1270b83aafff0d3b6aa3311afd482649
-drifted_from_default: true
-cSpell:ignore: customizer distro
+default_lang_commit: 2d89b60b2e09d42ba96757b0afdbc31f54a2b0e7
+cSpell:ignore: distro
 ---
 
 <!-- markdownlint-disable blanks-around-fences -->
@@ -24,14 +23,7 @@ Vous pouvez mettre à jour la configuration à l'aide de propriétés dans le
 fichier `application.properties` ou `application.yaml`, ou avec des variables
 d'environnement.
 
-Exemple `application.properties` :
-
-```properties
-otel.propagators=tracecontext,b3
-otel.resource.attributes.deployment.environment=dev
-otel.resource.attributes.service.name=cart
-otel.resource.attributes.service.namespace=shop
-```
+{{< tabpane text=true >}} {{% tab "Properties" %}}
 
 Exemple `application.yaml` :
 
@@ -54,6 +46,36 @@ Exemple de variables d'environnement :
 export OTEL_PROPAGATORS="tracecontext,b3"
 export OTEL_RESOURCE_ATTRIBUTES="deployment.environment=dev,service.name=cart,service.namespace=shop"
 ```
+
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+Les réglages au niveau du SDK (ressources, propagateurs, exportateurs) utilisent
+le
+[schéma standard de configuration déclarative](/docs/languages/sdk-configuration/declarative-configuration/)
+directement dans `application.yaml`. Les propriétés système et les variables
+d'environnement continuent de fonctionner pour surcharger des valeurs — voir
+[Surcharges par variables d'environnement](../declarative-configuration/#environment-variable-overrides).
+
+```yaml
+otel:
+  file_format: '1.0'
+
+  resource:
+    attributes:
+      - name: deployment.environment
+        value: dev
+      - name: service.name
+        value: cart
+      - name: service.namespace
+        value: shop
+
+  propagator:
+    composite:
+      - tracecontext:
+      - b3:
+```
+
+{{% /tab %}} {{< /tabpane >}}
 
 ## Surcharge des attributs de ressource {#overriding-resource-attributes}
 
@@ -87,121 +109,41 @@ de Spring Boot.
 
 ## Désactiver le OpenTelemetry Starter {#disable-the-opentelemetry-starter}
 
-{{% config_option name="otel.sdk.disabled" %}}
+{{< tabpane text=true >}} {{% tab "Properties" %}}
 
-Définissez la valeur à `true` pour désactiver le starter, par exemple à des fins
-de test.
+Définissez `otel.sdk.disabled` à `true` pour désactiver le starter, par exemple
+à des fins de test :
 
-{{% /config_option %}}
+```yaml
+otel:
+  sdk:
+    disabled: true
+```
+
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+Définissez `otel.disabled` à `true` pour désactiver le starter, par exemple à
+des fins de test.
+
+Note : avec la
+[configuration déclarative](../declarative-configuration/), le nom de la
+propriété est `otel.disabled`, et non `otel.sdk.disabled`.
+
+```yaml
+otel:
+  file_format: '1.0'
+  disabled: true
+```
+
+{{% /tab %}} {{< /tabpane >}}
 
 ## Configuration programmatique {#programmatic-configuration}
 
-Vous pouvez utiliser le `AutoConfigurationCustomizerProvider` pour la
-configuration programmatique. La configuration programmatique est recommandée
-pour les cas d'utilisation avancés, qui ne sont pas configurables à l'aide de
-propriétés.
-
-### Exclure les traces des les points de terminaison de l'actuateur {#exclude-actuator-endpoints-from-tracing}
-
-Par exemple, vous pouvez personnaliser l'échantillonneur pour exclure les traces
-des points de terminaison de vérification de la disponibilité :
-
-{{< tabpane text=true >}} {{% tab header="Maven (`pom.xml`)" lang=Maven %}}
-
-```xml
-<dependencies>
-  <dependency>
-    <groupId>io.opentelemetry.contrib</groupId>
-    <artifactId>opentelemetry-samplers</artifactId>
-    <version>1.33.0-alpha</version>
-  </dependency>
-</dependencies>
-```
-
-{{% /tab %}} {{% tab header="Gradle (`build.gradle`)" lang=Gradle %}}
-
-```kotlin
-dependencies {
-  implementation("io.opentelemetry.contrib:opentelemetry-samplers:1.33.0-alpha")
-}
-```
-
-{{% /tab %}} {{< /tabpane>}}
-
-<!-- prettier-ignore-start -->
-<?code-excerpt "src/main/java/otel/FilterPaths.java"?>
-```java
-package otel;
-
-import io.opentelemetry.api.trace.SpanKind;
-import io.opentelemetry.contrib.sampler.RuleBasedRoutingSampler;
-import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
-import io.opentelemetry.semconv.UrlAttributes;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
-@Configuration
-public class FilterPaths {
-
-  @Bean
-  public AutoConfigurationCustomizerProvider otelCustomizer() {
-    return p ->
-        p.addSamplerCustomizer(
-            (fallback, config) ->
-                RuleBasedRoutingSampler.builder(SpanKind.SERVER, fallback)
-                    .drop(UrlAttributes.URL_PATH, "^/actuator")
-                    .build());
-  }
-}
-```
-<!-- prettier-ignore-end -->
-
-### Configurer programmatiquement l'exportateur {#configure-the-exporter-programmatically}
-
-Vous pouvez également configurer programmatiquement les exportateurs OTLP. Cette
-configuration remplace l'exportateur OTLP par défaut et ajoute un en-tête
-personnalisé aux requêtes.
-
-<!-- prettier-ignore-start -->
-<?code-excerpt "src/main/java/otel/CustomAuth.java"?>
-```java
-package otel;
-
-import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
-import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
-import java.util.Collections;
-import java.util.Map;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
-@Configuration
-public class CustomAuth {
-  @Bean
-  public AutoConfigurationCustomizerProvider otelCustomizer() {
-    return p ->
-        p.addSpanExporterCustomizer(
-            (exporter, config) -> {
-              if (exporter instanceof OtlpHttpSpanExporter) {
-                return ((OtlpHttpSpanExporter) exporter)
-                    .toBuilder().setHeaders(this::headers).build();
-              }
-              return exporter;
-            });
-  }
-
-  private Map<String, String> headers() {
-    return Collections.singletonMap("Authorization", "Bearer " + refreshToken());
-  }
-
-  private String refreshToken() {
-    // par exemple, lire le jeton d'un secret kubernetes
-    return "token";
-  }
-}
-```
-<!-- prettier-ignore-end -->
+Voir [Configuration programmatique](../programmatic-configuration/).
 
 ## Fournisseurs de ressources {#resource-providers}
+
+{{< tabpane text=true >}} {{% tab "Properties" %}}
 
 L'OpenTelemetry Starter inclut les mêmes fournisseurs de ressources que l'agent
 Java :
@@ -232,12 +174,41 @@ FQN:
 | `service.name`    | `spring.application.name` ou `build.name` de `build-info.properties` (voir [Nom du service](#service-name)) |
 | `service.version` | `build.version` de `build-info.properties`                                                                  |
 
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+Avec la [configuration déclarative](../declarative-configuration/), les
+fournisseurs de ressources se configurent explicitement comme des détecteurs,
+sous `resource.detection/development.detectors`. Seuls les détecteurs listés
+sont actifs — rien n'est découvert automatiquement via SPI.
+
+```yaml
+otel:
+  resource:
+    detection/development:
+      detectors:
+        - container: # container.id
+        - host: # host.name, host.arch
+        - host_id: # host.id
+        - os: # os.type, os.description
+        - process: # process.pid, process.executable.path, process.command_line
+        - process_runtime: # process.runtime.name/version/description
+        - service: # service.name, service.instance.id
+        - spring: # service.name (depuis spring.application.name), service.version (depuis build-info)
+```
+
+Les attributs `telemetry.distro.name` et `telemetry.distro.version` sont
+toujours ajoutés automatiquement par le starter, à des fins de dépannage.
+
+{{% /tab %}} {{< /tabpane >}}
+
 ## Nom du service {#service-name}
 
 En utilisant ces fournisseurs de ressources, le nom du service est déterminé par
 les règles de précédence suivantes, conformément à la
 [spécification](/docs/languages/sdk-configuration/general/#otel_service_name)
 OpenTelemetry :
+
+{{< tabpane text=true >}} {{% tab "Properties" %}}
 
 1. Propriété spring `otel.service.name` ou variable d'environnement
    `OTEL_SERVICE_NAME` (plus haute précédence)
@@ -247,6 +218,47 @@ OpenTelemetry :
 4. `build-info.properties`
 5. `Implementation-Title` de META-INF/MANIFEST.MF
 6. La valeur par défaut est `unknown_service:java` (plus basse précédence)
+
+{{% /tab %}} {{% tab "Declarative Configuration" %}}
+
+Le nom du service dépend des détecteurs de ressources que vous incluez (voir
+[Fournisseurs de ressources](#resource-providers)) :
+
+1. `service.name` dans `otel.resource.attributes` (plus haute précédence) :
+
+   ```yaml
+   otel:
+     resource:
+       attributes:
+         - name: service.name
+           value: my-spring-app
+   ```
+
+2. Le détecteur `service` — s'il est inclus, détecte automatiquement depuis
+   `OTEL_SERVICE_NAME` :
+
+   ```yaml
+   otel:
+     resource:
+       detection/development:
+         detectors:
+           - service:
+   ```
+
+3. Le détecteur `spring` — s'il est inclus, détecte depuis
+   `spring.application.name` et `build-info.properties` :
+
+   ```yaml
+   otel:
+     resource:
+       detection/development:
+         detectors:
+           - spring:
+   ```
+
+4. La valeur par défaut est `unknown_service:java` (plus basse précédence)
+
+{{% /tab %}} {{< /tabpane >}}
 
 Utilisez l'extrait suivant dans votre fichier pom.xml pour générer le fichier
 `build-info.properties` :


### PR DESCRIPTION
Part of #8777. Completes the Spring Boot starter lot started in #11078, with the two pages that needed the heaviest restructuring.

### `out-of-the-box-instrumentation`

Every configuration table becomes a **Properties / Declarative Configuration** tab pane (8 panes, 16 tabs, matching the English page exactly). The declarative tabs add:

- the centralized instrumentation lists under `otel.distribution.spring_starter.instrumentation`, with the note that names use `_` (snake_case) rather than `-`;
- the `instrumentation/development.java.*` keys for the JDBC, Logback, Kafka, MongoDB and R2DBC options;
- the renamed Logback appender properties (`experimental_log_attributes/development` and friends).

### `sdk-configuration`

Same tab pane treatment for general configuration, disabling the starter, resource providers and service name. Beyond that:

- the **Programmatic configuration** section is replaced by a link to its own page, as upstream did;
- resource providers gain the declarative detector list under `resource.detection/development.detectors`, with the note that nothing is auto-discovered via SPI;
- the property to disable the starter is `otel.disabled` in declarative configuration, **not** `otel.sdk.disabled` — I kept that warning, it is an easy trap.

### Checks I ran

The `<?code-excerpt?>` blocks are byte-identical to the English source (verified programmatically), English heading anchors match the English slugs on all 19 headings across the two pages, and the tables are column-aligned.

Once #11076, #11077, #11078 and this PR land, the whole `zero-code/java` tree is back in sync with English.

### Note

I still cannot run `npm run fix:format` locally (no Node on this machine), so please flag any Prettier complaints from CI and I will push a fixup right away.

/cc @dmathieu