### PR TITLE
[ja] update translation of content/en/docs/languages/ruby/sampling.md

### DIFF
--- a/content/ja/docs/languages/ruby/sampling.md
+++ b/content/ja/docs/languages/ruby/sampling.md
@@ -1,8 +1,7 @@
 ---
 title: サンプリング
 weight: 80
-default_lang_commit: 06837fe15457a584f6a9e09579be0f0400593d57
-drifted_from_default: true
+default_lang_commit: f9b631a466855b3bb7ec11bb5a9d342470caa77a
 ---
 
 [サンプリング](/docs/concepts/sampling/)は、システムによって生成されるトレース量を制限するプロセスです。
@@ -42,3 +41,52 @@ export OTEL_TRACES_SAMPLER_ARG="0.1"
 
 `TraceIdRatioBased`サンプラーをコードで構成することは可能ですが、推奨されません。
 コードで構成するには、適切な構成オプションをすべて備えたトレーサープロバイダーを手動で設定する必要がありますが、`OpenTelemetry::SDK.configure` を使用するだけの場合と比べて正しく実行するのが困難です。
+
+## カスタムサンプラー {#custom-samplers}
+
+スパンの名前、属性、またはその他の識別基準に基づいて決定を行うカスタム [Sampler][] を作成したい場合があります。
+サンプラーは、サンプリングの決定に必要な情報がスパンの開始時に利用可能な場合に適しています。
+決定に必要な情報がスパンの終了時まで利用できない場合は、[スパンプロセッサー][span-processor]の使用を検討してください。
+
+以下は、`db.statement` の値が `;` であるすべてのスパンを除外するカスタム Sampler クラスの例です。
+
+このクエリは、Active Record と PostgreSQL（`pg` gem）を組み合わせて使用するアプリケーションでよく見られます。
+Active Record は2秒ごとにアクティブなデータベース接続を確認し、`pg` でステートメントが `;` だけのクエリを実行します。
+これにより、大量の不要なスパンが生成される可能性があります。
+
+スパンがこの基準を満たす場合、そのスパンはドロップされます。
+この基準を満たさない場合、サンプリングの決定はデリゲートサンプラーにフォールバックします。
+この場合、デリゲートサンプラーは `TraceIdRatioBased` サンプラーです。
+
+[Sampler]: https://www.rubydoc.info/gems/opentelemetry-sdk/OpenTelemetry/SDK/Trace/Samplers
+[span-processor]: https://www.rubydoc.info/gems/opentelemetry-sdk/OpenTelemetry/SDK/Trace/SpanProcessor
+
+```ruby
+class CustomSampler
+  def initialize(delegate)
+    @delegate = delegate
+  end
+
+  def should_sample?(trace_id:, parent_context:, links:, name:, kind:, attributes:)
+    if attributes && attributes["db.statement"] == ";"
+      OpenTelemetry::SDK::Trace::Samplers::Result.new(
+        decision: OpenTelemetry::SDK::Trace::Samplers::Decision::DROP,
+        tracestate: OpenTelemetry::Trace.current_span(parent_context).context.tracestate
+      )
+    else
+      @delegate.should_sample?(trace_id: trace_id, parent_context: parent_context,
+        links: links, name: name, kind: kind, attributes: attributes)
+    end
+  end
+
+  def description
+    "CustomSampler{#{@delegate.description}}"
+  end
+end
+
+# OpenTelemetry::SDK.configure の呼び出し後、サンプラーをデフォルトの
+# トレーサープロバイダーに割り当てることができます。
+
+OpenTelemetry.tracer_provider.sampler = CustomSampler.new(
+  OpenTelemetry::SDK::Trace::Samplers.trace_id_ratio_based(0.5))
+```


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/ruby/sampling.md` to match the latest English source at
`content/en/docs/languages/ruby/sampling.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff adds a new "Custom Samplers" section with explanatory text and a Ruby code example.
The Japanese translation adds the equivalent section with translated prose and code comments.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11255--opentelemetry.netlify.app/ja/docs/languages/ruby/sampling/
- **English (canonical):** https://opentelemetry.io/docs/languages/ruby/sampling/

_(deploy preview may take a few minutes to build.)_
<!-- preview-section-end -->