### PR TITLE
[ja] update translation of content/en/docs/zero-code/obi/configure/collector-receiver.md

### DIFF
--- a/content/ja/docs/zero-code/obi/configure/collector-receiver.md
+++ b/content/ja/docs/zero-code/obi/configure/collector-receiver.md
@@ -3,10 +3,15 @@ title: OpenTelemetry Collector レシーバーとしての OBI
 linkTitle: Collector レシーバー
 weight: 75
 description: テレメトリーを一元的に処理するために、OBI を OpenTelemetry Collector のレシーバーコンポーネントとして使用する方法を学びます。
-default_lang_commit: 4aa05a4d65591e780952439f45415c597f3047dd
-drifted_from_default: true
+default_lang_commit: 12862017e85a7b88fbd194241af00f4dbd4ee75c
 cSpell:ignore: bpftool PERFMON
 ---
+
+> [!NOTE]
+>
+> OBI v0.11.0 以降は、OBI Collector レシーバーの Config v1 と Config v2 の両方をサポートしています。
+> このページの例では Config v1 を使用しています。
+> Config v2 でレシーバーを設定するには、[Config v2 リファレンス](/docs/zero-code/obi/configure/config-v2/#collector-receiver-configuration)を参照するか、[レシーバーの移行手順](/docs/zero-code/obi/configure/migrate-to-config-v2/#migrate-a-collector-receiver)に従ってください。
 
 v0.5.0 以降、OBI は [OpenTelemetry Collector](/docs/collector) 内でレシーバーコンポーネントとして動作できます。
 この統合により、OBI のゼロコード eBPF 計装の利点を享受しながら、Collector の強力な処理パイプラインを活用できます。


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/obi/configure/collector-receiver.md` to match the latest English source at
`content/en/docs/zero-code/obi/configure/collector-receiver.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff added a `> [!NOTE]` block informing readers about Config v1/v2 support in OBI v0.11.0+. The note was translated and inserted at the same position in the Japanese file. The relative links in the note (`../config-v2/...`, `../migrate-to-config-v2/...`) were converted to root-relative paths (`/docs/zero-code/obi/configure/config-v2/...`, `/docs/zero-code/obi/configure/migrate-to-config-v2/...`) because the target Japanese pages do not exist yet; root-relative paths allow Hugo's render-link hook to handle locale fallback correctly.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11521--opentelemetry.netlify.app/ja/docs/zero-code/obi/configure/collector-receiver/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/obi/configure/collector-receiver/

<!-- preview-section-end -->
