### PR TITLE
fix typo in document `content/en/docs/platforms/kubernetes/getting-started.md`

### DIFF
--- a/content/ja/docs/platforms/kubernetes/getting-started.md
+++ b/content/ja/docs/platforms/kubernetes/getting-started.md
@@ -72,7 +72,7 @@ Kubernetesのテレメトリーを収集する最初のステップは、ノー�
 要件ではないですが、ノード上で実行されているアプリケーションが、そのトレース、メトリクス、ログを同じノード上で実行されているコレクターに送信することは一般的なプラクティスです。
 これにより、ネットワークの相互作用がシンプルに保たれ、`k8sattributes` プロセッサーを使用してKubernetesのメタデータを簡単に相関させることができます。
 
-### Kubernetes属性プロセッサー (Kubernetes Atributes Processor) {#kubernetes-attributes-processor}
+### Kubernetes属性プロセッサー (Kubernetes Attributes Processor) {#kubernetes-attributes-processor}
 
 [Kubernetes属性プロセッサー](/docs/platforms/kubernetes/collector/components/#kubernetes-attributes-processor)は、Kubernetesポッドからテレメトリーを受信するコレクターで強く推奨されるコンポーネントです。
 このプロセッサーは、Kubernetesポッドを自動的に検出し、ポッド名やノード名などのメタデータを抽出し、抽出したメタデータをリソース属性としてスパン、メトリクス、ログに追加します。


### PR DESCRIPTION
<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

## Summary

### Motivation

The Japanese Kubernetes getting-started page has a misspelling in the English term shown in parentheses: "Kubernetes Atributes Processor" is missing a "t". 
Through the English source (`content/en/docs/platforms/kubernetes/getting-started.md`) correctly reads "Kubernetes Attributes Processor".

### What I have done

fix typo like:

```diff
- Kubernetes Atributes Processor
+Kubernetes Attributes Processor
```

### Test Plans

N/A