### PR TITLE
[ja] add translation of content/en/announcements/kubecon-eu.md

### DIFF
--- a/content/ja/announcements/kubecon-eu.md
+++ b/content/ja/announcements/kubecon-eu.md
@@ -1,0 +1,19 @@
+---
+title: KubeCon + CloudNativeCon Europe 2026
+linkTitle: KubeCon EU 2026
+date: 2026-02-02
+expiryDate: 2026-03-26 # keep
+weight: 20260326
+params:
+  eventUrl: &eventUrl >-
+    https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/
+  blogPostURL: /blog/2026/kubecon-eu/
+default_lang_commit: 212fd3ead19d20d10975e270e840066902e82233
+---
+
+[**{{% param title %}}**][LF]が **<span class="text-nowrap">3月23日〜26日に</span>
+アムステルダムで開催**。
+<span class="d-none d-md-inline"><br></span> <span class="d-none d-sm-inline">Cloud Native コミュニティと一緒に</span>[協力し、学び、共有しましょう][blog]！
+
+[blog]: <{{% param blogPostURL %}}>
+[LF]: <{{% param eventUrl %}}register/?{{% _param utmParam %}}>


### PR DESCRIPTION
## Summary

Translates `content/en/announcements/kubecon-eu.md` into Japanese as `content/ja/announcements/kubecon-eu.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11159--opentelemetry.netlify.app/ja/announcements/kubecon-eu/
- **English (canonical):** https://opentelemetry.io/announcements/kubecon-eu/

<!-- preview-section-end -->
