### PR TITLE
[ja] update translation of content/en/docs/platforms/kubernetes/helm/demo.md

### DIFF
--- a/content/ja/docs/platforms/kubernetes/helm/demo.md
+++ b/content/ja/docs/platforms/kubernetes/helm/demo.md
@@ -1,8 +1,7 @@
 ---
 title: OpenTelemetryデモチャート
 linkTitle: デモチャート
-default_lang_commit: e8f18928513b726068be250802ebe7ece25e8851
-drifted_from_default: true
+default_lang_commit: c161165987d527c1efd6bc969d7fef905946c561
 ---
 
 [OpenTelemetry Demo](/docs/demo/) は、実世界に近い環境での OpenTelemetry の実装を説明することを意図した、マイクロサービスベースの分散システムです。
@@ -43,7 +42,6 @@ kubectl port-forward svc/my-otel-demo-frontendproxy 8080:8080
 | ウェブストア   | <http://localhost:8080>           |
 | Grafana        | <http://localhost:8080/grafana>   |
 | 機能フラグUI   | <http://localhost:8080/feature>   |
-| 負荷生成UI     | <http://localhost:8080/loadgen>   |
 | Jaeger UI      | <http://localhost:8080/jaeger/ui> |
 
 ウェブストアからのスパンを収集するには、OpenTelemetryコレクターOTLP/HTTPレシーバーを公開する必要があります。


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/platforms/kubernetes/helm/demo.md` to match the latest English source at
`content/en/docs/platforms/kubernetes/helm/demo.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff removed the "Load Generator UI" row from the table of available components.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11239--opentelemetry.netlify.app/ja/docs/platforms/kubernetes/helm/demo/
- **English (canonical):** https://opentelemetry.io/docs/platforms/kubernetes/helm/demo/

_(deploy preview status: pending. The URLs will work once Netlify finishes building.)_
<!-- preview-section-end -->