### PR TITLE
docs(contributing): update first-time contributor policy

### DIFF
--- a/.lycheecache
+++ b/.lycheecache
@@ -3921,6 +3921,7 @@ https://github.com/open-telemetry/opentelemetry.io/issues/6592,200,1785868419
 https://github.com/open-telemetry/opentelemetry.io/issues/9449,200,1785739344
 https://github.com/open-telemetry/opentelemetry.io/issues/new,200,1785868416
 https://github.com/open-telemetry/opentelemetry.io/labels/CI%2Finfra,200,1787230348
+https://github.com/open-telemetry/opentelemetry.io/labels/good%20first%20issue,200,1787035743
 https://github.com/open-telemetry/opentelemetry.io/labels/sig-approval-missing,200,1785868415
 https://github.com/open-telemetry/opentelemetry.io/pull/10911,200,1786028673
 https://github.com/open-telemetry/opentelemetry.io/pull/5891,200,1785739340

--- a/content/en/docs/contributing/_index.md
+++ b/content/en/docs/contributing/_index.md
@@ -63,7 +63,7 @@ the checklist asks you to confirm:
 > - [ ] I have the experience and knowledge necessary to understand, review,
 >   and validate all content in this PR. (Yes, I can answer maintainer
 >   questions about the content of this PR, without using AI.)
-
+>
 > [!CAUTION]
 > Issue or PR **spamming**, including **repeatedly soliciting feedback** through
 > any channel, or otherwise repeatedly disregarding this policy, can result in
