### PR TITLE
[ja] update translation of content/en/site/build/ci-workflows.md

### DIFF
--- a/content/ja/site/build/ci-workflows.md
+++ b/content/ja/site/build/ci-workflows.md
@@ -3,21 +3,15 @@ title: CI ワークフロー
 description: >-
   PR のチェック、ラベル管理、その他の CI/CD プロセスを自動化する GitHub Actions ワークフロー。
 weight: 10
-default_lang_commit: bf0881aa9c57519b487bf6b5c469ca7f188dceed
-drifted_from_default: true
+default_lang_commit: 55db3f6bcc48358f9de9cd97f9132d1e3322ba48
 ---
 
 ワークフローと（ほとんどの）ヘルパースクリプトについては、[.github][] 配下の `workflow` フォルダと `scripts` フォルダを参照してください。
 
 ## 依存関係のインストール {#dependency-installation}
 
-CI ジョブはコミット済みの `package-lock.json` から npm の依存関係をインストールします。
-
-- `npm run ci:min` はロックされた依存関係グラフをインストールします。ライフサイクルスクリプトは実行されず、`package.json` とロックファイルが同期していない場合はインストールが失敗します。
-- サイトをビルドするジョブは、インストールの後に `npm run ci:prepare` を実行します。これは `hugo-extended`（再有効化された唯一の依存関係フック）をリビルドし、リポジトリ独自の `prepare` セットアップを実行します。
-- devcontainer はかわりに `npm run install:safe` を使用します。同じ動作を保証しますが、`netlify-cli` などのローカルツールを含むオプショナルな依存関係を保持します。
-
-スクリプトの詳細については、[npm スクリプト](../npm-scripts/)を参照してください。
+CI ジョブはサイト全体の[インストール規約](../dependencies/#install-contracts)に従って npm の依存関係をインストールします。
+lock-exact かつ script-free で、ビルドジョブはレビュー済みの Hugo リビルドのみを再有効化します。
 
 ## PR 承認ラベル {#pr-approval-labels}
 

--- a/content/ja/site/build/ci-workflows.md
+++ b/content/ja/site/build/ci-workflows.md
@@ -11,7 +11,7 @@ default_lang_commit: 55db3f6bcc48358f9de9cd97f9132d1e3322ba48
 ## 依存関係のインストール {#dependency-installation}
 
 CI ジョブはサイト全体の[インストール規約](../dependencies/#install-contracts)に従って npm の依存関係をインストールします。
-lock-exact かつ script-free で、ビルドジョブはレビュー済みの Hugo リビルドのみを再有効化します。
+ロック固定かつスクリプト無効で、ビルドジョブはレビュー済みの Hugo リビルドのみを再有効化します。
 
 ## PR 承認ラベル {#pr-approval-labels}
 


### PR DESCRIPTION
## Summary

Updates `content/ja/site/build/ci-workflows.md` to match the latest English source at
`content/en/site/build/ci-workflows.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English change simplified the "Dependency installation" section from a multi-bullet
explanation into a single paragraph linking to the new `dependencies` page's install
contracts section.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11442--opentelemetry.netlify.app/ja/site/build/ci-workflows/
- **English (canonical):** https://opentelemetry.io/site/build/ci-workflows/

<!-- preview-section-end -->
