### PR TITLE
[ja] update translation of content/en/docs/zero-code/obi/configure/sample-traces.md

### DIFF
--- a/content/ja/docs/zero-code/obi/configure/sample-traces.md
+++ b/content/ja/docs/zero-code/obi/configure/sample-traces.md
@@ -3,9 +3,15 @@ title: OBI で OpenTelemetry トレースのサンプリングを設定する
 linkTitle: トレースのサンプリング
 description: OpenTelemetry トレースのサンプリング方法を設定する
 weight: 70
-default_lang_commit: f7dab5cfc4d44a8c788b7e02d07ec1e1d84e3845
-drifted_from_default: true
+default_lang_commit: 055e4933b5a29eb283300a071158d7caa0542b1c
 ---
+
+> [!NOTE]
+>
+> このページでは Config v1 のフィールド名と例を使用しています。
+> Config v2 では、トップレベルの `tracer_provider.sampler` フィールドでサンプリングを設定します。
+> 詳細は [Config v2 リファレンス](/docs/zero-code/obi/configure/config-v2/)を参照してください。
+> 既存のファイルを変換するには、[移行ガイド](/docs/zero-code/obi/configure/migrate-to-config-v2/)を使用してください。
 
 OBI は、トレースのサンプリングレートを設定するために標準的な OpenTelemetry 環境変数を受け付けます。
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/obi/configure/sample-traces.md` to match the latest English source at
`content/en/docs/zero-code/obi/configure/sample-traces.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff added a `> [!NOTE]` callout block about Config v1 vs Config v2, with links to the Config v2 reference and migration guide pages. The translated callout uses root-relative link paths (`/docs/zero-code/obi/configure/config-v2/` and `/docs/zero-code/obi/configure/migrate-to-config-v2/`) consistent with other sibling JA pages in the same directory that link to these untranslated EN pages.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11480--opentelemetry.netlify.app/ja/docs/zero-code/obi/configure/sample-traces/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/obi/configure/sample-traces/

<!-- preview-section-end -->
