### PR TITLE
[ja] add translation of content/en/community/end-user/otel-in-practice.md

### DIFF
--- a/content/ja/community/end-user/otel-in-practice.md
+++ b/content/ja/community/end-user/otel-in-practice.md
@@ -1,0 +1,23 @@
+---
+title: OTel In Practice
+linkTitle: OTel in Practice
+description: >-
+  _OTel in Practice_ は、End User SIG の一部のメンバーによって開始された一連のトークの
+  _シリーズ_ です。
+weight: 30
+default_lang_commit: 8ed2dab4f83e8f660c27d80b33b4ccd42dcf68c2
+---
+
+私たちの目標は以下の通りです。
+
+- OpenTelemetry の導入を成功させるうえで、開発チームがよく直面する実践的な問題に取り組む
+- 特定の言語に焦点を当てた開発者とのより強いつながりを構築する
+- 本番環境での OpenTelemetry 実装体験を改善する
+
+各 OTel in Practice セッションには通常、エンドユーザーやプロジェクトコントリビューターによる1つ以上のトークが含まれ、ディスカッションの場も設けられています。
+あらゆるバックグラウンドの方からのスピーカーを歓迎します！
+15分のライトニングトークや30分のセッションで学んだことを共有したい方は、[CNCF の Slack](https://slack.cncf.io) の [#otel-sig-end-user チャンネル](https://cloud-native.slack.com/archives/C01RT3MSWGZ)でご連絡ください。
+
+[OpenTelemetry YouTube チャンネル](https://youtube.com/@otel-official)で[過去のセッション](https://www.youtube.com/playlist?list=PLVYDBkQ1TdyxKgdGE4ThYLkNRCuLLYy9x)を視聴できます。
+
+[OpenTelemetry in Practice Meetup Group](https://www.meetup.com/opentelemetry-in-practice-meetup-group/) に参加して、次のトークの招待を受け取りましょう！


### PR DESCRIPTION
## Summary

Translates `content/en/community/end-user/otel-in-practice.md` into Japanese as `content/ja/community/end-user/otel-in-practice.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11264--opentelemetry.netlify.app/ja/community/end-user/otel-in-practice/
- **English (canonical):** https://opentelemetry.io/community/end-user/otel-in-practice/

<!-- preview-section-end -->
