### PR TITLE
[i18n][ko] Fix unrendered bold markdown on Korean homepage

### DIFF
--- a/content/ko/_index.md
+++ b/content/ko/_index.md
@@ -36,10 +36,10 @@ default_lang_commit: b97d606fe6299329b8731687dc235963bf100799
 
 {{% homepage/intro-section image="/img/homepage/collector-pipeline.svg" imageAlt="오픈텔레메트리 개요" %}}
 
-**오픈텔레메트리(OpenTelemetry)**는 클라우드 네이티브 소프트웨어를 위한 오픈소스
-옵저버빌리티(observability) 프레임워크이다. 애플리케이션의 분산 트레이스와
-메트릭을 수집하기 위해 API, 라이브러리, 에이전트, 컬렉터 서비스를 하나의 체계로
-제공한다.
+**오픈텔레메트리(OpenTelemetry)** 는 클라우드 네이티브 소프트웨어를 위한
+오픈소스 옵저버빌리티(observability) 프레임워크이다. 애플리케이션의 분산
+트레이스와 메트릭을 수집하기 위해 API, 라이브러리, 에이전트, 컬렉터 서비스를
+하나의 체계로 제공한다.
 
 오픈텔레메트리는 OpenTracing과 OpenCensus 프로젝트의 다년간의 경험을 바탕으로,
 커뮤니티의 검증된 아이디어와 모범 사례를 통합하여 만들어졌다.


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

<img width="323" height="41" alt="image" src="https://github.com/user-attachments/assets/a04384b2-99be-48bd-bec3-1163a83a8eb7" />

Fixes above unrendered `**bold**` markdown on the Korean homepage by adding a space after the closing `**`.

