### PR TITLE
fix(benchmarks): scope main styles

### DIFF
--- a/static/css/benchmarks.css
+++ b/static/css/benchmarks.css
@@ -1,4 +1,4 @@
-main {
+#main {
   margin: 8px;
   width: 100%;
   display: flex;


### PR DESCRIPTION
- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
  - used codex with pr development
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

---

## Summary

Scopes benchmark-page styles to the chart wrapper instead of every document `main` element. This prevents the sidebar and content from wrapping at medium widths and prevents horizontal overflow on narrow screens.

Fixes #3760

## Validation

- `npm run build:lean`
- `npm run check:format`
- `npm run test:public` (8/8)
- Manually served the production build in headless Chrome at 320, 394, 575, 576, 767, 768, 792, 793, and 1440px. The 793px content now remains beside the sidebar, every chart stays within the benchmark wrapper, and desktop page width is no longer enlarged by the global `main` rule.
