### PR TITLE
Move Diana Todea from triagers to approvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For more information about the maintainer role, see the
 
 These are the members of [@open-telemetry/docs-approvers][] (members-only):
 
--
+- [Diana Todea](https://github.com/didiViking), VictoriaMetrics
 
 For more information about the approver role, see the
 [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver).
@@ -85,7 +85,6 @@ For more information about the approver role, see the
 
 These are the members of [@open-telemetry/docs-triagers][] (members-only):
 
-- [Diana Todea](https://github.com/didiViking), VictoriaMetrics
 - [Emídio Neto](https://github.com/emdneto)
 - [Ezzio Moreira](https://github.com/EzzioMoreira)
 - [Michael Yao](https://github.com/windsonsea), DaoCloud


### PR DESCRIPTION
I would like to nominate @didiViking to become a member of @open-telemetry/docs-approvers. Diana has been an eager contributor to our repository via PRs, reviews and triage work. Thank you for all your help!

@didiViking: please approve this PR to acknowledge that you want to become an approver and that you read https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver and understand your responsibilities and privileges.

@open-telemetry/docs-maintainers please approve this PR to confirm that you agree with this nomination.