### PR TITLE
Link cache: merge with union strategy, refresh in registry auto-update

### DIFF
--- a/.claude/skills/resolve-link-cache-conflicts/SKILL.md
+++ b/.claude/skills/resolve-link-cache-conflicts/SKILL.md
@@ -35,16 +35,22 @@ At this point, we are ready to resolve the conflicts in the active branch:
 
 2. If merge or rebase is in progress (`git status`), skip this step. Otherwise,
    ask the user whether to run `git merge $BASE_BRANCH` or
-   `git rebase $BASE_BRANCH`, then run it.
+   `git rebase $BASE_BRANCH`, then run it. For a branch created before
+   `.gitattributes` gained the `.lycheecache` union rule, prefer rebase: merge
+   attributes resolve against the current checkout's tree, which during a rebase
+   is the updated base.
 
-3. If there are no conflicts: the union merge succeeded. If it changed
-   `.lycheecache`, jump to **Resolve** step 4; otherwise stop, we are done.
+3. If there are no conflicts, the operation completes on its own. Union merges
+   can still leave duplicate or stale `.lycheecache` entries: when the resulting
+   `.lycheecache` differs from both `$BASE_BRANCH` and `ORIG_HEAD` (the
+   pre-merge tip), jump to **Resolve** step 4. Otherwise stop, we are done.
 
 4. Conflicts other than `.lycheecache`: resolve them with the user.
 
-5. If no `.lycheecache` conflict remains: apply step 3's rule (jump to
-   **Resolve** step 4 when the merge changed `.lycheecache`, else stop).
-   Otherwise, proceed to **Resolve**.
+5. If a `.lycheecache` conflict remains, proceed to **Resolve**. Otherwise,
+   stage the resolved files and conclude the operation (**Resolve** step 2,
+   repeating for further rebase stops per **Resolve** step 3), then apply step
+   3's residue rule.
 
 ## Resolve
 

--- a/.claude/skills/resolve-link-cache-conflicts/SKILL.md
+++ b/.claude/skills/resolve-link-cache-conflicts/SKILL.md
@@ -1,18 +1,16 @@
 ---
 name: resolve-link-cache-conflicts
 description:
-  Skill for resolving .lycheecache merge or rebase conflicts in the current
-  branch or a specified PR.
+  Skill for recovering .lycheecache after a merge or rebase, whether from
+  residual conflicts or union-merge residue, in the current branch or a
+  specified PR.
 argument-hint: '[optional-pr-number]'
 ---
 
-`.lycheecache` is an auto-generated file that merges with Git's `union` strategy
-(see `.gitattributes`), so merges and rebases usually complete without conflict,
-but they can leave duplicate or stale cache entries that fail the
-`CACHE updates committed?` check. In either case the recovery is the same:
-finish the merge/rebase (taking the integration branch's side for any residual
-`.lycheecache` conflict), then run `npm run fix:link-cache` to restore any URLs
-unique to the active branch and rewrite the cache clean.
+`.lycheecache` is auto-generated and union-merged (policy: [Link cache][]), so
+merges and rebases usually complete without conflict but can leave residue that
+fails the `CACHE updates committed?` check. Either way, recover with the
+procedure below.
 
 ## Prerequisites
 
@@ -41,16 +39,16 @@ At this point, we are ready to resolve the conflicts in the active branch:
    is the updated base.
 
 3. If there are no conflicts, the operation completes on its own. Union merges
-   can still leave duplicate or stale `.lycheecache` entries: when the resulting
-   `.lycheecache` differs from both `$BASE_BRANCH` and `ORIG_HEAD` (the
-   pre-merge tip), jump to **Resolve** step 4. Otherwise stop, we are done.
+   can still leave residue: when `.lycheecache` now has duplicate URLs or
+   out-of-order lines (`cut -d, -f1 .lycheecache | sort | uniq -d` prints
+   duplicates, or `sort -c .lycheecache` fails), jump to **Resolve** step 4.
+   Otherwise stop, we are done.
 
 4. Conflicts other than `.lycheecache`: resolve them with the user.
 
 5. If a `.lycheecache` conflict remains, proceed to **Resolve**. Otherwise,
-   stage the resolved files and conclude the operation (**Resolve** step 2,
-   repeating for further rebase stops per **Resolve** step 3), then apply step
-   3's residue rule.
+   conclude the operation per **Resolve** steps 2-3, then apply **Preparation**
+   step 3's residue test.
 
 ## Resolve
 
