### PR TITLE
Move Fabrizio Ferri-Benedetti to emeritus

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ Here is a list of community roles with current and previous members:
 
 These are the members of [@open-telemetry/docs-maintainers][] (members-only):
 
-- [Fabrizio Ferri-Benedetti](https://github.com/theletterf), Elastic
 - [Jay DeLuca](https://github.com/jaydeluca), Grafana Labs
 - [Marylia Gutierrez](https://github.com/maryliag), Grafana Labs
 - [Patrice Chalin](https://github.com/chalin), CNCF
@@ -96,6 +95,7 @@ For more information about the triager role, see the
 ### Emeritus
 
 - [Austin Parker](https://github.com/austinlparker), Maintainer
+- [Fabrizio Ferri-Benedetti](https://github.com/theletterf), Maintainer
 - [jparsana](https://github.com/jparsana), Maintainer
 - [Kazunori Otani](https://github.com/katzchang), Triager
 - [Masaki Sugimoto](https://github.com/Msksgm), Triager


### PR DESCRIPTION
- [ ] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.

## Summary

- Move Fabrizio Ferri-Benedetti from active maintainers to Emeritus.
- Remove the Elastic affiliation, following the convention for emeritus members.

## Test plan

- [x] Run Prettier against `README.md`.
- [x] Run markdownlint against `README.md`.