### PR TITLE
fix: correct memory_delimiter typo in English doc `content/en/docs/demo/collector-data-flow-dashboard/index.md`

### DIFF
--- a/content/en/docs/demo/collector-data-flow-dashboard/index.md
+++ b/content/en/docs/demo/collector-data-flow-dashboard/index.md
@@ -11,7 +11,7 @@ capabilities of the OpenTelemetry demo application, offering a solid foundation
 for users to build upon. Collector Data Flow Dashboard provides valuable
 guidance on which metrics to monitor. Users can tailor their own dashboard
 variations by adding necessary metrics specific to their use cases, such as
-memory_delimiter processor or other data flow indicators. This demo dashboard
+memory_limiter processor or other data flow indicators. This demo dashboard
 serves as a starting point, enabling users to explore diverse usage scenarios
 and adapt the tool to their unique monitoring needs.
 
@@ -37,7 +37,7 @@ associated with these metrics is "otelcol," and the job name is labeled as
 Labels serve as a valuable tool for identifying specific metric sets (such as
 exporter, receiver, or job), enabling differentiation among metric sets within
 the overall namespace. It is important to note that you will only encounter
-refused metrics if the memory limits, as defined in the memory delimiter
+refused metrics if the memory limits, as defined in the memory_limiter
 processor, are exceeded.
 
 ### Ingress Traces Pipeline


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

## Summary

### Motivation

The English doc for the Collector Data Flow Dashboard references a `memory_delimiter` processor, which does not exist in the OpenTelemetry` Collector. 
The correct component name is `memory_limiter`, as already used correctly elsewhere in this repo (e.g. `content/en/docs/demo/sample-configurations/tail-sampling-service-criticality.md`).
This typo also propagated into localized translations (e.g. ja), so fixing it in the base (en) doc first allows the translations to be corrected downstream.

### What I have done

- Corrected two occurrences like

```diff
- memory_delimiter / "memory delimiter"
+ memory_limiter
```

### Test Plans

N/A