### PR TITLE
Raise npm dep cooldown to 7 days across the board

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,7 +18,7 @@
     {
       // config:best-practices (security:minimumReleaseAgeNpm) injects a 3-day
       // npm rule that overrides the global setting above; package rules apply
-      // in order, so this later rule restores the repo-wide 7 days for npm.
+      // in order, so this later rule restores the repo-wide value.
       matchDatasources: ['npm'],
       minimumReleaseAge: '7 days',
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,11 +15,21 @@
     minimumReleaseAge: '14 days',
   },
   packageRules: [
+    // security:minimumReleaseAgeNpm (config:best-practices) injects npm rules:
+    // 3 days plus null exemptions for update types without release timestamps.
+    // Repo packageRules apply after preset ones and re-apply after the patch:
+    // merge above, so restoring the intended ages takes explicit later rules,
+    // scoped to timestamp-bearing update types so the exemptions stay
+    // last-match.
     {
-      // security:minimumReleaseAgeNpm (config:best-practices) injects a 3-day
-      // npm rule; repo packageRules apply after preset ones, so this one wins.
       matchDatasources: ['npm'],
+      matchUpdateTypes: ['major', 'minor'],
       minimumReleaseAge: '7 days',
+    },
+    {
+      matchDatasources: ['npm'],
+      matchUpdateTypes: ['patch'],
+      minimumReleaseAge: '14 days',
     },
     {
       // Patch updates are typically non-breaking, so they group and automerge.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,11 +5,13 @@
     'docker:pinDigests',
     'helpers:pinGitHubActionDigestsToSemver',
   ],
-  // config:best-practices pulls in security:minimumReleaseAgeNpm, whose 3-day
-  // npm rule would override the ages below and re-apply after the patch:
-  // merge; ignoring it lets minimumReleaseAge and patch: govern npm too. Its
-  // exemptions for timestamp-less update types are restated in packageRules.
-  // Name-coupled: an upstream rename of that preset silently re-admits it.
+  // config:best-practices pulls in security:minimumReleaseAgeNpm: its 3-day
+  // npm rule would override the ages below, re-applying even after the patch:
+  // merge. Its exemptions for timestamp-less update types (pin, replacement,
+  // rollback, ...) are deliberately not kept: fail closed, those updates wait
+  // for a human, as they already do for every other datasource.
+  //
+  // IMPORTANT: an upstream rename of the preset silently re-admits it.
   ignorePresets: ['security:minimumReleaseAgeNpm'],
   minimumReleaseAge: '7 days',
   internalChecksFilter: 'strict',
@@ -21,19 +23,6 @@
     minimumReleaseAge: '14 days',
   },
   packageRules: [
-    {
-      // Update types without release timestamps never pass an age gate (the
-      // ignored preset's own exemption, restated).
-      matchDatasources: ['npm'],
-      matchUpdateTypes: [
-        'pin',
-        'replacement',
-        'bump',
-        'lockfileUpdate',
-        'rollback',
-      ],
-      minimumReleaseAge: null,
-    },
     {
       // Patch updates are typically non-breaking, so they group and automerge.
       groupName: 'all patch versions',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,8 +19,11 @@
     // 3 days plus null exemptions for update types without release timestamps.
     // Repo packageRules apply after preset ones and re-apply after the patch:
     // merge above, so restoring the intended ages takes explicit later rules,
-    // scoped to timestamp-bearing update types so the exemptions stay
-    // last-match.
+    // scoped to semantic update types. Renovate reports bump updates as their
+    // semantic type plus a 'bump' pseudo-type, so these rules would steal that
+    // exemption; the trailing null rule restores it. (isLockfileUpdate has no
+    // pseudo-type, so its preset exemption never matched to begin with:
+    // an upstream matcher gap, unfixable here.)
     {
       matchDatasources: ['npm'],
       matchUpdateTypes: ['major', 'minor'],
@@ -30,6 +33,11 @@
       matchDatasources: ['npm'],
       matchUpdateTypes: ['patch'],
       minimumReleaseAge: '14 days',
+    },
+    {
+      matchDatasources: ['npm'],
+      matchUpdateTypes: ['bump'],
+      minimumReleaseAge: null,
     },
     {
       // Patch updates are typically non-breaking, so they group and automerge.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,9 +16,8 @@
   },
   packageRules: [
     {
-      // config:best-practices (security:minimumReleaseAgeNpm) injects a 3-day
-      // npm rule that overrides the global setting above; package rules apply
-      // in order, so this later rule restores the repo-wide value.
+      // security:minimumReleaseAgeNpm (config:best-practices) injects a 3-day
+      // npm rule; repo packageRules apply after preset ones, so this one wins.
       matchDatasources: ['npm'],
       minimumReleaseAge: '7 days',
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,6 +5,12 @@
     'docker:pinDigests',
     'helpers:pinGitHubActionDigestsToSemver',
   ],
+  // config:best-practices pulls in security:minimumReleaseAgeNpm, whose 3-day
+  // npm rule would override the ages below and re-apply after the patch:
+  // merge; ignoring it lets minimumReleaseAge and patch: govern npm too. Its
+  // exemptions for timestamp-less update types are restated in packageRules.
+  // Name-coupled: an upstream rename of that preset silently re-admits it.
+  ignorePresets: ['security:minimumReleaseAgeNpm'],
   minimumReleaseAge: '7 days',
   internalChecksFilter: 'strict',
   labels: ['dependencies'],
@@ -15,28 +21,17 @@
     minimumReleaseAge: '14 days',
   },
   packageRules: [
-    // security:minimumReleaseAgeNpm (config:best-practices) injects npm rules:
-    // 3 days plus null exemptions for update types without release timestamps.
-    // Repo packageRules apply after preset ones and re-apply after the patch:
-    // merge above, so restoring the intended ages takes explicit later rules,
-    // scoped to semantic update types. Renovate reports bump updates as their
-    // semantic type plus a 'bump' pseudo-type, so these rules would steal that
-    // exemption; the trailing null rule restores it. (isLockfileUpdate has no
-    // pseudo-type, so its preset exemption never matched to begin with:
-    // an upstream matcher gap, unfixable here.)
     {
+      // Update types without release timestamps never pass an age gate (the
+      // ignored preset's own exemption, restated).
       matchDatasources: ['npm'],
-      matchUpdateTypes: ['major', 'minor'],
-      minimumReleaseAge: '7 days',
-    },
-    {
-      matchDatasources: ['npm'],
-      matchUpdateTypes: ['patch'],
-      minimumReleaseAge: '14 days',
-    },
-    {
-      matchDatasources: ['npm'],
-      matchUpdateTypes: ['bump'],
+      matchUpdateTypes: [
+        'pin',
+        'replacement',
+        'bump',
+        'lockfileUpdate',
+        'rollback',
+      ],
       minimumReleaseAge: null,
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,6 +16,13 @@
   },
   packageRules: [
     {
+      // config:best-practices (security:minimumReleaseAgeNpm) injects a 3-day
+      // npm rule that overrides the global setting above; package rules apply
+      // in order, so this later rule restores the repo-wide 7 days for npm.
+      matchDatasources: ['npm'],
+      minimumReleaseAge: '7 days',
+    },
+    {
       // Patch updates are typically non-breaking, so they group and automerge.
       groupName: 'all patch versions',
       matchUpdateTypes: ['patch'],

--- a/.lycheecache
+++ b/.lycheecache
@@ -645,6 +645,7 @@ https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/
 https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/schedule_and_quota_apis/clusterresourcequota-quota-openshift-io-v1,206,1787033412
 https://docs.renovatebot.com/,200,1786473193
 https://docs.renovatebot.com/configuration-options/#minimumreleaseage,200,1787032143
+https://docs.renovatebot.com/presets-security/#securityminimumreleaseagenpm,200,1787695025
 https://docs.roadrunner.dev/docs/logging-and-observability/otel,200,1787029661
 https://docs.rs/tower,200,1787032620
 https://docs.ruby-lang.org/en/3.4/Exception.html#method-i-full_message,200,1787032251

--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,6 @@
 # npm supply-chain controls; rationale:
 # https://opentelemetry.io/site/design/supply-chain-security/
 
-min-release-age=3
+min-release-age=7
 strict-allow-scripts=true
 engine-strict=true

--- a/content/en/site/build/dependencies.md
+++ b/content/en/site/build/dependencies.md
@@ -132,6 +132,8 @@ this page, so first work out which control your change relaxes.
 Out of the audit's scope:
 
 - GitHub workflow files
+- [Renovate][] configuration ([`.github/renovate.json5`][]): reviewed like code,
+  not audit-pinned
 - The [Docsy][] theme's own dependency install (audited upstream)
 - The build-half npm scripts past the install boundary
 
@@ -149,7 +151,9 @@ Version resolution ignores releases younger than the configured minimum age.
     variable, which outranks both.
 - **[Renovate][]**: applies its own cooldown to the update PRs it opens, set by
   `minimumReleaseAge` in [`.github/renovate.json5`][]; longer for the updates
-  that merge without human review.
+  that merge without human review. Update types Renovate can't date (`pin`,
+  `replacement`, `rollback`) never clear the cooldown: they wait on the
+  [Dependency Dashboard][] for a maintainer to perform the update.
 
 ### Lifecycle-script allowlist
 
@@ -230,6 +234,7 @@ with this rule through [drift tracking][].
 [`scripts/supply-chain-audit.test.mjs`]: https://github.com/open-telemetry/opentelemetry.io/blob/main/scripts/supply-chain-audit.test.mjs
 [build cache]: https://docs.netlify.com/build/configure-builds/troubleshooting-tips/
 [deploy context]: https://docs.netlify.com/deploy/deploy-overview/#deploy-contexts
+[Dependency Dashboard]: https://docs.renovatebot.com/key-concepts/dashboard/
 [Docsy]: https://www.docsy.dev/
 [drift tracking]: /docs/contributing/localization/#track-changes
 [includes a clone of the repository]: https://answers.netlify.com/t/what-does-clear-cache-and-deploy-site-do-specifically/9419/2

--- a/content/en/site/build/dependencies.md
+++ b/content/en/site/build/dependencies.md
@@ -152,8 +152,9 @@ Version resolution ignores releases younger than the configured minimum age.
 - **[Renovate][]**: applies its own cooldown to the update PRs it opens, set by
   `minimumReleaseAge` in [`.github/renovate.json5`][]; longer for the updates
   that merge without human review. Update types Renovate can't date (`pin`,
-  `replacement`, `rollback`) never clear the cooldown: they wait on the
-  [Dependency Dashboard][] for a maintainer to perform the update.
+  `replacement`, `rollback`) never clear the cooldown: their PRs open with a
+  permanently pending stability status (not a required check) and merge only
+  through normal review.
 
 ### Lifecycle-script allowlist
 
@@ -234,7 +235,6 @@ with this rule through [drift tracking][].
 [`scripts/supply-chain-audit.test.mjs`]: https://github.com/open-telemetry/opentelemetry.io/blob/main/scripts/supply-chain-audit.test.mjs
 [build cache]: https://docs.netlify.com/build/configure-builds/troubleshooting-tips/
 [deploy context]: https://docs.netlify.com/deploy/deploy-overview/#deploy-contexts
-[Dependency Dashboard]: https://docs.renovatebot.com/key-concepts/dashboard/
 [Docsy]: https://www.docsy.dev/
 [drift tracking]: /docs/contributing/localization/#track-changes
 [includes a clone of the repository]: https://answers.netlify.com/t/what-does-clear-cache-and-deploy-site-do-specifically/9419/2

--- a/content/en/site/design/supply-chain-security.md
+++ b/content/en/site/design/supply-chain-security.md
@@ -111,9 +111,8 @@ Enforcement at a glance:
 - Release cooldowns are established practice:
   - [pnpm defers][] releases younger than a day by default.
   - Renovate's long-standing [`minimumReleaseAge`][renovate] convention is 3
-    days, tracking npm's 72-hour unpublish window; the 7-day value here adds
-    margin for malware detection and takedown, matching cooldowns adopted
-    elsewhere in the ecosystem.
+    days, tracking npm's 72-hour unpublish window; the longer value used here
+    is in line with cooldowns adopted elsewhere in the ecosystem.
 - The control set maps onto established framework guidance:
   - [TUF's attack taxonomy][tuf]: arbitrary software installation,
     mix-and-match, and extraneous-dependencies attacks.

--- a/content/en/site/design/supply-chain-security.md
+++ b/content/en/site/design/supply-chain-security.md
@@ -110,8 +110,10 @@ Enforcement at a glance:
     `allowScripts`, version-exact entries included.
 - Release cooldowns are established practice:
   - [pnpm defers][] releases younger than a day by default.
-  - The 3-day value follows the long-standing [Renovate
-    `minimumReleaseAge`][renovate] convention.
+  - Renovate's long-standing [`minimumReleaseAge`][renovate] convention is 3
+    days, tracking npm's 72-hour unpublish window; the 7-day value here adds
+    margin for malware detection and takedown, matching cooldowns adopted
+    elsewhere in the ecosystem.
 - The control set maps onto established framework guidance:
   - [TUF's attack taxonomy][tuf]: arbitrary software installation,
     mix-and-match, and extraneous-dependencies attacks.

--- a/content/en/site/design/supply-chain-security.md
+++ b/content/en/site/design/supply-chain-security.md
@@ -111,8 +111,8 @@ Enforcement at a glance:
 - Release cooldowns are established practice:
   - [pnpm defers][] releases younger than a day by default.
   - Renovate's long-standing [`minimumReleaseAge`][renovate] convention is 3
-    days, tracking npm's 72-hour unpublish window; the longer value used here
-    is in line with cooldowns adopted elsewhere in the ecosystem.
+    days, tracking npm's 72-hour unpublish window; the longer value used here is
+    in line with cooldowns adopted elsewhere in the ecosystem.
 - The control set maps onto established framework guidance:
   - [TUF's attack taxonomy][tuf]: arbitrary software installation,
     mix-and-match, and extraneous-dependencies attacks.

--- a/content/en/site/design/supply-chain-security.md
+++ b/content/en/site/design/supply-chain-security.md
@@ -110,9 +110,9 @@ Enforcement at a glance:
     `allowScripts`, version-exact entries included.
 - Release cooldowns are established practice:
   - [pnpm defers][] releases younger than a day by default.
-  - Renovate's long-standing [`minimumReleaseAge`][renovate] convention is 3
-    days, tracking npm's 72-hour unpublish window; the longer value used here is
-    in line with cooldowns adopted elsewhere in the ecosystem.
+  - Renovate's npm [`minimumReleaseAge`][renovate] security preset sets 3 days,
+    tracking npm's 72-hour unpublish window; the longer value used here is in
+    line with cooldowns adopted elsewhere in the ecosystem.
 - The control set maps onto established framework guidance:
   - [TUF's attack taxonomy][tuf]: arbitrary software installation,
     mix-and-match, and extraneous-dependencies attacks.
@@ -140,7 +140,7 @@ Enforcement at a glance:
 [pnpm defers]: https://pnpm.io/settings/dependency-resolution
 [pnpm]: https://pnpm.io/settings/build
 [Refuse Hugo installer overrides]: #hugo-env
-[renovate]: https://docs.renovatebot.com/configuration-options/#minimumreleaseage
+[renovate]: https://docs.renovatebot.com/presets-security/#securityminimumreleaseagenpm
 [Resolve deliberately]: #deliberate
 [Resolve only cooled-down releases]: #cooldown-releases
 [RFC #54]: https://github.com/npm/rfcs/blob/main/accepted/0054-make-scripts-install-opt-in.md

--- a/scripts/supply-chain-audit.test.mjs
+++ b/scripts/supply-chain-audit.test.mjs
@@ -185,7 +185,7 @@ test('.npmrc carries exactly the reviewed npm settings', () => {
         (line) => line !== '' && !line.startsWith('#') && !line.startsWith(';'),
       )
       .sort(),
-    ['engine-strict=true', 'min-release-age=3', 'strict-allow-scripts=true'],
+    ['engine-strict=true', 'min-release-age=7', 'strict-allow-scripts=true'],
     'the npm settings match the reviewed set',
   );
 });


### PR DESCRIPTION
- **Makes the 7-day npm cooldown explicit end to end**: opts out of the preset-injected 3-day npm rule (`ignorePresets`) so the top-level `minimumReleaseAge` and the `patch:` block govern npm too; the config comment carries the mechanics, the supply-chain design page the rationale.
- **Restores the automerge-patch contract for npm**: the 14-day `patch:` cooldown never actually bound npm (the preset rule re-applied after the update-type merge).
- **Fails closed on timestamp-less npm update types**: the preset's exemptions are deliberately not kept; those updates wait for a human, as on every other datasource. The dependencies page documents the behavior and the audit boundary.
- **Aligns `.npmrc`** so local/manual resolution enforces the same window, with the supply-chain audit assertion updated in step.
- **Unchanged**: the CVE-driven `vulnerabilityAlerts` bypass.
- **Previews**:
  - <https://deploy-preview-11436--opentelemetry.netlify.app/site/design/supply-chain-security/>
  - <https://deploy-preview-11436--opentelemetry.netlify.app/site/build/dependencies/>
