### PR TITLE
Add Vartio mobile instrumentation (iOS, React Native) to the registry

### DIFF
--- a/data/registry/instrumentation-js-vartio-react-native.yml
+++ b/data/registry/instrumentation-js-vartio-react-native.yml
@@ -1,0 +1,21 @@
+title: Vartio Mobile Telemetry for React Native
+registryType: instrumentation
+language: js
+tags:
+  - react-native
+  - mobile
+  - instrumentation
+  - crash-reporting
+urls:
+  repo: https://github.com/vartio-dev/vartio-react-native
+license: Apache 2.0
+description: Mobile instrumentation for React Native apps — sessions, JavaScript crashes, screen loads, navigation, fetch spans and app memory over OTLP/HTTP to any OpenTelemetry backend.
+authors:
+  - name: Vartio
+    url: https://vartio.dev
+createdAt: 2026-08-05
+isFirstParty: false
+package:
+  registry: npm
+  name: '@vartio/react-native'
+  version: 0.1.0

--- a/data/registry/instrumentation-swift-vartio-mobile.yml
+++ b/data/registry/instrumentation-swift-vartio-mobile.yml
@@ -1,0 +1,18 @@
+title: Vartio Mobile Telemetry for iOS
+registryType: instrumentation
+language: swift
+tags:
+  - ios
+  - mobile
+  - instrumentation
+  - crash-reporting
+  - swift
+urls:
+  repo: https://github.com/vartio-dev/vartio-swift
+license: Apache 2.0
+description: Mobile instrumentation for iOS apps — sessions, crashes, screen loads, navigation, flow spans and app memory over OTLP/HTTP to any OpenTelemetry backend.
+authors:
+  - name: Vartio
+    url: https://vartio.dev
+createdAt: 2026-08-05
+isFirstParty: false


### PR DESCRIPTION
Adds two registry entries for open-source mobile instrumentation libraries:

- **Vartio Mobile Telemetry for iOS** — https://github.com/vartio-dev/vartio-swift (Swift Package Manager, Apache 2.0)
- **Vartio Mobile Telemetry for React Native** — https://github.com/vartio-dev/vartio-react-native (npm `@vartio/react-native`, Apache 2.0)

Both wrap the existing OpenTelemetry SDKs (opentelemetry-swift and the OpenTelemetry JS packages) with mobile-specific instrumentation — session tracking, crash and hang events, screen-load and navigation spans, HTTP client spans, and app memory — and export over plain OTLP/HTTP to any OpenTelemetry backend.

---

**Note from the maintainers**: this description was submitted without our [PR template](https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/PULL_REQUEST_TEMPLATE.md)'s checklist, which asks you to confirm:

- [ ] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [ ] I have the experience and knowledge necessary to understand, review, and validate all content in this PR. (Yes, I can answer maintainer questions about the content of this PR, without using AI.)

Per our [first-time contributor policy](https://github.com/open-telemetry/opentelemetry.io/issues/11243), answer these questions by ticking each box that applies.
