### PR TITLE
docs(prometheus): add Prometheus and Grafana histogram query examples (#11307)

### DIFF
--- a/content/en/docs/compatibility/prometheus/otlp-metrics-export.md
+++ b/content/en/docs/compatibility/prometheus/otlp-metrics-export.md
@@ -91,3 +91,99 @@ from the OTLP setup in your
 [language SDK documentation](/docs/languages/_index.md). If the environment
 variables are set up and loaded correctly, the OpenTelemetry SDK reads them
 automatically.
+
+## Querying histogram metrics in Prometheus and Grafana
+
+When OpenTelemetry exports histogram metrics to Prometheus (either directly or
+via the OpenTelemetry Collector using the Prometheus exporter/receiver), the
+data is stored using standard Prometheus histogram conventions:
+
+- `<metric_name>_bucket{le="..."}`: Cumulative count of measurements with values
+  less than or equal to `le`.
+- `<metric_name>_count`: Total count of recorded measurements.
+- `<metric_name>_sum`: Total sum of all recorded measurement values.
+
+Below are common PromQL example queries, how to interpret their results, and how
+to configure visualizations in Grafana.
+
+### 1. Calculating percentiles (quantiles, e.g. p95, p90, p50)
+
+To calculate latency percentiles (such as 95th percentile duration) over a
+5-minute time window, use `histogram_quantile()`:
+
+```promql
+histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le))
+```
+
+**How it works:**
+
+- **`rate(...[5m])`**: Histograms record cumulative counts over time. Taking the
+  `rate()` over a range window calculates the per-second rate of increase for
+  each bucket while correctly handling counter resets (such as application
+  restarts).
+- **`sum(...) by (le)`**: Aggregates the bucket rates across all instances or
+  resources while preserving the `le` (less-than-or-equal) boundary label
+  required by `histogram_quantile()`.
+
+**Grouping by specific attributes (e.g. span name or HTTP route):**
+
+If you want to view the 95th percentile per span or endpoint, add that attribute
+to the `by (...)` clause alongside `le`:
+
+```promql
+histogram_quantile(0.95, sum(rate(traces_span_metrics_duration_milliseconds_bucket[5m])) by (le, span_name))
+```
+
+> [!TIP] If grouping by attributes like `span_name` produces too many lines in
+> your chart, filter the metric to specific high-traffic spans or services using
+> label selectors:
+> `traces_span_metrics_duration_milliseconds_bucket{span_name=~"checkout|payment"}`.
+
+### 2. Calculating average value (average duration)
+
+To calculate the average duration across all requests over a 5-minute interval:
+
+```promql
+sum(rate(http_server_request_duration_seconds_sum[5m])) / sum(rate(http_server_request_duration_seconds_count[5m]))
+```
+
+**How it works:**
+
+- Divides the overall rate of time spent (`_sum`) by the overall rate of events
+  (`_count`).
+- To calculate the average per span or route, append `by (span_name)` to both
+  `sum(...)` aggregations:
+
+```promql
+sum(rate(traces_span_metrics_duration_milliseconds_sum[5m])) by (span_name)
+  /
+sum(rate(traces_span_metrics_duration_milliseconds_count[5m])) by (span_name)
+```
+
+### 3. Measuring request rate (throughput)
+
+To measure the overall throughput (requests per second) recorded by a histogram:
+
+```promql
+sum(rate(http_server_request_duration_seconds_count[5m]))
+```
+
+### 4. Visualizing histograms in Grafana Heatmaps
+
+Grafana Heatmap panels provide a visual representation of how measurement
+distributions change over time.
+
+To set up a Grafana Heatmap panel for an OpenTelemetry histogram:
+
+1. **PromQL Query**: Enter the bucket rate query:
+
+   ```promql
+   sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le)
+   ```
+
+2. **Format**: Set the query format to **Time series**.
+3. **Legend**: Set the Legend format to `{{le}}` so Grafana can extract bucket
+   boundaries from the `le` label.
+4. **Panel Type**: Select **Heatmap** as the panel visualization type. Under
+   Heatmap options, choose **Calculate from data** (or **Sum of rate**) to let
+   Grafana render the distribution buckets properly.

--- a/content/en/docs/compatibility/prometheus/otlp-metrics-export.md
+++ b/content/en/docs/compatibility/prometheus/otlp-metrics-export.md
@@ -175,15 +175,48 @@ distributions change over time.
 
 To set up a Grafana Heatmap panel for an OpenTelemetry histogram:
 
-1. **PromQL Query**: Enter the bucket rate query:
+1. **PromQL Query**: Enter the bucket rate query (for example, for HTTP duration
+   or span metrics):
 
    ```promql
    sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le)
    ```
 
-2. **Format**: Set the query format to **Time series**.
-3. **Legend**: Set the Legend format to `{{le}}` so Grafana can extract bucket
-   boundaries from the `le` label.
-4. **Panel Type**: Select **Heatmap** as the panel visualization type. Under
-   Heatmap options, choose **Calculate from data** (or **Sum of rate**) to let
-   Grafana render the distribution buckets properly.
+2. **Query Options**: In the query options below the PromQL query editor:
+   - Set **Format** to **Heatmap** (this allows Grafana to parse bucket metrics
+     into heatmap cells).
+   - Set **Legend** format to `{{le}}` so Grafana can extract bucket upper
+     boundaries from the `le` label.
+
+3. **Panel Settings**: On the panel configuration sidebar (on the right):
+   - Select **Heatmap** as the panel visualization type.
+   - Under **Calculate from data**, select **No** (unselected), because the
+     Prometheus query `rate(..._bucket[5m])` already calculates bucket rates
+     over time.
+
+### 5. Handling `le="+Inf"` bucket ordering
+
+Prometheus classic histograms include an `le="+Inf"` bucket to represent
+measurements greater than the highest numerical bucket boundary.
+
+Because Grafana sorts bucket labels string-wise by default, `le="+Inf"` can
+sometimes sort at the bottom of the heatmap y-axis (since `+` ranks before
+digits in string sorting).
+
+To ensure `+Inf` is rendered at the top of the heatmap scale, you can configure
+Prometheus `metric_relabel_configs` in `prometheus.yml` to replace `+Inf` with a
+high numeric value (such as `999`):
+
+```yaml
+scrape_configs:
+  - job_name: otlp-metrics
+    metric_relabel_configs:
+      - source_labels: [le]
+        separator: ;
+        regex: \+Inf
+        target_label: le
+        replacement: '999'
+```
+
+This relabeling rule replaces the `le="+Inf"` label value with `999`, allowing
+Grafana to sort all buckets numerically from lowest bound to highest.

--- a/content/en/docs/concepts/signals/metrics.md
+++ b/content/en/docs/concepts/signals/metrics.md
@@ -74,7 +74,9 @@ The instrument kind is one of the following:
   only to the aggregated value.
 - **Histogram**: A client-side aggregation of values, such as request latencies.
   A histogram is a good choice if you are interested in value statistics. For
-  example: How many requests take fewer than 1s?
+  example: How many requests take fewer than 1s? For PromQL and Grafana query
+  examples, see
+  [Querying histogram metrics](/docs/compatibility/prometheus/otlp-metrics-export/#querying-histogram-metrics-in-prometheus-and-grafana).
 
 For more on synchronous and asynchronous instruments, and which kind is best
 suited for your use case, see


### PR DESCRIPTION
Closes #11307

### Summary of Changes
- Added practical PromQL query examples for OpenTelemetry histograms in Prometheus (quantiles/percentiles, average duration, throughput).
- Added setup instructions for Grafana Heatmap panel visualization.
- Added cross-reference link in the Metrics concept doc to the new Prometheus & Grafana histogram query guide.
