### PR TITLE
l10n: resolve link-check failures via drift status, not page edits

### DIFF
--- a/.claude/skills/review-pull-request/SKILL.md
+++ b/.claude/skills/review-pull-request/SKILL.md
@@ -15,7 +15,7 @@ effort: medium
 
 Review workflow for pull requests in `open-telemetry/opentelemetry.io`. The
 contributing guide and the per-check decoder in [`pr-checks.md`][pr-checks] are
-the authoritative sources — when this skill drifts from them, trust them.
+the authoritative sources; when this skill drifts from them, trust them.
 
 For blog-specific rules (`gh-url-hash`, author front matter, publish-date
 gating), defer to the sibling `review-blog-post` skill. For label drafting
@@ -187,26 +187,22 @@ Source-of-truth files — read on demand:
   [`localization.md`][localization], [`issues.md`][issues] — process rules
   deep-linked above.
 
-[pr-checks]: ../../../content/en/docs/contributing/pr-checks.md
+<!-- prettier-ignore-start -->
+[cache-check]: ../../../content/en/docs/contributing/pr-checks.md#cache-updates-committed
 [checks]: ../../../content/en/docs/contributing/pr-checks.md#checks
 [cla]: ../../../content/en/docs/contributing/pr-checks.md#easy-cla
-[cache-check]:
-  ../../../content/en/docs/contributing/pr-checks.md#cache-updates-committed
-[handling-links]:
-  ../../../content/en/docs/contributing/pr-checks.md#handling-valid-external-links
+[co-owned]: ../../../content/en/docs/contributing/sig-practices.md#co-owned-prs
+[general]: ../../../content/en/docs/contributing/sig-practices.md#general
+[handling-links]: ../../../content/en/docs/contributing/pr-checks.md#handling-valid-external-links
+[issues]: ../../../content/en/docs/contributing/issues.md
+[keep-green]: ../../../content/en/docs/contributing/localization.md#keep-checks-green
+[link-fixes]: ../../../content/en/docs/contributing/localization.md#link-fixes-and-resource-updates
+[locale-span]: ../../../content/en/docs/contributing/localization.md#prs-should-not-span-locales
+[localization]: ../../../content/en/docs/contributing/localization.md
 [npm-scripts]: ../../../content/en/site/build/npm-scripts.md
+[pr-checks]: ../../../content/en/docs/contributing/pr-checks.md
+[prs]: ../../../content/en/docs/contributing/sig-practices.md#prs
 [pull-requests]: ../../../content/en/docs/contributing/pull-requests.md
 [sig-practices]: ../../../content/en/docs/contributing/sig-practices.md
-[localization]: ../../../content/en/docs/contributing/localization.md
-[issues]: ../../../content/en/docs/contributing/issues.md
-[prs]: ../../../content/en/docs/contributing/sig-practices.md#prs
-[co-owned]: ../../../content/en/docs/contributing/sig-practices.md#co-owned-prs
-[translation]:
-  ../../../content/en/docs/contributing/sig-practices.md#translation-prs
-[general]: ../../../content/en/docs/contributing/sig-practices.md#general
-[locale-span]:
-  ../../../content/en/docs/contributing/localization.md#prs-should-not-span-locales
-[keep-green]:
-  ../../../content/en/docs/contributing/localization.md#keep-checks-green
-[link-fixes]:
-  ../../../content/en/docs/contributing/localization.md#link-fixes-and-resource-updates
+[translation]: ../../../content/en/docs/contributing/sig-practices.md#translation-prs
+<!-- prettier-ignore-end -->

--- a/.claude/skills/review-pull-request/SKILL.md
+++ b/.claude/skills/review-pull-request/SKILL.md
@@ -83,8 +83,9 @@ validates and the local fix command. Caveats:
 - Submodules: non-maintainer PRs should not touch them; a maintainer fixes
   before merge — [`sig-practices.md#general`][general].
 - Locale span: semantic changes are per-locale; page-content changes may span
