### PR TITLE
[ja] update translation of content/en/docs/languages/dotnet/instrumentation.md

### DIFF
--- a/content/ja/docs/languages/dotnet/instrumentation.md
+++ b/content/ja/docs/languages/dotnet/instrumentation.md
@@ -3,8 +3,7 @@ title: 計装
 weight: 36
 aliases: [manual]
 description: OpenTelemetry .NET の計装
-default_lang_commit: 46b67485e928d406a3e5e74f024180d28583c84d
-drifted_from_default: true
+default_lang_commit: 5ccd63611a43a8c3b4a243dc995fb3755d46eafa
 cSpell:ignore: dicelib rolldice
 ---
 
@@ -285,6 +284,11 @@ meterProvider.Dispose();
 loggerFactory.Dispose();
 ```
 
+> [!IMPORTANT]
+>
+> アプリケーションがテレメトリーを生成している間は `TracerProvider` を生存させ続け、アプリケーションのシャットダウン時に明示的に破棄して残りのテレメトリーをフラッシュしてください。
+> 詳細については、[TracerProvider management](/docs/languages/dotnet/traces/best-practices/#tracerprovider-management) を参照してください。
+
 デバッグとローカル開発のために、このサンプルではテレメトリーをコンソールにエクスポートしています。
 手動計装のセットアップが完了したら、アプリのテレメトリーデータを1つ以上のテレメトリーバックエンドに[エクスポート](/docs/languages/dotnet/exporters/)するために、適切なエクスポーターを設定する必要があります。
 
@@ -318,6 +322,12 @@ dotnet run
 
 アプリケーションで手動トレースコードを書く場所には、[`ActivitySource`](/docs/concepts/signals/traces/#tracer) を設定する必要があります。
 これにより [`Activity`](/docs/concepts/signals/traces/#spans) 要素を使用してオペレーションをトレースできるようになります。
+
+> [!IMPORTANT]
+>
+> 各 `ActivitySource` の名前は、`TracerProvider` の設定時に `AddSource` に渡した名前と一致する必要があります。
+> 一致しない場合、そのソースで作成された Activity は収集されません。
+> アプリケーションが複数の `ActivitySource` 名を定義している場合は、それぞれを `AddSource` で登録してください。
 
 通常、計装対象のアプリ/サービスごとに `ActivitySource` を一度定義することが推奨されますが、シナリオに合わせて複数の `ActivitySource` をインスタンス化することもできます。
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/dotnet/instrumentation.md` to match the latest English source at
`content/en/docs/languages/dotnet/instrumentation.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

### Changes

Two new `[!IMPORTANT]` callout blocks were added on the English side:

1. After the console-app SDK initialization code block: a note about keeping `TracerProvider` alive during the application lifetime and explicitly disposing it on shutdown to flush remaining telemetry.
2. After the `ActivitySource` setup introduction paragraph: a note about ensuring each `ActivitySource` name matches a name passed to `AddSource` when configuring the `TracerProvider`.

Both were translated into Japanese and inserted at the corresponding positions.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11430--opentelemetry.netlify.app/ja/docs/languages/dotnet/instrumentation/
- **English (canonical):** https://opentelemetry.io/docs/languages/dotnet/instrumentation/

<!-- preview-section-end -->
