### PR TITLE
[ja] update translation of content/en/blog/2025/demystifying-auto-instrumentation.md

### DIFF
--- a/content/ja/blog/2025/demystifying-auto-instrumentation.md
+++ b/content/ja/blog/2025/demystifying-auto-instrumentation.md
@@ -7,8 +7,7 @@ author: >-
 canonical_url: https://www.causely.ai/blog/demystifying-automatic-instrumentation
 issue: https://github.com/open-telemetry/opentelemetry.io/issues/7810
 sig: Comms
-default_lang_commit: b291d077d4c7aba2b43ec5a1648c02bb5c43f870
-drifted_from_default: true
+default_lang_commit: 31d919c6dea163515e2ff36c84e65b569a675fb3
 cspell:ignore: Beyla bpftrace Causely libbpf premain uprobes
 ---
 
@@ -146,7 +145,7 @@ Java、Kotlin、Scala、その他の JVM 言語を変更なしに計装できま
 動的にロードされたコードや外部ソースからのコードを含め、JVM 上で動作するあらゆるコードを計装できます。
 ただし、バイトコード変換プロセスによるオーバーヘッドが多少あります。
 
-実際の実装では、[ByteBuddy](https://bytebuddy.net/#/) が Java におけるバイトコード計装のデファクトスタンダードのライブラリです。
+実際の実装では、[ByteBuddy](https://bytebuddy.net/) が Java におけるバイトコード計装のデファクトスタンダードのライブラリです。
 Java エージェントを作成するための強力で柔軟な API を提供し、バイトコード操作の複雑さの多くを抽象化して、計装ルールを定義するためのクリーンで型安全な方法を提供します。
 
 自分で試してみたい場合は、ラボの [Java のサンプル](https://github.com/causely-oss/automatic-instrumentation-lab#byte-code-instrumentation-java)を参照してください。


### PR DESCRIPTION
## Summary

Updates `content/ja/blog/2025/demystifying-auto-instrumentation.md` to match the latest English source at
`content/en/blog/2025/demystifying-auto-instrumentation.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The only English-side change was a URL fix: `https://bytebuddy.net/#/` → `https://bytebuddy.net/`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.


<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11196--opentelemetry.netlify.app/ja/blog/2025/demystifying-auto-instrumentation/
- **English (canonical):** https://opentelemetry.io/blog/2025/demystifying-auto-instrumentation/

<!-- preview-section-end -->
