### PR TITLE
[ja] update translation of content/en/docs/platforms/kubernetes/operator/troubleshooting/target-allocator.md

### DIFF
--- a/content/ja/docs/platforms/kubernetes/operator/troubleshooting/target-allocator.md
+++ b/content/ja/docs/platforms/kubernetes/operator/troubleshooting/target-allocator.md
@@ -1,7 +1,6 @@
 ---
 title: ターゲットアロケーター
-default_lang_commit: 39d3d2ef243d968e6a434fd9d2690c8070c3d7ea # patched
-drifted_from_default: true
+default_lang_commit: 21d692eb10d49a29a2cdecd51c753a202341c83c
 cSpell:ignore: bleh targetallocator
 ---
 
@@ -254,7 +253,7 @@ curl localhost:8080/jobs/serviceMonitor%2Fopentelemetry%2Fsm-example%2F0/targets
 
 > [!NOTE]
 >
-> `/jobs` エンドポイントのより詳細な情報については、[ターゲットアロケーターのREADME](https://github.com/open-telemetry/opentelemetry-operator/blob/main/cmd/otel-allocator/README.md?plain=1#L128-L134)を参照してください。
+> `/jobs` エンドポイントのより詳細な情報については、[ターゲットアロケーターのREADME](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/target-allocator/README.md#endpoints)を参照してください。
 
 ### ターゲットアロケーターは有効ですか？Prometheusのサービスディスカバリーは有効ですか？ {#is-the-target-allocator-enabled-is-prometheus-service-discovery-enabled}
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/platforms/kubernetes/operator/troubleshooting/target-allocator.md` to match the latest English source at
`content/en/docs/platforms/kubernetes/operator/troubleshooting/target-allocator.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff consists of two link target updates — the Target Allocator README and Prometheus service discovery links were moved from `cmd/otel-allocator/README.md` to `docs/target-allocator/README.md`. The second link had already been patched in the Japanese file; this PR fixes the remaining stale link and completes the sync.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.


<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11082--opentelemetry.netlify.app/ja/docs/platforms/kubernetes/operator/troubleshooting/target-allocator/
- **English (canonical):** https://opentelemetry.io/docs/platforms/kubernetes/operator/troubleshooting/target-allocator/

_(deploy preview may take a few minutes to build.)_
<!-- preview-section-end -->
