### PR TITLE
[ja] update translation of content/en/blog/_index.md

### DIFF
--- a/content/ja/blog/_index.md
+++ b/content/ja/blog/_index.md
@@ -2,8 +2,7 @@
 title: ブログ
 menu: { main: { weight: 50 } }
 description: OpenTelemetry ブログ
-default_lang_commit: 763b47b07a21aeda64a77446317478f603491f0f
-drifted_from_default: true
+default_lang_commit: 0c6808821dcfca1219d422dc752bdd071aaede4b
 ---
 
 <script>


### PR DESCRIPTION
## Summary

Updates `content/ja/blog/_index.md` to match the latest English source at
`content/en/blog/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff replaced the `htmltest:` / `IgnoreDirs:` frontmatter block
with a top-level `link_check_exclude_path:` block. The comment in the English
source explicitly says "DO NOT COPY the following config to non-en pages", so the
Japanese file correctly does not include this block (and never did). The only
change is the i18n bookkeeping update.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.