### PR TITLE
blog: Dual-exporting .NET metrics with OTLP and Prometheus

### DIFF
--- a/.lycheecache
+++ b/.lycheecache
@@ -3007,11 +3007,13 @@ https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/28
 https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases,200,1785621146
 https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/tree/main/examples/demo,200,1785868412
 https://github.com/open-telemetry/opentelemetry-dotnet/blob/core-1.15.3/src/OpenTelemetry/SuppressInstrumentationScope.cs#L12,200,1785911063
+https://github.com/open-telemetry/opentelemetry-dotnet/blob/fcd9fb6db19baf1d24373e517f6810126dd7d26a/docs/metrics/getting-started-prometheus-grafana/README.md,200,1786354351
 https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Api/Context/Propagation/EnvironmentVariableCarrier.cs,200,1785785939
 https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/README.md,200,1785739337
 https://github.com/open-telemetry/opentelemetry-dotnet/issues/4243,200,1786028671
 https://github.com/open-telemetry/opentelemetry-dotnet/releases,200,1785713002
 https://github.com/open-telemetry/opentelemetry-dotnet/releases/latest,200,1786341695
+https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/coreunstable-1.17.0-beta.1,200,1786354351
 https://github.com/open-telemetry/opentelemetry-dotnet/tree/core-1.16.0/src/OpenTelemetry.Exporter.OpenTelemetryProtocol#environment-variables,200,1786028671
 https://github.com/open-telemetry/opentelemetry-dotnet/tree/core-1.16.0/src/OpenTelemetry.Exporter.Zipkin#configuration-using-environment-variables,200,1786028671
 https://github.com/open-telemetry/opentelemetry-dotnet/tree/coreunstable-1.16.0-beta.1/src/OpenTelemetry.Exporter.Prometheus.HttpListener,200,1786028671
@@ -3856,6 +3858,9 @@ https://github.com/open-telemetry/opentelemetry-specification/#license,200,17857
 https://github.com/open-telemetry/opentelemetry-specification/#project-timeline,200,1785785937
 https://github.com/open-telemetry/opentelemetry-specification/#versioning-the-specification,200,1785785937
 https://github.com/open-telemetry/opentelemetry-specification/blob/02531b063da09bca753070d8071180ca2c287117/oteps/trace/0235-sampling-threshold-in-trace-state.md?from_branch=main,200,1785868518
+https://github.com/open-telemetry/opentelemetry-specification/blob/27b10516ad3a27c12a0ab5c63456ddc95766bc68/spec-compliance-matrix.md,200,1786354351
+https://github.com/open-telemetry/opentelemetry-specification/blob/27b10516ad3a27c12a0ab5c63456ddc95766bc68/specification/compatibility/prometheus_and_openmetrics.md,200,1786354351
+https://github.com/open-telemetry/opentelemetry-specification/blob/27b10516ad3a27c12a0ab5c63456ddc95766bc68/specification/metrics/sdk_exporters/prometheus.md,200,1786354351
 https://github.com/open-telemetry/opentelemetry-specification/blob/6837311818b3cedcda4cad222804c4f98f1fe402/spec-compliance-matrix.md,200,1785885400
 https://github.com/open-telemetry/opentelemetry-specification/blob/6837311818b3cedcda4cad222804c4f98f1fe402/specification/metrics/sdk.md#cardinality-limits,200,1785885399
 https://github.com/open-telemetry/opentelemetry-specification/blob/97c826b70e2f89cfdf655d5150791f3f0c2bae19/oteps/trace/0168-sampling-propagation.md?from_branch=main,200,1785134692
@@ -5102,6 +5107,8 @@ https://learn.microsoft.com/dotnet/api/system.threading.timer.activecount,200,17
 https://learn.microsoft.com/dotnet/core/diagnostics/built-in-metrics-system-net,200,1785868406
 https://learn.microsoft.com/dotnet/core/diagnostics/compare-metric-apis#systemdiagnosticsmetrics,200,1785868406
 https://learn.microsoft.com/dotnet/core/diagnostics/distributed-tracing-concepts,200,1785868406
