### PR TITLE
Registry: add MB3R Stack

### DIFF
--- a/data/registry/utilities-mb3r-stack.yml
+++ b/data/registry/utilities-mb3r-stack.yml
@@ -1,0 +1,33 @@
+# cSpell:ignore MB3R Bering Sheaft
+
+title: MB3R Stack
+
+registryType: utilities
+
+language: go
+
+tags:
+  - opentelemetry
+  - otlp
+  - traces
+  - observability
+  - resilience
+  - chaos-engineering
+  - model-discovery
+
+urls:
+  repo: https://github.com/MB3R-Lab/mb3r-stack
+  website: https://mb3r-lab.github.io/
+
+license: MIT
+
+description: Model-based resilience toolchain that uses OpenTelemetry trace evidence to discover application topology, simulate virtual failure scenarios, and produce continuous resilience signals and pre-release risk analysis.
+
+authors:
+  - name: Anatoly Krasnovsky
+    url: https://github.com/a-a-k
+
+createdAt: 2026-08-16
+
+isNative: true
+isFirstParty: false


### PR DESCRIPTION

* [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
* [x] This PR has content that I did not fully write myself.

  * [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
* [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]: Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

Adds [MB3R Stack](https://github.com/MB3R-Lab/mb3r-stack) to the OpenTelemetry Registry as a `utilities` entry.

MB3R Stack is an open-source model-based resilience toolchain that uses OpenTelemetry trace evidence to build an analyzable representation of a distributed application and evaluate its behavior under virtual failure scenarios.

The stack combines two components:

* **Bering** consumes OTLP trace evidence and produces stable topology and model artifacts, including rolling snapshots as the observed application changes.
* **Sheaft** consumes those artifacts to run model-based failure simulations and produce resilience analysis, posture signals, and optional release-gate decisions.

The main use cases are continuous resilience assessment alongside observability, pre-release resilience analysis, and prioritization of scenarios that should be validated with live chaos experiments.

### Research evidence

The underlying model-discovery and simulation approach has been evaluated against live fault-injection experiments in two published studies:

* [Model Discovery and Graph Simulation: A Lightweight Gateway to Chaos Engineering](https://conf.researchr.org/details/icse-2026/icse-2026-nier/25/Model-Discovery-and-Graph-Simulation-A-Lightweight-Gateway-to-Chaos-Engineering) — ICSE-NIER 2026, Distinguished Paper Award. The study evaluated trace-derived model discovery and graph simulation against live fault injection on DeathStarBench.
* [Refining Resilience Model Discovery: A Case Study on the Limited Role of Asynchronous Edges in the OpenTelemetry Demo](https://link.springer.com/chapter/[1](https://chatgpt.com/g/g-p-69afdf395ddc8191a9ad49ae216cc3fd-sheaft/c/6a815ff4-14b8-83ea-9f1f-f4df2a282f04#user-content-fn-i-know-my-stuff)0.1007/978-3-032-23304-2_24) — AINA 2026. The study used raw OpenTelemetry traces, Monte Carlo resilience simulation, and live container-kill experiments on the OpenTelemetry Demo.

Disclosure: I maintain [MB3R Stack](https://github.com/MB3R-Lab/mb3r-stack) and am the author of the related research.