### PR TITLE
[ja] add translation of content/en/ecosystem/integrations.md

### DIFF
--- a/content/ja/ecosystem/_includes/freeze-notice.md
+++ b/content/ja/ecosystem/_includes/freeze-notice.md
@@ -1,0 +1,7 @@
+---
+default_lang_commit: 7279d56948a75400445c97086d7b1e0da0dd0438
+---
+
+> [!WARNING] エコシステムリストは凍結中です
+>
+> [レジストリ](/ecosystem/registry/)を含む[エコシステム](/ecosystem/)リストへの新規エントリおよび既存エントリの更新は、メンテナーが各リストの今後の方針を検討している間、受け付けを停止しています。詳細および意見の共有については、[issue #11377](https://github.com/open-telemetry/opentelemetry.io/issues/11377)を参照してください。

--- a/content/ja/ecosystem/_includes/keep-up-to-date.md
+++ b/content/ja/ecosystem/_includes/keep-up-to-date.md
@@ -1,0 +1,9 @@
+---
+default_lang_commit: 7279d56948a75400445c97086d7b1e0da0dd0438
+---
+
+## {{ $1 }}情報を最新の状態に保つ {#keeping-up-to-date}
+
+{{ $1 }}情報を最新の状態に保つようにしてください。そうしない場合、レジストリまたは[エコシステムリスト][ecosystem list]から更新または削除されることがあります。詳細については、[レジストリ情報を最新の状態に保つ](/ecosystem/registry/updating/)を参照してください。
+
+[ecosystem list]: https://github.com/open-telemetry/opentelemetry.io/tree/main/data/ecosystem

--- a/content/ja/ecosystem/integrations.md
+++ b/content/ja/ecosystem/integrations.md
@@ -1,0 +1,52 @@
+---
+title: インテグレーション
+description: OpenTelemetry をファーストパーティでサポートするライブラリ、サービス、アプリケーション。
+aliases: [/integrations]
+default_lang_commit: 301a68c0bc3a170adfc8f1384f6788c8cebbf322
+---
+
+{{% include freeze-notice.md %}}
+
+OpenTelemetry のミッションは、[高品質でポータブルなテレメトリーをユビキタスにすることで、効果的なオブザーバビリティを実現する](/community/mission/)ことです。
+つまり、開発するソフトウェアにオブザーバビリティが組み込まれているべきです。
+
+[ゼロコード計装ソリューション](/docs/concepts/instrumentation/zero-code)や[計装ライブラリ](/docs/specs/otel/overview/#instrumentation-libraries)を使った外部からの計装は、アプリケーションをオブザーバブルにする便利な方法です。
+しかし、最終的にはすべてのアプリケーションが、ネイティブテレメトリーのために OpenTelemetry API と SDK を直接統合するか、そのソフトウェアのエコシステムに適合するファーストパーティプラグインを提供するべきだと私たちは考えています。
+
+このページには、ネイティブ計装またはファーストパーティプラグインを提供するライブラリ、サービス、アプリケーションのサンプルが掲載されています。
+
+## ライブラリ {#libraries}
+
+OpenTelemetry によるネイティブライブラリ計装は、ユーザーにとってより優れたオブザーバビリティと開発者体験を提供し、ライブラリがフックを公開してドキュメント化する必要をなくします。
+以下は、OpenTelemetry API を使用してすぐに利用可能なオブザーバビリティを提供するライブラリのリストです。
+
+{{% ecosystem/integrations-table "native libraries" %}}
+
+## アプリケーションとサービス {#applications-and-services}
+
+以下のリストには、ネイティブテレメトリーのために OpenTelemetry API と SDK を直接統合したか、独自の拡張エコシステムに適合するファーストパーティプラグインを提供するライブラリ、サービス、アプリケーションのサンプルが含まれています。
+
+オープンソースプロジェクト（OSS）がリストの先頭にあり、商用プロジェクトがそれに続きます。
+[CNCF](https://www.cncf.io/) に所属するプロジェクトには、名前の横に CNCF のロゴが付いています。
+
+{{% ecosystem/integrations-table "application integrations" %}}
+
+## インテグレーションの追加 {#how-to-add}
+
+ライブラリ、サービス、またはアプリケーションをリストに掲載するには、[レジストリ](/ecosystem/registry/adding)にエントリを追加した [PR を提出][submit a PR]してください。
+エントリには以下を含める必要があります。
+
+- ライブラリ、サービス、またはアプリケーションのメインページへのリンク
+- OpenTelemetry を使用してオブザーバビリティを有効にする方法を説明するドキュメントへのリンク
+
+> [!NOTE]
+>
+> ライブラリ、サービス、またはアプリケーションに対して OpenTelemetry の外部インテグレーションを提供している場合は、[レジストリへの追加を検討してください](/ecosystem/registry/adding)。
+>
+> エンドユーザーとしてオブザーバビリティのために OpenTelemetry を採用しており、OpenTelemetry に関連するサービスを提供していない場合は、[採用企業](/ecosystem/adopters)を参照してください。
+>
+> エンドユーザーにオブザーバビリティを提供するために OpenTelemetry を利用するソリューションを提供している場合は、[ベンダー](/ecosystem/vendors)を参照してください。
+
+[submit a PR]: /docs/contributing/pull-requests/
+
+{{% include keep-up-to-date.md integration %}}


### PR DESCRIPTION
## Summary

Translates `content/en/ecosystem/integrations.md` into Japanese as `content/ja/ecosystem/integrations.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11428--opentelemetry.netlify.app/ja/ecosystem/integrations/
- **English (canonical):** https://opentelemetry.io/ecosystem/integrations/

<!-- preview-section-end -->
