### PR TITLE
Add Google Cloud C++ Client Libraries to the registry

### DIFF
--- a/.lycheecache
+++ b/.lycheecache
@@ -222,6 +222,8 @@ https://cloud.google.com/blog/products/serverless/cloud-functions-2nd-generation
 https://cloud.google.com/compute/docs/instances/custom-hostname-vm,200,1787029640
 https://cloud.google.com/compute/docs/internal-dns#instance-fully-qualified-domain-names,200,1787032253
 https://cloud.google.com/compute/docs/metadata/querying-metadata#waitforchange,200,1787032334
+https://cloud.google.com/cpp/docs,200,1787608482
+https://cloud.google.com/cpp/docs/quickstart-open-telemetry,200,1787608475
 https://cloud.google.com/discover/what-are-ai-agents,200,1787029627
 https://cloud.google.com/error-reporting/reference/rest/v1beta1/projects.events/report,200,1787032252
 https://cloud.google.com/functions/docs/concepts/execution-environment,200,1787032256
@@ -1412,6 +1414,8 @@ https://github.com/google/docsy/pull/2714,200,1786734904
 https://github.com/google/pprof,200,1786028735
 https://github.com/google/pprof/tree/main/proto,200,1785739372
 https://github.com/google/sqlcommenter/issues/284,200,1786341741
+https://github.com/googleapis,200,1787608482
+https://github.com/googleapis/google-cloud-cpp,200,1787608482
 https://github.com/googleapis/google-http-java-client,200,1786427568
 https://github.com/googleapis/googleapis/blob/6a8c7914d1b79bd832b5157a09a9332e8cbd16d4/google/rpc/error_details.proto#L119,200,1787032334
 https://github.com/googleapis/googleapis/blob/6a8c7914d1b79bd832b5157a09a9332e8cbd16d4/google/rpc/error_details.proto#L40,200,1787032334

--- a/data/registry/instrumentation-cpp-google-cloud.yml
+++ b/data/registry/instrumentation-cpp-google-cloud.yml
@@ -1,0 +1,20 @@
+title: Google Cloud C++ Client Libraries
+registryType: instrumentation
+language: cpp
+tags:
+  - google-cloud
+  - client-libraries
+  - c++
+license: Apache-2.0
+description:
+  The Google Cloud Client Libraries for C++ natively emit OpenTelemetry traces
+  for supported Google Cloud services.
+authors:
+  - name: Google Cloud C++ Authors
+    url: https://github.com/googleapis
+urls:
+  website: https://cloud.google.com/cpp/docs
+  repo: https://github.com/googleapis/google-cloud-cpp
+  docs: https://cloud.google.com/cpp/docs/quickstart-open-telemetry
+createdAt: '2026-08-23'
+isNative: true


### PR DESCRIPTION
- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the **First-time contributing?** section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.

---

Adds the Google Cloud C++ Client Libraries to the OpenTelemetry Registry as native C++ instrumentation. The entry links to the official library repository, documentation, and OpenTelemetry tracing quickstart, and sets `isNative: true` following the maintainer guidance in #4753.

Fixes #4753.

Validation:

- registry schema validation: 1,166 files processed, 0 issues
- Prettier, cspell, textlint, and `git diff --check`
- lean Hugo build; verified the entry on the Registry, Integrations, and C++ library pages
- all four referenced external URLs returned HTTP 200