### PR TITLE
[ja] update translation of content/en/docs/zero-code/python/_index.md

### DIFF
--- a/content/ja/docs/zero-code/python/_index.md
+++ b/content/ja/docs/zero-code/python/_index.md
@@ -3,9 +3,8 @@ title: Pythonゼロコード・計装
 linkTitle: Python
 weight: 40
 cascade:
-  collector_vers: 0.158.0
-default_lang_commit: bdfe463187e63311ab3e137f1e314acfb877fd8b
-drifted_from_default: true
+  collector_vers: 0.159.0
+default_lang_commit: 126c82550c0d12caf7ab4258e1b1ab09d977fd8f
 cSpell:ignore: distro
 ---
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/python/_index.md` to match the latest English source at
`content/en/docs/zero-code/python/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The only English change was a `cascade.collector_vers` version bump from `0.158.0` to `0.159.0`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11517--opentelemetry.netlify.app/ja/docs/zero-code/python/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/python/

<!-- preview-section-end -->
