### PR TITLE
[ja] update translation of content/en/docs/languages/java/_index.md

### DIFF
--- a/content/ja/docs/languages/java/_index.md
+++ b/content/ja/docs/languages/java/_index.md
@@ -12,9 +12,9 @@ cascade:
     instrumentation: 2.31.1
     otel: 1.65.0
     contrib: 1.60.0
-    semconv: 1.43.0
+    semconv: 1.44.0
 weight: 150
-default_lang_commit: 64ccb143bb09d15e1623ad639e7d2524f8de86b1
+default_lang_commit: 6ebb7334b0d849d64488cf5b9b1819d4afa5bab9
 ---
 
 {{% docs/languages/index-intro java /%}}

--- a/content/ja/docs/languages/java/_index.md
+++ b/content/ja/docs/languages/java/_index.md
@@ -9,13 +9,12 @@ redirects:
   - { from: /docs/java/*, to: ':splat' }
 cascade:
   vers:
-    instrumentation: 2.30.0
-    otel: 1.64.0
-    contrib: 1.59.0
+    instrumentation: 2.31.1
+    otel: 1.65.0
+    contrib: 1.60.0
     semconv: 1.43.0
 weight: 150
-default_lang_commit: ec870712704ae037419e4e420b7fa3be04e10297
-drifted_from_default: true
+default_lang_commit: 64ccb143bb09d15e1623ad639e7d2524f8de86b1
 ---
 
 {{% docs/languages/index-intro java /%}}


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/languages/java/_index.md` to match the latest English source at
`content/en/docs/languages/java/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff is a version bump in `cascade.vers`:
- `instrumentation: 2.30.0` → `2.31.1`
- `otel: 1.64.0` → `1.65.0`
- `contrib: 1.59.0` → `1.60.0`

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11625--opentelemetry.netlify.app/ja/docs/languages/java/
- **English (canonical):** https://opentelemetry.io/docs/languages/java/

<!-- preview-section-end -->
