### PR TITLE
[ja] update translation of content/en/docs/demo/architecture.md

### DIFF
--- a/content/ja/docs/demo/architecture.md
+++ b/content/ja/docs/demo/architecture.md
@@ -3,8 +3,7 @@ title: デモのアーキテクチャ
 linkTitle: アーキテクチャ
 aliases: [current_architecture]
 body_class: otel-mermaid-max-width
-default_lang_commit: 74d8cb2aaefe493295c6c49e2e8ef39801847880
-drifted_from_default: true
+default_lang_commit: f60f406894f94169947ecbd236b933ee4008354c
 ---
 
 **OpenTelemetryデモ** は、異なるプログラミング言語で書かれた複数のマイクロサービスから構成されており、gRPCとHTTPを使って相互に通信を行います。
@@ -15,8 +14,10 @@ graph TD
 subgraph サービス図
 accounting(会計):::dotnet
 ad(広告):::java
+agent(Agent):::python
 cache[(キャッシュ<br/>&#40Valkey&#41)]
 cart(カート):::dotnet
+chatbot(Chatbot):::python
 checkout(決済):::golang
 currency(通貨):::cpp
 email(メール):::ruby
@@ -27,6 +28,7 @@ frontend(フロントエンド):::typescript
 frontend-proxy(フロントエンドプロキシ <br/>&#40Envoy&#41):::cpp
 image-provider(画像プロバイダー <br/>&#40nginx&#41):::cpp
 load-generator([負荷生成ツール]):::golang
+mcp(MCP):::python
 payment(支払い):::javascript
 product-catalog(商品カタログ):::golang
 quoteservice(見積サービス):::php
@@ -38,6 +40,9 @@ postgresql[(データベース<br/>&#40PostgreSQL&#41)]
 
 accounting ---> postgresql
 
+agent -.->|HTTP| mcp
+agent -.->|HTTP| frontend
+
 ad ---->|gRPC| flagd
 
 checkout -->|gRPC| currency
@@ -46,6 +51,8 @@ checkout -->|TCP| queue
 
 cart --> cache
 cart -->|gRPC| flagd
+
+chatbot -->|HTTP| agent
 
 checkout -->|gRPC| payment
 checkout --->|HTTP| email
@@ -66,6 +73,9 @@ frontend-proxy -->|gRPC| flagd
 frontend-proxy -->|HTTP| frontend
 frontend-proxy -->|HTTP| flagd-ui
 frontend-proxy -->|HTTP| image-provider
+frontend-proxy -->|HTTP| chatbot
+
+mcp -->|HTTP| frontend
 
 payment -->|gRPC| flagd
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/demo/architecture.md` to match the latest English source at
`content/en/docs/demo/architecture.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

### Changes

Adds three new microservice nodes (`agent`, `chatbot`, `mcp` — all Python) and their
corresponding edges to the mermaid service diagram, matching the English source.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.