### PR TITLE
[ja] add translation of content/en/docs/zero-code/java/spring-boot-starter/sdk-configuration.md

### DIFF
--- a/content/ja/docs/zero-code/java/spring-boot-starter/programmatic-configuration.md
+++ b/content/ja/docs/zero-code/java/spring-boot-starter/programmatic-configuration.md
@@ -1,0 +1,165 @@
+---
+title: プログラムによる設定
+weight: 35
+vers:
+  contrib: 1.54.0
+default_lang_commit: 60d50174e01d221f65af4b69ad1ae946fbc16ec8
+cSpell:ignore: customizer fileconfig
+---
+
+<?code-excerpt path-base="examples/java/spring-starter"?>
+
+プログラムによる設定には `AutoConfigurationCustomizerProvider` を使用できます。
+プログラムによる設定は、プロパティでは設定できない高度なユースケースに推奨されます。
+
+> [!WARNING]
+>
+> `AutoConfigurationCustomizerProvider` は[宣言的設定](../declarative-configuration/)では動作しません。
+> 宣言的設定では、代わりに `DeclarativeConfigurationCustomizerProvider` を使用してください。
+> 詳細と例については、[エージェントの Extension API セクション](/docs/zero-code/java/agent/declarative-configuration/)を参照してください。
+
+## アクチュエーターエンドポイントをトレースから除外する {#exclude-actuator-endpoints-from-tracing}
+
+例として、ヘルスチェックエンドポイントをトレースから除外するようにサンプラーをカスタマイズできます。
+
+{{< tabpane text=true >}} {{% tab header="Maven (`pom.xml`)" lang=Maven %}}
+
+```xml
+<dependencies>
+  <dependency>
+    <groupId>io.opentelemetry.contrib</groupId>
+    <artifactId>opentelemetry-samplers</artifactId>
+    <version>{{% param vers.contrib %}}-alpha</version>
+  </dependency>
+</dependencies>
+```
+
+{{% /tab %}} {{% tab header="Gradle (`build.gradle`)" lang=Gradle %}}
+
+```kotlin
+dependencies {
+  implementation("io.opentelemetry.contrib:opentelemetry-samplers:{{% param vers.contrib %}}-alpha")
+}
+```
+
+{{% /tab %}} {{< /tabpane>}}
+
+<?code-excerpt "src/main/java/otel/FilterPaths.java"?>
+
+```java
+package otel;
+
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.contrib.sampler.RuleBasedRoutingSampler;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
+import io.opentelemetry.semconv.UrlAttributes;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FilterPaths {
+
+  @Bean
+  public AutoConfigurationCustomizerProvider otelCustomizer() {
+    return p ->
+        p.addSamplerCustomizer(
+            (fallback, config) ->
+                RuleBasedRoutingSampler.builder(SpanKind.SERVER, fallback)
+                    .drop(UrlAttributes.URL_PATH, "^/actuator")
+                    .build());
+  }
+}
+```
+
+## エクスポーターをプログラムで設定する {#configure-the-exporter-programmatically}
+
+OTLP エクスポーターをプログラムで設定することもできます。
+この設定はデフォルトの OTLP エクスポーターを置き換え、リクエストにカスタムヘッダーを追加します。
+
+<?code-excerpt "src/main/java/otel/CustomAuth.java"?>
+
+```java
+package otel;
+
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
+import java.util.Collections;
+import java.util.Map;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CustomAuth {
+  @Bean
+  public AutoConfigurationCustomizerProvider otelCustomizer() {
+    return p ->
+        p.addSpanExporterCustomizer(
+            (exporter, config) -> {
+              if (exporter instanceof OtlpHttpSpanExporter) {
+                return ((OtlpHttpSpanExporter) exporter)
+                    .toBuilder().setHeaders(this::headers).build();
+              }
+              return exporter;
+            });
+  }
+
+  private Map<String, String> headers() {
+    return Collections.singletonMap("Authorization", "Bearer " + refreshToken());
+  }
+
+  private String refreshToken() {
+    // 例: Kubernetes シークレットからトークンを読み取る
+    return "token";
+  }
+}
+```
+
+## 計装設定をプログラムで読み取る {#read-instrumentation-configuration-programmatically}
+
+> [!NOTE]
+>
+> OpenTelemetry Spring Boot スターターバージョン 2.30.0 以降が必要です。
+
+計装モジュールは、`application.properties` / `application.yaml` で設定した場合でも、[宣言的設定](../declarative-configuration/)で設定した場合でも、`ConfigProvider` Bean を通じて設定を読み取ります。
+自分のコードから計装設定の値を読み取る必要がある場合は、`ConfigProvider` Bean を直接オートワイヤーしてください。
+
+宣言的設定が有効な場合、`otelProperties`（`ConfigProperties`）Bean は互換性ブリッジとしてのみ提供されます。
+これは非推奨であり、3.0 で削除される予定です。
+かわりに `ConfigProvider` を使用してください。
+
+<?code-excerpt path-base="content-modules/opentelemetry-java-examples/spring-declarative-configuration"?>
+
+<?code-excerpt "src/main/java/io/opentelemetry/examples/fileconfig/ReadInstrumentationConfig.java" from="package"?>
+
+```java
+package io.opentelemetry.examples.fileconfig;
+
+import io.opentelemetry.api.incubator.config.ConfigProvider;
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import org.springframework.stereotype.Component;
+
+/** アプリケーションコードから計装設定を読み取る例。 */
+@Component
+public class ReadInstrumentationConfig {
+
+  private final ConfigProvider configProvider;
+
+  public ReadInstrumentationConfig(ConfigProvider configProvider) {
+    this.configProvider = configProvider;
+  }
+
+  public boolean isDbQuerySanitizationEnabled() {
+    DeclarativeConfigProperties dbConfig =
+        configProvider
+            .getInstrumentationConfig()
+            .get("java")
+            .get("common")
+            .get("db")
+            .get("query_sanitization");
+    return dbConfig.getBoolean("enabled", true);
+  }
+}
+```
+
+`getInstrumentationConfig()` 配下のキーは、値を `otel.instrumentation.*` プロパティで設定した場合でも、宣言的 YAML で設定した場合でも、[宣言的設定](../declarative-configuration/#instrumentation-configuration)で使用されるのと同じ `instrumentation/development.java.*` 構造に従います。
+プロパティ名がこの構造にどのようにマッピングされるかは、[マッピングテーブル](../declarative-configuration/#instrumentation-configuration)を参照してください。

--- a/content/ja/docs/zero-code/java/spring-boot-starter/sdk-configuration.md
+++ b/content/ja/docs/zero-code/java/spring-boot-starter/sdk-configuration.md
@@ -8,7 +8,7 @@ cSpell:ignore: distro
 <!-- markdownlint-disable blanks-around-fences -->
 <?code-excerpt path-base="examples/java/spring-starter"?>
 
-この Spring スターターは[設定メタデータ](https://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html)をサポートしており、IDE で利用可能なすべてのプロパティを確認・オートコンプリートできます。
+この Spring スターターは[設定メタデータ](https://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html)をサポートしており、IDE で利用可能なすべてのプロパティを確認・自動補完できます。
 
 ## 一般的な設定 {#general-configuration}
 

--- a/content/ja/docs/zero-code/java/spring-boot-starter/sdk-configuration.md
+++ b/content/ja/docs/zero-code/java/spring-boot-starter/sdk-configuration.md
@@ -1,0 +1,259 @@
+---
+title: SDK 設定
+weight: 30
+default_lang_commit: 60d50174e01d221f65af4b69ad1ae946fbc16ec8
+cSpell:ignore: distro
+---
+
+<!-- markdownlint-disable blanks-around-fences -->
+<?code-excerpt path-base="examples/java/spring-starter"?>
+
+この Spring スターターは[設定メタデータ](https://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html)をサポートしており、IDE で利用可能なすべてのプロパティを確認・オートコンプリートできます。
+
+## 一般的な設定 {#general-configuration}
+
+OpenTelemetry スターターは、すべての [SDK 自動設定](/docs/zero-code/java/agent/configuration/#sdk-configuration)をサポートしています（2.2.0 以降）。
+
+`application.properties` ファイルや `application.yaml` ファイルのプロパティ、または環境変数を使用して設定を更新できます。
+
+{{< tabpane text=true >}} {{% tab "プロパティ" %}}
+
+`application.yaml` の例：
+
+```yaml
+otel:
+  propagators:
+    - tracecontext
+    - b3
+  resource:
+    attributes:
+      deployment.environment: dev
+      service:
+        name: cart
+        namespace: shop
+```
+
+環境変数の例：
+
+```shell
+export OTEL_PROPAGATORS="tracecontext,b3"
+export OTEL_RESOURCE_ATTRIBUTES="deployment.environment=dev,service.name=cart,service.namespace=shop"
+```
+
+{{% /tab %}} {{% tab "宣言的設定" %}}
+
+SDK レベルの設定（リソース、プロパゲーター、エクスポーター）は、`application.yaml` 内で標準の[宣言的設定スキーマ](/docs/languages/sdk-configuration/declarative-configuration/)を直接使用します。
+システムプロパティや環境変数でも値をオーバーライドできます。
+[環境変数によるオーバーライド](../declarative-configuration/#environment-variable-overrides)を参照してください。
+
+```yaml
+otel:
+  file_format: '1.0'
+
+  resource:
+    attributes:
+      - name: deployment.environment
+        value: dev
+      - name: service.name
+        value: cart
+      - name: service.namespace
+        value: shop
+
+  propagator:
+    composite:
+      - tracecontext:
+      - b3:
+```
+
+{{% /tab %}} {{< /tabpane >}}
+
+## リソース属性のオーバーライド {#overriding-resource-attributes}
+
+Spring Boot では通常どおり、`application.properties` ファイルや `application.yaml` ファイルのプロパティを環境変数でオーバーライドできます。
+
+たとえば、標準の `OTEL_RESOURCE_ATTRIBUTES` 環境変数を設定することで、リソース属性 `deployment.environment` を設定またはオーバーライドできます（`service.name` や `service.namespace` は変更しません）。
+
+```shell
+export OTEL_RESOURCE_ATTRIBUTES="deployment.environment=prod"
+```
+
+また、`OTEL_RESOURCE_ATTRIBUTES_DEPLOYMENT_ENVIRONMENT` 環境変数を使用して、単一のリソース属性を設定またはオーバーライドすることもできます。
+
+```shell
+export OTEL_RESOURCE_ATTRIBUTES_DEPLOYMENT_ENVIRONMENT="prod"
+```
+
+2番目のオプションは [SpEL](https://docs.spring.io/spring-framework/docs/3.2.x/spring-framework-reference/html/expressions.html) 式をサポートしています。
+
+`DEPLOYMENT_ENVIRONMENT` は、Spring Boot の [Relaxed Binding](https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.external-config.typesafe-configuration-properties.relaxed-binding.environment-variables) によって `deployment.environment` に変換されることに注意してください。
+
+## OpenTelemetry スターターの無効化 {#disable-the-opentelemetry-starter}
+
+{{< tabpane text=true >}} {{% tab "プロパティ" %}}
+
+テスト目的などでスターターを無効にするには、`otel.sdk.disabled` を `true` に設定します。
+
+```yaml
+otel:
+  sdk:
+    disabled: true
+```
+
+{{% /tab %}} {{% tab "宣言的設定" %}}
+
+テスト目的などでスターターを無効にするには、`otel.disabled` を `true` に設定します。
+
+注意：[宣言的設定](../declarative-configuration/)では、プロパティ名は `otel.sdk.disabled` ではなく `otel.disabled` です。
+
+```yaml
+otel:
+  file_format: '1.0'
+  disabled: true
+```
+
+{{% /tab %}} {{< /tabpane >}}
+
+## プログラムによる設定 {#programmatic-configuration}
+
+[プログラムによる設定](../programmatic-configuration/)を参照してください。
+
+## リソースプロバイダー {#resource-providers}
+
+{{< tabpane text=true >}} {{% tab "プロパティ" %}}
+
+OpenTelemetry スターターには、Java エージェントと同じリソースプロバイダーが含まれています。
+
+- [共通リソースプロバイダー](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/resources/library)
+- [デフォルトで無効になっているリソースプロバイダー](/docs/zero-code/java/agent/configuration/#enable-resource-providers-that-are-disabled-by-default)
+
+さらに、OpenTelemetry スターターには以下の Spring Boot 固有のリソースプロバイダーが含まれています。
+
+### ディストリビューションリソースプロバイダー {#distribution-resource-provider}
+
+FQN:
+`io.opentelemetry.instrumentation.spring.autoconfigure.resources.DistroVersionResourceProvider`
+
+| 属性                       | 値                                  |
+| -------------------------- | ----------------------------------- |
+| `telemetry.distro.name`    | `opentelemetry-spring-boot-starter` |
+| `telemetry.distro.version` | スターターのバージョン              |
+
+### Spring リソースプロバイダー {#spring-resource-provider}
+
+FQN:
+`io.opentelemetry.instrumentation.spring.autoconfigure.resources.SpringResourceProvider`
+
+| 属性              | 値                                                                                                            |
+| ----------------- | ------------------------------------------------------------------------------------------------------------- |
+| `service.name`    | `spring.application.name` または `build-info.properties` の `build.name`（[サービス名](#service-name)を参照） |
+| `service.version` | `build-info.properties` の `build.version`                                                                    |
+
+{{% /tab %}} {{% tab "宣言的設定" %}}
+
+[宣言的設定](../declarative-configuration/)では、リソースプロバイダーは `resource.detection/development.detectors` 配下のディテクターとして明示的に設定します。
+リストに含まれたディテクターのみが有効になり、SPI による自動検出は行われません。
+
+```yaml
+otel:
+  resource:
+    detection/development:
+      detectors:
+        - container: # container.id
+        - host: # host.name, host.arch
+        - host_id: # host.id
+        - os: # os.type, os.description
+        - process: # process.pid, process.executable.path, process.command_line
+        - process_runtime: # process.runtime.name/version/description
+        - service: # service.name, service.instance.id
+        - spring: # service.name (from spring.application.name), service.version (from build-info)
+```
+
+属性 `telemetry.distro.name` と `telemetry.distro.version` は、トラブルシューティングのためにスターターによって常に自動的に追加されます。
+
+{{% /tab %}} {{< /tabpane >}}
+
+## サービス名 {#service-name}
+
+これらのリソースプロバイダーを使用した場合、サービス名は OpenTelemetry の[仕様](/docs/languages/sdk-configuration/general/#otel_service_name)に従い、以下の優先順位ルールで決定されます。
+
+{{< tabpane text=true >}} {{% tab "プロパティ" %}}
+
+1. `otel.service.name` Spring プロパティまたは `OTEL_SERVICE_NAME` 環境変数（最も優先度が高い）
+2. `otel.resource.attributes` システム/Spring プロパティまたは `OTEL_RESOURCE_ATTRIBUTES` 環境変数の `service.name`
+3. `spring.application.name` Spring プロパティ
+4. `build-info.properties`
+5. META-INF/MANIFEST.MF の `Implementation-Title`
+6. デフォルト値は `unknown_service:java`（最も優先度が低い）
+
+{{% /tab %}} {{% tab "宣言的設定" %}}
+
+サービス名は、含めるリソースディテクターによって決まります（[リソースプロバイダー](#resource-providers)を参照）。
+
+1. `otel.resource.attributes` の `service.name`（最も優先度が高い）：
+
+   ```yaml
+   otel:
+     resource:
+       attributes:
+         - name: service.name
+           value: my-spring-app
+   ```
+
+2. `service` ディテクター — 含まれている場合、`OTEL_SERVICE_NAME` から自動検出します：
+
+   ```yaml
+   otel:
+     resource:
+       detection/development:
+         detectors:
+           - service:
+   ```
+
+3. `spring` ディテクター — 含まれている場合、`spring.application.name` と `build-info.properties` から検出します：
+
+   ```yaml
+   otel:
+     resource:
+       detection/development:
+         detectors:
+           - spring:
+   ```
+
+4. デフォルト値は `unknown_service:java`（最も優先度が低い）
+
+{{% /tab %}} {{< /tabpane >}}
+
+`build-info.properties` ファイルを生成するには、pom.xml ファイルで以下のスニペットを使用してください。
+
+{{< tabpane text=true >}} {{% tab header="Maven (`pom.xml`)" lang=Maven %}}
+
+```xml
+<build>
+    <finalName>${project.artifactId}</finalName>
+    <plugins>
+        <plugin>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-maven-plugin</artifactId>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>build-info</goal>
+                        <goal>repackage</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
+    </plugins>
+</build>
+```
+
+{{% /tab %}} {{% tab header="Gradle (`build.gradle`)" lang=Gradle %}}
+
+```kotlin
+springBoot {
+  buildInfo {
+  }
+}
+```
+
+{{% /tab %}} {{< /tabpane>}}


### PR DESCRIPTION
## Summary

Translates `content/en/docs/zero-code/java/spring-boot-starter/sdk-configuration.md` into Japanese as `content/ja/docs/zero-code/java/spring-boot-starter/sdk-configuration.md`.

Also translates the sibling page `content/en/docs/zero-code/java/spring-boot-starter/programmatic-configuration.md` into `content/ja/docs/zero-code/java/spring-boot-starter/programmatic-configuration.md`, because the primary page links to it via a relative path.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

### docs/zero-code/java/spring-boot-starter/programmatic-configuration/
- **Japanese (this PR):** https://deploy-preview-11343--opentelemetry.netlify.app/ja/docs/zero-code/java/spring-boot-starter/programmatic-configuration/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/java/spring-boot-starter/programmatic-configuration/

### docs/zero-code/java/spring-boot-starter/sdk-configuration/
- **Japanese (this PR):** https://deploy-preview-11343--opentelemetry.netlify.app/ja/docs/zero-code/java/spring-boot-starter/sdk-configuration/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/java/spring-boot-starter/sdk-configuration/

<!-- preview-section-end -->
