### PR TITLE
[ja] update translation of content/en/docs/zero-code/obi/setup/standalone.md

### DIFF
--- a/content/ja/docs/zero-code/obi/setup/standalone.md
+++ b/content/ja/docs/zero-code/obi/setup/standalone.md
@@ -3,8 +3,7 @@ title: OBIをスタンドアロンプロセスとして実行する
 linkTitle: スタンドアロン
 description: OBIをLinuxのスタンドアロンプロセスとしてセットアップして実行する方法を学びます。
 weight: 5
-default_lang_commit: aea54f0fb2574c21a52fb1dc1bb64af38ed7b948
-drifted_from_default: true
+default_lang_commit: 7279d56948a75400445c97086d7b1e0da0dd0438
 cSpell:ignore: cyclonedx
 ---
 
@@ -32,7 +31,7 @@ OBIは Linux（amd64 および arm64）向けのビルド済みバイナリを�
 ```sh
 # 希望するバージョンを設定（最新版は
 # https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases を参照）
-VERSION=0.10.0
+VERSION=0.12.1
 
 # アーキテクチャを指定
 # Intel/AMD 64ビットの場合: amd64
@@ -68,7 +67,6 @@ obi-v${VERSION}-linux-${ARCH}.tar.gz: OK
 アーカイブには以下が含まれます。
 
 - `obi` - メインの OBI バイナリ
-- `k8s-cache` - Kubernetes キャッシュバイナリ
 - `LICENSE` - プロジェクトライセンス
 - `NOTICE` - 法的通知
 - `NOTICES/` - サードパーティのライセンスと帰属表示


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/obi/setup/standalone.md` to match the latest English source at
`content/en/docs/zero-code/obi/setup/standalone.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

Changes applied:
- Version bump: `VERSION=0.10.0` → `VERSION=0.12.1`
- Removed `k8s-cache` from the archive contents list (no longer included)

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11422--opentelemetry.netlify.app/ja/docs/zero-code/obi/setup/standalone/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/obi/setup/standalone/

<!-- preview-section-end -->
