### PR TITLE
Clarify .NET TracerProvider lifetime

### DIFF
--- a/content/en/docs/languages/dotnet/instrumentation.md
+++ b/content/en/docs/languages/dotnet/instrumentation.md
@@ -307,11 +307,8 @@ loggerFactory.Dispose();
 > [!IMPORTANT]
 >
 > Keep the `TracerProvider` alive for as long as the application creates
-> telemetry. If you move its creation into a helper method, return the
-> `TracerProvider` to the caller. Don't create it with a local `using`
-> declaration in a `void` method, because the provider is disposed when the
-> method returns. Dispose the provider during application shutdown so that it
-> can flush any remaining telemetry. For more information, see
+> telemetry, and explicitly dispose it during application shutdown to flush any
+> remaining telemetry. For more information, see
 > [TracerProvider management](/docs/languages/dotnet/traces/best-practices/#tracerprovider-management).
 
 For debugging and local development purposes, the example exports telemetry to

--- a/content/en/docs/languages/dotnet/instrumentation.md
+++ b/content/en/docs/languages/dotnet/instrumentation.md
@@ -304,6 +304,16 @@ meterProvider.Dispose();
 loggerFactory.Dispose();
 ```
 
+> [!IMPORTANT]
+>
+> Keep the `TracerProvider` alive for as long as the application creates
+> telemetry. If you move its creation into a helper method, return the
+> `TracerProvider` to the caller. Don't create it with a local `using`
+> declaration in a `void` method, because the provider is disposed when the
+> method returns. Dispose the provider during application shutdown so that it
+> can flush any remaining telemetry. For more information, see
+> [TracerProvider management](/docs/languages/dotnet/traces/best-practices/#tracerprovider-management).
+
 For debugging and local development purposes, the example exports telemetry to
 the console. After you have finished setting up manual instrumentation, you need
 to configure an appropriate exporter to


### PR DESCRIPTION
- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the **First-time contributing?** section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

Clarify the lifetime requirements for a manually created .NET `TracerProvider`.
The new callout explains that console and other non-DI applications must keep the
provider alive while they produce telemetry, avoid disposing it inside a
`void` helper method, and dispose it during application shutdown.

Validation:

- Prettier
- markdownlint
- CSpell
- textlint
- Full Hugo site build

Fixes #2048
