### PR TITLE
Add freeze notice to ecosystem list pages

### DIFF
--- a/.lycheecache
+++ b/.lycheecache
@@ -3917,6 +3917,7 @@ https://github.com/open-telemetry/opentelemetry.io/issues,200,1786341698
 https://github.com/open-telemetry/opentelemetry.io/issues/10449,206,1784355925
 https://github.com/open-telemetry/opentelemetry.io/issues/10990,200,1786028672
 https://github.com/open-telemetry/opentelemetry.io/issues/11210,200,1786391968
+https://github.com/open-telemetry/opentelemetry.io/issues/11377,200,1787313382
 https://github.com/open-telemetry/opentelemetry.io/issues/6592,200,1785868419
 https://github.com/open-telemetry/opentelemetry.io/issues/9449,200,1785739344
 https://github.com/open-telemetry/opentelemetry.io/issues/new,200,1785868416

--- a/content/en/ecosystem/_includes/freeze-notice.md
+++ b/content/en/ecosystem/_includes/freeze-notice.md
@@ -1,0 +1,9 @@
+---
+---
+
+> [!WARNING] Ecosystem lists are frozen
+>
+> New entries and updates to the [ecosystem](/ecosystem/) lists, including the
+> [registry](/ecosystem/registry/), are no longer being accepted while
+> maintainers work out each list's future. For details and to share input, see
+> [issue #11377](https://github.com/open-telemetry/opentelemetry.io/issues/11377).

--- a/content/en/ecosystem/_includes/freeze-notice.md
+++ b/content/en/ecosystem/_includes/freeze-notice.md
@@ -1,6 +1,3 @@
----
----
-
 > [!WARNING] Ecosystem lists are frozen
 >
 > New entries and updates to the [ecosystem](/ecosystem/) lists, including the

--- a/content/en/ecosystem/_index.md
+++ b/content/en/ecosystem/_index.md
@@ -7,3 +7,5 @@ description: >-
 cascade: { type: docs }
 menu: { main: { weight: 20 } }
 ---
+
+{{% include freeze-notice.md %}}

--- a/content/en/ecosystem/adopters.md
+++ b/content/en/ecosystem/adopters.md
@@ -3,6 +3,8 @@ title: Adopters
 description: Organizations that use OpenTelemetry
 ---
 
+{{% include freeze-notice.md %}}
+
 OpenTelemetry's mission is to enable effective observability for all its
 end-users. If you are thinking about adopting OpenTelemetry for your
 organization, you may be curious about other adoption journeys. The table below

--- a/content/en/ecosystem/distributions.md
+++ b/content/en/ecosystem/distributions.md
@@ -5,6 +5,8 @@ description:
   List of open source OpenTelemetry distributions maintained by third parties.
 ---
 
+{{% include freeze-notice.md %}}
+
 OpenTelemetry [distributions][] are a way of customizing OpenTelemetry
 [components][] so that they're easier to deploy and use with specific
 observability backends.

--- a/content/en/ecosystem/integrations.md
+++ b/content/en/ecosystem/integrations.md
@@ -5,6 +5,8 @@ description:
 aliases: [/integrations]
 ---
 
+{{% include freeze-notice.md %}}
+
 The mission of OpenTelemetry is
 [to enable effective observability by making high-quality, portable telemetry ubiquitous](/community/mission/).
 In other words, observability should be built in into the software you develop.

--- a/content/en/ecosystem/registry/adding.md
+++ b/content/en/ecosystem/registry/adding.md
@@ -5,6 +5,8 @@ description: How to add entries to the registry.
 cSpell:ignore: zpages
 ---
 
+{{% include freeze-notice.md %}}
+
 Do you maintain or contribute to an integration for OpenTelemetry? We'd love to
 feature your project in the [registry](../)!
 

--- a/content/en/ecosystem/registry/updating.md
+++ b/content/en/ecosystem/registry/updating.md
@@ -3,6 +3,8 @@ title: Keeping registry and list information current
 linkTitle: Updating
 ---
 
+{{% include freeze-notice.md %}}
+
 We periodically review [registry](..) entry and [list data][], such as external
 links, to ensure that only [adopters](../../adopters/),
 [distributions](../../distributions/),

--- a/content/en/ecosystem/vendors.md
+++ b/content/en/ecosystem/vendors.md
@@ -4,6 +4,8 @@ description: Vendors who natively support OpenTelemetry
 aliases: [/vendors]
 ---
 
+{{% include freeze-notice.md %}}
+
 A non-exhaustive list of organizations offering solutions that consume
 OpenTelemetry natively via [OTLP](/docs/specs/otlp/), such as observability
 backends and observability pipelines.


### PR DESCRIPTION
- Contributes to #11377
- Adds a shared `_includes/freeze-notice.md` warning, posted on the ecosystem index, the four list pages (vendors, distributions, integrations, adopters), and the registry adding and updating pages
- **Previews**:
  - [ecosystem](https://deploy-preview-11394--opentelemetry.netlify.app/ecosystem/)
  - [vendors](https://deploy-preview-11394--opentelemetry.netlify.app/ecosystem/vendors/)
  - [distributions](https://deploy-preview-11394--opentelemetry.netlify.app/ecosystem/distributions/)
  - [integrations](https://deploy-preview-11394--opentelemetry.netlify.app/ecosystem/integrations/)
  - [adopters](https://deploy-preview-11394--opentelemetry.netlify.app/ecosystem/adopters/)
  - [registry/adding](https://deploy-preview-11394--opentelemetry.netlify.app/ecosystem/registry/adding/)
  - [registry/updating](https://deploy-preview-11394--opentelemetry.netlify.app/ecosystem/registry/updating/)
