### PR TITLE
docs(languages): specify OTEL_EXPORTER_OTLP_HEADERS format

### DIFF
--- a/content/en/docs/languages/sdk-configuration/otlp-exporter.md
+++ b/content/en/docs/languages/sdk-configuration/otlp-exporter.md
@@ -117,8 +117,8 @@ Headers are represented in a format matching to the
 [W3C Baggage](https://www.w3.org/TR/baggage/#header-content), for example
 `key1=value1,key2=value2`. Semi-colon delimited
 [metadata](https://www.w3.org/TR/baggage/#property) is not supported. For more
-details, see [Specifying headers via environment
-variables](/docs/specs/otel/protocol/exporter/#specifying-headers-via-environment-variables)
+details, see
+[Specifying headers via environment variables](/docs/specs/otel/protocol/exporter/#specifying-headers-via-environment-variables)
 in the protocol specification.
 
 ### `OTEL_EXPORTER_OTLP_HEADERS`

--- a/content/en/docs/languages/sdk-configuration/otlp-exporter.md
+++ b/content/en/docs/languages/sdk-configuration/otlp-exporter.md
@@ -113,6 +113,14 @@ ends with `v1/profiles` when using OTLP/HTTP.
 The following environment variables let you configure additional headers as a
 list of key-value pairs to add in outgoing gRPC or HTTP requests.
 
+Headers are represented in a format matching to the
+[W3C Baggage](https://www.w3.org/TR/baggage/#header-content), for example
+`key1=value1,key2=value2`. Semi-colon delimited
+[metadata](https://www.w3.org/TR/baggage/#property) is not supported. For more
+details, see [Specifying headers via environment
+variables](/docs/specs/otel/protocol/exporter/#specifying-headers-via-environment-variables)
+in the protocol specification.
+
 ### `OTEL_EXPORTER_OTLP_HEADERS`
 
 A list of headers to apply to all outgoing data (traces, metrics, and logs).


### PR DESCRIPTION
Fixes #11093

## What

The [OTLP Exporter Configuration](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/) page showed an example (`api-key=key,other-config-value=value`) but never defined the syntax for keys and values — which characters are allowed, how commas and equals are handled, and whether quoting/escaping is possible.

## Why

Users configuring exporters cannot tell from this page whether they need to escape commas in values or how to include special characters. The protocol specification already answers this: headers must match the [W3C Baggage](https://www.w3.org/TR/baggage/#header-content) format, and semi-colon delimited metadata is not supported.

## How

Added a paragraph to the Header configuration section stating the W3C Baggage format, the `key1=value1,key2=value2` shape, the semi-colon metadata exclusion, and a link to the authoritative [Specifying headers via environment variables](/docs/specs/otel/protocol/exporter/#specifying-headers-via-environment-variables) section of the protocol spec.

English source only. The pt and ja locale mirrors of this page have the same gap, but I'm leaving those for the localization teams to sync.

## Verification

- All three linked URLs return 200 (checked with `curl`).
- Content-only change, no code.