### PR TITLE
[ja] add translation of content/en/docs/zero-code/php/distro/reference/supported-technologies.md

### DIFF
--- a/content/ja/docs/zero-code/php/distro/reference/supported-technologies.md
+++ b/content/ja/docs/zero-code/php/distro/reference/supported-technologies.md
@@ -54,22 +54,22 @@ OpenTelemetry の互換性を継承し、ネイティブコンポーネントに
 
 ## 同梱の自動計装パッケージ {#included-auto-instrumentation-packages}
 
-| Name                | Included from distro version | Package                                                                                                                     |
-| ------------------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `curl`              | 1.0                          | [open-telemetry/opentelemetry-auto-curl](https://packagist.org/packages/open-telemetry/opentelemetry-auto-curl)             |
-| `http-async-client` | 1.0                          | [open-telemetry/opentelemetry-auto-http-async](https://packagist.org/packages/open-telemetry/opentelemetry-auto-http-async) |
-| `laravel`           | 1.0                          | [open-telemetry/opentelemetry-auto-laravel](https://packagist.org/packages/open-telemetry/opentelemetry-auto-laravel)       |
-| `mysqli`            | 1.0                          | [open-telemetry/opentelemetry-auto-mysqli](https://packagist.org/packages/open-telemetry/opentelemetry-auto-mysqli)         |
-| `pdo`               | 1.0                          | [open-telemetry/opentelemetry-auto-pdo](https://packagist.org/packages/open-telemetry/opentelemetry-auto-pdo)               |
-| `postgresql`        | 1.2                          | [open-telemetry/opentelemetry-auto-postgresql](https://packagist.org/packages/open-telemetry/opentelemetry-auto-postgresql) |
-| `psr18`             | 0.5                          | [open-telemetry/opentelemetry-auto-psr18](https://packagist.org/packages/open-telemetry/opentelemetry-auto-psr18)           |
-| `slim`              | 1.0                          | [open-telemetry/opentelemetry-auto-slim](https://packagist.org/packages/open-telemetry/opentelemetry-auto-slim)             |
+| 名前                | ディストロバージョン | パッケージ                                                                                                                  |
+| ------------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `curl`              | 1.0                  | [open-telemetry/opentelemetry-auto-curl](https://packagist.org/packages/open-telemetry/opentelemetry-auto-curl)             |
+| `http-async-client` | 1.0                  | [open-telemetry/opentelemetry-auto-http-async](https://packagist.org/packages/open-telemetry/opentelemetry-auto-http-async) |
+| `laravel`           | 1.0                  | [open-telemetry/opentelemetry-auto-laravel](https://packagist.org/packages/open-telemetry/opentelemetry-auto-laravel)       |
+| `mysqli`            | 1.0                  | [open-telemetry/opentelemetry-auto-mysqli](https://packagist.org/packages/open-telemetry/opentelemetry-auto-mysqli)         |
+| `pdo`               | 1.0                  | [open-telemetry/opentelemetry-auto-pdo](https://packagist.org/packages/open-telemetry/opentelemetry-auto-pdo)               |
+| `postgresql`        | 1.2                  | [open-telemetry/opentelemetry-auto-postgresql](https://packagist.org/packages/open-telemetry/opentelemetry-auto-postgresql) |
+| `psr18`             | 0.5                  | [open-telemetry/opentelemetry-auto-psr18](https://packagist.org/packages/open-telemetry/opentelemetry-auto-psr18)           |
+| `slim`              | 1.0                  | [open-telemetry/opentelemetry-auto-slim](https://packagist.org/packages/open-telemetry/opentelemetry-auto-slim)             |
 
 ## 同梱のメトリクスパッケージ {#included-metrics-packages}
 
-| Included from distro version | Package                                                                                                                     | Emitted metrics                          |
-| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
-| 0.6.0                        | [open-telemetry/opentelemetry-metrics-runtime](https://packagist.org/packages/open-telemetry/opentelemetry-metrics-runtime) | PHP memory usage, GC cycles, peak memory |
+| ディストロバージョン | パッケージ                                                                                                                  | 出力メトリクス                           |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| 0.6.0                | [open-telemetry/opentelemetry-metrics-runtime](https://packagist.org/packages/open-telemetry/opentelemetry-metrics-runtime) | PHP memory usage, GC cycles, peak memory |
 
 ## 追加のランタイム機能 {#additional-runtime-features}
 

--- a/content/ja/docs/zero-code/php/distro/reference/supported-technologies.md
+++ b/content/ja/docs/zero-code/php/distro/reference/supported-technologies.md
@@ -1,0 +1,85 @@
+---
+title: 対応テクノロジー
+description: >-
+  OpenTelemetry PHP Distro が対応する PHP バージョン、SAPI、オペレーティングシステム、フレームワーク、ライブラリ。
+weight: 2
+default_lang_commit: cf9f44c2aaeb97ab9cd891f3de7d27a9f47ac8c9
+cSpell:ignore: apk httplug musl mysqli psr
+---
+
+OpenTelemetry PHP Distro は OpenTelemetry PHP のディストリビューションです。
+OpenTelemetry の互換性を継承し、ネイティブコンポーネントによってランタイム機能を拡張します。
+
+## 自動計装の範囲 {#auto-instrumentation-scope}
+
+自動計装は対応するフレームワークやライブラリのテレメトリーをキャプチャしますが、以下は計装しません。
+
+- プロプライエタリまたはカスタムフレームワークの内部
+- 計装フックのないクローズドソースコンポーネント
+- アプリケーション固有のビジネスロジック
+
+対応していない領域については、手動の OpenTelemetry 計装を使用してください。
+
+## PHP バージョン {#php-versions}
+
+対応する PHP バージョン: `8.1` から `8.5`。
+
+## 対応する SAPI {#supported-sapis}
+
+- `php-cli`
+- `php-fpm`
+- `php-cgi`/`fcgi`
+- `mod_php`（prefork）
+
+## 対応するオペレーティングシステム {#supported-operating-systems}
+
+- Linux
+  - アーキテクチャ: `x86_64`、`arm64`
+  - glibc ベースのシステム: `deb`、`rpm`
+  - musl ベースのシステム（Alpine）: `apk`
+
+## 計装済みフレームワーク {#instrumented-frameworks}
+
+- Laravel `6.x` から `13.x`
+- Slim `4.x`
+
+## 計装済みライブラリ {#instrumented-libraries}
+
+- cURL
+- HTTP async（`php-http/httplug`）
+- MySQLi
+- PDO
+- PostgreSQL
+- PSR-18 HTTP Client（`psr/http-client`）
+
+## 同梱の自動計装パッケージ {#included-auto-instrumentation-packages}
+
+| Name                | Included from distro version | Package                                                                                                                     |
+| ------------------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `curl`              | 1.0                          | [open-telemetry/opentelemetry-auto-curl](https://packagist.org/packages/open-telemetry/opentelemetry-auto-curl)             |
+| `http-async-client` | 1.0                          | [open-telemetry/opentelemetry-auto-http-async](https://packagist.org/packages/open-telemetry/opentelemetry-auto-http-async) |
+| `laravel`           | 1.0                          | [open-telemetry/opentelemetry-auto-laravel](https://packagist.org/packages/open-telemetry/opentelemetry-auto-laravel)       |
+| `mysqli`            | 1.0                          | [open-telemetry/opentelemetry-auto-mysqli](https://packagist.org/packages/open-telemetry/opentelemetry-auto-mysqli)         |
+| `pdo`               | 1.0                          | [open-telemetry/opentelemetry-auto-pdo](https://packagist.org/packages/open-telemetry/opentelemetry-auto-pdo)               |
+| `postgresql`        | 1.2                          | [open-telemetry/opentelemetry-auto-postgresql](https://packagist.org/packages/open-telemetry/opentelemetry-auto-postgresql) |
+| `psr18`             | 0.5                          | [open-telemetry/opentelemetry-auto-psr18](https://packagist.org/packages/open-telemetry/opentelemetry-auto-psr18)           |
+| `slim`              | 1.0                          | [open-telemetry/opentelemetry-auto-slim](https://packagist.org/packages/open-telemetry/opentelemetry-auto-slim)             |
+
+## 同梱のメトリクスパッケージ {#included-metrics-packages}
+
+| Included from distro version | Package                                                                                                                     | Emitted metrics                          |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| 0.6.0                        | [open-telemetry/opentelemetry-metrics-runtime](https://packagist.org/packages/open-telemetry/opentelemetry-metrics-runtime) | PHP memory usage, GC cycles, peak memory |
+
+## 追加のランタイム機能 {#additional-runtime-features}
+
+- 自動ルートスパン生成
+- ルートスパンの URL グルーピング
+- 推論スパン
+- [属性ベースの計装](/docs/zero-code/php/distro/reference/attribute-instrumentation/)
+  （`#[WithSpan]`、`#[SpanAttribute]`）
+- バックグラウンドテレメトリー送信
+- PHP ランタイムメトリクス（メモリ、GC — ネイティブ非同期トランスポート経由で自動的にエクスポート）
+
+バックグラウンド送信（ノンブロッキングエクスポート）は OTLP `http/protobuf`（デフォルト）で動作します。
+エクスポーターまたはプロトコルが対応していないトランスポート（たとえば gRPC）に変更された場合、エクスポートは同期的になります。


### PR DESCRIPTION
## Summary

Translates `content/en/docs/zero-code/php/distro/reference/supported-technologies.md` into Japanese as `content/ja/docs/zero-code/php/distro/reference/supported-technologies.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11641--opentelemetry.netlify.app/ja/docs/zero-code/php/distro/reference/supported-technologies/
- **English (canonical):** https://opentelemetry.io/docs/zero-code/php/distro/reference/supported-technologies/

<!-- preview-section-end -->
