### PR TITLE
Fix OpenAI Codex observability link in GenAI observability blog post

### DIFF
--- a/content/en/blog/2026/genai-observability/index.md
+++ b/content/en/blog/2026/genai-observability/index.md
@@ -33,7 +33,7 @@ monitoring with OpenTelemetry:
 
 - [VS Code Copilot](https://code.visualstudio.com/docs/copilot/guides/monitoring-agents)
   emits traces, metrics, and events for every agent interaction.
-- [OpenAI Codex](https://developers.openai.com/codex/config-advanced#observability-and-telemetry)
+- [OpenAI Codex](https://learn.chatgpt.com/docs/config-file/config-advanced#__codexlocalizedvalueprops__codextranslations-u0087-observability-and-telemetry)
   exports structured log events and OTel metrics for API requests, tool calls,
   and sessions.
 - [Claude Code](https://code.claude.com/docs/en/monitoring-usage) exports

--- a/content/ja/blog/2026/genai-observability/index.md
+++ b/content/ja/blog/2026/genai-observability/index.md
@@ -6,6 +6,7 @@ author: '[James Newton-King](https://github.com/jamesnk) (Microsoft)'
 issue: https://github.com/open-telemetry/opentelemetry.io/issues/9707
 sig: SIG GenAI Observability
 default_lang_commit: 39d3d2ef243d968e6a434fd9d2690c8070c3d7ea
+drifted_from_default: true
 cSpell:ignore: genai
 ---
 


### PR DESCRIPTION
- The OpenAI Codex link in the GenAI observability blog post fails the link check: `developers.openai.com/codex/config-advanced#observability-and-telemetry` now redirects to `learn.chatgpt.com`, where the section anchor changed.
- Point the English post at the current URL and anchor.
- Refresh the drift status of the ja copy; the link checker skips drifted pages, and the ja team reconciles the link on its side.
- Unblocks the link check on #11565.