### PR TITLE
i18n: translate Swift language page to Spanish

### DIFF
--- a/content/es/docs/languages/swift/_index.md
+++ b/content/es/docs/languages/swift/_index.md
@@ -1,0 +1,17 @@
+---
+title: Swift
+description: >-
+  <img width="35" class="img-initial otel-icon" src="/img/logos/32x32/Swift.svg"
+  alt="Swift"> Una implementación específica del lenguaje de OpenTelemetry en
+  Swift.
+weight: 220
+default_lang_commit: 2d447daa701636c3246c116d4b8c4a2f2c35de60
+drifted_from_default: true
+---
+
+{{% docs/languages/index-intro swift /%}}
+
+## Más información
+
+- [OpenTelemetry para Swift en GitHub](https://github.com/open-telemetry/opentelemetry-swift)
+- [Instalación](https://github.com/open-telemetry/opentelemetry-swift#installation)


### PR DESCRIPTION
Part of #5229.

Adds the Spanish translation for `content/en/docs/languages/swift/_index.md`, following the existing Spanish language page conventions.
