### PR TITLE
Add Alfred to the registry (utilities, Python)

### DIFF
--- a/data/registry/utilities-python-alfred.yml
+++ b/data/registry/utilities-python-alfred.yml
@@ -1,0 +1,21 @@
+title: Alfred
+registryType: utilities
+language: python
+tags:
+  - genai
+  - agents
+  - traces
+  - audit
+  - mandate
+urls:
+  repo: https://github.com/adriencr81/Check-Alfred
+  website: https://adriencr81.github.io/Check-Alfred/
+  docs: https://adriencr81.github.io/Check-Alfred/
+license: Apache 2.0
+description: Reads the OpenTelemetry GenAI spans emitted by an AI agent and computes a daily digest of what the agent did, checked against a mandate declared in YAML. Every statement in the digest is anchored to a trace event ID.
+authors:
+  - name: Adrien Deleuil
+    url: https://github.com/adriencr81
+createdAt: 2026-07-31
+isNative: false
+isFirstParty: false


### PR DESCRIPTION
Adds a registry entry for [Alfred](https://github.com/adriencr81/Check-Alfred), an Apache-2.0 Python package that reads the OpenTelemetry GenAI spans emitted by an AI agent and computes a daily digest of what the agent did, checked against a mandate declared in YAML.

`registryType: utilities` — Alfred is not an exporter, instrumentation or collector component. It is a tool people use to work with OpenTelemetry data: it consumes GenAI spans that are already being produced and reports on them. `isNative` and `isFirstParty` are both false.

---

**Note from the maintainers**: this description was submitted without our [PR template](https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/PULL_REQUEST_TEMPLATE.md)'s checklist, which asks you to confirm:

- [ ] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [ ] I have the experience and knowledge necessary to understand, review, and validate all content in this PR. (Yes, I can answer maintainer questions about the content of this PR, without using AI.)

Per our [first-time contributor policy](https://github.com/open-telemetry/opentelemetry.io/issues/11243), answer these questions by ticking each box that applies.
