### PR TITLE
ci: apply zizmor review followups

### DIFF
--- a/.github/workflows/component-owners.yml
+++ b/.github/workflows/component-owners.yml
@@ -31,7 +31,9 @@ jobs:
                 github.rest.repos.getContent({ ...context.repo, path, ref: pullRequest.base.sha }),
                 github.rest.repos.getContent({ owner: headOwner, repo: headRepo, path, ref: pullRequest.head.sha }),
               ]);
-              return baseFile.data.sha === headFile.data.sha ? 'true' : 'false';
+              if (baseFile.data.sha === headFile.data.sha) return 'true';
+              core.notice(`${path} differs from the base branch; skipping owner assignment for this PR.`);
+              return 'false';
             } catch (error) {
               core.warning(`Unable to verify ${path}: ${error.message}`);
               return 'false';

--- a/.github/workflows/label-manager.yml
+++ b/.github/workflows/label-manager.yml
@@ -18,8 +18,12 @@ permissions:
   contents: read
 
 concurrency:
+  # Include the event name so a review-triggered workflow_run run never
+  # cancels an in-flight pull_request_target run (whose component-label pass
+  # would not be re-run by the canceling run).
   group:
-    ${{ github.workflow }}-${{ github.event.pull_request.number ||
+    ${{ github.workflow }}-${{ github.event_name }}-${{
+    github.event.pull_request.number ||
     github.event.workflow_run.pull_requests[0].number || github.run_id }}
   cancel-in-progress: true
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   push:
     branches: [main]
+  schedule:
+    # Weekly, per the shared-workflow consumer template: the action installs
+    # the latest zizmor, so a cadence surfaces new-rule findings between pushes.
+    - cron: 45 9 * * 5
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
- Follow-up to #11427: the non-blocking findings from its security review, none affecting scan coverage or the required check.
- **Adds a weekly `schedule` trigger** to the zizmor caller: the shared workflow installs the latest zizmor, so a cadence surfaces new-rule findings between pushes; matches the shared-workflow consumer template.
- **Emits a notice when component-owners skips** its privileged steps on a config mismatch: the skip was silent (and stays fail-closed); reviewers touching `component-owners.yml` now see why owners were not assigned.
- **Keys label-manager concurrency by event name** so a review-triggered `workflow_run` run cannot cancel an in-flight `pull_request_target` run, which would drop that push's component-label pass.
