### PR TITLE
[ja] update translation of content/en/docs/zero-code/obi/configure/filter-metrics-traces.md

### DIFF
--- a/content/ja/docs/zero-code/obi/configure/filter-metrics-traces.md
+++ b/content/ja/docs/zero-code/obi/configure/filter-metrics-traces.md
@@ -3,9 +3,14 @@ title: 属性値でメトリクスとトレースをフィルタリングする
 linkTitle: データのフィルタリング
 description: 属性値でメトリクスとトレースをフィルタリングするように OBI を設定する
 weight: 40
-default_lang_commit: f7dab5cfc4d44a8c788b7e02d07ec1e1d84e3845
-drifted_from_default: true
+default_lang_commit: 5ccd63611a43a8c3b4a243dc995fb3755d46eafa
 ---
+
+> [!NOTE]
+>
+> このページでは Config v1 のフィールド名と例を使用しています。
+> Config v2 については [Config v2 リファレンス](/docs/zero-code/obi/configure/config-v2/)を参照してください。
+> 既存のファイルを変換するには[移行ガイド](/docs/zero-code/obi/configure/migrate-to-config-v2/)を使用してください。
 
 属性の値に基づいて、レポートするメトリクスやトレースを非常に具体的なイベントタイプに限定したい場合があります(たとえば、TCP トラフィックのみをレポートするようにネットワークメトリクスをフィルタリングする、など)。
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/obi/configure/filter-metrics-traces.md` to match the latest English source at
`content/en/docs/zero-code/obi/configure/filter-metrics-traces.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

### Changes

- Added the new `> [!NOTE]` callout block about Config v1/v2, matching the English source addition.
- Converted relative links (`../config-v2/`, `../migrate-to-config-v2/`) to root-relative paths (`/docs/zero-code/obi/configure/config-v2/`, `/docs/zero-code/obi/configure/migrate-to-config-v2/`) because the linked pages do not yet have Japanese translations — Hugo's render-link hook will route them to the English pages correctly.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11431--opentelemetry.netlify.app/ja/docs/zero-code/obi/configure/filter-metrics-traces/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/obi/configure/filter-metrics-traces/

<!-- preview-section-end -->
