### PR TITLE
[ja] update translation of content/en/docs/languages/php/getting-started.md

### DIFF
--- a/content/ja/docs/languages/php/getting-started.md
+++ b/content/ja/docs/languages/php/getting-started.md
@@ -3,8 +3,7 @@ title: はじめに
 description: PHP 向け OpenTelemetry を使い始めましょう。
 aliases: [getting_started]
 weight: 10
-default_lang_commit: 1604e4a539552aea3cd5caff67e7c476d26ab7d6
-drifted_from_default: true
+default_lang_commit: af0d7e75a955c3a53c6353994d16f5ba9e8753de
 cSpell:ignore: darwin pecl rolldice strval
 ---
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/php/getting-started.md` to match the latest English source at
`content/en/docs/languages/php/getting-started.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The only English-side change since the last sync was a link target update
(`/docs/zero-code/php/#install-the-opentelemetry-extension` →
`/docs/zero-code/php/auto/#install-the-opentelemetry-extension`).
The Japanese file already had the correct (updated) link, so the only changes
in this PR are the frontmatter bookkeeping fields.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11371--opentelemetry.netlify.app/ja/docs/languages/php/getting-started/
- **English (canonical):** https://opentelemetry.io/docs/languages/php/getting-started/

<!-- preview-section-end -->
