### PR TITLE
[ja] update translation of content/en/docs/demo/docker-deployment.md

### DIFF
--- a/content/ja/docs/demo/docker-deployment.md
+++ b/content/ja/docs/demo/docker-deployment.md
@@ -2,8 +2,7 @@
 title: Docker デプロイ
 linkTitle: Docker
 aliases: [docker_deployment]
-default_lang_commit: 12862017e85a7b88fbd194241af00f4dbd4ee75c
-drifted_from_default: true
+default_lang_commit: ef74cd393090313b5ad970e74d499a97505fffb8
 cSpell:ignore: Firepit otlphttp span_metrics
 ---
 
@@ -121,6 +120,7 @@ docker run --rm --network opentelemetry-demo \
 イメージがビルドされ、コンテナが開始されると以下にアクセスできるようになります。
 
 - ウェブストア: <http://localhost:8080/>
+- ロードジェネレーター UI: <http://localhost:8080/loadgen/>
 - Flagd 設定 UI: <http://localhost:8080/feature>
 - テレメトリードキュメント（Weaver で生成）:
   <http://localhost:8080/telemetry/>


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/demo/docker-deployment.md` to match the latest English source at
`content/en/docs/demo/docker-deployment.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

### Changes

- Added the new "Load Generator UI" entry (`ロードジェネレーター UI`) to the list of accessible URLs.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11592--opentelemetry.netlify.app/ja/docs/demo/docker-deployment/
- **English (canonical):** https://opentelemetry.io/docs/demo/docker-deployment/

<!-- preview-section-end -->
