### PR TITLE
[ja] update translation of content/en/site/build/scripts.md

### DIFF
--- a/content/ja/site/build/scripts.md
+++ b/content/ja/site/build/scripts.md
@@ -3,8 +3,7 @@ title: ヘルパースクリプト
 description: >-
   ラベル管理、リンクチェック、レジストリ更新などに CI ワークフローやローカル開発で使用されるシェルスクリプト。
 weight: 30
-default_lang_commit: 1cc5320d70b48ffcf7bc62af0657bc7ef1d001a9
-drifted_from_default: true
+default_lang_commit: ded1c6de0f5ac0393d3aa6da1a7c030045d4a8ae
 ---
 
 すべてのスクリプトは [`.github/scripts/`](https://github.com/open-telemetry/opentelemetry.io/tree/main/.github/scripts) 配下にあります。
@@ -21,7 +20,7 @@ npm run fix:i18n:new
 ## pr-approval-labels.sh {#pr-approval-labelssh}
 
 レビュー状態とファイルオーナーシップに基づいて PR の承認ラベルを管理します。
-[`pr-approval-labels` ワークフロー](../ci-workflows/#pr-approval-labels)から呼び出されます。
+[`label-manager` ワークフロー](../ci-workflows/#pr-approval-labels)から呼び出されます。
 
 **動作の仕組み：**
 


### PR DESCRIPTION
## Summary

Updates `content/ja/site/build/scripts.md` to match the latest English source at
`content/en/site/build/scripts.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English change renamed a workflow link text from `pr-approval-labels` to
`label-manager` (the anchor target is unchanged).

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11508--opentelemetry.netlify.app/ja/site/build/scripts/
- **English (canonical):** https://opentelemetry.io/site/build/scripts/

<!-- preview-section-end -->
