### PR TITLE
docs: add Windows note for reserved ZPages port

### DIFF
--- a/content/en/docs/collector/quick-start.md
+++ b/content/en/docs/collector/quick-start.md
@@ -82,7 +82,13 @@ need to adjust the command syntax.
      otel/opentelemetry-collector:{{% param vers %}} \
      2>&1 | tee collector-output.txt
    ```
-
+      > **Note**
+   >
+   > On Windows, port `55679` may be reserved by the operating system (for example,
+   > because of Hyper-V). If Docker reports a port binding error, update the
+   > Collector configuration to use another available port (for example, `9999`)
+   > and change the Docker port mapping to match.
+   
    The previous command runs the Collector locally and opens three ports:
    - `4317` — OTLP over gRPC, the default for most SDKs
    - `4318` — OTLP over HTTP, for clients that don't support gRPC


### PR DESCRIPTION
## Summary

- Add a note for Windows users that port `55679` may be reserved by the operating system.
- Suggest using another available port if Docker reports a port binding error.

Fixes #5231

---

**Note from the maintainers**: this description was submitted without our [PR template](https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/PULL_REQUEST_TEMPLATE.md)'s checklist, which asks you to confirm:

- [ ] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [ ] I have the experience and knowledge necessary to understand, review, and validate all content in this PR. (Yes, I can answer maintainer questions about the content of this PR, without using AI.)

Per our [first-time contributor policy](https://github.com/open-telemetry/opentelemetry.io/issues/11243), answer these questions by ticking each box that applies.
