### PR TITLE
[ja] update translation of content/en/docs/zero-code/obi/configure/internal-metrics-reporter.md

### DIFF
--- a/content/ja/docs/zero-code/obi/configure/internal-metrics-reporter.md
+++ b/content/ja/docs/zero-code/obi/configure/internal-metrics-reporter.md
@@ -3,9 +3,14 @@ title: OBI 内部メトリクスレポーターを設定する
 linkTitle: 内部メトリクスレポーター
 description: オプションの内部メトリクスレポーターコンポーネントが、自動計装ツールの内部動作に関するメトリクスを Prometheus 形式でレポートする方法を設定する
 weight: 80
-default_lang_commit: 4c8d57fea0147ce76633951315c40a27c55fad2e
-drifted_from_default: true
+default_lang_commit: 55db3f6bcc48358f9de9cd97f9132d1e3322ba48
 ---
+
+> [!NOTE]
+>
+> このページでは Config v1 のフィールド名と設定例を使用しています。
+> Config v2 については、[Config v2 リファレンス](/docs/zero-code/obi/configure/config-v2/)を参照してください。
+> 既存のファイルを変換するには、[移行ガイド](/docs/zero-code/obi/configure/migrate-to-config-v2/)を使用してください。
 
 YAML セクション: `internal_metrics`
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/obi/configure/internal-metrics-reporter.md` to match the latest English source at
`content/en/docs/zero-code/obi/configure/internal-metrics-reporter.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff added a Config v1/v2 NOTE callout at the top of the page. The relative links
`../config-v2/` and `../migrate-to-config-v2/` were converted to root-relative paths because
the linked pages do not yet have Japanese translations.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11444--opentelemetry.netlify.app/ja/docs/zero-code/obi/configure/internal-metrics-reporter/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/obi/configure/internal-metrics-reporter/

<!-- preview-section-end -->
