### PR TITLE
Rewire auto-update-versions push to the otelbot-docs App token

### DIFF
--- a/.github/workflows/auto-update-versions.yml
+++ b/.github/workflows/auto-update-versions.yml
@@ -18,8 +18,6 @@ jobs:
   auto-update:
     name: Auto-update versions
     runs-on: ubuntu-latest
-    permissions:
-      contents: write # Required by the version updater's authenticated git push.
     if: github.repository == 'open-telemetry/opentelemetry.io'
     env:
       DEPTH: --depth 999 # submodule clone depth
@@ -27,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          persist-credentials: true # zizmor: ignore[artipacked] Required by the version updater's later git push.
+          persist-credentials: false
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -42,15 +40,23 @@ jobs:
           git config user.name otelbot
           git config user.email 197425009+otelbot@users.noreply.github.com
 
+      # Minted only after dependency preparation so that no write credential is
+      # present while `npm` lifecycle scripts run.
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
           client-id: ${{ vars.OTELBOT_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
-          permission-contents: read
+          permission-contents: write # For the version updater's git push.
           permission-pull-requests: write
 
-      - run: ./scripts/auto-update/all-versions.sh
+      # Authenticate the push remote just in time: the App token backs both the
+      # script's `git push` (via the remote URL) and its `gh` calls (via
+      # GH_TOKEN), and is scoped to this step only.
+      - run: |
+          git remote set-url origin \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          ./scripts/auto-update/all-versions.sh
         env:
           # change to ${{ secrets.GITHUB_TOKEN }} and comment out the step above when testing against a fork
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}

--- a/.github/workflows/auto-update-versions.yml
+++ b/.github/workflows/auto-update-versions.yml
@@ -60,7 +60,9 @@ jobs:
 
       - run: ./scripts/auto-update/all-versions.sh
         env:
-          # change to ${{ secrets.GITHUB_TOKEN }} and comment out the mint step above when testing against a fork
+          # Fork testing: drop the mint step, grant this job `contents: write`
+          # + `pull-requests: write`, and set GH_TOKEN to
+          # ${{ secrets.GITHUB_TOKEN }} here and in the setup-git step.
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
 
   report-failure:

--- a/.github/workflows/auto-update-versions.yml
+++ b/.github/workflows/auto-update-versions.yml
@@ -45,20 +45,22 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
-          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          # The base otelbot App lacks contents permission; use the
+          # push-capable docs App.
+          client-id: ${{ vars.OTELBOT_DOCS_CLIENT_ID }}
+          private-key: ${{ secrets.OTELBOT_DOCS_PRIVATE_KEY }}
           permission-contents: write # For the version updater's git push.
           permission-pull-requests: write
 
-      # Authenticate the push remote just in time: the App token backs both the
-      # script's `git push` (via the remote URL) and its `gh` calls (via
-      # GH_TOKEN), and is scoped to this step only.
-      - run: |
-          git remote set-url origin \
-            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          ./scripts/auto-update/all-versions.sh
+      # Let git resolve credentials through the gh CLI (which reads GH_TOKEN
+      # from each step's env) instead of persisting the token in .git/config.
+      - run: gh auth setup-git
         env:
-          # change to ${{ secrets.GITHUB_TOKEN }} and comment out the step above when testing against a fork
+          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+
+      - run: ./scripts/auto-update/all-versions.sh
+        env:
+          # change to ${{ secrets.GITHUB_TOKEN }} and comment out the mint step above when testing against a fork
           GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
 
   report-failure:

--- a/scripts/auto-update/version-in-file.sh
+++ b/scripts/auto-update/version-in-file.sh
@@ -11,7 +11,9 @@ if [[ -n "$GITHUB_ACTIONS" ]]; then
   # different commit (e.g., a freshly bumped tag).
   git checkout main
   git reset --hard origin/main
-  npm run get:submodule
+  # Remove the App token from each npm command's direct child environment.
+  # This limits accidental access; it is not a process-isolation boundary.
+  (unset GH_TOKEN; npm run get:submodule)
 elif [[ "$1" != "-f" ]]; then
   # Do a dry-run when script it executed locally, unless the
   # force flag is specified (-f).
@@ -110,7 +112,7 @@ fi
 # and the commit below records a gitlink consistent with the pin.
 if [[ "$pin_updated" == "true" ]]; then
   echo "Switching to $repo at tag $latest_version"
-  ( set -x;
+  ( unset GH_TOKEN; set -x;
     npm run get:submodule -- content-modules/$repo &&
     cd content-modules/$repo &&
     git fetch &&
@@ -122,7 +124,7 @@ fi
 
 # Sync any code-excerpt directives that embed upstream files, so the build
 # doesn't fail if the new version changed an excerpted file.
-npm run fix:code-excerpts
+(unset GH_TOKEN; npm run fix:code-excerpts)
 
 $GIT checkout -b "$branch"
 $GIT commit -a -m "$message"


### PR DESCRIPTION
- Contributes to #11496
- **Least-privilege rewire** of the hourly version-update workflow: drops the job's built-in-token write grant and the persisted checkout credential; the push and PR creation move to a scoped App token minted only after dependency installation, so no write credential exists while npm-installed code runs.
- **Push principal**: the site-scoped otelbot-docs App, this repo's established push principal (`auto-update-registry.yml` since #11324, `refcache-refresh.yml`); the shared otelbot App deliberately lacks contents permission ([community assets.md](https://github.com/open-telemetry/community/blob/main/assets.md#otelbot)), so no new installation grant is needed.
- **Token kept off disk**: git authenticates through the `gh` credential helper with a per-step `GH_TOKEN` (the `reusable-patch-pr.yml` pattern), and the update script unsets `GH_TOKEN` around its npm runs, matching `update-registry-versions.sh`.
- **Re-enable path**: the workflow stays `disabled_manually`; enable + a `workflow_dispatch` test can follow merge, with no admin precondition. A separate gap remains behind #11496: `first-timer-response`'s OTELBOT mint exceeds that App's current registration, an org-admin ask still to be raised on the issue.
