### PR TITLE
[ja] update translation of content/en/docs/contributing/issues.md

### DIFF
--- a/content/ja/docs/contributing/issues.md
+++ b/content/ja/docs/contributing/issues.md
@@ -3,8 +3,7 @@ title: イシュー
 description: 既存イシューの修正方法、またはバグ、セキュリティ、潜在的な改善の報告方法
 weight: 10
 _issues: https://github.com/open-telemetry/opentelemetry.io/issues
-default_lang_commit: bb20a7fb593782fea0e05e988d1478831726f9f5
-drifted_from_default: true
+default_lang_commit: f60f406894f94169947ecbd236b933ee4008354c
 ---
 
 ## 既存のイシューの修正 {#fixing-an-existing-issue}
@@ -16,13 +15,27 @@ drifted_from_default: true
 
    > [!WARNING] 重要！
    >
-   > {{% param chooseAnIssueAtYourLevel %}}
+   > {{% param chooseAnIssueAtYourLevel %}} [`CI/infra` ラベルが付いたイシューはメンテナー専用です](#ci-infra)。
 
 3. イシューにコメントがある場合、内容を読んでください。
 4. このイシューがまだ関係あるかをメンテナーに尋ね、明らかにしたい質問がある場合はイシューにコメントを投稿して質問してください。
 5. この旨のコメントを追加して、問題に取り組む意向を共有してください。
 6. イシューの修正に取り組みましょう。問題が発生した場合は、メンテナーに知らせてください。
-7. 準備ができれば、[プルリクエストを通じてあなたの作業を提出してください](../pull-requests)。
+7. 準備ができれば、[プルリクエストを通じてあなたの作業を提出してください](../pull-requests)（PR）。
+
+## CI とインフラストラクチャのイシュー {#ci-infra}
+
+[CI/infra][] ラベルが付いたイシューは**メンテナー*専用***です。
+リポジトリ自体のワークフロー、必須チェック、ツール、設定に関するものです。
+コンテンツやローカリゼーションの作業とは異なり、以下の特徴があります。
+
+- この領域の変更は、メンテナー以外が有意義にテストすることができません。
+  たとえば、障害モードは上流の CI やマージ時の動作で表面化します。
+- 作業はメンテナーのロードマップやイシューのテキストからは見えないコンテキストに依存することが多いです。
+- 一部のコンテキストは意図的に非公開です。
+  サイトのセキュリティ体制に影響する作業（堅牢化や修正）は、マージされるまで公には議論されません。
+
+このようなイシューに `triage:accepted` が付いている場合、問題が確認されたことを意味するのであり、作業を誰でも自由に引き受けられるという意味ではありません。
 
 ## イシューの報告 {#reporting-an-issue}
 
@@ -41,7 +54,7 @@ drifted_from_default: true
 新しいコンテンツや機能のアイデアを持っているが、どこに配置すべきかわからない場合、イシューに提出できます。
 バグとセキュリティの脆弱性も同様に報告できます。
 
-1. [GitHub](https://github.com/open-telemetry/opentelemetry.io/issues/new/) に行って **Issues** タブ内の **New issue** を選択してください。
+1. GitHub に行って **Issues** タブから **[New issue][]** を選択してください。
 2. 要望または疑問に最も適したイシューの種類を選択してください。
 3. テンプレートに入力してください。
 4. イシューを提出してください。
@@ -55,8 +68,15 @@ drifted_from_default: true
 - イシューの範囲は合理的な範囲に制限してください。問題の範囲が大きい場合は、小さなイシューに分割してください。たとえば、「セキュリティドキュメントを修正する」は広すぎますが、「『ネットワークアクセスの制限』のトピックに詳細を追加する」は具体的で実行しやすいです。
 - 新しいイシューに関連していて似たようなイシューが存在していないか探してください。
 - 新しいイシューがほかのイシューやプルリクエストに関連している場合は、該当する URL 全文を記載するか、`#` をつけてイシュー番号やプルリクエスト番号を記述してください。たとえば、`Introduced by #987654` です。
-- [Code of Conduct](https://github.com/open-telemetry/community/blob/main/code-of-conduct.md) に従ってください。ほかのコントリビューターを尊重しましょう。「このドキュメントはひどい」のような発言は、有益でも礼儀正しくもありません。
+- [Code of Conduct][] に従ってください。
+  ほかのコントリビューターを尊重しましょう。
+  「このドキュメントはひどい」のような発言は、有益でも礼儀正しくもありません。
 
+<!-- prettier-ignore-start -->
+[CI/infra]: https://github.com/open-telemetry/opentelemetry.io/labels/CI%2Finfra
+[Code of Conduct]: https://github.com/open-telemetry/community/blob/main/code-of-conduct.md
+[new issue]: https://github.com/open-telemetry/opentelemetry.io/issues/new/
+<!-- prettier-ignore-end -->
 <!-- markdownlint-disable link-image-reference-definitions -->
 
 [choose an issue]: <{{% param _issues %}}>


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/contributing/issues.md` to match the latest English source at
`content/en/docs/contributing/issues.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

### Changes

- Added new "CI and infrastructure issues" section (`{#ci-infra}`)
- Added `CI/infra` label reference in the WARNING block
- Updated "Suggesting new content or features" list to use reference-style links (`[New issue][]`)
- Updated Code of Conduct link to reference-style (`[Code of Conduct][]`)
- Added reference link definitions for `[CI/infra]`, `[Code of Conduct]`, and `[new issue]`
- Added `(PR)` abbreviation to match English source

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.