### PR TITLE
[ja] update translation of content/en/docs/contributing/development.md

### DIFF
--- a/content/ja/docs/contributing/development.md
+++ b/content/ja/docs/contributing/development.md
@@ -6,8 +6,7 @@ what-next: >
   これで、[ビルド](#build)、[サーブ](#serve)、Web サイトファイルの更新を行う準備が整いました。
   変更の提出方法の詳細については、[コンテンツの提出](../pull-requests)を参照してください。
 weight: 60
-default_lang_commit: bf0881aa9c57519b487bf6b5c469ca7f188dceed
-drifted_from_default: true
+default_lang_commit: ec40cad3a7ca79640aa6a6f97264fbbe0d00aa87
 cSpell:ignore: TOCSS
 ---
 
@@ -16,8 +15,6 @@ cSpell:ignore: TOCSS
 > ビルドは Linux ベースの環境と macOS で公式にサポートされています。
 > [DevContainers](#devcontainers) などの他の環境は、ベストエフォートベースでサポートされています。
 > Windows でのビルドについては、Windows Subsystem for Linux コマンドライン [WSL][] を使用して Linux と同様の手順に従うことができます。
-
-以下の手順では、この Web サイトの開発環境をセットアップする方法を説明します。
 
 ## クラウド IDE のセットアップ {#cloud-ide-setup}
 
@@ -70,31 +67,20 @@ GitHub [Codespaces][] で作業するには、下記にしたがってくださ�
     nvm install lts && nvm use lts
     ```
 
-4.  npm パッケージとその他の依存関係をインストールします。
-
-    ```sh
-    npm install
-    ```
-
-    または、CI や DevContainer が使用する[ロックファイルに厳密に準拠し、スクリプトを抑制するセットアップ][ci-install]を使用する場合は、次のコマンドを実行してください。
+4.  DevContainer が使用する[ロックファイルに厳密に準拠し、スクリプトを抑制するセットアップ][ci-install]で、npm パッケージとその他の依存関係をインストールします。
 
     ```sh
     npm run install:safe
     ```
 
-    どちらのインストールでも、コミットされた `package-lock.json` に固定された依存関係のバージョンを使用します。
-    ロックファイルに関するケースは以下のとおりです。
-    - **依存関係を変更した場合**: ロックファイルを再生成し、`package.json` と一緒にコミットしてください。
+    または、標準のインストールを使用します。
 
-      ```sh
-      npm install --package-lock-only --ignore-scripts
-      ```
+    ```sh
+    npm install
+    ```
 
-    - **ロックファイルにマージコンフリクトが発生した場合**: `main` のバージョンを採用し、上記のコマンドを再実行してください。
-    - **依存関係を変更していないのにロックファイルが変更された場合**（`postinstall` チェックがインストール時にこれを検知すると警告します）: これはドリフトを示しています。
-      書き換えをコミットするのではなく、ロックファイルを復元して調査してください。
-
-    サイトメンテナーは[その他のロックファイルのメンテナンス][ci-install]を管理しています。
+    どちらのインストールでも、コミットされた `package-lock.json` に固定された依存関係のバージョンを使用し、実行されるライフサイクルスクリプトはレビュー済みの許可リストに従います。
+    関連情報: [ロックファイルのメンテナンス][dep-updates]
 
 お好みの IDE を起動してください。{{% param what-next %}}
 
@@ -139,13 +125,9 @@ npm run serve
 
 サイトは [localhost:1313][] でサーブされます。
 
-[Netlify][] のリダイレクトをテストする必要がある場合は、次のコマンドを実行し、[localhost:8888][] にアクセスしてください。
-
-```sh
-npm run serve:netlify
-```
-
 この `serve` コマンドは、ディスクではなくメモリ上のファイルを提供します。
+
+Netlify のリダイレクトをテストするには、PR の[デプロイプレビュー][deploy preview]を使用してください。
 
 macOS で `too many open files` や `pipe failed` というエラーが発生する場合は、ファイルディスクリプタの制限を増やす必要があるかもしれません。
 詳しくは [Hugo のイシューの #6109](https://github.com/gohugoio/hugo/issues/6109) を参照してください。
@@ -229,18 +211,18 @@ npm run check:code-excerpts
 [code-excerpter]: https://github.com/chalin/code-excerpter
 
 <!-- prettier-ignore-start -->
-[ci-install]: /site/build/ci-workflows/#dependency-installation
+[ci-install]: /site/build/dependencies/#install-contracts
+[dep-updates]: /site/build/dependencies/#lock-file-maintenance
 [clone]: https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository
 [codespaces]: https://docs.github.com/en/codespaces
 [cs-devc]: https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers#about-dev-containers
+[deploy preview]: ../pull-requests/#site-deploys-and-pr-previews
 [devcontainers]: https://containers.dev/
 [fork]: https://docs.github.com/en/get-started/quickstart/fork-a-repo
 [gitpod.io]: https://gitpod.io
 [gitpod.io/workspaces]: https://gitpod.io/workspaces
 [hugo]: https://gohugo.io
 [localhost:1313]: http://localhost:1313
-[localhost:8888]: http://localhost:8888
-[netlify]: https://netlify.com
 [nodejs-rel]: https://nodejs.org/en/about/previous-releases
 [nodejs-win]: https://docs.microsoft.com/en-us/windows/dev-environment/javascript/nodejs-on-windows
 [nvm-windows]: https://github.com/coreybutler/nvm-windows

--- a/content/ja/docs/contributing/development.md
+++ b/content/ja/docs/contributing/development.md
@@ -7,6 +7,7 @@ what-next: >
   変更の提出方法の詳細については、[コンテンツの提出](../pull-requests)を参照してください。
 weight: 60
 default_lang_commit: ec40cad3a7ca79640aa6a6f97264fbbe0d00aa87
+drifted_from_default: true
 cSpell:ignore: TOCSS
 ---
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/contributing/development.md` to match the latest English source at
`content/en/docs/contributing/development.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

### Changes

- Removed introductory paragraph ("The following instructions explain...")
- Reordered Step 4 install commands: `npm run install:safe` is now the primary recommendation, with `npm install` as the alternative
- Simplified lock-file maintenance explanation, linking to `[dep-updates]`
- Replaced `npm run serve:netlify` instructions with a link to the deploy preview for PRs
- Updated `[ci-install]` link target to `/site/build/dependencies/#install-contracts`
- Added `[dep-updates]` and `[deploy preview]` reference definitions
- Removed `[localhost:8888]` and `[netlify]` reference definitions

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11473--opentelemetry.netlify.app/ja/docs/contributing/development/
- **English (canonical):** https://opentelemetry.io/docs/contributing/development/

<!-- preview-section-end -->
