### PR TITLE
Update contrib docs: CI/infra issues are for maintainers only

### DIFF
--- a/.lycheecache
+++ b/.lycheecache
@@ -3913,6 +3913,7 @@ https://github.com/open-telemetry/opentelemetry.io/issues/11210,200,1786391968
 https://github.com/open-telemetry/opentelemetry.io/issues/6592,200,1785868419
 https://github.com/open-telemetry/opentelemetry.io/issues/9449,200,1785739344
 https://github.com/open-telemetry/opentelemetry.io/issues/new,200,1785868416
+https://github.com/open-telemetry/opentelemetry.io/labels/CI%2Finfra,200,1787230348
 https://github.com/open-telemetry/opentelemetry.io/labels/sig-approval-missing,200,1785868415
 https://github.com/open-telemetry/opentelemetry.io/pull/10911,200,1786028673
 https://github.com/open-telemetry/opentelemetry.io/pull/5891,200,1785739340

--- a/content/en/docs/contributing/issues.md
+++ b/content/en/docs/contributing/issues.md
@@ -18,9 +18,8 @@ issue.
 
    > [!WARNING] Important!
    >
-   > {{% param chooseAnIssueAtYourLevel %}}
-   >
-   > Issues labeled `CI/infra` are maintainer-handled; see
+   > {{% param chooseAnIssueAtYourLevel %}} Issues labeled `CI/infra` are
+   > maintainer-handled; see
    > [CI and infrastructure issues](#ci-and-infrastructure-issues).
 
 3. Read through the issue comments, if any.
@@ -33,7 +32,7 @@ issue.
 
 ## CI and infrastructure issues
 
-Issues labeled [`CI/infra`][] are for **maintainers _only_**: they concern the
+Issues labeled [CI/infra][] are for **maintainers _only_**: they concern the
 repository's own workflows, required checks, tooling, and settings. Unlike
 content and localization work:
 
@@ -70,15 +69,10 @@ If you have an idea for new content or a feature, but you aren't sure where it
 should go, you can still file an issue. You can also report bugs and security
 vulnerabilities.
 
-1. Go to
-   [GitHub](https://github.com/open-telemetry/opentelemetry.io/issues/new/) and
-   select **New issue** inside the **Issues** tab.
-
-1. Select the type of issue that best applies to your request or doubt.
-
-1. Fill out the template.
-
-1. Submit the issue.
+1. Go to GitHub and select **[New issue][]** from the **Issues** tab.
+2. Select the type of issue that best applies to your request or doubt.
+3. Fill out the template.
+4. Submit the issue.
 
 ### How to file great issues
 
@@ -96,13 +90,14 @@ Keep the following in mind when filing an issue:
 - If the new issue relates to another issue or pull request, refer to it either
   by its full URL or by the issue or pull request number prefixed with a `#`
   character. For example, `Introduced by #987654`.
-- Follow the
-  [Code of Conduct](https://github.com/open-telemetry/community/blob/main/code-of-conduct.md).
-  Respect your fellow contributors. For example, "The docs are terrible" is not
-  helpful or polite feedback.
+- Follow the [Code of Conduct][]. Respect your fellow contributors. For example,
+  "The docs are terrible" is not helpful or polite feedback.
 
+<!-- prettier-ignore-start -->
+[CI/infra]: https://github.com/open-telemetry/opentelemetry.io/labels/CI%2Finfra
+[Code of Conduct]: https://github.com/open-telemetry/community/blob/main/code-of-conduct.md
+[new issue]: https://github.com/open-telemetry/opentelemetry.io/issues/new/
+<!-- prettier-ignore-end -->
 <!-- markdownlint-disable link-image-reference-definitions -->
 
-[`CI/infra`]:
-  https://github.com/open-telemetry/opentelemetry.io/labels/CI%2Finfra
 [choose an issue]: <{{% param _issues %}}>

--- a/content/en/docs/contributing/issues.md
+++ b/content/en/docs/contributing/issues.md
@@ -18,8 +18,8 @@ issue.
 
    > [!WARNING] Important!
    >
-   > {{% param chooseAnIssueAtYourLevel %}} Issues labeled [`CI/infra` are for
-   > maintainers only](#ci-and-infrastructure-issues).
+   > {{% param chooseAnIssueAtYourLevel %}} Issues labeled
+   > [`CI/infra` are for maintainers only](#ci-infra).
 
 3. Read through the issue comments, if any.
 4. Ask maintainers if this issue is still relevant, and ask any questions you
@@ -29,7 +29,7 @@ issue.
 6. Work on fixing the issue. Let maintainers know if you run into any problems.
 7. When ready, [submit your work through a pull request](../pull-requests) (PR).
 
-## CI and infrastructure issues
+## CI and infrastructure issues {#ci-infra}
 
 Issues labeled [CI/infra][] are for **maintainers _only_**: they concern the
 repository's own workflows, required checks, tooling, and settings. Unlike

--- a/content/en/docs/contributing/issues.md
+++ b/content/en/docs/contributing/issues.md
@@ -18,8 +18,8 @@ issue.
 
    > [!WARNING] Important!
    >
-   > {{% param chooseAnIssueAtYourLevel %}} Issues labeled `CI/infra` are
-   > maintainer-handled; see
+   > {{% param chooseAnIssueAtYourLevel %}} Issues labeled `CI/infra` are for
+   > maintainers only; see
    > [CI and infrastructure issues](#ci-and-infrastructure-issues).
 
 3. Read through the issue comments, if any.

--- a/content/en/docs/contributing/issues.md
+++ b/content/en/docs/contributing/issues.md
@@ -19,6 +19,9 @@ issue.
    > [!WARNING] Important!
    >
    > {{% param chooseAnIssueAtYourLevel %}}
+   >
+   > Issues labeled `CI/infra` are maintainer-handled; see
+   > [CI and infrastructure issues](#ci-and-infrastructure-issues).
 
 3. Read through the issue comments, if any.
 4. Ask maintainers if this issue is still relevant, and ask any questions you
@@ -27,6 +30,17 @@ issue.
    effect.
 6. Work on fixing the issue. Let maintainers know if you run into any problems.
 7. When ready, [submit your work through a pull request](../pull-requests) (PR).
+
+## CI and infrastructure issues
+
+Issues labeled [`CI/infra`][] are **maintainer-handled**: don't pick them up or
+submit PRs for them unless a maintainer invites contributions on the issue. Such
+issues concern the repository's own workflows, required checks, tooling, and
+settings. Unlike content and localization work, changes in this area can't be
+meaningfully tested from a fork (their failure modes surface in upstream CI and
+merge-time behavior), and they often depend on maintainer roadmaps and context
+not visible in the issue text. Note that `triage:accepted` on such an issue
+means that the problem is confirmed, not that the work is up for grabs.
 
 ## Reporting an issue
 
@@ -83,4 +97,6 @@ Keep the following in mind when filing an issue:
 
 <!-- markdownlint-disable link-image-reference-definitions -->
 
+[`CI/infra`]:
+  https://github.com/open-telemetry/opentelemetry.io/labels/CI%2Finfra
 [choose an issue]: <{{% param _issues %}}>

--- a/content/en/docs/contributing/issues.md
+++ b/content/en/docs/contributing/issues.md
@@ -33,15 +33,20 @@ issue.
 
 ## CI and infrastructure issues
 
-Issues labeled [`CI/infra`][] are for **maintainers _only_**. Such issues
-concern the repository's own workflows, required checks, tooling, and settings.
-Unlike content and localization work, changes in this area can't be meaningfully
-tested from a fork (their failure modes surface in upstream CI and merge-time
-behavior), and they often depend on maintainer roadmaps and context not visible
-in the issue text. Some of that context is deliberately private: work affecting
-the site's security posture, such as hardening and embargoed fixes, isn't
-discussed publicly before it lands. Note that `triage:accepted` on such an issue
-means that the problem is confirmed, not that the work is up for grabs.
+Issues labeled [`CI/infra`][] are for **maintainers _only_**: they concern the
+repository's own workflows, required checks, tooling, and settings. Unlike
+content and localization work:
+
+- Changes in this area can't be meaningfully tested from a fork: their failure
+  modes surface in upstream CI and merge-time behavior.
+- The work often depends on maintainer roadmaps and context not visible in the
+  issue text.
+- Some of that context is deliberately private: work affecting the site's
+  security posture, such as hardening and embargoed fixes, isn't discussed
+  publicly before it lands.
+
+Note that `triage:accepted` on such an issue means that the problem is
+confirmed, not that the work is up for grabs.
 
 ## Reporting an issue
 

--- a/content/en/docs/contributing/issues.md
+++ b/content/en/docs/contributing/issues.md
@@ -38,12 +38,12 @@ repository's own workflows, required checks, tooling, and settings. Unlike
 content and localization work:
 
 - Changes in this area can't be meaningfully tested by non-maintainers; for
-  example,failure modes surface in upstream CI and merge-time behavior.
+  example, failure modes surface in upstream CI and merge-time behavior.
 - The work often depends on maintainer roadmaps and context not visible in the
   issue text.
 - Some context is deliberately private: work affecting the site's security
-  posture, hardening and remediation fixes, aren't discussed publicly before
-  they are merged.
+  posture (hardening and remediation fixes) isn't discussed publicly before it
+  is merged.
 
 Note that `triage:accepted` on such an issue means that the problem is
 confirmed, not that the work is up for grabs.

--- a/content/en/docs/contributing/issues.md
+++ b/content/en/docs/contributing/issues.md
@@ -37,13 +37,13 @@ Issues labeled [`CI/infra`][] are for **maintainers _only_**: they concern the
 repository's own workflows, required checks, tooling, and settings. Unlike
 content and localization work:
 
-- Changes in this area can't be meaningfully tested from a fork: their failure
-  modes surface in upstream CI and merge-time behavior.
+- Changes in this area can't be meaningfully tested by non-maintainers; for
+  example,failure modes surface in upstream CI and merge-time behavior.
 - The work often depends on maintainer roadmaps and context not visible in the
   issue text.
-- Some of that context is deliberately private: work affecting the site's
-  security posture, such as hardening and embargoed fixes, isn't discussed
-  publicly before it lands.
+- Some context is deliberately private: work affecting the site's security
+  posture, hardening and remediation fixes, aren't discussed publicly before
+  they are merged.
 
 Note that `triage:accepted` on such an issue means that the problem is
 confirmed, not that the work is up for grabs.

--- a/content/en/docs/contributing/issues.md
+++ b/content/en/docs/contributing/issues.md
@@ -18,9 +18,8 @@ issue.
 
    > [!WARNING] Important!
    >
-   > {{% param chooseAnIssueAtYourLevel %}} Issues labeled `CI/infra` are for
-   > maintainers only; see
-   > [CI and infrastructure issues](#ci-and-infrastructure-issues).
+   > {{% param chooseAnIssueAtYourLevel %}} Issues labeled [`CI/infra` are for
+   > maintainers only](#ci-and-infrastructure-issues).
 
 3. Read through the issue comments, if any.
 4. Ask maintainers if this issue is still relevant, and ask any questions you

--- a/content/en/docs/contributing/issues.md
+++ b/content/en/docs/contributing/issues.md
@@ -33,13 +33,14 @@ issue.
 
 ## CI and infrastructure issues
 
-Issues labeled [`CI/infra`][] are **maintainer-handled**: don't pick them up or
-submit PRs for them unless a maintainer invites contributions on the issue. Such
-issues concern the repository's own workflows, required checks, tooling, and
-settings. Unlike content and localization work, changes in this area can't be
-meaningfully tested from a fork (their failure modes surface in upstream CI and
-merge-time behavior), and they often depend on maintainer roadmaps and context
-not visible in the issue text. Note that `triage:accepted` on such an issue
+Issues labeled [`CI/infra`][] are for **maintainers _only_**. Such issues
+concern the repository's own workflows, required checks, tooling, and settings.
+Unlike content and localization work, changes in this area can't be meaningfully
+tested from a fork (their failure modes surface in upstream CI and merge-time
+behavior), and they often depend on maintainer roadmaps and context not visible
+in the issue text. Some of that context is deliberately private: work affecting
+the site's security posture, such as hardening and embargoed fixes, isn't
+discussed publicly before it lands. Note that `triage:accepted` on such an issue
 means that the problem is confirmed, not that the work is up for grabs.
 
 ## Reporting an issue


### PR DESCRIPTION
- Adds an anchorable "CI and infrastructure issues" section to the contributing docs, giving the `CI/infra` label's maintainers-only policy a prose home that issue comments and the label can link to
- Wires it into the pick-an-issue warning at point of use
- Motivation: recent outside PRs on `CI/infra` issues (e.g. #11260) cost more maintainer time to review and realign than doing the work directly; see also the discussion in #11243

**Preview**: [/docs/contributing/issues/#ci-and-infrastructure-issues](https://deploy-preview-11383--opentelemetry.netlify.app/docs/contributing/issues/#ci-and-infrastructure-issues)
