### PR TITLE
[ja] update translation of content/en/docs/zero-code/obi/configure/export-modes.md

### DIFF
--- a/content/ja/docs/zero-code/obi/configure/export-modes.md
+++ b/content/ja/docs/zero-code/obi/configure/export-modes.md
@@ -3,9 +3,14 @@ title: OBI のエクスポートモードを構成する
 linkTitle: エクスポートモード
 description: OTLP エンドポイントへ直接データをエクスポートするように OBI を構成する
 weight: 1
-default_lang_commit: dc2fb5771163265cb804a39b1dacc536b95bdb96
-drifted_from_default: true
+default_lang_commit: 7279d56948a75400445c97086d7b1e0da0dd0438
 ---
+
+> [!NOTE]
+>
+> このページでは Config v1 のフィールド名と例を使用しています。
+> Config v2 については、[Config v2 リファレンス](/docs/zero-code/obi/configure/config-v2/)を参照してください。
+> 既存のファイルを変換するには、[移行ガイド](/docs/zero-code/obi/configure/migrate-to-config-v2/)を使用してください。
 
 Direct モードでは、OBI は OpenTelemetry protocol（OTLP）を使用して、メトリクスとトレースをリモートエンドポイントへ直接プッシュします。
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/obi/configure/export-modes.md` to match the latest English source at
`content/en/docs/zero-code/obi/configure/export-modes.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff adds a Config v1/v2 NOTE callout block at the top of the page. The relative links to
`../config-v2/` and `../migrate-to-config-v2/` were converted to root-relative paths because those
sibling pages do not yet have Japanese translations.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11423--opentelemetry.netlify.app/ja/docs/zero-code/obi/configure/export-modes/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/obi/configure/export-modes/

<!-- preview-section-end -->
