### PR TITLE
Promote reyang to docs-zh-maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -81,9 +81,9 @@
 /.cspell/uk-*.txt @open-telemetry/docs-uk-approvers @open-telemetry/docs-approvers
 /content/uk/      @open-telemetry/docs-uk-approvers @open-telemetry/docs-approvers
 
-# zh (unstaffed)
-/.cspell/zh-*.txt @open-telemetry/docs-zh-approvers @open-telemetry/docs-approvers
-/content/zh/      @open-telemetry/docs-zh-approvers @open-telemetry/docs-approvers
+# zh
+/.cspell/zh-*.txt @open-telemetry/docs-zh-approvers
+/content/zh/      @open-telemetry/docs-zh-approvers
 
 # END locale-owners
 

--- a/data/locale-teams.yaml
+++ b/data/locale-teams.yaml
@@ -45,5 +45,5 @@ locales:
     maintainers: []
     approvers: []
   zh:
-    maintainers: []
-    approvers: [chluknight1224, my-git9, reyang, windsonsea]
+    maintainers: [reyang]
+    approvers: [chluknight1224, my-git9, windsonsea]


### PR DESCRIPTION
Promotes @reyang to zh (Chinese) localization maintainer, staffing @open-telemetry/docs-zh-maintainers, empty until now. With the team staffed, the generated CODEOWNERS entry drops the @open-telemetry/docs-zh-approvers  fallback: `content/zh/` review is gated by the zh team alone, and `/auto-merge` becomes available for zh-only PRs.

Reiley is the zh team's most active reviewer: 66 zh PRs reviewed (170 repo-wide) since 2021, sustained through this week. As a TC member, he has a deep understanding of project goals, direction, and terminology, which is the judgment the maintainer role calls for. He has agreed to take on the role.

- zh PRs reviewed: https://github.com/open-telemetry/opentelemetry.io/pulls?q=is%3Apr+reviewed-by%3Areyang+-author%3Areyang+label%3Alang%3Azh
- All PRs reviewed: https://github.com/open-telemetry/opentelemetry.io/pulls?q=is%3Apr+reviewed-by%3Areyang+-author%3Areyang
- PRs authored: https://github.com/open-telemetry/opentelemetry.io/pulls?q=is%3Apr+author%3Areyang

Per the [membership guidelines](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#becoming-a-maintainer): @open-telemetry/docs-maintainers please approve to make it official, and @reyang please approve to formally accept the nomination.

> [!IMPORTANT]
>
> **Post-merge TODO**: an org admin applies the live team change. Add @reyang as a direct team maintainer of `docs-zh-maintainers` (matching the role convention of the other locale teams) and remove his direct `docs-zh-approvers` membership (child-team members surface in the parent roster automatically).

