### PR TITLE
[ja] update translation of content/en/docs/zero-code/java/spring-boot-starter/getting-started.md

### DIFF
--- a/content/ja/docs/zero-code/java/spring-boot-starter/getting-started.md
+++ b/content/ja/docs/zero-code/java/spring-boot-starter/getting-started.md
@@ -1,8 +1,7 @@
 ---
 title: はじめに
 weight: 20
-default_lang_commit: a790e3cf91025305c683047b181120ab6bbae3de
-drifted_from_default: true
+default_lang_commit: 21add8ce39004043e871566b88ce97ad0eba3435
 cSpell:ignore: springboot
 ---
 
@@ -27,7 +26,7 @@ OpenTelemetryスターターを使用する際は、すべてのOpenTelemetry依
 > Mavenを使用する場合は、プロジェクト内の他のBOMよりも前にOpenTelemetry BOMをインポートしてください。
 > たとえば、`spring-boot-dependencies` BOMをインポートする場合は、OpenTelemetry BOMの後に宣言する必要があります。
 >
-> Gradleは依存関係の[最新バージョン](https://docs.gradle.org/current/userguide/dependency_resolution.html#2_perform_conflict_resolution)を選択するため、BOMの順序は重要ではありません。
+> Gradleは依存関係の[最新バージョン](https://docs.gradle.org/current/userguide/dependency_constraints_conflicts.html#sub:resolving-version-conflicts)を選択するため、BOMの順序は重要ではありません。
 
 以下の例は、Mavenを使用してOpenTelemetry BOMをインポートする方法を示しています。
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/java/spring-boot-starter/getting-started.md` to match the latest English source at
`content/en/docs/zero-code/java/spring-boot-starter/getting-started.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The only substantive change is an updated Gradle documentation link (`dependency_resolution.html#2_perform_conflict_resolution` → `dependency_constraints_conflicts.html#sub:resolving-version-conflicts`).

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11223--opentelemetry.netlify.app/ja/docs/zero-code/java/spring-boot-starter/getting-started/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/java/spring-boot-starter/getting-started/

_(deploy preview may take a few minutes to build.)_
<!-- preview-section-end -->
