### PR TITLE
[ja] add translation of content/en/docs/zero-code/php/auto.md

### DIFF
--- a/content/ja/docs/zero-code/php/_index.md
+++ b/content/ja/docs/zero-code/php/_index.md
@@ -1,0 +1,33 @@
+---
+title: PHP ゼロコード計装
+linkTitle: PHP
+weight: 30
+default_lang_commit: f60f406894f94169947ecbd236b933ee4008354c
+cSpell:ignore: PECL
+---
+
+OpenTelemetry は PHP 向けに2つのゼロコード計装アプローチを提供しています。
+
+|                      | [自動計装](auto/)                | [PHP Distro](/docs/zero-code/php/distro/) |
+| -------------------- | -------------------------------- | ----------------------------------------- |
+| **インストール**     | Composer + PECL エクステンション | OS パッケージ（`deb`、`rpm`、`apk`）      |
+| **プラットフォーム** | Linux、macOS、Windows            | Linux のみ                                |
+| **セットアップ**     | Composer オートローディング      | パッケージをインストールし、PHP を再起動  |
+| **制御**             | 完全な手動制御                   | こだわりのあるデフォルト設定              |
+| **最適な用途**       | 柔軟な環境、カスタム設定         | 本番 Linux デプロイメント                 |
+
+## 自動計装を選択する {#choose-auto-instrumentation}
+
+次のような場合は、[PHP ゼロコード自動計装](auto/)を使用してください。
+
+- すでに Composer を使用している
+- macOS または Windows で実行する必要がある
+- 計装と設定を最大限制御したい
+
+## PHP Distro を選択する {#choose-php-distro}
+
+次のような場合は、[OpenTelemetry PHP Distro](/docs/zero-code/php/distro/) を使用してください。
+
+- Linux にデプロイし、パッケージ管理されたインストール（`deb`、`rpm`、`apk`）を希望する
+- アプリケーションコードや Composer に手を加えずにゼロコードオンボーディングを行いたい
+- 本番環境向けに調整されたデフォルト設定（バックグラウンドエクスポート、推論されたスパン、OpAMP）を使用したい

