### PR TITLE
[ja] update translation of content/en/docs/zero-code/obi/configure/routes-decorator.md

### DIFF
--- a/content/ja/docs/zero-code/obi/configure/routes-decorator.md
+++ b/content/ja/docs/zero-code/obi/configure/routes-decorator.md
@@ -3,9 +3,14 @@ title: OBI ルートデコレーターを設定する
 linkTitle: ルートデコレーター
 description: OBI がパイプラインの次のステージにデータを送信する前に、ルートデコレーターコンポーネントを設定します。
 weight: 50
-default_lang_commit: 2728c8fbf4f09cf3b8257a1b628a7631fc77d639
-drifted_from_default: true
+default_lang_commit: ec40cad3a7ca79640aa6a6f97264fbbe0d00aa87
 ---
+
+> [!NOTE]
+>
+> このページでは Config v1 のフィールド名と例を使用しています。
+> Config v2 については、[Config v2 リファレンス](/docs/zero-code/obi/configure/config-v2/)を参照してください。
+> 既存のファイルを変換するには、[移行ガイド](/docs/zero-code/obi/configure/migrate-to-config-v2/)を使用してください。
 
 YAML セクション: `routes`
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/obi/configure/routes-decorator.md` to match the latest English source at
`content/en/docs/zero-code/obi/configure/routes-decorator.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff added a `> [!NOTE]` callout block pointing readers to the Config v2 reference and migration guide.
Link targets use root-relative paths (`/docs/zero-code/obi/configure/config-v2/` and `/docs/zero-code/obi/configure/migrate-to-config-v2/`), consistent with other translated pages in the same directory that link to these untranslated pages.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11472--opentelemetry.netlify.app/ja/docs/zero-code/obi/configure/routes-decorator/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/obi/configure/routes-decorator/

<!-- preview-section-end -->
