### PR TITLE
Registry: document that TypeScript projects use language js

### DIFF
--- a/data/registry-schema.json
+++ b/data/registry-schema.json
@@ -39,7 +39,7 @@
     },
     "language": {
       "type": "string",
-      "description": "The programming language of the entry. Use js for TypeScript projects.",
+      "description": "The programming language of the entry; use js for TypeScript projects",
       "enum": [
         "android",
         "collector",

--- a/data/registry-schema.json
+++ b/data/registry-schema.json
@@ -39,7 +39,7 @@
     },
     "language": {
       "type": "string",
-      "description": "The programming language of the entry",
+      "description": "The programming language of the entry. Use js for TypeScript projects.",
       "enum": [
         "android",
         "collector",

--- a/templates/registry-entry.yml
+++ b/templates/registry-entry.yml
@@ -1,7 +1,7 @@
 # cSpell:ignore # add words unknown to cspell, remove this line if not required
 title: My OpenTelemetry Integration # the name of your project
 registryType: <exporter/core/instrumentation> # See https://opentelemetry.io/ecosystem/registry/adding/#registry-types for all possible values and definitions
-language: <js/go/dotnet/etc. or collector for collector plugins>
+language: <js/go/dotnet/etc. or collector for collector plugins> # use js for TypeScript projects
 tags:
   - <other useful search terms>
 urls:


### PR DESCRIPTION
- Adds the hint at the two places entry contributors look: the schema's `language` description and the entry template's `language` comment.
- Motivated by #10112, which stalled on a schema-invalid `language: typescript`: JS and TS share the `js` registry bucket, since the JS SIG covers both languages.
- Related: #11270, a companion registry-docs fix from the same audit.

cc @open-telemetry/javascript-maintainers