### PR TITLE
Add blog post: The Humans of OpenTelemetry - KubeCon Japan 2026

### DIFF
--- a/.lycheecache
+++ b/.lycheecache
@@ -1199,6 +1199,7 @@ https://github.com/chalin,200,1787029623
 https://github.com/chalin/,200,1787029613
 https://github.com/chalin/code-excerpter,200,1787029638
 https://github.com/chluknight1224,200,1787032234
+https://github.com/chmikata,200,1787733269
 https://github.com/christiand93,200,1787032520
 https://github.com/christos68k,200,1787032231
 https://github.com/chrlic,200,1786427594
@@ -1376,6 +1377,7 @@ https://github.com/federicobond,200,1786427595
 https://github.com/felixge,200,1786427587
 https://github.com/fengshunli,200,1786427595
 https://github.com/ferd,200,1787032235
+https://github.com/ffjlabo,200,1787733269
 https://github.com/flc1125,200,1787029626
 https://github.com/flipt-io,200,1787029674
 https://github.com/flipt-io/flipt,200,1787029674
@@ -1762,6 +1764,7 @@ https://github.com/ocelotl,200,1787032424
 https://github.com/odeke-em,200,1787029630
 https://github.com/odubajDT,200,1787032239
 https://github.com/oertl,200,1787032245
+https://github.com/okamototk,200,1787733269
 https://github.com/olgasafonova,200,1787032539
 https://github.com/olgasafonova/mcp-otel-go,200,1787032539
 https://github.com/onurtemizkan,200,1787032239
@@ -4787,6 +4790,7 @@ https://github.com/yumosx,200,1787029632
 https://github.com/yuriolisa,200,1787032238
 https://github.com/yurishkuro,200,1787029632
 https://github.com/yurishkuro/opentracing-tutorial/tree/master/python,200,1786427566
+https://github.com/yuzujoe,200,1787733269
 https://github.com/zacharycmontoya,200,1787032234
 https://github.com/zalando,200,1787032509
 https://github.com/zalando/otelcol-lightstep-receiver,200,1787032509

