### PR TITLE
[ja] update translation of content/en/docs/demo/architecture.md

### DIFF
--- a/content/ja/docs/demo/architecture.md
+++ b/content/ja/docs/demo/architecture.md
@@ -3,12 +3,11 @@ title: デモのアーキテクチャ
 linkTitle: アーキテクチャ
 aliases: [current_architecture]
 body_class: otel-mermaid-max-width
-default_lang_commit: 867f1ba6a44275ce3bc7d8708765a78baaa0287f
-drifted_from_default: true
+default_lang_commit: f6befc31e5602c7019a9949ccd5f7e11d845134e
 ---
 
 **OpenTelemetryデモ** は、異なるプログラミング言語で書かれた複数のマイクロサービスから構成されており、gRPCとHTTPを使って相互に通信を行います。
-さらに、負荷生成ツールが含まれており、[Locust](https://locust.io/)というツールを使用して、ユーザートラフィックを模擬的に生成します。
+さらに、負荷生成ツールが含まれており、[k6](https://k6.io/)を使用して、ユーザートラフィックを模擬的に生成します。
 
 ```mermaid
 graph TD
@@ -26,7 +25,7 @@ fraud-detection(不正検知):::kotlin
 frontend(フロントエンド):::typescript
 frontend-proxy(フロントエンドプロキシ <br/>&#40Envoy&#41):::cpp
 image-provider(画像プロバイダー <br/>&#40nginx&#41):::cpp
-load-generator([負荷生成ツール]):::python
+load-generator([負荷生成ツール]):::golang
 payment(支払い):::javascript
 product-catalog(商品カタログ):::golang
 quoteservice(見積サービス):::php


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/demo/architecture.md` to match the latest English source at
`content/en/docs/demo/architecture.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

Changes applied:
- Load generator tool reference updated: Locust → k6 (link target changed accordingly)
- Mermaid service diagram: load-generator class changed from `python` to `golang`

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11205--opentelemetry.netlify.app/ja/docs/demo/architecture/
- **English (canonical):** https://opentelemetry.io/docs/demo/architecture/

_(deploy preview may still be building — the URL will work once Netlify finishes.)_
<!-- preview-section-end -->
