### PR TITLE
Add AISIX AI Gateway to the registry

### DIFF
--- a/.lycheecache
+++ b/.lycheecache
@@ -11,6 +11,7 @@ https://ai.pydantic.dev/,200,1787032238
 https://andygol-otel.netlify.app/uk/,200,1787032337
 https://answers.netlify.com/t/what-does-clear-cache-and-deploy-site-do-specifically/9419/2,200,1786569032
 https://anywhere.eks.amazonaws.com/docs/getting-started/optional/hostosconfig/,200,1787029611
+https://api7.ai/ai-gateway,200,1787150578
 https://apicontext.com/,200,1787029661
 https://apisix.apache.org/,200,1787032615
 https://app.netlify.com/sites/opentelemetry/overview,200,1786427565
@@ -378,6 +379,7 @@ https://doc.rust-lang.org/cargo/,200,1787029615
 https://doc.rust-lang.org/std/io/trait.Write.html,200,1787032523
 https://doc.traefik.io/traefik-hub/operations/metrics,200,1787032365
 https://doc.traefik.io/traefik/observability/tracing/opentelemetry/,200,1787029661
+https://docs.api7.ai/ai-gateway/observability/exporters,200,1787150578
 https://docs.apica.io/integrations/list-of-integrations/opentelemetry,200,1787029660
 https://docs.apimetrics.io/docs/export-with-opentelemetry,200,1787032365
 https://docs.astral.sh/uv/,200,1787032156
@@ -1095,6 +1097,8 @@ https://github.com/apache/cassandra/blob/cassandra-5.0/doc/native_protocol_v5.sp
 https://github.com/apache/dubbo,200,1787029742
 https://github.com/apache/dubbo/,200,1787029636
 https://github.com/apache/struts,200,1786427568
+https://github.com/api7,200,1787150580
+https://github.com/api7/aisix,200,1787150580
 https://github.com/argoproj/argo-workflows,200,1787032456
 https://github.com/arminru,200,1787032231
 https://github.com/arthi-arumugam-git,200,1786427576

--- a/data/registry/application-integration-rust-aisix.yml
+++ b/data/registry/application-integration-rust-aisix.yml
@@ -1,0 +1,24 @@
+# cSpell:ignore aisix
+title: AISIX AI Gateway
+registryType: application integration
+language: rust
+tags:
+  - rust
+  - aisix
+  - ai
+  - gateway
+  - llm
+license: Apache-2.0
+description:
+  AISIX is an open-source AI gateway for LLMs and AI agents that natively
+  exports OTLP trace spans following the GenAI semantic conventions, alongside
+  Prometheus metrics.
+authors:
+  - name: API7.ai
+    url: https://github.com/api7
+urls:
+  website: https://api7.ai/ai-gateway
+  repo: https://github.com/api7/aisix
+  docs: https://docs.api7.ai/ai-gateway/observability/exporters
+createdAt: '2026-07-30'
+isNative: true

--- a/data/registry/application-integration-rust-aisix.yml
+++ b/data/registry/application-integration-rust-aisix.yml
@@ -10,7 +10,7 @@ tags:
   - llm
 license: Apache-2.0
 description:
-  AISIX is an open-source AI gateway for LLMs and AI agents that natively
+  AISIX is an open source AI gateway for LLMs and AI agents that natively
   exports OTLP trace spans following the GenAI semantic conventions, alongside
   Prometheus metrics.
 authors:


### PR DESCRIPTION
This PR adds AISIX AI Gateway to the registry as an `application integration` entry.

AISIX is an open-source (Apache-2.0) AI gateway for LLMs and AI agents, written in Rust. OpenTelemetry support is built into the gateway itself: it exports OTLP trace spans that follow the GenAI semantic conventions (one span per LLM request, carrying `gen_ai.*` attributes) and exposes Prometheus metrics, with no plugin or external instrumentation library required — hence `isNative: true`.

- Repo: https://github.com/api7/aisix
- Docs (OTLP exporter configuration): https://docs.api7.ai/ai-gateway/observability/exporters

The entry file follows the template at `templates/registry-entry.yml` and the field set used by existing application-integration gateway entries in `data/registry`.

---

**Note from the maintainers**: this description was submitted without our [PR template](https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/PULL_REQUEST_TEMPLATE.md)'s checklist, which asks you to confirm:

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR. (Yes, I can answer maintainer questions about the content of this PR, without using AI.)

Per our [first-time contributor policy](https://github.com/open-telemetry/opentelemetry.io/issues/11243), answer these questions by ticking each box that applies.
