### PR TITLE
Document how to set trace state and trace flags in Python

### DIFF
--- a/content/en/docs/languages/python/cookbook.md
+++ b/content/en/docs/languages/python/cookbook.md
@@ -126,6 +126,174 @@ finally:
     context.detach(token)
 ```
 
+## Setting trace state and trace flags
+
+The [trace state](https://www.w3.org/TR/trace-context/#tracestate-header) of a
+span, which carries the vendor-specific `tracestate` header of
+[W3C Trace Context](https://www.w3.org/TR/trace-context/), and its
+[trace flags](https://www.w3.org/TR/trace-context/#trace-flags) are not
+parameters of `start_span` or `start_as_current_span`. They are results of
+starting a span, not inputs to it, so there are only two ways to set them:
+inherit them from a valid parent span context, or have a sampler produce them.
+
+A common mistake is to build a `Context` out of a plain dictionary of trace
+fields. That does not work, because a `Context` is an opaque key-value mapping
+whose keys are generated at run time rather than a record with `trace_id` and
+`span_id` fields. Writing those names into it stores values that nothing reads,
+and the span is started as a root span with an empty trace state.
+
+### Inheriting trace state from a parent
+
+To start a span under a parent that carries a trace state, wrap the parent span
+context in a `NonRecordingSpan` and set it in a `Context`, as in
+[Manually setting span context](#manually-setting-span-context):
+
+```python
+from opentelemetry import trace
+from opentelemetry.context import Context
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags, TraceState
+from opentelemetry.sdk.trace import TracerProvider
+
+trace.set_tracer_provider(TracerProvider())
+tracer: trace.Tracer = trace.get_tracer("my.tracer")
+
+# The trace and span IDs must be valid, that is, non-zero. A span context built
+# from all-zero IDs is not valid, so the SDK ignores it, starts a root span and
+# discards the trace state without raising an error.
+parent_span_context: SpanContext = SpanContext(
+    trace_id=0x0AF7651916CD43DD8448EB211C80319C,
+    span_id=0x00F067AA0BA902B7,
+    is_remote=True,
+    trace_flags=TraceFlags(TraceFlags.SAMPLED),
+    trace_state=TraceState([("vendor_key", "vendor_value")]),
+)
+ctx: Context = trace.set_span_in_context(NonRecordingSpan(parent_span_context))
+
+with tracer.start_as_current_span("child", context=ctx) as span:
+    # Prints: vendor_key=vendor_value
+    print(span.get_span_context().trace_state.to_header())
+```
+
+Usually you do not build the parent span context by hand. A propagator does it
+for you when it extracts the `traceparent` and `tracestate` headers of an
+incoming request, as described in [Propagation](../propagation/).
+
+### Adding an entry to a trace state
+
+A `TraceState` is immutable, so `add`, `update` and `delete` return a new
+instance instead of modifying the original. To contribute your own entry to an
+incoming trace state, build a new span context from the one you received:
+
+```python
+from opentelemetry import trace
+from opentelemetry.context import Context
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceState
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+from opentelemetry.sdk.trace import TracerProvider
+
+trace.set_tracer_provider(TracerProvider())
+tracer: trace.Tracer = trace.get_tracer("my.tracer")
+
+carrier: dict[str, str] = {
+    "traceparent": "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01",
+    "tracestate": "vendor_key=vendor_value",
+}
+incoming_ctx: Context = TraceContextTextMapPropagator().extract(carrier=carrier)
+incoming: SpanContext = trace.get_current_span(incoming_ctx).get_span_context()
+
+updated_trace_state: TraceState = incoming.trace_state.add("my_key", "my_value")
+
+updated_span_context: SpanContext = SpanContext(
+    trace_id=incoming.trace_id,
+    span_id=incoming.span_id,
+    is_remote=incoming.is_remote,
+    trace_flags=incoming.trace_flags,
+    trace_state=updated_trace_state,
+)
+updated_ctx: Context = trace.set_span_in_context(NonRecordingSpan(updated_span_context))
+
+with tracer.start_as_current_span("child", context=updated_ctx) as span:
+    # Prints: my_key=my_value,vendor_key=vendor_value
+    print(span.get_span_context().trace_state.to_header())
+```
+
+New entries are placed first, as the W3C Trace Context specification requires.
+
+### Setting trace state on a root span
+
+A root span has no parent to inherit from, so the only way to give it a trace
+state is a sampler: the SDK takes the trace state of every new span from the
+`SamplingResult` that the sampler returns. Wrap the sampler you already use so
+that it keeps its sampling decision and only supplies a trace state when there
+is none:
+
+```python
+from collections.abc import Sequence
+
+from opentelemetry import trace
+from opentelemetry.context import Context
+from opentelemetry.trace import Link, SpanKind, TraceState
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.sampling import ALWAYS_ON, ParentBased, Sampler, SamplingResult
+from opentelemetry.util.types import Attributes
+
+
+class TraceStateSeedingSampler(Sampler):
+    """Delegates the sampling decision and seeds a trace state onto root spans."""
+
+    def __init__(self, delegate: Sampler, seed: TraceState) -> None:
+        self._delegate: Sampler = delegate
+        self._seed: TraceState = seed
+
+    def should_sample(
+        self,
+        parent_context: Context | None,
+        trace_id: int,
+        name: str,
+        kind: SpanKind | None = None,
+        attributes: Attributes = None,
+        links: Sequence[Link] | None = None,
+        trace_state: TraceState | None = None,
+    ) -> SamplingResult:
+        result: SamplingResult = self._delegate.should_sample(
+            parent_context, trace_id, name, kind, attributes, links, trace_state
+        )
+        if result.trace_state:
+            return result
+        return SamplingResult(result.decision, result.attributes, self._seed)
+
+    def get_description(self) -> str:
+        return f"TraceStateSeedingSampler{{{self._delegate.get_description()}}}"
+
+
+# Only the root sampler is wrapped, so spans that do have a parent keep
+# inheriting the trace state of that parent.
+provider: TracerProvider = TracerProvider(
+    sampler=ParentBased(
+        root=TraceStateSeedingSampler(ALWAYS_ON, TraceState([("vendor_key", "vendor_value")]))
+    )
+)
+tracer: trace.Tracer = provider.get_tracer("my.tracer")
+
+with tracer.start_as_current_span("root") as span:
+    # Prints: vendor_key=vendor_value
+    print(span.get_span_context().trace_state.to_header())
+```
+
+### Trace flags
+
+You cannot set the `sampled` bit of a span you create. The SDK derives it from
+the sampling decision: a span is marked as sampled if, and only if, the sampler
+returns a sampling decision that records and samples it.
+
+This means you control trace flags by choosing a sampler. The default sampler,
+`ParentBased(root=ALWAYS_ON)`, honors the decision of a remote parent, so a
+parent span context created with `TraceFlags(TraceFlags.SAMPLED)` as shown above
+produces a sampled, recording child, and one created with
+`TraceFlags(TraceFlags.DEFAULT)` produces a child that is neither. In both cases
+the trace state is inherited, because inheriting a trace state does not depend
+on the sampling decision.
+
 ## Using multiple tracer providers with different Resource
 
 ```python

