### PR TITLE
[ja] add translation of content/en/announcements/kubecon-china.md

### DIFF
--- a/content/ja/announcements/kubecon-china.md
+++ b/content/ja/announcements/kubecon-china.md
@@ -1,0 +1,23 @@
+---
+title: KubeCon + CloudNativeCon China 2025
+linkTitle: KubeCon China 2025
+date: 2025-05-20
+expiryDate: 2025-06-11 # keep
+weight: 20250611
+params:
+  # As of 2026-01-26, LF reports the event through lfasiallc.com
+  eventUrl: &eventUrl >-
+    https://www.lfasiallc.com/kubecon-cloudnativecon-openinfra-summit-china/
+  blogPostURL: /blog/2025/kubecon-china/
+  # This is the old URL. Keeping for now. TODO: remove after 2026-08-31
+  oldEventUrl: >- # This now redirects to the new URL
+    https://events.linuxfoundation.org/kubecon-cloudnativecon-china/reg/register/?utm_source=opentelemetry&utm_medium=website&utm_content=slim-banner
+default_lang_commit: 8f68733f41ce6d7f0029edfaa14561ad95cc4aa0
+---
+
+[**{{% param title %}}**][LF]が **<span class="text-nowrap">6月10日〜11日に</span>
+香港で開催**。
+<span class="d-none d-md-inline"><br></span> <span class="d-none d-sm-inline">Cloud Native コミュニティと一緒に</span>[協力し、学び、共有しましょう][blog]！
+
+[blog]: <{{% param blogPostURL %}}>
+[LF]: <{{% param eventUrl %}}?{{% _param utmParam %}}>


### PR DESCRIPTION
## Summary

Translates `content/en/announcements/kubecon-china.md` into Japanese as `content/ja/announcements/kubecon-china.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11086--opentelemetry.netlify.app/ja/announcements/kubecon-china/
- **English (canonical):** https://opentelemetry.io/announcements/kubecon-china/

<!-- preview-section-end -->
