### PR TITLE
fix(registry): wrap long titles on mobile

### DIFF
--- a/assets/scss/_registry.scss
+++ b/assets/scss/_registry.scss
@@ -12,6 +12,14 @@
       margin-bottom: 0.2rem;
     }
 
+    // Long package paths must be able to shrink within the card instead of
+    // widening the viewport on narrow screens.
+    .card-title > a {
+      min-width: 0;
+      max-width: 100%;
+      overflow-wrap: anywhere;
+    }
+
     &-body {
       flex: 1;
     }


### PR DESCRIPTION
- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
  - used codex with pr development
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

## Summary

Constrains registry-title links so long package paths wrap within their cards on narrow viewports instead of widening the page.

Fixes #5588

## Validation

- `npm run build:lean`
- `npm run check:format`
- Manually served the production build and checked every registry card in headless Chrome at 320, 375, 575, 576, 768, and 1440px. All title links, headings, and badges remained inside their cards; the originally overflowing title fits at both mobile widths.
