### PR TITLE
[ja] update translation of content/en/docs/languages/_index.md

### DIFF
--- a/content/ja/docs/languages/_index.md
+++ b/content/ja/docs/languages/_index.md
@@ -5,8 +5,7 @@ weight: 250
 aliases: [/docs/instrumentation]
 redirects:
   - { from: 'net/*', to: 'dotnet/:splat' }
-default_lang_commit: 68c29178b21e7ace970d27c5817a4edcff3ea9fb
-drifted_from_default: true
+default_lang_commit: 0c6808821dcfca1219d422dc752bdd071aaede4b
 ---
 
 OpenTelemetryのコード[計装][instrumentation]は、以下の[ステータスとリリース](#status-and-releases)の表に記載されている言語でサポートされています。
@@ -19,7 +18,7 @@ Kubernetesを使用している場合は、[OpenTelemetry Operator for Kubernete
 
 ## ステータスとリリース {#status-and-releases}
 
-OpenTelemetryの主要な機能コンポーネントの現在のステータスは以下の通りです。
+OpenTelemetryの主要な機能コンポーネントの現在の[ステータス](/docs/specs/otel/versioning-and-stability/)は以下の通りです。
 
 > [!WARNING]
 >


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/_index.md` to match the latest English source at
`content/en/docs/languages/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English change added a hyperlink around "status" in the "Status and Releases" section,
pointing to `/docs/specs/otel/versioning-and-stability/`. The Japanese translation applies
the same link around "ステータス".

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.