### PR TITLE
[ja] add translation of content/en/docs/zero-code/java/agent/annotations.md

### DIFF
--- a/content/ja/docs/zero-code/java/agent/annotations.md
+++ b/content/ja/docs/zero-code/java/agent/annotations.md
@@ -1,0 +1,141 @@
+---
+title: アノテーション
+description: Java エージェントで計装アノテーションを使用する。
+aliases: [/docs/instrumentation/java/annotations]
+weight: 20
+default_lang_commit: a3833f515c4dbb7f22deeab950b60af22a7f3384
+cSpell:ignore: Flowable javac reactivestreams reactivex
+---
+
+ほとんどのユーザーにとって、デフォルトの計装で十分であり、追加の作業は必要ありません。
+しかし、コードをほとんど変更せずに、独自のカスタムコードに対して[スパン](/docs/concepts/signals/traces/#spans)を作成したい場合もあります。
+`WithSpan` と `SpanAttribute` アノテーションはこのようなユースケースをサポートします。
+
+## 依存関係 {#dependencies}
+
+`@WithSpan` アノテーションを使用するには、`opentelemetry-instrumentation-annotations` ライブラリへの依存関係を追加する必要があります。
+
+{{< tabpane text=true >}} {{% tab "Maven" %}}
+
+```xml
+<dependencies>
+  <dependency>
+    <groupId>io.opentelemetry.instrumentation</groupId>
+    <artifactId>opentelemetry-instrumentation-annotations</artifactId>
+    <version>{{% param vers.instrumentation %}}</version>
+  </dependency>
+</dependencies>
+```
+
+{{% /tab %}} {{% tab "Gradle" %}}
+
+### Gradle
+
+```groovy
+dependencies {
+    implementation('io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:{{% param vers.instrumentation %}}')
+}
+```
+
+{{% /tab %}} {{< /tabpane >}}
+
+## `@WithSpan` でメソッドにスパンを作成する {#creating-spans-around-methods-with-withspan}
+
+特定のメソッドを計装する[スパン](/docs/concepts/signals/traces/#spans)を作成するには、メソッドに `@WithSpan` アノテーションを付けます。
+
+```java
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+
+public class MyClass {
+  @WithSpan
+  public void myMethod() {
+      <...>
+  }
+}
+```
+
+アプリケーションがアノテーション付きのメソッドを呼び出すたびに、その実行時間を示し、スローされた例外を記録するスパンが作成されます。
+デフォルトでは、スパン名は `<className>.<methodName>` になりますが、`value` アノテーションパラメーターで名前を指定することもできます。
+
+`@WithSpan` でアノテーションされたメソッドの戻り値の型が、以下に示す [future またはPromise に類似した](https://en.wikipedia.org/wiki/Futures_and_promises)型のいずれかである場合、スパンは future が完了するまで終了しません。
+
+- [java.util.concurrent.CompletableFuture](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html)
+- [java.util.concurrent.CompletionStage](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html)
+- [com.google.common.util.concurrent.ListenableFuture](https://guava.dev/releases/10.0/api/docs/com/google/common/util/concurrent/ListenableFuture.html)
+- [org.reactivestreams.Publisher](https://www.reactive-streams.org/reactive-streams-1.0.1-javadoc/org/reactivestreams/Publisher.html)
+- [reactor.core.publisher.Mono](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html)
+- [reactor.core.publisher.Flux](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html)
+- [io.reactivex.Completable](https://reactivex.io/RxJava/2.x/javadoc/index.html?io/reactivex/Completable.html)
+- [io.reactivex.Maybe](https://reactivex.io/RxJava/2.x/javadoc/index.html?io/reactivex/Maybe.html)
+- [io.reactivex.Single](https://reactivex.io/RxJava/2.x/javadoc/index.html?io/reactivex/Single.html)
+- [io.reactivex.Observable](https://reactivex.io/RxJava/2.x/javadoc/index.html?io/reactivex/Observable.html)
+- [io.reactivex.Flowable](https://reactivex.io/RxJava/2.x/javadoc/index.html?io/reactivex/Flowable.html)
+- [io.reactivex.parallel.ParallelFlowable](https://reactivex.io/RxJava/2.x/javadoc/index.html?io/reactivex/parallel/ParallelFlowable.html)
+
+### パラメーター {#parameters}
+
+`@WithSpan` 属性はスパンのカスタマイズのために以下のオプションパラメーターをサポートしています。
+
+| 名前             | 型                | デフォルト | 説明                                                                                                                                     |
+| ---------------- | ----------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `value`          | `String`          | `""`       | スパン名。指定しない場合、デフォルトの `<className>.<methodName>` が使用されます。                                                       |
+| `kind`           | `SpanKind` (enum) | `INTERNAL` | [スパンの種類](/docs/specs/otel/trace/api/#spankind)。                                                                                   |
+| `inheritContext` | `boolean`         | `true`     | 2.14.0以降。新しいスパンが既存の（現在の）コンテキストの子になるかどうかを制御します。`false` の場合、新しいコンテキストが作成されます。 |
+
+パラメーターの使用例：
+
+```java
+@WithSpan(kind = SpanKind.CLIENT, inheritContext = false, value = "my span name")
+public void myMethod() {
+    <...>
+}
+
+@WithSpan("my span name")
+public void myOtherMethod() {
+    <...>
+}
+```
+
+## `@SpanAttribute` でスパンに属性を追加する {#adding-attributes-to-the-span-with-spanattribute}
+
+アノテーション付きのメソッドに対して[スパン](/docs/concepts/signals/traces/#spans)が作成される際、メソッド呼び出しの引数の値を、作成されたスパンの[属性](/docs/concepts/signals/traces/#attributes)として自動的に追加できます。
+メソッドのパラメーターに `@SpanAttribute` アノテーションを付けるだけです。
+
+```java
+import io.opentelemetry.instrumentation.annotations.SpanAttribute;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+
+public class MyClass {
+
+    @WithSpan
+    public void myMethod(@SpanAttribute("parameter1") String parameter1,
+        @SpanAttribute("parameter2") long parameter2) {
+        <...>
+    }
+}
+```
+
+アノテーションの引数として指定しない場合、属性名は `-parameters` オプションを `javac` コンパイラーに渡して `.class` ファイルにコンパイルされた仮パラメーター名から導出されます。
+
+## `@WithSpan` 計装の抑制 {#suppressing-withspan-instrumentation}
+
+`@WithSpan` の抑制は、`@WithSpan` で過剰に計装されたコードがあり、コードを変更せずに一部を抑制したい場合に便利です。
+
+{{% config_option
+  name="otel.instrumentation.opentelemetry-instrumentation-annotations.exclude-methods" %}} 特定のメソッドに対する `@WithSpan` 計装を抑制します。
+形式は `my.package.MyClass1[method1,method2];my.package.MyClass2[method3]` です。
+{{% /config_option %}}
+
+## `otel.instrumentation.methods.include` でメソッドにスパンを作成する {#creating-spans-around-methods-with-otelinstrumentationmethodsinclude}
+
+コードを変更できない場合でも、特定のメソッドにスパンをキャプチャするように Java エージェントを設定できます。
+
+{{% config_option name="otel.instrumentation.methods.include" %}} `@WithSpan` のかわりに特定のメソッドに計装を追加します。
+形式は `my.package.MyClass1[method1,method2];my.package.MyClass2[method3]` です。
+{{% /config_option %}}
+
+メソッドがオーバーロードされている場合（同じクラスに同じ名前で異なるパラメーターを持つメソッドが複数存在する場合）、そのメソッドのすべてのバージョンが計装されます。
+
+## 次のステップ {#next-steps}
+
+アノテーションの使用に加えて、OpenTelemetry API を使用すると、[カスタム計装](../api)に使えるトレーサーを取得できます。

--- a/content/ja/docs/zero-code/java/agent/api.md
+++ b/content/ja/docs/zero-code/java/agent/api.md
@@ -1,0 +1,74 @@
+---
+title: API による計装の拡張
+linkTitle: API による拡張
+description: OpenTelemetry API を Java エージェントと組み合わせて使用し、自動生成されたテレメトリーをカスタムスパンやメトリクスで拡張する
+weight: 21
+default_lang_commit: a3833f515c4dbb7f22deeab950b60af22a7f3384
+---
+
+## はじめに {#introduction}
+
+デフォルトの計装に加えて、OpenTelemetry API を使用したカスタム手動計装で Java エージェントを拡張できます。
+これにより、コードをほとんど変更することなく、独自のコードに対して[スパン](/docs/concepts/signals/traces/#spans)や[メトリクス](/docs/concepts/signals/metrics)を作成できます。
+
+## 依存関係 {#dependencies}
+
+`opentelemetry-api` ライブラリへの依存関係を追加します。
+
+### Maven
+
+```xml
+<dependencies>
+  <dependency>
+    <groupId>io.opentelemetry</groupId>
+    <artifactId>opentelemetry-api</artifactId>
+    <version>{{% param vers.otel %}}</version>
+  </dependency>
+</dependencies>
+```
+
+### Gradle
+
+```groovy
+dependencies {
+    implementation('io.opentelemetry:opentelemetry-api:{{% param vers.otel %}}')
+}
+```
+
+## OpenTelemetry
+
+Java エージェントは `GlobalOpenTelemetry` がエージェントによって設定される特殊なケースです。
+`GlobalOpenTelemetry.getOrNoop()` を呼び出すだけで `OpenTelemetry` インスタンスにアクセスできます。
+
+## スパン {#span}
+
+> [!NOTE]
+>
+> 最も一般的なユースケースでは、手動計装の代わりに `@WithSpan` アノテーションを使用してください。
+> 詳細は[アノテーション](../annotations)を参照してください。
+
+```java
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Tracer;
+
+Tracer tracer = GlobalOpenTelemetry.getTracer("application");
+```
+
+[スパン](/docs/languages/java/api/#span)セクションの説明に従って、`Tracer` を使用してスパンを作成します。
+
+完全な例は[サンプルリポジトリ][example repository]にあります。
+
+## メーター {#meter}
+
+```java
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.metrics.Meter;
+
+Meter meter = GlobalOpenTelemetry.getMeter("application");
+```
+
+[メーター](/docs/languages/java/api/#meter)セクションの説明に従って、`Meter` を使用してカウンター、ゲージ、またはヒストグラムを作成します。
+
+完全な例は[サンプルリポジトリ][example repository]にあります。
+
+[example repository]: https://github.com/open-telemetry/opentelemetry-java-examples/tree/main/javaagent


### PR DESCRIPTION
## Summary

Translates `content/en/docs/zero-code/java/agent/annotations.md` into Japanese as `content/ja/docs/zero-code/java/agent/annotations.md`.

Also translates `content/en/docs/zero-code/java/agent/api.md` as `content/ja/docs/zero-code/java/agent/api.md` (required by the relative link `../api` in the annotations page).

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

### docs/zero-code/java/agent/annotations/
- **Japanese (this PR):** https://deploy-preview-11411--opentelemetry.netlify.app/ja/docs/zero-code/java/agent/annotations/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/java/agent/annotations/

### docs/zero-code/java/agent/api/
- **Japanese (this PR):** https://deploy-preview-11411--opentelemetry.netlify.app/ja/docs/zero-code/java/agent/api/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/java/agent/api/

<!-- preview-section-end -->
