### PR TITLE
ci: retry the Hugo-binary fetch with bounded backoff

### DIFF
--- a/.cspell/en-words.txt
+++ b/.cspell/en-words.txt
@@ -65,5 +65,6 @@ undercounts
 unitless
 unsampled
 unshallow
+unstaffed
 upstreamed
 upstreaming

--- a/content/en/site/build/dependencies.md
+++ b/content/en/site/build/dependencies.md
@@ -15,7 +15,8 @@ CI, the devcontainer, and Netlify install lock-exact and script-free, then
 explicitly re-enable the one reviewed hook: the `hugo-extended` rebuild that
 fetches the pinned Hugo binary. The rebuild runs through
 `scripts/rebuild-hugo-extended.mjs`, which retries the fetch with bounded
-backoff. Per environment:
+backoff and refuses to run while any `HUGO_*` installer override is set. Per
+environment:
 
 - **CI**: `npm run ci:min`; jobs that build the site follow with
   `npm run ci:prepare`.

--- a/content/en/site/build/dependencies.md
+++ b/content/en/site/build/dependencies.md
@@ -40,8 +40,10 @@ invokes Docsy's own lock-exact, script-free theme-dependency install.
 Netlify keeps a build cache per [deploy context][]:
 
 - One for production
-- One per already-built PR, seeded from the production cache on the PR's first
-  build.
+- One per **head branch name** for Deploy Previews, seeded from the production
+  cache on the name's first build. Cache lineages die only by explicit clear:
+  branch deletion is invisible to Netlify, so a branch recreated under the same
+  name -- recycled bot-branch names included -- re-attaches to the old cache.
 
 Each cache [includes a clone of the repository][], and checking out a commit
 that drops a git submodule leaves the submodule's working tree in place, so a
@@ -53,15 +55,17 @@ Clear the affected [build cache][] rather than adding the path to `.gitignore`:
 
 - **Production**:
   - Clear cache and deploy site, under **Deploys** > **Trigger deploy**.
-- **Deploy Previews**: each already-built PR holds its own cache copy, untouched
-  by a production clear after the fact.
+- **Deploy Previews**: each already-built branch holds its own cache copy,
+  untouched by a production clear after the fact.
   - Clear it from the PR's latest deploy page with **Retry** > **Clear cache and
-    retry with latest branch commit**. There is no bulk clear across PRs.
+    retry with latest branch commit**. There is no bulk clear across branches.
 
 > [!IMPORTANT]
 >
 > After removing a git submodule, clear the production build cache as part of
-> the removal, before the residue seeds per-PR caches.
+> the removal, before the residue seeds per-branch caches -- and clear the
+> lineage of any recycled bot-branch name, which a production clear never
+> reaches.
 
 ## Updating dependencies {#updating}
 

--- a/content/en/site/build/dependencies.md
+++ b/content/en/site/build/dependencies.md
@@ -14,8 +14,8 @@ these controls, see [Supply-chain security][].
 CI, the devcontainer, and Netlify install lock-exact and script-free, then
 explicitly re-enable the one reviewed hook: the `hugo-extended` rebuild that
 fetches the pinned Hugo binary. The rebuild runs through
-`scripts/rebuild-hugo-extended.mjs`, which retries transient binary-fetch
-failures with bounded backoff. Per environment:
+`scripts/rebuild-hugo-extended.mjs`, which retries failed binary fetches with
+bounded backoff. Per environment:
 
 - **CI**: `npm run ci:min`; jobs that build the site follow with
   `npm run ci:prepare`.

--- a/content/en/site/build/dependencies.md
+++ b/content/en/site/build/dependencies.md
@@ -13,7 +13,9 @@ these controls, see [Supply-chain security][].
 
 CI, the devcontainer, and Netlify install lock-exact and script-free, then
 explicitly re-enable the one reviewed hook: the `hugo-extended` rebuild that
-fetches the pinned Hugo binary. Per environment:
+fetches the pinned Hugo binary. The rebuild runs through
+`scripts/rebuild-hugo-extended.mjs`, which retries transient binary-fetch
+failures with bounded backoff. Per environment:
 
 - **CI**: `npm run ci:min`; jobs that build the site follow with
   `npm run ci:prepare`.

--- a/content/en/site/build/dependencies.md
+++ b/content/en/site/build/dependencies.md
@@ -14,8 +14,8 @@ these controls, see [Supply-chain security][].
 CI, the devcontainer, and Netlify install lock-exact and script-free, then
 explicitly re-enable the one reviewed hook: the `hugo-extended` rebuild that
 fetches the pinned Hugo binary. The rebuild runs through
