### PR TITLE
Registry: document the 8 registryType values missing from adding.md

### DIFF
--- a/content/en/ecosystem/registry/adding.md
+++ b/content/en/ecosystem/registry/adding.md
@@ -155,8 +155,7 @@ that automatically detects and adds resource information to telemetry.
 
 ### `sdk`
 
-**Use for**: Packages that implement the OpenTelemetry SDK for a language,
-including alternative implementations of the API.
+**Use for**: Packages that implement the OpenTelemetry SDK for a language.
 
 **Examples**: The Ruby `opentelemetry-sdk`, `opentelemetry-metrics-sdk`, and
 `opentelemetry-logs-sdk` gems.

--- a/content/en/ecosystem/registry/adding.md
+++ b/content/en/ecosystem/registry/adding.md
@@ -35,6 +35,24 @@ instrumentation libraries.
 >
 > This is the only registry type that allows commercial/proprietary licenses.
 
+### `api`
+
+**Use for**: Packages that implement the OpenTelemetry API for a language: the
+interfaces and no-op implementations that instrumented code and libraries depend
+on, independent of any SDK.
+
+**Examples**: The Ruby `opentelemetry-api`, `opentelemetry-metrics-api`, and
+`opentelemetry-logs-api` gems.
+
+### `connector`
+
+**Use for**: OpenTelemetry Collector connector components, which join two
+pipelines by acting as the exporter of one and the receiver of the other,
+possibly translating between signal types.
+
+**Examples**: Count connectors, span-to-metrics connectors, or failover
+connectors.
+
 ### `core`
 
 **Use for**: Core OpenTelemetry project components only. This is never
@@ -60,6 +78,12 @@ functionality.
 health checks/pprof/zpages, or other components that augment Collector/SDK
 behavior.
 
+### `id-generator`
+
+**Use for**: SDK components that customize how trace and span IDs are generated.
+
+**Examples**: AWS X-Ray-compatible ID generators.
+
 ### `instrumentation`
 
 **Use for**: Instrumentation libraries or native instrumentations for specific
@@ -78,12 +102,24 @@ familiar logging APIs.
 SLF4J/Log4j/Logback, Python logging, JavaScript Winston/Pino, and Go
 log/slog/zap.
 
+### `metric-producer`
+
+**Use for**: SDK components that bridge metrics from third-party sources into an
+SDK metric reader.
+
 ### `processor`
 
 **Use for**: OpenTelemetry Collector processor components.
 
 **Examples**: Batch processors, attribute processors, sampling processors, or
 any component that processes telemetry data within the collector pipeline.
+
+### `propagator`
+
+**Use for**: Context propagators, which carry trace context and baggage across
+process boundaries in a specific wire format.
+
+**Examples**: B3, Jaeger, or AWS X-Ray propagators.
 
 ### `provider`
 
@@ -110,6 +146,26 @@ receives telemetry data from external sources.
 
 **Examples**: AWS resource detectors, GCP resource detectors, or any component
 that automatically detects and adds resource information to telemetry.
+
+### `sampler`
+
+**Use for**: SDK samplers, which decide which spans are recorded and exported.
+
+**Examples**: AWS X-Ray remote samplers or rule-based samplers.
+
+### `sdk`
+
+**Use for**: Packages that implement the OpenTelemetry SDK for a language,
+including alternative implementations of the API.
+
+**Examples**: The Ruby `opentelemetry-sdk`, `opentelemetry-metrics-sdk`, and
+`opentelemetry-logs-sdk` gems.
+
+### `semantic-convention`
+
+**Use for**: Packages that provide semantic-convention constants for a language.
+
+**Examples**: The Ruby `opentelemetry-semantic_conventions` gem.
 
 ### `utilities`
 


### PR DESCRIPTION
- **Closes the docs gap**: [§ Registry Types](https://opentelemetry.io/ecosystem/registry/adding/#registry-types) covered 11 of the schema's 19 `registryType` values, while the entry template points there for "all possible values and definitions".
  - Adds the missing 8: `api`, `connector`, `id-generator`, `metric-producer`, `propagator`, `sampler`, `sdk`, `semantic-convention`, in the section's existing "Use for / Examples" shape.
  - 7 of the 8 already have live registry entries (23 `propagator`, 15 `connector`, …): contributors have been picking types the page never defined. The new sections' examples are drawn from those entries.
- **Question for maintainers**: `metric-producer` has zero registry entries; documented here with a one-liner for enum parity, but happy to drop it from both the schema and this page instead if preferred.
- **Heads-up** @ymotongpoo: this touches the page your #11250 translates; fold in or let the drift marker track it, whichever you prefer.
- **Related**: #11269, a companion registry-docs fix from the same audit.
- **Preview**: https://deploy-preview-11270--opentelemetry.netlify.app/ecosystem/registry/adding/