### PR TITLE
[ja] Fix typo: 計測 -> 計装 in zero-code Python example

### DIFF
--- a/content/ja/docs/zero-code/python/example.md
+++ b/content/ja/docs/zero-code/python/example.md
@@ -28,7 +28,7 @@ cSpell:ignore: Aiohttp ASGI distro instrumentor mkdir MSIE Referer Starlette ven
 これにより、OpenTelemetry をアプリケーションコードに統合するのに必要な作業量を減らせます。
 以下に、手動、自動、プログラムで計装された Flask ルートの違いを示します。
 
-## 手動計測サーバー {#manually-instrumented-server}
+## 手動計装サーバー {#manually-instrumented-server}
 
 `server_manual.py`
 
@@ -56,7 +56,7 @@ def server_request():
     return "served"
 ```
 
-## プログラム計測サーバー {#programmatically-instrumented-server}
+## プログラム計装サーバー {#programmatically-instrumented-server}
 
 `server_programmatic.py`
 
@@ -117,7 +117,7 @@ opentelemetry-bootstrap -a install
 
 この節では、サーバーの計装を手動で行うプロセスと、自動的に計装されたサーバーを実行するプロセスについて説明します。
 
-## 手動で計測したサーバーを実行する {#execute-the-manually-instrumented-server}
+## 手動で計装したサーバーを実行する {#execute-the-manually-instrumented-server}
 
 この例を構成するスクリプトをそれぞれ実行するために、2つの別々のコンソールでサーバーを実行します。
 
@@ -227,7 +227,7 @@ python client.py
 }
 ```
 
-自動計装は手動計測とまったく同じことをするので、両方の出力が同じであることがわかります。
+自動計装は手動計装とまったく同じことをするので、両方の出力が同じであることがわかります。
 
 ## プログラムで計装されたサーバーを実行する {#execute-the-programmatically-instrumented-server}
 


### PR DESCRIPTION
## Summary
- Fixes a typo in the Japanese translation of the zero-code Python example page: 「手動計測」was incorrectly used instead of 「手動計装」in two places.


## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.