### PR TITLE
[ja] add translation of content/en/announcements/kubecon-na.md

### DIFF
--- a/content/ja/announcements/kubecon-na.md
+++ b/content/ja/announcements/kubecon-na.md
@@ -1,0 +1,22 @@
+---
+title: KubeCon + CloudNativeCon North America 2026
+linkTitle: KubeCon NA 2026
+date: 2026-09-09
+expiryDate: 2026-11-12 # keep
+weight: 20261112
+params:
+  # CNCF's campaign parameters for this event, source adjusted for this site
+  utmParam: >-
+    utm_source=opentelemetry&utm_medium=ribbon-banner&utm_campaign=KubeCon-CloudNativeCon-NA-2026&utm_content=hero
+  eventUrl: &eventUrl >-
+    https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/
+  # Use this when the blog post is ready:
+  # blogPostURL: /blog/2026/kubecon-na/
+  blogPostURL: *eventUrl
+default_lang_commit: e40bcd417c14310cf8855f302d7fcb3673cf550c
+---
+
+[**{{% param title %}}**][LF] • <span class="text-nowrap">11月9日〜12日</span> • ソルトレイクシティ • [詳細][blog]
+
+[blog]: <{{% param blogPostURL %}}>
+[LF]: <{{% param eventUrl %}}register/?{{% _param utmParam %}}>


### PR DESCRIPTION
## Summary

Translates `content/en/announcements/kubecon-na.md` into Japanese as `content/ja/announcements/kubecon-na.md`.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

- **Japanese (this PR):** https://deploy-preview-11660--opentelemetry.netlify.app/ja/announcements/kubecon-na/
- **English (canonical):** https://opentelemetry.io/announcements/kubecon-na/

<!-- preview-section-end -->
