### PR TITLE
[ja] update translation of content/en/docs/zero-code/java/_index.md

### DIFF
--- a/content/ja/docs/zero-code/java/_index.md
+++ b/content/ja/docs/zero-code/java/_index.md
@@ -6,11 +6,10 @@ aliases:
   - /docs/languages/java/automatic_instrumentation
 cascade:
   vers:
-    instrumentation: 2.30.0
-    otel: 1.64.0
+    instrumentation: 2.31.1
+    otel: 1.65.0
     contrib: 1.54.0
-default_lang_commit: 867f1ba6a44275ce3bc7d8708765a78baaa0287f
-drifted_from_default: true
+default_lang_commit: 64ccb143bb09d15e1623ad639e7d2524f8de86b1
 ---
 
 Javaでゼロコード計装を行う一般的なオプションには、Java エージェント JAR、Spring Boot Starter、Quarkus OpenTelemetry Extension があります。


### PR DESCRIPTION
## Summary

Updates `content/ja/docs/zero-code/java/_index.md` to match the latest English source at
`content/en/docs/zero-code/java/_index.md`. Refreshes `default_lang_commit` and removes the
`drifted_from_default` flag.

The English diff was a frontmatter-only change: `cascade.vers.instrumentation` bumped from
`2.30.0` to `2.31.1` and `cascade.vers.otel` from `1.64.0` to `1.65.0`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11626--opentelemetry.netlify.app/ja/docs/zero-code/java/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/java/

<!-- preview-section-end -->
