### PR TITLE
Remove reference to `/debug/tracez` endpoint

### DIFF
--- a/content/en/docs/collector/quick-start.md
+++ b/content/en/docs/collector/quick-start.md
@@ -129,10 +129,7 @@ need to adjust the command syntax.
    ...
    ```
 
-6. To explore the traces visually, open <http://localhost:55679/debug/tracez> in
-   your browser and select one of the traces from the table.
-
-7. Press <kbd>Control-C</kbd> to stop the Collector.
+6. Press <kbd>Control-C</kbd> to stop the Collector.
 
 ## Next steps
 


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

The `/debug/tracez` endpoint mentioned in the quickstart responds with 404.

Traces are no-op by default since https://github.com/open-telemetry/opentelemetry-collector/issues/15135. The `/debug/tracez` endpoint is therefore never mounted in the quickstart setup.
