### PR TITLE
Upgrade Docsy to 0.17.0 pre-release (FA 7 + override ports)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,7 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/google/docsy.git
-	docsy-pin = theme/v0.16.0-29-g53701191
+	docsy-pin = theme/v0.16.0-50-g36f73a06
 	docsy-note = "2024-04-01 Switching to google/docsy.git from cncf/docsy.git since we don't have any CNCF customizations."
 	docsy-reminder = "Ensure that any tag referenced by `docsy-pin` is present in the remote repo (url), otherwise add (push) the tags to the repo."
 [submodule "content-modules/opentelemetry-specification"]

--- a/assets/scss/_external_link.scss
+++ b/assets/scss/_external_link.scss
@@ -1,3 +1,5 @@
+@use 'td/support/fa';
+
 // External-link icon after an external link
 //
 // To ensure that the external-link icon word-wraps along with the preceding
@@ -15,7 +17,7 @@ $nbsp: \00A0;
   @include font-size(60%);
   opacity: 0.8;
   vertical-align: text-top;
-  content: fa-content($nbsp + $fa-var-external-link-alt);
+  content: fa.fa-content($nbsp + fa.$var-external-link-alt);
 }
 
 .td-sidebar-nav a[target='_blank']:after,

--- a/assets/scss/_java.scss
+++ b/assets/scss/_java.scss
@@ -1,3 +1,5 @@
+@use 'td/support/fa';
+
 // Java-SDK page content styles
 
 .config-option {
@@ -20,13 +22,13 @@
       &::after {
         color: $secondary;
         @extend .fas;
-        content: fa-content($nbsp + $fa-var-plus-circle);
+        content: fa.fa-content($nbsp + fa.$var-plus-circle);
       }
     }
 
     &[open] summary::after {
       @extend .fas;
-      content: fa-content($nbsp + $fa-var-minus-circle);
+      content: fa.fa-content($nbsp + fa.$var-minus-circle);
     }
   }
 }

--- a/layouts/_partials/search-input.html
+++ b/layouts/_partials/search-input.html
@@ -1,5 +1,5 @@
 <div class="td-search">
-  <div class="td-search__icon"></div>
+  <div class="td-search__icon" aria-hidden="true"></div>
   <input
     type="search"
     data-bs-toggle="popover"

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -10,6 +10,7 @@
     {{ partial "head.html" . }}
   </head>
   <body class="td-{{ .Kind }}{{ with .Page.Params.body_class }} {{ . }}{{ end }}">
+    {{ partial "llms-directive.html" . -}}
     <header>
       {{ partial "navbar.html" . }}
     </header>

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -12,6 +12,7 @@
     {{ partial "head.html" . }}
   </head>
   <body class="td-{{ .Kind }}{{ with .Page.Params.body_class }} {{ . }}{{ end }}">
+    {{ partial "llms-directive.html" . -}}
     <header>
       {{ partial "navbar.html" . }}
     </header>


### PR DESCRIPTION
- **Theme pin**: moves to the docsy `main` tip pseudo-version (`36f73a06`); there are no `theme/` changes since the previous `54b561dc` pin, so this is a metadata-only move.
- **Release staging**: once v0.17.0 is tagged, a follow-up commit moves the pin to the tag and sets the site version identity (manifest, site-info badge) to 0.17.0; the PR title flips to "Release 0.17.0" then.
