### PR TITLE
[i18n][ko] Localize announcements page to Korean

### DIFF
--- a/content/ko/announcements/_index.md
+++ b/content/ko/announcements/_index.md
@@ -1,0 +1,6 @@
+---
+title: 공지사항
+# cascade is omitted because it is for the en locale only.
+redirects: [{ from: '*', to: '? 302' }]
+default_lang_commit: 774549b0f6181e901fa28f61672c0b0099cbdbda
+---


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

Adds Korean (ko) localization of the announcements page (`content/ko/announcements/_index.md`).
