### PR TITLE
[ja] update translation of content/en/docs/zero-code/python/troubleshooting.md

### DIFF
--- a/content/ja/docs/zero-code/python/troubleshooting.md
+++ b/content/ja/docs/zero-code/python/troubleshooting.md
@@ -2,8 +2,7 @@
 title: Pythonの自動計装に関する問題のトラブルシューティング
 linkTitle: Troubleshooting
 weight: 40
-default_lang_commit: 1f686d5f7b6bbdfaa30dafdc6ca0214c6f2308db
-drifted_from_default: true
+default_lang_commit: bdfe463187e63311ab3e137f1e314acfb877fd8b
 cSpell:ignore: ASGI gunicorn uvicorn
 ---
 
@@ -157,6 +156,24 @@ async def root():
 
 ```sh
 uvicorn main:app --workers 2
+```
+
+##### Gunicornのポストフォークによるプログラム自動計装の使用 {#use-gunicorn-post-fork-for-programmatic-auto-instrumentation}
+
+Gunicornを使用している場合、`opentelemetry-instrument` のかわりにポストフォークフックの一部として[プログラム自動計装](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/opentelemetry-instrumentation/README.rst#programmatic-auto-instrumentation)で OpenTelemetry を初期化できます。
+たとえば、`your_app.py` と同じディレクトリにある `gunicorn_config.py` ファイルで次のように設定します。
+
+```python
+from opentelemetry.instrumentation.auto_instrumentation import initialize
+
+def post_fork(server, worker):
+    initialize()
+```
+
+次のコマンドで実行します。
+
+```sh
+gunicorn --config gunicorn_config.py --workers=2 your_app:app
 ```
 
 ##### PrometheusでOTLPを直接使用 {#use-prometheus-with-direct-otlp}


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/python/troubleshooting.md` to match the latest English source at
`content/en/docs/zero-code/python/troubleshooting.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff adds a new section "Use Gunicorn post-fork for programmatic auto-instrumentation"
under the pre-fork server workarounds. The Japanese translation inserts the corresponding section
at the same position.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.