### PR TITLE
Registry: title the genai-otel-instrument entry by its package name

### DIFF
--- a/data/registry/instrumentation-python-traceverde.yml
+++ b/data/registry/instrumentation-python-traceverde.yml
@@ -1,5 +1,5 @@
 # cSpell:ignore genai openai langchain crewai Kshitij Thakkar
-title: TraceVerde (genai-otel-instrument)
+title: genai-otel-instrument
 registryType: instrumentation
 language: python
 tags:


### PR DESCRIPTION
The entry for the Python GenAI instrumentation `genai-otel-instrument` is titled `TraceVerde (genai-otel-instrument)`.

`TraceVerde` is not the name of anything a reader can install, and it is not the name the project is published or documented under. It leads the title with an unfamiliar word and puts the installable name in parentheses, so the entry is hard to match against the package someone actually encounters (`pip install genai-otel-instrument`, `github.com/Mandark-droid/genai_otel_instrument`).

This retitles it to `genai-otel-instrument`, matching the package name in the entry's own `package:` block. Other registry entries title themselves by package name in the same way, e.g. `opentelemetry-instrumentation-ruby_llm`.

Title only; no other field is changed, and the file name is left alone so any existing link to the entry keeps working.