### PR TITLE
[ja] add translation of content/en/site/design/agent-support.md

### DIFF
--- a/content/ja/site/design/_index.md
+++ b/content/ja/site/design/_index.md
@@ -1,0 +1,9 @@
+---
+title: 設計
+description: >-
+  OpenTelemetry ウェブサイトのアーキテクチャ設計から低レベル設計までのドキュメント。
+weight: 30
+default_lang_commit: 885c8388de720f12d52a55b555316b2155b2a12c
+---
+
+このセクションでは、OpenTelemetry ウェブサイトの設計上の決定を記録します。

--- a/content/ja/site/design/agent-support.md
+++ b/content/ja/site/design/agent-support.md
@@ -1,0 +1,50 @@
+---
+title: エージェントサポート
+description: >-
+  エージェントが OpenTelemetry ウェブサイトのコンテンツを利用しやすくするための設計メモ。
+weight: 10
+default_lang_commit: 885c8388de720f12d52a55b555316b2155b2a12c
+---
+
+より広範な[エージェントフレンドリーなコンテンツ配信](/site/features/)機能の設計メモです。
+
+## Markdown コンテンツネゴシエーション {#markdown-content-negotiation}
+
+リクエストが明示的に `text/markdown` を要求または優先する場合、Netlify Edge Function を使用して Hugo のビルド済み `index.md` 出力を配信します。
+
+### 根拠 {#rationale}
+
+- すべての HTML ページに Markdown 版が必要なわけではありません。
+- HTTP ネゴシエーションは配信レイヤーに属します。
+- Markdown の成果物が存在しない場合、この関数は通常の HTML にフォールバックできます。
+
+### ルール {#rules}
+
+- `GET` と `HEAD` のみが対象です。
+- `.md` やその他のページ以外のリソースへのリクエストはネゴシエーションをバイパスします。
+- ページ的なリクエストには以下が含まれます:
+  - スラッシュで終わるパス
+  - 拡張子なしのパス
+  - `.../index.html` パス
+- `text/markdown` が `q` がゼロより大きい値で受け入れられ、かつその `q` が `text/html` / `application/xhtml+xml` の最も高い `q` **以上**の場合に Markdown が配信されます（同じ重みの場合は Markdown が選択されます）。
+- `*/*` のようなワイルドカードは意図的に無視されます。
+  明示的な markdown/html メディアタイプのみが q 値に寄与します。
+  これは保守的な選択であり、後で見直される可能性があります。
+- Markdown が見つからない場合は通常の HTML レスポンスにフォールバックします。
+- ネゴシエーションされたレスポンスは `Vary: Accept` を設定します。
+- `/search/` は HTML のみを出力するため、常に HTML にフォールバックします。
+
+パスマッピングに関する注意事項:
+
+- `/docs/` のようなきれいな URL は、Hugo の `/docs/index.md` 出力にマッピングされます。
+- `index.html` は隣接する `.md` ファイルにマッピングされます（例: `/docs/index.html` → `/docs/index.md`）。
+- その他の `.html` パスは Netlify の通常のリダイレクトとルーティングに委ねられます。
+  たとえば、Netlify は `/docs.html` を `/docs/` にリダイレクトします。
+
+### 関連する実装 {#related-implementation}
+
+- `config/_default/hugo.yaml` がこのサイトの Markdown 出力を有効にしています。
+- `content/en/search.md` が `outputs: [HTML]` で検索ページを除外しています。
+- `netlify.toml` が他のルートハンドリングより前に Edge Function を配置します。
+- `netlify/edge-functions/markdown-negotiation/index.ts` がネゴシエーションを実装しています。
+  `netlify/edge-functions/markdown-negotiation.ts` はそれを再エクスポートする Netlify のエントリスタブです。


### PR DESCRIPTION
## Summary

Translates `content/en/site/design/agent-support.md` into Japanese as `content/ja/site/design/agent-support.md`.

Also adds the missing ancestor section index `content/ja/site/design/_index.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.