### PR TITLE
Add telemetry.dev to vendors list

### DIFF
--- a/.lycheecache
+++ b/.lycheecache
@@ -5920,6 +5920,7 @@ https://svnbook.red-bean.com/en/1.7/svn.tour.revs.specifiers.html,206,1784356055
 https://tapestry.apache.org/,206,1784284679
 https://tech.bureau.id/connecting-the-dots-with-opentelemetry-part-ii-5ea5f6b06c29,200,1785134672
 https://techdocs.broadcom.com/us/en/ca-enterprise-software/it-operations-management/dx-operational-observability/saas/monitoring/opentelemetry.html,206,1784355907
+https://telemetry.dev/integrations/opentelemetry,200,1785321714
 https://thanos.io/,200,1784960539
 https://thanos.io/tip/thanos/tracing.md/#opentelemetry-otlp,200,1784284816
 https://thrift.apache.org/,200,1785134662

--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -637,3 +637,9 @@
   contact: frank@respan.ai
   oss: false
   commercial: true
+- name: telemetry.dev
+  nativeOTLP: true
+  url: https://telemetry.dev/integrations/opentelemetry
+  contact: https://github.com/ephraimduncan
+  oss: false
+  commercial: true


### PR DESCRIPTION
Adding telemetry.dev, an observability platform for LLM and agent apps. It consumes OpenTelemetry natively: any OTLP/HTTP exporter can send traces, logs, or metrics straight to the ingest endpoint, and the linked integration page documents the setup. Entry shape matches the recent Respan and TrueWatch additions. I built telemetry.dev.

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.