### PR TITLE
[ja] update translations of content/en/site/build/localization/_index.md and content/en/docs/contributing/localization.md

### DIFF
--- a/content/ja/docs/contributing/localization.md
+++ b/content/ja/docs/contributing/localization.md
@@ -3,8 +3,7 @@ title: サイトのローカリゼーション
 description: 非英語ローカリゼーションのサイトページの作成と管理
 linkTitle: ローカリゼーション
 weight: 25
-default_lang_commit: d5226a763e8d2f8a04ad16927d4e5961686a3b5e
-drifted_from_default: true
+default_lang_commit: 3c1e6e89077b2afbb9a3ffd5ff61a132b53152aa
 cSpell:ignore: Dowair shortcodes
 ---
 
@@ -350,8 +349,9 @@ OpenTelemetryウェブサイトの新しいローカリゼーションを始め�
      - [ ] Update Hugo config for `LANG_ID`
      - [ ] Configure cSpell and other tooling support
      - [ ] Create an issue label for `lang:LANG_ID`
-     - [ ] Create org-level group for `LANG_ID` approvers
-     - [ ] Update components owners for `content/LANG_ID`
+     - [ ] Create org-level teams for `LANG_ID` approvers and maintainers
+     - [ ] Add the locale to `data/locale-teams.yaml` and run
+           `npm run fix:codeowners`
    - [ ] Create an issue to track the localization of the **glossary**. Add the
          issue number here. For details, see
          [Localize the glossary](https://opentelemetry.io/docs/contributing/localization/#glossary).
@@ -364,7 +364,7 @@ OpenTelemetryウェブサイトの新しいローカリゼーションを始め�
 
 [homepage]: https://github.com/open-telemetry/opentelemetry.io/blob/main/content/en/_index.md
 
-最初のPRがマージされた後、メンテナーはイシューラベル、組織レベルのグループ、およびコンポーネント所有者を設定します。
+最初のPRがマージされた後、メンテナーはイシューラベルと組織レベルのチームを設定します。
 
 ### 4. 用語集をローカライズする {#glossary}
 
@@ -423,11 +423,40 @@ NPM パッケージ [@cspell/dict-LANG_ID][] として利用可能な [cSpell �
   - `dictionaryDefinitions` の下に、`name`（たとえば `LANG_ID-words`）と `path`（たとえば `.cspell/LANG_ID-words.txt`）を持つエントリを追加します。
   - `dictionaries` の下に、上記のステップと同じ `name` の値を追加します（ファイルパスではありません）。
 
+#### チームとコードオーナー {#teams-and-code-owners}
+
+新しいロケールを [`data/locale-teams.yaml`][] に追加し、`npm run fix:codeowners` を実行して CODEOWNERS のロケールセクションを再生成します。
+これらの変更はそのロケールの最初の PR に含めてください。
+CI はレジストリが `content/` 配下のロケールディレクトリと一致することを要求します。
+新しいロケールは通常[未配置](#locale-teams)の状態で始まるため、そのロケールが[昇格](#locale-teams)するまで、CODEOWNERS の行には `docs-approvers` のフォールバックが記載されます。
+
 #### その他のツールサポート {#other-tooling-support}
 
 - Prettierサポート：`LANG_ID`がPrettierで十分にサポートされていない場合は、`.prettierignore`に無視ルールを追加します
 
 ## 承認者およびメンテナー向けガイダンス {#approver-and-maintainer-guidance}
+
+### ロケールチーム、コードオーナー、配置状況 {#locale-teams}
+
+各ロケールには `docs-LANG_ID-approvers` と `docs-LANG_ID-maintainers` の GitHub チームがあります。
+メンテナーは承認者も兼ねます。
+承認者チームはそのロケールのパスの[コードオーナー][code owner]であるため、ロケール承認者のレビューはロケール限定の PR に必要なコードオーナーのレビューを満たします。
+ロケールのメンテナーは、そのような PR を[自動マージ](#auto-merge)することもできます。
+
+ロケールチームの想定されるメンバーは [`data/locale-teams.yaml`][] レジストリに記録されており、このレジストリはリポジトリの [CODEOWNERS][] ファイルのロケールセクションも生成します。
+メンバーの変更はレジストリに対する PR として提案されるため、監査証跡が残ります。
+実際のチームへの反映は組織の管理者が行います。
+ジェネレーターとそれが体現している規約については、[locale-codeowners README][] を参照してください。
+
+メンテナーがいないロケールは**未配置**です。
+その CODEOWNERS の行にはフォールバックオーナーとして `@open-telemetry/docs-approvers` が記載されるため、ドキュメントの承認者がそのロケールの PR をレビューしてブロックを解除できます。
+[自動マージ](#auto-merge)にはロケールのメンテナーが必要なため、このような PR はドキュメントのメンテナーが手動でマージします。
+
+未配置のロケールにメンテナーが加わったら、そのメンテナーを記録して CODEOWNERS のロケールセクションを再生成する（`npm run fix:codeowners`）レジストリの PR を提出してください。
+これによりそのロケールの行から `docs-approvers` のフォールバックが外れ、以降はロケールチームが自身の PR を管理するようになります。
+これがロケールの**昇格**です。
+例については [zh の昇格 PR][zh graduation PR] を参照してください。
+ロケールチームが後に活動を停止した場合は、レジストリを逆方向に変更することでフォールバックが復活します。
 
 ### ロケール限定の PR で自動マージを有効にする {#auto-merge}
 
@@ -526,11 +555,18 @@ npm run fix:i18n:status -- PATHS_TO_FAILING_LOCALIZED_PAGES
 
 最後に、`npm run check:links` を再実行して、リンクの失敗が残っていないことを確認してください。
 
+<!-- prettier-ignore-start -->
 [aliases]: https://gohugo.io/content-management/urls/#aliases
+[code owner]: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+[CODEOWNERS]: https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/CODEOWNERS
+[`data/locale-teams.yaml`]: https://github.com/open-telemetry/opentelemetry.io/blob/main/data/locale-teams.yaml
 [front matter]: https://gohugo.io/content-management/front-matter/
+[locale-codeowners README]: https://github.com/open-telemetry/opentelemetry.io/tree/main/scripts/gh/locale-codeowners
 [main]: https://github.com/open-telemetry/opentelemetry.io/commits/main/
 [maintainers]: https://github.com/orgs/open-telemetry/teams/docs-maintainers
 [multilingual framework]: https://gohugo.io/content-management/multilingual/
 [new issue]: https://github.com/open-telemetry/opentelemetry.io/issues/new
 [PRs]: ../pull-requests/
 [slack]: https://slack.cncf.io/
+[zh graduation PR]: https://github.com/open-telemetry/opentelemetry.io/pull/11516
+<!-- prettier-ignore-end -->

--- a/content/ja/site/build/localization/_index.md
+++ b/content/ja/site/build/localization/_index.md
@@ -4,14 +4,14 @@ linkTitle: ローカリゼーションのセットアップ
 description: >-
   OpenTelemetry ウェブサイトに新しい言語のローカリゼーションをオンボーディングするための、メンテナー向けステップバイステップガイド。
 weight: 50
-default_lang_commit: 346b2912021b98de4349f80753c829d9223a1f25
-drifted_from_default: true
+default_lang_commit: 3c1e6e89077b2afbb9a3ffd5ff61a132b53152aa
 ---
 
 このガイドでは、OTel ウェブサイトのメンテナーが新しい言語のローカリゼーションをオンボーディングするために必要なすべての変更手順を説明します。
 リポジトリレベルの変更と GitHub 組織レベルのセットアップの両方を扱います。
 
 コントリビューター向けの情報（翻訳ガイダンス、差分の追跡、継続的なメンテナンス）については、[Site localization][] を参照してください。
+リポジトリ側のステップをエージェントで実行するバージョンについては、[`setup-new-localization` skill][] を参照してください。
 
 アクティブなローカリゼーションチームとそのリソースの正式なレジストリは [`projects/localization.md`][] にあります。
 
@@ -215,11 +215,27 @@ lang:LANG_ID:
 
 ### コードオーナー {#code-owners}
 
-- [`.github/CODEOWNERS`][] で、ロケールチームにそのファイルの**単独**所有権を付与します。
-  ファイル内に記載されているガイダンスに従ってください。
-- エントリはアルファベット順に配置してください。
-- [`.github/component-owners.yml`][] にはエントリを**追加しないでください**。
-  2026年6月時点で、このファイルへの変更は不要になっています。
+[`.github/CODEOWNERS`][] のロケールセクションは [`data/locale-teams.yaml`][] レジストリから生成されます。手動で編集しないでください。
+
+1. レジストリにロケールをアルファベット順で追加し、メンターと初期コントリビューターを承認者として記載します。
+
+   ```yaml
+   LANG_ID:
+     maintainers: []
+     approvers: [GITHUB_HANDLE1, GITHUB_HANDLE2]
+   ```
+
+   メンテナーが不在のロケールは[未配置][unstaffed]です。そのロケールが昇格するまで、CODEOWNERS の行にはフォールバックオーナーとして `@open-telemetry/docs-approvers` も記載されます。
+
+2. CODEOWNERS のロケールセクションを再生成します。
+
+   ```sh
+   npm run fix:codeowners
+   ```
+
+`content/LANG_ID/` を追加する PR に、両方の変更を含めてください。CI はレジストリとロケールディレクトリの一致を要求します。
+
+[`.github/component-owners.yml`][] にはエントリを**追加しないでください**。2026年6月時点で、このファイルへの変更は不要になっています。
 
 ## ステップ 6 — GitHub 組織レベルのセットアップ {#gh-org}
 
@@ -291,7 +307,7 @@ lang:LANG_ID:
 - [ ] **ステップ 3** — cSpell を設定した。
       辞書をインストールした（またはロケールを `ignorePaths` に追加した）、`.cspell/LANG_ID-words.txt` にカスタム単語リストを作成した、`.cspell.yml` を更新した
 - [ ] **ステップ 4** — `.prettierignore` を更新した（スクリプトに該当する場合）
-- [ ] **ステップ 5** — `.github/component-label-map.yml`（ラベルエントリ）と `.github/CODEOWNERS`（単独所有権ブロック）をロケール用に更新した
+- [ ] **ステップ 5** — `.github/component-label-map.yml`（ラベルエントリ）と `data/locale-teams.yaml`（レジストリエントリ）を更新した。`.github/CODEOWNERS` を再生成した
 - [ ] **ステップ 6** — `open-telemetry/admin` にチーム PR を作成した。
       チームメンバーを手動で追加した
 - [ ] **ステップ 7** — Slack チャンネル `#otel-localization-LANG_ID` を作成した。
@@ -304,12 +320,14 @@ lang:LANG_ID:
 
 - **`npm run build`** — Hugo がエラーなしで新しい言語を認識することを確認します。
 - **`npm run check:spelling`** — cspell の設定が有効であり、新しい辞書エントリによってエラーが発生していないことを確認します。
+- **`npm run check:codeowners`** — CODEOWNERS のロケールセクションがレジストリと一致していることを確認します。
 - **GitHub ラベルの自動化** — `content/LANG_ID/` 配下のファイルに触れるテスト PR を作成し、`lang:LANG_ID` ラベルが自動的に付与されることを確認します。
 
 [`.cspell.yml`]: https://github.com/open-telemetry/opentelemetry.io/blob/main/.cspell.yml
 [`.prettierignore`]: https://github.com/open-telemetry/opentelemetry.io/blob/main/.prettierignore
 [`.github/component-label-map.yml`]: https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/component-label-map.yml
 [`.github/CODEOWNERS`]: https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/CODEOWNERS
+[`data/locale-teams.yaml`]: https://github.com/open-telemetry/opentelemetry.io/blob/main/data/locale-teams.yaml
 [`.github/component-owners.yml`]: https://github.com/open-telemetry/opentelemetry.io/blob/main/.github/component-owners.yml
 [`projects/localization.md`]: https://github.com/open-telemetry/opentelemetry.io/blob/main/projects/localization.md
 [`config/_default/module-template.yaml`]: https://github.com/open-telemetry/opentelemetry.io/blob/main/config/_default/module-template.yaml
@@ -317,5 +335,7 @@ lang:LANG_ID:
 [kickoff issue]: /docs/contributing/localization/#kickoff
 [New localizations]: /docs/contributing/localization/#new-localizations
 [Site localization]: /docs/contributing/localization/
+[`setup-new-localization` skill]: https://github.com/open-telemetry/opentelemetry.io/blob/main/.claude/skills/setup-new-localization/SKILL.md
+[unstaffed]: /docs/contributing/localization/#locale-teams
 [ISO 639-1]: https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
 [CNCF Slack workspace]: https://cloud-native.slack.com


### PR DESCRIPTION
## Summary

Updates two Japanese pages to match their latest English sources. Both refresh
`default_lang_commit` and drop the `drifted_from_default` flag.

- `content/ja/site/build/localization/_index.md` — sync with
  `content/en/site/build/localization/_index.md`.
- `content/ja/docs/contributing/localization.md` — sync with
  `content/en/docs/contributing/localization.md` (adds the `Teams and code owners`
  and `Locale teams, code owners, and staffing {#locale-teams}` sections from
  #10931).

The second file is required to keep **CHECK LINKS** green: the first page now
carries `[unstaffed]: /docs/contributing/localization/#locale-teams`, which
resolves to `/ja/docs/contributing/localization/#locale-teams`. That anchor did
not exist while the Japanese contributing page was still drifted, so lychee
reported `Cannot find fragment`. Translating the missing sections restores the
anchor.

Verified locally with `npm run check:links:internal`: 0 errors (the drifted-page
exclude count drops from 360 to 359, confirming the contributing page is now
checked).

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11655--opentelemetry.netlify.app/ja/site/build/localization/
- **English (canonical):** https://opentelemetry.io/site/build/localization/
- **Japanese (this PR):** https://deploy-preview-11655--opentelemetry.netlify.app/ja/docs/contributing/localization/
- **English (canonical):** https://opentelemetry.io/docs/contributing/localization/

<!-- preview-section-end -->

