### PR TITLE
[ja] add translation of content/en/announcements/kubecon-india.md

### DIFF
--- a/content/ja/announcements/kubecon-india.md
+++ b/content/ja/announcements/kubecon-india.md
@@ -1,0 +1,21 @@
+---
+title: KubeCon + CloudNativeCon India 2026
+linkTitle: KubeCon India 2026
+date: 2026-04-25
+expiryDate: 2026-06-19 # keep
+weight: 20260619
+params:
+  eventUrl: &eventUrl >-
+    https://events.linuxfoundation.org/kubecon-cloudnativecon-india/
+  # Use this when the blog post is ready:
+  # blogPostURL: /blog/2026/kubecon-india/
+  blogPostURL: *eventUrl
+default_lang_commit: b1ffeb18d523211cca6f1c9d2892b7bb1e24fe4f
+---
+
+[**{{% param title %}}**][LF]が **<span class="text-nowrap">6月18日〜19日に</span>ムンバイで開催**。
+<span class="d-none d-md-inline"><br></span>
+<span class="d-none d-sm-inline"> Cloud Nativeコミュニティと一緒に</span>、[協力し、学び、共有しましょう][blog]！
+
+[blog]: <{{% param blogPostURL %}}>
+[LF]: <{{% param eventUrl %}}register/?{{% _param utmParam %}}>


### PR DESCRIPTION
## Summary

Translates `content/en/announcements/kubecon-india.md` into Japanese as `content/ja/announcements/kubecon-india.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11104--opentelemetry.netlify.app/ja/announcements/kubecon-india/
- **English (canonical):** https://opentelemetry.io/announcements/kubecon-india/

<!-- preview-section-end -->
