### PR TITLE
Fix context propagation example direction

### DIFF
--- a/content/en/docs/concepts/context-propagation/index.md
+++ b/content/en/docs/concepts/context-propagation/index.md
@@ -87,7 +87,7 @@ In the case of metrics, context propagation enables you to aggregate
 measurements in that context. For example, instead of only looking at the
 response time of all the `GET /product` requests, you can also get metrics for
 combinations of `POST /cart/add > GET /product` and
-`GET /checkout < GET /product`.
+`GET /checkout > GET /product`.
 
 | Name                            | Calls Per Second | Average Response Time |
 | ------------------------------- | ---------------- | --------------------- |

--- a/content/en/docs/concepts/context-propagation/index.md
+++ b/content/en/docs/concepts/context-propagation/index.md
@@ -92,7 +92,7 @@ combinations of `POST /cart/add > GET /product` and
 | Name                            | Calls Per Second | Average Response Time |
 | ------------------------------- | ---------------- | --------------------- |
 | `* > GET /product`              | 370              | 300ms                 |
-| `POST /card/add > GET /product` | 330              | 130ms                 |
+| `POST /cart/add > GET /product` | 330              | 130ms                 |
 | `GET /checkout > GET /product`  | 40               | 1703ms                |
 
 ## Custom Context Propagation


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

Corrected the direction of the context propagation for the example `GET /checkout < GET /product`

<img width="753" height="357" alt="Screenshot 2026-08-08 at 11 09 27" src="https://github.com/user-attachments/assets/fc0539b5-7c41-4f44-95be-9ae4d5b50179" />
