### PR TITLE
[ja] update translation of content/en/site/build/npm-scripts.md

### DIFF
--- a/content/ja/site/build/npm-scripts.md
+++ b/content/ja/site/build/npm-scripts.md
@@ -4,22 +4,33 @@ description: >-
   OpenTelemetry ウェブサイトのビルド、配信、検証、メンテナンスのための NPM スクリプト。
 weight: 20
 todo: Keep table entries sorted
-default_lang_commit: 0aff0aab149003b5592edfe186c193047e40c766
-drifted_from_default: true
+default_lang_commit: b8a25353c25d781a375b51f354011248a8140113
 ---
 
-スクリプトの定義はリポジトリルートの [`package.json`](https://github.com/open-telemetry/opentelemetry.io/blob/main/package.json) にあります。
-`npm run <script-name>` で任意のスクリプトを実行できます。
-名前が `_` で始まるスクリプトは内部ヘルパーであり、直接実行することを想定していません。
+スクリプトの定義はリポジトリルートの [`package.json`][] にあります。
+スクリプトを実行するには、`npm run` _`SCRIPT_NAME`_ を使用してください。
 
-> [!NOTE] デフォルトと `:all` スクリプトバリアント
->
-> **`check`**、**`fix`**、**`test`** スクリプトは、各アクションでもっとも一般的に必要とされるサブスクリプトを実行します。
-> すべてのサブスクリプトを実行するには、**`*:all`** バリアントを使用してください。
->
-> - `check:all`
-> - `fix:all`
-> - `test:all`
+## 命名規則 {#nomenclature}
+
+- **内部スクリプト**
+  - 名前が `_` で始まるスクリプトは内部ヘルパーであり、直接実行することを想定していません。
+  - `NAME::pre` および `NAME::post` スクリプトも同様です。
+    これらは `NAME` の明示的に呼び出される前処理・後処理ステップです。
+- **デフォルトと `:all` スクリプトバリアント**
+  - **`check`**、**`fix`**、**`test`** スクリプトは、各アクションでもっとも一般的に必要とされるサブスクリプトを実行します。
+  - **`*:all`** バリアント `check:all`、`fix:all`、`test:all` は、より広範なサブスクリプトセットを実行します。
+    各バリアントのテーブルエントリにスコープが記載されています。
+
+## 依存関係のインストールと更新 {#installing-and-updating-dependencies}
+
+| スクリプト        | 説明                                                                                                              |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `ci:min`          | CI 用の [Lock-exact inert install][]：ライフサイクルスクリプトなし、オプション依存なし。                          |
+| `ci:prepare`      | `ci:min` 実行後のセットアップ：[ピンされた Hugo バイナリの取得][fetch the pinned Hugo binary]、そして `prepare`。 |
+| `install:safe`    | [Lock-exact local setup][]：オプション依存を維持する inert インストール、そして `ci:prepare`。                    |
+| `prepare`         | インストールステップ：`get:submodule` を実行し、Docsy の [lock-exact theme dependency install][]。                |
+| `update:hugo`     | 最新の hugo-extended をインストールし、バンプに伴う [`allowScripts` approval][] を更新します。                    |
+| `update:packages` | npm-check-updates を実行して依存関係を更新します（[release cooldown][] の対象）。                                 |
 
 ## ビルドと配信 {#build-and-serve}
 
@@ -32,31 +43,30 @@ drifted_from_default: true
 | `build`            | サイトをビルドします。デフォルトはリーンです。[Build kinds][] を参照。 |
 | `clean`            | `make clean` を実行します。                                            |
 | `serve:hugo`       | インメモリレンダリングで Hugo サーバーを起動します。                   |
-| `serve:netlify`    | Hugo を使用して Netlify Dev を起動します。                             |
 | `serve`            | Hugo 開発サーバーを起動します（デフォルト、フルレンダリング）。        |
 
 ## チェック {#checking}
 
-| スクリプト             | 説明                                                                    |
-| ---------------------- | ----------------------------------------------------------------------- |
-| `check:all`            | すべてのチェックスクリプトを順番に実行します。                          |
-| `check:code-excerpts`  | コード抜粋をチェックし、更新が必要な場合は失敗します。                  |
-| `check:codeowners`     | CODEOWNERS のロケールセクションがレジストリと一致することを検証します。 |
-| `check:collector-sync` | collector-sync チェックを実行します。                                   |
-| `check:expired`        | 期限切れのコンテンツ（フロントマターに基づく）をリストします。          |
-| `check:filenames`      | [ファイル名の検証と廃止されたファイル/フォルダの検出][fn]。             |
-| `check:format`         | Prettier と prose-wrap のチェック。                                     |
-| `check:i18n`           | ローカリゼーションフロントマター（`default_lang_commit`）を検証します。 |
-| `check:l10n`           | ローカリゼーションチェックを実行します。                                |
-| `check:links:diff`     | 変更されたファイルのみの Lychee リンクチェック。                        |
-| `check:links:internal` | オフラインリンクチェック（内部リンクのみ）。最初にリーンビルドを実行。  |
-| `check:links`          | Lychee でサイト全体をリンクチェックします。最初にリーンビルドを実行。   |
-| `check:markdown:specs` | `tmp/` 内の仕様フラグメントの Markdown lint。                           |
-| `check:markdown`       | Markdown lint（コンテンツおよびプロジェクト）。                         |
-| `check:registry`       | `data/registry/` 配下のレジストリ YAML を検証します。                   |
-| `check:spelling`       | コンテンツ、データ、レイアウト Markdown に対する cspell。               |
-| `check:text`           | コンテンツとデータに対する textlint。                                   |
-| `check`                | もっとも一般的に必要なチェックスクリプトを順番に実行します。            |
+| スクリプト             | 説明                                                                          |
+| ---------------------- | ----------------------------------------------------------------------------- |
+| `check:all`            | すべてのチェックスクリプトを順番に実行します。                                |
+| `check:code-excerpts`  | コード抜粋をチェックし、更新が必要な場合は失敗します。                        |
+| `check:codeowners`     | CODEOWNERS のロケールセクションがレジストリと一致することを検証します。       |
+| `check:collector-sync` | collector-sync チェックを実行します。                                         |
+| `check:expired`        | 期限切れのコンテンツ（フロントマターに基づく）をリストします。                |
+| `check:filenames`      | [ファイル名の検証と廃止されたファイル/フォルダの検出][fn]。                   |
+| `check:format`         | Prettier と prose-wrap のチェック。                                           |
+| `check:i18n`           | ローカリゼーションフロントマター（`default_lang_commit`）を検証します。       |
+| `check:l10n`           | ローカリゼーションチェックを実行します。                                      |
+| `check:links:diff`     | 変更されたファイルのみの Lychee リンクチェック。                              |
+| `check:links:internal` | オフラインリンクチェック（内部リンクのみ）。最初にリーンビルドを実行。        |
+| `check:links`          | Lychee でサイト全体を[リンクチェック][link check]。最初にリーンビルドを実行。 |
+| `check:markdown:specs` | `tmp/` 内の仕様フラグメントの Markdown lint。                                 |
+| `check:markdown`       | Markdown lint（コンテンツおよびプロジェクト）。                               |
+| `check:registry`       | `data/registry/` 配下のレジストリ YAML を検証します。                         |
+| `check:spelling`       | コンテンツ、データ、レイアウト Markdown に対する cspell。                     |
+| `check:text`           | コンテンツとデータに対する textlint。                                         |
+| `check`                | もっとも一般的に必要なチェックスクリプトを順番に実行します。                  |
 
 ## 修正 {#fixing}
 
@@ -70,11 +80,11 @@ drifted_from_default: true
 | `fix:format:staged`           | ステージングされたファイルのみをフォーマットします。                        |
 | `fix:i18n`                    | i18n フロントマターを追加/修正します（`fix:i18n:new`、`fix:i18n:status`）。 |
 | `fix:l10n`                    | ローカリゼーションの修正を適用します。                                      |
-| `fix:link-cache`              | リンクチェックを実行し、コミット済みの `.lycheecache` を更新します。        |
+| `fix:link-cache`              | リンクチェックを実行し、コミット済みの [`.lycheecache`][] を更新します。    |
 | `fix:link-cache:double-check` | [ブラウザプローブで失敗したリンクを再検証します][dc]。                      |
 | `fix:link-cache:refresh`      | もっとも古いキャッシュエントリをプルーンし、`fix:link-cache` を実行します。 |
 | `fix:markdown`                | Markdown lint の問題と末尾の空白を修正します。                              |
-| `fix:submodule`               | サブモジュールのリビジョンをピンします（`pin:submodule` と同じ）。          |
+| `fix:submodule`               | サブモジュールの更新、再ピン、リビジョンの一覧表示。                        |
 | `fix:filenames`               | [ファイルのリネームと廃止されたファイル/フォルダの削除][fn]。               |
 | `fix:dict`                    | cspell ワードリストをソートし、フロントマターを正規化します。               |
 | `fix:expired`                 | `check:expired` で報告されたファイルを削除します。                          |
@@ -95,25 +105,26 @@ drifted_from_default: true
 
 ## テストと CI {#test-and-ci}
 
-| スクリプト                 | 説明                                                                             |
-| -------------------------- | -------------------------------------------------------------------------------- |
-| `diff:check`               | ワーキングツリーにコミットされていない変更がある場合に警告します。               |
-| `diff:fail`                | ワーキングツリーに変更がある場合に失敗します（例: ビルド後）。                   |
-| `fix-and-test:all`         | すべての修正（i18n を含む）を実行し、その後チェック。リンクチェックは1回。[^fat] |
-| `netlify-build:preview`    | `build:preview` を実行し、その後 `diff:check`。                                  |
-| `netlify-build:production` | `build:production` を実行し、その後 `diff:check`。                               |
-| `test-and-fix`             | 修正スクリプト（i18n/link-cache/submodule を除く）を実行し、その後チェック。     |
-| `test:all`                 | `test:base` を実行し、その後 `test:compound-tests`。                             |
-| `test:base`                | 基本テスト（`check` と同じ）。                                                   |
-| `test:collector-sync`      | collector-sync テスト。                                                          |
-| `test:compound-tests`      | 複合 `test:*-*` スクリプトを実行します。[^categories]                            |
-| `test:double-check:live`   | [double-check プローブ][dc]のライブスモークチェック。                            |
-| `test:edge-functions:live` | 任意の `node:test` ライブスイート。`--help` をサポート。                         |
-| `test:edge-functions`      | `netlify/edge-functions/**/*.test.ts` に対する Node テストランナー。             |
-| `test:local-tools`         | `scripts/**/*.test.mjs` に対する Node テストランナー。[^categories]              |
-| `test:local-tools:lychee`  | `test:local-tools` の lychee バイナリスライス（注記を参照）。                    |
-| `test:public`              | ビルドされたサイトに対して `tests/public/` チェックを実行します。[^categories]   |
-| `test`                     | もっとも一般的に必要なテストを実行します。                                       |
+| スクリプト                 | 説明                                                                              |
+| -------------------------- | --------------------------------------------------------------------------------- |
+| `diff:check`               | ワーキングツリーにコミットされていない変更がある場合に警告します。                |
+| `diff:fail`                | ワーキングツリーに変更がある場合に失敗します（例: ビルド後）。                    |
+| `fix-and-test:all`         | すべての修正（i18n を含む）を実行し、その後チェック。リンクチェックは1回。[^fat]  |
+| `is:clean`                 | Git のワーキングツリーに未追跡ファイルを含む変更がある場合に失敗します。          |
+| `netlify-build:preview`    | Netlify デプロイプレビューをビルドします。                                        |
+| `netlify-build:production` | Netlify プロダクションサイトをビルドします。                                      |
+| `test-and-fix`             | 修正スクリプト（i18n/link-cache/submodule を除く）を実行し、その後チェック。      |
+| `test:all`                 | `test:base` を実行し、その後 `test:compound-tests`。                              |
+| `test:base`                | 基本テスト（`check` と同じ）。                                                    |
+| `test:collector-sync`      | collector-sync テスト。                                                           |
+| `test:compound-tests`      | 複合 `test:*-*` スクリプトを実行します。[^categories]                             |
+| `test:double-check:live`   | [double-check プローブ][dc]のライブスモークチェック。                             |
+| `test:edge-functions:live` | 任意の `node:test` ライブスイート。`--help` をサポート。                          |
+| `test:edge-functions`      | `netlify/edge-functions/**/*.test.ts` に対する Node テストランナー。              |
+| `test:local-tools`         | `scripts/**/*.test.mjs` に対する Node テストランナー。[^categories]               |
+| `test:local-tools:lychee`  | `test:local-tools` の lychee バイナリスライス。バイナリ不在時はスキップされます。 |
+| `test:public`              | ビルドされたサイトに対して `tests/public/` チェックを実行します。[^categories]    |
+| `test`                     | もっとも一般的に必要なテストを実行します。                                        |
 
 [^categories]:
     これらのスクリプトはテストスクリプトの命名規則に従います。
@@ -127,30 +138,26 @@ drifted_from_default: true
 
 ## ユーティリティ {#utilities}
 
-| スクリプト                     | 説明                                                                                      |
-| ------------------------------ | ----------------------------------------------------------------------------------------- |
-| `seq`                          | 指定されたスクリプト名を順番に実行します。最初の失敗で終了。                              |
-| `all`                          | 指定されたすべてのスクリプトを実行し、いずれかが失敗した場合は失敗で終了。                |
-| `locale-auto-merge`            | [ロケール自動マージヘルパー CLI][locale-auto-merge]（`--help`）。                         |
-| `prepare`                      | インストールステップ: `get:submodule` を実行し、Docsy テーマの `postinstall` を実行。     |
-| `prebuild:*`                   | `build*` の前に実行されるフック。各フックは `_prebuild` を実行。                          |
-| `update:hugo`                  | 最新の hugo-extended をインストールします。                                               |
-| `update:packages`              | npm-check-updates を実行して依存関係を更新します。                                        |
-| `generate:config:links`        | `lychee.base.toml` とページフロントマターから git 無視の `lychee.toml` を生成します。     |
-| `log:build`、`log:check:links` | 対応するスクリプトを実行し、出力を `tmp/` に tee し、スクリプトの終了コードを伝搬します。 |
+| スクリプト                     | 説明                                                                                             |
+| ------------------------------ | ------------------------------------------------------------------------------------------------ |
+| `all`                          | 指定されたすべてのスクリプトを実行し、失敗があっても続行。いずれかが失敗した場合は非ゼロで終了。 |
+| `generate:config:links`        | `lychee.base.toml` とページフロントマターから git 無視の `lychee.toml` を生成します。            |
+| `locale-auto-merge`            | [ロケール自動マージヘルパー CLI][locale-auto-merge]（`--help`）。                                |
+| `log:build`、`log:check:links` | 対応するスクリプトを実行し、出力を `tmp/` に tee し、スクリプトの終了コードを伝搬します。        |
+| `seq`                          | 指定されたスクリプト名を順番に実行します。最初の失敗で終了。                                     |
 
-## 注記 {#notes}
-
-- **リンクキャッシュ。**
-  リンクチェックスクリプトはコミット済みの `.lycheecache` を読み書きします。
-  詳細は[リンクチェック](/site/build/link-checking/)を参照してください。
-- **`test:local-tools:lychee`** は `test:local-tools` のうち `lychee` バイナリを必要とするサブセット（動作フラグメントおよび設定チェックテスト、およびエンドツーエンドのドリフトオーバーレイシナリオ）です。
-  バイナリが存在しない場合はそれらのテストはスキップされるため、`test:local-tools` は一般的なテストジョブですでにカバーしています。
-  末尾の `:lychee` はこのスクリプトを `test:compound-tests`（`test:*-*` にマッチ）から除外し、スイートが2回実行されないようにします。
-  リンクチェック CI ジョブは lychee をインストールし、このスクリプトを実行して実際にテストを実行します。
-- **`all`** はリスト内のスクリプトを1つが失敗してもすべて実行し、いずれかが失敗した場合は非ゼロステータスで終了します。
-
+<!-- prettier-ignore-start -->
+[`allowScripts` approval]: /site/build/dependencies/#script-bearing-packages
+[`.lycheecache`]: /site/build/link-checking/#link-cache
+[`package.json`]: https://github.com/open-telemetry/opentelemetry.io/blob/main/package.json
 [build kinds]: /site/build/#build-kinds
 [dc]: /site/build/link-checking/#double-check
+[fetch the pinned Hugo binary]: /site/build/dependencies/#install-contracts
 [fn]: /docs/contributing/pr-checks/#filename-check
-[locale-auto-merge]: ../ci-workflows/#locale-auto-merge
+[link check]: /site/build/link-checking/
+[locale-auto-merge]: /site/build/ci-workflows/#locale-auto-merge
+[lock-exact inert install]: /site/build/dependencies/#install-contracts
+[lock-exact local setup]: /site/build/dependencies/#install-contracts
+[lock-exact theme dependency install]: /site/build/dependencies/#install-contracts
+[release cooldown]: /site/build/dependencies/#release-cooldown
+<!-- prettier-ignore-end -->


### PR DESCRIPTION
## Summary

Updates `content/ja/site/build/npm-scripts.md` to match the latest English source at
`content/en/site/build/npm-scripts.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

### Changes applied

- **Opening paragraph** rewritten to match the new English text (link format and wording changed).
- **New section "命名規則" (Nomenclature)** added, replacing the old `> [!NOTE]` callout. Covers internal scripts (`_`-prefixed and `NAME::pre`/`NAME::post`) and default vs `:all` variants.
- **New section "依存関係のインストールと更新" (Installing and updating dependencies)** added with 6 script entries (`ci:min`, `ci:prepare`, `install:safe`, `prepare`, `update:hugo`, `update:packages`).
- **Build and serve:** `serve:netlify` row removed (deleted upstream).
- **Checking:** `check:links` description updated to use `[link check][]` reference link.
- **Fixing:** `fix:link-cache` description updated to use `[`.lycheecache`][]` reference link; `fix:submodule` description updated.
- **Test and CI:** `is:clean` row added; `netlify-build:preview` and `netlify-build:production` descriptions simplified; `test:local-tools:lychee` description updated.
- **Utilities:** table reordered alphabetically; `prepare`, `prebuild:*`, `update:hugo`, `update:packages` rows removed (moved to new sections).
- **Notes section** removed entirely (content absorbed into table entries or removed upstream).
- **Reference link definitions** updated with many new entries and switched from relative to absolute paths where Japanese sibling pages don't exist.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

### site/build/ci-workflows/
- **Japanese (this PR):** https://deploy-preview-11310--opentelemetry.netlify.app/ja/site/build/ci-workflows/
- **English (canonical):** https://opentelemetry.io/site/build/ci-workflows/

### site/build/npm-scripts/
- **Japanese (this PR):** https://deploy-preview-11310--opentelemetry.netlify.app/ja/site/build/npm-scripts/
- **English (canonical):** https://opentelemetry.io/site/build/npm-scripts/

<!-- preview-section-end -->
