### PR TITLE
Add docs for OpenTelemetry system packages on Linux hosts

### DIFF
--- a/content/en/docs/platforms/linux/_index.md
+++ b/content/en/docs/platforms/linux/_index.md
@@ -1,0 +1,78 @@
+---
+title: OpenTelemetry on Linux hosts
+linkTitle: Linux
+description:
+  Install OpenTelemetry as a system package to automatically instrument the
+  applications running on a Linux host.
+weight: 250
+cSpell:ignore: metapackage
+---
+
+Setting up OpenTelemetry usually depends on where your applications run. Some
+environments are highly automated, such as
+[Kubernetes](/docs/platforms/kubernetes/), thanks to the OpenTelemetry Operator,
+or [Functions as a Service](/docs/platforms/faas/) with the OpenTelemetry Lambda
+layers. But many Java, .NET, Node.js, and Python applications run directly on
+Linux hosts, where instrumenting them has traditionally meant downloading agents
+by hand and wiring up environment variables yourself.
+
+The
+[OpenTelemetry Packaging SIG](https://github.com/open-telemetry/opentelemetry-packaging)
+provides **system packages** that make OpenTelemetry a dependency of the host
+itself. After installing a single package and restarting your applications, the
+Java, .NET, Node.js, and Python processes on the host are automatically
+instrumented and start emitting telemetry.
+
+## How it works
+
+The `opentelemetry` package is a metapackage that bundles:
+
+- The
+  [OpenTelemetry Injector](https://github.com/open-telemetry/opentelemetry-injector),
+  which configures the dynamic linker so that supported runtimes load the
+  matching auto-instrumentation when a process starts.
+- The OpenTelemetry SDKs and auto-instrumentation for Java, .NET, Node.js, and
+  Python.
+
+Once installed, the injector adds the auto-instrumentation to every new process
+of a supported runtime on the host. Applications that were already running are
+instrumented after they are restarted. By default, telemetry is exported using
+OTLP to `localhost` on ports `4317` (gRPC) and `4318` (HTTP), so you typically
+run a local [OpenTelemetry Collector](/docs/collector/) to receive and forward
+it.
+
+## Get started
+
+- [Installation](installation/): add the repository and install the package on
+  Debian, Ubuntu, Fedora, or RHEL and derivatives.
+- [Configuration](configuration/): point the injector at your Collector or
+  backend and tune what gets instrumented.
+
+## Status and limitations
+
+> [!WARNING]
+>
+> The system packages are early in their journey and are **not yet meant for
+> production workloads**. Expect changes as the packaging story matures.
+>
+> Specifically:
+>
+> - The APT and YUM repositories are currently hosted on GitHub Pages, which is
+>   **not their final home**.
+> - Packages are **not yet signed**, so the installation instructions disable
+>   signature verification.
+> - The [OpenTelemetry Collector](/docs/collector/) is not yet part of the base
+>   metapackage; you install and run it separately for now.
+>
+> The Packaging SIG is actively looking for end-user feedback. Please try the
+> packages and open issues in the
+> [opentelemetry-packaging](https://github.com/open-telemetry/opentelemetry-packaging)
+> repository.
+
+## Learn more
+
+- Blog post:
+  [One-command OpenTelemetry setup on Linux hosts](/blog/2026/packaging-first-repo/)
+- The
+  [opentelemetry-packaging](https://github.com/open-telemetry/opentelemetry-packaging)
+  repository and its weekly SIG meeting.

--- a/content/en/docs/platforms/linux/_index.md
+++ b/content/en/docs/platforms/linux/_index.md
@@ -34,16 +34,23 @@ The `opentelemetry` package is a metapackage that depends on:
 - The language-specific auto-instrumentation packages for Java, .NET, Node.js,
   and Python.
 
-Once installed, the injector adds the auto-instrumentation to every new process
-of a supported runtime on the host. Applications that were already running are
-instrumented after they are restarted. By default, telemetry is exported using
-OTLP to `localhost` on ports `4317` (gRPC) and `4318` (HTTP), so you typically
-run a local [OpenTelemetry Collector](/docs/collector/) to receive and forward
-it.
+Once installed, the injector attaches to every newly started, dynamically linked
+process on the host. It only has a visible effect on processes of a supported
+runtime, loading the matching auto-instrumentation for them; processes of
+runtimes without an OpenTelemetry SDK are left unaffected. Applications that
+were already running are instrumented after they are restarted. By default,
+telemetry is exported using OTLP to `localhost` on ports `4317` (gRPC) and
+`4318` (HTTP), so you typically run a local
+[OpenTelemetry Collector](/docs/collector/) to receive and forward it. The
+Collector itself is distributed as system packages by the
+[OpenTelemetry Collector Releases](https://github.com/open-telemetry/opentelemetry-collector-releases)
+project; integrating it into this system-package repository is tracked in
+[opentelemetry-collector-releases#1561](https://github.com/open-telemetry/opentelemetry-collector-releases/issues/1561).
 
 The Packaging and OBI SIGs also plan to deliver
 [OpenTelemetry eBPF Instrumentation](/docs/zero-code/obi/) as a system package,
-extending zero-code instrumentation to additional runtimes such as Go.
+extending zero-code instrumentation to additional runtimes such as Go, Rust, and
+C++.
 
 ## Get started
 

--- a/content/en/docs/platforms/linux/_index.md
+++ b/content/en/docs/platforms/linux/_index.md
@@ -25,14 +25,14 @@ instrumented and start emitting telemetry.
 
 ## How it works
 
-The `opentelemetry` package is a metapackage that bundles:
+The `opentelemetry` package is a metapackage that depends on:
 
 - The
   [OpenTelemetry Injector](https://github.com/open-telemetry/opentelemetry-injector),
   which configures the dynamic linker so that supported runtimes load the
   matching auto-instrumentation when a process starts.
-- The OpenTelemetry SDKs and auto-instrumentation for Java, .NET, Node.js, and
-  Python.
+- The language-specific auto-instrumentation packages for Java, .NET, Node.js,
+  and Python.
 
 Once installed, the injector adds the auto-instrumentation to every new process
 of a supported runtime on the host. Applications that were already running are
@@ -40,6 +40,10 @@ instrumented after they are restarted. By default, telemetry is exported using
 OTLP to `localhost` on ports `4317` (gRPC) and `4318` (HTTP), so you typically
 run a local [OpenTelemetry Collector](/docs/collector/) to receive and forward
 it.
+
+The Packaging and OBI SIGs also plan to deliver
+[OpenTelemetry eBPF Instrumentation](/docs/zero-code/obi/) as a system package,
+extending zero-code instrumentation to additional runtimes such as Go.
 
 ## Get started
 

--- a/content/en/docs/platforms/linux/configuration.md
+++ b/content/en/docs/platforms/linux/configuration.md
@@ -20,10 +20,34 @@ The recommended setup is to run a local
 [OpenTelemetry Collector](/docs/collector/) on the host that receives this
 telemetry and forwards it to your backend.
 
-To send telemetry somewhere else, edit the injector environment file at
-`/etc/opentelemetry/injector/default_env.conf`. Any environment variable set
-there is applied to every instrumented process. For example, to export directly
-to an OTLP endpoint that requires an API key:
+To send telemetry somewhere else, the recommended way is to use a configuration
+file. You rarely need to write one from scratch: each language package ships a
+ready-to-use reference file at `/etc/opentelemetry/<language>/otel-config.yaml`
+that wires up the exporter endpoint, headers, and service name through
+environment-variable interpolation. Copy or adapt one of these files with your
+[declarative configuration](/docs/languages/sdk-configuration/declarative-configuration/),
+then activate it by setting `OTEL_CONFIG_FILE` in the injector environment file
+at `/etc/opentelemetry/injector/default_env.conf`:
+
+```conf
+OTEL_CONFIG_FILE=/etc/opentelemetry/config.yaml
+```
+
+> [!NOTE]
+>
+> For .NET, file-based configuration also requires
+> `OTEL_EXPERIMENTAL_FILE_BASED_CONFIGURATION_ENABLED=true`. Without it, the
+> configuration file is silently ignored.
+
+Restart your applications for configuration changes to take effect.
+
+## Configure with environment variables
+
+If you prefer not to use a configuration file, you can set standard
+OpenTelemetry environment variables directly in the injector environment file at
+`/etc/opentelemetry/injector/default_env.conf`. Any variable set there is
+applied to every instrumented process. For example, to export directly to an
+OTLP endpoint that requires an API key:
 
 ```conf
 OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.example.com
@@ -37,28 +61,6 @@ you can configure any SDK behavior the same way, such as `OTEL_SERVICE_NAME`,
 list.
 
 Restart your applications for configuration changes to take effect.
-
-## Use a configuration file
-
-For richer setups you can drive the instrumentation with a
-[declarative configuration](/docs/languages/sdk-configuration/declarative-configuration/)
-file instead of individual environment variables. You rarely need to write one
-from scratch: each language package ships a ready-to-use reference file at
-`/etc/opentelemetry/<language>/otel-config.yaml` that wires up the exporter
-endpoint, headers, and service name through environment-variable interpolation.
-
-Copy or adapt that file to a location of your choice, then activate it by
-setting `OTEL_CONFIG_FILE` in `/etc/opentelemetry/injector/default_env.conf`:
-
-```conf
-OTEL_CONFIG_FILE=/etc/opentelemetry/config.yaml
-```
-
-> [!NOTE]
->
-> For .NET, file-based configuration also requires
-> `OTEL_EXPERIMENTAL_FILE_BASED_CONFIGURATION_ENABLED=true`. Without it, the
-> configuration file is silently ignored.
 
 ## Run a local Collector
 

--- a/content/en/docs/platforms/linux/configuration.md
+++ b/content/en/docs/platforms/linux/configuration.md
@@ -1,0 +1,64 @@
+---
+title: Configuration
+weight: 20
+description:
+  Point the OpenTelemetry Injector at your Collector or backend and control what
+  gets instrumented on a Linux host.
+cSpell:ignore: metapackage
+---
+
+After [installing](../installation/) the system packages, the
+[OpenTelemetry Injector](https://github.com/open-telemetry/opentelemetry-injector)
+instruments supported applications with sensible defaults. This page describes
+how to change where telemetry is sent and how to adjust the injected
+configuration.
+
+## Set the export destination
+
+By default, the injected instrumentation exports telemetry using OTLP to
+`localhost` on ports `4317` (gRPC) and `4318` (HTTP). The recommended setup is
+to run a local [OpenTelemetry Collector](/docs/collector/) that receives this
+telemetry and forwards it to your backend.
+
+To send telemetry somewhere else, edit the injector environment file at
+`/etc/opentelemetry/injector/default_env.conf`. Any environment variable set
+there is applied to every instrumented process. For example, to export directly
+to an OTLP endpoint that requires an API key:
+
+```conf
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.example.com
+OTEL_EXPORTER_OTLP_HEADERS=api-key=REPLACE_ME
+```
+
+Because `default_env.conf` uses standard OpenTelemetry environment variables,
+you can configure any SDK behavior the same way, such as `OTEL_SERVICE_NAME`,
+`OTEL_RESOURCE_ATTRIBUTES`, or the various sampler and exporter settings. See
+[SDK environment variables](/docs/languages/sdk-configuration/) for the full
+list.
+
+Restart your applications for configuration changes to take effect.
+
+## Use a configuration file
+
+For richer setups you can point the instrumentation at a
+[declarative configuration](/docs/languages/sdk-configuration/declarative-configuration/)
+file with the `OTEL_CONFIG_FILE` environment variable in
+`/etc/opentelemetry/injector/default_env.conf`:
+
+```conf
+OTEL_CONFIG_FILE=/etc/opentelemetry/config.yaml
+```
+
+## Run a local Collector
+
+Running a [Collector](/docs/collector/) on the host lets you keep the export
+configuration of your applications simple: they send OTLP to `localhost`, and
+the Collector handles batching, retries, and routing to one or more backends.
+Install and run the Collector separately for now; it is not yet part of the base
+`opentelemetry` metapackage.
+
+## Next steps
+
+- Learn more about the [OpenTelemetry Collector](/docs/collector/).
+- Review the available
+  [SDK environment variables](/docs/languages/sdk-configuration/).

--- a/content/en/docs/platforms/linux/configuration.md
+++ b/content/en/docs/platforms/linux/configuration.md
@@ -9,15 +9,15 @@ cSpell:ignore: metapackage
 
 After [installing](../installation/) the system packages, the
 [OpenTelemetry Injector](https://github.com/open-telemetry/opentelemetry-injector)
-instruments supported applications with sensible defaults. This page describes
-how to change where telemetry is sent and how to adjust the injected
+instruments supported applications and exports telemetry using OTLP to
+`localhost` on ports `4317` (gRPC) and `4318` (HTTP) by default. This page
+describes how to change where telemetry is sent and how to adjust the injected
 configuration.
 
 ## Set the export destination
 
-By default, the injected instrumentation exports telemetry using OTLP to
-`localhost` on ports `4317` (gRPC) and `4318` (HTTP). The recommended setup is
-to run a local [OpenTelemetry Collector](/docs/collector/) that receives this
+The recommended setup is to run a local
+[OpenTelemetry Collector](/docs/collector/) on the host that receives this
 telemetry and forwards it to your backend.
 
 To send telemetry somewhere else, edit the injector environment file at
@@ -40,14 +40,25 @@ Restart your applications for configuration changes to take effect.
 
 ## Use a configuration file
 
-For richer setups you can point the instrumentation at a
+For richer setups you can drive the instrumentation with a
 [declarative configuration](/docs/languages/sdk-configuration/declarative-configuration/)
-file with the `OTEL_CONFIG_FILE` environment variable in
-`/etc/opentelemetry/injector/default_env.conf`:
+file instead of individual environment variables. You rarely need to write one
+from scratch: each language package ships a ready-to-use reference file at
+`/etc/opentelemetry/<language>/otel-config.yaml` that wires up the exporter
+endpoint, headers, and service name through environment-variable interpolation.
+
+Copy or adapt that file to a location of your choice, then activate it by
+setting `OTEL_CONFIG_FILE` in `/etc/opentelemetry/injector/default_env.conf`:
 
 ```conf
 OTEL_CONFIG_FILE=/etc/opentelemetry/config.yaml
 ```
+
+> [!NOTE]
+>
+> For .NET, file-based configuration also requires
+> `OTEL_EXPERIMENTAL_FILE_BASED_CONFIGURATION_ENABLED=true`. Without it, the
+> configuration file is silently ignored.
 
 ## Run a local Collector
 

--- a/content/en/docs/platforms/linux/installation.md
+++ b/content/en/docs/platforms/linux/installation.md
@@ -4,7 +4,7 @@ weight: 10
 description:
   Add the OpenTelemetry package repository and install the system packages on
   Debian, Ubuntu, Fedora, or RHEL and derivatives.
-cSpell:ignore: COPR metapackage
+cSpell:ignore: metapackage
 ---
 
 The OpenTelemetry system packages are published to an APT repository for
@@ -47,9 +47,6 @@ EOF
 sudo dnf install opentelemetry
 ```
 
-Fedora users can alternatively install the packages from
-[Fedora COPR](https://copr.fedorainfracloud.org/).
-
 ## Verify the installation
 
 Restart an application written in a supported language, or start a new one, and
@@ -63,10 +60,12 @@ the data.
 
 The `opentelemetry` metapackage installs the injector together with the
 auto-instrumentation for all supported languages. If you only need a subset, you
-can install the language-specific packages on their own, for example just the
-Python or the Java instrumentation. See the
-[opentelemetry-packaging](https://github.com/open-telemetry/opentelemetry-packaging)
-repository for the current list of published packages.
+can install the language-specific packages on their own:
+
+- `opentelemetry-java`
+- `opentelemetry-nodejs`
+- `opentelemetry-dotnet`
+- `opentelemetry-python`
 
 ## Next steps
 

--- a/content/en/docs/platforms/linux/installation.md
+++ b/content/en/docs/platforms/linux/installation.md
@@ -1,0 +1,74 @@
+---
+title: Installation
+weight: 10
+description:
+  Add the OpenTelemetry package repository and install the system packages on
+  Debian, Ubuntu, Fedora, or RHEL and derivatives.
+cSpell:ignore: COPR metapackage
+---
+
+The OpenTelemetry system packages are published to an APT repository for
+Debian-based distributions and a YUM repository for RPM-based distributions.
+This page covers adding the repository and installing the `opentelemetry`
+metapackage, which pulls in the
+[OpenTelemetry Injector](https://github.com/open-telemetry/opentelemetry-injector)
+and the auto-instrumentation for Java, .NET, Node.js, and Python.
+
+> [!WARNING]
+>
+> These packages are early in their journey and are not yet meant for production
+> workloads. The repositories are hosted on GitHub Pages and the packages are
+> not yet signed, so the instructions below disable signature verification. See
+> [Status and limitations](../#status-and-limitations).
+
+## Debian, Ubuntu, and derivatives {#apt}
+
+Add the APT repository and install the package:
+
+```sh
+echo "deb [trusted=yes] https://open-telemetry.github.io/opentelemetry-packaging/debian stable main" |
+  sudo tee /etc/apt/sources.list.d/opentelemetry.list
+sudo apt update
+sudo apt install opentelemetry
+```
+
+## Fedora, RHEL, and derivatives {#yum}
+
+Add the YUM repository and install the package:
+
+```sh
+cat <<EOF | sudo tee /etc/yum.repos.d/opentelemetry.repo
+[opentelemetry]
+name=OpenTelemetry Auto-Instrumentation System Packages
+baseurl=https://open-telemetry.github.io/opentelemetry-packaging/rpm/packages
+enabled=1
+gpgcheck=0
+EOF
+sudo dnf install opentelemetry
+```
+
+Fedora users can alternatively install the packages from
+[Fedora COPR](https://copr.fedorainfracloud.org/).
+
+## Verify the installation
+
+Restart an application written in a supported language, or start a new one, and
+confirm that it emits telemetry to your configured destination. Until you
+[configure a destination](../configuration/), telemetry is sent using OTLP to
+`localhost` on ports `4317` (gRPC) and `4318` (HTTP), so you need a
+[Collector](/docs/collector/) or another OTLP receiver listening there to see
+the data.
+
+## Install individual languages
+
+The `opentelemetry` metapackage installs the injector together with the
+auto-instrumentation for all supported languages. If you only need a subset, you
+can install the language-specific packages on their own, for example just the
+Python or the Java instrumentation. See the
+[opentelemetry-packaging](https://github.com/open-telemetry/opentelemetry-packaging)
+repository for the current list of published packages.
+
+## Next steps
+
+- [Configuration](../configuration/): send telemetry to your Collector or
+  backend and control what gets instrumented.


### PR DESCRIPTION
## Description

Adds a first round of documentation for the OpenTelemetry **system packages**
produced by the [Packaging SIG](https://github.com/open-telemetry/opentelemetry-packaging),
so end users have a docs home on the website (beyond the
[launch blog post](https://opentelemetry.io/blog/2026/packaging-first-repo/)).

This responds to the SIG request to "craft a first round of docs for the
opentelemetry.io website" for the `apt install opentelemetry` /
`yum install opentelemetry` packages.

### What's added

A new `content/en/docs/platforms/linux/` section (fits alongside the existing
`kubernetes` and `faas` platform docs):

- **`_index.md`** — overview: how the `opentelemetry` metapackage + Injector
  auto-instrument Java, .NET, Node.js, and Python apps on a host, plus a
  **Status and limitations** callout (early / not for production, GitHub Pages
  hosting is temporary, packages unsigned, Collector not yet bundled).
- **`installation.md`** — add the APT (Debian/Ubuntu) and YUM (Fedora/RHEL)
  repositories and install the package; verify; install individual language
  packages; Fedora COPR note.
- **`configuration.md`** — set the export destination via
  `/etc/opentelemetry/injector/default_env.conf`, declarative config file, and
  running a local Collector.

### Notes for reviewers

- Content is drawn from the launch blog post and the `opentelemetry-packaging`
  README; commands and the injector env-file path may need a sanity check from
  the SIG against the latest release.
- Opened as a **draft** for the Packaging SIG to review wording, page structure,
  and placement (`platforms/linux` vs `zero-code`).
- Local `prettier`, `cspell`, and `markdownlint` all pass. External links (e.g.
  the packaging repo/blog) may need a refcache refresh in CI.
