### PR TITLE
[ja] update translation of content/en/docs/zero-code/python/example.md

### DIFF
--- a/content/ja/docs/zero-code/python/example.md
+++ b/content/ja/docs/zero-code/python/example.md
@@ -2,8 +2,7 @@
 title: 自動計装の例
 linkTitle: Example
 weight: 20
-default_lang_commit: 39d3d2ef243d968e6a434fd9d2690c8070c3d7ea
-drifted_from_default: true
+default_lang_commit: f6befc31e5602c7019a9949ccd5f7e11d845134e
 # prettier-ignore
 cSpell:ignore: Aiohttp ASGI distro instrumentor mkdir MSIE Referer Starlette venv
 ---
@@ -342,6 +341,6 @@ export OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SANITIZE_FIELDS=".*session.*,se
 [semantic convention]: /docs/specs/semconv/http/http-spans/
 [api reference]: https://opentelemetry-python.readthedocs.io/en/latest/index.html
 [instrumentation]: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-instrumentation
-[monkey-patching]: https://stackoverflow.com/questions/5626193/what-is-monkey-patching
+[monkey-patching]: https://stackoverflow.com/questions/5626193/what-is-monkey-patching?link-check=no&last-validated=2026-08-02
 [opentracing example]: https://github.com/yurishkuro/opentracing-tutorial/tree/master/python
 [source files]: https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples/auto-instrumentation


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/python/example.md` to match the latest English source at
`content/en/docs/zero-code/python/example.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff was a single reference-link URL update (`[monkey-patching]` gained `?link-check=no&last-validated=2026-08-02`).

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11207--opentelemetry.netlify.app/ja/docs/zero-code/python/example/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/python/example/

_(deploy preview may still be building)_
<!-- preview-section-end -->
