### PR TITLE
[ja] update translation of content/en/docs/languages/go/exporters.md

### DIFF
--- a/content/ja/docs/languages/go/exporters.md
+++ b/content/ja/docs/languages/go/exporters.md
@@ -2,8 +2,7 @@
 title: エクスポーター
 aliases: [exporting_data]
 weight: 50
-default_lang_commit: 813498074d85258c7180d137ace9e272d0149353
-drifted_from_default: true
+default_lang_commit: 11fecfb1d12e8682c9619b3a477eccb21c736b99
 # prettier-ignore
 cSpell:ignore: autoexport otlplog otlploggrpc otlploghttp otlpmetric otlpmetricgrpc otlpmetrichttp otlptrace otlptracegrpc otlptracehttp sdkmetric sdktrace stdoutlog stdouttrace
 ---


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/go/exporters.md` to match the latest English source at
`content/en/docs/languages/go/exporters.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff since the last sync only changed the Jaeger Docker command (removed
`-e COLLECTOR_OTLP_ENABLED=true` and changed `jaegertracing/all-in-one:latest` to
`jaegertracing/jaeger:latest`). The Japanese file already had both changes applied,
so this PR is a pure bookkeeping update.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11180--opentelemetry.netlify.app/ja/docs/languages/go/exporters/
- **English (canonical):** https://opentelemetry.io/docs/languages/go/exporters/

<!-- preview-section-end -->
