### PR TITLE
fix(scss): scope otel-with-contributions-from style to direct child paragraphs

### DIFF
--- a/assets/scss/_blog.scss
+++ b/assets/scss/_blog.scss
@@ -6,7 +6,7 @@
     .article-meta {
       margin: 0;
     }
-    p:first-of-type {
+    > p:first-of-type {
       @extend .small;
       opacity: 0.65;
       padding-top: 0.2rem;


### PR DESCRIPTION
Fixes #11301

The `.td-blog.otel-with-contributions-from` body class was applying small/dimmed/margined styling to any first `p` under `.td-content`, including the first paragraph inside alert/callout components.

Change the nested selector from `p:first-of-type` to `> p:first-of-type` so the styling only targets the intended direct-child intro paragraph.

Verification:
- `python3 /home/ubuntu/Projects/open-source/scripts/preflight_ship.py --repo open-telemetry/opentelemetry.io --local repos/opentelemetry.io --branch main --issue 11301 --file assets/scss/_blog.scss --must-contain 'p:first-of-type {'` passes (bug marker present, no open PR references #11301).\n- `npm run check:format` passes.\n- I also ran `npm run build:lean`; it did not complete because `content-modules/opentelemetry-java-instrumentation` could not be cloned in this environment (`fatal: transport 'file' not allowed`). The CSS one-liner is otherwise syntax-valid per Prettier/SCSS.,