### PR TITLE
Fix double-check probing of GitHub line-reference fragments

### DIFF
--- a/scripts/lychee/double-check/README.md
+++ b/scripts/lychee/double-check/README.md
@@ -25,8 +25,8 @@ The probe fetches the URL through headless Chrome ([puppeteer-core][]) with
 bot-evasion measures (browser user agent, `Accept-Language` header). Beyond the
 plain HTTP status, it:
 
-- **Verifies URL fragments** against the rendered page, including GitHub
-  line-range (`#L10-L20`) and `-ov-file` tab anchors.
+- **Verifies URL fragments** against the rendered page, including GitHub line
+  references (all `#L…` forms) and `-ov-file` tab anchors.
 - **Special-cases misleading hosts**: crates.io serves 404 for page requests
   even when the page exists, so the page body is analyzed instead; npmjs.com can
   redirect to a signin page for nonexistent packages and bot-wall (403) valid

--- a/scripts/lychee/double-check/get-url-status.mjs
+++ b/scripts/lychee/double-check/get-url-status.mjs
@@ -61,17 +61,42 @@ async function checkForFragment(url, page, status) {
   return status;
 }
 
+// GitHub line-reference fragment (#L10, #L10-L20, column forms like
+// #L10C6-L10C20): returns the highest referenced line number, or null when
+// the fragment is not a line reference. Line and column numbers are 1-based;
+// zero or leading-zero values are rejected.
+export function parseGitHubLineRef(fragmentID) {
+  const m = fragmentID.match(
+    /^L([1-9]\d*)(?:C[1-9]\d*)?(?:-L([1-9]\d*)(?:C[1-9]\d*)?)?$/,
+  );
+  return m ? Math.max(+m[1], +(m[2] ?? 0)) : null;
+}
+
+// GitHub-specific fragment checks. GitHub renders anchors client-side, so
+// what "exists" means depends on the fragment form:
+//
+// - Line references (see parseGitHubLineRef): no target element ever appears
+//   in the DOM; instead, verify that the file has at least that many lines,
+//   via the code view's read-only textarea. Columns are accepted but not
+//   verified: GitHub clamps out-of-range columns to the line end.
+// - Anything else (headings in rendered markdown, repo-landing-page tabs):
+//   look for a link to the fragment, accepting GitHub's `-ov-file` tab-anchor
+//   suffix.
+//
+// Both probes are coupled to GitHub UI internals and can rot silently when
+// the UI changes: the textarea selector replaced a `div.highlighted-line`
+// check that GitHub's React code view stopped rendering. The live smoke
+// check (./live-check.mjs) exercises both a valid and an out-of-range line
+// reference so such drift is observable.
 async function anchorExistsInGitHub(page, fragmentID) {
-  if (/L\d+(-L\d+)?/.test(fragmentID)) {
-    // Line references: GitHub marks the targeted lines as highlighted.
-    return await page.evaluate(() => {
-      return !!document.querySelector('div.highlighted-line');
-    });
+  const maxLine = parseGitHubLineRef(fragmentID);
+  if (maxLine !== null) {
+    return await page.evaluate((max) => {
+      const ta = document.querySelector('textarea#read-only-cursor-text-area');
+      return !!ta && ta.value.split('\n').length >= max;
+    }, maxLine);
   }
 
-  // Other fragments (README tabs, headings in rendered markdown): look for a
-  // link to the fragment, possibly with the `-ov-file` suffix that GitHub
-  // uses as anchors of tabs on repo landing pages.
   return await page.evaluate((name) => {
     const elt = document.querySelector(
       `a[href="#${name}"], a[href="#${name}-ov-file"]`,

--- a/scripts/lychee/double-check/get-url-status.test.mjs
+++ b/scripts/lychee/double-check/get-url-status.test.mjs
@@ -9,6 +9,7 @@ import {
   isHttp2XX,
   isStatusNotFound,
   npmPackageNameFromUrl,
+  parseGitHubLineRef,
 } from './get-url-status.mjs';
 
 suite('npmPackageNameFromUrl', () => {
@@ -37,6 +38,34 @@ suite('npmPackageNameFromUrl', () => {
   for (const [url, expected] of cases) {
     test(`${url} -> ${expected}`, () => {
       assert.equal(npmPackageNameFromUrl(url), expected);
+    });
+  }
+});
+
+suite('parseGitHubLineRef', () => {
+  const cases = [
+    // Valid forms: single line, ranges, column forms, mixed sides.
+    ['L5', 5],
+    ['L10-L20', 20],
+    ['L157C6-L157C20', 157],
+    ['L5C1-L10', 10],
+    ['L20-L10', 20], // reversed range: GitHub still selects it
+    // Not line references: rejected (fall through to the anchor-link check).
+    ['L0', null], // lines are 1-based
+    ['L5C0', null], // columns are 1-based
+    ['L05', null], // no leading zeros
+    ['l5', null], // GitHub fragments are uppercase L
+    ['L', null],
+    ['L5-', null],
+    ['L5C', null],
+    ['L5x', null],
+    ['readme-server-authenticators', null],
+    ['', null],
+  ];
+
+  for (const [fragment, expected] of cases) {
+    test(`${JSON.stringify(fragment)} -> ${expected}`, () => {
+      assert.equal(parseGitHubLineRef(fragment), expected);
     });
   }
 });

--- a/scripts/lychee/double-check/live-check.mjs
+++ b/scripts/lychee/double-check/live-check.mjs
@@ -15,6 +15,17 @@ const cases = [
     url: 'https://opentelemetry.io/docs/what-is-opentelemetry/#what-is-observability',
     expect: '2xx',
   },
+  // GitHub line references are verified against the code view's read-only
+  // textarea (see anchorExistsInGitHub); these two probes catch drift in
+  // that GitHub UI dependency.
+  {
+    url: 'https://github.com/open-telemetry/opentelemetry.io/blob/main/package.json#L2C3-L2C9',
+    expect: '2xx',
+  },
+  {
+    url: 'https://github.com/open-telemetry/opentelemetry.io/blob/main/package.json#L99999',
+    expect: [422],
+  },
 ];
 
 let failures = 0;


### PR DESCRIPTION
- Fixes the double-check probe's verification of GitHub line-reference fragments: GitHub's React code view stopped rendering `div.highlighted-line`, so every `#Ln` link failed (422) even when valid — surfaced by a kubelet `#L157C6-L157C20` link during the #11191 link-cache refresh, which carries a browser-verified interim cache entry for it.
- Parses refs with a pure exported helper, `parseGitHubLineRef()` (`#Ln`, `#Ln-Lm`, column forms; 1-based, rejects zero/leading-zero), and verifies the file's line count via the code view's read-only textarea. Columns are accepted but not verified by design: GitHub clamps out-of-range columns.
- Adds 15 offline test cases for the helper, plus a valid + out-of-range live-smoke pair so future drift in GitHub's code-view internals is observable.
- Unblocks re-pruning browser-verified GitHub line-ref cache entries once merged (the refresh loop currently depends on the interim entry from #11191).

Validation: `node --test scripts/lychee/double-check/*.test.mjs` — 61/61 pass; `npm run test:double-check:live` — 5/5 live probes pass.

GPT-5.6 Sol reviewed and approved.
