### PR TITLE
[ja] update translation of content/en/docs/zero-code/obi/configure/_index.md

### DIFF
--- a/content/ja/docs/zero-code/obi/configure/_index.md
+++ b/content/ja/docs/zero-code/obi/configure/_index.md
@@ -3,8 +3,7 @@ title: OBI の構成
 linkTitle: 構成
 description: OBI の構成方法を学びます。
 weight: 4
-default_lang_commit: dc2fb5771163265cb804a39b1dacc536b95bdb96
-drifted_from_default: true
+default_lang_commit: 0fee5e1c7ff48dc9fb39c919c9882a9a8d8da4aa
 ---
 
 OBI は、[エクスポートモード](export-modes/)、グローバルプロパティ、コンポーネントオプションを設定することで構成できます。
@@ -13,3 +12,14 @@ OBI がエクスポートするメトリクスの情報については、[エク
 
 低カーディナリティのルートデコレーターを構成するには、[ルートデコレーター](routes-decorator/)のドキュメントを参照してください。
 最適な結果を得るために非常に重要です。
+
+## 構成バージョン {#configuration-versions}
+
+OBI v0.11.0 以降では Config v2 を使用してください。
+Config v2 はスタンドアロン OBI と OBI Collector レシーバーの両方で動作し、共通設定には OpenTelemetry の宣言的構成構造を使用し、OBI 固有の設定は `extensions.obi` 配下に配置します。
+
+- 新しい構成を作成するには、[Config v2 リファレンス](/docs/zero-code/obi/configure/config-v2/)を参照してください。
+- 既存の Config v1 ファイルを変換するには、[Config v1 から v2 への移行ガイド](/docs/zero-code/obi/configure/migrate-to-config-v2/)に従ってください。
+
+特に記載がない限り、このセクションの他のページは Config v1 について説明しています。
+各ページから対応する Config v2 のガイダンスへのリンクがあります。


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/obi/configure/_index.md` to match the latest English source at
`content/en/docs/zero-code/obi/configure/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

### Changes

- Added the new "Configuration versions" section (`## 構成バージョン {#configuration-versions}`) — pure addition of Config v2 guidance and migration links.
- Links to `config-v2/` and `migrate-to-config-v2/` use root-relative paths (`/docs/zero-code/obi/configure/config-v2/`, `/docs/zero-code/obi/configure/migrate-to-config-v2/`) because those pages do not yet have Japanese translations. This matches the pattern used by sibling JA pages (e.g. `export-modes.md`, `filter-metrics-traces.md`).

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11464--opentelemetry.netlify.app/ja/docs/zero-code/obi/configure/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/obi/configure/

<!-- preview-section-end -->
