### PR TITLE
CI: fetch full history in workflows that run fix:link-cache

### DIFF
--- a/.github/workflows/auto-update-community-members.yml
+++ b/.github/workflows/auto-update-community-members.yml
@@ -18,7 +18,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with: { persist-credentials: false }
+        with:
+          persist-credentials: false
+          # Full history: `fix:link-cache` regenerates the link-report config,
+          # whose drift-pending overlay diffs against the l10n drift-status
+          # baseline commit.
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/auto-update-community-members.yml
+++ b/.github/workflows/auto-update-community-members.yml
@@ -20,9 +20,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-          # Full history: `fix:link-cache` regenerates the link-report config,
-          # whose drift-pending overlay diffs against the l10n drift-status
-          # baseline commit.
+          # Full history: fix:link-cache needs the drift-status baseline commit
           fetch-depth: 0
 
       - name: Set up Node.js

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -18,7 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with: { persist-credentials: false }
+        with:
+          persist-credentials: false
+          # Full history: `fix:link-cache` regenerates the link-report config,
+          # whose drift-pending overlay diffs against the l10n drift-status
+          # baseline commit.
+          fetch-depth: 0
 
       - name: Create NPM cache-hash input file
         run: |

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -20,9 +20,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-          # Full history: `fix:link-cache` regenerates the link-report config,
-          # whose drift-pending overlay diffs against the l10n drift-status
-          # baseline commit.
+          # Full history: fix:link-cache needs the drift-status baseline commit
           fetch-depth: 0
 
       - name: Create NPM cache-hash input file


### PR DESCRIPTION
- Fixes #11085
- **Root cause**: shallow checkout can't resolve the `data/l10n-drift.yaml` baseline commit that `fix:link-cache`'s drift-pending overlay diffs against, so the fail-loud guard (#11061) throws; full analysis in the issue
- **Adds `fetch-depth: 0`** to the checkouts of `auto-update-community-members.yml` (tripped nightly) and `build-dev.yml` (same latent issue, manual dispatch only), matching housekeeping, refcache-refresh, and pr-actions' fix job
