### PR TITLE
[ja] update translation of content/en/site/testing/_index.md

### DIFF
--- a/content/ja/site/testing/_index.md
+++ b/content/ja/site/testing/_index.md
@@ -1,8 +1,7 @@
 ---
 title: テスト
 description: チェックとテストの戦略、プロセス、テストページ。
-default_lang_commit: ee923995f520211ef16f8744ce0a9b28a24bcca9
-drifted_from_default: true
+default_lang_commit: d6988a2bfec7521e701d8a15d36696cbb35a129b
 ---
 
 このセクションには、ウェブサイトのテストやデプロイ後のライブチェックで使用されるチェックとテストの戦略、プロセス、テストページが含まれています。
@@ -23,6 +22,10 @@ drifted_from_default: true
   `public/` がない場合にスキップする規約に従ってください。
   これらは意図的に `test:compound-tests`（ビルドを行わない）から除外されており、かわりに CI で既存のビルドアーティファクトを再利用するジョブで実行されます。
 - **`test:*:live`** スクリプトは、デプロイ済みのライブサイトに対するオプションのチェックです。
+
+複合テストスイートのうち、`test:local-tools` は[サプライチェーン監査](../build/dependencies/#audit)も実行します。
+コミット済みのインストール強化制御がリグレッションした場合に失敗します。
+発生時の対処方法はそのページに記載されています。
 
 ## テストアサーション {#test-assertions}
 


### PR DESCRIPTION
## Summary

Updates `content/ja/site/testing/_index.md` to match the latest English source at
`content/en/site/testing/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11453--opentelemetry.netlify.app/ja/site/testing/
- **English (canonical):** https://opentelemetry.io/site/testing/

<!-- preview-section-end -->
