### PR TITLE
Mint the first-timer-response token from the docs App

### DIFF
--- a/.github/workflows/first-timer-response.yml
+++ b/.github/workflows/first-timer-response.yml
@@ -63,8 +63,9 @@ jobs:
         id: otelbot-token
         if: steps.check-trigger.outputs.match == 'true'
         with:
-          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
-          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          # The base otelbot App lacks issues permission; use the docs App.
+          client-id: ${{ vars.OTELBOT_DOCS_CLIENT_ID }}
+          private-key: ${{ secrets.OTELBOT_DOCS_PRIVATE_KEY }}
           permission-issues: write
           permission-members: read
 


### PR DESCRIPTION
- **Swaps `first-timer-response.yml`'s token mint to the site-scoped otelbot-docs App.** The shared otelbot App's registration now covers only `members: read`, `metadata: read`, and `pull_requests: write` ([public App record](https://api.github.com/apps/otelbot), per the [assets.md](https://github.com/open-telemetry/community/blob/main/assets.md#otelbot) boundary), so this workflow's `issues: write` request is unsatisfiable at any installation.
- **Failure class is proven, not observed here**: requesting an ungranted permission from this App fails the mint with a 422, as in `auto-update-versions` [run 33184573945](https://github.com/open-telemetry/opentelemetry.io/actions/runs/33184573945) (tracked in #11496, resolved by #11498 with the same App swap). This workflow itself has no failed runs: its label/phrase gates have skipped every recent run, so the broken mint is latent until the next organic assignment-request comment from a non-member.
- **Both requested permissions are live-proven on the docs App**: `issues: write` (collector-sync) and org-level `members: read` (blog-publish-labels), both mint-verified 2026-08-28.
- **No behavior change**: same permissions requested, same steps; the bot identity on posted comments becomes otelbot-docs. No `workflow_dispatch` trigger exists, so the fix is verified by the first organic trigger after merge.
