### PR TITLE
[ja] add translation of content/en/docs/platforms/linux/

### DIFF
--- a/content/ja/docs/platforms/linux/_index.md
+++ b/content/ja/docs/platforms/linux/_index.md
@@ -1,0 +1,59 @@
+---
+title: Linux ホスト上の OpenTelemetry
+linkTitle: Linux
+description: OpenTelemetry をシステムパッケージとしてインストールし、Linux
+  ホスト上で動作するアプリケーションを自動的に計装します。
+weight: 250
+default_lang_commit: 6fa8e87cacb431b31061635fcddb55990e80538a
+---
+
+OpenTelemetry のセットアップは通常、アプリケーションの実行環境に依存します。
+OpenTelemetry Operator のおかげで高度に自動化されている [Kubernetes](/docs/platforms/kubernetes/) や、OpenTelemetry Lambda レイヤーを備えた [Functions as a Service](/docs/platforms/faas/) のような環境もあります。
+しかし、多くの Java、.NET、Node.js、Python アプリケーションは Linux ホスト上で直接動作しており、これらの計装にはエージェントを手動でダウンロードし、環境変数を自分で設定する必要がありました。
+
+[OpenTelemetry Packaging SIG](https://github.com/open-telemetry/opentelemetry-packaging) は、OpenTelemetry をホスト自体の依存関係にする**システムパッケージ**を提供しています。
+パッケージを1つインストールしてアプリケーションを再起動するだけで、ホスト上の Java、.NET、Node.js、Python プロセスが自動的に計装され、テレメトリーの送信を開始します。
+
+## 仕組み {#how-it-works}
+
+`opentelemetry` パッケージは、以下に依存するメタパッケージです。
+
+- [OpenTelemetry Injector](https://github.com/open-telemetry/opentelemetry-injector)。
+  プロセスの起動時にサポートされているランタイムが対応する自動計装を読み込むよう、ダイナミックリンカーを設定します。
+- Java、.NET、Node.js、Python 向けの言語固有の自動計装パッケージ。
+
+インストール後、インジェクターはホスト上で新たに起動された、動的リンクされたすべてのプロセスにアタッチします。
+サポートされているランタイムのプロセスにのみ作用し、対応する自動計装を読み込みます。
+OpenTelemetry SDK がないランタイムのプロセスには影響しません。
+すでに実行中のアプリケーションは、再起動後に計装されます。
+デフォルトでは、テレメトリーは OTLP を使用して `localhost` のポート `4317`（gRPC）および `4318`（HTTP）にエクスポートされるため、通常はローカルの [OpenTelemetry Collector](/docs/collector/) を実行してテレメトリーを受信し、転送します。
+Collector 自体は [OpenTelemetry Collector Releases](https://github.com/open-telemetry/opentelemetry-collector-releases) プロジェクトによってシステムパッケージとして配布されています。
+このシステムパッケージリポジトリへの統合は [opentelemetry-collector-releases#1561](https://github.com/open-telemetry/opentelemetry-collector-releases/issues/1561) で追跡されています。
+
+Packaging SIG と OBI SIG は、[OpenTelemetry eBPF Instrumentation](/docs/zero-code/obi/) もシステムパッケージとして提供し、Go、Rust、C++ などの追加ランタイムにゼロコード計装を拡張する予定です。
+
+## はじめに {#get-started}
+
+- [インストール](installation/)：リポジトリを追加し、Debian、Ubuntu、Fedora、または RHEL とその派生ディストリビューションにパッケージをインストールします。
+- [設定](configuration/)：インジェクターが Collector またはバックエンドを参照するよう設定し、計装対象を調整します。
+
+## ステータスと制限事項 {#status-and-limitations}
+
+> [!WARNING]
+>
+> システムパッケージはまだ初期段階にあり、**本番ワークロードでの使用は想定されていません**。
+> パッケージングの成熟に伴い、変更が発生する可能性があります。
+>
+> 具体的には以下のとおりです。
+>
+> - APT および YUM リポジトリは現在 GitHub Pages 上でホストされていますが、これは**最終的な提供場所ではありません**。
+> - パッケージは**まだ署名されていない**ため、インストール手順では署名検証を無効にしています。
+> - [OpenTelemetry Collector](/docs/collector/) はまだベースのメタパッケージに含まれていないため、現時点では別途インストールして実行する必要があります。
+>
+> Packaging SIG はエンドユーザーからのフィードバックを積極的に求めています。
+> パッケージを試して、[opentelemetry-packaging](https://github.com/open-telemetry/opentelemetry-packaging) リポジトリにイシューを報告してください。
+
+## さらに詳しく {#learn-more}
+
+- ブログ記事：[One-command OpenTelemetry setup on Linux hosts](/blog/2026/packaging-first-repo/)
+- [opentelemetry-packaging](https://github.com/open-telemetry/opentelemetry-packaging) リポジトリと毎週開催される SIG ミーティング。

--- a/content/ja/docs/platforms/linux/configuration.md
+++ b/content/ja/docs/platforms/linux/configuration.md
@@ -1,0 +1,58 @@
+---
+title: 設定
+weight: 20
+description: OpenTelemetry Injector の参照先を Collector
+  またはバックエンドに変更し、Linux ホスト上で計装する対象を制御します。
+default_lang_commit: 6fa8e87cacb431b31061635fcddb55990e80538a
+---
+
+システムパッケージの[インストール](../installation/)後、[OpenTelemetry Injector](https://github.com/open-telemetry/opentelemetry-injector) はサポートされているアプリケーションを計装し、デフォルトで OTLP を使用してテレメトリーを `localhost` のポート `4317`（gRPC）および `4318`（HTTP）にエクスポートします。
+このページでは、テレメトリーの送信先の変更方法と、注入される設定の調整方法について説明します。
+
+## エクスポート先の設定 {#set-the-export-destination}
+
+推奨されるセットアップは、テレメトリーを受信してバックエンドに転送するローカルの [OpenTelemetry Collector](/docs/collector/) をホスト上で実行することです。
+
+テレメトリーを別の場所に送信するには、設定ファイルを使用する方法が推奨されます。
+一から書く必要はほとんどありません。
+各言語パッケージには、環境変数の補間を通じてエクスポーターのエンドポイント、ヘッダー、サービス名を設定する、すぐに使えるリファレンスファイルが `/etc/opentelemetry/<language>/otel-config.yaml` に用意されています。
+これらのファイルをコピーまたは[宣言的設定](/docs/languages/sdk-configuration/declarative-configuration/)に合わせて編集し、`/etc/opentelemetry/injector/default_env.conf` のインジェクター環境ファイルで `OTEL_CONFIG_FILE` を設定して有効化します。
+
+```conf
+OTEL_CONFIG_FILE=/etc/opentelemetry/config.yaml
+```
+
+> [!NOTE]
+>
+> .NET の場合、ファイルベースの設定には `OTEL_EXPERIMENTAL_FILE_BASED_CONFIGURATION_ENABLED=true` も必要です。
+> これがないと、設定ファイルは無視されます。
+
+設定の変更を反映するには、アプリケーションを再起動してください。
+
+## 環境変数による設定 {#configure-with-environment-variables}
+
+設定ファイルを使用しない場合は、`/etc/opentelemetry/injector/default_env.conf` のインジェクター環境ファイルに標準の OpenTelemetry 環境変数を直接設定できます。
+ここに設定された変数は、すべての計装されたプロセスに適用されます。
+たとえば、API キーを必要とする OTLP エンドポイントに直接エクスポートするには以下のように設定します。
+
+```conf
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.example.com
+OTEL_EXPORTER_OTLP_HEADERS=api-key=REPLACE_ME
+```
+
+`default_env.conf` は標準の OpenTelemetry 環境変数を使用するため、`OTEL_SERVICE_NAME`、`OTEL_RESOURCE_ATTRIBUTES`、各種サンプラーやエクスポーターの設定など、あらゆる SDK の動作を同じ方法で設定できます。
+完全な一覧は [SDK 環境変数](/docs/languages/sdk-configuration/)を参照してください。
+
+設定の変更を反映するには、アプリケーションを再起動してください。
+
+## ローカル Collector の実行 {#run-a-local-collector}
+
+ホスト上で [Collector](/docs/collector/) を実行すると、アプリケーションのエクスポート設定をシンプルに保てます。
+アプリケーションは OTLP を `localhost` に送信し、Collector がバッチ処理、リトライ、1つ以上のバックエンドへのルーティングを処理します。
+現時点では Collector は別途インストールして実行する必要があります。
+ベースの `opentelemetry` メタパッケージにはまだ含まれていません。
+
+## 次のステップ {#next-steps}
+
+- [OpenTelemetry Collector](/docs/collector/) の詳細を学ぶ。
+- 利用可能な [SDK 環境変数](/docs/languages/sdk-configuration/)を確認する。

--- a/content/ja/docs/platforms/linux/installation.md
+++ b/content/ja/docs/platforms/linux/installation.md
@@ -1,0 +1,63 @@
+---
+title: インストール
+weight: 10
+description:
+  OpenTelemetry パッケージリポジトリを追加し、Debian、Ubuntu、Fedora、または RHEL
+  とその派生ディストリビューションにシステムパッケージをインストールします。
+default_lang_commit: 6fa8e87cacb431b31061635fcddb55990e80538a
+---
+
+OpenTelemetry システムパッケージは、Debian ベースのディストリビューション向けの APT リポジトリと、RPM ベースのディストリビューション向けの YUM リポジトリに公開されています。
+このページでは、リポジトリの追加と `opentelemetry` メタパッケージのインストールについて説明します。
+このメタパッケージは [OpenTelemetry Injector](https://github.com/open-telemetry/opentelemetry-injector) と Java、.NET、Node.js、Python の自動計装を取り込みます。
+
+> [!WARNING]
+>
+> これらのパッケージはまだ初期段階にあり、本番ワークロードでの使用は想定されていません。
+> リポジトリは GitHub Pages 上でホストされており、パッケージはまだ署名されていないため、以下の手順では署名検証を無効にしています。
+> [ステータスと制限事項](../#status-and-limitations)を参照してください。
+
+## Debian、Ubuntu、およびその派生ディストリビューション {#apt}
+
+APT リポジトリを追加してパッケージをインストールします。
+
+```sh
+echo "deb [trusted=yes] https://open-telemetry.github.io/opentelemetry-packaging/debian stable main" |
+  sudo tee /etc/apt/sources.list.d/opentelemetry.list
+sudo apt update
+sudo apt install opentelemetry
+```
+
+## Fedora、RHEL、およびその派生ディストリビューション {#yum}
+
+YUM リポジトリを追加してパッケージをインストールします。
+
+```sh
+cat <<EOF | sudo tee /etc/yum.repos.d/opentelemetry.repo
+[opentelemetry]
+name=OpenTelemetry Auto-Instrumentation System Packages
+baseurl=https://open-telemetry.github.io/opentelemetry-packaging/rpm/packages
+enabled=1
+gpgcheck=0
+EOF
+sudo dnf install opentelemetry
+```
+
+## インストールの確認 {#verify-the-installation}
+
+サポートされている言語で書かれたアプリケーションを再起動するか、新しいアプリケーションを起動して、設定した送信先にテレメトリーが送信されていることを確認します。
+[送信先を設定する](../configuration/)までは、テレメトリーは OTLP を使用して `localhost` のポート `4317`（gRPC）および `4318`（HTTP）に送信されるため、データを確認するにはそこでリッスンしている [Collector](/docs/collector/) または他の OTLP レシーバーが必要です。
+
+## 個別の言語のインストール {#install-individual-languages}
+
+`opentelemetry` メタパッケージは、インジェクターとサポートされているすべての言語の自動計装をインストールします。
+一部の言語のみ必要な場合は、言語固有のパッケージを個別にインストールできます。
+
+- `opentelemetry-java`
+- `opentelemetry-nodejs`
+- `opentelemetry-dotnet`
+- `opentelemetry-python`
+
+## 次のステップ {#next-steps}
+
+- [設定](../configuration/)：テレメトリーを Collector またはバックエンドに送信し、計装対象を制御します。


### PR DESCRIPTION
## Summary

Translates `content/en/docs/platforms/linux/_index.md`, `content/en/docs/platforms/linux/installation.md`, and `content/en/docs/platforms/linux/configuration.md` into Japanese as `content/ja/docs/platforms/linux/_index.md`, `content/ja/docs/platforms/linux/installation.md`, and `content/ja/docs/platforms/linux/configuration.md`.

The sibling pages (`installation.md` and `configuration.md`) are included in this PR because the `_index.md` links to them with relative URLs, which would 404 without Japanese translations.

## Checks

- [x] I have read and followed the [Contributing](https://opentelemetry.io/docs/contributing/) docs, especially the "**First-time contributing?**" section.
- [x] This PR has content that I did not fully write myself.
  - [x] I used AI and I have read and followed the [Generative AI Contribution Policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
- [x] I have the experience and knowledge necessary to understand, review, and validate all content in this PR.[^I-know-my-stuff]

[^I-know-my-stuff]:
    Yes, I can answer maintainer questions about the content of this PR, without using AI.

<!-- preview-section-start -->

## Preview

### docs/platforms/linux/
- **Japanese (this PR):** https://deploy-preview-11689--opentelemetry.netlify.app/ja/docs/platforms/linux/
- **English (canonical):** https://opentelemetry.io/docs/platforms/linux/

### docs/platforms/linux/configuration/
- **Japanese (this PR):** https://deploy-preview-11689--opentelemetry.netlify.app/ja/docs/platforms/linux/configuration/
- **English (canonical):** https://opentelemetry.io/docs/platforms/linux/configuration/

### docs/platforms/linux/installation/
- **Japanese (this PR):** https://deploy-preview-11689--opentelemetry.netlify.app/ja/docs/platforms/linux/installation/
- **English (canonical):** https://opentelemetry.io/docs/platforms/linux/installation/

<!-- preview-section-end -->
