### PR TITLE
Use the SHA from the latest EN commit for the `default_lang_commit` parameter

### DIFF
--- a/.github/localization.instructions.md
+++ b/.github/localization.instructions.md
@@ -51,7 +51,7 @@ npm run check:i18n -- diff content/zh  # Show detailed diff for drift
 **Update Localization Tracking:**
 
 ```bash
-npm run check:i18n -- commit HEAD --new content/zh # Add default_lang_commit to new pages
+npm run check:i18n -- --from-src-latest --new content/zh # Add default_lang_commit to new pages
 npm run check:i18n -- commit <HASH> content/zh     # Update existing pages commit hash (also syncs drift status)
 npm run fix:i18n:status -- <PATHS>                 # Sync drift status; in PRs, pass only the pages a failing check reports (tree-wide runs are Housekeeping's)
 ```
@@ -130,7 +130,8 @@ default_lang_commit: <commit-hash-of-english-page>
 1. Review changes: `npm run check:i18n -- diff content/xx/path/to/page`
 2. Update your localized page to match new English content
 3. Update `default_lang_commit` to latest hash (this also clears the page's
-   drift status): `npm run check:i18n -- commit HEAD content/xx/path/to/page`
+   drift status): `npm run check:i18n -- commit HEAD content/xx/path/to/page` or
+   `npm run check:i18n -- --from-src-latest content/xx/path/to/page`
 
 **Patching (build fixes only):**
 
@@ -252,6 +253,7 @@ npm run fix:i18n:status -- <PATHS>
 
 # Batch update commit hashes after updating multiple files
 npm run check:i18n -- commit HEAD content/xx/
+npm run check:i18n -- --from-src-latest content/xx/
 
 # Help and options
 npm run check:i18n -- -h

--- a/.github/localization.instructions.md
+++ b/.github/localization.instructions.md
@@ -51,7 +51,7 @@ npm run check:i18n -- diff content/zh  # Show detailed diff for drift
 **Update Localization Tracking:**
 
 ```bash
-npm run check:i18n -- --from-src-latest --new content/zh # Add default_lang_commit to new pages
+npm run check:i18n -- commit --from-src-latest --new content/zh # Add default_lang_commit to new pages
 npm run check:i18n -- commit <HASH> content/zh     # Update existing pages commit hash (also syncs drift status)
 npm run fix:i18n:status -- <PATHS>                 # Sync drift status; in PRs, pass only the pages a failing check reports (tree-wide runs are Housekeeping's)
 ```
@@ -129,9 +129,10 @@ default_lang_commit: <commit-hash-of-english-page>
 
 1. Review changes: `npm run check:i18n -- diff content/xx/path/to/page`
 2. Update your localized page to match new English content
-3. Update `default_lang_commit` to latest hash (this also clears the page's
-   drift status): `npm run check:i18n -- commit HEAD content/xx/path/to/page` or
-   `npm run check:i18n -- --from-src-latest content/xx/path/to/page`
+3. Update `default_lang_commit` to the latest commit of the English page (this
+   also clears the page's drift status):
+   `npm run check:i18n -- commit --from-src-latest content/xx/path/to/page` — or
+   use `commit HEAD content/xx/path/to/page` to pin to `main@HEAD` explicitly.
 
 **Patching (build fixes only):**
 
@@ -252,8 +253,8 @@ npm run check:i18n
 npm run fix:i18n:status -- <PATHS>
 
 # Batch update commit hashes after updating multiple files
+npm run check:i18n -- commit --from-src-latest content/xx/
 npm run check:i18n -- commit HEAD content/xx/
-npm run check:i18n -- --from-src-latest content/xx/
 
 # Help and options
 npm run check:i18n -- -h

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -268,7 +268,7 @@ argument if your pages are now synced with `main` at `HEAD`. For example:
 
 ```sh
 npm run check:i18n -- commit 1ca30b4d --new content/ja
-npm run check:i18n -- commit HEAD --new content/zh/docs/concepts
+npm run check:i18n -- --from-src-latest --new content/zh/docs/concepts
 ```
 
 To list localization page files with missing hash keys, run:
@@ -287,17 +287,20 @@ commit hash.
 >
 > If your localized page now corresponds to the English language version in
 > `main` at `HEAD`, then run
-> `npm run check:i18n -- commit HEAD <PATH-TO-YOUR-PAGE>`: the
+> `npm run check:i18n -- commit HEAD <PATH-TO-YOUR-PAGE>` or
+> `npm run check:i18n -- --from-src-latest <PATH-TO-YOUR-PAGE>`: the
 > `default_lang_commit` hash is refreshed and the page's
 > [drift status](#drift-status) is cleared in the same write.
 
 If you have batch updated all of your localization pages that had drifted, you
-can update the commit hash of these files using the `commit` subcommand followed
-by a commit hash or 'HEAD' to use `main@HEAD`.
+can update the commit hash of these files using the `commit` subcommand. Pass a
+commit hash for a specific source commit, or use `HEAD` as a legitimate shortcut
+for `main@HEAD`.
 
 ```sh
 npm run check:i18n -- commit <HASH> <PATH-TO-YOUR-UPDATED-FILES>
 npm run check:i18n -- commit HEAD <PATH-TO-YOUR-UPDATED-FILES>
+npm run check:i18n -- --from-src-latest <PATH-TO-YOUR-UPDATED-FILES>
 ```
 
 > [!IMPORTANT]

--- a/content/en/docs/contributing/localization.md
+++ b/content/en/docs/contributing/localization.md
@@ -268,7 +268,7 @@ argument if your pages are now synced with `main` at `HEAD`. For example:
 
 ```sh
 npm run check:i18n -- commit 1ca30b4d --new content/ja
-npm run check:i18n -- --from-src-latest --new content/zh/docs/concepts
+npm run check:i18n -- commit --from-src-latest --new content/zh/docs/concepts
 ```
 
 To list localization page files with missing hash keys, run:
@@ -286,21 +286,23 @@ commit hash.
 > [!TIP]
 >
 > If your localized page now corresponds to the English language version in
-> `main` at `HEAD`, then run
-> `npm run check:i18n -- commit HEAD <PATH-TO-YOUR-PAGE>` or
-> `npm run check:i18n -- --from-src-latest <PATH-TO-YOUR-PAGE>`: the
-> `default_lang_commit` hash is refreshed and the page's
-> [drift status](#drift-status) is cleared in the same write.
+> `main` at `HEAD`, run
+> `npm run check:i18n -- commit --from-src-latest <PATH-TO-YOUR-PAGE>` to pin it
+> to the page's latest commit on `main` — or
+> `npm run check:i18n -- commit HEAD <PATH-TO-YOUR-PAGE>` to pin it to
+> `main@HEAD` explicitly: the `default_lang_commit` hash is refreshed and the
+> page's [drift status](#drift-status) is cleared in the same write.
 
 If you have batch updated all of your localization pages that had drifted, you
 can update the commit hash of these files using the `commit` subcommand. Pass a
-commit hash for a specific source commit, or use `HEAD` as a legitimate shortcut
-for `main@HEAD`.
+commit hash for a specific source commit, use `HEAD` as a legitimate shortcut
+for `main@HEAD`, or use `--from-src-latest` to pin each page to the latest
+commit of its English counterpart:
 
 ```sh
 npm run check:i18n -- commit <HASH> <PATH-TO-YOUR-UPDATED-FILES>
 npm run check:i18n -- commit HEAD <PATH-TO-YOUR-UPDATED-FILES>
-npm run check:i18n -- --from-src-latest <PATH-TO-YOUR-UPDATED-FILES>
+npm run check:i18n -- commit --from-src-latest <PATH-TO-YOUR-UPDATED-FILES>
 ```
 
 > [!IMPORTANT]

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "fix:format:diff": "npm run _fix:format:diff -- $(npm -s run _list:diff:all)",
     "fix:format:staged": "npx prettier --write --ignore-unknown $(npm -s run _list:diff-never-empty -- --cached)",
     "fix:format": "npm run format; npm run _fix:trailing-spaces",
-    "fix:i18n:new": "node scripts/i18n/drift.mjs --from-src-latest --new",
+    "fix:i18n:new": "node scripts/i18n/drift.mjs commit --from-src-latest --new",
     "fix:i18n:status": "node scripts/i18n/drift.mjs status --write",
     "fix:i18n": "npm run fix:i18n:new && npm run fix:i18n:status -- --all",
     "fix:l10n:do-not-copy-images-etc": "npm run check:l10n:do-not-copy-images-etc -- --fix",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "fix:format:diff": "npm run _fix:format:diff -- $(npm -s run _list:diff:all)",
     "fix:format:staged": "npx prettier --write --ignore-unknown $(npm -s run _list:diff-never-empty -- --cached)",
     "fix:format": "npm run format; npm run _fix:trailing-spaces",
-    "fix:i18n:new": "node scripts/i18n/drift.mjs commit HEAD --new",
+    "fix:i18n:new": "node scripts/i18n/drift.mjs --from-src-latest --new",
     "fix:i18n:status": "node scripts/i18n/drift.mjs status --write",
     "fix:i18n": "npm run fix:i18n:new && npm run fix:i18n:status -- --all",
     "fix:l10n:do-not-copy-images-etc": "npm run check:l10n:do-not-copy-images-etc -- --fix",

--- a/scripts/check-i18n.sh
+++ b/scripts/check-i18n.sh
@@ -9,6 +9,7 @@ DEFAULT_TARGET="$DEFAULT_CONTENT"
 EXIT_STATUS=0
 EXTRA_DIFF_ARGS="--numstat"
 FLAG_CHANGE_OR_ADD=0
+FLAG_CHANGE_FROM_EN_LAST_COMMIT=0
 FLAG_COMPLETENESS=0
 FLAG_DIFF_DETAILS=0
 FLAG_DRIFTED_STATUS=0
@@ -50,6 +51,9 @@ Options:
            TIP: first fetch and pull the upstream 'main' if you want to use the
                 remote HEAD hash.
 
+  -e       Change or add the '$I18N_DLC_KEY' key value to the latest commit SHA
+           of the corresponding English page for each selected localization page.
+
   -C       Report completeness: percentage of English pages that have a translation
            for each language under TARGET_PATH. Use with -v to list missing pages.
 
@@ -74,7 +78,7 @@ function usage() {
 }
 
 function process_CLI_args() {
-  while getopts ":ac:CdDhinqvx" opt; do
+  while getopts ":ac:CdDehinqvx" opt; do
     case $opt in
       a)
         LIST_KIND="ALL";;
@@ -86,6 +90,8 @@ function process_CLI_args() {
       d)
         FLAG_DIFF_DETAILS=1
         EXTRA_DIFF_ARGS="";;
+      e)
+        FLAG_CHANGE_FROM_EN_LAST_COMMIT=1;;
       D)
         FLAG_DRIFTED_STATUS=1;;
       h)
