### PR TITLE
[ja] update translation of content/en/docs/platforms/client-apps/android.md

### DIFF
--- a/content/ja/docs/platforms/client-apps/android.md
+++ b/content/ja/docs/platforms/client-apps/android.md
@@ -4,9 +4,8 @@ description: >-
   Android プラットフォーム上で動作するアプリで OpenTelemetry を使う
 weight: 10
 vers:
-  ot-android: 1.6.0
-default_lang_commit: 60d50174e01d221f65af4b69ad1ae946fbc16ec8
-drifted_from_default: true
+  ot-android: 1.7.0
+default_lang_commit: 635c7435bab2fbc655d08e5bb84b127e10242a7d
 cSpell:ignore: inactivity
 ---
 


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/platforms/client-apps/android.md` to match the latest English source at
`content/en/docs/platforms/client-apps/android.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English change was a version bump only (`vers.ot-android: 1.6.0` → `1.7.0`).

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11602--opentelemetry.netlify.app/ja/docs/platforms/client-apps/android/
- **English (canonical):** https://opentelemetry.io/docs/platforms/client-apps/android/

<!-- preview-section-end -->
