### PR TITLE
[ja] update translation of content/en/docs/zero-code/java/spring-boot-starter/other-spring-autoconfig.md

### DIFF
--- a/content/ja/docs/zero-code/java/spring-boot-starter/other-spring-autoconfig.md
+++ b/content/ja/docs/zero-code/java/spring-boot-starter/other-spring-autoconfig.md
@@ -1,8 +1,7 @@
 ---
 title: その他のSpring自動設定
 weight: 70
-default_lang_commit: c88a006471f039334aed7990736e089a62b33f94
-drifted_from_default: true
+default_lang_commit: 21add8ce39004043e871566b88ce97ad0eba3435
 cSpell:ignore: autoconfigurations
 ---
 
@@ -14,7 +13,7 @@ OpenTelemetry Spring スターターを使用するかわりに、OpenTelemetry 
 ## Zipkin スターター {#zipkin-starter}
 
 OpenTelemetry Zipkin Exporter スターターは、分散トレーシングの設定に必要な `opentelemetry-api`、`opentelemetry-sdk`、`opentelemetry-extension-annotations`、`opentelemetry-logging-exporter`、`opentelemetry-spring-boot-autoconfigurations` および Spring フレームワークスターターを含むスターターパッケージです。
-また、[opentelemetry-exporters-zipkin](https://github.com/open-telemetry/opentelemetry-java/tree/main/exporters/zipkin)アーティファクトと対応するエクスポーター自動設定も提供します。
+また、[opentelemetry-exporters-zipkin](https://github.com/open-telemetry/opentelemetry-java/tree/v1.64.0/exporters/zipkin)アーティファクトと対応するエクスポーター自動設定も提供します。
 
 実行時にクラスパスにエクスポーターが存在し、Spring アプリケーションコンテキストにエクスポーターの Spring Bean が存在しない場合、エクスポーター Bean が初期化され、アクティブなトレーサープロバイダー内のシンプルスパンプロセッサーに追加されます。
 詳細については、[実装 (OpenTelemetryAutoConfiguration.java)](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/spring/spring-boot-autoconfigure/src/main/java/io/opentelemetry/instrumentation/spring/autoconfigure/OpenTelemetryAutoConfiguration.java)を参照してください。


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/java/spring-boot-starter/other-spring-autoconfig.md` to match the latest English source at
`content/en/docs/zero-code/java/spring-boot-starter/other-spring-autoconfig.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The only substantive change is a link target update: the `opentelemetry-exporters-zipkin` link was pinned from `tree/main/` to `tree/v1.64.0/`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.


<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11224--opentelemetry.netlify.app/ja/docs/zero-code/java/spring-boot-starter/other-spring-autoconfig/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/java/spring-boot-starter/other-spring-autoconfig/

_(deploy preview may still be building. The URLs will work once Netlify finishes.)_
<!-- preview-section-end -->
