### PR TITLE
[ja] update translation of content/en/docs/demo/architecture.md

### DIFF
--- a/content/ja/docs/demo/architecture.md
+++ b/content/ja/docs/demo/architecture.md
@@ -3,8 +3,7 @@ title: デモのアーキテクチャ
 linkTitle: アーキテクチャ
 aliases: [current_architecture]
 body_class: otel-mermaid-max-width
-default_lang_commit: f60f406894f94169947ecbd236b933ee4008354c
-drifted_from_default: true
+default_lang_commit: 055e4933b5a29eb283300a071158d7caa0542b1c
 ---
 
 **OpenTelemetryデモ** は、異なるプログラミング言語で書かれた複数のマイクロサービスから構成されており、gRPCとHTTPを使って相互に通信を行います。
@@ -37,71 +36,70 @@ recommendation(レコメンデーション):::python
 shipping(配送):::rust
 queue[(キュー<br/>&#40Kafka&#41)]:::java
 react-native-app(React Native<br>アプリケーション):::typescript
-postgresql[(データベース<br/>&#40PostgreSQL&#41)]
+postgresql[(astronomy-db<br/>&#40PostgreSQL&#41)]
 
-accounting ---> postgresql
-
-agent -.->|HTTP| mcp
+chatbot -->|HTTP| agent
 agent -.->|HTTP| frontend
+agent -.->|HTTP| mcp
 
-ad ---->|gRPC| flagd
+ad --->|gRPC| flagd
 
 checkout -->|gRPC| currency
 checkout -->|gRPC| cart
-checkout -->|TCP| queue
-
 cart --> cache
-cart -->|gRPC| flagd
+cart --->|gRPC| flagd
 
-chatbot -->|HTTP| agent
-
-checkout -->|gRPC| payment
+checkout --->|gRPC| payment
 checkout --->|HTTP| email
-checkout -->|gRPC| product-catalog
+checkout -->|TCP| queue
+checkout ---->|gRPC| product-catalog
 checkout -->|HTTP| shipping
+shipping -->|HTTP| quote
 
-fraud-detection -->|gRPC| flagd
+fraud-detection --->|gRPC| flagd
 
 frontend -->|gRPC| ad
+frontend ---->|gRPC| cart
 frontend -->|gRPC| currency
-frontend -->|gRPC| cart
 frontend -->|gRPC| checkout
 frontend -->|HTTP| shipping
-frontend ---->|gRPC| recommendation
 frontend -->|gRPC| product-catalog
+frontend --->|gRPC| recommendation
 
 frontend-proxy -->|gRPC| flagd
-frontend-proxy -->|HTTP| frontend
 frontend-proxy -->|HTTP| flagd-ui
 frontend-proxy -->|HTTP| image-provider
+frontend-proxy -->|HTTP| frontend
 frontend-proxy -->|HTTP| chatbot
 
 mcp -->|HTTP| frontend
 
-payment -->|gRPC| flagd
+payment --->|gRPC| flagd
 
-queue -->|TCP| accounting
 queue -->|TCP| fraud-detection
 
-recommendation -->|gRPC| flagd
 recommendation -->|gRPC| product-catalog
+recommendation ----->|gRPC| flagd
 
-shipping -->|HTTP| quote
+product-catalog --> postgresql
 
 Internet -->|HTTP| frontend-proxy
 load-generator -->|HTTP| frontend-proxy
 react-native-app -->|HTTP| frontend-proxy
+accounting --> postgresql
+queue -->|TCP| accounting
+
 end
 
-classDef dotnet fill:#178600,color:white;
+classDef dotnet fill:#311a7f,color:white;
 classDef cpp fill:#f34b7d,color:white;
 classDef elixir fill:#b294bb,color:black;
 classDef golang fill:#00add8,color:black;
 classDef java fill:#b07219,color:white;
 classDef javascript fill:#f1e05a,color:black;
-classDef kotlin fill:#560ba1,color:white;
-classDef php fill:#4f5d95,color:white;
-classDef python fill:#3572A5,color:white;
+classDef kotlin fill:#6b57ff,color:white;
+classDef php fill:#4F5B93,color:white;
+classDef python fill:#82b043,color:white;
 classDef ruby fill:#701516,color:white;
 classDef rust fill:#dea584,color:black;
 classDef typescript fill:#e98516,color:black;
@@ -124,15 +122,15 @@ subgraph サービスの凡例
   typescriptsvc(TypeScript):::typescript
 end
 
-classDef dotnet fill:#178600,color:white;
+classDef dotnet fill:#311a7f,color:white;
 classDef cpp fill:#f34b7d,color:white;
 classDef elixir fill:#b294bb,color:black;
 classDef golang fill:#00add8,color:black;
 classDef java fill:#b07219,color:white;
 classDef javascript fill:#f1e05a,color:black;
-classDef kotlin fill:#560ba1,color:white;
-classDef php fill:#4f5d95,color:white;
-classDef python fill:#3572A5,color:white;
+classDef kotlin fill:#6b57ff,color:white;
+classDef php fill:#4F5B93,color:white;
+classDef python fill:#82b043,color:white;
 classDef ruby fill:#701516,color:white;
 classDef rust fill:#dea584,color:black;
 classDef typescript fill:#e98516,color:black;


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/demo/architecture.md` to match the latest English source at
`content/en/docs/demo/architecture.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

### Changes applied

All changes are within mermaid diagram code blocks (no prose or heading changes):

- **postgresql node label**: `データベース` → `astronomy-db` (the EN source renamed "Database" to "astronomy-db", a proper noun)
- **Edge reordering**: service connection edges reordered to match the updated EN diagram layout
- **Arrow lengths**: adjusted dash counts on several edges to match EN (purely visual layout changes)
- **New edges**: `product-catalog --> postgresql`, `accounting --> postgresql` (moved from earlier position)
- **Removed edges**: `accounting ---> postgresql` (moved to end of diagram)
- **classDef color changes** (both diagrams): `dotnet` (#178600→#311a7f), `kotlin` (#560ba1→#6b57ff), `php` (#4f5d95→#4F5B93), `python` (#3572A5→#82b043)

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11479--opentelemetry.netlify.app/ja/docs/demo/architecture/
- **English (canonical):** https://opentelemetry.io/docs/demo/architecture/

<!-- preview-section-end -->
