### PR TITLE
[ja] update translation of content/en/docs/collector/quick-start.md

### DIFF
--- a/content/ja/docs/collector/quick-start.md
+++ b/content/ja/docs/collector/quick-start.md
@@ -1,8 +1,7 @@
 ---
 title: クイックスタート
 description: コレクターのセットアップとテレメトリーの収集をすぐに始めてみましょう！
-default_lang_commit: 813498074d85258c7180d137ace9e272d0149353
-drifted_from_default: true
+default_lang_commit: 36a8a53c4a20a6d7a706539e9f3b4887327be781
 ---
 
 <!-- markdownlint-disable ol-prefix blanks-around-fences -->
@@ -114,9 +113,7 @@ export GOBIN=${GOBIN:-$(go env GOPATH)/bin}
    ...
    ```
 
-6. トレースを視覚的に確認するには、ブラウザで <http://localhost:55679/debug/tracez> を開き、表の中から1つトレースを選択してください。
-
-7. <kbd>Control-C</kbd> を押してコレクターを停止します。
+6. <kbd>Control-C</kbd> を押して Collector を停止します。
 
 ## この次のステップ
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/collector/quick-start.md` to match the latest English source at
`content/en/docs/collector/quick-start.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff removed step 6 (opening ZPages in the browser) and renumbered step 7 to step 6.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11489--opentelemetry.netlify.app/ja/docs/collector/quick-start/
- **English (canonical):** https://opentelemetry.io/docs/collector/quick-start/

<!-- preview-section-end -->
