### PR TITLE
[ja] update translation of content/en/docs/guidance/_index.md

### DIFF
--- a/content/ja/docs/guidance/_index.md
+++ b/content/ja/docs/guidance/_index.md
@@ -2,8 +2,7 @@
 title: ブループリントとリファレンス実装
 description: 一般的な環境でOpenTelemetryを導入・実装する際のベストプラクティスに関するブループリントとサンプルアーキテクチャ
 weight: 600
-default_lang_commit: 62c8cb2f4ea2e121cab3b4880f5cdf8c21aaea13
-drifted_from_default: true
+default_lang_commit: 4c76a8ab64aef829003446e6ff8d2869c51c03a6
 ---
 
 OpenTelemetry を大規模に採用するには、個々のコンポーネントを設定するだけでは不十分です。
@@ -29,3 +28,8 @@ OpenTelemetry をデプロイする単一の「正しい」方法はないため
 - [リファレンス実装](https://github.com/open-telemetry/sig-end-user/issues/new?template=reference_implementation.yml)
 
 [標準テンプレート](https://github.com/open-telemetry/sig-end-user/tree/main/architecture)に沿った高品質なドキュメントの作成から、最終的な公式ドキュメントへのコントリビューションまで、End User SIG メンバーが一連のプロセスを案内します。
+
+> [!NOTE]
+>
+> まず [End User SIG リポジトリ](https://github.com/open-telemetry/sig-end-user)で提案イシューを提出し、レビューおよび承認を受けてから、[opentelemetry.io リポジトリ](https://github.com/open-telemetry/opentelemetry.io)に対してドキュメントのプルリクエストを作成してください。
+> 提案から公開までの完全なコントリビューションワークフローは、[ブループリントおよびリファレンス実装のコントリビューションプロセス](https://github.com/open-telemetry/sig-end-user/blob/main/architecture/README.md)に記載されています。


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/guidance/_index.md` to match the latest English source at
`content/en/docs/guidance/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff added a `> [!NOTE]` callout block at the end of the "How to contribute"
section, advising contributors to submit a proposal issue before opening a documentation
PR. The Japanese translation of this block has been appended at the corresponding position.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11599--opentelemetry.netlify.app/ja/docs/guidance/
- **English (canonical):** https://opentelemetry.io/docs/guidance/

<!-- preview-section-end -->