+https://learn.microsoft.com/dotnet/core/diagnostics/dotnet-counters,200,1786354350
+https://learn.microsoft.com/dotnet/core/diagnostics/metrics-instrumentation,200,1786354350
 https://learn.microsoft.com/dotnet/core/extensions/dependency-injection,200,1786341692
 https://learn.microsoft.com/dotnet/core/extensions/logger-message-generator#log-method-anatomy,200,1785739337
 https://learn.microsoft.com/dotnet/core/extensions/logger-message-generator,200,1786341692
@@ -5802,6 +5809,7 @@ https://prometheus.io/docs/instrumenting/content_negotiation/,200,1785785936
 https://prometheus.io/docs/instrumenting/escaping_schemes/,200,1785875437
 https://prometheus.io/docs/instrumenting/exposition_formats/#basic-info,200,1785911058
 https://prometheus.io/docs/instrumenting/exposition_formats/#comments-help-text-and-type-information,200,1785785936
+https://prometheus.io/docs/instrumenting/exposition_formats/,200,1786354350
 https://prometheus.io/docs/instrumenting/writing_clientlibs/#overall-structure,200,1785785936
 https://prometheus.io/docs/introduction/overview/,200,1786341692
 https://prometheus.io/docs/practices/naming/#metric-names,200,1785911060
@@ -5821,6 +5829,7 @@ https://prometheus.io/docs/specs/native_histograms/#gauge-histograms-vs-counter-
 https://prometheus.io/docs/specs/native_histograms/#staleness-markers,200,1786028734
 https://prometheus.io/docs/specs/native_histograms/,200,1785911058
 https://prometheus.io/docs/specs/om/open_metrics_spec/#exemplars,200,1786341720
+https://prometheus.io/docs/specs/om/open_metrics_spec_2_0/,200,1786354350
 https://prometheus.io/docs/specs/prw/remote_write_spec_2_0/,200,1786028734
 https://prometheus.io/download/,200,1785868406
 https://promlabs.com/promql-cheat-sheet/,200,1785713001