--- a/content/ja/docs/zero-code/php/auto.md
+++ b/content/ja/docs/zero-code/php/auto.md
@@ -1,0 +1,252 @@
+---
+title: PHP ゼロコード計装
+linkTitle: 自動計装
+weight: 20
+aliases:
+  - /docs/languages/php/automatic
+  - /docs/zero-code/php/
+default_lang_commit: f60f406894f94169947ecbd236b933ee4008354c
+cSpell:ignore: centos democlass epel pecl phar remi
+---
+
+## 要件 {#requirements}
+
+PHP の自動計装には以下が必要です。
+
+- PHP 8.0 以上
+- [OpenTelemetry PHP エクステンション](https://github.com/open-telemetry/opentelemetry-php-instrumentation)
+- [Composer オートローディング](https://getcomposer.org/doc/01-basic-usage.md#autoloading)
+- [OpenTelemetry SDK](https://packagist.org/packages/open-telemetry/sdk)
+- 1つ以上の[計装ライブラリ](/ecosystem/registry/?component=instrumentation&language=php)
+- [設定](#configuration)
+
+## OpenTelemetry エクステンションのインストール {#install-the-opentelemetry-extension}
+
+> [!IMPORTANT]
+>
+> OpenTelemetry エクステンションをインストールするだけではトレースは生成されません。
+
+エクステンションは pecl、[pickle](https://github.com/FriendsOfPHP/pickle)、[PIE](https://github.com/php/pie)、または [php-extension-installer](https://github.com/mlocati/docker-php-extension-installer)（Docker 専用）経由でインストールできます。
+一部の Linux パッケージマネージャー向けにパッケージ化されたバージョンのエクステンションも利用できます。
+
+### Linux パッケージ {#linux-packages}
+
+RPM と APK パッケージは以下から提供されています。
+
+- [Remi repository](https://blog.remirepo.net/pages/PECL-extensions-RPM-status) -
+  RPM
+- [Alpine Linux](https://pkgs.alpinelinux.org/packages?name=*pecl-opentelemetry) -
+  APK（現在は
+  [_testing_ ブランチ](https://wiki.alpinelinux.org/wiki/Repositories#Testing)にあります）
+
+{{< tabpane text=true >}} {{% tab "RPM" %}}
+
+```sh
+#この例は CentOS 7 向けです。PHP バージョンは
+#remi-<version> を有効にすることで変更できます。例: "yum config-manager --enable remi-php83"
+yum update -y
+yum install -y epel-release yum-utils
+yum install -y http://rpms.remirepo.net/enterprise/remi-release-7.rpm
+yum-config-manager --enable remi-php81
+yum install -y php php-pecl-opentelemetry
+
+php --ri opentelemetry
+```
+
+{{% /tab %}} {{% tab "APK" %}}
+
+```sh
+#執筆時点では、PHP 8.1 がデフォルトの PHP バージョンでした。デフォルトが変更された場合、
+#"php81" を変更する必要があるかもしれません。"apk add php<version>" で
+#PHP バージョンを選択することもできます。例: "apk add php83"
+echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+apk add php php81-pecl-opentelemetry@testing
+php --ri opentelemetry
+```
+
+{{% /tab %}} {{< /tabpane >}}
+
+### PECL {#pecl}
+
+1. 開発環境のセットアップ。
+   ソースからのインストールには適切な開発環境といくつかの依存関係が必要です。
+
+   {{< tabpane text=true >}} {{% tab "Linux (apt)" %}}
+
+   ```sh
+   sudo apt-get install gcc make autoconf
+   ```
+
+   {{% /tab %}} {{% tab "macOS (homebrew)" %}}
+
+   ```sh
+   brew install gcc make autoconf
+   ```
+
+   {{% /tab %}} {{< /tabpane >}}
+
+2. エクステンションのビルド/インストール。
+   環境をセットアップしたら、エクステンションをインストールできます。
+
+   {{< tabpane text=true >}} {{% tab pecl %}}
+
+   ```sh
+   pecl install opentelemetry
+   ```
+
+   {{% /tab %}} {{% tab pickle %}}
+
+   ```sh
+   php pickle.phar install opentelemetry
+   ```
+
+   {{% /tab %}} {{% tab "php-extension-installer (docker)" %}}
+
+   ```sh
+   install-php-extensions opentelemetry
+   ```
+
+   {{% /tab %}} {{< /tabpane >}}
+
+3. エクステンションを `php.ini` ファイルに追加します。
+
+   ```ini
+   [opentelemetry]
+   extension=opentelemetry.so
+   ```
+
+4. エクステンションがインストールされ、有効になっていることを確認します。
+
+   ```sh
+   php -m | grep opentelemetry
+   ```
+
+## SDK と計装ライブラリのインストール {#install-sdk-and-instrumentation-libraries}
+
+エクステンションをインストールしたら、OpenTelemetry SDK と1つ以上の計装ライブラリをインストールします。
+
+自動計装は、一般的に使用される多くの PHP ライブラリで利用できます。
+完全なリストは、[packagist の計装ライブラリ](https://packagist.org/search/?query=open-telemetry&tags=instrumentation)を参照してください。
+
+アプリケーションが Slim Framework と PSR-18 HTTP クライアントを使用していて、OTLP プロトコルでトレースをエクスポートするとします。
+
+その場合、SDK、エクスポーター、および Slim Framework と PSR-18 用の自動計装パッケージをインストールします。
+
+```shell
+composer require \
+    open-telemetry/sdk \
+    open-telemetry/exporter-otlp \
+    open-telemetry/opentelemetry-auto-slim \
+    open-telemetry/opentelemetry-auto-psr18
+```
+
+## 設定 {#configuration}
+
+OpenTelemetry SDK と組み合わせて使用する場合、環境変数または `php.ini` ファイルを使用して自動計装を設定できます。
+
+### 環境変数による設定 {#environment-configuration}
+
+```sh
+OTEL_PHP_AUTOLOAD_ENABLED=true \
+OTEL_SERVICE_NAME=your-service-name \
+OTEL_TRACES_EXPORTER=otlp \
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4318 \
+OTEL_PROPAGATORS=baggage,tracecontext \
+php myapp.php
+```
+
+### php.ini による設定 {#phpini-configuration}
+
+以下を `php.ini`、または PHP が処理する別の `ini` ファイルに追加します。
+
+```ini
+OTEL_PHP_AUTOLOAD_ENABLED="true"
+OTEL_SERVICE_NAME=your-service-name
+OTEL_TRACES_EXPORTER=otlp
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4318
+OTEL_PROPAGATORS=baggage,tracecontext
+```
+
+## アプリケーションの実行 {#run-your-application}
+
+上記のすべてがインストールおよび設定されたら、通常どおりアプリケーションを起動します。
+
+OpenTelemetry Collector にエクスポートされるトレースは、インストールした計装ライブラリと、アプリケーション内で実行されたコードパスによって異なります。
+前の例で Slim Framework と PSR-18 の計装ライブラリを使用している場合、次のようなスパンが表示されるはずです。
+
+- HTTP トランザクションを表すルートスパン
+- 実行されたアクションのスパン
+- PSR-18 クライアントが送信した各 HTTP トランザクションのスパン
+
+PSR-18 クライアントの計装は、送信 HTTP リクエストに[分散トレーシング](/docs/concepts/context-propagation/#propagation)ヘッダーを付加することに注意してください。
+
+## 仕組み {#how-it-works}
+
+> [!NOTE] Optional
+>
+> すぐに使い始めたい場合や、アプリケーションに適した計装ライブラリがある場合は、このセクションをスキップできます。
+
+このエクステンションは、PHP コードとしてオブザーバー関数をクラスやメソッドに対して登録し、対象メソッドの実行前後にそれらの関数を実行できるようにします。
+
+フレームワークやアプリケーション用の計装ライブラリがない場合は、独自に作成できます。
+以下の例では、計装対象のコードを示し、OpenTelemetry エクステンションを使用してそのコードの実行をトレースする方法を説明します。
+
+```php
+<?php
+
+use OpenTelemetry\API\Instrumentation\CachedInstrumentation;
+use OpenTelemetry\API\Trace\Span;
+use OpenTelemetry\API\Trace\StatusCode;
+use OpenTelemetry\Context\Context;
+
+require 'vendor/autoload.php';
+
+/* 計装対象のクラス */
+class DemoClass
+{
+    public function run(): void
+    {
+        echo 'Hello, world';
+    }
+}
+
+/* 自動計装コード */
+OpenTelemetry\Instrumentation\hook(
+    class: DemoClass::class,
+    function: 'run',
+    pre: static function (DemoClass $demo, array $params, string $class, string $function, ?string $filename, ?int $lineno) {
+        static $instrumentation;
+        $instrumentation ??= new CachedInstrumentation('example');
+        $span = $instrumentation->tracer()->spanBuilder('democlass-run')->startSpan();
+        Context::storage()->attach($span->storeInContext(Context::getCurrent()));
+    },
+    post: static function (DemoClass $demo, array $params, $returnValue, ?Throwable $exception) {
+        $scope = Context::storage()->scope();
+        $scope->detach();
+        $span = Span::fromContext($scope->context());
+        if ($exception) {
+            $span->recordException($exception);
+            $span->setStatus(StatusCode::STATUS_ERROR);
+        }
+        $span->end();
+    }
+);
+
+/* 計装されたコードを実行し、トレースを生成する */
+$demo = new DemoClass();
+$demo->run();
+```
+
+前の例では `DemoClass` を定義し、その `run` メソッドに `pre` および `post` フック関数を登録しています。
+フック関数は `DemoClass::run()` メソッドの実行前後に実行されます。
+`pre` 関数はスパンを開始してアクティブにし、`post` 関数はスパンを終了します。
+
+`DemoClass::run()` が例外をスローした場合、`post` 関数は例外の伝搬に影響を与えずに例外を記録します。
+
+## 次のステップ {#next-steps}
+
+アプリケーションやサービスに自動計装を設定した後は、[手動計装](/docs/languages/php/instrumentation)を追加してカスタムテレメトリーデータを収集することもできます。
+
+その他の例については、[opentelemetry-php-contrib/examples](https://github.com/open-telemetry/opentelemetry-php-contrib/tree/main/examples) を参照してください。

--- a/content/ja/docs/zero-code/php/auto.md
+++ b/content/ja/docs/zero-code/php/auto.md
@@ -36,14 +36,14 @@ RPM と APK パッケージは以下から提供されています。
 - [Remi repository](https://blog.remirepo.net/pages/PECL-extensions-RPM-status) -
   RPM
 - [Alpine Linux](https://pkgs.alpinelinux.org/packages?name=*pecl-opentelemetry) -
-  APK（現在は
-  [_testing_ ブランチ](https://wiki.alpinelinux.org/wiki/Repositories#Testing)にあります）
+  APK（現在は [_testing_ ブランチ](https://wiki.alpinelinux.org/wiki/Repositories#Testing)にあります）
 
 {{< tabpane text=true >}} {{% tab "RPM" %}}
 
 ```sh
-#この例は CentOS 7 向けです。PHP バージョンは
-#remi-<version> を有効にすることで変更できます。例: "yum config-manager --enable remi-php83"
+#この例は CentOS 7 向けです。
+#PHP バージョンは remi-<version> を有効にすることで変更できます。
+#例: "yum config-manager --enable remi-php83"
 yum update -y
 yum install -y epel-release yum-utils
 yum install -y http://rpms.remirepo.net/enterprise/remi-release-7.rpm
@@ -56,9 +56,10 @@ php --ri opentelemetry
 {{% /tab %}} {{% tab "APK" %}}
 
 ```sh
-#執筆時点では、PHP 8.1 がデフォルトの PHP バージョンでした。デフォルトが変更された場合、
-#"php81" を変更する必要があるかもしれません。"apk add php<version>" で
-#PHP バージョンを選択することもできます。例: "apk add php83"
+#執筆時点では、PHP 8.1 がデフォルトの PHP バージョンでした。
+#デフォルトが変更された場合、"php81" を変更する必要があるかもしれません。
+#"apk add php<version>" で PHP バージョンを選択することもできます。
+#例: "apk add php83"
 echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
 apk add php php81-pecl-opentelemetry@testing
 php --ri opentelemetry


### PR DESCRIPTION
## Summary

Translates `content/en/docs/zero-code/php/auto.md` into Japanese as `content/ja/docs/zero-code/php/auto.md`.

Also adds the required ancestor section index `content/ja/docs/zero-code/php/_index.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

### docs/zero-code/php/
- **Japanese (this PR):** https://deploy-preview-11399--opentelemetry.netlify.app/ja/docs/zero-code/php/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/php/

### docs/zero-code/php/auto/
- **Japanese (this PR):** https://deploy-preview-11399--opentelemetry.netlify.app/ja/docs/zero-code/php/auto/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/php/auto/

<!-- preview-section-end -->
