### PR TITLE
[ja] add translation of content/en/ecosystem/registry/updating.md

### DIFF
--- a/content/ja/ecosystem/_includes/freeze-notice.md
+++ b/content/ja/ecosystem/_includes/freeze-notice.md
@@ -1,0 +1,7 @@
+---
+default_lang_commit: 7279d56948a75400445c97086d7b1e0da0dd0438
+---
+
+> [!WARNING] エコシステムリストは凍結中です
+>
+> [レジストリ](/ecosystem/registry/)を含む[エコシステム](/ecosystem/)リストへの新規エントリおよび既存エントリの更新は、メンテナーが各リストの今後の方針を検討している間、受け付けを停止しています。詳細および意見の共有については、[issue #11377](https://github.com/open-telemetry/opentelemetry.io/issues/11377)を参照してください。

--- a/content/ja/ecosystem/registry/updating.md
+++ b/content/ja/ecosystem/registry/updating.md
@@ -1,0 +1,16 @@
+---
+title: レジストリとリスト情報を最新に保つ
+linkTitle: 更新
+default_lang_commit: d6988a2bfec7521e701d8a15d36696cbb35a129b
+---
+
+{{% include freeze-notice.md %}}
+
+私たちは定期的に[レジストリ](..)のエントリと[リストデータ][list data]（外部リンクなど）をレビューし、OpenTelemetry を積極的にサポートしている[採用者](/ecosystem/adopters/)、[ディストリビューション](/ecosystem/distributions/)、[インテグレーション、ライブラリ](/ecosystem/integrations/)、[ベンダー](/ecosystem/vendors/)のみがレジストリに含まれるようにしています。
+
+エントリの作成者は、アクティブかつ最新のディストリビューション、ドキュメント、ライブラリへのリンクを維持することが推奨されます。
+私たちは、OpenTelemetry を積極的にサポートしていないと思われるコンポーネントのエントリを更新または削除する権利を留保します。
+これは、たとえば外部リンクが無効になった場合に発生することがあります。
+私たちは、最初にエントリデータを送信した GitHub ユーザーにベストエフォートで連絡を試みますが、それ以外の場合はエントリおよびエントリデータを編集・削除する権利を留保します。
+
+[list data]: https://github.com/open-telemetry/opentelemetry.io/tree/main/data/ecosystem


### PR DESCRIPTION
## Summary

Translates `content/en/ecosystem/registry/updating.md` into Japanese as `content/ja/ecosystem/registry/updating.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11455--opentelemetry.netlify.app/ja/ecosystem/registry/updating/
- **English (canonical):** https://opentelemetry.io/ecosystem/registry/updating/

<!-- preview-section-end -->
