### PR TITLE
[ja] update translation of content/en/docs/collector/_index.md

### DIFF
--- a/content/ja/docs/collector/_index.md
+++ b/content/ja/docs/collector/_index.md
@@ -4,10 +4,9 @@ description: テレメトリーデータを受信、処理、エクスポート�
 aliases: [collector/about]
 sidebar_root_for: children
 cascade:
-  vers: 0.157.0
+  vers: 0.158.0
 weight: 270
-default_lang_commit: b7589cf40b05480bc7a2022cf2dd36cc299904fa
-drifted_from_default: true
+default_lang_commit: 6d5bce8500b2a358ae30dd1343770bc83ac325e7
 ---
 
 ![Jaeger、OTLP、Prometheusを統合したOpenTelemetryコレクターのダイアグラム](img/otel-collector.svg)


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/collector/_index.md` to match the latest English source at
`content/en/docs/collector/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The only English-side change was a `cascade.vers` version bump (`0.157.0` → `0.158.0`).

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11263--opentelemetry.netlify.app/ja/docs/collector/
- **English (canonical):** https://opentelemetry.io/docs/collector/

_(deploy preview will be available once Netlify finishes building.)_
<!-- preview-section-end -->