@@ -88,3 +86,7 @@ At this point, we are ready to resolve the conflicts in the active branch:
 6. Push:
    - Merge: `git push`
    - Rebase: `git push --force-with-lease`
+
+<!-- prettier-ignore-start -->
+[Link cache]: https://opentelemetry.io/site/build/link-checking/#link-cache
+<!-- prettier-ignore-end -->

--- a/.claude/skills/resolve-link-cache-conflicts/SKILL.md
+++ b/.claude/skills/resolve-link-cache-conflicts/SKILL.md
@@ -6,9 +6,13 @@ description:
 argument-hint: '[optional-pr-number]'
 ---
 
-`.lycheecache` is an auto-generated file. Resolving conflicts requires first
-taking the integration branch's side, finishing the merge/rebase, then running
-`npm run fix:link-cache` to restore any URLs unique to the active branch.
+`.lycheecache` is an auto-generated file that merges with Git's `union` strategy
+(see `.gitattributes`), so merges and rebases usually complete without conflict,
+but they can leave duplicate or stale cache entries that fail the
+`CACHE updates committed?` check. In either case the recovery is the same:
+finish the merge/rebase (taking the integration branch's side for any residual
+`.lycheecache` conflict), then run `npm run fix:link-cache` to restore any URLs
+unique to the active branch and rewrite the cache clean.
 
 ## Prerequisites
 
@@ -33,12 +37,14 @@ At this point, we are ready to resolve the conflicts in the active branch:
    ask the user whether to run `git merge $BASE_BRANCH` or
    `git rebase $BASE_BRANCH`, then run it.
 
-3. If there are no conflicts: stop, we are done.
+3. If there are no conflicts: the union merge succeeded. If it changed
+   `.lycheecache`, jump to **Resolve** step 4; otherwise stop, we are done.
 
 4. Conflicts other than `.lycheecache`: resolve them with the user.
 
-5. If no `.lycheecache` conflict remains: stop, we are done. Otherwise, proceed
-   to **Resolve**.
+5. If no `.lycheecache` conflict remains: apply step 3's rule (jump to
+   **Resolve** step 4 when the merge changed `.lycheecache`, else stop).
+   Otherwise, proceed to **Resolve**.
 
 ## Resolve
 

--- a/.claude/skills/resolve-link-cache-conflicts/SKILL.md
+++ b/.claude/skills/resolve-link-cache-conflicts/SKILL.md
@@ -38,17 +38,27 @@ At this point, we are ready to resolve the conflicts in the active branch:
    attributes resolve against the current checkout's tree, which during a rebase
    is the updated base.
 
