### PR TITLE
docs: document OBI tracefs mount requirement

### DIFF
--- a/content/en/docs/zero-code/obi/security.md
+++ b/content/en/docs/zero-code/obi/security.md
@@ -76,6 +76,31 @@ OBI requires the following list of capabilities for its functionality:
 | `CAP_SYS_RESOURCE`       | Increase the amount of locked memory available, **kernels < 5.11** only                                                                                                                                                           |
 | `CAP_SYS_ADMIN`          | Library-level Go trace-context propagation via `bpf_probe_write_user()` and access to BTF data by the BPF metrics exporter                                                                                                        |
 
+## Required host mount for context propagation
+
+Starting with OBI v0.12.0, on kernel versions 6.6.128+, 6.12.75+, 6.18.14+,
+and 6.19+, OBI requires the host's `/sys/kernel/tracing` directory to be
+mounted into the OBI container at the same path. OBI uses this to run its
+FIONREAD compensation check. If this mount is missing, OBI cannot perform
+this check and automatically disables context propagation to avoid
+producing incorrect trace data.
+
+To provide this mount in Kubernetes, add the following to your Pod spec:
+
+```yaml
+spec:
+  containers:
+    - name: obi
+      volumeMounts:
+        - name: tracefs
+          mountPath: /sys/kernel/tracing
+  volumes:
+    - name: tracefs
+      hostPath:
+        path: /sys/kernel/tracing
+        type: Directory
+```
+
 ### Performance monitoring tasks
 
 Access to `CAP_PERFMON` is subject to `perf_events` access controls governed by

--- a/content/en/docs/zero-code/obi/security.md
+++ b/content/en/docs/zero-code/obi/security.md
@@ -78,12 +78,12 @@ OBI requires the following list of capabilities for its functionality:
 
 ## Required host mount for context propagation
 
-Starting with OBI v0.12.0, on kernel versions 6.6.128+, 6.12.75+, 6.18.14+,
-and 6.19+, OBI requires the host's `/sys/kernel/tracing` directory to be
-mounted into the OBI container at the same path. OBI uses this to run its
-FIONREAD compensation check. If this mount is missing, OBI cannot perform
-this check and automatically disables context propagation to avoid
-producing incorrect trace data.
+Starting with OBI v0.12.0, on kernel versions 6.6.128+, 6.12.75+, 6.18.14+, and
+6.19+, OBI requires the host's `/sys/kernel/tracing` directory to be mounted
+into the OBI container at the same path. OBI uses this to run its FIONREAD
+compensation check. If this mount is missing, OBI cannot perform this check and
+automatically disables context propagation to avoid producing incorrect trace
+data.
 
 To provide this mount in Kubernetes, add the following to your Pod spec:
 

--- a/content/en/docs/zero-code/obi/setup/kubernetes.md
+++ b/content/en/docs/zero-code/obi/setup/kubernetes.md
@@ -92,6 +92,17 @@ You can deploy OBI in Kubernetes in two different ways:
 - As a sidecar container
 - As a DaemonSet
 