--- a/content/en/blog/2026/dual-dotnet-metrics-export-with-otlp-and-prometheus.md
+++ b/content/en/blog/2026/dual-dotnet-metrics-export-with-otlp-and-prometheus.md
@@ -4,7 +4,6 @@ linkTitle: dual-dotnet-metrics-export-with-otlp-and-prometheus
 date: 2026-08-10
 author: >-
   [Martin Costello](https://github.com/martincostello) (Grafana Labs)
-draft: true # TODO: remove this line once your post is ready to be published
 issue: 11227
 sig: SIG .NET
 ---

--- a/content/en/blog/2026/dual-dotnet-metrics-export-with-otlp-and-prometheus.md
+++ b/content/en/blog/2026/dual-dotnet-metrics-export-with-otlp-and-prometheus.md
@@ -35,7 +35,7 @@ The
 of the OpenTelemetry Prometheus exporter for .NET allows you to take this exact
 approach with your production metrics. You can use the
 [.NET Meter class](https://learn.microsoft.com/dotnet/core/diagnostics/metrics-instrumentation)
-from your application and framework code to collect metrics and export it to
+from your application and framework code to collect metrics and export them to
 both Prometheus and another exporter, such as the
 [OTLP exporter](/docs/specs/otel/protocol/exporter/).
 
@@ -102,7 +102,9 @@ public class BlogPostComments
 
 It's then a small amount of code to configure the OpenTelemetry SDK to export
 your metrics to both Prometheus and over OTLP to a backend that supports
-OpenTelemetry.
+OpenTelemetry by adding the
+[`OpenTelemetry.Exporter.Prometheus.AspNetCore`](https://www.nuget.org/packages/OpenTelemetry.Exporter.Prometheus.AspNetCore)
+NuGet package to your project.
 
 ```csharp
 using OpenTelemetry.Exporter;
@@ -114,6 +116,27 @@ using var meterProvider = Sdk.CreateMeterProviderBuilder()
     .AddOtlpExporter()
     .AddPrometheusExporter()
     .Build();
+```
+
+Your application will also need to expose the HTTP scrape endpoint that
+Prometheus will use to collect metrics from your application. This can be done
+by adding the `UseOpenTelemetryPrometheusScrapingEndpoint` extension method to
+your `IApplicationBuilder` in the `Configure` method of your `Startup` class.
+
+For example:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+// Configure services here
+
+var app = builder.Build();
+
+// Configure other middleware here
+
+app.MapPrometheusScrapingEndpoint();
+
+app.Run();
 ```
 
 Using the `Meter` APIs to export metrics makes your application code more
@@ -135,7 +158,7 @@ command line flag.
 
 Then configure the OTLP exporter similarly to the code snippet above, but in
 this case you wouldn't need to use the Prometheus exporter as well. Also note
-that the OTLP exporter specified a base path for the metrics OTLP endpoint and
+that the OTLP exporter specifies a base path for the metrics OTLP endpoint and
 uses HTTP/protobuf as the protocol for the OTLP exporter.
 
 ```csharp

--- a/content/en/blog/2026/dual-dotnet-metrics-export-with-otlp-and-prometheus.md
+++ b/content/en/blog/2026/dual-dotnet-metrics-export-with-otlp-and-prometheus.md
@@ -1,0 +1,170 @@
+---
+title: 'Dual-exporting .NET metrics with OTLP and Prometheus'
+linkTitle: dual-dotnet-metrics-export-with-otlp-and-prometheus
+date: { { dateFormat "2026-08-10" .Date } }
+author: >-
+  [Martin Costello](https://github.com/martincostello) (Grafana Labs)
+draft: true # TODO: remove this line once your post is ready to be published
+issue: 11227
+sig: SIG .NET
+---
+
+Many applications export their metrics directly to
+[Prometheus](https://prometheus.io/). If you're unfamiliar with Prometheus, in a
+nutshell it's a time-series database for storing metrics, like counters and
+histograms. Applications that store their metrics in Prometheus typically use a
+popular Prometheus client as part of the integration.
+
+Now that OpenTelemetry is
+[a graduated CNCF project](/blog/2026/otel-graduates/), many companies are now
+increasingly looking to move to OpenTelemetry to add more signals beyond metrics
+to their observability architecture. Logs and traces are popular additions for
+getting further insight into how applications behave. Profiles are also starting
+to become a popular fourth telemetry signal for even deeper understanding.
+
+This can create a migration hurdle - how can we migrate our applications from
+one system to another for metrics without having a single cut-over event? To
+de-risk any migration an incremental approach would be preferred, where metrics
+are exported to both systems for a period of time so that "before" and "after"
+states can be compared and checked to ensure there is no loss of production
+visibility in either system for observing metrics or driving alerting.
+
+## Using the OpenTelemetry Prometheus exporter for .NET
+
+The
+[latest release](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/coreunstable-1.17.0-beta.1)
+of the OpenTelemetry Prometheus exporter for .NET allows you to take this exact
+approach with your production metrics. You can use the
+[.NET Meter class](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/metrics-instrumentation)
+from your application and framework code to collect metrics and export it to
+both Prometheus and another exporter, such as the
+[OTLP exporter](/docs/specs/otel/protocol/exporter/).
+
+The Prometheus exporter is effectively a
+[Prometheus client library](https://prometheus.io/docs/instrumenting/clientlibs/)
+written on top of the OpenTelemetry SDK, exposing an HTTP scrape endpoint in
+your application to allow a Prometheus server to collect metrics from your
+application at regular intervals. The exporter implements the OpenTelemetry
+[Prometheus specification](https://github.com/open-telemetry/opentelemetry-specification/blob/27b10516ad3a27c12a0ab5c63456ddc95766bc68/specification/metrics/sdk_exporters/prometheus.md)
+([matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/27b10516ad3a27c12a0ab5c63456ddc95766bc68/spec-compliance-matrix.md))
+and implements all of the
+[documented text exposition formats](https://prometheus.io/docs/instrumenting/exposition_formats/)
+(except
+[OpenMetrics 2.0](https://prometheus.io/docs/specs/om/open_metrics_spec_2_0/),
+which is still experimental) to allow for
+[compatibility with OpenMetrics](https://github.com/open-telemetry/opentelemetry-specification/blob/27b10516ad3a27c12a0ab5c63456ddc95766bc68/specification/compatibility/prometheus_and_openmetrics.md).
+
+```mermaid
+flowchart LR
+    subgraph APP["Application"]
+        AC["Application code"]
+        SDK["OpenTelemetry SDK"]
+        PE["Prometheus exporter"]
+        OE["OTLP exporter (Client)"]
+        EP["GET /metrics HTTP endpoint (Server)"]
+
+        AC -->|"Generates metrics"| SDK
+        SDK -->|"Feeds metrics"| PE
+        PE -->|"Serves metrics as text/plain"| EP
+        SDK -->|"Feeds metrics"| OE
+    end
+
+    P["Prometheus (Client)"]
+    OTB["OpenTelemetry Backend (Server)"]
+
+    P -->|"HTTP GET /metrics (scrape request)"| EP
+    EP -->|"Metrics response (text format)"| P
+
+    OE -->|"OTLP export request"| OTB
+    OTB -->|"OTLP response/ack"| OE
+```
+
+By using only the `Meter` class alongside the `Counter<T>`, `Gauge<T>` and
+`Histogram<T>` instruments in your .NET application code metrics can be
+collected without needing to use both the .NET OpenTelemetry SDK and a dedicated
+Prometheus client.
+
+```csharp
+public class BlogPostComments
+{
+    private readonly Meter _meter;
+    private readonly Counter<long> _likes;
+
+    public BlogPostComments(IMeterFactory meterFactory)
+    {
+        _meter = meterFactory.Create("OpenTelemetry.Blog");
+        _likes = _meter.CreateCounter<long>("blog_post_likes");
+    }
+
+    public void BlogPostLiked(long id) =>
+        _likes.Add(1, new KeyValuePair<string, object?>("post_id", id));
+}
+```
+
+It's then a small amount of code to configure the OpenTelemetry SDK to export
+your metrics to both Prometheus and over OTLP to a back-end that supports
+OpenTelemetry.
+
+```csharp
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Metrics;
+
+using var meterProvider = Sdk.CreateMeterProviderBuilder()
+    .SetResourceBuilder(CreateResourceBuilder())
+    .AddMeter("OpenTelemetry.Blog")
+    .AddOtlpExporter()
+    .AddPrometheusExporter()
+    .Build();
+```
+
+Using the `Meter` APIs to export metrics makes your application code more
+portable and uncoupled from Prometheus specific APIs. This allows you to remove
+any Prometheus client library dependencies from your application code. As well
+as making your code ready for use with the OpenTelemetry ecosystem, it also
+opens up the ability for you to use other .NET ecosystem tooling such as the
+[dotnet-counters](https://learn.microsoft.com/dotnet/core/diagnostics/dotnet-counters)
+tool to view metrics.
+
+## Pushing metrics to Prometheus using OTLP
+
+Alternatively if you only have a Prometheus server and no OTLP compatible
+back-end and only want to export metrics, Prometheus itself has opt-in support
+for ingesting metrics pushed to it over OTLP.
+
+First ensure that you run Prometheus with the `--web.enable-otlp-receiver`
+command line flag.
+
+Then configure the OTLP exporter similarly to the code snippet above, but in
+this case you wouldn't need to use the Prometheus exporter as well. Also note
+that the OTLP exporter specified a base path for the metrics OTLP endpoint and
+uses HTTP/protobuf as the protocol for the OTLP exporter.
+
+```csharp
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Metrics;
+
+using var meterProvider = Sdk.CreateMeterProviderBuilder()
+    .SetResourceBuilder(CreateResourceBuilder())
+    .AddMeter("OpenTelemetry.Blog")
+    .AddOtlpExporter((options, _) =>
+    {
+        options.Endpoint = new Uri("http://prometheus:9090/api/v1/otlp/v1/metrics");
+        options.Protocol = OtlpExportProtocol.HttpProtobuf;
+    })
+    .Build();
+```
+
+This approach allows you to push metrics to Prometheus with the OpenTelemetry
+.NET SDK over OTLP without depending on a Prometheus client library in your
+application code.
+
+You can find a complete example for this approach in the
+[Getting Started with Prometheus and Grafana](https://github.com/open-telemetry/opentelemetry-dotnet/blob/fcd9fb6db19baf1d24373e517f6810126dd7d26a/docs/metrics/getting-started-prometheus-grafana/README.md)
+sample in the OpenTelemetry .NET repository.
+
+## Summary
+
+With minimal runtime overhead, the application can both push OTLP metrics and
+have Prometheus metrics pulled, allowing for both systems to be used in parallel
+until such time that you decide to go all-in with an OpenTelemetry-compatible
+back-end for your metrics.

--- a/content/en/blog/2026/dual-dotnet-metrics-export-with-otlp-and-prometheus.md
+++ b/content/en/blog/2026/dual-dotnet-metrics-export-with-otlp-and-prometheus.md
@@ -1,7 +1,7 @@
 ---
 title: 'Dual-exporting .NET metrics with OTLP and Prometheus'
 linkTitle: dual-dotnet-metrics-export-with-otlp-and-prometheus
-date: { { dateFormat "2026-08-10" .Date } }
+date: 2026-08-10
 author: >-
   [Martin Costello](https://github.com/martincostello) (Grafana Labs)
 draft: true # TODO: remove this line once your post is ready to be published

--- a/content/en/blog/2026/dual-dotnet-metrics-export-with-otlp-and-prometheus.md
+++ b/content/en/blog/2026/dual-dotnet-metrics-export-with-otlp-and-prometheus.md
@@ -35,7 +35,7 @@ The
 [latest release](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/coreunstable-1.17.0-beta.1)
 of the OpenTelemetry Prometheus exporter for .NET allows you to take this exact
 approach with your production metrics. You can use the
-[.NET Meter class](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/metrics-instrumentation)
+[.NET Meter class](https://learn.microsoft.com/dotnet/core/diagnostics/metrics-instrumentation)
 from your application and framework code to collect metrics and export it to
 both Prometheus and another exporter, such as the
 [OTLP exporter](/docs/specs/otel/protocol/exporter/).
@@ -102,7 +102,7 @@ public class BlogPostComments
 ```
 
 It's then a small amount of code to configure the OpenTelemetry SDK to export
-your metrics to both Prometheus and over OTLP to a back-end that supports
+your metrics to both Prometheus and over OTLP to a backend that supports
 OpenTelemetry.
 
 ```csharp
@@ -122,13 +122,13 @@ portable and uncoupled from Prometheus specific APIs. This allows you to remove
 any Prometheus client library dependencies from your application code. As well
 as making your code ready for use with the OpenTelemetry ecosystem, it also
 opens up the ability for you to use other .NET ecosystem tooling such as the
-[dotnet-counters](https://learn.microsoft.com/dotnet/core/diagnostics/dotnet-counters)
+[`dotnet-counters`](https://learn.microsoft.com/dotnet/core/diagnostics/dotnet-counters)
 tool to view metrics.
 
 ## Pushing metrics to Prometheus using OTLP
 
 Alternatively if you only have a Prometheus server and no OTLP compatible
-back-end and only want to export metrics, Prometheus itself has opt-in support
+backend and only want to export metrics, Prometheus itself has opt-in support
 for ingesting metrics pushed to it over OTLP.
 
 First ensure that you run Prometheus with the `--web.enable-otlp-receiver`
@@ -167,4 +167,4 @@ sample in the OpenTelemetry .NET repository.
 With minimal runtime overhead, the application can both push OTLP metrics and
 have Prometheus metrics pulled, allowing for both systems to be used in parallel
 until such time that you decide to go all-in with an OpenTelemetry-compatible
-back-end for your metrics.
+backend for your metrics.


### PR DESCRIPTION
- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] ~~This PR has content that I did not fully write myself.~~
  - [ ] ~~I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).~~
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.

---

Add blog post on dual exporting metrics to OTLP and Prometheus using the .NET SDK.

Resolves #11227.
