### PR TITLE
[ja] update translation of content/en/docs/zero-code/obi/setup/docker.md

### DIFF
--- a/content/ja/docs/zero-code/obi/setup/docker.md
+++ b/content/ja/docs/zero-code/obi/setup/docker.md
@@ -3,8 +3,7 @@ title: DockerコンテナとしてOBIを実行する
 linkTitle: Docker
 description: OBIをDockerコンテナとしてセットアップして実行し、別のコンテナを計装する方法を学びます。
 weight: 3
-default_lang_commit: 4c8d57fea0147ce76633951315c40a27c55fad2e
-drifted_from_default: true
+default_lang_commit: 7279d56948a75400445c97086d7b1e0da0dd0438
 cSpell:ignore: goblog
 ---
 
@@ -36,7 +35,7 @@ OBIコンテナイメージは、GitHub Actions の OIDC（OpenID Connect）プ�
 以下のコマンドを使用して、コンテナイメージの署名を検証できます。
 
 ```sh
-export VERSION=v0.10.0
+export VERSION=v0.12.1
 
 # Docker Hub のリリースイメージを検証する
 cosign verify --certificate-identity-regexp 'https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' otel/ebpf-instrument:${VERSION}
@@ -70,7 +69,7 @@ The following checks were performed on each of these signatures:
 コンテナがない場合は、[Goで書かれたシンプルなブログエンジンサービス](https://macias.info)を使用できます。
 
 ```sh
-export VERSION=v0.10.0
+export VERSION=v0.12.1
 docker run -p 18443:8443 --name goblog mariomac/goblog:dev
 ```
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/obi/setup/docker.md` to match the latest English source at
`content/en/docs/zero-code/obi/setup/docker.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff consists of two version bumps in code blocks (`v0.10.0` → `v0.12.1`).

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11421--opentelemetry.netlify.app/ja/docs/zero-code/obi/setup/docker/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/obi/setup/docker/

<!-- preview-section-end -->
