### PR TITLE
Run fix:link-cache in update-registry-versions script

### DIFF
--- a/.github/scripts/update-registry-versions.sh
+++ b/.github/scripts/update-registry-versions.sh
@@ -172,6 +172,7 @@ fi
 if [[ -n $(git status --porcelain) ]]; then
     echo "Versions have been updated, formatting and pushing changes."
 
+    $NPM run fix:link-cache
     $NPM run fix:format
 
     $GIT checkout -b "$branch"


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

Added a command to run 'fix:link-cache' before formatting and committing changes.

This is necessary for when the update script add/removes urls as part of the ruby update process and would avoid pr’s such as https://github.com/open-telemetry/opentelemetry.io/pull/11176 being in error.
