### PR TITLE
Add NATS Collector exporter and receiver to registry

### DIFF
--- a/data/registry/collector-exporter-nats.yml
+++ b/data/registry/collector-exporter-nats.yml
@@ -1,0 +1,23 @@
+# cSpell:ignore natsexporter synadia
+title: NATS Collector Exporter
+registryType: exporter
+language: collector
+tags:
+  - go
+  - exporter
+  - collector
+  - nats
+license: Apache 2.0
+description: Publishes OpenTelemetry traces, metrics, and logs onto NATS subjects (Core NATS or JetStream) as OTLP, with OTTL-based subject routing.
+authors:
+  - name: Erik
+    url: https://github.com/suckatrash
+  - name: Synadia
+    url: https://synadia.com
+urls:
+  repo: https://github.com/synadia-io/opentelemetry-collector-nats/tree/main/exporter/natsexporter
+createdAt: 2026-08-19
+package:
+  registry: go-collector
+  name: github.com/synadia-io/opentelemetry-collector-nats/exporter/natsexporter
+  version: v0.2.0

--- a/data/registry/collector-receiver-nats.yml
+++ b/data/registry/collector-receiver-nats.yml
@@ -1,0 +1,23 @@
+# cSpell:ignore natsreceiver synadia
+title: NATS Collector Receiver
+registryType: receiver
+language: collector
+tags:
+  - go
+  - receiver
+  - collector
+  - nats
+license: Apache 2.0
+description: Consumes OTLP traces, metrics, and logs off NATS subjects — Core NATS subscriptions or a JetStream durable consumer that acks after the pipeline accepts each message.
+authors:
+  - name: Erik
+    url: https://github.com/suckatrash
+  - name: Synadia
+    url: https://synadia.com
+urls:
+  repo: https://github.com/synadia-io/opentelemetry-collector-nats/tree/main/receiver/natsreceiver
+createdAt: 2026-08-19
+package:
+  registry: go-collector
+  name: github.com/synadia-io/opentelemetry-collector-nats/receiver/natsreceiver
+  version: v0.2.0


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [X] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [X] This PR has content that I did not fully write myself.
  - [X] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [X] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

Adds two OpenTelemetry Registry entries for a pair of Collector components that bridge the Collector and [NATS](https://nats.io)

Source & docs: https://github.com/synadia-io/opentelemetry-collector-nats

Related:
- Tracking issue: open-telemetry/opentelemetry-collector-contrib#39540 (NATS as a Receiver and Exporter)
- Prior art: 
  - open-telemetry/opentelemetry-collector-contrib#42186
  - open-telemetry/opentelemetry-collector-contrib#42304
  - open-telemetry/opentelemetry-collector-contrib#42452
