### PR TITLE
Clarify Python pre-fork resource identity

### DIFF
--- a/content/en/docs/zero-code/python/troubleshooting.md
+++ b/content/en/docs/zero-code/python/troubleshooting.md
@@ -115,6 +115,26 @@ deadlocks described in [Python issue 6721](https://bugs.python.org/issue6721).
 
 #### Workarounds
 
+Initializing OpenTelemetry after the server forks is the preferred workaround.
+Each worker then has its own SDK components and resource, avoiding shared
+background threads and locks and giving each metrics writer a distinct resource
+identity.
+
+If the SDK must be initialized before the fork, use OpenTelemetry Python SDK
+1.44.0 or later and enable the process resource detector before starting the
+server:
+
+```sh
+export OTEL_EXPERIMENTAL_RESOURCE_DETECTORS=process
+```
+
+The SDK automatically generates a unique `service.instance.id` and refreshes
+process-dependent resource attributes after a fork. With the process detector
+enabled, each worker therefore reports its own `process.pid` and
+`service.instance.id`. Avoid configuring one shared `service.instance.id` for
+multiple workers; metrics producers are expected to follow the
+[single-writer principle](/docs/specs/otel/metrics/data-model/#single-writer).
+
 There are some workarounds for pre-fork servers with OpenTelemetry. The
 following table summarizes the current support of signal export by different
 auto-instrumented web server gateway stacks that have been pre-forked with


### PR DESCRIPTION
- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

## Description

Clarify the Python zero-code guidance for pre-fork servers by:

- recommending post-fork OpenTelemetry initialization as the preferred workaround;
- documenting the Python SDK 1.44.0+ resource refresh behavior and the `process` resource detector configuration;
- explaining why each worker needs distinct `process.pid` and `service.instance.id` resource identity for metrics.

Closes #7633.

Technical references:

- [Process-dependent resource refresh](https://github.com/open-telemetry/opentelemetry-python/pull/5280)
- [`ServiceInstanceIdResourceDetector`](https://github.com/open-telemetry/opentelemetry-python/pull/5259)

## Validation

- `git diff origin/main...HEAD --check`
- Confirmed the documented behavior against the Python SDK 1.44.0 implementation and release notes.
