### PR TITLE
[ja] add translation of content/en/site/features.md

### DIFF
--- a/content/ja/site/features.md
+++ b/content/ja/site/features.md
@@ -1,0 +1,19 @@
+---
+title: 機能
+description: >-
+  主要なサイト機能の概要と、それぞれの主なリファレンスへのリンク。
+weight: 20
+default_lang_commit: 60d50174e01d221f65af4b69ad1ae946fbc16ec8
+---
+
+## エージェントフレンドリーなコンテンツ配信 {#agent-friendly-content-delivery}
+
+サイトのコンテンツをエージェントが発見しやすく、利用しやすくします。
+現在の作業では、コンテンツページの Markdown 出力と `Accept: text/markdown` の HTTP ネゴシエーションを追加しています。
+
+- ステータス: 進行中
+- 設計: [Agent support](../design/agent-support/)
+- 実装: `netlify/edge-functions/markdown-negotiation.ts` 配下のロジックとテスト用フォルダー。
+- リファレンス:
+  [opentelemetry.io#9449](https://github.com/open-telemetry/opentelemetry.io/issues/9449),
+  [docsy#2596](https://github.com/google/docsy/issues/2596)


### PR DESCRIPTION
## Summary

Translates `content/en/site/features.md` into Japanese as `content/ja/site/features.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11337--opentelemetry.netlify.app/ja/site/features/
- **English (canonical):** https://opentelemetry.io/site/features/

<!-- preview-section-end -->
