### PR TITLE
[ja] update translation of content/en/docs/guidance/blueprints/managed-telemetry-platforms-for-k8s-workloads.md

### DIFF
--- a/content/ja/docs/guidance/blueprints/managed-telemetry-platforms-for-k8s-workloads.md
+++ b/content/ja/docs/guidance/blueprints/managed-telemetry-platforms-for-k8s-workloads.md
@@ -1,8 +1,7 @@
 ---
 title: 'Kubernetes ワークロード向けマネージドテレメトリープラットフォーム'
 linkTitle: 'K8s ワークロード向けマネージドテレメトリープラットフォーム'
-default_lang_commit: 87b4cea0e74dccab17d61601c4bd80e15dc95d08
-drifted_from_default: true
+default_lang_commit: b1ffeb18d523211cca6f1c9d2892b7bb1e24fe4f
 cSpell:ignore: Autoscaler kube OTTL SDLC Skyscanner statefulset
 ---
 
@@ -793,7 +792,7 @@ OTLP エクスポーター設定と同様に、オペレーターはデータの
 [28]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/README.md
 [31]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/redactionprocessor/README.md
 [32]: https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/getting-started/compatibility.md#compatibility-matrix
-[33]: https://github.com/open-telemetry/opentelemetry-operator#opentelemetry-auto-instrumentation-injection
+[33]: https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/auto-instrumentation/README.md
 [34]: /docs/platforms/kubernetes/operator/
 [35]: /docs/platforms/kubernetes/operator/automatic/
 [36]: /docs/zero-code/


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/guidance/blueprints/managed-telemetry-platforms-for-k8s-workloads.md` to match the latest English source at
`content/en/docs/guidance/blueprints/managed-telemetry-platforms-for-k8s-workloads.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English change was a single link reference URL update (`[33]`), pointing to the new auto-instrumentation documentation location in the operator repository.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.


<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11109--opentelemetry.netlify.app/ja/docs/guidance/blueprints/managed-telemetry-platforms-for-k8s-workloads/
- **English (canonical):** https://opentelemetry.io/docs/guidance/blueprints/managed-telemetry-platforms-for-k8s-workloads/

_(deploy preview status: pending. The URLs will work once Netlify finishes building.)_
<!-- preview-section-end -->
