### PR TITLE
[ja] add translation of content/en/announcements/zoom-migration-lfx.md

### DIFF
--- a/content/ja/announcements/zoom-migration-lfx.md
+++ b/content/ja/announcements/zoom-migration-lfx.md
@@ -1,0 +1,16 @@
+---
+title: Zoom ミーティングが LFX Project Control Center に移行します
+linkTitle: Zoom → LFX PCC
+date: 2026-07-21
+expiryDate: 2026-09-01
+params:
+  issueUrl: https://github.com/open-telemetry/community/issues/3548
+default_lang_commit: 11fecfb1d12e8682c9619b3a477eccb21c736b99
+cSpell:ignore: lfx
+---
+
+すべての Zoom ミーティングが **[LFX Project Control
+Center][issue]** に移行します。<span class="d-none d-sm-inline">問題がありますか？</span>[コメントを残す][issue]か、[Slack](https://slack.cncf.io/)<span class="d-none d-sm-inline">の
+`#opentelemetry`</span> で質問してください。
+
+[issue]: <{{% param issueUrl %}}>

--- a/content/ja/announcements/zoom-migration-lfx.md
+++ b/content/ja/announcements/zoom-migration-lfx.md
@@ -9,8 +9,7 @@ default_lang_commit: 11fecfb1d12e8682c9619b3a477eccb21c736b99
 cSpell:ignore: lfx
 ---
 
-すべての Zoom ミーティングが **[LFX Project Control
-Center][issue]** に移行します。<span class="d-none d-sm-inline">問題がありますか？</span>[コメントを残す][issue]か、[Slack](https://slack.cncf.io/)<span class="d-none d-sm-inline">の
-`#opentelemetry`</span> で質問してください。
+すべての Zoom ミーティングが **[LFX Project Control Center][issue]** に移行します。
+<span class="d-none d-sm-inline">問題がありますか？</span>[コメントを残す][issue]か、[Slack](https://slack.cncf.io/)<span class="d-none d-sm-inline">の `#opentelemetry`</span> で質問してください。
 
 [issue]: <{{% param issueUrl %}}>


### PR DESCRIPTION
## Summary

Translates `content/en/announcements/zoom-migration-lfx.md` into Japanese as `content/ja/announcements/zoom-migration-lfx.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11174--opentelemetry.netlify.app/ja/announcements/zoom-migration-lfx/
- **English (canonical):** https://opentelemetry.io/announcements/zoom-migration-lfx/

<!-- preview-section-end -->
