### PR TITLE
Fix textlint iOS false positive on Romanian -țios words

### DIFF
--- a/.textlintrc.yml
+++ b/.textlintrc.yml
@@ -22,6 +22,9 @@ filters:
       - /src=".*?"/
       # Other:
       - /<https?:\/\/.*?>/ # Raw URLs
+      # Romanian -țios words (silențios, prețios, etc.): the terminology rule's
+      # ASCII-only \b treats ț as a word boundary, misreading the tail as iOS:
+      - /țios/
 rules:
   prh:
     rulePaths:


### PR DESCRIPTION
- Unblocks #11384, whose `TEXT linter` check flags "silențios" on a Romanian page as an iOS misuse.
- Root cause: textlint-rule-terminology compiles its term regexes without the `u` flag, so `\b`/`\w` are ASCII-only and `ț` (U+021B) registers as a word boundary, letting the tail of word-final `-țios` (silențios, prețios, grațios, …) match the `iOS` term. The durable fix is upstream; this allowlist entry is the local workaround.
- The entry masks only the `-țios` tail: a genuine standalone `ios` is still flagged.
