### PR TITLE
Add interlock-cb to the instrumentation registry

### DIFF
--- a/data/registry/instrumentation-python-interlock.yml
+++ b/data/registry/instrumentation-python-interlock.yml
@@ -1,0 +1,27 @@
+# cSpell:ignore bagowix
+title: interlock-cb
+registryType: instrumentation
+language: python
+tags:
+  - python
+  - instrumentation
+  - metrics
+  - circuit-breaker
+  - resilience
+license: MIT
+description:
+  Native OpenTelemetry metrics for interlock, a circuit breaker for Python —
+  call duration, rejected calls, state transitions, resets, and coordinated
+  storage and pipeline events.
+authors:
+  - name: bagowix
+    url: https://github.com/bagowix
+urls:
+  repo: https://github.com/bagowix/interlock
+  docs: https://bagowix.github.io/interlock/guides/observability/
+package:
+  name: interlock-cb
+  registry: pip
+createdAt: '2026-08-06'
+isNative: true
+isFirstParty: false


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

Adds `interlock-cb` to the OpenTelemetry instrumentation registry.

The entry describes the package native OpenTelemetry metrics for circuit-breaker calls, rejections, state transitions, resets, and coordinated storage and pipeline events, and links to its repository and observability documentation.