### PR TITLE
Describe the recommendation service after its Spring Boot rewrite

### DIFF
--- a/content/en/docs/demo/services/_index.md
+++ b/content/en/docs/demo/services/_index.md
@@ -26,6 +26,6 @@ To visualize request flows, see the [Service Diagram](../architecture/).
 | [payment](payment/)                   | JavaScript | Charges the given credit card info (mock/) with the given amount and returns a transaction ID.                                       |
 | [product-catalog](product-catalog/)   | Go         | Provides the list of products from a JSON file and ability to search products and get individual products.                           |
 | [quote](quote/)                       | PHP        | Calculates the shipping costs, based on the number of items to be shipped.                                                           |
-| [recommendation](recommendation/)     | Python     | Recommends other products based on what's given in the cart.                                                                         |
+| [recommendation](recommendation/)     | Java       | Recommends other products based on what's given in the cart.                                                                         |
 | [shipping](shipping/)                 | Rust       | Gives shipping cost estimates based on the shopping cart. Ships items to the given address (mock/).                                  |
 | [react-native-app](react-native-app/) | TypeScript | React Native mobile application that provides a UI on top of the shopping services.                                                  |

--- a/content/en/docs/demo/services/recommendation.md
+++ b/content/en/docs/demo/services/recommendation.md
@@ -12,10 +12,13 @@ based on existing product IDs the user is browsing.
 
 ## Instrumentation
 
-<!-- YOUR WORDS: Spring Boot 4 app, gRPC via Spring gRPC, telemetry via Micrometer
-and the spring-boot-starter-opentelemetry starter, no Java agent. Endpoints, resource
-attributes and service name come from the OTEL_* environment variables, which Spring Boot
-maps itself. Only telemetry setting in application.yaml is the sampling probability. -->
+This service is a Spring Boot 4 application that uses Spring gRPC for
+communication. Rather than using a standalone Java agent, the service produces
+its own traces, metrics and logs using Micrometer and the
+`spring-boot-starter-opentelemetry` starter. Endpoints, service names, and
+resource attributes come from the standard `OTEL_*` environment variables mapped
+by Spring Boot. The only telemetry setting in `application.yaml` is the sampling
+probability.
 
 ```yaml
 management:
@@ -28,14 +31,16 @@ management:
 
 ### gRPC spans
 
-<!-- YOUR WORDS: Spring gRPC registers Micrometer observation interceptors on the server
-and on every client channel, so the ListRecommendations server span and the ListProducts
-client span exist without code, with W3C trace context propagated. -->
+Spring gRPC registers Micrometer observation interceptors on the server and on
+every client channel. Because of this, the `ListRecommendations` server span and
+the `ListProducts` client span exist without any custom code, with W3C trace
+context propagated automatically.
 
 ### Add attributes to the current span
 
-<!-- YOUR WORDS: the current span comes from the Micrometer Tracing Tracer; tag keeps the
-value type; done in listRecommendations for the server span. -->
+To add attributes to the current span, it is retrieved from the Micrometer
+Tracing `Tracer`. A tag keeps the value type. This is done inside
+`listRecommendations` for the server span.
 
 ```java
 Span span = tracer.currentSpan();
