### PR TITLE
[ja] update translation of content/en/docs/zero-code/java/agent/extensions.md

### DIFF
--- a/content/ja/docs/zero-code/java/agent/extensions.md
+++ b/content/ja/docs/zero-code/java/agent/extensions.md
@@ -3,8 +3,7 @@ title: エクステンション
 aliases: [/docs/instrumentation/java/extensions]
 description: エクステンションは、個別のディストリビューションを作成することなくエージェントに機能を追加します。
 weight: 300
-default_lang_commit: cb8364effee3fd3f2dc33c15da7c47bde0432122
-drifted_from_default: true
+default_lang_commit: 2d447daa701636c3246c116d4b8c4a2f2c35de60
 cSpell:ignore: Customizer Dotel myextension
 ---
 
@@ -46,7 +45,7 @@ java {
 
 dependencies {
     // BOM を使用して OpenTelemetry の依存バージョンを管理する
-    compileOnly(platform("io.opentelemetry:opentelemetry-bom:1.61.0"))
+    compileOnly(platform("io.opentelemetry:opentelemetry-bom:1.64.0"))
 
     // OpenTelemetry SDK 自動設定 SPI（エージェントが提供する）
     compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/java/agent/extensions.md` to match the latest English source at
`content/en/docs/zero-code/java/agent/extensions.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English change was a single version bump in the quick-start `build.gradle.kts` code block:
`io.opentelemetry:opentelemetry-bom` from `1.61.0` to `1.64.0`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11217--opentelemetry.netlify.app/ja/docs/zero-code/java/agent/extensions/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/java/agent/extensions/

<!-- preview-section-end -->
