### PR TITLE
[ja] update translation of content/en/docs/zero-code/obi/configure/example.md

### DIFF
--- a/content/ja/docs/zero-code/obi/configure/example.md
+++ b/content/ja/docs/zero-code/obi/configure/example.md
@@ -1,11 +1,16 @@
 ---
-title: OBI 設定 YAML の例
-linkTitle: YAML の例
-description: OBI 設定 YAML の例
+title: OBI Config v1 YAML の例
+linkTitle: Config v1 YAML の例
+description: OBI の Config v1 YAML ファイルの例
 weight: 100
-default_lang_commit: f7dab5cfc4d44a8c788b7e02d07ec1e1d84e3845
-drifted_from_default: true
+default_lang_commit: 12862017e85a7b88fbd194241af00f4dbd4ee75c
 ---
+
+> [!NOTE]
+>
+> このページでは Config v1 のフィールド名と例を使用しています。
+> Config v2 については [Config v2 リファレンス](/docs/zero-code/obi/configure/config-v2/)を参照してください。
+> 既存のファイルを変換するには[移行ガイド](/docs/zero-code/obi/configure/migrate-to-config-v2/)を参照してください。
 
 ## YAML ファイルの例 {#yaml-file-example}
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/obi/configure/example.md` to match the latest English source at
`content/en/docs/zero-code/obi/configure/example.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

Changes applied:
- Updated frontmatter `title`, `linkTitle`, `description` to reflect the rename from "OBI configuration YAML" to "OBI Config v1 YAML"
- Added translated `> [!NOTE]` block pointing to Config v2 reference and migration guide

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11525--opentelemetry.netlify.app/ja/docs/zero-code/obi/configure/example/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/obi/configure/example/

<!-- preview-section-end -->
