### PR TITLE
docs(demo): specify docker compose file layers in docker deployment guide (#11292)

### DIFF
--- a/content/en/docs/demo/docker-deployment.md
+++ b/content/en/docs/demo/docker-deployment.md
@@ -41,7 +41,7 @@ make start
     {{% /tab %}} {{% tab Docker %}}
 
 ```shell
-docker compose up --force-recreate --remove-orphans --detach
+docker compose -f compose.yaml -f compose.full.yaml -f compose.observability.yaml -f compose.extras.yaml up --force-recreate --remove-orphans --detach
 ```
 
     {{% /tab %}} {{< /tabpane >}}
@@ -60,7 +60,7 @@ make start-minimal
     {{% /tab %}} {{% tab Docker %}}
 
 ```shell
-docker compose -f docker-compose.minimal.yml up --force-recreate --remove-orphans --detach
+docker compose -f compose.yaml -f compose.observability.yaml -f compose.extras.yaml up --force-recreate --remove-orphans --detach
 ```
 
     {{% /tab %}} {{< /tabpane >}}
@@ -117,7 +117,7 @@ ENVOY_PORT=8081 make start
     {{% /tab %}} {{% tab Docker %}}
 
 ```shell
-ENVOY_PORT=8081 docker compose up --force-recreate --remove-orphans --detach
+ENVOY_PORT=8081 docker compose -f compose.yaml -f compose.full.yaml -f compose.observability.yaml -f compose.extras.yaml up --force-recreate --remove-orphans --detach
 ```
 
     {{% /tab %}} {{< /tabpane >}}


### PR DESCRIPTION
Closes #11292

### Summary of Changes
- Updated the `docker compose up` commands in the Docker deployment guide (`content/en/docs/demo/docker-deployment.md`) under the Docker tab to include the compose file layers (`-f compose.yaml -f compose.full.yaml -f compose.observability.yaml -f compose.extras.yaml`).
- Ensured all services (including Grafana, Jaeger, feature flags UI) start properly when running Docker Compose without Make.
