### PR TITLE
Add DeepSeek Harness instrumentation to registry

### DIFF
--- a/.lycheecache
+++ b/.lycheecache
@@ -4946,6 +4946,7 @@ https://npmjs.com/package/@google-cloud/opentelemetry-cloud-trace-exporter,206,1
 https://npmjs.com/package/@instana/opentelemetry-exporter,200,1787035595
 https://npmjs.com/package/@jenniferplusplus/opentelemetry-instrumentation-bullmq,206,1786427907
 https://npmjs.com/package/@jufab/opentelemetry-angular-interceptor,206,1787036041
+https://npmjs.com/package/@loongsuite/dsh-plugin,206,1787098345
 https://npmjs.com/package/@opentelemetry/baggage-log-record-processor,200,1787035629
 https://npmjs.com/package/@opentelemetry/baggage-span-processor,206,1787036041
 https://npmjs.com/package/@opentelemetry/exporter-jaeger,206,1786509202

--- a/.lycheecache
+++ b/.lycheecache
@@ -1637,6 +1637,9 @@ https://github.com/lightstep/opentelemetry-exporter-go,200,1787032519
 https://github.com/lightstep/opentelemetry-exporter-python,200,1787032521
 https://github.com/lizthegrey,200,1787029628
 https://github.com/lmolkova,200,1786427581
+https://github.com/loongsuite,200,1787098643
+https://github.com/loongsuite/dsh-plugin#readme,200,1787098644
+https://github.com/loongsuite/dsh-plugin,200,1787098644
 https://github.com/lopes-felipe,200,1787029628
 https://github.com/lquerel,200,1787032233
 https://github.com/lucacavenaghi97,200,1787032236

--- a/data/registry/instrumentation-js-deepseek-harness.yml
+++ b/data/registry/instrumentation-js-deepseek-harness.yml
@@ -1,0 +1,27 @@
+# cSpell:ignore deepseek dsh genai loongsuite otlp
+title: DeepSeek Harness Instrumentation
+registryType: instrumentation
+language: js
+tags:
+  - javascript
+  - instrumentation
+  - deepseek
+  - genai
+urls:
+  repo: https://github.com/loongsuite/dsh-plugin
+  docs: https://github.com/loongsuite/dsh-plugin#readme
+license: Apache 2.0
+description:
+  Instrumentation for DeepSeek Harness that converts session, agent loop, LLM,
+  and tool lifecycle events into GenAI traces and metrics over OTLP/HTTP.
+  Content capture is disabled by default.
+authors:
+  - name: LoongSuite Authors
+    url: https://github.com/loongsuite
+createdAt: 2026-08-18
+package:
+  registry: npm
+  name: '@loongsuite/dsh-plugin'
+  version: 0.1.1
+isNative: false
+isFirstParty: false


### PR DESCRIPTION
Adds a registry entry for [`@loongsuite/dsh-plugin`](https://github.com/loongsuite/dsh-plugin), OpenTelemetry GenAI instrumentation for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (an open-source coding-agent runtime).

The plugin runs inside the harness process and maps its native session, agent-loop, LLM, and tool lifecycle events onto the GenAI semantic conventions, exporting over OTLP/HTTP. Content capture is off by default.

- `registryType: instrumentation`, `language: js`, published on npm as `@loongsuite/dsh-plugin` (`0.1.1`), Apache 2.0.
- `isNative: false` and `isFirstParty: false`: this is a third-party plugin, not affiliated with DeepSeek.

Validated locally: `data/registry-schema.json` passes, and cspell reports no issues for the new file.