### PR TITLE
feat(registry): add Puppet module for OpenTelemetry Collector

### DIFF
--- a/data/registry/tools-puppet-voxpupuli-otelcol.yml
+++ b/data/registry/tools-puppet-voxpupuli-otelcol.yml
@@ -1,7 +1,7 @@
 # cSpell:ignore voxpupuli otelcol
 title: Puppet module for OpenTelemetry Collector
 registryType: utilities
-language: puppet
+language: ruby
 tags:
   - collector
   - puppet

--- a/data/registry/tools-puppet-voxpupuli-otelcol.yml
+++ b/data/registry/tools-puppet-voxpupuli-otelcol.yml
@@ -1,0 +1,19 @@
+# cSpell:ignore voxpupuli otelcol
+title: Puppet module for OpenTelemetry Collector
+registryType: utilities
+language: puppet
+tags:
+  - collector
+  - puppet
+  - puppet-module
+license: Apache-2.0
+description:
+  Puppet module by Vox Pupuli to install and manage OpenTelemetry Collector
+  across multiple machines
+authors:
+  - name: Vox Pupuli
+    url: https://github.com/voxpupuli/
+urls:
+  repo: https://github.com/voxpupuli/puppet-otelcol
+  docs: https://forge.puppet.com/modules/puppet/otelcol
+createdAt: 2026-07-08


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [X] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [X] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

## Add Puppet module for OpenTelemetry Collector to registry

Adds [puppet-otelcol](https://github.com/voxpupuli/puppet-otelcol) by [Vox Pupuli](https://voxpupuli.org/) to the OpenTelemetry registry.

This is a Puppet module that installs and manages the OpenTelemetry Collector across multiple machines, supporting Debian, RedHat, and Windows. It is published on the [Puppet Forge](https://forge.puppet.com/modules/puppet/otelcol) and licensed under Apache-2.0.

Registry type: `utilities` (similar to the existing [Ansible role by Grafana](https://opentelemetry.io/ecosystem/registry/?s=ansible&component=&language=)).