### PR TITLE
docs(python): fix uv add argument in python zero code troubleshooting

### DIFF
--- a/content/en/docs/zero-code/python/troubleshooting.md
+++ b/content/en/docs/zero-code/python/troubleshooting.md
@@ -58,7 +58,7 @@ uv add opentelemetry-distro opentelemetry-exporter-otlp
 Now, you can install the auto instrumentation:
 
 ```sh
-uv run opentelemetry-bootstrap -a requirements | uv add --requirement -
+uv run opentelemetry-bootstrap -a requirements | uv add --requirements -
 ```
 
 Finally, use `uv run` to start your application (see


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

I spotted a typo in the argument to the `uv add` invocation in the python zero code troubleshooting documentation today. This fixes it by adding the missing `s`.