--- a/content/en/docs/languages/python/propagation.md
+++ b/content/en/docs/languages/python/propagation.md
@@ -88,12 +88,14 @@ def hello():
     # Example: Log headers received in the request in API 2
     headers = dict(request.headers)
     print(f"Received headers: {headers}")
-    carrier ={'traceparent': headers['Traceparent']}
+    # Propagators look up lowercase header names, so normalize the keys and
+    # hand over the whole carrier. Picking out single headers would silently
+    # drop the incoming tracestate.
+    carrier = {key.lower(): value for key, value in headers.items()}
     ctx = TraceContextTextMapPropagator().extract(carrier=carrier)
     print(f"Received context: {ctx}")
 
-    b2 ={'baggage': headers['Baggage']}
-    ctx2 = W3CBaggagePropagator().extract(b2, context=ctx)
+    ctx2 = W3CBaggagePropagator().extract(carrier, context=ctx)
     print(f"Received context2: {ctx2}")
 
     # Start a new span


### PR DESCRIPTION
Fixes #11470

- [ ] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [ ] This PR has content that I did not fully write myself.
  - [ ] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [ ] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

The reporter of #11470 spent about a day trying to set a `trace_state` and
`trace_flags` on a Python span and could not find any guidance. The Python docs
never mention `tracestate` outside of empty console output, so there was nothing
to find.

The underlying source of confusion is that `trace_state` and `trace_flags` are
not parameters of `start_span` or `start_as_current_span`. They are results of
starting a span. The SDK takes the trace state of a new span from the
`SamplingResult` the sampler returns, and it derives the `sampled` bit from the
sampling decision. So there are only two ways in: inherit from a valid parent
span context, or have a sampler produce it.

Two details make the failure hard to diagnose, because neither raises an error:

- A `Context` is an opaque key-value mapping whose keys are generated at run
  time, not a record with `trace_id` and `span_id` fields. Building one from a
  plain dictionary of trace fields stores values that nothing reads, so the span
  starts as a root span with an empty trace state.
- A span context built from all-zero IDs is not valid, so the SDK discards it
  and starts a root span, dropping the trace state along with it. These are
  exactly the values named `INVALID_TRACE_ID` and `INVALID_SPAN_ID`.

## Changes

Add a **Setting trace state and trace flags** section to the Python cookbook,
covering the three cases a reader can hit, plus trace flags:

- inheriting a trace state from a valid parent span context
- adding an entry to an incoming trace state, since `TraceState` is immutable
  and `add`, `update` and `delete` return a new instance
- seeding a trace state onto a root span through a sampler, which is the only
  way in when there is no parent to inherit from
- why the `sampled` bit cannot be set on a span directly, and how `ParentBased`
  makes a remote parent's decision carry over

Also fix the receiving-service example in the Python propagation page. It built
its carrier as `{'traceparent': headers['Traceparent']}`, which silently
discarded any incoming `tracestate` before extraction, and extracted baggage
from a second one-key carrier for the same reason. Propagators look up lowercase
header names, which is why the original code could not pass
`dict(request.headers)` straight through, so the keys are now normalized to
lowercase and the whole carrier is handed to both propagators.

## Validation

Each Python example was extracted from the rendered markdown and run as a
standalone script. All of them execute as written and print the output their
comments claim. `check:format`, `check:spelling`, `check:markdown` and
`check:text` pass on both changed files.
