### PR TITLE
[pt] localize content/en/docs/platforms/faas/lambda-manual-instrument.md

### DIFF
--- a/content/pt/docs/platforms/faas/lambda-manual-instrument.md
+++ b/content/pt/docs/platforms/faas/lambda-manual-instrument.md
@@ -1,0 +1,28 @@
+---
+title: Instrumentação manual do Lambda
+weight: 11
+description: Instrumente manualmente seus Lambdas com o OpenTelemetry
+default_lang_commit: f49ec57e5a0ec766b07c7c8e8974c83531620af3
+---
+
+A comunidade oferece camadas de auto-instrumentação apenas para as linguagens
+listadas no
+[documento de auto-instrumentação do Lambda](../lambda-auto-instrument/). Para
+as demais, siga as orientações gerais de instrumentação da linguagem escolhida e
+adicione a camada Lambda do Collector para enviar seus dados.
+
+## Adicione o ARN da camada Lambda do OTel Collector {#add-the-arn-of-the-otel-collector-lambda-layer}
+
+Veja as [orientações sobre a camada Lambda do Collector](../lambda-collector/)
+para adicionar a camada à sua aplicação e configurar o Collector. Recomenda-se
+fazer isso primeiro.
+
+## Instrumente o Lambda com o OTel {#instrument-the-lambda-with-otel}
+
+Consulte as [orientações de instrumentação da linguagem](/docs/languages/)
+escolhida para instrumentar manualmente sua aplicação.
+
+## Publique seu Lambda {#publish-your-lambda}
+
+Publique uma nova versão do seu Lambda para implantar as novas alterações e a
+instrumentação.


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

Adresses issue #7545 

> Note: `lambda-manual-instrument.md` now links to `../lambda-auto-instrument/` (the PT page). That's a relative link scoped to the pt locale, so it only resolves once the PT `lambda-auto-instrument.md` page actually exists on main.
> If the `lambda-manual-instrument` PR merges before the [`lambda-auto-instrument` PR](https://github.com/open-telemetry/opentelemetry.io/pull/11540), that link 404s in the meantime.

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.