@@ -101,10 +101,10 @@ The pages in this section describe how to contribute to OpenTelemetry
 
 For guidance on how to contribute to the OpenTelemetry project in general, see
 the community [OpenTelemetry New Contributor Guide][]. Every [OTel
-repository][org] for language implementations, the Collector, and conventions
-have their own project-specific contributing guides.
+repository](https://github.com/open-telemetry) for language implementations,
+the Collector, and conventions have their own project-specific contributing
+guides.
 
-[choose an issue]: issues/#fixing-an-existing-issue
 [issues]: issues/
 [OpenTelemetry New Contributor Guide]:
   https://github.com/open-telemetry/community/blob/main/guides/contributor

--- a/content/en/docs/contributing/_index.md
+++ b/content/en/docs/contributing/_index.md
@@ -18,26 +18,57 @@ cascade:
 
 ## <i class='far fa-exclamation-triangle text-warning '></i> First time contributing? {#first-time-contributing}
 
-- **[Choose an issue][]** with the following labels:
-  - [Good first issue](<{{% param _issue %}}%22good%20first%20issue%22>)
-  - [Help wanted](<{{% param _issue %}}%22help%20wanted%22>)
+If you have not yet had a non-trivial PR merged in this repository, you are a
+**first-time contributor** here. Welcome!
 
-  > [!WARNING] We do not assign issues
-  >
-  > We **_do not_ assign issues** to those who have not already made
-  > contributions to the [OpenTelemetry organization][org], unless part of a
-  > confirmed mentorship or onboarding process.
-  >
-  > [org]: https://github.com/open-telemetry
+### Choose _one_
 
-- {{% param chooseAnIssueAtYourLevel %}}
+As a first-time contributor, you can do **one** of the following:
 
-- Read our [Generative AI contribution policy](pull-requests#using-ai)
+- **Open a single issue** describing a problem or proposal, and wait for
+  maintainer feedback before doing anything else. Keep to one open issue at a
+  time.
+- **Submit a single PR** for _one_ of:
+  - An open issue labeled
+    [`good first issue`](https://github.com/open-telemetry/opentelemetry.io/labels/good%20first%20issue):
+    - If there are no such issues, check back later.
+    - **Link to the issue** from your PR description.
+      ⚠️ **NOTE**: issues are **not** claimed, reserved, or
+      [assigned](#first-time-contributing); the first adequate PR wins.
+  - A [registry](/ecosystem/registry/adding/) or
+    [vendor](/ecosystem/vendors/#how-to-add) self-addition, following the linked
+    instructions. As with all first-timer PRs: one open PR at a time.
+  - A _trivial editorial fix_ (typo, broken link) without an issue; such PRs
+    are accepted at maintainer discretion.
 
-- Want to work other issues or larger changes? [Discuss it with maintainers
-  first][].
+> [!IMPORTANT]
+> You remain a first-time contributor until a non-trivial PR of yours is
+> merged: a merged trivial fix or registry/vendor self-addition doesn't change
+> your status.
 
-[discuss it with maintainers first]: issues/#fixing-an-existing-issue
+### Answer the PR template questions
+
+Every PR opens with our
+[pull request template](https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/PULL_REQUEST_TEMPLATE.md).
+First-time contributors **must** complete its checklist truthfully; PRs with an
+unaddressed or dishonestly completed checklist will be closed. As a reminder,
+the checklist asks you to confirm:
+
+> - [ ] I have read and followed the
+>   [Contributing](/docs/contributing/) docs, especially the
+>   "**First-time contributing?**" section.
+> - [ ] This PR has content that I did not fully write myself.
+>   - [ ] I used AI and I have read and followed the
+>     [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
+> - [ ] I have the experience and knowledge necessary to understand, review,
+>   and validate all content in this PR. (Yes, I can answer maintainer
+>   questions about the content of this PR, without using AI.)
+
+> [!CAUTION]
+> Issue or PR **spamming**, including **repeatedly soliciting feedback** through
+> any channel, or otherwise repeatedly disregarding this policy, can result in
+> interaction limits, being blocked, or escalation per the
+> [OpenTelemetry Code of Conduct](https://github.com/open-telemetry/community/blob/main/code-of-conduct.md).
 
 ## Jump right in!
 

--- a/content/en/docs/contributing/_index.md
+++ b/content/en/docs/contributing/_index.md
@@ -32,19 +32,18 @@ As a first-time contributor, you can do **one** of the following:
   - An open issue labeled
     [`good first issue`](https://github.com/open-telemetry/opentelemetry.io/labels/good%20first%20issue):
     - If there are no such issues, check back later.
-    - **Link to the issue** from your PR description.
-      ⚠️ **NOTE**: issues are **not** claimed, reserved, or
-      [assigned](#first-time-contributing); the first adequate PR wins.
+    - **Link to the issue** from your PR description. ⚠️ **NOTE**: issues are
+      **not** claimed, reserved, or [assigned](#first-time-contributing); the
+      first adequate PR wins.
   - A [registry](/ecosystem/registry/adding/) or
     [vendor](/ecosystem/vendors/#how-to-add) self-addition, following the linked
     instructions. As with all first-timer PRs: one open PR at a time.
-  - A _trivial editorial fix_ (typo, broken link) without an issue; such PRs
-    are accepted at maintainer discretion.
+  - A _trivial editorial fix_ (typo, broken link) without an issue; such PRs are
+    accepted at maintainer discretion.
 
-> [!IMPORTANT]
-> You remain a first-time contributor until a non-trivial PR of yours is
-> merged: a merged trivial fix or registry/vendor self-addition doesn't change
-> your status.
+> [!IMPORTANT] You remain a first-time contributor until a non-trivial PR of
+> yours is merged: a merged trivial fix or registry/vendor self-addition doesn't
+> change your status.
 
 ### Answer the PR template questions
 
@@ -54,20 +53,18 @@ First-time contributors **must** complete its checklist truthfully; PRs with an
 unaddressed or dishonestly completed checklist will be closed. As a reminder,
 the checklist asks you to confirm:
 
-> - [ ] I have read and followed the
->   [Contributing](/docs/contributing/) docs, especially the
->   "**First-time contributing?**" section.
+> - [ ] I have read and followed the [Contributing](/docs/contributing/) docs,
+>       especially the "**First-time contributing?**" section.
 > - [ ] This PR has content that I did not fully write myself.
 >   - [ ] I used AI and I have read and followed the
->     [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
-> - [ ] I have the experience and knowledge necessary to understand, review,
->   and validate all content in this PR. (Yes, I can answer maintainer
->   questions about the content of this PR, without using AI.)
+>         [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
+> - [ ] I have the experience and knowledge necessary to understand, review, and
+>       validate all content in this PR. (Yes, I can answer maintainer questions
+>       about the content of this PR, without using AI.)
 >
-> [!CAUTION]
-> Issue or PR **spamming**, including **repeatedly soliciting feedback** through
-> any channel, or otherwise repeatedly disregarding this policy, can result in
-> interaction limits, being blocked, or escalation per the
+> [!CAUTION] Issue or PR **spamming**, including **repeatedly soliciting
+> feedback** through any channel, or otherwise repeatedly disregarding this
+> policy, can result in interaction limits, being blocked, or escalation per the
 > [OpenTelemetry Code of Conduct](https://github.com/open-telemetry/community/blob/main/code-of-conduct.md).
 
 ## Jump right in!
@@ -100,10 +97,10 @@ The pages in this section describe how to contribute to OpenTelemetry
 **documentation**.
 
 For guidance on how to contribute to the OpenTelemetry project in general, see
-the community [OpenTelemetry New Contributor Guide][]. Every [OTel
-repository](https://github.com/open-telemetry) for language implementations,
-the Collector, and conventions have their own project-specific contributing
-guides.
+the community [OpenTelemetry New Contributor Guide][]. Every
+[OTel repository](https://github.com/open-telemetry) for language
+implementations, the Collector, and conventions have their own project-specific
+contributing guides.
 
 [issues]: issues/
 [OpenTelemetry New Contributor Guide]:


### PR DESCRIPTION
## Problem

The ["First time contributing?"](https://opentelemetry.io/docs/contributing/#first-time-contributing) section of the contributing guide used a simple bullet list (choose an issue, no-assignment warning, level guidance) that did not clearly communicate the first-time contributor constraints: the one-issue/one-PR limit, acceptable PR types, status persistence rules, PR template truthfulness requirements, or anti-spam escalation.

Issue #11243 (filed by maintainer `chalin`, labeled `p1-high`) specifies the exact replacement text.

## Fix

Replace the entire "First time contributing?" section with the comprehensive first-time contributor policy from #11243:

- Define "first-time contributor" status and its persistence rules (non-trivial merge required to advance)
- Restrict first-timers to one open issue **or** one open PR at a time
- List acceptable first-timer PR types (GFI, registry/vendor self-addition, trivial editorial fix)
- Require PR template checklist truthfulness; warn that dishonest completions will be closed
- Add spam/escalation warning referencing the OpenTelemetry Code of Conduct

## Linked issue

Fixes #11243

## Test plan

- N/A — docs-only change. No code, build config, or template logic modified.
- Content verified against the exact replacement text specified in issue #11243.
- All links point to valid GitHub or opentelemetry.io URLs.

## AI disclosure

This PR was prepared with AI assistance.
Assisted-by: Claude (Anthropic)

Per the [CNCF Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md), I have read and followed the policy. I can answer maintainer questions about the content of this PR.