### PR TITLE
[ja] update translation of content/en/docs/zero-code/obi/configure/options.md

### DIFF
--- a/content/ja/docs/zero-code/obi/configure/options.md
+++ b/content/ja/docs/zero-code/obi/configure/options.md
@@ -3,10 +3,15 @@ title: OBI グローバル設定プロパティ
 linkTitle: グローバルプロパティ
 description: OBI コアに適用されるグローバル設定プロパティを設定する
 weight: 2
-default_lang_commit: 4c8d57fea0147ce76633951315c40a27c55fad2e
-drifted_from_default: true
+default_lang_commit: 0fee5e1c7ff48dc9fb39c919c9882a9a8d8da4aa
 cSpell:ignore: healthz
 ---
+
+> [!NOTE]
+>
+> このページでは Config v1 のフィールド名、例、環境変数を使用しています。
+> Config v2 については、[Config v2 リファレンス](/docs/zero-code/obi/configure/config-v2/)を参照してください。
+> 既存のファイルを変換するには、[移行ガイド](/docs/zero-code/obi/configure/migrate-to-config-v2/)を使用してください。
 
 OBI は、環境変数またはコマンドライン引数 `-config` か環境変数 `OTEL_EBPF_CONFIG_PATH` を使用して渡す YAML 設定ファイルを通じて設定できます。
 環境変数は設定ファイルのプロパティよりも優先されます。


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/obi/configure/options.md` to match the latest English source at
`content/en/docs/zero-code/obi/configure/options.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff adds a Config v1/v2 note callout block at the top of the page (matching the
same note already present in other sibling pages like `export-modes.md`, `filter-metrics-traces.md`,
etc.). Links use root-relative paths (`/docs/zero-code/obi/configure/config-v2/` and
`/docs/zero-code/obi/configure/migrate-to-config-v2/`) consistent with other Japanese pages
in this directory, since the target pages do not yet have Japanese translations.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11463--opentelemetry.netlify.app/ja/docs/zero-code/obi/configure/options/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/obi/configure/options/

<!-- preview-section-end -->
