### PR TITLE
Add Open Multi-Agent OpenTelemetry adapter for JavaScript to registry

### DIFF
--- a/data/registry/instrumentation-js-open-multi-agent.yml
+++ b/data/registry/instrumentation-js-open-multi-agent.yml
@@ -1,0 +1,25 @@
+title: Open Multi-Agent OpenTelemetry Adapter
+registryType: instrumentation
+language: js
+tags:
+  - TypeScript
+  - Node.js
+  - multi-agent
+  - tracing
+urls:
+  repo: https://github.com/open-multi-agent/open-multi-agent
+  docs: https://github.com/open-multi-agent/open-multi-agent/tree/main/packages/otel
+license: MIT
+description: >-
+  Adapter that converts Open Multi-Agent TraceRecord v2 batches into spans on an
+  application-owned OpenTelemetry tracer or TracerProvider.
+authors:
+  - name: open-multi-agent
+    url: https://github.com/open-multi-agent
+createdAt: 2026-08-10
+package:
+  registry: npm
+  name: '@open-multi-agent/otel'
+  version: 0.1.1
+isNative: false
+isFirstParty: true


### PR DESCRIPTION
## What this adds

Adds a registry entry for `@open-multi-agent/otel`, the optional OpenTelemetry adapter for Open Multi-Agent.

The adapter converts OMA TraceRecord v2 batches into spans using an application-owned OpenTelemetry tracer or TracerProvider. The entry classifies it as JavaScript instrumentation and links to the canonical repository and package documentation.

## Validation

- `npm run ci:min`
- `npm run check:registry`
- Targeted Prettier and cspell checks for `data/registry/instrumentation-js-open-multi-agent.yml`

## Checklist

- [x] I have read and followed the Contributing documentation.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and have read and followed the Generative AI Contribution Policy.
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.
