### PR TITLE
[ja] update translation of content/en/site/build/npm-scripts.md

### DIFF
--- a/content/ja/site/build/npm-scripts.md
+++ b/content/ja/site/build/npm-scripts.md
@@ -4,8 +4,7 @@ description: >-
   OpenTelemetry ウェブサイトのビルド、配信、検証、メンテナンスのための NPM スクリプト。
 weight: 20
 todo: Keep table entries sorted
-default_lang_commit: b8a25353c25d781a375b51f354011248a8140113
-drifted_from_default: true
+default_lang_commit: 55db3f6bcc48358f9de9cd97f9132d1e3322ba48
 ---
 
 スクリプトの定義はリポジトリルートの [`package.json`][] にあります。
@@ -26,9 +25,9 @@ drifted_from_default: true
 
 | スクリプト        | 説明                                                                                                              |
 | ----------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `ci:min`          | CI 用の [Lock-exact inert install][]：ライフサイクルスクリプトなし、オプション依存なし。                          |
+| `ci:min`          | CI 用の [Lock-exact inert install][]：ライフサイクルスクリプトなし。                                              |
 | `ci:prepare`      | `ci:min` 実行後のセットアップ：[ピンされた Hugo バイナリの取得][fetch the pinned Hugo binary]、そして `prepare`。 |
-| `install:safe`    | [Lock-exact local setup][]：オプション依存を維持する inert インストール、そして `ci:prepare`。                    |
+| `install:safe`    | [Lock-exact local setup][]：inert インストール、そして `ci:prepare`。                                             |
 | `prepare`         | インストールステップ：`get:submodule` を実行し、Docsy の [lock-exact theme dependency install][]。                |
 | `update:hugo`     | 最新の hugo-extended をインストールし、バンプに伴う [`allowScripts` approval][] を更新します。                    |
 | `update:packages` | npm-check-updates を実行して依存関係を更新します（[release cooldown][] の対象）。                                 |


### PR DESCRIPTION
## Summary

Updates `content/ja/site/build/npm-scripts.md` to match the latest English source at
`content/en/site/build/npm-scripts.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

### Changes

- `ci:min` description: removed "、オプション依存なし" to match EN removal of ", no optional deps."
- `install:safe` description: removed "オプション依存を維持する" to match EN removal of "keeping optional deps".

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11443--opentelemetry.netlify.app/ja/site/build/npm-scripts/
- **English (canonical):** https://opentelemetry.io/site/build/npm-scripts/

<!-- preview-section-end -->
