### PR TITLE
fix[ja]: correct typo in `content/ja/docs/concepts/context-propagation/index.md`

### DIFF
--- a/content/ja/docs/concepts/context-propagation/index.md
+++ b/content/ja/docs/concepts/context-propagation/index.md
@@ -36,7 +36,7 @@ OpenTelemetryは、いくつかの公式のプロパゲーターをメンテナ�
 ## 例 {#example}
 
 `Frontend`というサービスは、`POST /cart/add`や`GET /checkout/`などのさまざまなHTTPエンドポイントを提供し、`GET /product`というHTTPエンドポイントを介して下流サービスである`Product Catalog`にアクセスしてユーザーがカートに追加したい商品や決済対象の一部である商品の詳細を取得します。
-`Frontend`からのリクストのコンテキスト内で`Product Catalog`サービスのアクティビティを把握するために、コンテキスト（ここではトレースIDと「親ID」としてのスパンID）はW3C TraceContext仕様で定義されている`traceparent`ヘッダーを使用して伝搬されます。
+`Frontend`からのリクエストのコンテキスト内で`Product Catalog`サービスのアクティビティを把握するために、コンテキスト（ここではトレースIDと「親ID」としてのスパンID）はW3C TraceContext仕様で定義されている`traceparent`ヘッダーを使用して伝搬されます。
 これはつまり、IDがヘッダーのフィールドに埋め込まれていることを意味します。
 
 ```text


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

## Summary

### Motivation

I found typo in file, so need to fix it.

### What I have done

```diff
- リクスト
+ リクエスト
```
### Test Plans

N/A