### PR TITLE
[ja] update translation of content/en/announcements/kubecon-china.md

### DIFF
--- a/content/ja/announcements/kubecon-china.md
+++ b/content/ja/announcements/kubecon-china.md
@@ -1,24 +1,21 @@
 ---
-title: KubeCon + CloudNativeCon China 2025
-linkTitle: KubeCon China 2025
-date: 2025-05-20
-expiryDate: 2025-06-11 # keep
-weight: 20250611
+title: KubeCon + CloudNativeCon China 2026
+linkTitle: KubeCon China 2026
+date: 2026-08-25
+expiryDate: 2026-09-09 # keep
+weight: 20260909
 params:
-  # As of 2026-01-26, LF reports the event through lfasiallc.com
+  # As of 2026-08-25, LF reports the event through lfopensource.cn
   eventUrl: &eventUrl >-
-    https://www.lfasiallc.com/kubecon-cloudnativecon-openinfra-summit-china/
-  blogPostURL: /blog/2025/kubecon-china/
-  # This is the old URL. Keeping for now. TODO: remove after 2026-08-31
-  oldEventUrl: >- # This now redirects to the new URL
-    https://events.linuxfoundation.org/kubecon-cloudnativecon-china/reg/register/?utm_source=opentelemetry&utm_medium=website&utm_content=slim-banner
-default_lang_commit: 8f68733f41ce6d7f0029edfaa14561ad95cc4aa0
-drifted_from_default: true
+    https://www.lfopensource.cn/kubecon-cloudnativecon-openinfra-summit-pytorch-conference-china/
+  # Use this when the blog post is ready:
+  # blogPostURL: /blog/2026/kubecon-china/
+  blogPostURL: *eventUrl
+default_lang_commit: 552bd64ff45ca252d1da0ca875abd1584a619d7f
 ---
 
-[**{{% param title %}}**][LF]が **<span class="text-nowrap">6月10日〜11日に</span>
-香港で開催**。
-<span class="d-none d-md-inline"><br></span> <span class="d-none d-sm-inline">Cloud Native コミュニティと一緒に</span>[協力し、学び、共有しましょう][blog]！
+[**{{% param title %}}**][LF] · <span class="text-nowrap">9月7日〜9日</span> ·
+上海 · [詳細][blog]
 
 [blog]: <{{% param blogPostURL %}}>
-[LF]: <{{% param eventUrl %}}?{{% _param utmParam %}}>
+[LF]: <{{% param eventUrl %}}register/?{{% _param utmParam %}}>


### PR DESCRIPTION
## Summary

Updates `content/ja/announcements/kubecon-china.md` to match the latest English source at
`content/en/announcements/kubecon-china.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11533--opentelemetry.netlify.app/ja/announcements/kubecon-china/
- **English (canonical):** https://opentelemetry.io/announcements/kubecon-china/

<!-- preview-section-end -->
