### PR TITLE
[ja] update translation of content/en/docs/zero-code/obi/configure/service-discovery.md

### DIFF
--- a/content/ja/docs/zero-code/obi/configure/service-discovery.md
+++ b/content/ja/docs/zero-code/obi/configure/service-discovery.md
@@ -3,8 +3,7 @@ title: OBI サービスディスカバリーの設定
 linkTitle: サービスディスカバリー
 description: OBI のサービスディスカバリーコンポーネントが計装対象のプロセスを検索する方法を設定します。
 weight: 20
-default_lang_commit: e17943afc3a71a67fcdd3a69dcd428c3e45b306d # patched
-drifted_from_default: true
+default_lang_commit: c060ef7682b152a285d3a2f0c6a84c93ff877070
 # prettier-ignore
 cSpell:ignore: filestorecsi kube-node-lease kube-system rdns replicaset statefulset testserver volumepopulator
 ---


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/obi/configure/service-discovery.md` to match the latest English source at
`content/en/docs/zero-code/obi/configure/service-discovery.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff since the last sync is minimal: a single link URL was updated
(`README.md#...` → `docs/auto-instrumentation/resource-attributes.md#...`).
The Japanese file had already been patched with the correct URL (the previous
`default_lang_commit` carried a `# patched` annotation), so the only changes
in this PR are the frontmatter bookkeeping updates.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.


<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11103--opentelemetry.netlify.app/ja/docs/zero-code/obi/configure/service-discovery/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/obi/configure/service-discovery/

<!-- preview-section-end -->