-`scripts/rebuild-hugo-extended.mjs`, which retries failed binary fetches with
-bounded backoff. Per environment:
+`scripts/rebuild-hugo-extended.mjs`, which retries the fetch with bounded
+backoff. Per environment:
 
 - **CI**: `npm run ci:min`; jobs that build the site follow with
   `npm run ci:prepare`.
@@ -43,7 +43,7 @@ Netlify keeps a build cache per [deploy context][]:
 - One per **head branch name** for Deploy Previews, seeded from the production
   cache on the name's first build. Cache lineages die only by explicit clear:
   branch deletion is invisible to Netlify, so a branch recreated under the same
-  name -- recycled bot-branch names included -- re-attaches to the old cache.
+  name (recycled bot-branch names included) re-attaches to the old cache.
 
 Each cache [includes a clone of the repository][], and checking out a commit
 that drops a git submodule leaves the submodule's working tree in place, so a
@@ -63,9 +63,8 @@ Clear the affected [build cache][] rather than adding the path to `.gitignore`:
 > [!IMPORTANT]
 >
 > After removing a git submodule, clear the production build cache as part of
-> the removal, before the residue seeds per-branch caches -- and clear the
-> lineage of any recycled bot-branch name, which a production clear never
-> reaches.
+> the removal, before the residue seeds per-branch caches. Also clear the
+> lineage of any recycled bot-branch name; a production clear never reaches it.
 
 ## Updating dependencies {#updating}
 

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "check:text": "npm run _check:text -- ",
     "check": "CMD_SKIP=collector-sync npm run check:all",
     "ci:min": "npm ci --ignore-scripts --omit=optional",
-    "ci:prepare": "npm rebuild --ignore-scripts=false hugo-extended && npm run prepare",
+    "ci:prepare": "node scripts/rebuild-hugo-extended.mjs && npm run prepare",
     "clean": "make clean",
     "code-excerpts": "node -e 'console.error(\"\\x1b[31mWARNING: THIS IS A DEPRECATED ALIAS, instead use: `fix:code-excerpts` or `check:code-excerpts`\\x1b[0m\")' && npm run fix:code-excerpts --",
     "cp:spec": "scripts/content-modules/cp-pages.sh",

--- a/scripts/rebuild-hugo-extended.mjs
+++ b/scripts/rebuild-hugo-extended.mjs
@@ -1,8 +1,8 @@
 // Retrying wrapper around `npm rebuild hugo-extended`: the rebuild fetches
 // the pinned Hugo binary from GitHub releases on every clean install, and
 // transient fetch failures ("Hugo installation failed" / "TypeError: fetch
-// failed") otherwise fail whole Netlify deploys. Bounded backoff; refuses
-// hugo-extended installer env overrides so the rebuild stays pinned.
+// failed") otherwise fail whole Netlify deploys. Refuses hugo-extended
+// installer env overrides so the rebuild stays pinned.
 
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';

