### PR TITLE
Pin Mermaid.js version and add Renovate config to bump it

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,4 +30,16 @@
       enabled: false,
     },
   ],
+  customManagers: [
+    {
+      // Track the Mermaid version pinned for Docsy's Mermaid partial.
+      customType: 'regex',
+      managerFilePatterns: ['/^config/_default/hugo\\.yaml$/'],
+      matchStrings: [
+        'mermaid:\\s*\\n\\s*version:\\s*[\'"](?<currentValue>[^\'"]+)[\'"]',
+      ],
+      depNameTemplate: 'mermaid',
+      datasourceTemplate: 'npm',
+    },
+  ],
 }

--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -139,7 +139,7 @@ params:
 
   # Pin the Mermaid version Docsy loads via jsDelivr
   mermaid:
-    version: "11.16.0"
+    version: '11.16.0'
 
   ## Social media image path, such as Open Graph's og:image
   #

--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -137,6 +137,10 @@ params:
   github_branch: main
   gcs_engine_id: 015faf7de29c34606
 
+  # Pin the Mermaid version Docsy loads via jsDelivr
+  mermaid:
+    version: "11.16.0"
+
   ## Social media image path, such as Open Graph's og:image
   #
   # IMPORTANT: if you change the image but not the path, also increment the


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

Closes https://github.com/open-telemetry/opentelemetry.io/issues/11157.

This PRs:

- Pins Mermaid version in `hugo.yaml` instead of using the default `@latest` configured by Docsy.
- Adds a `customManager` to Renovate config to regex-match the version and bump the package accordingly.
