### PR TITLE
Add Linux platform approvers to component owners

### DIFF
--- a/.github/component-owners.yml
+++ b/.github/component-owners.yml
@@ -66,6 +66,8 @@ components:
     - open-telemetry/rust-approvers
   content/en/docs/languages/swift:
     - open-telemetry/swift-approvers
+‎  content/en/docs/platforms/linux:
+    - open-telemetry/packaging-approvers
   content/en/docs/security:
     - open-telemetry/sig-security-maintainers
   content/en/docs/specs:

--- a/.github/component-owners.yml
+++ b/.github/component-owners.yml
@@ -40,6 +40,8 @@ components:
     - open-telemetry/browser-approvers
   content/en/docs/platforms/faas:
     - open-telemetry/lambda-extension-approvers
+  content/en/docs/platforms/linux:
+    - open-telemetry/packaging-approvers
   content/en/docs/languages/cpp:
     - open-telemetry/cpp-approvers
   content/en/docs/languages/erlang:
@@ -66,8 +68,6 @@ components:
     - open-telemetry/rust-approvers
   content/en/docs/languages/swift:
     - open-telemetry/swift-approvers
-‎  content/en/docs/platforms/linux:
-    - open-telemetry/packaging-approvers
   content/en/docs/security:
     - open-telemetry/sig-security-maintainers
   content/en/docs/specs:


### PR DESCRIPTION
- [X] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [X] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

Due to new content landing with https://github.com/open-telemetry/opentelemetry.io/pull/11193, we need to define [packaging](https://github.com/open-telemetry/opentelemetry-packaging/) component owners.