### PR TITLE
[chore] Update Oodle URL in vendors.yaml

### DIFF
--- a/data/ecosystem/vendors.yaml
+++ b/data/ecosystem/vendors.yaml
@@ -621,7 +621,7 @@
   contact: owen@velodb.io
 - name: Oodle AI
   nativeOTLP: true
-  url: https://docs.oodle.ai/integrations/metrics/otel/
+  url: https://docs.oodle.ai/integrations/opentelemetry/
   contact: support@oodle.ai
   oss: false
   commercial: true


### PR DESCRIPTION
- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

The Oodle entry links to a page that only covers OTLP metrics. Oodle accepts OTLP for metrics, logs, traces and GenAI spans, and now has a page that documents native OTLP ingestion for all of them on one endpoint: https://docs.oodle.ai/integrations/opentelemetry/

This updates the entry to point at that page, same as #11287 did for Splunk.