### PR TITLE
[ja] add translation of content/en/community/events.md

### DIFF
--- a/content/ja/community/_index.md
+++ b/content/ja/community/_index.md
@@ -1,0 +1,25 @@
+---
+title: コミュニティ
+menu: { main: { weight: 40 } }
+cascade:
+  type: docs
+default_lang_commit: 11fecfb1d12e8682c9619b3a477eccb21c736b99
+---
+
+{{% community-lists %}}
+
+## エンドユーザーリソース {#end-user-resources}
+
+OpenTelemetry ユーザーとして、メンテナーに共有したいフィードバックはありませんか？
+他の OpenTelemetry ユーザーと課題や成功事例を共有することに興味はありませんか？
+詳しくは[エンドユーザーリソース](/community/end-user/)をご覧ください！
+
+## Special Interest Group {#special-interest-groups}
+
+ワークフローを改善し、コミュニティプロジェクトをより簡単に管理するために、私たちはコミュニティを [Special Interest Group（SIG）](https://github.com/open-telemetry/community#special-interest-groups)として組織しています。
+詳しくは[コミュニティリポジトリ](https://github.com/open-telemetry/community)をご覧ください。
+
+## エコシステム {#ecosystem}
+
+コンポーネント、サンプル、インテグレーションなどをお探しですか？
+[エコシステム](/ecosystem/)をご覧ください。

--- a/content/ja/community/events.md
+++ b/content/ja/community/events.md
@@ -1,0 +1,80 @@
+---
+title: イベント
+weight: 30
+default_lang_commit: 31d919c6dea163515e2ff36c84e65b569a675fb3
+---
+
+OpenTelemetry コミュニティは、コントリビューター、メンテナー、エンドユーザーを結びつけるために、年間を通じてさまざまなイベントに参加・主催しています。
+これらのイベントは、学び、経験を共有し、プロジェクトでコラボレーションし、より広いオブザーバビリティコミュニティとつながる機会を提供します。
+
+## 今後のイベント {#upcoming-events}
+
+{{% community-events %}}
+
+## 主要なコミュニティイベント {#key-community-events}
+
+### SIG End-User バーチャルイベント {#sig-end-user-virtual-events}
+
+OpenTelemetry SIG End-User グループは、エンドユーザーを集め、経験を共有し、実際の実装における課題と成功について議論するために、定期的なバーチャルイベントを開催しています。
+これらのイベントには以下が含まれます。
+
+- バーチャルミートアップとディスカッション
+- エンドユーザーのケーススタディとプレゼンテーション
+- コミュニティとの Q&A セッション
+
+すべての SIG End-User バーチャルイベントの確認やコミュニティへの参加は、[Open Community Groups](https://ocgroups.dev/cncf/group/xkrw4uk) から行えます。
+
+### KubeCon + CloudNativeCon {#kubecon--cloudnativecon}
+
+OpenTelemetry は世界中の KubeCon + CloudNativeCon イベントで大きな存在感を示しています。
+これらのイベントでは以下が行われます。
+
+- OpenTelemetry メンテナーによる講演やワークショップ
+- OpenTelemetry Observatory でのコミュニティミートアップ
+- ハンズオンセッションやチュートリアル
+- コントリビューターやエンドユーザーとの交流の機会
+
+### OpenTelemetry Community Day {#opentelemetry-community-day}
+
+OpenTelemetry Community Day は、OpenTelemetry に完全に特化した専門イベントで、以下の内容が行われます。
+
+- 技術的なディープダイブセッション
+- エンドユーザーのケーススタディや成功事例
+- ハンズオンワークショップやチュートリアル
+- コミュニティロードマップに関するディスカッション
+- メンテナーやコントリビューターとの交流
+
+最新の OpenTelemetry Community Day の告知は、[CNCF Events ページ](https://events.linuxfoundation.org/)をご確認ください。
+
+### Kubernetes Community Days（KCD） {#kubernetes-community-days-kcd}
+
+OpenTelemetry のコントリビューターは、世界中のローカル Kubernetes Community Days で定期的に登壇しています。
+これらのイベントでは以下が提供されます。
+
+- ローカルコミュニティとの交流
+- OpenTelemetry の導入事例
+- 技術的なディープダイブとベストプラクティス
+- ハンズオンワークショップ
+
+お近くの KCD は [community.cncf.io](https://community.cncf.io/) で見つけられます。
+
+### Open Observability Summit {#open-observability-summit}
+
+Open Observability Summit は、OpenTelemetry のコントリビューターやユーザーを含むオブザーバビリティコミュニティを集め、以下について議論します。
+
+- オブザーバビリティの最新動向
+- OpenTelemetry のインテグレーションパターン
+- 業界のベストプラクティス
+- オブザーバビリティ標準の将来
+
+## 特別イベントコンテンツ {#special-event-content}
+
+### Humans of OpenTelemetry {#humans-of-opentelemetry}
+
+主要なイベントでは、コントリビューター、メンテナー、エンドユーザーへの「Humans of OpenTelemetry」インタビューを実施し、プロジェクトに関するストーリーや経験を共有しています。
+これらのインタビューでは、以下のような洞察が得られます。
+
+- OpenTelemetry に関わるようになったきっかけ
+- 実際の利用パターンと成功事例
+- オブザーバビリティに関するコミュニティの視点
+- OpenTelemetry プロジェクトの人間的な側面


### PR DESCRIPTION
## Summary

Translates `content/en/community/events.md` into Japanese as `content/ja/community/events.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11197--opentelemetry.netlify.app/ja/community/events/
- **English (canonical):** https://opentelemetry.io/community/events/

<!-- preview-section-end -->
