### PR TITLE
[ja] update translation of content/en/docs/demo/architecture.md

### DIFF
--- a/content/ja/docs/demo/architecture.md
+++ b/content/ja/docs/demo/architecture.md
@@ -3,8 +3,7 @@ title: デモのアーキテクチャ
 linkTitle: アーキテクチャ
 aliases: [current_architecture]
 body_class: otel-mermaid-max-width
-default_lang_commit: f6befc31e5602c7019a9949ccd5f7e11d845134e
-drifted_from_default: true
+default_lang_commit: 74d8cb2aaefe493295c6c49e2e8ef39801847880
 ---
 
 **OpenTelemetryデモ** は、異なるプログラミング言語で書かれた複数のマイクロサービスから構成されており、gRPCとHTTPを使って相互に通信を行います。
@@ -131,6 +130,9 @@ classDef typescript fill:#e98516,color:black;
 
 コレクターの設定は [otelcol-config.yml](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/otel-collector/otelcol-config.yml) で行われており、代替のエクスポーターをここで設定することができます。
 
+オブザーバビリティスタックと合わせて実行する場合、Collector は [OpAMP エクステンション](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/opampextension)を通じてデモの OpAMP サーバーにも接続し、ヘルス、バージョン、属性、および有効な設定を報告します。
+OpAMP UI（<http://localhost:8080/opamp/>）を開き、Collector インスタンスを選択して報告されたステータスを確認してください。
+
 ```mermaid
 graph TB
 subgraph tdf[テレメトリーデータフロー]
@@ -162,11 +164,27 @@ subgraph tdf[テレメトリーデータフロー]
            oc-proc --> oc-opensearch
            oc-proc --> oc-spanmetrics
            oc-spanmetrics --> oc-prom
+
+           oc-opamp[/"OpAMP エクステンション"/]
+
        end
 
        oc-prom -->|"localhost:9090/api/v1/otlp"| pr-sc
        oc-otlp -->|gRPC| ja-col
        oc-opensearch -->|HTTP| os-http
+
+       subgraph op[OpAMP サーバー]
+           style op fill:#a6ce39,color:black;
+           op-srv["OpAMP サーバー"]
+           op-http[/"OpAMP HTTP<br/>リッスン先：<br/>localhost:8080/opamp/"/]
+
+           op-srv --> op-http
+       end
+
+       oc-opamp -->|"ステータスを報告<br/>WebSocket 経由"| op-srv
+
+       op-b{{"ブラウザ<br/>OpAMP UI"}}
+       op-http -->|"localhost:8080/opamp/"| op-b
 
        subgraph pr[Prometheus]
            style pr fill:#e75128,color:black;


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/demo/architecture.md` to match the latest English source at
`content/en/docs/demo/architecture.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

### Changes

- Added new paragraph about the Collector's OpAMP server connection (health, version, attributes, and configuration reporting)
- Added OpAMP Extension node inside the OTel Collector subgraph in the Telemetry Data Flow Mermaid diagram
- Added OpAMP Server subgraph with server node, HTTP listener, and browser UI node
- Added connection from OpAMP Extension to OpAMP Server (status reporting over WebSocket)
- All new Mermaid labels translated following existing conventions (サーバー, エクステンション, ブラウザ, リッスン先, ステータスを報告)

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11266--opentelemetry.netlify.app/ja/docs/demo/architecture/
- **English (canonical):** https://opentelemetry.io/docs/demo/architecture/

<!-- preview-section-end -->
