### PR TITLE
docs(demo): drop retired Tracetest step from Docker deployment guide

### DIFF
--- a/content/en/docs/demo/docker-deployment.md
+++ b/content/en/docs/demo/docker-deployment.md
@@ -2,7 +2,7 @@
 title: Docker deployment
 linkTitle: Docker
 aliases: [docker_deployment]
-cSpell:ignore: otlphttp spanmetrics tracetest tracetesting
+cSpell:ignore: otlphttp spanmetrics
 ---
 
 <!-- markdownlint-disable code-block-style ol-prefix -->
@@ -72,22 +72,6 @@ docker compose -f docker-compose.minimal.yml up --force-recreate --remove-orphan
     - `flagd-ui`
     - `kafka`
 
-4. (Optional) Enable API observability-driven testing[^1]:
-
-    {{< tabpane text=true >}} {{% tab Make %}}
-
-```shell
-make run-tracetesting
-```
-
-    {{% /tab %}} {{% tab Docker %}}
-
-```shell
-docker compose -f docker-compose-tests.yml run traceBasedTests
-```
-
-    {{% /tab %}} {{< /tabpane >}}
-
 ## Verify the web store and Telemetry
 
 Once the images are built and containers are started you can access:
@@ -96,8 +80,6 @@ Once the images are built and containers are started you can access:
 - Grafana: <http://localhost:8080/grafana/>
 - Jaeger UI: <http://localhost:8080/jaeger/ui/>
 - OpAMP UI: <http://localhost:8080/opamp/>
-- Tracetest UI: <http://localhost:11633/>, only when using
-  `make run-tracetesting`
 - Flagd configurator UI: <http://localhost:8080/feature>
 
 ## Changing the demo's primary port number


### PR DESCRIPTION
Fixes #11358
Contributes to the remaining work listed in #11120: "remove rather than update the trace-testing section" (see also the [closing findings of #11184](https://github.com/open-telemetry/opentelemetry.io/pull/11184#issuecomment-5226889400), which note the swap-in command was just as dead).

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.

## What

Removes optional step 4 ("Enable API observability-driven testing" with `make run-tracetesting` / `docker compose -f docker-compose-tests.yml run traceBasedTests`) and the "Tracetest UI" bullet from the [Docker deployment](https://opentelemetry.io/docs/demo/docker-deployment/) page, and drops the now-unused `tracetest tracetesting` entries from the page's `cSpell:ignore`.

## Why

Tracetest was removed from the demo in open-telemetry/opentelemetry-demo#3602 (June 2026). On current demo `main`:

- there is no `docker-compose-tests.yml`; the tests overlay was renamed to `compose.tests.yaml` in open-telemetry/opentelemetry-demo#3229, and its only service is `frontendTests` — no `traceBasedTests` service exists;
- the `run-tracetesting` Make target no longer exists (current targets are `run-frontend-tests` and `run-telemetry-tests`).

Both documented commands fail for anyone following the page, which is what #11358 reports. Per the maintainer direction quoted above, the section is removed rather than rewritten around a different test suite.

## Scope

- English source only; locale mirrors sync via the l10n tooling.
- The minimal-mode command fix from the same #11120 remaining-work list is deliberately left to the open PRs that already address it (#11309, #11095).
- Follow-up worth tracking separately: [`content/en/docs/demo/tests.md`](https://opentelemetry.io/docs/demo/tests/) still describes Tracetest, `traceBasedTests`, and `integrationTests` flows that no longer exist; rewriting that page is the "broader edit" deferred in the #11184 findings, so it is not bundled here.

## Verification

- Confirmed against opentelemetry-demo `main`: `compose.tests.yaml` defines only `frontendTests`; `make run-tracetesting` and `traceBasedTests` are absent (only historical CHANGELOG/README-fork mentions remain).
- `npx prettier@3.9.6 --check` passes on the modified file (matches `npm run check:format`).
- Pure deletion in one file; no code or frontmatter behavior changes beyond the trimmed cSpell list.

