### PR TITLE
Document OBI Go Trace API activation

### DIFF
--- a/.lycheecache
+++ b/.lycheecache
@@ -3035,6 +3035,11 @@ https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/1137
 https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/1139,200,1785739362
 https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/1140,200,1785739363
 https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/1157,200,1785739362
+https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2793,200,1786140070
+https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2794,200,1786140069
+https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2932,200,1786140069
+https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2958,200,1786140070
+https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2959,200,1786140069
 https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22goal%3A%202026%22%20label%3Aepic,200,1785739361
 https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues?q=is%3Aissue+is%3Aopen+label%3A%22goal%3A+2026%22,200,1785739362
 https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkgs/container/opentelemetry-ebpf-instrumentation%2Febpf-instrument,200,1785868413

--- a/content/en/docs/zero-code/obi/distributed-traces.md
+++ b/content/en/docs/zero-code/obi/distributed-traces.md
@@ -207,13 +207,10 @@ OBI integrates automatically with manual spans using the
 [Auto SDK](/docs/zero-code/go/autosdk). See the docs on the Auto SDK to learn
 more.
 
-Starting with OBI v0.11.0, an application can create spans through the global
-`otel.Tracer` API without configuring an SDK, `TracerProvider`, span processor,
-exporter, or other application-side telemetry pipeline. OBI activates the Auto
-SDK only when the application and host meet all requirements. The application
-must not install a provider itself, including by calling
-`otel.SetTracerProvider(auto.TracerProvider())`, for OBI to activate the Auto
-SDK.
+Starting with OBI v0.11.0, OBI can activate the Auto SDK for spans created
+through the global `otel.Tracer` API when no `TracerProvider` is registered and
+the application and host meet all requirements. Calling
+`otel.SetTracerProvider(auto.TracerProvider())` prevents this activation.
 
 See the
 [runnable OBI Go Trace API example](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/tree/main/examples/go-trace-api)

--- a/content/en/docs/zero-code/obi/distributed-traces.md
+++ b/content/en/docs/zero-code/obi/distributed-traces.md
@@ -215,9 +215,9 @@ must not install a provider itself, including by calling
 `otel.SetTracerProvider(auto.TracerProvider())`, for this automatic path.
 
 See the
-[runnable OBI Go Trace API example](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/tree/main/examples/go-trace-api)
+[runnable OBI Go Trace API example](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/tree/main/examples/go-trace-api?link-check=no&last-validated=2026-08-07)
 for setup and troubleshooting. OBI's
