### PR TITLE
Upgrade Docsy to v0.16.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,7 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/google/docsy.git
-  # cSpell:disable-next-line
-	docsy-pin = v0.15.0-41-g79448e2b
+	docsy-pin = v0.16.0
 	docsy-note = "2024-04-01 Switching to google/docsy.git from cncf/docsy.git since we don't have any CNCF customizations."
 	docsy-reminder = "Ensure that any tag referenced by `docsy-pin` is present in the remote repo (url), otherwise add (push) the tags to the repo."
 [submodule "content-modules/opentelemetry-specification"]


### PR DESCRIPTION
- Pins the Docsy submodule at the `v0.16.0` release tag (`9e5d51b7`), the same theme commit validated pre-release; every other [0.16.0 upgrade-guide](https://www.docsy.dev/blog/2026/0.16.0/) action already landed via #10906
- Drops the pin's `cSpell:disable-next-line` guard, needed only for hash-suffixed pins
- Validates clean at this pin: full local `npm run seq -- test` green; pre-release A/B output diff vs main showed buildDate-only churn
- **Preview(s)**:
  - https://deploy-preview-11100--opentelemetry.netlify.app/
