### PR TITLE
[ja] add translation of content/en/_includes/page-not-translated-msg.md

### DIFF
--- a/content/ja/_includes/page-not-translated-msg.md
+++ b/content/ja/_includes/page-not-translated-msg.md
@@ -1,0 +1,6 @@
+---
+default_lang_commit: 63c0544931da26813836bc6fe49ee2888cacf64a
+---
+
+<i class="fa-solid fa-circle-info" style="margin-left: -1.5rem"></i> このページはまだ完全に翻訳されていないため、**英語版**を表示しています。
+翻訳に協力いただける方は[コントリビューション](/docs/contributing/)をご覧ください。


### PR DESCRIPTION
## Summary

Translates `content/en/_includes/page-not-translated-msg.md` into Japanese as `content/ja/_includes/page-not-translated-msg.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
<!-- preview-section-start -->

## Preview

This file is an `_includes` snippet displayed as a banner on untranslated Japanese pages. To verify:

- **Japanese (any untranslated page):** https://deploy-preview-11084--opentelemetry.netlify.app/ja/docs/
- **English (canonical):** https://opentelemetry.io/docs/

_(The banner appears on any `/ja/` page that does not yet have a Japanese translation.)_
<!-- preview-section-end -->