-[support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md#go-global-trace-api-and-auto-sdk-activation)
+[support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md?link-check=no&last-validated=2026-08-07#go-global-trace-api-and-auto-sdk-activation)
 documents the exact v0.11.0 version allowlists, canonical checksum requirements,
 supported architectures, required-symbol and offset gating, and
 `bpf_probe_write_user` permission conditions. OBI fails closed when a gate is

--- a/content/en/docs/zero-code/obi/distributed-traces.md
+++ b/content/en/docs/zero-code/obi/distributed-traces.md
@@ -207,6 +207,40 @@ OBI integrates automatically with manual spans using the
 [Auto SDK](/docs/zero-code/go/autosdk). See the docs on the Auto SDK to learn
 more.
 
+Starting with OBI v0.11.0, an application can create spans through the global
+`otel.Tracer` API without configuring an SDK, `TracerProvider`, span processor,
+exporter, or other application-side telemetry pipeline. OBI activates the Auto
+SDK path only when every compatibility and safety gate passes. The application
+must not install a provider itself, including by calling
+`otel.SetTracerProvider(auto.TracerProvider())`, for this automatic path.
+
+See the
+[runnable OBI Go Trace API example](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/tree/main/examples/go-trace-api)
+for setup and troubleshooting. OBI's
+[support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md#go-global-trace-api-and-auto-sdk-activation)
+documents the exact v0.11.0 version allowlists, canonical checksum requirements,
+supported architectures, required-symbol and offset gating, and
+`bpf_probe_write_user` permission conditions. OBI fails closed when a gate is
+not satisfied.
+
+For an otherwise no-SDK application, the API spans remain non-recording without
+rich Auto SDK activation, and OBI may emit only its reduced-fidelity synthetic
+spans. Synthetic fallback does not preserve the complete application-authored
+scope, events, kind, attributes, or parenting semantics and is not equivalent to
+rich activation. If the application has registered an SDK delegate, OBI defers
+to that SDK instead of activating the Auto SDK or creating a competing synthetic
+span.
+
+In v0.11.0, each rich serialized span payload is limited to 16 KiB. Larger
+payloads are not emitted, and there is no operator-visible oversized-payload
+drop metric or warning. Other known limitations cover
+[sampling](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2793),
+[context handoffs](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2794),
+[external and remote parents and `TraceState`](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2959),
+[larger payloads and drop observability](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2958),
+and
+[log enrichment](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2932).
+
 #### Kernel integrity mode limitations
 
 In order to write the `traceparent` value in outgoing HTTP/gRPC request headers,

--- a/content/en/docs/zero-code/obi/distributed-traces.md
+++ b/content/en/docs/zero-code/obi/distributed-traces.md
@@ -223,17 +223,19 @@ supported architectures, required-symbol and offset gating, and
 `bpf_probe_write_user` permission conditions. OBI fails closed when a gate is
 not satisfied.
 
-For an otherwise no-SDK application, the API spans remain non-recording without
-rich Auto SDK activation, and OBI may emit only its reduced-fidelity synthetic
-spans. Synthetic fallback does not preserve the complete application-authored
-scope, events, kind, attributes, or parenting semantics and is not equivalent to
-rich activation. If the application has registered an SDK delegate, OBI defers
-to that SDK instead of activating the Auto SDK or creating a competing synthetic
-span.
+For an otherwise no-SDK application, the API spans remain non-recording when OBI
+cannot activate the Auto SDK. OBI may still construct synthetic spans from
+ordinary Go probes. A synthetic span may contain the span name, parent
+relationship, status, and some primitive attributes, but it does not contain the
+instrumentation scope, events, or requested span kind. It is not a substitute
+for the application-authored span. If the application has registered an SDK
+delegate, OBI defers to that SDK instead of activating the Auto SDK or creating
+a competing synthetic span.
 
-In v0.11.0, each rich serialized span payload is limited to 16 KiB. Larger
-payloads are not emitted, and there is no operator-visible oversized-payload
-drop metric or warning. Other known limitations cover
+The Auto SDK serializes each application-authored span as OTLP JSON. In v0.11.0,
+OBI accepts payloads up to 16 KiB and does not emit larger payloads. There is no
+operator-visible drop metric or warning for this condition. Other known
+limitations cover
 [sampling](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2793),
 [context handoffs](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2794),
 [external and remote parents and `TraceState`](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2959),

--- a/content/en/docs/zero-code/obi/distributed-traces.md
+++ b/content/en/docs/zero-code/obi/distributed-traces.md
@@ -210,32 +210,33 @@ more.
 Starting with OBI v0.11.0, an application can create spans through the global
 `otel.Tracer` API without configuring an SDK, `TracerProvider`, span processor,
 exporter, or other application-side telemetry pipeline. OBI activates the Auto
-SDK path only when every compatibility and safety gate passes. The application
+SDK only when the application and host meet all requirements. The application
 must not install a provider itself, including by calling
-`otel.SetTracerProvider(auto.TracerProvider())`, for this automatic path.
+`otel.SetTracerProvider(auto.TracerProvider())`, for OBI to activate the Auto
+SDK.
 
 See the
-[runnable OBI Go Trace API example](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/tree/main/examples/go-trace-api?link-check=no&last-validated=2026-08-07)
+[runnable OBI Go Trace API example](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/tree/main/examples/go-trace-api)
 for setup and troubleshooting. OBI's
-[support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md?link-check=no&last-validated=2026-08-07#go-global-trace-api-and-auto-sdk-activation)
-documents the exact v0.11.0 version allowlists, canonical checksum requirements,
-supported architectures, required-symbol and offset gating, and
-`bpf_probe_write_user` permission conditions. OBI fails closed when a gate is
-not satisfied.
+[support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md#go-global-trace-api-and-auto-sdk-activation)
+documents the exact v0.11.0 module versions and checksum requirements, supported
+architectures, executable requirements, and `bpf_probe_write_user` permission
+conditions. If any requirement is not met, OBI leaves the Auto SDK inactive.
 
-For an otherwise no-SDK application, the API spans remain non-recording when OBI
-cannot activate the Auto SDK. OBI may still construct synthetic spans from
-ordinary Go probes. A synthetic span may contain the span name, parent
-relationship, status, and some primitive attributes, but it does not contain the
-instrumentation scope, events, or requested span kind. It is not a substitute
-for the application-authored span. If the application has registered an SDK
-delegate, OBI defers to that SDK instead of activating the Auto SDK or creating
-a competing synthetic span.
+For an application that has not configured an SDK, the API spans remain
+non-recording when OBI cannot activate the Auto SDK. When OBI can observe calls
+to the global Trace API, it may still construct synthetic spans. A synthetic
+span may contain the span name, parent relationship, status, and some primitive
+attributes, but it does not contain the instrumentation scope, events, or
+requested span kind. It is not a substitute for the application-authored span.
+If the application has registered an SDK `TracerProvider`, OBI defers to that
+provider instead of activating the Auto SDK or creating a competing synthetic
+span.
 
-The Auto SDK serializes each application-authored span as OTLP JSON. In v0.11.0,
-OBI accepts payloads up to 16 KiB and does not emit larger payloads. There is no
-operator-visible drop metric or warning for this condition. Other known
-limitations cover
+In v0.11.0, each application-authored span must fit within a 16 KiB encoded
+payload. Spans whose payloads exceed this limit are not exported. v0.11.0 does
+not log a warning or publish a metric when this happens. Other known limitations
+cover
 [sampling](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2793),
 [context handoffs](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2794),
 [external and remote parents and `TraceState`](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2959),


### PR DESCRIPTION
## Summary

Document OBI v0.11.0's automatic activation of application-authored spans
created through the global Go `otel.Tracer` API when no `TracerProvider` is
registered.

The new guidance:

- links the maintained runnable example and exact OBI support matrix
- describes the requirements for activation and identifies the
  application-supplied fields that synthetic spans omit
- records the 16 KiB Auto SDK payload limit without claiming unavailable drop
  telemetry
- links the sampling, context-handoff, remote-parent/`TraceState`, payload, and
  log-enrichment follow-ups

Companion implementation: https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2962

## Validation

- `prettier --check content/en/docs/zero-code/obi/distributed-traces.md`
- `markdownlint-cli2 content/en/docs/zero-code/obi/distributed-traces.md`
- `cspell content/en/docs/zero-code/obi/distributed-traces.md`

All three checks pass locally.
