### PR TITLE
Clarify .NET ActivitySource registration

### DIFF
--- a/content/en/docs/languages/dotnet/instrumentation.md
+++ b/content/en/docs/languages/dotnet/instrumentation.md
@@ -356,9 +356,8 @@ will be how you trace operations with
 >
 > The name of each `ActivitySource` must match a name passed to `AddSource` when
 > configuring the `TracerProvider`; otherwise, activities created by that source
-> aren't collected. Reuse the same string or constant in both places. If your
-> application defines multiple `ActivitySource` names, register each one with
-> `AddSource`.
+> aren't collected. If your application defines multiple `ActivitySource` names,
+> register each one with `AddSource`.
 
 It’s generally recommended to define `ActivitySource` once per app/service that
 is been instrumented, but you can instantiate several `ActivitySource`s if that

--- a/content/en/docs/languages/dotnet/instrumentation.md
+++ b/content/en/docs/languages/dotnet/instrumentation.md
@@ -352,6 +352,14 @@ configure an [`ActivitySource`](/docs/concepts/signals/traces/#tracer), which
 will be how you trace operations with
 [`Activity`](/docs/concepts/signals/traces/#spans) elements.
 
+> [!IMPORTANT]
+>
+> The name of each `ActivitySource` must match a name passed to `AddSource` when
+> configuring the `TracerProvider`; otherwise, activities created by that source
+> aren't collected. Reuse the same string or constant in both places. If your
+> application defines multiple `ActivitySource` names, register each one with
+> `AddSource`.
+
 It’s generally recommended to define `ActivitySource` once per app/service that
 is been instrumented, but you can instantiate several `ActivitySource`s if that
 suits your scenario.


### PR DESCRIPTION
- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the **First-time contributing?** section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

Make the relationship between .NET `ActivitySource` names and `AddSource`
registration prominent in the manual instrumentation guide. The new callout
also clarifies that applications using multiple source names must register each
one with the `TracerProvider`.

Validation:

- Prettier
- markdownlint
- CSpell
- textlint
- Full Hugo site build

Fixes #2472