+> [!NOTE]
+>
+> On kernel versions 6.6.128+, 6.12.75+, 6.18.14+, and 6.19+, OBI v0.12.0+
+> requires the host's `/sys/kernel/tracing` directory to be mounted into the
+> OBI container at the same path. Without this mount, OBI cannot run its
+> FIONREAD compensation check and automatically disables trace context
+> propagation. All deployment examples in this document include this
+> mount. See
+> [Security, permissions, and capabilities](../../security/#required-host-mount-for-context-propagation)
+> for details.
+
 ### Deploy OBI as a sidecar container
 
 This is the way you can deploy OBI if you want to monitor a given service that
@@ -173,6 +184,15 @@ spec:
             # required if you want kubernetes metadata decoration
             - name: OTEL_EBPF_KUBE_METADATA_ENABLE
               value: 'true'
+          volumeMounts:
+            # required for trace context propagation, see security docs
+            - name: tracefs
+              mountPath: /sys/kernel/tracing
+      volumes:
+        - name: tracefs
+          hostPath:
+            path: /sys/kernel/tracing
+            type: Directory
 ```
 
 Using the wildcard approach is less error prone than specifying individual
@@ -236,6 +256,15 @@ spec:
               # required if you want kubernetes metadata decoration
             - name: OTEL_EBPF_KUBE_METADATA_ENABLE
               value: 'true'
+          volumeMounts:
+            # required for trace context propagation, see security docs
+            - name: tracefs
+              mountPath: /sys/kernel/tracing
+      volumes:
+        - name: tracefs
+          hostPath:
+            path: /sys/kernel/tracing
+            type: Directory
 ```
 
 For more information about the different configuration options, check the
@@ -292,6 +321,15 @@ spec:
               # required if you want kubernetes metadata decoration
             - name: OTEL_EBPF_KUBE_METADATA_ENABLE
               value: 'true'
+          volumeMounts:
+            # required for trace context propagation, see security docs
+            - name: tracefs
+              mountPath: /sys/kernel/tracing
+      volumes:
+        - name: tracefs
+          hostPath:
+            path: /sys/kernel/tracing
+            type: Directory
 ```
 
 ### Deploy OBI unprivileged
@@ -391,6 +429,8 @@ spec:
               mountPath: /var/run/obi
             - name: cgroup
               mountPath: /sys/fs/cgroup
+            - name: tracefs
+              mountPath: /sys/kernel/tracing
       tolerations:
         - effect: NoSchedule
           operator: Exists
@@ -402,6 +442,10 @@ spec:
         - name: cgroup
           hostPath:
             path: /sys/fs/cgroup
+        - name: tracefs
+          hostPath:
+            path: /sys/kernel/tracing
+            type: Directory
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -566,6 +610,8 @@ spec:
               name: obi-config
             - mountPath: /var/run/obi
               name: var-run-obi
+            - mountPath: /sys/kernel/tracing
+              name: tracefs
           env:
             # tell OBI where to find the configuration file
             - name: OTEL_EBPF_CONFIG_PATH
@@ -576,6 +622,10 @@ spec:
             name: obi-config
         - name: var-run-obi
           emptyDir: {}
+        - name: tracefs
+          hostPath:
+            path: /sys/kernel/tracing
+            type: Directory
 ```
 
 ## Providing secret configuration

--- a/content/en/docs/zero-code/obi/setup/kubernetes.md
+++ b/content/en/docs/zero-code/obi/setup/kubernetes.md
@@ -95,11 +95,10 @@ You can deploy OBI in Kubernetes in two different ways:
 > [!NOTE]
 >
 > On kernel versions 6.6.128+, 6.12.75+, 6.18.14+, and 6.19+, OBI v0.12.0+
-> requires the host's `/sys/kernel/tracing` directory to be mounted into the
-> OBI container at the same path. Without this mount, OBI cannot run its
-> FIONREAD compensation check and automatically disables trace context
-> propagation. All deployment examples in this document include this
-> mount. See
+> requires the host's `/sys/kernel/tracing` directory to be mounted into the OBI
+> container at the same path. Without this mount, OBI cannot run its FIONREAD
+> compensation check and automatically disables trace context propagation. All
+> deployment examples in this document include this mount. See
 > [Security, permissions, and capabilities](../../security/#required-host-mount-for-context-propagation)
 > for details.
 


### PR DESCRIPTION
## Summary

- Document the `/sys/kernel/tracing` host mount requirement introduced with OBI v0.12.0 on affected kernel versions.
- Add the required `tracefs` host mount to the Kubernetes deployment examples.
- Explain that the mount is required for OBI's FIONREAD compensation check and trace context propagation.

Fixes #11497

## Checklist

- [x] I have read and followed the [[Contributing](https://opentelemetry.io/docs/contributing/)](https://opentelemetry.io/docs/contributing/) docs, especially the **First-time contributing?** section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [[Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md)](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.