### PR TITLE
[ja] update translation of content/en/docs/collector/extend/custom-component/receiver.md

### DIFF
--- a/content/ja/docs/collector/extend/custom-component/receiver.md
+++ b/content/ja/docs/collector/extend/custom-component/receiver.md
@@ -5,8 +5,7 @@ weight: 100
 aliases:
   - /docs/collector/trace-receiver
   - /docs/collector/building/receiver
-default_lang_commit: 11fecfb1d12e8682c9619b3a477eccb21c736b99
-drifted_from_default: true
+default_lang_commit: 3899955672f4abc64710cad23217b76528d7a961
 # prettier-ignore
 cSpell:ignore: backendsystem crand debugexporter mapstructure pcommon pdata ptrace rcvr resourcespans struct tailtracer telemetrygen uber
 ---
@@ -1245,7 +1244,7 @@ func fillResourceWithAtm(resource *pcommon.Resource, atm Atm){
 `BackendSystem` エンティティには、[オペレーティングシステム](/docs/specs/semconv/resource/os/)と[クラウド](/docs/specs/semconv/resource/cloud/)に関連する情報を表すフィールドがあります。
 リソースセマンティック規約で指定された属性名と値を使用して、この情報をその `Resource` に表現します。
 
-リソースセマンティック規約のキーとよく知られた値は、OpenTelemetry セマンティック規約パッケージ [`go.opentelemetry.io/otel/semconv/v1.38.0`](https://pkg.go.dev/go.opentelemetry.io/otel/semconv/v1.38.0) で定義されています。
+リソースセマンティック規約のキーとよく知られた値は、OpenTelemetry セマンティック規約パッケージ [`go.opentelemetry.io/otel/semconv/v1.43.0`](https://pkg.go.dev/go.opentelemetry.io/otel/semconv/v1.43.0) で定義されています。
 
 `BackendSystem` インスタンスからフィールド値を読み取り、それらを属性として `pcommon.Resource` インスタンスに書き込む関数を作成しましょう。
 `tailtracer/model.go` ファイルを開き、次の関数を追加してください。
@@ -1300,7 +1299,7 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	"go.opentelemetry.io/otel/semconv/v1.38.0"
+	"go.opentelemetry.io/otel/semconv/v1.43.0"
 )
 
 type Atm struct {
@@ -1685,7 +1684,7 @@ import (
 	"github.com/google/uuid"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	"go.opentelemetry.io/otel/semconv/v1.38.0"
+	"go.opentelemetry.io/otel/semconv/v1.43.0"
 )
 
 type Atm struct {
@@ -2080,7 +2079,7 @@ import (
 	"github.com/google/uuid"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	 "go.opentelemetry.io/otel/semconv/v1.38.0"
+	 "go.opentelemetry.io/otel/semconv/v1.43.0"
 )
 
 type Atm struct {


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/collector/extend/custom-component/receiver.md` to match the latest English source at
`content/en/docs/collector/extend/custom-component/receiver.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff consists of 4 hunks, all bumping the Go semconv package version from `v1.38.0` to `v1.43.0` in code blocks and a prose reference link.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11548--opentelemetry.netlify.app/ja/docs/collector/extend/custom-component/receiver/
- **English (canonical):** https://opentelemetry.io/docs/collector/extend/custom-component/receiver/

<!-- preview-section-end -->
