### PR TITLE
[ja] update translation of content/en/docs/zero-code/obi/configure/tune-performance.md

### DIFF
--- a/content/ja/docs/zero-code/obi/configure/tune-performance.md
+++ b/content/ja/docs/zero-code/obi/configure/tune-performance.md
@@ -3,10 +3,16 @@ title: OBI のパフォーマンスを設定する
 linkTitle: パフォーマンスチューニング
 description: eBPF トレーサーコンポーネントが外部プロセスの HTTP および GRPC サービスを計装し、パイプラインの次のステージに転送するトレースを作成する方法を設定します。
 weight: 90
-default_lang_commit: 4c8d57fea0147ce76633951315c40a27c55fad2e
-drifted_from_default: true
+default_lang_commit: 36a8a53c4a20a6d7a706539e9f3b4887327be781
 cSpell:ignore: qdisc
 ---
+
+> [!NOTE]
+>
+> このページでは Config v1 のフィールド名と設定例を使用しています。
+> Config v2 では、これらの設定を `capture.engine` およびプロトコル固有のセクションで構成してください。
+> 詳細は [Config v2 リファレンス](/docs/zero-code/obi/configure/config-v2/) を参照してください。
+> 既存のファイルを変換するには、[移行ガイド](/docs/zero-code/obi/configure/migrate-to-config-v2/) を使用してください。
 
 eBPF トレーサーを使用して、OBI のパフォーマンスを細かく調整できます。
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/obi/configure/tune-performance.md` to match the latest English source at
`content/en/docs/zero-code/obi/configure/tune-performance.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff adds a `> [!NOTE]` callout block informing readers that the page uses Config v1 field names and examples, with links to the Config v2 reference and migration guide.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11490--opentelemetry.netlify.app/ja/docs/zero-code/obi/configure/tune-performance/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/obi/configure/tune-performance/

<!-- preview-section-end -->