--- a/content/en/blog/2026/humans-of-otel-japan.md
+++ b/content/en/blog/2026/humans-of-otel-japan.md
@@ -1,0 +1,130 @@
+---
+title: The Humans of OpenTelemetry - KubeCon Japan 2026
+linkTitle: Humans of OTel Japan 2026
+date: 2026-08-26
+author: >-
+  [Yoshi Yamaguchi](https://github.com/ymotongpoo) (Grafana Labs)
+sig: End User SIG
+# prettier-ignore
+cSpell:ignore: fujikane kohei loglass mikata mixi ohira okamoto sugimoto yoshi yoshiki yuzuru
+---
+
+We're back with our fifth edition of
+[Humans of OpenTelemetry](/blog/2025/humans-of-otel-eu/), and for the first
+time, from Japan! At KubeCon + CloudNativeCon Japan 2026 in Yokohama, I
+interviewed OpenTelemetry end users and practitioners from the Japanese cloud
+native community, and learned how they got involved with OTel:
+
+- [Yuzuru Ohira](https://github.com/yuzujoe) (LayerX)
+- [Mikata](https://github.com/chmikata) (Loglass)
+- [Yoshiki Fujikane](https://github.com/ffjlabo) (CyberAgent)
+- [Takashi Okamoto](https://github.com/okamototk) (NTT DATA)
+- [Kohei Sugimoto](https://github.com/kohbis) (MIXI)
+
+The interviews were conducted in Japanese, and the transcript below is an
+English translation.
+
+<!-- TODO: Embed the YouTube recording once the edited footage is published. -->
+
+Thanks to everyone who has contributed to OpenTelemetry to date. We look forward
+to your continued contributions in 2026 and beyond! 🎉
+
+## Transcript
+
+If reading is more your thing, check out the following transcript of our
+conversations.
+
+### 1- Meet the Humans of OTel
+
+**YUZURU OHIRA:** I'm Yuzuru Ohira. I work as an engineering manager at LayerX.
+
+**MIKATA:** My name is Mikata, and I'm an SRE at Loglass.
+
+**YOSHIKI FUJIKANE:** My name is Yoshiki Fujikane, and I work as a platform
+engineer.
+
+**TAKASHI OKAMOTO:** I'm Takashi Okamoto, an AI strategist at NTT DATA.
+
+**KOHEI SUGIMOTO:** My name is Kohei Sugimoto, and I'm an SRE at MIXI.
+
+### 2- How did you get involved in OpenTelemetry?
+
+**YUZURU OHIRA:** I used to work at an observability company, where I worked on
+OpenTelemetry, and I've stayed involved by actually using OpenTelemetry at my
+current company.
+
+**MIKATA:** We had a project to introduce the Grafana stack, and that was my
+first encounter with OpenTelemetry.
+
+**YOSHIKI FUJIKANE:** To improve observability on the platform we run
+internally, we use SaaS tools like Datadog, and we're now at the stage where we
+want to adopt the OpenTelemetry Collector in particular. We're currently in the
+evaluation phase, and starting to use it for that evaluation is what got me
+involved.
+
+**TAKASHI OKAMOTO:** When we first started with observability, every vendor was
+doing things differently, but then it got standardized with OpenTelemetry. I
+thought that was great, and that's what got me involved.
+
+**KOHEI SUGIMOTO:** While using observability SaaS products, I was looking for
+something that would fit us better, and that's when I came across OpenTelemetry.
+
+### 3- What is the meaning of observability?
+
+**YUZURU OHIRA:** To me, it's part of the system architecture — something you
+design as part of the architecture of the code you write.
+
+**MIKATA:** I think of it as essential information for showing the health status
+of a system.
+
+**YOSHIKI FUJIKANE:** Observability is one of the essential keys to operating a
+system. As you develop services of all sizes, years go by and knowledge about
+those services fades away. Even so, you can continuously collect signals from
+the system and use them to understand the system as a black box, which I find
+valuable from an operations standpoint. In that sense, I feel observability is
+something we truly need.
+
+**TAKASHI OKAMOTO:** Observability is like a peephole that lets you see
+everything in the system — the bad parts and the good parts.
+
+**KOHEI SUGIMOTO:** I think it's a means to correctly understand your system and
+improve it in the right direction.
+
+### 4- What is OpenTelemetry to you?
+
+**YUZURU OHIRA:** OpenTelemetry is the most fundamental way of thinking when
+designing observability, so for me it's like a textbook — I refer to what
+OpenTelemetry implements when building my own implementations.
+
+**MIKATA:** I think of it as the standard rules and specifications for
+expressing the health status of a system.
+
+**YOSHIKI FUJIKANE:** What is OpenTelemetry to me? That's a really hard one. For
+me, at this point, it's a fascinating thing to experiment with.
+
+**TAKASHI OKAMOTO:** OpenTelemetry is what feeds that peephole — it carries all
+kinds of data: metrics, logs, and traces. So it's a pipe. Well, calling it a
+"hole" would be rude — it's a pipe.
+
+**KOHEI SUGIMOTO:** Observability comes with a lot of difficulties, and I think
+OpenTelemetry is something that gives us a guiding principle amid all that.
+
+### 5- What is your favorite telemetry signal?
+
+**YUZURU OHIRA:** I love tracing.
+
+**MIKATA:** Traces. I believe traces are the foundation of everything — the
+first, most important core part — so I really love traces.
+
+**YOSHIKI FUJIKANE:** My favorite signal would be traces. Personally, I really
+enjoy learning how systems work, so a signal that tells me what behavior
+occurred inside the system and what happened as a result fits me best. That's
+why I chose traces.
+
+**TAKASHI OKAMOTO:** Rather than a signal per se — I've been working on
+observability for AI agents lately, so I like the
+[Generative AI semantic conventions](/docs/specs/semconv/gen-ai/).
+
+**KOHEI SUGIMOTO:** Metrics. Among the many kinds of telemetry data, metrics can
+nicely absorb the others and contribute to things like cost optimization and
+summarization. That's why.

--- a/content/en/blog/2026/humans-of-otel-japan.md
+++ b/content/en/blog/2026/humans-of-otel-japan.md
@@ -127,7 +127,7 @@ observability for AI agents lately, so I like the
 
 **KOHEI SUGIMOTO:** Metrics. Among the many kinds of telemetry data, metrics can
 nicely absorb the others and contribute to things like cost optimization and
-summarization. That's why.
+summarization.
 
 ## Join us!
 

--- a/content/en/blog/2026/humans-of-otel-japan.md
+++ b/content/en/blog/2026/humans-of-otel-japan.md
@@ -6,7 +6,7 @@ author: >-
   [Yoshi Yamaguchi](https://github.com/ymotongpoo) (Grafana Labs)
 sig: End User SIG
 # prettier-ignore
-cSpell:ignore: fujikane kohei loglass mikata mixi ohira okamoto sugimoto yoshi yoshiki yuzuru
+cSpell:ignore: chikahisa fujikane kohei loglass mikata mixi ohira okamoto sugimoto yoshi yoshiki yuzuru
 ---
 
 We're back with our fifth edition of
@@ -16,7 +16,7 @@ interviewed OpenTelemetry end users and practitioners from the Japanese cloud
 native community, and learned how they got involved with OTel:
 
 - [Yuzuru Ohira](https://github.com/yuzujoe) (LayerX)
-- [Mikata](https://github.com/chmikata) (Loglass)
+- [Mikata Chikahisa](https://github.com/chmikata) (Loglass)
 - [Yoshiki Fujikane](https://github.com/ffjlabo) (CyberAgent)
 - [Takashi Okamoto](https://github.com/okamototk) (NTT DATA)
 - [Kohei Sugimoto](https://github.com/kohbis) (MIXI)
@@ -38,7 +38,7 @@ conversations.
 
 **YUZURU OHIRA:** I'm Yuzuru Ohira. I work as an engineering manager at LayerX.
 
-**MIKATA:** My name is Mikata, and I'm an SRE at Loglass.
+**MIKATA CHIKAHISA:** My name is Mikata, and I'm an SRE at Loglass.
 
 **YOSHIKI FUJIKANE:** My name is Yoshiki Fujikane, and I work as a platform
 engineer.
@@ -53,8 +53,8 @@ engineer.
 OpenTelemetry, and I've stayed involved by actually using OpenTelemetry at my
 current company.
 
-**MIKATA:** We had a project to introduce the Grafana stack, and that was my
-first encounter with OpenTelemetry.
+**MIKATA CHIKAHISA:** We had a project to introduce the Grafana stack, and that
+was my first encounter with OpenTelemetry.
 
 **YOSHIKI FUJIKANE:** To improve observability on the platform we run
 internally, we use SaaS tools like Datadog, and we're now at the stage where we
@@ -74,8 +74,8 @@ something that would fit us better, and that's when I came across OpenTelemetry.
 **YUZURU OHIRA:** To me, it's part of the system architecture — something you
 design as part of the architecture of the code you write.
 
-**MIKATA:** I think of it as essential information for showing the health status
-of a system.
+**MIKATA CHIKAHISA:** I think of it as essential information for showing the
+health status of a system.
 
 **YOSHIKI FUJIKANE:** Observability is one of the essential keys to operating a
 system. As you develop services of all sizes, years go by and knowledge about
@@ -96,7 +96,7 @@ improve it in the right direction.
 designing observability, so for me it's like a textbook — I refer to what
 OpenTelemetry implements when building my own implementations.
 
-**MIKATA:** I think of it as the standard rules and specifications for
+**MIKATA CHIKAHISA:** I think of it as the standard rules and specifications for
 expressing the health status of a system.
 
 **YOSHIKI FUJIKANE:** What is OpenTelemetry to me? That's a really hard one. For
@@ -113,8 +113,8 @@ OpenTelemetry is something that gives us a guiding principle amid all that.
 
 **YUZURU OHIRA:** I love tracing.
 
-**MIKATA:** Traces. I believe traces are the foundation of everything — the
-first, most important core part — so I really love traces.
+**MIKATA CHIKAHISA:** Traces. I believe traces are the foundation of everything
+— the first, most important core part — so I really love traces.
 
 **YOSHIKI FUJIKANE:** My favorite signal would be traces. Personally, I really
 enjoy learning how systems work, so a signal that tells me what behavior
@@ -128,3 +128,28 @@ observability for AI agents lately, so I like the
 **KOHEI SUGIMOTO:** Metrics. Among the many kinds of telemetry data, metrics can
 nicely absorb the others and contribute to things like cost optimization and
 summarization. That's why.
+
+## Join us!
+
+If you have a story to share about how you use OpenTelemetry at your
+organization, we'd love to hear from you! Ways to share:
+
+- Join the
+  [#otel-sig-end-user channel](https://cloud-native.slack.com/archives/C01RT3MSWGZ)
+  on the
+  [CNCF Community Slack](https://communityinviter.com/apps/cloud-native/cncf)
+- Join our [OTel in Practice](/community/end-user/otel-in-practice/) sessions
+- Share your stories on the [OpenTelemetry blog](/docs/contributing/blog/)
+- Contact us on the
+  [CNCF Community Slack](https://communityinviter.com/apps/cloud-native/cncf)
+  for any other types of sessions you'd like to see!
+
+Be sure to follow OpenTelemetry on
+[Bluesky](https://bsky.app/profile/opentelemetry.io),
+[Mastodon](https://fosstodon.org/@opentelemetry) and
+[LinkedIn](https://www.linkedin.com/company/opentelemetry/), and share your
+stories using the **#OpenTelemetry** hashtag!
+
+And don't forget to subscribe to our
+[YouTube channel](https://youtube.com/@otel-official) for more great
+OpenTelemetry content!


### PR DESCRIPTION
## Description

This adds a new [Humans of OpenTelemetry](https://opentelemetry.io/blog/2025/humans-of-otel-eu/) blog post, this time from KubeCon + CloudNativeCon Japan 2026 in Yokohama (July 29–30, 2026) — the first edition from Japan.

I interviewed five OpenTelemetry end users and practitioners from the Japanese cloud native community:

- Yuzuru Ohira (LayerX)
- Mikata Chikahisa (Loglass)
- Yoshiki Fujikane (CyberAgent)
- Takashi Okamoto (NTT DATA)
- Kohei Sugimoto (MIXI)

The interviews were conducted in Japanese; the transcript in the post is an English translation.

All recorded videos and raw transcription files are in [this folder](https://drive.google.com/drive/folders/1mBbFfvCjl8ASEnBVc-pv3IsgY0PYGmlH?usp=drive_link).

## Notes for reviewers

- This PR is the outcome of a discussion in the OpenTelemetry End User SIG ([meeting notes](https://docs.google.com/document/d/1e-UNZA3Tuno9b53RQbe--whUcO0VIXF3P81oXsrBK6g/edit?tab=t.0)), and we are now in the process of getting approval from the OpenTelemetry Communications SIG.
- This is a **draft**: we have just started the request for editing the video footage, so it will take some time. The YouTube embed is left as a TODO comment; I will add it and update the `date` field before marking the PR ready for review.
- The post follows the structure of the previous Humans of OTel posts.
- `prettier` and `cspell` checks pass locally.

## Sponsors
I have supports from End User SIG members on this, and @avillela willingly [offered to be the official sponsor on this PR](https://cloud-native.slack.com/archives/C01RT3MSWGZ/p1787728846879989?thread_ts=1786516431.107679&cid=C01RT3MSWGZ).

ref: https://github.com/open-telemetry/sig-end-user/issues/354