### PR TITLE
[ja] update translation of content/en/docs/zero-code/dotnet/_index.md

### DIFF
--- a/content/ja/docs/zero-code/dotnet/_index.md
+++ b/content/ja/docs/zero-code/dotnet/_index.md
@@ -5,8 +5,7 @@ linkTitle: .NET
 aliases: [net]
 redirects: [{ from: /docs/languages/net/automatic/*, to: ':splat' }]
 weight: 30
-default_lang_commit: d03483e1d5cc696a5541f8bcc8ff97170f2f2ca1
-drifted_from_default: true
+default_lang_commit: 2d447daa701636c3246c116d4b8c4a2f2c35de60
 cSpell:ignore: coreutils HKLM iisreset Sonoma
 ---
 
@@ -229,7 +228,7 @@ IIS にデプロイされたすべてのアプリケーションに共通の環�
 
 ## NuGet パッケージ {#nuget-package}
 
-[`self-contained`](https://learn.microsoft.com/en-us/dotnet/core/deploying/#publish-self-contained) アプリケーションを NuGet パッケージを使用して計装できます。
+[`self-contained`](https://learn.microsoft.com/en-us/dotnet/core/deploying/#publish-as-self-contained) アプリケーションを NuGet パッケージを使用して計装できます。
 詳細については、[NuGet パッケージ](./nuget-packages)を参照してください。
 
 ## コンテナの計装 {#instrument-a-container}


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/dotnet/_index.md` to match the latest English source at
`content/en/docs/zero-code/dotnet/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The only English-side change was a link target update in the NuGet package section:
`#publish-self-contained` → `#publish-as-self-contained`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.


<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11216--opentelemetry.netlify.app/ja/docs/zero-code/dotnet/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/dotnet/

_(deploy preview will be available once Netlify finishes building.)_
<!-- preview-section-end -->
