### PR TITLE
[ja] fix textlint violation in site/build/npm-scripts.md

### DIFF
--- a/content/ja/site/build/npm-scripts.md
+++ b/content/ja/site/build/npm-scripts.md
@@ -136,7 +136,7 @@ default_lang_commit: 0aff0aab149003b5592edfe186c193047e40c766
 | `update:hugo`                  | 最新の hugo-extended をインストールします。                                               |
 | `update:packages`              | npm-check-updates を実行して依存関係を更新します。                                        |
 | `generate:config:links`        | `lychee.base.toml` とページフロントマターから git 無視の `lychee.toml` を生成します。     |
-| `log:build`、`log:check:links` | 対応するスクリプトを実行し、出力を `tmp/` に tee し、スクリプトの終了コードを伝播します。 |
+| `log:build`、`log:check:links` | 対応するスクリプトを実行し、出力を `tmp/` に tee し、スクリプトの終了コードを伝搬します。 |
 
 ## 注記 {#notes}
 


### PR DESCRIPTION
Follow-up to #11006, which was merged just before the textlint fix was pushed to the PR branch. As a result, `main` now contains 伝播, which the ja textlint glossary rule rejects in favor of 伝搬, causing the TEXT linter check to fail for any PR touching content.

This PR applies the one-character fix (伝播 → 伝搬). Verified locally: `npm run check:text` passes, Prettier (`--prose-wrap preserve`) clean, i18n drift state in sync.