### PR TITLE
Add KubeCon NA 2026 banner

### DIFF
--- a/.lycheecache
+++ b/.lycheecache
@@ -800,10 +800,13 @@ https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/program/schedule
 https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/program/schedule/?id=1283896,200,1787917016
 https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/register/,200,1787917015
 https://events.linuxfoundation.org/kubecon-cloudnativecon-japan/register/?utm_source=opentelemetry&utm_medium=website&utm_content=blog,200,1788846196
+https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/,200,1788965855
 https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/?utm_source=opentelemetry&amp;utm_medium=website&amp;utm_content=blog,200,1788414934
 https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/co-located-events/observability-day/?utm_source=opentelemetry&amp;utm_medium=website&amp;utm_content=blog,200,1788414933
 https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/features-add-ons/maintainer-summit/?utm_source=opentelemetry&amp;utm_medium=website&amp;utm_content=blog,200,1788414933
 https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/register/?utm_source=opentelemetry&amp;utm_medium=website&amp;utm_content=blog,200,1788414933
+https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/register/?utm_source=opentelemetry&utm_medium=website&utm_content=community-events,200,1788965857
+https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/register/?utm_source=opentelemetry&utm_medium=website&utm_content=slim-banner,200,1788965857
 https://events.linuxfoundation.org/open-observability-summit-otel-community-day/,200,1787917020
 https://events.linuxfoundation.org/open-observability-summit-otel-community-day/program/schedule/,200,1788241855
 https://events.linuxfoundation.org/open-source-summit-north-america/,200,1787917020

--- a/.lycheecache
+++ b/.lycheecache
@@ -805,6 +805,8 @@ https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/?utm_sou
 https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/co-located-events/observability-day/?utm_source=opentelemetry&amp;utm_medium=website&amp;utm_content=blog,200,1788414933
 https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/features-add-ons/maintainer-summit/?utm_source=opentelemetry&amp;utm_medium=website&amp;utm_content=blog,200,1788414933
 https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/register/?utm_source=opentelemetry&amp;utm_medium=website&amp;utm_content=blog,200,1788414933
+https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/register/?utm_source=opentelemetry&utm_medium=ribbon-banner&utm_campaign=KubeCon-CloudNativeCon-NA-2026&utm_content=community-events,200,1788966463
+https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/register/?utm_source=opentelemetry&utm_medium=ribbon-banner&utm_campaign=KubeCon-CloudNativeCon-NA-2026&utm_content=hero,200,1788966462
 https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/register/?utm_source=opentelemetry&utm_medium=website&utm_content=community-events,200,1788965857
 https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/register/?utm_source=opentelemetry&utm_medium=website&utm_content=slim-banner,200,1788965857
 https://events.linuxfoundation.org/open-observability-summit-otel-community-day/,200,1787917020

--- a/content/en/announcements/kubecon-china.md
+++ b/content/en/announcements/kubecon-china.md
@@ -13,8 +13,8 @@ params:
   blogPostURL: *eventUrl
 ---
 
-[**{{% param title %}}**][LF] · <span class="text-nowrap">Sep 7–9</span> ·
-Shanghai · [Details][blog]
+[**{{% param title %}}**][LF] • <span class="text-nowrap">Sep 7–9</span> •
+Shanghai • [Details][blog]
 
 [blog]: <{{% param blogPostURL %}}>
 [LF]: <{{% param eventUrl %}}register/?{{% _param utmParam %}}>

--- a/content/en/announcements/kubecon-na.md
+++ b/content/en/announcements/kubecon-na.md
@@ -15,8 +15,8 @@ params:
   blogPostURL: *eventUrl
 ---
 
-[**{{% param title %}}**][LF] · <span class="text-nowrap">Nov 9–12</span> · Salt
-Lake City · [Details][blog]
+[**{{% param title %}}**][LF] **·** <span class="text-nowrap">Nov 9–12</span>
+**·** Salt Lake City **·** [Details][blog]
 
 [blog]: <{{% param blogPostURL %}}>
 [LF]: <{{% param eventUrl %}}register/?{{% _param utmParam %}}>