-3. If there are no conflicts, the operation completes on its own. Union merges
-   can still leave residue: when `.lycheecache` now has duplicate URLs or
-   out-of-order lines (`cut -d, -f1 .lycheecache | sort | uniq -d` prints
-   duplicates, or `sort -c .lycheecache` fails), jump to **Resolve** step 4.
-   Otherwise stop, we are done.
+3. If there are no conflicts, the operation completes on its own. Run the
+   [residue test](#residue-test), then stop: we are done.
 
 4. Conflicts other than `.lycheecache`: resolve them with the user.
 
 5. If a `.lycheecache` conflict remains, proceed to **Resolve**. Otherwise,
-   conclude the operation per **Resolve** steps 2-3, then apply **Preparation**
-   step 3's residue test.
+   conclude the operation per **Resolve** steps 2-3, then run the
+   [residue test](#residue-test).
+
+## Residue test
+
+A conflict-free union merge can still leave residue that fails the
+`CACHE updates committed?` check: duplicate URLs or out-of-order lines.
+
+```sh
+cut -d, -f1 .lycheecache | sort | uniq -d # any output: duplicate URLs
+sort -c .lycheecache                      # any error: out-of-order lines
+```
+
+If either check trips, run **Resolve** steps 4-6 to regenerate, commit, and push
+the cache.
 
 ## Resolve
 

--- a/.claude/skills/review-pull-request/SKILL.md
+++ b/.claude/skills/review-pull-request/SKILL.md
@@ -173,7 +173,7 @@ Do not hand-edit `.lycheecache`. If a URL returns a non-200 for server reasons
 (blocked bot, LinkedIn 999, …), append `?link-check=no` (or `&link-check=no`) to
 the URL — [`pr-checks.md#handling-valid-external-links`][handling-links].
 
-For resolving merge/rebase conflicts in `.lycheecache`, see the
+For `.lycheecache` conflicts or post-merge cache residue, see the
 `resolve-link-cache-conflicts` skill.
 
 ## References

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,4 @@
-# The link cache is generated (one CSV line per URL) and refreshed by several
-# scheduled workflows, so concurrent updates routinely conflict. Union merge
-# keeps both sides' lines; duplicate entries are benign because the next
-# link-check pass rewrites the cache in normalized form. For details, see
+# The link cache is one line per URL, so union-merging its routinely
+# conflicting concurrent updates is safe. For details, see
 # https://opentelemetry.io/site/build/link-checking/#link-cache.
 /.lycheecache merge=union

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# The link cache is generated (one CSV line per URL) and refreshed by several
+# scheduled workflows, so concurrent updates routinely conflict. Union merge
+# keeps both sides' lines; duplicate entries are benign because the next
+# link-check pass rewrites the cache in normalized form. For details, see
+# https://opentelemetry.io/site/build/link-checking/#link-cache.
+/.lycheecache merge=union

--- a/.github/scripts/update-registry-versions.sh
+++ b/.github/scripts/update-registry-versions.sh
@@ -172,9 +172,11 @@ fi
 if [[ -n $(git status --porcelain) ]]; then
     echo "Versions have been updated, formatting and pushing changes."
 
-    $NPM run fix:link-cache ||
+    # npm steps run dependency-controlled code: keep the App token (GH_TOKEN)
+    # out of their env.
+    env -u GH_TOKEN $NPM run fix:link-cache ||
       echo "Link checking failed. Continuing so we can commit the link cache update."
-    $NPM run fix:format
+    env -u GH_TOKEN $NPM run fix:format
 
     $GIT checkout -b "$branch"
     $GIT commit -a -m "$message"

--- a/.github/scripts/update-registry-versions.sh
+++ b/.github/scripts/update-registry-versions.sh
@@ -173,10 +173,10 @@ if [[ -n $(git status --porcelain) ]]; then
     echo "Versions have been updated, formatting and pushing changes."
 
     # npm steps run dependency-controlled code: keep the App token (GH_TOKEN)
-    # out of their env.
-    env -u GH_TOKEN $NPM run fix:link-cache ||
+    # out of their environment.
+    (unset GH_TOKEN; $NPM run fix:link-cache) ||
       echo "Link checking failed. Continuing so we can commit the link cache update."
-    env -u GH_TOKEN $NPM run fix:format
+    (unset GH_TOKEN; $NPM run fix:format)
 
     $GIT checkout -b "$branch"
     $GIT commit -a -m "$message"

--- a/.github/scripts/update-registry-versions.sh
+++ b/.github/scripts/update-registry-versions.sh
@@ -172,6 +172,10 @@ fi
 if [[ -n $(git status --porcelain) ]]; then
     echo "Versions have been updated, formatting and pushing changes."
 
+    # Registry updates can add or remove external URLs; refresh the link cache
+    # so that the PR passes the link check. Ignore link-check failures so we
+    # can still commit link-cache updates.
+    $NPM run fix:link-cache || true
     $NPM run fix:format
 
     $GIT checkout -b "$branch"

--- a/.github/scripts/update-registry-versions.sh
+++ b/.github/scripts/update-registry-versions.sh
@@ -172,10 +172,8 @@ fi
 if [[ -n $(git status --porcelain) ]]; then
     echo "Versions have been updated, formatting and pushing changes."
 
-    # Registry updates can add or remove external URLs; refresh the link cache
-    # so that the PR passes the link check. Ignore link-check failures so we
-    # can still commit link-cache updates.
-    $NPM run fix:link-cache || true
+    $NPM run fix:link-cache ||
+      echo "Link checking failed. Continuing so we can commit the link cache update."
     $NPM run fix:format
 
     $GIT checkout -b "$branch"

--- a/.github/workflows/auto-update-registry.yml
+++ b/.github/workflows/auto-update-registry.yml
@@ -6,7 +6,6 @@ on:
     # At 04:31, every day
     - cron: 31 4 * * *
 
-# Declare default permissions as read only.
 permissions: read-all
 
 # Overlapping runs would race the script's existing-PR check.
@@ -59,11 +58,12 @@ jobs:
         run: |
           .github/scripts/update-registry-versions.sh
         env:
-          # Two tokens, each least-privilege for its consumer:
+          # Two tokens, one per consumer:
           #
-          # `gh` calls run as otelbot via the App token; see above.
+          # `gh` calls run as otelbot via the App token.
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
-          # Default workflow token for the link checker, set by `permissions`
+          # Default workflow token, for the link checker; its scope comes from
+          # the job's `permissions`.
           GITHUB_TOKEN: ${{ github.token }}
 
   report-failure:

--- a/.github/workflows/auto-update-registry.yml
+++ b/.github/workflows/auto-update-registry.yml
@@ -54,12 +54,11 @@ jobs:
         run: |
           .github/scripts/update-registry-versions.sh
         env:
-          # change to ${{ secrets.GITHUB_TOKEN }} and comment out the step above when testing against a fork
+          # Two tokens, each least-privilege for its consumer:
+          #
+          # `gh` calls run as otelbot via the App token; see above.
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
-          # Use the low-privilege built-in token for the authenticated
-          # github.com link checks (rate limits): when GITHUB_TOKEN is unset,
-          # the link-check scripts bridge in `gh`'s token, which here is the
-          # App token.
+          # Default read-only token for the link checker.
           GITHUB_TOKEN: ${{ github.token }}
 
   report-failure:

--- a/.github/workflows/auto-update-registry.yml
+++ b/.github/workflows/auto-update-registry.yml
@@ -9,6 +9,11 @@ on:
 # Declare default permissions as read only.
 permissions: read-all
 
+# Overlapping runs would race the script's existing-PR check.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   auto-update:
     name: Auto-update registry versions

--- a/.github/workflows/auto-update-registry.yml
+++ b/.github/workflows/auto-update-registry.yml
@@ -26,7 +26,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Full history, so that link-check config generation can diff
-          # content against the drift-status baseline commit.
+          # content against the drift-status baseline commit. (Simpler than
+          # check-links.yml's targeted deepen; clone cost is immaterial in a
+          # daily job.)
           fetch-depth: 0
 
       - name: Use CLA approved github bot

--- a/.github/workflows/auto-update-registry.yml
+++ b/.github/workflows/auto-update-registry.yml
@@ -48,6 +48,9 @@ jobs:
           fi
           git fetch --depth=1 origin --end-of-options "$sha"
 
+      # Keep this mint below the install/build steps, next to its only
+      # consumer: dependency-controlled code must not run with the App token
+      # available.
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:

--- a/.github/workflows/auto-update-registry.yml
+++ b/.github/workflows/auto-update-registry.yml
@@ -58,7 +58,7 @@ jobs:
           #
           # `gh` calls run as otelbot via the App token; see above.
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
-          # Default read-only token for the link checker.
+          # Built-in token for the link checker.
           GITHUB_TOKEN: ${{ github.token }}
 
   report-failure:

--- a/.github/workflows/auto-update-registry.yml
+++ b/.github/workflows/auto-update-registry.yml
@@ -20,12 +20,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history, so that link-check config generation can diff
+          # content against the drift-status baseline commit.
+          fetch-depth: 0
 
       - name: Use CLA approved github bot
         run: |
           git config user.name otelbot
           git config user.email 197425009+otelbot@users.noreply.github.com
 
+      # Toolchain for the link-cache refresh (fix:link-cache) that the update
+      # script runs before committing.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
@@ -36,21 +42,8 @@ jobs:
 
       - uses: ./.github/actions/install-lychee
 
-      # The drift-pending overlay used by link-check config generation diffs
-      # against the drift-status baseline; deepen the shallow clone to it.
-      # Same extraction as in check-links.yml; keep the two in sync.
-      - name: Deepen history to the drift-status baseline
-        run: |
-          sha=$(sed -n 's/^commit: \([0-9a-f]\{40\}\)$/\1/p' data/l10n-drift.yaml)
-          if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "::error file=data/l10n-drift.yaml::Expected a single 'commit: FULL_SHA' line."
-            exit 1
-          fi
-          git fetch --depth=1 origin --end-of-options "$sha"
-
-      # Keep this mint below the install/build steps, next to its only
-      # consumer: dependency-controlled code must not run with the App token
-      # available.
+      # Create the App token right before the step that uses it, keeping its
+      # lifetime clear of the dependency-controlled install steps above.
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
@@ -63,9 +56,10 @@ jobs:
         env:
           # change to ${{ secrets.GITHUB_TOKEN }} and comment out the step above when testing against a fork
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
-          # Authenticated github.com link checks (rate limits). Set explicitly:
-          # the link-check scripts otherwise bridge a token from `gh`, which
-          # here would be the higher-privileged App token above.
+          # Use the low-privilege built-in token for the authenticated
+          # github.com link checks (rate limits): when GITHUB_TOKEN is unset,
+          # the link-check scripts bridge in `gh`'s token, which here is the
+          # App token.
           GITHUB_TOKEN: ${{ github.token }}
 
   report-failure:

--- a/.github/workflows/auto-update-registry.yml
+++ b/.github/workflows/auto-update-registry.yml
@@ -63,7 +63,7 @@ jobs:
           #
           # `gh` calls run as otelbot via the App token; see above.
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
-          # Built-in token for the link checker.
+          # Default workflow token for the link checker, set by `permissions`
           GITHUB_TOKEN: ${{ github.token }}
 
   report-failure:

--- a/.github/workflows/auto-update-registry.yml
+++ b/.github/workflows/auto-update-registry.yml
@@ -26,6 +26,28 @@ jobs:
           git config user.name otelbot
           git config user.email 197425009+otelbot@users.noreply.github.com
 
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - run: npm run ci:min
+      - run: npm run ci:prepare
+
+      - uses: ./.github/actions/install-lychee
+
+      # The drift-pending overlay used by link-check config generation diffs
+      # against the drift-status baseline; deepen the shallow clone to it.
+      # Same extraction as in check-links.yml; keep the two in sync.
+      - name: Deepen history to the drift-status baseline
+        run: |
+          sha=$(sed -n 's/^commit: \([0-9a-f]\{40\}\)$/\1/p' data/l10n-drift.yaml)
+          if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error file=data/l10n-drift.yaml::Expected a single 'commit: FULL_SHA' line."
+            exit 1
+          fi
+          git fetch --depth=1 origin --end-of-options "$sha"
+
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
@@ -38,6 +60,10 @@ jobs:
         env:
           # change to ${{ secrets.GITHUB_TOKEN }} and comment out the step above when testing against a fork
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+          # Authenticated github.com link checks (rate limits). Set explicitly:
+          # the link-check scripts otherwise bridge a token from `gh`, which
+          # here would be the higher-privileged App token above.
+          GITHUB_TOKEN: ${{ github.token }}
 
   report-failure:
     needs: auto-update

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -70,8 +70,7 @@ jobs:
       # baseline; a depth-1 fetch of that commit is all the (shallow) clone
       # needs. Config generation fails if the baseline can't be resolved.
       # The extraction enforces the same 'commit: FULL_SHA' shape as
-      # BASELINE_COMMIT_RE in scripts/i18n/drift.mjs; keep the two in sync,
-      # along with the copy of this step in auto-update-registry.yml.
+      # BASELINE_COMMIT_RE in scripts/i18n/drift.mjs; keep the two in sync.
       # Kill switch: exporting DRIFT_BASELINE=HEAD on the config-generation
       # step below empties the overlay, restoring pre-overlay behavior.
       - name: Deepen history to the drift-status baseline

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -70,7 +70,8 @@ jobs:
       # baseline; a depth-1 fetch of that commit is all the (shallow) clone
       # needs. Config generation fails if the baseline can't be resolved.
       # The extraction enforces the same 'commit: FULL_SHA' shape as
-      # BASELINE_COMMIT_RE in scripts/i18n/drift.mjs; keep the two in sync.
+      # BASELINE_COMMIT_RE in scripts/i18n/drift.mjs; keep the two in sync,
+      # along with the copy of this step in auto-update-registry.yml.
       # Kill switch: exporting DRIFT_BASELINE=HEAD on the config-generation
       # step below empties the overlay, restoring pre-overlay behavior.
       - name: Deepen history to the drift-status baseline

--- a/.lycheecache
+++ b/.lycheecache
@@ -4169,6 +4169,7 @@ https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/upda
 https://github.com/open-telemetry/opentelemetry.io/blob/main/.cspell.yml,200,1785868417
 https://github.com/open-telemetry/opentelemetry.io/blob/main/.cspell/,200,1785739340
 https://github.com/open-telemetry/opentelemetry.io/blob/main/.cspell/all-words.txt,200,1785739340
+https://github.com/open-telemetry/opentelemetry.io/blob/main/.gitattributes,200,1786632270
 https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/CODEOWNERS,200,1786427572
 https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/PULL_REQUEST_TEMPLATE.md,200,1785868416
 https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/component-label-map.yml,200,1786427569

--- a/content/en/site/build/link-checking.md
+++ b/content/en/site/build/link-checking.md
@@ -81,8 +81,7 @@ Since the cache is routinely updated by several
 merged line-by-line with Git's `union` strategy (see [`.gitattributes`][])
 rather than reported as conflicts. Such merges can leave duplicate or stale
 entries behind; these are benign for the checker, and the next link-check run
-rewrites the cache clean. In a PR, that rewrite must be committed to satisfy
-[`CACHE updates committed?`][pr-checks].
+rewrites the cache clean. In a PR, commit that rewrite.
 
 If you add or change external links, run `npm run check:links` **before
 submitting your PR** — the site build dominates the run time — and commit the
@@ -92,14 +91,13 @@ updated `.lycheecache` along with your content changes. Otherwise the
 
 ## Cache refresh and housekeeping workflows {#workflows}
 
-The following workflows are scheduled daily and run a link checking command over
-a **full** build, unless noted otherwise:
+The following workflows are scheduled daily and run a link checking command:
 
 | Workflow                              | Link-check command                            |
 | ------------------------------------- | --------------------------------------------- |
-| Refcache refresh                      | `log:check:links` (after pruning)             |
-| [Housekeeping][] (`fix-and-test:all`) | `fix:link-cache`                              |
-| Registry auto-update                  | `fix:link-cache` (lean build, when PR-worthy) |
+| Refcache refresh                      | `log:check:links` (full build, after pruning) |
+| [Housekeeping][] (`fix-and-test:all`) | `fix:link-cache` (full build)                 |
+| [Auto-update registry versions][]     | `fix:link-cache`                              |
 
 Refcache refresh prunes the oldest cache entries (the count is a workflow input)
 and re-runs the link check, which refreshes the cache entries for the pruned
@@ -134,12 +132,13 @@ That job fails if any link check fails, and hands the cache it refreshed to the
 `.lycheecache` stale.
 
 <!-- prettier-ignore-start -->
+[`.gitattributes`]: https://github.com/open-telemetry/opentelemetry.io/blob/main/.gitattributes
+[Auto-update registry versions]: ../scripts/#update-registry-versionssh
 [blog-index]: https://github.com/open-telemetry/opentelemetry.io/blob/main/content/en/blog/_index.md
 [Build kinds: full and lean]: ../#build-kinds
 [ci]: ../ci-workflows/
 [double-check README]: https://github.com/open-telemetry/opentelemetry.io/blob/main/scripts/lychee/double-check/README.md
 [drifted]: /docs/contributing/localization/#track-changes
-[`.gitattributes`]: https://github.com/open-telemetry/opentelemetry.io/blob/main/.gitattributes
 [Housekeeping]: ../ci-workflows/#housekeeping
 [link cache]: #link-cache
 [Lychee]: https://lychee.cli.rs/

--- a/content/en/site/build/link-checking.md
+++ b/content/en/site/build/link-checking.md
@@ -79,9 +79,10 @@ run.
 Since the cache is routinely updated by several
 [scheduled workflows](#workflows) as well as content PRs, concurrent updates are
 merged line-by-line with Git's `union` strategy (see [`.gitattributes`][])
-rather than reported as conflicts. Any duplicate entries that such merges
-produce are benign: the next link-check run rewrites the cache in normalized
-form.
+rather than reported as conflicts. Such merges can leave duplicate or stale
+entries behind; these are benign for the checker, and the next link-check run
+rewrites the cache clean. In a PR, that rewrite must be committed to satisfy
+[`CACHE updates committed?`][pr-checks].
 
 If you add or change external links, run `npm run check:links` **before
 submitting your PR** — the site build dominates the run time — and commit the
@@ -92,12 +93,13 @@ updated `.lycheecache` along with your content changes. Otherwise the
 ## Cache refresh and housekeeping workflows {#workflows}
 
 The following workflows are scheduled daily and run a link checking command over
-a **full** build:
+a **full** build, unless noted otherwise:
 
-| Workflow                              | Link-check command                |
-| ------------------------------------- | --------------------------------- |
-| Refcache refresh                      | `log:check:links` (after pruning) |
-| [Housekeeping][] (`fix-and-test:all`) | `fix:link-cache`                  |
+| Workflow                              | Link-check command                            |
+| ------------------------------------- | --------------------------------------------- |
+| Refcache refresh                      | `log:check:links` (after pruning)             |
+| [Housekeeping][] (`fix-and-test:all`) | `fix:link-cache`                              |
+| Registry auto-update                  | `fix:link-cache` (lean build, when PR-worthy) |
 
 Refcache refresh prunes the oldest cache entries (the count is a workflow input)
 and re-runs the link check, which refreshes the cache entries for the pruned

--- a/content/en/site/build/link-checking.md
+++ b/content/en/site/build/link-checking.md
@@ -136,7 +136,9 @@ That job fails if any link check fails, and hands the cache it refreshed to the
 [ci]: ../ci-workflows/
 [double-check README]: https://github.com/open-telemetry/opentelemetry.io/blob/main/scripts/lychee/double-check/README.md
 [drifted]: /docs/contributing/localization/#track-changes
-[`.gitattributes`]: https://github.com/open-telemetry/opentelemetry.io/blob/main/.gitattributes
+<!-- Skip-marker covers the bootstrap 404: the file first exists on main once
+  the PR introducing it (and this link) merges; harmless afterwards. -->
+[`.gitattributes`]: https://github.com/open-telemetry/opentelemetry.io/blob/main/.gitattributes?link-check=no
 [Housekeeping]: ../ci-workflows/#housekeeping
 [link cache]: #link-cache
 [Lychee]: https://lychee.cli.rs/

--- a/content/en/site/build/link-checking.md
+++ b/content/en/site/build/link-checking.md
@@ -76,6 +76,12 @@ control so that checks only fetch URLs that are new or whose cache entries have
 expired. Lychee caches successful results only, so failures are retried on every
 run.
 
+Since the cache is routinely updated by several scheduled workflows as well as
+content PRs, concurrent updates are merged line-by-line with Git's `union`
+strategy (see [`.gitattributes`][]) rather than reported as conflicts. Any
+duplicate entries that such merges produce are benign: the next link-check run
+rewrites the cache in normalized form.
+
 If you add or change external links, run `npm run check:links` **before
 submitting your PR** — the site build dominates the run time — and commit the
 updated `.lycheecache` along with your content changes. Otherwise the
@@ -130,6 +136,7 @@ That job fails if any link check fails, and hands the cache it refreshed to the
 [ci]: ../ci-workflows/
 [double-check README]: https://github.com/open-telemetry/opentelemetry.io/blob/main/scripts/lychee/double-check/README.md
 [drifted]: /docs/contributing/localization/#track-changes
+[`.gitattributes`]: https://github.com/open-telemetry/opentelemetry.io/blob/main/.gitattributes
 [Housekeeping]: ../ci-workflows/#housekeeping
 [link cache]: #link-cache
 [Lychee]: https://lychee.cli.rs/

--- a/content/en/site/build/link-checking.md
+++ b/content/en/site/build/link-checking.md
@@ -76,11 +76,12 @@ control so that checks only fetch URLs that are new or whose cache entries have
 expired. Lychee caches successful results only, so failures are retried on every
 run.
 
-Since the cache is routinely updated by several scheduled workflows as well as
-content PRs, concurrent updates are merged line-by-line with Git's `union`
-strategy (see [`.gitattributes`][]) rather than reported as conflicts. Any
-duplicate entries that such merges produce are benign: the next link-check run
-rewrites the cache in normalized form.
+Since the cache is routinely updated by several
+[scheduled workflows](#workflows) as well as content PRs, concurrent updates are
+merged line-by-line with Git's `union` strategy (see [`.gitattributes`][])
+rather than reported as conflicts. Any duplicate entries that such merges
+produce are benign: the next link-check run rewrites the cache in normalized
+form.
 
 If you add or change external links, run `npm run check:links` **before
 submitting your PR** — the site build dominates the run time — and commit the
@@ -136,9 +137,7 @@ That job fails if any link check fails, and hands the cache it refreshed to the
 [ci]: ../ci-workflows/
 [double-check README]: https://github.com/open-telemetry/opentelemetry.io/blob/main/scripts/lychee/double-check/README.md
 [drifted]: /docs/contributing/localization/#track-changes
-<!-- Skip-marker covers the bootstrap 404: the file first exists on main once
-  the PR introducing it (and this link) merges; harmless afterwards. -->
-[`.gitattributes`]: https://github.com/open-telemetry/opentelemetry.io/blob/main/.gitattributes?link-check=no
+[`.gitattributes`]: https://github.com/open-telemetry/opentelemetry.io/blob/main/.gitattributes
 [Housekeeping]: ../ci-workflows/#housekeeping
 [link cache]: #link-cache
 [Lychee]: https://lychee.cli.rs/

--- a/content/en/site/build/scripts.md
+++ b/content/en/site/build/scripts.md
@@ -51,6 +51,8 @@ registries. Supports: npm, Packagist, RubyGems, Go, NuGet, Hex, Maven.
 Deduplicates PRs by generating a SHA-1 tag from the update summary.
 
 When versions have changed, the script refreshes the [link cache][] before
-committing, since registry updates can add or remove external URLs.
+committing, since registry updates can add or remove external URLs. A transient
+failure during that refresh can leave the bot PR with `CACHE updates committed?`
+red even though links pass; comment `/fix:link-cache` on the PR to repair it.
 
 [link cache]: ../link-checking/#link-cache

--- a/content/en/site/build/scripts.md
+++ b/content/en/site/build/scripts.md
@@ -48,9 +48,9 @@ registries. Supports: npm, Packagist, RubyGems, Go, NuGet, Hex, Maven.
 - Locally: runs in **dry-run** mode by default. Use `-f` to force real
   execution.
 
+Deduplicates PRs by generating a SHA-1 tag from the update summary.
+
 When versions have changed, the script refreshes the [link cache][] before
 committing, since registry updates can add or remove external URLs.
-
-Deduplicates PRs by generating a SHA-1 tag from the update summary.
 
 [link cache]: ../link-checking/#link-cache

--- a/content/en/site/build/scripts.md
+++ b/content/en/site/build/scripts.md
@@ -48,4 +48,9 @@ registries. Supports: npm, Packagist, RubyGems, Go, NuGet, Hex, Maven.
 - Locally: runs in **dry-run** mode by default. Use `-f` to force real
   execution.
 
+When versions have changed, the script refreshes the [link cache][] before
+committing, since registry updates can add or remove external URLs.
+
 Deduplicates PRs by generating a SHA-1 tag from the update summary.
+
+[link cache]: ../link-checking/#link-cache

--- a/content/en/site/build/scripts.md
+++ b/content/en/site/build/scripts.md
@@ -53,6 +53,10 @@ Deduplicates PRs by generating a SHA-1 tag from the update summary.
 When versions have changed, the script refreshes the [link cache][] before
 committing, since registry updates can add or remove external URLs. A transient
 failure during that refresh can leave the bot PR with `CACHE updates committed?`
-red even though links pass; comment `/fix:link-cache` on the PR to repair it.
+red even though links pass; comment [`/fix:link-cache`][] on the PR to repair
+it.
 
+<!-- prettier-ignore-start -->
+[`/fix:link-cache`]: /docs/contributing/pull-requests/#fixing-prs-in-github
 [link cache]: ../link-checking/#link-cache
+<!-- prettier-ignore-end -->

--- a/content/en/site/build/scripts.md
+++ b/content/en/site/build/scripts.md
@@ -54,7 +54,8 @@ When versions have changed, the script refreshes the [link cache][] before
 committing, since registry updates can add or remove external URLs. A transient
 failure during that refresh can leave the bot PR with `CACHE updates committed?`
 red even though links pass; comment [`/fix:link-cache`][] on the PR to repair
-it.
+it. If instead the update introduced a genuinely broken URL, the bot PR arrives
+red on the link check itself; fix the URL rather than rerunning the cache fix.
 
 <!-- prettier-ignore-start -->
 [`/fix:link-cache`]: /docs/contributing/pull-requests/#fixing-prs-in-github


### PR DESCRIPTION
- This is the first to a PR pair.
- **Union-merges `.lycheecache`** (new `.gitattributes`):
  - Ends routine conflicts between scheduled cache writers and content PRs (e.g. #11284); policy and residue behavior: [Link checking § Link cache](https://opentelemetry.io/site/build/link-checking/#link-cache)
  - Transition: branches created before this lands (notably existing `otelbot/*` integration branches) keep conflicting until the attribute reaches their tree; they may need one last manual resolve
  - Server-side bound: GitHub's merge surfaces (conflict indicator, update-branch, merge queue) are expected, but not documented, to honor the attribute; worst case there is the status quo
- **Refreshes the link cache in registry auto-update** before it opens its PR:
  - Fixes bot PRs arriving red when registry updates add/remove external URLs, each needing a manual `fix:link-cache` (as suggested in #11178)
  - Wires the workflow with the repo's standard link-check step set, mirroring `check-links.yml` and `specs-integration.yml`
- **Documents both**: merge policy in [Link checking](https://opentelemetry.io/site/build/link-checking/#link-cache); script behavior in [Helper scripts](https://opentelemetry.io/site/build/scripts/)
- **Preview(s)**:
  - https://deploy-preview-11320--opentelemetry.netlify.app/site/build/link-checking/
  - https://deploy-preview-11320--opentelemetry.netlify.app/site/build/scripts/
