### PR TITLE
[ja] update translation of content/en/docs/concepts/context-propagation/index.md

### DIFF
--- a/content/ja/docs/concepts/context-propagation/index.md
+++ b/content/ja/docs/concepts/context-propagation/index.md
@@ -2,8 +2,7 @@
 title: コンテキスト伝搬
 weight: 10
 description: 分散トレーシングを可能にするコンセプトについて学びます。
-default_lang_commit: fc509b751d6882b99824ea78a1dd8e638dd9055a
-drifted_from_default: true
+default_lang_commit: cc127cac40d5d6aaf48e015f1cf4dbf76bff587b
 ---
 
 コンテキスト伝搬を使用すると、[シグナル](../signals/)（[トレース](../signals/traces/)、[メトリクス](../signals/metrics/)、および[ログ](../signals/logs/)）を生成された場所に関係なく相互に関連づけることができます。
@@ -67,12 +66,12 @@ OpenTelemetry SDKは、ログをトレースと自動的に関連づけること
 ### メトリクス {#metrics}
 
 メトリクスの場合、コンテキスト伝搬により、そのコンテキスト内の測定値を集約できます。
-たとえば、すべての`GET /product`リクエストのレスポンスタイムを確認するだけでなく、`POST /cart/add > GET /product`および`GET /checkout < GET /product`といった組み合わせのメトリクスも取得できます。
+たとえば、すべての`GET /product`リクエストのレスポンスタイムを確認するだけでなく、`POST /cart/add > GET /product`および`GET /checkout > GET /product`といった組み合わせのメトリクスも取得できます。
 
 | 名前                            | 毎秒の呼び出し回数 | 平均レスポンスタイム |
 | ------------------------------- | ------------------ | -------------------- |
 | `* > GET /product`              | 370                | 300ms                |
-| `POST /card/add > GET /product` | 330                | 130ms                |
+| `POST /cart/add > GET /product` | 330                | 130ms                |
 | `GET /checkout > GET /product`  | 40                 | 1703ms               |
 
 ## カスタムコンテキスト伝搬 {#custom-context-propagation}


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/concepts/context-propagation/index.md` to match the latest English source at
`content/en/docs/concepts/context-propagation/index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

Changes applied:
- Fixed arrow direction in metrics example: `GET /checkout < GET /product` → `GET /checkout > GET /product`
- Fixed typo in metrics table: `POST /card/add > GET /product` → `POST /cart/add > GET /product`

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.