### PR TITLE
[ja] update translation of content/en/docs/languages/ruby/exporters.md

### DIFF
--- a/content/ja/docs/languages/ruby/exporters.md
+++ b/content/ja/docs/languages/ruby/exporters.md
@@ -1,8 +1,7 @@
 ---
 title: エクスポーター
 weight: 50
-default_lang_commit: 5a3937c47b391b207465e0e464006f3b03bf242f
-drifted_from_default: true
+default_lang_commit: c161165987d527c1efd6bc969d7fef905946c561
 ---
 
 {{% docs/languages/exporters/intro %}}
@@ -56,15 +55,10 @@ env OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318" rails server -p 8080
 
 ```shell
 docker run -d --name jaeger \
-  -p 6831:6831/udp \
-  -p 6832:6832/udp \
   -p 5778:5778 \
   -p 16686:16686 \
   -p 4317:4317 \
   -p 4318:4318 \
-  -p 14250:14250 \
-  -p 14268:14268 \
-  -p 14269:14269 \
   -p 9411:9411 \
   jaegertracing/jaeger:latest
 ```


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/ruby/exporters.md` to match the latest English source at
`content/en/docs/languages/ruby/exporters.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff simplified the Jaeger `docker run` command by removing deprecated port
mappings (`6831`, `6832`, `14250`, `14268`, `14269`) and environment variables.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11241--opentelemetry.netlify.app/ja/docs/languages/ruby/exporters/
- **English (canonical):** https://opentelemetry.io/docs/languages/ruby/exporters/

_(deploy preview URLs will work once Netlify finishes building.)_
<!-- preview-section-end -->