### PR TITLE
[ja] add translation of content/en/site/testing/tests/regular.md

### DIFF
--- a/content/ja/site/testing/tests/regular.md
+++ b/content/ja/site/testing/tests/regular.md
@@ -1,0 +1,7 @@
+---
+title: 通常のテストページ
+aliases: [regular-alias]
+default_lang_commit: bdfe463187e63311ab3e137f1e314acfb877fd8b
+---
+
+これはテストページです。


### PR DESCRIPTION
## Summary

Translates `content/en/site/testing/tests/regular.md` into Japanese as `content/ja/site/testing/tests/regular.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11392--opentelemetry.netlify.app/ja/site/testing/tests/regular/
- **English (canonical):** https://opentelemetry.io/site/testing/tests/regular/

<!-- preview-section-end -->
