### PR TITLE
[ja] add translation of content/en/docs/demo/telemetry-features/manual-span-attributes.md

### DIFF
--- a/content/ja/docs/demo/telemetry-features/_index.md
+++ b/content/ja/docs/demo/telemetry-features/_index.md
@@ -1,0 +1,44 @@
+---
+title: テレメトリー機能
+linkTitle: テレメトリー機能
+aliases: [demo_features, features]
+default_lang_commit: 3560c03d5cbe845c6189e6e30441434c7760eca0
+---
+
+## OpenTelemetry {#opentelemetry}
+
+- **[OpenTelemetry トレース](/docs/concepts/signals/traces/)**：すべてのサービスは、OpenTelemetry が提供する計装ライブラリを使用して計装されています。
+- **[OpenTelemetry メトリクス](/docs/concepts/signals/metrics/)**：一部のサービスは、OpenTelemetry が提供する計装ライブラリを使用して計装されています。
+  関連する SDK がリリースされ次第、さらに追加される予定です。
+- **[OpenTelemetry ログ](/docs/concepts/signals/logs/)**：一部のサービスは、OpenTelemetry が提供する計装ライブラリを使用して計装されています。
+  関連する SDK がリリースされ次第、さらに追加される予定です。
+- **[OpenTelemetry Collector](/docs/collector/)**：すべてのサービスは計装され、生成されたトレースとメトリクスを gRPC 経由で OpenTelemetry Collector に送信します。
+  受信したトレースはログと Jaeger にエクスポートされ、受信したメトリクスとエグザンプラーはログと Prometheus にエクスポートされます。
+- **[OpAMP](/docs/specs/opamp/)**：OpenTelemetry Collector は、正常性、バージョン、属性、有効な設定をデモの OpAMP サーバーに報告します。
+  報告されたステータスは OpAMP UI（<http://localhost:8080/opamp/>）で確認できます。
+- **SDK 自己オブザーバビリティ**：一部のサービスは、OpenTelemetry SDK 自体が出力する実験的な `otel.sdk.*` 内部メトリクスをオプトインしており、[自己オブザーバビリティダッシュボード](/docs/demo/self-observability-dashboard/)で可視化されます。
+
+## オブザーバビリティソリューション {#observability-solutions}
+
+- **[Grafana](https://github.com/grafana/grafana)**：すべてのメトリクスダッシュボードは Grafana に保存されています。
+- **[Jaeger](https://www.jaegertracing.io/)**：生成されたすべてのトレースは Jaeger に送信されています。
+- **[OpenSearch](https://opensearch.org/)**：生成されたすべてのログは Data Prepper に送信されます。
+  OpenSearch はサービスからのログデータを集約するために使用されます。
+- **[Prometheus](https://prometheus.io/)**：生成されたすべてのメトリクスとエグザンプラーは Prometheus によって収集されます。
+
+## 環境 {#environments}
+
+- **[Docker](https://docs.docker.com)**：このフォークされたサンプルは Docker で実行できます。
+- **[Kubernetes](https://kubernetes.io/)**：このアプリケーションは Helm チャートを使用して Kubernetes 上で実行するように設計されています（ローカルおよびクラウドの両方）。
+
+## プロトコル {#protocols}
+
+- **[gRPC](https://grpc.io/)**：マイクロサービスは互いに通信するために大量の gRPC 呼び出しを使用します。
+- **[HTTP](https://www.rfc-editor.org/rfc/rfc9110.html)**：マイクロサービスは gRPC が利用できないか十分にサポートされていない場合に HTTP を使用します。
+
+## その他のコンポーネント {#other-components}
+
+- **[Envoy](https://www.envoyproxy.io/)**：Envoy は、フロントエンドやフィーチャーフラグサービスなどのユーザー向け Web インターフェイスのリバースプロキシとして使用されます。
+- **[k6](https://k6.io)**：合成負荷生成ツールを使用してウェブサイト上で現実的な使用パターンを作成するバックグラウンドジョブです。
+- **[OpenFeature](https://openfeature.dev)**：アプリケーション内の機能の有効化と無効化を可能にするフィーチャーフラグ API および SDK です。
+- **[flagd](https://flagd.dev)**：デモアプリケーション内のフィーチャーフラグを管理するために使用されるフィーチャーフラグデーモンです。

--- a/content/ja/docs/demo/telemetry-features/_index.md
+++ b/content/ja/docs/demo/telemetry-features/_index.md
@@ -3,6 +3,7 @@ title: テレメトリー機能
 linkTitle: テレメトリー機能
 aliases: [demo_features, features]
 default_lang_commit: 3560c03d5cbe845c6189e6e30441434c7760eca0
+drifted_from_default: true
 ---
 
 ## OpenTelemetry {#opentelemetry}

--- a/content/ja/docs/demo/telemetry-features/manual-span-attributes.md
+++ b/content/ja/docs/demo/telemetry-features/manual-span-attributes.md
@@ -1,0 +1,119 @@
+---
+title: 手動スパン属性
+aliases: [manual_span_attributes, ../manual-span-attributes]
+default_lang_commit: 3560c03d5cbe845c6189e6e30441434c7760eca0
+---
+
+このページでは、デモ全体で使用される手動スパン属性を一覧にしています。
+
+## 広告 {#ad}
+
+| 名前                        | 型     | 説明                                                   |
+| --------------------------- | ------ | ------------------------------------------------------ |
+| `app.ads.category`          | string | 返された広告のカテゴリ                                 |
+| `app.ads.contextKeys`       | string | 関連する広告を見つけるために使用されるコンテキストキー |
+| `app.ads.contextKeys.count` | number | 使用されたユニークなコンテキストキーの数               |
+| `app.ads.count`             | number | ユーザーに返された広告の数                             |
+| `app.ads.ad_request_type`   | string | `targeted` または `not_targeted`                       |
+| `app.ads.ad_response_type`  | string | `targeted` または `random`                             |
+
+## カート {#cart}
+
+| 名前                   | 型     | 説明                           |
+| ---------------------- | ------ | ------------------------------ |
+| `app.cart.items.count` | number | カート内のユニークなアイテム数 |
+| `app.product.id`       | string | カートアイテムの商品 ID        |
+| `app.product.quantity` | string | カートアイテムの数量           |
+| `app.user.id`          | string | ユーザー ID                    |
+
+## 決済 {#checkout}
+
+| 名前                         | 型     | 説明                         |
+| ---------------------------- | ------ | ---------------------------- |
+| `app.cart.items.count`       | number | カート内のアイテムの合計数   |
+| `app.order.amount`           | number | 注文金額                     |
+| `app.order.id`               | string | 注文 ID                      |
+| `app.order.items.count`      | number | 注文内のユニークなアイテム数 |
+| `app.payment.transaction.id` | string | 支払いトランザクション ID    |
+| `app.shipping.amount`        | number | 配送料                       |
+| `app.shipping.tracking.id`   | string | 配送追跡 ID                  |
+| `app.user.currency`          | string | ユーザーの通貨               |
+| `app.user.id`                | string | ユーザー ID                  |
+
+## 通貨 {#currency}
+
+| 名前                           | 型     | 説明               |
+| ------------------------------ | ------ | ------------------ |
+| `app.currency.conversion.from` | string | 変換元の通貨コード |
+| `app.currency.conversion.to`   | string | 変換先の通貨コード |
+
+## メール {#email}
+
+| 名前                  | 型     | 説明                               |
+| --------------------- | ------ | ---------------------------------- |
+| `app.email.recipient` | string | 注文確認に使用されるメールアドレス |
+| `app.order.id`        | string | 注文 ID                            |
+
+## フロントエンド {#frontend}
+
+| 名前                     | 型     | 説明                           |
+| ------------------------ | ------ | ------------------------------ |
+| `app.cart.size`          | number | カート内のアイテムの合計数     |
+| `app.cart.items.count`   | number | カート内のユニークなアイテム数 |
+| `app.cart.shipping.cost` | number | カートの送料                   |
+| `app.cart.total.price`   | number | カートの合計金額               |
+| `app.currency`           | string | ユーザーの通貨                 |
+| `app.currency.new`       | string | 設定する新しい通貨             |
+| `app.order.total`        | number | 注文の合計金額                 |
+| `app.product.id`         | string | 商品 ID                        |
+| `app.product.quantity`   | number | 商品の数量                     |
+| `app.products.count`     | number | 表示された商品の合計数         |
+| `app.request.id`         | string | リクエスト ID                  |
+| `app.session.id`         | string | セッション ID                  |
+| `app.user.id`            | string | ユーザー ID                    |
+
+## 負荷生成ツール {#load-generator}
+
+| 名前 | 型  | 説明 |
+| ---- | --- | ---- |
+| なし |     |      |
+
+## 支払い {#payment}
+
+| 名前                     | 型      | 説明                                                   |
+| ------------------------ | ------- | ------------------------------------------------------ |
+| `app.payment.amount`     | number  | 支払いの合計金額                                       |
+| `app.payment.card_type`  | string  | 支払いに使用されたカードの種類                         |
+| `app.payment.card_valid` | boolean | 使用されたカードが有効かどうか                         |
+| `app.payment.charged`    | boolean | 請求が成功したかどうか（負荷生成ツール使用時は false） |
+
+## 商品カタログ {#product-catalog}
+
+| 名前                        | 型     | 説明                 |
+| --------------------------- | ------ | -------------------- |
+| `app.product.id`            | string | 商品 ID              |
+| `app.product.name`          | string | 商品名               |
+| `app.products.count`        | number | カタログ内の商品数   |
+| `app.products_search.count` | number | 検索で返された商品数 |
+
+## 見積もり {#quote}
+
+| 名前                    | 型     | 説明                     |
+| ----------------------- | ------ | ------------------------ |
+| `app.quote.items.count` | number | 出荷するアイテムの合計数 |
+| `app.quote.cost.total`  | number | 送料の見積もり合計       |
+
+## レコメンデーション {#recommendation}
+
+| 名前                             | 型      | 説明                                   |
+| -------------------------------- | ------- | -------------------------------------- |
+| `app.filtered_products.count`    | number  | フィルタリングされて返された商品数     |
+| `app.products.count`             | number  | カタログ内の商品数                     |
+| `app.products_recommended.count` | number  | レコメンデーションとして返された商品数 |
+| `app.cache_hit`                  | boolean | キャッシュにアクセスしたかどうか       |
+
+## 配送 {#shipping}
+
+| 名前                      | 型     | 説明       |
+| ------------------------- | ------ | ---------- |
+| `app.shipping.cost.total` | number | 送料の合計 |


### PR DESCRIPTION
## Summary

Translates `content/en/docs/demo/telemetry-features/manual-span-attributes.md` into Japanese as `content/ja/docs/demo/telemetry-features/manual-span-attributes.md`.

Also translates the ancestor section index `content/en/docs/demo/telemetry-features/_index.md` as `content/ja/docs/demo/telemetry-features/_index.md` to prevent Hugo auto-generation of the section page and CHECK LINKS failure.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

### docs/demo/telemetry-features/
- **Japanese (this PR):** https://deploy-preview-11532--opentelemetry.netlify.app/ja/docs/demo/telemetry-features/
- **English (canonical):** https://opentelemetry.io/docs/demo/telemetry-features/

### docs/demo/telemetry-features/manual-span-attributes/
- **Japanese (this PR):** https://deploy-preview-11532--opentelemetry.netlify.app/ja/docs/demo/telemetry-features/manual-span-attributes/
- **English (canonical):** https://opentelemetry.io/docs/demo/telemetry-features/manual-span-attributes/

<!-- preview-section-end -->
