### PR TITLE
fix: correct php -S command syntax in English doc `content/en/docs/languages/php/instrumentation.md`

### DIFF
--- a/content/en/docs/languages/php/instrumentation.md
+++ b/content/en/docs/languages/php/instrumentation.md
@@ -439,7 +439,7 @@ Start your app as follows, and then send it requests by visiting
 <http://localhost:8080/rolldice?rolls=12> with your browser or `curl`.
 
 ```sh
-php -S 8080 localhost
+php -S localhost:8080
 ```
 
 After a while, you should see the spans printed in the console by the


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

## Summary

### Motivation

The English PHP instrumentation guide contains an invalid `php -S` command. PHP's built-in server expects the address as a single `host:port` argument.So,  `php -S 8080 localhost` fails to start the server, breaking the tutorial for anyone following it.
This is the base-language counterpart to #11618 , which fixed the same issue in the Japanese translation but was flagged for spanning locales. 
Per [the localization guidelines](https://opentelemetry.io/docs/contributing/localization/#prs-should-not-span-locales), the base (en) page should be fixed first, so this PR splits that fix out on its own.

### What I have done

Corrected the command from `php -S 8080 localhost` to `php -S localhost:8080` in `content/en/docs/languages/php/instrumentation.md`.

### Test Plans

N/A Because of only fixed documentation.

#### Notes

- After this PR is merged, I'll follow up on #11618 
  - Remove the English-fix commit from that branch (it's now redundant, since this PR supersedes it)
  - Refresh `default_lang_commit` to point at this PR's merge commit, clearing `drifted_from_default`