### PR TITLE
[ja] update translation of content/en/docs/platforms/kubernetes/operator/_index.md

### DIFF
--- a/content/ja/docs/platforms/kubernetes/operator/_index.md
+++ b/content/ja/docs/platforms/kubernetes/operator/_index.md
@@ -10,8 +10,7 @@ redirects:
   - { from: /docs/operator/*, to: ':splat' }
   - { from: /docs/k8s-operator/*, to: ':splat' }
   - { from: /docs/platforms/kubernetes-operator/*, to: ':splat' }
-default_lang_commit: 8db50c269e4c19d13ff6e32e2cf16a872e45402a
-drifted_from_default: true
+default_lang_commit: 6d5bce8500b2a358ae30dd1343770bc83ac325e7
 ---
 
 ## はじめに {#introduction}
@@ -21,7 +20,7 @@ drifted_from_default: true
 Operatorは以下を管理します。
 
 - [OpenTelemetryコレクター](https://github.com/open-telemetry/opentelemetry-collector)
-- [OpenTelemetryの計装ライブラリを使用したワークロードの自動計装](https://github.com/open-telemetry/opentelemetry-operator#opentelemetry-auto-instrumentation-injection)
+- [OpenTelemetryの計装ライブラリを使用したワークロードの自動計装](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/auto-instrumentation/README.md)
 
 ## Getting started {#getting-started}
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/platforms/kubernetes/operator/_index.md` to match the latest English source at
`content/en/docs/platforms/kubernetes/operator/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff is a single link target change: the auto-instrumentation bullet point link was updated from
`https://github.com/open-telemetry/opentelemetry-operator#opentelemetry-auto-instrumentation-injection` to
`https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/auto-instrumentation/README.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11262--opentelemetry.netlify.app/ja/docs/platforms/kubernetes/operator/
- **English (canonical):** https://opentelemetry.io/docs/platforms/kubernetes/operator/

_(deploy preview may take a few minutes to build.)_
<!-- preview-section-end -->
