### PR TITLE
docs: update collector configs to use non-deprecated aliases file_log, load_balancing and prometheus_remote_write

### DIFF
--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -3,7 +3,7 @@ title: Configuration
 weight: 20
 description: Learn how to configure the Collector to suit your needs
 # prettier-ignore
-cSpell:ignore: cfssl cfssljson configtls fluentforward gencert genkey initca oidc pprof prodevent prometheusremotewrite spanevents unredacted upsert zpages
+cSpell:ignore: cfssl cfssljson configtls fluentforward gencert genkey initca oidc pprof prodevent spanevents unredacted upsert zpages
 ---
 
 <!-- markdownlint-disable link-fragments -->

--- a/content/en/docs/collector/configuration.md
+++ b/content/en/docs/collector/configuration.md
@@ -494,7 +494,7 @@ exporters:
     namespace: default
 
   # Data sources: metrics
-  prometheusremotewrite:
+  prometheus_remote_write:
     endpoint: http://prometheus.example.com:9411/api/prom/push
     # When using the official Prometheus (running via Docker)
     # endpoint: 'http://prometheus:9090/api/v1/write', add:

--- a/content/en/docs/collector/deploy/agent.md
+++ b/content/en/docs/collector/deploy/agent.md
@@ -4,7 +4,6 @@ linkTitle: Agent pattern
 description: Send signals to Collectors and then export to backends
 aliases: [/docs/collector/deployment/agent]
 weight: 200
-cSpell:ignore: prometheusremotewrite
 ---
 
 In the agent deployment pattern, telemetry signals can come from

--- a/content/en/docs/collector/deploy/agent.md
+++ b/content/en/docs/collector/deploy/agent.md
@@ -71,7 +71,7 @@ receivers:
         endpoint: 0.0.0.0:4318
 
 exporters:
-  prometheusremotewrite: # the PRW exporter, to ingest metrics to backend
+  prometheus_remote_write: # the PRW exporter, to ingest metrics to backend
     endpoint: https://prw.example.com/v1/api/remote_write
     sending_queue:
       batch:
@@ -80,7 +80,7 @@ service:
   pipelines:
     metrics/prod:
       receivers: [otlp]
-      exporters: [prometheusremotewrite]
+      exporters: [prometheus_remote_write]
 ```
 
 {{% /tab %}} {{% tab Logs %}}

--- a/content/en/docs/collector/deploy/gateway.md
+++ b/content/en/docs/collector/deploy/gateway.md
@@ -124,7 +124,7 @@ receivers:
         endpoint: 0.0.0.0:4317
 
 exporters:
-  loadbalancing:
+  load_balancing:
     protocol:
       otlp:
         tls:
@@ -140,7 +140,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [loadbalancing]
+      exporters: [load_balancing]
 ```
 
 {{% /tab %}} {{% tab DNS %}}
@@ -153,7 +153,7 @@ receivers:
         endpoint: 0.0.0.0:4317
 
 exporters:
-  loadbalancing:
+  load_balancing:
     protocol:
       otlp:
         tls:
@@ -166,7 +166,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [loadbalancing]
+      exporters: [load_balancing]
 ```
 
 {{% /tab %}} {{% tab "DNS with service" %}}
@@ -179,7 +179,7 @@ receivers:
         endpoint: 0.0.0.0:4317
 
 exporters:
-  loadbalancing:
+  load_balancing:
     routing_key: service
     protocol:
       otlp:
@@ -194,7 +194,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [loadbalancing]
+      exporters: [load_balancing]
 ```
 
 {{% /tab %}} {{< /tabpane >}}

--- a/content/en/docs/collector/deploy/other/agent-to-gateway/_index.md
+++ b/content/en/docs/collector/deploy/other/agent-to-gateway/_index.md
@@ -210,7 +210,7 @@ processors:
 
 exporters:
   # Load balance by trace ID
-  loadbalancing:
+  load_balancing:
     resolver:
       dns:
         hostname: otel-gateway-headless
@@ -226,7 +226,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [memory_limiter]
-      exporters: [loadbalancing]
+      exporters: [load_balancing]
 ```
 
 ### Example gateway configuration
@@ -354,9 +354,9 @@ graph LR
     end
 
     subgraph "Agent Collectors (DaemonSet)"
-        AC1[Agent 1<br/>loadbalancing]
-        AC2[Agent 2<br/>loadbalancing]
-        AC3[Agent 3<br/>loadbalancing]
+        AC1[Agent 1<br/>load_balancing]
+        AC2[Agent 2<br/>load_balancing]
+        AC3[Agent 3<br/>load_balancing]
     end
 
     subgraph "Gateway Collectors"

--- a/content/en/docs/collector/scaling.md
+++ b/content/en/docs/collector/scaling.md
@@ -387,7 +387,7 @@ receivers:
 processors:
 
 exporters:
-  loadbalancing:
+  load_balancing:
     protocol:
       otlp:
     resolver:
@@ -401,5 +401,5 @@ service:
         - otlp
       processors: []
       exporters:
-        - loadbalancing
+        - load_balancing
 ```

--- a/content/en/docs/platforms/kubernetes/collector/components.md
+++ b/content/en/docs/platforms/kubernetes/collector/components.md
@@ -281,7 +281,7 @@ Since Kubernetes logs normally fit a set of standard formats, a typical Filelog
 Receiver configuration for Kubernetes looks like:
 
 ```yaml
-filelog:
+file_log:
   include:
     - /var/log/pods/*/*/*.log
   exclude:

--- a/content/en/docs/zero-code/obi/trace-log-correlation.md
+++ b/content/en/docs/zero-code/obi/trace-log-correlation.md
@@ -225,11 +225,11 @@ logs to your backend.
 When OBI suppresses the original line, container log files contain a line of NUL
 bytes in its place. For writes up to 8 KiB, filter these placeholder lines
 downstream with `^[\x00\s]*$`. For example, with the OpenTelemetry Collector
-`filelog` receiver:
+`file_log` receiver:
 
 ```yaml
 receivers:
-  filelog:
+  file_log:
     include:
       - /var/log/pods/*/*/*.log
     start_at: end


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

Recently, there has been an endeavor to replace collector component names with `lower_snake_case` variants. This PR updates collector configs for three of these components:

- `receiver/file_log`, changed in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46750
- `exporter/load_balancing`, changed in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48533
- `receiver/prometheus_remote_write`, changed in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46726