### PR TITLE
[ja] update translation of content/en/docs/collector/extend/custom-component/receiver.md

### DIFF
--- a/content/ja/docs/collector/extend/custom-component/receiver.md
+++ b/content/ja/docs/collector/extend/custom-component/receiver.md
@@ -5,8 +5,7 @@ weight: 100
 aliases:
   - /docs/collector/trace-receiver
   - /docs/collector/building/receiver
-default_lang_commit: 2af96e42fca16c64f346a174d62a9d53f43545b3
-drifted_from_default: true
+default_lang_commit: 11fecfb1d12e8682c9619b3a477eccb21c736b99
 # prettier-ignore
 cSpell:ignore: backendsystem crand debugexporter mapstructure pcommon pdata ptrace rcvr resourcespans struct tailtracer telemetrygen uber
 ---


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/collector/extend/custom-component/receiver.md` to match the latest English source at
`content/en/docs/collector/extend/custom-component/receiver.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

Note: The Japanese content already contained the correct docker command (`jaegertracing/jaeger:latest` without
the `-e COLLECTOR_OTLP_ENABLED=true` flag). This PR only updates the frontmatter bookkeeping to clear the drift marker.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11172--opentelemetry.netlify.app/ja/docs/collector/extend/custom-component/receiver/
- **English (canonical):** https://opentelemetry.io/docs/collector/extend/custom-component/receiver/

_(deploy preview may take a few minutes to build.)_
<!-- preview-section-end -->