--- a/content/en/announcements/kubecon-na.md
+++ b/content/en/announcements/kubecon-na.md
@@ -5,6 +5,9 @@ date: 2026-09-09
 expiryDate: 2026-11-12 # keep
 weight: 20261112
 params:
+  # CNCF's campaign parameters for this event, source adjusted for this site
+  utmParam: >-
+    utm_source=opentelemetry&utm_medium=ribbon-banner&utm_campaign=KubeCon-CloudNativeCon-NA-2026&utm_content=hero
   eventUrl: &eventUrl >-
     https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/
   # Use this when the blog post is ready:

--- a/content/en/announcements/kubecon-na.md
+++ b/content/en/announcements/kubecon-na.md
@@ -1,0 +1,19 @@
+---
+title: KubeCon + CloudNativeCon North America 2026
+linkTitle: KubeCon NA 2026
+date: 2026-09-09
+expiryDate: 2026-11-12 # keep
+weight: 20261112
+params:
+  eventUrl: &eventUrl >-
+    https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/
+  # Use this when the blog post is ready:
+  # blogPostURL: /blog/2026/kubecon-na/
+  blogPostURL: *eventUrl
+---
+
+[**{{% param title %}}**][LF] · <span class="text-nowrap">Nov 9–12</span> ·
+Salt Lake City · [Details][blog]
+
+[blog]: <{{% param blogPostURL %}}>
+[LF]: <{{% param eventUrl %}}register/?{{% _param utmParam %}}>

--- a/content/en/announcements/kubecon-na.md
+++ b/content/en/announcements/kubecon-na.md
@@ -15,8 +15,8 @@ params:
   blogPostURL: *eventUrl
 ---
 
-[**{{% param title %}}**][LF] **·** <span class="text-nowrap">Nov 9–12</span>
-**·** Salt Lake City **·** [Details][blog]
+[**{{% param title %}}**][LF] • <span class="text-nowrap">Nov 9–12</span> • Salt
+Lake City • [Details][blog]
 
 [blog]: <{{% param blogPostURL %}}>
 [LF]: <{{% param eventUrl %}}register/?{{% _param utmParam %}}>

--- a/content/en/announcements/kubecon-na.md
+++ b/content/en/announcements/kubecon-na.md
@@ -12,8 +12,8 @@ params:
   blogPostURL: *eventUrl
 ---
 
-[**{{% param title %}}**][LF] · <span class="text-nowrap">Nov 9–12</span> ·
-Salt Lake City · [Details][blog]
+[**{{% param title %}}**][LF] · <span class="text-nowrap">Nov 9–12</span> · Salt
+Lake City · [Details][blog]
 
 [blog]: <{{% param blogPostURL %}}>
 [LF]: <{{% param eventUrl %}}register/?{{% _param utmParam %}}>


### PR DESCRIPTION
- **Scope**: KubeCon + CloudNativeCon NA 2026 banner, at CNCF's request for project sites.
  - New `content/en/announcements/kubecon-na.md`, hello-bar format as for KubeCon China 2026 (#11437), plus its link-cache entries.
  - UTM: CNCF's campaign parameters for the event with `utm_source=opentelemetry`, as a page-level `utmParam` override; same approach as kubernetes/website#57461.
  - Separators: `•` (U+2022) rather than `·`, whose weight in the site's font is much lighter than the hello-bar's dot in Clarity City. Applied to `kubecon-china.md` too, so the next copy starts from a consistent template.
- **Out of scope**:
  - ja-locale override (follow-up PR, needs the merged en hash).
  - Blog post for NA 2026 (`blogPostURL` points at the event page until then).
- **Preview**: https://deploy-preview-11648--opentelemetry.netlify.app/
