### PR TITLE
[ja] update translation of content/en/docs/languages/_includes/exporters/jaeger.md

### DIFF
--- a/content/ja/docs/languages/_includes/exporters/jaeger.md
+++ b/content/ja/docs/languages/_includes/exporters/jaeger.md
@@ -1,6 +1,5 @@
 ---
-default_lang_commit: 6f3712c5cda4ea79f75fb410521880396ca30c91
-drifted_from_default: true
+default_lang_commit: 11fecfb1d12e8682c9619b3a477eccb21c736b99
 ---
 
 ## Jaeger {#jaeger}


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/_includes/exporters/jaeger.md` to match the latest English source at
`content/en/docs/languages/_includes/exporters/jaeger.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The Japanese code block already matched the current English source (the Jaeger v2 docker image change from
`jaegertracing/all-in-one:latest` to `jaegertracing/jaeger:latest` and removal of the
`COLLECTOR_ZIPKIN_HOST_PORT` env var were applied in a prior commit). This PR updates only the
frontmatter bookkeeping to clear the drift marker.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

This file is an `_includes` partial and does not have its own rendered URL. It is included by language-specific exporter pages. Example consumer pages:

- **Japanese (this PR):** https://deploy-preview-11182--opentelemetry.netlify.app/ja/docs/languages/js/exporters/
- **English (canonical):** https://opentelemetry.io/docs/languages/js/exporters/

<!-- preview-section-end -->
