### PR TITLE
Ruby API link points to api docs

### DIFF
--- a/content/en/docs/languages/ruby/api.md
+++ b/content/en/docs/languages/ruby/api.md
@@ -1,7 +1,7 @@
 ---
 title: API reference
 linkTitle: API
-redirect: https://www.rubydoc.info/gems/opentelemetry-sdk
+redirect: https://www.rubydoc.info/gems/opentelemetry-api
 manualLinkTarget: _blank
 build: { render: link }
 weight: 210


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

This updates the ruby api link to now point to the api docs, this way the link accurately reflects what you will see. If you want to see docs for other gems these are all available via the registry since #10606 was merged.

This if someone clicks the api link they will see the docs of what they need to implement.

Note the github pages will be decommissioned.

closes #2512 
