### PR TITLE
[ja] update translation of content/en/docs/languages/go/instrumentation.md

### DIFF
--- a/content/ja/docs/languages/go/instrumentation.md
+++ b/content/ja/docs/languages/go/instrumentation.md
@@ -5,8 +5,7 @@ aliases:
   - manual_instrumentation
 weight: 30
 description: OpenTelemetry Goのマニュアルインストルメンテーション
-default_lang_commit: c1e141558ab36cc1ab9f864728e4665e272ac131
-drifted_from_default: true
+default_lang_commit: 3899955672f4abc64710cad23217b76528d7a961
 cSpell:ignore: fatalf logr logrus otlplog otlploghttp sdktrace sighup
 ---
 
@@ -41,7 +40,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.43.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -185,7 +184,7 @@ span.SetAttributes(myKey.String("a value"))
 #### セマンティック属性 {#semantic-attributes}
 
 セマンティック属性は、HTTPメソッド、ステータスコード、ユーザーエージェントなどの一般的な概念について、複数の言語、フレームワーク、ランタイム間で共有される属性キーのセットを提供するために[OpenTelemetry仕様][OpenTelemetry Specification]によって定義された属性です。
-これらの属性は`go.opentelemetry.io/otel/semconv/v1.40.0`パッケージで利用できます。
+これらの属性は`go.opentelemetry.io/otel/semconv/v1.43.0`パッケージで利用できます。
 
 詳細については、[トレースセマンティック規約][Trace semantic conventions]を参照してください。
 
@@ -335,7 +334,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.43.0"
 )
 
 func main() {
@@ -741,7 +740,7 @@ import (
 	"net/http"
 
 	"go.opentelemetry.io/otel/metric"
-	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.43.0"
 )
 
 func init() {
@@ -950,7 +949,7 @@ import (
 	"go.opentelemetry.io/otel/log/global"
 	"go.opentelemetry.io/otel/sdk/log"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.43.0"
 )
 
 func main() {


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/go/instrumentation.md` to match the latest English source at
`content/en/docs/languages/go/instrumentation.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff is a semconv version bump (`v1.40.0` → `v1.43.0`) across 4 import statements and 1 inline code span.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11547--opentelemetry.netlify.app/ja/docs/languages/go/instrumentation/
- **English (canonical):** https://opentelemetry.io/docs/languages/go/instrumentation/

<!-- preview-section-end -->
