### PR TITLE
[ja] update translation of content/en/docs/zero-code/java/agent/supported-libraries.md

### DIFF
--- a/content/ja/docs/zero-code/java/agent/supported-libraries.md
+++ b/content/ja/docs/zero-code/java/agent/supported-libraries.md
@@ -2,8 +2,7 @@
 title: サポートされているライブラリ
 linkTitle: サポートされているライブラリ
 weight: 11
-default_lang_commit: 8c95bffcf7243a916f79a0d525cf55b6a3d34ad7 # patched
-drifted_from_default: true
+default_lang_commit: 11fecfb1d12e8682c9619b3a477eccb21c736b99
 # prettier-ignore
 cSpell:ignore: activej akka armeria avaje clickhouse couchbase dbcp dropwizard dubbo finatra helidon hikari hikaricp httpasyncclient httpclient hystrix javalin jedis jodd ktor logmanager mojarra mybatis myfaces nats okhttp openai oshi payara pekko rabbitmq ratpack rediscala redisson resteasy restlet rocketmq shenyu SOFARPC spymemcached twilio vaadin vertx vibur webflux webmvc
 ---

--- a/content/ja/docs/zero-code/java/agent/supported-libraries.md
+++ b/content/ja/docs/zero-code/java/agent/supported-libraries.md
@@ -3,6 +3,7 @@ title: サポートされているライブラリ
 linkTitle: サポートされているライブラリ
 weight: 11
 default_lang_commit: 11fecfb1d12e8682c9619b3a477eccb21c736b99
+drifted_from_default: true
 # prettier-ignore
 cSpell:ignore: activej akka armeria avaje clickhouse couchbase dbcp dropwizard dubbo finatra helidon hikari hikaricp httpasyncclient httpclient hystrix javalin jedis jodd ktor logmanager mojarra mybatis myfaces nats okhttp openai oshi payara pekko rabbitmq ratpack rediscala redisson resteasy restlet rocketmq shenyu SOFARPC spymemcached twilio vaadin vertx vibur webflux webmvc
 ---


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/java/agent/supported-libraries.md` to match the latest English source at
`content/en/docs/zero-code/java/agent/supported-libraries.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The content change (Spring JMS link URL update) had already been applied via the `# patched` mechanism;
this PR completes the bookkeeping by updating `default_lang_commit` to the current HEAD and removing
the `drifted_from_default` and `# patched` markers.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11173--opentelemetry.netlify.app/ja/docs/zero-code/java/agent/supported-libraries/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/java/agent/supported-libraries/

_(deploy preview status: pending. The URLs will work once Netlify finishes building.)_
<!-- preview-section-end -->
