### PR TITLE
[ja] update translation of content/en/docs/platforms/faas/lambda-auto-instrument.md

### DIFF
--- a/content/ja/docs/platforms/faas/lambda-auto-instrument.md
+++ b/content/ja/docs/platforms/faas/lambda-auto-instrument.md
@@ -2,8 +2,7 @@
 title: Lambda 自動計装
 weight: 11
 description: あなたのLambdaをOpenTelemetryで自動的に計装する
-default_lang_commit: dd98ac8ecbbb60996860f62ec1f9eeb63a408a34 # patched
-drifted_from_default: true
+default_lang_commit: 21d692eb10d49a29a2cdecd51c753a202341c83c
 cSpell:ignore: Corretto
 ---
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/platforms/faas/lambda-auto-instrument.md` to match the latest English source at
`content/en/docs/platforms/faas/lambda-auto-instrument.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The only English-side change since the previous `# patched` commit was a link target update
(`#supported-runtimes` → `#python-version-support`) which was already applied by the patch.
This PR completes the sync by updating `default_lang_commit` to current HEAD and removing the drift marker.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.


<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11083--opentelemetry.netlify.app/ja/docs/platforms/faas/lambda-auto-instrument/
- **English (canonical):** https://opentelemetry.io/docs/platforms/faas/lambda-auto-instrument/

_(deploy preview status: pending. The URLs will work once Netlify finishes building.)_
<!-- preview-section-end -->