@@ -114,8 +120,8 @@ function process_CLI_args() {
     validate_hash $COMMIT_HASH_ARG
   fi
 
-  if (( FLAG_CHANGE_OR_ADD + FLAG_COMPLETENESS + FLAG_DIFF_DETAILS + FLAG_DRIFTED_STATUS > 1 )); then
-    echo -e "ERROR: you can't use -c, -C, -d, and -D at the same time; choose one. For help use -h.\n"
+  if (( FLAG_CHANGE_OR_ADD + FLAG_CHANGE_FROM_EN_LAST_COMMIT + FLAG_COMPLETENESS + FLAG_DIFF_DETAILS + FLAG_DRIFTED_STATUS > 1 )); then
+    echo -e "ERROR: you can't use -c, -e, -C, -d, and -D at the same time; choose one. For help use -h.\n"
     exit 1
   fi
 
@@ -212,6 +218,11 @@ function set_file_i18n_hash() {
   if [[ -z $FLAG_QUIET ]]; then
     echo -e "$pre_msg\t$f $HASH $post_msg"
   fi
+}
+
+function get_last_commit_hash_for_file() {
+  local f="$1"
+  git log -1 --format=%H -- "$f"
 }
 
 function update_file_i18n_hash() {
@@ -339,8 +350,8 @@ function main() {
     # if [[ -n $FLAG_VERBOSE ]]; then echo -e "All targets: $TARGETS"; fi
   fi
 
-  local LASTCOMMIT_FF=""       # commit From File (FF), i.e., $f in the loop below
-  local LASTCOMMIT_GIT=""      # last commit of `en` version of $f from git
+  local PIN_COMMIT_FROM_FILE="" # commit from front matter pin in the current target file
+  local SOURCE_LAST_COMMIT=""   # latest commit of source-language version of target file
   local FILE_COUNT=0           # Number of TLP
   local FILE_PROCESSED_COUNT=0 # Number of TLP actually listed
 
@@ -352,20 +363,44 @@ function main() {
   for f in $TARGETS; do
     ((FILE_COUNT++))
 
-    LASTCOMMIT_FF=$(perl -ne "print \"\$1\" if /^$I18N_DLC_KEY:\\s*([a-f0-9]+)/i" "$f")
-    LASTCOMMIT="$LASTCOMMIT_FF"
+    PIN_COMMIT_FROM_FILE=$(perl -ne "print \"\$1\" if /^$I18N_DLC_KEY:\\s*([a-f0-9]+)/i" "$f")
+    PIN_COMMIT="$PIN_COMMIT_FROM_FILE"
 
-    if [[ $LIST_KIND == "ALL" && -n $COMMIT_HASH_ARG ]]; then
+    SOURCE_PATH=$(echo "$f" | sed "s/$DEFAULT_CONTENT\/.\{2,5\}\//$DEFAULT_CONTENT\/$DEFAULT_LANG\//g")
+    SOURCE_LAST_COMMIT=""
+    if [[ -e "$SOURCE_PATH" ]]; then
+      SOURCE_LAST_COMMIT=$(get_last_commit_hash_for_file "$SOURCE_PATH")
+    fi
+
+    if [[ $LIST_KIND == "ALL" && (-n $COMMIT_HASH_ARG || $FLAG_CHANGE_FROM_EN_LAST_COMMIT != 0) ]]; then
         ((FILE_PROCESSED_COUNT++))
-        set_file_i18n_hash "$f" "$COMMIT_HASH_ARG"
+        if [[ $FLAG_CHANGE_FROM_EN_LAST_COMMIT != 0 ]]; then
+          if [[ ! -e "$SOURCE_PATH" || -z "$SOURCE_LAST_COMMIT" ]]; then
+            echo "ERROR: cannot determine latest commit for default-language file: $f -> $SOURCE_PATH" >&2
+            EXIT_STATUS=1
+            continue
+          fi
+          set_file_i18n_hash "$f" "$SOURCE_LAST_COMMIT"
+        else
+          set_file_i18n_hash "$f" "$COMMIT_HASH_ARG"
+        fi
         continue
     fi
 
     if [[ $LIST_KIND == "NEW" ]]; then
-      if [[ -n $LASTCOMMIT_FF ]]; then continue; fi
+      if [[ -n $PIN_COMMIT_FROM_FILE ]]; then continue; fi
       ((FILE_PROCESSED_COUNT++))
-      if [[ -n $COMMIT_HASH_ARG ]]; then
-        set_file_i18n_hash "$f" "$COMMIT_HASH_ARG" "" "key ADDED"
+      if [[ -n $COMMIT_HASH_ARG || $FLAG_CHANGE_FROM_EN_LAST_COMMIT != 0 ]]; then
+        if [[ $FLAG_CHANGE_FROM_EN_LAST_COMMIT != 0 ]]; then
+          if [[ ! -e "$SOURCE_PATH" || -z "$SOURCE_LAST_COMMIT" ]]; then
+            echo "ERROR: cannot determine latest commit for default-language file: $f -> $SOURCE_PATH" >&2
+            EXIT_STATUS=1
+            continue
+          fi
+          set_file_i18n_hash "$f" "$SOURCE_LAST_COMMIT" "" "key ADDED"
+        else
+          set_file_i18n_hash "$f" "$COMMIT_HASH_ARG" "" "key ADDED"
+        fi
       elif [[ -z $FLAG_QUIET ]]; then
         echo "$f - has no $I18N_DLC_KEY front-matter key"
       fi
@@ -375,8 +410,7 @@ function main() {
     ## Processing $LIST_KIND DRIFTED
 
     # Does $f have an default-language version?
-    EN_VERSION=$(echo "$f" | sed "s/$DEFAULT_CONTENT\/.\{2,5\}\//$DEFAULT_CONTENT\/$DEFAULT_LANG\//g")
-    if [[ ! -e "$EN_VERSION" ]]; then
+    if [[ ! -e "$SOURCE_PATH" ]]; then
       ((FILE_PROCESSED_COUNT++))
       if [[ -z $FLAG_QUIET ]]; then
         echo -e "File not found:\t$f - $DEFAULT_LANG page was removed or renamed"
@@ -386,37 +420,51 @@ function main() {
     fi
 
     # Check default-language version for changes
-    DIFF=$(git diff --exit-code $EXTRA_DIFF_ARGS $LASTCOMMIT...HEAD "$EN_VERSION" 2>&1)
-    DIFF_STATUS=$?
+    SOURCE_DIFF=$(git diff --exit-code $EXTRA_DIFF_ARGS $PIN_COMMIT...HEAD "$SOURCE_PATH" 2>&1)
+    SOURCE_DIFF_STATUS=$?
     DRIFTED_STATUS="false"
-    if [ $DIFF_STATUS -gt 1 ]; then
+    if [ $SOURCE_DIFF_STATUS -gt 1 ]; then
       ((FILE_PROCESSED_COUNT++))
-      EXIT_STATUS=$DIFF_STATUS
-      echo -e "HASH\tERROR\t$f: git diff error ($DIFF_STATUS) or invalid hash $LASTCOMMIT. For details, use -v."
-      if [[ -n $FLAG_VERBOSE ]]; then echo "$DIFF"; fi
+      EXIT_STATUS=$SOURCE_DIFF_STATUS
+      echo -e "HASH\tERROR\t$f: git diff error ($SOURCE_DIFF_STATUS) or invalid hash $PIN_COMMIT. For details, use -v."
+      if [[ -n $FLAG_VERBOSE ]]; then echo "$SOURCE_DIFF"; fi
       continue
-    elif [[ -n "$DIFF" ]]; then
+    elif [[ -n "$SOURCE_DIFF" ]]; then
       ((FILE_PROCESSED_COUNT++))
       DRIFTED_STATUS="true"
       if [[ $FLAG_DIFF_DETAILS != 0 ]]; then
-        echo "$DIFF"
+        echo "$SOURCE_DIFF"
       elif [[ -n $COMMIT_HASH_ARG ]]; then
-        update_file_i18n_hash "$f" "$COMMIT_HASH_ARG" "$DIFF"
+        update_file_i18n_hash "$f" "$COMMIT_HASH_ARG" "$SOURCE_DIFF"
+      elif [[ $FLAG_CHANGE_FROM_EN_LAST_COMMIT != 0 ]]; then
+        if [[ -z "$SOURCE_LAST_COMMIT" ]]; then
+          echo "ERROR: cannot determine latest commit for default-language file: $f -> $SOURCE_PATH" >&2
+          EXIT_STATUS=1
+          continue
+        fi
+        set_file_i18n_hash "$f" "$SOURCE_LAST_COMMIT" "$SOURCE_DIFF"
       elif [[ -z $FLAG_QUIET ]]; then
         echo -n "> Drifted file: $f"
-        if [[ -n $FLAG_VERBOSE ]]; then echo "; diff summary: $DIFF"; else echo; fi
+        if [[ -n $FLAG_VERBOSE ]]; then echo "; diff summary: $SOURCE_DIFF"; else echo; fi
       fi
-    elif [[ -z $LASTCOMMIT ]]; then
+    elif [[ -z $PIN_COMMIT ]]; then
       ((FILE_PROCESSED_COUNT++))
       local msg="New i18n file"
       if [[ -n $COMMIT_HASH_ARG ]]; then
         set_file_i18n_hash "$f" "$COMMIT_HASH_ARG" "$msg" "key ADDED"
+      elif [[ $FLAG_CHANGE_FROM_EN_LAST_COMMIT != 0 ]]; then
+        if [[ -z "$SOURCE_LAST_COMMIT" ]]; then
+          echo "ERROR: cannot determine latest commit for default-language file: $f -> $SOURCE_PATH" >&2
+          EXIT_STATUS=1
+          continue
+        fi
+        set_file_i18n_hash "$f" "$SOURCE_LAST_COMMIT" "$msg" "key ADDED"
       elif [[ -z $FLAG_QUIET ]]; then
         echo "$msg - $f"
       fi
     elif [[ $LIST_KIND == "ALL" || -n $FLAG_VERBOSE ]]; then
       ((FILE_PROCESSED_COUNT++))
-      echo -e "File is in sync\t$f - $LASTCOMMIT"
+      echo -e "File is in sync\t$f - $PIN_COMMIT"
     fi
     set_file_drifted_status "$f" $DRIFTED_STATUS
   done
@@ -425,7 +473,7 @@ function main() {
     echo "$LIST_KIND files: $FILE_PROCESSED_COUNT out of $FILE_COUNT"
   fi
 
-  if [[ $FILE_PROCESSED_COUNT -gt 0 && -z $COMMIT_HASH_ARG ]]; then
+  if [[ $FILE_PROCESSED_COUNT -gt 0 && -z $COMMIT_HASH_ARG && $FLAG_CHANGE_FROM_EN_LAST_COMMIT == 0 ]]; then
     EXIT_STATUS=$((EXIT_STATUS || FLAG_FAIL_ON_LIST_OR_MISSING))
   fi
   exit $EXIT_STATUS

--- a/scripts/check-i18n.sh
+++ b/scripts/check-i18n.sh
@@ -54,6 +54,9 @@ Options:
   -e       Change or add the '$I18N_DLC_KEY' key value to the latest commit SHA
            of the corresponding English page for each selected localization page.
 
+           TIP: first fetch and pull the upstream 'main' if you want the latest
+                commit of the English page to reflect the remote HEAD.
+
   -C       Report completeness: percentage of English pages that have a translation
            for each language under TARGET_PATH. Use with -v to list missing pages.
 
@@ -222,7 +225,16 @@ function set_file_i18n_hash() {
 
 function get_last_commit_hash_for_file() {
   local f="$1"
-  git log -1 --format=%H -- "$f"
+  # Anchor to the canonical repo's main: upstream/main on a contributor's
+  # local fork checkout, origin/main in CI (where origin is the canonical repo
+  # and no upstream remote exists), falling back to plain 'main'.
+  local main_ref="main"
+  if git remote | grep -qx upstream; then
+    main_ref="upstream/main"
+  elif git remote | grep -qx origin; then
+    main_ref="origin/main"
+  fi
+  git log -1 --format=%H "$main_ref" -- "$f"
 }
 
 function update_file_i18n_hash() {
@@ -350,8 +362,8 @@ function main() {
     # if [[ -n $FLAG_VERBOSE ]]; then echo -e "All targets: $TARGETS"; fi
   fi
 
-  local PIN_COMMIT_FROM_FILE="" # commit from front matter pin in the current target file
-  local SOURCE_LAST_COMMIT=""   # latest commit of source-language version of target file
+  local LASTCOMMIT_FF=""       # commit From File (FF), i.e., $f in the loop below
+  local LASTCOMMIT_GIT=""      # last commit of `en` version of $f from git
   local FILE_COUNT=0           # Number of TLP
   local FILE_PROCESSED_COUNT=0 # Number of TLP actually listed
 
@@ -363,24 +375,24 @@ function main() {
   for f in $TARGETS; do
     ((FILE_COUNT++))
 
-    PIN_COMMIT_FROM_FILE=$(perl -ne "print \"\$1\" if /^$I18N_DLC_KEY:\\s*([a-f0-9]+)/i" "$f")
-    PIN_COMMIT="$PIN_COMMIT_FROM_FILE"
+    LASTCOMMIT_FF=$(perl -ne "print \"\$1\" if /^$I18N_DLC_KEY:\\s*([a-f0-9]+)/i" "$f")
+    LASTCOMMIT="$LASTCOMMIT_FF"
 
-    SOURCE_PATH=$(echo "$f" | sed "s/$DEFAULT_CONTENT\/.\{2,5\}\//$DEFAULT_CONTENT\/$DEFAULT_LANG\//g")
-    SOURCE_LAST_COMMIT=""
-    if [[ -e "$SOURCE_PATH" ]]; then
-      SOURCE_LAST_COMMIT=$(get_last_commit_hash_for_file "$SOURCE_PATH")
+    EN_VERSION=$(echo "$f" | sed "s/$DEFAULT_CONTENT\/.\{2,5\}\//$DEFAULT_CONTENT\/$DEFAULT_LANG\//g")
+    LASTCOMMIT_GIT=""
+    if [[ -e "$EN_VERSION" ]]; then
+      LASTCOMMIT_GIT=$(get_last_commit_hash_for_file "$EN_VERSION")
     fi
 
     if [[ $LIST_KIND == "ALL" && (-n $COMMIT_HASH_ARG || $FLAG_CHANGE_FROM_EN_LAST_COMMIT != 0) ]]; then
         ((FILE_PROCESSED_COUNT++))
         if [[ $FLAG_CHANGE_FROM_EN_LAST_COMMIT != 0 ]]; then
-          if [[ ! -e "$SOURCE_PATH" || -z "$SOURCE_LAST_COMMIT" ]]; then
-            echo "ERROR: cannot determine latest commit for default-language file: $f -> $SOURCE_PATH" >&2
+          if [[ ! -e "$EN_VERSION" || -z "$LASTCOMMIT_GIT" ]]; then
+            echo "ERROR: cannot determine latest commit for EN file: $f -> $EN_VERSION" >&2
             EXIT_STATUS=1
             continue
           fi
-          set_file_i18n_hash "$f" "$SOURCE_LAST_COMMIT"
+          set_file_i18n_hash "$f" "$LASTCOMMIT_GIT"
         else
           set_file_i18n_hash "$f" "$COMMIT_HASH_ARG"
         fi
@@ -388,16 +400,16 @@ function main() {
     fi
 
     if [[ $LIST_KIND == "NEW" ]]; then
-      if [[ -n $PIN_COMMIT_FROM_FILE ]]; then continue; fi
+      if [[ -n $LASTCOMMIT_FF ]]; then continue; fi
       ((FILE_PROCESSED_COUNT++))
       if [[ -n $COMMIT_HASH_ARG || $FLAG_CHANGE_FROM_EN_LAST_COMMIT != 0 ]]; then
         if [[ $FLAG_CHANGE_FROM_EN_LAST_COMMIT != 0 ]]; then
-          if [[ ! -e "$SOURCE_PATH" || -z "$SOURCE_LAST_COMMIT" ]]; then
-            echo "ERROR: cannot determine latest commit for default-language file: $f -> $SOURCE_PATH" >&2
+          if [[ ! -e "$EN_VERSION" || -z "$LASTCOMMIT_GIT" ]]; then
+            echo "ERROR: cannot determine latest commit for EN file: $f -> $EN_VERSION" >&2
             EXIT_STATUS=1
             continue
           fi
-          set_file_i18n_hash "$f" "$SOURCE_LAST_COMMIT" "" "key ADDED"
+          set_file_i18n_hash "$f" "$LASTCOMMIT_GIT" "" "key ADDED"
         else
           set_file_i18n_hash "$f" "$COMMIT_HASH_ARG" "" "key ADDED"
         fi
@@ -410,7 +422,7 @@ function main() {
     ## Processing $LIST_KIND DRIFTED
 
     # Does $f have an default-language version?
-    if [[ ! -e "$SOURCE_PATH" ]]; then
+    if [[ ! -e "$EN_VERSION" ]]; then
       ((FILE_PROCESSED_COUNT++))
       if [[ -z $FLAG_QUIET ]]; then
         echo -e "File not found:\t$f - $DEFAULT_LANG page was removed or renamed"
@@ -420,51 +432,51 @@ function main() {
     fi
 
     # Check default-language version for changes
-    SOURCE_DIFF=$(git diff --exit-code $EXTRA_DIFF_ARGS $PIN_COMMIT...HEAD "$SOURCE_PATH" 2>&1)
-    SOURCE_DIFF_STATUS=$?
+    DIFF=$(git diff --exit-code $EXTRA_DIFF_ARGS $LASTCOMMIT...HEAD "$EN_VERSION" 2>&1)
+    DIFF_STATUS=$?
     DRIFTED_STATUS="false"
-    if [ $SOURCE_DIFF_STATUS -gt 1 ]; then
+    if [ $DIFF_STATUS -gt 1 ]; then
       ((FILE_PROCESSED_COUNT++))
-      EXIT_STATUS=$SOURCE_DIFF_STATUS
-      echo -e "HASH\tERROR\t$f: git diff error ($SOURCE_DIFF_STATUS) or invalid hash $PIN_COMMIT. For details, use -v."
-      if [[ -n $FLAG_VERBOSE ]]; then echo "$SOURCE_DIFF"; fi
+      EXIT_STATUS=$DIFF_STATUS
+      echo -e "HASH\tERROR\t$f: git diff error ($DIFF_STATUS) or invalid hash $LASTCOMMIT. For details, use -v."
+      if [[ -n $FLAG_VERBOSE ]]; then echo "$DIFF"; fi
       continue
-    elif [[ -n "$SOURCE_DIFF" ]]; then
+    elif [[ -n "$DIFF" ]]; then
       ((FILE_PROCESSED_COUNT++))
       DRIFTED_STATUS="true"
       if [[ $FLAG_DIFF_DETAILS != 0 ]]; then
-        echo "$SOURCE_DIFF"
+        echo "$DIFF"
       elif [[ -n $COMMIT_HASH_ARG ]]; then
-        update_file_i18n_hash "$f" "$COMMIT_HASH_ARG" "$SOURCE_DIFF"
+        update_file_i18n_hash "$f" "$COMMIT_HASH_ARG" "$DIFF"
       elif [[ $FLAG_CHANGE_FROM_EN_LAST_COMMIT != 0 ]]; then
-        if [[ -z "$SOURCE_LAST_COMMIT" ]]; then
-          echo "ERROR: cannot determine latest commit for default-language file: $f -> $SOURCE_PATH" >&2
+        if [[ -z "$LASTCOMMIT_GIT" ]]; then
+          echo "ERROR: cannot determine latest commit for EN file: $f -> $EN_VERSION" >&2
           EXIT_STATUS=1
           continue
         fi
-        set_file_i18n_hash "$f" "$SOURCE_LAST_COMMIT" "$SOURCE_DIFF"
+        set_file_i18n_hash "$f" "$LASTCOMMIT_GIT" "$DIFF"
       elif [[ -z $FLAG_QUIET ]]; then
         echo -n "> Drifted file: $f"
-        if [[ -n $FLAG_VERBOSE ]]; then echo "; diff summary: $SOURCE_DIFF"; else echo; fi
+        if [[ -n $FLAG_VERBOSE ]]; then echo "; diff summary: $DIFF"; else echo; fi
       fi
-    elif [[ -z $PIN_COMMIT ]]; then
+    elif [[ -z $LASTCOMMIT ]]; then
       ((FILE_PROCESSED_COUNT++))
       local msg="New i18n file"
       if [[ -n $COMMIT_HASH_ARG ]]; then
         set_file_i18n_hash "$f" "$COMMIT_HASH_ARG" "$msg" "key ADDED"
       elif [[ $FLAG_CHANGE_FROM_EN_LAST_COMMIT != 0 ]]; then
-        if [[ -z "$SOURCE_LAST_COMMIT" ]]; then
-          echo "ERROR: cannot determine latest commit for default-language file: $f -> $SOURCE_PATH" >&2
+        if [[ -z "$LASTCOMMIT_GIT" ]]; then
+          echo "ERROR: cannot determine latest commit for EN file: $f -> $EN_VERSION" >&2
           EXIT_STATUS=1
           continue
         fi
-        set_file_i18n_hash "$f" "$SOURCE_LAST_COMMIT" "$msg" "key ADDED"
+        set_file_i18n_hash "$f" "$LASTCOMMIT_GIT" "$msg" "key ADDED"
       elif [[ -z $FLAG_QUIET ]]; then
         echo "$msg - $f"
       fi
     elif [[ $LIST_KIND == "ALL" || -n $FLAG_VERBOSE ]]; then
       ((FILE_PROCESSED_COUNT++))
-      echo -e "File is in sync\t$f - $PIN_COMMIT"
+      echo -e "File is in sync\t$f - $LASTCOMMIT"
     fi
     set_file_drifted_status "$f" $DRIFTED_STATUS
   done

--- a/scripts/i18n/drift-pr-guard.mjs
+++ b/scripts/i18n/drift-pr-guard.mjs
@@ -95,15 +95,15 @@ async function mainCLI() {
   console.log(diff);
   console.log(`---
 Each localized page changed by this PR must leave the PR with an accurate
-drift state; the diff above shows the corrections needed. Either sync a page
-with its English counterpart and refresh its pin with the valid
-'commit HEAD' form,
+drift state; the diff above shows the corrections needed. Sync a page with
+its English counterpart and refresh its pin — preferably to the EN page's
+latest commit on main,
+
+    npm run check:i18n -- commit --from-src-latest PATHS
+
+or to main's HEAD explicitly,
 
     npm run check:i18n -- commit HEAD PATHS
-
-or, equivalently,
-
-    npm run check:i18n -- --from-src-latest PATHS
 
 or record the remaining drift,
 

--- a/scripts/i18n/drift-pr-guard.mjs
+++ b/scripts/i18n/drift-pr-guard.mjs
@@ -96,9 +96,14 @@ async function mainCLI() {
   console.log(`---
 Each localized page changed by this PR must leave the PR with an accurate
 drift state; the diff above shows the corrections needed. Either sync a page
-with its English counterpart and refresh its pin,
+with its English counterpart and refresh its pin with the valid
+'commit HEAD' form,
 
     npm run check:i18n -- commit HEAD PATHS
+
+or, equivalently,
+
+    npm run check:i18n -- --from-src-latest PATHS
 
 or record the remaining drift,
 

--- a/scripts/i18n/drift.mjs
+++ b/scripts/i18n/drift.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
 // Drift-status core: answers "which localized pages have drifted from their
-// source-language counterparts?" as a library (link-check config gen, npm scripts) and a
+// EN counterparts?" as a library (link-check config gen, npm scripts) and a
 // thin CLI. Semantics match scripts/check-i18n.sh: a page with front-matter
-// pin `default_lang_commit: SHA` is drifted iff its source counterpart changed in
-// `git diff SHA...HEAD` (three-dot); a missing source counterpart is reported as
+// pin `default_lang_commit: SHA` is drifted iff its EN counterpart changed in
+// `git diff SHA...HEAD` (three-dot); a missing EN counterpart is reported as
 // `file not found`; a page without a pin is `new`. Precise mode needs history
 // back to the oldest pin (fine locally and in Housekeeping; not in shallow CI
 // checkouts — there, the link-check config gen uses its baseline overlay).
@@ -53,22 +53,17 @@ export function parseStatus(fileText) {
 
 // The one stored-status skip predicate, shared by the status writer and the
 // link-check config generation: a `true` or `file not found` status means
-// the page is presumed out of sync with source (its source counterpart changed or
+// the page is presumed out of sync with EN (its EN counterpart changed or
 // was deleted), so its outbound links are not checked.
 export function isDriftedStatus(status) {
   return status === 'true' || status === 'file not found';
 }
 
-export function sourceCounterpartOf(pagePath) {
+export function enCounterpartOf(pagePath) {
   return pagePath.replace(
     new RegExp(`^${CONTENT_DIR}/[^/]{2,5}/`),
     `${CONTENT_DIR}/${DEFAULT_LANG}/`,
   );
-}
-
-// Backward-compatible alias.
-export function enCounterpartOf(pagePath) {
-  return sourceCounterpartOf(pagePath);
 }
 
 export function groupByPin(pagePins) {
@@ -212,20 +207,18 @@ export function classifyCliArgs(args) {
   }
 
   if (cli.useSrcLatest) {
-    if (cli.noun === 'diff') {
-      throw new Error(`--from-src-latest applies to status/commit only`);
+    if (cli.noun !== 'commit') {
+      throw new Error(`--from-src-latest applies to the commit noun only`);
     }
     if (cli.hash) {
       throw new Error(`Use either --from-src-latest or HASH|HEAD, not both`);
     }
-    cli.noun = 'commit';
-    cli.write = true;
   }
 
   if (writeFlag && cli.noun !== 'status') {
     throw new Error(`--write applies to the status noun only`);
   }
-  cli.write = writeFlag || !!cli.hash;
+  cli.write = writeFlag || !!cli.hash || cli.useSrcLatest;
   if (writeFlag && cli.check) {
     throw new Error(`--check is a read-mode flag; drop it with --write`);
   }
@@ -261,23 +254,16 @@ export function classifyCliArgs(args) {
   return cli;
 }
 
-// Core engine, effects injected: `sourceExists(sourcePath)` and async
-// `changedSourceSince(sha)` -> Set of source-language pages changed in SHA...HEAD.
+// Core engine, effects injected: `enExists(enPath)` and async
+// `changedEnSince(sha)` -> Set of EN paths changed in SHA...HEAD.
 // Returns Map page -> { status, sha?, patched? } with status one of:
 // 'drifted' | 'in-sync' | 'file not found' | 'new' | 'error'.
-export async function driftReport(
-  pagePins,
-  { sourceExists, changedSourceSince, enExists, changedEnSince },
-) {
-  // Compatibility fallback for existing call sites/tests using old option keys.
-  sourceExists ??= enExists;
-  changedSourceSince ??= changedEnSince;
-
+export async function driftReport(pagePins, { enExists, changedEnSince }) {
   const report = new Map();
   const pending = new Map(); // sha -> pages awaiting that pin's diff
 
   for (const [page, pin] of pagePins) {
-    if (!sourceExists(sourceCounterpartOf(page))) {
+    if (!enExists(enCounterpartOf(page))) {
       report.set(page, { ...(pin ?? {}), status: 'file not found' });
     } else if (!pin) {
       report.set(page, { status: 'new' });
@@ -289,10 +275,10 @@ export async function driftReport(
 
   const shas = [...pending.keys()];
   await mapLimit(shas, GIT_CONCURRENCY, async (sha) => {
-    let changedSourcePages;
+    let changed;
     let status;
     try {
-      changedSourcePages = await changedSourceSince(sha);
+      changed = await changedEnSince(sha);
     } catch {
       status = 'error';
     }
@@ -301,9 +287,7 @@ export async function driftReport(
         ...pin,
         status:
           status ??
-          (changedSourcePages.has(sourceCounterpartOf(page))
-            ? 'drifted'
-            : 'in-sync'),
+          (changed.has(enCounterpartOf(page)) ? 'drifted' : 'in-sync'),
       });
     }
   });
@@ -325,14 +309,14 @@ async function mapLimit(items, limit, fn) {
 
 export function localizedPagesOf(rootDir, targets = [CONTENT_DIR]) {
   const pages = [];
-  const sourceLangPrefix = path.join(CONTENT_DIR, DEFAULT_LANG) + path.sep;
+  const enPrefix = path.join(CONTENT_DIR, DEFAULT_LANG) + path.sep;
   const walk = (dir) => {
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
       const p = path.join(dir, entry.name);
       if (entry.isDirectory()) walk(p);
       else if (
         entry.name.endsWith('.md') &&
-        !p.startsWith(path.join(rootDir, sourceLangPrefix))
+        !p.startsWith(path.join(rootDir, enPrefix))
       )
         pages.push(path.relative(rootDir, p));
     }
@@ -355,8 +339,8 @@ export async function driftReportForRepo(rootDir, targets) {
     ]),
   );
   return driftReport(pagePins, {
-    sourceExists: (sourcePath) => existsSync(path.join(rootDir, sourcePath)),
-    changedSourceSince: async (sha) => {
+    enExists: (enPath) => existsSync(path.join(rootDir, enPath)),
+    changedEnSince: async (sha) => {
       const { stdout } = await execFileP(
         'git',
         [
@@ -379,8 +363,7 @@ export async function driftReportForRepo(rootDir, targets) {
 // link-check config generation overlays the pages *presumed* drifted since
 // the status baseline: the commit that the last tree-wide status write (the
 // nightly Housekeeping run) computed the stored statuses against. Locale
-// copies of source-language pages changed (or deleted) since then get skipped,
-// unless the
+// copies of EN pages changed (or deleted) since then get skipped, unless the
 // copy itself changed too (activity exemption: someone is working on it, and
 // stored-status semantics check unmarked pages anyway).
 
@@ -430,7 +413,7 @@ export async function baselineAgeDays(rootDir, sha) {
 
 // Whether a tree-wide sync that changed no statuses should refresh the
 // baseline anyway: yes when the committed baseline is missing, malformed,
-// unresolvable, or older than the refresh heartbeat. (Any status-relevant source
+// unresolvable, or older than the refresh heartbeat. (Any status-relevant EN
 // change flips a status on the next sweep and refreshes the baseline through
 // the statuses-changed arm, so a quiet stretch leaves nothing new to skip;
 // the heartbeat is a freshness bound, not a correctness need.)
@@ -454,7 +437,7 @@ export async function baselineNeedsRefresh(rootDir) {
 // (older branch, PR run) it errs older, which only widens the overlay —
 // under-checking, never a spurious red. Recording `main` itself would be
 // wrong there: a baseline newer than the tree the statuses were computed
-// against leaves the source-language changes in between covered by neither the stored
+// against leaves the EN changes in between covered by neither the stored
 // statuses nor the overlay. As an ancestor of main, the recorded SHA is also
 // always fetchable from the canonical repo (the CHECK LINKS deepen step).
 export async function writeBaseline(rootDir) {
@@ -468,25 +451,24 @@ export async function writeBaseline(rootDir) {
   return sha;
 }
 
-// Pure core: locale copies presumed drifted, given the source-language pages
-// changed since the baseline. Deleted source pages are covered too: their locale copies
+// Pure core: locale copies presumed drifted, given the EN pages changed
+// since the baseline. Deleted EN pages are covered too: their locale copies
 // still exist and are what gets reported. Copies in `changedLocalePages` are
 // exempt (activity exemption). `pageExists` is injected for testability.
 export function driftPendingPages(
-  changedSourcePages,
+  changedEnPages,
   locales,
   pageExists,
   changedLocalePages = new Set(),
 ) {
   const pages = [];
-  const sourceLangPrefix = `${CONTENT_DIR}/${DEFAULT_LANG}/`;
-  for (const sourcePath of changedSourcePages) {
+  const enPrefix = `${CONTENT_DIR}/${DEFAULT_LANG}/`;
+  for (const enPath of changedEnPages) {
     // `.md` only: no localized `.html` pages exist in the content tree; if
     // that ever changes, align this filter with pageIgnoreDirOf's
     // `.md`/`.html` mapping in scripts/lychee/config/index.mjs.
-    if (!sourcePath.startsWith(sourceLangPrefix) || !sourcePath.endsWith('.md'))
-      continue;
-    const subPath = sourcePath.slice(sourceLangPrefix.length);
+    if (!enPath.startsWith(enPrefix) || !enPath.endsWith('.md')) continue;
+    const subPath = enPath.slice(enPrefix.length);
     for (const locale of locales) {
       const localePath = `${CONTENT_DIR}/${locale}/${subPath}`;
       if (!pageExists(localePath)) continue;
@@ -499,7 +481,7 @@ export function driftPendingPages(
 
 // Repo adapter: one git diff of `content` against the baseline (two-dot,
 // vs the working tree — no merge-base needed, so a baseline-deepened
-// shallow clone suffices), split source / non-source. Throws when the baseline
+// shallow clone suffices), split EN / non-EN. Throws when the baseline
 // isn't resolvable (e.g. too-shallow clone).
 export async function driftPendingForRepo(rootDir, baseline) {
   const source = baseline
@@ -549,12 +531,12 @@ export async function driftPendingForRepo(rootDir, baseline) {
   })
     .filter((e) => e.isDirectory() && e.name !== DEFAULT_LANG)
     .map((e) => e.name);
-  const sourceLangPrefix = `${CONTENT_DIR}/${DEFAULT_LANG}/`;
+  const enPrefix = `${CONTENT_DIR}/${DEFAULT_LANG}/`;
   return driftPendingPages(
-    changed.filter((p) => p.startsWith(sourceLangPrefix)),
+    changed.filter((p) => p.startsWith(enPrefix)),
     locales,
     (p) => existsSync(path.join(rootDir, p)),
-    new Set(changed.filter((p) => !p.startsWith(sourceLangPrefix))),
+    new Set(changed.filter((p) => !p.startsWith(enPrefix))),
   );
 }
 
@@ -562,10 +544,10 @@ export async function driftPendingForRepo(rootDir, baseline) {
 // ([page, action] with action ADDED | UPDATED | REMOVED), skipping no-ops.
 
 // Persists the report's statuses (status --write, was -D): drifted -> true,
-// missing source page -> "file not found", in-sync or unpinned-in-sync -> status
+// missing EN -> "file not found", in-sync or unpinned-in-sync -> status
 // removed. Pages whose pin errored are left untouched, as are unpinned
-// pages whose source counterpart is gone (no pin line to anchor the status —
-// pin them first, e.g. with `--from-src-latest --new`).
+// pages whose EN counterpart is gone (no pin line to anchor the status —
+// pin them first, e.g. with `commit --from-src-latest --new`).
 export function writeStatuses(rootDir, report) {
   const statusOf = {
     drifted: 'true',
@@ -579,7 +561,7 @@ export function writeStatuses(rootDir, report) {
     if (status === 'file not found' && !sha) {
       console.error(
         `WARNING: ${page} has no ${I18N_DLC_KEY} key to anchor its ` +
-          `'file not found' status; pin the page first (--from-src-latest --new)`,
+          `'file not found' status; pin the page first (commit --from-src-latest --new)`,
       );
       continue;
     }
@@ -603,7 +585,19 @@ async function git(rootDir, ...args) {
   return stdout.trim();
 }
 
-// A page with no pin: `new`, or `file not found` when its source counterpart is
+// The ref that anchors "the latest commit of an EN page": upstream/main on a
+// contributor's local fork checkout (where upstream is the canonical repo),
+// origin/main in CI (where origin is the canonical repo and no upstream
+// remote exists), falling back to the plain `main` ref for clones without
+// those remotes (e.g. test repos). Same resolution as check-i18n.sh -e.
+export async function mainAnchorRef(rootDir) {
+  const remotes = (await git(rootDir, 'remote')).split('\n');
+  if (remotes.includes('upstream')) return 'upstream/main';
+  if (remotes.includes('origin')) return 'origin/main';
+  return 'main';
+}
+
+// A page with no pin: `new`, or `file not found` when its EN counterpart is
 // gone too (bash's `-n` list kind selected both — pin presence alone).
 export function isUnpinned({ status, sha }) {
   return status === 'new' || (status === 'file not found' && !sha);
@@ -620,8 +614,8 @@ function selectPagesForPinWrite(report, list) {
 }
 
 // Upserts pins (commit HASH|HEAD, was -c) on the pages the report and list
-// kind select: `new` -> unpinned pages only (as bash `-n`, source counterpart or
-// not); `drifted` (default) -> drifted and unpinned-with-source pages, as in
+// kind select: `new` -> unpinned pages only (as bash `-n`, EN counterpart or
+// not); `drifted` (default) -> drifted and unpinned-with-EN pages, as in
 // bash; `all` -> every page. As in bash, a pin
 // *update* requires the hash to be on main (adds are unchecked), and `HEAD`
 // means main's HEAD, not the checked-out commit. Unlike bash, the hash is
@@ -678,23 +672,26 @@ export async function writePins(rootDir, report, { hash, list }) {
 }
 
 export async function writePinsFromEnLatest(rootDir, report, { list }) {
-  // In source-latest mode, include error pages so broken pins can be repaired.
   const selected = [...report].filter(([, r]) =>
     list === 'all'
       ? true
       : list === 'new'
         ? isUnpinned(r)
-        : ['drifted', 'new', 'error'].includes(r.status),
+        : ['drifted', 'new'].includes(r.status),
   );
 
   const actions = [];
   const written = [];
   let hadErrors = false;
+  // Resolve against the canonical repo's main — upstream/main locally,
+  // origin/main in CI — as `commit HEAD` does: a pin must reference a commit
+  // on the default branch, never a local-only change.
+  const anchor = await mainAnchorRef(rootDir);
   for (const [page] of selected) {
-    const sourcePath = sourceCounterpartOf(page);
-    if (!existsSync(path.join(rootDir, sourcePath))) {
+    const enPath = enCounterpartOf(page);
+    if (!existsSync(path.join(rootDir, enPath))) {
       console.error(
-        `ERROR: cannot determine latest commit for source-language file: ${page} -> ${sourcePath}`,
+        `ERROR: cannot determine latest commit for EN file: ${page} -> ${enPath}`,
       );
       hadErrors = true;
       continue;
@@ -705,12 +702,13 @@ export async function writePinsFromEnLatest(rootDir, report, { list }) {
       'log',
       '-1',
       '--format=%H',
+      anchor,
       '--',
-      sourcePath,
+      enPath,
     );
     if (!resolved) {
       console.error(
-        `ERROR: cannot determine latest commit for source-language file: ${page} -> ${sourcePath}`,
+        `ERROR: cannot determine latest commit for EN file: ${page} -> ${enPath}`,
       );
       hadErrors = true;
       continue;
@@ -741,7 +739,7 @@ export async function writePinsFromEnLatest(rootDir, report, { list }) {
 const USAGE = `Usage: drift.mjs [NOUN] [OPTIONS] [--] [PATHS...]
 
 Report, and optionally update, the drift state of localized pages relative to
-their source-language counterparts. Nouns name the aspects of a page's drift state;
+their English counterparts. Nouns name the aspects of a page's drift state;
 bare nouns read, a write always carries its payload.
 
   drift.mjs [status] [PATHS...]     Read (default noun): drift report
@@ -753,13 +751,15 @@ bare nouns read, a write always carries its payload.
       --write                         persist statuses: sets
                                       drifted_from_default to true or "file not
                                       found", removes it from in-sync pages
-      --from-src-latest               commit write mode: pin each page to the
-                                      latest commit of its source counterpart
-  drift.mjs diff PATHS...           Read: source changes since each page's pin
+  drift.mjs diff PATHS...           Read: EN changes since each page's pin
   drift.mjs commit [PATHS...]       Read: print pinned commits
   drift.mjs commit HASH|HEAD PATHS  Write: upsert default_lang_commit to HASH
                                     (HEAD = main's HEAD) and sync the status of
                                     written pages
+  drift.mjs commit --from-src-latest PATHS
+                                    Write: pin each page to the latest commit
+                                    of its EN counterpart (resolved against
+                                    main) and sync the status of written pages
 
 PATHS are localized page files or directories; the default is 'content'.
 Tree-wide writes require PATHS or an explicit --all (pin writes accept --new
@@ -843,7 +843,7 @@ async function diffCLI(rootDir, cli, report) {
       'diff',
       `${sha}...HEAD`,
       '--',
-      sourceCounterpartOf(page),
+      enCounterpartOf(page),
     );
     console.log(diff);
   }

--- a/scripts/i18n/drift.mjs
+++ b/scripts/i18n/drift.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
 // Drift-status core: answers "which localized pages have drifted from their
-// EN counterparts?" as a library (link-check config gen, npm scripts) and a
+// source-language counterparts?" as a library (link-check config gen, npm scripts) and a
 // thin CLI. Semantics match scripts/check-i18n.sh: a page with front-matter
-// pin `default_lang_commit: SHA` is drifted iff its EN counterpart changed in
-// `git diff SHA...HEAD` (three-dot); a missing EN counterpart is reported as
+// pin `default_lang_commit: SHA` is drifted iff its source counterpart changed in
+// `git diff SHA...HEAD` (three-dot); a missing source counterpart is reported as
 // `file not found`; a page without a pin is `new`. Precise mode needs history
 // back to the oldest pin (fine locally and in Housekeeping; not in shallow CI
 // checkouts — there, the link-check config gen uses its baseline overlay).
@@ -53,17 +53,22 @@ export function parseStatus(fileText) {
 
 // The one stored-status skip predicate, shared by the status writer and the
 // link-check config generation: a `true` or `file not found` status means
-// the page is presumed out of sync with EN (its EN counterpart changed or
+// the page is presumed out of sync with source (its source counterpart changed or
 // was deleted), so its outbound links are not checked.
 export function isDriftedStatus(status) {
   return status === 'true' || status === 'file not found';
 }
 
-export function enCounterpartOf(pagePath) {
+export function sourceCounterpartOf(pagePath) {
   return pagePath.replace(
     new RegExp(`^${CONTENT_DIR}/[^/]{2,5}/`),
     `${CONTENT_DIR}/${DEFAULT_LANG}/`,
   );
+}
+
+// Backward-compatible alias.
+export function enCounterpartOf(pagePath) {
+  return sourceCounterpartOf(pagePath);
 }
 
 export function groupByPin(pagePins) {
@@ -162,6 +167,7 @@ export function classifyCliArgs(args) {
     noun: 'status',
     write: false,
     hash: null,
+    useSrcLatest: false,
     paths: [],
     list: 'drifted',
     check: false,
@@ -180,6 +186,7 @@ export function classifyCliArgs(args) {
       positionals.push(arg);
     } else if (arg === '--new') cli.list = 'new';
     else if (arg === '--all') cli.list = 'all';
+    else if (arg === '--from-src-latest') cli.useSrcLatest = true;
     else if (arg === '--check') cli.check = true;
     else if (arg === '--write') writeFlag = true;
     else if (arg === '--json') cli.json = true;
@@ -203,6 +210,18 @@ export function classifyCliArgs(args) {
       positionals.shift();
     }
   }
+
+  if (cli.useSrcLatest) {
+    if (cli.noun === 'diff') {
+      throw new Error(`--from-src-latest applies to status/commit only`);
+    }
+    if (cli.hash) {
+      throw new Error(`Use either --from-src-latest or HASH|HEAD, not both`);
+    }
+    cli.noun = 'commit';
+    cli.write = true;
+  }
+
   if (writeFlag && cli.noun !== 'status') {
     throw new Error(`--write applies to the status noun only`);
   }
@@ -224,7 +243,11 @@ export function classifyCliArgs(args) {
   if (cli.noun === 'diff' && !cli.paths.length) {
     throw new Error('diff requires at least one path');
   }
-  if (cli.hash && !cli.paths.length && cli.list === 'drifted') {
+  if (
+    (cli.hash || cli.useSrcLatest) &&
+    !cli.paths.length &&
+    cli.list === 'drifted'
+  ) {
     throw new Error(
       'Tree-wide pin write refused: pass PATHS, --new, or an explicit --all',
     );
@@ -238,16 +261,23 @@ export function classifyCliArgs(args) {
   return cli;
 }
 
-// Core engine, effects injected: `enExists(enPath)` and async
-// `changedEnSince(sha)` -> Set of EN paths changed in SHA...HEAD.
+// Core engine, effects injected: `sourceExists(sourcePath)` and async
+// `changedSourceSince(sha)` -> Set of source-language pages changed in SHA...HEAD.
 // Returns Map page -> { status, sha?, patched? } with status one of:
 // 'drifted' | 'in-sync' | 'file not found' | 'new' | 'error'.
-export async function driftReport(pagePins, { enExists, changedEnSince }) {
+export async function driftReport(
+  pagePins,
+  { sourceExists, changedSourceSince, enExists, changedEnSince },
+) {
+  // Compatibility fallback for existing call sites/tests using old option keys.
+  sourceExists ??= enExists;
+  changedSourceSince ??= changedEnSince;
+
   const report = new Map();
   const pending = new Map(); // sha -> pages awaiting that pin's diff
 
   for (const [page, pin] of pagePins) {
-    if (!enExists(enCounterpartOf(page))) {
+    if (!sourceExists(sourceCounterpartOf(page))) {
       report.set(page, { ...(pin ?? {}), status: 'file not found' });
     } else if (!pin) {
       report.set(page, { status: 'new' });
@@ -259,10 +289,10 @@ export async function driftReport(pagePins, { enExists, changedEnSince }) {
 
   const shas = [...pending.keys()];
   await mapLimit(shas, GIT_CONCURRENCY, async (sha) => {
-    let changed;
+    let changedSourcePages;
     let status;
     try {
-      changed = await changedEnSince(sha);
+      changedSourcePages = await changedSourceSince(sha);
     } catch {
       status = 'error';
     }
@@ -271,7 +301,9 @@ export async function driftReport(pagePins, { enExists, changedEnSince }) {
         ...pin,
         status:
           status ??
-          (changed.has(enCounterpartOf(page)) ? 'drifted' : 'in-sync'),
+          (changedSourcePages.has(sourceCounterpartOf(page))
+            ? 'drifted'
+            : 'in-sync'),
       });
     }
   });
@@ -293,14 +325,14 @@ async function mapLimit(items, limit, fn) {
 
 export function localizedPagesOf(rootDir, targets = [CONTENT_DIR]) {
   const pages = [];
-  const enPrefix = path.join(CONTENT_DIR, DEFAULT_LANG) + path.sep;
+  const sourceLangPrefix = path.join(CONTENT_DIR, DEFAULT_LANG) + path.sep;
   const walk = (dir) => {
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
       const p = path.join(dir, entry.name);
       if (entry.isDirectory()) walk(p);
       else if (
         entry.name.endsWith('.md') &&
-        !p.startsWith(path.join(rootDir, enPrefix))
+        !p.startsWith(path.join(rootDir, sourceLangPrefix))
       )
         pages.push(path.relative(rootDir, p));
     }
@@ -323,8 +355,8 @@ export async function driftReportForRepo(rootDir, targets) {
     ]),
   );
   return driftReport(pagePins, {
-    enExists: (enPath) => existsSync(path.join(rootDir, enPath)),
-    changedEnSince: async (sha) => {
+    sourceExists: (sourcePath) => existsSync(path.join(rootDir, sourcePath)),
+    changedSourceSince: async (sha) => {
       const { stdout } = await execFileP(
         'git',
         [
@@ -347,7 +379,8 @@ export async function driftReportForRepo(rootDir, targets) {
 // link-check config generation overlays the pages *presumed* drifted since
 // the status baseline: the commit that the last tree-wide status write (the
 // nightly Housekeeping run) computed the stored statuses against. Locale
-// copies of EN pages changed (or deleted) since then get skipped, unless the
+// copies of source-language pages changed (or deleted) since then get skipped,
+// unless the
 // copy itself changed too (activity exemption: someone is working on it, and
 // stored-status semantics check unmarked pages anyway).
 
@@ -397,7 +430,7 @@ export async function baselineAgeDays(rootDir, sha) {
 
 // Whether a tree-wide sync that changed no statuses should refresh the
 // baseline anyway: yes when the committed baseline is missing, malformed,
-// unresolvable, or older than the refresh heartbeat. (Any status-relevant EN
+// unresolvable, or older than the refresh heartbeat. (Any status-relevant source
 // change flips a status on the next sweep and refreshes the baseline through
 // the statuses-changed arm, so a quiet stretch leaves nothing new to skip;
 // the heartbeat is a freshness bound, not a correctness need.)
@@ -421,7 +454,7 @@ export async function baselineNeedsRefresh(rootDir) {
 // (older branch, PR run) it errs older, which only widens the overlay —
 // under-checking, never a spurious red. Recording `main` itself would be
 // wrong there: a baseline newer than the tree the statuses were computed
-// against leaves the EN changes in between covered by neither the stored
+// against leaves the source-language changes in between covered by neither the stored
 // statuses nor the overlay. As an ancestor of main, the recorded SHA is also
 // always fetchable from the canonical repo (the CHECK LINKS deepen step).
 export async function writeBaseline(rootDir) {
@@ -435,24 +468,25 @@ export async function writeBaseline(rootDir) {
   return sha;
 }
 
-// Pure core: locale copies presumed drifted, given the EN pages changed
-// since the baseline. Deleted EN pages are covered too: their locale copies
+// Pure core: locale copies presumed drifted, given the source-language pages
+// changed since the baseline. Deleted source pages are covered too: their locale copies
 // still exist and are what gets reported. Copies in `changedLocalePages` are
 // exempt (activity exemption). `pageExists` is injected for testability.
 export function driftPendingPages(
-  changedEnPages,
+  changedSourcePages,
   locales,
   pageExists,
   changedLocalePages = new Set(),
 ) {
   const pages = [];
-  const enPrefix = `${CONTENT_DIR}/${DEFAULT_LANG}/`;
-  for (const enPath of changedEnPages) {
+  const sourceLangPrefix = `${CONTENT_DIR}/${DEFAULT_LANG}/`;
+  for (const sourcePath of changedSourcePages) {
     // `.md` only: no localized `.html` pages exist in the content tree; if
     // that ever changes, align this filter with pageIgnoreDirOf's
     // `.md`/`.html` mapping in scripts/lychee/config/index.mjs.
-    if (!enPath.startsWith(enPrefix) || !enPath.endsWith('.md')) continue;
-    const subPath = enPath.slice(enPrefix.length);
+    if (!sourcePath.startsWith(sourceLangPrefix) || !sourcePath.endsWith('.md'))
+      continue;
+    const subPath = sourcePath.slice(sourceLangPrefix.length);
     for (const locale of locales) {
       const localePath = `${CONTENT_DIR}/${locale}/${subPath}`;
       if (!pageExists(localePath)) continue;
@@ -465,7 +499,7 @@ export function driftPendingPages(
 
 // Repo adapter: one git diff of `content` against the baseline (two-dot,
 // vs the working tree — no merge-base needed, so a baseline-deepened
-// shallow clone suffices), split EN / non-EN. Throws when the baseline
+// shallow clone suffices), split source / non-source. Throws when the baseline
 // isn't resolvable (e.g. too-shallow clone).
 export async function driftPendingForRepo(rootDir, baseline) {
   const source = baseline
@@ -515,12 +549,12 @@ export async function driftPendingForRepo(rootDir, baseline) {
   })
     .filter((e) => e.isDirectory() && e.name !== DEFAULT_LANG)
     .map((e) => e.name);
-  const enPrefix = `${CONTENT_DIR}/${DEFAULT_LANG}/`;
+  const sourceLangPrefix = `${CONTENT_DIR}/${DEFAULT_LANG}/`;
   return driftPendingPages(
-    changed.filter((p) => p.startsWith(enPrefix)),
+    changed.filter((p) => p.startsWith(sourceLangPrefix)),
     locales,
     (p) => existsSync(path.join(rootDir, p)),
-    new Set(changed.filter((p) => !p.startsWith(enPrefix))),
+    new Set(changed.filter((p) => !p.startsWith(sourceLangPrefix))),
   );
 }
 
@@ -528,10 +562,10 @@ export async function driftPendingForRepo(rootDir, baseline) {
 // ([page, action] with action ADDED | UPDATED | REMOVED), skipping no-ops.
 
 // Persists the report's statuses (status --write, was -D): drifted -> true,
-// missing EN -> "file not found", in-sync or unpinned-in-sync -> status
+// missing source page -> "file not found", in-sync or unpinned-in-sync -> status
 // removed. Pages whose pin errored are left untouched, as are unpinned
-// pages whose EN counterpart is gone (no pin line to anchor the status —
-// pin them first, e.g. with `commit HEAD --new`).
+// pages whose source counterpart is gone (no pin line to anchor the status —
+// pin them first, e.g. with `--from-src-latest --new`).
 export function writeStatuses(rootDir, report) {
   const statusOf = {
     drifted: 'true',
@@ -545,7 +579,7 @@ export function writeStatuses(rootDir, report) {
     if (status === 'file not found' && !sha) {
       console.error(
         `WARNING: ${page} has no ${I18N_DLC_KEY} key to anchor its ` +
-          `'file not found' status; pin the page first (commit HEAD --new)`,
+          `'file not found' status; pin the page first (--from-src-latest --new)`,
       );
       continue;
     }
@@ -569,15 +603,25 @@ async function git(rootDir, ...args) {
   return stdout.trim();
 }
 
-// A page with no pin: `new`, or `file not found` when its EN counterpart is
+// A page with no pin: `new`, or `file not found` when its source counterpart is
 // gone too (bash's `-n` list kind selected both — pin presence alone).
 export function isUnpinned({ status, sha }) {
   return status === 'new' || (status === 'file not found' && !sha);
 }
 
+function selectPagesForPinWrite(report, list) {
+  return [...report].filter(([, r]) =>
+    list === 'all'
+      ? r.status !== 'error'
+      : list === 'new'
+        ? isUnpinned(r)
+        : ['drifted', 'new'].includes(r.status),
+  );
+}
+
 // Upserts pins (commit HASH|HEAD, was -c) on the pages the report and list
-// kind select: `new` -> unpinned pages only (as bash `-n`, EN counterpart or
-// not); `drifted` (default) -> drifted and unpinned-with-EN pages, as in
+// kind select: `new` -> unpinned pages only (as bash `-n`, source counterpart or
+// not); `drifted` (default) -> drifted and unpinned-with-source pages, as in
 // bash; `all` -> every page. As in bash, a pin
 // *update* requires the hash to be on main (adds are unchecked), and `HEAD`
 // means main's HEAD, not the checked-out commit. Unlike bash, the hash is
@@ -591,13 +635,7 @@ export async function writePins(rootDir, report, { hash, list }) {
     hash === 'HEAD' ? 'main' : `${hash}^{commit}`,
   );
 
-  const selected = [...report].filter(([, r]) =>
-    list === 'all'
-      ? r.status !== 'error'
-      : list === 'new'
-        ? isUnpinned(r)
-        : ['drifted', 'new'].includes(r.status),
-  );
+  const selected = selectPagesForPinWrite(report, list);
 
   const needsOnMainCheck = selected.some(([, { sha }]) => sha);
   if (needsOnMainCheck) {
@@ -639,10 +677,71 @@ export async function writePins(rootDir, report, { hash, list }) {
   return actions;
 }
 
+export async function writePinsFromEnLatest(rootDir, report, { list }) {
+  // In source-latest mode, include error pages so broken pins can be repaired.
+  const selected = [...report].filter(([, r]) =>
+    list === 'all'
+      ? true
+      : list === 'new'
+        ? isUnpinned(r)
+        : ['drifted', 'new', 'error'].includes(r.status),
+  );
+
+  const actions = [];
+  const written = [];
+  let hadErrors = false;
+  for (const [page] of selected) {
+    const sourcePath = sourceCounterpartOf(page);
+    if (!existsSync(path.join(rootDir, sourcePath))) {
+      console.error(
+        `ERROR: cannot determine latest commit for source-language file: ${page} -> ${sourcePath}`,
+      );
+      hadErrors = true;
+      continue;
+    }
+
+    const resolved = await git(
+      rootDir,
+      'log',
+      '-1',
+      '--format=%H',
+      '--',
+      sourcePath,
+    );
+    if (!resolved) {
+      console.error(
+        `ERROR: cannot determine latest commit for source-language file: ${page} -> ${sourcePath}`,
+      );
+      hadErrors = true;
+      continue;
+    }
+
+    const abs = path.join(rootDir, page);
+    const { text, action } = setPinInText(readFileSync(abs, 'utf8'), resolved);
+    if (!action) continue;
+    writeFileSync(abs, text);
+    actions.push([page, action]);
+    written.push(page);
+  }
+
+  if (written.length) {
+    const postReport = await driftReportForRepo(rootDir, written);
+    actions.push(
+      ...writeStatuses(rootDir, postReport).map(([page, action]) => [
+        page,
+        `status ${action}`,
+      ]),
+    );
+  }
+
+  if (hadErrors) process.exitCode = 1;
+  return actions;
+}
+
 const USAGE = `Usage: drift.mjs [NOUN] [OPTIONS] [--] [PATHS...]
 
 Report, and optionally update, the drift state of localized pages relative to
-their English counterparts. Nouns name the aspects of a page's drift state;
+their source-language counterparts. Nouns name the aspects of a page's drift state;
 bare nouns read, a write always carries its payload.
 
   drift.mjs [status] [PATHS...]     Read (default noun): drift report
@@ -654,12 +753,13 @@ bare nouns read, a write always carries its payload.
       --write                         persist statuses: sets
                                       drifted_from_default to true or "file not
                                       found", removes it from in-sync pages
-  drift.mjs diff PATHS...           Read: EN changes since each page's pin
+      --from-src-latest               commit write mode: pin each page to the
+                                      latest commit of its source counterpart
+  drift.mjs diff PATHS...           Read: source changes since each page's pin
   drift.mjs commit [PATHS...]       Read: print pinned commits
   drift.mjs commit HASH|HEAD PATHS  Write: upsert default_lang_commit to HASH
                                     (HEAD = main's HEAD) and sync the status of
                                     written pages
-      --new                           add-only: pages missing the key
 
 PATHS are localized page files or directories; the default is 'content'.
 Tree-wide writes require PATHS or an explicit --all (pin writes accept --new
@@ -743,18 +843,22 @@ async function diffCLI(rootDir, cli, report) {
       'diff',
       `${sha}...HEAD`,
       '--',
-      enCounterpartOf(page),
+      sourceCounterpartOf(page),
     );
     console.log(diff);
   }
 }
 
 async function commitCLI(rootDir, cli, report) {
-  if (cli.hash) {
-    const actions = await writePins(rootDir, report, {
-      hash: cli.hash,
-      list: cli.list,
-    });
+  if (cli.hash || cli.useSrcLatest) {
+    const actions = cli.useSrcLatest
+      ? await writePinsFromEnLatest(rootDir, report, {
+          list: cli.list,
+        })
+      : await writePins(rootDir, report, {
+          hash: cli.hash,
+          list: cli.list,
+        });
     if (!cli.quiet) {
       for (const [page, action] of actions) console.log(`${page} ${action}`);
     }

--- a/scripts/i18n/drift.test.mjs
+++ b/scripts/i18n/drift.test.mjs
@@ -24,12 +24,14 @@ import {
   groupByPin,
   isDriftedStatus,
   isUnpinned,
+  mainAnchorRef,
   parsePin,
   parseStatus,
   readBaseline,
   setPinInText,
   setStatusInText,
   writeBaseline,
+  writePinsFromEnLatest,
   writeStatuses,
 } from './drift.mjs';
 
@@ -463,6 +465,227 @@ describe('classifyCliArgs()', () => {
       () => classifyCliArgs(['commit', '--check']),
       /status noun only/,
     );
+  });
+
+  it('parses commit --from-src-latest as a pin write', () => {
+    const cli = classifyCliArgs(['commit', '--from-src-latest', 'content/ja']);
+    assert.deepEqual(
+      {
+        write: cli.write,
+        useSrcLatest: cli.useSrcLatest,
+        hash: cli.hash,
+        noun: cli.noun,
+      },
+      { write: true, useSrcLatest: true, hash: null, noun: 'commit' },
+    );
+  });
+
+  it('commit --from-src-latest with --new is a tree-wide write', () => {
+    const cli = classifyCliArgs(['commit', '--from-src-latest', '--new']);
+    assert.deepEqual(
+      { write: cli.write, useSrcLatest: cli.useSrcLatest, list: cli.list },
+      { write: true, useSrcLatest: true, list: 'new' },
+    );
+  });
+
+  it('rejects --from-src-latest on nouns other than commit', () => {
+    assert.throws(
+      () => classifyCliArgs(['status', '--from-src-latest']),
+      /commit noun only/,
+    );
+    assert.throws(
+      () => classifyCliArgs(['diff', '--from-src-latest', 'content/ja']),
+      /commit noun only/,
+    );
+    // The default noun is status: a bare --from-src-latest must not silently
+    // mutate the noun to commit.
+    assert.throws(
+      () => classifyCliArgs(['--from-src-latest']),
+      /commit noun only/,
+    );
+  });
+
+  it('rejects --from-src-latest combined with a hash', () => {
+    assert.throws(
+      () =>
+        classifyCliArgs([
+          'commit',
+          '--from-src-latest',
+          'abc1234',
+          'content/ja/a.md',
+        ]),
+      /not both/,
+    );
+    assert.throws(
+      () =>
+        classifyCliArgs([
+          'commit',
+          'HEAD',
+          '--from-src-latest',
+          'content/ja/a.md',
+        ]),
+      /not both/,
+    );
+  });
+
+  it('refuses a tree-wide --from-src-latest write without paths or --new/--all', () => {
+    assert.throws(
+      () => classifyCliArgs(['commit', '--from-src-latest']),
+      /Tree-wide pin write refused/,
+    );
+  });
+});
+
+describe('writePinsFromEnLatest()', () => {
+  const repo = () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'drift-src-latest-'));
+    const git = (...args) =>
+      execFileSync('git', args, {
+        cwd: root,
+        encoding: 'utf8',
+        env: { ...process.env },
+      }).trim();
+    git('init', '-q', '-b', 'main');
+    git('config', 'user.email', 'test@example.invalid');
+    git('config', 'user.name', 'Test');
+    mkdirSync(path.join(root, 'content/en/docs'), { recursive: true });
+    writeFileSync(path.join(root, 'content/en/docs/a.md'), '# EN v1\n');
+    git('add', '.');
+    git('commit', '-q', '-m', 'EN v1');
+    const mainSha = git('rev-parse', 'HEAD');
+    return { root, git, mainSha };
+  };
+  const jaPage = (sha) =>
+    `---\ntitle: a\ndefault_lang_commit: ${sha}\n---\n# ja\n`;
+  const addJaPage = (root, git, sha = '1111111') => {
+    mkdirSync(path.join(root, 'content/ja/docs'), { recursive: true });
+    writeFileSync(path.join(root, 'content/ja/docs/a.md'), jaPage(sha));
+    git('add', '.');
+    git('commit', '-q', '-m', 'ja page');
+  };
+
+  it('resolves pins against main, not the checked-out commit', async () => {
+    const { root, git, mainSha } = repo();
+    // EN changes on a feature branch only — never merged to main.
+    git('checkout', '-q', '-b', 'feature');
+    writeFileSync(path.join(root, 'content/en/docs/a.md'), '# EN v2\n');
+    git('commit', '-qam', 'EN v2 on feature');
+    const featureSha = git('rev-parse', 'HEAD');
+    assert.notEqual(featureSha, mainSha);
+    addJaPage(root, git); // pinned to the bogus 1111111
+    const report = new Map([
+      ['content/ja/docs/a.md', { status: 'drifted', sha: '1111111' }],
+    ]);
+    await writePinsFromEnLatest(root, report, { list: 'drifted' });
+    assert.match(
+      readFileSync(path.join(root, 'content/ja/docs/a.md'), 'utf8'),
+      new RegExp(`^default_lang_commit: ${mainSha}$`, 'm'),
+      'pin resolves to main, not the feature-branch HEAD',
+    );
+  });
+
+  it('default selection excludes error pages', async () => {
+    const { root, git } = repo();
+    addJaPage(root, git);
+    const report = new Map([
+      ['content/ja/docs/a.md', { status: 'error', sha: '1111111' }],
+    ]);
+    const actions = await writePinsFromEnLatest(root, report, {
+      list: 'drifted',
+    });
+    assert.deepEqual(actions, []);
+    assert.match(
+      readFileSync(path.join(root, 'content/ja/docs/a.md'), 'utf8'),
+      /^default_lang_commit: 1111111$/m,
+      'error page is left untouched',
+    );
+  });
+
+  it('--all includes error pages so broken pins can be repaired', async () => {
+    const { root, git, mainSha } = repo();
+    addJaPage(root, git);
+    const report = new Map([
+      ['content/ja/docs/a.md', { status: 'error', sha: '1111111' }],
+    ]);
+    await writePinsFromEnLatest(root, report, { list: 'all' });
+    assert.match(
+      readFileSync(path.join(root, 'content/ja/docs/a.md'), 'utf8'),
+      new RegExp(`^default_lang_commit: ${mainSha}$`, 'm'),
+      '--all re-pins the error page to main',
+    );
+  });
+
+  it('resolves pins against upstream/main when an upstream remote exists', async () => {
+    const { root, git, mainSha } = repo();
+    // Stand in for the canonical repo: a sibling checkout whose main has a
+    // newer EN revision than the local (fork) main.
+    const up = mkdtempSync(path.join(tmpdir(), 'drift-src-latest-upstream-'));
+    const ugit = (...args) =>
+      execFileSync('git', args, {
+        cwd: up,
+        encoding: 'utf8',
+        env: { ...process.env },
+      }).trim();
+    ugit('init', '-q', '-b', 'main');
+    ugit('config', 'user.email', 'test@example.invalid');
+    ugit('config', 'user.name', 'Test');
+    mkdirSync(path.join(up, 'content/en/docs'), { recursive: true });
+    writeFileSync(path.join(up, 'content/en/docs/a.md'), '# EN v2\n');
+    ugit('add', '.');
+    ugit('commit', '-q', '-m', 'EN v2 on upstream main');
+    const upSha = ugit('rev-parse', 'HEAD');
+    assert.notEqual(upSha, mainSha);
+
+    git('remote', 'add', 'upstream', up);
+    git('fetch', '-q', 'upstream');
+    addJaPage(root, git); // pinned to the bogus 1111111
+    const report = new Map([
+      ['content/ja/docs/a.md', { status: 'drifted', sha: '1111111' }],
+    ]);
+    await writePinsFromEnLatest(root, report, { list: 'drifted' });
+    assert.match(
+      readFileSync(path.join(root, 'content/ja/docs/a.md'), 'utf8'),
+      new RegExp(`^default_lang_commit: ${upSha}$`, 'm'),
+      'pin resolves to upstream/main, not the fork-local main',
+    );
+  });
+});
+
+describe('mainAnchorRef()', () => {
+  const repo = () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'drift-anchor-ref-'));
+    const git = (...args) =>
+      execFileSync('git', args, {
+        cwd: root,
+        encoding: 'utf8',
+        env: { ...process.env },
+      }).trim();
+    git('init', '-q', '-b', 'main');
+    git('config', 'user.email', 'test@example.invalid');
+    git('config', 'user.name', 'Test');
+    mkdirSync(path.join(root, 'content/en/docs'), { recursive: true });
+    writeFileSync(path.join(root, 'content/en/docs/a.md'), '# EN v1\n');
+    git('add', '.');
+    git('commit', '-q', '-m', 'EN v1');
+    return { root, git };
+  };
+
+  it('defaults to main when no remotes exist', async () => {
+    const { root } = repo();
+    assert.equal(await mainAnchorRef(root), 'main');
+  });
+
+  it('prefers origin/main over main when only origin exists', async () => {
+    const { root, git } = repo();
+    git('remote', 'add', 'origin', 'https://example.invalid/origin.git');
+    assert.equal(await mainAnchorRef(root), 'origin/main');
+  });
+
+  it('prefers upstream/main over origin/main', async () => {
+    const { root, git } = repo();
+    git('remote', 'add', 'origin', 'https://example.invalid/origin.git');
+    git('remote', 'add', 'upstream', 'https://example.invalid/upstream.git');
+    assert.equal(await mainAnchorRef(root), 'upstream/main');
   });
 });
 


### PR DESCRIPTION
This PR adds additional functionality that allows you to use not only the HEAD or a specific commit number, but also to retrieve the latest SHA of a commit from the English source to populate the `default_lang_commit` field in localized files.

<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.