### PR TITLE
[ja] add translation of content/en/announcements/kubecon-asia.md

### DIFF
--- a/content/ja/announcements/kubecon-asia.md
+++ b/content/ja/announcements/kubecon-asia.md
@@ -1,0 +1,21 @@
+---
+title: KubeCon + CloudNativeCon Asia 2025
+linkTitle: KubeCon Asia 2025
+date: 2025-05-20
+# Expire after Japan event
+expiryDate: 2025-06-17 # keep
+weight: 20250617
+params:
+  eventUrlBase: &eventUrl >-
+    https://events.linuxfoundation.org/kubecon-cloudnativecon
+  blogPostURL: /blog/2025/kubecon-japan/
+default_lang_commit: 7cded84e3bd5923350bc541714655e12401a59cf
+---
+
+[**KubeCon + CloudNativeCon**][kubecon]、**<span class="text-nowrap">[東京、6月16日-17日][LF-Japan]</span>** および [**ハイデラバード（インド）、8月6日-7日**][LF-India]。
+<span class="d-none d-md-inline"><br></span>[協力し、学び、共有しましょう][blog]<span class="d-none d-sm-inline"> Cloud Native コミュニティと一緒に</span>！
+
+[blog]: <{{% param blogPostURL %}}>
+[kubecon]: https://www.cncf.io/kubecon-cloudnativecon-events
+[LF-Japan]: <{{% param eventUrlBase %}}-japan/register/?{{% _param utmParam %}}>
+[LF-India]: <{{% param eventUrlBase %}}-india/register/?{{% _param utmParam %}}>


### PR DESCRIPTION
## Summary

Translates `content/en/announcements/kubecon-asia.md` into Japanese as `content/ja/announcements/kubecon-asia.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11091--opentelemetry.netlify.app/ja/announcements/kubecon-asia/
- **English (canonical):** https://opentelemetry.io/announcements/kubecon-asia/

<!-- preview-section-end -->
