### PR TITLE
[ja] update translation of content/en/docs/demo/telemetry-features/_index.md

### DIFF
--- a/content/ja/docs/demo/telemetry-features/_index.md
+++ b/content/ja/docs/demo/telemetry-features/_index.md
@@ -2,8 +2,7 @@
 title: テレメトリー機能
 linkTitle: テレメトリー機能
 aliases: [demo_features, features]
-default_lang_commit: 3560c03d5cbe845c6189e6e30441434c7760eca0
-drifted_from_default: true
+default_lang_commit: a44df6dd383b504864f60165b21459b7f5e005c5
 ---
 
 ## OpenTelemetry {#opentelemetry}
@@ -39,7 +38,7 @@ drifted_from_default: true
 
 ## その他のコンポーネント {#other-components}
 
-- **[Envoy](https://www.envoyproxy.io/)**：Envoy は、フロントエンドやフィーチャーフラグサービスなどのユーザー向け Web インターフェイスのリバースプロキシとして使用されます。
-- **[k6](https://k6.io)**：合成負荷生成ツールを使用してウェブサイト上で現実的な使用パターンを作成するバックグラウンドジョブです。
+- **[Envoy](https://www.envoyproxy.io/)**：Envoy は、フロントエンドやロードジェネレーター、フィーチャーフラグサービスなどのユーザー向け Web インターフェイスのリバースプロキシとして使用されます。
+- **[Locust](https://locust.io)**：合成負荷生成ツールを使用してウェブサイト上で現実的な使用パターンを作成するバックグラウンドジョブです。
 - **[OpenFeature](https://openfeature.dev)**：アプリケーション内の機能の有効化と無効化を可能にするフィーチャーフラグ API および SDK です。
 - **[flagd](https://flagd.dev)**：デモアプリケーション内のフィーチャーフラグを管理するために使用されるフィーチャーフラグデーモンです。


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/demo/telemetry-features/_index.md` to match the latest English source at
`content/en/docs/demo/telemetry-features/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

### Changes

- **Envoy**: Added "load generator" to the list of user-facing web interfaces that Envoy reverse-proxies (フロントエンドやロードジェネレーター、フィーチャーフラグサービス).
- **k6 → Locust**: Updated the load generator tool name and URL from k6 (`https://k6.io`) to Locust (`https://locust.io`).

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11608--opentelemetry.netlify.app/ja/docs/demo/telemetry-features/
- **English (canonical):** https://opentelemetry.io/docs/demo/telemetry-features/

<!-- preview-section-end -->