-  locales only to keep checks green (such fixes append `# patched` to
-  `default_lang_commit`); content-neutral maintenance is exempt —
+  locales only as [build fixes][keep-green] (marked `# patched`); link-check
+  failures on localized pages never qualify and take a [drift-status
+  refresh][link-fixes] instead. Content-neutral maintenance is exempt —
   [`localization.md#prs-should-not-span-locales`][locale-span].
 
 **Branch state**
@@ -123,8 +124,8 @@ Walk this checklist before writing the review:
 - [ ] Netlify preview builds.
 - [ ] Each failing `check-*` assessed against [`pr-checks.md#checks`][checks].
 - [ ] Linked issue is `triage:accepted` (or this is an auto/hotfix PR).
-- [ ] Does not span locales — or does so only for checks-green fixes (marked
-      `# patched`) or content-neutral maintenance.
+- [ ] Does not span locales — or does so only for [build fixes][keep-green]
+      (marked `# patched`) or content-neutral maintenance.
 - [ ] First-time-contributor AI checklist in the PR description is filled in and
       looks human-written.
 - [ ] No unrelated changes bundled.
@@ -205,3 +206,7 @@ Source-of-truth files — read on demand:
 [general]: ../../../content/en/docs/contributing/sig-practices.md#general
 [locale-span]:
   ../../../content/en/docs/contributing/localization.md#prs-should-not-span-locales
+[keep-green]:
+  ../../../content/en/docs/contributing/localization.md#keep-checks-green
+[link-fixes]:
+  ../../../content/en/docs/contributing/localization.md#link-fixes-and-resource-updates

--- a/.github/localization.instructions.md
+++ b/.github/localization.instructions.md
@@ -225,7 +225,7 @@ default_lang_commit: <commit-hash-of-english-page>
 
 - Semantic changes should affect only one language per PR
 - Exception: changes strictly required to keep the site build green (build
-  fixes) can span locales; link-check failures never qualify — see "Patching"
+  fixes) can span locales; link-check failures never qualify; see "Patching"
   above
 - Exception: content-neutral maintenance (site-wide tooling, configuration,
   front-matter, or markup updates) can span locales; for the full policy, see

--- a/.github/localization.instructions.md
+++ b/.github/localization.instructions.md
@@ -140,7 +140,9 @@ default_lang_commit: <commit-hash-of-english-page>
   localized pages without syncing them
 - Never edit localized page content to fix links: resolve link-check failures on
   localized pages through drift-status updates
-  (`npm run fix:i18n:status -- <PATHS>`)
+  (`npm run fix:i18n:status -- PATHS`); in the rare case where a failing link
+  exists only in a localized page, report it and coordinate a fix with its
+  locale team
 - Make only the edits the fix requires, and add the `# patched` comment to the
   `default_lang_commit` line in front matter
 - Any other change to localized page content — including targeted content

--- a/.github/localization.instructions.md
+++ b/.github/localization.instructions.md
@@ -134,10 +134,12 @@ default_lang_commit: <commit-hash-of-english-page>
 3. Update `default_lang_commit` to latest hash (this also clears the page's
    drift status): `npm run check:i18n -- commit HEAD content/xx/path/to/page`
 
-**Patching (build and check fixes only):**
+**Patching (build fixes only):**
 
-- Fixes strictly required to keep the site build and its checks green (link
-  fixes, build fixes) may edit localized pages without syncing them
+- Fixes strictly required to keep the site build green (build fixes) may edit
+  localized pages without syncing them; link-check failures are instead resolved
+  through drift-status updates (`npm run fix:i18n:status -- <PATHS>`) — never
+  edit localized page content to fix links
 - Make only the edits the fix requires, and add the `# patched` comment to the
   `default_lang_commit` line in front matter
 - Any other change to localized page content — including targeted content
@@ -221,8 +223,9 @@ default_lang_commit: <commit-hash-of-english-page>
 **Single-Language PRs:**
 
 - Semantic changes should affect only one language per PR
