### PR TITLE
[ja] update translation of content/en/docs/contributing/blog.md

### DIFF
--- a/content/ja/docs/contributing/blog.md
+++ b/content/ja/docs/contributing/blog.md
@@ -2,8 +2,7 @@
 title: ブログ
 description: ブログ投稿する方法を学びます。
 weight: 30
-default_lang_commit: 0009192ae1f96290e0b5ecc7e800c2947d209f69
-drifted_from_default: true
+default_lang_commit: 38e36ae231c523f9e54499ad6ca05de7c49501c5
 ---
 
 [OpenTelemetry ブログ](/blog/)は OpenTelemetry に関連する可能性のある、新機能、コミュニティレポートそしてニュースを発信します。
@@ -94,13 +93,13 @@ SIG スポンサーは、Comms SIG が記事を確認する前にレビューを
 1. リポジトリルートから以下のコマンドを実行してください
 
    ```sh
-   npx hugo new content/en/blog/$(date +%Y)/short-name-for-post.md
+   npm exec --no -- hugo new content/en/blog/$(date +%Y)/short-name-for-post.md
    ```
 
    投稿に画像やその他のアセットが含まれている場合、次のコマンドを実行してください。
 
    ```sh
-   npx hugo new content/en/blog/$(date +%Y)/short-name-for-post/index.md
+   npm exec --no -- hugo new content/en/blog/$(date +%Y)/short-name-for-post/index.md
    ```
 
 2. 前のコマンドで提供したパスのマークダウンファイルを編集してください。このファイルは、[archetypes](https://github.com/open-telemetry/opentelemetry.io/tree/main/archetypes/)配下のブログ記事スターターから初期化されます。


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/contributing/blog.md` to match the latest English source at
`content/en/docs/contributing/blog.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff replaced `npx hugo new` with `npm exec --no -- hugo new` in two code
block examples. This is a code-only change inside fenced blocks — no prose translation
was needed.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.