### PR TITLE
Add KubeCon China 2026 banner

### DIFF
--- a/.cspell/all-words.txt
+++ b/.cspell/all-words.txt
@@ -49,6 +49,7 @@ kubecon
 kubernetes
 laravel
 lfasiallc
+lfopensource
 lightstep
 llms
 Loffay

--- a/.lycheecache
+++ b/.lycheecache
@@ -6417,6 +6417,9 @@ https://www.krakend.io/,200,1787032460
 https://www.krakend.io/docs/telemetry/opentelemetry/,200,1786427574
 https://www.langchain.com/langgraph,200,1787032238
 https://www.lfasiallc.com/kubecon-cloudnativecon-openinfra-summit-pytorch-conference-china/?utm_source=opentelemetry&utm_medium=website&utm_content=blog,200,1787032431
+https://www.lfopensource.cn/kubecon-cloudnativecon-openinfra-summit-pytorch-conference-china/,200,1787690578
+https://www.lfopensource.cn/kubecon-cloudnativecon-openinfra-summit-pytorch-conference-china/register/?utm_source=opentelemetry&utm_medium=website&utm_content=community-events,200,1787690581
+https://www.lfopensource.cn/kubecon-cloudnativecon-openinfra-summit-pytorch-conference-china/register/?utm_source=opentelemetry&utm_medium=website&utm_content=slim-banner,200,1787690578
 https://www.linkedin.com/company/opentelemetry/,200,1787032240
 https://www.linkedin.com/feed/update/urn:li:activity:7459538615640010752/,200,1787032415
 https://www.linkedin.com/in/reese-lee/,206,1787036041

--- a/content/en/announcements/kubecon-china.md
+++ b/content/en/announcements/kubecon-china.md
@@ -13,8 +13,8 @@ params:
   blogPostURL: *eventUrl
 ---
 
-[**{{% param title %}}**][LF], **<span class="text-nowrap">September 7–9,</span>
-Shanghai**. [Details][blog]
+[**{{% param title %}}**][LF] ·
+<span class="text-nowrap">Sep 7–9</span> · Shanghai · [Details][blog]
 
 [blog]: <{{% param blogPostURL %}}>
 [LF]: <{{% param eventUrl %}}register/?{{% _param utmParam %}}>

--- a/content/en/announcements/kubecon-china.md
+++ b/content/en/announcements/kubecon-china.md
@@ -13,8 +13,8 @@ params:
   blogPostURL: *eventUrl
 ---
 
-[**{{% param title %}}**][LF] ·
-<span class="text-nowrap">Sep 7–9</span> · Shanghai · [Details][blog]
+[**{{% param title %}}**][LF] · <span class="text-nowrap">Sep 7–9</span> ·
+Shanghai · [Details][blog]
 
 [blog]: <{{% param blogPostURL %}}>
 [LF]: <{{% param eventUrl %}}register/?{{% _param utmParam %}}>

--- a/content/en/announcements/kubecon-china.md
+++ b/content/en/announcements/kubecon-china.md
@@ -14,9 +14,7 @@ params:
 ---
 
 [**{{% param title %}}**][LF], **<span class="text-nowrap">September 7–9,</span>
-Shanghai**. <span class="d-none d-md-inline"><br></span> Come [collaborate,
-learn, and share][blog]<span class="d-none d-sm-inline"> with the Cloud Native
-community</span>!
+Shanghai**. [Details][blog]
 
 [blog]: <{{% param blogPostURL %}}>
-[LF]: <{{% param eventUrl %}}?{{% _param utmParam %}}>
+[LF]: <{{% param eventUrl %}}register/?{{% _param utmParam %}}>

--- a/content/en/announcements/kubecon-china.md
+++ b/content/en/announcements/kubecon-china.md
@@ -1,21 +1,20 @@
 ---
-title: KubeCon + CloudNativeCon China 2025
-linkTitle: KubeCon China 2025
-date: 2025-05-20
-expiryDate: 2025-06-11 # keep
-weight: 20250611
+title: KubeCon + CloudNativeCon China 2026
+linkTitle: KubeCon China 2026
+date: 2026-08-25
+expiryDate: 2026-09-09 # keep
+weight: 20260909
 params:
-  # As of 2026-01-26, LF reports the event through lfasiallc.com
+  # As of 2026-08-25, LF reports the event through lfopensource.cn
   eventUrl: &eventUrl >-
-    https://www.lfasiallc.com/kubecon-cloudnativecon-openinfra-summit-china/
-  blogPostURL: /blog/2025/kubecon-china/
-  # This is the old URL. Keeping for now. TODO: remove after 2026-08-31
-  oldEventUrl: >- # This now redirects to the new URL
-    https://events.linuxfoundation.org/kubecon-cloudnativecon-china/reg/register/?utm_source=opentelemetry&utm_medium=website&utm_content=slim-banner
+    https://www.lfopensource.cn/kubecon-cloudnativecon-openinfra-summit-pytorch-conference-china/
+  # Use this when the blog post is ready:
+  # blogPostURL: /blog/2026/kubecon-china/
+  blogPostURL: *eventUrl
 ---
 
-[**{{% param title %}}**][LF], **<span class="text-nowrap">June 10-11,</span>
-Hong Kong**. <span class="d-none d-md-inline"><br></span> [Come collaborate,
+[**{{% param title %}}**][LF], **<span class="text-nowrap">September 7–9,</span>
+Shanghai**. <span class="d-none d-md-inline"><br></span> Come [collaborate,
 learn, and share][blog]<span class="d-none d-sm-inline"> with the Cloud Native
 community</span>!
 


### PR DESCRIPTION
- Replaces the expired KubeCon China 2025 banner with the 2026 edition (Sep 7–9, Shanghai), matching what the CNCF hello-bar currently promotes.
- Points the banner at the event's registration page until a blog post exists, following the KubeCon Japan 2026 pattern (#10933).
- **Preview**: <https://deploy-preview-11437--opentelemetry.netlify.app/>

