### PR TITLE
[ja] update translation of content/en/docs/platforms/kubernetes/operator/troubleshooting/automatic.md

### DIFF
--- a/content/ja/docs/platforms/kubernetes/operator/troubleshooting/automatic.md
+++ b/content/ja/docs/platforms/kubernetes/operator/troubleshooting/automatic.md
@@ -1,7 +1,6 @@
 ---
 title: 自動計装
-default_lang_commit: 1f686d5f7b6bbdfaa30dafdc6ca0214c6f2308db
-drifted_from_default: true
+default_lang_commit: c060ef7682b152a285d3a2f0c6a84c93ff877070
 cSpell:ignore: PYTHONPATH
 ---
 
@@ -255,7 +254,7 @@ annotations:
 
 ここでの `opentelemetry` は `Instrumentation` リソースの名前空間で、`my-instrumentation` は `Instrumentation` リソースの名前です。
 
-[アノテーションに利用できる値は次のとおりです](https://github.com/open-telemetry/opentelemetry-operator/blob/main/README.md?plain=1#L151-L156)。
+[アノテーションに利用できる値は次のとおりです](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/collector/sidecar-injection.md?plain=1#L54-L59)。
 
 - "true" - 名前空間から `OpenTelemetryCollector` リソースを挿入する。
 - "sidecar-for-my-app" - 現在の名前空間内の `OpenTelemetryCollector` カスタムリソースインスタンスの名前。


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/platforms/kubernetes/operator/troubleshooting/automatic.md` to match the latest English source at
`content/en/docs/platforms/kubernetes/operator/troubleshooting/automatic.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The only content change is a link target update: the annotation values reference moved from the operator `README.md` to `docs/collector/sidecar-injection.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.


<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11102--opentelemetry.netlify.app/ja/docs/platforms/kubernetes/operator/troubleshooting/automatic/
- **English (canonical):** https://opentelemetry.io/docs/platforms/kubernetes/operator/troubleshooting/automatic/

_(deploy preview status: pending. The URLs will work once Netlify finishes building.)_
<!-- preview-section-end -->
