### PR TITLE
[ja] update translation of content/en/docs/demo/kubernetes-deployment.md

### DIFF
--- a/content/ja/docs/demo/kubernetes-deployment.md
+++ b/content/ja/docs/demo/kubernetes-deployment.md
@@ -2,9 +2,8 @@
 title: Kubernetesデプロイ
 linkTitle: Kubernetes
 aliases: [kubernetes_deployment]
-default_lang_commit: c1e141558ab36cc1ab9f864728e4665e272ac131
-drifted_from_default: true
-cSpell:ignore: loadgen otlphttp spanmetrics
+default_lang_commit: 11fecfb1d12e8682c9619b3a477eccb21c736b99
+cSpell:ignore: otlphttp spanmetrics
 ---
 
 既存のKubernetesクラスターにデモをデプロイするのに役立つ[OpenTelemetry Demo Helmチャート](/docs/platforms/kubernetes/helm/demo/)を提供しています。
@@ -79,7 +78,6 @@ frontend-proxyをport-forwardで設定すると、次のURLにアクセスでき
 
 - Web store: <http://localhost:8080/>
 - Grafana: <http://localhost:8080/grafana/>
-- Load Generator UI: <http://localhost:8080/loadgen/>
 - Jaeger UI: <http://localhost:8080/jaeger/ui/>
 - Flagd configurator UI: <http://localhost:8080/feature>
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/demo/kubernetes-deployment.md` to match the latest English source at
`content/en/docs/demo/kubernetes-deployment.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

Changes applied:
- Removed `loadgen` from `cSpell:ignore` frontmatter field
- Removed `Load Generator UI` entry from the URL list

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.


<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11181--opentelemetry.netlify.app/ja/docs/demo/kubernetes-deployment/
- **English (canonical):** https://opentelemetry.io/docs/demo/kubernetes-deployment/

<!-- preview-section-end -->
