### PR TITLE
Upgrade Docsy to 0.17.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,7 @@
 [submodule "themes/docsy"]
 	path = themes/docsy
 	url = https://github.com/google/docsy.git
-	docsy-pin = theme/v0.16.0-50-g36f73a06
+	docsy-pin = v0.17.0
 	docsy-note = "2024-04-01 Switching to google/docsy.git from cncf/docsy.git since we don't have any CNCF customizations."
 	docsy-reminder = "Ensure that any tag referenced by `docsy-pin` is present in the remote repo (url), otherwise add (push) the tags to the repo."
 [submodule "content-modules/opentelemetry-specification"]


### PR DESCRIPTION
- **Pin-only bump**: `themes/docsy` moves from the 0.17.0 pre-release pin (#11515) to the released `v0.17.0` tag; all 0.17.0 upgrade actions landed earlier (#11420 Dart Sass, #11515 FA 7 + override ports + llms directive).
- **Rendered delta**: only the mode-menu toggler fix (google/docsy#2758) -- localized, mode-tracking button label and tooltip.
- **Validation**: full `npm run test` suite green; rebuilt `public/` diff traces entirely to the toggler change (per-locale home pages, `main.js`) and content merged since the last snapshot.
- **Preview**: [home page](https://deploy-preview-11524--opentelemetry.netlify.app/) (mode-menu toggler change, on every page's navbar).
