### PR TITLE
[ja] update translation of content/en/docs/demo/docker-deployment.md

### DIFF
--- a/content/ja/docs/demo/docker-deployment.md
+++ b/content/ja/docs/demo/docker-deployment.md
@@ -2,8 +2,7 @@
 title: Docker デプロイ
 linkTitle: Docker
 aliases: [docker_deployment]
-default_lang_commit: 953ac190ae2ae3a67f19f85ca7ce5f9efb990deb
-drifted_from_default: true
+default_lang_commit: b1ffeb18d523211cca6f1c9d2892b7bb1e24fe4f
 cSpell:ignore: otlphttp spanmetrics tracetest tracetesting
 ---
 
@@ -94,7 +93,6 @@ docker compose -f docker-compose-tests.yml run traceBasedTests
 
 - ウェブストア: <http://localhost:8080/>
 - Grafana: <http://localhost:8080/grafana/>
-- 負荷生成 UI: <http://localhost:8080/loadgen/>
 - Jaeger UI: <http://localhost:8080/jaeger/ui/>
 - トレーステスト UI: <http://localhost:11633/>、`make run-tracetesting` の使用時のみ
 - Flagd 設定 UI: <http://localhost:8080/feature>


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/demo/docker-deployment.md` to match the latest English source at
`content/en/docs/demo/docker-deployment.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The only English change was the removal of the "Load Generator UI" line from the
"Verify the web store and Telemetry" section. The corresponding Japanese line
(`負荷生成 UI`) has been removed.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.


<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11110--opentelemetry.netlify.app/ja/docs/demo/docker-deployment/
- **English (canonical):** https://opentelemetry.io/docs/demo/docker-deployment/

_(deploy preview status: pending. The URLs will work once Netlify finishes building.)_
<!-- preview-section-end -->
