### PR TITLE
Rename qryn vendor entry to Gigapipe

### DIFF
--- a/.lycheecache
+++ b/.lycheecache
@@ -840,6 +840,7 @@ https://geminicli.com/docs/cli/telemetry/#opentelemetry-integration,200,17879167
 https://geode.apache.org/,200,1787981986
 https://getcomposer.org/,200,1787981969
 https://getcomposer.org/doc/01-basic-usage.md#autoloading,200,1788327798
+https://gigapipe.com/opentelemetry,200,1788975322
 https://gist.github.com/braydonk/b2381da98dc3c4fd5ac064045d556634,200,1787916982
 https://gist.github.com/fardjad/ea3c38d566c845e0b353237d3959e365,200,1787916982
 https://gist.github.com/zeitlinger/09585b1ab57c454f87e6dcb9a6f50a5c,200,1787916712

--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -169,7 +169,7 @@
   commercial: true
 - name: Gigapipe
   nativeOTLP: true
-  url: https://gigapipe.com/docs/api
+  url: https://gigapipe.com/opentelemetry
   contact: rita@gigapipe.com
   oss: true
   commercial: true

--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -167,6 +167,12 @@
   contact:
   oss: true
   commercial: true
+- name: Gigapipe
+  nativeOTLP: true
+  url: https://gigapipe.com/docs/api
+  contact: rita@gigapipe.com
+  oss: true
+  commercial: true
 - name: Google Cloud Platform
   nativeOTLP: true
   url: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlecloudexporter
@@ -381,12 +387,6 @@
   nativeOTLP: true
   url: https://www.parseable.com/docs/ingest-data/otel
   contact: hi@parseable.com
-  oss: true
-  commercial: true
-- name: qryn
-  nativeOTLP: true
-  url: https://qryn.metrico.in/#/support?id=tempo-api&link-check=no
-  contact: https://github.com/lmangani
   oss: true
   commercial: true
 - name: Sentry


### PR DESCRIPTION
## What this changes

The vendor entry named `qryn` is renamed to **Gigapipe**, its URL repointed to the current documentation, and the entry moved into alphabetical order.

qryn was renamed to Gigapipe. The project is the same one — same maintainers, same repository lineage — and the name change is reflected everywhere else, including this repo's own registry entry, which already reads [`collector-exporter-gigapipe.yml`](https://github.com/open-telemetry/opentelemetry.io/blob/main/data/registry/collector-exporter-gigapipe.yml) and describes it as "Gigapipe (formerly qryn)". The vendors list is the last place still carrying the old name.

## Details

- **Name** — `qryn` → `Gigapipe`.
- **URL** — `https://qryn.metrico.in/#/support?id=tempo-api&link-check=no` → `https://gigapipe.com/docs/api`. The old URL still resolves, so this is not a broken-link fix; it points at the superseded docs site and carries a `link-check=no` escape that is no longer needed.
- **Contact** — updated to a current maintainer address; the previous contact is no longer the right first point of contact.
- **Position** — moved from between Parseable and Sentry (its old alphabetical slot under "q") to between Elastic and Google Cloud Platform, so the file stays sorted under the new name.

`oss: true`, `commercial: true` and `nativeOTLP: true` are unchanged and still accurate: the project is AGPL-3.0 with a commercial hosted offering, and ingests OTLP over both HTTP and gRPC.

## Verification

- `data/ecosystem/vendors.yaml` parses, with the vendor count unchanged at 105.
- The new URL returns HTTP 200.
- `data/ecosystem/vendors.yaml` is listed in `ignorePaths` in `.cspell.yml`, so no dictionary entry is needed for the new name.

## Disclosure

I work at Gigapipe. Submitting this as a correction to an existing entry for a project that has since been renamed, not as a new listing.
