### PR TITLE
[ja] add translation of content/en/community/members.md

### DIFF
--- a/content/ja/community/_index.md
+++ b/content/ja/community/_index.md
@@ -1,0 +1,25 @@
+---
+title: コミュニティ
+menu: { main: { weight: 40 } }
+cascade:
+  type: docs
+default_lang_commit: 11fecfb1d12e8682c9619b3a477eccb21c736b99
+---
+
+{{% community-lists %}}
+
+## エンドユーザーリソース {#end-user-resources}
+
+OpenTelemetry ユーザーとして、メンテナーに共有したいフィードバックはありませんか？
+他の OpenTelemetry ユーザーと課題や成功事例を共有することに興味はありませんか？
+詳しくは[エンドユーザーリソース](/community/end-user/)をご覧ください！
+
+## Special Interest Group {#special-interest-groups}
+
+ワークフローを改善し、コミュニティプロジェクトをより簡単に管理するために、私たちはコミュニティを [Special Interest Group（SIG）](https://github.com/open-telemetry/community#special-interest-groups)として組織しています。
+詳しくは[コミュニティリポジトリ](https://github.com/open-telemetry/community)をご覧ください。
+
+## エコシステム {#ecosystem}
+
+コンポーネント、サンプル、インテグレーションなどをお探しですか？
+[エコシステム](/ecosystem/)をご覧ください。

--- a/content/ja/community/members.md
+++ b/content/ja/community/members.md
@@ -1,0 +1,59 @@
+---
+title: OpenTelemetry プロジェクトのメンバー
+linkTitle: メンバー
+weight: 50
+default_lang_commit: 31d919c6dea163515e2ff36c84e65b569a675fb3
+---
+
+OpenTelemetry コミュニティは、さまざまなバックグラウンドを持つ多くの個人で構成されており、プロジェクトの[ビジョンとミッション](/community/mission/)の達成を支えています。
+
+以下に、プロジェクトにおけるさまざまな役割でのコミュニティメンバーの一覧を掲載しています。
+
+すでに OpenTelemetry プロジェクトへのコントリビューターであるにもかかわらず、ここに掲載されていない場合は、[メンバーシップを公開に設定](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-your-membership-in-organizations/publicizing-or-hiding-organization-membership)していないか、[コントリビューターガイドライン](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md)を確認してメンバーとしてのコントリビューター活動を始め、メンテナーまでステップアップしていく方法をご覧ください。
+
+## ガバナンス委員会 {#governance-committee}
+
+ガバナンス委員会（GC）は、OpenTelemetry プロジェクトの統括組織です。
+GC のメンバーは、[OpenTelemetry コミュニティの Members Of Standing によって選出](https://github.com/open-telemetry/community/blob/main/governance-charter.md#elections)されます。
+
+{{% community/members-list "governance-committee" %}}
+
+## 技術委員会 {#technical-committee}
+
+技術委員会（TC）は、OpenTelemetry プロジェクトにおけるすべての技術開発を統括します。
+
+{{% community/members-list "technical-committee" %}}
+
+## 仕様スポンサー {#specification-sponsors}
+
+仕様スポンサーは技術委員会の信頼されたコラボレーターであり、[OpenTelemetry 仕様](/docs/specs/otel/)のイシューやプルリクエストのレビュー、承認、スポンサーを担います。
+
+{{% community/members-list "spec-sponsors" %}}
+
+## メンテナー {#maintainers}
+
+メンテナーは、OpenTelemetry プロジェクト内のサブプロジェクトにおける技術的な権限を持ちます。
+メンテナーはサブプロジェクトの技術的方向性を定め、設計上の決定を行うか承認します。
+
+{{% community/members-list "maintainers" %}}
+
+## 承認者 {#approvers}
+
+コード承認者は、コードのコントリビューションのレビューと承認の両方を行うことができ、またメンテナーがイシューのトリアージやプロジェクト管理を行うのを支援します。
+
+{{% community/members-list "approvers" %}}
+
+## トリアージ担当者 {#triagers}
+
+トリアージ担当者は、メンテナーや承認者のプロジェクト管理やバックログの整理を支援します。
+具体的なワークフローやトリアージの要件はプロジェクトによって異なり、プロジェクトのメンテナーが定めます。
+
+{{% community/members-list "triagers" %}}
+
+## メンバー {#members}
+
+メンバーは、コミュニティにおいて継続的に活動するコントリビューターです。
+メンバーにはイシューやプルリクエストをアサインすることができます。
+メンバーは SIG に参加し、コミュニティへの継続的な貢献者であり続けることが期待されます。
+
+{{% community/members-list "members" %}}


### PR DESCRIPTION
## Summary

Translates `content/en/community/members.md` into Japanese as `content/ja/community/members.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11201--opentelemetry.netlify.app/ja/community/members/
- **English (canonical):** https://opentelemetry.io/community/members/

<!-- preview-section-end -->
