### PR TITLE
[ja] update translation of content/en/docs/zero-code/obi/configure/metrics-traces-attributes.md

### DIFF
--- a/content/ja/docs/zero-code/obi/configure/metrics-traces-attributes.md
+++ b/content/ja/docs/zero-code/obi/configure/metrics-traces-attributes.md
@@ -3,10 +3,15 @@ title: OBI のメトリクスとトレースの属性を設定する
 linkTitle: メトリクス属性
 description: 計装された Kubernetes Pod のインスタンス ID デコレーションとメタデータを含む、報告される属性を制御するメトリクスとトレースの属性コンポーネントを設定します。
 weight: 30
-default_lang_commit: ec870712704ae037419e4e420b7fa3be04e10297
-drifted_from_default: true
+default_lang_commit: d6988a2bfec7521e701d8a15d36696cbb35a129b
 cSpell:ignore: kube kubecache kubeconfig OpenShift replicaset statefulset
 ---
+
+> [!NOTE]
+>
+> このページでは Config v1 のフィールド名と例を使用しています。
+> Config v2 については [Config v2 リファレンス](/docs/zero-code/obi/configure/config-v2/) を参照してください。
+> 既存のファイルを変換するには [移行ガイド](/docs/zero-code/obi/configure/migrate-to-config-v2/) を使用してください。
 
 OBI がメトリクスとトレースの属性をどのように装飾するかを設定できます。
 属性の設定や有効化には、トップレベルの YAML セクション `attributes` を使用します。


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/obi/configure/metrics-traces-attributes.md` to match the latest English source at
`content/en/docs/zero-code/obi/configure/metrics-traces-attributes.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff added a `> [!NOTE]` block at the top of the page pointing readers to the Config v2 reference and migration guide. The links use root-relative paths because the linked pages (`config-v2.md` and `migrate-to-config-v2.md`) do not yet have Japanese translations.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11452--opentelemetry.netlify.app/ja/docs/zero-code/obi/configure/metrics-traces-attributes/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/obi/configure/metrics-traces-attributes/

<!-- preview-section-end -->