@@ -46,9 +51,11 @@ if (span != null) {
 
 ### Create new spans
 
-<!-- YOUR WORDS: tracer.nextSpan() plus tracer.withSpan(span) for get_product_list, ended
-in a finally block. Micrometer spans only take scalar tags, so the one array attribute
-(demo.product.filtered.list) is set through the OpenTelemetry API on the same span. -->
+Custom spans are generated using `tracer.nextSpan()` and scoped using
+`tracer.withSpan(span)` for the `get_product_list` operation, which ends in a
+`finally` block. Because Micrometer spans only take scalar tags, the array
+attribute `demo.product.filtered.list` is set through the OpenTelemetry API on
+the same span.
 
 ```java
 Span span = tracer.nextSpan().name("get_product_list").start();
@@ -70,8 +77,9 @@ io.opentelemetry.api.trace.Span.current().setAttribute(FILTERED_LIST, recommende
 
 ### Custom metrics
 
-<!-- YOUR WORDS: a Micrometer Counter on the auto-configured MeterRegistry; the OTLP
-registry keeps the dotted name, so it arrives as demo.recommendation.requests. -->
+Custom application metrics use a Micrometer `Counter` on the auto-configured
+`MeterRegistry`. The OTLP registry keeps the dotted name, so it arrives as
+`demo.recommendation.requests`.
 
 ```java
 Counter.builder("demo.recommendation.requests")
@@ -83,15 +91,16 @@ Counter.builder("demo.recommendation.requests")
 
 ### Auto-instrumented metrics
 
-<!-- YOUR WORDS: Spring Boot's Micrometer auto-configuration binds the JVM and system
-meters (memory, GC, threads, CPU), exported next to the counter; they show the memory
-growth when the recommendationCacheFailure flag is on. -->
+Spring Boot's Micrometer auto-configuration automatically binds JVM and system
+meters for memory, GC, threads, and CPU. These are exported next to the counter,
+and they show memory growth when the `recommendationCacheFailure` flag is on.
 
 ## Logs
 
-<!-- YOUR WORDS: Logback; console keeps Spring Boot's default pattern with trace and span
-ids; the OpenTelemetry Logback appender exports the same records over OTLP; the appender is
-connected to the auto-configured OpenTelemetry instance once at startup. -->
+Logging goes through Logback. The console keeps Spring Boot's default pattern
+with trace and span IDs, while the OpenTelemetry Logback appender exports the
+same records over OTLP. The appender connects to the auto-configured
+OpenTelemetry instance once at startup.
 
 ```java
 @Component

--- a/content/en/docs/demo/services/recommendation.md
+++ b/content/en/docs/demo/services/recommendation.md
@@ -2,7 +2,7 @@
 title: Recommendation Service
 linkTitle: Recommendation
 aliases: [recommendationservice]
-cSpell:ignore: cpython instrumentor NOTSET
+cSpell:ignore: Logback Micrometer
 ---
 
 This service is responsible to get a list of recommended products for the user
@@ -10,130 +10,96 @@ based on existing product IDs the user is browsing.
 
 [Recommendation service source](https://github.com/open-telemetry/opentelemetry-demo/blob/main/src/recommendation/)
 
-## Auto-instrumentation
+## Instrumentation
 
-This Python based service, makes use of the OpenTelemetry auto-instrumentor for
-Python, accomplished by leveraging the `opentelemetry-instrument` Python wrapper
-to run the scripts. This can be done in the `ENTRYPOINT` command for the
-service's `Dockerfile`.
+<!-- YOUR WORDS: Spring Boot 4 app, gRPC via Spring gRPC, telemetry via Micrometer
+and the spring-boot-starter-opentelemetry starter, no Java agent. Endpoints, resource
+attributes and service name come from the OTEL_* environment variables, which Spring Boot
+maps itself. Only telemetry setting in application.yaml is the sampling probability. -->
 
-```dockerfile
-ENTRYPOINT [ "opentelemetry-instrument", "python", "recommendation_server.py" ]
+```yaml
+management:
+  tracing:
+    sampling:
+      probability: 1.0
 ```
 
 ## Traces
 
-### Initializing Tracing
+### gRPC spans
 
-The OpenTelemetry SDK is initialized in the `__main__` code block. This code
-will create a tracer provider, and establish a Span Processor to use. Export
-endpoints, resource attributes, and service name are automatically set by the
-OpenTelemetry auto instrumentor based on environment variables.
+<!-- YOUR WORDS: Spring gRPC registers Micrometer observation interceptors on the server
+and on every client channel, so the ListRecommendations server span and the ListProducts
+client span exist without code, with W3C trace context propagated. -->
 
-```python
-tracer = trace.get_tracer_provider().get_tracer("recommendation")
-```
+### Add attributes to the current span
 
-### Add attributes to auto-instrumented spans
+<!-- YOUR WORDS: the current span comes from the Micrometer Tracing Tracer; tag keeps the
+value type; done in listRecommendations for the server span. -->
 
-Within the execution of auto-instrumented code you can get current span from
-context.
-
-```python
-span = trace.get_current_span()
-```
-
-Adding attributes to a span is accomplished using `set_attribute` on the span
-object. In the `ListRecommendations` function an attribute is added to the span.
-
-```python
-span.set_attribute("app.products_recommended.count", len(prod_list))
+```java
+Span span = tracer.currentSpan();
+if (span != null) {
+  span.tag("demo.product.recommended.count", productIds.size());
+}
 ```
 
 ### Create new spans
 
-New spans can be created and placed into active context using
-`start_as_current_span` from an OpenTelemetry Tracer object. When used in
-conjunction with a `with` block, the span will automatically be ended when the
-block ends execution. This is done in the `get_product_list` function.
+<!-- YOUR WORDS: tracer.nextSpan() plus tracer.withSpan(span) for get_product_list, ended
+in a finally block. Micrometer spans only take scalar tags, so the one array attribute
+(demo.product.filtered.list) is set through the OpenTelemetry API on the same span. -->
 
-```python
-with tracer.start_as_current_span("get_product_list") as span:
+```java
+Span span = tracer.nextSpan().name("get_product_list").start();
+try (Tracer.SpanInScope ignored = tracer.withSpan(span)) {
+  ...
+} catch (RuntimeException e) {
+  span.error(e);
+  throw e;
+} finally {
+  span.end();
+}
+```
+
+```java
+io.opentelemetry.api.trace.Span.current().setAttribute(FILTERED_LIST, recommended);
 ```
 
 ## Metrics
 
-### Initializing Metrics
-
-The OpenTelemetry SDK is initialized in the `__main__` code block. This code
-will create a meter provider. Export endpoints, resource attributes, and service
-name are automatically set by the OpenTelemetry auto instrumentor based on
-environment variables.
-
-```python
-meter = metrics.get_meter_provider().get_meter("recommendation")
-```
-
 ### Custom metrics
 
-The following custom metrics are currently available:
+<!-- YOUR WORDS: a Micrometer Counter on the auto-configured MeterRegistry; the OTLP
+registry keeps the dotted name, so it arrives as demo.recommendation.requests. -->
 
-- `app_recommendations_counter`: Cumulative count of # recommended products per
-  service call
+```java
+Counter.builder("demo.recommendation.requests")
+    .description("Counts the total number of given recommendations")
+    .baseUnit("{recommendation}")
+    .tag("recommendation.type", "catalog")
+    .register(meterRegistry);
+```
 
 ### Auto-instrumented metrics
 
-The following metrics are available through auto-instrumentation, courtesy of
-the `opentelemetry-instrumentation-system-metrics`, which is installed as part
-of `opentelemetry-bootstrap` on building the recommendation service Docker
-image:
-
-- `runtime.cpython.cpu_time`
-- `runtime.cpython.memory`
-- `runtime.cpython.gc_count`
+<!-- YOUR WORDS: Spring Boot's Micrometer auto-configuration binds the JVM and system
+meters (memory, GC, threads, CPU), exported next to the counter; they show the memory
+growth when the recommendationCacheFailure flag is on. -->
 
 ## Logs
 
-### Initializing logs
+<!-- YOUR WORDS: Logback; console keeps Spring Boot's default pattern with trace and span
+ids; the OpenTelemetry Logback appender exports the same records over OTLP; the appender is
+connected to the auto-configured OpenTelemetry instance once at startup. -->
 
-The OpenTelemetry SDK is initialized in the `__main__` code block. The following
-code creates a logger provider with a batch processor, an OTLP log exporter, and
-a logging handler. Finally, it creates a logger for use throughout the
-application.
-
-```python
-logger_provider = LoggerProvider(
-    resource=Resource.create(
-        {
-            'service.name': service_name,
-        }
-    ),
-)
-set_logger_provider(logger_provider)
-log_exporter = OTLPLogExporter(insecure=True)
-logger_provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter))
-handler = LoggingHandler(level=logging.NOTSET, logger_provider=logger_provider)
-
-logger = logging.getLogger('main')
-logger.addHandler(handler)
+```java
+@Component
+class OpenTelemetryAppenderInitializer implements InitializingBean {
+  ...
+  @Override
+  public void afterPropertiesSet() {
+    OpenTelemetryAppender.install(this.openTelemetry);
+  }
+}
 ```
-
-### Create log records
-
-Create logs using the logger. Examples can be found in `ListRecommendations` and
-`get_product_list` functions.
-
-```python
-logger.info(f"Receive ListRecommendations for product ids:{prod_list}")
-```
-
-As you can see, after the initialization, log records can be created in the same
-way as in standard Python. OpenTelemetry libraries automatically add a trace ID
-and span ID for each log record and, in this way, enable correlating logs and
-traces.
-
-### Notes
-
-Logs for Python are still experimental, and some changes can be expected. The
-implementation in this service follows the
-[Python log example](https://github.com/open-telemetry/opentelemetry-python/blob/stable/docs/examples/logs/example.py).


### PR DESCRIPTION
I am updating the Recommendation service page because I am rewriting the service in Java on Spring Boot 4 to replace the old Python version. Instead of relying on the Java agent the other Java services use to generate telemetry, this new version produces its own traces, metrics, and logs natively using Micrometer and the Spring Boot OpenTelemetry starter, while the main services table changes the language row from Python to Java. 

I am making this move to resolve an open issue and am tracking the code rewrite over in a pull request. Please keep this change as a draft for now, since we shouldn't publish the updated page until a live demo release actually ships with the Java service, after which we can also push through the companion update for the helm charts.

- Issue: https://github.com/open-telemetry/opentelemetry-demo/issues/1368
- Rewrite PR: https://github.com/open-telemetry/opentelemetry-demo/pull/3966
- Helm chart companion: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/2398

References:
- https://spring.io/blog/2025/11/18/opentelemetry-with-spring-boot
- https://docs.spring.io/spring-grpc/reference/
- https://docs.micrometer.io/tracing/reference/

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
- [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.
