### PR TITLE
Registry auto-update: scope push credentials and treat registry input as data

### DIFF
--- a/.github/scripts/update-registry-versions.sh
+++ b/.github/scripts/update-registry-versions.sh
@@ -11,7 +11,7 @@ GIT_PUSH_AUTH=()
 
 if [[ -n "$GITHUB_ACTIONS" ]]; then
   if [[ -z "${GH_TOKEN:-}" ]]; then
-    echo "::error::Expected the App token in GH_TOKEN." >&2
+    echo "::error::Expected the App token in GH_TOKEN."
     exit 1
   fi
 
@@ -19,7 +19,7 @@ if [[ -n "$GITHUB_ACTIONS" ]]; then
 
   # Supply the App token only to a github.com push. Reset configured helpers
   # first, then use a host-scoped helper that keeps the token out of argv,
-  # git config, and disk, and declines a repointed origin.
+  # git config, and disk, and declines a cross-host repoint.
   # shellcheck disable=SC2016 # the helper body is evaluated by git, not here
   GIT_PUSH_AUTH=(
     -c credential.helper=
@@ -177,7 +177,8 @@ for yaml_file in ${FILES}; do
     fi
 done;
 
-# Preserve existing PR keys while making the row encoding unambiguous.
+# Preserve existing PR keys for ordinary rows while making the encoding
+# unambiguous.
 tag_input=${body//\\/\\\\}
 tag_input=${tag_input//$'\n'/\\n}
 tag=$(printf '%s\n' "${tag_input}" | sha1sum | awk '{print $1;}')
@@ -185,7 +186,8 @@ message="Auto-update registry versions (${tag})"
 branch="otelbot/auto-update-registry-${tag}"
 
 
-existing_pr_count=$(gh pr list --state all --search "in:title $message" | wc -l)
+existing_prs=$(gh pr list --state all --search "in:title $message")
+existing_pr_count=$(printf '%s' "$existing_prs" | awk 'END {print NR}')
 if [ "$existing_pr_count" -gt 0 ]; then
     echo "PR(s) already exist for '$message'"
     gh pr list --state all --search "\"$message\" in:title"

--- a/.github/scripts/update-registry-versions.sh
+++ b/.github/scripts/update-registry-versions.sh
@@ -2,7 +2,7 @@
 
 UPDATE_YAML="yq eval -i"
 GIT=git
-GH=gh
+GH_WRITE=gh
 NPM=npm
 FILES="${FILES:-./data/registry/*.yml}"
 
@@ -31,7 +31,7 @@ elif [[ "$1" != "-f" ]]; then
   echo "Doing a dry-run when run locally. Use -f as the first argument to force execution."
   UPDATE_YAML="yq eval"
   GIT="echo > DRY RUN: git "
-  GH="echo > DRY RUN: gh "
+  GH_WRITE="echo > DRY RUN: gh "
   NPM="echo > DRY RUN: npm "
 else
   # Local execution with -f flag (force real vs. dry run)
@@ -186,11 +186,11 @@ message="Auto-update registry versions (${tag})"
 branch="otelbot/auto-update-registry-${tag}"
 
 
-existing_prs=$(gh pr list --state all --search "in:title $message")
-existing_pr_count=$(printf '%s' "$existing_prs" | awk 'END {print NR}')
+pr_search="\"$message\" in:title"
+existing_pr_count=$(gh pr list --state all --search "$pr_search" --json number --jq length)
 if [ "$existing_pr_count" -gt 0 ]; then
     echo "PR(s) already exist for '$message'"
-    gh pr list --state all --search "\"$message\" in:title"
+    gh pr list --state all --search "$pr_search"
     echo "So we won't create another. Exiting."
     exit 0
 fi
@@ -213,7 +213,7 @@ if [[ -n $(git status --porcelain) ]]; then
     printf '%s' "${body}" >> "${body_file}"
 
     echo "Submitting auto-update PR '$message'."
-    $GH pr create --title "$message" --body-file "${body_file}"
+    $GH_WRITE pr create --title "$message" --body-file "${body_file}"
 
 else
     echo "No changes detected."

--- a/.github/scripts/update-registry-versions.sh
+++ b/.github/scripts/update-registry-versions.sh
@@ -185,8 +185,8 @@ fi
 if [[ -n $(git status --porcelain) ]]; then
     echo "Versions have been updated, formatting and pushing changes."
 
-    # npm steps run dependency-controlled code: keep the App token (GH_TOKEN)
-    # out of their environment.
+    # Remove the App token from each npm command's direct child environment.
+    # This limits accidental access; it is not a process-isolation boundary.
     (unset GH_TOKEN; $NPM run fix:link-cache) ||
       echo "Link checking failed. Continuing so we can commit the link cache update."
     (unset GH_TOKEN; $NPM run fix:format)

--- a/.github/scripts/update-registry-versions.sh
+++ b/.github/scripts/update-registry-versions.sh
@@ -166,9 +166,10 @@ for yaml_file in ${FILES}; do
     fi
 done;
 
-# Keep PR identity stable in a canonical escaped-newline form, independent of
-# how the body file renders its line breaks.
-tag_input=${body//$'\n'/\\n}
+# Keep PR identity stable for ordinary input while encoding row separators
+# unambiguously: escape data backslashes first, then rendered newlines.
+tag_input=${body//\\/\\\\}
+tag_input=${tag_input//$'\n'/\\n}
 tag=$(printf '%s\n' "${tag_input}" | sha1sum | awk '{print $1;}')
 message="Auto-update registry versions (${tag})"
 branch="otelbot/auto-update-registry-${tag}"

--- a/.github/scripts/update-registry-versions.sh
+++ b/.github/scripts/update-registry-versions.sh
@@ -166,8 +166,7 @@ for yaml_file in ${FILES}; do
     fi
 done;
 
-# Keep PR identity stable for ordinary input while encoding row separators
-# unambiguously: escape data backslashes first, then rendered newlines.
+# Preserve existing PR keys while making the row encoding unambiguous.
 tag_input=${body//\\/\\\\}
 tag_input=${tag_input//$'\n'/\\n}
 tag=$(printf '%s\n' "${tag_input}" | sha1sum | awk '{print $1;}')

--- a/.github/scripts/update-registry-versions.sh
+++ b/.github/scripts/update-registry-versions.sh
@@ -123,8 +123,11 @@ for yaml_file in ${FILES}; do
 
         # Registry metadata is third-party input: accept only plain ASCII https
         # URLs (IDNs are expected in punycode), and pass the value as data
-        # (strenv) rather than as part of the yq expression.
-        if [[ ! "$url" =~ ^https://[A-Za-z0-9._~:/?#@!$\&\'\(\)*+,\;=%-]+$ ]]; then
+        # (strenv) rather than as part of the yq expression. The pattern lives
+        # in a variable so that bash applies no escape-quoting to the class,
+        # which would otherwise admit a literal backslash.
+        url_re="^https://[A-Za-z0-9._~:/?#@!\$&'()*+,;=%-]+\$"
+        if [[ ! "$url" =~ $url_re ]]; then
             return
         fi
 

--- a/.github/scripts/update-registry-versions.sh
+++ b/.github/scripts/update-registry-versions.sh
@@ -166,8 +166,10 @@ for yaml_file in ${FILES}; do
     fi
 done;
 
-# We use the sha1 over all version updates to uniquely identify the PR.
-tag=$(echo "${body}" | sha1sum | awk '{print $1;}')
+# Keep PR identity stable in a canonical escaped-newline form, independent of
+# how the body file renders its line breaks.
+tag_input=${body//$'\n'/\\n}
+tag=$(printf '%s\n' "${tag_input}" | sha1sum | awk '{print $1;}')
 message="Auto-update registry versions (${tag})"
 branch="otelbot/auto-update-registry-${tag}"
 

--- a/.github/scripts/update-registry-versions.sh
+++ b/.github/scripts/update-registry-versions.sh
@@ -7,9 +7,22 @@ NPM=npm
 FILES="${FILES:-./data/registry/*.yml}"
 
 
+# Extra `git` arguments for the push below; none outside CI.
+GIT_PUSH_AUTH=()
+
 if [[ -n "$GITHUB_ACTIONS" ]]; then
   # Ensure that we're starting from a clean state
   git reset --hard origin/main
+
+  # Supply the App token to the push through an inline credential helper: it
+  # stays out of the command line, out of git config, and off disk. The empty
+  # value first drops any helper the runner has configured, so none of them
+  # gets offered the credential either.
+  # shellcheck disable=SC2016 # the helper body is evaluated by git, not here
+  GIT_PUSH_AUTH=(
+    -c credential.helper=
+    -c 'credential.helper=!f() { test "$1" = get && printf "username=x-access-token\npassword=%s\n" "$GH_TOKEN"; }; f'
+  )
 elif [[ "$1" != "-f" ]]; then
   # Do a dry-run when script it executed locally, unless the
   # force flag is specified (-f).
@@ -180,15 +193,7 @@ if [[ -n $(git status --porcelain) ]]; then
 
     $GIT checkout -b "$branch"
     $GIT commit -a -m "$message"
-
-    # In CI, authenticate the push via a per-invocation config override: the
-    # token is never written to git config or anywhere else on disk.
-    if [[ -n "$GITHUB_ACTIONS" ]]; then
-      $GIT -c "remote.origin.url=https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
-        push --set-upstream origin "$branch"
-    else
-      $GIT push --set-upstream origin "$branch"
-    fi
+    $GIT "${GIT_PUSH_AUTH[@]}" push --set-upstream origin "$branch"
 
     body_file=$(mktemp)
     echo -en "${body}" >> "${body_file}"

--- a/.github/scripts/update-registry-versions.sh
+++ b/.github/scripts/update-registry-versions.sh
@@ -56,16 +56,17 @@ for yaml_file in ${FILES}; do
                 curl -s "https://registry.npmjs.org/${package_name}/latest" | jq -r '.version'
                 ;;
             packagist)
-                curl -s "https://repo.packagist.org/p2/${package_name}.json" | jq -r ".packages.\"${package_name}\"[0].version"
+                curl -s "https://repo.packagist.org/p2/${package_name}.json" |
+                    jq -r --arg name "$package_name" '.packages[$name][0].version'
                 ;;
             gems)
                 curl -s "https://rubygems.org/api/v1/versions/${package_name}/latest.json" | jq -r '.version'
                 ;;
             go)
-                go list -m --versions "$package_name" | awk '{ if (NF > 1) print $NF ; else print "" }'
+                go list -m --versions -- "$package_name" | awk '{ if (NF > 1) print $NF ; else print "" }'
                 ;;
             go-collector)
-                go list -m --versions "$package_name" | awk '{ if (NF > 1) print $NF ; else print "" }'
+                go list -m --versions -- "$package_name" | awk '{ if (NF > 1) print $NF ; else print "" }'
                 ;;
             nuget)
                 lower_case_package_name=$(echo "$package_name" | tr '[:upper:]' '[:lower:]')
@@ -118,17 +119,21 @@ for yaml_file in ${FILES}; do
 
         url="$(jq -r "$json_path" <<< "$json")"
 
-        if [ -z "$url" ] || [ "$url" = "null" ]; then
+        # Registry metadata is third-party input: accept only plain https URLs,
+        # and pass the value as data (strenv) rather than as part of the yq
+        # expression.
+        if [[ ! "$url" =~ ^https://[A-Za-z0-9._~:/?#@!$\&\'\(\)*+,\;=%-]+$ ]]; then
             return
         fi
 
         # Check HTTP status (no output, no body)
-        status="$(curl -s -o /dev/null -w '%{http_code}' "$url")"
+        status="$(curl -s -o /dev/null -w '%{http_code}' -- "$url")"
 
         # Only update when status is 2xx
         case "$status" in
             2??)
-                ${UPDATE_YAML} "${setting_path} = \"$url\"" "$yaml_file"
+                export CHECKED_URL="$url"
+                ${UPDATE_YAML} "${setting_path} = strenv(CHECKED_URL)" "$yaml_file"
                 ;;
         esac
     }
@@ -151,17 +156,19 @@ for yaml_file in ${FILES}; do
         elif [ -z "$latest_version" ]; then
             echo "${yaml_file} ($registry): Could not get latest version from registry."
         elif [ -z "$current_version" ]; then
-            ${UPDATE_YAML} ".package.version = \"$latest_version\"" "$yaml_file"
+            export LATEST_VERSION="$latest_version"
+            ${UPDATE_YAML} '.package.version = strenv(LATEST_VERSION)' "$yaml_file"
             update_metadata "$name" "$registry" "$yaml_file"
             row="${yaml_file} ($registry): Version field was missing. Populated with the latest version: $latest_version"
             echo "${row}"
-            body="${body}\n- ${row}"
+            body="${body}"$'\n'"- ${row}"
         elif [ "$latest_version" != "$current_version" ]; then
-            ${UPDATE_YAML} ".package.version = \"$latest_version\"" "$yaml_file"
+            export LATEST_VERSION="$latest_version"
+            ${UPDATE_YAML} '.package.version = strenv(LATEST_VERSION)' "$yaml_file"
             update_metadata "$name" "$registry" "$yaml_file"
             row="($registry): Updated version from $current_version to $latest_version in $yaml_file"
             echo "${yaml_file} ${row}"
-            body="${body}\n- ${row}"
+            body="${body}"$'\n'"- ${row}"
         else
             echo "${yaml_file} ($registry): Version is already up to date."
         fi
@@ -196,7 +203,8 @@ if [[ -n $(git status --porcelain) ]]; then
     $GIT "${GIT_PUSH_AUTH[@]}" push --set-upstream origin "$branch"
 
     body_file=$(mktemp)
-    echo -en "${body}" >> "${body_file}"
+    # printf, not echo -e: registry-derived text must not be re-interpreted.
+    printf '%s' "${body}" >> "${body_file}"
 
     echo "Submitting auto-update PR '$message'."
     $GH pr create --title "$message" --body-file "${body_file}"

--- a/.github/scripts/update-registry-versions.sh
+++ b/.github/scripts/update-registry-versions.sh
@@ -180,7 +180,17 @@ if [[ -n $(git status --porcelain) ]]; then
 
     $GIT checkout -b "$branch"
     $GIT commit -a -m "$message"
+
+    # Authenticate the remote only around the push: the token must not be
+    # config-resident while dependency-controlled code (the npm steps above)
+    # runs. The workflow's cleanup step is the failsafe reset.
+    if [[ -n "$GITHUB_ACTIONS" ]]; then
+      git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+    fi
     $GIT push --set-upstream origin "$branch"
+    if [[ -n "$GITHUB_ACTIONS" ]]; then
+      git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+    fi
 
     body_file=$(mktemp)
     echo -en "${body}" >> "${body_file}"

--- a/.github/scripts/update-registry-versions.sh
+++ b/.github/scripts/update-registry-versions.sh
@@ -17,11 +17,13 @@ if [[ -n "$GITHUB_ACTIONS" ]]; then
   # Supply the App token to the push through an inline credential helper: it
   # stays out of the command line, out of git config, and off disk. The empty
   # value first drops any helper the runner has configured, so none of them
-  # gets offered the credential either.
+  # gets offered the credential either. Binding the helper to github.com keeps
+  # it from answering for some other host, should anything have repointed
+  # `origin` between checkout and the push.
   # shellcheck disable=SC2016 # the helper body is evaluated by git, not here
   GIT_PUSH_AUTH=(
     -c credential.helper=
-    -c 'credential.helper=!f() { test "$1" = get && printf "username=x-access-token\npassword=%s\n" "$GH_TOKEN"; }; f'
+    -c 'credential.https://github.com.helper=!f() { test "$1" = get && printf "username=x-access-token\npassword=%s\n" "$GH_TOKEN"; }; f'
   )
 elif [[ "$1" != "-f" ]]; then
   # Do a dry-run when script it executed locally, unless the
@@ -119,9 +121,9 @@ for yaml_file in ${FILES}; do
 
         url="$(jq -r "$json_path" <<< "$json")"
 
-        # Registry metadata is third-party input: accept only plain https URLs,
-        # and pass the value as data (strenv) rather than as part of the yq
-        # expression.
+        # Registry metadata is third-party input: accept only plain ASCII https
+        # URLs (IDNs are expected in punycode), and pass the value as data
+        # (strenv) rather than as part of the yq expression.
         if [[ ! "$url" =~ ^https://[A-Za-z0-9._~:/?#@!$\&\'\(\)*+,\;=%-]+$ ]]; then
             return
         fi

--- a/.github/scripts/update-registry-versions.sh
+++ b/.github/scripts/update-registry-versions.sh
@@ -10,6 +10,11 @@ FILES="${FILES:-./data/registry/*.yml}"
 GIT_PUSH_AUTH=()
 
 if [[ -n "$GITHUB_ACTIONS" ]]; then
+  if [[ -z "${GH_TOKEN:-}" ]]; then
+    echo "::error::Expected the App token in GH_TOKEN." >&2
+    exit 1
+  fi
+
   git reset --hard origin/main
 
   # Supply the App token only to a github.com push. Reset configured helpers
@@ -114,10 +119,16 @@ for yaml_file in ${FILES}; do
 
         url="$(jq -r "$json_path" <<< "$json")"
 
-        # Treat third-party metadata as data, accepting ASCII HTTPS only (IDNs
-        # as punycode). A variable avoids Bash escape-quoting admitting `\`.
+        # Treat third-party metadata as data, accepting ASCII HTTPS without
+        # userinfo (IDNs as punycode). A variable avoids Bash escape-quoting
+        # admitting `\`.
         url_re="^https://[A-Za-z0-9._~:/?#@!\$&'()*+,;=%-]+\$"
         if [[ ! "$url" =~ $url_re ]]; then
+            return
+        fi
+        authority=${url#https://}
+        authority=${authority%%[/?#]*}
+        if [[ "$authority" == *"@"* ]]; then
             return
         fi
 

--- a/.github/scripts/update-registry-versions.sh
+++ b/.github/scripts/update-registry-versions.sh
@@ -181,15 +181,13 @@ if [[ -n $(git status --porcelain) ]]; then
     $GIT checkout -b "$branch"
     $GIT commit -a -m "$message"
 
-    # Authenticate the remote only around the push: the token must not be
-    # config-resident while dependency-controlled code (the npm steps above)
-    # runs. The workflow's cleanup step is the failsafe reset.
+    # In CI, authenticate the push via a per-invocation config override: the
+    # token is never written to git config or anywhere else on disk.
     if [[ -n "$GITHUB_ACTIONS" ]]; then
-      git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-    fi
-    $GIT push --set-upstream origin "$branch"
-    if [[ -n "$GITHUB_ACTIONS" ]]; then
-      git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+      $GIT -c "remote.origin.url=https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+        push --set-upstream origin "$branch"
+    else
+      $GIT push --set-upstream origin "$branch"
     fi
 
     body_file=$(mktemp)

--- a/.github/scripts/update-registry-versions.sh
+++ b/.github/scripts/update-registry-versions.sh
@@ -7,19 +7,14 @@ NPM=npm
 FILES="${FILES:-./data/registry/*.yml}"
 
 
-# Extra `git` arguments for the push below; none outside CI.
 GIT_PUSH_AUTH=()
 
 if [[ -n "$GITHUB_ACTIONS" ]]; then
-  # Ensure that we're starting from a clean state
   git reset --hard origin/main
 
-  # Supply the App token to the push through an inline credential helper: it
-  # stays out of the command line, out of git config, and off disk. The empty
-  # value first drops any helper the runner has configured, so none of them
-  # gets offered the credential either. Binding the helper to github.com keeps
-  # it from answering for some other host, should anything have repointed
-  # `origin` between checkout and the push.
+  # Supply the App token only to a github.com push. Reset configured helpers
+  # first, then use a host-scoped helper that keeps the token out of argv,
+  # git config, and disk, and declines a repointed origin.
   # shellcheck disable=SC2016 # the helper body is evaluated by git, not here
   GIT_PUSH_AUTH=(
     -c credential.helper=
@@ -42,13 +37,11 @@ body=""
 
 for yaml_file in ${FILES}; do
     echo "$yaml_file"
-    # Check if yq is installed
     if ! command -v yq &> /dev/null; then
         echo "yq could not be found, please install yq."
         exit 1
     fi
 
-    # Function to get latest version based on registry
     get_latest_version() {
         package_name=$1
         registry=$2
@@ -121,20 +114,15 @@ for yaml_file in ${FILES}; do
 
         url="$(jq -r "$json_path" <<< "$json")"
 
-        # Registry metadata is third-party input: accept only plain ASCII https
-        # URLs (IDNs are expected in punycode), and pass the value as data
-        # (strenv) rather than as part of the yq expression. The pattern lives
-        # in a variable so that bash applies no escape-quoting to the class,
-        # which would otherwise admit a literal backslash.
+        # Treat third-party metadata as data, accepting ASCII HTTPS only (IDNs
+        # as punycode). A variable avoids Bash escape-quoting admitting `\`.
         url_re="^https://[A-Za-z0-9._~:/?#@!\$&'()*+,;=%-]+\$"
         if [[ ! "$url" =~ $url_re ]]; then
             return
         fi
 
-        # Check HTTP status (no output, no body)
         status="$(curl -s -o /dev/null -w '%{http_code}' -- "$url")"
 
-        # Only update when status is 2xx
         case "$status" in
             2??)
                 export CHECKED_URL="$url"
@@ -143,7 +131,6 @@ for yaml_file in ${FILES}; do
         esac
     }
 
-    # Read package details
     name=$(yq eval '.package.name' "$yaml_file")
     registry=$(yq eval '.package.registry' "$yaml_file")
     current_version=$(yq eval '.package.version' "$yaml_file")
@@ -151,7 +138,6 @@ for yaml_file in ${FILES}; do
     if [ -z "$name" ] || [ -z "$registry" ]; then
         echo "${yaml_file}: Package name and/or registry are missing in the YAML file."
     else
-        # Get latest version
         latest_version=$(get_latest_version "$name" "$registry" || echo "Could not fetch version.")
 
         if [ "$latest_version" == "Could not fetch version." ]; then

--- a/.github/workflows/auto-update-registry.yml
+++ b/.github/workflows/auto-update-registry.yml
@@ -22,9 +22,11 @@ jobs:
     if: github.repository == 'open-telemetry/opentelemetry.io'
     steps:
       - name: Checkout
+        id: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # The push credential is scoped to the auto-update step below.
+          # The push credential is scoped to the update script's push (see
+          # update-registry-versions.sh).
           persist-credentials: false
           # Full history, so that link-check config generation can diff
           # content against the drift-status baseline commit. (Simpler than
@@ -63,9 +65,6 @@ jobs:
 
       - name: Auto-update
         run: |
-          # Just-in-time push credential: authenticate the remote with the App
-          # token only for this step; the cleanup step below removes it.
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           .github/scripts/update-registry-versions.sh
         env:
           # Two tokens, one per consumer:
@@ -76,8 +75,11 @@ jobs:
           # workflow's `permissions`.
           GITHUB_TOKEN: ${{ github.token }}
 
+      # Failsafe: the script resets the remote after its push, but not when it
+      # aborts in between.
       - name: Remove push credential
-        if: always()
+        if: always() && steps.checkout.outcome == 'success'
+        continue-on-error: true
         run:
           git remote set-url origin
           "https://github.com/${GITHUB_REPOSITORY}.git"

--- a/.github/workflows/auto-update-registry.yml
+++ b/.github/workflows/auto-update-registry.yml
@@ -6,7 +6,8 @@ on:
     # At 04:31, every day
     - cron: 31 4 * * *
 
-permissions: read-all
+permissions:
+  contents: read
 
 # Overlapping runs would race the script's existing-PR check.
 concurrency:
@@ -17,14 +18,14 @@ jobs:
   auto-update:
     name: Auto-update registry versions
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     # Remove the if statement below when testing against a fork
     if: github.repository == 'open-telemetry/opentelemetry.io'
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # The push credential is scoped to the auto-update step below.
+          persist-credentials: false
           # Full history, so that link-check config generation can diff
           # content against the drift-status baseline commit. (Simpler than
           # check-links.yml's targeted deepen; clone cost is immaterial in a
@@ -55,18 +56,31 @@ jobs:
         with:
           client-id: ${{ vars.OTELBOT_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          # Scope the token to what the auto-update script needs: push the
+          # update branch, then open its PR.
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Auto-update
         run: |
+          # Just-in-time push credential: authenticate the remote with the App
+          # token only for this step; the cleanup step below removes it.
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           .github/scripts/update-registry-versions.sh
         env:
           # Two tokens, one per consumer:
           #
-          # `gh` calls run as otelbot via the App token.
+          # The branch push and `gh` calls run as otelbot via the App token.
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
-          # Default workflow token, for the link checker; its scope comes from
-          # the job's `permissions`.
+          # Default workflow token, for the link checker; read-only per the
+          # workflow's `permissions`.
           GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Remove push credential
+        if: always()
+        run:
+          git remote set-url origin
+          "https://github.com/${GITHUB_REPOSITORY}.git"
 
   report-failure:
     needs: auto-update

--- a/.github/workflows/auto-update-registry.yml
+++ b/.github/workflows/auto-update-registry.yml
@@ -51,8 +51,10 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
-          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          # The docs App has contents permission; the base otelbot App does
+          # not, so it cannot mint the push credential this job requires.
+          client-id: ${{ vars.OTELBOT_DOCS_CLIENT_ID }}
+          private-key: ${{ secrets.OTELBOT_DOCS_PRIVATE_KEY }}
           # Scope the token to what the auto-update script needs: push the
           # update branch, then open its PR.
           permission-contents: write
@@ -64,7 +66,7 @@ jobs:
         env:
           # Separate tokens for write operations and link checking:
           #
-          # The branch push and `gh` calls run as otelbot via the App token.
+          # The branch push and `gh` calls run as otelbot-docs via the App token.
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
           # Default workflow token, for the link checker; read-only per the
           # workflow's `permissions`.

--- a/.github/workflows/auto-update-registry.yml
+++ b/.github/workflows/auto-update-registry.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           .github/scripts/update-registry-versions.sh
         env:
-          # Two tokens, one per consumer:
+          # Separate tokens for write operations and link checking:
           #
           # The branch push and `gh` calls run as otelbot via the App token.
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}

--- a/.github/workflows/auto-update-registry.yml
+++ b/.github/workflows/auto-update-registry.yml
@@ -6,8 +6,7 @@ on:
     # At 04:31, every day
     - cron: 31 4 * * *
 
-permissions:
-  contents: read
+permissions: { contents: read }
 
 # Overlapping runs would race the script's existing-PR check.
 concurrency:
@@ -22,16 +21,12 @@ jobs:
     if: github.repository == 'open-telemetry/opentelemetry.io'
     steps:
       - name: Checkout
-        id: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # The push credential is scoped to the update script's push (see
           # update-registry-versions.sh).
           persist-credentials: false
-          # Full history, so that link-check config generation can diff
-          # content against the drift-status baseline commit. (Simpler than
-          # check-links.yml's targeted deepen; clone cost is immaterial in a
-          # daily job.)
+          # Full history needed for drift-status baseline commit.
           fetch-depth: 0
 
       - name: Use CLA approved github bot
@@ -74,15 +69,6 @@ jobs:
           # Default workflow token, for the link checker; read-only per the
           # workflow's `permissions`.
           GITHUB_TOKEN: ${{ github.token }}
-
-      # Failsafe: the script resets the remote after its push, but not when it
-      # aborts in between.
-      - name: Remove push credential
-        if: always() && steps.checkout.outcome == 'success'
-        continue-on-error: true
-        run:
-          git remote set-url origin
-          "https://github.com/${GITHUB_REPOSITORY}.git"
 
   report-failure:
     needs: auto-update

--- a/.github/workflows/auto-update-registry.yml
+++ b/.github/workflows/auto-update-registry.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # The push credential is scoped to the update script's push (see
-          # update-registry-versions.sh).
+          # Disable checkout's default auth: it would supply the push's
+          # Authorization header instead of the script's App-token helper.
           persist-credentials: false
           # Full history needed for drift-status baseline commit.
           fetch-depth: 0

--- a/.github/workflows/auto-update-registry.yml
+++ b/.github/workflows/auto-update-registry.yml
@@ -51,12 +51,10 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          # The docs App has contents permission; the base otelbot App does
-          # not, so it cannot mint the push credential this job requires.
+          # The base otelbot App lacks contents permission; use the
+          # push-capable docs App.
           client-id: ${{ vars.OTELBOT_DOCS_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_DOCS_PRIVATE_KEY }}
-          # Scope the token to what the auto-update script needs: push the
-          # update branch, then open its PR.
           permission-contents: write
           permission-pull-requests: write
 


### PR DESCRIPTION
- Contributes to #11289
- **Removes persisted write authentication**:
  - Runs checkout and setup under the read-only workflow token
  - Keeps write credentials out of repository config and off disk
- **Scopes App-token use**:
  - Uses the established push-capable `otelbot-docs` App; registry PR authorship changes from `otelbot` to `otelbot-docs`
  - Mints its repository-scoped token immediately before the auto-update step
  - Removes it from direct npm child environments and supplies it to Git only through a github.com-scoped helper on the push
- **Treats registry responses as data**:
  - Prevents registry-controlled values from extending jq/yq expressions
  - Restricts recorded metadata links to ASCII HTTPS URLs
- **Requires live verification**:
  - PR checks validate the workflow and script but cannot exercise publication
  - A reviewed post-merge `workflow_dispatch` with a forced-stale registry entry exercises the push path

