### PR TITLE
[ja] add translation of content/en/ecosystem/demo.md

### DIFF
--- a/content/ja/ecosystem/demo.md
+++ b/content/ja/ecosystem/demo.md
@@ -1,0 +1,30 @@
+---
+title: OpenTelemetry デモ
+linkTitle: デモ
+description: OpenTelemetry デモは、実際の環境に近い形で OpenTelemetry の実装を説明するために設計された、マイクロサービスベースの分散システムです。
+aliases:
+  - /community/demo
+  - /docs/getting-started/demo
+  - /docs/opentelemetry-demo
+weight: 10
+default_lang_commit: d6988a2bfec7521e701d8a15d36696cbb35a129b
+---
+
+[OpenTelemetry デモ](/docs/demo/)は以下のことを行います。
+
+- OpenTelemetry の計装とオブザーバビリティを実演するために使用できる、分散システムの現実的な例を提供します。
+- ベンダー、ツール開発者、その他の人々が、自身の OpenTelemetry インテグレーションを拡張し実演するための基盤を構築します。
+- OpenTelemetry コントリビューターが API、SDK、その他のコンポーネントや機能拡張の新バージョンをテストするために使用できる、生きた例を提供します。
+
+次のような疑問を感じたことがあるなら、デモが役立ちます。
+
+- 自分の言語の SDK をどのように使えばよいのか？
+- OpenTelemetry API を使う最善の方法は何か？
+- サービスをどのように設定すべきか？
+- OpenTelemetry Collector をどのように設定すべきか？
+- OpenTelemetry を使ったシステムの[アーキテクチャ](/docs/demo/architecture/)をどのように検討すればよいのか？
+
+詳しくは以下を参照してください。
+
+- [デモのドキュメント](/docs/demo/)
+- [デモのリポジトリ](https://github.com/open-telemetry/opentelemetry-demo)


### PR DESCRIPTION
## Summary

Translates `content/en/ecosystem/demo.md` into Japanese as `content/ja/ecosystem/demo.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11448--opentelemetry.netlify.app/ja/ecosystem/demo/
- **English (canonical):** https://opentelemetry.io/ecosystem/demo/

<!-- preview-section-end -->
