### PR TITLE
docs(go): add trace instrumentation testing guide

### DIFF
--- a/content/en/docs/languages/go/testing.md
+++ b/content/en/docs/languages/go/testing.md
@@ -15,7 +15,7 @@ Use the `tracetest` package to capture spans in memory during tests.
 
 Ensure you have the right packages installed:
 
-```bash
+```sh
 go get go.opentelemetry.io/otel/sdk/trace \
   go.opentelemetry.io/otel/sdk/trace/tracetest
 ```

--- a/content/en/docs/languages/go/testing.md
+++ b/content/en/docs/languages/go/testing.md
@@ -1,0 +1,64 @@
+---
+title: Testing Instrumentation
+weight: 35
+description: How to test OpenTelemetry Go instrumentation
+---
+
+When instrumenting a library or application, it is important to verify
+that your instrumentation works as expected without needing a real backend
+such as Jaeger or Prometheus. OpenTelemetry Go provides testing helper
+packages for this purpose.
+
+## Traces
+
+Use the `tracetest` package to capture spans in memory during tests.
+
+Ensure you have the right packages installed:
+
+```bash
+go get go.opentelemetry.io/otel/sdk/trace \
+  go.opentelemetry.io/otel/sdk/trace/tracetest
+```
+
+The `SpanRecorder` acts as a `SpanProcessor` that records all started
+and ended spans in memory. You can then assert on those spans in your
+test.
+
+```go
+package yourpackage_test
+
+import (
+    "context"
+    "testing"
+
+    sdktrace "go.opentelemetry.io/otel/sdk/trace"
+    "go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestSpanRecorder(t *testing.T) {
+    ctx := context.Background()
+
+    // Set up an in-memory span recorder and tracer provider.
+    sr := tracetest.NewSpanRecorder()
+    tp := sdktrace.NewTracerProvider(
+        sdktrace.WithSpanProcessor(sr),
+    )
+    defer tp.Shutdown(ctx)
+
+    tracer := tp.Tracer("example/simple")
+
+    // Start and end a span.
+    _, span := tracer.Start(ctx, "test-span")
+    span.End()
+
+    // Assert on the recorded spans.
+    spans := sr.Ended()
+    if len(spans) != 1 {
+        t.Fatalf("expected 1 span, got %d", len(spans))
+    }
+    if spans[0].Name() != "test-span" {
+        t.Errorf("expected span name 'test-span', got %s",
+            spans[0].Name())
+    }
+}
+```


### PR DESCRIPTION
## Description
this PR adds the new `testing.md` page which have the steps and instructions on how to test trace instrumentation using [trace.SpanRecorder](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/trace/tracetest#SpanRecorder)

this PR fixes the subpart(tracer) of the issue #6899. Will raise the follow-up PR for the metrics and logs




<!-- MAINTAINER NOTE: each list item should be on a single line. -->

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]


[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