-- Exception: changes strictly required to keep the site build and its checks
-  green (link fixes, build fixes) can span locales
+- Exception: changes strictly required to keep the site build green (build
+  fixes) can span locales; link-check failures on localized pages are resolved
+  through drift-status updates instead, never content edits
 - Exception: content-neutral maintenance (site-wide tooling, configuration,
   front-matter, or markup updates) can span locales; for the full policy, see
   `content/en/docs/contributing/localization.md#prs-should-not-span-locales`

--- a/.github/localization.instructions.md
+++ b/.github/localization.instructions.md
@@ -137,9 +137,10 @@ default_lang_commit: <commit-hash-of-english-page>
 **Patching (build fixes only):**
 
 - Fixes strictly required to keep the site build green (build fixes) may edit
-  localized pages without syncing them; link-check failures are instead resolved
-  through drift-status updates (`npm run fix:i18n:status -- <PATHS>`) — never
-  edit localized page content to fix links
+  localized pages without syncing them
+- Never edit localized page content to fix links: resolve link-check failures on
+  localized pages through drift-status updates
+  (`npm run fix:i18n:status -- <PATHS>`)
 - Make only the edits the fix requires, and add the `# patched` comment to the
   `default_lang_commit` line in front matter
 - Any other change to localized page content — including targeted content
@@ -224,8 +225,8 @@ default_lang_commit: <commit-hash-of-english-page>
 
 - Semantic changes should affect only one language per PR
 - Exception: changes strictly required to keep the site build green (build
-  fixes) can span locales; link-check failures on localized pages are resolved
-  through drift-status updates instead, never content edits
+  fixes) can span locales; link-check failures never qualify — see "Patching"
+  above
 - Exception: content-neutral maintenance (site-wide tooling, configuration,
   front-matter, or markup updates) can span locales; for the full policy, see
   `content/en/docs/contributing/localization.md#prs-should-not-span-locales`

--- a/.github/localization.instructions.md
+++ b/.github/localization.instructions.md
@@ -140,9 +140,10 @@ default_lang_commit: <commit-hash-of-english-page>
   localized pages without syncing them
 - Never edit localized page content to fix links: resolve link-check failures on
   localized pages through drift-status updates
-  (`npm run fix:i18n:status -- PATHS`); in the rare case where a failing link
+  (`npm run fix:i18n:status -- <PATHS>`); in the rare case where a failing link
   exists only in a localized page, report it and coordinate a fix with its
-  locale team
+  locale team; for the full policy, see
+  `content/en/docs/contributing/localization.md#link-fixes-and-resource-updates`
 - Make only the edits the fix requires, and add the `# patched` comment to the
   `default_lang_commit` line in front matter
 - Any other change to localized page content — including targeted content

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -308,10 +308,10 @@ npm run check:i18n -- commit HEAD <PATH-TO-YOUR-UPDATED-FILES>
 
 ### Patching localized pages {#patched}
 