--- a/scripts/rebuild-hugo-extended.mjs
+++ b/scripts/rebuild-hugo-extended.mjs
@@ -84,6 +84,8 @@ export async function rebuildHugoExtended({
     return rebuild();
   }
   const attemptCount = RETRY_DELAYS_SECONDS.length;
+  // Retries are cause-blind by design: classifying npm/installer output is
+  // brittle, and the bounded budget adds at most ~17s to a failing build.
   for (const [index, delay] of RETRY_DELAYS_SECONDS.entries()) {
     if (delay > 0) {
       log(`Retrying Hugo install in ${delay}s...`);

--- a/scripts/rebuild-hugo-extended.mjs
+++ b/scripts/rebuild-hugo-extended.mjs
@@ -26,7 +26,9 @@ export function runNpmRebuild({
   error = console.error,
   spawn = spawnSync,
 } = {}) {
-  const npmExecPath = env.npm_execpath;
+  // Trimmed: a whitespace-only value is as deterministic a failure as a
+  // missing one, and must not consume the retry budget.
+  const npmExecPath = env.npm_execpath?.trim();
   if (!npmExecPath) {
     error('npm_execpath is unavailable; run this helper through npm');
     return 1;
@@ -62,7 +64,7 @@ export async function rebuildHugoExtended({
   }
 
   const rebuild = run ?? (() => runNpmRebuild({ env, error }));
-  if (!run && !env.npm_execpath) {
+  if (!run && !env.npm_execpath?.trim()) {
     // Fail before the retry loop: a missing npm CLI path is deterministic.
     return rebuild();
   }

--- a/scripts/rebuild-hugo-extended.mjs
+++ b/scripts/rebuild-hugo-extended.mjs
@@ -21,6 +21,14 @@ export const UNSAFE_HUGO_ENV = [
   'HUGO_SKIP_VERIFY',
 ];
 
+// Deterministic misconfigurations must not consume the retry budget: an
+// unset, whitespace-only, or nonexistent npm CLI path fails on the first
+// attempt.
+const npmCliPath = (env) => {
+  const cliPath = env.npm_execpath?.trim();
+  return cliPath && fs.existsSync(cliPath) ? cliPath : undefined;
+};
+
 export function runNpmRebuild({
   env = process.env,
   error = console.error,
@@ -28,7 +36,7 @@ export function runNpmRebuild({
 } = {}) {
   // Trimmed: a whitespace-only value is as deterministic a failure as a
   // missing one, and must not consume the retry budget.
-  const npmExecPath = env.npm_execpath?.trim();
+  const npmExecPath = npmCliPath(env);
   if (!npmExecPath) {
     error('npm_execpath is unavailable; run this helper through npm');
     return 1;
@@ -71,7 +79,7 @@ export async function rebuildHugoExtended({
   }
 
   const rebuild = run ?? (() => runNpmRebuild({ env, error }));
-  if (!run && !env.npm_execpath?.trim()) {
+  if (!run && !npmCliPath(env)) {
     // Fail before the retry loop: a missing npm CLI path is deterministic.
     return rebuild();
   }

--- a/scripts/rebuild-hugo-extended.mjs
+++ b/scripts/rebuild-hugo-extended.mjs
@@ -1,0 +1,91 @@
+// Retrying wrapper around `npm rebuild hugo-extended`: the rebuild fetches
+// the pinned Hugo binary from GitHub releases on every clean install, and
+// transient fetch failures ("Hugo installation failed" / "TypeError: fetch
+// failed") otherwise fail whole Netlify deploys. Bounded backoff; refuses
+// hugo-extended installer env overrides so the rebuild stays pinned.
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
+
+export const RETRY_DELAYS_SECONDS = [0, 2, 5, 10];
+export const UNSAFE_HUGO_ENV = [
+  'HUGO_BIN_PATH',
+  'HUGO_FORCE_STANDARD',
+  'HUGO_MIRROR_BASE_URL',
+  'HUGO_NO_EXTENDED',
+  'HUGO_OVERRIDE_VERSION',
+  'HUGO_SKIP_CHECKSUM',
+  'HUGO_SKIP_DOWNLOAD',
+  'HUGO_SKIP_VERIFY',
+];
+
+export function runNpmRebuild({
+  env = process.env,
+  error = console.error,
+  spawn = spawnSync,
+} = {}) {
+  const npmExecPath = env.npm_execpath;
+  if (!npmExecPath) {
+    error('npm_execpath is unavailable; run this helper through npm');
+    return 1;
+  }
+
+  // Use npm's JavaScript CLI directly so no command shell is involved.
+  const result = spawn(
+    process.execPath,
+    [npmExecPath, 'rebuild', 'hugo-extended', '--ignore-scripts=false'],
+    { env, stdio: 'inherit' },
+  );
+  if (result.error) {
+    error(`Unable to start the Hugo rebuild: ${result.error.message}`);
+  }
+  return result.status ?? 1;
+}
+
+export async function rebuildHugoExtended({
+  env = process.env,
+  error = console.error,
+  log = console.log,
+  run,
+  wait = (delay) => sleep(delay * 1000),
+} = {}) {
+  // Canonical-name lookups suffice on Windows: process.env access is
+  // case-insensitive there (Node semantics), the same folding the
+  // installer sees. Empty string matches the installer's falsy handling.
+  for (const name of UNSAFE_HUGO_ENV) {
+    if ((env[name] ?? '') !== '') {
+      error(`${name} must be unset for the pinned Hugo rebuild`);
+      return 1;
+    }
+  }
+
+  const rebuild = run ?? (() => runNpmRebuild({ env, error }));
+  if (!run && !env.npm_execpath) {
+    // Fail before the retry loop: a missing npm CLI path is deterministic.
+    return rebuild();
+  }
+  const attemptCount = RETRY_DELAYS_SECONDS.length;
+  for (const [index, delay] of RETRY_DELAYS_SECONDS.entries()) {
+    if (delay > 0) {
+      log(`Retrying Hugo install in ${delay}s...`);
+      await wait(delay);
+    }
+
+    log(`Hugo install attempt ${index + 1}/${attemptCount}`);
+    if (rebuild() === 0) return 0;
+  }
+
+  error(`Hugo install failed after ${attemptCount} attempts`);
+  return 1;
+}
+
+// Realpaths on both sides so a symlinked invocation can't silently no-op;
+// importing this module never runs the rebuild. No try/catch: an
+// entry-time realpath throw must crash loud, not exit 0.
+const isMain =
+  Boolean(process.argv[1]) &&
+  fs.realpathSync(process.argv[1]) ===
+    fs.realpathSync(fileURLToPath(import.meta.url));
+if (isMain) process.exitCode = await rebuildHugoExtended();

--- a/scripts/rebuild-hugo-extended.mjs
+++ b/scripts/rebuild-hugo-extended.mjs
@@ -43,6 +43,13 @@ export function runNpmRebuild({
   if (result.error) {
     error(`Unable to start the Hugo rebuild: ${result.error.message}`);
   }
+  // Report terminations so a killed attempt is never silent; it stays
+  // retryable: an attempt-scoped kill (e.g. the OOM killer picking the npm
+  // child) is as recoverable as a failed fetch, and a build cancellation
+  // signals this wrapper too.
+  if (result.signal) {
+    error(`The Hugo rebuild attempt was terminated by ${result.signal}`);
+  }
   return result.status ?? 1;
 }
 

--- a/scripts/rebuild-hugo-extended.test.mjs
+++ b/scripts/rebuild-hugo-extended.test.mjs
@@ -107,6 +107,22 @@ test('npm rebuild reports a signal-terminated attempt', () => {
   );
 });
 
+test('npm rebuild reports a failure to start', () => {
+  const errors = [];
+  const status = runNpmRebuild({
+    env: { npm_execpath: '/npm/bin/npm-cli.js' },
+    error: (message) => errors.push(message),
+    spawn: () => ({ error: new Error('ENOENT'), status: null }),
+  });
+
+  assert.equal(status, 1, 'a failed start returns nonzero');
+  assert.deepEqual(
+    errors,
+    ['Unable to start the Hugo rebuild: ENOENT'],
+    'the start failure is reported',
+  );
+});
+
 test('Hugo rebuild retries with backoff until it succeeds', async () => {
   const { attempts, errors, logs, status, waited } = await runProbe(3);
 
@@ -196,19 +212,22 @@ test('helper entry point runs the default npm rebuild', () => {
 
   const env = { ...process.env, npm_execpath: recorder };
   for (const name of expectedUnsafeHugoEnv) delete env[name];
-  const result = spawnSync(process.execPath, [helperPath], {
-    encoding: 'utf8',
-    env,
-  });
-  const recorded = JSON.parse(readFileSync(argvFile, 'utf8'));
-  rmSync(tmp, { recursive: true, force: true });
-
-  assert.equal(
-    result.status,
-    0,
-    `entry point exits successfully: ${result.stderr}`,
-  );
-  assert.match(result.stdout, /Hugo install attempt 1\/4/);
+  let recorded;
+  try {
+    const result = spawnSync(process.execPath, [helperPath], {
+      encoding: 'utf8',
+      env,
+    });
+    assert.equal(
+      result.status,
+      0,
+      `entry point exits successfully: ${result.stderr}`,
+    );
+    assert.match(result.stdout, /Hugo install attempt 1\/4/);
+    recorded = JSON.parse(readFileSync(argvFile, 'utf8'));
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
   assert.deepEqual(
     recorded,
     ['rebuild', 'hugo-extended', '--ignore-scripts=false'],

--- a/scripts/rebuild-hugo-extended.test.mjs
+++ b/scripts/rebuild-hugo-extended.test.mjs
@@ -1,0 +1,200 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import {
+  RETRY_DELAYS_SECONDS,
+  UNSAFE_HUGO_ENV,
+  rebuildHugoExtended,
+  runNpmRebuild,
+} from './rebuild-hugo-extended.mjs';
+
+const helperPath = fileURLToPath(
+  new URL('rebuild-hugo-extended.mjs', import.meta.url),
+);
+
+// Deliberately literal: the content pin for the helper's UNSAFE_HUGO_ENV
+// export, which the supply-chain audit imports; a name dropped there
+// goes red here.
+const expectedUnsafeHugoEnv = [
+  'HUGO_BIN_PATH',
+  'HUGO_FORCE_STANDARD',
+  'HUGO_MIRROR_BASE_URL',
+  'HUGO_NO_EXTENDED',
+  'HUGO_OVERRIDE_VERSION',
+  'HUGO_SKIP_CHECKSUM',
+  'HUGO_SKIP_DOWNLOAD',
+  'HUGO_SKIP_VERIFY',
+];
+
+async function runProbe(succeedAt, env = {}) {
+  const attempts = [];
+  const errors = [];
+  const logs = [];
+  const waited = [];
+  const status = await rebuildHugoExtended({
+    env,
+    error: (message) => errors.push(message),
+    log: (message) => logs.push(message),
+    run: () => {
+      attempts.push(attempts.length + 1);
+      return attempts.length >= succeedAt ? 0 : 1;
+    },
+    wait: async (delay) => waited.push(delay),
+  });
+  return { attempts, errors, logs, status, waited };
+}
+
+test('Hugo rebuild policy is bounded and rejects installer controls', () => {
+  assert.deepEqual(
+    RETRY_DELAYS_SECONDS,
+    [0, 2, 5, 10],
+    'retry delays define four bounded attempts',
+  );
+  assert.deepEqual(
+    UNSAFE_HUGO_ENV,
+    expectedUnsafeHugoEnv,
+    'unsafe Hugo controls stay complete',
+  );
+});
+
+test('npm rebuild uses the current npm CLI and exact arguments', () => {
+  const env = { npm_execpath: '/npm/bin/npm-cli.js' };
+  const calls = [];
+  const status = runNpmRebuild({
+    env,
+    spawn(file, args, options) {
+      calls.push({ args, file, options });
+      return { status: 0 };
+    },
+  });
+
+  assert.equal(status, 0, 'successful npm rebuild returns zero');
+  assert.deepEqual(
+    calls,
+    [
+      {
+        args: [
+          '/npm/bin/npm-cli.js',
+          'rebuild',
+          'hugo-extended',
+          '--ignore-scripts=false',
+        ],
+        file: process.execPath,
+        options: { env, stdio: 'inherit' },
+      },
+    ],
+    'rebuild runs the locked package through the current npm CLI',
+  );
+});
+
+test('Hugo rebuild retries with backoff until it succeeds', async () => {
+  const { attempts, errors, logs, status, waited } = await runProbe(3);
+
+  assert.equal(status, 0, 'retry policy returns zero after success');
+  assert.deepEqual(attempts, [1, 2, 3], 'retry policy stops after success');
+  assert.deepEqual(waited, [2, 5], 'retry policy uses the first two delays');
+  assert.deepEqual(errors, [], 'successful retry policy reports no errors');
+  assert.ok(
+    logs.includes('Hugo install attempt 3/4'),
+    'successful attempt is logged',
+  );
+});
+
+test('Hugo rebuild fails after four attempts', async () => {
+  const { attempts, errors, status, waited } = await runProbe(5);
+
+  assert.equal(status, 1, 'exhausted retry policy returns nonzero');
+  assert.deepEqual(attempts, [1, 2, 3, 4], 'retry policy makes four attempts');
+  assert.deepEqual(waited, [2, 5, 10], 'retry policy uses every delay');
+  assert.deepEqual(
+    errors,
+    ['Hugo install failed after 4 attempts'],
+    'retry exhaustion is reported',
+  );
+});
+
+test('Hugo rebuild rejects installer control variables', async () => {
+  for (const name of expectedUnsafeHugoEnv) {
+    const { attempts, errors, status, waited } = await runProbe(1, {
+      [name]: '1',
+    });
+
+    assert.equal(status, 1, `${name} returns nonzero`);
+    assert.deepEqual(attempts, [], `${name} permits no rebuild attempt`);
+    assert.deepEqual(waited, [], `${name} permits no retry wait`);
+    assert.deepEqual(
+      errors,
+      [`${name} must be unset for the pinned Hugo rebuild`],
+      `${name} rejection is reported`,
+    );
+  }
+});
+
+test('Hugo rebuild treats an empty control variable as unset', async () => {
+  // Pins the documented carve-out: empty string matches the installer's
+  // falsy handling, so it must not trip the screen.
+  const { attempts, errors, status } = await runProbe(1, {
+    HUGO_SKIP_DOWNLOAD: '',
+  });
+
+  assert.equal(status, 0, 'an empty control variable permits the rebuild');
+  assert.deepEqual(attempts, [1], 'the rebuild runs once');
+  assert.deepEqual(errors, [], 'no rejection is reported');
+});
+
+test('Hugo rebuild fails fast without the npm CLI path', async () => {
+  const errors = [];
+  const status = await rebuildHugoExtended({
+    env: {},
+    error: (message) => errors.push(message),
+    log: () => {},
+    wait: () => assert.fail('a missing npm CLI path permits no retry wait'),
+  });
+
+  assert.equal(status, 1, 'missing npm CLI path returns nonzero');
+  assert.deepEqual(
+    errors,
+    ['npm_execpath is unavailable; run this helper through npm'],
+    'missing npm CLI path is reported once',
+  );
+});
+
+// End-to-end: the entry point fires and the default rebuild reaches npm's
+// CLI with the exact argument vector, proving the wiring the in-memory
+// policy tests bypass.
+test('helper entry point runs the default npm rebuild', () => {
+  const tmp = mkdtempSync(path.join(os.tmpdir(), 'otel-hugo-entry-'));
+  const recorder = path.join(tmp, 'fake-npm-cli.js');
+  const argvFile = path.join(tmp, 'argv.json');
+  writeFileSync(
+    recorder,
+    `require('node:fs').writeFileSync(${JSON.stringify(argvFile)},` +
+      ` JSON.stringify(process.argv.slice(2)));`,
+  );
+
+  const env = { ...process.env, npm_execpath: recorder };
+  for (const name of expectedUnsafeHugoEnv) delete env[name];
+  const result = spawnSync(process.execPath, [helperPath], {
+    encoding: 'utf8',
+    env,
+  });
+  const recorded = JSON.parse(readFileSync(argvFile, 'utf8'));
+  rmSync(tmp, { recursive: true, force: true });
+
+  assert.equal(
+    result.status,
+    0,
+    `entry point exits successfully: ${result.stderr}`,
+  );
+  assert.match(result.stdout, /Hugo install attempt 1\/4/);
+  assert.deepEqual(
+    recorded,
+    ['rebuild', 'hugo-extended', '--ignore-scripts=false'],
+    'entry point drives the exact targeted rebuild through the npm CLI',
+  );
+});

--- a/scripts/rebuild-hugo-extended.test.mjs
+++ b/scripts/rebuild-hugo-extended.test.mjs
@@ -92,13 +92,29 @@ test('npm rebuild uses the current npm CLI and exact arguments', () => {
   );
 });
 
+test('npm rebuild reports a signal-terminated attempt', () => {
+  const errors = [];
+  const status = runNpmRebuild({
+    env: { npm_execpath: '/npm/bin/npm-cli.js' },
+    error: (message) => errors.push(message),
+    spawn: () => ({ status: null, signal: 'SIGTERM' }),
+  });
+
+  assert.equal(status, 1, 'a terminated attempt returns nonzero');
+  assert.deepEqual(
+    errors,
+    ['The Hugo rebuild attempt was terminated by SIGTERM'],
+    'the termination is reported',
+  );
+});
+
 test('Hugo rebuild retries with backoff until it succeeds', async () => {
   const { attempts, errors, logs, status, waited } = await runProbe(3);
 
   assert.equal(status, 0, 'retry policy returns zero after success');
   assert.deepEqual(attempts, [1, 2, 3], 'retry policy stops after success');
   assert.deepEqual(waited, [2, 5], 'retry policy uses the first two delays');
-  assert.deepEqual(errors, [], 'successful retry policy reports no errors');
+  assert.deepEqual(errors, [], 'the error log stays empty on success');
   assert.ok(
     logs.includes('Hugo install attempt 3/4'),
     'successful attempt is logged',
@@ -125,8 +141,8 @@ test('Hugo rebuild rejects installer control variables', async () => {
     });
 
     assert.equal(status, 1, `${name} returns nonzero`);
-    assert.deepEqual(attempts, [], `${name} permits no rebuild attempt`);
-    assert.deepEqual(waited, [], `${name} permits no retry wait`);
+    assert.deepEqual(attempts, [], `attempts stay empty under ${name}`);
+    assert.deepEqual(waited, [], `waits stay empty under ${name}`);
     assert.deepEqual(
       errors,
       [`${name} must be unset for the pinned Hugo rebuild`],
@@ -144,7 +160,7 @@ test('Hugo rebuild treats an empty control variable as unset', async () => {
 
   assert.equal(status, 0, 'an empty control variable permits the rebuild');
   assert.deepEqual(attempts, [1], 'the rebuild runs once');
-  assert.deepEqual(errors, [], 'no rejection is reported');
+  assert.deepEqual(errors, [], 'the error log stays empty');
 });
 
 test('Hugo rebuild fails fast without the npm CLI path', async () => {
@@ -155,7 +171,7 @@ test('Hugo rebuild fails fast without the npm CLI path', async () => {
       env: npmExecPath === undefined ? {} : { npm_execpath: npmExecPath },
       error: (message) => errors.push(message),
       log: () => {},
-      wait: () => assert.fail('a missing npm CLI path permits no retry wait'),
+      wait: () => assert.fail('the helper returns before the first retry wait'),
     });
 
     assert.equal(status, 1, 'missing npm CLI path returns nonzero');

--- a/scripts/rebuild-hugo-extended.test.mjs
+++ b/scripts/rebuild-hugo-extended.test.mjs
@@ -148,20 +148,23 @@ test('Hugo rebuild treats an empty control variable as unset', async () => {
 });
 
 test('Hugo rebuild fails fast without the npm CLI path', async () => {
-  const errors = [];
-  const status = await rebuildHugoExtended({
-    env: {},
-    error: (message) => errors.push(message),
-    log: () => {},
-    wait: () => assert.fail('a missing npm CLI path permits no retry wait'),
-  });
+  // Whitespace-only is as unavailable as unset: both fail once, no retries.
+  for (const npmExecPath of [undefined, '   ']) {
+    const errors = [];
+    const status = await rebuildHugoExtended({
+      env: npmExecPath === undefined ? {} : { npm_execpath: npmExecPath },
+      error: (message) => errors.push(message),
+      log: () => {},
+      wait: () => assert.fail('a missing npm CLI path permits no retry wait'),
+    });
 
-  assert.equal(status, 1, 'missing npm CLI path returns nonzero');
-  assert.deepEqual(
-    errors,
-    ['npm_execpath is unavailable; run this helper through npm'],
-    'missing npm CLI path is reported once',
-  );
+    assert.equal(status, 1, 'missing npm CLI path returns nonzero');
+    assert.deepEqual(
+      errors,
+      ['npm_execpath is unavailable; run this helper through npm'],
+      'missing npm CLI path is reported once',
+    );
+  }
 });
 
 // End-to-end: the entry point fires and the default rebuild reaches npm's

--- a/scripts/rebuild-hugo-extended.test.mjs
+++ b/scripts/rebuild-hugo-extended.test.mjs
@@ -62,7 +62,8 @@ test('Hugo rebuild policy is bounded and rejects installer controls', () => {
 });
 
 test('npm rebuild uses the current npm CLI and exact arguments', () => {
-  const env = { npm_execpath: '/npm/bin/npm-cli.js' };
+  // Any existing file stands in for the npm CLI; spawn is mocked.
+  const env = { npm_execpath: helperPath };
   const calls = [];
   const status = runNpmRebuild({
     env,
@@ -78,7 +79,7 @@ test('npm rebuild uses the current npm CLI and exact arguments', () => {
     [
       {
         args: [
-          '/npm/bin/npm-cli.js',
+          helperPath,
           'rebuild',
           'hugo-extended',
           '--ignore-scripts=false',
@@ -94,7 +95,7 @@ test('npm rebuild uses the current npm CLI and exact arguments', () => {
 test('npm rebuild reports a signal-terminated attempt', () => {
   const errors = [];
   const status = runNpmRebuild({
-    env: { npm_execpath: '/npm/bin/npm-cli.js' },
+    env: { npm_execpath: helperPath },
     error: (message) => errors.push(message),
     spawn: () => ({ status: null, signal: 'SIGTERM' }),
   });
@@ -110,7 +111,7 @@ test('npm rebuild reports a signal-terminated attempt', () => {
 test('npm rebuild reports a failure to start', () => {
   const errors = [];
   const status = runNpmRebuild({
-    env: { npm_execpath: '/npm/bin/npm-cli.js' },
+    env: { npm_execpath: helperPath },
     error: (message) => errors.push(message),
     spawn: () => ({ error: new Error('ENOENT'), status: null }),
   });
@@ -178,8 +179,8 @@ test('Hugo rebuild treats an empty control variable as unset', async () => {
 });
 
 test('Hugo rebuild fails fast without the npm CLI path', async () => {
-  // Whitespace-only is as unavailable as unset.
-  for (const npmExecPath of [undefined, '   ']) {
+  // Whitespace-only or nonexistent is as unavailable as unset.
+  for (const npmExecPath of [undefined, '   ', '/no/such/npm-cli.js']) {
     const errors = [];
     const status = await rebuildHugoExtended({
       env: npmExecPath === undefined ? {} : { npm_execpath: npmExecPath },

--- a/scripts/rebuild-hugo-extended.test.mjs
+++ b/scripts/rebuild-hugo-extended.test.mjs
@@ -1,6 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -29,6 +35,41 @@ const expectedUnsafeHugoEnv = [
   'HUGO_SKIP_DOWNLOAD',
   'HUGO_SKIP_VERIFY',
 ];
+
+// The installer's env surface, verified against the installed package:
+// every HUGO_* token in hugo-extended is either a screened control or a
+// reviewed non-control, so an update:hugo bump that adds a knob goes red
+// here instead of silently escaping the screen.
+test('UNSAFE_HUGO_ENV covers the installed installer env surface', () => {
+  // Log-only controls, plus a comment-only mention the installer
+  // explicitly does not honor.
+  const reviewedNonControls = ['HUGO_QUIET', 'HUGO_SILENT', 'HUGO_VERSION'];
+  const packageDir = fileURLToPath(
+    new URL('../node_modules/hugo-extended', import.meta.url),
+  );
+  const tokens = new Set();
+  const scan = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        scan(entryPath);
+      } else if (/\.(mjs|cjs|js)$/.test(entry.name)) {
+        for (const [token] of readFileSync(entryPath, 'utf8').matchAll(
+          /\bHUGO_[A-Z][A-Z_]*\b/g,
+        )) {
+          tokens.add(token);
+        }
+      }
+    }
+  };
+  scan(packageDir);
+
+  assert.deepEqual(
+    [...tokens].sort(),
+    [...expectedUnsafeHugoEnv, ...reviewedNonControls].sort(),
+    'every installer HUGO_* token is a screened control or a reviewed non-control',
+  );
+});
 
 async function runProbe(succeedAt, env = {}) {
   const attempts = [];

--- a/scripts/rebuild-hugo-extended.test.mjs
+++ b/scripts/rebuild-hugo-extended.test.mjs
@@ -17,9 +17,8 @@ const helperPath = fileURLToPath(
   new URL('rebuild-hugo-extended.mjs', import.meta.url),
 );
 
-// Deliberately literal: the content pin for the helper's UNSAFE_HUGO_ENV
-// export, which the supply-chain audit imports; a name dropped there
-// goes red here.
+// Deliberately literal: content-pins the helper's UNSAFE_HUGO_ENV export
+// so a silently dropped name goes red here.
 const expectedUnsafeHugoEnv = [
   'HUGO_BIN_PATH',
   'HUGO_FORCE_STANDARD',
@@ -152,8 +151,7 @@ test('Hugo rebuild rejects installer control variables', async () => {
 });
 
 test('Hugo rebuild treats an empty control variable as unset', async () => {
-  // Pins the documented carve-out: empty string matches the installer's
-  // falsy handling, so it must not trip the screen.
+  // Pins the empty-string carve-out documented at the helper's env screen.
   const { attempts, errors, status } = await runProbe(1, {
     HUGO_SKIP_DOWNLOAD: '',
   });
@@ -164,7 +162,7 @@ test('Hugo rebuild treats an empty control variable as unset', async () => {
 });
 
 test('Hugo rebuild fails fast without the npm CLI path', async () => {
-  // Whitespace-only is as unavailable as unset: both fail once, no retries.
+  // Whitespace-only is as unavailable as unset.
   for (const npmExecPath of [undefined, '   ']) {
     const errors = [];
     const status = await rebuildHugoExtended({


### PR DESCRIPTION
- **Hugo-binary fetch resilience**:
  - What: Routes `ci:prepare`'s `npm rebuild hugo-extended` through a retrying wrapper, `scripts/rebuild-hugo-extended.mjs`, which also refuses `HUGO_*` installer env overrides.
  - Why: Transient GitHub-releases fetch failures were failing whole Netlify deploys, each needing a manual retry.
- **Riders**:
  - adds `unstaffed` to the cSpell dictionary (used in CODEOWNERS comments)
  - corrects the Netlify build-cache doc: caches are keyed per branch name and survive branch deletion, so recycled bot-branch names re-attach to old lineages
- **Source**: ported and adapted from google/docsy#2714 (merged).
- **Follow-up**: the committed supply-chain audit that shared this branch's original scope lands in its own PR.
- **Preview**: [site/build/dependencies](https://deploy-preview-11325--opentelemetry.netlify.app/site/build/dependencies/)
