### PR TITLE
fix(semconv): render Shields badges inline

### DIFF
--- a/assets/scss/_docsy.scss
+++ b/assets/scss/_docsy.scss
@@ -1,6 +1,6 @@
 // Docsy style customization and overrides
 
-.td-content img:not(.img-initial) {
+.td-content img:not(.img-initial):not([src*='img.shields.io']) {
   display: block;
   border: $border-width solid $border-color;
   margin-bottom: $paragraph-margin-bottom;


### PR DESCRIPTION
- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
  - used codex with pr development
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

## Summary

Exempts Shields.io badges from the global documentation-image treatment so generated semantic-convention badges render inline, borderless, and without image margins.

Fixes #8288

## Validation

- `npm run check:format`
- `npm run build:lean`
- `npm run check:markdown`
- `npm run check:spelling`
- Manually served the build in headless Chrome at 320px and 1440px. All eight affected badges rendered inline with no border or bottom margin, while a normal documentation image retained its block, border, and margin styling.
- `npm run check` reaches the repository's i18n-history check but cannot complete in this shallow checkout because its required historical `default_lang_commit` objects are unavailable; this is unrelated to the one-line CSS change.