-[Build and check fixes](#keep-checks-green) sometimes require editing a
-localized page without syncing it to its English counterpart — for example,
-retargeting a link after an English page was moved. Mark each localized page
-fixed in this way as **patched**, whether or not the fix spans locales:
+[Build fixes](#keep-checks-green) sometimes require editing a localized page
+without syncing it to its English counterpart — for example, repairing a
+shortcode invocation after the shared shortcode changed. Mark each localized
+page fixed in this way as **patched**, whether or not the fix spans locales:
 
 - Make only the edits that the fix requires — no other changes to the page.
 - Append the `# patched` YAML comment to the page's `default_lang_commit` line:
@@ -577,19 +577,20 @@ PRs.
 A PR that changes localized page **content** may span multiple locales only when
 that is strictly required to keep the site build and its checks green:
 
-- **Link fixes**: repairing link-check failures on localized pages after an
-  English page is moved or deleted, or an external resource has moved. See
-  [Link fixes and resource updates](#link-fixes-and-resource-updates).
 - **Build fixes**: repairing site-build breakage on localized pages, for
   example, after a shared shortcode, include file, or data source changes. A
   page's [drift status](#drift-status) only shields it from link checking, not
-  from the Hugo build.
+  from the Hugo build. Mark every localized page that you fix as
+  [patched](#patched).
 
-In both cases, mark every localized page that you fix as [patched](#patched).
+Link-check failures on localized pages are **not** such a case: resolve them
+through [drift status](#drift-status) updates, never through edits to localized
+page content. See
+[Link fixes and resource updates](#link-fixes-and-resource-updates).
 
 The check-green minimum applies to drift-status bookkeeping too: when a failing
-check calls for refreshing `drifted_from_default` (see the deleted-page case
-below), update only the pages that the failing check reports — the daily
+check calls for refreshing `drifted_from_default`, update only the pages that
+the failing check reports — the daily
 [Housekeeping run](/site/build/ci-workflows/#housekeeping) completes the rest.
 Status-only edits are [content-neutral maintenance](#semantic-changes).
 
@@ -602,47 +603,37 @@ adding a new glossary term.
 Changes to the English documentation can result in link-check failures for
 non-English locales. This happens when documentation pages, or sections within
 them, are moved or deleted; links to moved external resources can fail
-similarly. A moved or deleted page's localized copies themselves don't need to
-be touched: [drift tracking](#track-changes) flags them for their locale teams.
-What may need fixing are the localized pages that **link** to such targets.
-Proceed according to the fate of the link target:
+similarly. Fix such failures on English pages only — **never edit localized page
+content to fix links**. [Drift tracking](#track-changes) flags outdated
+localized copies for their locale teams, and reconciliation — link fixes
+included — is left to each team.
 
-- **A page was moved**:
+First, contain the fallout on the English side:
 
-  1. Ensure that the moved English page declares an [alias][aliases] for its old
-     path. The alias keeps previously published links to the page working, but
-     only for site visitors: aliases are published as server-side redirects, and
-     the link checker resolves links against the built site's canonical page
-     paths. Links to the old path therefore still need fixing.
-  2. Update the link to the new path on each non-English page that fails link
-     checking, and mark each edited page as [patched](#patched).
-     ([Drifted](#drift-status) pages are skipped by the link checker, so this
-     typically applies to in-sync pages.)
+- **A page was moved**: ensure that the moved English page declares an
+  [alias][aliases] for its old path. The alias keeps previously published links
+  to the page working, but only for site visitors: aliases are published as
+  server-side redirects, and the link checker resolves links against the built
+  site's canonical page paths. Links to the old path therefore still need fixing
+  on English pages.
+- **A section was moved within its page**: preserve its [heading ID](#headings)
+  so that links to the section keep working. (Aliases can't help in this case,
+  since they redirect page paths, not fragments.)
 
-- **A section was moved**: aliases can't help in this case, since they redirect
-  page paths, not fragments. If the section moved within its page, preserve its
-  [heading ID](#headings) so that links to the section keep working. Otherwise,
-  update links to the section on each page that fails link checking, and mark
-  each edited localized page as [patched](#patched).
+Then let drift handling cover the localized pages. Fixing the English pages that
+linked to a moved or deleted target makes their localized copies drift; the link
+checker already skips such copies as [drift pending](#drift-status), and the
+daily Housekeeping run persists their status. If a localized page still fails
+link checking, refresh its [drift status](#drift-status) directly:
 
-- **A page or section was deleted**: choosing a replacement or dropping the
-  reference is a [semantic change](#semantic-changes) for each affected locale,
-  so don't patch such links. Fixing the English pages that linked to the deleted
-  target makes their localized copies drift; the link checker already skips such
-  copies as [drift pending](#drift-status), and the daily Housekeeping run
-  persists their status. If a localized page still fails link checking, refresh
-  its [drift status](#drift-status) directly:
-  `npm run fix:i18n:status -- <PATHS-TO-FAILING-LOCALIZED-PAGES>`.
-  Reconciliation is left to each page's locale team. In the rare case where a
-  failing link exists only in a localized page, coordinate a fix with its locale
-  team.
+```sh
+npm run fix:i18n:status -- <PATHS-TO-FAILING-LOCALIZED-PAGES>
+```
 
-- **An external resource was moved**, but is otherwise semantically unchanged
-  (such as a relocated GitHub file): update the link on each page that fails
-  link checking, marking each edited localized page as [patched](#patched).
+In the rare case where a failing link exists only in a localized page, report it
+and coordinate a fix with its locale team.
 
-In all cases, rerun `npm run check:links` and confirm that no link failures
-remain.
+Finally, rerun `npm run check:links` and confirm that no link failures remain.
 
 [aliases]: https://gohugo.io/content-management/urls/#aliases
 [front matter]: https://gohugo.io/content-management/front-matter/

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -309,7 +309,7 @@ npm run check:i18n -- commit HEAD <PATH-TO-YOUR-UPDATED-FILES>
 ### Patching localized pages {#patched}
 
 [Build fixes](#keep-checks-green) sometimes require editing a localized page
-without syncing it to its English counterpart — for example, repairing a
+without syncing it to its English counterpart: for example, repairing a
 shortcode invocation after the shared shortcode changed. Mark each localized
 page fixed in this way as **patched**, whether or not the fix spans locales:
 
@@ -587,7 +587,7 @@ resolve them, see
 
 The check-green minimum applies to drift-status bookkeeping too: when a failing
 check calls for refreshing `drifted_from_default`, update only the pages that
-the failing check reports — the daily
+the failing check reports; the daily
 [Housekeeping run](/site/build/ci-workflows/#housekeeping) completes the rest.
 Status-only edits are [content-neutral maintenance](#semantic-changes).
 
@@ -602,8 +602,8 @@ non-English locales. This happens when documentation pages, or sections within
 them, are moved or deleted; links to moved external resources can fail
 similarly. Fix such failures on English pages only — **never edit localized page
 content to fix links**. [Drift tracking](#track-changes) flags outdated
-localized copies for their locale teams, and reconciliation — link fixes
-included — is left to each team.
+localized copies for their locale teams, and reconciliation, link fixes
+included, is left to each team.
 
 First, contain the fallout on the English side by fixing the failing links. Some
 target fates offer additional mitigations:
@@ -618,13 +618,13 @@ target fates offer additional mitigations:
   so that links to the section keep working. (Aliases can't help in this case,
   since they redirect page paths, not fragments.)
 
-Other fates — a section moved to a different page, a moved external resource, or
-a deleted target — have no such mitigation: fixing the English links is the
-whole English-side fix.
+Other fates (a section moved to a different page, a moved external resource, or
+a deleted target) have no such mitigation: fixing the English links is the whole
+English-side fix.
 
 Then let drift handling cover the localized pages: fixing the English pages
-makes their localized copies drift, and the link checker skips drifted copies —
-see [Drift status](#drift-status). If a localized page still fails link
+makes their localized copies drift, and the link checker skips drifted copies
+(see [Drift status](#drift-status)). If a localized page still fails link
 checking, refresh its drift status directly:
 
 ```sh

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -600,7 +600,7 @@ adding a new glossary term.
 Changes to the English documentation can result in link-check failures for
 non-English locales. This happens when documentation pages, or sections within
 them, are moved or deleted; links to moved external resources can fail
-similarly. Fix such failures on English pages only — **never edit localized page
+similarly. Fix such failures on English pages only; **never edit localized page
 content to fix links**. [Drift tracking](#track-changes) flags outdated
 localized copies for their locale teams, and reconciliation, link fixes
 included, is left to each team.
@@ -629,7 +629,7 @@ drifted copies. If a localized page still fails link checking, refresh its drift
 status directly:
 
 ```sh
-npm run fix:i18n:status -- <PATHS-TO-FAILING-LOCALIZED-PAGES>
+npm run fix:i18n:status -- PATHS_TO_FAILING_LOCALIZED_PAGES
 ```
 
 In the rare case where a failing link exists only in a localized page, report it

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -572,16 +572,14 @@ PRs.
 > status-only edits alike. Such changes don't alter the meaning of localized
 > pages.
 
-#### Keeping the build and checks green {#keep-checks-green}
+#### Keeping the build green {#keep-checks-green}
 
 A PR that changes localized page **content** may span multiple locales only when
-that is strictly required to keep the site build and its checks green:
-
-- **Build fixes**: repairing site-build breakage on localized pages, for
-  example, after a shared shortcode, include file, or data source changes. A
-  page's [drift status](#drift-status) only shields it from link checking, not
-  from the Hugo build. Mark every localized page that you fix as
-  [patched](#patched).
+that is strictly required to keep the site build green. Such **build fixes**
+repair site-build breakage on localized pages, for example, after a shared
+shortcode, include file, or data source changes. A page's
+[drift status](#drift-status) only shields it from link checking, not from the
+Hugo build. Mark every localized page that you fix as [patched](#patched).
 
 Link-check failures on localized pages are **not** such a case; for how to
 resolve them, see

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -585,7 +585,7 @@ Link-check failures on localized pages are **not** such a case; for how to
 resolve them, see
 [Link fixes and resource updates](#link-fixes-and-resource-updates).
 
-The check-green minimum applies to drift-status bookkeeping too: when a failing
+The same minimum-fix rule applies to drift-status bookkeeping: when a failing
 check calls for refreshing `drifted_from_default`, update only the pages that
 the failing check reports; the daily
 [Housekeeping run](/site/build/ci-workflows/#housekeeping) completes the rest.

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -615,17 +615,18 @@ target fates offer additional mitigations:
   site's canonical page paths. Links to the old path therefore still need fixing
   on English pages.
 - **A section was moved within its page**: preserve its [heading ID](#headings)
-  so that links to the section keep working. (Aliases can't help in this case,
-  since they redirect page paths, not fragments.)
+  so that links to the section keep working. Aliases can't help in this case:
+  they redirect page paths, not fragments.
 
-Other fates (a section moved to a different page, a moved external resource, or
-a deleted target) have no such mitigation: fixing the English links is the whole
-English-side fix.
+The other fates have no such mitigation: a section moved to a different page, a
+moved external resource, or a deleted target. Fixing the English links is the
+whole English-side fix; for a deleted target, that means choosing a replacement
+target or dropping the reference on each linking page.
 
 Then let drift handling cover the localized pages: fixing the English pages
-makes their localized copies drift, and the link checker skips drifted copies
-(see [Drift status](#drift-status)). If a localized page still fails link
-checking, refresh its drift status directly:
+makes their localized copies [drift](#drift-status), and the link checker skips
+drifted copies. If a localized page still fails link checking, refresh its drift
+status directly:
 
 ```sh
 npm run fix:i18n:status -- <PATHS-TO-FAILING-LOCALIZED-PAGES>

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -583,9 +583,8 @@ that is strictly required to keep the site build and its checks green:
   from the Hugo build. Mark every localized page that you fix as
   [patched](#patched).
 
-Link-check failures on localized pages are **not** such a case: resolve them
-through [drift status](#drift-status) updates, never through edits to localized
-page content. See
+Link-check failures on localized pages are **not** such a case; for how to
+resolve them, see
 [Link fixes and resource updates](#link-fixes-and-resource-updates).
 
 The check-green minimum applies to drift-status bookkeeping too: when a failing
@@ -608,7 +607,8 @@ content to fix links**. [Drift tracking](#track-changes) flags outdated
 localized copies for their locale teams, and reconciliation — link fixes
 included — is left to each team.
 
-First, contain the fallout on the English side:
+First, contain the fallout on the English side by fixing the failing links. Some
+target fates offer additional mitigations:
 
 - **A page was moved**: ensure that the moved English page declares an
   [alias][aliases] for its old path. The alias keeps previously published links
@@ -620,11 +620,14 @@ First, contain the fallout on the English side:
   so that links to the section keep working. (Aliases can't help in this case,
   since they redirect page paths, not fragments.)
 
-Then let drift handling cover the localized pages. Fixing the English pages that
-linked to a moved or deleted target makes their localized copies drift; the link
-checker already skips such copies as [drift pending](#drift-status), and the
-daily Housekeeping run persists their status. If a localized page still fails
-link checking, refresh its [drift status](#drift-status) directly:
+Other fates — a section moved to a different page, a moved external resource, or
+a deleted target — have no such mitigation: fixing the English links is the
+whole English-side fix.
+
+Then let drift handling cover the localized pages: fixing the English pages
+makes their localized copies drift, and the link checker skips drifted copies —
+see [Drift status](#drift-status). If a localized page still fails link
+checking, refresh its drift status directly:
 
 ```sh
 npm run fix:i18n:status -- <PATHS-TO-FAILING-LOCALIZED-PAGES>

--- a/content/en/site/skills/refresh-link-cache-pr-fix.md
+++ b/content/en/site/skills/refresh-link-cache-pr-fix.md
@@ -93,8 +93,8 @@ re-verifies them through a real browser; see
    Stop and wait for reviewer approval -- never self-approve recommendations.
 
 5. **Apply approved fixes.** Perform the maintainer-approved fix and follow-up
-   actions, and only those. Restrict content edits to English pages under
-   `content/en/`: **never edit localized page content**.
+   actions, and only those. For page content under `content/`, edit English
+   pages only: **never edit localized page content**.
 
 6. Run `npm run fix:link-cache` to re-check links and refresh `.lycheecache`
    after those source-link changes. If a localized page still fails, refresh its
@@ -104,8 +104,10 @@ re-verifies them through a real browser; see
    npm run fix:i18n:status -- PATHS_TO_FAILING_LOCALIZED_PAGES
    ```
 
-   For more details, see [Link fixes and resource updates][]. Repeat the steps
-   in this section (from step 1) until the check passes.
+   In the rare case where a failing link exists only in a localized page, report
+   it and coordinate a fix with its locale team. For more details, see [Link
+   fixes and resource updates][]. Repeat the steps in this section (from step 1)
+   until the check passes.
 
 ## Wrap up
 

--- a/content/en/site/skills/refresh-link-cache-pr-fix.md
+++ b/content/en/site/skills/refresh-link-cache-pr-fix.md
@@ -94,8 +94,11 @@ re-verifies them through a real browser; see
 
 5. **Apply approved fixes.** Perform the maintainer-approved fix and follow-up
    actions, and only those. Restrict content edits to English pages under
-   `content/en/`: **never edit localized page content**. When a localized page
-   fails link checking, refresh its [drift status][] instead:
+   `content/en/`: **never edit localized page content**.
+
+6. Run `npm run fix:link-cache` to re-check links (and refresh `.lycheecache`)
+   after those source-link changes. If a localized page still fails, refresh its
+   [drift status][] instead of editing it:
 
    ```sh
    npm run fix:i18n:status -- PATHS_TO_FAILING_LOCALIZED_PAGES
@@ -104,11 +107,8 @@ re-verifies them through a real browser; see
    The link checker skips drifted pages, and reconciliation is left to each
    page's locale team. In the rare case where a failing link exists only in a
    localized page, report it and defer to a maintainer to coordinate a fix with
-   the locale team.
-
-6. Run `npm run fix:link-cache` to re-check links (and refresh `.lycheecache`)
-   after those source-link changes, then repeat the steps in this section (from
-   step 1) until the check passes.
+   the locale team. Repeat the steps in this section (from step 1) until the
+   check passes.
 
 ## Wrap up
 

--- a/content/en/site/skills/refresh-link-cache-pr-fix.md
+++ b/content/en/site/skills/refresh-link-cache-pr-fix.md
@@ -93,8 +93,18 @@ re-verifies them through a real browser; see
    Stop and wait for reviewer approval -- never self-approve recommendations.
 
 5. **Apply approved fixes.** Perform the maintainer-approved fix and follow-up
-   actions, and only those. For edits outside `content/en/`, follow
-   [Localization][] gating requirements and conventions (e.g. `# patched` tags).
+   actions, and only those. Restrict content edits to English pages under
+   `content/en/`: **never edit localized page content**. When a localized page
+   fails link checking, refresh its [drift status][] instead:
+
+   ```sh
+   npm run fix:i18n:status -- PATHS_TO_FAILING_LOCALIZED_PAGES
+   ```
+
+   The link checker skips drifted pages, and reconciliation is left to each
+   page's locale team. In the rare case where a failing link exists only in a
+   localized page, report it and defer to a maintainer to coordinate a fix with
+   the locale team.
 
 6. Run `npm run fix:link-cache` to re-check links (and refresh `.lycheecache`)
    after those source-link changes, then repeat the steps in this section (from
@@ -173,5 +183,5 @@ Show that the fetched page names or otherwise matches the linked resource:
   [Keeping registry and list information current](/ecosystem/registry/updating/).
 
 <!-- prettier-ignore-start -->
-[Localization]: /docs/contributing/localization/#link-fixes-and-resource-updates
+[drift status]: /docs/contributing/localization/#drift-status
 <!-- prettier-ignore-end -->

--- a/content/en/site/skills/refresh-link-cache-pr-fix.md
+++ b/content/en/site/skills/refresh-link-cache-pr-fix.md
@@ -96,7 +96,7 @@ re-verifies them through a real browser; see
    actions, and only those. Restrict content edits to English pages under
    `content/en/`: **never edit localized page content**.
 
-6. Run `npm run fix:link-cache` to re-check links (and refresh `.lycheecache`)
+6. Run `npm run fix:link-cache` to re-check links and refresh `.lycheecache`
    after those source-link changes. If a localized page still fails, refresh its
    [drift status][] instead of editing it:
 
@@ -104,9 +104,8 @@ re-verifies them through a real browser; see
    npm run fix:i18n:status -- PATHS_TO_FAILING_LOCALIZED_PAGES
    ```
 
-   For the policy behind this, including the rare case of a link that exists
-   only in a localized page, see [Link fixes and resource updates][]. Repeat the
-   steps in this section (from step 1) until the check passes.
+   For more details, see [Link fixes and resource updates][]. Repeat the steps
+   in this section (from step 1) until the check passes.
 
 ## Wrap up
 

--- a/content/en/site/skills/refresh-link-cache-pr-fix.md
+++ b/content/en/site/skills/refresh-link-cache-pr-fix.md
@@ -104,11 +104,9 @@ re-verifies them through a real browser; see
    npm run fix:i18n:status -- PATHS_TO_FAILING_LOCALIZED_PAGES
    ```
 
-   The link checker skips drifted pages, and reconciliation is left to each
-   page's locale team. In the rare case where a failing link exists only in a
-   localized page, report it and defer to a maintainer to coordinate a fix with
-   the locale team. Repeat the steps in this section (from step 1) until the
-   check passes.
+   For the policy behind this, including the rare case of a link that exists
+   only in a localized page, see [Link fixes and resource updates][]. Repeat the
+   steps in this section (from step 1) until the check passes.
 
 ## Wrap up
 
@@ -184,4 +182,6 @@ Show that the fetched page names or otherwise matches the linked resource:
 
 <!-- prettier-ignore-start -->
 [drift status]: /docs/contributing/localization/#drift-status
+[link fixes and resource updates]:
+  /docs/contributing/localization/#link-fixes-and-resource-updates
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
- Contributes to the policy direction set post-#10930/#11058/#11087: link-check failures on localized pages are resolved through drift status, never through edits to localized page content
- Prompted by #11156, whose link-cache fix loop patched `fr`/`ja` pages
- **Policy**: reworks `localization.md` § link-fixes-and-resource-updates around the no-edit/drift model (English-side containment first, drift handling covers the rest); `# patched` now covers build fixes only
- **Skill**: step 5 of the link-cache fix-loop skill now restricts page-content edits to `content/en/` and points failing localized pages at `npm run fix:i18n:status`
- **Agent instructions**: mirrors the same model in `.github/localization.instructions.md`
- **Previews**:
  - <https://deploy-preview-11163--opentelemetry.netlify.app/docs/contributing/localization/#link-fixes-and-resource-updates>
  - <https://deploy-preview-11163--opentelemetry.netlify.app/site/skills/refresh-link-cache-pr-fix/>


